### PR TITLE
Fix IllegalArgumentException in RelationPlanner

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
@@ -689,11 +689,8 @@ class RelationPlanner
 
     private RowExpression rewriteRow(Expression row)
     {
-        Expression expression = Coercer.addCoercions(row, analysis);
-        expression = ExpressionTreeRewriter.rewriteWith(new ParameterRewriter(analysis.getParameters(), analysis), expression);
-
         // resolve enum literals
-        expression = ExpressionTreeRewriter.rewriteWith(new ExpressionRewriter<Void>() {
+        Expression expression = ExpressionTreeRewriter.rewriteWith(new ExpressionRewriter<Void>() {
             @Override
             public Expression rewriteDereferenceExpression(DereferenceExpression node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
             {
@@ -704,7 +701,9 @@ class RelationPlanner
                 }
                 return node;
             }
-        }, expression);
+        }, row);
+        expression = Coercer.addCoercions(expression, analysis);
+        expression = ExpressionTreeRewriter.rewriteWith(new ParameterRewriter(analysis.getParameters(), analysis), expression);
         return castToRowExpression(expression);
     }
 

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -365,6 +365,9 @@ public abstract class AbstractTestQueries
         assertQuery("SELECT a.col1[2].col0, a.col1[2].col1 FROM (VALUES ROW(cast(row(1.0, ARRAY[row(31, 4.1E0), row(32, 4.2E0)], row(3, 4.0E0)) AS ROW(col0 double, col1 array(row(col0 integer, col1 double)), col2 row(col0 integer, col1 double))))) t(a)", "SELECT 32, 4.2");
 
         assertQuery("SELECT CAST(row(11, 12) AS row(col0 bigint, col1 bigint)).col0", "SELECT 11");
+
+        // Dereference in VALUES node
+        assertQuery("SELECT v FROM ( VALUES (ARRAY[ CAST( ROW(2, 'a') AS ROW( int_field BIGINT, str_field VARCHAR ) )][1].str_field)) AS t (v)", "SELECT 'a'");
     }
 
     @Test


### PR DESCRIPTION
in RelationPlanner, when we process values node, we would add coercions for
type only coercion expression. This could change the expression, which does
not exist in the analysis. For Enum literals, we want to rewrite the
dereference to enum literal. Previously this is done after the coercion rewrite.
Thus if the original expression has type only coercions, we could get
IllegalArgumentException when trying to get the type of the node. Moving the
dereference to enum rewrite before the coercion should solve this problem.

Test plan - (Please fill in how you tested your changes)

Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines.

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.
```
== NO RELEASE NOTE ==
```
