### PR TITLE
Revert "Upgrade ZSTD version"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1512,7 +1512,7 @@
             <dependency>
                 <groupId>com.github.luben</groupId>
                 <artifactId>zstd-jni</artifactId>
-                <version>1.4.5-4</version>
+                <version>1.3.5-4</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
The zstd version, 1.4.5-4 is casuing full GCs in the release 238.
Hence reverting it to the previous stable version.

```
== RELEASE NOTES ==
General Changes
* Downgrade ZSTD JNI compressor version to resolve the frequent excessive GC events introduced in version 0.238.
```