### PR TITLE
Remove QueryInfo from DispatchManager

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/dispatcher/DispatchManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/dispatcher/DispatchManager.java
@@ -272,11 +272,6 @@ public class DispatchManager
         return queryTracker.getQuery(queryId).getBasicQueryInfo();
     }
 
-    public QueryInfo getFullQueryInfo(QueryId queryId)
-    {
-        return queryTracker.getQuery(queryId).getQueryInfo();
-    }
-
     public Optional<DispatchInfo> getDispatchInfo(QueryId queryId)
     {
         return queryTracker.tryGetQuery(queryId)

--- a/presto-main/src/main/java/com/facebook/presto/dispatcher/FailedDispatchQuery.java
+++ b/presto-main/src/main/java/com/facebook/presto/dispatcher/FailedDispatchQuery.java
@@ -15,7 +15,6 @@ package com.facebook.presto.dispatcher;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.execution.ExecutionFailureInfo;
-import com.facebook.presto.execution.QueryInfo;
 import com.facebook.presto.execution.QueryState;
 import com.facebook.presto.execution.StateMachine.StateChangeListener;
 import com.facebook.presto.server.BasicQueryInfo;
@@ -31,8 +30,8 @@ import java.net.URI;
 import java.util.Optional;
 import java.util.concurrent.Executor;
 
-import static com.facebook.presto.execution.QueryInfo.immediateFailureQueryInfo;
 import static com.facebook.presto.execution.QueryState.FAILED;
+import static com.facebook.presto.server.BasicQueryInfo.immediateFailureQueryInfo;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static io.airlift.units.DataSize.Unit.BYTE;
 import static java.util.Objects.requireNonNull;
@@ -41,7 +40,6 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 public class FailedDispatchQuery
         implements DispatchQuery
 {
-    private final QueryInfo queryInfo;
     private final BasicQueryInfo basicQueryInfo;
     private final Session session;
     private final Executor executor;
@@ -62,27 +60,20 @@ public class FailedDispatchQuery
         requireNonNull(failure, "failure is null");
         requireNonNull(executor, "executor is null");
 
-        this.queryInfo = immediateFailureQueryInfo(session, query, self, resourceGroup, failure);
-        this.basicQueryInfo = new BasicQueryInfo(queryInfo);
+        this.basicQueryInfo = immediateFailureQueryInfo(session, query, self, resourceGroup, failure);
         this.session = requireNonNull(session, "session is null");
         this.executor = requireNonNull(executor, "executor is null");
 
         this.dispatchInfo = DispatchInfo.failed(
                 failure,
-                queryInfo.getQueryStats().getElapsedTime(),
-                queryInfo.getQueryStats().getQueuedTime());
+                basicQueryInfo.getQueryStats().getElapsedTime(),
+                basicQueryInfo.getQueryStats().getQueuedTime());
     }
 
     @Override
     public BasicQueryInfo getBasicQueryInfo()
     {
         return basicQueryInfo;
-    }
-
-    @Override
-    public QueryInfo getQueryInfo()
-    {
-        return queryInfo;
     }
 
     @Override
@@ -124,7 +115,7 @@ public class FailedDispatchQuery
     @Override
     public QueryId getQueryId()
     {
-        return queryInfo.getQueryId();
+        return basicQueryInfo.getQueryId();
     }
 
     @Override
@@ -136,7 +127,7 @@ public class FailedDispatchQuery
     @Override
     public Optional<ErrorCode> getErrorCode()
     {
-        return Optional.ofNullable(queryInfo.getErrorCode());
+        return Optional.ofNullable(basicQueryInfo.getErrorCode());
     }
 
     @Override
@@ -145,13 +136,13 @@ public class FailedDispatchQuery
     @Override
     public DateTime getLastHeartbeat()
     {
-        return queryInfo.getQueryStats().getEndTime();
+        return basicQueryInfo.getQueryStats().getEndTime();
     }
 
     @Override
     public DateTime getCreateTime()
     {
-        return queryInfo.getQueryStats().getCreateTime();
+        return basicQueryInfo.getQueryStats().getCreateTime();
     }
 
     @Override
@@ -163,7 +154,7 @@ public class FailedDispatchQuery
     @Override
     public Optional<DateTime> getEndTime()
     {
-        return Optional.ofNullable(queryInfo.getQueryStats().getEndTime());
+        return Optional.ofNullable(basicQueryInfo.getQueryStats().getEndTime());
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/dispatcher/LocalDispatchQuery.java
+++ b/presto-main/src/main/java/com/facebook/presto/dispatcher/LocalDispatchQuery.java
@@ -19,7 +19,6 @@ import com.facebook.presto.event.QueryMonitor;
 import com.facebook.presto.execution.ClusterSizeMonitor;
 import com.facebook.presto.execution.ExecutionFailureInfo;
 import com.facebook.presto.execution.QueryExecution;
-import com.facebook.presto.execution.QueryInfo;
 import com.facebook.presto.execution.QueryState;
 import com.facebook.presto.execution.QueryStateMachine;
 import com.facebook.presto.execution.StateMachine.StateChangeListener;
@@ -226,14 +225,6 @@ public class LocalDispatchQuery
     }
 
     @Override
-    public QueryInfo getQueryInfo()
-    {
-        return tryGetQueryExecution()
-                .map(QueryExecution::getQueryInfo)
-                .orElse(stateMachine.getQueryInfo(Optional.empty()));
-    }
-
-    @Override
     public Session getSession()
     {
         return stateMachine.getSession();
@@ -251,10 +242,10 @@ public class LocalDispatchQuery
     public void cancel()
     {
         if (stateMachine.transitionToCanceled()) {
-            QueryInfo queryInfo = stateMachine.getQueryInfo(Optional.empty());
+            BasicQueryInfo queryInfo = stateMachine.getBasicQueryInfo(Optional.empty());
             ExecutionFailureInfo failureInfo = queryInfo.getFailureInfo();
             failureInfo = failureInfo != null ? failureInfo : toFailure(new PrestoException(USER_CANCELED, "Query was canceled"));
-            queryMonitor.queryImmediateFailureEvent(new BasicQueryInfo(queryInfo), failureInfo);
+            queryMonitor.queryImmediateFailureEvent(queryInfo, failureInfo);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/ManagedQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/ManagedQueryExecution.java
@@ -45,8 +45,6 @@ public interface ManagedQueryExecution
 
     BasicQueryInfo getBasicQueryInfo();
 
-    QueryInfo getQueryInfo();
-
     boolean isDone();
 
     /**

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
@@ -320,14 +320,6 @@ public class QueryStateMachine
         // never be visible.
         QueryState state = queryState.get();
 
-        ErrorCode errorCode = null;
-        if (state == QueryState.FAILED) {
-            ExecutionFailureInfo failureCause = this.failureCause.get();
-            if (failureCause != null) {
-                errorCode = failureCause.getErrorCode();
-            }
-        }
-
         BasicStageExecutionStats stageStats = rootStage.orElse(EMPTY_STAGE_STATS);
         BasicQueryStats queryStats = new BasicQueryStats(
                 queryStateTimer.getCreateTime(),
@@ -373,8 +365,7 @@ public class QueryStateMachine
                 self,
                 query,
                 queryStats,
-                errorCode == null ? null : errorCode.getType(),
-                errorCode,
+                failureCause.get(),
                 queryType,
                 warningCollector.getWarnings());
     }

--- a/presto-main/src/main/java/com/facebook/presto/server/BasicQueryInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/BasicQueryInfo.java
@@ -60,6 +60,7 @@ public class BasicQueryInfo
     private final BasicQueryStats queryStats;
     private final ErrorType errorType;
     private final ErrorCode errorCode;
+    private final ExecutionFailureInfo failureInfo;
     private final Optional<QueryType> queryType;
     private final List<PrestoWarning> warnings;
 
@@ -76,6 +77,7 @@ public class BasicQueryInfo
             @JsonProperty("queryStats") BasicQueryStats queryStats,
             @JsonProperty("errorType") ErrorType errorType,
             @JsonProperty("errorCode") ErrorCode errorCode,
+            @JsonProperty("failureInfo") ExecutionFailureInfo failureInfo,
             @JsonProperty("queryType") Optional<QueryType> queryType,
             @JsonProperty("warnings") List<PrestoWarning> warnings)
     {
@@ -86,6 +88,7 @@ public class BasicQueryInfo
         this.memoryPool = memoryPool;
         this.errorType = errorType;
         this.errorCode = errorCode;
+        this.failureInfo = failureInfo;
         this.scheduled = scheduled;
         this.self = requireNonNull(self, "self is null");
         this.query = requireNonNull(query, "query is null");
@@ -118,8 +121,9 @@ public class BasicQueryInfo
                 self,
                 query,
                 queryStats,
-                failureInfo != null && failureInfo.getErrorCode() != null ? failureInfo.getErrorCode().getType() : null,
+                (failureInfo != null && failureInfo.getErrorCode() != null) ? failureInfo.getErrorCode().getType() : null,
                 failureInfo != null ? failureInfo.getErrorCode() : null,
+                failureInfo,
                 queryType, warnings);
     }
 
@@ -136,6 +140,7 @@ public class BasicQueryInfo
                 new BasicQueryStats(queryInfo.getQueryStats()),
                 queryInfo.getErrorType(),
                 queryInfo.getErrorCode(),
+                queryInfo.getFailureInfo(),
                 queryInfo.getQueryType(),
                 queryInfo.getWarnings());
     }
@@ -223,6 +228,13 @@ public class BasicQueryInfo
     public ErrorCode getErrorCode()
     {
         return errorCode;
+    }
+
+    @Nullable
+    @JsonProperty
+    public ExecutionFailureInfo getFailureInfo()
+    {
+        return failureInfo;
     }
 
     @JsonProperty

--- a/presto-main/src/main/java/com/facebook/presto/server/BasicQueryStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/BasicQueryStats.java
@@ -28,7 +28,9 @@ import java.util.OptionalDouble;
 import java.util.Set;
 
 import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.units.DataSize.Unit.BYTE;
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 /**
  * Lightweight version of QueryStats. Parts of the web UI depend on the fields
@@ -161,6 +163,36 @@ public class BasicQueryStats
                 queryStats.getBlockedReasons(),
                 queryStats.getTotalAllocation(),
                 queryStats.getProgressPercentage());
+    }
+
+    public static BasicQueryStats immediateFailureQueryStats()
+    {
+        DateTime now = DateTime.now();
+        return new BasicQueryStats(
+                now,
+                now,
+                new Duration(0, MILLISECONDS),
+                new Duration(0, MILLISECONDS),
+                new Duration(0, MILLISECONDS),
+                0,
+                0,
+                0,
+                0,
+                0,
+                new DataSize(0, BYTE),
+                0,
+                0,
+                new DataSize(0, BYTE),
+                new DataSize(0, BYTE),
+                new DataSize(0, BYTE),
+                new DataSize(0, BYTE),
+                new DataSize(0, BYTE),
+                new Duration(0, MILLISECONDS),
+                new Duration(0, MILLISECONDS),
+                false,
+                ImmutableSet.of(),
+                new DataSize(0, BYTE),
+                OptionalDouble.empty());
     }
 
     @JsonProperty

--- a/presto-main/src/main/java/com/facebook/presto/server/QueryResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/QueryResource.java
@@ -81,11 +81,17 @@ public class QueryResource
         requireNonNull(queryId, "queryId is null");
 
         try {
-            QueryInfo queryInfo = dispatchManager.getFullQueryInfo(queryId);
+            QueryInfo queryInfo = queryManager.getFullQueryInfo(queryId);
             return Response.ok(queryInfo).build();
         }
         catch (NoSuchElementException e) {
-            return Response.status(Status.GONE).build();
+            try {
+                BasicQueryInfo basicQueryInfo = dispatchManager.getQueryInfo(queryId);
+                return Response.ok(basicQueryInfo).build();
+            }
+            catch (NoSuchElementException ex) {
+                return Response.status(Status.GONE).build();
+            }
         }
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/MockManagedQueryExecution.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/MockManagedQueryExecution.java
@@ -16,11 +16,11 @@ package com.facebook.presto.execution;
 import com.facebook.presto.Session;
 import com.facebook.presto.execution.StateMachine.StateChangeListener;
 import com.facebook.presto.server.BasicQueryInfo;
+import com.facebook.presto.server.BasicQueryStats;
 import com.facebook.presto.spi.ErrorCode;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.memory.MemoryPoolId;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
@@ -30,17 +30,18 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalDouble;
 
-import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
 import static com.facebook.presto.SystemSessionProperties.QUERY_PRIORITY;
 import static com.facebook.presto.execution.QueryState.FAILED;
 import static com.facebook.presto.execution.QueryState.FINISHED;
 import static com.facebook.presto.execution.QueryState.QUEUED;
 import static com.facebook.presto.execution.QueryState.RUNNING;
-import static com.facebook.presto.operator.BlockedReason.WAITING_FOR_MEMORY;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static io.airlift.units.DataSize.Unit.BYTE;
 import static io.airlift.units.DataSize.succinctBytes;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 public class MockManagedQueryExecution
         implements ManagedQueryExecution
@@ -97,91 +98,44 @@ public class MockManagedQueryExecution
     @Override
     public BasicQueryInfo getBasicQueryInfo()
     {
-        return new BasicQueryInfo(getQueryInfo());
-    }
-
-    @Override
-    public QueryInfo getQueryInfo()
-    {
-        return new QueryInfo(
+        return new BasicQueryInfo(
                 new QueryId("test"),
-                TEST_SESSION.toSessionRepresentation(),
+                session.toSessionRepresentation(),
+                Optional.empty(),
                 state,
-                new MemoryPoolId("reserved"),
-                true,
-                URI.create("1"),
-                ImmutableList.of("2", "3"),
+                new MemoryPoolId("test"),
+                !state.isDone(),
+                URI.create("http://test"),
                 "SELECT 1",
-                new QueryStats(
-                        DateTime.parse("1991-09-06T05:00-05:30"),
-                        DateTime.parse("1991-09-06T05:01-05:30"),
-                        DateTime.parse("1991-09-06T05:02-05:30"),
-                        DateTime.parse("1991-09-06T06:00-05:30"),
-                        Duration.valueOf("8m"),
-                        Duration.valueOf("7m"),
-                        Duration.valueOf("34m"),
-                        Duration.valueOf("35m"),
-                        Duration.valueOf("44m"),
-                        Duration.valueOf("9m"),
-                        Duration.valueOf("10m"),
-                        Duration.valueOf("11m"),
-                        13,
-                        14,
+                new BasicQueryStats(
+                        new DateTime(1),
+                        new DateTime(2),
+                        new Duration(3, NANOSECONDS),
+                        new Duration(4, NANOSECONDS),
+                        new Duration(5, NANOSECONDS),
+                        5,
+                        6,
+                        7,
+                        8,
+                        9,
+                        new DataSize(14, BYTE),
                         15,
-                        16,
-                        100,
-                        17,
-                        18,
-                        34,
-                        19,
-                        20.0,
-                        DataSize.valueOf("21GB"),
-                        DataSize.valueOf("22GB"),
-                        DataSize.valueOf("23GB"),
-                        DataSize.valueOf("24GB"),
-                        DataSize.valueOf("25GB"),
-                        DataSize.valueOf("26GB"),
-                        true,
-                        Duration.valueOf("23m"),
-                        Duration.valueOf("24m"),
-                        Duration.valueOf("0m"),
-                        Duration.valueOf("26m"),
-                        true,
-                        ImmutableSet.of(WAITING_FOR_MEMORY),
-                        DataSize.valueOf("123MB"),
-                        DataSize.valueOf("27GB"),
-                        28,
-                        DataSize.valueOf("29GB"),
-                        30,
-                        DataSize.valueOf("31GB"),
-                        32,
-                        33,
-                        DataSize.valueOf("34GB"),
-                        DataSize.valueOf("35GB"),
-                        DataSize.valueOf("36GB"),
-                        ImmutableList.of(),
-                        ImmutableList.of()),
-                Optional.empty(),
-                Optional.empty(),
-                ImmutableMap.of(),
-                ImmutableSet.of(),
-                ImmutableMap.of(),
-                ImmutableMap.of(),
-                ImmutableSet.of(),
-                Optional.empty(),
-                false,
-                "33",
-                Optional.empty(),
+                        16.0,
+                        new DataSize(17, BYTE),
+                        new DataSize(18, BYTE),
+                        new DataSize(19, BYTE),
+                        new DataSize(20, BYTE),
+                        new DataSize(21, BYTE),
+                        new Duration(22, NANOSECONDS),
+                        new Duration(23, NANOSECONDS),
+                        false,
+                        ImmutableSet.of(),
+                        new DataSize(24, BYTE),
+                        OptionalDouble.empty()),
                 null,
                 null,
-                ImmutableList.of(),
-                ImmutableSet.of(),
                 Optional.empty(),
-                false,
-                Optional.empty(),
-                Optional.empty(),
-                Optional.empty(),
-                Optional.empty());
+                ImmutableList.of());
     }
 
     @Override

--- a/presto-main/src/test/java/com/facebook/presto/execution/MockManagedQueryExecution.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/MockManagedQueryExecution.java
@@ -133,7 +133,6 @@ public class MockManagedQueryExecution
                         new DataSize(24, BYTE),
                         OptionalDouble.empty()),
                 null,
-                null,
                 Optional.empty(),
                 ImmutableList.of());
     }

--- a/presto-tests/src/test/java/com/facebook/presto/execution/TestQueues.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TestQueues.java
@@ -20,6 +20,7 @@ import com.facebook.airlift.json.ObjectMapperProvider;
 import com.facebook.presto.Session;
 import com.facebook.presto.dispatcher.DispatchManager;
 import com.facebook.presto.resourceGroups.ResourceGroupManagerPlugin;
+import com.facebook.presto.server.BasicQueryInfo;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
@@ -347,14 +348,14 @@ public class TestQueues
         waitForQueryState(queryRunner, secondDashboardQuery, QUEUED);
 
         // Retrieve information for the queued query
-        QueryInfo queryInfo = getQueryInfo("/v1/query/" + secondDashboardQuery.getId());
+        BasicQueryInfo queryInfo = getBasicQueryInfo("/v1/query/" + secondDashboardQuery.getId());
         assertNotNull(queryInfo);
         assertEquals(queryInfo.getState(), QUEUED);
         assertEquals(queryInfo.getQuery(), LONG_LASTING_QUERY);
         assertNotNull(queryInfo.getQueryStats());
 
         killQuery(format("/v1/query/%s/killed", secondDashboardQuery.getId()));
-        queryInfo = getQueryInfo("/v1/query/" + secondDashboardQuery.getId());
+        queryInfo = getBasicQueryInfo("/v1/query/" + secondDashboardQuery.getId());
         assertNotNull(queryInfo);
         assertEquals(queryInfo.getErrorCode(), ADMINISTRATIVELY_KILLED.toErrorCode());
 
@@ -363,7 +364,7 @@ public class TestQueues
         waitForQueryState(queryRunner, thirdDashboardQuery, QUEUED);
 
         killQuery(format("/v1/query/%s/preempted", thirdDashboardQuery.getId()));
-        queryInfo = getQueryInfo("/v1/query/" + thirdDashboardQuery.getId());
+        queryInfo = getBasicQueryInfo("/v1/query/" + thirdDashboardQuery.getId());
         assertNotNull(queryInfo);
         assertEquals(queryInfo.getErrorCode(), ADMINISTRATIVELY_PREEMPTED.toErrorCode());
     }
@@ -446,13 +447,13 @@ public class TestQueues
                 .build());
     }
 
-    private QueryInfo getQueryInfo(String path)
+    private BasicQueryInfo getBasicQueryInfo(String path)
             throws IOException
     {
         requireNonNull(path, "path is null");
         Request request = prepareGet().setUri(queryRunner.getCoordinator().resolve(path)).build();
         String body = client.execute(request, createStringResponseHandler()).getBody();
-        return objectMapper.readValue(body, QueryInfo.class);
+        return objectMapper.readValue(body, BasicQueryInfo.class);
     }
 
     private void killQuery(String path)

--- a/presto-tests/src/test/java/com/facebook/presto/memory/TestClusterMemoryLeakDetector.java
+++ b/presto-tests/src/test/java/com/facebook/presto/memory/TestClusterMemoryLeakDetector.java
@@ -103,7 +103,6 @@ public class TestClusterMemoryLeakDetector
                         DataSize.valueOf("123MB"),
                         OptionalDouble.of(20)),
                 null,
-                null,
                 Optional.empty(),
                 ImmutableList.of());
     }


### PR DESCRIPTION
QueryInfo is a large class which is expensive to serialize,
and is not necessary prior to query execution.

Test plan - Locally run TpchQueryRunner and inject a condition to gurantee queueing; observing correct behavior in UI and endpoint.

```
== NO RELEASE NOTE ==
```
