### PR TITLE
Separate operator and stage statistics from query statistics

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/event/QueryMonitor.java
+++ b/presto-main/src/main/java/com/facebook/presto/event/QueryMonitor.java
@@ -26,6 +26,7 @@ import com.facebook.presto.execution.ExecutionFailureInfo;
 import com.facebook.presto.execution.Input;
 import com.facebook.presto.execution.QueryInfo;
 import com.facebook.presto.execution.QueryStats;
+import com.facebook.presto.execution.StageExecutionInfo;
 import com.facebook.presto.execution.StageInfo;
 import com.facebook.presto.execution.TaskId;
 import com.facebook.presto.execution.TaskInfo;
@@ -33,12 +34,14 @@ import com.facebook.presto.execution.TaskState;
 import com.facebook.presto.metadata.FunctionManager;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.SessionPropertyManager;
+import com.facebook.presto.operator.OperatorInfo;
 import com.facebook.presto.operator.OperatorStats;
 import com.facebook.presto.operator.TableFinishInfo;
 import com.facebook.presto.operator.TaskStats;
 import com.facebook.presto.server.BasicQueryInfo;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.spi.eventlistener.OperatorStatistics;
 import com.facebook.presto.spi.eventlistener.QueryCompletedEvent;
 import com.facebook.presto.spi.eventlistener.QueryContext;
 import com.facebook.presto.spi.eventlistener.QueryCreatedEvent;
@@ -49,6 +52,7 @@ import com.facebook.presto.spi.eventlistener.QueryMetadata;
 import com.facebook.presto.spi.eventlistener.QueryOutputMetadata;
 import com.facebook.presto.spi.eventlistener.QueryStatistics;
 import com.facebook.presto.spi.eventlistener.ResourceDistribution;
+import com.facebook.presto.spi.eventlistener.StageStatistics;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
 import com.facebook.presto.transaction.TransactionId;
 import com.google.common.collect.ImmutableList;
@@ -80,8 +84,8 @@ public class QueryMonitor
     private static final Logger log = Logger.get(QueryMonitor.class);
 
     private final JsonCodec<StageInfo> stageInfoCodec;
-    private final JsonCodec<OperatorStats> operatorStatsCodec;
     private final JsonCodec<ExecutionFailureInfo> executionFailureInfoCodec;
+    private final JsonCodec<OperatorInfo> operatorInfoCodec;
     private final EventListenerManager eventListenerManager;
     private final String serverVersion;
     private final String serverAddress;
@@ -93,8 +97,8 @@ public class QueryMonitor
     @Inject
     public QueryMonitor(
             JsonCodec<StageInfo> stageInfoCodec,
-            JsonCodec<OperatorStats> operatorStatsCodec,
             JsonCodec<ExecutionFailureInfo> executionFailureInfoCodec,
+            JsonCodec<OperatorInfo> operatorInfoCodec,
             EventListenerManager eventListenerManager,
             NodeInfo nodeInfo,
             NodeVersion nodeVersion,
@@ -104,7 +108,7 @@ public class QueryMonitor
     {
         this.eventListenerManager = requireNonNull(eventListenerManager, "eventListenerManager is null");
         this.stageInfoCodec = requireNonNull(stageInfoCodec, "stageInfoCodec is null");
-        this.operatorStatsCodec = requireNonNull(operatorStatsCodec, "operatorStatsCodec is null");
+        this.operatorInfoCodec = requireNonNull(operatorInfoCodec, "operatorInfoCodec is null");
         this.executionFailureInfoCodec = requireNonNull(executionFailureInfoCodec, "executionFailureInfoCodec is null");
         this.serverVersion = requireNonNull(nodeVersion, "nodeVersion is null").toString();
         this.serverAddress = requireNonNull(nodeInfo, "nodeInfo is null").getExternalAddress();
@@ -165,12 +169,8 @@ public class QueryMonitor
                         0,
                         0,
                         0,
-                        ImmutableList.of(),
                         0,
-                        true,
-                        ImmutableList.of(),
-                        ImmutableList.of(),
-                        ImmutableList.of()),
+                        true),
                 createQueryContext(queryInfo.getSession(), queryInfo.getResourceGroupId()),
                 new QueryIOMetadata(ImmutableList.of(), Optional.empty()),
                 createQueryFailureInfo(failure, Optional.empty()),
@@ -179,7 +179,9 @@ public class QueryMonitor
                 ImmutableList.of(),
                 ofEpochMilli(queryInfo.getQueryStats().getCreateTime().getMillis()),
                 ofEpochMilli(queryInfo.getQueryStats().getEndTime().getMillis()),
-                ofEpochMilli(queryInfo.getQueryStats().getEndTime().getMillis())));
+                ofEpochMilli(queryInfo.getQueryStats().getEndTime().getMillis()),
+                ImmutableList.of(),
+                ImmutableList.of()));
 
         logQueryTimeline(queryInfo);
     }
@@ -187,6 +189,11 @@ public class QueryMonitor
     public void queryCompletedEvent(QueryInfo queryInfo)
     {
         QueryStats queryStats = queryInfo.getQueryStats();
+        ImmutableList.Builder<StageStatistics> stageStatisticsBuilder = ImmutableList.builder();
+        if (queryInfo.getOutputStage().isPresent()) {
+            computeStageStatistics(queryInfo.getOutputStage().get(), stageStatisticsBuilder);
+        }
+
         eventListenerManager.queryCompleted(
                 new QueryCompletedEvent(
                         createQueryMetadata(queryInfo),
@@ -201,29 +208,11 @@ public class QueryMonitor
                                 .collect(toImmutableList()),
                         ofEpochMilli(queryStats.getCreateTime().getMillis()),
                         ofEpochMilli(queryStats.getExecutionStartTime().getMillis()),
-                        ofEpochMilli(queryStats.getEndTime() != null ? queryStats.getEndTime().getMillis() : 0)));
+                        ofEpochMilli(queryStats.getEndTime() != null ? queryStats.getEndTime().getMillis() : 0),
+                        stageStatisticsBuilder.build(),
+                        createOperatorStatistics(queryInfo)));
 
         logQueryTimeline(queryInfo);
-    }
-
-    public static ResourceDistribution createResourceDistribution(
-            int stageId,
-            int tasks,
-            DistributionSnapshot distributionSnapshot)
-    {
-        return new ResourceDistribution(
-                stageId,
-                tasks,
-                distributionSnapshot.getP25(),
-                distributionSnapshot.getP50(),
-                distributionSnapshot.getP75(),
-                distributionSnapshot.getP90(),
-                distributionSnapshot.getP95(),
-                distributionSnapshot.getP99(),
-                distributionSnapshot.getMin(),
-                distributionSnapshot.getMax(),
-                (long) distributionSnapshot.getTotal(),
-                distributionSnapshot.getTotal() / distributionSnapshot.getCount());
     }
 
     private QueryMetadata createQueryMetadata(QueryInfo queryInfo)
@@ -242,20 +231,52 @@ public class QueryMonitor
                         .collect(toImmutableList()));
     }
 
+    private List<OperatorStatistics> createOperatorStatistics(QueryInfo queryInfo)
+    {
+        return queryInfo.getQueryStats().getOperatorSummaries().stream()
+                .map(operatorSummary -> new OperatorStatistics(
+                        operatorSummary.getStageId(),
+                        operatorSummary.getStageExecutionId(),
+                        operatorSummary.getPipelineId(),
+                        operatorSummary.getOperatorId(),
+                        operatorSummary.getPlanNodeId(),
+                        operatorSummary.getOperatorType(),
+                        operatorSummary.getTotalDrivers(),
+                        operatorSummary.getAddInputCalls(),
+                        operatorSummary.getAddInputWall(),
+                        operatorSummary.getAddInputCpu(),
+                        operatorSummary.getAddInputAllocation(),
+                        operatorSummary.getRawInputDataSize(),
+                        operatorSummary.getRawInputPositions(),
+                        operatorSummary.getInputDataSize(),
+                        operatorSummary.getInputPositions(),
+                        operatorSummary.getSumSquaredInputPositions(),
+                        operatorSummary.getGetOutputCalls(),
+                        operatorSummary.getGetOutputWall(),
+                        operatorSummary.getGetOutputCpu(),
+                        operatorSummary.getGetOutputAllocation(),
+                        operatorSummary.getOutputDataSize(),
+                        operatorSummary.getOutputPositions(),
+                        operatorSummary.getPhysicalWrittenDataSize(),
+                        operatorSummary.getBlockedWall(),
+                        operatorSummary.getFinishCalls(),
+                        operatorSummary.getFinishWall(),
+                        operatorSummary.getFinishCpu(),
+                        operatorSummary.getFinishAllocation(),
+                        operatorSummary.getUserMemoryReservation(),
+                        operatorSummary.getRevocableMemoryReservation(),
+                        operatorSummary.getSystemMemoryReservation(),
+                        operatorSummary.getPeakUserMemoryReservation(),
+                        operatorSummary.getPeakSystemMemoryReservation(),
+                        operatorSummary.getPeakTotalMemoryReservation(),
+                        operatorSummary.getSpilledDataSize(),
+                        Optional.ofNullable(operatorSummary.getInfo()).map(operatorInfoCodec::toJson)))
+                .collect(toImmutableList());
+    }
+
     private QueryStatistics createQueryStatistics(QueryInfo queryInfo)
     {
-        ImmutableList.Builder<String> operatorSummaries = ImmutableList.builder();
-        for (OperatorStats summary : queryInfo.getQueryStats().getOperatorSummaries()) {
-            operatorSummaries.add(operatorStatsCodec.toJson(summary));
-        }
-
         QueryStats queryStats = queryInfo.getQueryStats();
-
-        ImmutableList.Builder<ResourceDistribution> cpuDistributionBuilder = ImmutableList.builder();
-        ImmutableList.Builder<ResourceDistribution> memoryDistributionBuilder = ImmutableList.builder();
-        if (queryInfo.getOutputStage().isPresent()) {
-            computeCpuAndMemoryDistributions(queryInfo.getOutputStage().get(), cpuDistributionBuilder, memoryDistributionBuilder);
-        }
 
         return new QueryStatistics(
                 ofMillis(queryStats.getTotalCpuTime().toMillis()),
@@ -277,12 +298,8 @@ public class QueryMonitor
                 queryStats.getWrittenIntermediatePhysicalDataSize().toBytes(),
                 queryStats.getSpilledDataSize().toBytes(),
                 queryStats.getCumulativeUserMemory(),
-                queryStats.getStageGcStatistics(),
                 queryStats.getCompletedDrivers(),
-                queryInfo.isCompleteInfo(),
-                cpuDistributionBuilder.build(),
-                memoryDistributionBuilder.build(),
-                operatorSummaries.build());
+                queryInfo.isCompleteInfo());
     }
 
     private QueryContext createQueryContext(SessionRepresentation session, Optional<ResourceGroupId> resourceGroup)
@@ -535,31 +552,51 @@ public class QueryMonitor
                 queryEndTime);
     }
 
-    private static void computeCpuAndMemoryDistributions(
+    private static ResourceDistribution createResourceDistribution(
+            DistributionSnapshot distributionSnapshot)
+    {
+        return new ResourceDistribution(
+                distributionSnapshot.getP25(),
+                distributionSnapshot.getP50(),
+                distributionSnapshot.getP75(),
+                distributionSnapshot.getP90(),
+                distributionSnapshot.getP95(),
+                distributionSnapshot.getP99(),
+                distributionSnapshot.getMin(),
+                distributionSnapshot.getMax(),
+                (long) distributionSnapshot.getTotal(),
+                distributionSnapshot.getTotal() / distributionSnapshot.getCount());
+    }
+
+    private static void computeStageStatistics(
             StageInfo stageInfo,
-            ImmutableList.Builder<ResourceDistribution> cpuDistributionBuilder,
-            ImmutableList.Builder<ResourceDistribution> memoryDistributionBuilder)
+            ImmutableList.Builder<StageStatistics> stageStatisticsBuilder)
     {
         Distribution cpuDistribution = new Distribution();
         Distribution memoryDistribution = new Distribution();
 
-        for (TaskInfo taskInfo : stageInfo.getLatestAttemptExecutionInfo().getTasks()) {
+        StageExecutionInfo executionInfo = stageInfo.getLatestAttemptExecutionInfo();
+
+        for (TaskInfo taskInfo : executionInfo.getTasks()) {
             cpuDistribution.add(NANOSECONDS.toMillis(taskInfo.getStats().getTotalCpuTimeInNanos()));
             memoryDistribution.add(taskInfo.getStats().getPeakTotalMemoryInBytes());
         }
 
-        cpuDistributionBuilder.add(createResourceDistribution(
+        stageStatisticsBuilder.add(new StageStatistics(
                 stageInfo.getStageId().getId(),
-                stageInfo.getLatestAttemptExecutionInfo().getTasks().size(),
-                cpuDistribution.snapshot()));
+                executionInfo.getStats().getGcInfo().getStageExecutionId(),
+                executionInfo.getTasks().size(),
+                executionInfo.getStats().getTotalScheduledTime(),
+                executionInfo.getStats().getTotalCpuTime(),
+                executionInfo.getStats().getRetriedCpuTime(),
+                executionInfo.getStats().getTotalBlockedTime(),
+                executionInfo.getStats().getRawInputDataSize(),
+                executionInfo.getStats().getProcessedInputDataSize(),
+                executionInfo.getStats().getPhysicalWrittenDataSize(),
+                executionInfo.getStats().getGcInfo(),
+                createResourceDistribution(cpuDistribution.snapshot()),
+                createResourceDistribution(memoryDistribution.snapshot())));
 
-        memoryDistributionBuilder.add(createResourceDistribution(
-                stageInfo.getStageId().getId(),
-                stageInfo.getLatestAttemptExecutionInfo().getTasks().size(),
-                memoryDistribution.snapshot()));
-
-        for (StageInfo subStage : stageInfo.getSubStages()) {
-            computeCpuAndMemoryDistributions(subStage, cpuDistributionBuilder, memoryDistributionBuilder);
-        }
+        stageInfo.getSubStages().forEach(subStage -> computeStageStatistics(subStage, stageStatisticsBuilder));
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
@@ -95,6 +95,7 @@ import com.facebook.presto.memory.TotalReservationLowMemoryKiller;
 import com.facebook.presto.memory.TotalReservationOnBlockedNodesLowMemoryKiller;
 import com.facebook.presto.metadata.CatalogManager;
 import com.facebook.presto.operator.ForScheduler;
+import com.facebook.presto.operator.OperatorInfo;
 import com.facebook.presto.server.protocol.ExecutingStatementResource;
 import com.facebook.presto.server.protocol.LocalQueryProvider;
 import com.facebook.presto.server.protocol.QueuedStatementResource;
@@ -214,6 +215,7 @@ public class CoordinatorModule
         httpClientBinder(binder).bindHttpClient("workerInfo", ForWorkerInfo.class);
 
         // query monitor
+        jsonCodecBinder(binder).bindJsonCodec(OperatorInfo.class);
         configBinder(binder).bindConfig(QueryMonitorConfig.class);
         binder.bind(QueryMonitor.class).in(Scopes.SINGLETON);
 

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
@@ -78,6 +78,7 @@ import com.facebook.presto.metadata.StaticFunctionNamespaceStoreConfig;
 import com.facebook.presto.metadata.TablePropertyManager;
 import com.facebook.presto.metadata.ViewDefinition;
 import com.facebook.presto.operator.LookupJoinOperators;
+import com.facebook.presto.operator.OperatorInfo;
 import com.facebook.presto.operator.OperatorStats;
 import com.facebook.presto.operator.PagesIndex;
 import com.facebook.presto.operator.TableCommitContext;
@@ -353,6 +354,7 @@ public class PrestoSparkModule
         binder.bind(SpillerStats.class).in(Scopes.SINGLETON);
 
         // monitoring
+        jsonCodecBinder(binder).bindJsonCodec(OperatorInfo.class);
         binder.bind(QueryMonitor.class).in(Scopes.SINGLETON);
         configBinder(binder).bindConfig(QueryMonitorConfig.class);
         binder.bind(SplitMonitor.class).in(Scopes.SINGLETON);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/OperatorStatistics.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/OperatorStatistics.java
@@ -1,0 +1,350 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.eventlistener;
+
+import com.facebook.presto.spi.plan.PlanNodeId;
+import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
+
+import javax.annotation.concurrent.Immutable;
+
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+@Immutable
+public class OperatorStatistics
+{
+    private final int stageId;
+    private final int stageExecutionId;
+    private final int pipelineId;
+    private final int operatorId;
+    private final PlanNodeId planNodeId;
+    private final String operatorType;
+
+    private final long totalDrivers;
+
+    private final long addInputCalls;
+    private final Duration addInputWall;
+    private final Duration addInputCpu;
+    private final DataSize addInputAllocation;
+    private final DataSize rawInputDataSize;
+    private final long rawInputPositions;
+    private final DataSize inputDataSize;
+    private final long inputPositions;
+    private final double sumSquaredInputPositions;
+
+    private final long getOutputCalls;
+    private final Duration getOutputWall;
+    private final Duration getOutputCpu;
+    private final DataSize getOutputAllocation;
+    private final DataSize outputDataSize;
+    private final long outputPositions;
+
+    private final DataSize physicalWrittenDataSize;
+
+    private final Duration blockedWall;
+
+    private final long finishCalls;
+    private final Duration finishWall;
+    private final Duration finishCpu;
+    private final DataSize finishAllocation;
+
+    private final DataSize userMemoryReservation;
+    private final DataSize revocableMemoryReservation;
+    private final DataSize systemMemoryReservation;
+    private final DataSize peakUserMemoryReservation;
+    private final DataSize peakSystemMemoryReservation;
+    private final DataSize peakTotalMemoryReservation;
+
+    private final DataSize spilledDataSize;
+
+    private final Optional<String> info;
+
+    public OperatorStatistics(
+            int stageId,
+            int stageExecutionId,
+            int pipelineId,
+            int operatorId,
+            PlanNodeId planNodeId,
+            String operatorType,
+
+            long totalDrivers,
+
+            long addInputCalls,
+            Duration addInputWall,
+            Duration addInputCpu,
+            DataSize addInputAllocation,
+            DataSize rawInputDataSize,
+            long rawInputPositions,
+            DataSize inputDataSize,
+            long inputPositions,
+            double sumSquaredInputPositions,
+
+            long getOutputCalls,
+            Duration getOutputWall,
+            Duration getOutputCpu,
+            DataSize getOutputAllocation,
+            DataSize outputDataSize,
+            long outputPositions,
+
+            DataSize physicalWrittenDataSize,
+
+            Duration blockedWall,
+
+            long finishCalls,
+            Duration finishWall,
+            Duration finishCpu,
+            DataSize finishAllocation,
+
+            DataSize userMemoryReservation,
+            DataSize revocableMemoryReservation,
+            DataSize systemMemoryReservation,
+            DataSize peakUserMemoryReservation,
+            DataSize peakSystemMemoryReservation,
+            DataSize peakTotalMemoryReservation,
+
+            DataSize spilledDataSize,
+
+            Optional<String> info)
+    {
+        this.stageId = stageId;
+        this.stageExecutionId = stageExecutionId;
+        this.pipelineId = pipelineId;
+
+        this.operatorId = operatorId;
+        this.planNodeId = requireNonNull(planNodeId, "planNodeId is null");
+        this.operatorType = requireNonNull(operatorType, "operatorType is null");
+
+        this.totalDrivers = totalDrivers;
+
+        this.addInputCalls = addInputCalls;
+        this.addInputWall = requireNonNull(addInputWall, "addInputWall is null");
+        this.addInputCpu = requireNonNull(addInputCpu, "addInputCpu is null");
+        this.addInputAllocation = requireNonNull(addInputAllocation, "addInputAllocation is null");
+        this.rawInputDataSize = requireNonNull(rawInputDataSize, "rawInputDataSize is null");
+        this.rawInputPositions = requireNonNull(rawInputPositions, "rawInputPositions is null");
+        this.inputDataSize = requireNonNull(inputDataSize, "inputDataSize is null");
+        this.inputPositions = inputPositions;
+        this.sumSquaredInputPositions = sumSquaredInputPositions;
+
+        this.getOutputCalls = getOutputCalls;
+        this.getOutputWall = requireNonNull(getOutputWall, "getOutputWall is null");
+        this.getOutputCpu = requireNonNull(getOutputCpu, "getOutputCpu is null");
+        this.getOutputAllocation = requireNonNull(getOutputAllocation, "getOutputAllocation is null");
+        this.outputDataSize = requireNonNull(outputDataSize, "outputDataSize is null");
+        this.outputPositions = outputPositions;
+
+        this.physicalWrittenDataSize = requireNonNull(physicalWrittenDataSize, "writtenDataSize is null");
+
+        this.blockedWall = requireNonNull(blockedWall, "blockedWall is null");
+
+        this.finishCalls = finishCalls;
+        this.finishWall = requireNonNull(finishWall, "finishWall is null");
+        this.finishCpu = requireNonNull(finishCpu, "finishCpu is null");
+        this.finishAllocation = requireNonNull(finishAllocation, "finishAllocation is null");
+
+        this.userMemoryReservation = requireNonNull(userMemoryReservation, "userMemoryReservation is null");
+        this.revocableMemoryReservation = requireNonNull(revocableMemoryReservation, "revocableMemoryReservation is null");
+        this.systemMemoryReservation = requireNonNull(systemMemoryReservation, "systemMemoryReservation is null");
+
+        this.peakUserMemoryReservation = requireNonNull(peakUserMemoryReservation, "peakUserMemoryReservation is null");
+        this.peakSystemMemoryReservation = requireNonNull(peakSystemMemoryReservation, "peakSystemMemoryReservation is null");
+        this.peakTotalMemoryReservation = requireNonNull(peakTotalMemoryReservation, "peakTotalMemoryReservation is null");
+
+        this.spilledDataSize = requireNonNull(spilledDataSize, "spilledDataSize is null");
+
+        this.info = requireNonNull(info, "info is null");
+    }
+
+    public int getStageId()
+    {
+        return stageId;
+    }
+
+    public int getStageExecutionId()
+    {
+        return stageExecutionId;
+    }
+
+    public int getPipelineId()
+    {
+        return pipelineId;
+    }
+
+    public int getOperatorId()
+    {
+        return operatorId;
+    }
+
+    public PlanNodeId getPlanNodeId()
+    {
+        return planNodeId;
+    }
+
+    public String getOperatorType()
+    {
+        return operatorType;
+    }
+
+    public long getTotalDrivers()
+    {
+        return totalDrivers;
+    }
+
+    public long getAddInputCalls()
+    {
+        return addInputCalls;
+    }
+
+    public Duration getAddInputWall()
+    {
+        return addInputWall;
+    }
+
+    public Duration getAddInputCpu()
+    {
+        return addInputCpu;
+    }
+
+    public DataSize getAddInputAllocation()
+    {
+        return addInputAllocation;
+    }
+
+    public DataSize getRawInputDataSize()
+    {
+        return rawInputDataSize;
+    }
+
+    public long getRawInputPositions()
+    {
+        return rawInputPositions;
+    }
+
+    public DataSize getInputDataSize()
+    {
+        return inputDataSize;
+    }
+
+    public long getInputPositions()
+    {
+        return inputPositions;
+    }
+
+    public double getSumSquaredInputPositions()
+    {
+        return sumSquaredInputPositions;
+    }
+
+    public long getGetOutputCalls()
+    {
+        return getOutputCalls;
+    }
+
+    public Duration getGetOutputWall()
+    {
+        return getOutputWall;
+    }
+
+    public Duration getGetOutputCpu()
+    {
+        return getOutputCpu;
+    }
+
+    public DataSize getGetOutputAllocation()
+    {
+        return getOutputAllocation;
+    }
+
+    public DataSize getOutputDataSize()
+    {
+        return outputDataSize;
+    }
+
+    public long getOutputPositions()
+    {
+        return outputPositions;
+    }
+
+    public DataSize getPhysicalWrittenDataSize()
+    {
+        return physicalWrittenDataSize;
+    }
+
+    public Duration getBlockedWall()
+    {
+        return blockedWall;
+    }
+
+    public long getFinishCalls()
+    {
+        return finishCalls;
+    }
+
+    public Duration getFinishWall()
+    {
+        return finishWall;
+    }
+
+    public Duration getFinishCpu()
+    {
+        return finishCpu;
+    }
+
+    public DataSize getFinishAllocation()
+    {
+        return finishAllocation;
+    }
+
+    public DataSize getUserMemoryReservation()
+    {
+        return userMemoryReservation;
+    }
+
+    public DataSize getRevocableMemoryReservation()
+    {
+        return revocableMemoryReservation;
+    }
+
+    public DataSize getSystemMemoryReservation()
+    {
+        return systemMemoryReservation;
+    }
+
+    public DataSize getPeakUserMemoryReservation()
+    {
+        return peakUserMemoryReservation;
+    }
+
+    public DataSize getPeakSystemMemoryReservation()
+    {
+        return peakSystemMemoryReservation;
+    }
+
+    public DataSize getPeakTotalMemoryReservation()
+    {
+        return peakTotalMemoryReservation;
+    }
+
+    public DataSize getSpilledDataSize()
+    {
+        return spilledDataSize;
+    }
+
+    public Optional<String> getInfo()
+    {
+        return info;
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/QueryCompletedEvent.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/QueryCompletedEvent.java
@@ -32,6 +32,8 @@ public class QueryCompletedEvent
     private final List<PrestoWarning> warnings;
     private final Optional<QueryType> queryType;
     private final List<String> failedTasks;
+    private final List<StageStatistics> stageStatistics;
+    private final List<OperatorStatistics> operatorStatistics;
 
     private final Instant createTime;
     private final Instant executionStartTime;
@@ -48,7 +50,9 @@ public class QueryCompletedEvent
             List<String> failedTasks,
             Instant createTime,
             Instant executionStartTime,
-            Instant endTime)
+            Instant endTime,
+            List<StageStatistics> stageStatistics,
+            List<OperatorStatistics> operatorStatistics)
     {
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.statistics = requireNonNull(statistics, "statistics is null");
@@ -61,6 +65,8 @@ public class QueryCompletedEvent
         this.createTime = requireNonNull(createTime, "createTime is null");
         this.executionStartTime = requireNonNull(executionStartTime, "executionStartTime is null");
         this.endTime = requireNonNull(endTime, "endTime is null");
+        this.stageStatistics = requireNonNull(stageStatistics, "stageStatistics is null");
+        this.operatorStatistics = requireNonNull(operatorStatistics, "operatorStatistics is null");
     }
 
     public QueryMetadata getMetadata()
@@ -116,5 +122,15 @@ public class QueryCompletedEvent
     public Instant getEndTime()
     {
         return endTime;
+    }
+
+    public List<StageStatistics> getStageStatistics()
+    {
+        return stageStatistics;
+    }
+
+    public List<OperatorStatistics> getOperatorStatistics()
+    {
+        return operatorStatistics;
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/QueryStatistics.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/QueryStatistics.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.spi.eventlistener;
 
 import java.time.Duration;
-import java.util.List;
 import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
@@ -44,15 +43,8 @@ public class QueryStatistics
 
     private final double cumulativeMemory;
 
-    private final List<StageGcStatistics> stageGcStatistics;
-
     private final int completedSplits;
     private final boolean complete;
-
-    private final List<ResourceDistribution> cpuTimeDistribution;
-    private final List<ResourceDistribution> peakMemoryDistribution;
-
-    private final List<String> operatorSummaries;
 
     public QueryStatistics(
             Duration cpuTime,
@@ -74,12 +66,8 @@ public class QueryStatistics
             long writtenIntermediateBytes,
             long spilledBytes,
             double cumulativeMemory,
-            List<StageGcStatistics> stageGcStatistics,
             int completedSplits,
-            boolean complete,
-            List<ResourceDistribution> cpuTimeDistribution,
-            List<ResourceDistribution> peakMemoryDistribution,
-            List<String> operatorSummaries)
+            boolean complete)
     {
         this.cpuTime = requireNonNull(cpuTime, "cpuTime is null");
         this.retriedCpuTime = requireNonNull(retriedCpuTime, "retriedCpuTime is null");
@@ -100,12 +88,8 @@ public class QueryStatistics
         this.writtenIntermediateBytes = writtenIntermediateBytes;
         this.spilledBytes = spilledBytes;
         this.cumulativeMemory = cumulativeMemory;
-        this.stageGcStatistics = requireNonNull(stageGcStatistics, "stageGcStatistics is null");
         this.completedSplits = completedSplits;
         this.complete = complete;
-        this.cpuTimeDistribution = requireNonNull(cpuTimeDistribution, "cpuTimeDistribution is null");
-        this.peakMemoryDistribution = requireNonNull(peakMemoryDistribution, "peakMemoryDistribution is null");
-        this.operatorSummaries = requireNonNull(operatorSummaries, "operatorSummaries is null");
     }
 
     public Duration getCpuTime()
@@ -203,11 +187,6 @@ public class QueryStatistics
         return cumulativeMemory;
     }
 
-    public List<StageGcStatistics> getStageGcStatistics()
-    {
-        return stageGcStatistics;
-    }
-
     public int getCompletedSplits()
     {
         return completedSplits;
@@ -216,20 +195,5 @@ public class QueryStatistics
     public boolean isComplete()
     {
         return complete;
-    }
-
-    public List<ResourceDistribution> getCpuTimeDistribution()
-    {
-        return cpuTimeDistribution;
-    }
-
-    public List<ResourceDistribution> getPeakMemoryDistribution()
-    {
-        return peakMemoryDistribution;
-    }
-
-    public List<String> getOperatorSummaries()
-    {
-        return operatorSummaries;
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/ResourceDistribution.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/ResourceDistribution.java
@@ -18,8 +18,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class ResourceDistribution
 {
-    private final int stageId;
-    private final int tasks;
     private final long p25;
     private final long p50;
     private final long p75;
@@ -33,8 +31,6 @@ public class ResourceDistribution
 
     @JsonCreator
     public ResourceDistribution(
-            @JsonProperty("stageId") int stageId,
-            @JsonProperty("tasks") int tasks,
             @JsonProperty("p25") long p25,
             @JsonProperty("p50") long p50,
             @JsonProperty("p75") long p75,
@@ -46,8 +42,6 @@ public class ResourceDistribution
             @JsonProperty("total") long total,
             @JsonProperty("average") double average)
     {
-        this.stageId = stageId;
-        this.tasks = tasks;
         this.p25 = p25;
         this.p50 = p50;
         this.p75 = p75;
@@ -58,18 +52,6 @@ public class ResourceDistribution
         this.max = max;
         this.total = total;
         this.average = average;
-    }
-
-    @JsonProperty
-    public int getStageId()
-    {
-        return stageId;
-    }
-
-    @JsonProperty
-    public int getTasks()
-    {
-        return tasks;
     }
 
     @JsonProperty

--- a/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/StageStatistics.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/StageStatistics.java
@@ -1,0 +1,134 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.eventlistener;
+
+import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
+
+import static java.util.Objects.requireNonNull;
+
+public class StageStatistics
+{
+    private final int stageId;
+    private final int stageExecutionId;
+    private final int tasks;
+
+    private final Duration totalScheduledTime;
+    private final Duration totalCpuTime;
+    private final Duration retriedCpuTime;
+    private final Duration totalBlockedTime;
+
+    private final DataSize rawInputDataSize;
+    private final DataSize processedInputDataSize;
+    private final DataSize physicalWrittenDataSize;
+
+    private final StageGcStatistics gcStatistics;
+    private final ResourceDistribution cpuDistribution;
+    private final ResourceDistribution memoryDistribution;
+
+    public StageStatistics(
+            int stageId,
+            int stageExecutionId,
+            int tasks,
+            Duration totalScheduledTime,
+            Duration totalCpuTime,
+            Duration retriedCpuTime,
+            Duration totalBlockedTime,
+            DataSize rawInputDataSize,
+            DataSize processedInputDataSize,
+            DataSize physicalWrittenDataSize,
+            StageGcStatistics gcStatistics,
+            ResourceDistribution cpuDistribution,
+            ResourceDistribution memoryDistribution)
+    {
+        this.stageId = stageId;
+        this.stageExecutionId = stageExecutionId;
+        this.tasks = tasks;
+        this.totalScheduledTime = requireNonNull(totalScheduledTime, "totalScheduledTime is null");
+        this.totalCpuTime = requireNonNull(totalCpuTime, "totalCpuTime is null");
+        this.retriedCpuTime = requireNonNull(retriedCpuTime, "retriedCpuTime is null");
+        this.totalBlockedTime = requireNonNull(totalBlockedTime, "totalBlockedTime is null");
+        this.rawInputDataSize = requireNonNull(rawInputDataSize, "rawDataInputSize is null");
+        this.processedInputDataSize = requireNonNull(processedInputDataSize, "processedInputDataSize is null");
+        this.physicalWrittenDataSize = requireNonNull(physicalWrittenDataSize, "physicalWrittenDataSize is null");
+        this.gcStatistics = requireNonNull(gcStatistics, "gcStatistics is null");
+        this.cpuDistribution = requireNonNull(cpuDistribution, "cpuDistribution is null");
+        this.memoryDistribution = requireNonNull(memoryDistribution, "memoryDistribution is null");
+    }
+
+    public int getStageId()
+    {
+        return stageId;
+    }
+
+    public int getStageExecutionId()
+    {
+        return stageExecutionId;
+    }
+
+    public int getTasks()
+    {
+        return tasks;
+    }
+
+    public Duration getTotalScheduledTime()
+    {
+        return totalScheduledTime;
+    }
+
+    public Duration getTotalCpuTime()
+    {
+        return totalCpuTime;
+    }
+
+    public Duration getRetriedCpuTime()
+    {
+        return retriedCpuTime;
+    }
+
+    public Duration getTotalBlockedTime()
+    {
+        return totalBlockedTime;
+    }
+
+    public DataSize getRawInputDataSize()
+    {
+        return rawInputDataSize;
+    }
+
+    public DataSize getProcessedInputDataSize()
+    {
+        return processedInputDataSize;
+    }
+
+    public DataSize getPhysicalWrittenDataSize()
+    {
+        return physicalWrittenDataSize;
+    }
+
+    public StageGcStatistics getGcStatistics()
+    {
+        return gcStatistics;
+    }
+
+    public ResourceDistribution getCpuDistribution()
+    {
+        return cpuDistribution;
+    }
+
+    public ResourceDistribution getMemoryDistribution()
+    {
+        return memoryDistribution;
+    }
+}


### PR DESCRIPTION
Add new classes `StageStatistics` and `OperatorStatistics` which helps add
stage and operator level stats when the query completes. In addition to this,
removed all operator and stage related stats from QueryCompletedEvent

This change is necessary because of 2 reasons:

1. By moving from JSON to structured objects, it helps us to better understand
   what is being logged and the users of this data, can log this structured data
   more efficiently
2. It should make adding new stats a lot easier since we have the 3 layers of
   abstraction clearly there now - query, stage, operator

This PR does duplicate a lot of fields in `StageExecutionStats` as `StageStatistics` and `OperatorStats` in `OperatorStatistics`, but I feel that the separate classes are a better way forward since all the fields are not really suitable for end of query stats (like `runningDrivers`). In addition to that, while adding a new entry to the `*Statistics` class will make people ensure that this is indeed information that the developer wants to export in stats.

Test plan - Unittests in Travis and ran local test runs where I ensured that the appropriate fields are being logged correctly.

```
== RELEASE NOTES ==

SPI Changes
* Add ``StageStatistics`` and ``OperatorStatistics`` to ``QueryCompletedEvent`` and remove stage and operator statistics from ``QueryStatistics``.
```