### PR TITLE
Adding approxMostFrequent aggregate from prestoSQL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1778,6 +1778,12 @@
                 <version>2.0.2-6</version>
                 <scope>provided</scope>
             </dependency>
+
+            <dependency>
+                <groupId>com.clearspring.analytics</groupId>
+                <artifactId>stream</artifactId>
+                <version>2.9.5</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/presto-docs/src/main/sphinx/functions/aggregate.rst
+++ b/presto-docs/src/main/sphinx/functions/aggregate.rst
@@ -732,6 +732,25 @@ where :math:`f(x)` is the partial density function of :math:`x`.
         consider using the version taking ``(bucket_count, x, weight, "fixed_histogram_mle", min, max)``,
         as this will reduce memory and running time.
 
+.. function:: approx_most_frequent(buckets, value, capacity) -> map<[same as value], bigint>
+
+    Computes the top frequent values up to ``buckets`` elements approximately.
+    Approximate estimation of the function enables us to pick up the frequent
+    values with less memory. Larger ``capacity`` improves the accuracy of
+    underlying algorithm with sacrificing the memory capacity. The returned
+    value is a map containing the top elements with corresponding estimated
+    frequency.
+
+    The error of the function depends on the permutation of the values and its
+    cardinality. We can set the capacity same as the cardinality of the
+    underlying data to achieve the least error.
+
+    ``buckets`` and ``capacity`` must be ``bigint``. ``value`` can be numeric
+    or string type.
+
+    The function uses the stream summary data structure proposed in the paper
+    `Efficient computation of frequent and top-k elements in data streams <https://www.cse.ust.hk/~raywong/comp5331/References/EfficientComputationOfFrequentAndTop-kElementsInDataStreams.pdf>`_ by A.Metwalley, D.Agrawl and A.Abbadi.
+
 
 ---------------------------
 

--- a/presto-main/pom.xml
+++ b/presto-main/pom.xml
@@ -337,6 +337,17 @@
             <artifactId>lucene-analyzers-common</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>com.clearspring.analytics</groupId>
+            <artifactId>stream</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>it.unimi.dsi</groupId>
+                    <artifactId>fastutil</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
         <!-- for testing -->
         <dependency>
             <groupId>org.testng</groupId>

--- a/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInFunctionNamespaceManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInFunctionNamespaceManager.java
@@ -71,6 +71,8 @@ import com.facebook.presto.operator.aggregation.RealRegressionAggregation;
 import com.facebook.presto.operator.aggregation.RealSumAggregation;
 import com.facebook.presto.operator.aggregation.SumDataSizeForStats;
 import com.facebook.presto.operator.aggregation.VarianceAggregation;
+import com.facebook.presto.operator.aggregation.approxmostfrequent.BigintApproximateMostFrequent;
+import com.facebook.presto.operator.aggregation.approxmostfrequent.VarcharApproximateMostFrequent;
 import com.facebook.presto.operator.aggregation.arrayagg.ArrayAggregationFunction;
 import com.facebook.presto.operator.aggregation.differentialentropy.DifferentialEntropyAggregation;
 import com.facebook.presto.operator.aggregation.histogram.Histogram;
@@ -511,6 +513,8 @@ public class BuiltInFunctionNamespaceManager
                 .aggregates(ClassificationPrecisionAggregation.class)
                 .aggregates(ClassificationRecallAggregation.class)
                 .aggregates(ClassificationThresholdsAggregation.class)
+                .aggregates(VarcharApproximateMostFrequent.class)
+                .aggregates(BigintApproximateMostFrequent.class)
                 .scalar(RepeatFunction.class)
                 .scalars(SequenceFunction.class)
                 .scalars(SessionFunctions.class)

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/approxmostfrequent/ApproximateMostFrequentBucketDeserializer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/approxmostfrequent/ApproximateMostFrequentBucketDeserializer.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.approxmostfrequent;
+
+import io.airlift.slice.SliceInput;
+
+public interface ApproximateMostFrequentBucketDeserializer<K>
+{
+    void deserialize(SliceInput input, ApproximateMostFrequentHistogram<K> histogram);
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/approxmostfrequent/ApproximateMostFrequentBucketSerializer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/approxmostfrequent/ApproximateMostFrequentBucketSerializer.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.approxmostfrequent;
+
+import io.airlift.slice.DynamicSliceOutput;
+
+public interface ApproximateMostFrequentBucketSerializer<K>
+{
+    public void serialize(K key, long count, DynamicSliceOutput output);
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/approxmostfrequent/ApproximateMostFrequentHistogram.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/approxmostfrequent/ApproximateMostFrequentHistogram.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.approxmostfrequent;
+
+import com.clearspring.analytics.stream.Counter;
+import com.clearspring.analytics.stream.StreamSummary;
+import com.clearspring.analytics.util.ListNode2;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.slice.DynamicSliceOutput;
+import io.airlift.slice.Slice;
+import io.airlift.slice.SliceInput;
+import org.openjdk.jol.info.ClassLayout;
+
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.Math.toIntExact;
+import static java.util.Objects.requireNonNull;
+
+/**
+ *  Calculate the histogram approximately for topk elements based on the
+ *  <i>Space-Saving</i> algorithm and the <i>Stream-Summary</i> data structure
+ *  as described in:
+ *  <i>Efficient Computation of Frequent and Top-k Elements in Data Streams</i>
+ *  by Metwally, Agrawal, and Abbadi
+ * @param <K>
+ */
+public class ApproximateMostFrequentHistogram<K>
+{
+    private static final byte FORMAT_TAG = 0;
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(ApproximateMostFrequentHistogram.class).instanceSize();
+
+    private static final int STREAM_SUMMARY_SIZE = ClassLayout.parseClass(StreamSummary.class).instanceSize();
+    private static final int LIST_NODE2_SIZE = ClassLayout.parseClass(ListNode2.class).instanceSize();
+    private static final int COUNTER_SIZE = ClassLayout.parseClass(Counter.class).instanceSize();
+
+    private final StreamSummary<K> streamSummary;
+    private final int maxBuckets;
+    private final int capacity;
+    private final ApproximateMostFrequentBucketSerializer<K> serializer;
+    private final ApproximateMostFrequentBucketDeserializer<K> deserializer;
+
+    /**
+     * @param maxBuckets The maximum number of elements stored in the bucket.
+     * @param capacity The maximum capacity of the stream summary data structure.
+     * @param serializer It serializes a bucket into varbinary slice.
+     * @param deserializer It appends a bucket into the histogram.
+     */
+    public ApproximateMostFrequentHistogram(
+            int maxBuckets,
+            int capacity,
+            ApproximateMostFrequentBucketSerializer<K> serializer,
+            ApproximateMostFrequentBucketDeserializer<K> deserializer)
+    {
+        requireNonNull(serializer, "serializer is null");
+        requireNonNull(deserializer, "deserializer is null");
+        streamSummary = new StreamSummary<>(capacity);
+        this.maxBuckets = maxBuckets;
+        this.capacity = capacity;
+        this.serializer = serializer;
+        this.deserializer = deserializer;
+    }
+
+    public ApproximateMostFrequentHistogram(
+            Slice serialized,
+            ApproximateMostFrequentBucketSerializer<K> serializer,
+            ApproximateMostFrequentBucketDeserializer<K> deserializer)
+    {
+        SliceInput input = serialized.getInput();
+
+        checkArgument(input.readByte() == FORMAT_TAG, "Unsupported format tag");
+
+        this.maxBuckets = input.readInt();
+        this.capacity = input.readInt();
+        int bucketSize = input.readInt();
+        this.streamSummary = new StreamSummary<>(capacity);
+        this.serializer = serializer;
+        this.deserializer = deserializer;
+
+        for (int i = 0; i < bucketSize; i++) {
+            this.deserializer.deserialize(input, this);
+        }
+    }
+
+    public void add(K value)
+    {
+        streamSummary.offer(value);
+    }
+
+    public void add(K value, long incrementCount)
+    {
+        streamSummary.offer(value, toIntExact(incrementCount));
+    }
+
+    public Slice serialize()
+    {
+        List<Counter<K>> counters = streamSummary.topK(maxBuckets);
+        int estimatedSliceSize = Byte.BYTES + // FORMAT_TAG
+                Integer.BYTES + // maxBuckets
+                Integer.BYTES + // capacity
+                Integer.BYTES + // Counters size
+                counters.size() * Long.BYTES * 2; // Bytes allocated for item and count. Although the estimation is not correct for variable length slices, it should work.
+        DynamicSliceOutput output = new DynamicSliceOutput(estimatedSliceSize);
+        output.appendByte(FORMAT_TAG);
+        output.appendInt(maxBuckets);
+        output.appendInt(capacity);
+        output.appendInt(counters.size());
+        // Serialize key and counts.
+        for (Counter<K> counter : counters) {
+            serializer.serialize(counter.getItem(), counter.getCount(), output);
+        }
+
+        return output.slice();
+    }
+
+    public void merge(ApproximateMostFrequentHistogram<K> other)
+    {
+        List<Counter<K>> counters = other.streamSummary.topK(maxBuckets);
+        for (Counter<K> counter : counters) {
+            add(counter.getItem(), counter.getCount());
+        }
+    }
+
+    public void forEachBucket(BucketConsumer<K> consumer)
+    {
+        List<Counter<K>> counters = streamSummary.topK(maxBuckets);
+        for (Counter<K> counter : counters) {
+            consumer.process(counter.getItem(), counter.getCount());
+        }
+    }
+
+    @VisibleForTesting
+    public Map<K, Long> getBuckets()
+    {
+        ImmutableMap.Builder<K, Long> buckets = new ImmutableMap.Builder<>();
+        forEachBucket(buckets::put);
+
+        return buckets.build();
+    }
+
+    public long estimatedInMemorySize()
+    {
+        // imperfect estimate of the size of the underlying StreamSummary. TODO: reimplement StreamSummary with flat structures and proper size accounting
+        return INSTANCE_SIZE +
+                STREAM_SUMMARY_SIZE +
+                streamSummary.size() * (LIST_NODE2_SIZE + COUNTER_SIZE + Long.BYTES); // Long.BYTES as a proxy for the size of K
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/approxmostfrequent/BigintApproximateMostFrequent.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/approxmostfrequent/BigintApproximateMostFrequent.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.approxmostfrequent;
+
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.BigintType;
+import com.facebook.presto.operator.aggregation.state.LongApproximateMostFrequentStateFactory;
+import com.facebook.presto.operator.aggregation.state.LongApproximateMostFrequentStateSerializer;
+import com.facebook.presto.spi.function.AccumulatorState;
+import com.facebook.presto.spi.function.AccumulatorStateMetadata;
+import com.facebook.presto.spi.function.AggregationFunction;
+import com.facebook.presto.spi.function.AggregationState;
+import com.facebook.presto.spi.function.CombineFunction;
+import com.facebook.presto.spi.function.InputFunction;
+import com.facebook.presto.spi.function.OutputFunction;
+import com.facebook.presto.spi.function.SqlType;
+
+import static com.facebook.presto.common.type.StandardTypes.BIGINT;
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static com.facebook.presto.util.Failures.checkCondition;
+import static java.lang.Math.toIntExact;
+
+/**
+ *  <p>
+ *  Aggregation function that approximates the frequency of the top-K elements.
+ *  This function keeps counts for a "frequent" subset of elements and assumes all other elements
+ *  once fewer than the least-frequent "frequent" element.
+ *  </p>
+ *
+ * <p>
+ * The algorithm is based loosely on:
+ * <a href="https://dl.acm.org/doi/10.1007/978-3-540-30570-5_27">Efficient Computation of Frequent and Top-*k* Elements in Data Streams</a>
+ * by Ahmed Metwally, Divyakant Agrawal, and Amr El Abbadi
+ * </p>
+ */
+@AggregationFunction("approx_most_frequent")
+public final class BigintApproximateMostFrequent
+{
+    private BigintApproximateMostFrequent() {}
+
+    @AccumulatorStateMetadata(stateSerializerClass = LongApproximateMostFrequentStateSerializer.class, stateFactoryClass = LongApproximateMostFrequentStateFactory.class)
+    public interface State
+            extends AccumulatorState
+    {
+        ApproximateMostFrequentHistogram<Long> get();
+
+        void set(ApproximateMostFrequentHistogram<Long> value);
+    }
+
+    @InputFunction
+    public static void input(@AggregationState State state, @SqlType(BIGINT) long buckets, @SqlType(BIGINT) long value, @SqlType(BIGINT) long capacity)
+    {
+        ApproximateMostFrequentHistogram<Long> histogram = state.get();
+        if (histogram == null) {
+            checkCondition(buckets >= 2, INVALID_FUNCTION_ARGUMENT, "approx_most_frequent bucket count must be greater than one");
+            histogram = new ApproximateMostFrequentHistogram<Long>(
+                    toIntExact(buckets),
+                    toIntExact(capacity),
+                    LongApproximateMostFrequentStateSerializer::serializeBucket,
+                    LongApproximateMostFrequentStateSerializer::deserializeBucket);
+            state.set(histogram);
+        }
+
+        histogram.add(value);
+    }
+
+    @CombineFunction
+    public static void combine(@AggregationState State state, @AggregationState State otherState)
+    {
+        ApproximateMostFrequentHistogram<Long> otherHistogram = otherState.get();
+
+        ApproximateMostFrequentHistogram<Long> histogram = state.get();
+        if (histogram == null) {
+            state.set(otherHistogram);
+        }
+        else {
+            histogram.merge(otherHistogram);
+        }
+    }
+
+    @OutputFunction("map(bigint,bigint)")
+    public static void output(@AggregationState State state, BlockBuilder out)
+    {
+        if (state.get() == null) {
+            out.appendNull();
+        }
+        else {
+            BlockBuilder entryBuilder = out.beginBlockEntry();
+            state.get().forEachBucket((key, value) -> {
+                BigintType.BIGINT.writeLong(entryBuilder, key);
+                BigintType.BIGINT.writeLong(entryBuilder, value);
+            });
+            out.closeEntry();
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/approxmostfrequent/BucketConsumer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/approxmostfrequent/BucketConsumer.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.approxmostfrequent;
+
+@FunctionalInterface
+public interface BucketConsumer<K>
+{
+    void process(K key, long value);
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/approxmostfrequent/VarcharApproximateMostFrequent.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/approxmostfrequent/VarcharApproximateMostFrequent.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.approxmostfrequent;
+
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.BigintType;
+import com.facebook.presto.common.type.VarcharType;
+import com.facebook.presto.operator.aggregation.state.StringApproximateMostFrequentStateFactory;
+import com.facebook.presto.operator.aggregation.state.StringApproximateMostFrequentStateSerializer;
+import com.facebook.presto.spi.function.AccumulatorState;
+import com.facebook.presto.spi.function.AccumulatorStateMetadata;
+import com.facebook.presto.spi.function.AggregationFunction;
+import com.facebook.presto.spi.function.AggregationState;
+import com.facebook.presto.spi.function.CombineFunction;
+import com.facebook.presto.spi.function.InputFunction;
+import com.facebook.presto.spi.function.OutputFunction;
+import com.facebook.presto.spi.function.SqlType;
+import io.airlift.slice.Slice;
+
+import static com.facebook.presto.common.type.StandardTypes.BIGINT;
+import static com.facebook.presto.common.type.StandardTypes.VARCHAR;
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static com.facebook.presto.util.Failures.checkCondition;
+import static java.lang.Math.toIntExact;
+
+/**
+ *  <p>
+ *  Aggregation function that approximates the frequency of the top-K elements.
+ *  This function keeps counts for a "frequent" subset of elements and assumes all other elements
+ *  once fewer than the least-frequent "frequent" element.
+ *  </p>
+ *
+ * <p>
+ * The algorithm is based loosely on:
+ * <a href="https://dl.acm.org/doi/10.1007/978-3-540-30570-5_27">Efficient Computation of Frequent and Top-*k* Elements in Data Streams</a>
+ * by Ahmed Metwally, Divyakant Agrawal, and Amr El Abbadi
+ * </p>
+ */
+@AggregationFunction("approx_most_frequent")
+public final class VarcharApproximateMostFrequent
+{
+    private VarcharApproximateMostFrequent() {}
+
+    @AccumulatorStateMetadata(stateSerializerClass = StringApproximateMostFrequentStateSerializer.class, stateFactoryClass = StringApproximateMostFrequentStateFactory.class)
+    public interface State
+            extends AccumulatorState
+    {
+        ApproximateMostFrequentHistogram<Slice> get();
+        void set(ApproximateMostFrequentHistogram<Slice> value);
+    }
+
+    @InputFunction
+    public static void input(@AggregationState State state, @SqlType(BIGINT) long buckets, @SqlType(VARCHAR) Slice value, @SqlType(BIGINT) long capacity)
+    {
+        ApproximateMostFrequentHistogram<Slice> histogram = state.get();
+        if (histogram == null) {
+            checkCondition(buckets >= 2, INVALID_FUNCTION_ARGUMENT, "approx_most_frequent bucket count must be greater than one");
+            histogram = new ApproximateMostFrequentHistogram<>(
+                    toIntExact(buckets),
+                    toIntExact(capacity),
+                    StringApproximateMostFrequentStateSerializer::serializeBucket,
+                    StringApproximateMostFrequentStateSerializer::deserializeBucket);
+            state.set(histogram);
+        }
+
+        histogram.add(value);
+    }
+
+    @CombineFunction
+    public static void combine(@AggregationState State state, @AggregationState State otherState)
+    {
+        ApproximateMostFrequentHistogram<Slice> otherHistogram = otherState.get();
+
+        ApproximateMostFrequentHistogram<Slice> histogram = state.get();
+        if (histogram == null) {
+            state.set(otherHistogram);
+        }
+        else {
+            histogram.merge(otherHistogram);
+        }
+    }
+
+    @OutputFunction("map(varchar,bigint)")
+    public static void output(@AggregationState State state, BlockBuilder out)
+    {
+        if (state.get() == null) {
+            out.appendNull();
+        }
+        else {
+            BlockBuilder entryBuilder = out.beginBlockEntry();
+            state.get().forEachBucket((key, value) -> {
+                VarcharType.VARCHAR.writeSlice(entryBuilder, key);
+                BigintType.BIGINT.writeLong(entryBuilder, value);
+            });
+            out.closeEntry();
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/LongApproximateMostFrequentStateFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/LongApproximateMostFrequentStateFactory.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.state;
+
+import com.facebook.presto.array.ObjectBigArray;
+import com.facebook.presto.operator.aggregation.approxmostfrequent.ApproximateMostFrequentHistogram;
+import com.facebook.presto.operator.aggregation.approxmostfrequent.BigintApproximateMostFrequent;
+import com.facebook.presto.spi.function.AccumulatorStateFactory;
+
+public class LongApproximateMostFrequentStateFactory
+        implements AccumulatorStateFactory<BigintApproximateMostFrequent.State>
+{
+    @Override
+    public BigintApproximateMostFrequent.State createSingleState()
+    {
+        return new SingleLongApproximateMostFrequentState();
+    }
+
+    @Override
+    public Class<? extends BigintApproximateMostFrequent.State> getSingleStateClass()
+    {
+        return SingleLongApproximateMostFrequentState.class;
+    }
+
+    @Override
+    public BigintApproximateMostFrequent.State createGroupedState()
+    {
+        return new GroupedLongApproximateMostFrequentState();
+    }
+
+    @Override
+    public Class<? extends BigintApproximateMostFrequent.State> getGroupedStateClass()
+    {
+        return GroupedLongApproximateMostFrequentState.class;
+    }
+
+    public static class SingleLongApproximateMostFrequentState
+            implements BigintApproximateMostFrequent.State
+    {
+        private ApproximateMostFrequentHistogram<Long> histogram;
+        private long size;
+
+        @Override
+        public ApproximateMostFrequentHistogram<Long> get()
+        {
+            return histogram;
+        }
+
+        @Override
+        public void set(ApproximateMostFrequentHistogram<Long> histogram)
+        {
+            this.histogram = histogram;
+            size = histogram.estimatedInMemorySize();
+        }
+
+        @Override
+        public long getEstimatedSize()
+        {
+            return size;
+        }
+    }
+
+    public static class GroupedLongApproximateMostFrequentState
+            extends AbstractGroupedAccumulatorState
+            implements BigintApproximateMostFrequent.State
+    {
+        private final ObjectBigArray<ApproximateMostFrequentHistogram<Long>> histograms = new ObjectBigArray<>();
+        private long size;
+
+        @Override
+        public ApproximateMostFrequentHistogram<Long> get()
+        {
+            return histograms.get(getGroupId());
+        }
+
+        @Override
+        public void set(ApproximateMostFrequentHistogram<Long> histogram)
+        {
+            ApproximateMostFrequentHistogram<Long> previous = get();
+            if (previous != null) {
+                size -= previous.estimatedInMemorySize();
+            }
+
+            histograms.set(getGroupId(), histogram);
+            size += histogram.estimatedInMemorySize();
+        }
+
+        @Override
+        public void ensureCapacity(long size)
+        {
+            histograms.ensureCapacity(size);
+        }
+
+        @Override
+        public long getEstimatedSize()
+        {
+            return size + histograms.sizeOf();
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/LongApproximateMostFrequentStateSerializer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/LongApproximateMostFrequentStateSerializer.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.state;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.operator.aggregation.approxmostfrequent.ApproximateMostFrequentHistogram;
+import com.facebook.presto.operator.aggregation.approxmostfrequent.BigintApproximateMostFrequent;
+import com.facebook.presto.spi.function.AccumulatorStateSerializer;
+import io.airlift.slice.DynamicSliceOutput;
+import io.airlift.slice.SliceInput;
+
+import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
+
+public class LongApproximateMostFrequentStateSerializer
+        implements AccumulatorStateSerializer<BigintApproximateMostFrequent.State>
+{
+    public static void serializeBucket(long key, long count, DynamicSliceOutput output)
+    {
+        output.appendLong(key);
+        output.appendLong(count);
+    }
+
+    public static void deserializeBucket(SliceInput input, ApproximateMostFrequentHistogram<Long> histogram)
+    {
+        long key = input.readLong();
+        long count = input.readLong();
+        histogram.add(key, count);
+    }
+
+    @Override
+    public Type getSerializedType()
+    {
+        return VARBINARY;
+    }
+
+    @Override
+    public void serialize(BigintApproximateMostFrequent.State state, BlockBuilder out)
+    {
+        if (state.get() == null) {
+            out.appendNull();
+        }
+        else {
+            VARBINARY.writeSlice(out, state.get().serialize());
+        }
+    }
+
+    @Override
+    public void deserialize(Block block, int index, BigintApproximateMostFrequent.State state)
+    {
+        state.set(new ApproximateMostFrequentHistogram<Long>(
+                VARBINARY.getSlice(block, index),
+                LongApproximateMostFrequentStateSerializer::serializeBucket,
+                LongApproximateMostFrequentStateSerializer::deserializeBucket));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/StringApproximateMostFrequentStateFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/StringApproximateMostFrequentStateFactory.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.state;
+
+import com.facebook.presto.array.ObjectBigArray;
+import com.facebook.presto.operator.aggregation.approxmostfrequent.ApproximateMostFrequentHistogram;
+import com.facebook.presto.operator.aggregation.approxmostfrequent.VarcharApproximateMostFrequent;
+import com.facebook.presto.spi.function.AccumulatorStateFactory;
+import io.airlift.slice.Slice;
+
+public class StringApproximateMostFrequentStateFactory
+        implements AccumulatorStateFactory<VarcharApproximateMostFrequent.State>
+{
+    @Override
+    public VarcharApproximateMostFrequent.State createSingleState()
+    {
+        return new StringApproximateMostFrequentStateFactory.SingleLongApproximateMostFrequentState();
+    }
+
+    @Override
+    public Class<? extends VarcharApproximateMostFrequent.State> getSingleStateClass()
+    {
+        return StringApproximateMostFrequentStateFactory.SingleLongApproximateMostFrequentState.class;
+    }
+
+    @Override
+    public VarcharApproximateMostFrequent.State createGroupedState()
+    {
+        return new StringApproximateMostFrequentStateFactory.GroupedLongApproximateMostFrequentState();
+    }
+
+    @Override
+    public Class<? extends VarcharApproximateMostFrequent.State> getGroupedStateClass()
+    {
+        return StringApproximateMostFrequentStateFactory.GroupedLongApproximateMostFrequentState.class;
+    }
+
+    public static class SingleLongApproximateMostFrequentState
+            implements VarcharApproximateMostFrequent.State
+    {
+        private ApproximateMostFrequentHistogram<Slice> histogram;
+        private long size;
+
+        @Override
+        public ApproximateMostFrequentHistogram<Slice> get()
+        {
+            return histogram;
+        }
+
+        @Override
+        public void set(ApproximateMostFrequentHistogram<Slice> histogram)
+        {
+            this.histogram = histogram;
+            this.size = histogram.estimatedInMemorySize();
+        }
+
+        @Override
+        public long getEstimatedSize()
+        {
+            return size;
+        }
+    }
+
+    public static class GroupedLongApproximateMostFrequentState
+            extends AbstractGroupedAccumulatorState
+            implements VarcharApproximateMostFrequent.State
+    {
+        private final ObjectBigArray<ApproximateMostFrequentHistogram<Slice>> histograms = new ObjectBigArray<>();
+        private long size;
+
+        @Override
+        public ApproximateMostFrequentHistogram<Slice> get()
+        {
+            return histograms.get(getGroupId());
+        }
+
+        @Override
+        public void set(ApproximateMostFrequentHistogram<Slice> histogram)
+        {
+            ApproximateMostFrequentHistogram<Slice> previous = get();
+            if (previous != null) {
+                size -= previous.estimatedInMemorySize();
+            }
+
+            histograms.set(getGroupId(), histogram);
+            this.size = histogram.estimatedInMemorySize();
+        }
+
+        @Override
+        public void ensureCapacity(long size)
+        {
+            histograms.ensureCapacity(size);
+        }
+
+        @Override
+        public long getEstimatedSize()
+        {
+            return size + histograms.sizeOf();
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/StringApproximateMostFrequentStateSerializer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/StringApproximateMostFrequentStateSerializer.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.state;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.operator.aggregation.approxmostfrequent.ApproximateMostFrequentHistogram;
+import com.facebook.presto.operator.aggregation.approxmostfrequent.VarcharApproximateMostFrequent;
+import com.facebook.presto.spi.function.AccumulatorStateSerializer;
+import io.airlift.slice.DynamicSliceOutput;
+import io.airlift.slice.Slice;
+import io.airlift.slice.SliceInput;
+
+import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
+
+public class StringApproximateMostFrequentStateSerializer
+        implements AccumulatorStateSerializer<VarcharApproximateMostFrequent.State>
+{
+    public static void serializeBucket(Slice key, Long count, DynamicSliceOutput output)
+    {
+        output.appendInt(key.length());
+        output.appendBytes(key);
+        output.appendLong(count);
+    }
+
+    public static void deserializeBucket(SliceInput input, ApproximateMostFrequentHistogram<Slice> histogram)
+    {
+        int keySize = input.readInt();
+        Slice key = input.readSlice(keySize);
+        long count = input.readLong();
+        histogram.add(key, count);
+    }
+
+    @Override
+    public Type getSerializedType()
+    {
+        return VARBINARY;
+    }
+
+    @Override
+    public void serialize(VarcharApproximateMostFrequent.State state, BlockBuilder out)
+    {
+        if (state.get() == null) {
+            out.appendNull();
+        }
+        else {
+            VARBINARY.writeSlice(out, state.get().serialize());
+        }
+    }
+
+    @Override
+    public void deserialize(Block block, int index, VarcharApproximateMostFrequent.State state)
+    {
+        state.set(new ApproximateMostFrequentHistogram<Slice>(
+                VARBINARY.getSlice(block, index),
+                StringApproximateMostFrequentStateSerializer::serializeBucket,
+                StringApproximateMostFrequentStateSerializer::deserializeBucket));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/approxmostfrequent/TestApproximateMostFrequentHistogram.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/approxmostfrequent/TestApproximateMostFrequentHistogram.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.approxmostfrequent;
+
+import com.facebook.presto.operator.aggregation.state.LongApproximateMostFrequentStateSerializer;
+import com.facebook.presto.operator.aggregation.state.StringApproximateMostFrequentStateSerializer;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestApproximateMostFrequentHistogram
+{
+    @Test
+    public void testLongHistogram()
+    {
+        ApproximateMostFrequentHistogram<Long> histogram = new ApproximateMostFrequentHistogram<Long>(3, 15, LongApproximateMostFrequentStateSerializer::serializeBucket, LongApproximateMostFrequentStateSerializer::deserializeBucket);
+
+        histogram.add(1L);
+        histogram.add(1L);
+        histogram.add(2L);
+        histogram.add(3L);
+        histogram.add(4L);
+
+        Map<Long, Long> buckets = histogram.getBuckets();
+
+        assertEquals(buckets.size(), 3);
+        assertEquals(buckets, ImmutableMap.of(1L, 2L, 2L, 1L, 3L, 1L));
+    }
+
+    @Test
+    public void testLongRoundtrip()
+    {
+        ApproximateMostFrequentHistogram<Long> original = new ApproximateMostFrequentHistogram<Long>(3, 15, LongApproximateMostFrequentStateSerializer::serializeBucket, LongApproximateMostFrequentStateSerializer::deserializeBucket);
+
+        original.add(1L);
+        original.add(1L);
+        original.add(2L);
+        original.add(3L);
+        original.add(4L);
+
+        Slice serialized = original.serialize();
+
+        ApproximateMostFrequentHistogram<Long> deserialized = new ApproximateMostFrequentHistogram<Long>(serialized, LongApproximateMostFrequentStateSerializer::serializeBucket, LongApproximateMostFrequentStateSerializer::deserializeBucket);
+
+        assertEquals(deserialized.getBuckets(), original.getBuckets());
+    }
+
+    @Test
+    public void testMerge()
+    {
+        ApproximateMostFrequentHistogram<Long> histogram1 = new ApproximateMostFrequentHistogram<Long>(3, 15, LongApproximateMostFrequentStateSerializer::serializeBucket, LongApproximateMostFrequentStateSerializer::deserializeBucket);
+
+        histogram1.add(1L);
+        histogram1.add(1L);
+        histogram1.add(2L);
+
+        ApproximateMostFrequentHistogram<Long> histogram2 = new ApproximateMostFrequentHistogram<Long>(3, 15, LongApproximateMostFrequentStateSerializer::serializeBucket, LongApproximateMostFrequentStateSerializer::deserializeBucket);
+        histogram2.add(3L);
+        histogram2.add(4L);
+
+        histogram1.merge(histogram2);
+        Map<Long, Long> buckets = histogram1.getBuckets();
+
+        assertEquals(buckets.size(), 3);
+        assertEquals(buckets, ImmutableMap.of(1L, 2L, 2L, 1L, 3L, 1L));
+    }
+
+    @Test
+    public void testStringHistogram()
+    {
+        ApproximateMostFrequentHistogram<Slice> histogram = new ApproximateMostFrequentHistogram<Slice>(3, 15, StringApproximateMostFrequentStateSerializer::serializeBucket, StringApproximateMostFrequentStateSerializer::deserializeBucket);
+
+        histogram.add(Slices.utf8Slice("A"));
+        histogram.add(Slices.utf8Slice("A"));
+        histogram.add(Slices.utf8Slice("B"));
+        histogram.add(Slices.utf8Slice("C"));
+        histogram.add(Slices.utf8Slice("D"));
+
+        Map<Slice, Long> buckets = histogram.getBuckets();
+
+        assertEquals(buckets.size(), 3);
+        assertEquals(buckets, ImmutableMap.of(Slices.utf8Slice("A"), 2L, Slices.utf8Slice("B"), 1L, Slices.utf8Slice("C"), 1L));
+    }
+
+    @Test
+    public void testStringRoundtrip()
+    {
+        ApproximateMostFrequentHistogram<Slice> original = new ApproximateMostFrequentHistogram<Slice>(3, 15, StringApproximateMostFrequentStateSerializer::serializeBucket, StringApproximateMostFrequentStateSerializer::deserializeBucket);
+
+        original.add(Slices.utf8Slice("A"));
+        original.add(Slices.utf8Slice("A"));
+        original.add(Slices.utf8Slice("B"));
+        original.add(Slices.utf8Slice("C"));
+        original.add(Slices.utf8Slice("D"));
+
+        Slice serialized = original.serialize();
+
+        ApproximateMostFrequentHistogram<Slice> deserialized = new ApproximateMostFrequentHistogram<Slice>(serialized, StringApproximateMostFrequentStateSerializer::serializeBucket, StringApproximateMostFrequentStateSerializer::deserializeBucket);
+
+        assertEquals(deserialized.getBuckets(), original.getBuckets());
+    }
+}


### PR DESCRIPTION
Test plan - Added tests in `AbstractTestQueries`

Back-porting `approx_most_frequent` function from prestosql
https://github.com/prestosql/presto/pull/3425
https://github.com/prestosql/presto/pull/4499

```
== RELEASE NOTES ==

General Changes
Back-porting `approx_most_frequent` function from prestosql

```