### PR TITLE
Optimize MetadataQueryOptimizer with filter pushdown enabled

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/ValuesMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/ValuesMatcher.java
@@ -27,12 +27,14 @@ import com.facebook.presto.sql.tree.LongLiteral;
 import com.facebook.presto.sql.tree.StringLiteral;
 import com.facebook.presto.sql.tree.SymbolReference;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import io.airlift.slice.Slice;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import static com.facebook.presto.sql.planner.assertions.MatchResult.NO_MATCH;
 import static com.facebook.presto.sql.planner.assertions.MatchResult.match;
@@ -41,6 +43,7 @@ import static com.facebook.presto.sql.relational.OriginalExpressionUtils.isExpre
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.util.Objects.requireNonNull;
 
 public class ValuesMatcher
@@ -48,7 +51,7 @@ public class ValuesMatcher
 {
     private final Map<String, Integer> outputSymbolAliases;
     private final Optional<Integer> expectedOutputSymbolCount;
-    private final Optional<List<List<Expression>>> expectedRows;
+    private final Optional<Set<List<Expression>>> expectedRows;
 
     public ValuesMatcher(
             Map<String, Integer> outputSymbolAliases,
@@ -57,7 +60,7 @@ public class ValuesMatcher
     {
         this.outputSymbolAliases = ImmutableMap.copyOf(outputSymbolAliases);
         this.expectedOutputSymbolCount = requireNonNull(expectedOutputSymbolCount, "expectedOutputSymbolCount is null");
-        this.expectedRows = requireNonNull(expectedRows, "expectedRows is null");
+        this.expectedRows = requireNonNull(expectedRows, "expectedRows is null").map(ImmutableSet::copyOf);
     }
 
     @Override
@@ -91,12 +94,12 @@ public class ValuesMatcher
                                 return new DoubleLiteral(String.valueOf(expression.getValue()));
                             }
                             if (expression.getType().getJavaType() == Slice.class) {
-                                return new StringLiteral(String.valueOf(expression.getValue()));
+                                return new StringLiteral(((Slice) expression.getValue()).toStringUtf8());
                             }
                             return new GenericLiteral(expression.getType().toString(), String.valueOf(expression.getValue()));
                         })
                         .collect(toImmutableList()))
-                .collect(toImmutableList())))
+                .collect(toImmutableSet())))
                 .orElse(true)) {
             return NO_MATCH;
         }


### PR DESCRIPTION
Test plan - Unit test + verifier run on internal queries

```
== RELEASE NOTES ==

Hive Changes
* Optimize metadata query optimizer so that it does not fetch all partitions from metastore when hive filter pushdown is enabled.
```
