### PR TITLE
Add IF EXISTS and IF NOT EXISTS checks to ALTER TABLE

### DIFF
--- a/presto-docs/src/main/sphinx/sql/alter-table.rst
+++ b/presto-docs/src/main/sphinx/sql/alter-table.rst
@@ -7,15 +7,21 @@ Synopsis
 
 .. code-block:: none
 
-    ALTER TABLE name RENAME TO new_name
-    ALTER TABLE name ADD COLUMN column_name data_type [ COMMENT comment ] [ WITH ( property_name = expression [, ...] ) ]
-    ALTER TABLE name DROP COLUMN column_name
-    ALTER TABLE name RENAME COLUMN column_name TO new_column_name
+    ALTER TABLE [ IF EXISTS ] name RENAME TO new_name
+    ALTER TABLE [ IF EXISTS ] name ADD COLUMN [ IF NOT EXISTS ] column_name data_type [ COMMENT comment ] [ WITH ( property_name = expression [, ...] ) ]
+    ALTER TABLE [ IF EXISTS ] name DROP COLUMN column_name
+    ALTER TABLE [ IF EXISTS ] name RENAME COLUMN [ IF EXISTS ] column_name TO new_column_name
 
 Description
 -----------
 
 Change the definition of an existing table.
+
+The optional ``IF EXISTS`` (when used before the table name) clause causes the error to be suppressed if the table does not exists.
+
+The optional ``IF EXISTS`` (when used before the column name) clause causes the error to be suppressed if the column does not exists.
+
+The optional ``IF NOT EXISTS`` clause causes the error to be suppressed if the column already exists.
 
 Examples
 --------
@@ -24,17 +30,33 @@ Rename table ``users`` to ``people``::
 
     ALTER TABLE users RENAME TO people;
 
+Rename table ``users`` to ``people`` if table ``users`` exists::
+
+    ALTER TABLE IF EXISTS users RENAME TO people;
+
 Add column ``zip`` to the ``users`` table::
 
     ALTER TABLE users ADD COLUMN zip varchar;
+
+Add column ``zip`` to the ``users`` table if table ``users`` exists and column ``zip`` not already exists::
+
+    ALTER TABLE IF EXISTS users ADD COLUMN IF NOT EXISTS zip varchar;
 
 Drop column ``zip`` from the ``users`` table::
 
     ALTER TABLE users DROP COLUMN zip;
 
+Drop column ``zip`` from the ``users`` table if table ``users`` and column ``zip`` exists::
+
+    ALTER TABLE IF EXISTS users DROP COLUMN IF EXISTS zip;
+
 Rename column ``id`` to ``user_id`` in the ``users`` table::
 
     ALTER TABLE users RENAME COLUMN id TO user_id;
+
+Rename column ``id`` to ``user_id`` in the ``users`` table if table ``users`` and column ``id`` exists::
+
+    ALTER TABLE IF EXISTS users RENAME column IF EXISTS id to user_id;
 
 See Also
 --------

--- a/presto-main/src/main/java/com/facebook/presto/execution/AddColumnTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/AddColumnTask.java
@@ -63,7 +63,10 @@ public class AddColumnTask
         QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getName());
         Optional<TableHandle> tableHandle = metadata.getTableHandle(session, tableName);
         if (!tableHandle.isPresent()) {
-            throw new SemanticException(MISSING_TABLE, statement, "Table '%s' does not exist", tableName);
+            if (!statement.isTableExists()) {
+                throw new SemanticException(MISSING_TABLE, statement, "Table '%s' does not exist", tableName);
+            }
+            return immediateFuture(null);
         }
 
         ConnectorId connectorId = metadata.getCatalogHandle(session, tableName.getCatalogName())
@@ -85,7 +88,10 @@ public class AddColumnTask
             throw new SemanticException(TYPE_MISMATCH, element, "Unknown type '%s' for column '%s'", element.getType(), element.getName());
         }
         if (columnHandles.containsKey(element.getName().getValue().toLowerCase(ENGLISH))) {
-            throw new SemanticException(COLUMN_ALREADY_EXISTS, statement, "Column '%s' already exists", element.getName());
+            if (!statement.isColumnNotExists()) {
+                throw new SemanticException(COLUMN_ALREADY_EXISTS, statement, "Column '%s' already exists", element.getName());
+            }
+            return immediateFuture(null);
         }
         if (!element.isNullable() && !metadata.getConnectorCapabilities(session, connectorId).contains(NOT_NULL_COLUMN_CONSTRAINT)) {
             throw new SemanticException(NOT_SUPPORTED, element, "Catalog '%s' does not support NOT NULL for column '%s'", connectorId.getCatalogName(), element.getName());

--- a/presto-main/src/main/java/com/facebook/presto/execution/RenameColumnTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/RenameColumnTask.java
@@ -27,6 +27,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static com.facebook.presto.metadata.MetadataUtil.createQualifiedObjectName;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.COLUMN_ALREADY_EXISTS;
@@ -50,8 +51,14 @@ public class RenameColumnTask
     {
         Session session = stateMachine.getSession();
         QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getTable());
-        TableHandle tableHandle = metadata.getTableHandle(session, tableName)
-                .orElseThrow(() -> new SemanticException(MISSING_TABLE, statement, "Table '%s' does not exist", tableName));
+        Optional<TableHandle> tableHandleOptional = metadata.getTableHandle(session, tableName);
+        if (!tableHandleOptional.isPresent()) {
+            if (!statement.isTableExists()) {
+                throw new SemanticException(MISSING_TABLE, statement, "Table '%s' does not exist", tableName);
+            }
+            return immediateFuture(null);
+        }
+        TableHandle tableHandle = tableHandleOptional.get();
 
         String source = statement.getSource().getValue().toLowerCase(ENGLISH);
         String target = statement.getTarget().getValue().toLowerCase(ENGLISH);
@@ -61,7 +68,10 @@ public class RenameColumnTask
         Map<String, ColumnHandle> columnHandles = metadata.getColumnHandles(session, tableHandle);
         ColumnHandle columnHandle = columnHandles.get(source);
         if (columnHandle == null) {
-            throw new SemanticException(MISSING_COLUMN, statement, "Column '%s' does not exist", source);
+            if (!statement.isColumnExists()) {
+                throw new SemanticException(MISSING_COLUMN, statement, "Column '%s' does not exist", source);
+            }
+            return immediateFuture(null);
         }
 
         if (columnHandles.containsKey(target)) {

--- a/presto-main/src/main/java/com/facebook/presto/execution/RenameTableTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/RenameTableTask.java
@@ -50,7 +50,10 @@ public class RenameTableTask
         QualifiedObjectName tableName = createQualifiedObjectName(session, statement, statement.getSource());
         Optional<TableHandle> tableHandle = metadata.getTableHandle(session, tableName);
         if (!tableHandle.isPresent()) {
-            throw new SemanticException(MISSING_TABLE, statement, "Table '%s' does not exist", tableName);
+            if (!statement.isExists()) {
+                throw new SemanticException(MISSING_TABLE, statement, "Table '%s' does not exist", tableName);
+            }
+            return immediateFuture(null);
         }
 
         QualifiedObjectName target = createQualifiedObjectName(session, statement, statement.getTarget());

--- a/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
+++ b/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
@@ -49,13 +49,14 @@ statement
     | DROP TABLE (IF EXISTS)? qualifiedName                            #dropTable
     | INSERT INTO qualifiedName columnAliases? query                   #insertInto
     | DELETE FROM qualifiedName (WHERE booleanExpression)?             #delete
-    | ALTER TABLE from=qualifiedName RENAME TO to=qualifiedName        #renameTable
-    | ALTER TABLE tableName=qualifiedName
-        RENAME COLUMN from=identifier TO to=identifier                 #renameColumn
-    | ALTER TABLE tableName=qualifiedName
-        DROP COLUMN column=qualifiedName                               #dropColumn
-    | ALTER TABLE tableName=qualifiedName
-        ADD COLUMN column=columnDefinition                             #addColumn
+    | ALTER TABLE (IF EXISTS)? from=qualifiedName
+        RENAME TO to=qualifiedName                                     #renameTable
+    | ALTER TABLE (IF EXISTS)? tableName=qualifiedName
+        RENAME COLUMN (IF EXISTS)? from=identifier TO to=identifier    #renameColumn
+    | ALTER TABLE (IF EXISTS)? tableName=qualifiedName
+        DROP COLUMN (IF EXISTS)? column=qualifiedName                  #dropColumn
+    | ALTER TABLE (IF EXISTS)? tableName=qualifiedName
+        ADD COLUMN (IF NOT EXISTS)? column=columnDefinition            #addColumn
     | ANALYZE qualifiedName (WITH properties)?                         #analyze
     | CREATE (OR REPLACE)? VIEW qualifiedName
             (SECURITY (DEFINER | INVOKER))? AS query                       #createView

--- a/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
@@ -1067,8 +1067,11 @@ public final class SqlFormatter
         @Override
         protected Void visitRenameTable(RenameTable node, Integer context)
         {
-            builder.append("ALTER TABLE ")
-                    .append(node.getSource())
+            builder.append("ALTER TABLE ");
+            if (node.isExists()) {
+                builder.append("IF EXISTS ");
+            }
+            builder.append(node.getSource())
                     .append(" RENAME TO ")
                     .append(node.getTarget());
 
@@ -1078,10 +1081,16 @@ public final class SqlFormatter
         @Override
         protected Void visitRenameColumn(RenameColumn node, Integer context)
         {
-            builder.append("ALTER TABLE ")
-                    .append(node.getTable())
-                    .append(" RENAME COLUMN ")
-                    .append(node.getSource())
+            builder.append("ALTER TABLE ");
+            if (node.isTableExists()) {
+                builder.append("IF EXISTS ");
+            }
+            builder.append(node.getTable())
+                    .append(" RENAME COLUMN ");
+            if (node.isColumnExists()) {
+                builder.append("IF EXISTS ");
+            }
+            builder.append(node.getSource())
                     .append(" TO ")
                     .append(node.getTarget());
 
@@ -1091,10 +1100,16 @@ public final class SqlFormatter
         @Override
         protected Void visitDropColumn(DropColumn node, Integer context)
         {
-            builder.append("ALTER TABLE ")
-                    .append(formatName(node.getTable()))
-                    .append(" DROP COLUMN ")
-                    .append(formatExpression(node.getColumn(), parameters));
+            builder.append("ALTER TABLE ");
+            if (node.isTableExists()) {
+                builder.append("IF EXISTS ");
+            }
+            builder.append(formatName(node.getTable()))
+                    .append(" DROP COLUMN ");
+            if (node.isColumnExists()) {
+                builder.append("IF EXISTS ");
+            }
+            builder.append(formatExpression(node.getColumn(), parameters));
 
             return null;
         }
@@ -1111,10 +1126,16 @@ public final class SqlFormatter
         @Override
         protected Void visitAddColumn(AddColumn node, Integer indent)
         {
-            builder.append("ALTER TABLE ")
-                    .append(node.getName())
-                    .append(" ADD COLUMN ")
-                    .append(formatColumnDefinition(node.getColumn()));
+            builder.append("ALTER TABLE ");
+            if (node.isTableExists()) {
+                builder.append("IF EXISTS ");
+            }
+            builder.append(node.getName())
+                    .append(" ADD COLUMN ");
+            if (node.isColumnNotExists()) {
+                builder.append("IF NOT EXISTS ");
+            }
+            builder.append(formatColumnDefinition(node.getColumn()));
 
             return null;
         }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
@@ -372,7 +372,7 @@ class AstBuilder
     @Override
     public Node visitRenameTable(SqlBaseParser.RenameTableContext context)
     {
-        return new RenameTable(getLocation(context), getQualifiedName(context.from), getQualifiedName(context.to));
+        return new RenameTable(getLocation(context), getQualifiedName(context.from), getQualifiedName(context.to), context.EXISTS() != null);
     }
 
     @Override
@@ -382,7 +382,9 @@ class AstBuilder
                 getLocation(context),
                 getQualifiedName(context.tableName),
                 (Identifier) visit(context.from),
-                (Identifier) visit(context.to));
+                (Identifier) visit(context.to),
+                context.EXISTS().stream().anyMatch(node -> node.getSymbol().getTokenIndex() < context.COLUMN().getSymbol().getTokenIndex()),
+                context.EXISTS().stream().anyMatch(node -> node.getSymbol().getTokenIndex() > context.COLUMN().getSymbol().getTokenIndex()));
     }
 
     @Override
@@ -401,13 +403,21 @@ class AstBuilder
     @Override
     public Node visitAddColumn(SqlBaseParser.AddColumnContext context)
     {
-        return new AddColumn(getLocation(context), getQualifiedName(context.qualifiedName()), (ColumnDefinition) visit(context.columnDefinition()));
+        return new AddColumn(getLocation(context),
+                getQualifiedName(context.qualifiedName()),
+                (ColumnDefinition) visit(context.columnDefinition()),
+                context.EXISTS().stream().anyMatch(node -> node.getSymbol().getTokenIndex() < context.COLUMN().getSymbol().getTokenIndex()),
+                context.EXISTS().stream().anyMatch(node -> node.getSymbol().getTokenIndex() > context.COLUMN().getSymbol().getTokenIndex()));
     }
 
     @Override
     public Node visitDropColumn(SqlBaseParser.DropColumnContext context)
     {
-        return new DropColumn(getLocation(context), getQualifiedName(context.tableName), (Identifier) visit(context.column));
+        return new DropColumn(getLocation(context),
+                getQualifiedName(context.tableName),
+                (Identifier) visit(context.column),
+                context.EXISTS().stream().anyMatch(node -> node.getSymbol().getTokenIndex() < context.COLUMN().getSymbol().getTokenIndex()),
+                context.EXISTS().stream().anyMatch(node -> node.getSymbol().getTokenIndex() > context.COLUMN().getSymbol().getTokenIndex()));
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/AddColumn.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/AddColumn.java
@@ -27,22 +27,27 @@ public class AddColumn
 {
     private final QualifiedName name;
     private final ColumnDefinition column;
+    private final boolean tableExists;
+    private final boolean columnNotExists;
 
-    public AddColumn(QualifiedName name, ColumnDefinition column)
+    public AddColumn(QualifiedName name, ColumnDefinition column, boolean tableExists, boolean columnNotExists)
+
     {
-        this(Optional.empty(), name, column);
+        this(Optional.empty(), name, column, tableExists, columnNotExists);
     }
 
-    public AddColumn(NodeLocation location, QualifiedName name, ColumnDefinition column)
+    public AddColumn(NodeLocation location, QualifiedName name, ColumnDefinition column, boolean tableExists, boolean columnNotExists)
     {
-        this(Optional.of(location), name, column);
+        this(Optional.of(location), name, column, tableExists, columnNotExists);
     }
 
-    private AddColumn(Optional<NodeLocation> location, QualifiedName name, ColumnDefinition column)
+    private AddColumn(Optional<NodeLocation> location, QualifiedName name, ColumnDefinition column, boolean tableExists, boolean columnNotExists)
     {
         super(location);
         this.name = requireNonNull(name, "table is null");
         this.column = requireNonNull(column, "column is null");
+        this.tableExists = tableExists;
+        this.columnNotExists = columnNotExists;
     }
 
     public QualifiedName getName()
@@ -53,6 +58,16 @@ public class AddColumn
     public ColumnDefinition getColumn()
     {
         return column;
+    }
+
+    public boolean isTableExists()
+    {
+        return tableExists;
+    }
+
+    public boolean isColumnNotExists()
+    {
+        return columnNotExists;
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/DropColumn.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/DropColumn.java
@@ -27,22 +27,26 @@ public class DropColumn
 {
     private final QualifiedName table;
     private final Identifier column;
+    private final boolean tableExists;
+    private final boolean columnExists;
 
-    public DropColumn(QualifiedName table, Identifier column)
+    public DropColumn(QualifiedName table, Identifier column, boolean tableExists, boolean columnExists)
     {
-        this(Optional.empty(), table, column);
+        this(Optional.empty(), table, column, tableExists, columnExists);
     }
 
-    public DropColumn(NodeLocation location, QualifiedName table, Identifier column)
+    public DropColumn(NodeLocation location, QualifiedName table, Identifier column, boolean tableExists, boolean columnExists)
     {
-        this(Optional.of(location), table, column);
+        this(Optional.of(location), table, column, tableExists, columnExists);
     }
 
-    private DropColumn(Optional<NodeLocation> location, QualifiedName table, Identifier column)
+    private DropColumn(Optional<NodeLocation> location, QualifiedName table, Identifier column, boolean tableExists, boolean columnExists)
     {
         super(location);
         this.table = requireNonNull(table, "table is null");
         this.column = requireNonNull(column, "column is null");
+        this.tableExists = tableExists;
+        this.columnExists = columnExists;
     }
 
     public QualifiedName getTable()
@@ -53,6 +57,16 @@ public class DropColumn
     public Identifier getColumn()
     {
         return column;
+    }
+
+    public boolean isTableExists()
+    {
+        return tableExists;
+    }
+
+    public boolean isColumnExists()
+    {
+        return columnExists;
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/RenameColumn.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/RenameColumn.java
@@ -28,23 +28,27 @@ public class RenameColumn
     private final QualifiedName table;
     private final Identifier source;
     private final Identifier target;
+    private final boolean tableExists;
+    private final boolean columnExists;
 
-    public RenameColumn(QualifiedName table, Identifier source, Identifier target)
+    public RenameColumn(QualifiedName table, Identifier source, Identifier target, boolean tableExists, boolean columnExists)
     {
-        this(Optional.empty(), table, source, target);
+        this(Optional.empty(), table, source, target, tableExists, columnExists);
     }
 
-    public RenameColumn(NodeLocation location, QualifiedName table, Identifier source, Identifier target)
+    public RenameColumn(NodeLocation location, QualifiedName table, Identifier source, Identifier target, boolean tableExists, boolean columnExists)
     {
-        this(Optional.of(location), table, source, target);
+        this(Optional.of(location), table, source, target, tableExists, columnExists);
     }
 
-    private RenameColumn(Optional<NodeLocation> location, QualifiedName table, Identifier source, Identifier target)
+    private RenameColumn(Optional<NodeLocation> location, QualifiedName table, Identifier source, Identifier target, boolean tableExists, boolean columnExists)
     {
         super(location);
         this.table = requireNonNull(table, "table is null");
         this.source = requireNonNull(source, "source is null");
         this.target = requireNonNull(target, "target is null");
+        this.tableExists = tableExists;
+        this.columnExists = columnExists;
     }
 
     public QualifiedName getTable()
@@ -60,6 +64,16 @@ public class RenameColumn
     public Identifier getTarget()
     {
         return target;
+    }
+
+    public boolean isTableExists()
+    {
+        return tableExists;
+    }
+
+    public boolean isColumnExists()
+    {
+        return columnExists;
     }
 
     @Override

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/RenameTable.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/RenameTable.java
@@ -27,22 +27,24 @@ public final class RenameTable
 {
     private final QualifiedName source;
     private final QualifiedName target;
+    private final boolean exists;
 
-    public RenameTable(QualifiedName source, QualifiedName target)
+    public RenameTable(QualifiedName source, QualifiedName target, boolean exists)
     {
-        this(Optional.empty(), source, target);
+        this(Optional.empty(), source, target, exists);
     }
 
-    public RenameTable(NodeLocation location, QualifiedName source, QualifiedName target)
+    public RenameTable(NodeLocation location, QualifiedName source, QualifiedName target, boolean exists)
     {
-        this(Optional.of(location), source, target);
+        this(Optional.of(location), source, target, exists);
     }
 
-    private RenameTable(Optional<NodeLocation> location, QualifiedName source, QualifiedName target)
+    private RenameTable(Optional<NodeLocation> location, QualifiedName source, QualifiedName target, boolean exists)
     {
         super(location);
         this.source = requireNonNull(source, "source name is null");
         this.target = requireNonNull(target, "target name is null");
+        this.exists = exists;
     }
 
     public QualifiedName getSource()
@@ -53,6 +55,11 @@ public final class RenameTable
     public QualifiedName getTarget()
     {
         return target;
+    }
+
+    public boolean isExists()
+    {
+        return exists;
     }
 
     @Override

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -1406,13 +1406,17 @@ public class TestSqlParser
     @Test
     public void testRenameTable()
     {
-        assertStatement("ALTER TABLE a RENAME TO b", new RenameTable(QualifiedName.of("a"), QualifiedName.of("b")));
+        assertStatement("ALTER TABLE a RENAME TO b", new RenameTable(QualifiedName.of("a"), QualifiedName.of("b"), false));
+        assertStatement("ALTER TABLE IF EXISTS a RENAME TO b", new RenameTable(QualifiedName.of("a"), QualifiedName.of("b"), true));
     }
 
     @Test
     public void testRenameColumn()
     {
-        assertStatement("ALTER TABLE foo.t RENAME COLUMN a TO b", new RenameColumn(QualifiedName.of("foo", "t"), identifier("a"), identifier("b")));
+        assertStatement("ALTER TABLE foo.t RENAME COLUMN a TO b", new RenameColumn(QualifiedName.of("foo", "t"), identifier("a"), identifier("b"), false, false));
+        assertStatement("ALTER TABLE IF EXISTS foo.t RENAME COLUMN a TO b", new RenameColumn(QualifiedName.of("foo", "t"), identifier("a"), identifier("b"), true, false));
+        assertStatement("ALTER TABLE foo.t RENAME COLUMN IF EXISTS a TO b", new RenameColumn(QualifiedName.of("foo", "t"), identifier("a"), identifier("b"), false, true));
+        assertStatement("ALTER TABLE IF EXISTS foo.t RENAME COLUMN IF EXISTS a TO b", new RenameColumn(QualifiedName.of("foo", "t"), identifier("a"), identifier("b"), true, true));
     }
 
     @Test
@@ -1438,16 +1442,31 @@ public class TestSqlParser
     public void testAddColumn()
     {
         assertStatement("ALTER TABLE foo.t ADD COLUMN c bigint", new AddColumn(QualifiedName.of("foo", "t"),
-                new ColumnDefinition(identifier("c"), "bigint", true, emptyList(), Optional.empty())));
+                new ColumnDefinition(identifier("c"), "bigint", true, emptyList(), Optional.empty()), false, false));
         assertStatement("ALTER TABLE foo.t ADD COLUMN d double NOT NULL", new AddColumn(QualifiedName.of("foo", "t"),
-                new ColumnDefinition(identifier("d"), "double", false, emptyList(), Optional.empty())));
+                new ColumnDefinition(identifier("d"), "double", false, emptyList(), Optional.empty()), false, false));
+
+        assertStatement("ALTER TABLE IF EXISTS foo.t ADD COLUMN d double NOT NULL",
+                new AddColumn(QualifiedName.of("foo", "t"),
+                        new ColumnDefinition(identifier("d"), "double", false, emptyList(), Optional.empty()), true, false));
+
+        assertStatement("ALTER TABLE foo.t ADD COLUMN IF NOT EXISTS d double NOT NULL",
+                new AddColumn(QualifiedName.of("foo", "t"),
+                        new ColumnDefinition(identifier("d"), "double", false, emptyList(), Optional.empty()), false, true));
+
+        assertStatement("ALTER TABLE IF EXISTS foo.t ADD COLUMN IF NOT EXISTS d double NOT NULL",
+                new AddColumn(QualifiedName.of("foo", "t"),
+                        new ColumnDefinition(identifier("d"), "double", false, emptyList(), Optional.empty()), true, true));
     }
 
     @Test
     public void testDropColumn()
     {
-        assertStatement("ALTER TABLE foo.t DROP COLUMN c", new DropColumn(QualifiedName.of("foo", "t"), identifier("c")));
-        assertStatement("ALTER TABLE \"t x\" DROP COLUMN \"c d\"", new DropColumn(QualifiedName.of("t x"), quotedIdentifier("c d")));
+        assertStatement("ALTER TABLE foo.t DROP COLUMN c", new DropColumn(QualifiedName.of("foo", "t"), identifier("c"), false, false));
+        assertStatement("ALTER TABLE \"t x\" DROP COLUMN \"c d\"", new DropColumn(QualifiedName.of("t x"), quotedIdentifier("c d"), false, false));
+        assertStatement("ALTER TABLE IF EXISTS foo.t DROP COLUMN c", new DropColumn(QualifiedName.of("foo", "t"), identifier("c"), true, false));
+        assertStatement("ALTER TABLE foo.t DROP COLUMN IF EXISTS c", new DropColumn(QualifiedName.of("foo", "t"), identifier("c"), false, true));
+        assertStatement("ALTER TABLE IF EXISTS foo.t DROP COLUMN IF EXISTS c", new DropColumn(QualifiedName.of("foo", "t"), identifier("c"), true, true));
     }
 
     @Test

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
@@ -386,6 +386,14 @@ public abstract class AbstractTestDistributedQueries
         MaterializedResult materializedRows = computeActual("SELECT x FROM test_rename_new");
         assertEquals(getOnlyElement(materializedRows.getMaterializedRows()).getField(0), 123);
 
+        assertUpdate("ALTER TABLE IF EXISTS test_rename_new RENAME TO test_rename");
+        materializedRows = computeActual("SELECT x FROM test_rename");
+        assertEquals(getOnlyElement(materializedRows.getMaterializedRows()).getField(0), 123);
+
+        assertUpdate("ALTER TABLE IF EXISTS test_rename RENAME TO test_rename_new");
+        materializedRows = computeActual("SELECT x FROM test_rename_new");
+        assertEquals(getOnlyElement(materializedRows.getMaterializedRows()).getField(0), 123);
+
         // provide new table name in uppercase
         assertUpdate("ALTER TABLE test_rename_new RENAME TO TEST_RENAME");
         materializedRows = computeActual("SELECT x FROM test_rename");
@@ -395,6 +403,10 @@ public abstract class AbstractTestDistributedQueries
 
         assertFalse(getQueryRunner().tableExists(getSession(), "test_rename"));
         assertFalse(getQueryRunner().tableExists(getSession(), "test_rename_new"));
+
+        assertUpdate("ALTER TABLE IF EXISTS test_rename RENAME TO test_rename_new");
+        assertFalse(getQueryRunner().tableExists(getSession(), "test_rename"));
+        assertFalse(getQueryRunner().tableExists(getSession(), "test_rename_new"));
     }
 
     @Test
@@ -402,27 +414,49 @@ public abstract class AbstractTestDistributedQueries
     {
         assertUpdate("CREATE TABLE test_rename_column AS SELECT 123 x", 1);
 
-        assertUpdate("ALTER TABLE test_rename_column RENAME COLUMN x TO y");
-        MaterializedResult materializedRows = computeActual("SELECT y FROM test_rename_column");
+        assertUpdate("ALTER TABLE test_rename_column RENAME COLUMN x TO before_y");
+        MaterializedResult materializedRows = computeActual("SELECT before_y FROM test_rename_column");
         assertEquals(getOnlyElement(materializedRows.getMaterializedRows()).getField(0), 123);
+
+        assertUpdate("ALTER TABLE test_rename_column RENAME COLUMN IF EXISTS before_y TO y");
+        materializedRows = computeActual("SELECT y FROM test_rename_column");
+        assertEquals(getOnlyElement(materializedRows.getMaterializedRows()).getField(0), 123);
+
+        assertUpdate("ALTER TABLE test_rename_column RENAME COLUMN IF EXISTS columnNotExists TO y");
 
         assertUpdate("ALTER TABLE test_rename_column RENAME COLUMN y TO Z");
         materializedRows = computeActual("SELECT z FROM test_rename_column");
         assertEquals(getOnlyElement(materializedRows.getMaterializedRows()).getField(0), 123);
 
+        assertUpdate("ALTER TABLE test_rename_column RENAME COLUMN IF EXISTS z TO a");
+        materializedRows = computeActual("SELECT a FROM test_rename_column");
+        assertEquals(getOnlyElement(materializedRows.getMaterializedRows()).getField(0), 123);
+
         assertUpdate("DROP TABLE test_rename_column");
+        assertFalse(getQueryRunner().tableExists(getSession(), "test_rename_column"));
+        assertUpdate("ALTER TABLE IF EXISTS test_rename_column RENAME COLUMN columnNotExists TO y");
+        assertUpdate("ALTER TABLE IF EXISTS test_rename_column RENAME COLUMN IF EXISTS columnNotExists TO y");
         assertFalse(getQueryRunner().tableExists(getSession(), "test_rename_column"));
     }
 
     @Test
     public void testDropColumn()
     {
-        assertUpdate("CREATE TABLE test_drop_column AS SELECT 123 x, 111 a", 1);
+        assertUpdate("CREATE TABLE test_drop_column AS SELECT 123 x, 456 y, 111 a", 1);
 
         assertUpdate("ALTER TABLE test_drop_column DROP COLUMN x");
+        assertUpdate("ALTER TABLE test_drop_column DROP COLUMN IF EXISTS y");
+        assertUpdate("ALTER TABLE test_drop_column DROP COLUMN IF EXISTS notExistColumn");
         assertQueryFails("SELECT x FROM test_drop_column", ".* Column 'x' cannot be resolved");
+        assertQueryFails("SELECT y FROM test_drop_column", ".* Column 'y' cannot be resolved");
 
         assertQueryFails("ALTER TABLE test_drop_column DROP COLUMN a", ".* Cannot drop the only column in a table");
+
+        assertUpdate("DROP TABLE test_drop_column");
+        assertFalse(getQueryRunner().tableExists(getSession(), "test_drop_column"));
+        assertUpdate("ALTER TABLE IF EXISTS test_drop_column DROP COLUMN notExistColumn");
+        assertUpdate("ALTER TABLE IF EXISTS test_drop_column DROP COLUMN IF EXISTS notExistColumn");
+        assertFalse(getQueryRunner().tableExists(getSession(), "test_drop_column"));
     }
 
     @Test
@@ -431,6 +465,7 @@ public abstract class AbstractTestDistributedQueries
         assertUpdate("CREATE TABLE test_add_column AS SELECT 123 x", 1);
         assertUpdate("CREATE TABLE test_add_column_a AS SELECT 234 x, 111 a", 1);
         assertUpdate("CREATE TABLE test_add_column_ab AS SELECT 345 x, 222 a, 33.3E0 b", 1);
+        assertUpdate("CREATE TABLE test_add_column_abc AS SELECT 456 x, 333 a, 66.6E0 b, 'fourth' c", 1);
 
         assertQueryFails("ALTER TABLE test_add_column ADD COLUMN x bigint", ".* Column 'x' already exists");
         assertQueryFails("ALTER TABLE test_add_column ADD COLUMN X bigint", ".* Column 'X' already exists");
@@ -457,12 +492,39 @@ public abstract class AbstractTestDistributedQueries
         assertEquals(materializedRows.getMaterializedRows().get(2).getField(1), 222L);
         assertEquals(materializedRows.getMaterializedRows().get(2).getField(2), 33.3);
 
+        assertUpdate("ALTER TABLE test_add_column ADD COLUMN IF NOT EXISTS c varchar");
+        assertUpdate("ALTER TABLE test_add_column ADD COLUMN IF NOT EXISTS c varchar");
+        assertUpdate("INSERT INTO test_add_column SELECT * FROM test_add_column_abc", 1);
+        materializedRows = computeActual("SELECT x, a, b, c FROM test_add_column ORDER BY x");
+        assertEquals(materializedRows.getMaterializedRows().get(0).getField(0), 123);
+        assertNull(materializedRows.getMaterializedRows().get(0).getField(1));
+        assertNull(materializedRows.getMaterializedRows().get(0).getField(2));
+        assertNull(materializedRows.getMaterializedRows().get(0).getField(3));
+        assertEquals(materializedRows.getMaterializedRows().get(1).getField(0), 234);
+        assertEquals(materializedRows.getMaterializedRows().get(1).getField(1), 111L);
+        assertNull(materializedRows.getMaterializedRows().get(1).getField(2));
+        assertNull(materializedRows.getMaterializedRows().get(1).getField(3));
+        assertEquals(materializedRows.getMaterializedRows().get(2).getField(0), 345);
+        assertEquals(materializedRows.getMaterializedRows().get(2).getField(1), 222L);
+        assertEquals(materializedRows.getMaterializedRows().get(2).getField(2), 33.3);
+        assertNull(materializedRows.getMaterializedRows().get(2).getField(3));
+        assertEquals(materializedRows.getMaterializedRows().get(3).getField(0), 456);
+        assertEquals(materializedRows.getMaterializedRows().get(3).getField(1), 333L);
+        assertEquals(materializedRows.getMaterializedRows().get(3).getField(2), 66.6);
+        assertEquals(materializedRows.getMaterializedRows().get(3).getField(3), "fourth");
+
         assertUpdate("DROP TABLE test_add_column");
         assertUpdate("DROP TABLE test_add_column_a");
         assertUpdate("DROP TABLE test_add_column_ab");
+        assertUpdate("DROP TABLE test_add_column_abc");
         assertFalse(getQueryRunner().tableExists(getSession(), "test_add_column"));
         assertFalse(getQueryRunner().tableExists(getSession(), "test_add_column_a"));
         assertFalse(getQueryRunner().tableExists(getSession(), "test_add_column_ab"));
+        assertFalse(getQueryRunner().tableExists(getSession(), "test_add_column_abc"));
+
+        assertUpdate("ALTER TABLE IF EXISTS test_add_column ADD COLUMN x bigint");
+        assertUpdate("ALTER TABLE IF EXISTS test_add_column ADD COLUMN IF NOT EXISTS x bigint");
+        assertFalse(getQueryRunner().tableExists(getSession(), "test_add_column"));
     }
 
     @Test


### PR DESCRIPTION

Chery pick of https://github.com/prestosql/presto/commit/cbc1c79af21587d3fe09e4b97ed83c1504319f47

Co-Authored-By:  y1275963 <1275963@gmail.com>

Fixes #15002 

```
== RELEASE NOTES ==

General Changes
* Add `IF EXISTS `and `IF NOT EXISTS` syntax to `ALTER TABLE`

```
