### PR TITLE
In PruneUnreferencedOutputs pass the parent context to child when WindowNode is skipped

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PruneUnreferencedOutputs.java
@@ -432,14 +432,13 @@ public class PruneUnreferencedOutputs
                 }
             }
 
-            PlanNode source = context.rewrite(node.getSource(), expectedInputs.build());
-
             Map<VariableReferenceExpression, WindowNode.Function> functions = functionsBuilder.build();
-
             if (functions.size() == 0) {
-                return source;
+                // As the window plan node is getting skipped, use the inputs needed by the parent of the Window plan node
+                return context.rewrite(node.getSource(), context.get());
             }
 
+            PlanNode source = context.rewrite(node.getSource(), expectedInputs.build());
             return new WindowNode(
                     node.getId(),
                     source,

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestPruneUnreferencedOutputs.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestPruneUnreferencedOutputs.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.common.block.SortOrder;
+import com.facebook.presto.spi.function.FunctionHandle;
+import com.facebook.presto.spi.plan.Assignments;
+import com.facebook.presto.spi.plan.Ordering;
+import com.facebook.presto.spi.plan.OrderingScheme;
+import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.sql.planner.assertions.OptimizerAssert;
+import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
+import com.facebook.presto.sql.planner.iterative.rule.test.RuleTester;
+import com.facebook.presto.sql.planner.plan.WindowNode;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.metadata.MetadataManager.createTestMetadataManager;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.output;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+import static com.facebook.presto.sql.planner.plan.WindowNode.Frame.BoundType.UNBOUNDED_FOLLOWING;
+import static com.facebook.presto.sql.planner.plan.WindowNode.Frame.BoundType.UNBOUNDED_PRECEDING;
+import static com.facebook.presto.sql.planner.plan.WindowNode.Frame.WindowType.RANGE;
+import static com.facebook.presto.sql.relational.Expressions.call;
+
+public class TestPruneUnreferencedOutputs
+        extends BaseRuleTest
+{
+    /**
+     * Test that the unreferenced output pruning works correctly when WindowNode is pruned as no downstream operators are consuming the window function output
+     */
+    @Test
+    public void windowNodePruning()
+    {
+        FunctionHandle functionHandle = createTestMetadataManager().getFunctionManager().lookupFunction("rank", ImmutableList.of());
+        CallExpression call = call("rank", functionHandle, BIGINT);
+        WindowNode.Frame frame = new WindowNode.Frame(
+                RANGE,
+                UNBOUNDED_PRECEDING,
+                Optional.empty(),
+                UNBOUNDED_FOLLOWING,
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty());
+
+        assertRuleApplication()
+                .on(p ->
+                        p.output(ImmutableList.of("user_uuid"), ImmutableList.of(p.variable("user_uuid", VARCHAR)),
+                                p.project(Assignments.of(p.variable("user_uuid", VARCHAR), p.variable("user_uuid", VARCHAR)),
+                                        p.window(
+                                                new WindowNode.Specification(
+                                                        ImmutableList.of(p.variable("user_uuid", VARCHAR)),
+                                                        Optional.of(new OrderingScheme(
+                                                                ImmutableList.of(
+                                                                        new Ordering(p.variable("expr"), SortOrder.ASC_NULLS_LAST),
+                                                                        new Ordering(p.variable("random"), SortOrder.ASC_NULLS_LAST))))),
+                                                ImmutableMap.of(
+                                                        p.variable("rank"),
+                                                        new WindowNode.Function(call, frame, false)),
+                                                p.project(Assignments.builder()
+                                                                .put(p.variable("user_uuid", VARCHAR), p.variable("user_uuid", VARCHAR))
+                                                                .put(p.variable("expr", BIGINT), p.variable("expr", BIGINT))
+                                                                .put(p.variable("random", BIGINT), p.rowExpression("random()"))
+                                                                .build(),
+                                                        p.values(p.variable("user_uuid", VARCHAR), p.variable("expr", BIGINT)))))))
+                .matches(
+                        output(
+                                project(
+                                        project(
+                                                values("user_uuid")))));
+    }
+
+    private OptimizerAssert assertRuleApplication()
+    {
+        RuleTester tester = tester();
+        return tester.assertThat(new PruneUnreferencedOutputs());
+    }
+}


### PR DESCRIPTION

Part of the one user query got into the following plan:
```
  Project(user_uuid_506)
    Filter (rank_554 = 1)
      Window(rank_554=rank(), orderingScheme=expr_538,random_553)
        Project(user_uuid_506, expr_538, random_553=random())
          Values(user_uuid_506, expr_538(cast(name as date)))
```
As the `Values()` operator doesn't have any data (original table got pruned), the `Filter` is removed as part of the `PredicatePushdown` rule
```
  Project(user_uuid_506)
    Window(rank_554=rank(), orderingScheme=expr_538,random_553)
      Project(user_uuid_506, expr_538, random_553=random())
        Values(user_uuid_506, expr_538(cast(name as date)))
```

In the remaining plan when trying to prune the unreferenced outputs (`PruneUnreferencedOutputs` rule), we remove the `WindowNode` as no one is looking at the `rank_554`, but the unreferenced variables `expr_538` and `random_553` are not removed as we pass the context that has variables from `Project(user_uuid_506)` and `Window(rank_554=rank(), orderingScheme=expr_538,random_553)`. This causes the issues later on in `PushdownSubfields` rule which expects the plan to have unreferenced output variables pruned.

One another way to resolve this is add `PruneUnreferencedVariables` rule just before the `PushdownSubfields` rule

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```
