### PR TITLE
Improve nested loop operator performance

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/Page.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/Page.java
@@ -33,6 +33,7 @@ import static java.util.Objects.requireNonNull;
 public final class Page
 {
     public static final int INSTANCE_SIZE = ClassLayout.parseClass(Page.class).instanceSize();
+    private static final Block[] EMPTY_BLOCKS = new Block[0];
 
     /**
      * Visible to give trusted classes like {@link PageBuilder} access to a constructor that doesn't
@@ -52,6 +53,11 @@ public final class Page
     public Page(Block... blocks)
     {
         this(true, determinePositionCount(blocks), blocks);
+    }
+
+    public Page(int positionCount)
+    {
+        this(false, positionCount, EMPTY_BLOCKS);
     }
 
     public Page(int positionCount, Block... blocks)

--- a/presto-main/src/main/java/com/facebook/presto/operator/NestedLoopJoinPagesBuilder.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/NestedLoopJoinPagesBuilder.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.operator;
 
 import com.facebook.presto.common.Page;
+import com.facebook.presto.operator.project.PageProcessor;
 import com.google.common.collect.ImmutableList;
 import io.airlift.units.DataSize;
 
@@ -23,11 +24,14 @@ import java.util.List;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkState;
 import static io.airlift.units.DataSize.Unit.BYTE;
+import static java.lang.Math.addExact;
+import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class NestedLoopJoinPagesBuilder
 {
     private final OperatorContext operatorContext;
+    private int emptyChannelPositionCounter;
     private List<Page> pages;
     private boolean finished;
 
@@ -41,15 +45,35 @@ public class NestedLoopJoinPagesBuilder
 
     public void addPage(Page page)
     {
-        checkState(!finished, "NestedLoopJoinPagesBuilder is finished");
+        checkNotFinished();
 
         // ignore empty pages
         if (page.getPositionCount() == 0) {
             return;
         }
 
+        // Fast path for empty output channels
+        if (page.getChannelCount() == 0) {
+            updatePagePositionCounter(page.getPositionCount());
+            return;
+        }
+
         pages.add(page);
         estimatedSize += page.getRetainedSizeInBytes();
+    }
+
+    private void updatePagePositionCounter(int positions)
+    {
+        // Overflow should not be possible here since both arguments start as ints
+        long nextPositionCount = addExact(this.emptyChannelPositionCounter, (long) positions);
+        while (nextPositionCount >= PageProcessor.MAX_BATCH_SIZE) {
+            nextPositionCount -= PageProcessor.MAX_BATCH_SIZE;
+            Page flushed = new Page(PageProcessor.MAX_BATCH_SIZE);
+            pages.add(flushed);
+            estimatedSize += flushed.getRetainedSizeInBytes();
+        }
+        // Overflow should not occur since MAX_BATCH_SIZE is itself a positive integer
+        this.emptyChannelPositionCounter = toIntExact(nextPositionCount);
     }
 
     public DataSize getEstimatedSize()
@@ -59,7 +83,7 @@ public class NestedLoopJoinPagesBuilder
 
     public void compact()
     {
-        checkState(!finished, "NestedLoopJoinPagesBuilder is finished");
+        checkNotFinished();
         long estimatedSize = 0L;
         for (Page page : pages) {
             page.compact();
@@ -70,11 +94,24 @@ public class NestedLoopJoinPagesBuilder
 
     public NestedLoopJoinPages build()
     {
-        checkState(!finished, "NestedLoopJoinPagesBuilder is already finished");
+        checkNotFinished();
+
+        // Flush the position counter if we're in empty channels mode
+        if (emptyChannelPositionCounter > 0) {
+            Page output = new Page(emptyChannelPositionCounter);
+            pages.add(output);
+            estimatedSize += output.getRetainedSizeInBytes();
+            this.emptyChannelPositionCounter = 0;
+        }
 
         finished = true;
         pages = ImmutableList.copyOf(pages);
         return new NestedLoopJoinPages(pages, getEstimatedSize(), operatorContext);
+    }
+
+    private void checkNotFinished()
+    {
+        checkState(!finished, "NestedLoopJoinPagesBuilder is already finished");
     }
 
     @Override

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestNestedLoopBuildOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestNestedLoopBuildOperator.java
@@ -17,6 +17,7 @@ import com.facebook.presto.common.Page;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.execution.Lifespan;
 import com.facebook.presto.operator.NestedLoopBuildOperator.NestedLoopBuildOperatorFactory;
+import com.facebook.presto.operator.project.PageProcessor;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.testing.TestingTaskContext;
 import com.google.common.collect.ImmutableList;
@@ -127,9 +128,40 @@ public class TestNestedLoopBuildOperator
         assertTrue(nestedLoopJoinBridge.getPagesFuture().isDone());
         List<Page> buildPages = nestedLoopJoinBridge.getPagesFuture().get().getPages();
 
-        assertEquals(buildPages.get(0), buildPage1);
-        assertEquals(buildPages.get(1), buildPage2);
+        assertEquals(buildPages.size(), 1);
+        assertEquals(buildPages.get(0).getPositionCount(), 3003);
+    }
+
+    @Test
+    public void testNestedLoopNoBlocksMaxSizeLimit()
+            throws Exception
+    {
+        TaskContext taskContext = createTaskContext();
+        List<Type> buildTypes = ImmutableList.of();
+        JoinBridgeManager<NestedLoopJoinBridge> nestedLoopJoinBridgeManager = new JoinBridgeManager<>(
+                false,
+                PipelineExecutionStrategy.UNGROUPED_EXECUTION,
+                PipelineExecutionStrategy.UNGROUPED_EXECUTION,
+                lifespan -> new NestedLoopJoinPagesSupplier(),
+                buildTypes);
+        NestedLoopBuildOperatorFactory nestedLoopBuildOperatorFactory = new NestedLoopBuildOperatorFactory(3, new PlanNodeId("test"), nestedLoopJoinBridgeManager);
+        DriverContext driverContext = taskContext.addPipelineContext(0, true, true, false).addDriverContext();
+        NestedLoopBuildOperator nestedLoopBuildOperator = (NestedLoopBuildOperator) nestedLoopBuildOperatorFactory.createOperator(driverContext);
+        NestedLoopJoinBridge nestedLoopJoinBridge = nestedLoopJoinBridgeManager.getJoinBridge(Lifespan.taskWide());
+
+        assertFalse(nestedLoopJoinBridge.getPagesFuture().isDone());
+
+        // build pages
+        Page massivePage = new Page(PageProcessor.MAX_BATCH_SIZE + 100);
+
+        nestedLoopBuildOperator.addInput(massivePage);
+        nestedLoopBuildOperator.finish();
+
+        assertTrue(nestedLoopJoinBridge.getPagesFuture().isDone());
+        List<Page> buildPages = nestedLoopJoinBridge.getPagesFuture().get().getPages();
         assertEquals(buildPages.size(), 2);
+        assertEquals(buildPages.get(0).getPositionCount(), PageProcessor.MAX_BATCH_SIZE);
+        assertEquals(buildPages.get(1).getPositionCount(), 100);
     }
 
     private TaskContext createTaskContext()

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestNestedLoopJoinOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestNestedLoopJoinOperator.java
@@ -18,7 +18,7 @@ import com.facebook.presto.common.Page;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.operator.NestedLoopBuildOperator.NestedLoopBuildOperatorFactory;
 import com.facebook.presto.operator.NestedLoopJoinOperator.NestedLoopJoinOperatorFactory;
-import com.facebook.presto.operator.NestedLoopJoinOperator.NestedLoopPageBuilder;
+import com.facebook.presto.operator.NestedLoopJoinOperator.NestedLoopOutputIterator;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.TestingTaskContext;
@@ -36,6 +36,7 @@ import static com.facebook.presto.RowPagesBuilder.rowPagesBuilder;
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.operator.NestedLoopJoinOperator.createNestedLoopOutputIterator;
 import static com.facebook.presto.operator.OperatorAssertion.assertOperatorEquals;
 import static com.facebook.presto.operator.ValuesOperator.ValuesOperatorFactory;
 import static com.facebook.presto.testing.MaterializedResult.resultBuilder;
@@ -444,7 +445,7 @@ public class TestNestedLoopJoinOperator
         Page buildPage = new Page(100);
         Page probePage = new Page(45);
 
-        NestedLoopPageBuilder resultPageBuilder = new NestedLoopPageBuilder(probePage, buildPage);
+        NestedLoopOutputIterator resultPageBuilder = createNestedLoopOutputIterator(probePage, buildPage);
         assertTrue(resultPageBuilder.hasNext(), "There should be at least one page.");
 
         long result = 0;
@@ -455,7 +456,7 @@ public class TestNestedLoopJoinOperator
 
         // force the product to be bigger than Integer.MAX_VALUE
         buildPage = new Page(Integer.MAX_VALUE - 10);
-        resultPageBuilder = new NestedLoopPageBuilder(probePage, buildPage);
+        resultPageBuilder = createNestedLoopOutputIterator(probePage, buildPage);
 
         result = 0;
         while (resultPageBuilder.hasNext()) {


### PR DESCRIPTION
Adaptation of comparable changes in https://github.com/prestosql/presto/pull/5276

Improvements:
- Modifies `NestedLoopJoinPagesBuilder` to combine empty pages (aka: positionCount only pages) when the build side of the nested loop join is empty
- Handles the case where either probe or build side outputs are empty and position counts are fewer by emitting the same page repeatedly, avoiding unnecessary per-iteration allocations
- Reduces the amount of block array copies made in the standard case by reusing a block buffer to build each page and letting the Page constructor clone it (ie: 1/2 as many allocations)
- Nullifies the output iterator as well as the probe page when finished iterating through it to make the referenced pages elligible for GC. Also nullifies more fields when the operator is closed for the same reason.
- Adds a constructor `Page(int positionCount)` that avoids per-invocation empty varargs array creation and copies.

```
== RELEASE NOTES ==

General Changes
* Improve performance of NestedLoopJoinOperator
```

