### PR TITLE
Add Hive procedure to sync table partitions

### DIFF
--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -640,6 +640,19 @@ Procedures
 
     Create an empty partition in the specified table.
 
+* ``system.sync_partition_metadata(schema_name, table_name, mode, case_sensitive)``
+
+    Check and update partitions list in metastore. There are three modes available:
+
+    * ``ADD`` : add any partitions that exist on the file system but not in the metastore.
+    * ``DROP``: drop any partitions that exist in the metastore but not on the file system.
+    * ``FULL``: perform both ``ADD`` and ``DROP``.
+
+    The ``case_sensitive`` argument is optional. The default value is ``true`` for compatibility
+    with Hive's ``MSCK REPAIR TABLE`` behavior, which expects the partition column names in
+    file system paths to use lowercase (e.g. ``col_x=SomeValue``). Partitions on the file system
+    not conforming to this convention are ignored, unless the argument is set to ``false``.
+
 Examples
 --------
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveProcedureModule.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveProcedureModule.java
@@ -29,5 +29,6 @@ public class HiveProcedureModule
     {
         Multibinder<Procedure> procedures = newSetBinder(binder, Procedure.class);
         procedures.addBinding().toProvider(CreateEmptyPartitionProcedure.class).in(Scopes.SINGLETON);
+        procedures.addBinding().toProvider(SyncPartitionMetadataProcedure.class).in(Scopes.SINGLETON);
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/SyncPartitionMetadataProcedure.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/SyncPartitionMetadataProcedure.java
@@ -1,0 +1,253 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.hive.metastore.Column;
+import com.facebook.presto.hive.metastore.Partition;
+import com.facebook.presto.hive.metastore.PartitionStatistics;
+import com.facebook.presto.hive.metastore.SemiTransactionalHiveMetastore;
+import com.facebook.presto.hive.metastore.Table;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.TableNotFoundException;
+import com.facebook.presto.spi.classloader.ThreadContextClassLoader;
+import com.facebook.presto.spi.procedure.Procedure;
+import com.facebook.presto.spi.procedure.Procedure.Argument;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Sets;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandle;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import static com.facebook.presto.common.block.MethodHandleUtil.methodHandle;
+import static com.facebook.presto.common.type.StandardTypes.BOOLEAN;
+import static com.facebook.presto.common.type.StandardTypes.VARCHAR;
+import static com.facebook.presto.hive.HiveErrorCode.HIVE_FILESYSTEM_ERROR;
+import static com.facebook.presto.hive.metastore.MetastoreUtil.PRESTO_QUERY_ID_NAME;
+import static com.facebook.presto.hive.metastore.MetastoreUtil.extractPartitionValues;
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_PROCEDURE_ARGUMENT;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.lang.Boolean.TRUE;
+import static java.util.Locale.ENGLISH;
+import static java.util.Objects.requireNonNull;
+
+public class SyncPartitionMetadataProcedure
+        implements Provider<Procedure>
+{
+    public enum SyncMode
+    {
+        ADD, DROP, FULL
+    }
+
+    private static final MethodHandle SYNC_PARTITION_METADATA = methodHandle(
+            SyncPartitionMetadataProcedure.class,
+            "syncPartitionMetadata",
+            ConnectorSession.class,
+            String.class,
+            String.class,
+            String.class,
+            boolean.class);
+
+    private final Supplier<TransactionalMetadata> hiveMetadataFactory;
+    private final HdfsEnvironment hdfsEnvironment;
+
+    @Inject
+    public SyncPartitionMetadataProcedure(
+            Supplier<TransactionalMetadata> hiveMetadataFactory,
+            HdfsEnvironment hdfsEnvironment)
+    {
+        this.hiveMetadataFactory = requireNonNull(hiveMetadataFactory, "hiveMetadataFactory is null");
+        this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
+    }
+
+    @Override
+    public Procedure get()
+    {
+        return new Procedure(
+                "system",
+                "sync_partition_metadata",
+                ImmutableList.of(
+                        new Argument("schema_name", VARCHAR),
+                        new Argument("table_name", VARCHAR),
+                        new Argument("mode", VARCHAR),
+                        new Argument("case_sensitive", BOOLEAN, false, TRUE)),
+                SYNC_PARTITION_METADATA.bindTo(this));
+    }
+
+    public void syncPartitionMetadata(ConnectorSession session, String schemaName, String tableName, String mode, boolean caseSensitive)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(getClass().getClassLoader())) {
+            doSyncPartitionMetadata(session, schemaName, tableName, mode, caseSensitive);
+        }
+    }
+
+    private void doSyncPartitionMetadata(ConnectorSession session, String schemaName, String tableName, String mode, boolean caseSensitive)
+    {
+        SyncMode syncMode = toSyncMode(mode);
+        HdfsContext context = new HdfsContext(session, schemaName, tableName);
+        SemiTransactionalHiveMetastore metastore = hiveMetadataFactory.get().getMetastore();
+        SchemaTableName schemaTableName = new SchemaTableName(schemaName, tableName);
+
+        Table table = metastore.getTable(schemaName, tableName)
+                .orElseThrow(() -> new TableNotFoundException(schemaTableName));
+        if (table.getPartitionColumns().isEmpty()) {
+            throw new PrestoException(INVALID_PROCEDURE_ARGUMENT, "Table is not partitioned: " + schemaTableName);
+        }
+        Path tableLocation = new Path(table.getStorage().getLocation());
+
+        Set<String> partitionsToAdd;
+        Set<String> partitionsToDrop;
+
+        try {
+            FileSystem fileSystem = hdfsEnvironment.getFileSystem(context, tableLocation);
+            List<String> partitionsInMetastore = metastore.getPartitionNames(schemaName, tableName)
+                    .orElseThrow(() -> new TableNotFoundException(schemaTableName));
+            List<String> partitionsInFileSystem = listDirectory(fileSystem, fileSystem.getFileStatus(tableLocation), table.getPartitionColumns(), table.getPartitionColumns().size(), caseSensitive).stream()
+                    .map(fileStatus -> fileStatus.getPath().toUri())
+                    .map(uri -> tableLocation.toUri().relativize(uri).getPath())
+                    .collect(toImmutableList());
+
+            // partitions in file system but not in metastore
+            partitionsToAdd = difference(partitionsInFileSystem, partitionsInMetastore);
+            // partitions in metastore but not in file system
+            partitionsToDrop = difference(partitionsInMetastore, partitionsInFileSystem);
+        }
+        catch (IOException e) {
+            throw new PrestoException(HIVE_FILESYSTEM_ERROR, e);
+        }
+
+        syncPartitions(partitionsToAdd, partitionsToDrop, syncMode, metastore, session, table);
+    }
+
+    private static List<FileStatus> listDirectory(FileSystem fileSystem, FileStatus current, List<Column> partitionColumns, int depth, boolean caseSensitive)
+    {
+        if (depth == 0) {
+            return ImmutableList.of(current);
+        }
+
+        try {
+            return Stream.of(fileSystem.listStatus(current.getPath()))
+                    .filter(fileStatus -> isValidPartitionPath(fileStatus, partitionColumns.get(partitionColumns.size() - depth), caseSensitive))
+                    .flatMap(directory -> listDirectory(fileSystem, directory, partitionColumns, depth - 1, caseSensitive).stream())
+                    .collect(toImmutableList());
+        }
+        catch (IOException e) {
+            throw new PrestoException(HIVE_FILESYSTEM_ERROR, e);
+        }
+    }
+
+    private static boolean isValidPartitionPath(FileStatus file, Column column, boolean caseSensitive)
+    {
+        String path = file.getPath().getName();
+        if (!caseSensitive) {
+            path = path.toLowerCase(ENGLISH);
+        }
+        String prefix = column.getName() + '=';
+        return file.isDirectory() && path.startsWith(prefix);
+    }
+
+    // calculate relative complement of set b with respect to set a
+    private static Set<String> difference(List<String> a, List<String> b)
+    {
+        return Sets.difference(new HashSet<>(a), new HashSet<>(b));
+    }
+
+    private static void syncPartitions(
+            Set<String> partitionsToAdd,
+            Set<String> partitionsToDrop,
+            SyncMode syncMode,
+            SemiTransactionalHiveMetastore metastore,
+            ConnectorSession session,
+            Table table)
+    {
+        if (syncMode == SyncMode.ADD || syncMode == SyncMode.FULL) {
+            addPartitions(metastore, session, table, partitionsToAdd);
+        }
+        if (syncMode == SyncMode.DROP || syncMode == SyncMode.FULL) {
+            dropPartitions(metastore, session, table, partitionsToDrop);
+        }
+        metastore.commit();
+    }
+
+    private static void addPartitions(
+            SemiTransactionalHiveMetastore metastore,
+            ConnectorSession session,
+            Table table,
+            Set<String> partitions)
+    {
+        for (String name : partitions) {
+            metastore.addPartition(
+                    session,
+                    table.getDatabaseName(),
+                    table.getTableName(),
+                    buildPartitionObject(session, table, name),
+                    new Path(table.getStorage().getLocation(), name),
+                    PartitionStatistics.empty());
+        }
+    }
+
+    private static void dropPartitions(
+            SemiTransactionalHiveMetastore metastore,
+            ConnectorSession session,
+            Table table,
+            Set<String> partitions)
+    {
+        for (String name : partitions) {
+            metastore.dropPartition(
+                    session,
+                    table.getDatabaseName(),
+                    table.getTableName(),
+                    extractPartitionValues(name));
+        }
+    }
+
+    private static Partition buildPartitionObject(ConnectorSession session, Table table, String partitionName)
+    {
+        return Partition.builder()
+                .setDatabaseName(table.getDatabaseName())
+                .setTableName(table.getTableName())
+                .setColumns(table.getDataColumns())
+                .setValues(extractPartitionValues(partitionName))
+                .setParameters(ImmutableMap.of(PRESTO_QUERY_ID_NAME, session.getQueryId()))
+                .withStorage(storage -> storage
+                        .setStorageFormat(table.getStorage().getStorageFormat())
+                        .setLocation(new Path(table.getStorage().getLocation(), partitionName).toString())
+                        .setBucketProperty(table.getStorage().getBucketProperty())
+                        .setSerdeParameters(table.getStorage().getSerdeParameters()))
+                .build();
+    }
+
+    private static SyncMode toSyncMode(String mode)
+    {
+        try {
+            return SyncMode.valueOf(mode.toUpperCase(ENGLISH));
+        }
+        catch (IllegalArgumentException e) {
+            throw new PrestoException(INVALID_PROCEDURE_ARGUMENT, "Invalid partition metadata sync mode: " + mode);
+        }
+    }
+}

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestSyncPartitionMetadata.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestSyncPartitionMetadata.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.tests.hive;
+
+import io.prestodb.tempto.ProductTest;
+import io.prestodb.tempto.assertions.QueryAssert;
+import io.prestodb.tempto.fulfillment.table.hive.HiveDataSource;
+import io.prestodb.tempto.hadoop.hdfs.HdfsClient;
+import io.prestodb.tempto.internal.hadoop.hdfs.HdfsDataSourceWriter;
+import io.prestodb.tempto.query.QueryResult;
+import org.testng.annotations.Test;
+
+import javax.inject.Inject;
+
+import static com.facebook.presto.tests.TestGroups.HIVE_PARTITIONING;
+import static com.facebook.presto.tests.TestGroups.SMOKE;
+import static io.prestodb.tempto.assertions.QueryAssert.Row.row;
+import static io.prestodb.tempto.assertions.QueryAssert.assertThat;
+import static io.prestodb.tempto.fulfillment.table.hive.InlineDataSource.createResourceDataSource;
+import static io.prestodb.tempto.query.QueryExecutor.query;
+import static java.lang.String.format;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestSyncPartitionMetadata
+        extends ProductTest
+{
+    private static final String WAREHOUSE_DIRECTORY_PATH = "/user/hive/warehouse/";
+
+    @Inject
+    private HdfsClient hdfsClient;
+
+    @Inject
+    private HdfsDataSourceWriter hdfsDataSourceWriter;
+
+    @Test(groups = {HIVE_PARTITIONING, SMOKE})
+    public void testAddPartition()
+    {
+        String tableName = "test_sync_partition_metadata_add_partition";
+        prepare(hdfsClient, hdfsDataSourceWriter, tableName);
+
+        query("CALL system.sync_partition_metadata('default', '" + tableName + "', 'ADD')");
+        assertPartitions(tableName, row("a", "1"), row("b", "2"), row("f", "9"));
+        assertThat(() -> query("SELECT payload, col_x, col_y FROM " + tableName + " ORDER BY 1, 2, 3 ASC"))
+                .failsWithMessage("Partition location does not exist: hdfs://hadoop-master:9000/user/hive/warehouse/" + tableName + "/col_x=b/col_y=2");
+        cleanup(tableName);
+    }
+
+    @Test(groups = {HIVE_PARTITIONING, SMOKE})
+    public void testDropPartition()
+    {
+        String tableName = "test_sync_partition_metadata_drop_partition";
+        prepare(hdfsClient, hdfsDataSourceWriter, tableName);
+
+        query("CALL system.sync_partition_metadata('default', '" + tableName + "', 'DROP')");
+        assertPartitions(tableName, row("a", "1"));
+        assertData(tableName, row(1, "a", "1"));
+
+        cleanup(tableName);
+    }
+
+    @Test(groups = {HIVE_PARTITIONING, SMOKE})
+    public void testFullSyncPartition()
+    {
+        String tableName = "test_sync_partition_metadata_add_drop_partition";
+        prepare(hdfsClient, hdfsDataSourceWriter, tableName);
+
+        query("CALL system.sync_partition_metadata('default', '" + tableName + "', 'FULL')");
+        assertPartitions(tableName, row("a", "1"), row("f", "9"));
+        assertData(tableName, row(1, "a", "1"), row(42, "f", "9"));
+
+        cleanup(tableName);
+    }
+
+    @Test(groups = {HIVE_PARTITIONING, SMOKE})
+    public void testInvalidSyncMode()
+    {
+        String tableName = "test_repair_invalid_mode";
+        prepare(hdfsClient, hdfsDataSourceWriter, tableName);
+
+        assertThat(() -> query("CALL system.sync_partition_metadata('default', '" + tableName + "', 'INVALID')"))
+                .failsWithMessageMatching("java.sql.SQLException: Query failed (.*): Invalid partition metadata sync mode: INVALID");
+
+        cleanup(tableName);
+    }
+
+    @Test(groups = {HIVE_PARTITIONING, SMOKE})
+    public void testMixedCasePartitionNames()
+    {
+        String tableName = "test_sync_partition_mixed_case";
+        prepare(hdfsClient, hdfsDataSourceWriter, tableName);
+        String tableLocation = WAREHOUSE_DIRECTORY_PATH + tableName;
+        HiveDataSource dataSource = createResourceDataSource(tableName, "com/facebook/presto/tests/hive/data/single_int_column/data.orc");
+        hdfsDataSourceWriter.ensureDataOnHdfs(tableLocation + "/col_x=h/col_Y=11", dataSource);
+        hdfsClient.createDirectory(tableLocation + "/COL_X=UPPER/COL_Y=12");
+        hdfsDataSourceWriter.ensureDataOnHdfs(tableLocation + "/COL_X=UPPER/COL_Y=12", dataSource);
+
+        query("CALL system.sync_partition_metadata('default', '" + tableName + "', 'FULL', false)");
+        assertPartitions(tableName, row("UPPER", "12"), row("a", "1"), row("f", "9"), row("g", "10"), row("h", "11"));
+        assertData(tableName, row(1, "a", "1"), row(42, "UPPER", "12"), row(42, "f", "9"), row(42, "g", "10"), row(42, "h", "11"));
+    }
+
+    @Test(groups = {HIVE_PARTITIONING, SMOKE})
+    public void testConflictingMixedCasePartitionNames()
+    {
+        String tableName = "test_sync_partition_mixed_case";
+        prepare(hdfsClient, hdfsDataSourceWriter, tableName);
+        String tableLocation = WAREHOUSE_DIRECTORY_PATH + tableName;
+        HiveDataSource dataSource = createResourceDataSource(tableName, "com/facebook/presto/tests/hive/data/single_int_column/data.orc");
+        // this conflicts with a partition that already exits in the metastore
+        hdfsDataSourceWriter.ensureDataOnHdfs(tableLocation + "/COL_X=a/cOl_y=1", dataSource);
+
+        assertThatThrownBy(() -> query("CALL system.sync_partition_metadata('default', '" + tableName + "', 'ADD', false)"))
+                .hasMessageContaining(format("One or more partitions already exist for table 'default.%s'", tableName));
+        assertPartitions(tableName, row("a", "1"), row("b", "2"));
+    }
+
+    private static void prepare(HdfsClient hdfsClient, HdfsDataSourceWriter hdfsDataSourceWriter, String tableName)
+    {
+        query("DROP TABLE IF EXISTS " + tableName);
+
+        query("CREATE TABLE " + tableName + " (payload bigint, col_x varchar, col_y varchar) WITH (format = 'ORC', partitioned_by = ARRAY[ 'col_x', 'col_y' ])");
+        query("INSERT INTO " + tableName + " VALUES (1, 'a', '1'), (2, 'b', '2')");
+
+        String tableLocation = WAREHOUSE_DIRECTORY_PATH + tableName;
+        // remove partition col_x=b/col_y=2
+        hdfsClient.delete(tableLocation + "/col_x=b/col_y=2");
+        // add partition directory col_x=f/col_y=9 with single_int_column/data.orc file
+        hdfsClient.createDirectory(tableLocation + "/col_x=f/col_y=9");
+        HiveDataSource dataSource = createResourceDataSource(tableName, "com/facebook/presto/tests/hive/data/single_int_column/data.orc");
+        hdfsDataSourceWriter.ensureDataOnHdfs(tableLocation + "/col_x=f/col_y=9", dataSource);
+        // should only be picked up when not in case sensitive mode
+        hdfsClient.createDirectory(tableLocation + "/COL_X=g/col_y=10");
+        hdfsDataSourceWriter.ensureDataOnHdfs(tableLocation + "/COL_X=g/col_y=10", dataSource);
+
+        // add invalid partition path
+        hdfsClient.createDirectory(tableLocation + "/col_x=d");
+        hdfsClient.createDirectory(tableLocation + "/col_y=3/col_x=h");
+        hdfsClient.createDirectory(tableLocation + "/col_y=3");
+        hdfsClient.createDirectory(tableLocation + "/xyz");
+
+        assertPartitions(tableName, row("a", "1"), row("b", "2"));
+    }
+
+    private static void cleanup(String tableName)
+    {
+        query("DROP TABLE " + tableName);
+    }
+
+    private static void assertPartitions(String tableName, QueryAssert.Row... rows)
+    {
+        QueryResult partitionListResult = query("SELECT * FROM \"" + tableName + "$partitions\" ORDER BY 1, 2");
+        assertThat(partitionListResult).containsExactly(rows);
+    }
+
+    private static void assertData(String tableName, QueryAssert.Row... rows)
+    {
+        QueryResult dataResult = query("SELECT payload, col_x, col_y FROM " + tableName + " ORDER BY 1, 2, 3 ASC");
+        assertThat(dataResult).containsExactly(rows);
+    }
+}


### PR DESCRIPTION
Cherry pick of
  https://github.com/prestosql/presto/commit/78cde41c3c0d05e0314920dca824a029fd392da1
  https://github.com/prestosql/presto/commit/bf7944cbc180182bee4f7c91f1b8c7479e80a85a
  https://github.com/prestosql/presto/commit/86886ef0cf5783dedb723bbf316a094f9e66d628
  https://github.com/prestosql/presto/commit/fa66094120d584ff60cd3303204d6f8cb3bc9ade

Co-authored by: 
           Hao Luo <hluo@twitter.com>
           Raunaq Morarka <raunaqmorarka@gmail.com>
           Alex Albu <alex.albu@starburstdata.com>

Fixes #14946 

```
== RELEASE NOTES ==

Hive Changes
* Add procedure system.sync_partition_metadata() to synchronize the partitions in the metastore with the partitions that are physically on the file system.
```

