### PR TITLE
Enable warnings from the parser and ASTBuilder

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryPreparer.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryPreparer.java
@@ -59,7 +59,7 @@ public class QueryPreparer
     public PreparedQuery prepareQuery(Session session, String query, WarningCollector warningCollector)
             throws ParsingException, PrestoException, SemanticException
     {
-        Statement wrappedStatement = sqlParser.createStatement(query, createParsingOptions(session, warningCollector));
+        Statement wrappedStatement = sqlParser.createStatement(query, createParsingOptions(session, warningCollector), warningCollector);
         if (warningCollector.hasWarnings() && getWarningHandlingLevel(session) == AS_ERROR) {
             throw new PrestoException(WARNING_AS_ERROR, format("Warning handling level set to AS_ERROR. Warnings: %n %s",
                     warningCollector.getWarnings().stream()

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/AstBuilder.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.parser;
 
+import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.sql.tree.AddColumn;
 import com.facebook.presto.sql.tree.AliasedRelation;
 import com.facebook.presto.sql.tree.AllColumns;
@@ -203,10 +204,12 @@ class AstBuilder
 {
     private int parameterPosition;
     private final ParsingOptions parsingOptions;
+    private final WarningCollector warningCollector;
 
-    AstBuilder(ParsingOptions parsingOptions)
+    AstBuilder(ParsingOptions parsingOptions, WarningCollector warningCollector)
     {
         this.parsingOptions = requireNonNull(parsingOptions, "parsingOptions is null");
+        this.warningCollector = requireNonNull(warningCollector, "warningCollector is null");
     }
 
     @Override


### PR DESCRIPTION
This change exposes WarningCollector in SqlParser and AstBuilder class.
Test plan - Running locally. 
First step towards https://github.com/prestodb/presto/issues/15105

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```
