### PR TITLE
Make generating the embedded plan JSON representation configurable

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -169,6 +169,7 @@ public final class SystemSessionProperties
     public static final String DYNAMIC_FILTERING_MAX_PER_DRIVER_SIZE = "dynamic_filtering_max_per_driver_size";
     public static final String LEGACY_TYPE_COERCION_WARNING_ENABLED = "legacy_type_coercion_warning_enabled";
     public static final String INLINE_SQL_FUNCTIONS = "inline_sql_functions";
+    public static final String EMBEDDED_JSON_PLAN_REPRESENTATION_ENABLED = "embedded_json_plan_representation_enabled";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -881,6 +882,11 @@ public final class SystemSessionProperties
                         INLINE_SQL_FUNCTIONS,
                         "Inline SQL function definition at plan time",
                         featuresConfig.isInlineSqlFunctions(),
+                        false),
+                booleanProperty(
+                        EMBEDDED_JSON_PLAN_REPRESENTATION_ENABLED,
+                        "Enable creating embedded JSON plan representations for the consumption by the Web UI",
+                        featuresConfig.isEmbeddedJsonPlanRepresentationEnabled(),
                         false));
     }
 
@@ -1491,5 +1497,10 @@ public final class SystemSessionProperties
     public static boolean isInlineSqlFunctions(Session session)
     {
         return session.getSystemProperty(INLINE_SQL_FUNCTIONS, Boolean.class);
+    }
+
+    public static boolean isEmbeddedJsonPlanRepresentationEnabled(Session session)
+    {
+        return session.getSystemProperty(EMBEDDED_JSON_PLAN_REPRESENTATION_ENABLED, Boolean.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/LegacySqlQueryScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/LegacySqlQueryScheduler.java
@@ -72,6 +72,7 @@ import static com.facebook.airlift.concurrent.MoreFutures.tryGetFutureValue;
 import static com.facebook.airlift.concurrent.MoreFutures.whenAnyComplete;
 import static com.facebook.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
 import static com.facebook.presto.SystemSessionProperties.getMaxConcurrentMaterializations;
+import static com.facebook.presto.SystemSessionProperties.isEmbeddedJsonPlanRepresentationEnabled;
 import static com.facebook.presto.SystemSessionProperties.isRuntimeOptimizerEnabled;
 import static com.facebook.presto.execution.BasicStageExecutionStats.aggregateBasicStageStats;
 import static com.facebook.presto.execution.StageExecutionState.ABORTED;
@@ -588,6 +589,10 @@ public class LegacySqlQueryScheduler
             newRoot = optimizer.optimize(newRoot, session, variableAllocator.getTypes(), variableAllocator, idAllocator, warningCollector);
         }
         if (newRoot != fragment.getRoot()) {
+            Optional<String> embeddedPlanJson = Optional.empty();
+            if (isEmbeddedJsonPlanRepresentationEnabled(session)) {
+                embeddedPlanJson = Optional.of(jsonFragmentPlan(newRoot, fragment.getVariables(), functionManager, session));
+            }
             return Optional.of(
                     // The partitioningScheme should stay the same
                     // even if the root's outputVariable layout is changed.
@@ -601,7 +606,7 @@ public class LegacySqlQueryScheduler
                             fragment.getStageExecutionDescriptor(),
                             fragment.isOutputTableWriterFragment(),
                             fragment.getStatsAndCosts(),
-                            Optional.of(jsonFragmentPlan(newRoot, fragment.getVariables(), functionManager, session))));
+                            embeddedPlanJson));
         }
         return Optional.empty();
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -162,6 +162,7 @@ public class FeaturesConfig
     private boolean optimizeNullsInJoin;
     private boolean pushdownDereferenceEnabled;
     private boolean inlineSqlFunctions = true;
+    private boolean embeddedJsonPlanRepresentationEnabled = true;
 
     private String warnOnNoTableLayoutFilter = "";
 
@@ -1396,6 +1397,18 @@ public class FeaturesConfig
     public FeaturesConfig setInlineSqlFunctions(boolean inlineSqlFunctions)
     {
         this.inlineSqlFunctions = inlineSqlFunctions;
+        return this;
+    }
+
+    public boolean isEmbeddedJsonPlanRepresentationEnabled()
+    {
+        return embeddedJsonPlanRepresentationEnabled;
+    }
+
+    @Config("embedded-json-plan-representations-enabled")
+    public FeaturesConfig setEmbeddedJsonPlanRepresentationEnabled(boolean embeddedJsonPlanRepresentationEnabled)
+    {
+        this.embeddedJsonPlanRepresentationEnabled = embeddedJsonPlanRepresentationEnabled;
         return this;
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -144,7 +144,8 @@ public class TestFeaturesConfig
                 .setPreferDistributedUnion(true)
                 .setOptimizeNullsInJoin(false)
                 .setWarnOnNoTableLayoutFilter("")
-                .setInlineSqlFunctions(true));
+                .setInlineSqlFunctions(true)
+                .setEmbeddedJsonPlanRepresentationEnabled(true));
     }
 
     @Test
@@ -245,6 +246,7 @@ public class TestFeaturesConfig
                 .put("optimize-nulls-in-join", "true")
                 .put("warn-on-no-table-layout-filter", "ry@nlikestheyankees,ds")
                 .put("inline-sql-functions", "false")
+                .put("embedded-json-plan-representations-enabled", "false")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -341,7 +343,8 @@ public class TestFeaturesConfig
                 .setPreferDistributedUnion(false)
                 .setOptimizeNullsInJoin(true)
                 .setWarnOnNoTableLayoutFilter("ry@nlikestheyankees,ds")
-                .setInlineSqlFunctions(false);
+                .setInlineSqlFunctions(false)
+                .setEmbeddedJsonPlanRepresentationEnabled(false);
         assertFullMapping(properties, expected);
     }
 


### PR DESCRIPTION
For particularly complex queries, the embedded JSON plan representation can be quite large and is only present to help display the query plan within the Web UI. Clients like the JDBC driver may want to avoid the extra overhead placed on the coordinator if they don't use this payload and some deployments may want to default to not generating them at all.

```
== RELEASE NOTES ==

General Changes
* Adds a configuration flag to control whether to generate the embedded plan JSON representation
```
