### PR TITLE
Clamp BackgroundHiveSplitLoader concurrency to usable parallelism

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
@@ -160,6 +160,7 @@ public class BackgroundHiveSplitLoader
         this.pathDomain = requireNonNull(pathDomain, "pathDomain is null");
         this.tableBucketInfo = requireNonNull(tableBucketInfo, "tableBucketInfo is null");
         this.loaderConcurrency = loaderConcurrency;
+        checkArgument(loaderConcurrency > 0, "loaderConcurrency must be > 0, found: %s", loaderConcurrency);
         this.session = requireNonNull(session, "session is null");
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
         this.namenodeStats = requireNonNull(namenodeStats, "namenodeStats is null");

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitManager.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitManager.java
@@ -255,7 +255,7 @@ public class HiveSplitManager
                 namenodeStats,
                 directoryLister,
                 executor,
-                splitLoaderConcurrency,
+                min(splitLoaderConcurrency, partitions.size()), // Avoid over-committing split loader concurrency
                 recursiveDfsWalkerEnabled,
                 splitSchedulingContext.schedulerUsesHostAddresses(),
                 layout.isPartialAggregationsPushedDown());


### PR DESCRIPTION
Comparable to changes contributed in https://github.com/prestosql/presto/pull/5260

Avoids allocation a greater level of concurrency to split loading than can actually be used based on the number of partititions being loaded. The effective usable concurrency in split loading can be significantly lower than the configured split loader concurrency value when the number of partitions scanned is small since each partition will be loaded by at most 1 thread at a time.

This change makes it feasible to configure a much higher concurrency value than before without overcommitting threads to loading tasks that provide no additional actual parallelism.


```
== RELEASE NOTES ==
Hive Changes
* Improve split loading thread utilization by reducing the number of tasks submitted for small scans
```
