### PR TITLE
Fix LimitQueryDeterminismAnalyzer

### DIFF
--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DeterminismAnalyzer.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DeterminismAnalyzer.java
@@ -115,12 +115,11 @@ public class DeterminismAnalyzer
         switch (limitQueryAnalysis) {
             case NOT_RUN:
             case FAILED_QUERY_FAILURE:
+            case DETERMINISTIC:
                 // try the next analysis
                 break;
             case NON_DETERMINISTIC:
                 return NON_DETERMINISTIC_LIMIT_CLAUSE;
-            case DETERMINISTIC:
-                return DETERMINISTIC;
             case FAILED_DATA_CHANGED:
                 return ANALYSIS_FAILED_DATA_CHANGED;
             default:

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/LimitQueryDeterminismAnalyzer.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/LimitQueryDeterminismAnalyzer.java
@@ -153,6 +153,9 @@ class LimitQueryDeterminismAnalyzer
             return NOT_RUN;
         }
         long limit = parseLong(query.getLimit().get());
+        if (rowCount < limit) {
+            return DETERMINISTIC;
+        }
         Optional<String> newLimit = Optional.of(Long.toString(limit + 1));
         Query newLimitQuery = new Query(query.getWith(), query.getQueryBody(), Optional.empty(), newLimit);
         return analyzeLimitNoOrderBy(newLimitQuery, limit);
@@ -211,6 +214,9 @@ class LimitQueryDeterminismAnalyzer
             return NOT_RUN;
         }
         long limit = parseLong(querySpecification.getLimit().get());
+        if (rowCount < limit) {
+            return DETERMINISTIC;
+        }
         Optional<String> newLimit = Optional.of(Long.toString(limit + 1));
         Optional<OrderBy> orderBy = querySpecification.getOrderBy();
 
@@ -262,7 +268,7 @@ class LimitQueryDeterminismAnalyzer
         if (rowCountHigherLimit == rowCount) {
             return DETERMINISTIC;
         }
-        if (rowCount >= limit && rowCountHigherLimit > rowCount) {
+        if (rowCountHigherLimit > rowCount) {
             return NON_DETERMINISTIC;
         }
         return FAILED_DATA_CHANGED;


### PR DESCRIPTION
Fix LimitQueryDeterminismAnalyzer to return `DETERMINISTIC` when the control query row count is less then the value of the limit clause. Before the fix, LimitQueryDeterminismAnalyzer concluded `ANALYSIS_FAILED_DATA_CHANGED` instead where there the data is not actually changed.

```
== RELEASE NOTES ==

Verifier Changes
* Fix an issue in determinism analysis would indicate failing due to data being changed while the data is not changed.
```