### PR TITLE
Clean up TrackedQuery

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/dispatcher/FailedDispatchQuery.java
+++ b/presto-main/src/main/java/com/facebook/presto/dispatcher/FailedDispatchQuery.java
@@ -143,12 +143,6 @@ public class FailedDispatchQuery
     public void recordHeartbeat() {}
 
     @Override
-    public int getRunningTaskCount()
-    {
-        return 0;
-    }
-
-    @Override
     public DateTime getLastHeartbeat()
     {
         return queryInfo.getQueryStats().getEndTime();

--- a/presto-main/src/main/java/com/facebook/presto/dispatcher/LocalDispatchQuery.java
+++ b/presto-main/src/main/java/com/facebook/presto/dispatcher/LocalDispatchQuery.java
@@ -190,12 +190,6 @@ public class LocalDispatchQuery
     }
 
     @Override
-    public int getRunningTaskCount()
-    {
-        return stateMachine.getCurrentRunningTaskCount();
-    }
-
-    @Override
     public Duration getTotalCpuTime()
     {
         return tryGetQueryExecution()

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryExecution.java
@@ -59,6 +59,8 @@ public interface QueryExecution
 
     DataSize getRawInputDataSize();
 
+    int getRunningTaskCount();
+
     DataSize getUserMemoryReservation();
 
     DataSize getTotalMemoryReservation();

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryTracker.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryTracker.java
@@ -230,10 +230,10 @@ public class QueryTracker<T extends TrackedQuery>
         int highestRunningTaskCount = 0;
         Optional<T> highestRunningTaskQuery = Optional.empty();
         for (T query : queries.values()) {
-            if (query.isDone()) {
+            if (query.isDone() || !(query instanceof QueryExecution)) {
                 continue;
             }
-            int runningTaskCount = query.getRunningTaskCount();
+            int runningTaskCount = ((QueryExecution) query).getRunningTaskCount();
             totalRunningTaskCount += runningTaskCount;
             if (runningTaskCount > highestRunningTaskCount) {
                 highestRunningTaskCount = runningTaskCount;
@@ -355,8 +355,6 @@ public class QueryTracker<T extends TrackedQuery>
         DateTime getLastHeartbeat();
 
         Optional<DateTime> getEndTime();
-
-        int getRunningTaskCount();
 
         void fail(Throwable cause);
 


### PR DESCRIPTION
getRunningTaskCount is only applicable if the query is a QueryExecution

Test plan - unit tests and local query submissions to TpchQueryRunner

```
== NO RELEASE NOTE ==
```
