### PR TITLE
Add support for versioning metastore API

### DIFF
--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/MetastoreClientConfig.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/MetastoreClientConfig.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.hive;
 
 import com.facebook.airlift.configuration.Config;
+import com.facebook.presto.hive.metastore.CachingHiveMetastore.MetastoreCacheScope;
 import com.google.common.net.HostAndPort;
 import io.airlift.units.Duration;
 import io.airlift.units.MinDuration;
@@ -41,6 +42,8 @@ public class MetastoreClientConfig
     private String recordingPath;
     private boolean replay;
     private Duration recordingDuration = new Duration(0, MINUTES);
+    private boolean partitionVersioningEnabled;
+    private MetastoreCacheScope metastoreCacheScope = MetastoreCacheScope.ALL;
 
     public HostAndPort getMetastoreSocksProxy()
     {
@@ -192,6 +195,31 @@ public class MetastoreClientConfig
     public MetastoreClientConfig setRequireHadoopNative(boolean requireHadoopNative)
     {
         this.requireHadoopNative = requireHadoopNative;
+        return this;
+    }
+
+    public boolean isPartitionVersioningEnabled()
+    {
+        return partitionVersioningEnabled;
+    }
+
+    @Config("hive.partition-versioning-enabled")
+    public MetastoreClientConfig setPartitionVersioningEnabled(boolean partitionVersioningEnabled)
+    {
+        this.partitionVersioningEnabled = partitionVersioningEnabled;
+        return this;
+    }
+
+    @NotNull
+    public MetastoreCacheScope getMetastoreCacheScope()
+    {
+        return metastoreCacheScope;
+    }
+
+    @Config("hive.metastore-cache-scope")
+    public MetastoreClientConfig setMetastoreCacheScope(MetastoreCacheScope metastoreCacheScope)
+    {
+        this.metastoreCacheScope = metastoreCacheScope;
         return this;
     }
 }

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/PartitionVersionFetcher.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/PartitionVersionFetcher.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import org.apache.hadoop.hive.metastore.api.Partition;
+
+import java.util.Optional;
+
+public interface PartitionVersionFetcher
+{
+    Optional<Integer> getPartitionVersion(Partition partition);
+}

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/CachingHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/CachingHiveMetastore.java
@@ -48,6 +48,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.function.Function;
 
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_PARTITION_DROPPED_DURING_QUERY;
+import static com.facebook.presto.hive.metastore.CachingHiveMetastore.MetastoreCacheScope.ALL;
 import static com.facebook.presto.hive.metastore.HivePartitionName.hivePartitionName;
 import static com.facebook.presto.hive.metastore.HiveTableName.hiveTableName;
 import static com.facebook.presto.hive.metastore.PartitionFilter.partitionFilter;
@@ -92,25 +93,41 @@ public class CachingHiveMetastore
     private final LoadingCache<String, Set<String>> rolesCache;
     private final LoadingCache<PrestoPrincipal, Set<RoleGrant>> roleGrantsCache;
 
+    private final boolean partitionVersioningEnabled;
+
     @Inject
-    public CachingHiveMetastore(@ForCachingHiveMetastore ExtendedHiveMetastore delegate, @ForCachingHiveMetastore ExecutorService executor, MetastoreClientConfig metastoreClientConfig)
+    public CachingHiveMetastore(
+            @ForCachingHiveMetastore ExtendedHiveMetastore delegate,
+            @ForCachingHiveMetastore ExecutorService executor,
+            MetastoreClientConfig metastoreClientConfig)
     {
         this(
                 delegate,
                 executor,
                 metastoreClientConfig.getMetastoreCacheTtl(),
                 metastoreClientConfig.getMetastoreRefreshInterval(),
-                metastoreClientConfig.getMetastoreCacheMaximumSize());
+                metastoreClientConfig.getMetastoreCacheMaximumSize(),
+                metastoreClientConfig.isPartitionVersioningEnabled(),
+                metastoreClientConfig.getMetastoreCacheScope());
     }
 
-    public CachingHiveMetastore(ExtendedHiveMetastore delegate, ExecutorService executor, Duration cacheTtl, Duration refreshInterval, long maximumSize)
+    public CachingHiveMetastore(
+            ExtendedHiveMetastore delegate,
+            ExecutorService executor,
+            Duration cacheTtl,
+            Duration refreshInterval,
+            long maximumSize,
+            boolean partitionVersioningEnabled,
+            MetastoreCacheScope metastoreCacheScope)
     {
         this(
                 delegate,
                 executor,
                 OptionalLong.of(cacheTtl.toMillis()),
                 refreshInterval.toMillis() >= cacheTtl.toMillis() ? OptionalLong.empty() : OptionalLong.of(refreshInterval.toMillis()),
-                maximumSize);
+                maximumSize,
+                partitionVersioningEnabled,
+                metastoreCacheScope);
     }
 
     public static CachingHiveMetastore memoizeMetastore(ExtendedHiveMetastore delegate, long maximumSize)
@@ -120,24 +137,65 @@ public class CachingHiveMetastore
                 newDirectExecutorService(),
                 OptionalLong.empty(),
                 OptionalLong.empty(),
-                maximumSize);
+                maximumSize,
+                false,
+                ALL);
     }
 
-    private CachingHiveMetastore(ExtendedHiveMetastore delegate, ExecutorService executor, OptionalLong expiresAfterWriteMillis, OptionalLong refreshMills, long maximumSize)
+    private CachingHiveMetastore(
+            ExtendedHiveMetastore delegate,
+            ExecutorService executor,
+            OptionalLong expiresAfterWriteMillis,
+            OptionalLong refreshMills,
+            long maximumSize,
+            boolean partitionVersioningEnabled,
+            MetastoreCacheScope metastoreCacheScope)
     {
         this.delegate = requireNonNull(delegate, "delegate is null");
         requireNonNull(executor, "executor is null");
+        this.partitionVersioningEnabled = partitionVersioningEnabled;
 
-        databaseNamesCache = newCacheBuilder(expiresAfterWriteMillis, refreshMills, maximumSize)
+        OptionalLong cacheExpiresAfterWriteMillis;
+        OptionalLong cacheRefreshMills;
+        long cacheMaxSize;
+
+        OptionalLong partitionCacheExpiresAfterWriteMillis;
+        OptionalLong partitionCacheRefreshMills;
+        long partitionCacheMaxSize;
+
+        switch (metastoreCacheScope) {
+            case PARTITION:
+                partitionCacheExpiresAfterWriteMillis = expiresAfterWriteMillis;
+                partitionCacheRefreshMills = refreshMills;
+                partitionCacheMaxSize = maximumSize;
+                cacheExpiresAfterWriteMillis = OptionalLong.of(0);
+                cacheRefreshMills = OptionalLong.of(0);
+                cacheMaxSize = 0;
+                break;
+
+            case ALL:
+                partitionCacheExpiresAfterWriteMillis = expiresAfterWriteMillis;
+                partitionCacheRefreshMills = refreshMills;
+                partitionCacheMaxSize = maximumSize;
+                cacheExpiresAfterWriteMillis = expiresAfterWriteMillis;
+                cacheRefreshMills = refreshMills;
+                cacheMaxSize = maximumSize;
+                break;
+
+            default:
+                throw new IllegalArgumentException("Unknown metastore-cache-scope: " + metastoreCacheScope);
+        }
+
+        databaseNamesCache = newCacheBuilder(cacheExpiresAfterWriteMillis, cacheRefreshMills, cacheMaxSize)
                 .build(asyncReloading(CacheLoader.from(this::loadAllDatabases), executor));
 
-        databaseCache = newCacheBuilder(expiresAfterWriteMillis, refreshMills, maximumSize)
+        databaseCache = newCacheBuilder(cacheExpiresAfterWriteMillis, cacheRefreshMills, cacheMaxSize)
                 .build(asyncReloading(CacheLoader.from(this::loadDatabase), executor));
 
-        tableNamesCache = newCacheBuilder(expiresAfterWriteMillis, refreshMills, maximumSize)
+        tableNamesCache = newCacheBuilder(cacheExpiresAfterWriteMillis, cacheRefreshMills, cacheMaxSize)
                 .build(asyncReloading(CacheLoader.from(this::loadAllTables), executor));
 
-        tableStatisticsCache = newCacheBuilder(expiresAfterWriteMillis, refreshMills, maximumSize)
+        tableStatisticsCache = newCacheBuilder(cacheExpiresAfterWriteMillis, cacheRefreshMills, cacheMaxSize)
                 .build(asyncReloading(new CacheLoader<HiveTableName, PartitionStatistics>()
                 {
                     @Override
@@ -147,7 +205,7 @@ public class CachingHiveMetastore
                     }
                 }, executor));
 
-        partitionStatisticsCache = newCacheBuilder(expiresAfterWriteMillis, refreshMills, maximumSize)
+        partitionStatisticsCache = newCacheBuilder(partitionCacheExpiresAfterWriteMillis, partitionCacheRefreshMills, partitionCacheMaxSize)
                 .build(asyncReloading(new CacheLoader<HivePartitionName, PartitionStatistics>()
                 {
                     @Override
@@ -163,19 +221,19 @@ public class CachingHiveMetastore
                     }
                 }, executor));
 
-        tableCache = newCacheBuilder(expiresAfterWriteMillis, refreshMills, maximumSize)
+        tableCache = newCacheBuilder(cacheExpiresAfterWriteMillis, cacheRefreshMills, cacheMaxSize)
                 .build(asyncReloading(CacheLoader.from(this::loadTable), executor));
 
-        viewNamesCache = newCacheBuilder(expiresAfterWriteMillis, refreshMills, maximumSize)
+        viewNamesCache = newCacheBuilder(cacheExpiresAfterWriteMillis, cacheRefreshMills, cacheMaxSize)
                 .build(asyncReloading(CacheLoader.from(this::loadAllViews), executor));
 
-        partitionNamesCache = newCacheBuilder(expiresAfterWriteMillis, refreshMills, maximumSize)
+        partitionNamesCache = newCacheBuilder(cacheExpiresAfterWriteMillis, cacheRefreshMills, cacheMaxSize)
                 .build(asyncReloading(CacheLoader.from(this::loadPartitionNames), executor));
 
-        partitionFilterCache = newCacheBuilder(expiresAfterWriteMillis, refreshMills, maximumSize)
+        partitionFilterCache = newCacheBuilder(cacheExpiresAfterWriteMillis, cacheRefreshMills, cacheMaxSize)
                 .build(asyncReloading(CacheLoader.from(this::loadPartitionNamesByFilter), executor));
 
-        partitionCache = newCacheBuilder(expiresAfterWriteMillis, refreshMills, maximumSize)
+        partitionCache = newCacheBuilder(partitionCacheExpiresAfterWriteMillis, partitionCacheRefreshMills, partitionCacheMaxSize)
                 .build(asyncReloading(new CacheLoader<HivePartitionName, Optional<Partition>>()
                 {
                     @Override
@@ -191,13 +249,13 @@ public class CachingHiveMetastore
                     }
                 }, executor));
 
-        tablePrivilegesCache = newCacheBuilder(expiresAfterWriteMillis, refreshMills, maximumSize)
+        tablePrivilegesCache = newCacheBuilder(cacheExpiresAfterWriteMillis, cacheRefreshMills, cacheMaxSize)
                 .build(asyncReloading(CacheLoader.from(key -> loadTablePrivileges(key.getDatabase(), key.getTable(), key.getPrincipal())), executor));
 
-        rolesCache = newCacheBuilder(expiresAfterWriteMillis, refreshMills, maximumSize)
+        rolesCache = newCacheBuilder(cacheExpiresAfterWriteMillis, cacheRefreshMills, cacheMaxSize)
                 .build(asyncReloading(CacheLoader.from(() -> loadRoles()), executor));
 
-        roleGrantsCache = newCacheBuilder(expiresAfterWriteMillis, refreshMills, maximumSize)
+        roleGrantsCache = newCacheBuilder(cacheExpiresAfterWriteMillis, cacheRefreshMills, cacheMaxSize)
                 .build(asyncReloading(CacheLoader.from(this::loadRoleGrants), executor));
     }
 
@@ -535,9 +593,37 @@ public class CachingHiveMetastore
             String tableName,
             Map<Column, Domain> partitionPredicates)
     {
+        if (partitionVersioningEnabled) {
+            List<PartitionNameWithVersion> partitionNamesWithVersion = getPartitionNamesWithVersionByFilter(databaseName, tableName, partitionPredicates);
+            List<String> result = partitionNamesWithVersion.stream().map(PartitionNameWithVersion::getPartitionName).collect(toImmutableList());
+            partitionNamesWithVersion.forEach(partitionNameWithVersion -> invalidateStalePartition(partitionNameWithVersion, databaseName, tableName));
+            return result;
+        }
         return get(
                 partitionFilterCache,
                 partitionFilter(databaseName, tableName, partitionPredicates));
+    }
+
+    @Override
+    public List<PartitionNameWithVersion> getPartitionNamesWithVersionByFilter(
+            String databaseName,
+            String tableName,
+            Map<Column, Domain> partitionPredicates)
+    {
+        return delegate.getPartitionNamesWithVersionByFilter(databaseName, tableName, partitionPredicates);
+    }
+
+    private void invalidateStalePartition(PartitionNameWithVersion partitionNameWithVersion, String databaseName, String tableName)
+    {
+        HivePartitionName hivePartitionName = hivePartitionName(databaseName, tableName, partitionNameWithVersion.getPartitionName());
+        Optional<Partition> partition = partitionCache.getIfPresent(hivePartitionName);
+        if (partition != null && partition.isPresent()) {
+            Optional<Integer> partitionVersion = partition.get().getPartitionVersion();
+            if (!partitionVersion.isPresent() || partitionVersion.get() < partitionNameWithVersion.getPartitionVersion()) {
+                partitionCache.invalidate(hivePartitionName);
+                partitionStatisticsCache.invalidate(hivePartitionName);
+            }
+        }
     }
 
     private List<String> loadPartitionNamesByFilter(PartitionFilter partitionFilter)

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/CachingHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/CachingHiveMetastore.java
@@ -72,6 +72,11 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 public class CachingHiveMetastore
         implements ExtendedHiveMetastore
 {
+    public enum MetastoreCacheScope
+    {
+        ALL, PARTITION
+    }
+
     protected final ExtendedHiveMetastore delegate;
     private final LoadingCache<String, Optional<Database>> databaseCache;
     private final LoadingCache<String, List<String>> databaseNamesCache;

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/ExtendedHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/ExtendedHiveMetastore.java
@@ -82,6 +82,11 @@ public interface ExtendedHiveMetastore
             String tableName,
             Map<Column, Domain> partitionPredicates);
 
+    List<PartitionNameWithVersion> getPartitionNamesWithVersionByFilter(
+            String databaseName,
+            String tableName,
+            Map<Column, Domain> partitionPredicates);
+
     Map<String, Optional<Partition>> getPartitionsByNames(String databaseName, String tableName, List<String> partitionNames);
 
     void addPartitions(String databaseName, String tableName, List<PartitionWithStatistics> partitions);

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/HivePartitionVersionFetcher.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/HivePartitionVersionFetcher.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.metastore;
+
+import com.facebook.presto.hive.PartitionVersionFetcher;
+import org.apache.hadoop.hive.metastore.api.Partition;
+
+import javax.inject.Inject;
+
+import java.util.Optional;
+
+public class HivePartitionVersionFetcher
+        implements PartitionVersionFetcher
+{
+    @Inject
+    public HivePartitionVersionFetcher() {}
+
+    @Override
+    public Optional<Integer> getPartitionVersion(Partition partition)
+    {
+        return Optional.empty();
+    }
+}

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/Partition.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/Partition.java
@@ -23,6 +23,7 @@ import javax.annotation.concurrent.Immutable;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Consumer;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -37,6 +38,7 @@ public class Partition
     private final Storage storage;
     private final List<Column> columns;
     private final Map<String, String> parameters;
+    private final Optional<Integer> partitionVersion;
 
     @JsonCreator
     public Partition(
@@ -45,7 +47,8 @@ public class Partition
             @JsonProperty("values") List<String> values,
             @JsonProperty("storage") Storage storage,
             @JsonProperty("columns") List<Column> columns,
-            @JsonProperty("parameters") Map<String, String> parameters)
+            @JsonProperty("parameters") Map<String, String> parameters,
+            @JsonProperty("partitionVersion") Optional<Integer> partitionVersion)
     {
         this.databaseName = requireNonNull(databaseName, "databaseName is null");
         this.tableName = requireNonNull(tableName, "tableName is null");
@@ -53,6 +56,7 @@ public class Partition
         this.storage = requireNonNull(storage, "storage is null");
         this.columns = ImmutableList.copyOf(requireNonNull(columns, "columns is null"));
         this.parameters = ImmutableMap.copyOf(requireNonNull(parameters, "parameters is null"));
+        this.partitionVersion = requireNonNull(partitionVersion, "partitionVersion is null");
     }
 
     @JsonProperty
@@ -91,6 +95,12 @@ public class Partition
         return parameters;
     }
 
+    @JsonProperty
+    public Optional<Integer> getPartitionVersion()
+    {
+        return partitionVersion;
+    }
+
     @Override
     public String toString()
     {
@@ -117,13 +127,14 @@ public class Partition
                 Objects.equals(values, partition.values) &&
                 Objects.equals(storage, partition.storage) &&
                 Objects.equals(columns, partition.columns) &&
-                Objects.equals(parameters, partition.parameters);
+                Objects.equals(parameters, partition.parameters) &&
+                Objects.equals(partitionVersion, partition.partitionVersion);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(databaseName, tableName, values, storage, columns, parameters);
+        return Objects.hash(databaseName, tableName, values, storage, columns, parameters, partitionVersion);
     }
 
     public static Builder builder()
@@ -144,6 +155,7 @@ public class Partition
         private List<String> values;
         private List<Column> columns;
         private Map<String, String> parameters = ImmutableMap.of();
+        private Optional<Integer> partitionVersion = Optional.empty();
 
         private Builder()
         {
@@ -158,6 +170,7 @@ public class Partition
             this.values = partition.getValues();
             this.columns = partition.getColumns();
             this.parameters = partition.getParameters();
+            this.partitionVersion = partition.getPartitionVersion();
         }
 
         public Builder setDatabaseName(String databaseName)
@@ -201,9 +214,15 @@ public class Partition
             return this;
         }
 
+        public Builder setPartitionVersion(int partitionVersion)
+        {
+            this.partitionVersion = Optional.of(partitionVersion);
+            return this;
+        }
+
         public Partition build()
         {
-            return new Partition(databaseName, tableName, values, storageBuilder.build(), columns, parameters);
+            return new Partition(databaseName, tableName, values, storageBuilder.build(), columns, parameters, partitionVersion);
         }
     }
 }

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/PartitionNameWithVersion.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/PartitionNameWithVersion.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.metastore;
+
+import static java.util.Objects.requireNonNull;
+
+public class PartitionNameWithVersion
+{
+    private final String partitionName;
+    private final int partitionVersion;
+
+    public PartitionNameWithVersion(String partitionName, int partitionVersion)
+    {
+        this.partitionName = requireNonNull(partitionName, "partitionName is null");
+        this.partitionVersion = partitionVersion;
+    }
+
+    public String getPartitionName()
+    {
+        return partitionName;
+    }
+
+    public int getPartitionVersion()
+    {
+        return partitionVersion;
+    }
+}

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/RecordingHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/RecordingHiveMetastore.java
@@ -356,6 +356,15 @@ public class RecordingHiveMetastore
     }
 
     @Override
+    public List<PartitionNameWithVersion> getPartitionNamesWithVersionByFilter(
+            String databaseName,
+            String tableName,
+            Map<Column, Domain> partitionPredicates)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public Map<String, Optional<Partition>> getPartitionsByNames(String databaseName, String tableName, List<String> partitionNames)
     {
         return loadValue(

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/alluxio/AlluxioHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/alluxio/AlluxioHiveMetastore.java
@@ -29,6 +29,7 @@ import com.facebook.presto.hive.metastore.HiveColumnStatistics;
 import com.facebook.presto.hive.metastore.HivePrivilegeInfo;
 import com.facebook.presto.hive.metastore.MetastoreUtil;
 import com.facebook.presto.hive.metastore.Partition;
+import com.facebook.presto.hive.metastore.PartitionNameWithVersion;
 import com.facebook.presto.hive.metastore.PartitionStatistics;
 import com.facebook.presto.hive.metastore.PartitionWithStatistics;
 import com.facebook.presto.hive.metastore.PrincipalPrivileges;
@@ -296,6 +297,15 @@ public class AlluxioHiveMetastore
     {
         List<String> parts = convertPredicateToParts(partitionPredicates);
         return getPartitionNamesByParts(databaseName, tableName, parts).orElse(ImmutableList.of());
+    }
+
+    @Override
+    public List<PartitionNameWithVersion> getPartitionNamesWithVersionByFilter(
+            String databaseName,
+            String tableName,
+            Map<Column, Domain> partitionPredicates)
+    {
+        throw new UnsupportedOperationException();
     }
 
     /**

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/file/FileHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/file/FileHiveMetastore.java
@@ -30,6 +30,7 @@ import com.facebook.presto.hive.metastore.HiveColumnStatistics;
 import com.facebook.presto.hive.metastore.HivePrivilegeInfo;
 import com.facebook.presto.hive.metastore.MetastoreUtil;
 import com.facebook.presto.hive.metastore.Partition;
+import com.facebook.presto.hive.metastore.PartitionNameWithVersion;
 import com.facebook.presto.hive.metastore.PartitionStatistics;
 import com.facebook.presto.hive.metastore.PartitionWithStatistics;
 import com.facebook.presto.hive.metastore.PrincipalPrivileges;
@@ -907,6 +908,15 @@ public class FileHiveMetastore
                 .filter(partitionName -> partitionMatches(partitionName, parts))
                 .collect(toImmutableList()))
                 .orElse(ImmutableList.of());
+    }
+
+    @Override
+    public List<PartitionNameWithVersion> getPartitionNamesWithVersionByFilter(
+            String databaseName,
+            String tableName,
+            Map<Column, Domain> partitionPredicates)
+    {
+        throw new UnsupportedOperationException();
     }
 
     private static boolean partitionMatches(String partitionName, List<String> parts)

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/file/PartitionMetadata.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/file/PartitionMetadata.java
@@ -174,6 +174,7 @@ public class PartitionMetadata
                         .setParameters(parameters)
                         .build(),
                 columns,
-                parameters);
+                parameters,
+                Optional.empty());
     }
 }

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/glue/GlueHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/glue/GlueHiveMetastore.java
@@ -67,6 +67,7 @@ import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
 import com.facebook.presto.hive.metastore.HivePrivilegeInfo;
 import com.facebook.presto.hive.metastore.MetastoreUtil;
 import com.facebook.presto.hive.metastore.Partition;
+import com.facebook.presto.hive.metastore.PartitionNameWithVersion;
 import com.facebook.presto.hive.metastore.PartitionStatistics;
 import com.facebook.presto.hive.metastore.PartitionWithStatistics;
 import com.facebook.presto.hive.metastore.PrincipalPrivileges;
@@ -672,6 +673,15 @@ public class GlueHiveMetastore
         String expression = buildGlueExpression(table.getPartitionColumns(), parts);
         List<Partition> partitions = getPartitions(databaseName, tableName, expression);
         return buildPartitionNames(table.getPartitionColumns(), partitions);
+    }
+
+    @Override
+    public List<PartitionNameWithVersion> getPartitionNamesWithVersionByFilter(
+            String databaseName,
+            String tableName,
+            Map<Column, Domain> partitionPredicates)
+    {
+        throw new UnsupportedOperationException();
     }
 
     private List<Partition> getPartitions(String databaseName, String tableName, String expression)

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/BridgingHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/BridgingHiveMetastore.java
@@ -23,6 +23,7 @@ import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
 import com.facebook.presto.hive.metastore.HivePrivilegeInfo;
 import com.facebook.presto.hive.metastore.MetastoreUtil;
 import com.facebook.presto.hive.metastore.Partition;
+import com.facebook.presto.hive.metastore.PartitionNameWithVersion;
 import com.facebook.presto.hive.metastore.PartitionStatistics;
 import com.facebook.presto.hive.metastore.PartitionWithStatistics;
 import com.facebook.presto.hive.metastore.PrincipalPrivileges;
@@ -264,6 +265,15 @@ public class BridgingHiveMetastore
             Map<Column, Domain> partitionPredicates)
     {
         return delegate.getPartitionNamesByFilter(databaseName, tableName, partitionPredicates);
+    }
+
+    @Override
+    public List<PartitionNameWithVersion> getPartitionNamesWithVersionByFilter(
+            String databaseName,
+            String tableName,
+            Map<Column, Domain> partitionPredicates)
+    {
+        return delegate.getPartitionNamesWithVersionByFilter(databaseName, tableName, partitionPredicates);
     }
 
     @Override

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/HiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/HiveMetastore.java
@@ -17,6 +17,7 @@ import com.facebook.presto.common.predicate.Domain;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.hive.metastore.Column;
 import com.facebook.presto.hive.metastore.HivePrivilegeInfo;
+import com.facebook.presto.hive.metastore.PartitionNameWithVersion;
 import com.facebook.presto.hive.metastore.PartitionStatistics;
 import com.facebook.presto.hive.metastore.PartitionWithStatistics;
 import com.facebook.presto.spi.PrestoException;
@@ -71,6 +72,11 @@ public interface HiveMetastore
     Optional<List<String>> getPartitionNamesByParts(String databaseName, String tableName, List<String> parts);
 
     List<String> getPartitionNamesByFilter(String databaseName, String tableName, Map<Column, Domain> partitionPredicates);
+
+    default List<PartitionNameWithVersion> getPartitionNamesWithVersionByFilter(String databaseName, String tableName, Map<Column, Domain> partitionPredicates)
+    {
+        throw new UnsupportedOperationException();
+    }
 
     Optional<Partition> getPartition(String databaseName, String tableName, List<String> partitionValues);
 

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftMetastoreUtil.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftMetastoreUtil.java
@@ -15,6 +15,7 @@ package com.facebook.presto.hive.metastore.thrift;
 
 import com.facebook.presto.hive.HiveBucketProperty;
 import com.facebook.presto.hive.HiveType;
+import com.facebook.presto.hive.PartitionVersionFetcher;
 import com.facebook.presto.hive.metastore.Column;
 import com.facebook.presto.hive.metastore.Database;
 import com.facebook.presto.hive.metastore.HiveColumnStatistics;
@@ -436,7 +437,7 @@ public final class ThriftMetastoreUtil
                 serdeInfo.getSerializationLib().equals(AVRO.getSerDe());
     }
 
-    public static Partition fromMetastoreApiPartition(org.apache.hadoop.hive.metastore.api.Partition partition)
+    public static Partition fromMetastoreApiPartition(org.apache.hadoop.hive.metastore.api.Partition partition, PartitionVersionFetcher partitionVersionFetcher)
     {
         StorageDescriptor storageDescriptor = partition.getSd();
         if (storageDescriptor == null) {
@@ -451,6 +452,9 @@ public final class ThriftMetastoreUtil
                         .map(ThriftMetastoreUtil::fromMetastoreApiFieldSchema)
                         .collect(toList()))
                 .setParameters(partition.getParameters());
+
+        // set the partition version if available
+        partitionVersionFetcher.getPartitionVersion(partition).ifPresent(partitionBuilder::setPartitionVersion);
 
         fromMetastoreApiStorageDescriptor(storageDescriptor, partitionBuilder.getStorageBuilder(), format("%s.%s", partition.getTableName(), partition.getValues()));
 

--- a/presto-hive-metastore/src/test/java/com/facebook/presto/hive/MockHiveMetastore.java
+++ b/presto-hive-metastore/src/test/java/com/facebook/presto/hive/MockHiveMetastore.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.common.predicate.Domain;
+import com.facebook.presto.hive.metastore.Column;
+import com.facebook.presto.hive.metastore.PartitionNameWithVersion;
+import com.facebook.presto.hive.metastore.thrift.ThriftHiveMetastore;
+import com.facebook.presto.spi.PrestoException;
+import org.apache.thrift.TException;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.facebook.presto.hive.HiveErrorCode.HIVE_METASTORE_ERROR;
+import static com.facebook.presto.hive.metastore.TestCachingHiveMetastore.MockHiveCluster;
+import static java.util.Objects.requireNonNull;
+
+public class MockHiveMetastore
+        extends ThriftHiveMetastore
+{
+    private final MockHiveCluster clientProvider;
+
+    public MockHiveMetastore(MockHiveCluster mockHiveCluster)
+    {
+        super(mockHiveCluster);
+        this.clientProvider = requireNonNull(mockHiveCluster, "mockHiveCluster is null");
+    }
+
+    @Override
+    public List<PartitionNameWithVersion> getPartitionNamesWithVersionByFilter(String databaseName, String tableName, Map<Column, Domain> partitionPredicates)
+    {
+        try {
+            return clientProvider.createPartitionVersionSupportedMetastoreClient().getPartitionNamesWithVersionByFilter(databaseName, tableName, partitionPredicates);
+        }
+        catch (TException e) {
+            throw new PrestoException(HIVE_METASTORE_ERROR, e);
+        }
+    }
+}

--- a/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/TestCachingHiveMetastore.java
+++ b/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/TestCachingHiveMetastore.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.hive.metastore;
 
 import com.facebook.presto.hive.PartitionVersionFetcher;
+import com.facebook.presto.hive.metastore.CachingHiveMetastore.MetastoreCacheScope;
 import com.facebook.presto.hive.metastore.thrift.BridgingHiveMetastore;
 import com.facebook.presto.hive.metastore.thrift.HiveCluster;
 import com.facebook.presto.hive.metastore.thrift.HiveMetastoreClient;
@@ -66,7 +67,9 @@ public class TestCachingHiveMetastore
                 executor,
                 new Duration(5, TimeUnit.MINUTES),
                 new Duration(1, TimeUnit.MINUTES),
-                1000);
+                1000,
+                false,
+                MetastoreCacheScope.ALL);
         stats = thriftHiveMetastore.getStats();
     }
 

--- a/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/TestCachingHiveMetastore.java
+++ b/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/TestCachingHiveMetastore.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.hive.metastore;
 
+import com.facebook.presto.hive.MockHiveMetastore;
 import com.facebook.presto.hive.PartitionVersionFetcher;
 import com.facebook.presto.hive.metastore.CachingHiveMetastore.MetastoreCacheScope;
 import com.facebook.presto.hive.metastore.thrift.BridgingHiveMetastore;
@@ -170,6 +171,58 @@ public class TestCachingHiveMetastore
         assertEquals(mockClient.getAccessCount(), 2);
     }
 
+    @Test
+    public void testCachingWithPartitionVersioning()
+    {
+        MockHiveMetastoreClient mockClient = new MockHiveMetastoreClient();
+        MockHiveCluster mockHiveCluster = new MockHiveCluster(mockClient);
+        ListeningExecutorService executor = listeningDecorator(newCachedThreadPool(daemonThreadsNamed("partition-versioning-test-%s")));
+        MockHiveMetastore mockHiveMetastore = new MockHiveMetastore(mockHiveCluster);
+        PartitionVersionFetcher hivePartitionVersionFetcher = new HivePartitionVersionFetcher();
+        boolean partitionVersioningEnabled = true;
+        CachingHiveMetastore partitionCachingEnabledmetastore = new CachingHiveMetastore(
+                new BridgingHiveMetastore(mockHiveMetastore, hivePartitionVersionFetcher),
+                executor,
+                new Duration(5, TimeUnit.MINUTES),
+                new Duration(1, TimeUnit.MINUTES),
+                1000,
+                partitionVersioningEnabled,
+                MetastoreCacheScope.PARTITION);
+
+        ImmutableList<String> expectedPartitions = ImmutableList.of(TEST_PARTITION1, TEST_PARTITION2);
+
+        assertEquals(mockClient.getAccessCount(), 0);
+        assertEquals(partitionCachingEnabledmetastore.getPartitionNamesByFilter(TEST_DATABASE, TEST_TABLE, ImmutableMap.of()), expectedPartitions);
+        assertEquals(mockClient.getAccessCount(), 1);
+        assertEquals(partitionCachingEnabledmetastore.getPartitionNamesByFilter(TEST_DATABASE, TEST_TABLE, ImmutableMap.of()), expectedPartitions);
+        // Assert that we did not hit cache
+        assertEquals(mockClient.getAccessCount(), 2);
+
+        // Select all of the available partitions and load them into the cache
+        assertEquals(partitionCachingEnabledmetastore.getPartitionsByNames(TEST_DATABASE, TEST_TABLE, ImmutableList.of(TEST_PARTITION1, TEST_PARTITION2)).size(), 2);
+        assertEquals(mockClient.getAccessCount(), 3);
+
+        // Now if we fetch any or both of them, they should hit the cache
+        assertEquals(partitionCachingEnabledmetastore.getPartitionsByNames(TEST_DATABASE, TEST_TABLE, ImmutableList.of(TEST_PARTITION1)).size(), 1);
+        assertEquals(partitionCachingEnabledmetastore.getPartitionsByNames(TEST_DATABASE, TEST_TABLE, ImmutableList.of(TEST_PARTITION2)).size(), 1);
+        assertEquals(partitionCachingEnabledmetastore.getPartitionsByNames(TEST_DATABASE, TEST_TABLE, ImmutableList.of(TEST_PARTITION1, TEST_PARTITION2)).size(), 2);
+        assertEquals(mockClient.getAccessCount(), 3);
+
+        // This call should invalidate the partition cache because when partition versioning is enabled
+        // partitions with older or empty version will be deleted from cache. And the hivePartitionVersionFetcher used in creating
+        // partitionCachingEnabledmetastore will set the version as Optional.empty() for all the partitions fetched.
+        assertEquals(partitionCachingEnabledmetastore.getPartitionNamesByFilter(TEST_DATABASE, TEST_TABLE, ImmutableMap.of()), expectedPartitions);
+        assertEquals(mockClient.getAccessCount(), 4);
+
+        assertEquals(partitionCachingEnabledmetastore.getPartitionsByNames(TEST_DATABASE, TEST_TABLE, ImmutableList.of(TEST_PARTITION1, TEST_PARTITION2)).size(), 2);
+        // Assert that the previous cache entry is invalidated and that we did not hit the cache
+        assertEquals(mockClient.getAccessCount(), 5);
+
+        // Assert we hit the partition cache
+        assertEquals(partitionCachingEnabledmetastore.getPartitionsByNames(TEST_DATABASE, TEST_TABLE, ImmutableList.of(TEST_PARTITION1, TEST_PARTITION2)).size(), 2);
+        assertEquals(mockClient.getAccessCount(), 5);
+    }
+
     public void testInvalidGetPartitionNamesByParts()
     {
         assertTrue(metastore.getPartitionNamesByFilter(BAD_DATABASE, TEST_TABLE, ImmutableMap.of()).isEmpty());
@@ -261,18 +314,23 @@ public class TestCachingHiveMetastore
         assertEquals(mockClient.getAccessCount(), 2);
     }
 
-    private static class MockHiveCluster
+    public static class MockHiveCluster
             implements HiveCluster
     {
-        private final HiveMetastoreClient client;
+        private final MockHiveMetastoreClient client;
 
-        private MockHiveCluster(HiveMetastoreClient client)
+        private MockHiveCluster(MockHiveMetastoreClient client)
         {
             this.client = client;
         }
 
         @Override
         public HiveMetastoreClient createMetastoreClient()
+        {
+            return client;
+        }
+
+        public MockHiveMetastoreClient createPartitionVersionSupportedMetastoreClient()
         {
             return client;
         }

--- a/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/TestCachingHiveMetastore.java
+++ b/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/TestCachingHiveMetastore.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.hive.metastore;
 
+import com.facebook.presto.hive.PartitionVersionFetcher;
 import com.facebook.presto.hive.metastore.thrift.BridgingHiveMetastore;
 import com.facebook.presto.hive.metastore.thrift.HiveCluster;
 import com.facebook.presto.hive.metastore.thrift.HiveMetastoreClient;
@@ -59,8 +60,9 @@ public class TestCachingHiveMetastore
         MockHiveCluster mockHiveCluster = new MockHiveCluster(mockClient);
         ListeningExecutorService executor = listeningDecorator(newCachedThreadPool(daemonThreadsNamed("test-%s")));
         ThriftHiveMetastore thriftHiveMetastore = new ThriftHiveMetastore(mockHiveCluster);
+        PartitionVersionFetcher hivePartitionVersionFetcher = new HivePartitionVersionFetcher();
         metastore = new CachingHiveMetastore(
-                new BridgingHiveMetastore(thriftHiveMetastore),
+                new BridgingHiveMetastore(thriftHiveMetastore, hivePartitionVersionFetcher),
                 executor,
                 new Duration(5, TimeUnit.MINUTES),
                 new Duration(1, TimeUnit.MINUTES),

--- a/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/TestHiveMetastoreUtil.java
+++ b/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/TestHiveMetastoreUtil.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.hive.metastore;
 
+import com.facebook.presto.hive.PartitionVersionFetcher;
 import com.facebook.presto.hive.metastore.thrift.ThriftMetastoreUtil;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -118,6 +119,7 @@ public class TestHiveMetastoreUtil
             1234567893,
             TEST_STORAGE_DESCRIPTOR_WITH_UNSUPPORTED_FIELDS,
             ImmutableMap.of("k1", "v1", "k2", "v2", "k3", "v3"));
+    private static final PartitionVersionFetcher TEST_PARTITION_VERSION_FETCHER = new HivePartitionVersionFetcher();
 
     static {
         TEST_STORAGE_DESCRIPTOR_WITH_UNSUPPORTED_FIELDS.setSkewedInfo(new SkewedInfo(
@@ -138,7 +140,7 @@ public class TestHiveMetastoreUtil
     @Test
     public void testPartitionRoundTrip()
     {
-        Partition partition = ThriftMetastoreUtil.fromMetastoreApiPartition(TEST_PARTITION);
+        Partition partition = ThriftMetastoreUtil.fromMetastoreApiPartition(TEST_PARTITION, TEST_PARTITION_VERSION_FETCHER);
         org.apache.hadoop.hive.metastore.api.Partition metastoreApiPartition = ThriftMetastoreUtil.toMetastoreApiPartition(partition);
         assertEquals(metastoreApiPartition, TEST_PARTITION);
     }
@@ -155,7 +157,7 @@ public class TestHiveMetastoreUtil
     public void testHiveSchemaPartition()
     {
         Properties expected = MetaStoreUtils.getPartitionMetadata(TEST_PARTITION_WITH_UNSUPPORTED_FIELDS, TEST_TABLE_WITH_UNSUPPORTED_FIELDS);
-        Properties actual = getHiveSchema(ThriftMetastoreUtil.fromMetastoreApiPartition(TEST_PARTITION_WITH_UNSUPPORTED_FIELDS), ThriftMetastoreUtil.fromMetastoreApiTable(TEST_TABLE_WITH_UNSUPPORTED_FIELDS, TEST_SCHEMA));
+        Properties actual = getHiveSchema(ThriftMetastoreUtil.fromMetastoreApiPartition(TEST_PARTITION_WITH_UNSUPPORTED_FIELDS, TEST_PARTITION_VERSION_FETCHER), ThriftMetastoreUtil.fromMetastoreApiTable(TEST_TABLE_WITH_UNSUPPORTED_FIELDS, TEST_SCHEMA));
         assertEquals(actual, expected);
     }
 
@@ -169,7 +171,7 @@ public class TestHiveMetastoreUtil
     @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Writing to skewed table/partition is not supported")
     public void testPartitionRoundTripUnsupported()
     {
-        Partition partition = ThriftMetastoreUtil.fromMetastoreApiPartition(TEST_PARTITION_WITH_UNSUPPORTED_FIELDS);
+        Partition partition = ThriftMetastoreUtil.fromMetastoreApiPartition(TEST_PARTITION_WITH_UNSUPPORTED_FIELDS, TEST_PARTITION_VERSION_FETCHER);
         ThriftMetastoreUtil.toMetastoreApiPartition(partition);
     }
 

--- a/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/TestMetastoreClientConfig.java
+++ b/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/TestMetastoreClientConfig.java
@@ -15,6 +15,7 @@ package com.facebook.presto.hive.metastore;
 
 import com.facebook.airlift.configuration.testing.ConfigAssertions;
 import com.facebook.presto.hive.MetastoreClientConfig;
+import com.facebook.presto.hive.metastore.CachingHiveMetastore.MetastoreCacheScope;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.net.HostAndPort;
 import io.airlift.units.Duration;
@@ -40,7 +41,9 @@ public class TestMetastoreClientConfig
                 .setMaxMetastoreRefreshThreads(100)
                 .setRecordingPath(null)
                 .setRecordingDuration(new Duration(0, TimeUnit.MINUTES))
-                .setReplay(false));
+                .setReplay(false)
+                .setPartitionVersioningEnabled(false)
+                .setMetastoreCacheScope(MetastoreCacheScope.ALL));
     }
 
     @Test
@@ -59,6 +62,8 @@ public class TestMetastoreClientConfig
                 .put("hive.metastore-recording-path", "/foo/bar")
                 .put("hive.metastore-recoding-duration", "42s")
                 .put("hive.replay-metastore-recording", "true")
+                .put("hive.partition-versioning-enabled", "true")
+                .put("hive.metastore-cache-scope", "PARTITION")
                 .build();
 
         MetastoreClientConfig expected = new MetastoreClientConfig()
@@ -73,7 +78,9 @@ public class TestMetastoreClientConfig
                 .setMaxMetastoreRefreshThreads(2500)
                 .setRecordingPath("/foo/bar")
                 .setRecordingDuration(new Duration(42, TimeUnit.SECONDS))
-                .setReplay(true);
+                .setReplay(true)
+                .setPartitionVersioningEnabled(true)
+                .setMetastoreCacheScope(MetastoreCacheScope.PARTITION);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/TestRecordingHiveMetastore.java
+++ b/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/TestRecordingHiveMetastore.java
@@ -94,7 +94,8 @@ public class TestRecordingHiveMetastore
             ImmutableList.of("value"),
             TABLE_STORAGE,
             ImmutableList.of(TABLE_COLUMN),
-            ImmutableMap.of("param", "value4"));
+            ImmutableMap.of("param", "value4"),
+            Optional.empty());
     private static final PartitionStatistics PARTITION_STATISTICS = new PartitionStatistics(
             new HiveBasicStatistics(10, 11, 10000, 10001),
             ImmutableMap.of("column", new HiveColumnStatistics(

--- a/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/UnimplementedHiveMetastore.java
+++ b/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/UnimplementedHiveMetastore.java
@@ -171,6 +171,15 @@ class UnimplementedHiveMetastore
     }
 
     @Override
+    public List<PartitionNameWithVersion> getPartitionNamesWithVersionByFilter(
+            String databaseName,
+            String tableName,
+            Map<Column, Domain> partitionPredicates)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public Map<String, Optional<Partition>> getPartitionsByNames(String databaseName, String tableName, List<String> partitionNames)
     {
         throw new UnsupportedOperationException();

--- a/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/thrift/MockHiveMetastoreClient.java
+++ b/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/thrift/MockHiveMetastoreClient.java
@@ -13,6 +13,9 @@
  */
 package com.facebook.presto.hive.metastore.thrift;
 
+import com.facebook.presto.common.predicate.Domain;
+import com.facebook.presto.hive.metastore.Column;
+import com.facebook.presto.hive.metastore.PartitionNameWithVersion;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -53,6 +56,8 @@ public class MockHiveMetastoreClient
     public static final String TEST_PARTITION2 = "key=testpartition2";
     public static final List<String> TEST_PARTITION_VALUES1 = ImmutableList.of("testpartition1");
     public static final List<String> TEST_PARTITION_VALUES2 = ImmutableList.of("testpartition2");
+    public static final PartitionNameWithVersion TEST_PARTITION_NAME_WITH_VERSION1 = new PartitionNameWithVersion(TEST_PARTITION1, 1);
+    public static final PartitionNameWithVersion TEST_PARTITION_NAME_WITH_VERSION2 = new PartitionNameWithVersion(TEST_PARTITION2, 2);
     public static final List<String> TEST_ROLES = ImmutableList.of("testrole");
     public static final List<RolePrincipalGrant> TEST_ROLE_GRANTS = ImmutableList.of(
             new RolePrincipalGrant("role1", "user", USER, false, 0, "grantor1", USER),
@@ -211,6 +216,19 @@ public class MockHiveMetastoreClient
             throw new NoSuchObjectException();
         }
         return ImmutableList.of(TEST_PARTITION1, TEST_PARTITION2);
+    }
+
+    public List<PartitionNameWithVersion> getPartitionNamesWithVersionByFilter(String dbName, String tableName, Map<Column, Domain> partitionPredicates)
+            throws TException
+    {
+        accessCount.incrementAndGet();
+        if (throwException) {
+            throw new RuntimeException();
+        }
+        if (!dbName.equals(TEST_DATABASE) || !tableName.equals(TEST_TABLE)) {
+            throw new NoSuchObjectException();
+        }
+        return ImmutableList.of(TEST_PARTITION_NAME_WITH_VERSION1, TEST_PARTITION_NAME_WITH_VERSION2);
     }
 
     @Override

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientModule.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientModule.java
@@ -22,6 +22,7 @@ import com.facebook.presto.hive.HiveDwrfEncryptionProvider.ForUnknown;
 import com.facebook.presto.hive.cache.HiveCachingHdfsConfiguration;
 import com.facebook.presto.hive.datasink.DataSinkFactory;
 import com.facebook.presto.hive.datasink.OutputStreamDataSinkFactory;
+import com.facebook.presto.hive.metastore.HivePartitionVersionFetcher;
 import com.facebook.presto.hive.orc.DwrfBatchPageSourceFactory;
 import com.facebook.presto.hive.orc.DwrfSelectivePageSourceFactory;
 import com.facebook.presto.hive.orc.OrcBatchPageSourceFactory;
@@ -190,6 +191,8 @@ public class HiveClientModule
 
         binder.bind(HiveEncryptionInformationProvider.class).in(Scopes.SINGLETON);
         newSetBinder(binder, EncryptionInformationSource.class);
+
+        binder.bind(PartitionVersionFetcher.class).to(HivePartitionVersionFetcher.class).in(Scopes.SINGLETON);
     }
 
     @ForHiveClient

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -43,6 +43,7 @@ import com.facebook.presto.hive.metastore.CachingHiveMetastore;
 import com.facebook.presto.hive.metastore.Column;
 import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
 import com.facebook.presto.hive.metastore.HiveColumnStatistics;
+import com.facebook.presto.hive.metastore.HivePartitionVersionFetcher;
 import com.facebook.presto.hive.metastore.HivePrivilegeInfo;
 import com.facebook.presto.hive.metastore.HivePrivilegeInfo.HivePrivilege;
 import com.facebook.presto.hive.metastore.Partition;
@@ -907,7 +908,7 @@ public abstract class AbstractTestHiveClient
 
         HiveCluster hiveCluster = new TestingHiveCluster(metastoreClientConfig, host, port);
         ExtendedHiveMetastore metastore = new CachingHiveMetastore(
-                new BridgingHiveMetastore(new ThriftHiveMetastore(hiveCluster)),
+                new BridgingHiveMetastore(new ThriftHiveMetastore(hiveCluster), new HivePartitionVersionFetcher()),
                 executor,
                 Duration.valueOf("1m"),
                 Duration.valueOf("15s"),

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -40,6 +40,7 @@ import com.facebook.presto.hive.LocationService.WriteInfo;
 import com.facebook.presto.hive.authentication.NoHdfsAuthentication;
 import com.facebook.presto.hive.datasink.OutputStreamDataSinkFactory;
 import com.facebook.presto.hive.metastore.CachingHiveMetastore;
+import com.facebook.presto.hive.metastore.CachingHiveMetastore.MetastoreCacheScope;
 import com.facebook.presto.hive.metastore.Column;
 import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
 import com.facebook.presto.hive.metastore.HiveColumnStatistics;
@@ -912,7 +913,9 @@ public abstract class AbstractTestHiveClient
                 executor,
                 Duration.valueOf("1m"),
                 Duration.valueOf("15s"),
-                10000);
+                10000,
+                false,
+                MetastoreCacheScope.ALL);
 
         setup(databaseName, hiveClientConfig, cacheConfig, metastoreClientConfig, metastore);
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystem.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystem.java
@@ -25,6 +25,7 @@ import com.facebook.presto.hive.datasink.OutputStreamDataSinkFactory;
 import com.facebook.presto.hive.metastore.CachingHiveMetastore;
 import com.facebook.presto.hive.metastore.Database;
 import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
+import com.facebook.presto.hive.metastore.HivePartitionVersionFetcher;
 import com.facebook.presto.hive.metastore.PrincipalPrivileges;
 import com.facebook.presto.hive.metastore.Table;
 import com.facebook.presto.hive.metastore.thrift.BridgingHiveMetastore;
@@ -181,7 +182,7 @@ public abstract class AbstractTestHiveFileSystem
 
         hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, metastoreClientConfig, new NoHdfsAuthentication());
         metastoreClient = new TestingHiveMetastore(
-                new BridgingHiveMetastore(new ThriftHiveMetastore(hiveCluster)),
+                new BridgingHiveMetastore(new ThriftHiveMetastore(hiveCluster), new HivePartitionVersionFetcher()),
                 executor,
                 metastoreClientConfig,
                 getBasePath(),

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestAbstractDwrfEncryptionInformationSource.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestAbstractDwrfEncryptionInformationSource.java
@@ -109,8 +109,8 @@ public class TestAbstractDwrfEncryptionInformationSource
                                 ImmutableList.of(new Subfield("col_struct.a"), new Subfield("col_struct.b.b2")),
                                 Optional.empty()))),
                 ImmutableMap.of(
-                        "ds=2020-01-01", new Partition("dbName", "tableName", ImmutableList.of("2020-01-01"), table.getStorage(), table.getDataColumns(), ImmutableMap.of()),
-                        "ds=2020-01-02", new Partition("dbName", "tableName", ImmutableList.of("2020-01-02"), table.getStorage(), table.getDataColumns(), ImmutableMap.of())));
+                        "ds=2020-01-01", new Partition("dbName", "tableName", ImmutableList.of("2020-01-01"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty()),
+                        "ds=2020-01-02", new Partition("dbName", "tableName", ImmutableList.of("2020-01-02"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty())));
 
         assertTrue(encryptionInformation.isPresent());
         assertEquals(
@@ -129,8 +129,8 @@ public class TestAbstractDwrfEncryptionInformationSource
                 table,
                 Optional.of(ImmutableSet.of()),
                 ImmutableMap.of(
-                        "ds=2020-01-01", new Partition("dbName", "tableName", ImmutableList.of("2020-01-01"), table.getStorage(), table.getDataColumns(), ImmutableMap.of()),
-                        "ds=2020-01-02", new Partition("dbName", "tableName", ImmutableList.of("2020-01-02"), table.getStorage(), table.getDataColumns(), ImmutableMap.of())));
+                        "ds=2020-01-01", new Partition("dbName", "tableName", ImmutableList.of("2020-01-01"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty()),
+                        "ds=2020-01-02", new Partition("dbName", "tableName", ImmutableList.of("2020-01-02"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty())));
 
         assertTrue(encryptionInformation.isPresent());
         assertEquals(
@@ -161,8 +161,8 @@ public class TestAbstractDwrfEncryptionInformationSource
                                 ImmutableList.of(new Subfield("col_struct.a"), new Subfield("col_struct.b.b2")),
                                 Optional.empty()))),
                 ImmutableMap.of(
-                        "ds=2020-01-01", new Partition("dbName", "tableName", ImmutableList.of("2020-01-01"), table.getStorage(), table.getDataColumns(), ImmutableMap.of()),
-                        "ds=2020-01-02", new Partition("dbName", "tableName", ImmutableList.of("2020-01-02"), table.getStorage(), table.getDataColumns(), ImmutableMap.of())));
+                        "ds=2020-01-01", new Partition("dbName", "tableName", ImmutableList.of("2020-01-01"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty()),
+                        "ds=2020-01-02", new Partition("dbName", "tableName", ImmutableList.of("2020-01-02"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty())));
 
         Map<String, byte[]> expectedFieldToKeyData = ImmutableMap.of("col_bigint", "key2".getBytes(), "col_struct.a", "key2".getBytes(), "col_struct.b.b2", "key1".getBytes());
         assertTrue(encryptionInformation.isPresent());

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientInMemoryMetastore.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientInMemoryMetastore.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.hive;
 
 import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
+import com.facebook.presto.hive.metastore.HivePartitionVersionFetcher;
 import com.facebook.presto.hive.metastore.thrift.BridgingHiveMetastore;
 import com.facebook.presto.hive.metastore.thrift.InMemoryHiveMetastore;
 
@@ -27,7 +28,7 @@ public class TestHiveClientInMemoryMetastore
     {
         File baseDir = new File(tempDir, "metastore");
         InMemoryHiveMetastore hiveMetastore = new InMemoryHiveMetastore(baseDir);
-        return new BridgingHiveMetastore(hiveMetastore);
+        return new BridgingHiveMetastore(hiveMetastore, new HivePartitionVersionFetcher());
     }
 
     @Override

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientInMemoryMetastoreWithFilterPushdown.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientInMemoryMetastoreWithFilterPushdown.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.hive;
 
 import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
+import com.facebook.presto.hive.metastore.HivePartitionVersionFetcher;
 import com.facebook.presto.hive.metastore.thrift.BridgingHiveMetastore;
 import com.facebook.presto.hive.metastore.thrift.InMemoryHiveMetastore;
 import com.google.common.collect.ImmutableSet;
@@ -42,7 +43,7 @@ public class TestHiveClientInMemoryMetastoreWithFilterPushdown
     {
         File baseDir = new File(tempDir, "metastore");
         InMemoryHiveMetastore hiveMetastore = new InMemoryHiveMetastore(baseDir);
-        return new BridgingHiveMetastore(hiveMetastore);
+        return new BridgingHiveMetastore(hiveMetastore, new HivePartitionVersionFetcher());
     }
 
     @Override

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMetadataFileFormatEncryptionSettings.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMetadataFileFormatEncryptionSettings.java
@@ -18,6 +18,7 @@ import com.facebook.presto.common.type.RowType;
 import com.facebook.presto.hive.datasink.OutputStreamDataSinkFactory;
 import com.facebook.presto.hive.metastore.Database;
 import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
+import com.facebook.presto.hive.metastore.HivePartitionVersionFetcher;
 import com.facebook.presto.hive.metastore.Partition;
 import com.facebook.presto.hive.metastore.thrift.BridgingHiveMetastore;
 import com.facebook.presto.hive.metastore.thrift.InMemoryHiveMetastore;
@@ -97,7 +98,7 @@ public class TestHiveMetadataFileFormatEncryptionSettings
     public void setup()
     {
         baseDirectory = new File(Files.createTempDir(), "metastore");
-        metastore = new BridgingHiveMetastore(new InMemoryHiveMetastore(baseDirectory));
+        metastore = new BridgingHiveMetastore(new InMemoryHiveMetastore(baseDirectory), new HivePartitionVersionFetcher());
         executor = newCachedThreadPool(daemonThreadsNamed("hive-encryption-test-%s"));
         transactionManager = new HiveTransactionManager();
         metadataFactory = new HiveMetadataFactory(

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestingSemiTransactionalHiveMetastore.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestingSemiTransactionalHiveMetastore.java
@@ -21,6 +21,7 @@ import com.facebook.presto.hive.metastore.Column;
 import com.facebook.presto.hive.metastore.Database;
 import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
 import com.facebook.presto.hive.metastore.HivePageSinkMetadata;
+import com.facebook.presto.hive.metastore.HivePartitionVersionFetcher;
 import com.facebook.presto.hive.metastore.HivePrivilegeInfo;
 import com.facebook.presto.hive.metastore.HiveTableName;
 import com.facebook.presto.hive.metastore.Partition;
@@ -74,7 +75,7 @@ public class TestingSemiTransactionalHiveMetastore
         HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationInitializer(config, metastoreClientConfig), ImmutableSet.of());
         HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, metastoreClientConfig, new NoHdfsAuthentication());
         HiveCluster hiveCluster = new TestingHiveCluster(metastoreClientConfig, HOST, PORT);
-        ExtendedHiveMetastore delegate = new BridgingHiveMetastore(new ThriftHiveMetastore(hiveCluster));
+        ExtendedHiveMetastore delegate = new BridgingHiveMetastore(new ThriftHiveMetastore(hiveCluster), new HivePartitionVersionFetcher());
         ExecutorService executor = newCachedThreadPool(daemonThreadsNamed("hive-%s"));
         ListeningExecutorService renameExecutor = listeningDecorator(executor);
 


### PR DESCRIPTION
```
== RELEASE NOTES ==

General Changes
* Add support for partition versioning. This can be enabled with ``hive.partition-versioning-enabled`` configuration property
* Add support for caching HiveMetastore calls at a more granular level . Supported levels:  'PARTITION' and 'ALL'(default). This can be set with ``hive.metastore-cache-scope`` configuration property.
```
depended by https://github.com/facebookexternal/presto-facebook/pull/1127