### PR TITLE
Move Presto Spark execution exceptions to presto-spark-classloader-interface

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
@@ -50,6 +50,7 @@ import com.facebook.presto.spark.classloader_interface.IPrestoSparkQueryExecutio
 import com.facebook.presto.spark.classloader_interface.IPrestoSparkTaskExecutor;
 import com.facebook.presto.spark.classloader_interface.MutablePartitionId;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkConfInitializer;
+import com.facebook.presto.spark.classloader_interface.PrestoSparkExecutionException;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkMutableRow;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkSerializedPage;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkSession;
@@ -60,7 +61,6 @@ import com.facebook.presto.spark.classloader_interface.PrestoSparkTaskInputs;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkTaskOutput;
 import com.facebook.presto.spark.classloader_interface.SerializedPrestoSparkTaskDescriptor;
 import com.facebook.presto.spark.classloader_interface.SerializedTaskInfo;
-import com.facebook.presto.spark.execution.PrestoSparkExecutionException;
 import com.facebook.presto.spark.execution.PrestoSparkExecutionExceptionFactory;
 import com.facebook.presto.spark.execution.PrestoSparkTaskExecutorFactory;
 import com.facebook.presto.spark.planner.PrestoSparkPlanFragmenter;

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkExecutionExceptionFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkExecutionExceptionFactory.java
@@ -15,6 +15,9 @@ package com.facebook.presto.spark.execution;
 
 import com.facebook.airlift.json.JsonCodec;
 import com.facebook.presto.execution.ExecutionFailureInfo;
+import com.facebook.presto.spark.classloader_interface.PrestoSparkExecutionException;
+import com.facebook.presto.spark.classloader_interface.PrestoSparkNonRetryableExecutionException;
+import com.facebook.presto.spark.classloader_interface.PrestoSparkRetryableExecutionException;
 import com.facebook.presto.spi.ErrorCode;
 import com.facebook.presto.spi.ErrorType;
 import org.apache.spark.SparkException;

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/TestPrestoSparkExecutionExceptionFactory.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/execution/TestPrestoSparkExecutionExceptionFactory.java
@@ -15,6 +15,7 @@ package com.facebook.presto.spark.execution;
 
 import com.facebook.presto.execution.ExecutionFailureInfo;
 import com.facebook.presto.execution.Failure;
+import com.facebook.presto.spark.classloader_interface.PrestoSparkExecutionException;
 import com.facebook.presto.spi.ErrorCode;
 import com.facebook.presto.spi.PrestoException;
 import com.google.common.collect.ImmutableList;

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkExecutionException.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkExecutionException.java
@@ -11,13 +11,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.spark.execution;
+package com.facebook.presto.spark.classloader_interface;
 
-public class PrestoSparkRetryableExecutionException
-        extends PrestoSparkExecutionException
+public abstract class PrestoSparkExecutionException
+        extends RuntimeException
 {
-    public PrestoSparkRetryableExecutionException(String message, String encodedExecutionFailureInfo, Throwable cause)
+    protected PrestoSparkExecutionException(String message, String encodedExecutionFailureInfo, Throwable cause)
     {
-        super(message, encodedExecutionFailureInfo, cause);
+        super(formatExceptionMessage(message, encodedExecutionFailureInfo), cause);
+    }
+
+    private static String formatExceptionMessage(String message, String encodedExecutionFailureInfo)
+    {
+        return message + " | ExecutionFailureInfo[" + encodedExecutionFailureInfo + "] |";
     }
 }

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkNonRetryableExecutionException.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkNonRetryableExecutionException.java
@@ -11,18 +11,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.spark.execution;
+package com.facebook.presto.spark.classloader_interface;
 
-public abstract class PrestoSparkExecutionException
-        extends RuntimeException
+public class PrestoSparkNonRetryableExecutionException
+        extends PrestoSparkExecutionException
 {
-    protected PrestoSparkExecutionException(String message, String encodedExecutionFailureInfo, Throwable cause)
+    public PrestoSparkNonRetryableExecutionException(String message, String encodedExecutionFailureInfo, Throwable cause)
     {
-        super(formatExceptionMessage(message, encodedExecutionFailureInfo), cause);
-    }
-
-    private static String formatExceptionMessage(String message, String encodedExecutionFailureInfo)
-    {
-        return message + " | ExecutionFailureInfo[" + encodedExecutionFailureInfo + "] |";
+        super(message, encodedExecutionFailureInfo, cause);
     }
 }

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkRetryableExecutionException.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkRetryableExecutionException.java
@@ -11,12 +11,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.spark.execution;
+package com.facebook.presto.spark.classloader_interface;
 
-public class PrestoSparkNonRetryableExecutionException
+public class PrestoSparkRetryableExecutionException
         extends PrestoSparkExecutionException
 {
-    public PrestoSparkNonRetryableExecutionException(String message, String encodedExecutionFailureInfo, Throwable cause)
+    public PrestoSparkRetryableExecutionException(String message, String encodedExecutionFailureInfo, Throwable cause)
     {
         super(message, encodedExecutionFailureInfo, cause);
     }


### PR DESCRIPTION
As they have to be serializable

```
== NO RELEASE NOTE ==
```
