### PR TITLE
Remove unused configuration property from properties.rst

### DIFF
--- a/presto-docs/src/main/sphinx/admin/properties.rst
+++ b/presto-docs/src/main/sphinx/admin/properties.rst
@@ -129,16 +129,6 @@ Memory Management Properties
     memory reservation across the cluster. The value of ``total-reservation-on-blocked-nodes``
     configures a policy that kills the query using the most memory on the workers that are out of memory (blocked).
 
-``driver.max-page-partitioning-buffer-count``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-    * **Type:** ``integer``
-    * **Default value:** ``1000000``
-
-    Maximum number of buffers used by repartitioning per driver. This number should be set
-    sufficiently large to avoid the error of requesting too many arrays from the array allocator
-    used in repartitioning.
-
 .. _tuning-spilling:
 
 Spilling Properties


### PR DESCRIPTION
driver.max-page-partitioning-buffer-count was removed in 0.238 but
the documentation for it was not removed. This commit removes it
from the properties.rst documentation.

```
== NO RELEASE NOTE ==
```
