### PR TITLE
Update drift library to 1.28

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <dep.okhttp.version>3.9.0</dep.okhttp.version>
         <dep.jdbi3.version>3.4.0</dep.jdbi3.version>
         <dep.oracle.version>19.3.0.0</dep.oracle.version>
-        <dep.drift.version>1.25</dep.drift.version>
+        <dep.drift.version>1.28</dep.drift.version>
         <dep.joda.version>2.10.5</dep.joda.version>
         <dep.tempto.version>1.50</dep.tempto.version>
         <dep.testng.version>6.10</dep.testng.version>


### PR DESCRIPTION
Test plan - (Please fill in how you tested your changes)

presto-facebook is using drift 1.28

```
== NO RELEASE NOTE ==
```
