### PR TITLE
Report peak task memory in Presto-on-Spark

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/TaskContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TaskContext.java
@@ -559,7 +559,7 @@ public class TaskContext
                 pipelineStats);
     }
 
-    private void updatePeakMemory()
+    public void updatePeakMemory()
     {
         long userMemory = taskMemoryContext.getUserMemory();
         long systemMemory = taskMemoryContext.getSystemMemory();

--- a/presto-main/src/main/java/com/facebook/presto/operator/TaskStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TaskStats.java
@@ -51,6 +51,8 @@ public class TaskStats
     private final long userMemoryReservationInBytes;
     private final long revocableMemoryReservationInBytes;
     private final long systemMemoryReservationInBytes;
+
+    private final long peakUserMemoryInBytes;
     private final long peakTotalMemoryInBytes;
 
     private final long totalScheduledTimeInNanos;
@@ -79,7 +81,8 @@ public class TaskStats
 
     public TaskStats(DateTime createTime, DateTime endTime)
     {
-        this(createTime,
+        this(
+                createTime,
                 null,
                 null,
                 null,
@@ -97,7 +100,8 @@ public class TaskStats
                 0L,
                 0L,
                 0L,
-                0,
+                0L,
+                0L,
                 0L,
                 0L,
                 0L,
@@ -138,7 +142,9 @@ public class TaskStats
             @JsonProperty("userMemoryReservation") long userMemoryReservationInBytes,
             @JsonProperty("revocableMemoryReservationInBytes") long revocableMemoryReservationInBytes,
             @JsonProperty("systemMemoryReservationInBytes") long systemMemoryReservationInBytes,
+
             @JsonProperty("peakTotalMemoryInBytes") long peakTotalMemoryInBytes,
+            @JsonProperty("peakUserMemoryInBytes") long peakUserMemoryInBytes,
 
             @JsonProperty("totalScheduledTimeInNanos") long totalScheduledTimeInNanos,
             @JsonProperty("totalCpuTimeInNanos") long totalCpuTimeInNanos,
@@ -194,7 +200,9 @@ public class TaskStats
         this.userMemoryReservationInBytes = userMemoryReservationInBytes;
         this.revocableMemoryReservationInBytes = revocableMemoryReservationInBytes;
         this.systemMemoryReservationInBytes = systemMemoryReservationInBytes;
+
         this.peakTotalMemoryInBytes = peakTotalMemoryInBytes;
+        this.peakUserMemoryInBytes = peakUserMemoryInBytes;
 
         this.totalScheduledTimeInNanos = totalScheduledTimeInNanos;
         this.totalCpuTimeInNanos = totalCpuTimeInNanos;
@@ -323,6 +331,12 @@ public class TaskStats
     public long getSystemMemoryReservationInBytes()
     {
         return systemMemoryReservationInBytes;
+    }
+
+    @JsonProperty
+    public long getPeakUserMemoryInBytes()
+    {
+        return peakUserMemoryInBytes;
     }
 
     @JsonProperty
@@ -461,6 +475,7 @@ public class TaskStats
                 revocableMemoryReservationInBytes,
                 systemMemoryReservationInBytes,
                 peakTotalMemoryInBytes,
+                peakUserMemoryInBytes,
                 totalScheduledTimeInNanos,
                 totalCpuTimeInNanos,
                 totalBlockedTimeInNanos,
@@ -501,6 +516,7 @@ public class TaskStats
                 revocableMemoryReservationInBytes,
                 systemMemoryReservationInBytes,
                 peakTotalMemoryInBytes,
+                peakUserMemoryInBytes,
                 totalScheduledTimeInNanos,
                 totalCpuTimeInNanos,
                 totalBlockedTimeInNanos,

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestTaskStats.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestTaskStats.java
@@ -47,6 +47,7 @@ public class TestTaskStats
             13,
             14,
             26,
+            27,
             15,
             16,
             18,

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
@@ -456,7 +456,7 @@ public class PrestoSparkQueryExecutionFactory
                 // there's no way to know how many tasks were running in parallel in Spark
                 // for now let's assume that all the tasks were running in parallel
                 peakRunningTasks++;
-                long taskPeakUserMemoryInBytes = taskInfo.getStats().getUserMemoryReservationInBytes();
+                long taskPeakUserMemoryInBytes = taskInfo.getStats().getPeakUserMemoryInBytes();
                 long taskPeakTotalMemoryInBytes = taskInfo.getStats().getPeakTotalMemoryInBytes();
                 peakUserMemoryReservationInBytes += taskPeakUserMemoryInBytes;
                 peakTotalMemoryReservationInBytes += taskPeakTotalMemoryInBytes;

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkTaskExecution.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkTaskExecution.java
@@ -138,6 +138,8 @@ public class PrestoSparkTaskExecution
                 "Fragment is partitioned, but not all partitioned drivers were found");
 
         taskHandle = createTaskHandle(taskStateMachine, taskContext, localExecutionPlan, taskExecutor);
+
+        // TODO: periodically call taskContext::updatePeakMemory
     }
 
     // this is a separate method to ensure that the `this` reference is not leaked during construction

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkTaskExecution.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkTaskExecution.java
@@ -51,6 +51,7 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -63,6 +64,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**
  * The PrestoSparkTaskExecution is a simplified version of SqlTaskExecution.
@@ -102,7 +104,8 @@ public class PrestoSparkTaskExecution
             LocalExecutionPlan localExecutionPlan,
             TaskExecutor taskExecutor,
             SplitMonitor splitMonitor,
-            Executor notificationExecutor)
+            Executor notificationExecutor,
+            ScheduledExecutorService memoryUpdateExecutor)
     {
         this.taskStateMachine = requireNonNull(taskStateMachine, "taskStateMachine is null");
         this.taskId = taskStateMachine.getTaskId();
@@ -139,7 +142,8 @@ public class PrestoSparkTaskExecution
 
         taskHandle = createTaskHandle(taskStateMachine, taskContext, localExecutionPlan, taskExecutor);
 
-        // TODO: periodically call taskContext::updatePeakMemory
+        requireNonNull(memoryUpdateExecutor, "memoryUpdateExecutor is null");
+        memoryUpdateExecutor.schedule(taskContext::updatePeakMemory, 1, SECONDS);
     }
 
     // this is a separate method to ensure that the `this` reference is not leaked during construction

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkTaskExecutorFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkTaskExecutorFactory.java
@@ -133,6 +133,7 @@ public class PrestoSparkTaskExecutorFactory
 
     private final Executor notificationExecutor;
     private final ScheduledExecutorService yieldExecutor;
+    private final ScheduledExecutorService memoryUpdateExecutor;
 
     private final LocalExecutionPlanner localExecutionPlanner;
     private final PrestoSparkExecutionExceptionFactory executionExceptionFactory;
@@ -164,6 +165,7 @@ public class PrestoSparkTaskExecutorFactory
             JsonCodec<TaskInfo> taskInfoJsonCodec,
             Executor notificationExecutor,
             ScheduledExecutorService yieldExecutor,
+            ScheduledExecutorService memoryUpdateExecutor,
             LocalExecutionPlanner localExecutionPlanner,
             PrestoSparkExecutionExceptionFactory executionExceptionFactory,
             TaskExecutor taskExecutor,
@@ -183,6 +185,7 @@ public class PrestoSparkTaskExecutorFactory
                 taskInfoJsonCodec,
                 notificationExecutor,
                 yieldExecutor,
+                memoryUpdateExecutor,
                 localExecutionPlanner,
                 executionExceptionFactory,
                 taskExecutor,
@@ -208,6 +211,7 @@ public class PrestoSparkTaskExecutorFactory
             JsonCodec<TaskInfo> taskInfoJsonCodec,
             Executor notificationExecutor,
             ScheduledExecutorService yieldExecutor,
+            ScheduledExecutorService memoryUpdateExecutor,
             LocalExecutionPlanner localExecutionPlanner,
             PrestoSparkExecutionExceptionFactory executionExceptionFactory,
             TaskExecutor taskExecutor,
@@ -231,6 +235,7 @@ public class PrestoSparkTaskExecutorFactory
         this.taskInfoJsonCodec = requireNonNull(taskInfoJsonCodec, "taskInfoJsonCodec is null");
         this.notificationExecutor = requireNonNull(notificationExecutor, "notificationExecutor is null");
         this.yieldExecutor = requireNonNull(yieldExecutor, "yieldExecutor is null");
+        this.memoryUpdateExecutor = requireNonNull(memoryUpdateExecutor, "memoryUpdateExecutor is null");
         this.localExecutionPlanner = requireNonNull(localExecutionPlanner, "localExecutionPlanner is null");
         this.executionExceptionFactory = requireNonNull(executionExceptionFactory, "executionExceptionFactory is null");
         this.taskExecutor = requireNonNull(taskExecutor, "taskExecutor is null");
@@ -436,7 +441,8 @@ public class PrestoSparkTaskExecutorFactory
                 localExecutionPlan,
                 taskExecutor,
                 splitMonitor,
-                notificationExecutor);
+                notificationExecutor,
+                memoryUpdateExecutor);
 
         taskExecution.start(taskSources);
 

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/SerializedTaskInfo.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/SerializedTaskInfo.java
@@ -37,6 +37,7 @@ public class SerializedTaskInfo
     }
 
     @Override
+    // Displayed at the Spark web interface
     public String toString()
     {
         return fragmentId + "." + taskId;


### PR DESCRIPTION
    The peak memory stats in TaskContext only get updated when
    TaskContext::getTaskStats(). Presto-on-Spark doesn't pull task stats
    actively so it needs to be updated explicitly.

---------------------

Test plan - Unit test. Also do production query test.

![Screen Shot 2020-09-24 at 10 12 31 PM](https://user-images.githubusercontent.com/799346/94228972-0eda2580-feb3-11ea-98f3-9e1afe63c3b8.png)

Note in the Presto-on-Spark context, "peak total memory" really mean "sum of peak task memory" 



```
== NO RELEASE NOTE ==
```
