### PR TITLE
Disallow partial aggregation pushdown in more cases

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSourceProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSourceProvider.java
@@ -422,6 +422,12 @@ public class HivePageSourceProvider
             }
         }
 
+        if (!hiveColumns.isEmpty() && hiveColumns.stream().allMatch(hiveColumnHandle -> hiveColumnHandle.getColumnType() == AGGREGATED)) {
+            throw new UnsupportedOperationException("Partial aggregation pushdown only supported for ORC/Parquet files. " +
+                    "Table " + tableName.toString() + " has file (" + path.toString() + ") of format " + storage.getStorageFormat().getOutputFormat() +
+                    ". Set session property hive.pushdown_partial_aggregations_into_scan=false and execute query again");
+        }
+
         for (HiveRecordCursorProvider provider : cursorProviders) {
             // GenericHiveRecordCursor will automatically do the coercion without HiveCoercionRecordCursor
             boolean doCoercion = !(provider instanceof GenericHiveRecordCursorProvider);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/AggregatedOrcPageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/AggregatedOrcPageSource.java
@@ -138,13 +138,14 @@ public class AggregatedOrcPageSource
             completedBytes += ((FixedWidthType) type).getFixedSize();
         }
 
+        String orcNoMinMaxMessage = "No min/max found for orc file. Set session property hive.pushdown_partial_aggregations_into_scan=false and execute query again";
         switch (orcType.getOrcTypeKind()) {
             case SHORT:
             case INT:
             case LONG: {
                 Long value = isMin ? columnStatistics.getIntegerStatistics().getMin() : columnStatistics.getIntegerStatistics().getMax();
                 if (value == null) {
-                    throw new UnsupportedOperationException("No min/max found for orc file. Set session property pushdown_partial_aggregations_into_scan=false and execute query again");
+                    throw new UnsupportedOperationException(orcNoMinMaxMessage);
                 }
                 else {
                     blockBuilder.writeLong(value);
@@ -156,7 +157,7 @@ public class AggregatedOrcPageSource
             case DATE: {
                 Integer value = isMin ? columnStatistics.getDateStatistics().getMin() : columnStatistics.getDateStatistics().getMax();
                 if (value == null) {
-                    throw new UnsupportedOperationException("No min/max found for orc file. Set session property pushdown_partial_aggregations_into_scan=false and execute query again");
+                    throw new UnsupportedOperationException(orcNoMinMaxMessage);
                 }
                 else {
                     blockBuilder.writeLong(Long.valueOf(value));
@@ -169,7 +170,7 @@ public class AggregatedOrcPageSource
             case STRING: {
                 Slice value = isMin ? columnStatistics.getStringStatistics().getMin() : columnStatistics.getStringStatistics().getMax();
                 if (value == null) {
-                    throw new UnsupportedOperationException("No min/max found for orc file. Set session property pushdown_partial_aggregations_into_scan=false and execute query again");
+                    throw new UnsupportedOperationException(orcNoMinMaxMessage);
                 }
                 else {
                     blockBuilder.writeBytes(value, 0, value.length()).closeEntry();
@@ -181,7 +182,7 @@ public class AggregatedOrcPageSource
             case FLOAT: {
                 Double value = isMin ? columnStatistics.getDoubleStatistics().getMin() : columnStatistics.getDoubleStatistics().getMax();
                 if (value == null) {
-                    throw new UnsupportedOperationException("No min/max found for orc file. Set session property pushdown_partial_aggregations_into_scan=false and execute query again");
+                    throw new UnsupportedOperationException(orcNoMinMaxMessage);
                 }
                 else {
                     blockBuilder.writeLong(floatToRawIntBits(value.floatValue()));
@@ -192,7 +193,7 @@ public class AggregatedOrcPageSource
             case DOUBLE: {
                 Double value = isMin ? columnStatistics.getDoubleStatistics().getMin() : columnStatistics.getDoubleStatistics().getMax();
                 if (value == null) {
-                    throw new UnsupportedOperationException("No min/max found for orc file. Set session property pushdown_partial_aggregations_into_scan=false and execute query again");
+                    throw new UnsupportedOperationException(orcNoMinMaxMessage);
                 }
                 else {
                     type.writeDouble(blockBuilder, value);
@@ -203,7 +204,7 @@ public class AggregatedOrcPageSource
             case DECIMAL:
                 BigDecimal value = isMin ? columnStatistics.getDecimalStatistics().getMin() : columnStatistics.getDecimalStatistics().getMax();
                 if (value == null) {
-                    throw new UnsupportedOperationException("No min/max found for orc file. Set session property pushdown_partial_aggregations_into_scan=false and execute query again");
+                    throw new UnsupportedOperationException(orcNoMinMaxMessage);
                 }
                 else {
                     Type definedType = hiveType.getType(typeManager);
@@ -232,7 +233,7 @@ public class AggregatedOrcPageSource
     {
         ColumnStatistics columnStatistics = footer.getFileStats().get(columnIndex + 1);
         if (!columnStatistics.hasNumberOfValues()) {
-            throw new UnsupportedOperationException("Number of values not set for orc file. Set session property pushdown_partial_aggregations_into_scan=false and execute query again");
+            throw new UnsupportedOperationException("Number of values not set for orc file. Set session property hive.pushdown_partial_aggregations_into_scan=false and execute query again");
         }
         blockBuilder.writeLong(columnStatistics.getNumberOfValues());
     }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcBatchPageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcBatchPageSourceFactory.java
@@ -270,7 +270,7 @@ public class OrcBatchPageSourceFactory
                 }
             }
 
-            if (!physicalColumns.isEmpty() && physicalColumns.get(0).getColumnType() == AGGREGATED) {
+            if (!physicalColumns.isEmpty() && physicalColumns.stream().allMatch(hiveColumnHandle -> hiveColumnHandle.getColumnType() == AGGREGATED)) {
                 return new AggregatedOrcPageSource(physicalColumns, reader.getFooter(), typeManager, functionResolution);
             }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcSelectivePageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcSelectivePageSourceFactory.java
@@ -335,7 +335,7 @@ public class OrcSelectivePageSourceFactory
 
             List<HiveColumnHandle> physicalColumns = getPhysicalHiveColumnHandles(columns, useOrcColumnNames, reader, path);
 
-            if (!physicalColumns.isEmpty() && physicalColumns.get(0).getColumnType() == AGGREGATED) {
+            if (!physicalColumns.isEmpty() && physicalColumns.stream().allMatch(hiveColumnHandle -> hiveColumnHandle.getColumnType() == AGGREGATED)) {
                 return new AggregatedOrcPageSource(physicalColumns, reader.getFooter(), typeManager, functionResolution);
             }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSourceFactory.java
@@ -206,7 +206,7 @@ public class ParquetPageSourceFactory
         try {
             FSDataInputStream inputStream = hdfsEnvironment.getFileSystem(user, path, configuration).openFile(path, hiveFileContext);
             ParquetMetadata parquetMetadata = MetadataReader.readFooter(inputStream, path, fileSize);
-            if (!columns.isEmpty() && columns.get(0).getColumnType() == AGGREGATED) {
+            if (!columns.isEmpty() && columns.stream().allMatch(hiveColumnHandle -> hiveColumnHandle.getColumnType() == AGGREGATED)) {
                 return new AggregatedParquetPageSource(columns, parquetMetadata, typeManager, functionResolution);
             }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePushdownDistributedQueries.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePushdownDistributedQueries.java
@@ -32,11 +32,15 @@ public class TestHivePushdownDistributedQueries
     public TestHivePushdownDistributedQueries()
     {
         super(() -> createQueryRunner(
-                    getTables(),
-                    ImmutableMap.of("experimental.pushdown-subfields-enabled", "true", "experimental.pushdown-dereference-enabled", "true"),
-                    "sql-standard",
-                    ImmutableMap.of("hive.pushdown-filter-enabled", "true", "hive.enable-parquet-dereference-pushdown", "true"),
-                    Optional.empty()));
+                getTables(),
+                ImmutableMap.of("experimental.pushdown-subfields-enabled", "true",
+                        "experimental.pushdown-dereference-enabled", "true"),
+                "sql-standard",
+                ImmutableMap.of("hive.pushdown-filter-enabled", "true",
+                        "hive.enable-parquet-dereference-pushdown", "true",
+                        "hive.partial_aggregation_pushdown_enabled", "true",
+                        "hive.partial_aggregation_pushdown_for_variable_length_datatypes_enabled", "true"),
+                Optional.empty()));
     }
 
     @Override

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePushdownFilterQueries.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePushdownFilterQueries.java
@@ -42,6 +42,7 @@ import static com.facebook.presto.common.type.StandardTypes.SMALLINT;
 import static com.facebook.presto.common.type.StandardTypes.TINYINT;
 import static com.facebook.presto.common.type.StandardTypes.VARCHAR;
 import static com.facebook.presto.hive.HiveQueryRunner.HIVE_CATALOG;
+import static com.facebook.presto.hive.HiveSessionProperties.PARTIAL_AGGREGATION_PUSHDOWN_ENABLED;
 import static com.facebook.presto.hive.HiveSessionProperties.PUSHDOWN_FILTER_ENABLED;
 import static com.facebook.presto.hive.HiveStorageFormat.RCBINARY;
 import static com.facebook.presto.hive.HiveStorageFormat.RCTEXT;
@@ -103,9 +104,13 @@ public class TestHivePushdownFilterQueries
             throws Exception
     {
         DistributedQueryRunner queryRunner = HiveQueryRunner.createQueryRunner(getTables(),
-                ImmutableMap.of("experimental.pushdown-subfields-enabled", "true", "experimental.pushdown-dereference-enabled", "true"),
+                ImmutableMap.of("experimental.pushdown-subfields-enabled", "true",
+                        "experimental.pushdown-dereference-enabled", "true"),
                 "sql-standard",
-                ImmutableMap.of("hive.pushdown-filter-enabled", "true", "hive.enable-parquet-dereference-pushdown", "true"),
+                ImmutableMap.of("hive.pushdown-filter-enabled", "true",
+                        "hive.enable-parquet-dereference-pushdown", "true",
+                        "hive.partial_aggregation_pushdown_enabled", "true",
+                        "hive.partial_aggregation_pushdown_for_variable_length_datatypes_enabled", "true"),
                 Optional.empty());
 
         queryRunner.execute(noPushdownFilter(queryRunner.getDefaultSession()),
@@ -1034,7 +1039,8 @@ public class TestHivePushdownFilterQueries
             // no filter
             assertQueryUsingH2Cte("SELECT * FROM test_file_format_orc", cte);
             assertQueryUsingH2Cte("SELECT comment FROM test_file_format_orc", cte);
-            assertQueryUsingH2Cte("SELECT COUNT(*) FROM test_file_format_orc", cte);
+            assertQueryFails("SELECT COUNT(*) FROM test_file_format_orc", "Partial aggregation pushdown only supported for ORC/Parquet files. Table tpch.test_file_format_orc has file ((.*?)) of format (.*?). Set session property hive.pushdown_partial_aggregations_into_scan=false and execute query again");
+            assertQueryUsingH2Cte(noPartialAggregationPushdown(queryRunner.getDefaultSession()), "SELECT COUNT(*) FROM test_file_format_orc", cte, Function.identity());
 
             // filter on partition column
             assertQueryUsingH2Cte("SELECT comment from test_file_format_orc WHERE ds='2019-11-01'", cte);
@@ -1134,6 +1140,11 @@ public class TestHivePushdownFilterQueries
         assertQueryUsingH2Cte(query, Function.identity());
     }
 
+    private void assertQueryUsingH2Cte(Session session, String query, String cte, Function<String, String> rewriter)
+    {
+        assertQuery(session, query, cte + toH2(rewriter.apply(query)));
+    }
+
     private void assertQueryUsingH2Cte(String query, Function<String, String> rewriter)
     {
         assertQuery(query, WITH_LINEITEM_EX + toH2(rewriter.apply(query)));
@@ -1168,6 +1179,13 @@ public class TestHivePushdownFilterQueries
     {
         return Session.builder(session)
                 .setCatalogSessionProperty(HIVE_CATALOG, PUSHDOWN_FILTER_ENABLED, "false")
+                .build();
+    }
+
+    private static Session noPartialAggregationPushdown(Session session)
+    {
+        return Session.builder(session)
+                .setCatalogSessionProperty(HIVE_CATALOG, PARTIAL_AGGREGATION_PUSHDOWN_ENABLED, "false")
                 .build();
     }
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePushdownIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePushdownIntegrationSmokeTest.java
@@ -36,9 +36,14 @@ public class TestHivePushdownIntegrationSmokeTest
     {
         super(() -> createQueryRunner(
                     ImmutableList.of(ORDERS, CUSTOMER, LINE_ITEM, PART_SUPPLIER),
-                    ImmutableMap.of("experimental.pushdown-subfields-enabled", "true", "experimental.pushdown-dereference-enabled", "true"),
+                    ImmutableMap.of("experimental.pushdown-subfields-enabled", "true",
+                            "experimental.pushdown-dereference-enabled", "true"),
                     "sql-standard",
-                    ImmutableMap.of("hive.pushdown-filter-enabled", "true", "hive.enable-parquet-dereference-pushdown", "true"),
+                    ImmutableMap.of("hive.pushdown-filter-enabled", "true",
+                            "hive.enable-parquet-dereference-pushdown", "true",
+                            "hive.partial_aggregation_pushdown_enabled", "true",
+                            "hive.partial_aggregation_pushdown_for_variable_length_datatypes_enabled", "true",
+                            "hive.orc.writer.string-statistics-limit", "128B"),
                     Optional.empty()),
                 createBucketedSession(Optional.of(new SelectedRole(ROLE, Optional.of("admin")))),
                 createMaterializeExchangesSession(Optional.of(new SelectedRole(ROLE, Optional.of("admin")))),

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestParquetDistributedQueries.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestParquetDistributedQueries.java
@@ -43,6 +43,8 @@ public class TestParquetDistributedQueries
                 .put("hive.parquet.use-column-names", "true")
                 .put("hive.compression-codec", "GZIP")
                 .put("hive.enable-parquet-dereference-pushdown", "true")
+                .put("hive.partial_aggregation_pushdown_enabled", "true")
+                .put("hive.partial_aggregation_pushdown_for_variable_length_datatypes_enabled", "true")
                 .build();
         return HiveQueryRunner.createQueryRunner(
                 getTables(),


### PR DESCRIPTION
Disallow partial aggregation pushdown when
1. Filters are pushed into tableScan
2. Storage format metadata is inconsistent with the file format

Also enable partial aggregation flags in more tests

Fixes #15157 
```
== NO RELEASE NOTE ==
```
