### PR TITLE
Add support for druid data ingestion

### DIFF
--- a/presto-druid/src/main/java/com/facebook/presto/druid/DruidConnector.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/DruidConnector.java
@@ -15,9 +15,11 @@ package com.facebook.presto.druid;
 
 import com.facebook.airlift.bootstrap.LifeCycleManager;
 import com.facebook.airlift.log.Logger;
+import com.facebook.presto.druid.ingestion.DruidPageSinkProvider;
 import com.facebook.presto.spi.ConnectorPlanOptimizer;
 import com.facebook.presto.spi.connector.Connector;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
+import com.facebook.presto.spi.connector.ConnectorPageSinkProvider;
 import com.facebook.presto.spi.connector.ConnectorPageSourceProvider;
 import com.facebook.presto.spi.connector.ConnectorPlanOptimizerProvider;
 import com.facebook.presto.spi.connector.ConnectorSplitManager;
@@ -42,6 +44,7 @@ public class DruidConnector
     private final DruidMetadata metadata;
     private final DruidSplitManager splitManager;
     private final DruidPageSourceProvider pageSourceProvider;
+    private final DruidPageSinkProvider pageSinkProvider;
     private final List<PropertyMetadata<?>> sessionProperties;
     private final ConnectorPlanOptimizer planOptimizer;
 
@@ -51,6 +54,7 @@ public class DruidConnector
             DruidMetadata metadata,
             DruidSplitManager splitManager,
             DruidPageSourceProvider pageSourceProvider,
+            DruidPageSinkProvider pageSinkProvider,
             DruidSessionProperties druidSessionProperties,
             DruidPlanOptimizer planOptimizer)
     {
@@ -58,6 +62,7 @@ public class DruidConnector
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.splitManager = requireNonNull(splitManager, "splitManager is null");
         this.pageSourceProvider = requireNonNull(pageSourceProvider, "pageSourceProvider is null");
+        this.pageSinkProvider = requireNonNull(pageSinkProvider, "pageSinkProvide is null");
         this.sessionProperties = ImmutableList.copyOf(requireNonNull(druidSessionProperties, "sessionProperties is null").getSessionProperties());
         this.planOptimizer = requireNonNull(planOptimizer, "plan optimizer is null");
     }
@@ -84,6 +89,12 @@ public class DruidConnector
     public ConnectorPageSourceProvider getPageSourceProvider()
     {
         return pageSourceProvider;
+    }
+
+    @Override
+    public ConnectorPageSinkProvider getPageSinkProvider()
+    {
+        return pageSinkProvider;
     }
 
     @Override

--- a/presto-druid/src/main/java/com/facebook/presto/druid/DruidHandleResolver.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/DruidHandleResolver.java
@@ -17,6 +17,7 @@ import com.facebook.presto.druid.ingestion.DruidIngestionTableHandle;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorHandleResolver;
 import com.facebook.presto.spi.ConnectorInsertTableHandle;
+import com.facebook.presto.spi.ConnectorOutputTableHandle;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.ConnectorTableHandle;
 import com.facebook.presto.spi.ConnectorTableLayoutHandle;
@@ -57,6 +58,12 @@ public class DruidHandleResolver
 
     @Override
     public Class<? extends ConnectorInsertTableHandle> getInsertTableHandleClass()
+    {
+        return DruidIngestionTableHandle.class;
+    }
+
+    @Override
+    public Class<? extends ConnectorOutputTableHandle> getOutputTableHandleClass()
     {
         return DruidIngestionTableHandle.class;
     }

--- a/presto-druid/src/main/java/com/facebook/presto/druid/DruidHandleResolver.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/DruidHandleResolver.java
@@ -13,8 +13,10 @@
  */
 package com.facebook.presto.druid;
 
+import com.facebook.presto.druid.ingestion.DruidIngestionTableHandle;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorHandleResolver;
+import com.facebook.presto.spi.ConnectorInsertTableHandle;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.ConnectorTableHandle;
 import com.facebook.presto.spi.ConnectorTableLayoutHandle;
@@ -51,5 +53,11 @@ public class DruidHandleResolver
     public Class<? extends ConnectorTransactionHandle> getTransactionHandleClass()
     {
         return DruidTransactionHandle.class;
+    }
+
+    @Override
+    public Class<? extends ConnectorInsertTableHandle> getInsertTableHandleClass()
+    {
+        return DruidIngestionTableHandle.class;
     }
 }

--- a/presto-druid/src/main/java/com/facebook/presto/druid/DruidMetadata.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/DruidMetadata.java
@@ -14,9 +14,11 @@
 package com.facebook.presto.druid;
 
 import com.facebook.presto.common.type.Type;
+import com.facebook.presto.druid.ingestion.DruidIngestionTableHandle;
 import com.facebook.presto.druid.metadata.DruidColumnInfo;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ColumnMetadata;
+import com.facebook.presto.spi.ConnectorInsertTableHandle;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ConnectorTableHandle;
 import com.facebook.presto.spi.ConnectorTableLayout;
@@ -27,11 +29,15 @@ import com.facebook.presto.spi.Constraint;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.SchemaTablePrefix;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
+import com.facebook.presto.spi.connector.ConnectorOutputMetadata;
+import com.facebook.presto.spi.statistics.ComputedStatistics;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import io.airlift.slice.Slice;
 
 import javax.inject.Inject;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -133,6 +139,19 @@ public class DruidMetadata
     public ColumnMetadata getColumnMetadata(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle columnHandle)
     {
         return ((DruidColumnHandle) columnHandle).getColumnMetadata();
+    }
+
+    @Override
+    public ConnectorInsertTableHandle beginInsert(ConnectorSession session, ConnectorTableHandle tableHandle)
+    {
+        DruidTableHandle druidTableHandle = (DruidTableHandle) tableHandle;
+        return new DruidIngestionTableHandle(druidTableHandle.getSchemaName(), druidTableHandle.getTableName());
+    }
+
+    @Override
+    public Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session, ConnectorInsertTableHandle insertHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
+    {
+        return Optional.empty();
     }
 
     private List<SchemaTableName> listTables(ConnectorSession session, SchemaTablePrefix prefix)

--- a/presto-druid/src/main/java/com/facebook/presto/druid/DruidMetadata.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/DruidMetadata.java
@@ -145,7 +145,8 @@ public class DruidMetadata
     public ConnectorInsertTableHandle beginInsert(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         DruidTableHandle druidTableHandle = (DruidTableHandle) tableHandle;
-        return new DruidIngestionTableHandle(druidTableHandle.getSchemaName(), druidTableHandle.getTableName());
+        List<DruidColumnInfo> columns = druidClient.getColumnDataType(druidTableHandle.getTableName());
+        return new DruidIngestionTableHandle(druidTableHandle.getSchemaName(), druidTableHandle.getTableName(), columns);
     }
 
     @Override

--- a/presto-druid/src/main/java/com/facebook/presto/druid/DruidMetadata.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/DruidMetadata.java
@@ -13,12 +13,14 @@
  */
 package com.facebook.presto.druid;
 
-import com.facebook.presto.common.type.Type;
 import com.facebook.presto.druid.ingestion.DruidIngestionTableHandle;
 import com.facebook.presto.druid.metadata.DruidColumnInfo;
+import com.facebook.presto.druid.metadata.DruidColumnType;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.ConnectorInsertTableHandle;
+import com.facebook.presto.spi.ConnectorNewTableLayout;
+import com.facebook.presto.spi.ConnectorOutputTableHandle;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ConnectorTableHandle;
 import com.facebook.presto.spi.ConnectorTableLayout;
@@ -42,12 +44,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
-import static com.facebook.presto.common.type.BigintType.BIGINT;
-import static com.facebook.presto.common.type.DoubleType.DOUBLE;
-import static com.facebook.presto.common.type.RealType.REAL;
-import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
-import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.druid.DruidTableHandle.fromSchemaTableName;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
@@ -155,6 +153,23 @@ public class DruidMetadata
         return Optional.empty();
     }
 
+    @Override
+    public ConnectorOutputTableHandle beginCreateTable(ConnectorSession session, ConnectorTableMetadata tableMetadata, Optional<ConnectorNewTableLayout> layout)
+    {
+        return new DruidIngestionTableHandle(
+                tableMetadata.getTable().getSchemaName(),
+                tableMetadata.getTable().getTableName(),
+                tableMetadata.getColumns().stream()
+                        .map(column -> new DruidColumnInfo(column.getName(), DruidColumnType.fromPrestoType(column.getType())))
+                        .collect(Collectors.toList()));
+    }
+
+    @Override
+    public Optional<ConnectorOutputMetadata> finishCreateTable(ConnectorSession session, ConnectorOutputTableHandle tableHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
+    {
+        return Optional.empty();
+    }
+
     private List<SchemaTableName> listTables(ConnectorSession session, SchemaTablePrefix prefix)
     {
         if (prefix.getTableName() == null) {
@@ -163,33 +178,13 @@ public class DruidMetadata
         return ImmutableList.of(prefix.toSchemaTableName());
     }
 
-    private static Type getType(String type)
-    {
-        switch (type.toUpperCase()) {
-            case "VARCHAR":
-            case "OTHER":
-                //hyperUnique, approxHistogram Druid column types
-                return VARCHAR;
-            case "BIGINT":
-                return BIGINT;
-            case "FLOAT":
-                return REAL;
-            case "DOUBLE":
-                return DOUBLE;
-            case "TIMESTAMP":
-                return TIMESTAMP;
-            default:
-                throw new IllegalArgumentException("unsupported type: " + type);
-        }
-    }
-
     private static ColumnMetadata toColumnMetadata(DruidColumnInfo column)
     {
-        return new ColumnMetadata(column.getColumnName(), getType(column.getDataType()));
+        return new ColumnMetadata(column.getColumnName(), column.getDataType().getPrestoType());
     }
 
     private static ColumnHandle toColumnHandle(DruidColumnInfo column)
     {
-        return new DruidColumnHandle(column.getColumnName(), getType(column.getDataType()));
+        return new DruidColumnHandle(column.getColumnName(), column.getDataType().getPrestoType());
     }
 }

--- a/presto-druid/src/main/java/com/facebook/presto/druid/DruidModule.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/DruidModule.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.druid;
 
 import com.facebook.presto.druid.ingestion.DruidPageSinkProvider;
+import com.facebook.presto.druid.ingestion.DruidPageWriter;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.Scopes;
@@ -39,6 +40,7 @@ public class DruidModule
         binder.bind(DruidSplitManager.class).in(Scopes.SINGLETON);
         binder.bind(DruidPageSourceProvider.class).in(Scopes.SINGLETON);
         binder.bind(DruidPageSinkProvider.class).in(Scopes.SINGLETON);
+        binder.bind(DruidPageWriter.class).in(Scopes.SINGLETON);
         binder.bind(DruidQueryGenerator.class).in(Scopes.SINGLETON);
         binder.bind(DruidSessionProperties.class).in(Scopes.SINGLETON);
     }

--- a/presto-druid/src/main/java/com/facebook/presto/druid/DruidModule.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/DruidModule.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.druid;
 
+import com.facebook.presto.druid.ingestion.DruidPageSinkProvider;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.Scopes;
@@ -37,6 +38,7 @@ public class DruidModule
         binder.bind(DruidPlanOptimizer.class).in(Scopes.SINGLETON);
         binder.bind(DruidSplitManager.class).in(Scopes.SINGLETON);
         binder.bind(DruidPageSourceProvider.class).in(Scopes.SINGLETON);
+        binder.bind(DruidPageSinkProvider.class).in(Scopes.SINGLETON);
         binder.bind(DruidQueryGenerator.class).in(Scopes.SINGLETON);
         binder.bind(DruidSessionProperties.class).in(Scopes.SINGLETON);
     }

--- a/presto-druid/src/main/java/com/facebook/presto/druid/DruidPageSourceProvider.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/DruidPageSourceProvider.java
@@ -39,7 +39,6 @@ import javax.inject.Inject;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
 
 import static com.facebook.presto.druid.DruidErrorCode.DRUID_DEEP_STORAGE_ERROR;
 import static com.facebook.presto.druid.DruidSplit.SplitType.BROKER;
@@ -55,7 +54,7 @@ public class DruidPageSourceProvider
     public DruidPageSourceProvider(DruidClient druidClient, DruidConfig config)
     {
         this.druidClient = requireNonNull(druidClient, "druid client is null");
-        this.hadoopConfiguration = readConfiguration(config.getHadoopConfiguration());
+        this.hadoopConfiguration = config.readHadoopConfiguration();
     }
 
     @Override
@@ -94,19 +93,5 @@ public class DruidPageSourceProvider
         catch (IOException e) {
             throw new PrestoException(DRUID_DEEP_STORAGE_ERROR, "Failed to create page source on " + segmentInfo.getDeepStoragePath(), e);
         }
-    }
-
-    private static Configuration readConfiguration(List<String> resourcePaths)
-    {
-        Configuration configuration = new Configuration(false);
-
-        for (String resourcePath : resourcePaths) {
-            Configuration resourceProperties = new Configuration(false);
-            resourceProperties.addResource(new Path(resourcePath));
-            for (Map.Entry<String, String> entry : resourceProperties) {
-                configuration.set(entry.getKey(), entry.getValue());
-            }
-        }
-        return configuration;
     }
 }

--- a/presto-druid/src/main/java/com/facebook/presto/druid/ingestion/DruidIngestTask.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/ingestion/DruidIngestTask.java
@@ -33,7 +33,7 @@ public class DruidIngestTask
     {
         private String dataSource;
         private String timestampColumn;
-        private List<String> dimentions;
+        private List<DruidIngestDimension> dimentions;
         private String baseDir;
         private boolean appendToExisting;
 
@@ -49,7 +49,7 @@ public class DruidIngestTask
             return this;
         }
 
-        public Builder withDimensions(List<String> dimensions)
+        public Builder withDimensions(List<DruidIngestDimension> dimensions)
         {
             this.dimentions = dimensions;
             return this;
@@ -174,17 +174,41 @@ public class DruidIngestTask
 
     public static class DruidIngestDimensionsSpec
     {
-        private final List<String> dimensions;
+        private final List<DruidIngestDimension> dimensions;
 
-        public DruidIngestDimensionsSpec(List<String> dimensions)
+        public DruidIngestDimensionsSpec(List<DruidIngestDimension> dimensions)
         {
             this.dimensions = dimensions;
         }
 
         @JsonProperty("dimensions")
-        public List<String> getDimensions()
+        public List<DruidIngestDimension> getDimensions()
         {
             return dimensions;
+        }
+    }
+
+    public static class DruidIngestDimension
+    {
+        private final String type;
+        private final String name;
+
+        public DruidIngestDimension(String type, String name)
+        {
+            this.type = type;
+            this.name = name;
+        }
+
+        @JsonProperty("type")
+        public String getType()
+        {
+            return type;
+        }
+
+        @JsonProperty("name")
+        public String getName()
+        {
+            return name;
         }
     }
 

--- a/presto-druid/src/main/java/com/facebook/presto/druid/ingestion/DruidIngestTask.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/ingestion/DruidIngestTask.java
@@ -1,0 +1,282 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.druid.ingestion;
+
+import com.facebook.airlift.json.JsonCodec;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public class DruidIngestTask
+{
+    private final String type;
+    private final DruidIngestSpec spec;
+
+    private DruidIngestTask(String type, DruidIngestSpec spec)
+    {
+        this.type = type;
+        this.spec = spec;
+    }
+
+    public static class Builder
+    {
+        private String dataSource;
+        private String timestampColumn;
+        private List<String> dimentions;
+        private String baseDir;
+        private boolean appendToExisting;
+
+        public Builder withDataSource(String dataSource)
+        {
+            this.dataSource = dataSource;
+            return this;
+        }
+
+        public Builder withTimestampColumn(String timestampColumn)
+        {
+            this.timestampColumn = timestampColumn;
+            return this;
+        }
+
+        public Builder withDimensions(List<String> dimensions)
+        {
+            this.dimentions = dimensions;
+            return this;
+        }
+
+        public Builder withBaseDir(String baseDir)
+        {
+            this.baseDir = baseDir;
+            return this;
+        }
+
+        public Builder withAppendToExisting(boolean appendToExisting)
+        {
+            this.appendToExisting = appendToExisting;
+            return this;
+        }
+
+        public DruidIngestTask build()
+        {
+            DruidIngestDataSchema dataSchema = new DruidIngestDataSchema(
+                    dataSource,
+                    new DruidIngestTimestampSpec(timestampColumn),
+                    new DruidIngestDimensionsSpec(dimentions));
+            DruidIngestIOConfig ioConfig = new DruidIngestIOConfig(
+                    "index_parallel",
+                    new DruidIngestInputSource("local", baseDir, "*.json.gz"),
+                    new DruidIngestInputFormat("json"),
+                    appendToExisting);
+            DruidIngestSpec spec = new DruidIngestSpec(dataSchema, ioConfig);
+            return new DruidIngestTask("index_parallel", spec);
+        }
+    }
+
+    @JsonProperty("type")
+    public String getType()
+    {
+        return type;
+    }
+
+    @JsonProperty("spec")
+    public DruidIngestSpec getSpec()
+    {
+        return spec;
+    }
+
+    public String toJson()
+    {
+        return JsonCodec.jsonCodec(DruidIngestTask.class).toJson(this);
+    }
+
+    public static class DruidIngestSpec
+    {
+        private final DruidIngestDataSchema dataSchema;
+        private final DruidIngestIOConfig ioConfig;
+
+        public DruidIngestSpec(DruidIngestDataSchema dataSchema, DruidIngestIOConfig ioConfig)
+        {
+            this.dataSchema = dataSchema;
+            this.ioConfig = ioConfig;
+        }
+
+        @JsonProperty("dataSchema")
+        public DruidIngestDataSchema getDataSchema()
+        {
+            return dataSchema;
+        }
+
+        @JsonProperty("ioConfig")
+        public DruidIngestIOConfig getIoConfig()
+        {
+            return ioConfig;
+        }
+    }
+
+    public static class DruidIngestDataSchema
+    {
+        private final String dataSource;
+        private final DruidIngestTimestampSpec timestampSpec;
+        private final DruidIngestDimensionsSpec dimensionsSpec;
+
+        public DruidIngestDataSchema(String dataSource, DruidIngestTimestampSpec timestampSpec, DruidIngestDimensionsSpec dimensionsSpec)
+        {
+            this.dataSource = dataSource;
+            this.timestampSpec = timestampSpec;
+            this.dimensionsSpec = dimensionsSpec;
+        }
+
+        @JsonProperty("dataSource")
+        public String getDataSource()
+        {
+            return dataSource;
+        }
+
+        @JsonProperty("timestampSpec")
+        public DruidIngestTimestampSpec getTimestampSpec()
+        {
+            return timestampSpec;
+        }
+
+        @JsonProperty("dimensionsSpec")
+        public DruidIngestDimensionsSpec getDimensionsSpec()
+        {
+            return dimensionsSpec;
+        }
+    }
+
+    public static class DruidIngestTimestampSpec
+    {
+        private final String column;
+
+        public DruidIngestTimestampSpec(String column)
+        {
+            this.column = column;
+        }
+
+        @JsonProperty("column")
+        public String getColumn()
+        {
+            return column;
+        }
+    }
+
+    public static class DruidIngestDimensionsSpec
+    {
+        private final List<String> dimensions;
+
+        public DruidIngestDimensionsSpec(List<String> dimensions)
+        {
+            this.dimensions = dimensions;
+        }
+
+        @JsonProperty("dimensions")
+        public List<String> getDimensions()
+        {
+            return dimensions;
+        }
+    }
+
+    public static class DruidIngestIOConfig
+    {
+        private final String type;
+        private final DruidIngestInputSource inputSource;
+        private final DruidIngestInputFormat inputFormat;
+        private final boolean appendToExisting;
+
+        public DruidIngestIOConfig(
+                String type,
+                DruidIngestInputSource inputSource,
+                DruidIngestInputFormat inputFormat,
+                boolean appendToExisting)
+        {
+            this.type = type;
+            this.inputSource = inputSource;
+            this.inputFormat = inputFormat;
+            this.appendToExisting = appendToExisting;
+        }
+
+        @JsonProperty("type")
+        public String getType()
+        {
+            return type;
+        }
+
+        @JsonProperty("inputSource")
+        public DruidIngestInputSource getInputSource()
+        {
+            return inputSource;
+        }
+
+        @JsonProperty("inputFormat")
+        public DruidIngestInputFormat getInputFormat()
+        {
+            return inputFormat;
+        }
+
+        @JsonProperty("appendToExisting")
+        public boolean isAppendToExisting()
+        {
+            return appendToExisting;
+        }
+    }
+
+    public static class DruidIngestInputSource
+    {
+        private final String type;
+        private final String baseDir;
+        private final String filter;
+
+        public DruidIngestInputSource(String type, String baseDir, String filter)
+        {
+            this.type = type;
+            this.baseDir = baseDir;
+            this.filter = filter;
+        }
+
+        @JsonProperty("type")
+        public String getType()
+        {
+            return type;
+        }
+
+        @JsonProperty("baseDir")
+        public String getBaseDir()
+        {
+            return baseDir;
+        }
+
+        @JsonProperty("filter")
+        public String getFilter()
+        {
+            return filter;
+        }
+    }
+
+    public static class DruidIngestInputFormat
+    {
+        private final String type;
+
+        public DruidIngestInputFormat(String type)
+        {
+            this.type = type;
+        }
+
+        @JsonProperty("type")
+        public String getType()
+        {
+            return type;
+        }
+    }
+}

--- a/presto-druid/src/main/java/com/facebook/presto/druid/ingestion/DruidIngestionTableHandle.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/ingestion/DruidIngestionTableHandle.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.druid.ingestion;
+
+import com.facebook.presto.spi.ConnectorInsertTableHandle;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public class DruidIngestionTableHandle
+        implements ConnectorInsertTableHandle
+{
+    private final String schemaName;
+    private final String tableName;
+
+    @JsonCreator
+    public DruidIngestionTableHandle(
+            @JsonProperty("schemaName") String schemaName,
+            @JsonProperty("tableName") String tableName)
+    {
+        this.schemaName = requireNonNull(schemaName, "schemaName is null");
+        this.tableName = requireNonNull(tableName, "tableName is null");
+    }
+
+    @JsonProperty
+    public String getSchemaName()
+    {
+        return schemaName;
+    }
+
+    @JsonProperty
+    public String getTableName()
+    {
+        return tableName;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(schemaName, tableName);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if ((obj == null) || (getClass() != obj.getClass())) {
+            return false;
+        }
+
+        DruidIngestionTableHandle other = (DruidIngestionTableHandle) obj;
+        return Objects.equals(this.schemaName, other.schemaName) &&
+                Objects.equals(this.tableName, other.tableName);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("schemaName", schemaName)
+                .add("tableName", tableName)
+                .toString();
+    }
+}

--- a/presto-druid/src/main/java/com/facebook/presto/druid/ingestion/DruidIngestionTableHandle.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/ingestion/DruidIngestionTableHandle.java
@@ -13,10 +13,12 @@
  */
 package com.facebook.presto.druid.ingestion;
 
+import com.facebook.presto.druid.metadata.DruidColumnInfo;
 import com.facebook.presto.spi.ConnectorInsertTableHandle;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.List;
 import java.util.Objects;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -27,14 +29,17 @@ public class DruidIngestionTableHandle
 {
     private final String schemaName;
     private final String tableName;
+    private final List<DruidColumnInfo> columns;
 
     @JsonCreator
     public DruidIngestionTableHandle(
             @JsonProperty("schemaName") String schemaName,
-            @JsonProperty("tableName") String tableName)
+            @JsonProperty("tableName") String tableName,
+            @JsonProperty("columns") List<DruidColumnInfo> columns)
     {
         this.schemaName = requireNonNull(schemaName, "schemaName is null");
         this.tableName = requireNonNull(tableName, "tableName is null");
+        this.columns = requireNonNull(columns, "columns is null");
     }
 
     @JsonProperty
@@ -47,6 +52,12 @@ public class DruidIngestionTableHandle
     public String getTableName()
     {
         return tableName;
+    }
+
+    @JsonProperty
+    public List<DruidColumnInfo> getColumns()
+    {
+        return columns;
     }
 
     @Override

--- a/presto-druid/src/main/java/com/facebook/presto/druid/ingestion/DruidIngestionTableHandle.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/ingestion/DruidIngestionTableHandle.java
@@ -15,6 +15,7 @@ package com.facebook.presto.druid.ingestion;
 
 import com.facebook.presto.druid.metadata.DruidColumnInfo;
 import com.facebook.presto.spi.ConnectorInsertTableHandle;
+import com.facebook.presto.spi.ConnectorOutputTableHandle;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -25,7 +26,7 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
 public class DruidIngestionTableHandle
-        implements ConnectorInsertTableHandle
+        implements ConnectorInsertTableHandle, ConnectorOutputTableHandle
 {
     private final String schemaName;
     private final String tableName;

--- a/presto-druid/src/main/java/com/facebook/presto/druid/ingestion/DruidPageSink.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/ingestion/DruidPageSink.java
@@ -16,7 +16,6 @@ package com.facebook.presto.druid.ingestion;
 import com.facebook.presto.common.Page;
 import com.facebook.presto.druid.DruidClient;
 import com.facebook.presto.druid.DruidConfig;
-import com.facebook.presto.druid.metadata.DruidColumnInfo;
 import com.facebook.presto.spi.ConnectorPageSink;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
@@ -70,7 +69,7 @@ public class DruidPageSink
                 .withTimestampColumn(TIMESTAMP_COLUMN)
                 .withDimensions(tableHandle.getColumns().stream()
                         .filter(column -> !column.getColumnName().equals(TIMESTAMP_COLUMN))
-                        .map(DruidColumnInfo::getColumnName)
+                        .map(column -> new DruidIngestTask.DruidIngestDimension(column.getDataType().getIngestType(), column.getColumnName()))
                         .collect(Collectors.toList()))
                 .withAppendToExisting(true)
                 .build();

--- a/presto-druid/src/main/java/com/facebook/presto/druid/ingestion/DruidPageSink.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/ingestion/DruidPageSink.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.druid.ingestion;
+
+import com.facebook.presto.common.Page;
+import com.facebook.presto.druid.DruidClient;
+import com.facebook.presto.spi.ConnectorPageSink;
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+
+import java.util.Collection;
+import java.util.concurrent.CompletableFuture;
+
+import static java.util.concurrent.CompletableFuture.completedFuture;
+
+public class DruidPageSink
+        implements ConnectorPageSink
+{
+    private final DruidClient druidClient;
+    private final DruidIngestionTableHandle tableHandle;
+
+    public DruidPageSink(DruidClient druidClient, DruidIngestionTableHandle tableHandle)
+    {
+        this.druidClient = druidClient;
+        this.tableHandle = tableHandle;
+    }
+
+    @Override
+    public CompletableFuture<?> appendPage(Page page)
+    {
+        return NOT_BLOCKED;
+    }
+
+    @Override
+    public CompletableFuture<Collection<Slice>> finish()
+    {
+        return completedFuture(ImmutableList.of());
+    }
+
+    @Override
+    public void abort()
+    {
+    }
+}

--- a/presto-druid/src/main/java/com/facebook/presto/druid/ingestion/DruidPageSinkProvider.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/ingestion/DruidPageSinkProvider.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.druid.ingestion;
+
+import com.facebook.presto.druid.DruidClient;
+import com.facebook.presto.spi.ConnectorInsertTableHandle;
+import com.facebook.presto.spi.ConnectorOutputTableHandle;
+import com.facebook.presto.spi.ConnectorPageSink;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.PageSinkProperties;
+import com.facebook.presto.spi.connector.ConnectorPageSinkProvider;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+
+import javax.inject.Inject;
+
+import static java.util.Objects.requireNonNull;
+
+public class DruidPageSinkProvider
+        implements ConnectorPageSinkProvider
+{
+    private final DruidClient druidClient;
+
+    @Inject
+    public DruidPageSinkProvider(DruidClient druidClient)
+    {
+        this.druidClient = requireNonNull(druidClient, "druid client is null");
+    }
+
+    @Override
+    public ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorOutputTableHandle outputTableHandle, PageSinkProperties pageSinkProperties)
+    {
+        throw new UnsupportedOperationException("Table creation is not supported by the druid connector");
+    }
+
+    @Override
+    public ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorInsertTableHandle insertTableHandle, PageSinkProperties pageSinkProperties)
+    {
+        DruidIngestionTableHandle tableHandle = (DruidIngestionTableHandle) insertTableHandle;
+        return new DruidPageSink(druidClient, tableHandle);
+    }
+}

--- a/presto-druid/src/main/java/com/facebook/presto/druid/ingestion/DruidPageSinkProvider.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/ingestion/DruidPageSinkProvider.java
@@ -48,7 +48,8 @@ public class DruidPageSinkProvider
     @Override
     public ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorOutputTableHandle outputTableHandle, PageSinkProperties pageSinkProperties)
     {
-        throw new UnsupportedOperationException("Table creation is not supported by the druid connector");
+        DruidIngestionTableHandle tableHandle = (DruidIngestionTableHandle) outputTableHandle;
+        return new DruidPageSink(druidConfig, druidClient, tableHandle, druidPageWriter);
     }
 
     @Override

--- a/presto-druid/src/main/java/com/facebook/presto/druid/ingestion/DruidPageSinkProvider.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/ingestion/DruidPageSinkProvider.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.druid.ingestion;
 
 import com.facebook.presto.druid.DruidClient;
+import com.facebook.presto.druid.DruidConfig;
 import com.facebook.presto.spi.ConnectorInsertTableHandle;
 import com.facebook.presto.spi.ConnectorOutputTableHandle;
 import com.facebook.presto.spi.ConnectorPageSink;
@@ -29,12 +30,19 @@ import static java.util.Objects.requireNonNull;
 public class DruidPageSinkProvider
         implements ConnectorPageSinkProvider
 {
+    private final DruidConfig druidConfig;
     private final DruidClient druidClient;
+    private final DruidPageWriter druidPageWriter;
 
     @Inject
-    public DruidPageSinkProvider(DruidClient druidClient)
+    public DruidPageSinkProvider(
+            DruidConfig druidConfig,
+            DruidClient druidClient,
+            DruidPageWriter druidPageWriter)
     {
+        this.druidConfig = requireNonNull(druidConfig, "druid config is null");
         this.druidClient = requireNonNull(druidClient, "druid client is null");
+        this.druidPageWriter = requireNonNull(druidPageWriter, "page writer is null");
     }
 
     @Override
@@ -47,6 +55,6 @@ public class DruidPageSinkProvider
     public ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorInsertTableHandle insertTableHandle, PageSinkProperties pageSinkProperties)
     {
         DruidIngestionTableHandle tableHandle = (DruidIngestionTableHandle) insertTableHandle;
-        return new DruidPageSink(druidClient, tableHandle);
+        return new DruidPageSink(druidConfig, druidClient, tableHandle, druidPageWriter);
     }
 }

--- a/presto-druid/src/main/java/com/facebook/presto/druid/ingestion/DruidPageWriter.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/ingestion/DruidPageWriter.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.druid.ingestion;
+
+import com.facebook.presto.common.Page;
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.druid.DruidConfig;
+import com.facebook.presto.druid.metadata.DruidColumnInfo;
+import com.facebook.presto.spi.PrestoException;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import javax.inject.Inject;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.UUID;
+import java.util.zip.GZIPOutputStream;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.RealType.REAL;
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.druid.DruidErrorCode.DRUID_DEEP_STORAGE_ERROR;
+import static java.util.Objects.requireNonNull;
+
+public class DruidPageWriter
+{
+    public static final JsonFactory JSON_FACTORY = new JsonFactory();
+    public static final String DATA_FILE_EXTENSION = ".json.gz";
+
+    private final Configuration hadoopConfiguration;
+    private final DruidConfig druidConfig;
+
+    @Inject
+    public DruidPageWriter(DruidConfig druidConfig)
+    {
+        this.druidConfig = requireNonNull(druidConfig, "druidConfig is null");
+        this.hadoopConfiguration = druidConfig.readHadoopConfiguration();
+    }
+
+    public void append(Page page, DruidIngestionTableHandle tableHandle, Path dataPath)
+    {
+        Path dataFile = new Path(dataPath, UUID.randomUUID() + DATA_FILE_EXTENSION);
+        try (FileSystem fileSystem = dataFile.getFileSystem(hadoopConfiguration);
+                FSDataOutputStream outputStream = fileSystem.create(dataFile);
+                GZIPOutputStream zipOutputStream = new GZIPOutputStream(outputStream);
+                JsonGenerator jsonGen = JSON_FACTORY.createGenerator(zipOutputStream)) {
+            jsonGen.writeStartArray();
+            for (int position = 0; position < page.getPositionCount(); position++) {
+                jsonGen.writeStartObject();
+                for (int channel = 0; channel < page.getChannelCount(); channel++) {
+                    DruidColumnInfo column = tableHandle.getColumns().get(channel);
+                    Block block = page.getBlock(channel);
+                    jsonGen.writeFieldName(column.getColumnName());
+                    writeFieldValue(jsonGen, column.getDataType(), block, position);
+                }
+                jsonGen.writeEndObject();
+            }
+            jsonGen.writeEndArray();
+        }
+        catch (IOException e) {
+            throw new PrestoException(DRUID_DEEP_STORAGE_ERROR, "Ingestion failed on " + tableHandle.getTableName(), e);
+        }
+    }
+
+    private void writeFieldValue(JsonGenerator jsonGen, String dataType, Block block, int position)
+            throws IOException
+    {
+        switch (dataType.toUpperCase()) {
+            case "VARCHAR":
+            case "OTHER":
+                //hyperUnique, approxHistogram Druid column types
+                jsonGen.writeString(VARCHAR.getSlice(block, position).toStringUtf8());
+                return;
+            case "BIGINT":
+                jsonGen.writeNumber(BIGINT.getLong(block, position));
+                return;
+            case "FLOAT":
+                jsonGen.writeNumber(REAL.getDouble(block, position));
+                return;
+            case "DOUBLE":
+                jsonGen.writeNumber(DOUBLE.getDouble(block, position));
+                return;
+            case "TIMESTAMP":
+                jsonGen.writeNumber(TIMESTAMP.getLong(block, position));
+                return;
+            default:
+                throw new IllegalArgumentException("unsupported type: " + dataType);
+        }
+    }
+}

--- a/presto-druid/src/main/java/com/facebook/presto/druid/ingestion/DruidPageWriter.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/ingestion/DruidPageWriter.java
@@ -28,7 +28,6 @@ import org.apache.hadoop.fs.Path;
 import javax.inject.Inject;
 
 import java.io.IOException;
-import java.net.URI;
 import java.util.UUID;
 import java.util.zip.GZIPOutputStream;
 
@@ -62,7 +61,6 @@ public class DruidPageWriter
                 FSDataOutputStream outputStream = fileSystem.create(dataFile);
                 GZIPOutputStream zipOutputStream = new GZIPOutputStream(outputStream);
                 JsonGenerator jsonGen = JSON_FACTORY.createGenerator(zipOutputStream)) {
-            jsonGen.writeStartArray();
             for (int position = 0; position < page.getPositionCount(); position++) {
                 jsonGen.writeStartObject();
                 for (int channel = 0; channel < page.getChannelCount(); channel++) {
@@ -72,8 +70,8 @@ public class DruidPageWriter
                     writeFieldValue(jsonGen, column.getDataType(), block, position);
                 }
                 jsonGen.writeEndObject();
+                jsonGen.writeRaw('\n');
             }
-            jsonGen.writeEndArray();
         }
         catch (IOException e) {
             throw new PrestoException(DRUID_DEEP_STORAGE_ERROR, "Ingestion failed on " + tableHandle.getTableName(), e);

--- a/presto-druid/src/main/java/com/facebook/presto/druid/metadata/DruidColumnInfo.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/metadata/DruidColumnInfo.java
@@ -22,12 +22,12 @@ import static java.util.Objects.requireNonNull;
 public class DruidColumnInfo
 {
     private final String columnName;
-    private final String dataType;
+    private final DruidColumnType dataType;
 
     @JsonCreator
     public DruidColumnInfo(
             @JsonProperty("COLUMN_NAME") String columnName,
-            @JsonProperty("DATA_TYPE") String dataType)
+            @JsonProperty("DATA_TYPE") DruidColumnType dataType)
     {
         this.columnName = requireNonNull(columnName, "columnName is null");
         this.dataType = requireNonNull(dataType, "dataType is null");
@@ -40,7 +40,7 @@ public class DruidColumnInfo
     }
 
     @JsonProperty
-    public String getDataType()
+    public DruidColumnType getDataType()
     {
         return dataType;
     }

--- a/presto-druid/src/main/java/com/facebook/presto/druid/metadata/DruidColumnType.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/metadata/DruidColumnType.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.druid.metadata;
+
+import com.facebook.presto.common.type.BigintType;
+import com.facebook.presto.common.type.DoubleType;
+import com.facebook.presto.common.type.RealType;
+import com.facebook.presto.common.type.TimestampType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.VarcharType;
+
+import static java.util.Objects.requireNonNull;
+
+public enum DruidColumnType
+{
+    BIGINT(BigintType.BIGINT, "long"),
+    DOUBLE(DoubleType.DOUBLE, "double"),
+    FLOAT(RealType.REAL, "float"),
+    OTHER(VarcharType.VARCHAR, "other"),
+    TIMESTAMP(TimestampType.TIMESTAMP, "timestamp"),
+    VARCHAR(VarcharType.VARCHAR, "string");
+
+    private final String ingestType;
+    private final Type prestoType;
+
+    DruidColumnType(Type prestoType, String ingestType)
+    {
+        this.prestoType = requireNonNull(prestoType, "ingestType is null");
+        this.ingestType = requireNonNull(ingestType, "ingestType is null");
+    }
+
+    public String getIngestType()
+    {
+        return ingestType;
+    }
+
+    public Type getPrestoType()
+    {
+        return prestoType;
+    }
+
+    public static DruidColumnType fromPrestoType(Type type)
+    {
+        if (type instanceof BigintType) {
+            return BIGINT;
+        }
+        if (type instanceof DoubleType) {
+            return DOUBLE;
+        }
+        if (type instanceof RealType) {
+            return FLOAT;
+        }
+        if (type instanceof TimestampType) {
+            return TIMESTAMP;
+        }
+        if (type instanceof VarcharType) {
+            return VARCHAR;
+        }
+        return OTHER;
+    }
+}

--- a/presto-druid/src/test/java/com/facebook/presto/druid/TestDruidConfig.java
+++ b/presto-druid/src/test/java/com/facebook/presto/druid/TestDruidConfig.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.druid;
 
 import com.facebook.airlift.configuration.testing.ConfigAssertions;
+import com.google.common.base.StandardSystemProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
@@ -38,7 +39,8 @@ public class TestDruidConfig
                 .setHadoopConfiguration("")
                 .setDruidAuthenticationType(NONE)
                 .setBasicAuthenticationUsername(null)
-                .setBasicAuthenticationPassword(null));
+                .setBasicAuthenticationPassword(null)
+                .setIngestionStoragePath(StandardSystemProperty.JAVA_IO_TMPDIR.value()));
     }
 
     @Test
@@ -53,6 +55,7 @@ public class TestDruidConfig
                 .put("druid.authentication.type", "BASIC")
                 .put("druid.basic.authentication.username", "http_basic_username")
                 .put("druid.basic.authentication.password", "http_basic_password")
+                .put("druid.ingestion.storage.path", "hdfs://foo/bar/")
                 .build();
 
         DruidConfig expected = new DruidConfig()
@@ -63,7 +66,8 @@ public class TestDruidConfig
                 .setHadoopConfiguration(ImmutableList.of("/etc/core-site.xml", "/etc/hdfs-site.xml"))
                 .setDruidAuthenticationType(BASIC)
                 .setBasicAuthenticationUsername("http_basic_username")
-                .setBasicAuthenticationPassword("http_basic_password");
+                .setBasicAuthenticationPassword("http_basic_password")
+                .setIngestionStoragePath("hdfs://foo/bar/");
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-druid/src/test/java/com/facebook/presto/druid/ingestion/TestDruidIngestTask.java
+++ b/presto-druid/src/test/java/com/facebook/presto/druid/ingestion/TestDruidIngestTask.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.druid.ingestion;
+
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestDruidIngestTask
+{
+    @Test
+    public void testDruidIngestTaskToJson()
+    {
+        DruidIngestTask ingestTask = new DruidIngestTask.Builder()
+                .withDataSource("test_table_name")
+                .withBaseDir("file://test_path")
+                .withTimestampColumn("__time")
+                .withDimensions(ImmutableList.of("__time", "test_column"))
+                .withAppendToExisting(true)
+                .build();
+        assertEquals(ingestTask.toJson(), "{\n" +
+                        "  \"type\" : \"index_parallel\",\n" +
+                        "  \"spec\" : {\n" +
+                        "    \"dataSchema\" : {\n" +
+                        "      \"dataSource\" : \"test_table_name\",\n" +
+                        "      \"timestampSpec\" : {\n" +
+                        "        \"column\" : \"__time\"\n" +
+                        "      },\n" +
+                        "      \"dimensionsSpec\" : {\n" +
+                        "        \"dimensions\" : [ \"__time\", \"test_column\" ]\n" +
+                        "      }\n" +
+                        "    },\n" +
+                        "    \"ioConfig\" : {\n" +
+                        "      \"type\" : \"index_parallel\",\n" +
+                        "      \"inputSource\" : {\n" +
+                        "        \"type\" : \"local\",\n" +
+                        "        \"baseDir\" : \"file://test_path\",\n" +
+                        "        \"filter\" : \"*.json.gz\"\n" +
+                        "      },\n" +
+                        "      \"inputFormat\" : {\n" +
+                        "        \"type\" : \"json\"\n" +
+                        "      },\n" +
+                        "      \"appendToExisting\" : true\n" +
+                        "    }\n" +
+                        "  }\n" +
+                        "}");
+    }
+}

--- a/presto-druid/src/test/java/com/facebook/presto/druid/ingestion/TestDruidIngestTask.java
+++ b/presto-druid/src/test/java/com/facebook/presto/druid/ingestion/TestDruidIngestTask.java
@@ -14,7 +14,10 @@
 package com.facebook.presto.druid.ingestion;
 
 import com.google.common.collect.ImmutableList;
+import org.apache.hadoop.fs.Path;
 import org.testng.annotations.Test;
+
+import java.util.Collections;
 
 import static org.testng.Assert.assertEquals;
 
@@ -25,7 +28,7 @@ public class TestDruidIngestTask
     {
         DruidIngestTask ingestTask = new DruidIngestTask.Builder()
                 .withDataSource("test_table_name")
-                .withBaseDir("file://test_path")
+                .withInputSource(new Path("file://test_path"), Collections.emptyList())
                 .withTimestampColumn("__time")
                 .withDimensions(ImmutableList.of(
                         new DruidIngestTask.DruidIngestDimension("string", "__time"),

--- a/presto-druid/src/test/java/com/facebook/presto/druid/ingestion/TestDruidIngestTask.java
+++ b/presto-druid/src/test/java/com/facebook/presto/druid/ingestion/TestDruidIngestTask.java
@@ -27,34 +27,42 @@ public class TestDruidIngestTask
                 .withDataSource("test_table_name")
                 .withBaseDir("file://test_path")
                 .withTimestampColumn("__time")
-                .withDimensions(ImmutableList.of("__time", "test_column"))
+                .withDimensions(ImmutableList.of(
+                        new DruidIngestTask.DruidIngestDimension("string", "__time"),
+                        new DruidIngestTask.DruidIngestDimension("double", "test_double_column")))
                 .withAppendToExisting(true)
                 .build();
         assertEquals(ingestTask.toJson(), "{\n" +
-                        "  \"type\" : \"index_parallel\",\n" +
-                        "  \"spec\" : {\n" +
-                        "    \"dataSchema\" : {\n" +
-                        "      \"dataSource\" : \"test_table_name\",\n" +
-                        "      \"timestampSpec\" : {\n" +
-                        "        \"column\" : \"__time\"\n" +
-                        "      },\n" +
-                        "      \"dimensionsSpec\" : {\n" +
-                        "        \"dimensions\" : [ \"__time\", \"test_column\" ]\n" +
-                        "      }\n" +
-                        "    },\n" +
-                        "    \"ioConfig\" : {\n" +
-                        "      \"type\" : \"index_parallel\",\n" +
-                        "      \"inputSource\" : {\n" +
-                        "        \"type\" : \"local\",\n" +
-                        "        \"baseDir\" : \"file://test_path\",\n" +
-                        "        \"filter\" : \"*.json.gz\"\n" +
-                        "      },\n" +
-                        "      \"inputFormat\" : {\n" +
-                        "        \"type\" : \"json\"\n" +
-                        "      },\n" +
-                        "      \"appendToExisting\" : true\n" +
-                        "    }\n" +
-                        "  }\n" +
-                        "}");
+                "  \"type\" : \"index_parallel\",\n" +
+                "  \"spec\" : {\n" +
+                "    \"dataSchema\" : {\n" +
+                "      \"dataSource\" : \"test_table_name\",\n" +
+                "      \"timestampSpec\" : {\n" +
+                "        \"column\" : \"__time\"\n" +
+                "      },\n" +
+                "      \"dimensionsSpec\" : {\n" +
+                "        \"dimensions\" : [ {\n" +
+                "          \"type\" : \"string\",\n" +
+                "          \"name\" : \"__time\"\n" +
+                "        }, {\n" +
+                "          \"type\" : \"double\",\n" +
+                "          \"name\" : \"test_double_column\"\n" +
+                "        } ]\n" +
+                "      }\n" +
+                "    },\n" +
+                "    \"ioConfig\" : {\n" +
+                "      \"type\" : \"index_parallel\",\n" +
+                "      \"inputSource\" : {\n" +
+                "        \"type\" : \"local\",\n" +
+                "        \"baseDir\" : \"file://test_path\",\n" +
+                "        \"filter\" : \"*.json.gz\"\n" +
+                "      },\n" +
+                "      \"inputFormat\" : {\n" +
+                "        \"type\" : \"json\"\n" +
+                "      },\n" +
+                "      \"appendToExisting\" : true\n" +
+                "    }\n" +
+                "  }\n" +
+                "}");
     }
 }


### PR DESCRIPTION
* Add support for 'insert into select'
* Add support for CTAS
* Add support for native batch (parallel) ingestion
   * Ingest data from a local holder

Ingest by CTAS
`create table new_dataset7 as select localtimestamp as __time, 'beinan' as name, bigint '18' as age, double '188.88' as height;`

```
presto:druid> desc new_dataset7;
 Column |   Type    | Extra | Comment
--------+-----------+-------+---------
 __time | timestamp |       |
 age    | bigint    |       |
 height | double    |       |
 name   | varchar   |       |
```

Ingest by Insert:
` insert into new_dataset7 select localtimestamp as __time, bigint '18' as age, double '288.88' as height, "Mike" as name;`
or even more
`insert into new_dataset7 SELECT cast(date_column as timestamp),bigint '18' as age, double '188.88' as height, 'aaa' as name FROM (VALUES (SEQUENCE(FROM_ISO8601_DATE('2010-01-01'), FROM_ISO8601_DATE('2020-12-31'), INTERVAL '1' DAY) ) ) AS t1(date_array) CROSS JOIN UNNEST(date_array) AS t2(date_column);`


Limitation:
Currently only supports limited data types such as timestamp, varchar, bigint, double and float.

```
== RELEASE NOTES ==

Druid Changes
* Add support for data ingestion
```


