### PR TITLE
Add release notes for 0.241

### DIFF
--- a/presto-docs/src/main/sphinx/release.rst
+++ b/presto-docs/src/main/sphinx/release.rst
@@ -5,6 +5,7 @@ Release Notes
 .. toctree::
     :maxdepth: 1
 
+    release/release-0.241
     release/release-0.240
     release/release-0.239.2
     release/release-0.239.1

--- a/presto-docs/src/main/sphinx/release/release-0.241.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.241.rst
@@ -1,0 +1,49 @@
+=============
+Release 0.241
+=============
+
+General Changes
+_______________
+* Fix incorrect results from function :func:`classification_precision` introduced in release 0.239.
+* Improve performance for queries with broadcast or collocated joins by adding dynamic filtering and bucket pruning support. This can be enabled with the ``experimental.enable-dynamic-filtering`` configuration property and ``enable_dynamic_filtering`` system session property. For more information please refer to (:pr:`15077`).
+* Add new warning message for ``UNION`` queries without ``ALL`` or ``DISTINCT`` keywords.
+* Downgrade the ZSTD JNI compressor version to resolve the frequent excessive GC events introduced in version 0.238.
+
+Security Changes
+________________
+* Implement REST endpoint authorization in Presto. See :doc:`/security/authorization`.
+
+JDBC Changes
+____________
+* Add support for ``ResultSet.getStatement``.
+* Add support for Oracle JDBC connections.
+
+Hive Changes
+____________
+* Fix several memory accounting bugs in ``OrcRecordReader`` and ``StreamReader``.
+* Add procedure ``system.sync_partition_metadata()`` to synchronize the partitions in the metastore with the partitions that are physically in the file system.
+* Add support for direct recursive file listings in ``PrestoS3FileSystem``.
+* Add support for non-Hive types to Hive views. This support had been removed in 0.233. If a view uses an unsupported type for any columns, only a single dummy column will be saved in the metastore.
+* Add support for pushing dereferences into Parquet table scan, so that only the required nested column is read when other projected nested columns are in the same base column. This can be enabled with the ``hive.enable-parquet-dereference-pushdown`` Hive configuration property and ``parquet_batch_reader_verification_enabled`` Hive session property.
+
+Druid Changes
+_____________
+* Add support for data ingestion. Three modes are supported: ``INSERT INTO SELECT``, ``CREATE TABLE AS``, and from local or HDFS folders.
+
+Oracle Changes
+______________
+* Add Oracle connector.
+
+Verifier Changes
+________________
+* Fix an issue during determinism analysis that queries with ``LIMIT`` clause are not identified as non-deterministic when a rerun of the control query fails.
+* Add support to allow multiple control and test clusters.
+
+SPI Changes
+___________
+* Add ``StageStatistics`` and ``OperatorStatistics`` to ``QueryCompletedEvent``, and remove stage and operator statistics from ``QueryStatistics``.
+
+Geospatial Changes
+__________________
+* Fix a bug when two envelopes intersect at a point for :func:`ST_Intersection`.
+* Add :func:`geometry_nearest_points` to find nearest points of a pair of geometries.


### PR DESCRIPTION
# Missing Release Notes
## Daniel Ohayon
- [x] https://github.com/prestodb/presto/pull/14728 Enums support #1: base types and operators (Merged by: Rongrong Zhong)

## George Wang
- [x] https://github.com/prestodb/presto/pull/15014 Add Oracle connector support (Merged by: James Sun)

## Vic Zhang
- [x] https://github.com/prestodb/presto/pull/15075 Fix precision definition in classification_precision function (Merged by: Maria Basmanova)

# Extracted Release Notes
- #14923 (Author: James Gill): Add geometry_nearest_points function
  - Add :func:`geometry_nearest_points` to find nearest points of a pair of geometries.
- #14955 (Author: Venki Korukanti): Push dereferences into table scan for parquet tables
  - This change adds planner side support for pushing dereferences into Parquet table scan. Pushing deferences into table scan enables efficient scans as only the required nested column is read when required independent of the other projected nested columns in the same base column. Currently this functionality is behind a configuration variable `hive.enable-parquet-dereference-pushdown`.
- #14983 (Author: prithvip): Add warning message for UNION queries without ALL/DISTINCT keyword
  - Added new warning message for UNION queries without ALL/DISTINCT keyword.
- #14995 (Author: Beinan Wang): Add support for druid data ingestion
  - Add support for data ingestion.
- #15013 (Author: Vivek Bharathan): Add Hive procedure to sync table partitions
  - Add procedure system.sync_partition_metadata() to synchronize the partitions in the metastore with the partitions that are physically on the file system.
- #15024 (Author: James Petty): Implement PrestoS3FileSystem#listFiles for direct recursive listings
  - Add support for direct recursive file listings in PrestoS3FileSystem.
- #15027 (Author: Adam J. Shook): Implement JDBC ResultSet.getStatement
  - Implemented ResultSet getStatement.
- #15028 (Author: Rohit Jain): Revert "Upgrade ZSTD version"
  - Downgrade ZSTD JNI compressor version to resolve the frequent excessive GC events introduced in version 0.238.
- #15040 (Author: Mayank Garg): Separate operator and stage statistics from query statistics
  - Add ``StageStatistics`` and ``OperatorStatistics`` to ``QueryCompletedEvent`` and remove stage and operator statistics from ``QueryStatistics``.
- #15042 (Author: Mayank Garg): Add documentation for Presto authorization
  - Implement REST endpoint authorization in Presto. See :doc:`/security/authorization`.
- #15056 (Author: Leiqing Cai): Improve error handling during determinism analysis
  - Fix an issue during determinism analysis where queries with LIMIT clause are not identified as non-deterministic when a rerun of the control query fails.
- #15065 (Author: Rebecca Schlussel): Support non-hive types in hive views
  - Add support for non-hive types to hive views.  This support had been removed in 0.233.  If a view uses an unsupported type for any columns ,we will store only a single dummy column for that view in the metastore.
- #15077 (Author: Ke Wang): Dynamic filtering integration with Aria
  - Add dynamic filtering and bucket pruning support for inner join and semi join. The feature avoids full table scan on probe side for broadcast join or colocated join when the build side is small. Set config `experimental.enable-dynamic-filtering` to `True` to enable the feature. Configs `experimental.dynamic-filtering-max-per-driver-row-count` and `experimental.dynamic-filtering-max-per-driver-size` are available to tune the size on the build side join key space. Currently, only Hive connector can benefit from the feature.
- #15078 (Author: Ying Su): Add memory tracking for OrcRecordReader
  - Added memory tracking for OrcRecordReader.
- #15099 (Author: Ying Su): Fix memory counting for SliceDictionaryBatchStreamReader
  - Fixed a memory counting bug in SliceDictionaryBatchStreamReader.
- #15104 (Author: James Gill): Fix incorrect intersection between two envelopes
  - Fix bug when two envelopes intersect at a point for :func:`ST_Intersection`.
- #15113 (Author: Leiqing Cai): Support multiple control and test clusters in Verifier
  - Add support to allow multiple control and test clusters.

# All Commits
- 61d5b873a8702c34f28a88e8fc79ec7fd48db410 Partial Aggregation Pushdown for ORC/Parquet (Vivek Bharathan)
- 731ea6b0fa8ff351c9b0fa4519b62429905c36e3 Fix incorrect intersection between two envelopes (James Gill)
- 7b07513ff9ae5c5c8990ed5821b40c37338ccc8e Add support to bounded varchar to BenchmarkSelectiveStreamReaders (Ying Su)
- a8dce28097f712f727e629d5ecd0bfa5e2462d1e Support multiple columns in BenchmarkSelectiveStreamReaders (Ying Su)
- 921393d63182df1f0bf86da0043ba567edfa4207 Allow custom filter rate for BenchmarkSelectiveStreamReaders (Ying Su)
- bc44dabd5617482bd255fedccbf93d4ff8eb0eac Add verification method to BenchmarkSelectiveStreamReaders (Ying Su)
- cf491372b7276d074b31e8ceb6d55132eecf4f7c Refactor BenchmarkSelectiveStreamReaders (Ying Su)
- 6c8ad659aeac266e61821925d5654e17358aa410 ParquetWriters cleanup (Zhenxiao Luo)
- eadfd1bbb5a948f45a10861e7455ac914311730b Add ConnectorMetadataUpdateHandle resolver (Nikhil Collooru)
- f02c93ddf08223574eb1b2d7eda1b467d869226c Add ConnectorMetadataUpdater to handle worker's metadata updates (Nikhil Collooru)
- e6995f4b62589a7abd809ccde12223b6d64921e8 Rename PageSinkProperties to PageSinkContext (Nikhil Collooru)
- ae0bdf8126b277ebadfa02b0aca65c7ad10e775e Remove getFileStatus on openFile with Alluxio Cache (Bin Fan)
- f74a84e8b610dcddff5d29d76b345fe7ac2de5a4 Dynamic filtering integration with hive filter pushdown (Ke Wang)
- 76442b33ae4a6a45f649805d516ca405dc29ed06 Support multiple control and test clusters in Verifier (Leiqing Cai)
- 2663a6679bd1ff8063e62e94f1818fd2620d178a Make equals() and hashCode() consistent in TableHandle (Shixuan Fan)
- 344a3f8bc9d8daa568d7fd9c3d52d1b464f4de0e Add check that dynamic filtering is not enabled with grouped execution (Ke Wang)
- 6b6b143f9cedc19098460725fb73a12bf7417c71 Rename dynamicFilterSupplier in ScanFilterAndProjectOperator (Ke Wang)
- e548af5502685683251be3c5e5d38fe87e8ac666 Wrap OrcZstdDecompressor with airlift Decompressor (Vic Zhang)
- b2139549f976acb307bc79ca3a3ae3d94223c7b1 Add zstd compression for PAGEFILE (Vic Zhang)
- 287c4711ccd8e8a2e407ba67d274a8bb26acf9cd Add debug logging when running Presto queries in Verifier (Leiqing Cai)
- eed4ae1a6ff52257ac7adf8f25ceadb10913d64a Make SimpleHttpResponseHandler generic (Tim Meehan)
- 5805f747b64f1109b764b55f2fef8cf364e4fe79 Make RequestErrorTracker generic (Tim Meehan)
- f2c70979d6fee1d2b95c8be1fe48debb074c265f Add tests for session propery ignore_unreadable_partition (Naveen007)
- 8ff1be57f652b07295ede68d54202405f564cf59 Add Session property to ignore non-readable hive partitions (Naveen007)
- 3d4931b1d753235aa9e6f8e8ad95bafca5a53247 Add testMemoryTracking in TestSelectiveOrcReader (Ying Su)
- 696ffca57d1b195a958854acb41ea290a68b19c5 Fix memory tracking for some SelectiveStreamReader's (Ying Su)
- d3756467f3b708db0fc3cd5612615269fd22f09c Add memory tracking for OrcSelectiveRecordReader (Ying Su)
- 9aaa21880110ad15de70840a78790be0b5c17298 Do not write buffered data when task is aborted (Vic Zhang)
- 1ac2744a1131dc3eda3d834ed03bef7c478ec12d Add ExecutionFailureInfo to BasicQueryInfo (Tim Meehan)
- 5d6ec74cadca9dc3f07869f7e93cd941719ab054 Remove QueryInfo from DispatchManager (Tim Meehan)
- 4375cd29031c826c14a33a2ab7f3bf09ed4b9475 Fix formatting in TestHiveIntegrationSmokeTest (Rebecca Schlussel)
- 256fb82858b7fa0ca36bf3a26c3ee73bdcc20b52 Suport non-hive types for Hive views (Rebecca Schlussel)
- a458ecbe56105226c88b0f89bcf13dc09b3fc103 Track cache objects sizes in CachingOrcDataSource (Ying Su)
- 91a1c79e431463eceb507a153f34ca6150df51c4 Create OrcPageSource using the OrcDataSource from OrcReader (Ying Su)
- b552b63595a5bb0eaa8ecb77453342b63a5be686 Fix memory counting for SliceDictionaryBatchStreamReader (Ying Su)
- 21c9c62b11afec44bd9d4385f67c73c5d0e37535 Update Presto on Spark splits assignment test (Vic Zhang)
- fe13c969b6acaa0fce8676dd9fc73e33a4c41266 Add config property for min spark partition count (Vic Zhang)
- dcf54c535b1e57ac14238e8a34805a3b6703a255 Add more error message for Presto-on-Spark (Wenlei Xie)
- 99e67bc9d490d51920473999cb43905037bb7ee5 Add enum operators (Daniel Ohayon)
- 3649366842b1267813e43f1fa3ea36be2015d0f3 Support enum literals in queries (Daniel Ohayon)
- f99842b17afdbb6b3bdca063049503ec86cf7a87 Support type bound in TypeVariableConstraint (Daniel Ohayon)
- 7ced455b02032a99b7ce8991412897baba60d14d Add long and varchar enum types (Daniel Ohayon)
- 9bde82176cc95b9fc3709793901eba6cf28ef4c9 Add Hive procedure to sync table partitions (Vivek)
- a703fc48010461d1100aa5268c4a50970fdc36aa Adds support for microsecond timestamp precision (Dmitry Borovsky)
- da8303be9054634e2b5c35b89906668ba22d1733 Categorize the AccessControlException as user error (Venki Korukanti)
- 9b61fd745160e547d4235ac05061b3f5e4303be8 Fix TestOrcMapNullKey (Masha Basmanova)
- 738bb9cca9804a94649bfb856f1733769a6d4628 Improve logging of queued queries (Tim Meehan)
- fbe8766f983ed862848f91bd805aecabad1b8085 Fix PrestoSparkQueryStatusInfo deserialization (Andrii Rosa)
- 1a8987f745365ec08467429cfc6c39fcf80addf9 Adds option to read null map keys from orc file (Dmitry Borovsky)
- 9d92f0ef5f2064346b8cbd32a9e5ff919973a890 Fix page splitter creating large dictionary page list (James Sun)
- d8a12ee72c91a82a09c9f86e43f8697070a90a33 Add test cases for making temp dir under both exist and non-exist folder (Beinan Wang)
- 3f34a616bb9a79b4736e60e7f44a1d1a1f76a0e0 Create temporary root folder when it does not exist and add unit test (Beinan Wang)
- c0ae3044443c163d227553d63ddeb4512fbd2c6e fix CTAS failures when using viewfs (Beinan Wang)
- 6923691a0e8f6e83340180aacbea5d1ad9852519 Allow to store query results into a file in Presto on Spark (Andrii Rosa)
- 6fa3632e2b5dababdf847ff1b4bd3b6605cb6710 Restructure PrestoSparkQueryInfo to resemble QueryResults (Andrii Rosa)
- 2222b94325783b3c664e184fa65e73bd9c1d704b Expose more session parameters in PrestoSparkRunner (Andrii Rosa)
- f8793a7477209fa91b800c997d34be46348c5795 Improve error handling during determinism analysis (Leiqing Cai)
- b18ccbe27262affe2943a0e86f846a196347da8f Fix precision definition in classification_precision function (Vic Zhang)
- b7d55392b38e16a17b35c2c08751347ff2f283f6 Clean up TrackedQuery (Tim Meehan)
- 86914fbd787a254c9691759cf274d133b2e7a332 Add max Spark input partition count for auto tune (Wenlei Xie)
- f16f757d171af7ce93dbe27f3b0bdef875b64ceb Recognize Presto-on-Spark error code in verifier (Wenlei Xie)
- 39872c40ec70acbb5579720d30dd75763e6305ef Move QueryNotAdequatelyPushedDownErrorCode to PinotErrorCode (Xiang Fu)
- ad31ac01727b5c500ed075a2fb3f3ca40a4af980 Add dynamic filter canonicalization in UnaliasSymbolReferences (Ke Wang)
- 0cfa23fd729a4ae6ab55c4c55ff8c1ccfd6b8be0 Refactor WarningCollector to spi module enabling connectors to pass warnings back to the engine (Naveen007)
- 95725f66bceceadd311eaaff9f7e5706b63a407a Implement PrestoS3FileSystem#listFiles for direct recursive listings (James Petty)
- e7af71b06a68b7f48cf432c4e4bd8a996b61a573 Add geometry_nearest_points function (James Gill)
- f25aa0cde71510e852803dcdf1fff8cfea10997f Fix multi-join dynamic filtering (Ke Wang)
- f4fd78618cb2dc1cb8f98b6bfe44ef02bd1e7358 Fix for Pinot queries where order by column is pruned in projection (Dharak Kharod)
- 4778753b805674babb8a4c036af9a7ec7dc3ec1f Separate operator and stage statistics from query statistics (Mayank Garg)
- 4066bd3a1130db56e2b81b99bfe3de4e813a9235 Invoke runtime plan checker in SqlQueryScheduler (Peizhen Guo)
- 9b29a7485953309f4ca0d17ef7def889d89d25d8 Refactor RuntimeReorderJoin use PropertyDerivation (Peizhen Guo)
- 7dd650c93f0d9f8048d2a7d9947483dc9e302abd Add documentation for Presto authorization (Mayank Garg)
- c02e90ef01a8f46e2a33879d5ff6dd888c3f9c56 Add error code for Presto-on-Spark (Wenlei Xie)
- ad1ab8b8e12e1f12506ef2f72c9ef42dfdfbf438 Remove OriginalExpression from PropertyDerivations (James Sun)
- d60c948fbbae5fd41d81f327c0dc20e97cf4d154 Remove OriginalExpression from StreamPropertyDerivations (James Sun)
- 5de7bca66493bfb2e502f3e0f332719b03535b9e Remove OriginalExpression from PushProjectionThroughUnion (James Sun)
- 0bd085450071e7db1ab19427fbf5a91632ea72bc Remove OriginalExpression from PushProjectionThroughExchange (James Sun)
- 49a2f198a7ac95ff38b4cb1eaee23aa7c7e9487d Add Oracle connector (George Wang)
- c79b71428ed777cfe8154e257aa39f1a4a2693f3 Fix TABLESAMPLE SYSTEM for Presto on Spark (Andrii Rosa)
- 36b78d2770132aa7866aff0084ed60649c2b1012 Fix pruning unreferenced variables when WindowNode is skipped in PruneUnreferencedOutputs (Venki Korukanti)
- 7e7be195b08ec491c54e64d2b3d3b6963dc8d732 Enable dereference pushdown in more testcases (Zhenxiao Luo)
- d07fbc573552fa380cb9d6f4806da419155494fc Implement JDBC ResultSet.getStatement (Adam J. Shook)
- 8338c0bc22f41c305e9802a47111413608f990a2 Improve DynamicFiltersChecker to catch unsupported dynamic filters (Ke Wang)
- 08e260c5fcedbb962002ac2763a05b43a2bdd4ed Cleanup nested dynamic filters in RemoveUnsupportedDynamicFilters (Ke Wang)
- 19cfbbc3e766b18be799106ec452975a52f55e62 Handle null analysis for try_cast (James Sun)
- 5dc949e2d7f6d3d19e34ae55124c205a59479e1f Fix NullabilityAnalyzer for RowExpression (James Sun)
- a1b15d6347532834f24a50fd3667f9f8143c8da8 Remove unused NullabilityAnalyzer for Expression (James Sun)
- f6fa7c821c59b723e287156c1cf6ff5371c1566f Catch and throw storage connection error properly (Nikhil Collooru)
- 99c0d2a123f31586afd7f349633e98dcc123b2b4 Use SYNTHESIZED type to represent pushed down Subfield in HiveColumnHandle (Venki Korukanti)
- 7d4a89246fce33b759cf5c3d88fadc796a8d49ca RowGroup pruning using the filter on pushed down subfield (Venki Korukanti)
- 04ed142e96e23a087dd541713ab40150ed278694 Fix the dereference validity check in PushdownDeferences rule (Venki Korukanti)
- a444c048cbc66df50f06986206651d0316fdf354 Update Parquet reader to read pushed down dereference columns (Venki Korukanti)
- 009eb3f0ab34dfb5ee853da2acf702c0a84f9741 Pushdown dereferences into table scan for parquet tables (Venki Korukanti)
- 871dbf3f7cb917ace5a4b5aed6499ab368ada1f2 Add an option to control Parquet dereferance pushdown (Venki Korukanti)
- 9f867d4ceba0a76d0a38ca2b32249253f0d107b1 Revert "Upgrade ZSTD version" (Rohit Jain)
- 172a552a266dac2a342e00397a3017cc0f3c2448 Improve shuffle statistics collection (Andrii Rosa)
- c8d9198860b46f6da72be2605ac2ac642c422184 Implement batching of tiny rows for Presto on Spark (Andrii Rosa)
- d2964bab2de8747645a110683e9893146d4a2a84 Use offset instead of size in PrestoSparkRowBatch (Andrii Rosa)
- de096455a8990263b4bd89e78be6d4d3aea524c4 Implement hdfs input source for druid ingestion (beinan)
- 8fb458d9b2d26e4a45d0b01a5fee9ade0125faf3 Implement druid ingestion by CTAS (beinan)
- d29764e698d169506744ba9fb773d50892ed753e Implement sending ingestion task to druid (beinan)
- 572a4cb8cf5a8807bb48e0cf30330382d8182f82 Write druid page data to gzip files (beinan)
- 84408b8d16283130017fb5c67e8423bc4bed129c Add ingestion storage path to DruidConfig (beinan)
- d5928f12cf505984d1d9ef2d3dc0b1925815648e Add druid table insert/ingestion skeleton code (beinan)
- 27e922f63cf90273b7746667c390bf3246117c4e Add warning message for UNION queries without ALL/DISTINCT keyword (prithvip)
- c6c34d6bc25486415497a4195eff32e4ca4d9764 Modify regex for compatibility with both mysql, mariadb (Amit Sadaphule)
- 0cd9fb183a7d1ce6f5b5865fc35c166920345ef6 Dynamic bucket pruning on workers (Ke Wang)