### PR TITLE
Add release notes for 0.240

### DIFF
--- a/presto-docs/src/main/sphinx/release.rst
+++ b/presto-docs/src/main/sphinx/release.rst
@@ -5,6 +5,7 @@ Release Notes
 .. toctree::
     :maxdepth: 1
 
+    release/release-0.240
     release/release-0.239.1
     release/release-0.239
     release/release-0.238.3

--- a/presto-docs/src/main/sphinx/release/release-0.240.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.240.rst
@@ -1,0 +1,76 @@
+=============
+Release 0.240
+=============
+
+**Highlights**
+==============
+* Add ability to spill window functions to local disk when a worker is out of memory.
+* Add support for inlining SQL functions at query planning time.
+* Add support for limit pushdown through union.
+* Add :func:`geometry_from_geojson` and :func:`geometry_as_geojson` to convert geometries from and to GeoJSON format.
+
+**Details**
+==============
+
+General Changes
+_______________
+* Fix compiler error due to incorrect LambdaDefinitionExpression canonicalization.
+* Fix compiler error in certain situations where sql functions with same lambda are used multiple times.
+* Add ``IF EXISTS`` and ``IF NOT EXISTS`` syntax to ``ALTER TABLE``.
+* Add ``query.max-scan-physical-bytes`` configuration and ``query_max_scan_physical_bytes`` session properties to limit total number of bytes read from storage during table scan. The default limit is 1PB.
+* Add support for inlining SQL functions at query planning time. This feature is enabled by default, and can be disabled with the ``inline_sql_functions`` session property.
+* Add :func:`geometry_from_geojson` and :func:`geometry_as_geojson` to convert geometries from and to GeoJSON format.
+* Add support for pushdown of dereference expressions for querying nested data. This can be enabled with the ``pushdown_dereference_enabled`` session property or the ``experimental.pushdown-dereference-enabled`` configuration property.
+* Use local private credentials (json key file) to refresh GCS access token. Usage : presto-cli --extra-credential hive.gcs.credentials.path="${PRIVATE_KEY_JSON_PATH}".
+* Add ability to spill window functions to local disk when a worker is out of memory.
+* Add support for limit pushdown through union.
+
+Thrift Connector Changes
+________________________
+* Rename ``presto-thrift-connector-api`` to ``presto-thrift-api`` and have separate packages for datatypes, valuesets and connector.
+
+Verifier Changes
+________________
+* Fix an issue where Verifier fails to start when failure resolver is disabled.
+* Add configuration property ``test_name``, to be passed in to the client info blob.
+* Add support to implement customized way of launching Presto queries.
+* Add support to populate client info for the queries issued by Verifier.
+* Add support to resubmit verification if test query fails with ``HIVE_PARTITION_OFFLINE``.
+* Add support to run helper queries on a separate cluster other than the control cluster.
+* Add support to skip running control queries and comparing results. This can be enabled by configuration property ``skip-control``.
+
+Cassandra Changes
+_________________
+* Add TLS security support.
+
+Druid Changes
+_____________
+* Add support for union all operation with more than 1 druid source.
+* Add support for filter on top of Aggregation.
+* Fix unhandled HTTP response error for druid client.
+
+Elasticserarch Changes
+______________________
+* Add support for IP data type.
+
+Geospatial Changes
+__________________
+* Improve :func:`geometry_to_bing_tiles` performance.  It is 50x faster on complex polygons, the limit on polygon complexity is removed, and some correctness bugs have been fixed.
+* Add geometry_to_dissolved_bing_tiles function, which dissolves complete sets of child tiles to their parent.
+* Introduce :func:`bing_tile_children` and :func:`bing_tile_parent` functions to get parents and children of a Bing tile.
+
+Hive Changes
+____________
+* Fix parquet statistics when min/max is not set.
+* Improve split generation performance.
+* Add support for Hudi realtime input format for hudi realtime queries.
+* Add support for splitting hive files when skip.header.line.count=1.
+* Allow presto-hive to use custom parquet input formats.
+
+Kafka Changes
+_____________
+* Support ``INSERT`` in Kafka connector.
+
+SPI Changes
+___________
+* Allow procedures to accept optional parameters.


### PR DESCRIPTION
# Missing Release Notes
## Beinan Wang
- [ ] https://github.com/prestodb/presto/pull/14890 Upgrade presto-hadoop-apache2 for GCS token refreshing (Merged by: Zhenxiao Luo)

## George Wang
- [ ] https://github.com/prestodb/presto/pull/14895 Add support for limit pushdown through union (Merged by: Rongrong Zhong)

## Jinyang Li
- [ ] https://github.com/prestodb/presto/pull/14922 Handle create page source for Druid segment on s3 (Merged by: Zhenxiao Luo)

## Saksham Sachdev
- [x] https://github.com/prestodb/presto/pull/14909 Implement Window Function Spilling (Merged by: James Sun)

## Weidong Duan
- [ ] https://github.com/prestodb/presto/pull/14980 Support more than 1 druid source (Merged by: Zhenxiao Luo)
- [ ] https://github.com/prestodb/presto/pull/14967 Fix druid connector bugs related to pushed down queries (Merged by: Zhenxiao Luo)

## agrawalreetika
- [ ] https://github.com/prestodb/presto/pull/14996 Add support for ip data type in ES Connector (Merged by: Zhenxiao Luo)

# Extracted Release Notes
- #14585 (Author: Beinan Wang): Use local private credentials (json key file) to refresh GCS access token
  - Use local private credentials (json key file) to refresh GCS access token presto-cli --extra-credential hive.gcs.credentials.path="${PRIVATE_KEY_JSON_PATH}".
- #14739 (Author: George Wang): Add a limit on total number of bytes read from storage in table scan
  - Add `query.max-scan-physical-bytes` configuration and `query_max_scan_physical_bytes` session properties to limit total number of bytes read from storage during table scan. The default limit is 1PB.
- #14795 (Author: Brandon Scheller): Add support for Hudi MOR queries
  - Allows presto-hive to use custom parquet input formats.
  - Add support for Hudi realtime input format for hudi realtime queries.
- #14823 (Author: Leiqing Cai): Support customizable ways of launching Presto queries in Verifier
  - Fix an issue where Verifier fails to start when failure resolver is disabled.
  - Add support to implement customized way of launching Presto queries.
  - Add support to run helper queries on a separate cluster other than the control cluster.
- #14829 (Author: Zhenxiao Luo): Pushdown dereference
  - Push down dereference expression.
- #14866 (Author: James Petty): Make skip.header.line.count=1 files splittable
  - Adds support for splitting hive files when skip.header.line.count=1.
- #14877 (Author: James Petty): Avoid checking isSplittable for files smaller than the split max size
  - Improves split generation by avoiding an unncessary splittable check when files are smaller than the initial split max size, regardless of their input format.
- #14896 (Author: James Gill): Add bing_tile_children and bing_tile_parent functions
  - Introduce ``bing_tile_children`` and ``bing_tile_parent`` functions to get parents and children of a Bing tile.
- #14899 (Author: James Gill): Add geometry_to_dissolved_bing_tiles and improve geometry_to_bing_tiles
  - Add geometry_to_dissolved_bing_tiles function, which dissolves complete sets of child tiles to their parent.
  - Improve geometry_to_bing_tiles.  It is 50x faster on complex polygons, the limit on polygon complexity is removed, and some correctness bugs have been fixed.
- #14901 (Author: Zhenxiao Luo): Kafka insert
  - Support insert in Kafka connector.
- #14903 (Author: Zhenxiao Luo): Fix Parquet long statistics handling when min/max not set
  - Fix parquet statistics when min/max is not set.
- #14912 (Author: Rongrong Zhong): Handle CAST in canonicalized LambdaDefinitionExpression
  - Fix LambdaDefinitionExpression canonicalization did not handle CAST.
- #14931 (Author: prithvip): Inline SQL functions at plan time
  - Add support for inlining SQL functions at query planning time. This feature is enabled by default, and can be disabled with the ``inline_sql_functions`` session property.
- #14941 (Author: Leiqing Cai): Populate ClientInfo in Verifier JDBC queries
  - Add support to populate client info for the queries issued by Verifier.
  - Add configuration property ``test_name``, to be passed in to the client info blob.
- #14950 (Author: SandishKumarHN): Connect to Cassandra cluster using SSL
  - Add TLS security support.
- #14958 (Author: Leiqing Cai): Support skipping control in Verifier
  - Add support to skip running control queries and comparing results. This can be enabled by configuration property ``skip-control``.
- #14959 (Author: Rongrong Zhong): Use the same RowExpressionCompiler when compiling expressions
  - Fix compiler error in certain situations where sql functions with same lambda are used multiple times.
- #14968 (Author: Rong Rong): Added conversion functions between Geometry and GeoJSON format. 
  - Added :func:`geometry_from_geojson` and :func:`geometry_as_geojson` to convert geometries from and to GeoJSON format.
- #14970 (Author: Leiqing Cai): Resubmit verification if test query fails with HIVE_PARTITION_OFFLINE
  - Add support to resubmit verification if test query fails with ``HIVE_PARTITION_OFFLINE``.
- #14985 (Author: Rongrong Zhong): Thrift udf api
  - Rename ``presto-thrift-connector-api`` to ``presto-thrift-api`` and have separate packages for datatypes, valuesets and connector.
- #14988 (Author: Vivek): Allow procedures to have optional arguments with default values
  - Allow procedures to have optional arguments with default values.
- #15003 (Author: Vivek): Add IF EXISTS and IF NOT EXISTS checks to ALTER TABLE
  - Add `IF EXISTS `and `IF NOT EXISTS` syntax to `ALTER TABLE`.

# All Commits
- 95e5ee485fc6099f5699c1641f09a9e5f501b8f2 Update java version parser for java 10, 11 or later (Beinan Wang)
- 7a0c1405f75c232c9521b82490a7dcb9898586d8 Support more than 1 druid source, allow union and union all operation (Weidong Duan)
- a9d5c4c405a1bd2affd2b4f9718090959fa8869c Inline SQL functions at plan time (prithvip)
- dfee819bb5b1a9debffa47a9cb9f6b1fcc98546d Add casts to expressions in SQL functions if coercible (prithvip)
- 6f1db903bd4fc2df2bb4fd817c8dc8852a0ebdec Fix improperly scoped argument binding in lambda expressions (prithvip)
- 4c869d6bb80b7c86beadf69eb9891504bfa4bfeb Fix OrcSelectivePageSource incorrect memory reporting (Sujay Jain)
- 06b6f96d2c6dc94ea78fd3f41d5ecef287054443 Deprecating NullableValue class (Saumitra Shahapure)
- 32dfebde7018103a5ae44d2eb5a2f2bc618ede69 Add IF EXISTS and IF NOT EXISTS checks to ALTER TABLE (Vivek)
- ec5b590d15c244fdf565805dc51c1ebf7e61935e Implement dynamic filtering collection for semi join (Ke Wang)
- 849b6a42f1eaa40295f4588ccd3e91bb52765dc2 Add semi join dynamic filter placeholder (Ke Wang)
- 603b77ce7c88bcdaf6a5a652daa5dccb6f9f0220 Move Presto Spark execution exceptions to presto-spark-classloader-interface (Andrii Rosa)
- c838111a7a8430ba5de8b4ed97055784e61f38a0 Change SQL function version to String (Rongrong Zhong)
- 569d71e950d89c0f8840d723727bcc807a95e4e5 Add language to FunctionMetadata (Rongrong Zhong)
- 22c79d824ec0748ffeb19c00fb68e5f98352d04a Fix equals, hashCode and toString for JoinFilterCacheKey (Shixuan Fan)
- a70b4156d4df51f32b349d2c220602168bedbbfd Fix hashCode for CacheKey in ExpressionCompiler (Shixuan Fan)
- 1b66b42ef8edba89c7a0ae8407b42ff58dd6e417 Allow procedures to have optional arguments with default values (Vivek)
- eed2581ebc6ba32f85f716b2e96ab562cba9f7b2 Add support for ip data type in ES Connector (agrawalreetika)
- 53467ec1162faf148059b945860c809a8730316c Support legacy date/timestamp to varchar coercion (Shixuan Fan)
- d9c1e8489e5cc890560f0a5fd57c94684116945f Add functions geometry_from_geojson and geometry_as_geojson (Rong Rong)
- 4c143d9ddd2aa9104098e3b97ca22e0058b7dca8 Upgrade Kudu to latest release 1.12.0 (SandishKumarHN)
- 922afacdd7cd2a9ef7f34e21ae948e15e08c773b Remove unnecessary annotation in ThriftUdfService (Rongrong Zhong)
- 4479e85c7b22e6cfb109c7459e94f65cdf2dedb7 Ensure exception thrown by scheduled tasks are logged (Andrii Rosa)
- 269c3acc1427830fb64b53ffa495fbe4e40ec0c8 Prefer builtin Page methods that avoid Block[] copies (James Petty)
- 91eb4b8e12b0c06a366366f9899e2db432bc14f8 Add copyPositions and extractChannels utility methods to Page (James Petty)
- 0f8a20e9925f9422abb58fea22140aa7988c939f Fix memorySize calculation for quantiles (Bhavani Hari)
- b99054213edc4009304be4a2fd40cbc96d04433e Add test for timestamp literal pushdown (beinan)
- be949c0035a7b7d0ab6ee2835adca6d24c5f2b52 Remove the unnecessary logic on time literal pushdown (beinan)
- 67c9fad3742e0a3ddfa66c5c0bf43eb231795f59 Timestamp literal push down for Druid connector (beinan)
- 7074294ac086f201006d9df56a827ba2fdc968fd Handle the error message from Druid broker (beinan)
- 42a472999fde5ac8e0dafd1f86421f81ae7ae318 Add druid connector to devel configs (beinan)
- b15ee864b8255a1ede251f399496d0c38e59589d Export slim query info to file upon PoS query completion (Wenlei Xie)
- 521df87997f05fa4393826e858135f041dd27c52 Support FilterNode on top of AggregationNode (Weidong Duan)
- d560b6e644e49cab94fa9076ec62406cd62afa68 Fix unhandled HTTP response error for druid client (Weidong Duan)
- 53c89ab0b52bed2d2bb3eae61a4ec1eada204285 Run distributed Hive join tests with and without dynamic filtering (Ke Wang)
- 8792a928c0c2ba36c792efebba98ae1a29f26412 Push dynamic filter to HivePageSourceProvider (Ke Wang)
- 740e18c29f53a587c8398317e567cb84f2bf3f42 Fix generation of dynamic filter (Ke Wang)
- eb4e582942793631a8de8cf6e6e1c06ce3053d75 Fix error message in SessionPropertyDefaults (Leiqing Cai)
- 1d52c576eca07e9cb77fea89a5e8330409033f82 prestodb connect to cassandra cluster with tls security (SandishKumarHN)
- dd95430e90d91ffe588e6999a9b23f51719c1081 Introduce Thrift UDF service APIs (Rongrong Zhong)
- b8a4ab3fe6fb3d4ae390e66b8b54c1ab87e02422 Refactor presto-thrift-connector-api (Rongrong Zhong)
- e1b40669f099ea7bdf9e01ce4a0e4b275f92db9e Resubmit verification if test query fails with HIVE_PARTITION_OFFLINE (Leiqing Cai)
- e12f5f4b264ea29c0638a2db80c6e8b1f263b44b Allow Raptor to run custom check before table creation (Shixuan Fan)
- a2183fa4541352f35f749de50ce1a22f4dada98a Convert memory to user pool on HashAggregation spill finish (Saksham Sachdev)
- cfb2e7aa077954a02c048e81c97a47994d329852 Add hive custom split support for Hudi (Brandon Scheller)
- c406344b34646fceda8f0ab537b1fea8ce6ed24b Support skipping control in Verifier (Leiqing Cai)
- 35ce159dd2df82a037d2840ddf324b4858341187 Collect shuffle statistics in Presto on Spark (Andrii Rosa)
- ea81b9f02eb88e2c2903a7eb4bbee3d4476c4901 Propagate fragment id to PrestoSparkShufflePageInput (Andrii Rosa)
- 1a909d55ea83c9066189163b75bd5f1b0f56e3d9 Refactor PrestoSparkMutableRowPageInput (Andrii Rosa)
- 46499f5c1f761620d9b7b2b9fd7759dabc35bc82 Update QueryDetails UI to use new TaskStats response structure (Ajay George)
- 88e0bd0fef55ac30b2f512fe6b1056aee142ce62 Flatten TaskStats and PipelineStats (Ajay George)
- c960ab417a0e47a2b338d1639ad56e24eea99407 Use the same RowExpressionCompiler when compiling expressions (Rongrong Zhong)
- e9f49df3d33baffa5236ce3874d9fe4dd1ebfaa1 Add support for limit pushdown through union (George Wang)
- e0718bbc4f42231688ede393f2b8ff2df3cdb3b0 Add a constructor to PrestoQueryException (Leiqing Cai)
- d45ad4709a21d9600bd5ae87c57c0739ddc43a5e Make PrestoQueryException.queryActionStats non-optional (Leiqing Cai)
- 4959b793a4966da780784f0dc8add5b071ac58d8 Allow extra stats to be emitted even when query stats are missing (Leiqing Cai)
- 1c406b0c6ce2365f6b315c036f5b3e2e863bdc2c Allow TableScanNode#getCurrentConstraint returns null on worker (Wenlei Xie)
- 2c247c51967e4c44011c940bcb76b590680b6cd6 Add logging on Presto-on-Spark worker (Wenlei Xie)
- fecb4a9c690ef29952b2f25d63e83cc2dc68acb0 Use totalSize statistics for simple join plan (Peizhen Guo)
- fb604581abbf29a8253e80b71fe523a8de021d05 Add unit tests for LocalDynamicFilter and LocalDynamicFilterCollector (Ke Wang)
- c9db6e2d6d6feb54ecd3ef934030443d995e7bea Short circuit page source when dynamic filter is none and Clean up LocalDynamicFiltersCollector (Ke Wang)
- 43324080a1717d0f430b7d47381afe19a41182da Implement local dynamic filtering for broadcast inner-joins (Ke Wang)
- 882fb2389d1e155462684a6a4190176ebbf8a2bb Allow creating unlimited TypedSet (Ke Wang)
- 56503cfc8808b3c416006bd358e11c56ae01360b Add spilled bytes to QueryStatistics (Saksham Sachdev)
- 58237417f836633d0785c43c5cad9d462f7500d5 Extract dynamic filters in Hive ORC reader (Ke Wang)
- 66c22abe81919da6e6bcc14dca4b3baf93acc021 Extract dynamic filters in LocalExecutionPlanner (Ke Wang)
- dab5a607c93df0288a2d3d7d8b395a1ffbe2bc70 Remove unsupported dynamic filters (Ke Wang)
- 05553f80e3e2289d84183b71d9882096ed879529 Add query plan test for DynamicFilter (Ke Wang)
- 4d4f29f540585bb3e918aabfb09ae24c80168766 Generate DynamicFilter in optimization and cost calculation process (Ke Wang)
- c2ad7846291e99c248f94c149680d5ef7138a036 Introduce dynamicFilters into JoinNode and PlanPrinter (Ke Wang)
- 1f5da2e17dc99e490576f80ad62559aa11861be4 Introduce DynamicFilter placeholder and its builtin function (Ke Wang)
- af8d095b277dd7b7784fa212bc51abb90a26b5d5 Add session properties for dynamic filtering (Ke Wang)
- 28b60627a52edc25aee976c4d0da225fd32b2942 Close spiller in Operator#close() for window spilling (Saksham Sachdev)
- 9925cd319772d4e8f3aecce803a0b735c0f41979 Extract window queries tests to separate class (Saksham Sachdev)
- 0eeaf84ad44a19f5c73813d32eeceb06c958cbfe Convert revocable memory to user memory on fully buffered group (Saksham Sachdev)
- 19097b000b595e1eb9e29328dc449f94d211999b Use OrderingCompiler in WindowOperator spilling (Saksham Sachdev)
- 085e1e6281c8306e1525a4f825f5bfa4d8b1388c Implement spill to disk For WindowOperator (Saksham Sachdev)
- d8b4fa095ca0785e19eb023730da6cc737190d9e Introduce revocable aggregated memory context in OperatorContext (Saksham Sachdev)
- c4fc2d9183513b1436afbdbf06375ce8b50b885f Separate input PageSource work processor (Saksham Sachdev)
- 5351fa4ac7e575ef506c0eecbf53064e8a19afd3 Port window operator to work processors (Saksham Sachdev)
- 74cc2dd88b88bfad5c1e3608641d8c70f7b12aa0 Update airbase to 99 (Mayank Garg)
- 8e272aab8a8b3bde26305282789a200b3f632953 Add a user specified test name that is passed into client info (Leiqing Cai)
- 0cade1d9fc77ebd63d2f9cb7d2abd532c662eb90 Populate ClientInfo in Verifier JDBC queries (Leiqing Cai)
- 9a3b041b7d1fa99001c46366267647257869ea8f Fix nondeterminism in TestQueryResource (Tim Meehan)
- 5ebb3e2a51c4f1f230fae8d201005aff4d867685 Shade classes in presto-jdbc uber jar (Mayank Garg)
- 24ac335a4da1c2de3f02d9d2dd61fc949bce45ba Add blank line for format (Beinan Wang)
- e50f5dbcbc61edd9c297887ef77d1665c0c267fc Add Google OAuth scopes to extra credentials (Beinan Wang)
- 756f9f0281e1b7baf9368fc9e988994a2763aa41 Fix transitive dependencies conflict of google oauth libraries (Beinan Wang)
- d49e7686ad43d069d91c71d740295f8c27e1c53c Make presto jdbc driver support Google OAuth private key handling (Beinan Wang)
- d0dfd13752c2b3f2d0393bce2752dc6eecaab0be Make QueryRunner support GCS private key handling (Beinan Wang)
- 29c5f3ee61c5a4111e5975f3fcd92fee5b23f2dd Implement GCS OAuth token handler (Beinan Wang)
- 48be2a96e05b33584d06bb7c21a8756b7ba1fd5c Complete removal of joda-to-java-time-bridge. (Beinan Wang)
- fb43861d7d2354704031c8703f1bd3dcfbb730f3 Add the timezone Asia/Qostanay into zone-index (Beinan Wang)
- 0e3cd141eea2da944deb1e407b2dba21cb4db767 Fix incompatible types error on jdk 9 and 11 (Beinan Wang)
- fc699525ef6f5cef9a8e3c0f62845056be7c0616 Add dependency of javax.annotation into presto-catch's pom to fix build failure on java 11 (Beinan Wang)
- bd0c3e217f464985cb36641ffae769a5565e532b Move dereference pushdown below TranslateExpressions (Zhenxiao Luo)
- 6a2e94e2023fefdae97858c65fbef1ae6aa14359 Add session property to enable dereference pushdown (Zhenxiao Luo)
- d45962c68b0e7f788b544fc3fefc4ca4d135f36f Push down dereference expression (Zhenxiao Luo)
- a4f14e433587ad325a4f2ec18f1ef300cab36809 Handle create page source for Druid segment on s3 (Jinyang Li)
- 4a37013ba4c1095c23e50e76291b80f89e50bdb1 Simplify integration with Alluxio local cache (Bin Fan)
- fb8bb9fd0b94519cacb8e7fbb6fb7858d704baa4 Add a limit on total number of bytes read from storage in table scan (George Wang)
- 404581f4d323eca820f5a997f77d22e36df58b03 Disable TestDistributedSpilledQueries#testJoinPredicatePushdown (Saksham Sachdev)
- 186ea6dfac549ec70090297b3eb34804a2f7e7c5 Fix flaky testTransactionMetadataCleanup (Vic Zhang)
- a3feff4b1c1dc0f8191fef2bf14425e9e17a9163 Fix typo in "longitudeToTileY" function name (James Gill)
- d43913fd0778cb4de5966654afb2de9051735440 Make skip.header.line.count=1 files splittable (James Petty)
- 52a7529cbd372cb8c654163d48f3e7f9e79e91f3 Introduce additional methods in SqlExceptionClassifier interface (Leiqing Cai)
- 1704705f5fa7d4853d65e89a683bf8acdc417df4 Move Query#toStatementStats to a utility class (Leiqing Cai)
- 9f97c9c61b1a856bfbd71e0376cfa976b7542b2b Fix binding failure when failure resolver is disabled (Leiqing Cai)
- b027e1eb8f72820082984911af0cff93bdd74a39 Move the logic of mangling session properties into a utility method (Leiqing Cai)
- 6a2ed8b3e2403ec33f5096a9c88b70632437af5e Use a single metadata-timeout and checksum-timeout (Leiqing Cai)
- 6be7b056f27470884b2649df9f30fe81c05706f1 Allow additional data to be emitted in QueryStatsEvent (Leiqing Cai)
- 8bd1a527ca0ddf59b4848179d70ebd7c32f6fa4e Support customizable ways of launching Presto queries in Verifier (Leiqing Cai)
- 7a4dc5a4ef983c45c6392c3150ebf53987af0891 Make the entire JDBC QueryStats available in verification results (Leiqing Cai)
- e85e4e14bcfb074088a7004be384d8ccf2105abe Make control.http-port optional (Leiqing Cai)
- 426b48b43214aac074e396371abe4afb6488e25c Style improvments in DeterminismAnalyzer (Leiqing Cai)
- 8473d79a2b4088696601000f44cb99cfe66b222c Refactor geometry_to_bing_tiles to use new algorithm (James Gill)
- 5e5bb96a5c049d1e43a2f0e73d85c6efa1e73e0d Reformatting some geometry_to_bing_tiles tests (James Gill)
- 22c1167da87b9051b5d5e0fb77fe513424a90f91 Add test cases for geometry_to_bing_tiles (James Gill)
- b96c2a27e63f3e1c6704d534cfee03b09230dac6 Add geometry_to_dissolved_bing_tiles (James Gill)
- 52e6eb9667e9d82eb4f258c551a911ef97b71b55 Extract accelerateGeometry into GeometryUtils (James A. Gill)
- c53732e58dc722512ef8333a566681e88fd0d2fd [Test Only] Remove allFragments from PlanPrinter#formatFragment (Wenlei Xie)
- 4110ec688b528abd8298989b1245a5368a6b8816 Avoid checking isSplittable for files smaller than initial split size (James Petty)
- e4aa4e36fe618d87c7b32672064d8946f8f5f928 Minor refactor to LocalQueryRunner (Wenlei Xie)
- 53a26bb340d016789b0597dc247b46953a125c9a Add BingTile.findChildren() and findParent() (James Gill)
- 040a48ace574b3a5730df5be815732ecf46286c7 Rename RowExpressionPredicatePushDown to PredicatePushDown (James Sun)
- 0cfbeff302c0b3cb321b3644eba1b1fb5d57c828 Remove unused functions in ExpressionUtils (James Sun)
- 990a119bdd007a226087bc27be45371f13fbfc11 Remove SubExpressionExtractor (James Sun)
- 04beda34e1931abd180482de7a2ad3f7bf30dafe Rename RowExpressionEqualityInference to EqualityInference (James Sun)
- ae6d0ff88916a171f433d7897a455a2393934b78 Remove EqualityInference (James Sun)
- 502bc0601813a679faf400e23092aa86f49a3b7c Rename RowExpressionPredicateExtractor to EffectivePredicateExtractor (James Sun)
- 40abdcef862986258e2eb4c00a361519101e7a89 Remove EffectivePredicateExtractor (James Sun)
- 9ae92b5f248fee15ea1b90a796a0a0959095697b Move TranslateExpressions above all PredicatePushDowns (James Sun)
- 6528824c2360774a5040206c9ff0ad7d222924d6 Add "Test plan" field to PR template (Mayank Garg)
- d34897d37a57694c9ee2533c96d18f4c8889d359 Put time limit on `TestDistributedSpillQueries#testJoinPredicatePushdown` (Mayank Garg)
- 0438c0e259159428f140499af495bae5c8126435 Upgrade hadoop-apache for refreshing GCS OAuth token automatically (Beinan Wang)
- 55a685d4b31a67ca415ba01cb5fadcc2aa94129e Fix Kafka product tests avro schema (Zhenxiao Luo)
- b52bab6802e2bb7e1f938ada1f146efd43ab8386 Add Kafka raw encoder (Zhenxiao Luo)
- ad1bca38d06d15cbcd3d9f8aadc75d1184c30150 Improve Kafka round trip test (Zhenxiao Luo)
- 27865e4543b343ed4930e865606f362c9cfa7c16 Fix resource warning in KafkaPageSink#appendPage (Zhenxiao Luo)
- 3c4d47bd6b34ae65aefb16ac8b28bc41171a6200 Add row to Kafka round trip test (Zhenxiao Luo)
- 45637696b23284408b1d31e9731d499e362e7d1e Add Kafka Avro encoder (Zhenxiao Luo)
- 6ff59216b3bbcc7a7001d2fadc3350154fb3ecdd Make Kafka RowEncoder Closeable (Zhenxiao Luo)
- 5a00a63d7c79efcf0d87f6f9e491842f6aa99486 Move column handle validation for Kafka encoders into constructor (Zhenxiao Luo)
- 9c74b623c307a20f4891f0ddad2a8a3a09459d45 Remove Kafka connector suppress warnings labels (Zhenxiao Luo)
- a1635df838f981c6595e31d9b5f6808d91562b49 Add Kafka CSV encoder (Zhenxiao Luo)
- 8eee85915f9a65746ad9497515c3f589b7a24539 Implements Inserts for Kafka connector (Zhenxiao Luo)
- 611d210fa73479a784c9dcba2505399cf69a6baa Remove unused functions in ExpressionUtils (James Sun)
- 56bfdebed18e5f86bd8f6826d0f10aec2482d55a Move TranslateExpressions above all PickTableLayouts (James Sun)
- ddd2766d69418a70532e0b5b3a8b112f0fd6d36c Move TranslateExpressions above PushAggregationThroughOuterJoin (James Sun)
- 5f30def53593ec4d7621b1a15c490710d0da7765 Move TranslateExpressions below PushAggregationThroughOuterJoin (James Sun)
- fe32cbd0f31647bcdc04ce2a2880974618420fc4 Move TranslateExpressions above IndexJoinOptimizer (James Sun)
- 3f1023d4273ae163c06dc9d7f8bb5c6b7add42d9 Move TranslateExpressions above SimplifyCountOverConstant (James Sun)
- a07948a2353db039d87d323bb14e5e5a07d122e0 Move TranslateExpressions above LimitPushDown (James Sun)
- d46226cd4dfe723ec72651fcfb0fca5bfd97e8e0 Move TranslateExpressions above WindowFilterPushDown (Yi He)
- 19634dcde35ed768b7c54134242ccfa6b7ba2dfb Move TranslateExpressions above GatherAndMergeWindows (James Sun)
- b39ecadfabe11f56a4de7dcc65304d06c93211e7 Move TranslateExpressions below GatherAndMergeWindows (James Sun)
- fa288b807416141287681d220c3e968aead544fc Handle CAST in canonicalized LambdaDefinitionExpression (Rongrong Zhong)
- 3eb8442ad46eb47761faf6a4086591a34c80f604 Fix Parquet long statistics handling when min/max not set (Zhenxiao Luo)