### PR TITLE
Adding Pinot distinctCount UDFs

### DIFF
--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/functions/PinotDistinctCountAggregationFunction.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/functions/PinotDistinctCountAggregationFunction.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.pinot.functions;
+
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.spi.function.AccumulatorState;
+import com.facebook.presto.spi.function.AggregationFunction;
+import com.facebook.presto.spi.function.CombineFunction;
+import com.facebook.presto.spi.function.Description;
+import com.facebook.presto.spi.function.InputFunction;
+import com.facebook.presto.spi.function.OutputFunction;
+import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.function.TypeParameter;
+import io.airlift.slice.Slice;
+
+@Description("Pinot UDF: A distinct count function, should always be pushed down to Pinot")
+@AggregationFunction("distinctCount")
+public class PinotDistinctCountAggregationFunction
+{
+    private PinotDistinctCountAggregationFunction()
+    {
+    }
+
+    @InputFunction
+    @TypeParameter("T")
+    public static void input(AccumulatorState state, @SqlType("T") Slice value)
+    {
+        throw new IllegalStateException("Expected 'distinctCount' function to be always pushed down to Pinot.");
+    }
+
+    @CombineFunction
+    public static void combine(AccumulatorState state, AccumulatorState otherState)
+    {
+        throw new IllegalStateException("Expected 'distinctCount' function to be always pushed down to Pinot.");
+    }
+
+    @OutputFunction(StandardTypes.BIGINT)
+    public static void output(AccumulatorState state, BlockBuilder out)
+    {
+        throw new IllegalStateException("Expected 'distinctCount' function to be always pushed down to Pinot.");
+    }
+}

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/functions/PinotSegmentPartitionedDistinctCountAggregationFunction.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/functions/PinotSegmentPartitionedDistinctCountAggregationFunction.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.pinot.functions;
+
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.spi.function.AccumulatorState;
+import com.facebook.presto.spi.function.AggregationFunction;
+import com.facebook.presto.spi.function.CombineFunction;
+import com.facebook.presto.spi.function.Description;
+import com.facebook.presto.spi.function.InputFunction;
+import com.facebook.presto.spi.function.OutputFunction;
+import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.function.TypeParameter;
+import io.airlift.slice.Slice;
+
+@Description("Pinot UDF: A distinct count function implemented partitioned by segments, should always be pushed down to Pinot")
+@AggregationFunction("segmentPartitionedDistinctCount")
+public class PinotSegmentPartitionedDistinctCountAggregationFunction
+{
+    private PinotSegmentPartitionedDistinctCountAggregationFunction()
+    {
+    }
+
+    @InputFunction
+    @TypeParameter("T")
+    public static void input(AccumulatorState state, @SqlType("T") Slice value)
+    {
+        throw new IllegalStateException("Expected 'segmentPartitionedDistinctCount' function to be always pushed down to Pinot.");
+    }
+
+    @CombineFunction
+    public static void combine(AccumulatorState state, AccumulatorState otherState)
+    {
+        throw new IllegalStateException("Expected 'segmentPartitionedDistinctCount' function to be always pushed down to Pinot.");
+    }
+
+    @OutputFunction(StandardTypes.BIGINT)
+    public static void output(AccumulatorState state, BlockBuilder out)
+    {
+        throw new IllegalStateException("Expected 'segmentPartitionedDistinctCount' function to be always pushed down to Pinot.");
+    }
+}

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/query/PinotQueryGenerator.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/query/PinotQueryGenerator.java
@@ -85,6 +85,7 @@ public class PinotQueryGenerator
                     .put("sum", "sum")
                     .put("distinctcount", "DISTINCTCOUNT")
                     .put("approx_distinct", "DISTINCTCOUNTHLL")
+                    .put("segmentpartitioneddistinctcount", "SEGMENTPARTITIONEDDISTINCTCOUNT")
                     .build();
 
     private final PinotConfig pinotConfig;

--- a/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotQueryBase.java
+++ b/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotQueryBase.java
@@ -23,6 +23,8 @@ import com.facebook.presto.metadata.FunctionManager;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.metadata.SessionPropertyManager;
+import com.facebook.presto.pinot.functions.PinotDistinctCountAggregationFunction;
+import com.facebook.presto.pinot.functions.PinotSegmentPartitionedDistinctCountAggregationFunction;
 import com.facebook.presto.pinot.query.PinotQueryGeneratorContext;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorId;
@@ -74,6 +76,7 @@ import static com.facebook.presto.common.type.DoubleType.DOUBLE;
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.metadata.FunctionExtractor.extractFunctions;
 import static com.facebook.presto.pinot.PinotColumnHandle.PinotColumnType.REGULAR;
 import static com.facebook.presto.pinot.query.PinotQueryGeneratorContext.Origin.DERIVED;
 import static com.facebook.presto.pinot.query.PinotQueryGeneratorContext.Origin.TABLE_COLUMN;
@@ -104,6 +107,13 @@ public class TestPinotQueryBase
     protected static final Metadata metadata = MetadataManager.createTestMetadataManager();
 
     protected final PinotConfig pinotConfig = new PinotConfig();
+
+    static {
+        metadata.registerBuiltInFunctions(extractFunctions(PinotDistinctCountAggregationFunction.class));
+        metadata.registerBuiltInFunctions(extractFunctions(PinotSegmentPartitionedDistinctCountAggregationFunction.class));
+        functionMetadataManager.registerBuiltInFunctions(extractFunctions(PinotDistinctCountAggregationFunction.class));
+        functionMetadataManager.registerBuiltInFunctions(extractFunctions(PinotSegmentPartitionedDistinctCountAggregationFunction.class));
+    }
 
     protected static final Map<VariableReferenceExpression, PinotQueryGeneratorContext.Selection> testInput =
             ImmutableMap.<VariableReferenceExpression, PinotQueryGeneratorContext.Selection>builder()

--- a/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/query/TestPinotQueryGenerator.java
+++ b/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/query/TestPinotQueryGenerator.java
@@ -272,6 +272,13 @@ public class TestPinotQueryGenerator
     }
 
     @Test
+    public void testDistinctCountUDFs()
+    {
+        testUnaryAggregationHelper((planBuilder, aggregationBuilder) -> aggregationBuilder.addAggregation(planBuilder.variable("segmentPartitionedDistinctCount"), getRowExpression("segmentPartitionedDistinctCount(fare)", defaultSessionHolder)), "SEGMENTPARTITIONEDDISTINCTCOUNT(fare)");
+        testUnaryAggregationHelper((planBuilder, aggregationBuilder) -> aggregationBuilder.addAggregation(planBuilder.variable("distinctCount"), getRowExpression("distinctCount(fare)", defaultSessionHolder)), "DISTINCTCOUNT(fare)");
+    }
+
+    @Test
     public void testAggWithUDFInGroupBy()
     {
         LinkedHashMap<String, String> aggProjection = new LinkedHashMap<>();

--- a/presto-pinot/src/main/java/com/facebook/presto/pinot/PinotPlugin.java
+++ b/presto-pinot/src/main/java/com/facebook/presto/pinot/PinotPlugin.java
@@ -13,9 +13,14 @@
  */
 package com.facebook.presto.pinot;
 
+import com.facebook.presto.pinot.functions.PinotDistinctCountAggregationFunction;
+import com.facebook.presto.pinot.functions.PinotSegmentPartitionedDistinctCountAggregationFunction;
 import com.facebook.presto.spi.Plugin;
 import com.facebook.presto.spi.connector.ConnectorFactory;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Set;
 
 public class PinotPlugin
         implements Plugin
@@ -24,5 +29,14 @@ public class PinotPlugin
     public Iterable<ConnectorFactory> getConnectorFactories()
     {
         return ImmutableList.of(new PinotConnectorFactory());
+    }
+
+    @Override
+    public Set<Class<?>> getFunctions()
+    {
+        return ImmutableSet.<Class<?>>builder()
+            .add(PinotSegmentPartitionedDistinctCountAggregationFunction.class)
+            .add(PinotDistinctCountAggregationFunction.class)
+            .build();
     }
 }


### PR DESCRIPTION
```
== RELEASE NOTES ==

Pinot Changes
* Adding Pinot UDF pushdown support for: distinctCount and segmentPartitionedDistinctCount
```
Sample queries:
```
SELECT distinctCount(user_id) as num_unique_users FROM myTable limit 1;
SELECT segmentPartitionedDistinctCount(user_id) as num_unique_users FROM myTable limit 1;
```