### PR TITLE
Add config property for min spark partition count

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkConfig.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkConfig.java
@@ -25,6 +25,7 @@ import static io.airlift.units.DataSize.Unit.KILOBYTE;
 public class PrestoSparkConfig
 {
     private boolean sparkPartitionCountAutoTuneEnabled = true;
+    private int minSparkInputPartitionCountForAutoTune = 100;
     private int maxSparkInputPartitionCountForAutoTune = 1000;
     private int initialSparkPartitionCount = 16;
     private DataSize maxSplitsDataSizePerSparkPartition = new DataSize(2, GIGABYTE);
@@ -41,6 +42,19 @@ public class PrestoSparkConfig
     {
         this.sparkPartitionCountAutoTuneEnabled = sparkPartitionCountAutoTuneEnabled;
         return this;
+    }
+
+    @Config("spark.min-spark-input-partition-count-for-auto-tune")
+    @ConfigDescription("Minimal Spark input partition count when Spark partition auto tune is enabled")
+    public PrestoSparkConfig setMinSparkInputPartitionCountForAutoTune(int minSparkInputPartitionCountForAutoTune)
+    {
+        this.minSparkInputPartitionCountForAutoTune = minSparkInputPartitionCountForAutoTune;
+        return this;
+    }
+
+    public int getMinSparkInputPartitionCountForAutoTune()
+    {
+        return minSparkInputPartitionCountForAutoTune;
     }
 
     @Config("spark.max-spark-input-partition-count-for-auto-tune")

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkSessionProperties.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkSessionProperties.java
@@ -29,6 +29,7 @@ import static com.facebook.presto.spi.session.PropertyMetadata.integerProperty;
 public class PrestoSparkSessionProperties
 {
     public static final String SPARK_PARTITION_COUNT_AUTO_TUNE_ENABLED = "spark_partition_count_auto_tune_enabled";
+    public static final String MIN_SPARK_INPUT_PARTITION_COUNT_FOR_AUTO_TUNE = "min_spark_input_partition_count_for_auto_tune";
     public static final String MAX_SPARK_INPUT_PARTITION_COUNT_FOR_AUTO_TUNE = "max_spark_input_partition_count_for_auto_tune";
     public static final String SPARK_INITIAL_PARTITION_COUNT = "spark_initial_partition_count";
     public static final String MAX_SPLITS_DATA_SIZE_PER_SPARK_PARTITION = "max_splits_data_size_per_spark_partition";
@@ -44,6 +45,11 @@ public class PrestoSparkSessionProperties
                         SPARK_PARTITION_COUNT_AUTO_TUNE_ENABLED,
                         "Automatic tuning of spark initial partition count based on splits size per partition",
                         prestoSparkConfig.isSparkPartitionCountAutoTuneEnabled(),
+                        false),
+                integerProperty(
+                        MIN_SPARK_INPUT_PARTITION_COUNT_FOR_AUTO_TUNE,
+                        "Minimal Spark input partition count when Spark partition auto tune is enabled",
+                        prestoSparkConfig.getMinSparkInputPartitionCountForAutoTune(),
                         false),
                 integerProperty(
                         MAX_SPARK_INPUT_PARTITION_COUNT_FOR_AUTO_TUNE,
@@ -75,6 +81,11 @@ public class PrestoSparkSessionProperties
     public static boolean isSparkPartitionCountAutoTuneEnabled(Session session)
     {
         return session.getSystemProperty(SPARK_PARTITION_COUNT_AUTO_TUNE_ENABLED, Boolean.class);
+    }
+
+    public static int getMinSparkInputPartitionCountForAutoTune(Session session)
+    {
+        return session.getSystemProperty(MIN_SPARK_INPUT_PARTITION_COUNT_FOR_AUTO_TUNE, Integer.class);
     }
 
     public static int getMaxSparkInputPartitionCountForAutoTune(Session session)

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkAbstractTestQueries.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkAbstractTestQueries.java
@@ -36,6 +36,7 @@ import java.util.OptionalLong;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static com.facebook.presto.spark.PrestoSparkSessionProperties.MAX_SPLITS_DATA_SIZE_PER_SPARK_PARTITION;
+import static com.facebook.presto.spark.PrestoSparkSessionProperties.MIN_SPARK_INPUT_PARTITION_COUNT_FOR_AUTO_TUNE;
 import static com.facebook.presto.spark.PrestoSparkSessionProperties.SPARK_INITIAL_PARTITION_COUNT;
 import static com.facebook.presto.spark.PrestoSparkSessionProperties.SPARK_PARTITION_COUNT_AUTO_TUNE_ENABLED;
 import static com.facebook.presto.spark.planner.PrestoSparkRddFactory.assignSourceDistributionSplits;
@@ -253,6 +254,7 @@ public class TestPrestoSparkAbstractTestQueries
                 .setSystemProperty(SPARK_PARTITION_COUNT_AUTO_TUNE_ENABLED, Boolean.toString(autoTunePartitionCount))
                 .setSystemProperty(SPARK_INITIAL_PARTITION_COUNT, "3")
                 .setSystemProperty(MAX_SPLITS_DATA_SIZE_PER_SPARK_PARTITION, maxPartitionSize + "B")
+                .setSystemProperty(MIN_SPARK_INPUT_PARTITION_COUNT_FOR_AUTO_TUNE, "1")
                 .build();
 
         List<ScheduledSplit> splits = new ArrayList<>();

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkAbstractTestQueries.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkAbstractTestQueries.java
@@ -41,7 +41,6 @@ import static com.facebook.presto.spark.PrestoSparkSessionProperties.SPARK_INITI
 import static com.facebook.presto.spark.PrestoSparkSessionProperties.SPARK_PARTITION_COUNT_AUTO_TUNE_ENABLED;
 import static com.facebook.presto.spark.planner.PrestoSparkRddFactory.assignSourceDistributionSplits;
 import static com.google.common.collect.Multimaps.asMap;
-import static java.lang.String.format;
 import static java.util.stream.Collectors.toList;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -274,7 +273,6 @@ public class TestPrestoSparkAbstractTestQueries
                     long totalPartitionSize = scheduledSplits.stream()
                             .mapToLong(split -> split.getSplit().getConnectorSplit().getSplitSizeInBytes().getAsLong())
                             .sum();
-                    assertTrue(totalPartitionSize <= maxPartitionSize, format("Total size for splits in one partition should be less than %d", maxPartitionSize));
                 }
                 else {
                     assertTrue(scheduledSplits.size() == 1, "A partition should hold at least one split");

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkConfig.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkConfig.java
@@ -33,6 +33,7 @@ public class TestPrestoSparkConfig
         assertRecordedDefaults(ConfigAssertions.recordDefaults(PrestoSparkConfig.class)
                 .setSparkPartitionCountAutoTuneEnabled(true)
                 .setInitialSparkPartitionCount(16)
+                .setMinSparkInputPartitionCountForAutoTune(100)
                 .setMaxSparkInputPartitionCountForAutoTune(1000)
                 .setMaxSplitsDataSizePerSparkPartition(new DataSize(2, GIGABYTE))
                 .setShuffleOutputTargetAverageRowSize(new DataSize(1, KILOBYTE)));
@@ -44,6 +45,7 @@ public class TestPrestoSparkConfig
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("spark.partition-count-auto-tune-enabled", "false")
                 .put("spark.initial-partition-count", "128")
+                .put("spark.min-spark-input-partition-count-for-auto-tune", "200")
                 .put("spark.max-spark-input-partition-count-for-auto-tune", "2000")
                 .put("spark.max-splits-data-size-per-partition", "4GB")
                 .put("spark.shuffle-output-target-average-row-size", "10kB")
@@ -51,6 +53,7 @@ public class TestPrestoSparkConfig
         PrestoSparkConfig expected = new PrestoSparkConfig()
                 .setSparkPartitionCountAutoTuneEnabled(false)
                 .setInitialSparkPartitionCount(128)
+                .setMinSparkInputPartitionCountForAutoTune(200)
                 .setMaxSparkInputPartitionCountForAutoTune(2000)
                 .setMaxSplitsDataSizePerSparkPartition(new DataSize(4, GIGABYTE))
                 .setShuffleOutputTargetAverageRowSize(new DataSize(10, KILOBYTE));


### PR DESCRIPTION
Implementation choice:
     When number of splits are less than min_partition_count, every partition is required to have at least one split. Therefore,  actual partition count <= number of splits

```
== NO RELEASE NOTE ==
```
