### PR TITLE
Add plan check for runtime optimization

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
@@ -480,7 +480,10 @@ public class SqlQueryExecution
                         runtimePlanOptimizers,
                         stateMachine.getWarningCollector(),
                         idAllocator,
-                        variableAllocator.get()) :
+                        variableAllocator.get(),
+                        planChecker,
+                        metadata,
+                        sqlParser) :
                 SqlQueryScheduler.createSqlQueryScheduler(
                         locationFactory,
                         executionPolicy,
@@ -498,7 +501,10 @@ public class SqlQueryExecution
                         runtimePlanOptimizers,
                         stateMachine.getWarningCollector(),
                         idAllocator,
-                        variableAllocator.get());
+                        variableAllocator.get(),
+                        planChecker,
+                        metadata,
+                        sqlParser);
 
         queryScheduler.set(scheduler);
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -607,7 +607,7 @@ public class PlanOptimizers
                 statsCalculator,
                 costCalculator,
                 ImmutableList.of(),
-                ImmutableSet.of(new RuntimeReorderJoinSides())));
+                ImmutableSet.of(new RuntimeReorderJoinSides(metadata, sqlParser))));
         this.runtimeOptimizers = runtimeBuilder.build();
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RuntimeReorderJoinSides.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RuntimeReorderJoinSides.java
@@ -18,20 +18,28 @@ import com.facebook.airlift.log.Logger;
 import com.facebook.presto.cost.StatsProvider;
 import com.facebook.presto.matching.Captures;
 import com.facebook.presto.matching.Pattern;
+import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.TableScanNode;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.optimizations.StreamPreferredProperties;
+import com.facebook.presto.sql.planner.optimizations.StreamPropertyDerivations;
 import com.facebook.presto.sql.planner.plan.ExchangeNode;
 import com.facebook.presto.sql.planner.plan.JoinNode;
-import com.google.common.collect.ImmutableSet;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 import static com.facebook.presto.SystemSessionProperties.getTaskConcurrency;
+import static com.facebook.presto.SystemSessionProperties.isSpillEnabled;
 import static com.facebook.presto.sql.planner.optimizations.PlanNodeSearcher.searchFrom;
+import static com.facebook.presto.sql.planner.optimizations.StreamPreferredProperties.defaultParallelism;
+import static com.facebook.presto.sql.planner.optimizations.StreamPreferredProperties.exactlyPartitionedOn;
+import static com.facebook.presto.sql.planner.optimizations.StreamPreferredProperties.fixedParallelism;
+import static com.facebook.presto.sql.planner.optimizations.StreamPreferredProperties.singleStream;
+import static com.facebook.presto.sql.planner.optimizations.StreamPropertyDerivations.StreamProperties;
 import static com.facebook.presto.sql.planner.plan.ExchangeNode.Scope.LOCAL;
 import static com.facebook.presto.sql.planner.plan.ExchangeNode.gatheringExchange;
 import static com.facebook.presto.sql.planner.plan.ExchangeNode.systemPartitionedExchange;
@@ -42,6 +50,7 @@ import static com.facebook.presto.sql.planner.plan.JoinNode.Type.RIGHT;
 import static com.facebook.presto.sql.planner.plan.Patterns.join;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
 
 public class RuntimeReorderJoinSides
         implements Rule<JoinNode>
@@ -49,6 +58,15 @@ public class RuntimeReorderJoinSides
     private static final Logger log = Logger.get(RuntimeReorderJoinSides.class);
 
     private static final Pattern<JoinNode> PATTERN = join();
+
+    private final Metadata metadata;
+    private final SqlParser parser;
+
+    public RuntimeReorderJoinSides(Metadata metadata, SqlParser parser)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.parser = requireNonNull(parser, "parser is null");
+    }
 
     @Override
     public Pattern<JoinNode> getPattern()
@@ -99,25 +117,28 @@ public class RuntimeReorderJoinSides
         JoinNode swapped = joinNode.flipChildren();
 
         PlanNode newLeft = swapped.getLeft();
-        PlanNode resolvedSwappedLeft = context.getLookup().resolve(newLeft);
+        Optional<VariableReferenceExpression> leftHashVariable = swapped.getLeftHashVariable();
         // Remove unnecessary LocalExchange in the current probe side. If the immediate left child (new probe side) of the join node
         // is a localExchange, there are two cases: an Exchange introduced by the current probe side (previous build side); or it is a UnionNode.
-        // If the exchangeNode has more than 1 sources, it corresponds to the second case, otherwise it corresponds to the first case and safe to remove
-        Optional<VariableReferenceExpression> leftHashVariable = swapped.getLeftHashVariable();
+        // If the exchangeNode has more than 1 sources, it corresponds to the second case, otherwise it corresponds to the first case and could be safe to remove
+        PlanNode resolvedSwappedLeft = context.getLookup().resolve(newLeft);
         if (resolvedSwappedLeft instanceof ExchangeNode && resolvedSwappedLeft.getSources().size() == 1) {
-            newLeft = resolvedSwappedLeft.getSources().get(0);
-            // The HashGenerationOptimizer will generate hashVariables and append to the output layout of the nodes following the same order. Therefore,
-            // we use the index of the old hashVariable in the ExchangeNode output layout to retrieve the hashVariable from the new left node, and feed
-            // it as the leftHashVariable of the swapped join node.
-            if (swapped.getLeftHashVariable().isPresent()) {
-                int hashVariableIndex = resolvedSwappedLeft.getOutputVariables().indexOf(swapped.getLeftHashVariable().get());
-                leftHashVariable = Optional.of(resolvedSwappedLeft.getSources().get(0).getOutputVariables().get(hashVariableIndex));
-                // When join output layout contains new left side's hashVariable (e.g., a nested join in a single stage, the inner join's output layout possibly
-                // carry the join hashVariable from its new probe), after removing the local exchange at the new probe, the output variables of the join node will
-                // also change, which has to be broadcast upwards (rewriting plan nodes) until the point where this hashVariable is no longer the output.
-                // This is against typical iterativeOptimizer behavior and given this case is rare, just abort the swapping for this scenario.
-                if (swapped.getOutputVariables().contains(swapped.getLeftHashVariable().get())) {
-                    return Result.empty();
+            // Ensure the new probe after skipping the local exchange will satisfy the required probe side property
+            if (checkProbeSidePropertySatisfied(resolvedSwappedLeft.getSources().get(0), context)) {
+                newLeft = resolvedSwappedLeft.getSources().get(0);
+                // The HashGenerationOptimizer will generate hashVariables and append to the output layout of the nodes following the same order. Therefore,
+                // we use the index of the old hashVariable in the ExchangeNode output layout to retrieve the hashVariable from the new left node, and feed
+                // it as the leftHashVariable of the swapped join node.
+                if (swapped.getLeftHashVariable().isPresent()) {
+                    int hashVariableIndex = resolvedSwappedLeft.getOutputVariables().indexOf(swapped.getLeftHashVariable().get());
+                    leftHashVariable = Optional.of(resolvedSwappedLeft.getSources().get(0).getOutputVariables().get(hashVariableIndex));
+                    // When join output layout contains new left side's hashVariable (e.g., a nested join in a single stage, the inner join's output layout possibly
+                    // carry the join hashVariable from its new probe), after removing the local exchange at the new probe, the output variables of the join node will
+                    // also change, which has to be broadcast upwards (rewriting plan nodes) until the point where this hashVariable is no longer the output.
+                    // This is against typical iterativeOptimizer behavior and given this case is rare, just abort the swapping for this scenario.
+                    if (swapped.getOutputVariables().contains(swapped.getLeftHashVariable().get())) {
+                        return Result.empty();
+                    }
                 }
             }
         }
@@ -127,7 +148,7 @@ public class RuntimeReorderJoinSides
                 .map(JoinNode.EquiJoinClause::getRight)
                 .collect(toImmutableList());
         PlanNode newRight = swapped.getRight();
-        if (needLocalExchange(swapped.getRight(), ImmutableSet.copyOf(buildJoinVariables), context)) {
+        if (!checkBuildSidePropertySatisfied(swapped.getRight(), buildJoinVariables, context)) {
             if (getTaskConcurrency(context.getSession()) > 1) {
                 newRight = systemPartitionedExchange(
                         context.getIdAllocator().getNextId(),
@@ -164,27 +185,40 @@ public class RuntimeReorderJoinSides
                 !(join.getDistributionType().get() == PARTITIONED && join.getCriteria().isEmpty() && join.getType() == RIGHT);
     }
 
-    private boolean needLocalExchange(PlanNode root, Set<VariableReferenceExpression> partitioningColumns, Context context)
+    // Check if the new probe side after removing unnecessary local exchange is valid.
+    private boolean checkProbeSidePropertySatisfied(PlanNode node, Context context)
     {
-        PlanNode actual = context.getLookup().resolve(root);
-        if (actual instanceof ExchangeNode) {
-            // when distribution matches, no need to add localExchange.
-            if (!partitioningColumns.isEmpty() && ((ExchangeNode) actual).getPartitioningScheme().getPartitioning().getVariableReferences().equals(partitioningColumns)) {
-                return false;
-            }
-            // If parent partitioningColumn does not require partitioning on any columns, no need to add exchange.
-            // If current exchange is GATHER, repartition won't possibly happen after it in practice, and so no need to add exchange.
-            // Only need adding localExchange when parent actually have partitioningColumns requirements and is inconsistent with current exchangeNode's partitioning scheme.
-            return !partitioningColumns.isEmpty() && ((ExchangeNode) actual).getType() != ExchangeNode.Type.GATHER;
+        StreamPreferredProperties requiredProbeProperty;
+        if (isSpillEnabled(context.getSession())) {
+            requiredProbeProperty = fixedParallelism();
         }
-        if (actual.getSources().isEmpty()) {
-            return true;
+        else {
+            requiredProbeProperty = defaultParallelism(context.getSession());
         }
-        for (PlanNode child : actual.getSources()) {
-            if (needLocalExchange(child, partitioningColumns, context)) {
-                return true;
-            }
+        StreamProperties nodeProperty = derivePropertiesRecursively(node, metadata, parser, context);
+        return requiredProbeProperty.isSatisfiedBy(nodeProperty);
+    }
+
+    // Check if the property of a planNode satisfies the requirements for directly feeding as the build side of a JoinNode.
+    private boolean checkBuildSidePropertySatisfied(PlanNode node, List<VariableReferenceExpression> partitioningColumns, Context context)
+    {
+        StreamPreferredProperties requiredBuildProperty;
+        if (getTaskConcurrency(context.getSession()) > 1) {
+            requiredBuildProperty = exactlyPartitionedOn(partitioningColumns);
         }
-        return false;
+        else {
+            requiredBuildProperty = singleStream();
+        }
+        StreamProperties nodeProperty = derivePropertiesRecursively(node, metadata, parser, context);
+        return requiredBuildProperty.isSatisfiedBy(nodeProperty);
+    }
+
+    private StreamProperties derivePropertiesRecursively(PlanNode node, Metadata metadata, SqlParser parser, Context context)
+    {
+        PlanNode actual = context.getLookup().resolve(node);
+        List<StreamProperties> inputProperties = actual.getSources().stream()
+                .map(source -> derivePropertiesRecursively(source, metadata, parser, context))
+                .collect(toImmutableList());
+        return StreamPropertyDerivations.deriveProperties(actual, inputProperties, metadata, context.getSession(), context.getVariableAllocator().getTypes(), parser);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/StreamPreferredProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/StreamPreferredProperties.java
@@ -37,7 +37,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
 
-class StreamPreferredProperties
+public class StreamPreferredProperties
 {
     private final Optional<StreamDistribution> distribution;
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/PlanChecker.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/PlanChecker.java
@@ -57,7 +57,8 @@ public final class PlanChecker
                         new NoSubqueryExpressionLeftChecker(),
                         new NoIdentifierLeftChecker(),
                         new VerifyNoFilteredAggregations(),
-                        new VerifyNoOriginalExpression())
+                        new VerifyNoOriginalExpression(),
+                        new ValidateStreamingJoins())
                 .putAll(
                         Stage.FINAL,
                         new CheckUnsupportedExternalFunctions(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateStreamingJoins.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateStreamingJoins.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.sanity;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.execution.warnings.WarningCollector;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.planner.TypeProvider;
+import com.facebook.presto.sql.planner.optimizations.StreamPreferredProperties;
+import com.facebook.presto.sql.planner.optimizations.StreamPropertyDerivations.StreamProperties;
+import com.facebook.presto.sql.planner.plan.InternalPlanVisitor;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.sql.planner.plan.RemoteSourceNode;
+import com.facebook.presto.sql.planner.sanity.PlanChecker.Checker;
+
+import java.util.List;
+
+import static com.facebook.presto.SystemSessionProperties.getTaskConcurrency;
+import static com.facebook.presto.SystemSessionProperties.isSpillEnabled;
+import static com.facebook.presto.sql.planner.optimizations.PlanNodeSearcher.searchFrom;
+import static com.facebook.presto.sql.planner.optimizations.StreamPreferredProperties.defaultParallelism;
+import static com.facebook.presto.sql.planner.optimizations.StreamPreferredProperties.exactlyPartitionedOn;
+import static com.facebook.presto.sql.planner.optimizations.StreamPreferredProperties.fixedParallelism;
+import static com.facebook.presto.sql.planner.optimizations.StreamPreferredProperties.singleStream;
+import static com.facebook.presto.sql.planner.optimizations.StreamPropertyDerivations.derivePropertiesRecursively;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+public class ValidateStreamingJoins
+        implements Checker
+{
+    @Override
+    public void validate(PlanNode planNode, Session session, Metadata metadata, SqlParser sqlParser, TypeProvider types, WarningCollector warningCollector)
+    {
+        planNode.accept(new Visitor(session, metadata, sqlParser, types, warningCollector), null);
+    }
+
+    private static final class Visitor
+            extends InternalPlanVisitor<Void, Void>
+    {
+        private final Session session;
+        private final Metadata metadata;
+        private final SqlParser sqlParser;
+        private final TypeProvider types;
+        private final WarningCollector warningCollector;
+
+        private Visitor(Session sesstion, Metadata metadata, SqlParser sqlParser, TypeProvider types, WarningCollector warningCollector)
+        {
+            this.session = sesstion;
+            this.metadata = metadata;
+            this.sqlParser = sqlParser;
+            this.types = types;
+            this.warningCollector = warningCollector;
+        }
+
+        @Override
+        public Void visitPlan(PlanNode node, Void context)
+        {
+            node.getSources().forEach(source -> source.accept(this, context));
+            return null;
+        }
+
+        @Override
+        public Void visitJoin(JoinNode node, Void context)
+        {
+            // Validate the streaming property of the join node is satisfied when no RemoteSourceNode is involved.
+            if (!searchFrom(node).where(RemoteSourceNode.class::isInstance).matches()) {
+                List<VariableReferenceExpression> buildJoinVariables = node.getCriteria().stream()
+                        .map(JoinNode.EquiJoinClause::getRight)
+                        .collect(toImmutableList());
+                StreamPreferredProperties requiredBuildProperty;
+                if (getTaskConcurrency(session) > 1) {
+                    requiredBuildProperty = exactlyPartitionedOn(buildJoinVariables);
+                }
+                else {
+                    requiredBuildProperty = singleStream();
+                }
+                StreamProperties buildProperties = derivePropertiesRecursively(node.getRight(), metadata, session, types, sqlParser);
+                checkArgument(requiredBuildProperty.isSatisfiedBy(buildProperties), "Build side needs an additional local exchange for join: %s", node.getId());
+
+                StreamPreferredProperties requiredProbeProperty;
+                if (isSpillEnabled(session)) {
+                    requiredProbeProperty = fixedParallelism();
+                }
+                else {
+                    requiredProbeProperty = defaultParallelism(session);
+                }
+                StreamProperties probeProperties = derivePropertiesRecursively(node.getLeft(), metadata, session, types, sqlParser);
+                checkArgument(requiredProbeProperty.isSatisfiedBy(probeProperties), "Probe side needs an additional local exchange for join: %s", node.getId());
+            }
+            return null;
+        }
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestCostCalculator.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestCostCalculator.java
@@ -172,7 +172,7 @@ public class TestCostCalculator
                 .memory(0)
                 .network(0);
 
-        assertCostFragmentedPlan(tableScan, ImmutableMap.of(), ImmutableMap.of("ts", statsEstimate(tableScan, 1000)), types)
+        assertCostSingleStageFragmentedPlan(tableScan, ImmutableMap.of(), ImmutableMap.of("ts", statsEstimate(tableScan, 1000)), types)
                 .cpu(1000 * IS_NULL_OVERHEAD)
                 .memory(0)
                 .network(0);
@@ -203,7 +203,7 @@ public class TestCostCalculator
                 .memory(0)
                 .network(0);
 
-        assertCostFragmentedPlan(project, costs, stats, types)
+        assertCostSingleStageFragmentedPlan(project, costs, stats, types)
                 .cpu(1000 + 4000 * OFFSET_AND_IS_NULL_OVERHEAD)
                 .memory(0)
                 .network(0);
@@ -245,7 +245,7 @@ public class TestCostCalculator
                 .memory(1000 * IS_NULL_OVERHEAD)
                 .network((6000 + 1000) * IS_NULL_OVERHEAD);
 
-        assertCostFragmentedPlan(join, costs, stats, types)
+        assertCostSingleStageFragmentedPlan(join, costs, stats, types)
                 .cpu(6000 + 1000 + (12000 + 6000 + 1000) * IS_NULL_OVERHEAD)
                 .memory(1000 * IS_NULL_OVERHEAD)
                 .network(0);
@@ -288,7 +288,7 @@ public class TestCostCalculator
                 .memory(1000 * NUMBER_OF_NODES * IS_NULL_OVERHEAD)
                 .network(1000 * NUMBER_OF_NODES * IS_NULL_OVERHEAD);
 
-        assertCostFragmentedPlan(join, costs, stats, types)
+        assertCostSingleStageFragmentedPlan(join, costs, stats, types)
                 .cpu(1000 + 6000 + (12000 + 6000 + 10000 + 1000 * (NUMBER_OF_NODES - 1)) * IS_NULL_OVERHEAD)
                 .memory(1000 * NUMBER_OF_NODES * IS_NULL_OVERHEAD)
                 .network(0);
@@ -371,7 +371,7 @@ public class TestCostCalculator
                         2000 * IS_NULL_OVERHEAD // join memory footprint
                                 + 128); // ts1 memory footprint
 
-        assertCostFragmentedPlan(join23, costs, stats, types)
+        assertCostSingleStageFragmentedPlan(join23, costs, stats, types)
                 .memory(
                         100 * IS_NULL_OVERHEAD // join23 memory footprint
                                 + 64 + 32) // ts2, ts3 memory footprint
@@ -379,7 +379,7 @@ public class TestCostCalculator
                         100 * IS_NULL_OVERHEAD // join23 memory footprint
                                 + 64); // ts2 memory footprint
 
-        assertCostFragmentedPlan(join, costs, stats, types)
+        assertCostSingleStageFragmentedPlan(join, costs, stats, types)
                 .memory(
                         2000 * IS_NULL_OVERHEAD // join memory footprint
                                 + 100 * IS_NULL_OVERHEAD + 64 // join23 total memory when outputting
@@ -413,7 +413,7 @@ public class TestCostCalculator
                 .memory(13 * IS_NULL_OVERHEAD)
                 .network(6000 * IS_NULL_OVERHEAD);
 
-        assertCostFragmentedPlan(aggregation, costs, stats, types)
+        assertCostSingleStageFragmentedPlan(aggregation, costs, stats, types)
                 .cpu(6000 + 6000 * IS_NULL_OVERHEAD)
                 .memory(13 * IS_NULL_OVERHEAD)
                 .network(0 * IS_NULL_OVERHEAD);
@@ -553,7 +553,7 @@ public class TestCostCalculator
         return assertCost(costCalculatorWithEstimatedExchanges, node, costs, stats);
     }
 
-    private CostAssertionBuilder assertCostFragmentedPlan(
+    private CostAssertionBuilder assertCostSingleStageFragmentedPlan(
             PlanNode node,
             Map<String, PlanCostEstimate> costs,
             Map<String, PlanNodeStatsEstimate> stats,
@@ -562,9 +562,9 @@ public class TestCostCalculator
         TypeProvider typeProvider = TypeProvider.copyOf(types);
         StatsProvider statsProvider = new CachingStatsProvider(statsCalculator(stats), session, typeProvider);
         CostProvider costProvider = new TestingCostProvider(costs, costCalculatorUsingExchanges, statsProvider, session);
-        PlanNode plan = translateExpression(node, statsCalculator(stats), typeProvider);
-        SubPlan subPlan = fragment(new Plan(plan, typeProvider, StatsAndCosts.create(node, statsProvider, costProvider)));
-        return new CostAssertionBuilder(subPlan.getFragment().getStatsAndCosts().getCosts().getOrDefault(node.getId(), PlanCostEstimate.unknown()));
+        // Explicitly generate the statsAndCosts, bypass fragment generation and sanity checks for mock plans.
+        StatsAndCosts statsAndCosts = StatsAndCosts.create(node, statsProvider, costProvider).getForSubplan(node);
+        return new CostAssertionBuilder(statsAndCosts.getCosts().getOrDefault(node.getId(), PlanCostEstimate.unknown()));
     }
 
     private PlanNode translateExpression(PlanNode node, StatsCalculator statsCalculator, TypeProvider typeProvider)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestRuntimeReorderJoinSides.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestRuntimeReorderJoinSides.java
@@ -276,6 +276,6 @@ public class TestRuntimeReorderJoinSides
 
     private RuleAssert assertReorderJoinSides()
     {
-        return tester.assertThat(new RuntimeReorderJoinSides());
+        return tester.assertThat(new RuntimeReorderJoinSides(tester.getMetadata(), tester.getSqlParser()));
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/sanity/TestValidateStreamingJoins.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/sanity/TestValidateStreamingJoins.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.sanity;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.execution.warnings.WarningCollector;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ConnectorId;
+import com.facebook.presto.spi.TableHandle;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.planner.TypeProvider;
+import com.facebook.presto.sql.planner.assertions.BasePlanTest;
+import com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder;
+import com.facebook.presto.sql.planner.plan.ExchangeNode;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.testing.TestingTransactionHandle;
+import com.facebook.presto.tpch.TpchColumnHandle;
+import com.facebook.presto.tpch.TpchTableHandle;
+import com.facebook.presto.tpch.TpchTableLayoutHandle;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.sql.planner.plan.JoinNode.Type.INNER;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+
+public class TestValidateStreamingJoins
+        extends BasePlanTest
+{
+    private Session testSession;
+    private Metadata metadata;
+    private SqlParser sqlParser;
+    private PlanNodeIdAllocator idAllocator = new PlanNodeIdAllocator();
+    private TableHandle nationTableHandle;
+    private TableHandle supplierTableHandle;
+    private ColumnHandle nationColumnHandle;
+    private ColumnHandle suppColumnHandle;
+
+    @BeforeClass
+    public void setup()
+    {
+        Session.SessionBuilder sessionBuilder = testSessionBuilder()
+                .setCatalog("local")
+                .setSchema("tiny");
+        testSession = sessionBuilder.build();
+        metadata = getQueryRunner().getMetadata();
+        sqlParser = getQueryRunner().getSqlParser();
+
+        TpchTableHandle nationTpchTableHandle = new TpchTableHandle("nation", 1.0);
+        TpchTableHandle supplierTpchTableHandle = new TpchTableHandle("supplier", 1.0);
+        ConnectorId connectorId = getCurrentConnectorId();
+        nationTableHandle = new TableHandle(
+                connectorId,
+                nationTpchTableHandle,
+                TestingTransactionHandle.create(),
+                Optional.of(new TpchTableLayoutHandle(nationTpchTableHandle, TupleDomain.all())));
+        supplierTableHandle = new TableHandle(
+                connectorId,
+                supplierTpchTableHandle,
+                TestingTransactionHandle.create(),
+                Optional.of(new TpchTableLayoutHandle(supplierTpchTableHandle, TupleDomain.all())));
+        nationColumnHandle = new TpchColumnHandle("nationkey", BIGINT);
+        suppColumnHandle = new TpchColumnHandle("suppkey", BIGINT);
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        testSession = null;
+        metadata = null;
+        sqlParser = null;
+        idAllocator = null;
+        nationTableHandle = null;
+        supplierTableHandle = null;
+    }
+
+    @Test
+    public void testValidateSuccessful()
+    {
+        validatePlan(
+                p -> p.join(
+                        INNER,
+                        p.tableScan(nationTableHandle, ImmutableList.of(p.variable("nationkeyN", BIGINT)), ImmutableMap.of(p.variable("nationkeyN", BIGINT), nationColumnHandle)),
+                        p.exchange(e -> e
+                                .scope(ExchangeNode.Scope.LOCAL)
+                                .type(ExchangeNode.Type.REPARTITION)
+                                .addSource(p.tableScan(supplierTableHandle, ImmutableList.of(p.variable("nationkeyS", BIGINT), p.variable("suppkey", BIGINT)), ImmutableMap.of(p.variable("nationkeyS", BIGINT), nationColumnHandle, p.variable("suppkey", BIGINT), suppColumnHandle)))
+                                .addInputsSet(ImmutableList.of(p.variable("nationkeyS", BIGINT), p.variable("suppkey", BIGINT)))
+                                .fixedHashDistributionParitioningScheme(ImmutableList.of(p.variable("nationkeyS", BIGINT), p.variable("suppkey", BIGINT)), ImmutableList.of(p.variable("nationkeyS", BIGINT)))),
+                        ImmutableList.of(new JoinNode.EquiJoinClause(p.variable("nationkeyN", BIGINT), p.variable("nationkeyS", BIGINT))),
+                        ImmutableList.of(p.variable("nationkeyN", BIGINT), p.variable("nationkeyS", BIGINT), p.variable("suppkey", BIGINT)),
+                        Optional.empty()));
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Build side needs an additional local exchange for join: [0-9]*")
+    public void testValidateFailed()
+    {
+        validatePlan(
+                p -> p.join(
+                        INNER,
+                        p.tableScan(nationTableHandle, ImmutableList.of(p.variable("nationkeyN", BIGINT)), ImmutableMap.of(p.variable("nationkeyN", BIGINT), nationColumnHandle)),
+                        p.tableScan(supplierTableHandle, ImmutableList.of(p.variable("nationkeyS", BIGINT), p.variable("suppkey", BIGINT)), ImmutableMap.of(p.variable("nationkeyS", BIGINT), nationColumnHandle, p.variable("suppkey", BIGINT), suppColumnHandle)),
+                        ImmutableList.of(new JoinNode.EquiJoinClause(p.variable("nationkeyN", BIGINT), p.variable("nationkeyS", BIGINT))),
+                        ImmutableList.of(p.variable("nationkeyN", BIGINT), p.variable("nationkeyS", BIGINT), p.variable("suppkey", BIGINT)),
+                        Optional.empty()));
+    }
+
+    private void validatePlan(Function<PlanBuilder, PlanNode> planProvider)
+    {
+        PlanBuilder builder = new PlanBuilder(TEST_SESSION, idAllocator, metadata);
+        PlanNode planNode = planProvider.apply(builder);
+        TypeProvider types = builder.getTypes();
+        getQueryRunner().inTransaction(testSession, session -> {
+            session.getCatalog().ifPresent(catalog -> metadata.getCatalogHandle(session, catalog));
+            new ValidateStreamingJoins().validate(planNode, session, metadata, sqlParser, types, WarningCollector.NOOP);
+            return null;
+        });
+    }
+}


### PR DESCRIPTION
This PR implements the following:
1) Refactor the add/remove local exchange logic in RuntimeReorderJoinSides rule to use the same checking logic as the planning time optimization rule AddLocalExchange. Namely, the StreamPropertyDerivations class.
2) Extend the plan checker to be also invoked during runtime for each rewritten fragment.

```
== NO RELEASE NOTE ==
```
