### PR TITLE
Adds support for microsecond timestamp precision

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/DecodeTimestampOptions.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/DecodeTimestampOptions.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc;
+
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+
+import java.util.concurrent.TimeUnit;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+public class DecodeTimestampOptions
+{
+    private final long unitsPerSecond;
+    private final long nanosecondsPerUnit;
+    private final long baseSeconds;
+
+    public DecodeTimestampOptions(DateTimeZone hiveStorageTimeZone, boolean enableMicroPrecision)
+    {
+        TimeUnit timeUnit = enableMicroPrecision ? MICROSECONDS : MILLISECONDS;
+
+        requireNonNull(hiveStorageTimeZone, "hiveStorageTimeZone is null");
+
+        this.unitsPerSecond = timeUnit.convert(1, TimeUnit.SECONDS);
+        this.nanosecondsPerUnit = TimeUnit.NANOSECONDS.convert(1, timeUnit);
+
+        this.baseSeconds = MILLISECONDS.toSeconds(new DateTime(2015, 1, 1, 0, 0, hiveStorageTimeZone).getMillis());
+    }
+
+    public long getUnitsPerSecond()
+    {
+        return unitsPerSecond;
+    }
+
+    public long getNanosPerUnit()
+    {
+        return nanosecondsPerUnit;
+    }
+
+    /**
+     * @return Seconds since 01/01/2015 (see https://orc.apache.org/specification/ORCv1/) in hive storage timezone (see {@link DecodeTimestampOptions#DecodeTimestampOptions(DateTimeZone, boolean)} })
+     */
+    public long getBaseSeconds()
+    {
+        return baseSeconds;
+    }
+}

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcReaderOptions.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcReaderOptions.java
@@ -24,19 +24,27 @@ public class OrcReaderOptions
     private final DataSize maxBlockSize;
     private final boolean zstdJniDecompressionEnabled;
     private final boolean mapNullKeysEnabled;
+    private final boolean enableTimestampMicroPrecision;
 
     public OrcReaderOptions(DataSize maxMergeDistance, DataSize tinyStripeThreshold, DataSize maxBlockSize, boolean zstdJniDecompressionEnabled)
     {
-        this(maxMergeDistance, tinyStripeThreshold, maxBlockSize, zstdJniDecompressionEnabled, false);
+        this(maxMergeDistance, tinyStripeThreshold, maxBlockSize, zstdJniDecompressionEnabled, false, false);
     }
 
-    public OrcReaderOptions(DataSize maxMergeDistance, DataSize tinyStripeThreshold, DataSize maxBlockSize, boolean zstdJniDecompressionEnabled, boolean mapNullKeysEnabled)
+    public OrcReaderOptions(
+            DataSize maxMergeDistance,
+            DataSize tinyStripeThreshold,
+            DataSize maxBlockSize,
+            boolean zstdJniDecompressionEnabled,
+            boolean mapNullKeysEnabled,
+            boolean enableTimestampMicroPrecision)
     {
         this.maxMergeDistance = requireNonNull(maxMergeDistance, "maxMergeDistance is null");
         this.maxBlockSize = requireNonNull(maxBlockSize, "maxBlockSize is null");
         this.tinyStripeThreshold = requireNonNull(tinyStripeThreshold, "tinyStripeThreshold is null");
         this.zstdJniDecompressionEnabled = zstdJniDecompressionEnabled;
         this.mapNullKeysEnabled = mapNullKeysEnabled;
+        this.enableTimestampMicroPrecision = enableTimestampMicroPrecision;
     }
 
     public DataSize getMaxMergeDistance()
@@ -62,5 +70,10 @@ public class OrcReaderOptions
     public boolean mapNullKeysEnabled()
     {
         return mapNullKeysEnabled;
+    }
+
+    public boolean enableTimestampMicroPrecision()
+    {
+        return enableTimestampMicroPrecision;
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcRecordReaderOptions.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcRecordReaderOptions.java
@@ -23,18 +23,25 @@ public class OrcRecordReaderOptions
     private final DataSize tinyStripeThreshold;
     private final DataSize maxBlockSize;
     private final boolean mapNullKeysEnabled;
+    private final boolean enableTimestampMicroPrecision;
 
     public OrcRecordReaderOptions(OrcReaderOptions options)
     {
-        this(options.getMaxMergeDistance(), options.getTinyStripeThreshold(), options.getMaxBlockSize(), options.mapNullKeysEnabled());
+        this(options.getMaxMergeDistance(), options.getTinyStripeThreshold(), options.getMaxBlockSize(), options.mapNullKeysEnabled(), options.enableTimestampMicroPrecision());
     }
 
-    public OrcRecordReaderOptions(DataSize maxMergeDistance, DataSize tinyStripeThreshold, DataSize maxBlockSize, boolean mapNullKeysEnabled)
+    public OrcRecordReaderOptions(
+            DataSize maxMergeDistance,
+            DataSize tinyStripeThreshold,
+            DataSize maxBlockSize,
+            boolean mapNullKeysEnabled,
+            boolean enableTimestampMicroPrecision)
     {
         this.maxMergeDistance = requireNonNull(maxMergeDistance, "maxMergeDistance is null");
         this.maxBlockSize = requireNonNull(maxBlockSize, "maxBlockSize is null");
         this.tinyStripeThreshold = requireNonNull(tinyStripeThreshold, "tinyStripeThreshold is null");
         this.mapNullKeysEnabled = mapNullKeysEnabled;
+        this.enableTimestampMicroPrecision = enableTimestampMicroPrecision;
     }
 
     public DataSize getMaxMergeDistance()
@@ -55,5 +62,10 @@ public class OrcRecordReaderOptions
     public boolean mapNullKeysEnabled()
     {
         return mapNullKeysEnabled;
+    }
+
+    public boolean enableTimestampMicroPrecision()
+    {
+        return enableTimestampMicroPrecision;
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/BatchStreamReaders.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/BatchStreamReaders.java
@@ -49,7 +49,7 @@ public final class BatchStreamReaders
             case CHAR:
                 return new SliceBatchStreamReader(type, streamDescriptor, systemMemoryContext);
             case TIMESTAMP:
-                return new TimestampBatchStreamReader(type, streamDescriptor, hiveStorageTimeZone);
+                return new TimestampBatchStreamReader(type, streamDescriptor, hiveStorageTimeZone, options);
             case LIST:
                 return new ListBatchStreamReader(type, streamDescriptor, hiveStorageTimeZone, options, systemMemoryContext);
             case STRUCT:

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SelectiveStreamReaders.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SelectiveStreamReaders.java
@@ -103,7 +103,13 @@ public final class SelectiveStreamReaders
             case TIMESTAMP: {
                 checkArgument(requiredSubfields.isEmpty(), "Timestamp stream reader doesn't support subfields");
                 verifyStreamType(streamDescriptor, outputType, TimestampType.class::isInstance);
-                return new TimestampSelectiveStreamReader(streamDescriptor, getOptionalOnlyFilter(type, filters), hiveStorageTimeZone, outputType.isPresent(), systemMemoryContext.newOrcLocalMemoryContext(SelectiveStreamReaders.class.getSimpleName()));
+                return new TimestampSelectiveStreamReader(
+                        streamDescriptor,
+                        getOptionalOnlyFilter(type, filters),
+                        hiveStorageTimeZone,
+                        outputType.isPresent(),
+                        systemMemoryContext.newOrcLocalMemoryContext(SelectiveStreamReaders.class.getSimpleName()),
+                        options);
             }
             case LIST:
                 verifyStreamType(streamDescriptor, outputType, ArrayType.class::isInstance);

--- a/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
@@ -1458,7 +1458,8 @@ public class OrcTester
                         new DataSize(1, MEGABYTE),
                         MAX_BLOCK_SIZE,
                         false,
-                        mapNullKeysEnabled),
+                        mapNullKeysEnabled,
+                        false),
                 cacheable,
                 new DwrfEncryptionProvider(new UnsupportedEncryptionLibrary(), new TestingEncryptionLibrary()));
 
@@ -1584,7 +1585,8 @@ public class OrcTester
                         new DataSize(1, MEGABYTE),
                         MAX_BLOCK_SIZE,
                         false,
-                        mapNullKeysEnabled),
+                        mapNullKeysEnabled,
+                        false),
                 false,
                 new DwrfEncryptionProvider(new UnsupportedEncryptionLibrary(), new TestingEncryptionLibrary()));
 

--- a/presto-orc/src/test/java/com/facebook/presto/orc/reader/TestApacheHiveTimestampDecoder.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/reader/TestApacheHiveTimestampDecoder.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.orc.reader;
+
+import com.facebook.presto.orc.DecodeTimestampOptions;
+import org.joda.time.DateTime;
+import org.joda.time.format.ISODateTimeFormat;
+import org.testng.annotations.Test;
+
+import java.sql.Timestamp;
+import java.util.concurrent.TimeUnit;
+
+import static com.facebook.presto.orc.reader.ApacheHiveTimestampDecoder.decodeTimestamp;
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+import static org.joda.time.DateTimeZone.UTC;
+import static org.testng.Assert.assertEquals;
+
+public class TestApacheHiveTimestampDecoder
+{
+    @Test
+    public void testMicroseconds()
+    {
+        test(694310400, 7994, true, parseTimestamp("2037-01-01T00:00:00", 999));
+        test(-378691200, 1776, true, parseTimestamp("2003-01-01T00:00:00", 0));
+        test(-504921600, 7999999992L, true, parseTimestamp("1999-01-01T00:00:00", 999999));
+        test(-631152000, 5511111104L, true, parseTimestamp("1995-01-01T00:00:00", 688888));
+        test(-410227200, 15, true, parseTimestamp("2002-01-01T00:00:00", 100000));
+        test(-152582400, 72008, true, parseTimestamp("2010-03-02T00:00:00", 9));
+        test(-315532800, 17832, true, parseTimestamp("2005-01-01T00:00:00", 2));
+
+        test(-283996800, 7201624024L, true, parseTimestamp("2006-01-01T00:00:00", 900203));
+        test(-378691200, 6400000056L, true, parseTimestamp("2003-01-01T00:00:00", 800000));
+        test(-581130000, 5784806472L, true, parseTimestamp("1996-08-01T23:00:00", 723100));
+        test(-510105600, 6858725144L, true, parseTimestamp("1998-11-02T00:00:00", 857340));
+        test(-197168400, 0, true, parseTimestamp("2008-10-01T23:00:00", 0));
+    }
+
+    @Test
+    public void testMilliseconds()
+    {
+        test(694310400, 7994, false, parseTimestamp("2037-01-01T00:00:00", 0));
+        test(-378691200, 1776, false, parseTimestamp("2003-01-01T00:00:00", 0));
+        test(-504921600, 7999999992L, false, parseTimestamp("1999-01-01T00:00:00", 999000));
+        test(-631152000, 5511111104L, false, parseTimestamp("1995-01-01T00:00:00", 688000));
+        test(-410227200, 15, false, parseTimestamp("2002-01-01T00:00:00", 100000));
+        test(-152582400, 72008, false, parseTimestamp("2010-03-02T00:00:00", 0));
+        test(-315532800, 17832, false, parseTimestamp("2005-01-01T00:00:00", 0));
+        test(-283996800, 7201624024L, false, parseTimestamp("2006-01-01T00:00:00", 900000));
+        test(-378691200, 6400000056L, false, parseTimestamp("2003-01-01T00:00:00", 800000));
+        test(-581130000, 5784806472L, false, parseTimestamp("1996-08-01T23:00:00", 723000));
+        test(-510105600, 6858725144L, false, parseTimestamp("1998-11-02T00:00:00", 857000));
+        test(-197168400, 0, false, parseTimestamp("2008-10-01T23:00:00", 0));
+    }
+
+    private static void test(long seconds, long nanos, boolean microsecondsPrecision, Timestamp expected)
+    {
+        long tsAsLong = decodeTimestamp(seconds, nanos, new DecodeTimestampOptions(UTC, microsecondsPrecision));
+        TimeUnit unit = microsecondsPrecision ? MICROSECONDS : MILLISECONDS;
+        long unitsPerSec = unit.convert(1, TimeUnit.SECONDS);
+        Timestamp ts = new Timestamp(1000 * (tsAsLong / unitsPerSec));
+        ts.setNanos((int) NANOSECONDS.convert(tsAsLong % unitsPerSec, unit));
+        assertEquals(ts, expected);
+    }
+
+    private static Timestamp parseTimestamp(String s, int micros)
+    {
+        Timestamp ts = new Timestamp(DateTime.parse(s, ISODateTimeFormat.dateTimeParser().withZoneUTC()).getMillis());
+        ts.setNanos((int) TimeUnit.MICROSECONDS.toNanos(micros));
+        return ts;
+    }
+}


### PR DESCRIPTION
Adds support for microseconds precision for presto-orc reader. There are no plans to enable it for presto sql, but other projects may employ the setting for higher precision.

Test plan - added unit test TestApacheHiveTimestampDecoder

```
== NO RELEASE NOTE ==
```
