### PR TITLE
Fix memory counting for SliceDictionaryBatchStreamReader

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDictionaryBatchStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDictionaryBatchStreamReader.java
@@ -403,6 +403,11 @@ public class SliceDictionaryBatchStreamReader
     @Override
     public long getRetainedSizeInBytes()
     {
-        return INSTANCE_SIZE + sizeOf(stripeDictionaryLength);
+        return INSTANCE_SIZE +
+                sizeOf(stripeDictionaryData) +
+                sizeOf(stripeDictionaryLength) +
+                sizeOf(stripeDictionaryOffsetVector) +
+                sizeOf(rowGroupDictionaryLength) +
+                (dictionaryBlock == null ? 0 : dictionaryBlock.getRetainedSizeInBytes());
     }
 }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcReaderMemoryUsage.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcReaderMemoryUsage.java
@@ -95,7 +95,7 @@ public class TestOrcReaderMemoryUsage
                 // StripeReader memory should increase after reading a block.
                 assertGreaterThan(reader.getCurrentStripeRetainedSizeInBytes(), stripeReaderRetainedSize);
                 // SliceDictionaryBatchStreamReader uses stripeDictionaryLength local buffer.
-                assertEquals(reader.getStreamReaderRetainedSizeInBytes() - streamReaderRetainedSize, 4L);
+                assertEquals(reader.getStreamReaderRetainedSizeInBytes() - streamReaderRetainedSize, 49L);
                 // The total retained size and system memory usage should be greater than 0 byte because of the instance sizes.
                 assertGreaterThan(reader.getRetainedSizeInBytes() - readerRetainedSize, 0L);
                 assertGreaterThan(reader.getSystemMemoryUsage() - readerSystemMemoryUsage, 0L);


### PR DESCRIPTION
```
== RELEASE NOTES ==

Hive Changes
* Fixed a memory counting bug in SliceDictionaryBatchStreamReader 
```
