### PR TITLE
Add support in parquet reader for reading TIMESTAMP_MICROS type.

### DIFF
--- a/presto-hive/pom.xml
+++ b/presto-hive/pom.xml
@@ -271,6 +271,13 @@
             <scope>runtime</scope>
         </dependency>
 
+        <!-- used only by tests but also needed transitively -->
+        <dependency>
+            <groupId>org.apache.parquet</groupId>
+            <artifactId>parquet-common</artifactId>
+            <version>${dep.parquet.version}</version>
+        </dependency>
+
         <!-- Presto SPI -->
         <dependency>
             <groupId>com.facebook.presto</groupId>

--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/AbstractTestParquetReader.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/AbstractTestParquetReader.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.hive.common.type.HiveDecimal;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.JavaHiveDecimalObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.DecimalTypeInfo;
+import org.apache.parquet.schema.MessageTypeParser;
 import org.joda.time.DateTimeZone;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -69,6 +70,7 @@ import static com.facebook.presto.common.type.DoubleType.DOUBLE;
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static com.facebook.presto.common.type.RealType.REAL;
 import static com.facebook.presto.common.type.RowType.field;
+import static com.facebook.presto.common.type.TimeZoneKey.UTC_KEY;
 import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
@@ -843,6 +845,33 @@ public abstract class AbstractTestParquetReader
             }
             tester.testRoundTrip(javaIntObjectInspector, intValues, expectedValues.build(), createDecimalType(precision, scale), Optional.of(parquetSchema));
         }
+    }
+
+    @Test
+    public void testTimestampMicrosBackedByINT64()
+            throws Exception
+    {
+        org.apache.parquet.schema.MessageType parquetSchema =
+                MessageTypeParser.parseMessageType("message ts_micros { optional INT64 test (TIMESTAMP_MICROS); }");
+        ContiguousSet<Long> longValues = longsBetween(1_000_000, 1_001_000);
+        ImmutableList.Builder<SqlTimestamp> expectedValues = new ImmutableList.Builder<>();
+        for (Long value : longValues) {
+            expectedValues.add(new SqlTimestamp(value / 1000L, UTC_KEY));
+        }
+        tester.testRoundTrip(javaTimestampObjectInspector, longValues, expectedValues.build(), TIMESTAMP, parquetSchema);
+    }
+
+    @Test
+    public void testTimestampMillisBackedByINT64()
+            throws Exception
+    {
+        MessageType parquetSchema = parseMessageType("message ts_millis { optional INT64 test (TIMESTAMP_MILLIS); }");
+        ContiguousSet<Long> longValues = longsBetween(1_000_000, 1_001_000);
+        ImmutableList.Builder<SqlTimestamp> expectedValues = new ImmutableList.Builder<>();
+        for (Long value : longValues) {
+            expectedValues.add(new SqlTimestamp(value, UTC_KEY));
+        }
+        tester.testRoundTrip(javaLongObjectInspector, longValues, expectedValues.build(), TIMESTAMP, Optional.of(parquetSchema));
     }
 
     @Test

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/ColumnReaderFactory.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/ColumnReaderFactory.java
@@ -23,6 +23,8 @@ import com.facebook.presto.parquet.batchreader.Int32FlatBatchReader;
 import com.facebook.presto.parquet.batchreader.Int32NestedBatchReader;
 import com.facebook.presto.parquet.batchreader.Int64FlatBatchReader;
 import com.facebook.presto.parquet.batchreader.Int64NestedBatchReader;
+import com.facebook.presto.parquet.batchreader.Int64TimestampMicrosFlatBatchReader;
+import com.facebook.presto.parquet.batchreader.Int64TimestampMicrosNestedBatchReader;
 import com.facebook.presto.parquet.batchreader.TimestampFlatBatchReader;
 import com.facebook.presto.parquet.batchreader.TimestampNestedBatchReader;
 import com.facebook.presto.parquet.reader.AbstractColumnReader;
@@ -33,6 +35,7 @@ import com.facebook.presto.parquet.reader.FloatColumnReader;
 import com.facebook.presto.parquet.reader.IntColumnReader;
 import com.facebook.presto.parquet.reader.LongColumnReader;
 import com.facebook.presto.parquet.reader.LongDecimalColumnReader;
+import com.facebook.presto.parquet.reader.LongTimestampMicrosColumnReader;
 import com.facebook.presto.parquet.reader.ShortDecimalColumnReader;
 import com.facebook.presto.parquet.reader.TimestampColumnReader;
 import com.facebook.presto.spi.PrestoException;
@@ -41,6 +44,7 @@ import org.apache.parquet.schema.OriginalType;
 import java.util.Optional;
 
 import static com.facebook.presto.parquet.ParquetTypeUtils.createDecimalType;
+import static com.facebook.presto.parquet.ParquetTypeUtils.isTimeStampMicrosType;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 
 public class ColumnReaderFactory
@@ -61,6 +65,9 @@ public class ColumnReaderFactory
                 case FLOAT:
                     return isNested ? new Int32NestedBatchReader(descriptor) : new Int32FlatBatchReader(descriptor);
                 case INT64:
+                    if (isTimeStampMicrosType(descriptor)) {
+                        return isNested ? new Int64TimestampMicrosNestedBatchReader(descriptor) : new Int64TimestampMicrosFlatBatchReader(descriptor);
+                    }
                 case DOUBLE:
                     return isNested ? new Int64NestedBatchReader(descriptor) : new Int64FlatBatchReader(descriptor);
                 case INT96:
@@ -76,6 +83,9 @@ public class ColumnReaderFactory
             case INT32:
                 return createDecimalColumnReader(descriptor).orElse(new IntColumnReader(descriptor));
             case INT64:
+                if (OriginalType.TIMESTAMP_MICROS.equals(descriptor.getPrimitiveType().getOriginalType())) {
+                    return new LongTimestampMicrosColumnReader(descriptor);
+                }
                 return createDecimalColumnReader(descriptor).orElse(new LongColumnReader(descriptor));
             case INT96:
                 return new TimestampColumnReader(descriptor);

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/ParquetTypeUtils.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/ParquetTypeUtils.java
@@ -17,6 +17,7 @@ import com.facebook.presto.common.Subfield;
 import com.facebook.presto.common.type.DecimalType;
 import com.facebook.presto.common.type.Type;
 import com.google.common.collect.ImmutableList;
+import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.Encoding;
 import org.apache.parquet.io.ColumnIO;
 import org.apache.parquet.io.ColumnIOFactory;
@@ -28,6 +29,7 @@ import org.apache.parquet.io.PrimitiveColumnIO;
 import org.apache.parquet.schema.DecimalMetadata;
 import org.apache.parquet.schema.GroupType;
 import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.OriginalType;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -326,5 +328,10 @@ public final class ParquetTypeUtils
         columnPath.add(subfield.getRootName());
         columnPath.addAll(nestedColumnPath(subfield));
         return columnPath.build();
+    }
+
+    public static boolean isTimeStampMicrosType(ColumnDescriptor descriptor)
+    {
+        return OriginalType.TIMESTAMP_MICROS.equals(descriptor.getPrimitiveType().getOriginalType());
     }
 }

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/decoders/Decoders.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/decoders/Decoders.java
@@ -21,15 +21,18 @@ import com.facebook.presto.parquet.RichColumnDescriptor;
 import com.facebook.presto.parquet.batchreader.decoders.delta.BinaryDeltaValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.delta.Int32DeltaBinaryPackedValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.delta.Int64DeltaBinaryPackedValuesDecoder;
+import com.facebook.presto.parquet.batchreader.decoders.delta.Int64TimestampMicrosDeltaBinaryPackedValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.plain.BinaryPlainValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.plain.BooleanPlainValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.plain.Int32PlainValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.plain.Int64PlainValuesDecoder;
+import com.facebook.presto.parquet.batchreader.decoders.plain.Int64TimestampMicrosPlainValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.plain.TimestampPlainValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.rle.BinaryRLEDictionaryValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.rle.BooleanRLEValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.rle.Int32RLEDictionaryValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.rle.Int64RLEDictionaryValuesDecoder;
+import com.facebook.presto.parquet.batchreader.decoders.rle.Int64TimestampMicrosRLEDictionaryValuesDecoder;
 import com.facebook.presto.parquet.batchreader.decoders.rle.TimestampRLEDictionaryValuesDecoder;
 import com.facebook.presto.parquet.batchreader.dictionary.BinaryBatchDictionary;
 import com.facebook.presto.parquet.batchreader.dictionary.TimestampDictionary;
@@ -57,6 +60,7 @@ import static com.facebook.presto.parquet.ParquetEncoding.RLE_DICTIONARY;
 import static com.facebook.presto.parquet.ParquetErrorCode.PARQUET_IO_READ_ERROR;
 import static com.facebook.presto.parquet.ParquetErrorCode.PARQUET_UNSUPPORTED_COLUMN_TYPE;
 import static com.facebook.presto.parquet.ParquetErrorCode.PARQUET_UNSUPPORTED_ENCODING;
+import static com.facebook.presto.parquet.ParquetTypeUtils.isTimeStampMicrosType;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.String.format;
 import static org.apache.parquet.bytes.BytesUtils.getWidthFromMaxInt;
@@ -95,7 +99,11 @@ public class Decoders
                 case INT32:
                 case FLOAT:
                     return new Int32PlainValuesDecoder(buffer, offset, length);
-                case INT64:
+                case INT64: {
+                    if (isTimeStampMicrosType(columnDescriptor)) {
+                        return new Int64TimestampMicrosPlainValuesDecoder(buffer, offset, length);
+                    }
+                }
                 case DOUBLE:
                     return new Int64PlainValuesDecoder(buffer, offset, length);
                 case INT96:
@@ -122,7 +130,11 @@ public class Decoders
                 case FLOAT: {
                     return new Int32RLEDictionaryValuesDecoder(bitWidth, inputStream, (IntegerDictionary) dictionary);
                 }
-                case INT64:
+                case INT64: {
+                    if (isTimeStampMicrosType(columnDescriptor)) {
+                        return new Int64TimestampMicrosRLEDictionaryValuesDecoder(bitWidth, inputStream, (LongDictionary) dictionary);
+                    }
+                }
                 case DOUBLE: {
                     return new Int64RLEDictionaryValuesDecoder(bitWidth, inputStream, (LongDictionary) dictionary);
                 }
@@ -145,7 +157,11 @@ public class Decoders
                 case FLOAT: {
                     return new Int32DeltaBinaryPackedValuesDecoder(valueCount, inputStream);
                 }
-                case INT64:
+                case INT64: {
+                    if (isTimeStampMicrosType(columnDescriptor)) {
+                        return new Int64TimestampMicrosDeltaBinaryPackedValuesDecoder(valueCount, inputStream);
+                    }
+                }
                 case DOUBLE: {
                     return new Int64DeltaBinaryPackedValuesDecoder(valueCount, inputStream);
                 }

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/decoders/ValuesDecoder.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/decoders/ValuesDecoder.java
@@ -54,6 +54,16 @@ public interface ValuesDecoder
                 throws IOException;
     }
 
+    interface Int64TimestampMicrosValuesDecoder
+            extends ValuesDecoder
+    {
+        void readNext(long[] values, int offset, int length)
+                throws IOException;
+
+        void skip(int length)
+                throws IOException;
+    }
+
     interface TimestampValuesDecoder
             extends ValuesDecoder
     {

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/decoders/delta/Int64TimestampMicrosDeltaBinaryPackedValuesDecoder.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/decoders/delta/Int64TimestampMicrosDeltaBinaryPackedValuesDecoder.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.parquet.batchreader.decoders.delta;
+
+import com.facebook.presto.parquet.batchreader.decoders.ValuesDecoder.Int64TimestampMicrosValuesDecoder;
+import org.apache.parquet.bytes.ByteBufferInputStream;
+import org.apache.parquet.column.values.delta.DeltaBinaryPackingValuesReader;
+
+import java.io.IOException;
+
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
+
+/**
+ * Note: this is not an optimized values decoder. It makes use of the existing Parquet decoder. Given that this type encoding
+ * is not a common one, just use the existing one provided by Parquet library and add a wrapper around it that satisfies the
+ * {@link Int64ValuesDecoder} interface.
+ */
+public class Int64TimestampMicrosDeltaBinaryPackedValuesDecoder
+        implements Int64TimestampMicrosValuesDecoder
+{
+    private final DeltaBinaryPackingValuesReader innerReader;
+
+    public Int64TimestampMicrosDeltaBinaryPackedValuesDecoder(int valueCount, ByteBufferInputStream bufferInputStream)
+            throws IOException
+    {
+        innerReader = new DeltaBinaryPackingValuesReader();
+        innerReader.initFromPage(valueCount, bufferInputStream);
+    }
+
+    @Override
+    public void readNext(long[] values, int offset, int length)
+    {
+        int endOffset = offset + length;
+        for (int i = offset; i < endOffset; i++) {
+            values[i] = MICROSECONDS.toMillis(innerReader.readLong());
+        }
+    }
+
+    @Override
+    public void skip(int length)
+    {
+        while (length > 0) {
+            innerReader.skip();
+            length--;
+        }
+    }
+}

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/decoders/plain/Int64TimestampMicrosPlainValuesDecoder.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/decoders/plain/Int64TimestampMicrosPlainValuesDecoder.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.parquet.batchreader.decoders.plain;
+
+import com.facebook.presto.parquet.batchreader.BytesUtils;
+import com.facebook.presto.parquet.batchreader.decoders.ValuesDecoder.Int64TimestampMicrosValuesDecoder;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
+
+public class Int64TimestampMicrosPlainValuesDecoder
+        implements Int64TimestampMicrosValuesDecoder
+{
+    private final byte[] byteBuffer;
+    private final int bufferEnd;
+
+    private int bufferOffset;
+
+    public Int64TimestampMicrosPlainValuesDecoder(byte[] byteBuffer, int bufferOffset, int length)
+    {
+        this.byteBuffer = byteBuffer;
+        this.bufferOffset = bufferOffset;
+        this.bufferEnd = bufferOffset + length;
+    }
+
+    @Override
+    public void readNext(long[] values, int offset, int length)
+    {
+        checkArgument(bufferOffset + length * 8 <= bufferEnd, "End of stream: invalid read request");
+        checkArgument(length >= 0 && offset >= 0, "invalid read request: offset %s, length", offset, length);
+
+        final int endOffset = offset + length;
+        final byte[] localByteBuffer = byteBuffer;
+        int localBufferOffset = bufferOffset;
+
+        while (offset < endOffset) {
+            values[offset++] = MICROSECONDS.toMillis(BytesUtils.getLong(localByteBuffer, localBufferOffset));
+            localBufferOffset += 8;
+        }
+
+        bufferOffset = localBufferOffset;
+    }
+
+    @Override
+    public void skip(int length)
+    {
+        checkArgument(bufferOffset + length * 8 <= bufferEnd, "End of stream: invalid read request");
+        checkArgument(length >= 0, "invalid length %s", length);
+        bufferOffset += length * 8;
+    }
+}

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/decoders/rle/Int64TimestampMicrosRLEDictionaryValuesDecoder.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/batchreader/decoders/rle/Int64TimestampMicrosRLEDictionaryValuesDecoder.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.parquet.batchreader.decoders.rle;
+
+import com.facebook.presto.parquet.batchreader.decoders.ValuesDecoder.Int64TimestampMicrosValuesDecoder;
+import com.facebook.presto.parquet.dictionary.LongDictionary;
+import org.apache.parquet.io.ParquetDecodingException;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
+
+public class Int64TimestampMicrosRLEDictionaryValuesDecoder
+        extends BaseRLEBitPackedDecoder
+        implements Int64TimestampMicrosValuesDecoder
+{
+    private final LongDictionary dictionary;
+
+    public Int64TimestampMicrosRLEDictionaryValuesDecoder(int bitWidth, InputStream inputStream, LongDictionary dictionary)
+    {
+        super(Integer.MAX_VALUE, bitWidth, inputStream);
+        this.dictionary = dictionary;
+    }
+
+    @Override
+    public void readNext(long[] values, int offset, int length)
+            throws IOException
+    {
+        int destinationIndex = offset;
+        int remainingToCopy = length;
+        while (remainingToCopy > 0) {
+            if (currentCount == 0) {
+                if (!decode()) {
+                    break;
+                }
+            }
+
+            int numEntriesToFill = Math.min(remainingToCopy, currentCount);
+            int endIndex = destinationIndex + numEntriesToFill;
+            switch (mode) {
+                case RLE: {
+                    final int rleValue = currentValue;
+                    final long rleDictionaryValue = MICROSECONDS.toMillis(dictionary.decodeToLong(rleValue));
+                    while (destinationIndex < endIndex) {
+                        values[destinationIndex++] = rleDictionaryValue;
+                    }
+                    break;
+                }
+                case PACKED: {
+                    final int[] localBuffer = currentBuffer;
+                    final LongDictionary localDictionary = dictionary;
+                    for (int srcIndex = currentBuffer.length - currentCount; destinationIndex < endIndex; srcIndex++) {
+                        long dictionaryValue = localDictionary.decodeToLong(localBuffer[srcIndex]);
+                        values[destinationIndex++] = MICROSECONDS.toMillis(dictionaryValue);
+                    }
+                    break;
+                }
+                default:
+                    throw new ParquetDecodingException("not a valid mode " + mode);
+            }
+
+            currentCount -= numEntriesToFill;
+            remainingToCopy -= numEntriesToFill;
+        }
+
+        checkState(remainingToCopy == 0, "End of stream: Invalid read size request");
+    }
+
+    @Override
+    public void skip(int length)
+            throws IOException
+    {
+        checkArgument(length >= 0, "invalid length %s", length);
+        int remaining = length;
+        while (remaining > 0) {
+            if (currentCount == 0) {
+                if (!decode()) {
+                    break;
+                }
+            }
+
+            int chunkSize = Math.min(remaining, currentCount);
+            currentCount -= chunkSize;
+            remaining -= chunkSize;
+        }
+
+        checkState(remaining == 0, "End of stream: Invalid skip size request: %s", length);
+    }
+}

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/reader/LongTimestampMicrosColumnReader.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/reader/LongTimestampMicrosColumnReader.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.parquet.reader;
+
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.TimestampWithTimeZoneType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.parquet.RichColumnDescriptor;
+
+import static com.facebook.presto.common.type.DateTimeEncoding.packDateTimeWithZone;
+import static com.facebook.presto.common.type.TimeZoneKey.UTC_KEY;
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
+
+public class LongTimestampMicrosColumnReader
+        extends AbstractColumnReader
+{
+    public LongTimestampMicrosColumnReader(RichColumnDescriptor descriptor)
+    {
+        super(descriptor);
+    }
+
+    @Override
+    protected void readValue(BlockBuilder blockBuilder, Type type)
+    {
+        if (definitionLevel == columnDescriptor.getMaxDefinitionLevel()) {
+            long utcMillis = MICROSECONDS.toMillis(valuesReader.readLong());
+            // TODO: specialize the class at creation time
+            if (type instanceof TimestampWithTimeZoneType) {
+                type.writeLong(blockBuilder, packDateTimeWithZone(utcMillis, UTC_KEY));
+            }
+            else {
+                type.writeLong(blockBuilder, utcMillis);
+            }
+        }
+        else if (isValueNull()) {
+            blockBuilder.appendNull();
+        }
+    }
+
+    @Override
+    protected void skipValue()
+    {
+        if (definitionLevel == columnDescriptor.getMaxDefinitionLevel()) {
+            valuesReader.readLong();
+        }
+    }
+}

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/reader/MetadataReader.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/reader/MetadataReader.java
@@ -266,6 +266,8 @@ public final class MetadataReader
                 return OriginalType.DATE;
             case TIME_MILLIS:
                 return OriginalType.TIME_MILLIS;
+            case TIMESTAMP_MICROS:
+                return OriginalType.TIMESTAMP_MICROS;
             case TIMESTAMP_MILLIS:
                 return OriginalType.TIMESTAMP_MILLIS;
             case INTERVAL:

--- a/presto-parquet/src/main/resources/freemarker/data/ParquetTypes.tdd
+++ b/presto-parquet/src/main/resources/freemarker/data/ParquetTypes.tdd
@@ -17,6 +17,12 @@
             blockType: "ByteArrayBlock",
             valuesDecoder: "BooleanValuesDecoder",
             primitiveType: "byte"
+        },
+        {
+            classNamePrefix: "Int64TimestampMicros",
+            blockType: "LongArrayBlock",
+            valuesDecoder: "Int64TimestampMicrosValuesDecoder",
+            primitiveType: "long"
         }
     ]
 }


### PR DESCRIPTION
Summary:
Right now presto always assumes TIMESTAMP_MILLIS as the OriginalType when int64 is used to
represent timestamp type in the schema. This causes an issue.

When we use createParquetPageSource we use our own type convertor and this does not have a check
for TIMESTAMP_MICROS and this can fail the query

Fix: In this change I am adding three ValueDecoders one for plain and one for RLE compression format and
one for the non batch reader. All of these are in 3 new classes so that during creation we
instantiate the class based on the OriginalType. One Alternate approach is to do this check inside
LongValueDecoders but that would make this check inside the most critical path and can affect query
performance. The fix simply divides the micros seconds by 1000 to get the milliseconds and this should
be ok because in presto we anyway operate at the millisecond granularity. Note that the non batch reader
also checks for whether timezone is present in the data while the batch readers don't because that
information is not available.

For testing, the ValueDecoders have their own unit test. Apart from that have also added a new test in
ParquetTester to check if timestamp stored as int64 with OriginalType TIMESTAMP_MICROS works.

Note: We use hive parquet writer and schema definition as defined in the presto-hive package
which is a shaded jar with a old version of hive. This packs an old version of parquet-mr that does not
have the TIMESTAMP_MICROS type. However, in the read path, we use the independent parquet dependency
which is more recent and so we use the version where the new enum is available. If we upgrade all the tests
to use the new version of parquet, we would not be testing parquet version written
by the packaged hive writer. We would need a version of the test that would work with the new definitions.
For now I have done this only for the timestamp type to test TIMESTAMP_MICROS. As part of seperate change
we can make sure all the test are tested with latest parquet writer. This change uses ExampleParquetWriter
which is supposed to be used only for demo or test purposes. We cannot use presto's parquet writer as well because
the one used in test always stored timestamp as millis and does not store any annotated type and using
that we will not be able to test our code.

Test plan - tested in local docker container, also added unit test to test this out.

Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines.

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== RELEASE NOTES ==

General Changes
* parquet files written by parquet-avro library that uses TIMESTAMP_MICROS as the OriginalType to represent timestamp can now be queried by presto
```
