### PR TITLE
Support non-hive types in hive views

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -4733,12 +4733,12 @@ public class TestHiveIntegrationSmokeTest
         assertUpdate(
                 smallStripeSession,
                 "CREATE TABLE test_pagefile_small_stripe\n" +
-                "WITH (\n" +
-                "format = 'PAGEFILE'\n" +
-                ") AS\n" +
-                "SELECT\n" +
-                "*\n" +
-                "FROM tpch.orders",
+                        "WITH (\n" +
+                        "format = 'PAGEFILE'\n" +
+                        ") AS\n" +
+                        "SELECT\n" +
+                        "*\n" +
+                        "FROM tpch.orders",
                 "SELECT count(*) FROM orders");
 
         assertQuery("SELECT count(*) FROM test_pagefile_small_stripe", "SELECT count(*) FROM orders");

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -3918,6 +3918,18 @@ public class TestHiveIntegrationSmokeTest
     }
 
     @Test
+    public void testCreateViewWithNonHiveType()
+    {
+        String testTable = "test_create_view_table";
+        String testView = "test_view_with_hll";
+        assertUpdate(format("CREATE TABLE %s AS SELECT user_name, account_name" +
+                "  FROM (VALUES ('user1', 'account1'), ('user2', 'account2'))" +
+                "  t (user_name, account_name)", testTable), 2);
+        assertUpdate(format("CREATE VIEW %s AS SELECT approx_set(account_name) as hll FROM %s", testView, testTable));
+        assertQuery(format("SELECT cardinality(hll) from %s", testView), "VALUES '2'");
+    }
+
+    @Test
     public void testCollectColumnStatisticsOnCreateTable()
     {
         String tableName = "test_collect_column_statistics_on_create_table";


### PR DESCRIPTION
Test plan - unit test

```
== RELEASE NOTES ==


Hive Changes
* Add support for non-hive types to hive views.  This support had been removed in 0.233.  If a view uses an unsupported type for any columns ,we will store only a single dummy column for that view in the metastore.
```
