### PR TITLE
Track cache objects sizes in CachingOrcDataSource

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcBatchPageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcBatchPageSourceFactory.java
@@ -280,7 +280,7 @@ public class OrcBatchPageSourceFactory
 
             return new OrcBatchPageSource(
                     recordReader,
-                    orcDataSource,
+                    reader.getOrcDataSource(),
                     physicalColumns,
                     typeManager,
                     systemMemoryUsage,

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcSelectivePageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcSelectivePageSourceFactory.java
@@ -406,7 +406,7 @@ public class OrcSelectivePageSourceFactory
 
             return new OrcSelectivePageSource(
                     recordReader,
-                    orcDataSource,
+                    reader.getOrcDataSource(),
                     systemMemoryUsage,
                     stats);
         }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/AbstractOrcRecordReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/AbstractOrcRecordReader.java
@@ -221,7 +221,7 @@ abstract class AbstractOrcRecordReader<T extends StreamReader>
         this.stripes = stripes.build();
         this.stripeFilePositions = stripeFilePositions.build();
 
-        orcDataSource = wrapWithCacheIfTinyStripes(orcDataSource, this.stripes, maxMergeDistance, tinyStripeThreshold);
+        orcDataSource = wrapWithCacheIfTinyStripes(orcDataSource, this.stripes, maxMergeDistance, tinyStripeThreshold, systemMemoryUsage);
         this.orcDataSource = orcDataSource;
         this.splitLength = splitLength;
 
@@ -427,7 +427,7 @@ abstract class AbstractOrcRecordReader<T extends StreamReader>
     }
 
     @VisibleForTesting
-    static OrcDataSource wrapWithCacheIfTinyStripes(OrcDataSource dataSource, List<StripeInformation> stripes, DataSize maxMergeDistance, DataSize tinyStripeThreshold)
+    static OrcDataSource wrapWithCacheIfTinyStripes(OrcDataSource dataSource, List<StripeInformation> stripes, DataSize maxMergeDistance, DataSize tinyStripeThreshold, OrcAggregatedMemoryContext systemMemoryContext)
     {
         if (dataSource instanceof CachingOrcDataSource) {
             return dataSource;
@@ -437,7 +437,7 @@ abstract class AbstractOrcRecordReader<T extends StreamReader>
                 return dataSource;
             }
         }
-        return new CachingOrcDataSource(dataSource, createTinyStripesRangeFinder(stripes, maxMergeDistance, tinyStripeThreshold));
+        return new CachingOrcDataSource(dataSource, createTinyStripesRangeFinder(stripes, maxMergeDistance, tinyStripeThreshold), systemMemoryContext.newOrcLocalMemoryContext(CachingOrcDataSource.class.getSimpleName()));
     }
 
     /**

--- a/presto-orc/src/main/java/com/facebook/presto/orc/CachingOrcDataSource.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/CachingOrcDataSource.java
@@ -28,15 +28,17 @@ public class CachingOrcDataSource
 {
     private final OrcDataSource dataSource;
     private final RegionFinder regionFinder;
+    private final OrcLocalMemoryContext systemMemoryContext;
 
     private long cachePosition;
     private int cacheLength;
     private byte[] cache;
 
-    public CachingOrcDataSource(OrcDataSource dataSource, RegionFinder regionFinder)
+    public CachingOrcDataSource(OrcDataSource dataSource, RegionFinder regionFinder, OrcLocalMemoryContext systemMemoryContext)
     {
         this.dataSource = requireNonNull(dataSource, "dataSource is null");
         this.regionFinder = requireNonNull(regionFinder, "regionFinder is null");
+        this.systemMemoryContext = requireNonNull(systemMemoryContext, "systemMemoryContext is null");
         this.cache = new byte[0];
     }
 
@@ -73,6 +75,7 @@ public class CachingOrcDataSource
         cacheLength = newCacheRange.getLength();
         if (cache.length < cacheLength) {
             cache = new byte[cacheLength];
+            systemMemoryContext.setBytes(cacheLength);
         }
         dataSource.readFully(newCacheRange.getOffset(), cache, 0, cacheLength);
     }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcReader.java
@@ -225,7 +225,7 @@ public class OrcReader
             Map<Integer, Slice> columnsToIntermediateKeys)
             throws OrcCorruptionException
     {
-        return createBatchRecordReader(includedColumns, predicate, 0, orcDataSource.getSize(), hiveStorageTimeZone, systemMemoryUsage, initialBatchSize, columnsToIntermediateKeys);
+        return createBatchRecordReader(includedColumns, predicate, 0, getOrcDataSource().getSize(), hiveStorageTimeZone, systemMemoryUsage, initialBatchSize, columnsToIntermediateKeys);
     }
 
     public OrcBatchRecordReader createBatchRecordReader(
@@ -246,7 +246,7 @@ public class OrcReader
                 footer.getStripes(),
                 footer.getFileStats(),
                 metadata.getStripeStatsList(),
-                orcDataSource,
+                getOrcDataSource(),
                 offset,
                 length,
                 footer.getTypes(),
@@ -302,7 +302,7 @@ public class OrcReader
                 footer.getStripes(),
                 footer.getFileStats(),
                 metadata.getStripeStatsList(),
-                orcDataSource,
+                getOrcDataSource(),
                 offset,
                 length,
                 footer.getTypes(),
@@ -387,5 +387,10 @@ public class OrcReader
         if (writeValidation.isPresent() && !test.test(writeValidation.get())) {
             throw new OrcCorruptionException(orcDataSource.getId(), "Write validation failed: " + messageFormat, args);
         }
+    }
+
+    public OrcDataSource getOrcDataSource()
+    {
+        return orcDataSource;
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcReader.java
@@ -111,7 +111,7 @@ public class OrcReader
             throws IOException
     {
         this.orcReaderOptions = requireNonNull(orcReaderOptions, "orcReaderOptions is null");
-        orcDataSource = wrapWithCacheIfTiny(orcDataSource, orcReaderOptions.getTinyStripeThreshold());
+        orcDataSource = wrapWithCacheIfTiny(orcDataSource, orcReaderOptions.getTinyStripeThreshold(), aggregatedMemoryContext);
         this.orcDataSource = orcDataSource;
         requireNonNull(orcEncoding, "orcEncoding is null");
         this.metadataReader = new ExceptionWrappingMetadataReader(orcDataSource.getId(), orcEncoding.createMetadataReader());
@@ -326,7 +326,7 @@ public class OrcReader
                 cacheable);
     }
 
-    private static OrcDataSource wrapWithCacheIfTiny(OrcDataSource dataSource, DataSize maxCacheSize)
+    private static OrcDataSource wrapWithCacheIfTiny(OrcDataSource dataSource, DataSize maxCacheSize, OrcAggregatedMemoryContext systemMemoryContext)
     {
         if (dataSource instanceof CachingOrcDataSource) {
             return dataSource;
@@ -335,7 +335,7 @@ public class OrcReader
             return dataSource;
         }
         DiskRange diskRange = new DiskRange(0, toIntExact(dataSource.getSize()));
-        return new CachingOrcDataSource(dataSource, desiredOffset -> diskRange);
+        return new CachingOrcDataSource(dataSource, desiredOffset -> diskRange, systemMemoryContext.newOrcLocalMemoryContext(CachingOrcDataSource.class.getSimpleName()));
     }
 
     static void validateFile(

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestCachingOrcDataSource.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestCachingOrcDataSource.java
@@ -44,9 +44,9 @@ import static com.facebook.airlift.testing.Assertions.assertGreaterThanOrEqual;
 import static com.facebook.airlift.testing.Assertions.assertInstanceOf;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.orc.AbstractOrcRecordReader.LinearProbeRangeFinder.createTinyStripesRangeFinder;
+import static com.facebook.presto.orc.AbstractOrcRecordReader.wrapWithCacheIfTinyStripes;
 import static com.facebook.presto.orc.DwrfEncryptionProvider.NO_ENCRYPTION;
 import static com.facebook.presto.orc.NoopOrcAggregatedMemoryContext.NOOP_ORC_AGGREGATED_MEMORY_CONTEXT;
-import static com.facebook.presto.orc.OrcBatchRecordReader.wrapWithCacheIfTinyStripes;
 import static com.facebook.presto.orc.OrcEncoding.ORC;
 import static com.facebook.presto.orc.OrcReader.INITIAL_BATCH_SIZE;
 import static com.facebook.presto.orc.OrcTester.Format.ORC_12;
@@ -94,18 +94,22 @@ public class TestCachingOrcDataSource
         DataSize maxMergeDistance = new DataSize(1, Unit.MEGABYTE);
         DataSize tinyStripeThreshold = new DataSize(8, Unit.MEGABYTE);
 
+        OrcAggregatedMemoryContext systemMemoryContext = new TestingHiveOrcAggregatedMemoryContext();
+
         OrcDataSource actual = wrapWithCacheIfTinyStripes(
                 FakeOrcDataSource.INSTANCE,
                 ImmutableList.of(),
                 maxMergeDistance,
-                tinyStripeThreshold);
+                tinyStripeThreshold,
+                systemMemoryContext);
         assertInstanceOf(actual, CachingOrcDataSource.class);
 
         actual = wrapWithCacheIfTinyStripes(
                 FakeOrcDataSource.INSTANCE,
                 ImmutableList.of(new StripeInformation(123, 3, 10, 10, 10, ImmutableList.of())),
                 maxMergeDistance,
-                tinyStripeThreshold);
+                tinyStripeThreshold,
+                systemMemoryContext);
         assertInstanceOf(actual, CachingOrcDataSource.class);
 
         actual = wrapWithCacheIfTinyStripes(
@@ -115,7 +119,8 @@ public class TestCachingOrcDataSource
                         new StripeInformation(123, 33, 10, 10, 10, ImmutableList.of()),
                         new StripeInformation(123, 63, 10, 10, 10, ImmutableList.of())),
                 maxMergeDistance,
-                tinyStripeThreshold);
+                tinyStripeThreshold,
+                systemMemoryContext);
         assertInstanceOf(actual, CachingOrcDataSource.class);
 
         actual = wrapWithCacheIfTinyStripes(
@@ -125,7 +130,8 @@ public class TestCachingOrcDataSource
                         new StripeInformation(123, 33, 10, 10, 10, ImmutableList.of()),
                         new StripeInformation(123, 63, 1048576 * 8 - 20, 10, 10, ImmutableList.of())),
                 maxMergeDistance,
-                tinyStripeThreshold);
+                tinyStripeThreshold,
+                systemMemoryContext);
         assertInstanceOf(actual, CachingOrcDataSource.class);
 
         actual = wrapWithCacheIfTinyStripes(
@@ -135,7 +141,8 @@ public class TestCachingOrcDataSource
                         new StripeInformation(123, 33, 10, 10, 10, ImmutableList.of()),
                         new StripeInformation(123, 63, 1048576 * 8 - 20 + 1, 10, 10, ImmutableList.of())),
                 maxMergeDistance,
-                tinyStripeThreshold);
+                tinyStripeThreshold,
+                systemMemoryContext);
         assertNotInstanceOf(actual, CachingOrcDataSource.class);
     }
 
@@ -146,16 +153,24 @@ public class TestCachingOrcDataSource
         DataSize maxMergeDistance = new DataSize(1, Unit.MEGABYTE);
         DataSize tinyStripeThreshold = new DataSize(8, Unit.MEGABYTE);
 
+        OrcAggregatedMemoryContext systemMemoryContext = new TestingHiveOrcAggregatedMemoryContext();
+
         TestingOrcDataSource testingOrcDataSource = new TestingOrcDataSource(FakeOrcDataSource.INSTANCE);
         CachingOrcDataSource cachingOrcDataSource = new CachingOrcDataSource(
                 testingOrcDataSource,
                 createTinyStripesRangeFinder(
-                        ImmutableList.of(new StripeInformation(123, 3, 10, 10, 10, ImmutableList.of()), new StripeInformation(123, 33, 10, 10, 10, ImmutableList.of()), new StripeInformation(123, 63, 1048576 * 8 - 20, 10, 10, ImmutableList.of())),
+                        ImmutableList.of(
+                                new StripeInformation(123, 3, 10, 10, 10, ImmutableList.of()),
+                                new StripeInformation(123, 33, 10, 10, 10, ImmutableList.of()),
+                                new StripeInformation(123, 63, 1048576 * 8 - 20, 10, 10, ImmutableList.of())),
                         maxMergeDistance,
-                        tinyStripeThreshold));
+                        tinyStripeThreshold),
+                systemMemoryContext.newOrcLocalMemoryContext(CachingOrcDataSource.class.getSimpleName()));
         cachingOrcDataSource.readCacheAt(3);
         assertEquals(testingOrcDataSource.getLastReadRanges(), ImmutableList.of(new DiskRange(3, 60)));
         cachingOrcDataSource.readCacheAt(63);
+        // The allocated cache size is the length of the merged disk range 1048576 * 8.
+        assertEquals(systemMemoryContext.getBytes(), 8 * 1048576);
         assertEquals(testingOrcDataSource.getLastReadRanges(), ImmutableList.of(new DiskRange(63, 8 * 1048576)));
 
         testingOrcDataSource = new TestingOrcDataSource(FakeOrcDataSource.INSTANCE);
@@ -167,10 +182,13 @@ public class TestCachingOrcDataSource
                                 new StripeInformation(123, 33, 10, 10, 10, ImmutableList.of()),
                                 new StripeInformation(123, 63, 1048576 * 8 - 20, 10, 10, ImmutableList.of())),
                         maxMergeDistance,
-                        tinyStripeThreshold));
+                        tinyStripeThreshold),
+                systemMemoryContext.newOrcLocalMemoryContext(CachingOrcDataSource.class.getSimpleName()));
         cachingOrcDataSource.readCacheAt(62); // read at the end of a stripe
         assertEquals(testingOrcDataSource.getLastReadRanges(), ImmutableList.of(new DiskRange(3, 60)));
         cachingOrcDataSource.readCacheAt(63);
+        // The newly allocated cache size is the length of the merged disk range 1048576 * 8 so the total size is 8 * 1048576 * 2.
+        assertEquals(systemMemoryContext.getBytes(), 8 * 1048576 * 2);
         assertEquals(testingOrcDataSource.getLastReadRanges(), ImmutableList.of(new DiskRange(63, 8 * 1048576)));
 
         testingOrcDataSource = new TestingOrcDataSource(FakeOrcDataSource.INSTANCE);
@@ -182,10 +200,13 @@ public class TestCachingOrcDataSource
                                 new StripeInformation(123, 4, 1048576, 1048576, 1048576 * 3, ImmutableList.of()),
                                 new StripeInformation(123, 4 + 1048576 * 5, 1048576, 1048576, 1048576, ImmutableList.of())),
                         maxMergeDistance,
-                        tinyStripeThreshold));
+                        tinyStripeThreshold),
+                systemMemoryContext.newOrcLocalMemoryContext(CachingOrcDataSource.class.getSimpleName()));
         cachingOrcDataSource.readCacheAt(3);
         assertEquals(testingOrcDataSource.getLastReadRanges(), ImmutableList.of(new DiskRange(3, 1 + 1048576 * 5)));
         cachingOrcDataSource.readCacheAt(4 + 1048576 * 5);
+        // The newly allocated cache size is the length of the first merged disk range 1048576 * 5 + 1.
+        assertEquals(systemMemoryContext.getBytes(), 8 * 1048576 * 2 + 1048576 * 5 + 1);
         assertEquals(testingOrcDataSource.getLastReadRanges(), ImmutableList.of(new DiskRange(4 + 1048576 * 5, 3 * 1048576)));
     }
 
@@ -209,6 +230,8 @@ public class TestCachingOrcDataSource
     public void doIntegration(TestingOrcDataSource orcDataSource, DataSize maxMergeDistance, DataSize maxReadSize, DataSize tinyStripeThreshold)
             throws IOException
     {
+        OrcAggregatedMemoryContext systemMemoryContext = new TestingHiveOrcAggregatedMemoryContext();
+
         OrcReader orcReader = new OrcReader(
                 orcDataSource,
                 ORC,
@@ -224,7 +247,7 @@ public class TestCachingOrcDataSource
         // Sanity check number of stripes. This can be three or higher because of orc writer low memory mode.
         assertGreaterThanOrEqual(stripes.size(), 3);
         //verify wrapped by CachingOrcReader
-        assertInstanceOf(wrapWithCacheIfTinyStripes(orcDataSource, stripes, maxMergeDistance, tinyStripeThreshold), CachingOrcDataSource.class);
+        assertInstanceOf(wrapWithCacheIfTinyStripes(orcDataSource, stripes, maxMergeDistance, tinyStripeThreshold, systemMemoryContext), CachingOrcDataSource.class);
 
         OrcBatchRecordReader orcRecordReader = orcReader.createBatchRecordReader(
                 ImmutableMap.of(0, VARCHAR),


### PR DESCRIPTION
The cache object in CachingOrcDataSource was not tracked before. This PR updates the PageSource's system memory usage whenever a new cache
object is allocated.

```
== RELEASE NOTES ==


Hive Changes
* Fixed a memory tracking issue in OrcPageSource
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```
