### PR TITLE
Support smallint, tinyint, date type of Cassandra

### DIFF
--- a/presto-cassandra/pom.xml
+++ b/presto-cassandra/pom.xml
@@ -171,6 +171,11 @@
             <groupId>com.facebook.airlift</groupId>
             <artifactId>security</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraClientConfig.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraClientConfig.java
@@ -402,6 +402,7 @@ public class CassandraClientConfig
         return this;
     }
 
+    @NotNull
     public ProtocolVersion getProtocolVersion()
     {
         return protocolVersion;

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraMetadata.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraMetadata.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.cassandra;
 
+import com.datastax.driver.core.ProtocolVersion;
 import com.facebook.airlift.json.JsonCodec;
 import com.facebook.presto.cassandra.util.CassandraCqlUtils;
 import com.facebook.presto.common.predicate.TupleDomain;
@@ -70,6 +71,7 @@ public class CassandraMetadata
     private final CassandraSession cassandraSession;
     private final CassandraPartitionManager partitionManager;
     private final boolean allowDropTable;
+    private final ProtocolVersion protocolVersion;
 
     private final JsonCodec<List<ExtraColumnMetadata>> extraColumnMetadataCodec;
 
@@ -86,6 +88,7 @@ public class CassandraMetadata
         this.cassandraSession = requireNonNull(cassandraSession, "cassandraSession is null");
         this.allowDropTable = requireNonNull(config, "config is null").getAllowDropTable();
         this.extraColumnMetadataCodec = requireNonNull(extraColumnMetadataCodec, "extraColumnMetadataCodec is null");
+        this.protocolVersion = requireNonNull(config, "config is null").getProtocolVersion();
     }
 
     @Override
@@ -294,7 +297,7 @@ public class CassandraMetadata
             queryBuilder.append(", ")
                     .append(name)
                     .append(" ")
-                    .append(toCassandraType(type).name().toLowerCase(ENGLISH));
+                    .append(toCassandraType(type, protocolVersion).name().toLowerCase(ENGLISH));
         }
         queryBuilder.append(") ");
 

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraPageSink.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraPageSink.java
@@ -13,7 +13,9 @@
  */
 package com.facebook.presto.cassandra;
 
+import com.datastax.driver.core.LocalDate;
 import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.ProtocolVersion;
 import com.datastax.driver.core.querybuilder.Insert;
 import com.facebook.presto.common.Page;
 import com.facebook.presto.common.block.Block;
@@ -22,17 +24,17 @@ import com.facebook.presto.spi.ConnectorPageSink;
 import com.facebook.presto.spi.PrestoException;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
+import org.joda.time.format.DateTimeFormatter;
+import org.joda.time.format.ISODateTimeFormat;
 
 import java.sql.Timestamp;
-import java.time.Instant;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 
 import static com.datastax.driver.core.querybuilder.QueryBuilder.bindMarker;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.insertInto;
@@ -42,11 +44,14 @@ import static com.facebook.presto.common.type.DateType.DATE;
 import static com.facebook.presto.common.type.DoubleType.DOUBLE;
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static com.facebook.presto.common.type.RealType.REAL;
+import static com.facebook.presto.common.type.SmallintType.SMALLINT;
 import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.common.type.TinyintType.TINYINT;
 import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.common.type.Varchars.isVarcharType;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.primitives.Shorts.checkedCast;
 import static java.lang.Float.intBitsToFloat;
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
@@ -55,15 +60,17 @@ import static java.util.concurrent.CompletableFuture.completedFuture;
 public class CassandraPageSink
         implements ConnectorPageSink
 {
-    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE.withZone(ZoneId.of("UTC"));
+    private static final DateTimeFormatter DATE_FORMATTER = ISODateTimeFormat.date().withZoneUTC();
 
     private final CassandraSession cassandraSession;
     private final PreparedStatement insert;
     private final List<Type> columnTypes;
     private final boolean generateUUID;
+    private final Function<Long, Object> toCassandraDate;
 
     public CassandraPageSink(
             CassandraSession cassandraSession,
+            ProtocolVersion protocolVersion,
             String schemaName,
             String tableName,
             List<String> columnNames,
@@ -76,6 +83,13 @@ public class CassandraPageSink
         requireNonNull(columnNames, "columnNames is null");
         this.columnTypes = ImmutableList.copyOf(requireNonNull(columnTypes, "columnTypes is null"));
         this.generateUUID = generateUUID;
+
+        if (protocolVersion.toInt() <= ProtocolVersion.V3.toInt()) {
+            toCassandraDate = value -> DATE_FORMATTER.print(TimeUnit.DAYS.toMillis(value));
+        }
+        else {
+            toCassandraDate = value -> LocalDate.fromDaysSinceEpoch(toIntExact(value));
+        }
 
         Insert insert = insertInto(schemaName, tableName);
         if (generateUUID) {
@@ -123,6 +137,12 @@ public class CassandraPageSink
         else if (INTEGER.equals(type)) {
             values.add(toIntExact(type.getLong(block, position)));
         }
+        else if (SMALLINT.equals(type)) {
+            values.add(checkedCast(type.getLong(block, position)));
+        }
+        else if (TINYINT.equals(type)) {
+            values.add((byte) type.getLong(block, position));
+        }
         else if (DOUBLE.equals(type)) {
             values.add(type.getDouble(block, position));
         }
@@ -130,7 +150,7 @@ public class CassandraPageSink
             values.add(intBitsToFloat(toIntExact(type.getLong(block, position))));
         }
         else if (DATE.equals(type)) {
-            values.add(DATE_FORMATTER.format(Instant.ofEpochMilli(TimeUnit.DAYS.toMillis(type.getLong(block, position)))));
+            values.add(toCassandraDate.apply(type.getLong(block, position)));
         }
         else if (TIMESTAMP.equals(type)) {
             values.add(new Timestamp(type.getLong(block, position)));

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraPageSinkProvider.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraPageSinkProvider.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.cassandra;
 
+import com.datastax.driver.core.ProtocolVersion;
 import com.facebook.presto.spi.ConnectorInsertTableHandle;
 import com.facebook.presto.spi.ConnectorOutputTableHandle;
 import com.facebook.presto.spi.ConnectorPageSink;
@@ -30,11 +31,13 @@ public class CassandraPageSinkProvider
         implements ConnectorPageSinkProvider
 {
     private final CassandraSession cassandraSession;
+    private final ProtocolVersion protocolVersion;
 
     @Inject
-    public CassandraPageSinkProvider(CassandraSession cassandraSession)
+    public CassandraPageSinkProvider(CassandraSession cassandraSession, CassandraClientConfig cassandraClientConfig)
     {
         this.cassandraSession = requireNonNull(cassandraSession, "cassandraSession is null");
+        this.protocolVersion = requireNonNull(cassandraClientConfig, "cassandraClientConfig is null").getProtocolVersion();
     }
 
     @Override
@@ -47,6 +50,7 @@ public class CassandraPageSinkProvider
 
         return new CassandraPageSink(
                 cassandraSession,
+                protocolVersion,
                 handle.getSchemaName(),
                 handle.getTableName(),
                 handle.getColumnNames(),
@@ -64,6 +68,7 @@ public class CassandraPageSinkProvider
 
         return new CassandraPageSink(
                 cassandraSession,
+                protocolVersion,
                 handle.getSchemaName(),
                 handle.getTableName(),
                 handle.getColumnNames(),

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraRecordCursor.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraRecordCursor.java
@@ -95,11 +95,17 @@ public class CassandraRecordCursor
         switch (getCassandraType(i)) {
             case INT:
                 return currentRow.getInt(i);
+            case SMALLINT:
+                return currentRow.getShort(i);
+            case TINYINT:
+                return currentRow.getByte(i);
             case BIGINT:
             case COUNTER:
                 return currentRow.getLong(i);
             case TIMESTAMP:
                 return currentRow.getTimestamp(i).getTime();
+            case DATE:
+                return currentRow.getDate(i).getDaysSinceEpoch();
             case FLOAT:
                 return floatToRawIntBits(currentRow.getFloat(i));
             default:

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraType.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraType.java
@@ -14,6 +14,8 @@
 package com.facebook.presto.cassandra;
 
 import com.datastax.driver.core.DataType;
+import com.datastax.driver.core.LocalDate;
+import com.datastax.driver.core.ProtocolVersion;
 import com.datastax.driver.core.Row;
 import com.datastax.driver.core.utils.Bytes;
 import com.facebook.presto.cassandra.util.CassandraCqlUtils;
@@ -24,7 +26,9 @@ import com.facebook.presto.common.type.DateType;
 import com.facebook.presto.common.type.DoubleType;
 import com.facebook.presto.common.type.IntegerType;
 import com.facebook.presto.common.type.RealType;
+import com.facebook.presto.common.type.SmallintType;
 import com.facebook.presto.common.type.TimestampType;
+import com.facebook.presto.common.type.TinyintType;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.VarbinaryType;
 import com.facebook.presto.spi.PrestoException;
@@ -66,7 +70,10 @@ public enum CassandraType
     FLOAT(RealType.REAL, Float.class),
     INET(createVarcharType(Constants.IP_ADDRESS_STRING_MAX_LENGTH), InetAddress.class),
     INT(IntegerType.INTEGER, Integer.class),
+    SMALLINT(SmallintType.SMALLINT, Short.class),
+    TINYINT(TinyintType.TINYINT, Byte.class),
     TEXT(createUnboundedVarcharType(), String.class),
+    DATE(DateType.DATE, LocalDate.class),
     TIMESTAMP(TimestampType.TIMESTAMP, Date.class),
     UUID(createVarcharType(Constants.UUID_STRING_MAX_LENGTH), java.util.UUID.class),
     TIMEUUID(createVarcharType(Constants.UUID_STRING_MAX_LENGTH), java.util.UUID.class),
@@ -127,6 +134,8 @@ public enum CassandraType
                 return COUNTER;
             case CUSTOM:
                 return CUSTOM;
+            case DATE:
+                return DATE;
             case DECIMAL:
                 return DECIMAL;
             case DOUBLE:
@@ -143,12 +152,16 @@ public enum CassandraType
                 return MAP;
             case SET:
                 return SET;
+            case SMALLINT:
+                return SMALLINT;
             case TEXT:
                 return TEXT;
             case TIMESTAMP:
                 return TIMESTAMP;
             case TIMEUUID:
                 return TIMEUUID;
+            case TINYINT:
+                return TINYINT;
             case UUID:
                 return UUID;
             case VARCHAR:
@@ -160,16 +173,16 @@ public enum CassandraType
         }
     }
 
-    public static NullableValue getColumnValue(Row row, int i, FullCassandraType fullCassandraType)
+    public static NullableValue getColumnValue(Row row, int position, FullCassandraType fullCassandraType)
     {
-        return getColumnValue(row, i, fullCassandraType.getCassandraType(), fullCassandraType.getTypeArguments());
+        return getColumnValue(row, position, fullCassandraType.getCassandraType(), fullCassandraType.getTypeArguments());
     }
 
-    public static NullableValue getColumnValue(Row row, int i, CassandraType cassandraType,
+    public static NullableValue getColumnValue(Row row, int position, CassandraType cassandraType,
             List<CassandraType> typeArguments)
     {
         Type nativeType = cassandraType.getNativeType();
-        if (row.isNull(i)) {
+        if (row.isNull(position)) {
             return NullableValue.asNull(nativeType);
         }
         else {
@@ -177,41 +190,41 @@ public enum CassandraType
                 case ASCII:
                 case TEXT:
                 case VARCHAR:
-                    return NullableValue.of(nativeType, utf8Slice(row.getString(i)));
+                    return NullableValue.of(nativeType, utf8Slice(row.getString(position)));
                 case INT:
-                    return NullableValue.of(nativeType, (long) row.getInt(i));
+                    return NullableValue.of(nativeType, (long) row.getInt(position));
                 case BIGINT:
                 case COUNTER:
-                    return NullableValue.of(nativeType, row.getLong(i));
+                    return NullableValue.of(nativeType, row.getLong(position));
                 case BOOLEAN:
-                    return NullableValue.of(nativeType, row.getBool(i));
+                    return NullableValue.of(nativeType, row.getBool(position));
                 case DOUBLE:
-                    return NullableValue.of(nativeType, row.getDouble(i));
+                    return NullableValue.of(nativeType, row.getDouble(position));
                 case FLOAT:
-                    return NullableValue.of(nativeType, (long) floatToRawIntBits(row.getFloat(i)));
+                    return NullableValue.of(nativeType, (long) floatToRawIntBits(row.getFloat(position)));
                 case DECIMAL:
-                    return NullableValue.of(nativeType, row.getDecimal(i).doubleValue());
+                    return NullableValue.of(nativeType, row.getDecimal(position).doubleValue());
                 case UUID:
                 case TIMEUUID:
-                    return NullableValue.of(nativeType, utf8Slice(row.getUUID(i).toString()));
+                    return NullableValue.of(nativeType, utf8Slice(row.getUUID(position).toString()));
                 case TIMESTAMP:
-                    return NullableValue.of(nativeType, row.getTimestamp(i).getTime());
+                    return NullableValue.of(nativeType, row.getTimestamp(position).getTime());
                 case INET:
-                    return NullableValue.of(nativeType, utf8Slice(toAddrString(row.getInet(i))));
+                    return NullableValue.of(nativeType, utf8Slice(toAddrString(row.getInet(position))));
                 case VARINT:
-                    return NullableValue.of(nativeType, utf8Slice(row.getVarint(i).toString()));
+                    return NullableValue.of(nativeType, utf8Slice(row.getVarint(position).toString()));
                 case BLOB:
                 case CUSTOM:
-                    return NullableValue.of(nativeType, wrappedBuffer(row.getBytesUnsafe(i)));
+                    return NullableValue.of(nativeType, wrappedBuffer(row.getBytesUnsafe(position)));
                 case SET:
                     checkTypeArguments(cassandraType, 1, typeArguments);
-                    return NullableValue.of(nativeType, utf8Slice(buildSetValue(row, i, typeArguments.get(0))));
+                    return NullableValue.of(nativeType, utf8Slice(buildSetValue(row, position, typeArguments.get(0))));
                 case LIST:
                     checkTypeArguments(cassandraType, 1, typeArguments);
-                    return NullableValue.of(nativeType, utf8Slice(buildListValue(row, i, typeArguments.get(0))));
+                    return NullableValue.of(nativeType, utf8Slice(buildListValue(row, position, typeArguments.get(0))));
                 case MAP:
                     checkTypeArguments(cassandraType, 2, typeArguments);
-                    return NullableValue.of(nativeType, utf8Slice(buildMapValue(row, i, typeArguments.get(0), typeArguments.get(1))));
+                    return NullableValue.of(nativeType, utf8Slice(buildMapValue(row, position, typeArguments.get(0), typeArguments.get(1))));
                 default:
                     throw new IllegalStateException("Handling of type " + cassandraType
                             + " is not implemented");
@@ -219,40 +232,40 @@ public enum CassandraType
         }
     }
 
-    public static NullableValue getColumnValueForPartitionKey(Row row, int i, CassandraType cassandraType, List<CassandraType> typeArguments)
+    public static NullableValue getColumnValueForPartitionKey(Row row, int position, CassandraType cassandraType, List<CassandraType> typeArguments)
     {
         Type nativeType = cassandraType.getNativeType();
-        if (row.isNull(i)) {
+        if (row.isNull(position)) {
             return NullableValue.asNull(nativeType);
         }
         switch (cassandraType) {
             case ASCII:
             case TEXT:
             case VARCHAR:
-                return NullableValue.of(nativeType, utf8Slice(row.getString(i)));
+                return NullableValue.of(nativeType, utf8Slice(row.getString(position)));
             case UUID:
             case TIMEUUID:
-                return NullableValue.of(nativeType, utf8Slice(row.getUUID(i).toString()));
+                return NullableValue.of(nativeType, utf8Slice(row.getUUID(position).toString()));
             default:
-                return getColumnValue(row, i, cassandraType, typeArguments);
+                return getColumnValue(row, position, cassandraType, typeArguments);
         }
     }
 
-    private static String buildSetValue(Row row, int i, CassandraType elemType)
+    private static String buildSetValue(Row row, int position, CassandraType elemType)
     {
-        return buildArrayValue(row.getSet(i, elemType.javaType), elemType);
+        return buildArrayValue(row.getSet(position, elemType.javaType), elemType);
     }
 
-    private static String buildListValue(Row row, int i, CassandraType elemType)
+    private static String buildListValue(Row row, int position, CassandraType elemType)
     {
-        return buildArrayValue(row.getList(i, elemType.javaType), elemType);
+        return buildArrayValue(row.getList(position, elemType.javaType), elemType);
     }
 
-    private static String buildMapValue(Row row, int i, CassandraType keyType, CassandraType valueType)
+    private static String buildMapValue(Row row, int position, CassandraType keyType, CassandraType valueType)
     {
         StringBuilder sb = new StringBuilder();
         sb.append("{");
-        for (Map.Entry<?, ?> entry : row.getMap(i, keyType.javaType, valueType.javaType).entrySet()) {
+        for (Map.Entry<?, ?> entry : row.getMap(position, keyType.javaType, valueType.javaType).entrySet()) {
             if (sb.length() > 1) {
                 sb.append(",");
             }
@@ -279,8 +292,7 @@ public enum CassandraType
         return sb.toString();
     }
 
-    private static void checkTypeArguments(CassandraType type, int expectedSize,
-            List<CassandraType> typeArguments)
+    private static void checkTypeArguments(CassandraType type, int expectedSize, List<CassandraType> typeArguments)
     {
         if (typeArguments == null || typeArguments.size() != expectedSize) {
             throw new IllegalArgumentException("Wrong number of type arguments " + typeArguments
@@ -288,9 +300,9 @@ public enum CassandraType
         }
     }
 
-    public static String getColumnValueForCql(Row row, int i, CassandraType cassandraType)
+    public static String getColumnValueForCql(Row row, int position, CassandraType cassandraType)
     {
-        if (row.isNull(i)) {
+        if (row.isNull(position)) {
             return null;
         }
         else {
@@ -298,32 +310,32 @@ public enum CassandraType
                 case ASCII:
                 case TEXT:
                 case VARCHAR:
-                    return CassandraCqlUtils.quoteStringLiteral(row.getString(i));
+                    return CassandraCqlUtils.quoteStringLiteral(row.getString(position));
                 case INT:
-                    return Integer.toString(row.getInt(i));
+                    return Integer.toString(row.getInt(position));
                 case BIGINT:
                 case COUNTER:
-                    return Long.toString(row.getLong(i));
+                    return Long.toString(row.getLong(position));
                 case BOOLEAN:
-                    return Boolean.toString(row.getBool(i));
+                    return Boolean.toString(row.getBool(position));
                 case DOUBLE:
-                    return Double.toString(row.getDouble(i));
+                    return Double.toString(row.getDouble(position));
                 case FLOAT:
-                    return Float.toString(row.getFloat(i));
+                    return Float.toString(row.getFloat(position));
                 case DECIMAL:
-                    return row.getDecimal(i).toString();
+                    return row.getDecimal(position).toString();
                 case UUID:
                 case TIMEUUID:
-                    return row.getUUID(i).toString();
+                    return row.getUUID(position).toString();
                 case TIMESTAMP:
-                    return Long.toString(row.getTimestamp(i).getTime());
+                    return Long.toString(row.getTimestamp(position).getTime());
                 case INET:
-                    return CassandraCqlUtils.quoteStringLiteral(toAddrString(row.getInet(i)));
+                    return CassandraCqlUtils.quoteStringLiteral(toAddrString(row.getInet(position)));
                 case VARINT:
-                    return row.getVarint(i).toString();
+                    return row.getVarint(position).toString();
                 case BLOB:
                 case CUSTOM:
-                    return Bytes.toHexString(row.getBytesUnsafe(i));
+                    return Bytes.toHexString(row.getBytesUnsafe(position));
                 default:
                     throw new IllegalStateException("Handling of type " + cassandraType
                             + " is not implemented");
@@ -340,6 +352,7 @@ public enum CassandraType
             case UUID:
             case TIMEUUID:
             case TIMESTAMP:
+            case DATE:
             case INET:
             case VARINT:
                 return CassandraCqlUtils.quoteStringLiteralForJson(object.toString());
@@ -347,7 +360,8 @@ public enum CassandraType
             case BLOB:
             case CUSTOM:
                 return CassandraCqlUtils.quoteStringLiteralForJson(Bytes.toHexString((ByteBuffer) object));
-
+            case SMALLINT:
+            case TINYINT:
             case INT:
             case BIGINT:
             case COUNTER:
@@ -400,6 +414,8 @@ public enum CassandraType
             case INET:
                 return InetAddresses.forString(((Slice) nativeValue).toStringUtf8());
             case INT:
+            case SMALLINT:
+            case TINYINT:
                 return ((Long) nativeValue).intValue();
             case FLOAT:
                 // conversion can result in precision lost
@@ -411,6 +427,8 @@ public enum CassandraType
                 return new BigDecimal(nativeValue.toString());
             case TIMESTAMP:
                 return new Date((Long) nativeValue);
+            case DATE:
+                return LocalDate.fromDaysSinceEpoch(((Long) nativeValue).intValue());
             case UUID:
             case TIMEUUID:
                 return java.util.UUID.fromString(((Slice) nativeValue).toStringUtf8());
@@ -468,9 +486,12 @@ public enum CassandraType
             case DOUBLE:
             case INET:
             case INT:
+            case SMALLINT:
+            case TINYINT:
             case FLOAT:
             case DECIMAL:
             case TIMESTAMP:
+            case DATE:
             case UUID:
             case TIMEUUID:
                 return value;
@@ -487,7 +508,7 @@ public enum CassandraType
         }
     }
 
-    public static CassandraType toCassandraType(Type type)
+    public static CassandraType toCassandraType(Type type, ProtocolVersion protocolVersion)
     {
         if (type.equals(BooleanType.BOOLEAN)) {
             return BOOLEAN;
@@ -497,6 +518,12 @@ public enum CassandraType
         }
         else if (type.equals(IntegerType.INTEGER)) {
             return INT;
+        }
+        else if (type.equals(SmallintType.SMALLINT)) {
+            return SMALLINT;
+        }
+        else if (type.equals(TinyintType.TINYINT)) {
+            return TINYINT;
         }
         else if (type.equals(DoubleType.DOUBLE)) {
             return DOUBLE;
@@ -508,7 +535,7 @@ public enum CassandraType
             return TEXT;
         }
         else if (type.equals(DateType.DATE)) {
-            return TEXT;
+            return protocolVersion.toInt() <= ProtocolVersion.V3.toInt() ? TEXT : DATE;
         }
         else if (type.equals(VarbinaryType.VARBINARY)) {
             return BLOB;

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/util/CassandraCqlUtils.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/util/CassandraCqlUtils.java
@@ -39,11 +39,11 @@ public final class CassandraCqlUtils
     private static final String[] KEYWORDS = {"ADD", "ALL", "ALLOW", "ALTER", "AND", "APPLY",
             "ASC", "ASCII", "AUTHORIZE", "BATCH", "BEGIN", "BIGINT", "BLOB", "BOOLEAN", "BY",
             "CLUSTERING", "COLUMNFAMILY", "COMPACT", "COUNT", "COUNTER", "CREATE", "DECIMAL",
-            "DELETE", "DESC", "DOUBLE", "DROP", "FILTERING", "FLOAT", "FROM", "GRANT", "IN",
+            "DATE", "DELETE", "DESC", "DOUBLE", "DROP", "FILTERING", "FLOAT", "FROM", "GRANT", "IN",
             "INDEX", "INET", "INSERT", "INT", "INTO", "KEY", "KEYSPACE", "KEYSPACES", "LIMIT",
             "LIST", "MAP", "MODIFY", "NORECURSIVE", "NOSUPERUSER", "OF", "ON", "ORDER", "PASSWORD",
             "PERMISSION", "PERMISSIONS", "PRIMARY", "RENAME", "REVOKE", "SCHEMA", "SELECT", "SET",
-            "STORAGE", "SUPERUSER", "TABLE", "TEXT", "TIMESTAMP", "TIMEUUID", "TO", "TOKEN",
+            "SMALLINT", "STORAGE", "SUPERUSER", "TABLE", "TEXT", "TIMESTAMP", "TIMEUUID", "TINYINT", "TO", "TOKEN",
             "TRUNCATE", "TTL", "TYPE", "UNLOGGED", "UPDATE", "USE", "USER", "USERS", "USING",
             "UUID", "VALUES", "VARCHAR", "VARINT", "WHERE", "WITH", "WRITETIME"};
 

--- a/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraType.java
+++ b/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraType.java
@@ -32,6 +32,9 @@ public class TestCassandraType
         assertTrue(isValidJson(CassandraType.buildArrayValue(Lists.newArrayList(1, 2, 3), CassandraType.INT)));
         assertTrue(isValidJson(CassandraType.buildArrayValue(Lists.newArrayList(100000L, 200000000L, 3000000000L), CassandraType.BIGINT)));
         assertTrue(isValidJson(CassandraType.buildArrayValue(Lists.newArrayList(1.0, 2.0, 3.0), CassandraType.DOUBLE)));
+        assertTrue(isValidJson(CassandraType.buildArrayValue(Lists.newArrayList((short) -32768, (short) 0, (short) 32767), CassandraType.SMALLINT)));
+        assertTrue(isValidJson(CassandraType.buildArrayValue(Lists.newArrayList((byte) -128, (byte) 0, (byte) 127), CassandraType.TINYINT)));
+        assertTrue(isValidJson(CassandraType.buildArrayValue(Lists.newArrayList("1970-01-01", "5555-06-15", "9999-12-31"), CassandraType.DATE)));
     }
 
     private static void continueWhileNotNull(JsonParser parser, JsonToken token)

--- a/presto-docs/src/main/sphinx/connector/cassandra.rst
+++ b/presto-docs/src/main/sphinx/connector/cassandra.rst
@@ -218,6 +218,9 @@ TIMESTAMP         TIMESTAMP
 TIMEUUID          VARCHAR
 VARCHAR           VARCHAR
 VARIANT           VARCHAR
+SMALLINT          INTEGER
+TINYINT           INTEGER
+DATE              DATE
 ================  ======
 
 Any collection (LIST/MAP/SET) can be designated as FROZEN, and the value is
@@ -239,6 +242,9 @@ Partition keys can only be of the following types:
 | TIMESTAMP
 | UUID
 | TIMEUUID
+| SMALLINT
+| TINYINT
+| DATE
 
 Limitations
 -----------

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/cassandra/DataTypesTableDefinition.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/cassandra/DataTypesTableDefinition.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.tests.cassandra;
 
+import com.datastax.driver.core.LocalDate;
 import com.datastax.driver.core.utils.Bytes;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -42,9 +43,9 @@ public class DataTypesTableDefinition
     private static final String ALL_TYPES_TABLE_NAME = "all_types";
 
     private static final String ALL_TYPES_DDL =
-            "CREATE TABLE %NAME% (a ascii, b bigint, bl blob, bo boolean, d decimal, do double," +
+            "CREATE TABLE %NAME% (a ascii, b bigint, bl blob, bo boolean, d decimal, do double, dt date," +
                     "f float, fr frozen<set<int>>, i inet, integer int, l list<int>, m map<text,int>," +
-                    "s set<int>, t text, ti timestamp, tu timeuuid, u uuid, v varchar, vari varint," +
+                    "s set<int>, si smallint, t text, ti tinyint, ts timestamp, tu timeuuid, u uuid, v varchar, vari varint," +
                     "PRIMARY KEY (a))";
 
     static {
@@ -52,25 +53,25 @@ public class DataTypesTableDefinition
             try {
                 return ImmutableList.<List<Object>>of(
                         ImmutableList.of("\0", Long.MIN_VALUE, Bytes.fromHexString("0x00"), false,
-                                BigDecimal.ZERO, Double.MIN_VALUE, Float.MIN_VALUE, ImmutableSet.of(0),
+                                BigDecimal.ZERO, Double.MIN_VALUE, Float.MIN_VALUE, LocalDate.fromYearMonthDay(1970, 1, 2), ImmutableSet.of(0),
                                 Inet4Address.getByName("0.0.0.0"), Integer.MIN_VALUE, ImmutableList.of(0),
-                                ImmutableMap.of("a", 0, "\0", Integer.MIN_VALUE), ImmutableSet.of(0),
-                                "\0", Timestamp.valueOf(LocalDateTime.of(1970, 1, 1, 0, 0)),
+                                ImmutableMap.of("a", 0, "\0", Integer.MIN_VALUE), ImmutableSet.of(0), Short.MIN_VALUE,
+                                "\0", Byte.MIN_VALUE, Timestamp.valueOf(LocalDateTime.of(1970, 1, 1, 0, 0)),
                                 UUID.fromString("d2177dd0-eaa2-11de-a572-001b779c76e3"),
                                 UUID.fromString("01234567-0123-0123-0123-0123456789ab"),
                                 "\0", BigInteger.valueOf(Long.MIN_VALUE)),
                         ImmutableList.of("the quick brown fox jumped over the lazy dog", Long.MAX_VALUE,
                                 Bytes.fromHexString("0x3031323334"), true,
                                 new BigDecimal(new Double("99999999999999999999999999999999999999")),
-                                Double.MAX_VALUE, Float.MAX_VALUE, ImmutableSet.of(4, 5, 6, 7),
+                                Double.MAX_VALUE, LocalDate.fromYearMonthDay(9999, 12, 31), Float.MAX_VALUE, ImmutableSet.of(4, 5, 6, 7),
                                 Inet4Address.getByName("255.255.255.255"), Integer.MAX_VALUE,
-                                ImmutableList.of(4, 5, 6), ImmutableMap.of("a", 1, "b", 2), ImmutableSet.of(4, 5, 6),
-                                "this is a text value", Timestamp.valueOf(LocalDateTime.of(9999, 12, 31, 23, 59, 59)),
+                                ImmutableList.of(4, 5, 6), ImmutableMap.of("a", 1, "b", 2), ImmutableSet.of(4, 5, 6), Short.MAX_VALUE,
+                                "this is a text value", Byte.MAX_VALUE, Timestamp.valueOf(LocalDateTime.of(9999, 12, 31, 23, 59, 59)),
                                 UUID.fromString("d2177dd0-eaa2-11de-a572-001b779c76e3"),
                                 UUID.fromString("01234567-0123-0123-0123-0123456789ab"),
                                 "abc", BigInteger.valueOf(Long.MAX_VALUE)),
                         Arrays.asList(new Object[] {"def", null, null, null, null, null, null, null, null, null,
-                                null, null, null, null, null, null, null, null, null})
+                                null, null, null, null, null, null, null, null, null, null, null, null})
                 ).iterator();
             }
             catch (UnknownHostException e) {


### PR DESCRIPTION
Support smallint, tinyint, date type of Cassandra

```
== RELEASE NOTES ==
Cassandra Change
* Add `SMALLINT`, `TINYINT`, and `DATE` type support to Cassandra connector.
```