### PR TITLE
Support CREATE VIEW and CREATE TABLE verification

### DIFF
--- a/presto-verifier/pom.xml
+++ b/presto-verifier/pom.xml
@@ -230,6 +230,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-tpch</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.facebook.airlift</groupId>
             <artifactId>testing</artifactId>
             <scope>test</scope>

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/AbstractVerification.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/AbstractVerification.java
@@ -122,7 +122,7 @@ public abstract class AbstractVerification<B extends QueryBundle, R extends Matc
             Optional<R> matchResult,
             Optional<Throwable> throwable);
 
-    protected abstract void updateQueryInfo(QueryInfo.Builder queryInfo, Optional<QueryResult<V>> queryResult);
+    protected void updateQueryInfo(QueryInfo.Builder queryInfo, Optional<QueryResult<V>> queryResult) {}
 
     protected PrestoAction getHelperAction()
     {

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/CreateTableVerification.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/CreateTableVerification.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.verifier.framework;
+
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.tree.CreateTable;
+import com.facebook.presto.sql.tree.QualifiedName;
+import com.facebook.presto.sql.tree.ShowCreate;
+import com.facebook.presto.sql.tree.Statement;
+import com.facebook.presto.verifier.prestoaction.PrestoAction.ResultSetConverter;
+import com.facebook.presto.verifier.prestoaction.QueryActions;
+import com.facebook.presto.verifier.prestoaction.SqlExceptionClassifier;
+import com.facebook.presto.verifier.rewrite.QueryRewriter;
+
+import java.sql.SQLException;
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.facebook.presto.sql.tree.ShowCreate.Type.TABLE;
+import static java.util.Objects.requireNonNull;
+
+public class CreateTableVerification
+        extends DdlVerification<CreateTable>
+{
+    public static final ResultSetConverter<String> SHOW_CREATE_TABLE_CONVERTER = resultSet -> {
+        try {
+            return Optional.of(resultSet.getString("Create Table"));
+        }
+        catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    };
+    private static final QualifiedName DUMMY_TABLE_NAME = QualifiedName.of("dummy");
+
+    private final QueryRewriter queryRewriter;
+
+    public CreateTableVerification(
+            SqlParser sqlParser,
+            QueryActions queryActions,
+            SourceQuery sourceQuery,
+            QueryRewriter queryRewriter,
+            SqlExceptionClassifier exceptionClassifier,
+            VerificationContext verificationContext,
+            VerifierConfig verifierConfig)
+    {
+        super(sqlParser, queryActions, sourceQuery, exceptionClassifier, verificationContext, verifierConfig, SHOW_CREATE_TABLE_CONVERTER);
+        this.queryRewriter = requireNonNull(queryRewriter, "queryRewriter is null");
+    }
+
+    @Override
+    protected QueryObjectBundle getQueryRewrite(ClusterType clusterType)
+    {
+        return queryRewriter.rewriteQuery(getSourceQuery().getQuery(clusterType), clusterType);
+    }
+
+    @Override
+    protected Statement getChecksumQuery(QueryObjectBundle queryBundle)
+    {
+        return new ShowCreate(TABLE, queryBundle.getObjectName());
+    }
+
+    @Override
+    protected boolean match(CreateTable controlObject, CreateTable testObject, QueryObjectBundle control, QueryObjectBundle test)
+    {
+        controlObject = new CreateTable(
+                DUMMY_TABLE_NAME,
+                controlObject.getElements(),
+                controlObject.isNotExists(),
+                controlObject.getProperties(),
+                controlObject.getComment());
+        testObject = new CreateTable(
+                DUMMY_TABLE_NAME,
+                testObject.getElements(),
+                testObject.isNotExists(),
+                testObject.getProperties(),
+                testObject.getComment());
+        return Objects.equals(controlObject, testObject);
+    }
+}

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/CreateViewVerification.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/CreateViewVerification.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.verifier.framework;
+
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.tree.CreateView;
+import com.facebook.presto.sql.tree.QualifiedName;
+import com.facebook.presto.sql.tree.ShowCreate;
+import com.facebook.presto.sql.tree.Statement;
+import com.facebook.presto.verifier.prestoaction.PrestoAction.ResultSetConverter;
+import com.facebook.presto.verifier.prestoaction.QueryActions;
+import com.facebook.presto.verifier.prestoaction.SqlExceptionClassifier;
+import com.facebook.presto.verifier.rewrite.QueryRewriter;
+
+import java.sql.SQLException;
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.facebook.presto.sql.tree.ShowCreate.Type.VIEW;
+import static java.util.Objects.requireNonNull;
+
+public class CreateViewVerification
+        extends DdlVerification<CreateView>
+{
+    public static final ResultSetConverter<String> SHOW_CREATE_VIEW_CONVERTER = resultSet -> {
+        try {
+            return Optional.of(resultSet.getString("Create View"));
+        }
+        catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    };
+    private static final QualifiedName DUMMY_VIEW_NAME = QualifiedName.of("dummy");
+
+    private final QueryRewriter queryRewriter;
+
+    public CreateViewVerification(
+            SqlParser sqlParser,
+            QueryActions queryActions,
+            SourceQuery sourceQuery,
+            QueryRewriter queryRewriter,
+            SqlExceptionClassifier exceptionClassifier,
+            VerificationContext verificationContext,
+            VerifierConfig verifierConfig)
+    {
+        super(sqlParser, queryActions, sourceQuery, exceptionClassifier, verificationContext, verifierConfig, SHOW_CREATE_VIEW_CONVERTER);
+        this.queryRewriter = requireNonNull(queryRewriter, "queryRewriter is null");
+    }
+
+    @Override
+    protected QueryObjectBundle getQueryRewrite(ClusterType clusterType)
+    {
+        return queryRewriter.rewriteQuery(getSourceQuery().getQuery(clusterType), clusterType);
+    }
+
+    @Override
+    protected Statement getChecksumQuery(QueryObjectBundle queryBundle)
+    {
+        return new ShowCreate(VIEW, queryBundle.getObjectName());
+    }
+
+    @Override
+    protected boolean match(CreateView controlObject, CreateView testObject, QueryObjectBundle control, QueryObjectBundle test)
+    {
+        controlObject = new CreateView(
+                DUMMY_VIEW_NAME,
+                controlObject.getQuery(),
+                controlObject.isReplace(),
+                controlObject.getSecurity());
+        testObject = new CreateView(
+                DUMMY_VIEW_NAME,
+                testObject.getQuery(),
+                testObject.isReplace(),
+                testObject.getSecurity());
+        return Objects.equals(controlObject, testObject);
+    }
+}

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DataVerification.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DataVerification.java
@@ -38,7 +38,7 @@ import static com.google.common.collect.Iterables.getOnlyElement;
 import static java.util.Objects.requireNonNull;
 
 public class DataVerification
-        extends AbstractVerification<DataQueryBundle, DataMatchResult, Void>
+        extends AbstractVerification<QueryObjectBundle, DataMatchResult, Void>
 {
     private final QueryRewriter queryRewriter;
     private final DeterminismAnalyzer determinismAnalyzer;
@@ -67,25 +67,25 @@ public class DataVerification
     }
 
     @Override
-    protected DataQueryBundle getQueryRewrite(ClusterType clusterType)
+    protected QueryObjectBundle getQueryRewrite(ClusterType clusterType)
     {
         return queryRewriter.rewriteQuery(getSourceQuery().getQuery(clusterType), clusterType);
     }
 
     @Override
     public DataMatchResult verify(
-            DataQueryBundle control,
-            DataQueryBundle test,
+            QueryObjectBundle control,
+            QueryObjectBundle test,
             Optional<QueryResult<Void>> controlQueryResult,
             Optional<QueryResult<Void>> testQueryResult,
             ChecksumQueryContext controlContext,
             ChecksumQueryContext testContext)
     {
-        List<Column> controlColumns = getColumns(getHelperAction(), typeManager, control.getTableName());
-        List<Column> testColumns = getColumns(getHelperAction(), typeManager, test.getTableName());
+        List<Column> controlColumns = getColumns(getHelperAction(), typeManager, control.getObjectName());
+        List<Column> testColumns = getColumns(getHelperAction(), typeManager, test.getObjectName());
 
-        Query controlChecksumQuery = checksumValidator.generateChecksumQuery(control.getTableName(), controlColumns);
-        Query testChecksumQuery = checksumValidator.generateChecksumQuery(test.getTableName(), testColumns);
+        Query controlChecksumQuery = checksumValidator.generateChecksumQuery(control.getObjectName(), controlColumns);
+        Query testChecksumQuery = checksumValidator.generateChecksumQuery(test.getObjectName(), testColumns);
 
         controlContext.setChecksumQuery(formatSql(controlChecksumQuery));
         testContext.setChecksumQuery(formatSql(testChecksumQuery));
@@ -101,15 +101,15 @@ public class DataVerification
     }
 
     @Override
-    protected DeterminismAnalysisDetails analyzeDeterminism(DataQueryBundle control, DataMatchResult matchResult)
+    protected DeterminismAnalysisDetails analyzeDeterminism(QueryObjectBundle control, DataMatchResult matchResult)
     {
         return determinismAnalyzer.analyze(control, matchResult.getControlChecksum());
     }
 
     @Override
     protected Optional<String> resolveFailure(
-            Optional<DataQueryBundle> control,
-            Optional<DataQueryBundle> test,
+            Optional<QueryObjectBundle> control,
+            Optional<QueryObjectBundle> test,
             QueryContext controlQueryContext,
             Optional<DataMatchResult> matchResult,
             Optional<Throwable> throwable)

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DataVerification.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DataVerification.java
@@ -19,7 +19,6 @@ import com.facebook.presto.sql.tree.Query;
 import com.facebook.presto.verifier.checksum.ChecksumResult;
 import com.facebook.presto.verifier.checksum.ChecksumValidator;
 import com.facebook.presto.verifier.event.DeterminismAnalysisDetails;
-import com.facebook.presto.verifier.event.QueryInfo;
 import com.facebook.presto.verifier.prestoaction.QueryActions;
 import com.facebook.presto.verifier.prestoaction.SqlExceptionClassifier;
 import com.facebook.presto.verifier.resolver.FailureResolverManager;
@@ -123,10 +122,5 @@ public class DataVerification
             return failureResolverManager.resolveException(controlQueryContext.getMainQueryStats().get(), throwable.get(), test);
         }
         return Optional.empty();
-    }
-
-    @Override
-    protected void updateQueryInfo(QueryInfo.Builder queryInfo, Optional<QueryResult<Void>> voidQueryResult)
-    {
     }
 }

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DdlMatchResult.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DdlMatchResult.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.verifier.framework;
+
+import com.facebook.presto.sql.parser.ParsingException;
+
+import java.util.Optional;
+
+import static com.facebook.presto.verifier.framework.DdlMatchResult.MatchType.MATCH;
+import static com.google.common.base.Throwables.getStackTraceAsString;
+import static java.util.Objects.requireNonNull;
+
+public class DdlMatchResult
+        implements MatchResult
+{
+    public enum MatchType
+    {
+        MATCH,
+        MISMATCH,
+        CONTROL_NOT_PARSABLE,
+        TEST_NOT_PARSABLE,
+    }
+
+    private final MatchType matchType;
+    private final Optional<ParsingException> exception;
+    private final String controlObject;
+    private final String testObject;
+
+    public DdlMatchResult(MatchType matchType, Optional<ParsingException> exception, String controlObject, String testObject)
+    {
+        this.matchType = requireNonNull(matchType, "matchType is null");
+        this.exception = requireNonNull(exception, "exception is null");
+        this.controlObject = requireNonNull(controlObject, "controlObject is null");
+        this.testObject = requireNonNull(testObject, "testObject is null");
+    }
+
+    @Override
+    public boolean isMatched()
+    {
+        return matchType == MATCH;
+    }
+
+    @Override
+    public String getMatchTypeName()
+    {
+        return matchType.name();
+    }
+
+    @Override
+    public boolean isMismatchPossiblyCausedByNonDeterminism()
+    {
+        return false;
+    }
+
+    @Override
+    public String getReport()
+    {
+        StringBuilder message = new StringBuilder()
+                .append(getMatchTypeName())
+                .append("\n\n");
+        exception.ifPresent(e -> message.append(getStackTraceAsString(e)).append("\n"));
+        return message.append("Control:\n")
+                .append(controlObject.trim())
+                .append("\n\n")
+                .append("Test:")
+                .append(testObject.trim())
+                .append("\n")
+                .toString();
+    }
+}

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DdlVerification.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DdlVerification.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.verifier.framework;
+
+import com.facebook.presto.jdbc.QueryStats;
+import com.facebook.presto.sql.parser.ParsingException;
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.tree.Statement;
+import com.facebook.presto.verifier.event.DeterminismAnalysisDetails;
+import com.facebook.presto.verifier.prestoaction.PrestoAction.ResultSetConverter;
+import com.facebook.presto.verifier.prestoaction.QueryActions;
+import com.facebook.presto.verifier.prestoaction.SqlExceptionClassifier;
+
+import java.util.Optional;
+
+import static com.facebook.presto.verifier.framework.DdlMatchResult.MatchType.CONTROL_NOT_PARSABLE;
+import static com.facebook.presto.verifier.framework.DdlMatchResult.MatchType.MATCH;
+import static com.facebook.presto.verifier.framework.DdlMatchResult.MatchType.MISMATCH;
+import static com.facebook.presto.verifier.framework.DdlMatchResult.MatchType.TEST_NOT_PARSABLE;
+import static com.facebook.presto.verifier.framework.QueryStage.CONTROL_CHECKSUM;
+import static com.facebook.presto.verifier.framework.QueryStage.TEST_CHECKSUM;
+import static com.facebook.presto.verifier.framework.VerifierUtil.PARSING_OPTIONS;
+import static com.facebook.presto.verifier.framework.VerifierUtil.callAndConsume;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static java.util.Objects.requireNonNull;
+
+public abstract class DdlVerification<S extends Statement>
+        extends AbstractVerification<QueryObjectBundle, DdlMatchResult, Void>
+{
+    private final SqlParser sqlParser;
+    private final ResultSetConverter<String> checksumConverter;
+
+    public DdlVerification(
+            SqlParser sqlParser,
+            QueryActions queryActions,
+            SourceQuery sourceQuery,
+            SqlExceptionClassifier exceptionClassifier,
+            VerificationContext verificationContext,
+            VerifierConfig verifierConfig,
+            ResultSetConverter<String> checksumConverter)
+    {
+        super(queryActions, sourceQuery, exceptionClassifier, verificationContext, Optional.empty(), verifierConfig);
+        this.sqlParser = requireNonNull(sqlParser, "sqlParser");
+        this.checksumConverter = requireNonNull(checksumConverter, "checksumConverter is null");
+    }
+
+    protected abstract Statement getChecksumQuery(QueryObjectBundle queryBundle);
+
+    protected abstract boolean match(S controlObject, S testObject, QueryObjectBundle control, QueryObjectBundle test);
+
+    @Override
+    @SuppressWarnings("unchecked")
+    protected DdlMatchResult verify(
+            QueryObjectBundle control,
+            QueryObjectBundle test,
+            Optional<QueryResult<Void>> controlQueryResult,
+            Optional<QueryResult<Void>> testQueryResult,
+            ChecksumQueryContext controlContext,
+            ChecksumQueryContext testContext)
+    {
+        Statement controlChecksumQuery = getChecksumQuery(control);
+        Statement testChecksumQuery = getChecksumQuery(test);
+
+        controlContext.setChecksumQuery(formatSql(controlChecksumQuery));
+        testContext.setChecksumQuery(formatSql(testChecksumQuery));
+
+        String controlChecksum = getOnlyElement(callAndConsume(
+                () -> getHelperAction().execute(controlChecksumQuery, CONTROL_CHECKSUM, checksumConverter),
+                stats -> stats.getQueryStats().map(QueryStats::getQueryId).ifPresent(controlContext::setChecksumQueryId)).getResults());
+        String testChecksum = getOnlyElement(callAndConsume(
+                () -> getHelperAction().execute(testChecksumQuery, TEST_CHECKSUM, checksumConverter),
+                stats -> stats.getQueryStats().map(QueryStats::getQueryId).ifPresent(testContext::setChecksumQueryId)).getResults());
+
+        S controlObject;
+        S testObject;
+
+        try {
+            controlObject = (S) sqlParser.createStatement(controlChecksum, PARSING_OPTIONS);
+        }
+        catch (ParsingException e) {
+            return new DdlMatchResult(CONTROL_NOT_PARSABLE, Optional.of(e), controlChecksum, testChecksum);
+        }
+
+        try {
+            testObject = (S) sqlParser.createStatement(testChecksum, PARSING_OPTIONS);
+        }
+        catch (ParsingException e) {
+            return new DdlMatchResult(TEST_NOT_PARSABLE, Optional.of(e), controlChecksum, testChecksum);
+        }
+
+        return new DdlMatchResult(
+                match(controlObject, testObject, control, test) ? MATCH : MISMATCH,
+                Optional.empty(),
+                controlChecksum,
+                testChecksum);
+    }
+
+    @Override
+    protected DeterminismAnalysisDetails analyzeDeterminism(QueryObjectBundle control, DdlMatchResult matchResult)
+    {
+        throw new UnsupportedOperationException("analyzeDeterminism is not supported for DdlVerification");
+    }
+
+    @Override
+    protected Optional<String> resolveFailure(Optional<QueryObjectBundle> control, Optional<QueryObjectBundle> test, QueryContext controlQueryContext, Optional<DdlMatchResult> matchResult, Optional<Throwable> throwable)
+    {
+        return Optional.empty();
+    }
+}

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DeterminismAnalyzer.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DeterminismAnalyzer.java
@@ -90,14 +90,14 @@ public class DeterminismAnalyzer
         this.handleLimitQuery = config.isHandleLimitQuery();
     }
 
-    protected DeterminismAnalysisDetails analyze(DataQueryBundle control, ChecksumResult controlChecksum)
+    protected DeterminismAnalysisDetails analyze(QueryObjectBundle control, ChecksumResult controlChecksum)
     {
         DeterminismAnalysisDetails.Builder determinismAnalysisDetails = DeterminismAnalysisDetails.builder();
         DeterminismAnalysis analysis = analyze(control, controlChecksum, determinismAnalysisDetails);
         return determinismAnalysisDetails.build(analysis);
     }
 
-    private DeterminismAnalysis analyze(DataQueryBundle control, ChecksumResult controlChecksum, DeterminismAnalysisDetails.Builder determinismAnalysisDetails)
+    private DeterminismAnalysis analyze(QueryObjectBundle control, ChecksumResult controlChecksum, DeterminismAnalysisDetails.Builder determinismAnalysisDetails)
     {
         // Handle mutable catalogs
         if (isNonDeterministicCatalogReferenced(control.getQuery())) {
@@ -127,12 +127,12 @@ public class DeterminismAnalyzer
         }
 
         // Rerun control query multiple times
-        List<Column> columns = getColumns(prestoAction, typeManager, control.getTableName());
+        List<Column> columns = getColumns(prestoAction, typeManager, control.getObjectName());
         Map<QueryBundle, DeterminismAnalysisRun.Builder> queryRuns = new HashMap<>();
         try {
             for (int i = 0; i < maxAnalysisRuns; i++) {
-                DataQueryBundle queryBundle = queryRewriter.rewriteQuery(sourceQuery.getQuery(CONTROL), CONTROL);
-                DeterminismAnalysisRun.Builder run = determinismAnalysisDetails.addRun().setTableName(queryBundle.getTableName().toString());
+                QueryObjectBundle queryBundle = queryRewriter.rewriteQuery(sourceQuery.getQuery(CONTROL), CONTROL);
+                DeterminismAnalysisRun.Builder run = determinismAnalysisDetails.addRun().setTableName(queryBundle.getObjectName().toString());
                 queryRuns.put(queryBundle, run);
 
                 // Rerun setup and main query
@@ -144,7 +144,7 @@ public class DeterminismAnalyzer
                         stats -> stats.getQueryStats().map(QueryStats::getQueryId).ifPresent(run::setQueryId));
 
                 // Run checksum query
-                Query checksumQuery = checksumValidator.generateChecksumQuery(queryBundle.getTableName(), columns);
+                Query checksumQuery = checksumValidator.generateChecksumQuery(queryBundle.getObjectName(), columns);
                 ChecksumResult testChecksum = getOnlyElement(callAndConsume(
                         () -> prestoAction.execute(checksumQuery, DETERMINISM_ANALYSIS_CHECKSUM, ChecksumResult::fromResultSet),
                         stats -> stats.getQueryStats().map(QueryStats::getQueryId).ifPresent(run::setChecksumQueryId)).getResults());

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/QueryObjectBundle.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/QueryObjectBundle.java
@@ -20,24 +20,24 @@ import java.util.List;
 
 import static java.util.Objects.requireNonNull;
 
-public class DataQueryBundle
+public class QueryObjectBundle
         extends QueryBundle
 {
-    private final QualifiedName tableName;
+    private final QualifiedName objectName;
 
-    public DataQueryBundle(
-            QualifiedName tableName,
+    public QueryObjectBundle(
+            QualifiedName objectName,
             List<Statement> setupQueries,
             Statement query,
             List<Statement> teardownQueries,
             ClusterType cluster)
     {
         super(setupQueries, query, teardownQueries, cluster);
-        this.tableName = requireNonNull(tableName, "tableName is null");
+        this.objectName = requireNonNull(objectName, "objectName is null");
     }
 
-    public QualifiedName getTableName()
+    public QualifiedName getObjectName()
     {
-        return tableName;
+        return objectName;
     }
 }

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/QueryType.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/QueryType.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.verifier.framework;
 
+import com.facebook.presto.sql.tree.CreateTable;
 import com.facebook.presto.sql.tree.CreateTableAsSelect;
 import com.facebook.presto.sql.tree.CreateView;
 import com.facebook.presto.sql.tree.Insert;
@@ -27,6 +28,7 @@ public enum QueryType
     INSERT(Insert.class),
     QUERY(Query.class),
     CREATE_VIEW(CreateView.class),
+    CREATE_TABLE(CreateTable.class),
     UNSUPPORTED();
 
     private final Optional<Class<? extends Statement>> statementClass;

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/QueryType.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/QueryType.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.verifier.framework;
 
 import com.facebook.presto.sql.tree.CreateTableAsSelect;
+import com.facebook.presto.sql.tree.CreateView;
 import com.facebook.presto.sql.tree.Insert;
 import com.facebook.presto.sql.tree.Query;
 import com.facebook.presto.sql.tree.Statement;
@@ -25,6 +26,7 @@ public enum QueryType
     CREATE_TABLE_AS_SELECT(CreateTableAsSelect.class),
     INSERT(Insert.class),
     QUERY(Query.class),
+    CREATE_VIEW(CreateView.class),
     UNSUPPORTED();
 
     private final Optional<Class<? extends Statement>> statementClass;

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/QueryType.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/QueryType.java
@@ -16,52 +16,27 @@ package com.facebook.presto.verifier.framework;
 import com.facebook.presto.sql.tree.CreateTableAsSelect;
 import com.facebook.presto.sql.tree.Insert;
 import com.facebook.presto.sql.tree.Query;
-import com.facebook.presto.sql.tree.ShowCatalogs;
-import com.facebook.presto.sql.tree.ShowColumns;
-import com.facebook.presto.sql.tree.ShowFunctions;
-import com.facebook.presto.sql.tree.ShowSchemas;
-import com.facebook.presto.sql.tree.ShowSession;
-import com.facebook.presto.sql.tree.ShowTables;
 import com.facebook.presto.sql.tree.Statement;
 
 import java.util.Optional;
 
-import static com.facebook.presto.verifier.framework.QueryType.Category.DATA_PRODUCING;
-import static com.facebook.presto.verifier.framework.QueryType.Category.METADATA_READ;
-import static java.util.Objects.requireNonNull;
-
 public enum QueryType
 {
-    CREATE_TABLE_AS_SELECT(DATA_PRODUCING, CreateTableAsSelect.class),
-    INSERT(DATA_PRODUCING, Insert.class),
-    QUERY(DATA_PRODUCING, Query.class),
-    SHOW_CATALOGS(METADATA_READ, ShowCatalogs.class),
-    SHOW_COLUMNS(METADATA_READ, ShowColumns.class),
-    SHOW_FUNCTIONS(METADATA_READ, ShowFunctions.class),
-    SHOW_SCHEMAS(METADATA_READ, ShowSchemas.class),
-    SHOW_SESSION(METADATA_READ, ShowSession.class),
-    SHOW_TABLES(METADATA_READ, ShowTables.class),
-    UNSUPPORTED(Category.UNSUPPORTED, Optional.empty());
+    CREATE_TABLE_AS_SELECT(CreateTableAsSelect.class),
+    INSERT(Insert.class),
+    QUERY(Query.class),
+    UNSUPPORTED();
 
-    public enum Category
-    {
-        DATA_PRODUCING,
-        METADATA_READ,
-        UNSUPPORTED,
-    }
-
-    private final Category category;
     private final Optional<Class<? extends Statement>> statementClass;
 
-    QueryType(Category category, Class<? extends Statement> statementClass)
+    QueryType(Class<? extends Statement> statementClass)
     {
-        this(category, Optional.of(statementClass));
+        this.statementClass = Optional.of(statementClass);
     }
 
-    QueryType(Category category, Optional<Class<? extends Statement>> statementClass)
+    QueryType()
     {
-        this.category = requireNonNull(category, "category is null");
-        this.statementClass = requireNonNull(statementClass, "statementClass is null");
+        this.statementClass = Optional.empty();
     }
 
     public static QueryType of(Statement statement)
@@ -72,10 +47,5 @@ public enum QueryType
             }
         }
         return UNSUPPORTED;
-    }
-
-    public Category getCategory()
-    {
-        return category;
     }
 }

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerificationFactory.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerificationFactory.java
@@ -86,8 +86,10 @@ public class VerificationFactory
                     sqlParser);
         }
 
-        switch (queryType.getCategory()) {
-            case DATA_PRODUCING:
+        switch (queryType) {
+            case CREATE_TABLE_AS_SELECT:
+            case INSERT:
+            case QUERY:
                 QueryRewriter queryRewriter = queryRewriterFactory.create(queryActions.getHelperAction());
                 DeterminismAnalyzer determinismAnalyzer = new DeterminismAnalyzer(
                         sourceQuery,

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerificationFactory.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerificationFactory.java
@@ -119,6 +119,15 @@ public class VerificationFactory
                         exceptionClassifier,
                         verificationContext,
                         verifierConfig);
+            case CREATE_TABLE:
+                return new CreateTableVerification(
+                        sqlParser,
+                        queryActions,
+                        sourceQuery,
+                        queryRewriter,
+                        exceptionClassifier,
+                        verificationContext,
+                        verifierConfig);
             default:
                 throw new IllegalStateException(format("Unsupported query type: %s", queryType));
         }

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerificationFactory.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerificationFactory.java
@@ -86,11 +86,11 @@ public class VerificationFactory
                     sqlParser);
         }
 
+        QueryRewriter queryRewriter = queryRewriterFactory.create(queryActions.getHelperAction());
         switch (queryType) {
             case CREATE_TABLE_AS_SELECT:
             case INSERT:
             case QUERY:
-                QueryRewriter queryRewriter = queryRewriterFactory.create(queryActions.getHelperAction());
                 DeterminismAnalyzer determinismAnalyzer = new DeterminismAnalyzer(
                         sourceQuery,
                         queryActions.getHelperAction(),
@@ -110,6 +110,15 @@ public class VerificationFactory
                         verifierConfig,
                         typeManager,
                         checksumValidator);
+            case CREATE_VIEW:
+                return new CreateViewVerification(
+                        sqlParser,
+                        queryActions,
+                        sourceQuery,
+                        queryRewriter,
+                        exceptionClassifier,
+                        verificationContext,
+                        verifierConfig);
             default:
                 throw new IllegalStateException(format("Unsupported query type: %s", queryType));
         }

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerificationManager.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerificationManager.java
@@ -52,7 +52,6 @@ import static com.facebook.presto.verifier.event.VerifierQueryEvent.EventStatus.
 import static com.facebook.presto.verifier.event.VerifierQueryEvent.EventStatus.SUCCEEDED;
 import static com.facebook.presto.verifier.framework.ClusterType.CONTROL;
 import static com.facebook.presto.verifier.framework.ClusterType.TEST;
-import static com.facebook.presto.verifier.framework.QueryType.Category.DATA_PRODUCING;
 import static com.facebook.presto.verifier.framework.QueryType.UNSUPPORTED;
 import static com.facebook.presto.verifier.framework.SkippedReason.CUSTOM_FILTER;
 import static com.facebook.presto.verifier.framework.SkippedReason.MISMATCHED_QUERY_TYPE;
@@ -228,9 +227,6 @@ public class VerificationManager
                 }
                 else if (controlQueryType != testQueryType) {
                     postEvent(VerifierQueryEvent.skipped(sourceQuery.getSuite(), testId, sourceQuery, MISMATCHED_QUERY_TYPE, skipControl));
-                }
-                else if (controlQueryType.getCategory() != DATA_PRODUCING) {
-                    postEvent(VerifierQueryEvent.skipped(sourceQuery.getSuite(), testId, sourceQuery, UNSUPPORTED_QUERY_TYPE, skipControl));
                 }
                 else {
                     selected.add(sourceQuery);

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/ChecksumExceededTimeLimitFailureResolver.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/ChecksumExceededTimeLimitFailureResolver.java
@@ -14,8 +14,8 @@
 package com.facebook.presto.verifier.resolver;
 
 import com.facebook.presto.jdbc.QueryStats;
-import com.facebook.presto.verifier.framework.DataQueryBundle;
 import com.facebook.presto.verifier.framework.QueryException;
+import com.facebook.presto.verifier.framework.QueryObjectBundle;
 import com.google.common.collect.ImmutableSet;
 
 import java.util.Optional;
@@ -30,7 +30,7 @@ public class ChecksumExceededTimeLimitFailureResolver
     public static final String NAME = "checksum-exceeded-time-limit";
 
     @Override
-    public Optional<String> resolveQueryFailure(QueryStats controlQueryStats, QueryException queryException, Optional<DataQueryBundle> test)
+    public Optional<String> resolveQueryFailure(QueryStats controlQueryStats, QueryException queryException, Optional<QueryObjectBundle> test)
     {
         return mapMatchingPrestoException(queryException, CONTROL_CHECKSUM, ImmutableSet.of(EXCEEDED_TIME_LIMIT),
                 e -> Optional.of("Time limit exceeded when running control checksum query"));

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/ExceededGlobalMemoryLimitFailureResolver.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/ExceededGlobalMemoryLimitFailureResolver.java
@@ -14,8 +14,8 @@
 package com.facebook.presto.verifier.resolver;
 
 import com.facebook.presto.jdbc.QueryStats;
-import com.facebook.presto.verifier.framework.DataQueryBundle;
 import com.facebook.presto.verifier.framework.QueryException;
+import com.facebook.presto.verifier.framework.QueryObjectBundle;
 import com.google.common.collect.ImmutableSet;
 
 import java.util.Optional;
@@ -30,7 +30,7 @@ public class ExceededGlobalMemoryLimitFailureResolver
     public static final String NAME = "exceeded-global-memory-limit";
 
     @Override
-    public Optional<String> resolveQueryFailure(QueryStats controlQueryStats, QueryException queryException, Optional<DataQueryBundle> test)
+    public Optional<String> resolveQueryFailure(QueryStats controlQueryStats, QueryException queryException, Optional<QueryObjectBundle> test)
     {
         return mapMatchingPrestoException(queryException, TEST_MAIN, ImmutableSet.of(EXCEEDED_GLOBAL_MEMORY_LIMIT),
                 e -> e.getQueryActionStats().getQueryStats().isPresent()

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/ExceededTimeLimitFailureResolver.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/ExceededTimeLimitFailureResolver.java
@@ -14,8 +14,8 @@
 package com.facebook.presto.verifier.resolver;
 
 import com.facebook.presto.jdbc.QueryStats;
-import com.facebook.presto.verifier.framework.DataQueryBundle;
 import com.facebook.presto.verifier.framework.QueryException;
+import com.facebook.presto.verifier.framework.QueryObjectBundle;
 import com.google.common.collect.ImmutableSet;
 
 import java.util.Optional;
@@ -30,7 +30,7 @@ public class ExceededTimeLimitFailureResolver
     public static final String NAME = "exceeded-time-limit";
 
     @Override
-    public Optional<String> resolveQueryFailure(QueryStats controlQueryStats, QueryException queryException, Optional<DataQueryBundle> test)
+    public Optional<String> resolveQueryFailure(QueryStats controlQueryStats, QueryException queryException, Optional<QueryObjectBundle> test)
     {
         return mapMatchingPrestoException(queryException, TEST_MAIN, ImmutableSet.of(EXCEEDED_TIME_LIMIT),
                 e -> Optional.of("Time limit exceeded on test cluster"));

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/FailureResolver.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/FailureResolver.java
@@ -15,15 +15,15 @@ package com.facebook.presto.verifier.resolver;
 
 import com.facebook.presto.jdbc.QueryStats;
 import com.facebook.presto.verifier.framework.DataMatchResult;
-import com.facebook.presto.verifier.framework.DataQueryBundle;
 import com.facebook.presto.verifier.framework.QueryBundle;
 import com.facebook.presto.verifier.framework.QueryException;
+import com.facebook.presto.verifier.framework.QueryObjectBundle;
 
 import java.util.Optional;
 
 public interface FailureResolver
 {
-    default Optional<String> resolveQueryFailure(QueryStats controlQueryStats, QueryException queryException, Optional<DataQueryBundle> test)
+    default Optional<String> resolveQueryFailure(QueryStats controlQueryStats, QueryException queryException, Optional<QueryObjectBundle> test)
     {
         return Optional.empty();
     }

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/FailureResolverManager.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/FailureResolverManager.java
@@ -14,9 +14,9 @@
 package com.facebook.presto.verifier.resolver;
 
 import com.facebook.presto.verifier.framework.DataMatchResult;
-import com.facebook.presto.verifier.framework.DataQueryBundle;
 import com.facebook.presto.verifier.framework.QueryBundle;
 import com.facebook.presto.verifier.framework.QueryException;
+import com.facebook.presto.verifier.framework.QueryObjectBundle;
 import com.facebook.presto.verifier.prestoaction.QueryActionStats;
 
 import java.util.Optional;
@@ -33,7 +33,7 @@ public class FailureResolverManager
         this.failureResolvers = requireNonNull(failureResolvers, "failureResolvers is null");
     }
 
-    public Optional<String> resolveException(QueryActionStats controlStats, Throwable throwable, Optional<DataQueryBundle> test)
+    public Optional<String> resolveException(QueryActionStats controlStats, Throwable throwable, Optional<QueryObjectBundle> test)
     {
         if (!(throwable instanceof QueryException)) {
             return Optional.of("Verifier Error");

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/FailureResolverModule.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/FailureResolverModule.java
@@ -63,9 +63,9 @@ public class FailureResolverModule
     {
         configBinder(binder).bindConfig(FailureResolverConfig.class);
         binder.bind(FailureResolverManagerFactory.class).in(SINGLETON);
+        newSetBinder(binder, FailureResolver.class);
+        newSetBinder(binder, FailureResolverFactory.class);
         if (!buildConfigObject(FailureResolverConfig.class).isEnabled()) {
-            newSetBinder(binder, FailureResolver.class);
-            newSetBinder(binder, FailureResolverFactory.class);
             return;
         }
 

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/TooManyOpenPartitionsFailureResolver.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/TooManyOpenPartitionsFailureResolver.java
@@ -22,8 +22,8 @@ import com.facebook.presto.sql.tree.LongLiteral;
 import com.facebook.presto.sql.tree.Property;
 import com.facebook.presto.sql.tree.ShowCreate;
 import com.facebook.presto.verifier.annotation.ForTest;
-import com.facebook.presto.verifier.framework.DataQueryBundle;
 import com.facebook.presto.verifier.framework.QueryException;
+import com.facebook.presto.verifier.framework.QueryObjectBundle;
 import com.facebook.presto.verifier.prestoaction.PrestoAction;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.units.Duration;
@@ -73,7 +73,7 @@ public class TooManyOpenPartitionsFailureResolver
     }
 
     @Override
-    public Optional<String> resolveQueryFailure(QueryStats controlQueryStats, QueryException queryException, Optional<DataQueryBundle> test)
+    public Optional<String> resolveQueryFailure(QueryStats controlQueryStats, QueryException queryException, Optional<QueryObjectBundle> test)
     {
         if (!test.isPresent()) {
             return Optional.empty();
@@ -82,7 +82,7 @@ public class TooManyOpenPartitionsFailureResolver
         return mapMatchingPrestoException(queryException, TEST_MAIN, ImmutableSet.of(HIVE_TOO_MANY_OPEN_PARTITIONS),
                 e -> {
                     try {
-                        ShowCreate showCreate = new ShowCreate(TABLE, test.get().getTableName());
+                        ShowCreate showCreate = new ShowCreate(TABLE, test.get().getObjectName());
                         String showCreateResult = getOnlyElement(prestoAction.execute(showCreate, DESCRIBE, resultSet -> Optional.of(resultSet.getString(1))).getResults());
                         CreateTable createTable = (CreateTable) sqlParser.createStatement(showCreateResult, ParsingOptions.builder().setDecimalLiteralTreatment(AS_DOUBLE).build());
                         List<Property> bucketCountProperty = createTable.getProperties().stream()

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/VerifierLimitationFailureResolver.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/resolver/VerifierLimitationFailureResolver.java
@@ -14,8 +14,8 @@
 package com.facebook.presto.verifier.resolver;
 
 import com.facebook.presto.jdbc.QueryStats;
-import com.facebook.presto.verifier.framework.DataQueryBundle;
 import com.facebook.presto.verifier.framework.QueryException;
+import com.facebook.presto.verifier.framework.QueryObjectBundle;
 import com.google.common.collect.ImmutableSet;
 
 import java.util.Optional;
@@ -31,7 +31,7 @@ public class VerifierLimitationFailureResolver
     public static final String NAME = "verifier-limitation";
 
     @Override
-    public Optional<String> resolveQueryFailure(QueryStats controlQueryStats, QueryException queryException, Optional<DataQueryBundle> test)
+    public Optional<String> resolveQueryFailure(QueryStats controlQueryStats, QueryException queryException, Optional<QueryObjectBundle> test)
     {
         return mapMatchingPrestoException(queryException, CONTROL_CHECKSUM, ImmutableSet.of(COMPILER_ERROR, GENERATED_BYTECODE_TOO_LARGE),
                 e -> Optional.of("Checksum query too large"));

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/rewrite/QueryRewriter.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/rewrite/QueryRewriter.java
@@ -26,7 +26,9 @@ import com.facebook.presto.sql.tree.AllColumns;
 import com.facebook.presto.sql.tree.Cast;
 import com.facebook.presto.sql.tree.CreateTable;
 import com.facebook.presto.sql.tree.CreateTableAsSelect;
+import com.facebook.presto.sql.tree.CreateView;
 import com.facebook.presto.sql.tree.DropTable;
+import com.facebook.presto.sql.tree.DropView;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.Identifier;
 import com.facebook.presto.sql.tree.Insert;
@@ -37,9 +39,11 @@ import com.facebook.presto.sql.tree.Query;
 import com.facebook.presto.sql.tree.QuerySpecification;
 import com.facebook.presto.sql.tree.Select;
 import com.facebook.presto.sql.tree.SelectItem;
+import com.facebook.presto.sql.tree.ShowCreate;
 import com.facebook.presto.sql.tree.SingleColumn;
 import com.facebook.presto.sql.tree.Statement;
 import com.facebook.presto.verifier.framework.ClusterType;
+import com.facebook.presto.verifier.framework.QueryException;
 import com.facebook.presto.verifier.framework.QueryObjectBundle;
 import com.facebook.presto.verifier.prestoaction.PrestoAction;
 import com.facebook.presto.verifier.prestoaction.PrestoAction.ResultSetConverter;
@@ -67,7 +71,9 @@ import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.common.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.sql.tree.LikeClause.PropertiesOption.INCLUDING;
+import static com.facebook.presto.sql.tree.ShowCreate.Type.VIEW;
 import static com.facebook.presto.type.UnknownType.UNKNOWN;
+import static com.facebook.presto.verifier.framework.CreateViewVerification.SHOW_CREATE_VIEW_CONVERTER;
 import static com.facebook.presto.verifier.framework.QueryStage.REWRITE;
 import static com.facebook.presto.verifier.framework.VerifierUtil.PARSING_OPTIONS;
 import static com.facebook.presto.verifier.framework.VerifierUtil.getColumnNames;
@@ -75,6 +81,7 @@ import static com.facebook.presto.verifier.framework.VerifierUtil.getColumnTypes
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.Iterables.getOnlyElement;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
 import static java.util.Map.Entry;
@@ -112,7 +119,7 @@ public class QueryRewriter
         List<Property> properties = tableProperties.get(clusterType);
         if (statement instanceof CreateTableAsSelect) {
             CreateTableAsSelect createTableAsSelect = (CreateTableAsSelect) statement;
-            QualifiedName temporaryTableName = generateTemporaryTableName(Optional.of(createTableAsSelect.getName()), prefix);
+            QualifiedName temporaryTableName = generateTemporaryName(Optional.of(createTableAsSelect.getName()), prefix);
             return new QueryObjectBundle(
                     temporaryTableName,
                     ImmutableList.of(),
@@ -130,7 +137,7 @@ public class QueryRewriter
         if (statement instanceof Insert) {
             Insert insert = (Insert) statement;
             QualifiedName originalTableName = insert.getTarget();
-            QualifiedName temporaryTableName = generateTemporaryTableName(Optional.of(originalTableName), prefix);
+            QualifiedName temporaryTableName = generateTemporaryName(Optional.of(originalTableName), prefix);
             return new QueryObjectBundle(
                     temporaryTableName,
                     ImmutableList.of(
@@ -148,7 +155,7 @@ public class QueryRewriter
                     clusterType);
         }
         if (statement instanceof Query) {
-            QualifiedName temporaryTableName = generateTemporaryTableName(Optional.empty(), prefix);
+            QualifiedName temporaryTableName = generateTemporaryName(Optional.empty(), prefix);
             ResultSetMetaData metadata = getResultMetadata((Query) statement);
             List<Identifier> columnAliases = generateStorageColumnAliases(metadata);
             Query rewrite = rewriteNonStorableColumns((Query) statement, metadata);
@@ -166,11 +173,45 @@ public class QueryRewriter
                     ImmutableList.of(new DropTable(temporaryTableName, true)),
                     clusterType);
         }
+        if (statement instanceof CreateView) {
+            CreateView createView = (CreateView) statement;
+            QualifiedName temporaryViewName = generateTemporaryName(Optional.empty(), prefix);
+            ImmutableList.Builder<Statement> setupQueries = ImmutableList.builder();
+
+            // Check to see if there is an existing view with the specified view name.
+            // If view exists, create a temporary view that are has the same definition as the existing view.
+            // Otherwise, do not pre-create temporary view.
+            try {
+                String createExistingViewQuery = getOnlyElement(prestoAction.execute(
+                        new ShowCreate(VIEW, createView.getName()),
+                        REWRITE,
+                        SHOW_CREATE_VIEW_CONVERTER).getResults());
+                CreateView createExistingView = (CreateView) sqlParser.createStatement(createExistingViewQuery, PARSING_OPTIONS);
+                setupQueries.add(new CreateView(
+                        temporaryViewName,
+                        createExistingView.getQuery(),
+                        false,
+                        createExistingView.getSecurity()));
+            }
+            catch (QueryException e) {
+                // no-op
+            }
+            return new QueryObjectBundle(
+                    temporaryViewName,
+                    setupQueries.build(),
+                    new CreateView(
+                            temporaryViewName,
+                            createView.getQuery(),
+                            createView.isReplace(),
+                            createView.getSecurity()),
+                    ImmutableList.of(new DropView(temporaryViewName, true)),
+                    clusterType);
+        }
 
         throw new IllegalStateException(format("Unsupported query type: %s", statement.getClass()));
     }
 
-    private QualifiedName generateTemporaryTableName(Optional<QualifiedName> originalName, QualifiedName prefix)
+    private QualifiedName generateTemporaryName(Optional<QualifiedName> originalName, QualifiedName prefix)
     {
         List<String> parts = new ArrayList<>();
         int originalSize = originalName.map(QualifiedName::getOriginalParts).map(List::size).orElse(0);

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/rewrite/QueryRewriter.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/rewrite/QueryRewriter.java
@@ -70,11 +70,9 @@ import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.sql.tree.LikeClause.PropertiesOption.INCLUDING;
 import static com.facebook.presto.type.UnknownType.UNKNOWN;
 import static com.facebook.presto.verifier.framework.QueryStage.REWRITE;
-import static com.facebook.presto.verifier.framework.QueryType.Category.DATA_PRODUCING;
 import static com.facebook.presto.verifier.framework.VerifierUtil.PARSING_OPTIONS;
 import static com.facebook.presto.verifier.framework.VerifierUtil.getColumnNames;
 import static com.facebook.presto.verifier.framework.VerifierUtil.getColumnTypes;
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
@@ -111,7 +109,6 @@ public class QueryRewriter
         checkState(prefixes.containsKey(clusterType), "Unsupported cluster type: %s", clusterType);
         Statement statement = sqlParser.createStatement(query, PARSING_OPTIONS);
         QueryType queryType = QueryType.of(statement);
-        checkArgument(queryType.getCategory() == DATA_PRODUCING, "Unsupported statement type: %s", queryType);
 
         QualifiedName prefix = prefixes.get(clusterType);
         List<Property> properties = tableProperties.get(clusterType);

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/rewrite/QueryRewriter.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/rewrite/QueryRewriter.java
@@ -207,6 +207,21 @@ public class QueryRewriter
                     ImmutableList.of(new DropView(temporaryViewName, true)),
                     clusterType);
         }
+        if (statement instanceof CreateTable) {
+            CreateTable createTable = (CreateTable) statement;
+            QualifiedName temporaryTableName = generateTemporaryName(Optional.empty(), prefix);
+            return new QueryObjectBundle(
+                    temporaryTableName,
+                    ImmutableList.of(),
+                    new CreateTable(
+                            temporaryTableName,
+                            createTable.getElements(),
+                            createTable.isNotExists(),
+                            applyPropertyOverride(createTable.getProperties(), properties),
+                            createTable.getComment()),
+                    ImmutableList.of(new DropTable(temporaryTableName, true)),
+                    clusterType);
+        }
 
         throw new IllegalStateException(format("Unsupported query type: %s", statement.getClass()));
     }

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/VerifierTestUtil.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/VerifierTestUtil.java
@@ -35,7 +35,7 @@ import com.facebook.presto.verifier.checksum.MapColumnValidator;
 import com.facebook.presto.verifier.checksum.RowColumnValidator;
 import com.facebook.presto.verifier.checksum.SimpleColumnValidator;
 import com.facebook.presto.verifier.framework.Column;
-import com.facebook.presto.verifier.framework.DataQueryBundle;
+import com.facebook.presto.verifier.framework.QueryObjectBundle;
 import com.facebook.presto.verifier.framework.VerifierConfig;
 import com.facebook.presto.verifier.source.MySqlSourceQueryConfig;
 import com.facebook.presto.verifier.source.VerifierDao;
@@ -65,7 +65,7 @@ public class VerifierTestUtil
     public static final String XDB = "presto";
     public static final String VERIFIER_QUERIES_TABLE = "verifier_queries";
 
-    public static final DataQueryBundle TEST_BUNDLE = new DataQueryBundle(
+    public static final QueryObjectBundle TEST_BUNDLE = new QueryObjectBundle(
             QualifiedName.of("test"),
             ImmutableList.of(),
             new SqlParser(new SqlParserOptions().allowIdentifierSymbol(AT_SIGN, COLON)).createStatement(

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/AbstractDdlVerificationTest.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/AbstractDdlVerificationTest.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.verifier.framework;
+
+import com.facebook.presto.sql.tree.ShowCreate;
+import com.facebook.presto.sql.tree.Statement;
+import com.facebook.presto.verifier.event.VerifierQueryEvent;
+import com.facebook.presto.verifier.framework.DdlMatchResult.MatchType;
+import com.facebook.presto.verifier.prestoaction.PrestoAction;
+import com.facebook.presto.verifier.prestoaction.QueryActionStats;
+import com.google.common.collect.ImmutableMap;
+
+import java.sql.SQLException;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.presto.verifier.event.VerifierQueryEvent.EventStatus;
+import static java.lang.String.format;
+import static org.testng.Assert.assertEquals;
+
+public class AbstractDdlVerificationTest
+        extends AbstractVerificationTest
+{
+    public AbstractDdlVerificationTest()
+            throws Exception
+    {
+    }
+
+    protected void assertEvent(
+            VerifierQueryEvent event,
+            EventStatus expectedStatus,
+            Optional<MatchType> expectedMatchType,
+            boolean hasSetupQuery)
+    {
+        assertEquals(event.getSuite(), SUITE);
+        assertEquals(event.getTestId(), TEST_ID);
+        assertEquals(event.getName(), NAME);
+        assertEquals(event.getStatus(), expectedStatus.name());
+        expectedMatchType.ifPresent(matchType -> assertEquals(event.getMatchType(), matchType.name()));
+
+        int setupQueryCount = hasSetupQuery ? 1 : 0;
+        assertEquals(event.getControlQueryInfo().getSetupQueries().size(), setupQueryCount);
+        assertEquals(event.getTestQueryInfo().getSetupQueries().size(), setupQueryCount);
+        assertEquals(event.getControlQueryInfo().getTeardownQueries().size(), 1);
+        assertEquals(event.getTestQueryInfo().getTeardownQueries().size(), 1);
+    }
+
+    protected class MockPrestoAction
+            implements PrestoAction
+    {
+        private final PrestoAction prestoAction = getPrestoAction(Optional.empty());
+
+        private final Map<Integer, String> showCreateResultByInvocation;
+        private int invocationCount;
+
+        public MockPrestoAction(Map<Integer, String> showCreateResultByInvocation)
+        {
+            this.showCreateResultByInvocation = ImmutableMap.copyOf(showCreateResultByInvocation);
+        }
+
+        @Override
+        public QueryActionStats execute(Statement statement, QueryStage queryStage)
+        {
+            return prestoAction.execute(statement, queryStage);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <R> QueryResult<R> execute(Statement statement, QueryStage queryStage, ResultSetConverter<R> converter)
+        {
+            if (statement instanceof ShowCreate) {
+                invocationCount += 1;
+                if (showCreateResultByInvocation.containsKey(invocationCount)) {
+                    return (QueryResult<R>) prestoAction.execute(
+                            getSqlParser().createStatement(format("SELECT '%s'", showCreateResultByInvocation.get(invocationCount).replaceAll("'", "''")), PARSING_OPTIONS),
+                            queryStage,
+                            resultSet -> {
+                                try {
+                                    return Optional.of(resultSet.getString(1));
+                                }
+                                catch (SQLException e) {
+                                    throw new RuntimeException(e);
+                                }
+                            });
+                }
+            }
+            return prestoAction.execute(statement, queryStage, converter);
+        }
+    }
+}

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/AbstractVerificationTest.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/AbstractVerificationTest.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.verifier.framework;
+
+import com.facebook.airlift.bootstrap.Bootstrap;
+import com.facebook.airlift.bootstrap.LifeCycleManager;
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.sql.parser.ParsingOptions;
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.parser.SqlParserOptions;
+import com.facebook.presto.tests.StandaloneQueryRunner;
+import com.facebook.presto.verifier.event.VerifierQueryEvent;
+import com.facebook.presto.verifier.prestoaction.JdbcPrestoAction;
+import com.facebook.presto.verifier.prestoaction.PrestoAction;
+import com.facebook.presto.verifier.prestoaction.PrestoActionConfig;
+import com.facebook.presto.verifier.prestoaction.PrestoExceptionClassifier;
+import com.facebook.presto.verifier.prestoaction.QueryActions;
+import com.facebook.presto.verifier.prestoaction.QueryActionsConfig;
+import com.facebook.presto.verifier.resolver.FailureResolverManagerFactory;
+import com.facebook.presto.verifier.resolver.FailureResolverModule;
+import com.facebook.presto.verifier.retry.RetryConfig;
+import com.facebook.presto.verifier.rewrite.QueryRewriteConfig;
+import com.facebook.presto.verifier.rewrite.QueryRewriterFactory;
+import com.facebook.presto.verifier.rewrite.VerificationQueryRewriterFactory;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Injector;
+import org.testng.annotations.AfterClass;
+
+import java.util.Optional;
+
+import static com.facebook.presto.sql.parser.IdentifierSymbol.AT_SIGN;
+import static com.facebook.presto.sql.parser.IdentifierSymbol.COLON;
+import static com.facebook.presto.sql.parser.ParsingOptions.DecimalLiteralTreatment.AS_DOUBLE;
+import static com.facebook.presto.verifier.VerifierTestUtil.CATALOG;
+import static com.facebook.presto.verifier.VerifierTestUtil.SCHEMA;
+import static com.facebook.presto.verifier.VerifierTestUtil.createChecksumValidator;
+import static com.facebook.presto.verifier.VerifierTestUtil.createTypeManager;
+import static com.facebook.presto.verifier.VerifierTestUtil.setupPresto;
+
+public abstract class AbstractVerificationTest
+{
+    protected static final String SUITE = "test-suite";
+    protected static final String NAME = "test-query";
+    protected static final String TEST_ID = "test-id";
+    protected static final QueryConfiguration QUERY_CONFIGURATION = new QueryConfiguration(CATALOG, SCHEMA, Optional.of("user"), Optional.empty(), Optional.empty());
+    protected static final ParsingOptions PARSING_OPTIONS = ParsingOptions.builder().setDecimalLiteralTreatment(AS_DOUBLE).build();
+    protected static final String CONTROL_TABLE_PREFIX = "tmp_verifier_c";
+    protected static final String TEST_TABLE_PREFIX = "tmp_verifier_t";
+
+    private final StandaloneQueryRunner queryRunner;
+
+    private final Injector injector;
+    private final SqlParser sqlParser = new SqlParser(new SqlParserOptions().allowIdentifierSymbol(COLON, AT_SIGN));
+    private final PrestoExceptionClassifier exceptionClassifier = PrestoExceptionClassifier.defaultBuilder().build();
+    private final DeterminismAnalyzerConfig determinismAnalyzerConfig = new DeterminismAnalyzerConfig().setMaxAnalysisRuns(3).setRunTeardown(true);
+    private final FailureResolverManagerFactory failureResolverManagerFactory;
+
+    public AbstractVerificationTest()
+            throws Exception
+    {
+        this.queryRunner = setupPresto();
+        this.injector = new Bootstrap(ImmutableList.of(FailureResolverModule.BUILT_IN))
+                .setRequiredConfigurationProperties(ImmutableMap.of("too-many-open-partitions.failure-resolver.enabled", "false"))
+                .initialize();
+        this.failureResolverManagerFactory = injector.getInstance(FailureResolverManagerFactory.class);
+    }
+
+    @AfterClass
+    public void teardown()
+    {
+        try {
+            injector.getInstance(LifeCycleManager.class).stop();
+        }
+        catch (Throwable ignored) {
+        }
+    }
+
+    public StandaloneQueryRunner getQueryRunner()
+    {
+        return queryRunner;
+    }
+
+    public SqlParser getSqlParser()
+    {
+        return sqlParser;
+    }
+
+    protected SourceQuery getSourceQuery(String controlQuery, String testQuery)
+    {
+        return new SourceQuery(SUITE, NAME, controlQuery, testQuery, QUERY_CONFIGURATION, QUERY_CONFIGURATION);
+    }
+
+    protected Optional<VerifierQueryEvent> runExplain(String controlQuery, String testQuery)
+    {
+        return verify(getSourceQuery(controlQuery, testQuery), true, Optional.empty());
+    }
+
+    protected Optional<VerifierQueryEvent> runVerification(String controlQuery, String testQuery)
+    {
+        return verify(getSourceQuery(controlQuery, testQuery), false, Optional.empty());
+    }
+
+    protected Optional<VerifierQueryEvent> verify(SourceQuery sourceQuery, boolean explain)
+    {
+        return verify(sourceQuery, explain, Optional.empty());
+    }
+
+    protected Optional<VerifierQueryEvent> verify(SourceQuery sourceQuery, boolean explain, PrestoAction mockPrestoAction)
+    {
+        return verify(sourceQuery, explain, Optional.of(mockPrestoAction));
+    }
+
+    private Optional<VerifierQueryEvent> verify(SourceQuery sourceQuery, boolean explain, Optional<PrestoAction> mockPrestoAction)
+    {
+        VerificationContext verificationContext = VerificationContext.create(NAME, SUITE);
+        VerifierConfig verifierConfig = new VerifierConfig().setTestId(TEST_ID).setExplain(explain);
+        RetryConfig retryConfig = new RetryConfig();
+        QueryActionsConfig queryActionsConfig = new QueryActionsConfig();
+        TypeManager typeManager = createTypeManager();
+        PrestoAction prestoAction = mockPrestoAction.orElseGet(() -> new JdbcPrestoAction(
+                exceptionClassifier,
+                sourceQuery.getControlConfiguration(),
+                verificationContext,
+                new PrestoActionConfig()
+                        .setHosts(queryRunner.getServer().getAddress().getHost())
+                        .setJdbcPort(queryRunner.getServer().getAddress().getPort()),
+                queryActionsConfig.getMetadataTimeout(),
+                queryActionsConfig.getChecksumTimeout(),
+                retryConfig,
+                retryConfig,
+                verifierConfig));
+        QueryRewriterFactory queryRewriterFactory = new VerificationQueryRewriterFactory(
+                sqlParser,
+                typeManager,
+                new QueryRewriteConfig().setTablePrefix(CONTROL_TABLE_PREFIX),
+                new QueryRewriteConfig().setTablePrefix(TEST_TABLE_PREFIX));
+
+        VerificationFactory verificationFactory = new VerificationFactory(
+                sqlParser,
+                (source, context) -> new QueryActions(prestoAction, prestoAction, prestoAction),
+                queryRewriterFactory,
+                failureResolverManagerFactory,
+                createChecksumValidator(verifierConfig),
+                exceptionClassifier,
+                verifierConfig,
+                typeManager,
+                determinismAnalyzerConfig);
+        return verificationFactory.get(sourceQuery, Optional.empty()).run().getEvent();
+    }
+}

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestCreateTableVerification.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestCreateTableVerification.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.verifier.framework;
+
+import com.facebook.presto.verifier.event.VerifierQueryEvent;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static com.facebook.presto.verifier.event.VerifierQueryEvent.EventStatus.FAILED;
+import static com.facebook.presto.verifier.event.VerifierQueryEvent.EventStatus.SKIPPED;
+import static com.facebook.presto.verifier.event.VerifierQueryEvent.EventStatus.SUCCEEDED;
+import static com.facebook.presto.verifier.framework.DdlMatchResult.MatchType.CONTROL_NOT_PARSABLE;
+import static com.facebook.presto.verifier.framework.DdlMatchResult.MatchType.MATCH;
+import static com.facebook.presto.verifier.framework.DdlMatchResult.MatchType.MISMATCH;
+import static com.facebook.presto.verifier.framework.DdlMatchResult.MatchType.TEST_NOT_PARSABLE;
+import static org.testng.Assert.assertTrue;
+
+@Test(singleThreaded = true)
+public class TestCreateTableVerification
+        extends AbstractDdlVerificationTest
+{
+    public TestCreateTableVerification()
+            throws Exception
+    {
+    }
+
+    @Test
+    public void testSucceeded()
+    {
+        String query = "CREATE TABLE succeeded (x int, ds varchar) COMMENT 'test table'";
+
+        Optional<VerifierQueryEvent> event = runVerification(query, query);
+        assertTrue(event.isPresent());
+        assertEvent(event.get(), SUCCEEDED, Optional.of(MATCH), false);
+
+        getQueryRunner().execute("CREATE TABLE like_table (x int, ds varchar)");
+        query = "CREATE TABLE succeeded (LIKE like_table INCLUDING PROPERTIES)";
+
+        event = runVerification(query, query);
+        assertTrue(event.isPresent());
+        System.out.println(event.get().getErrorMessage());
+        assertEvent(event.get(), SUCCEEDED, Optional.of(MATCH), false);
+
+        getQueryRunner().execute("DROP TABLE like_table");
+    }
+
+    @Test
+    public void testSucceededExists()
+    {
+        getQueryRunner().execute("CREATE TABLE succeeded_exists (x int, ds varchar)");
+        String query = "CREATE TABLE IF NOT EXISTS succeeded_exists (x int, ds varchar)";
+
+        Optional<VerifierQueryEvent> event = runVerification(query, query);
+        assertTrue(event.isPresent());
+        assertEvent(event.get(), SUCCEEDED, Optional.of(MATCH), false);
+
+        getQueryRunner().execute("DROP TABLE succeeded_exists");
+    }
+
+    @Test
+    public void testControlNotParsable()
+    {
+        String query = "CREATE TABLE control_not_parsable (x int, ds varchar) COMMENT 'test table'";
+        MockPrestoAction prestoAction = new MockPrestoAction(ImmutableMap.of(1, "CREATE TABLE succeeded (x int, ds varchar) 'test table'"));
+
+        Optional<VerifierQueryEvent> event = verify(getSourceQuery(query, query), false, prestoAction);
+        assertTrue(event.isPresent());
+        System.out.println(event.get().getErrorMessage());
+        assertEvent(event.get(), FAILED, Optional.of(CONTROL_NOT_PARSABLE), false);
+    }
+
+    @Test
+    public void testTestNotParsable()
+    {
+        String query = "CREATE TABLE test_not_parsable (x int, ds varchar) COMMENT 'test table'";
+        MockPrestoAction prestoAction = new MockPrestoAction(ImmutableMap.of(2, "CREATE TABLE test_not_parsable (x int, ds varchar) 'test table'"));
+
+        Optional<VerifierQueryEvent> event = verify(getSourceQuery(query, query), false, prestoAction);
+        assertTrue(event.isPresent());
+        assertEvent(event.get(), FAILED, Optional.of(TEST_NOT_PARSABLE), false);
+    }
+
+    @Test
+    public void testMismatched()
+    {
+        String query = "CREATE TABLE mismatched (x int, ds varchar)";
+        MockPrestoAction prestoAction = new MockPrestoAction(ImmutableMap.of(
+                1, "CREATE TABLE mismatched (x int, ds varchar)",
+                2, "CREATE TABLE mismatched (ds varchar)"));
+
+        Optional<VerifierQueryEvent> event = verify(getSourceQuery(query, query), false, prestoAction);
+        assertTrue(event.isPresent());
+        assertEvent(event.get(), FAILED, Optional.of(MISMATCH), false);
+    }
+
+    @Test
+    public void testSkipped()
+    {
+        Optional<VerifierQueryEvent> event = runVerification(
+                "CREATE TABLE failed (LIKE non_existing)",
+                "CREATE TABLE failed (LIKE non_existing)");
+        assertTrue(event.isPresent());
+        assertEvent(event.get(), SKIPPED, Optional.empty(), false);
+    }
+
+    @Test
+    public void testFailed()
+    {
+        Optional<VerifierQueryEvent> event = runVerification(
+                "CREATE TABLE failed (x int, ds varchar)",
+                "CREATE TABLE failed (LIKE non_existing)");
+        assertTrue(event.isPresent());
+        assertEvent(event.get(), FAILED, Optional.empty(), false);
+    }
+}

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestCreateViewVerification.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestCreateViewVerification.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.verifier.framework;
+
+import com.facebook.presto.tpch.TpchPlugin;
+import com.facebook.presto.verifier.event.VerifierQueryEvent;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static com.facebook.presto.verifier.event.VerifierQueryEvent.EventStatus.FAILED;
+import static com.facebook.presto.verifier.event.VerifierQueryEvent.EventStatus.SKIPPED;
+import static com.facebook.presto.verifier.event.VerifierQueryEvent.EventStatus.SUCCEEDED;
+import static com.facebook.presto.verifier.framework.DdlMatchResult.MatchType.CONTROL_NOT_PARSABLE;
+import static com.facebook.presto.verifier.framework.DdlMatchResult.MatchType.MATCH;
+import static com.facebook.presto.verifier.framework.DdlMatchResult.MatchType.MISMATCH;
+import static com.facebook.presto.verifier.framework.DdlMatchResult.MatchType.TEST_NOT_PARSABLE;
+import static org.testng.Assert.assertTrue;
+
+@Test(singleThreaded = true)
+public class TestCreateViewVerification
+        extends AbstractDdlVerificationTest
+{
+    public TestCreateViewVerification()
+            throws Exception
+    {
+        getQueryRunner().installPlugin(new TpchPlugin());
+        getQueryRunner().createCatalog("tpch", "tpch");
+    }
+
+    @Test
+    public void testSucceededNotExists()
+    {
+        String query = "CREATE VIEW succeeded_not_exists AS SELECT * FROM tpch.tiny.nation";
+
+        Optional<VerifierQueryEvent> event = runVerification(query, query);
+        assertTrue(event.isPresent());
+        assertEvent(event.get(), SUCCEEDED, Optional.of(MATCH), false);
+    }
+
+    @Test
+    public void testSucceededExists()
+    {
+        getQueryRunner().execute("CREATE VIEW succeeded_exists SECURITY INVOKER AS SELECT * FROM tpch.tiny.customer");
+        String query = "CREATE OR REPLACE VIEW succeeded_exists SECURITY DEFINER AS SELECT * FROM tpch.tiny.nation";
+
+        Optional<VerifierQueryEvent> event = runVerification(query, query);
+        assertTrue(event.isPresent());
+        assertEvent(event.get(), SUCCEEDED, Optional.of(MATCH), true);
+
+        getQueryRunner().execute("DROP VIEW succeeded_exists");
+    }
+
+    @Test
+    public void testSkippedExists()
+    {
+        getQueryRunner().execute("CREATE VIEW skipped_exists AS SELECT * FROM tpch.tiny.customer");
+        String query = "CREATE VIEW skipped_exists AS SELECT * FROM tpch.tiny.nation";
+
+        Optional<VerifierQueryEvent> event = runVerification(query, query);
+        assertTrue(event.isPresent());
+        assertEvent(event.get(), SKIPPED, Optional.empty(), true);
+
+        getQueryRunner().execute("DROP VIEW skipped_exists");
+    }
+
+    @Test
+    public void testControlNotParsable()
+    {
+        String query = "CREATE VIEW control_not_parsable AS SELECT * FROM tpch.tiny.nation";
+        MockPrestoAction prestoAction = new MockPrestoAction(ImmutableMap.of(3, "CREATE VIEW control_not_parsable SELECT * FROM tpch.tiny.nation"));
+
+        Optional<VerifierQueryEvent> event = verify(getSourceQuery(query, query), false, prestoAction);
+        assertTrue(event.isPresent());
+        assertEvent(event.get(), FAILED, Optional.of(CONTROL_NOT_PARSABLE), false);
+    }
+
+    @Test
+    public void testTestNotParsable()
+    {
+        String query = "CREATE VIEW test_not_parsable AS SELECT * FROM tpch.tiny.nation";
+        MockPrestoAction prestoAction = new MockPrestoAction(ImmutableMap.of(4, "CREATE VIEW test_not_parsable SELECT * FROM tpch.tiny.nation"));
+
+        Optional<VerifierQueryEvent> event = verify(getSourceQuery(query, query), false, prestoAction);
+        assertTrue(event.isPresent());
+        assertEvent(event.get(), FAILED, Optional.of(TEST_NOT_PARSABLE), false);
+    }
+
+    @Test
+    public void testMismatched()
+    {
+        String query = "CREATE VIEW mismatch AS SELECT * FROM tpch.tiny.nation";
+        MockPrestoAction prestoAction = new MockPrestoAction(ImmutableMap.of(
+                3, "CREATE VIEW mismatch AS SELECT * FROM tpch.tiny.nation",
+                4, "CREATE VIEW mismatch SECURITY DEFINER AS SELECT * FROM tpch.tiny.nation"));
+
+        Optional<VerifierQueryEvent> event = verify(getSourceQuery(query, query), false, prestoAction);
+        assertTrue(event.isPresent());
+        assertEvent(event.get(), FAILED, Optional.of(MISMATCH), false);
+    }
+
+    @Test
+    public void testColumnMismatched()
+    {
+        getQueryRunner().execute("CREATE VIEW column_mismatched AS SELECT * FROM tpch.tiny.customer");
+        Optional<VerifierQueryEvent> event = runVerification(
+                "CREATE OR REPLACE VIEW column_mismatched AS SELECT name FROM tpch.tiny.nation",
+                "CREATE OR REPLACE VIEW column_mismatched AS SELECT concat(name, name) name FROM tpch.tiny.nation");
+        assertTrue(event.isPresent());
+        assertEvent(event.get(), FAILED, Optional.of(MISMATCH), true);
+
+        getQueryRunner().execute("DROP VIEW column_mismatched");
+    }
+
+    @Test
+    public void testFailed()
+    {
+        getQueryRunner().execute("CREATE VIEW failed AS SELECT * FROM tpch.tiny.customer");
+        Optional<VerifierQueryEvent> event = runVerification(
+                "CREATE OR REPLACE VIEW failed AS SELECT name FROM tpch.tiny.nation",
+                "CREATE OR REPLACE VIEW failed AS SELECT nonexistent_column FROM tpch.tiny.nation");
+        assertTrue(event.isPresent());
+        assertEvent(event.get(), FAILED, Optional.empty(), true);
+
+        getQueryRunner().execute("DROP VIEW failed");
+    }
+}

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestDataVerification.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestDataVerification.java
@@ -13,35 +13,12 @@
  */
 package com.facebook.presto.verifier.framework;
 
-import com.facebook.presto.common.type.TypeManager;
-import com.facebook.presto.sql.parser.ParsingOptions;
-import com.facebook.presto.sql.parser.SqlParser;
-import com.facebook.presto.sql.parser.SqlParserOptions;
-import com.facebook.presto.tests.StandaloneQueryRunner;
-import com.facebook.presto.verifier.checksum.ChecksumValidator;
 import com.facebook.presto.verifier.event.DeterminismAnalysisRun;
 import com.facebook.presto.verifier.event.QueryInfo;
 import com.facebook.presto.verifier.event.VerifierQueryEvent;
 import com.facebook.presto.verifier.event.VerifierQueryEvent.EventStatus;
-import com.facebook.presto.verifier.prestoaction.JdbcPrestoAction;
-import com.facebook.presto.verifier.prestoaction.PrestoAction;
-import com.facebook.presto.verifier.prestoaction.PrestoActionConfig;
-import com.facebook.presto.verifier.prestoaction.PrestoExceptionClassifier;
-import com.facebook.presto.verifier.prestoaction.QueryActions;
-import com.facebook.presto.verifier.prestoaction.QueryActionsConfig;
-import com.facebook.presto.verifier.resolver.ChecksumExceededTimeLimitFailureResolver;
-import com.facebook.presto.verifier.resolver.ExceededGlobalMemoryLimitFailureResolver;
-import com.facebook.presto.verifier.resolver.ExceededTimeLimitFailureResolver;
-import com.facebook.presto.verifier.resolver.FailureResolverManager;
-import com.facebook.presto.verifier.resolver.VerifierLimitationFailureResolver;
-import com.facebook.presto.verifier.retry.RetryConfig;
-import com.facebook.presto.verifier.rewrite.QueryRewriteConfig;
-import com.facebook.presto.verifier.rewrite.QueryRewriter;
-import com.facebook.presto.verifier.rewrite.VerificationQueryRewriterFactory;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.util.List;
@@ -50,14 +27,8 @@ import java.util.regex.Pattern;
 import java.util.stream.IntStream;
 
 import static com.facebook.presto.SystemSessionProperties.QUERY_MAX_EXECUTION_TIME;
-import static com.facebook.presto.sql.parser.IdentifierSymbol.AT_SIGN;
-import static com.facebook.presto.sql.parser.IdentifierSymbol.COLON;
-import static com.facebook.presto.sql.parser.ParsingOptions.DecimalLiteralTreatment.AS_DOUBLE;
 import static com.facebook.presto.verifier.VerifierTestUtil.CATALOG;
 import static com.facebook.presto.verifier.VerifierTestUtil.SCHEMA;
-import static com.facebook.presto.verifier.VerifierTestUtil.createChecksumValidator;
-import static com.facebook.presto.verifier.VerifierTestUtil.createTypeManager;
-import static com.facebook.presto.verifier.VerifierTestUtil.setupPresto;
 import static com.facebook.presto.verifier.event.VerifierQueryEvent.EventStatus.FAILED;
 import static com.facebook.presto.verifier.event.VerifierQueryEvent.EventStatus.FAILED_RESOLVED;
 import static com.facebook.presto.verifier.event.VerifierQueryEvent.EventStatus.SKIPPED;
@@ -78,83 +49,11 @@ import static org.testng.Assert.assertTrue;
 
 @Test(singleThreaded = true)
 public class TestDataVerification
+        extends AbstractVerificationTest
 {
-    private static final String SUITE = "test-suite";
-    private static final String NAME = "test-query";
-    private static final String TEST_ID = "test-id";
-    private static final QueryConfiguration QUERY_CONFIGURATION = new QueryConfiguration(CATALOG, SCHEMA, Optional.of("user"), Optional.empty(), Optional.empty());
-    private static final ParsingOptions PARSING_OPTIONS = ParsingOptions.builder().setDecimalLiteralTreatment(AS_DOUBLE).build();
-    private static final SqlParser sqlParser = new SqlParser();
-
-    private static StandaloneQueryRunner queryRunner;
-
-    @BeforeClass
-    public void setupClass()
+    public TestDataVerification()
             throws Exception
     {
-        queryRunner = setupPresto();
-    }
-
-    private Optional<VerifierQueryEvent> runVerification(String controlQuery, String testQuery)
-    {
-        return runVerification(controlQuery, testQuery, new DeterminismAnalyzerConfig().setRunTeardown(true));
-    }
-
-    private Optional<VerifierQueryEvent> runVerification(String controlQuery, String testQuery, DeterminismAnalyzerConfig determinismAnalyzerConfig)
-    {
-        SourceQuery sourceQuery = new SourceQuery(SUITE, NAME, controlQuery, testQuery, QUERY_CONFIGURATION, QUERY_CONFIGURATION);
-        return runVerification(sourceQuery, Optional.empty(), determinismAnalyzerConfig);
-    }
-
-    private Optional<VerifierQueryEvent> runVerification(SourceQuery sourceQuery, Optional<PrestoAction> mockPrestoAction, DeterminismAnalyzerConfig determinismAnalyzerConfig)
-    {
-        PrestoExceptionClassifier exceptionClassifier = PrestoExceptionClassifier.defaultBuilder().build();
-        VerificationContext verificationContext = VerificationContext.create(NAME, SUITE);
-        VerifierConfig verifierConfig = new VerifierConfig().setTestId(TEST_ID);
-        RetryConfig retryConfig = new RetryConfig();
-        QueryActionsConfig queryActionsConfig = new QueryActionsConfig();
-        TypeManager typeManager = createTypeManager();
-        PrestoAction prestoAction = mockPrestoAction.orElseGet(() -> {
-            return new JdbcPrestoAction(
-                    exceptionClassifier,
-                    sourceQuery.getControlConfiguration(),
-                    verificationContext,
-                    new PrestoActionConfig()
-                            .setHosts(queryRunner.getServer().getAddress().getHost())
-                            .setJdbcPort(queryRunner.getServer().getAddress().getPort()),
-                    queryActionsConfig.getMetadataTimeout(),
-                    queryActionsConfig.getChecksumTimeout(),
-                    retryConfig,
-                    retryConfig,
-                    verifierConfig);
-        });
-        QueryRewriter queryRewriter = new VerificationQueryRewriterFactory(
-                new SqlParser(new SqlParserOptions().allowIdentifierSymbol(COLON, AT_SIGN)),
-                typeManager,
-                new QueryRewriteConfig().setTablePrefix("tmp_verifier_c"),
-                new QueryRewriteConfig().setTablePrefix("tmp_verifier_t")).create(prestoAction);
-        ChecksumValidator checksumValidator = createChecksumValidator(verifierConfig);
-        return new DataVerification(
-                new QueryActions(prestoAction, prestoAction, prestoAction),
-                sourceQuery,
-                queryRewriter,
-                new DeterminismAnalyzer(
-                        sourceQuery,
-                        prestoAction,
-                        queryRewriter,
-                        checksumValidator,
-                        typeManager,
-                        determinismAnalyzerConfig),
-                new FailureResolverManager(ImmutableSet.of(
-                        new ExceededGlobalMemoryLimitFailureResolver(),
-                        new ExceededTimeLimitFailureResolver(),
-                        new ChecksumExceededTimeLimitFailureResolver(),
-                        new VerifierLimitationFailureResolver())),
-                exceptionClassifier,
-                verificationContext,
-                verifierConfig,
-                typeManager,
-                checksumValidator).run().getEvent();
     }
 
     @Test
@@ -164,7 +63,7 @@ public class TestDataVerification
         assertTrue(event.isPresent());
         assertEvent(event.get(), SUCCEEDED, Optional.empty(), Optional.empty(), Optional.empty());
 
-        queryRunner.execute("CREATE TABLE success_test (x double)");
+        getQueryRunner().execute("CREATE TABLE success_test (x double)");
         event = runVerification("INSERT INTO success_test SELECT 1.0", "INSERT INTO success_test SELECT 1.00001");
         assertTrue(event.isPresent());
         assertEvent(event.get(), SUCCEEDED, Optional.empty(), Optional.empty(), Optional.empty());
@@ -218,19 +117,6 @@ public class TestDataVerification
                         "  _col0 \\(double\\) relative error: 9\\.995002498749525E-4\n" +
                         "    control\t\\(sum: 1\\.0, NaN: 0, \\+infinity: 0, -infinity: 0, mean: 1\\.0\\)\n" +
                         "    test\t\\(sum: 1\\.001, NaN: 0, \\+infinity: 0, -infinity: 0, mean: 1\\.001\\)\n"));
-    }
-
-    @Test
-    public void testParsingFailed()
-    {
-        Optional<VerifierQueryEvent> event = runVerification("SELECT", "SELECT 1");
-        assertTrue(event.isPresent());
-        assertEvent(
-                event.get(),
-                SKIPPED,
-                Optional.empty(),
-                Optional.of("VERIFIER_INTERNAL_ERROR"),
-                Optional.of("Test state NOT_RUN, Control state NOT_RUN\\..*"));
     }
 
     @Test
@@ -288,7 +174,7 @@ public class TestDataVerification
         assertDeterminismAnalysisRun(runs.get(0), false);
 
         // Insert
-        queryRunner.execute("CREATE TABLE non_deterministic_test (x double)");
+        getQueryRunner().execute("CREATE TABLE non_deterministic_test (x double)");
         event = runVerification("INSERT INTO non_deterministic_test SELECT rand()", "INSERT INTO non_deterministic_test SELECT 2.0");
         assertTrue(event.isPresent());
         assertEquals(event.get().getSkippedReason(), NON_DETERMINISTIC.name());
@@ -301,9 +187,7 @@ public class TestDataVerification
     @Test
     public void testArrayOfRow()
     {
-        Optional<VerifierQueryEvent> event = runVerification(
-                "SELECT ARRAY[ROW(1, 'a'), ROW(2, null)]", "SELECT ARRAY[ROW(1, 'a'), ROW(2, null)]",
-                new DeterminismAnalyzerConfig().setMaxAnalysisRuns(3));
+        Optional<VerifierQueryEvent> event = runVerification("SELECT ARRAY[ROW(1, 'a'), ROW(2, null)]", "SELECT ARRAY[ROW(1, 'a'), ROW(2, null)]");
         assertTrue(event.isPresent());
         assertEvent(event.get(), SUCCEEDED, Optional.empty(), Optional.empty(), Optional.empty());
 
@@ -323,9 +207,10 @@ public class TestDataVerification
                         "    test\t\\(checksum: b4 3c 7d 02 2b 14 77 12, cardinality_checksum: ad 20 38 f3 85 7c ba 56, cardinality_sum: 2\\)\n"));
 
         List<DeterminismAnalysisRun> runs = event.get().getDeterminismAnalysisDetails().getRuns();
-        assertEquals(runs.size(), 2);
+        assertEquals(runs.size(), 3);
         assertDeterminismAnalysisRun(runs.get(0), false);
         assertDeterminismAnalysisRun(runs.get(1), false);
+        assertDeterminismAnalysisRun(runs.get(2), false);
     }
 
     @Test
@@ -392,7 +277,7 @@ public class TestDataVerification
     public void testChecksumQueryCompilerError()
     {
         List<String> columns = IntStream.range(0, 1000).mapToObj(i -> "c" + i).collect(toImmutableList());
-        queryRunner.execute(format("CREATE TABLE checksum_test (%s)", columns.stream().map(column -> column + " double").collect(joining(","))));
+        getQueryRunner().execute(format("CREATE TABLE checksum_test (%s)", columns.stream().map(column -> column + " double").collect(joining(","))));
 
         String query = format("SELECT %s FROM checksum_test", Joiner.on(",").join(columns));
         Optional<VerifierQueryEvent> event = runVerification(query, query);
@@ -410,7 +295,7 @@ public class TestDataVerification
     {
         QueryConfiguration configuration = new QueryConfiguration(CATALOG, SCHEMA, Optional.of("user"), Optional.empty(), Optional.of(ImmutableMap.of(QUERY_MAX_EXECUTION_TIME, "20m")));
         SourceQuery sourceQuery = new SourceQuery(SUITE, NAME, "SELECT 1.0", "SELECT 1.00001", configuration, configuration);
-        Optional<VerifierQueryEvent> event = runVerification(sourceQuery, Optional.empty(), new DeterminismAnalyzerConfig());
+        Optional<VerifierQueryEvent> event = verify(sourceQuery, false);
         assertTrue(event.isPresent());
         assertEvent(event.get(), SUCCEEDED, Optional.empty(), Optional.empty(), Optional.empty());
     }
@@ -437,7 +322,7 @@ public class TestDataVerification
         }
 
         if (event.getStatus().equals(SUCCEEDED.name())) {
-            QueryType queryType = QueryType.of(sqlParser.createStatement(event.getControlQueryInfo().getOriginalQuery(), PARSING_OPTIONS));
+            QueryType queryType = QueryType.of(getSqlParser().createStatement(event.getControlQueryInfo().getOriginalQuery(), PARSING_OPTIONS));
             assertSuccessQueryInfo(queryType, event.getControlQueryInfo());
             assertSuccessQueryInfo(queryType, event.getTestQueryInfo());
         }

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestExplainVerification.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestExplainVerification.java
@@ -13,25 +13,12 @@
  */
 package com.facebook.presto.verifier.framework;
 
-import com.facebook.presto.sql.parser.SqlParser;
-import com.facebook.presto.tests.StandaloneQueryRunner;
 import com.facebook.presto.verifier.event.VerifierQueryEvent;
 import com.facebook.presto.verifier.event.VerifierQueryEvent.EventStatus;
-import com.facebook.presto.verifier.prestoaction.JdbcPrestoAction;
-import com.facebook.presto.verifier.prestoaction.PrestoAction;
-import com.facebook.presto.verifier.prestoaction.PrestoActionConfig;
-import com.facebook.presto.verifier.prestoaction.PrestoExceptionClassifier;
-import com.facebook.presto.verifier.prestoaction.QueryActions;
-import com.facebook.presto.verifier.prestoaction.QueryActionsConfig;
-import com.facebook.presto.verifier.retry.RetryConfig;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.util.Optional;
 
-import static com.facebook.presto.verifier.VerifierTestUtil.CATALOG;
-import static com.facebook.presto.verifier.VerifierTestUtil.SCHEMA;
-import static com.facebook.presto.verifier.VerifierTestUtil.setupPresto;
 import static com.facebook.presto.verifier.event.VerifierQueryEvent.EventStatus.FAILED;
 import static com.facebook.presto.verifier.event.VerifierQueryEvent.EventStatus.SUCCEEDED;
 import static org.testng.Assert.assertEquals;
@@ -41,26 +28,17 @@ import static org.testng.Assert.assertTrue;
 
 @Test(singleThreaded = true)
 public class TestExplainVerification
+        extends AbstractVerificationTest
 {
-    private static final String SUITE = "test-suite";
-    private static final String NAME = "test-query";
-    private static final String TEST_ID = "test-id";
-    private static final QueryConfiguration QUERY_CONFIGURATION = new QueryConfiguration(CATALOG, SCHEMA, Optional.of("user"), Optional.empty(), Optional.empty());
-    private static final SqlParser sqlParser = new SqlParser();
-
-    private static StandaloneQueryRunner queryRunner;
-
-    @BeforeClass
-    public void setupClass()
+    public TestExplainVerification()
             throws Exception
     {
-        queryRunner = setupPresto();
     }
 
     @Test
     public void testSuccess()
     {
-        Optional<VerifierQueryEvent> event = runVerification("SHOW FUNCTIONS");
+        Optional<VerifierQueryEvent> event = runExplain("SHOW FUNCTIONS", "SHOW FUNCTIONS");
         assertTrue(event.isPresent());
 
         assertEvent(event.get(), SUCCEEDED);
@@ -74,8 +52,8 @@ public class TestExplainVerification
     @Test
     public void testStructureMismatch()
     {
-        queryRunner.execute("CREATE TABLE structure_mismatch (x int, ds varchar)");
-        Optional<VerifierQueryEvent> event = runVerification(
+        getQueryRunner().execute("CREATE TABLE structure_mismatch (x int, ds varchar)");
+        Optional<VerifierQueryEvent> event = runExplain(
                 "SELECT count(*) FROM structure_mismatch",
                 "SELECT count(*) FROM structure_mismatch CROSS JOIN structure_mismatch");
         assertTrue(event.isPresent());
@@ -92,7 +70,7 @@ public class TestExplainVerification
     @Test
     public void testDetailsMismatch()
     {
-        Optional<VerifierQueryEvent> event = runVerification("SELECT 1", "SELECT 2");
+        Optional<VerifierQueryEvent> event = runExplain("SELECT 1", "SELECT 2");
         assertTrue(event.isPresent());
 
         // Explain verification do not fail in case of plan changes.
@@ -107,7 +85,7 @@ public class TestExplainVerification
     @Test
     public void testFailure()
     {
-        Optional<VerifierQueryEvent> event = runVerification("SELECT 1", "SELECT x");
+        Optional<VerifierQueryEvent> event = runExplain("SELECT 1", "SELECT x");
         assertTrue(event.isPresent());
 
         assertEvent(event.get(), FAILED);
@@ -116,40 +94,6 @@ public class TestExplainVerification
         assertEquals(event.get().getTestQueryInfo().getQuery().trim(), "EXPLAIN (FORMAT JSON)\nSELECT x");
         assertNotNull(event.get().getControlQueryInfo().getJsonPlan());
         assertNull(event.get().getTestQueryInfo().getJsonPlan());
-    }
-
-    private Optional<VerifierQueryEvent> runVerification(String query)
-    {
-        return runVerification(query, query);
-    }
-
-    private Optional<VerifierQueryEvent> runVerification(String controlQuery, String testQuery)
-    {
-        SourceQuery sourceQuery = new SourceQuery(SUITE, NAME, controlQuery, testQuery, QUERY_CONFIGURATION, QUERY_CONFIGURATION);
-        PrestoExceptionClassifier exceptionClassifier = PrestoExceptionClassifier.defaultBuilder().build();
-        VerificationContext verificationContext = VerificationContext.create(NAME, SUITE);
-        VerifierConfig verifierConfig = new VerifierConfig().setTestId(TEST_ID);
-        RetryConfig retryConfig = new RetryConfig();
-        QueryActionsConfig queryActionsConfig = new QueryActionsConfig();
-        PrestoAction prestoAction = new JdbcPrestoAction(
-                exceptionClassifier,
-                sourceQuery.getControlConfiguration(),
-                verificationContext,
-                new PrestoActionConfig()
-                        .setHosts(queryRunner.getServer().getAddress().getHost())
-                        .setJdbcPort(queryRunner.getServer().getAddress().getPort()),
-                queryActionsConfig.getMetadataTimeout(),
-                queryActionsConfig.getChecksumTimeout(),
-                retryConfig,
-                retryConfig,
-                verifierConfig);
-        return new ExplainVerification(
-                new QueryActions(prestoAction, prestoAction, prestoAction),
-                sourceQuery,
-                exceptionClassifier,
-                verificationContext,
-                verifierConfig,
-                sqlParser).run().getEvent();
     }
 
     private void assertEvent(

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestVerificationManager.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestVerificationManager.java
@@ -155,7 +155,7 @@ public class TestVerificationManager
         List<SourceQuery> queries = ImmutableList.of(
                 createSourceQuery("q1", "CREATE TABLE t1 (x int)", "CREATE TABLE t1 (x int)"),
                 createSourceQuery("q2", "CREATE TABLE t1 (x int)", "CREATE TABLE t1 (x int)"),
-                createSourceQuery("q3", "CREATE TABLE t1 (x int)", "CREATE TABLE t1 (x int)"),
+                createSourceQuery("q3", "SHOW TABLES", "SHOW TABLES"),
                 createSourceQuery("q4", "SHOW FUNCTIONS", "SHOW FUNCTIONS"),
                 createSourceQuery("q5", "SELECT * FROM t1", "INSERT INTO t2 SELECT * FROM t1"),
                 createSourceQuery("q6", "SELECT * FROM t1", "SELECT FROM t1"));

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/resolver/TestIgnoredFunctionsMismatchResolver.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/resolver/TestIgnoredFunctionsMismatchResolver.java
@@ -18,7 +18,7 @@ import com.facebook.presto.sql.parser.SqlParserOptions;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.verifier.checksum.ColumnMatchResult;
 import com.facebook.presto.verifier.checksum.SimpleColumnChecksum;
-import com.facebook.presto.verifier.framework.DataQueryBundle;
+import com.facebook.presto.verifier.framework.QueryObjectBundle;
 import com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
 
@@ -58,9 +58,9 @@ public class TestIgnoredFunctionsMismatchResolver
         assertNotResolved(createBundle("SELECT count() FROM source"), mismatchedColumn);
     }
 
-    private static DataQueryBundle createBundle(String query)
+    private static QueryObjectBundle createBundle(String query)
     {
-        return new DataQueryBundle(
+        return new QueryObjectBundle(
                 QualifiedName.of("test"),
                 ImmutableList.of(),
                 sqlParser.createStatement(query, PARSING_OPTIONS),

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/resolver/TestTooManyOpenPartitionsFailureResolver.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/resolver/TestTooManyOpenPartitionsFailureResolver.java
@@ -21,9 +21,9 @@ import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.Statement;
 import com.facebook.presto.verifier.TestingResultSetMetaData;
 import com.facebook.presto.verifier.TestingResultSetMetaData.ColumnInfo;
-import com.facebook.presto.verifier.framework.DataQueryBundle;
 import com.facebook.presto.verifier.framework.PrestoQueryException;
 import com.facebook.presto.verifier.framework.QueryException;
+import com.facebook.presto.verifier.framework.QueryObjectBundle;
 import com.facebook.presto.verifier.framework.QueryResult;
 import com.facebook.presto.verifier.framework.QueryStage;
 import com.facebook.presto.verifier.prestoaction.PrestoAction;
@@ -80,7 +80,7 @@ public class TestTooManyOpenPartitionsFailureResolver
 
     private static final String TABLE_NAME = "test";
     private static final int MAX_BUCKETS_PER_WRITER = 100;
-    private static final DataQueryBundle TEST_BUNDLE = new DataQueryBundle(
+    private static final QueryObjectBundle TEST_BUNDLE = new QueryObjectBundle(
             QualifiedName.of(TABLE_NAME),
             ImmutableList.of(),
             new SqlParser(new SqlParserOptions().allowIdentifierSymbol(AT_SIGN, COLON)).createStatement(

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/rewrite/TestQueryRewriter.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/rewrite/TestQueryRewriter.java
@@ -21,9 +21,9 @@ import com.facebook.presto.sql.tree.Query;
 import com.facebook.presto.sql.tree.Statement;
 import com.facebook.presto.tests.StandaloneQueryRunner;
 import com.facebook.presto.verifier.framework.ClusterType;
-import com.facebook.presto.verifier.framework.DataQueryBundle;
 import com.facebook.presto.verifier.framework.QueryBundle;
 import com.facebook.presto.verifier.framework.QueryConfiguration;
+import com.facebook.presto.verifier.framework.QueryObjectBundle;
 import com.facebook.presto.verifier.framework.VerificationContext;
 import com.facebook.presto.verifier.framework.VerifierConfig;
 import com.facebook.presto.verifier.prestoaction.JdbcPrestoAction;
@@ -300,9 +300,9 @@ public class TestQueryRewriter
             List<String> expectedTeardownTemplates)
     {
         for (ClusterType cluster : ClusterType.values()) {
-            DataQueryBundle bundle = queryRewriter.rewriteQuery(query, cluster);
+            QueryObjectBundle bundle = queryRewriter.rewriteQuery(query, cluster);
 
-            String tableName = bundle.getTableName().toString();
+            String tableName = bundle.getObjectName().toString();
             assertTrue(tableName.startsWith(prefix + "_"));
 
             assertStatements(bundle.getSetupQueries(), templateToStatements(expectedSetupTemplates, tableName));
@@ -313,8 +313,8 @@ public class TestQueryRewriter
 
     private static void assertTableName(QueryRewriter queryRewriter, @Language("SQL") String query, String expectedPrefix)
     {
-        DataQueryBundle bundle = queryRewriter.rewriteQuery(query, CONTROL);
-        assertTrue(bundle.getTableName().toString().startsWith(expectedPrefix));
+        QueryObjectBundle bundle = queryRewriter.rewriteQuery(query, CONTROL);
+        assertTrue(bundle.getObjectName().toString().startsWith(expectedPrefix));
     }
 
     private static void assertCreateTableAs(Statement statement, String selectQuery)


### PR DESCRIPTION
## Verify CREATE VIEW
If the specified view already exists, create a temporary view to match
the existing view. Otherwise, do nothing for setup queries. Rewrite the
target view name, and run both control and test queries. Run a SHOW
CREATE VIEW query and the returned CREATE VIEW statement needs to match.

## Verify CREATE TABLE
Rewrite the target table of the CREATE TABLE statement, run both
control and test queries, run SHOW CREATE TABLE query as the check.

```
== RELEASE NOTES ==

Verifier Changes
* Add support to verify ``CREATE VIEW`` and ``CREATE TABLE`` queries.
```
