### PR TITLE
Fix wrong group by column definition in druid connector

### DIFF
--- a/presto-druid/src/main/java/com/facebook/presto/druid/DruidQueryGenerator.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/DruidQueryGenerator.java
@@ -40,7 +40,6 @@ import javax.inject.Inject;
 
 import java.util.HashSet;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -300,7 +299,7 @@ public class DruidQueryGenerator
 
             // 2nd pass
             Map<VariableReferenceExpression, Selection> newSelections = new LinkedHashMap<>();
-            Set<VariableReferenceExpression> groupByColumns = new LinkedHashSet<>();
+            Map<VariableReferenceExpression, Selection> groupByColumns = new LinkedHashMap<>();
             Set<VariableReferenceExpression> hiddenColumnSet = new HashSet<>(context.getHiddenColumnSet());
             int aggregations = 0;
             boolean groupByExists = false;
@@ -314,7 +313,7 @@ public class DruidQueryGenerator
                         Selection druidColumn = requireNonNull(context.getSelections().get(groupByInputColumn), "Group By column " + groupByInputColumn + " doesn't exist in input " + context.getSelections());
 
                         newSelections.put(outputColumn, new Selection(druidColumn.getDefinition(), druidColumn.getOrigin()));
-                        groupByColumns.add(outputColumn);
+                        groupByColumns.put(outputColumn, new Selection(druidColumn.getDefinition(), druidColumn.getOrigin()));
                         groupByExists = true;
                         break;
                     }

--- a/presto-druid/src/test/java/com/facebook/presto/druid/TestDruidQueryGenerator.java
+++ b/presto-druid/src/test/java/com/facebook/presto/druid/TestDruidQueryGenerator.java
@@ -160,6 +160,17 @@ public class TestDruidQueryGenerator
     }
 
     @Test
+    public void testGroupByPushdown()
+    {
+        PlanNode justScan = buildPlan(planBuilder -> tableScan(planBuilder, druidTable, regionId, secondsSinceEpoch, city, fare));
+        testDQL(
+                planBuilder -> planBuilder.aggregation(
+                        aggBuilder -> aggBuilder.source(justScan).singleGroupingSet(variable("city"), variable("region.id"), variable("secondssinceepoch"))
+                                .addAggregation(variable("totalfare"), getRowExpression("sum(\"fare\")", defaultSessionHolder))),
+                "SELECT \"city\", \"region.Id\", \"secondsSinceEpoch\", sum(fare) FROM \"realtimeOnly\" GROUP BY \"city\", \"region.Id\", \"secondsSinceEpoch\"");
+    }
+
+    @Test
     public void testDistinctCountGroupByPushdown()
     {
         PlanNode justScan = buildPlan(planBuilder -> tableScan(planBuilder, druidTable, regionId, secondsSinceEpoch, city, fare));


### PR DESCRIPTION
Previous code may generate wrong group by name that end with suffix _number, and the dql could not be executed at druid side

```
== NO RELEASE NOTE ==
```
