### PR TITLE
Count distinct to approx distinct

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -49,6 +49,7 @@ import static com.facebook.presto.spi.session.PropertyMetadata.dataSizeProperty;
 import static com.facebook.presto.spi.session.PropertyMetadata.doubleProperty;
 import static com.facebook.presto.spi.session.PropertyMetadata.integerProperty;
 import static com.facebook.presto.spi.session.PropertyMetadata.stringProperty;
+import static com.facebook.presto.sql.analyzer.FeaturesConfig.ApproxResultsOption;
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.JoinDistributionType.BROADCAST;
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.JoinDistributionType.PARTITIONED;
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.JoinReorderingStrategy.ELIMINATE_CROSS_JOINS;
@@ -168,6 +169,7 @@ public final class SystemSessionProperties
     public static final String DYNAMIC_FILTERING_MAX_PER_DRIVER_SIZE = "dynamic_filtering_max_per_driver_size";
     public static final String LEGACY_TYPE_COERCION_WARNING_ENABLED = "legacy_type_coercion_warning_enabled";
     public static final String INLINE_SQL_FUNCTIONS = "inline_sql_functions";
+    public static final String APPROX_RESULTS_OPTION = "approx_results_option";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -875,7 +877,19 @@ public final class SystemSessionProperties
                         INLINE_SQL_FUNCTIONS,
                         "Inline SQL function definition at plan time",
                         featuresConfig.isInlineSqlFunctions(),
-                        false));
+                        false),
+                new PropertyMetadata<>(
+                        APPROX_RESULTS_OPTION,
+                        format("Experimental: Approx Results. Options are %s",
+                                Stream.of(ApproxResultsOption.values())
+                                        .map(ApproxResultsOption::name)
+                                        .collect(joining(","))),
+                        VARCHAR,
+                        ApproxResultsOption.class,
+                        featuresConfig.getApproxResultsOption(),
+                        false,
+                        value -> ApproxResultsOption.valueOf(((String) value).toUpperCase()),
+                        ApproxResultsOption::name));
     }
 
     public List<PropertyMetadata<?>> getSessionProperties()
@@ -1480,5 +1494,10 @@ public final class SystemSessionProperties
     public static boolean isInlineSqlFunctions(Session session)
     {
         return session.getSystemProperty(INLINE_SQL_FUNCTIONS, Boolean.class);
+    }
+
+    public static ApproxResultsOption getApproxResultsOption(Session session)
+    {
+        return session.getSystemProperty(APPROX_RESULTS_OPTION, ApproxResultsOption.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -222,6 +222,14 @@ public class FeaturesConfig
         }
     }
 
+    private ApproxResultsOption approxResultsOption = ApproxResultsOption.NONE;
+
+    public enum ApproxResultsOption
+    {
+        NONE,
+        APPROX_DISTINCT,
+    }
+
     public double getCpuCostWeight()
     {
         return cpuCostWeight;
@@ -1396,6 +1404,19 @@ public class FeaturesConfig
     public FeaturesConfig setInlineSqlFunctions(boolean inlineSqlFunctions)
     {
         this.inlineSqlFunctions = inlineSqlFunctions;
+        return this;
+    }
+
+    public ApproxResultsOption getApproxResultsOption()
+    {
+        return approxResultsOption;
+    }
+
+    @Config("approx-results-option")
+    @ConfigDescription("Approx Results using approx distinct")
+    public FeaturesConfig setApproxResultsOption(ApproxResultsOption approxResultsOption)
+    {
+        this.approxResultsOption = approxResultsOption;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -26,6 +26,7 @@ import com.facebook.presto.sql.planner.iterative.IterativeOptimizer;
 import com.facebook.presto.sql.planner.iterative.Rule;
 import com.facebook.presto.sql.planner.iterative.rule.AddIntermediateAggregations;
 import com.facebook.presto.sql.planner.iterative.rule.CanonicalizeExpressions;
+import com.facebook.presto.sql.planner.iterative.rule.CountDistinctToApproxDistinct;
 import com.facebook.presto.sql.planner.iterative.rule.CreatePartialTopN;
 import com.facebook.presto.sql.planner.iterative.rule.DesugarAtTimeZone;
 import com.facebook.presto.sql.planner.iterative.rule.DesugarCurrentUser;
@@ -268,6 +269,12 @@ public class PlanOptimizers
         PlanOptimizer predicatePushDown = new StatsRecordingPlanOptimizer(optimizerStats, new PredicatePushDown(metadata, sqlParser));
 
         builder.add(
+                new IterativeOptimizer(
+                        ruleStats,
+                        statsCalculator,
+                        estimatedExchangesCostCalculator,
+                        ImmutableSet.of(
+                                new CountDistinctToApproxDistinct(metadata))),
                 // Clean up all the sugar in expressions, e.g. AtTimeZone, must be run before all the other optimizers
                 new IterativeOptimizer(
                         ruleStats,

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/CountDistinctToApproxDistinct.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/CountDistinctToApproxDistinct.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.SystemSessionProperties;
+import com.facebook.presto.matching.Captures;
+import com.facebook.presto.matching.Pattern;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.plan.AggregationNode;
+import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.analyzer.FeaturesConfig.ApproxResultsOption;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.google.common.collect.ImmutableMap;
+
+import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static com.facebook.presto.sql.planner.plan.Patterns.aggregation;
+import static java.util.Objects.requireNonNull;
+
+public class CountDistinctToApproxDistinct
+        implements Rule<AggregationNode>
+{
+    private final Metadata metadata;
+
+    public CountDistinctToApproxDistinct(Metadata metadata)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+    }
+
+    @Override
+    public Pattern<AggregationNode> getPattern()
+    {
+        return aggregation().matching(this::isCountDistinct);
+    }
+
+    private boolean isCountDistinct(AggregationNode node)
+    {
+        return node.getAggregations().values().stream().anyMatch(a -> a.isDistinct() && a.getCall().getDisplayName().equals("count"));
+    }
+
+    @Override
+    public boolean isEnabled(Session session)
+    {
+        ApproxResultsOption approxResultsOption = SystemSessionProperties.getApproxResultsOption(session);
+        return isApproxDistinct(approxResultsOption);
+    }
+
+    public static boolean isApproxDistinct(ApproxResultsOption option)
+    {
+        return option == ApproxResultsOption.APPROX_DISTINCT;
+    }
+
+    @Override
+    public Result apply(AggregationNode node, Captures captures, Context context)
+    {
+        ImmutableMap.Builder<VariableReferenceExpression, AggregationNode.Aggregation> aggregations = ImmutableMap.builder();
+        for (VariableReferenceExpression var : node.getAggregations().keySet()) {
+            AggregationNode.Aggregation aggregation = node.getAggregations().get(var);
+            if (aggregation.isDistinct() && aggregation.getCall().getDisplayName().equals("count")) {
+                CallExpression call = aggregation.getCall();
+                AggregationNode.Aggregation aggregation1 = new AggregationNode.Aggregation(
+                        new CallExpression(
+                                "approx_distinct",
+                                metadata.getFunctionManager().lookupFunction("approx_distinct", fromTypes(call.getType())),
+                                call.getType(),
+                                call.getArguments()),
+                        aggregation.getFilter(),
+                        aggregation.getOrderBy(),
+                        false,
+                        aggregation.getMask());
+                aggregations.put(var, aggregation1);
+            }
+            else {
+                aggregations.put(var, aggregation);
+            }
+        }
+
+        AggregationNode newNode = new AggregationNode(
+                node.getId(),
+                node.getSource(),
+                aggregations.build(),
+                node.getGroupingSets(),
+                node.getPreGroupedVariables(),
+                node.getStep(),
+                node.getHashVariable(),
+                node.getGroupIdVariable());
+        return Result.ofPlanNode(newNode);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -30,6 +30,7 @@ import static com.facebook.airlift.configuration.testing.ConfigAssertions.assert
 import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.AggregationPartitioningMergingStrategy.LEGACY;
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.AggregationPartitioningMergingStrategy.TOP_DOWN;
+import static com.facebook.presto.sql.analyzer.FeaturesConfig.ApproxResultsOption;
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.JoinDistributionType.BROADCAST;
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.JoinDistributionType.PARTITIONED;
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.JoinReorderingStrategy.ELIMINATE_CROSS_JOINS;
@@ -144,7 +145,8 @@ public class TestFeaturesConfig
                 .setPreferDistributedUnion(true)
                 .setOptimizeNullsInJoin(false)
                 .setWarnOnNoTableLayoutFilter("")
-                .setInlineSqlFunctions(true));
+                .setInlineSqlFunctions(true)
+                .setApproxResultsOption(ApproxResultsOption.NONE));
     }
 
     @Test
@@ -245,6 +247,7 @@ public class TestFeaturesConfig
                 .put("optimize-nulls-in-join", "true")
                 .put("warn-on-no-table-layout-filter", "ry@nlikestheyankees,ds")
                 .put("inline-sql-functions", "false")
+                .put("approx-results-option", ApproxResultsOption.APPROX_DISTINCT.name())
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -341,7 +344,8 @@ public class TestFeaturesConfig
                 .setPreferDistributedUnion(false)
                 .setOptimizeNullsInJoin(true)
                 .setWarnOnNoTableLayoutFilter("ry@nlikestheyankees,ds")
-                .setInlineSqlFunctions(false);
+                .setInlineSqlFunctions(false)
+                .setApproxResultsOption(ApproxResultsOption.APPROX_DISTINCT);
         assertFullMapping(properties, expected);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestCountDistinctToApproxDistinct.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestCountDistinctToApproxDistinct.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.spi.plan.AggregationNode;
+import com.facebook.presto.sql.analyzer.FeaturesConfig.ApproxResultsOption;
+import com.facebook.presto.sql.planner.assertions.ExpectedValueProvider;
+import com.facebook.presto.sql.planner.assertions.PlanMatchPattern;
+import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
+import com.facebook.presto.sql.tree.FunctionCall;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.SystemSessionProperties.APPROX_RESULTS_OPTION;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.plan.AggregationNode.Step.FINAL;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.aggregation;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.expression;
+
+public class TestCountDistinctToApproxDistinct
+        extends BaseRuleTest
+{
+    @Test
+    public void testBasic()
+    {
+        ExpectedValueProvider<FunctionCall> aggregationPattern = PlanMatchPattern.functionCall("approx_distinct", ImmutableList.of("a"));
+
+        for (ApproxResultsOption option : ApproxResultsOption.values()) {
+            if (CountDistinctToApproxDistinct.isApproxDistinct(option)) {
+                tester().assertThat(new CountDistinctToApproxDistinct(tester().getMetadata()))
+                        .setSystemProperty(APPROX_RESULTS_OPTION, option.name())
+                        .on(p -> p.aggregation(af -> {
+                            af.globalGrouping()
+                                    .step(AggregationNode.Step.FINAL)
+                                    .addAggregation(p.variable("b"), expression("count(distinct a)"), ImmutableList.of(BIGINT))
+                                    .source(p.values(p.variable("a")));
+                        }))
+                        .matches(
+                                aggregation(
+                                        ImmutableMap.of("b", aggregationPattern),
+                                        FINAL,
+                                        values(ImmutableMap.of("a", 0))));
+            }
+        }
+    }
+
+    @Test
+    public void testSessionDisable()
+    {
+        for (ApproxResultsOption option : ApproxResultsOption.values()) {
+            if (!CountDistinctToApproxDistinct.isApproxDistinct(option)) {
+                tester().assertThat(new CountDistinctToApproxDistinct(tester().getMetadata()))
+                        .setSystemProperty(APPROX_RESULTS_OPTION, option.name())
+                        .on(p -> p.aggregation(af -> {
+                            af.globalGrouping()
+                                    .step(AggregationNode.Step.FINAL)
+                                    .addAggregation(p.variable("b"), expression("count(distinct a)"), ImmutableList.of(BIGINT))
+                                    .source(p.values(p.variable("a")));
+                        }))
+                        .doesNotFire();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adding a session parameter _approx_results_option_ that can cover various optimizations to make queries run faster while giving approximate results. In this first optimization, count distincts can be automatically converted to approx distincts. 

Test plan - 

1. Added unit tests
2. Manually tested on this [query](https://github.com/prestodb/presto/blob/df3192204bae7c23d0a282e78e3c8760a9c8a928/presto-benchto-benchmarks/src/main/resources/sql/presto/tpcds/q28.sql)

$ ./presto-cli/target/presto-cli-0.241-SNAPSHOT-executable.jar --catalog tpcds --schema sf10 -f q28.sql
SELECT *
SET SESSION
...
"77.94","363293","11077","69.58","352731","7017","134.01","279250","11856","82.31","315871","8590","61.54","361362","15859","39.35","298240","5652"

$ head -n 1 q28.sql
set session approx_results_option='APPROX_DISTINCT';

Also verified by manually changing all the count distincts in the file to approx distincts and got the same results

$ time ./presto-cli/target/presto-cli-0.241-SNAPSHOT-executable.jar --catalog tpcds --schema sf10 -f q28_2.sql
"77.94","363293","11077","69.58","352731","7017","134.01","279250","11856","82.31","315871","8590","61.54","361362","15859","39.35","298240","5652"

== RELEASE NOTES ==

General Changes
* Add session property ``approx_results_option`` with values 'NONE' (default) and 'APPROX_DISTINCT'. The latter can be used to automatically change all the count distincts in the query to approx distincts