### PR TITLE
Improve plan comparison for explain verification

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/JsonRenderer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/JsonRenderer.java
@@ -72,6 +72,7 @@ public class JsonRenderer
         private final List<JsonRenderedNode> children;
         private final List<String> remoteSources;
 
+        @JsonCreator
         public JsonRenderedNode(String id, String name, String identifier, String details, List<JsonRenderedNode> children, List<String> remoteSources)
         {
             this.id = requireNonNull(id, "id is null");

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/AbstractVerification.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/AbstractVerification.java
@@ -87,8 +87,7 @@ public abstract class AbstractVerification<B extends QueryBundle, R extends Matc
             SqlExceptionClassifier exceptionClassifier,
             VerificationContext verificationContext,
             Optional<ResultSetConverter<V>> mainQueryResultSetConverter,
-            VerifierConfig verifierConfig,
-            boolean skipControl)
+            VerifierConfig verifierConfig)
     {
         this.queryActions = requireNonNull(queryActions, "queryActions is null");
         this.sourceQuery = requireNonNull(sourceQuery, "sourceQuery is null");
@@ -101,7 +100,7 @@ public abstract class AbstractVerification<B extends QueryBundle, R extends Matc
         this.verificationResubmissionLimit = verifierConfig.getVerificationResubmissionLimit();
         this.setupOnMainClusters = verifierConfig.isSetupOnMainClusters();
         this.teardownOnMainClusters = verifierConfig.isTeardownOnMainClusters();
-        this.skipControl = skipControl;
+        this.skipControl = verifierConfig.isSkipControl();
     }
 
     protected abstract B getQueryRewrite(ClusterType clusterType);

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DataVerification.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DataVerification.java
@@ -58,7 +58,7 @@ public class DataVerification
             TypeManager typeManager,
             ChecksumValidator checksumValidator)
     {
-        super(queryActions, sourceQuery, exceptionClassifier, verificationContext, Optional.empty(), verifierConfig, verifierConfig.isSkipControl());
+        super(queryActions, sourceQuery, exceptionClassifier, verificationContext, Optional.empty(), verifierConfig);
         this.queryRewriter = requireNonNull(queryRewriter, "queryRewriter is null");
         this.determinismAnalyzer = requireNonNull(determinismAnalyzer, "determinismAnalyzer is null");
         this.failureResolverManager = requireNonNull(failureResolverManager, "failureResolverManager is null");

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/ExplainMatchResult.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/ExplainMatchResult.java
@@ -21,7 +21,8 @@ public class ExplainMatchResult
     public enum MatchType
     {
         MATCH,
-        PLAN_CHANGED,
+        STRUCTURE_MISMATCH,
+        DETAILS_MISMATCH,
     }
 
     private final MatchType matchType;

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/ExplainVerification.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/ExplainVerification.java
@@ -52,18 +52,8 @@ public class ExplainVerification
             VerifierConfig verifierConfig,
             SqlParser sqlParser)
     {
-        super(queryActions, sourceQuery, exceptionClassifier, verificationContext, Optional.of(QUERY_PLAN_RESULT_SET_CONVERTER), verifierConfig, shouldSkipControl(verifierConfig, sqlParser, sourceQuery));
+        super(queryActions, sourceQuery, exceptionClassifier, verificationContext, Optional.of(QUERY_PLAN_RESULT_SET_CONVERTER), verifierConfig);
         this.sqlParser = requireNonNull(sqlParser, "sqlParser is null");
-    }
-
-    private static boolean shouldSkipControl(VerifierConfig verifierConfig, SqlParser sqlParser, SourceQuery sourceQuery)
-    {
-        if (verifierConfig.isSkipControl()) {
-            return true;
-        }
-        // Skip control query and plan comparison for non-data-producing queries.
-        QueryType queryType = QueryType.of(sqlParser.createStatement(sourceQuery.getQuery(CONTROL), PARSING_OPTIONS));
-        return queryType != CREATE_TABLE_AS_SELECT && queryType != INSERT && queryType != QUERY;
     }
 
     @Override

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestExplainVerification.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestExplainVerification.java
@@ -60,13 +60,13 @@ public class TestExplainVerification
     @Test
     public void testSuccess()
     {
-        Optional<VerifierQueryEvent> event = runVerification("SELECT 1");
+        Optional<VerifierQueryEvent> event = runVerification("SHOW FUNCTIONS");
         assertTrue(event.isPresent());
 
         assertEvent(event.get(), SUCCEEDED);
         assertEquals(event.get().getMatchType(), "MATCH");
-        assertEquals(event.get().getControlQueryInfo().getQuery(), "EXPLAIN (FORMAT JSON)\nSELECT 1\n\n");
-        assertEquals(event.get().getTestQueryInfo().getQuery(), "EXPLAIN (FORMAT JSON)\nSELECT 1\n\n");
+        assertEquals(event.get().getControlQueryInfo().getQuery().trim(), "EXPLAIN (FORMAT JSON)\nSHOW FUNCTIONS");
+        assertEquals(event.get().getTestQueryInfo().getQuery().trim(), "EXPLAIN (FORMAT JSON)\nSHOW FUNCTIONS");
         assertNotNull(event.get().getControlQueryInfo().getJsonPlan());
         assertNotNull(event.get().getTestQueryInfo().getJsonPlan());
     }
@@ -80,22 +80,9 @@ public class TestExplainVerification
         // Explain verification do not fail in case of plan changes.
         assertEvent(event.get(), SUCCEEDED);
         assertEquals(event.get().getMatchType(), "PLAN_CHANGED");
-        assertEquals(event.get().getControlQueryInfo().getQuery(), "EXPLAIN (FORMAT JSON)\nSELECT 1\n\n");
-        assertEquals(event.get().getTestQueryInfo().getQuery(), "EXPLAIN (FORMAT JSON)\nSELECT 2\n\n");
+        assertEquals(event.get().getControlQueryInfo().getQuery().trim(), "EXPLAIN (FORMAT JSON)\nSELECT 1");
+        assertEquals(event.get().getTestQueryInfo().getQuery().trim(), "EXPLAIN (FORMAT JSON)\nSELECT 2");
         assertNotNull(event.get().getControlQueryInfo().getJsonPlan());
-        assertNotNull(event.get().getTestQueryInfo().getJsonPlan());
-    }
-
-    @Test
-    public void testSkipControl()
-    {
-        Optional<VerifierQueryEvent> event = runVerification("SHOW FUNCTIONS");
-        assertTrue(event.isPresent());
-
-        assertEvent(event.get(), SUCCEEDED);
-        assertNull(event.get().getMatchType());
-        assertNull(event.get().getControlQueryInfo());
-        assertEquals(event.get().getTestQueryInfo().getQuery(), "EXPLAIN (FORMAT JSON)\nSHOW FUNCTIONS");
         assertNotNull(event.get().getTestQueryInfo().getJsonPlan());
     }
 
@@ -107,8 +94,8 @@ public class TestExplainVerification
 
         assertEvent(event.get(), FAILED);
         assertNull(event.get().getMatchType());
-        assertEquals(event.get().getControlQueryInfo().getQuery(), "EXPLAIN (FORMAT JSON)\nSELECT 1\n\n");
-        assertEquals(event.get().getTestQueryInfo().getQuery(), "EXPLAIN (FORMAT JSON)\nSELECT x\n\n");
+        assertEquals(event.get().getControlQueryInfo().getQuery().trim(), "EXPLAIN (FORMAT JSON)\nSELECT 1");
+        assertEquals(event.get().getTestQueryInfo().getQuery().trim(), "EXPLAIN (FORMAT JSON)\nSELECT x");
         assertNotNull(event.get().getControlQueryInfo().getJsonPlan());
         assertNull(event.get().getTestQueryInfo().getJsonPlan());
     }


### PR DESCRIPTION
Plain text comparison for JSON plan is inaccurate. There are too many
factors in two different deployments to cause query plan to not match
exactly.

Replace MatchType PLAN_CHANGED with STRUCTURE_MISMATCH and
DETAILS_MISMATCH.

```
== RELEASE NOTES ==

Verifier Changes
* Improve JSON plan comparison for explain verification. (:pr:`15198`)
```
