### PR TITLE
Fix compiler error in LambdaBytecodeGenerator

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/LambdaBytecodeGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/LambdaBytecodeGenerator.java
@@ -144,7 +144,7 @@ public class LambdaBytecodeGenerator
                 .collect(toImmutableSet());
         ImmutableMap.Builder<LambdaDefinitionExpression, CompiledLambda> compiledLambdaMap = ImmutableMap.builder();
 
-        int counter = 0;
+        int counter = existingCompiledLambdas.size();
         for (LambdaDefinitionExpression lambdaExpression : lambdaExpressions) {
             CompiledLambda compiledLambda = LambdaBytecodeGenerator.preGenerateLambdaExpression(
                     lambdaExpression,


### PR DESCRIPTION
When there are lambda expressions from different SQL functions, and they are
compiled into the same class due to CSE, we need to make sure the generated
function names are always unique.

Test plan - (Please fill in how you tested your changes)
```
== RELEASE NOTES ==

General Changes
* Fix compiler error in LambdaBytecodeGenerator when CSE is enabled and multiple SQL functions contain lambda expressions.
```
