### PR TITLE
Improve error handling during determinism analysis

### DIFF
--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/LimitQueryDeterminismAnalysis.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/LimitQueryDeterminismAnalysis.java
@@ -19,4 +19,5 @@ public enum LimitQueryDeterminismAnalysis
     NON_DETERMINISTIC,
     DETERMINISTIC,
     FAILED_DATA_CHANGED,
+    FAILED_QUERY_FAILURE,
 }

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/LimitQueryDeterminismAnalyzer.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/LimitQueryDeterminismAnalyzer.java
@@ -46,6 +46,7 @@ import java.util.Set;
 import static com.facebook.presto.sql.QueryUtil.simpleQuery;
 import static com.facebook.presto.verifier.framework.LimitQueryDeterminismAnalysis.DETERMINISTIC;
 import static com.facebook.presto.verifier.framework.LimitQueryDeterminismAnalysis.FAILED_DATA_CHANGED;
+import static com.facebook.presto.verifier.framework.LimitQueryDeterminismAnalysis.FAILED_QUERY_FAILURE;
 import static com.facebook.presto.verifier.framework.LimitQueryDeterminismAnalysis.NON_DETERMINISTIC;
 import static com.facebook.presto.verifier.framework.LimitQueryDeterminismAnalysis.NOT_RUN;
 import static com.facebook.presto.verifier.framework.QueryStage.DETERMINISM_ANALYSIS_MAIN;
@@ -89,7 +90,14 @@ class LimitQueryDeterminismAnalyzer
 
     public LimitQueryDeterminismAnalysis analyze()
     {
-        LimitQueryDeterminismAnalysis analysis = analyzeInternal();
+        LimitQueryDeterminismAnalysis analysis;
+        try {
+            analysis = analyzeInternal();
+        }
+        catch (QueryException queryException) {
+            analysis = FAILED_QUERY_FAILURE;
+        }
+
         determinismAnalysisDetails.setLimitQueryAnalysis(analysis);
         return analysis;
     }


### PR DESCRIPTION
We rerun control queries first and then the limit query analysis,

In one case, we see a determinism analysis failed because the control
rerun failed due to a transient generic internal error. The query
contains a LIMIT clause, but limit query analysis was never run as
the exception is caught and the analysis is marked as
ANALYSIS_FAILED_QUERY_FAILURE.

To mitigate this issue:
- Run limit query analysis before control reruns, since it is a
  light-weight analysis.
- If analysis query is failing during limit query analysis, do
  not return and proceed to the control reruns.

```
== RELEASE NOTES ==

Verifier Changes
* Fix an issue during determinism analysis where queries with LIMIT clause are not identified
  as non-deterministic when a rerun of the control query fails.
```