### PR TITLE
Pinot Connector: Adding limit to push down order by for broker query

### DIFF
--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotConfig.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotConfig.java
@@ -92,6 +92,7 @@ public class PinotConfig
     private int fetchRetryCount = 2;
     private boolean useDateTrunc;
     private int nonAggregateLimitForBrokerQueries = DEFAULT_NON_AGGREGATE_LIMIT_FOR_BROKER_QUERIES;
+    private boolean pushdownTopNBrokerQueries;
 
     @NotNull
     public Map<String, String> getExtraHttpHeaders()
@@ -473,6 +474,20 @@ public class PinotConfig
     public PinotConfig setUsePinotSqlForBrokerQueries(boolean usePinotSqlForBrokerQueries)
     {
         this.usePinotSqlForBrokerQueries = usePinotSqlForBrokerQueries;
+        return this;
+    }
+
+    public boolean isPushdownTopNBrokerQueries()
+    {
+        return pushdownTopNBrokerQueries;
+    }
+
+    // This is used to switch on/off push down Pinot broker queries with ORDER BY clause and LIMIT.
+    // The reason is that presto doesn't retain the order of query response from Pinot for large number of records returned.
+    @Config("pinot.pushdown-topn-broker-queries")
+    public PinotConfig setPushdownTopNBrokerQueries(boolean pushdownTopNBrokerQueries)
+    {
+        this.pushdownTopNBrokerQueries = pushdownTopNBrokerQueries;
         return this;
     }
 }

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotSessionProperties.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotSessionProperties.java
@@ -40,6 +40,7 @@ public class PinotSessionProperties
     private static final String USE_DATE_TRUNC = "use_date_trunc";
     private static final String USE_PINOT_SQL_FOR_BROKER_QUERIES = "use_pinot_sql_for_broker_queries";
     private static final String NON_AGGREGATE_LIMIT_FOR_BROKER_QUERIES = "non_aggregate_limit_for_broker_queries";
+    private static final String PUSHDOWN_TOPN_BROKER_QUERIES = "pushdown_topn_broker_queries";
 
     @VisibleForTesting
     public static final String FORBID_SEGMENT_QUERIES = "forbid_segment_queries";
@@ -100,6 +101,11 @@ public class PinotSessionProperties
         return session.getProperty(NON_AGGREGATE_LIMIT_FOR_BROKER_QUERIES, Integer.class);
     }
 
+    public static boolean getPushdownTopnBrokerQueries(ConnectorSession session)
+    {
+        return session.getProperty(PUSHDOWN_TOPN_BROKER_QUERIES, Boolean.class);
+    }
+
     @Inject
     public PinotSessionProperties(PinotConfig pinotConfig)
     {
@@ -143,6 +149,11 @@ public class PinotSessionProperties
                         USE_PINOT_SQL_FOR_BROKER_QUERIES,
                         "Use Pinot SQL syntax and endpoint for broker query",
                         pinotConfig.isUsePinotSqlForBrokerQueries(),
+                        false),
+                booleanProperty(
+                        PUSHDOWN_TOPN_BROKER_QUERIES,
+                        "Push down order by to pinot broker for top queries",
+                        pinotConfig.isPushdownTopNBrokerQueries(),
                         false),
                 new PropertyMetadata<>(
                         CONNECTION_TIMEOUT,

--- a/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotConfig.java
+++ b/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotConfig.java
@@ -54,6 +54,7 @@ public class TestPinotConfig
                         .setNumSegmentsPerSplit(1)
                         .setFetchRetryCount(2)
                         .setMarkDataFetchExceptionsAsRetriable(true)
+                        .setPushdownTopNBrokerQueries(false)
                         .setIgnoreEmptyResponses(false)
                         .setUseDateTrunc(false)
                         .setForbidSegmentQueries(false)
@@ -94,6 +95,7 @@ public class TestPinotConfig
                 .put("pinot.non-aggregate-limit-for-broker-queries", "10")
                 .put("pinot.use-date-trunc", "true")
                 .put("pinot.limit-large-for-segment", "100")
+                .put("pinot.pushdown-topn-broker-queries", "true")
                 .put("pinot.forbid-segment-queries", "true")
                 .build();
 
@@ -127,6 +129,7 @@ public class TestPinotConfig
                 .setMarkDataFetchExceptionsAsRetriable(false)
                 .setNonAggregateLimitForBrokerQueries(10)
                 .setLimitLargeForSegment(100)
+                .setPushdownTopNBrokerQueries(true)
                 .setForbidSegmentQueries(true)
                 .setUseDateTrunc(true);
 

--- a/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/query/TestPinotQueryGeneratorSql.java
+++ b/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/query/TestPinotQueryGeneratorSql.java
@@ -27,9 +27,18 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
+import java.util.Optional;
+
+import static org.testng.Assert.assertFalse;
+
 public class TestPinotQueryGeneratorSql
         extends TestPinotQueryGenerator
 {
+    public TestPinotQueryGeneratorSql()
+    {
+        pinotConfig.setUsePinotSqlForBrokerQueries(useSqlSyntax());
+    }
+
     @Override
     public boolean useSqlSyntax()
     {
@@ -117,6 +126,8 @@ public class TestPinotQueryGeneratorSql
     @Test
     public void testAggregationWithOrderByPushDownInTopN()
     {
+        pinotConfig.setPushdownTopNBrokerQueries(true);
+        SessionHolder sessionHolder = new SessionHolder(pinotConfig);
         PlanBuilder planBuilder = createPlanBuilder(defaultSessionHolder);
         TableScanNode tableScanNode = tableScan(planBuilder, pinotTable, city, fare);
         AggregationNode agg = planBuilder.aggregation(
@@ -128,7 +139,7 @@ public class TestPinotQueryGeneratorSql
                 pinotConfig,
                 agg,
                 "SELECT city, sum(fare) FROM realtimeOnly GROUP BY city LIMIT 10000",
-                defaultSessionHolder,
+                sessionHolder,
                 ImmutableMap.of());
 
         TopNNode topN = new TopNNode(
@@ -141,7 +152,7 @@ public class TestPinotQueryGeneratorSql
                 pinotConfig,
                 topN,
                 "SELECT city, sum(fare) FROM realtimeOnly GROUP BY city ORDER BY city DESC LIMIT 50",
-                defaultSessionHolder,
+                sessionHolder,
                 ImmutableMap.of());
 
         topN = new TopNNode(
@@ -154,32 +165,74 @@ public class TestPinotQueryGeneratorSql
                 pinotConfig,
                 topN,
                 "SELECT city, sum(fare) FROM realtimeOnly GROUP BY city ORDER BY sum(fare) LIMIT 1000",
-                defaultSessionHolder,
+                sessionHolder,
+                ImmutableMap.of());
+
+        topN = new TopNNode(
+                planBuilder.getIdAllocator().getNextId(),
+                agg,
+                1000L,
+                new OrderingScheme(ImmutableList.of(new Ordering(variable("sum_fare"), SortOrder.ASC_NULLS_FIRST))),
+                TopNNode.Step.SINGLE);
+        testPinotQuery(
+                pinotConfig,
+                topN,
+                "SELECT city, sum(fare) FROM realtimeOnly GROUP BY city ORDER BY sum(fare) LIMIT 1000",
+                sessionHolder,
+                ImmutableMap.of());
+    }
+
+    @Test
+    public void testDefaultNoTopNPushdown()
+    {
+        PlanBuilder planBuilder = createPlanBuilder(defaultSessionHolder);
+        TableScanNode tableScanNode = tableScan(planBuilder, pinotTable, city, fare);
+        AggregationNode agg = planBuilder.aggregation(
+                aggBuilder -> aggBuilder
+                        .source(tableScanNode)
+                        .singleGroupingSet(variable("city"))
+                        .addAggregation(planBuilder.variable("sum_fare"), getRowExpression("sum(fare)", defaultSessionHolder)));
+        pinotConfig.setPushdownTopNBrokerQueries(false);
+        TopNNode topN = new TopNNode(planBuilder.getIdAllocator().getNextId(), agg, 1000,
+                new OrderingScheme(ImmutableList.of(new Ordering(variable("sum_fare"), SortOrder.ASC_NULLS_FIRST))),
+                TopNNode.Step.SINGLE);
+        Optional<PinotQueryGenerator.PinotQueryGeneratorResult> generatedQuery =
+                new PinotQueryGenerator(pinotConfig, typeManager, functionMetadataManager, standardFunctionResolution)
+                        .generate(topN, defaultSessionHolder.getConnectorSession());
+        assertFalse(generatedQuery.isPresent());
+        SessionHolder sessionHolder = new SessionHolder(pinotConfig);
+        testPinotQuery(
+                pinotConfig,
+                agg,
+                "SELECT city, sum(fare) FROM realtimeOnly GROUP BY city LIMIT 10000",
+                sessionHolder,
                 ImmutableMap.of());
     }
 
     @Test
     public void testSelectionWithOrderBy()
     {
+        pinotConfig.setPushdownTopNBrokerQueries(true);
         PlanBuilder planBuilder = createPlanBuilder(defaultSessionHolder);
         TableScanNode tableScanNode = tableScan(planBuilder, pinotTable, regionId, city, fare);
+        SessionHolder sessionHolder = new SessionHolder(pinotConfig);
         testPinotQuery(
                 pinotConfig,
                 topN(planBuilder, 50L, ImmutableList.of("fare"), ImmutableList.of(false), tableScanNode),
                 "SELECT regionId, city, fare FROM realtimeOnly ORDER BY fare DESC LIMIT 50",
-                defaultSessionHolder,
+                sessionHolder,
                 ImmutableMap.of());
         testPinotQuery(
                 pinotConfig,
                 topN(planBuilder, 50L, ImmutableList.of("fare", "city"), ImmutableList.of(true, false), tableScanNode),
                 "SELECT regionId, city, fare FROM realtimeOnly ORDER BY fare, city DESC LIMIT 50",
-                defaultSessionHolder,
+                sessionHolder,
                 ImmutableMap.of());
         testPinotQuery(
                 pinotConfig,
                 topN(planBuilder, 50L, ImmutableList.of("city", "fare"), ImmutableList.of(false, true), tableScanNode),
                 "SELECT regionId, city, fare FROM realtimeOnly ORDER BY city DESC, fare LIMIT 50",
-                defaultSessionHolder,
+                sessionHolder,
                 ImmutableMap.of());
 
         TopNNode topNNode = topN(planBuilder, 50L, ImmutableList.of("fare", "city"), ImmutableList.of(true, false), tableScanNode);
@@ -187,7 +240,7 @@ public class TestPinotQueryGeneratorSql
                 pinotConfig,
                 project(planBuilder, topNNode, ImmutableList.of("regionid", "city")),
                 "SELECT regionId, city FROM realtimeOnly ORDER BY fare, city DESC LIMIT 50",
-                defaultSessionHolder,
+                sessionHolder,
                 ImmutableMap.of());
 
         tableScanNode = tableScan(planBuilder, pinotTable, fare, city, regionId);
@@ -195,13 +248,13 @@ public class TestPinotQueryGeneratorSql
                 pinotConfig,
                 topN(planBuilder, 500L, ImmutableList.of("fare"), ImmutableList.of(false), tableScanNode),
                 "SELECT fare, city, regionId FROM realtimeOnly ORDER BY fare DESC LIMIT 500",
-                defaultSessionHolder,
+                sessionHolder,
                 ImmutableMap.of());
         testPinotQuery(
                 pinotConfig,
                 topN(planBuilder, 5000L, ImmutableList.of("fare", "city"), ImmutableList.of(true, false), tableScanNode),
                 "SELECT fare, city, regionId FROM realtimeOnly ORDER BY fare, city DESC LIMIT 5000",
-                defaultSessionHolder,
+                sessionHolder,
                 ImmutableMap.of());
     }
 


### PR DESCRIPTION
```
== RELEASE NOTES ==

Pinot Changes
* Adding config: `pinot.pushdown-topn-broker-queries` to support pushing down TOPN queries.

Presto doesn't retain the order of query response from Pinot for large number of records returned. So only enable this when doing small group by and order by results
```
