### PR TITLE
Fix for Pinot queries where order by column is pruned in projection

### DIFF
--- a/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/query/TestPinotQueryGenerator.java
+++ b/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/query/TestPinotQueryGenerator.java
@@ -22,6 +22,7 @@ import com.facebook.presto.spi.plan.DistinctLimitNode;
 import com.facebook.presto.spi.plan.Ordering;
 import com.facebook.presto.spi.plan.OrderingScheme;
 import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.ProjectNode;
 import com.facebook.presto.spi.plan.TableScanNode;
 import com.facebook.presto.spi.plan.TopNNode;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
@@ -366,6 +367,8 @@ public class TestPinotQueryGenerator
                 "SELECT regionId, city, fare FROM realtimeOnly ORDER BY fare, city DESC LIMIT 50",
                 defaultSessionHolder,
                 ImmutableMap.of());
+        ProjectNode projectNode = project(planBuilder, topnFareAndCity, ImmutableList.of("regionid", "city"));
+        testPinotQuery(pinotConfig, projectNode, "SELECT regionId, city FROM realtimeOnly ORDER BY fare, city DESC LIMIT 50", defaultSessionHolder, ImmutableMap.of());
     }
 
     @Test(expectedExceptions = NoSuchElementException.class)

--- a/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/query/TestPinotQueryGeneratorSql.java
+++ b/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/query/TestPinotQueryGeneratorSql.java
@@ -182,6 +182,14 @@ public class TestPinotQueryGeneratorSql
                 defaultSessionHolder,
                 ImmutableMap.of());
 
+        TopNNode topNNode = topN(planBuilder, 50L, ImmutableList.of("fare", "city"), ImmutableList.of(true, false), tableScanNode);
+        testPinotQuery(
+                pinotConfig,
+                project(planBuilder, topNNode, ImmutableList.of("regionid", "city")),
+                "SELECT regionId, city FROM realtimeOnly ORDER BY fare, city DESC LIMIT 50",
+                defaultSessionHolder,
+                ImmutableMap.of());
+
         tableScanNode = tableScan(planBuilder, pinotTable, fare, city, regionId);
         testPinotQuery(
                 pinotConfig,


### PR DESCRIPTION
Queries where order by columns are not part of the selection were failing with `NullPointerException` because column names for order by clause were being taken from final selections. 

To fix this now we are storing the selections for topN at the time we encounter topN node, which guarantees that the order by columns will be in the contemporary selections.

Test plan - Tested with failing query shapes, example as below
```
select city
from cityFares
where secondsSinceEpoch > 1597047119
order by secondsSinceEpoch desc, 1 desc
limit 1
```
```
== NO RELEASE NOTE ==
```
