### PR TITLE
Move QueryNotAdequatelyPushedDownErrorCode to PinotErrorCode

### DIFF
--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotErrorCode.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotErrorCode.java
@@ -19,6 +19,7 @@ import com.facebook.presto.spi.ErrorType;
 
 import static com.facebook.presto.spi.ErrorType.EXTERNAL;
 import static com.facebook.presto.spi.ErrorType.INTERNAL_ERROR;
+import static com.facebook.presto.spi.ErrorType.USER_ERROR;
 
 public enum PinotErrorCode
         implements ErrorCodeSupplier
@@ -35,7 +36,8 @@ public enum PinotErrorCode
     PINOT_INVALID_PQL_GENERATED(9, INTERNAL_ERROR),
     PINOT_INVALID_CONFIGURATION(10, INTERNAL_ERROR),
     PINOT_DATA_FETCH_EXCEPTION(11, EXTERNAL, true),
-    PINOT_REQUEST_GENERATOR_FAILURE(12, INTERNAL_ERROR), // Unable to generate Pinot request
+    PINOT_REQUEST_GENERATOR_FAILURE(12, INTERNAL_ERROR),
+    PINOT_PUSH_DOWN_QUERY_NOT_PRESENT(20, USER_ERROR),
     PINOT_UNCLASSIFIED_ERROR(100, EXTERNAL);
 
     /**

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotException.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotException.java
@@ -22,19 +22,19 @@ import static java.util.Objects.requireNonNull;
 public class PinotException
         extends PrestoException
 {
-    private final Optional<String> pql;
+    private final Optional<String> pinotQuery;
     private final PinotErrorCode pinotErrorCode;
 
-    public PinotException(PinotErrorCode errorCode, Optional<String> pql, String message)
+    public PinotException(PinotErrorCode errorCode, Optional<String> pinotQuery, String message)
     {
-        this(errorCode, pql, message, null);
+        this(errorCode, pinotQuery, message, null);
     }
 
-    public PinotException(PinotErrorCode pinotErrorCode, Optional<String> pql, String message, Throwable throwable)
+    public PinotException(PinotErrorCode pinotErrorCode, Optional<String> pinotQuery, String message, Throwable throwable)
     {
         super(requireNonNull(pinotErrorCode, "error code is null"), requireNonNull(message, "message is null"), throwable);
         this.pinotErrorCode = pinotErrorCode;
-        this.pql = requireNonNull(pql, "pql is null");
+        this.pinotQuery = requireNonNull(pinotQuery, "pinot query is null");
     }
 
     public PinotErrorCode getPinotErrorCode()
@@ -46,8 +46,8 @@ public class PinotException
     public String getMessage()
     {
         String message = super.getMessage();
-        if (pql.isPresent()) {
-            message += " with pql \"" + pql.get() + "\"";
+        if (pinotQuery.isPresent()) {
+            message += " with pinot query \"" + pinotQuery.get() + "\"";
         }
         return message;
     }

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotSplitManager.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotSplitManager.java
@@ -21,9 +21,6 @@ import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.ConnectorSplitSource;
 import com.facebook.presto.spi.ConnectorTableHandle;
 import com.facebook.presto.spi.ConnectorTableLayoutHandle;
-import com.facebook.presto.spi.ErrorCode;
-import com.facebook.presto.spi.ErrorCodeSupplier;
-import com.facebook.presto.spi.ErrorType;
 import com.facebook.presto.spi.FixedSplitSource;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.connector.ConnectorSplitManager;
@@ -44,7 +41,6 @@ import static com.facebook.presto.pinot.PinotSplit.createBrokerSplit;
 import static com.facebook.presto.pinot.PinotSplit.createSegmentSplit;
 import static com.facebook.presto.pinot.query.PinotQueryGeneratorContext.TABLE_NAME_SUFFIX_TEMPLATE;
 import static com.facebook.presto.pinot.query.PinotQueryGeneratorContext.TIME_BOUNDARY_FILTER_TEMPLATE;
-import static com.facebook.presto.spi.ErrorType.USER_ERROR;
 import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
 
@@ -132,37 +128,18 @@ public class PinotSplitManager
         }
     }
 
-    public enum QueryNotAdequatelyPushedDownErrorCode
-            implements ErrorCodeSupplier
-    {
-        PQL_NOT_PRESENT(1, USER_ERROR, "Query uses unsupported expressions that cannot be pushed into the storage engine. Please see https://XXX for more details");
-
-        private final ErrorCode errorCode;
-
-        QueryNotAdequatelyPushedDownErrorCode(int code, ErrorType type, String guidance)
-        {
-            errorCode = new ErrorCode(code + 0x0625_0000, name() + ": " + guidance, type);
-        }
-
-        @Override
-        public ErrorCode toErrorCode()
-        {
-            return errorCode;
-        }
-    }
-
     public static class QueryNotAdequatelyPushedDownException
-            extends PrestoException
+            extends PinotException
     {
         private final String connectorId;
         private final ConnectorTableHandle connectorTableHandle;
 
         public QueryNotAdequatelyPushedDownException(
-                QueryNotAdequatelyPushedDownErrorCode errorCode,
+                PinotErrorCode errorCode,
                 ConnectorTableHandle connectorTableHandle,
                 String connectorId)
         {
-            super(requireNonNull(errorCode, "error code is null"), (String) null);
+            super(requireNonNull(errorCode, "error code is null"), Optional.empty(), "Query uses unsupported expressions that cannot be pushed into Pinot.");
             this.connectorId = requireNonNull(connectorId, "connector id is null");
             this.connectorTableHandle = requireNonNull(connectorTableHandle, "connector table handle is null");
         }
@@ -183,7 +160,7 @@ public class PinotSplitManager
     {
         PinotTableLayoutHandle pinotLayoutHandle = (PinotTableLayoutHandle) layout;
         PinotTableHandle pinotTableHandle = pinotLayoutHandle.getTable();
-        Supplier<PrestoException> errorSupplier = () -> new QueryNotAdequatelyPushedDownException(QueryNotAdequatelyPushedDownErrorCode.PQL_NOT_PRESENT, pinotTableHandle, connectorId);
+        Supplier<PrestoException> errorSupplier = () -> new QueryNotAdequatelyPushedDownException(PinotErrorCode.PINOT_PUSH_DOWN_QUERY_NOT_PRESENT, pinotTableHandle, connectorId);
         if (!pinotTableHandle.getIsQueryShort().orElseThrow(errorSupplier)) {
             if (PinotSessionProperties.isForbidSegmentQueries(session)) {
                 throw errorSupplier.get();


### PR DESCRIPTION
Per slack discussion, Pinot connector accidentally took the error code space `0x0625`. 

This PR moves the corresponding error to PinotErrorCode space `0x0505`.

```
== NO RELEASE NOTE ==
```
