### PR TITLE
Implement Spilling Strategies

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskThresholdMemoryRevokingScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskThresholdMemoryRevokingScheduler.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution;
+
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.memory.QueryContext;
+import com.facebook.presto.memory.VoidTraversingQueryContextVisitor;
+import com.facebook.presto.operator.OperatorContext;
+import com.facebook.presto.sql.analyzer.FeaturesConfig;
+import com.google.common.annotations.VisibleForTesting;
+
+import javax.annotation.Nullable;
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.inject.Inject;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+public class TaskThresholdMemoryRevokingScheduler
+{
+    private static final Logger log = Logger.get(TaskThresholdMemoryRevokingScheduler.class);
+
+    private final Supplier<List<SqlTask>> currentTasksSupplier;
+    private final ScheduledExecutorService taskManagementExecutor;
+    private final long maxRevocableMemoryPerTask;
+
+    // Technically not thread safe but should be fine since we only call this on PostConstruct and PreDestroy.
+    // PreDestroy isn't called until server shuts down/ in between tests.
+    @Nullable
+    private ScheduledFuture<?> scheduledFuture;
+
+    private final AtomicBoolean checkPending = new AtomicBoolean();
+
+    @Inject
+    public TaskThresholdMemoryRevokingScheduler(
+            SqlTaskManager sqlTaskManager,
+            TaskManagementExecutor taskManagementExecutor,
+            FeaturesConfig config)
+    {
+        this(
+                requireNonNull(sqlTaskManager, "sqlTaskManager cannot be null")::getAllTasks,
+                requireNonNull(taskManagementExecutor, "taskManagementExecutor cannot be null").getExecutor(),
+                config.getMaxRevocableMemoryPerTask());
+        log.debug("Using TaskThresholdMemoryRevokingScheduler spilling strategy");
+    }
+
+    @VisibleForTesting
+    TaskThresholdMemoryRevokingScheduler(
+            Supplier<List<SqlTask>> currentTasksSupplier,
+            ScheduledExecutorService taskManagementExecutor,
+            long maxRevocableMemoryPerTask)
+    {
+        this.currentTasksSupplier = requireNonNull(currentTasksSupplier, "currentTasksSupplier is null");
+        this.taskManagementExecutor = requireNonNull(taskManagementExecutor, "taskManagementExecutor is null");
+        this.maxRevocableMemoryPerTask = maxRevocableMemoryPerTask;
+    }
+
+    @PostConstruct
+    public void start()
+    {
+        registerTaskMemoryPeriodicCheck();
+    }
+
+    private void registerTaskMemoryPeriodicCheck()
+    {
+        this.scheduledFuture = taskManagementExecutor.scheduleWithFixedDelay(() -> {
+            try {
+                revokeHighMemoryTasksIfNeeded();
+            }
+            catch (Throwable e) {
+                log.error(e, "Error requesting task memory revoking");
+            }
+        }, 1, 1, SECONDS);
+    }
+
+    @PreDestroy
+    public void stop()
+    {
+        if (scheduledFuture != null) {
+            scheduledFuture.cancel(true);
+            scheduledFuture = null;
+        }
+    }
+
+    @VisibleForTesting
+    void revokeHighMemoryTasksIfNeeded()
+    {
+        if (checkPending.compareAndSet(false, true)) {
+            revokeHighMemoryTasks();
+        }
+    }
+
+    private synchronized void revokeHighMemoryTasks()
+    {
+        if (checkPending.getAndSet(false)) {
+            Collection<SqlTask> sqlTasks = requireNonNull(currentTasksSupplier.get());
+            for (SqlTask task : sqlTasks) {
+                long currentTaskRevocableMemory = task.getTaskInfo().getStats().getRevocableMemoryReservationInBytes();
+                if (currentTaskRevocableMemory < maxRevocableMemoryPerTask) {
+                    continue;
+                }
+
+                AtomicLong remainingBytesToRevokeAtomic = new AtomicLong(currentTaskRevocableMemory - maxRevocableMemoryPerTask);
+                task.getQueryContext().accept(new VoidTraversingQueryContextVisitor<AtomicLong>()
+                {
+                    @Override
+                    public Void visitQueryContext(QueryContext queryContext, AtomicLong remainingBytesToRevoke)
+                    {
+                        if (remainingBytesToRevoke.get() < 0) {
+                            // exit immediately if no work needs to be done
+                            return null;
+                        }
+                        return super.visitQueryContext(queryContext, remainingBytesToRevoke);
+                    }
+
+                    @Override
+                    public Void visitOperatorContext(OperatorContext operatorContext, AtomicLong remainingBytesToRevoke)
+                    {
+                        if (remainingBytesToRevoke.get() > 0) {
+                            long revokedBytes = operatorContext.requestMemoryRevoking();
+                            if (revokedBytes > 0) {
+                                remainingBytesToRevoke.addAndGet(-revokedBytes);
+                                log.debug("taskId=%s: requested revoking %s; remaining %s", task.getTaskInfo().getTaskId(), revokedBytes, remainingBytesToRevoke.get());
+                            }
+                        }
+                        return null;
+                    }
+                }, remainingBytesToRevokeAtomic);
+            }
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/DriverContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/DriverContext.java
@@ -463,4 +463,10 @@ public class DriverContext
     {
         return driverMemoryContext;
     }
+
+    @VisibleForTesting
+    public void addOperatorContext(OperatorContext operatorContext)
+    {
+        operatorContexts.add(operatorContext);
+    }
 }

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestMemoryRevokingScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestMemoryRevokingScheduler.java
@@ -19,10 +19,13 @@ import com.facebook.airlift.stats.TestingGcMonitor;
 import com.facebook.presto.Session;
 import com.facebook.presto.block.BlockEncodingManager;
 import com.facebook.presto.execution.TestSqlTaskManager.MockExchangeClientSupplier;
+import com.facebook.presto.execution.buffer.OutputBuffers;
 import com.facebook.presto.execution.executor.TaskExecutor;
+import com.facebook.presto.execution.scheduler.TableWriteInfo;
 import com.facebook.presto.memory.MemoryPool;
 import com.facebook.presto.memory.QueryContext;
 import com.facebook.presto.memory.context.LocalMemoryContext;
+import com.facebook.presto.memory.context.MemoryTrackingContext;
 import com.facebook.presto.operator.DriverContext;
 import com.facebook.presto.operator.OperatorContext;
 import com.facebook.presto.operator.PipelineContext;
@@ -31,6 +34,7 @@ import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.memory.MemoryPoolId;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.spiller.SpillSpaceTracker;
+import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.gen.OrderingCompiler;
 import com.facebook.presto.sql.planner.LocalExecutionPlanner;
 import com.facebook.presto.testing.TestingSession;
@@ -45,19 +49,28 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.net.URI;
-import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.facebook.airlift.concurrent.Threads.threadsNamed;
+import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
 import static com.facebook.presto.execution.SqlTask.createSqlTask;
 import static com.facebook.presto.execution.TaskManagerConfig.TaskPriorityTracking.TASK_FAIR;
+import static com.facebook.presto.execution.TaskTestUtils.PLAN_FRAGMENT;
+import static com.facebook.presto.execution.TaskTestUtils.SPLIT;
+import static com.facebook.presto.execution.TaskTestUtils.TABLE_SCAN_NODE_ID;
 import static com.facebook.presto.execution.TaskTestUtils.createTestSplitMonitor;
 import static com.facebook.presto.execution.TaskTestUtils.createTestingPlanner;
+import static com.facebook.presto.execution.buffer.OutputBuffers.BufferType.PARTITIONED;
+import static com.facebook.presto.execution.buffer.OutputBuffers.createInitialEmptyOutputBuffers;
 import static com.facebook.presto.memory.LocalMemoryManager.GENERAL_POOL;
+import static com.facebook.presto.sql.analyzer.FeaturesConfig.TaskSpillingStrategy.ORDER_BY_CREATE_TIME;
+import static com.facebook.presto.sql.analyzer.FeaturesConfig.TaskSpillingStrategy.ORDER_BY_REVOCABLE_BYTES;
 import static io.airlift.units.DataSize.Unit.BYTE;
 import static io.airlift.units.DataSize.Unit.GIGABYTE;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
@@ -71,6 +84,7 @@ import static org.testng.Assert.assertTrue;
 @Test(singleThreaded = true)
 public class TestMemoryRevokingScheduler
 {
+    public static final OutputBuffers.OutputBufferId OUT = new OutputBuffers.OutputBufferId(0);
     private final AtomicInteger idGeneator = new AtomicInteger();
     private final Session session = TestingSession.testSessionBuilder().build();
     private final SpillSpaceTracker spillSpaceTracker = new SpillSpaceTracker(new DataSize(10, GIGABYTE));
@@ -103,9 +117,14 @@ public class TestMemoryRevokingScheduler
                 new BlockEncodingManager(),
                 new OrderingCompiler(),
                 createTestSplitMonitor(),
-                new TaskManagerConfig());
+                new TaskManagerConfig()
+                        .setPerOperatorAllocationTrackingEnabled(true)
+                        .setTaskCpuTimerEnabled(true)
+                        .setPerOperatorAllocationTrackingEnabled(true)
+                        .setTaskAllocationTrackingEnabled(true));
 
         allOperatorContexts = null;
+        TestOperatorContext.firstOperator = null;
     }
 
     @AfterMethod
@@ -137,8 +156,8 @@ public class TestMemoryRevokingScheduler
         OperatorContext operatorContext4 = driverContext211.addOperatorContext(4, new PlanNodeId("na"), "na");
         OperatorContext operatorContext5 = driverContext211.addOperatorContext(5, new PlanNodeId("na"), "na");
 
-        Collection<SqlTask> tasks = ImmutableList.of(sqlTask1, sqlTask2);
-        MemoryRevokingScheduler scheduler = new MemoryRevokingScheduler(singletonList(memoryPool), () -> tasks, executor, 1.0, 1.0);
+        List<SqlTask> tasks = ImmutableList.of(sqlTask1, sqlTask2);
+        MemoryRevokingScheduler scheduler = new MemoryRevokingScheduler(singletonList(memoryPool), () -> tasks, executor, 1.0, 1.0, ORDER_BY_CREATE_TIME);
 
         allOperatorContexts = ImmutableSet.of(operatorContext1, operatorContext2, operatorContext3, operatorContext4, operatorContext5);
         assertMemoryRevokingNotRequested();
@@ -187,7 +206,7 @@ public class TestMemoryRevokingScheduler
         revocableMemory5.setBytes(4);
         assertEquals(-7, memoryPool.getFreeBytes());
         requestMemoryRevoking(scheduler);
-        // no we have to trigger revoking for OC4
+        // now we have to trigger revoking for OC4
         assertMemoryRevokingRequestedFor(operatorContext3, operatorContext4);
     }
 
@@ -205,7 +224,7 @@ public class TestMemoryRevokingScheduler
         OperatorContext operatorContext2 = createContexts(sqlTask2);
 
         List<SqlTask> tasks = ImmutableList.of(sqlTask1, sqlTask2);
-        MemoryRevokingScheduler scheduler = new MemoryRevokingScheduler(asList(memoryPool, anotherMemoryPool), () -> tasks, executor, 1.0, 1.0);
+        MemoryRevokingScheduler scheduler = new MemoryRevokingScheduler(asList(memoryPool, anotherMemoryPool), () -> tasks, executor, 1.0, 1.0, ORDER_BY_CREATE_TIME);
         allOperatorContexts = ImmutableSet.of(operatorContext1, operatorContext2);
 
         /*
@@ -240,7 +259,7 @@ public class TestMemoryRevokingScheduler
 
         allOperatorContexts = ImmutableSet.of(operatorContext);
         List<SqlTask> tasks = ImmutableList.of(sqlTask);
-        MemoryRevokingScheduler scheduler = new MemoryRevokingScheduler(singletonList(memoryPool), () -> tasks, executor, 1.0, 1.0);
+        MemoryRevokingScheduler scheduler = new MemoryRevokingScheduler(singletonList(memoryPool), () -> tasks, executor, 1.0, 1.0, ORDER_BY_CREATE_TIME);
         scheduler.registerPoolListeners(); // no periodic check initiated
 
         // When
@@ -249,6 +268,122 @@ public class TestMemoryRevokingScheduler
 
         // Then
         assertMemoryRevokingRequestedFor(operatorContext);
+    }
+
+    /**
+     * Ensures that when revoking is requested, the first task to start revoking is based on the {@link FeaturesConfig.TaskSpillingStrategy}
+     */
+    @Test
+    public void testTaskRevokingOrderForCreateTime()
+            throws Exception
+    {
+        SqlTask sqlTask1 = newSqlTask();
+        TestOperatorContext operatorContext1 = createTestingOperatorContexts(sqlTask1, "operator1");
+
+        SqlTask sqlTask2 = newSqlTask();
+        TestOperatorContext operatorContext2 = createTestingOperatorContexts(sqlTask2, "operator2");
+
+        allOperatorContexts = ImmutableSet.of(operatorContext1, operatorContext2);
+        List<SqlTask> tasks = ImmutableList.of(sqlTask1, sqlTask2);
+        MemoryRevokingScheduler scheduler = new MemoryRevokingScheduler(singletonList(memoryPool), () -> tasks, executor, 1.0, 1.0, ORDER_BY_CREATE_TIME);
+        scheduler.registerPoolListeners(); // no periodic check initiated
+
+        assertMemoryRevokingNotRequested();
+
+        operatorContext1.localRevocableMemoryContext().setBytes(11);
+        operatorContext2.localRevocableMemoryContext().setBytes(12);
+
+        requestMemoryRevoking(scheduler);
+
+        assertMemoryRevokingRequestedFor(operatorContext1, operatorContext2);
+        assertEquals(TestOperatorContext.firstOperator, "operator1"); // operator1 should revoke first as it belongs to a task that was created earlier
+    }
+
+    @Test
+    public void testTaskRevokingOrderForRevocableBytes()
+            throws Exception
+    {
+        SqlTask sqlTask1 = newSqlTask();
+        TestOperatorContext operatorContext1 = createTestingOperatorContexts(sqlTask1, "operator1");
+
+        SqlTask sqlTask2 = newSqlTask();
+        TestOperatorContext operatorContext2 = createTestingOperatorContexts(sqlTask2, "operator2");
+
+        allOperatorContexts = ImmutableSet.of(operatorContext1, operatorContext2);
+        List<SqlTask> tasks = ImmutableList.of(sqlTask1, sqlTask2);
+        MemoryRevokingScheduler scheduler = new MemoryRevokingScheduler(singletonList(memoryPool), () -> tasks, executor, 1.0, 1.0, ORDER_BY_REVOCABLE_BYTES);
+        scheduler.registerPoolListeners(); // no periodic check initiated
+
+        assertMemoryRevokingNotRequested();
+
+        operatorContext1.localRevocableMemoryContext().setBytes(11);
+        operatorContext2.localRevocableMemoryContext().setBytes(12);
+
+        requestMemoryRevoking(scheduler);
+
+        assertMemoryRevokingRequestedFor(operatorContext1, operatorContext2);
+        assertEquals(TestOperatorContext.firstOperator, "operator2"); // operator2 should revoke first since it (and it's encompassing task) has allocated more bytes
+    }
+
+    @Test
+    public void testTaskThresholdRevokingScheduler()
+            throws Exception
+    {
+        SqlTask sqlTask1 = newSqlTask();
+        TestOperatorContext operatorContext11 = createTestingOperatorContexts(sqlTask1, "operator11");
+        TestOperatorContext operatorContext12 = createTestingOperatorContexts(sqlTask1, "operator12");
+
+        SqlTask sqlTask2 = newSqlTask();
+        TestOperatorContext operatorContext2 = createTestingOperatorContexts(sqlTask2, "operator2");
+
+        allOperatorContexts = ImmutableSet.of(operatorContext11, operatorContext12, operatorContext2);
+        List<SqlTask> tasks = ImmutableList.of(sqlTask1, sqlTask2);
+        TaskThresholdMemoryRevokingScheduler scheduler = new TaskThresholdMemoryRevokingScheduler(
+                () -> tasks, executor, 5L);
+
+        assertMemoryRevokingNotRequested();
+
+        operatorContext11.localRevocableMemoryContext().setBytes(3);
+        operatorContext2.localRevocableMemoryContext().setBytes(2);
+        // at this point, Task1 = 3 total bytes, Task2 = 2 total bytes
+
+        requestMemoryRevoking(scheduler);
+        assertMemoryRevokingNotRequested();
+
+        operatorContext12.localRevocableMemoryContext().setBytes(3);
+        // at this point, Task1 = 6 total bytes, Task2 = 2 total bytes
+
+        requestMemoryRevoking(scheduler);
+        // only operator11 should revoke since we need to revoke only 1 byte
+        // threshold - (operator11 + operator12) => 5 - (3 + 3) = 1 bytes to revoke
+        assertMemoryRevokingRequestedFor(operatorContext11);
+
+        // revoke 2 bytes in operator11
+        operatorContext11.localRevocableMemoryContext().setBytes(1);
+        // at this point, Task1 = 3 total bytes, Task2 = 2 total bytes
+        operatorContext11.resetMemoryRevokingRequested();
+        requestMemoryRevoking(scheduler);
+        assertMemoryRevokingNotRequested();
+
+        operatorContext12.localRevocableMemoryContext().setBytes(6); // operator12 fills up
+        // at this point, Task1 = 7 total bytes, Task2 = 2 total bytes
+        requestMemoryRevoking(scheduler);
+        // both operator11 and operator 12 are revoking since we revoke in order of operator creation within the task until we are below the memory revoking threshold
+        assertMemoryRevokingRequestedFor(operatorContext11, operatorContext12);
+
+        operatorContext11.localRevocableMemoryContext().setBytes(2);
+        operatorContext11.resetMemoryRevokingRequested();
+        operatorContext12.localRevocableMemoryContext().setBytes(2);
+        operatorContext12.resetMemoryRevokingRequested();
+        // at this point, Task1 = 4 total bytes, Task2 = 2 total bytes
+
+        requestMemoryRevoking(scheduler);
+        assertMemoryRevokingNotRequested(); // no need to revoke
+
+        operatorContext2.localRevocableMemoryContext().setBytes(6);
+        // at this point, Task1 = 4 total bytes, Task2 = 6 total bytes, operators in Task2 must be revoked
+        requestMemoryRevoking(scheduler);
+        assertMemoryRevokingRequestedFor(operatorContext2);
     }
 
     private OperatorContext createContexts(SqlTask sqlTask)
@@ -261,10 +396,73 @@ public class TestMemoryRevokingScheduler
         return operatorContext;
     }
 
+    private TestOperatorContext createTestingOperatorContexts(SqlTask sqlTask, String operatorName)
+    {
+        // update task to update underlying taskHolderReference with taskExecution + create a new taskContext
+        sqlTask.updateTask(TEST_SESSION,
+                Optional.of(PLAN_FRAGMENT),
+                ImmutableList.of(new TaskSource(TABLE_SCAN_NODE_ID, ImmutableSet.of(SPLIT), false)),
+                createInitialEmptyOutputBuffers(PARTITIONED).withBuffer(OUT, 0).withNoMoreBufferIds(),
+                Optional.of(new TableWriteInfo(Optional.empty(), Optional.empty(), Optional.empty())));
+
+        // use implicitly created task context from updateTask. It should be the only task in this QueryContext's tasks
+        TaskContext taskContext = sqlTask.getQueryContext().getTaskContextByTaskId(sqlTask.getTaskId());
+        PipelineContext pipelineContext = taskContext.addPipelineContext(0, false, false, false);
+        DriverContext driverContext = pipelineContext.addDriverContext();
+        TestOperatorContext testOperatorContext = new TestOperatorContext(
+                1,
+                new PlanNodeId("na"),
+                "na",
+                driverContext,
+                executor,
+                driverContext.getDriverMemoryContext().newMemoryTrackingContext(),
+                operatorName);
+        driverContext.addOperatorContext(testOperatorContext);
+        return testOperatorContext;
+    }
+
+    private static class TestOperatorContext
+            extends OperatorContext
+    {
+        public static String firstOperator;
+        private final String operatorName;
+
+        public TestOperatorContext(
+                int operatorId,
+                PlanNodeId planNodeId,
+                String operatorType,
+                DriverContext driverContext,
+                Executor executor,
+                MemoryTrackingContext operatorMemoryContext,
+                String operatorName)
+        {
+            super(operatorId, planNodeId, operatorType, driverContext, executor, operatorMemoryContext);
+            this.operatorName = operatorName;
+        }
+
+        @Override
+        public long requestMemoryRevoking()
+        {
+            if (firstOperator == null) {
+                // Due to the way MemoryRevokingScheduler works, revoking tasks one by one, simultaneous revoke of two tasks is impossible
+                // This is why updating this static member is safe
+                firstOperator = operatorName;
+            }
+            return super.requestMemoryRevoking();
+        }
+    }
+
     private void requestMemoryRevoking(MemoryRevokingScheduler scheduler)
             throws Exception
     {
         scheduler.requestMemoryRevokingIfNeeded();
+        awaitAsynchronousCallbacksRun();
+    }
+
+    private void requestMemoryRevoking(TaskThresholdMemoryRevokingScheduler scheduler)
+            throws Exception
+    {
+        scheduler.revokeHighMemoryTasksIfNeeded();
         awaitAsynchronousCallbacksRun();
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -37,6 +37,8 @@ import static com.facebook.presto.sql.analyzer.FeaturesConfig.JoinReorderingStra
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.PartialMergePushdownStrategy.PUSH_THROUGH_LOW_MEMORY_OPERATORS;
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.SPILLER_SPILL_PATH;
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.SPILL_ENABLED;
+import static com.facebook.presto.sql.analyzer.FeaturesConfig.TaskSpillingStrategy.ORDER_BY_CREATE_TIME;
+import static com.facebook.presto.sql.analyzer.FeaturesConfig.TaskSpillingStrategy.PER_TASK_MEMORY_THRESHOLD;
 import static com.facebook.presto.sql.analyzer.RegexLibrary.JONI;
 import static com.facebook.presto.sql.analyzer.RegexLibrary.RE2J;
 import static io.airlift.units.DataSize.Unit.GIGABYTE;
@@ -93,6 +95,8 @@ public class TestFeaturesConfig
                 .setSpillMaxUsedSpaceThreshold(0.9)
                 .setMemoryRevokingThreshold(0.9)
                 .setMemoryRevokingTarget(0.5)
+                .setTaskSpillingStrategy(ORDER_BY_CREATE_TIME)
+                .setMaxRevocableMemoryPerTask(500000L)
                 .setOptimizeMixedDistinctAggregations(false)
                 .setLegacyLogFunction(false)
                 .setIterativeOptimizerEnabled(true)
@@ -210,6 +214,8 @@ public class TestFeaturesConfig
                 .put("experimental.spiller-max-used-space-threshold", "0.8")
                 .put("experimental.memory-revoking-threshold", "0.2")
                 .put("experimental.memory-revoking-target", "0.8")
+                .put("experimental.spiller.task-spilling-strategy", "PER_TASK_MEMORY_THRESHOLD")
+                .put("experimental.spiller.max-revocable-task-memory", "100000")
                 .put("exchange.compression-enabled", "true")
                 .put("deprecated.legacy-timestamp", "false")
                 .put("optimizer.enable-intermediate-aggregations", "true")
@@ -302,6 +308,8 @@ public class TestFeaturesConfig
                 .setSpillMaxUsedSpaceThreshold(0.8)
                 .setMemoryRevokingThreshold(0.2)
                 .setMemoryRevokingTarget(0.8)
+                .setTaskSpillingStrategy(PER_TASK_MEMORY_THRESHOLD)
+                .setMaxRevocableMemoryPerTask(100000L)
                 .setLegacyLogFunction(true)
                 .setExchangeCompressionEnabled(true)
                 .setLegacyTimestamp(false)


### PR DESCRIPTION
This PR adds multiple different spilling strategies that can be swapped between using the config `experimental.spiller.task-spilling-strategy`.

ORDER_BY_CREATE_TIME - current default strategy. Watch memory pools for revocable memory exceeding threshold, sort tasks by create time, revoke individual operators until we reach the lower threshold.

ORDER_BY_REVOCABLE_BYTES - NEW. Watch memory pools for revocable memory exceeding threshold, sort tasks by most allocated revocable bytes, revoke individual operators until we reach the lower threshold.

PER_TASK_MEMORY_THRESHOLD - NEW. Watch revocable memory pool for memory exceeding per task memory threshold defined by `experimental.spiller.max-revocable-task-memory`. Spill operators in task until it lowers to this threshold.

TODO
* ~finish integration tests~
* ~better commit message~
* ~Release note~

```
== RELEASE NOTES ==

General Changes
* Add config `experimental.spiller.task-spilling-strategy` for choosing different spilling strategy to use.
```
