### PR TITLE
Push partial Top N through outer join.

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -84,6 +84,7 @@ import com.facebook.presto.sql.planner.iterative.rule.PushProjectionThroughExcha
 import com.facebook.presto.sql.planner.iterative.rule.PushProjectionThroughUnion;
 import com.facebook.presto.sql.planner.iterative.rule.PushRemoteExchangeThroughAssignUniqueId;
 import com.facebook.presto.sql.planner.iterative.rule.PushTableWriteThroughUnion;
+import com.facebook.presto.sql.planner.iterative.rule.PushTopNThroughOuterJoin;
 import com.facebook.presto.sql.planner.iterative.rule.PushTopNThroughUnion;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveEmptyDelete;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveFullSample;
@@ -501,6 +502,7 @@ public class PlanOptimizers
                 estimatedExchangesCostCalculator,
                 ImmutableSet.of(
                         new CreatePartialTopN(),
+                        new PushTopNThroughOuterJoin(),
                         new PushTopNThroughUnion())));
 
         builder.add(new IterativeOptimizer(

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushTopNThroughOuterJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushTopNThroughOuterJoin.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.matching.Capture;
+import com.facebook.presto.matching.Captures;
+import com.facebook.presto.matching.Pattern;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.TopNNode;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.List;
+
+import static com.facebook.presto.matching.Capture.newCapture;
+import static com.facebook.presto.spi.plan.TopNNode.Step.PARTIAL;
+import static com.facebook.presto.sql.planner.optimizations.QueryCardinalityUtil.isAtMost;
+import static com.facebook.presto.sql.planner.plan.JoinNode.Type.LEFT;
+import static com.facebook.presto.sql.planner.plan.JoinNode.Type.RIGHT;
+import static com.facebook.presto.sql.planner.plan.Patterns.Join.type;
+import static com.facebook.presto.sql.planner.plan.Patterns.TopN.step;
+import static com.facebook.presto.sql.planner.plan.Patterns.join;
+import static com.facebook.presto.sql.planner.plan.Patterns.source;
+import static com.facebook.presto.sql.planner.plan.Patterns.topN;
+
+/**
+ * Pushes a partial top N operation through a left or right outer join onto the preserved input.
+ * The ordering columns of the top N must be rewriteable to refer to only columns of
+ * the preserved input. Note that full outer joins are excluded as they
+ * can inject order affecting null rows into the join result.
+ */
+public class PushTopNThroughOuterJoin
+        implements Rule<TopNNode>
+{
+    private static final Capture<JoinNode> JOIN_CHILD = newCapture();
+
+    private static final Pattern<TopNNode> PATTERN =
+            topN().with(step().equalTo(PARTIAL))
+                    .with(source().matching(
+                            join().capturedAs(JOIN_CHILD).with(type().matching(type -> type == LEFT || type == RIGHT))));
+
+    @Override
+    public Pattern<TopNNode> getPattern()
+    {
+        return PATTERN;
+    }
+
+    @Override
+    public Result apply(TopNNode parent, Captures captures, Context context)
+    {
+        JoinNode joinNode = captures.get(JOIN_CHILD);
+
+        List<VariableReferenceExpression> orderBySymbols = parent.getOrderingScheme().getOrderByVariables();
+
+        PlanNode left = joinNode.getLeft();
+        PlanNode right = joinNode.getRight();
+        JoinNode.Type type = joinNode.getType();
+
+        if ((type == LEFT)
+                && ImmutableSet.copyOf(left.getOutputVariables()).containsAll(orderBySymbols)
+                && !isAtMost(left, context.getLookup(), parent.getCount())) {
+            return Result.ofPlanNode(
+                    joinNode.replaceChildren(ImmutableList.of(
+                            parent.replaceChildren(ImmutableList.of(left)),
+                            right)));
+        }
+
+        if ((type == RIGHT)
+                && ImmutableSet.copyOf(right.getOutputVariables()).containsAll(orderBySymbols)
+                && !isAtMost(right, context.getLookup(), parent.getCount())) {
+            return Result.ofPlanNode(
+                    joinNode.replaceChildren(ImmutableList.of(
+                            left,
+                            parent.replaceChildren(ImmutableList.of(right)))));
+        }
+
+        return Result.empty();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
@@ -299,7 +299,12 @@ public final class PlanMatchPattern
 
     public static PlanMatchPattern topN(long count, List<Ordering> orderBy, PlanMatchPattern source)
     {
-        return node(TopNNode.class, source).with(new TopNMatcher(count, orderBy));
+        return node(TopNNode.class, source).with(new TopNMatcher(count, orderBy, TopNNode.Step.SINGLE));
+    }
+
+    public static PlanMatchPattern topN(long count, List<Ordering> orderBy, TopNNode.Step step, PlanMatchPattern source)
+    {
+        return node(TopNNode.class, source).with(new TopNMatcher(count, orderBy, step));
     }
 
     public static PlanMatchPattern output(PlanMatchPattern source)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/TopNMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/TopNMatcher.java
@@ -18,6 +18,7 @@ import com.facebook.presto.cost.StatsProvider;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.TopNNode;
+import com.facebook.presto.spi.plan.TopNNode.Step;
 import com.facebook.presto.sql.planner.assertions.PlanMatchPattern.Ordering;
 import com.google.common.collect.ImmutableList;
 
@@ -35,11 +36,13 @@ public class TopNMatcher
 {
     private final long count;
     private final List<Ordering> orderBy;
+    private final Step step;
 
-    public TopNMatcher(long count, List<Ordering> orderBy)
+    public TopNMatcher(long count, List<Ordering> orderBy, Step step)
     {
         this.count = count;
         this.orderBy = ImmutableList.copyOf(requireNonNull(orderBy, "orderBy is null"));
+        this.step = requireNonNull(step, "step is null");
     }
 
     @Override

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -245,12 +245,17 @@ public class PlanBuilder
 
     public TopNNode topN(long count, List<VariableReferenceExpression> orderBy, PlanNode source)
     {
+        return topN(count, orderBy, TopNNode.Step.SINGLE, source);
+    }
+
+    public TopNNode topN(long count, List<VariableReferenceExpression> orderBy, TopNNode.Step step, PlanNode source)
+    {
         return new TopNNode(
                 idAllocator.getNextId(),
                 source,
                 count,
                 new OrderingScheme(orderBy.stream().map(variable -> new Ordering(variable, SortOrder.ASC_NULLS_FIRST)).collect(toImmutableList())),
-                TopNNode.Step.SINGLE);
+                step);
     }
 
     public SampleNode sample(double sampleRatio, SampleNode.Type type, PlanNode source)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/TestPushTopNThroughOuterJoin.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/TestPushTopNThroughOuterJoin.java
@@ -1,0 +1,239 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule.test;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.RuleStatsRecorder;
+import com.facebook.presto.sql.planner.iterative.IterativeOptimizer;
+import com.facebook.presto.sql.planner.iterative.rule.PushTopNThroughOuterJoin;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.testing.LocalQueryRunner;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.spi.plan.TopNNode.Step.FINAL;
+import static com.facebook.presto.spi.plan.TopNNode.Step.PARTIAL;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.equiJoinClause;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.join;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.sort;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.topN;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+import static com.facebook.presto.sql.planner.plan.JoinNode.Type.FULL;
+import static com.facebook.presto.sql.planner.plan.JoinNode.Type.LEFT;
+import static com.facebook.presto.sql.planner.plan.JoinNode.Type.RIGHT;
+import static com.facebook.presto.sql.tree.SortItem.NullOrdering.FIRST;
+import static com.facebook.presto.sql.tree.SortItem.Ordering.ASCENDING;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+
+public class TestPushTopNThroughOuterJoin
+        extends BaseRuleTest
+{
+    @Test
+    public void testPushTopNThroughLeftJoin()
+    {
+        tester().assertThat(new PushTopNThroughOuterJoin())
+                .on(p -> {
+                    VariableReferenceExpression leftKey = p.variable("leftKey");
+                    VariableReferenceExpression rightKey = p.variable("rightKey");
+                    return p.topN(
+                            1,
+                            ImmutableList.of(leftKey),
+                            PARTIAL,
+                            p.join(
+                                    LEFT,
+                                    p.values(5, leftKey),
+                                    p.values(5, rightKey),
+                                    new JoinNode.EquiJoinClause(leftKey, rightKey)));
+                })
+                .matches(
+                        join(
+                                LEFT,
+                                ImmutableList.of(equiJoinClause("leftKey", "rightKey")),
+                                topN(1, ImmutableList.of(sort("leftKey", ASCENDING, FIRST)), PARTIAL, values("leftKey")),
+                                values("rightKey")));
+    }
+
+    @Test
+    public void testPushTopNThroughRightJoin()
+    {
+        tester().assertThat(new PushTopNThroughOuterJoin())
+                .on(p -> {
+                    VariableReferenceExpression leftKey = p.variable("leftKey");
+                    VariableReferenceExpression rightKey = p.variable("rightKey");
+                    return p.topN(
+                            1,
+                            ImmutableList.of(rightKey),
+                            PARTIAL,
+                            p.join(
+                                    RIGHT,
+                                    p.values(5, leftKey),
+                                    p.values(5, rightKey),
+                                    new JoinNode.EquiJoinClause(leftKey, rightKey)));
+                })
+                .matches(
+                        join(
+                                RIGHT,
+                                ImmutableList.of(equiJoinClause("leftKey", "rightKey")),
+                                values("leftKey"),
+                                topN(1, ImmutableList.of(sort("rightKey", ASCENDING, FIRST)), PARTIAL, values("rightKey"))));
+    }
+
+    @Test
+    public void testPushTopNThroughLeftDeepJoin()
+    {
+        // TopN (order: Y, source: (( Values(5) as X RJ Values(5) as Y on X=Y) LJ Values(5) as Z ON Y=Z) =>
+        // (( Values(5) as X RJ (TopN (order: Y, source: Values(5) as Y) on X=Y)) LJ Values(5) as Z ON Y=Z)
+        Session.SessionBuilder sessionBuilder = testSessionBuilder()
+                .setCatalog("local")
+                .setSchema("tiny")
+                .setSystemProperty("task_concurrency", "1")
+                .setSystemProperty("iterative_optimizer_enabled", "true")
+                .setSystemProperty("iterative_optimizer_timeout", "1ms");
+        LocalQueryRunner queryRunner = new LocalQueryRunner(sessionBuilder.build());
+
+        IterativeOptimizer optimizer = new IterativeOptimizer(
+                new RuleStatsRecorder(),
+                queryRunner.getStatsCalculator(),
+                queryRunner.getCostCalculator(),
+                ImmutableSet.of(
+                        new PushTopNThroughOuterJoin()));
+
+        tester().assertThat(optimizer)
+                .on(p -> {
+                    VariableReferenceExpression x = p.variable("x");
+                    VariableReferenceExpression y = p.variable("y");
+                    VariableReferenceExpression z = p.variable("z");
+                    return p.topN(
+                            1,
+                            ImmutableList.of(y),
+                            PARTIAL,
+                            p.join(
+                                    LEFT,
+                                    p.join(
+                                            RIGHT,
+                                            p.values(5, x),
+                                            p.values(5, y),
+                                            new JoinNode.EquiJoinClause(x, y)
+                                    ), p.values(5, z),
+                                    new JoinNode.EquiJoinClause(y, z)));
+                }).matches(
+                join(LEFT,
+                        ImmutableList.of(equiJoinClause("y", "z")),
+                        join(
+                                RIGHT,
+                                ImmutableList.of(equiJoinClause("x", "y")),
+                                values("x"),
+                                topN(1,
+                                        ImmutableList.of(sort("y", ASCENDING, FIRST)), PARTIAL, values("y"))
+                        ), values("z")));
+    }
+
+    @Test
+    public void testFullJoin()
+    {
+        tester().assertThat(new PushTopNThroughOuterJoin())
+                .on(p -> {
+                    VariableReferenceExpression leftKey = p.variable("leftKey");
+                    VariableReferenceExpression rightKey = p.variable("rightKey");
+                    return p.topN(
+                            1,
+                            ImmutableList.of(rightKey),
+                            PARTIAL,
+                            p.join(
+                                    FULL,
+                                    p.values(5, leftKey),
+                                    p.values(5, rightKey),
+                                    new JoinNode.EquiJoinClause(leftKey, rightKey)));
+                })
+                .doesNotFire();
+
+        tester().assertThat(new PushTopNThroughOuterJoin())
+                .on(p -> {
+                    VariableReferenceExpression leftKey = p.variable("leftKey");
+                    VariableReferenceExpression rightKey = p.variable("rightKey");
+                    return p.topN(
+                            1,
+                            ImmutableList.of(leftKey),
+                            PARTIAL,
+                            p.join(
+                                    FULL,
+                                    p.values(5, leftKey),
+                                    p.values(5, rightKey),
+                                    new JoinNode.EquiJoinClause(leftKey, rightKey)));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testDoNotPushTopNWhenSymbolsFromBothSources()
+    {
+        tester().assertThat(new PushTopNThroughOuterJoin())
+                .on(p -> {
+                    VariableReferenceExpression leftKey = p.variable("leftKey");
+                    VariableReferenceExpression rightKey = p.variable("rightKey");
+                    return p.topN(
+                            1,
+                            ImmutableList.of(leftKey, rightKey),
+                            PARTIAL,
+                            p.join(
+                                    FULL,
+                                    p.values(5, leftKey),
+                                    p.values(5, rightKey),
+                                    new JoinNode.EquiJoinClause(leftKey, rightKey)));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testDoNotPushWhenAlreadyLimited()
+    {
+        tester().assertThat(new PushTopNThroughOuterJoin())
+                .on(p -> {
+                    VariableReferenceExpression leftKey = p.variable("leftKey");
+                    VariableReferenceExpression rightKey = p.variable("rightKey");
+                    return p.topN(
+                            1,
+                            ImmutableList.of(leftKey),
+                            PARTIAL,
+                            p.join(
+                                    LEFT,
+                                    p.limit(1, p.values(5, leftKey)),
+                                    p.values(5, rightKey),
+                                    new JoinNode.EquiJoinClause(leftKey, rightKey)));
+                })
+                .doesNotFire();
+    }
+
+    @Test
+    public void testDoNotPushWhenStepNotPartial()
+    {
+        tester().assertThat(new PushTopNThroughOuterJoin())
+                .on(p -> {
+                    VariableReferenceExpression leftKey = p.variable("leftKey");
+                    VariableReferenceExpression rightKey = p.variable("rightKey");
+                    return p.topN(
+                            1,
+                            ImmutableList.of(leftKey),
+                            FINAL,
+                            p.join(
+                                    FULL,
+                                    p.values(5, leftKey),
+                                    p.values(5, rightKey),
+                                    new JoinNode.EquiJoinClause(leftKey, rightKey)));
+                })
+                .doesNotFire();
+    }
+}


### PR DESCRIPTION
Pushes a partial Top N operation through a left or right outer join onto the preserved input. The ordering columns of the top N must be rewriteable to refer to only columns of the preserved input. Note that full outer joins are excluded as they can inject order affecting null rows into the join result.

Test plan - New tests that verify plan correctness were added to TestPushTopNThroughOuterJoin.java and TestLogicalPlanner.java. 

== NO RELEASE NOTE ==

