### PR TITLE
Collapse nested DEREF expressions into a single one

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/DereferenceCodeGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/DereferenceCodeGenerator.java
@@ -16,18 +16,20 @@ package com.facebook.presto.sql.gen;
 import com.facebook.presto.bytecode.BytecodeBlock;
 import com.facebook.presto.bytecode.BytecodeNode;
 import com.facebook.presto.bytecode.Variable;
-import com.facebook.presto.bytecode.control.IfStatement;
 import com.facebook.presto.bytecode.expression.BytecodeExpression;
 import com.facebook.presto.bytecode.instruction.LabelNode;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.spi.relation.ConstantExpression;
 import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.SpecialFormExpression;
+import com.google.common.collect.ImmutableList;
 
 import java.util.List;
 import java.util.Optional;
 
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.constantInt;
+import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.DEREFERENCE;
 import static com.facebook.presto.sql.gen.SpecialFormBytecodeGenerator.generateWrite;
 import static com.facebook.presto.sql.gen.SqlTypeBytecodeExpression.constantType;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -41,50 +43,67 @@ public class DereferenceCodeGenerator
         checkArgument(arguments.size() == 2);
         CallSiteBinder callSiteBinder = generator.getCallSiteBinder();
 
+        // Collect all nested intermediateDerefs
+        ImmutableList.Builder<RowExpression> nestedDerefernces = ImmutableList.builder();
+        RowExpression nestedObject = arguments.get(0);
+        int leafFieldIndex = ((Number) ((ConstantExpression) arguments.get(1)).getValue()).intValue();
+
+        // Find all the intermediate nestedDerefernces.
+        while (nestedObject instanceof SpecialFormExpression &&
+                ((SpecialFormExpression) nestedObject).getForm() == DEREFERENCE) {
+            nestedDerefernces.add(nestedObject);
+            nestedObject = ((SpecialFormExpression) nestedObject).getArguments().get(0);
+        }
+
+        // Here nestedObject is the inner-most expression (so the toplevel object)
+        // Just generate a loop
         BytecodeBlock block = new BytecodeBlock().comment("DEREFERENCE").setDescription("DEREFERENCE");
-        Variable wasNull = generator.wasNull();
         Variable rowBlock = generator.getScope().createTempVariable(Block.class);
-        int index = ((Number) ((ConstantExpression) arguments.get(1)).getValue()).intValue();
+        Variable wasNull = generator.wasNull();
 
-        // clear the wasNull flag before evaluating the row value
-        block.putVariable(wasNull, false);
-        block.append(generator.generate(arguments.get(0), Optional.empty())).putVariable(rowBlock);
-
-        IfStatement ifRowBlockIsNull = new IfStatement("if row block is null...")
-                .condition(wasNull);
-
-        Class<?> javaType = returnType.getJavaType();
+        // Labels for control-flow
         LabelNode end = new LabelNode("end");
-        ifRowBlockIsNull.ifTrue()
-                .comment("if row block is null, push null to the stack and goto 'end' label (return)")
-                .putVariable(wasNull, true)
-                .pushJavaDefault(javaType)
+        LabelNode returnNull = new LabelNode("returnNull");
+
+        // clear the wasNull flag before evaluating the row value and evaluate the root (innermost) object
+        block.putVariable(wasNull, false)
+                .append(generator.generate(nestedObject, Optional.empty()))
+                .putVariable(rowBlock)
+                .comment("If the object is null return null")
+                .append(wasNull)
+                .ifTrueGoto(returnNull);
+
+        for (RowExpression rowExpression : nestedDerefernces.build().reverse()) {
+            SpecialFormExpression nestedDerefernce = (SpecialFormExpression) rowExpression;
+            int fieldIndex = ((Number) ((ConstantExpression) nestedDerefernce.getArguments().get(1)).getValue()).intValue();
+            block.append(rowBlock)
+                    .push(fieldIndex)
+                    .invokeInterface(Block.class, "isNull", boolean.class, int.class)
+                    .comment("If the deref result is null return null")
+                    .ifTrueGoto(returnNull)
+                    .append(constantType(callSiteBinder, nestedDerefernce.getType()).getValue(rowBlock, constantInt(fieldIndex)))
+                    .putVariable(rowBlock);
+        }
+
+        block.append(rowBlock)
+                .push(((Number) ((ConstantExpression) arguments.get(1)).getValue()).intValue())
+                .invokeInterface(Block.class, "isNull", boolean.class, int.class)
+                .ifTrueGoto(returnNull);
+
+        BytecodeExpression value = constantType(callSiteBinder, returnType).getValue(rowBlock, constantInt(leafFieldIndex));
+        block.append(wasNull)
+                .ifTrueGoto(returnNull)
+                .append(value)
                 .gotoLabel(end);
 
-        block.append(ifRowBlockIsNull);
-
-        IfStatement ifFieldIsNull = new IfStatement("if row field is null...");
-        ifFieldIsNull.condition()
-                .comment("call rowBlock.isNull(index)")
-                .append(rowBlock)
-                .push(index)
-                .invokeInterface(Block.class, "isNull", boolean.class, int.class);
-
-        ifFieldIsNull.ifTrue()
+        // Here one of the enclosing objects is null
+        Class<?> javaType = returnType.getJavaType();
+        block.visitLabel(returnNull)
+                .pushJavaDefault(javaType)
                 .comment("if the field is null, push null to stack")
-                .putVariable(wasNull, true)
-                .pushJavaDefault(javaType);
+                .putVariable(wasNull, true);
 
-        BytecodeExpression value = constantType(callSiteBinder, returnType).getValue(rowBlock, constantInt(index));
-
-        ifFieldIsNull.ifFalse()
-                .comment("otherwise call type.getTYPE(rowBlock, index)")
-                .append(value)
-                .putVariable(wasNull, false);
-
-        block.append(ifFieldIsNull)
-                .visitLabel(end);
-
+        block.visitLabel(end);
         outputBlockVariable.ifPresent(output -> block.append(generateWrite(generator, returnType, output)));
         return block;
     }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -5376,4 +5376,21 @@ public abstract class AbstractTestQueries
                 "SELECT NULL IS DISTINCT FROM R.name FROM nation N LEFT OUTER JOIN region R ON N.regionkey = R.regionkey AND R.regionkey = 2 WHERE N.name='JAPAN'",
                 "SELECT TRUE");
     }
+
+    @Test
+    public void testDereference()
+    {
+        assertQuery(
+                "select cast(row(row(row(random(10), if(random(10) >= 0, 2)), random(10)), random(100)) AS row(x row(y row(a int, b int), c int), d int)).x.y.b",
+                "select 2");
+        assertQuery(
+                "select cast(row(row(row(random(10), if(random(10) < 0, 2)), random(10)), random(100)) AS row(x row(y row(a int, b int), c int), d int)).x.y.b",
+                "select null");
+        assertQuery(
+                "select cast(row(row(null, random(10)), random(100)) AS row(x row(y row(a int, b int), c int), d int)).x.y.b",
+                "select null");
+        assertQuery(
+                "select cast(row(row(null, if(random(100) >= 0, 4)), random(10)) AS row(x row(y row(a int, b int), c int), d int)).x.c",
+                "select 4");
+    }
 }


### PR DESCRIPTION
Currently, for expressions like a.b.c.d - we get multiple nested derefs (one for each '.'). And that results in excessive code generation especially because of the null checks. So the idea is t merge all these intermediated DEREFs into the same code block as the ultimate result of any of these being null is to just return null. This reduced code by 22% in some of the most expensive queries that make heavy use of ROW types.

Test plan - 

AbstractTestQueries has several test cases for this now.

```
== NO RELEASE NOTE ==
```
