### PR TITLE
Catch and throw storage connection error properly

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/FileSystemCommunicationException.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/FileSystemCommunicationException.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common;
+
+public class FileSystemCommunicationException
+        extends RuntimeException
+{
+    public FileSystemCommunicationException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
+
+    @Override
+    public String getMessage()
+    {
+        return super.getMessage();
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/HdfsOrcDataSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/HdfsOrcDataSource.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.hive.orc;
 
+import com.facebook.presto.common.FileSystemCommunicationException;
 import com.facebook.presto.hive.FileFormatDataSourceStats;
 import com.facebook.presto.orc.AbstractOrcDataSource;
 import com.facebook.presto.orc.OrcDataSourceId;
@@ -22,7 +23,6 @@ import org.apache.hadoop.fs.FSDataInputStream;
 
 import java.io.IOException;
 
-import static com.facebook.presto.hive.HiveErrorCode.HIVE_FILESYSTEM_ERROR;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_MISSING_DATA;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_UNKNOWN_ERROR;
 import static java.lang.String.format;
@@ -74,7 +74,7 @@ public class HdfsOrcDataSource
                 throw new PrestoException(HIVE_MISSING_DATA, message, e);
             }
             if (e instanceof IOException) {
-                throw new PrestoException(HIVE_FILESYSTEM_ERROR, message, e);
+                throw new FileSystemCommunicationException(message, e);
             }
             throw new PrestoException(HIVE_UNKNOWN_ERROR, message, e);
         }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcSelectivePageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcSelectivePageSource.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.hive.orc;
 
+import com.facebook.presto.common.FileSystemCommunicationException;
 import com.facebook.presto.common.InvalidFunctionArgumentException;
 import com.facebook.presto.common.Page;
 import com.facebook.presto.hive.FileFormatDataSourceStats;
@@ -28,6 +29,7 @@ import java.io.UncheckedIOException;
 
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_BAD_DATA;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_CURSOR_ERROR;
+import static com.facebook.presto.hive.HiveErrorCode.HIVE_FILESYSTEM_ERROR;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.lang.String.format;
@@ -96,6 +98,10 @@ public class OrcSelectivePageSource
         catch (PrestoException e) {
             closeWithSuppression(e);
             throw e;
+        }
+        catch (FileSystemCommunicationException e) {
+            closeWithSuppression(e);
+            throw new PrestoException(HIVE_FILESYSTEM_ERROR, e);
         }
         catch (OrcCorruptionException e) {
             closeWithSuppression(e);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/ExceptionWrappingMetadataReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/ExceptionWrappingMetadataReader.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.orc.metadata;
 
+import com.facebook.presto.common.FileSystemCommunicationException;
 import com.facebook.presto.orc.OrcCorruptionException;
 import com.facebook.presto.orc.OrcDataSourceId;
 import com.facebook.presto.orc.metadata.PostScript.HiveWriterVersion;
@@ -23,6 +24,7 @@ import java.io.InputStream;
 import java.util.List;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Throwables.propagateIfPossible;
 import static java.util.Objects.requireNonNull;
 
 public class ExceptionWrappingMetadataReader
@@ -112,6 +114,7 @@ public class ExceptionWrappingMetadataReader
 
     private OrcCorruptionException propagate(Throwable throwable, String message)
     {
+        propagateIfPossible(throwable, FileSystemCommunicationException.class);
         return new OrcCorruptionException(throwable, orcDataSourceId, message);
     }
 }


### PR DESCRIPTION
Currently, storage connection error is being returned as HIVE_BAD_DATA error. So fixed it to return it as HIVE_FILESYSTEM_ERROR instead.

This PR will fix https://github.com/prestodb/presto/issues/15021

```
== NO RELEASE NOTE ==
```
