### PR TITLE
Add zstd compression for PAGEFILE

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveCompressionCodec.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveCompressionCodec.java
@@ -33,7 +33,7 @@ public enum HiveCompressionCodec
     SNAPPY(SnappyCodec.class, CompressionKind.SNAPPY, CompressionCodecName.SNAPPY, f -> true),
     GZIP(GzipCodec.class, CompressionKind.ZLIB, CompressionCodecName.GZIP, f -> true),
     LZ4(null, CompressionKind.NONE, null, f -> f == PAGEFILE),
-    ZSTD(null, CompressionKind.ZSTD, null, f -> f == ORC || f == DWRF);
+    ZSTD(null, CompressionKind.ZSTD, null, f -> f == ORC || f == DWRF || f == PAGEFILE);
 
     private final Optional<Class<? extends CompressionCodec>> codec;
     private final CompressionKind orcCompressionKind;

--- a/presto-hive/src/main/java/com/facebook/presto/hive/pagefile/PageFileWriterFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/pagefile/PageFileWriterFactory.java
@@ -24,6 +24,8 @@ import com.facebook.presto.hive.metastore.StorageFormat;
 import com.facebook.presto.orc.DataSink;
 import com.facebook.presto.orc.zlib.DeflateCompressor;
 import com.facebook.presto.orc.zlib.InflateDecompressor;
+import com.facebook.presto.orc.zstd.ZstdJniCompressor;
+import com.facebook.presto.orc.zstd.ZstdJniDecompressor;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.page.PageCompressor;
@@ -150,6 +152,10 @@ public class PageFileWriterFactory
             case GZIP:
                 pageCompressor = new AirliftCompressorAdapter(new DeflateCompressor());
                 pageDecompressor = new AirliftDecompressorAdapter(new InflateDecompressor());
+                break;
+            case ZSTD:
+                pageCompressor = new AirliftCompressorAdapter(new ZstdJniCompressor());
+                pageDecompressor = new AirliftDecompressorAdapter(new ZstdJniDecompressor());
                 break;
             default:
                 throw new PrestoException(


### PR DESCRIPTION
1. Test covered by `TestHiveIntegrationSmokeTest::testPageFileCompression`
2. Make default compression algorithm for temporary file as zstd, all tests pass. 

```
== NO RELEASE NOTE ==
```
