### PR TITLE
Refactor more classes to use Page helper methods

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/Page.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/Page.java
@@ -329,6 +329,11 @@ public final class Page
         return wrapBlocksWithoutCopy(length, blocks);
     }
 
+    public Page extractChannel(int channel)
+    {
+        return wrapBlocksWithoutCopy(positionCount, new Block[]{this.blocks[channel]});
+    }
+
     public Page extractChannels(int[] channels)
     {
         requireNonNull(channels, "channels is null");

--- a/presto-main/src/main/java/com/facebook/presto/operator/HashSemiJoinOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/HashSemiJoinOperator.java
@@ -143,7 +143,7 @@ public class HashSemiJoinOperator
         // we know the exact size required for the block
         BlockBuilder blockBuilder = BOOLEAN.createFixedSizeBlockBuilder(page.getPositionCount());
 
-        Page probeJoinPage = new Page(page.getBlock(probeJoinChannel));
+        Page probeJoinPage = page.extractChannel(probeJoinChannel);
 
         // update hashing strategy to use probe cursor
         for (int position = 0; position < page.getPositionCount(); position++) {

--- a/presto-main/src/main/java/com/facebook/presto/operator/TopNRowNumberOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TopNRowNumberOperator.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.operator;
 
 import com.facebook.presto.common.Page;
-import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.SortOrder;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.memory.context.LocalMemoryContext;
@@ -129,7 +128,7 @@ public class TopNRowNumberOperator
     private final OperatorContext operatorContext;
     private final LocalMemoryContext localUserMemoryContext;
 
-    private final List<Integer> outputChannels;
+    private final int[] outputChannels;
 
     private final GroupByHash groupByHash;
     private final GroupedTopNBuilder groupedTopNBuilder;
@@ -162,7 +161,7 @@ public class TopNRowNumberOperator
         if (generateRowNumber) {
             outputChannelsBuilder.add(outputChannels.size());
         }
-        this.outputChannels = outputChannelsBuilder.build();
+        this.outputChannels = Ints.toArray(outputChannelsBuilder.build());
 
         checkArgument(maxRowCountPerPartition > 0, "maxRowCountPerPartition must be > 0");
 
@@ -253,13 +252,7 @@ public class TopNRowNumberOperator
 
         Page output = null;
         if (outputIterator.hasNext()) {
-            Page page = outputIterator.next();
-            // rewrite to expected column ordering
-            Block[] blocks = new Block[page.getChannelCount()];
-            for (int i = 0; i < outputChannels.size(); i++) {
-                blocks[i] = page.getBlock(outputChannels.get(i));
-            }
-            output = new Page(blocks);
+            output = outputIterator.next().extractChannels(outputChannels);
         }
         updateMemoryReservation();
         return output;

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/GenericAccumulatorFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/GenericAccumulatorFactory.java
@@ -550,14 +550,9 @@ public class GenericAccumulatorFactory
         @Override
         public void addInput(GroupByIdBlock groupIdsBlock, Page page)
         {
-            Block[] blocks = new Block[page.getChannelCount() + 1];
-            for (int i = 0; i < page.getChannelCount(); i++) {
-                blocks[i] = page.getBlock(i);
-            }
-            // Add group id block
-            blocks[page.getChannelCount()] = groupIdsBlock;
             groupCount = max(groupCount, groupIdsBlock.getGroupCount());
-            pagesIndex.addPage(new Page(blocks));
+            // Add group id block
+            pagesIndex.addPage(page.appendColumn(groupIdsBlock));
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/index/DynamicTupleFilterFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/index/DynamicTupleFilterFactory.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.operator.index;
 
 import com.facebook.presto.common.Page;
-import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.function.SqlFunctionProperties;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.operator.OperatorFactory;
@@ -91,8 +90,7 @@ public class DynamicTupleFilterFactory
 
     public OperatorFactory filterWithTuple(Page tuplePage)
     {
-        Page filterTuple = getFilterTuple(tuplePage);
-        Supplier<PageProcessor> processor = createPageProcessor(filterTuple, OptionalInt.empty());
+        Supplier<PageProcessor> processor = createPageProcessor(tuplePage.extractChannels(tupleFilterChannels), OptionalInt.empty());
         return new FilterAndProjectOperatorFactory(filterOperatorId, planNodeId, processor, outputTypes, new DataSize(0, BYTE), 0);
     }
 
@@ -106,14 +104,5 @@ public class DynamicTupleFilterFactory
                         .map(Supplier::get)
                         .collect(toImmutableList()),
                 initialBatchSize);
-    }
-
-    private Page getFilterTuple(Page tuplePage)
-    {
-        Block[] normalizedBlocks = new Block[tupleFilterChannels.length];
-        for (int i = 0; i < tupleFilterChannels.length; i++) {
-            normalizedBlocks[i] = tuplePage.getBlock(tupleFilterChannels[i]);
-        }
-        return new Page(normalizedBlocks);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/index/UnloadedIndexKeyRecordSet.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/index/UnloadedIndexKeyRecordSet.java
@@ -74,13 +74,8 @@ public class UnloadedIndexKeyRecordSet
         for (UpdateRequest request : requests) {
             Page page = request.getPage();
 
-            Block[] distinctBlocks = new Block[distinctChannels.length];
-            for (int i = 0; i < distinctBlocks.length; i++) {
-                distinctBlocks[i] = page.getBlock(distinctChannels[i]);
-            }
-
             // Move through the positions while advancing the cursors in lockstep
-            Work<GroupByIdBlock> work = groupByHash.getGroupIds(new Page(distinctBlocks));
+            Work<GroupByIdBlock> work = groupByHash.getGroupIds(page.extractChannels(distinctChannels));
             boolean done = work.process();
             // TODO: this class does not yield wrt memory limit; enable it
             verify(done);


### PR DESCRIPTION
Comparable to changes in https://github.com/prestosql/presto/pull/5218

Two commits:
- Adds `Page#extractChannel(int)` helper method to allow efficient single channel Page extraction
- Refactors more classes and operators to use application `Page` class helper methods which avoid extra allocations and copies of Block arrays

```
== NO RELEASE NOTE ==
```
