### PR TITLE
Update java version parser for presto running on java 10, 11 or later

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/JavaVersion.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/JavaVersion.java
@@ -27,8 +27,8 @@ import static java.lang.String.format;
 // TODO: remove this when we upgrade to Java 9 (replace with java.lang.Runtime.getVersion())
 public class JavaVersion
 {
-    // As described in JEP-223
-    private static final String VERSION_NUMBER = "(?<MAJOR>[1-9][0-9]*)(\\.(?<MINOR>(0|[1-9][0-9]*))(\\.(?:(0|[1-9][0-9]*)))?)?";
+    // As described in JEP-223 and JEP-322
+    private static final String VERSION_NUMBER = "(?<MAJOR>[1-9][0-9]*)(\\.(?<MINOR>(0|[1-9][0-9]*))(\\.(?:(0|[1-9][0-9]*)))?)*";
     private static final String PRE = "(?:-(?:[a-zA-Z0-9]+))?";
     private static final String BUILD = "(?:(?:\\+)(?:0|[1-9][0-9]*)?)?";
     private static final String OPT = "(?:-(?:[-a-zA-Z0-9.]+))?";

--- a/presto-main/src/test/java/com/facebook/presto/server/TestJavaVersion.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestJavaVersion.java
@@ -40,5 +40,6 @@ public class TestJavaVersion
         assertEquals(JavaVersion.parse("9+100"), new JavaVersion(9, 0));
         assertEquals(JavaVersion.parse("9.0.1+20"), new JavaVersion(9, 0));
         assertEquals(JavaVersion.parse("9.1.1+20"), new JavaVersion(9, 1));
+        assertEquals(JavaVersion.parse("11.0.7.0.4"), new JavaVersion(11, 0));
     }
 }


### PR DESCRIPTION
Update java version parser to fix the java version check failure on Java 11.

Java version specs for your quick reference:
https://openjdk.java.net/jeps/322
https://openjdk.java.net/jeps/223

```
== NO RELEASE NOTE ==
```
