### PR TITLE
Improve BenchmarkPageProcessor

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/BenchmarkPageProcessor.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/BenchmarkPageProcessor.java
@@ -40,6 +40,7 @@ import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openjdk.jmh.runner.options.VerboseMode;
+import org.testng.annotations.Test;
 
 import java.util.Iterator;
 import java.util.List;
@@ -82,6 +83,15 @@ public class BenchmarkPageProcessor
         return pageBuilder.build();
     }
 
+    @Test
+    public void verifyHandCoded()
+    {
+        BenchmarkData benchmarkData = new BenchmarkData();
+        benchmarkData.setup();
+        BenchmarkPageProcessor benchmarkPageProcessor = new BenchmarkPageProcessor();
+        benchmarkPageProcessor.handCoded(benchmarkData);
+    }
+
     @Benchmark
     public List<Optional<Page>> compiled(BenchmarkData data)
     {
@@ -91,6 +101,15 @@ public class BenchmarkPageProcessor
                         new DriverYieldSignal(),
                         newSimpleAggregatedMemoryContext().newLocalMemoryContext(PageProcessor.class.getSimpleName()),
                         data.inputPage));
+    }
+
+    @Test
+    public void verifyCompiled()
+    {
+        BenchmarkData benchmarkData = new BenchmarkData();
+        benchmarkData.setup();
+        BenchmarkPageProcessor benchmarkPageProcessor = new BenchmarkPageProcessor();
+        benchmarkPageProcessor.compiled(benchmarkData);
     }
 
     @State(Scope.Thread)
@@ -141,7 +160,6 @@ public class BenchmarkPageProcessor
             }
             return pageBuilder.build();
         }
-
 
         private final RowExpression createFilterExpression(FunctionManager functionManager)
         {

--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/BenchmarkPageProcessor.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/BenchmarkPageProcessor.java
@@ -35,6 +35,7 @@ import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.profile.GCProfiler;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
@@ -274,6 +275,7 @@ public class BenchmarkPageProcessor
         Options options = new OptionsBuilder()
                 .verbosity(VerboseMode.NORMAL)
                 .include(".*" + BenchmarkPageProcessor.class.getSimpleName() + ".*")
+                .addProfiler(GCProfiler.class)
                 .build();
 
         new Runner(options).run();


### PR DESCRIPTION
Previously BenchmarkPageProcessor filters out 100% rows, and this makes
project was not tested at all. This PR adds a new option for the
filter to pass all rows so that projection can be tested. It also moves the creation of data and processors into a new inner class BenchmarkData, which allows for easier future parameter based expansions.
 
```
== NO RELEASE NOTE ==
```
