### PR TITLE
Support distributed and local UNION ALL in Presto-on-Spark

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -159,6 +159,7 @@ public final class SystemSessionProperties
     public static final String USE_LEGACY_SCHEDULER = "use_legacy_scheduler";
     public static final String OPTIMIZE_COMMON_SUB_EXPRESSIONS = "optimize_common_sub_expressions";
     public static final String PREFER_DISTRIBUTED_UNION = "prefer_distributed_union";
+    public static final String PREFER_LOCAL_UNION = "prefer_local_union";
     public static final String WARNING_HANDLING = "warning_handling";
     public static final String OPTIMIZE_NULLS_IN_JOINS = "optimize_nulls_in_join";
     public static final String TARGET_RESULT_SIZE = "target_result_size";
@@ -821,6 +822,11 @@ public final class SystemSessionProperties
                         "Prefer distributed union",
                         featuresConfig.isPreferDistributedUnion(),
                         true),
+                booleanProperty(
+                        PREFER_LOCAL_UNION,
+                        "Prefer union using local exchange rather than remote exchange",
+                        featuresConfig.isPreferLocalUnion(),
+                        false),
                 new PropertyMetadata<>(
                         WARNING_HANDLING,
                         format("The level of warning handling. Levels are %s",
@@ -1440,6 +1446,11 @@ public final class SystemSessionProperties
     public static boolean isPreferDistributedUnion(Session session)
     {
         return session.getSystemProperty(PREFER_DISTRIBUTED_UNION, Boolean.class);
+    }
+
+    public static boolean isPreferLocalUnion(Session session)
+    {
+        return session.getSystemProperty(PREFER_LOCAL_UNION, Boolean.class);
     }
 
     public static WarningHandlingLevel getWarningHandlingLevel(Session session)

--- a/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
@@ -275,6 +275,7 @@ public class CoordinatorModule
         // planner
         binder.bind(PlanFragmenter.class).in(Scopes.SINGLETON);
         binder.bind(PlanOptimizers.class).in(Scopes.SINGLETON);
+        newExporter(binder).export(PlanFragmenter.class).withGeneratedName();
 
         // query explainer
         binder.bind(QueryExplainer.class).in(Scopes.SINGLETON);

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -159,6 +159,7 @@ public class FeaturesConfig
     private boolean useLegacyScheduler = true;
     private boolean optimizeCommonSubExpressions = true;
     private boolean preferDistributedUnion = true;
+    private boolean preferLocalUnion;
     private boolean optimizeNullsInJoin;
     private boolean pushdownDereferenceEnabled;
     private boolean inlineSqlFunctions = true;
@@ -1360,6 +1361,19 @@ public class FeaturesConfig
     public FeaturesConfig setPreferDistributedUnion(boolean preferDistributedUnion)
     {
         this.preferDistributedUnion = preferDistributedUnion;
+        return this;
+    }
+
+    public boolean isPreferLocalUnion()
+    {
+        return preferLocalUnion;
+    }
+
+    @Config("prefer-local-union")
+    @ConfigDescription("Prefer to execute UNION ALL using local exchange rather than remote exchange")
+    public FeaturesConfig setPreferLocalUnion(boolean preferLocalUnion)
+    {
+        this.preferLocalUnion = preferLocalUnion;
         return this;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -280,6 +280,7 @@ import static com.facebook.presto.sql.planner.RowExpressionInterpreter.rowExpres
 import static com.facebook.presto.sql.planner.SystemPartitioningHandle.COORDINATOR_DISTRIBUTION;
 import static com.facebook.presto.sql.planner.SystemPartitioningHandle.FIXED_ARBITRARY_DISTRIBUTION;
 import static com.facebook.presto.sql.planner.SystemPartitioningHandle.FIXED_BROADCAST_DISTRIBUTION;
+import static com.facebook.presto.sql.planner.SystemPartitioningHandle.FIXED_MODULAR_HASH_DISTRIBUTION;
 import static com.facebook.presto.sql.planner.SystemPartitioningHandle.SCALED_WRITER_DISTRIBUTION;
 import static com.facebook.presto.sql.planner.SystemPartitioningHandle.SINGLE_DISTRIBUTION;
 import static com.facebook.presto.sql.planner.plan.AssignmentUtils.identityAssignments;
@@ -465,6 +466,7 @@ public class LocalExecutionPlanner
     {
         if (partitioningScheme.getPartitioning().getHandle().equals(FIXED_BROADCAST_DISTRIBUTION) ||
                 partitioningScheme.getPartitioning().getHandle().equals(FIXED_ARBITRARY_DISTRIBUTION) ||
+                partitioningScheme.getPartitioning().getHandle().equals(FIXED_MODULAR_HASH_DISTRIBUTION) ||
                 partitioningScheme.getPartitioning().getHandle().equals(SCALED_WRITER_DISTRIBUTION) ||
                 partitioningScheme.getPartitioning().getHandle().equals(SINGLE_DISTRIBUTION) ||
                 partitioningScheme.getPartitioning().getHandle().equals(COORDINATOR_DISTRIBUTION)) {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanFragmenter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanFragmenter.java
@@ -78,6 +78,7 @@ import com.google.common.base.VerifyException;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import org.weakref.jmx.Managed;
 
 import javax.inject.Inject;
 
@@ -89,6 +90,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.facebook.presto.SystemSessionProperties.getExchangeMaterializationStrategy;
 import static com.facebook.presto.SystemSessionProperties.getQueryMaxStageCount;
@@ -146,6 +148,7 @@ public class PlanFragmenter
     public static final int ROOT_FRAGMENT_ID = 0;
     public static final String TOO_MANY_STAGES_MESSAGE = "If the query contains multiple DISTINCTs, please set the 'use_mark_distinct' session property to false. " +
             "If the query contains multiple CTEs that are referenced more than once, please create temporary table(s) for one or more of the CTEs.";
+    private static final AtomicInteger sourceDistributionOverwrite = new AtomicInteger();
 
     private final Metadata metadata;
     private final NodePartitioningManager nodePartitioningManager;
@@ -515,6 +518,12 @@ public class PlanFragmenter
                 default:
                     throw new IllegalArgumentException("Unexpected exchange scope: " + exchange.getScope());
             }
+        }
+
+        @Managed
+        public long getSourceDistributionOverwrite()
+        {
+            return sourceDistributionOverwrite.get();
         }
 
         private PlanNode createRemoteStreamingExchange(ExchangeNode exchange, RewriteContext<FragmentProperties> context)
@@ -897,6 +906,7 @@ public class PlanFragmenter
 
             // TODO: This seems never happens for current planner, consider to remove
             if (currentPartitioning.equals(SOURCE_DISTRIBUTION)) {
+                sourceDistributionOverwrite.incrementAndGet();
                 if (!isPreferLocalUnion(session)) {
                     this.partitioningHandle = Optional.of(distribution);
                 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/SystemPartitioningHandle.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/SystemPartitioningHandle.java
@@ -61,6 +61,7 @@ public final class SystemPartitioningHandle
     public static final PartitioningHandle FIXED_HASH_DISTRIBUTION = createSystemPartitioning(SystemPartitioning.FIXED, SystemPartitionFunction.HASH);
     public static final PartitioningHandle FIXED_ARBITRARY_DISTRIBUTION = createSystemPartitioning(SystemPartitioning.FIXED, SystemPartitionFunction.ROUND_ROBIN);
     public static final PartitioningHandle FIXED_BROADCAST_DISTRIBUTION = createSystemPartitioning(SystemPartitioning.FIXED, SystemPartitionFunction.BROADCAST);
+    public static final PartitioningHandle FIXED_MODULAR_HASH_DISTRIBUTION = createSystemPartitioning(SystemPartitioning.FIXED, SystemPartitionFunction.MODULAR_HASH);
     public static final PartitioningHandle SCALED_WRITER_DISTRIBUTION = createSystemPartitioning(SystemPartitioning.SCALED, SystemPartitionFunction.ROUND_ROBIN);
     public static final PartitioningHandle SOURCE_DISTRIBUTION = createSystemPartitioning(SystemPartitioning.SOURCE, SystemPartitionFunction.UNKNOWN);
     public static final PartitioningHandle ARBITRARY_DISTRIBUTION = createSystemPartitioning(SystemPartitioning.ARBITRARY, SystemPartitionFunction.UNKNOWN);
@@ -206,6 +207,13 @@ public final class SystemPartitioningHandle
 
                     return new HashBucketFunction(new InterpretedHashGenerator(partitionChannelTypes, hashChannels), bucketCount);
                 }
+            }
+        },
+        MODULAR_HASH {
+            @Override
+            public BucketFunction createBucketFunction(List<Type> partitionChannelTypes, boolean isHashPrecomputed, int bucketCount)
+            {
+                throw new UnsupportedOperationException();
             }
         },
         ROUND_ROBIN {

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -142,6 +142,7 @@ public class TestFeaturesConfig
                 .setUseLegacyScheduler(true)
                 .setOptimizeCommonSubExpressions(true)
                 .setPreferDistributedUnion(true)
+                .setPreferLocalUnion(false)
                 .setOptimizeNullsInJoin(false)
                 .setWarnOnNoTableLayoutFilter("")
                 .setInlineSqlFunctions(true));
@@ -242,6 +243,7 @@ public class TestFeaturesConfig
                 .put("use-legacy-scheduler", "false")
                 .put("optimize-common-sub-expressions", "false")
                 .put("prefer-distributed-union", "false")
+                .put("prefer-local-union", "true")
                 .put("optimize-nulls-in-join", "true")
                 .put("warn-on-no-table-layout-filter", "ry@nlikestheyankees,ds")
                 .put("inline-sql-functions", "false")
@@ -339,6 +341,7 @@ public class TestFeaturesConfig
                 .setUseLegacyScheduler(false)
                 .setOptimizeCommonSubExpressions(false)
                 .setPreferDistributedUnion(false)
+                .setPreferLocalUnion(true)
                 .setOptimizeNullsInJoin(true)
                 .setWarnOnNoTableLayoutFilter("ry@nlikestheyankees,ds")
                 .setInlineSqlFunctions(false);

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
@@ -204,6 +204,7 @@ public class PrestoSparkQueryRunner
                 ImmutableMap.of(
                         "presto.version", "testversion",
                         "query.hash-partition-count", Integer.toString(NODE_COUNT * 2),
+                        "prefer-local-union", "true",
                         "prefer-distributed-union", "false"),
                 ImmutableMap.of(),
                 Optional.empty(),


### PR DESCRIPTION
Goal:
   Avoid round robin shuffle for Presto on Spark and support distributed UNION ALL

TODO:
1. Remove `prefer-distributed-union` config if current PR works,  since it is always preferred to run in a distributed fashion.
2. Local UNION ALL for non-compatible bucket tables are not enabled yet, e.g.  10 buckets table UNION ALL 15 buckets table  ,  it can be set to `SOURCE_DISTRIBUTION` for this case
3. Monitor added JMX counter and do not overwrite an existing SOURCE PartitionHandle if it is verified to be dead code.

To reviewers:
Please help to suggest more test cases.

```
== NO RELEASE NOTE ==
```
