### PR TITLE
Throw proper exception for lambda expression in GROUP BY

### DIFF
--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Cube.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Cube.java
@@ -40,6 +40,7 @@ public final class Cube
     private Cube(Optional<NodeLocation> location, List<Expression> columns)
     {
         super(location);
+        validateExpressions(columns);
         this.columns = ImmutableList.copyOf(requireNonNull(columns, "columns is null"));
     }
 

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/GroupingElement.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/GroupingElement.java
@@ -31,4 +31,16 @@ public abstract class GroupingElement
     {
         return visitor.visitGroupingElement(this, context);
     }
+
+    void validateExpressions(List<Expression> expressions)
+    {
+        expressions.forEach(expression -> ExpressionTreeRewriter.rewriteWith(new ExpressionRewriter<Void>()
+        {
+            @Override
+            public Expression rewriteLambdaExpression(LambdaExpression node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
+            {
+                throw new UnsupportedOperationException("GROUP BY does not support lambda expressions, please use GROUP BY # instead");
+            }
+        }, expression, null));
+    }
 }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/GroupingSets.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/GroupingSets.java
@@ -45,6 +45,7 @@ public final class GroupingSets
         super(location);
         requireNonNull(sets, "sets is null");
         checkArgument(!sets.isEmpty(), "grouping sets cannot be empty");
+        sets.forEach(this::validateExpressions);
         this.sets = sets.stream().map(ImmutableList::copyOf).collect(toImmutableList());
     }
 

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Rollup.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Rollup.java
@@ -40,6 +40,7 @@ public final class Rollup
     private Rollup(Optional<NodeLocation> location, List<Expression> columns)
     {
         super(location);
+        validateExpressions(columns);
         this.columns = ImmutableList.copyOf(requireNonNull(columns, "columns is null"));
     }
 

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/SimpleGroupBy.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/SimpleGroupBy.java
@@ -40,6 +40,7 @@ public final class SimpleGroupBy
     private SimpleGroupBy(Optional<NodeLocation> location, List<Expression> simpleGroupByExpressions)
     {
         super(location);
+        validateExpressions(simpleGroupByExpressions);
         this.columns = ImmutableList.copyOf(requireNonNull(simpleGroupByExpressions, "simpleGroupByExpressions is null"));
     }
 


### PR DESCRIPTION
Due to how lambda expression is supported, it is hard to support them in
GROUP BY. Previously we would generate invalid logical plan then throw exception
during plan validation. Change it to throw UnsupportedOperationException.

Test plan -

```
== RELEASE NOTES ==

General Changes
* Throw UnsupportedOperationException for GROUP BY with lambda expression.
```