### PR TITLE
Support fetching queries to be verified using a Presto query

### DIFF
--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/QueryConfiguration.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/QueryConfiguration.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 
 import static com.facebook.presto.verifier.framework.QueryConfigurationOverrides.SessionPropertiesOverrideStrategy.OVERRIDE;
 import static com.facebook.presto.verifier.framework.QueryConfigurationOverrides.SessionPropertiesOverrideStrategy.SUBSTITUTE;
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
 public class QueryConfiguration
@@ -117,5 +118,17 @@ public class QueryConfiguration
     public int hashCode()
     {
         return Objects.hash(catalog, schema, username, password, sessionProperties);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("catalog", catalog)
+                .add("schema", schema)
+                .add("username", username)
+                .add("password", password)
+                .add("sessionProperties", sessionProperties)
+                .toString();
     }
 }

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/QueryStage.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/QueryStage.java
@@ -34,7 +34,10 @@ public enum QueryStage
     DESCRIBE(CONTROL),
     DETERMINISM_ANALYSIS_SETUP(CONTROL),
     DETERMINISM_ANALYSIS_MAIN(CONTROL),
-    DETERMINISM_ANALYSIS_CHECKSUM(CONTROL);
+    DETERMINISM_ANALYSIS_CHECKSUM(CONTROL),
+
+    // Running Presto query to fetch the source queries to be verified
+    SOURCE(CONTROL);
 
     private final ClusterType targetCluster;
 

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/SourceQuery.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/SourceQuery.java
@@ -17,6 +17,9 @@ import org.jdbi.v3.core.mapper.Nested;
 import org.jdbi.v3.core.mapper.reflect.ColumnName;
 import org.jdbi.v3.core.mapper.reflect.JdbiConstructor;
 
+import java.util.Objects;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
 public class SourceQuery
@@ -84,5 +87,42 @@ public class SourceQuery
             sql = sql.substring(0, sql.length() - 1).trim();
         }
         return sql;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if ((obj == null) || (getClass() != obj.getClass())) {
+            return false;
+        }
+        SourceQuery o = (SourceQuery) obj;
+        return Objects.equals(suite, o.suite) &&
+                Objects.equals(name, o.name) &&
+                Objects.equals(controlQuery, o.controlQuery) &&
+                Objects.equals(testQuery, o.testQuery) &&
+                Objects.equals(controlConfiguration, o.controlConfiguration) &&
+                Objects.equals(testConfiguration, o.testConfiguration);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(suite, name, controlQuery, testQuery, controlConfiguration, testConfiguration);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("suite", suite)
+                .add("name", name)
+                .add("controlQuery", controlQuery)
+                .add("testQuery", testQuery)
+                .add("controlConfiguration", controlConfiguration)
+                .add("testConfiguration", testConfiguration)
+                .toString();
     }
 }

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/source/PrestoQuerySourceQueryConfig.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/source/PrestoQuerySourceQueryConfig.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.verifier.source;
+
+import com.facebook.airlift.configuration.Config;
+
+import javax.validation.constraints.NotNull;
+
+import java.util.Optional;
+
+public class PrestoQuerySourceQueryConfig
+{
+    private String query;
+    private String catalog;
+    private String schema;
+    private Optional<String> username = Optional.empty();
+    private Optional<String> password = Optional.empty();
+
+    @NotNull
+    public String getQuery()
+    {
+        return query;
+    }
+
+    @Config("query")
+    public PrestoQuerySourceQueryConfig setQuery(String query)
+    {
+        this.query = query;
+        return this;
+    }
+
+    @NotNull
+    public String getCatalog()
+    {
+        return catalog;
+    }
+
+    @Config("catalog")
+    public PrestoQuerySourceQueryConfig setCatalog(String catalog)
+    {
+        this.catalog = catalog;
+        return this;
+    }
+
+    @NotNull
+    public String getSchema()
+    {
+        return schema;
+    }
+
+    @Config("schema")
+    public PrestoQuerySourceQueryConfig setSchema(String schema)
+    {
+        this.schema = schema;
+        return this;
+    }
+
+    @NotNull
+    public Optional<String> getUsername()
+    {
+        return username;
+    }
+
+    @Config("username")
+    public PrestoQuerySourceQueryConfig setUsername(String username)
+    {
+        this.username = Optional.ofNullable(username);
+        return this;
+    }
+
+    @NotNull
+    public Optional<String> getPassword()
+    {
+        return password;
+    }
+
+    @Config("password")
+    public PrestoQuerySourceQueryConfig setPassword(String password)
+    {
+        this.password = Optional.ofNullable(password);
+        return this;
+    }
+}

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/source/PrestoQuerySourceQuerySupplier.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/source/PrestoQuerySourceQuerySupplier.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.verifier.source;
+
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.verifier.annotation.ForHelper;
+import com.facebook.presto.verifier.framework.QueryConfiguration;
+import com.facebook.presto.verifier.framework.SourceQuery;
+import com.facebook.presto.verifier.framework.VerificationContext;
+import com.facebook.presto.verifier.prestoaction.PrestoAction;
+import com.facebook.presto.verifier.prestoaction.PrestoAction.ResultSetConverter;
+import com.facebook.presto.verifier.prestoaction.PrestoActionFactory;
+
+import javax.inject.Inject;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.facebook.presto.verifier.framework.QueryStage.SOURCE;
+import static com.facebook.presto.verifier.framework.VerifierUtil.PARSING_OPTIONS;
+import static java.util.Objects.requireNonNull;
+
+public class PrestoQuerySourceQuerySupplier
+        implements SourceQuerySupplier
+{
+    public static final String PRESTO_QUERY_SOURCE_QUERY_SUPPLIER = "presto-query";
+    private static final ResultSetConverter<SourceQuery> SOURCE_QUERY_CONVERTER = resultSet ->
+            Optional.of(new SourceQuery(
+                    resultSet.getString("suite"),
+                    resultSet.getString("name"),
+                    resultSet.getString("control_query"),
+                    resultSet.getString("test_query"),
+                    new QueryConfiguration(
+                            resultSet.getString("control_catalog"),
+                            resultSet.getString("control_schema"),
+                            Optional.ofNullable(resultSet.getString("control_username")),
+                            Optional.ofNullable(resultSet.getString("control_password")),
+                            Optional.ofNullable(resultSet.getString("control_session_properties"))
+                                    .map(StringToStringMapColumnMapper.CODEC::fromJson)),
+                    new QueryConfiguration(
+                            resultSet.getString("test_catalog"),
+                            resultSet.getString("test_schema"),
+                            Optional.ofNullable(resultSet.getString("test_username")),
+                            Optional.ofNullable(resultSet.getString("test_password")),
+                            Optional.ofNullable(resultSet.getString("test_session_properties"))
+                                    .map(StringToStringMapColumnMapper.CODEC::fromJson))));
+
+    private final PrestoAction helperAction;
+    private final SqlParser sqlParser;
+    private final String query;
+
+    @Inject
+    public PrestoQuerySourceQuerySupplier(
+            @ForHelper PrestoActionFactory helperActionFactory,
+            SqlParser sqlParser,
+            PrestoQuerySourceQueryConfig config)
+    {
+        this.helperAction = helperActionFactory.create(
+                new QueryConfiguration(config.getCatalog(), config.getSchema(), config.getUsername(), config.getPassword(), Optional.empty()),
+                VerificationContext.create("", ""));
+        this.sqlParser = requireNonNull(sqlParser, "sqlParser is null");
+        this.query = requireNonNull(config.getQuery(), "query is null");
+    }
+
+    @Override
+    public List<SourceQuery> get()
+    {
+        return helperAction.execute(sqlParser.createStatement(query, PARSING_OPTIONS), SOURCE, SOURCE_QUERY_CONVERTER).getResults();
+    }
+}

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/source/SourceQueryModule.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/source/SourceQueryModule.java
@@ -22,18 +22,21 @@ import java.util.Set;
 
 import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
 import static com.facebook.presto.verifier.source.MySqlSourceQuerySupplier.MYSQL_SOURCE_QUERY_SUPPLIER;
+import static com.facebook.presto.verifier.source.PrestoQuerySourceQuerySupplier.PRESTO_QUERY_SOURCE_QUERY_SUPPLIER;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.inject.Scopes.SINGLETON;
 
 public class SourceQueryModule
         extends AbstractConfigurationAwareModule
 {
+    private static final String SOURCE_QUERY_CONFIG_PREFIX = "source-query";
     private final Set<String> supportedSourceQuerySupplierTypes;
 
     public SourceQueryModule(Set<String> customSourceQuerySupplierTypes)
     {
         this.supportedSourceQuerySupplierTypes = ImmutableSet.<String>builder()
                 .add(MYSQL_SOURCE_QUERY_SUPPLIER)
+                .add(PRESTO_QUERY_SOURCE_QUERY_SUPPLIER)
                 .addAll(customSourceQuerySupplierTypes)
                 .build();
     }
@@ -45,8 +48,13 @@ public class SourceQueryModule
         checkArgument(supportedSourceQuerySupplierTypes.contains(sourceQuerySupplierType), "Unsupported SourceQuerySupplier: %s", sourceQuerySupplierType);
 
         if (MYSQL_SOURCE_QUERY_SUPPLIER.equals(sourceQuerySupplierType)) {
-            configBinder(binder).bindConfig(MySqlSourceQueryConfig.class, "source-query");
+            configBinder(binder).bindConfig(MySqlSourceQueryConfig.class, SOURCE_QUERY_CONFIG_PREFIX);
             binder.bind(SourceQuerySupplier.class).to(MySqlSourceQuerySupplier.class).in(SINGLETON);
+        }
+
+        if (PRESTO_QUERY_SOURCE_QUERY_SUPPLIER.equals(sourceQuerySupplierType)) {
+            configBinder(binder).bindConfig(PrestoQuerySourceQueryConfig.class, SOURCE_QUERY_CONFIG_PREFIX);
+            binder.bind(SourceQuerySupplier.class).to(PrestoQuerySourceQuerySupplier.class).in(SINGLETON);
         }
     }
 }

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/source/StringToStringMapColumnMapper.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/source/StringToStringMapColumnMapper.java
@@ -26,7 +26,7 @@ import static com.facebook.airlift.json.JsonCodec.mapJsonCodec;
 public class StringToStringMapColumnMapper
         implements ColumnMapper<Map<String, String>>
 {
-    private static final JsonCodec<Map<String, String>> CODEC = mapJsonCodec(String.class, String.class);
+    public static final JsonCodec<Map<String, String>> CODEC = mapJsonCodec(String.class, String.class);
 
     @Override
     public Map<String, String> map(ResultSet resultSet, int columnNumber, StatementContext ctx)

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/source/TestPrestoQuerySourceQueryConfig.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/source/TestPrestoQuerySourceQueryConfig.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.verifier.source;
+
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+
+public class TestPrestoQuerySourceQueryConfig
+{
+    @Test
+    public void testDefault()
+    {
+        assertRecordedDefaults(recordDefaults(PrestoQuerySourceQueryConfig.class)
+                .setQuery(null)
+                .setCatalog(null)
+                .setSchema(null)
+                .setUsername(null)
+                .setPassword(null));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("query", "SELECT query")
+                .put("catalog", "test_catalog")
+                .put("schema", "test_schema")
+                .put("username", "test_user")
+                .put("password", "test_password")
+                .build();
+        PrestoQuerySourceQueryConfig expected = new PrestoQuerySourceQueryConfig()
+                .setQuery("SELECT query")
+                .setCatalog("test_catalog")
+                .setSchema("test_schema")
+                .setUsername("test_user")
+                .setPassword("test_password");
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/source/TestPrestoQuerySourceQuerySupplier.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/source/TestPrestoQuerySourceQuerySupplier.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.verifier.source;
+
+import com.facebook.airlift.bootstrap.Bootstrap;
+import com.facebook.airlift.bootstrap.LifeCycleManager;
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.parser.SqlParserOptions;
+import com.facebook.presto.tests.StandaloneQueryRunner;
+import com.facebook.presto.verifier.framework.QueryConfiguration;
+import com.facebook.presto.verifier.framework.SourceQuery;
+import com.facebook.presto.verifier.framework.VerifierConfig;
+import com.facebook.presto.verifier.prestoaction.PrestoExceptionClassifier;
+import com.facebook.presto.verifier.prestoaction.QueryActionsModule;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
+import static com.facebook.airlift.testing.Closeables.closeQuietly;
+import static com.facebook.presto.testing.assertions.Assert.assertEquals;
+import static com.facebook.presto.verifier.VerifierTestUtil.CATALOG;
+import static com.facebook.presto.verifier.VerifierTestUtil.SCHEMA;
+import static com.facebook.presto.verifier.VerifierTestUtil.setupPresto;
+import static com.google.inject.Scopes.SINGLETON;
+import static java.lang.String.format;
+
+@Test(singleThreaded = true)
+public class TestPrestoQuerySourceQuerySupplier
+{
+    private static final Logger log = Logger.get(TestPrestoQuerySourceQuerySupplier.class);
+    private static final String SOURCE_FETCHING_QUERY = "SELECT\n" +
+            "    'test' suite,\n" +
+            "    name,\n" +
+            "    query control_query,\n" +
+            "    'catalog' control_catalog,\n" +
+            "    'schema' control_schema,\n" +
+            "    'user' control_username,\n" +
+            "    '{\"a\": \"b\"}' control_session_properties,\n" +
+            "    NULL control_password,\n" +
+            "    query test_query,\n" +
+            "    'catalog' test_catalog,\n" +
+            "    'schema' test_schema,\n" +
+            "    'user' test_username,\n" +
+            "    NULL test_password,\n" +
+            "    '{\"c\": \"d\"}' test_session_properties\n" +
+            "FROM (\n" +
+            "    VALUES\n" +
+            "        ('Q1', 'SELECT 1'),\n" +
+            "        ('Q2', 'INSERT INTO test_table SELECT 1')\n" +
+            ") queries(name, query)";
+    private static final QueryConfiguration CONTROL_CONFIGURATION = new QueryConfiguration(
+            "catalog", "schema", Optional.of("user"), Optional.empty(), Optional.of(ImmutableMap.of("a", "b")));
+    private static final QueryConfiguration TEST_CONFIGURATION = new QueryConfiguration(
+            "catalog", "schema", Optional.of("user"), Optional.empty(), Optional.of(ImmutableMap.of("c", "d")));
+    private static final List<SourceQuery> SOURCE_QUERIES = ImmutableList.of(
+            new SourceQuery("test", "Q1", "SELECT 1", "SELECT 1", CONTROL_CONFIGURATION, TEST_CONFIGURATION),
+            new SourceQuery("test", "Q2", "INSERT INTO test_table SELECT 1", "INSERT INTO test_table SELECT 1", CONTROL_CONFIGURATION, TEST_CONFIGURATION));
+
+    private static StandaloneQueryRunner queryRunner;
+    private static Injector injector;
+
+    @BeforeClass
+    public void setup()
+            throws Exception
+    {
+        queryRunner = setupPresto();
+
+        String host = queryRunner.getServer().getAddress().getHost();
+        int port = queryRunner.getServer().getAddress().getPort();
+
+        Bootstrap app = new Bootstrap(
+                ImmutableList.<Module>builder()
+                        .add(new SourceQueryModule(ImmutableSet.of()))
+                        .add(new QueryActionsModule(PrestoExceptionClassifier.defaultBuilder().build(), ImmutableSet.of()))
+                        .add(binder -> {
+                            configBinder(binder).bindConfig(VerifierConfig.class);
+                            binder.bind(SqlParserOptions.class).toInstance(new SqlParserOptions());
+                            binder.bind(SqlParser.class).in(SINGLETON);
+                        })
+                        .build());
+        injector = app.strictConfig()
+                .setRequiredConfigurationProperties(ImmutableMap.<String, String>builder()
+                        .put("test-id", "10000")
+                        .put("control.hosts", format("%s,%s", host, host))
+                        .put("control.jdbc-port", String.valueOf(port))
+                        .put("source-query.supplier", "presto-query")
+                        .put("source-query.query", SOURCE_FETCHING_QUERY)
+                        .put("source-query.catalog", CATALOG)
+                        .put("source-query.schema", SCHEMA)
+                        .put("source-query.username", "test_user")
+                        .build())
+                .initialize();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void destroy()
+    {
+        closeQuietly(queryRunner);
+        if (injector != null) {
+            try {
+                injector.getInstance(LifeCycleManager.class).stop();
+            }
+            catch (Throwable t) {
+                log.error(t);
+            }
+        }
+    }
+
+    @Test
+    public void testSupplyQueries()
+    {
+        SourceQuerySupplier sourceQuerySupplier = injector.getInstance(SourceQuerySupplier.class);
+        assertEquals(sourceQuerySupplier.get(), SOURCE_QUERIES);
+    }
+}


### PR DESCRIPTION
Currently, we support fetch source queries (pairs for queries to be
verified) from an MySQL table by a given suite. This is insufficient
in some cases, as it requires MySQL and is also bound by the limitation
of MySQL.

Add support to fetch source queries by running a Presto query. The
fetching query will be run on the helper cluster.

```
== RELEASE NOTES ==

Verifier Changes
* Add support to fetch the list of queries to be verified by running a Presto query.
```