### PR TITLE
Remove TypeManager.resolveOperator

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/type/LongEnumParametricType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/LongEnumParametricType.java
@@ -17,7 +17,7 @@ import com.facebook.presto.common.type.LongEnumType.LongEnumMap;
 
 import java.util.List;
 
-import static com.facebook.presto.common.type.StatisticalDigestParametricType.checkArgument;
+import static java.lang.String.format;
 
 public final class LongEnumParametricType
         implements ParametricType
@@ -38,7 +38,7 @@ public final class LongEnumParametricType
     }
 
     @Override
-    public Type createType(TypeManager typeManager, List<TypeParameter> parameters)
+    public Type createType(List<TypeParameter> parameters)
     {
         if (parameters.isEmpty()) {
             return new LongEnumType(name, enumMap);
@@ -49,5 +49,12 @@ public final class LongEnumParametricType
                 "Enum definition expected, got %s",
                 parameters);
         return new LongEnumType(name, parameters.get(0).getLongEnumMap());
+    }
+
+    private static void checkArgument(boolean argument, String format, Object... args)
+    {
+        if (!argument) {
+            throw new IllegalArgumentException(format(format, args));
+        }
     }
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/type/ParametricType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/ParametricType.java
@@ -19,5 +19,5 @@ public interface ParametricType
 {
     String getName();
 
-    Type createType(TypeManager typeManager, List<TypeParameter> parameters);
+    Type createType(List<TypeParameter> parameters);
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/type/StatisticalDigestParametricType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/StatisticalDigestParametricType.java
@@ -21,7 +21,7 @@ public abstract class StatisticalDigestParametricType
         implements ParametricType
 {
     @Override
-    public Type createType(TypeManager typeManager, List<TypeParameter> parameters)
+    public Type createType(List<TypeParameter> parameters)
     {
         checkArgument(parameters.size() == 1, "%s type expects exactly one type as a parameter, got %s", this.getName(), parameters);
         checkArgument(

--- a/presto-common/src/main/java/com/facebook/presto/common/type/TypeManager.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TypeManager.java
@@ -13,9 +13,6 @@
  */
 package com.facebook.presto.common.type;
 
-import com.facebook.presto.common.function.OperatorType;
-
-import java.lang.invoke.MethodHandle;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -49,6 +46,4 @@ public interface TypeManager
     boolean isTypeOnlyCoercion(Type actualType, Type expectedType);
 
     Optional<Type> coerceTypeBase(Type sourceType, String resultTypeBase);
-
-    MethodHandle resolveOperator(OperatorType operatorType, List<? extends Type> argumentTypes);
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/type/VarcharEnumParametricType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/VarcharEnumParametricType.java
@@ -17,7 +17,7 @@ import com.facebook.presto.common.type.VarcharEnumType.VarcharEnumMap;
 
 import java.util.List;
 
-import static com.facebook.presto.common.type.StatisticalDigestParametricType.checkArgument;
+import static java.lang.String.format;
 
 public final class VarcharEnumParametricType
         implements ParametricType
@@ -38,7 +38,7 @@ public final class VarcharEnumParametricType
     }
 
     @Override
-    public Type createType(TypeManager typeManager, List<TypeParameter> parameters)
+    public Type createType(List<TypeParameter> parameters)
     {
         if (parameters.isEmpty()) {
             return new VarcharEnumType(name, enumMap);
@@ -49,5 +49,12 @@ public final class VarcharEnumParametricType
                 "Enum definition expected, got %s",
                 parameters);
         return new VarcharEnumType(name, parameters.get(0).getVarcharEnumMap());
+    }
+
+    private static void checkArgument(boolean argument, String format, Object... args)
+    {
+        if (!argument) {
+            throw new IllegalArgumentException(format(format, args));
+        }
     }
 }

--- a/presto-common/src/test/java/com/facebook/presto/common/type/TestingTypeManager.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/type/TestingTypeManager.java
@@ -13,10 +13,8 @@
  */
 package com.facebook.presto.common.type;
 
-import com.facebook.presto.common.function.OperatorType;
 import com.google.common.collect.ImmutableList;
 
-import java.lang.invoke.MethodHandle;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -83,12 +81,6 @@ public class TestingTypeManager
 
     @Override
     public Optional<Type> coerceTypeBase(Type sourceType, String resultTypeBase)
-    {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public MethodHandle resolveOperator(OperatorType operatorType, List<? extends Type> argumentTypes)
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-main/src/main/java/com/facebook/presto/testing/TestingEnvironment.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/TestingEnvironment.java
@@ -14,19 +14,26 @@
 package com.facebook.presto.testing;
 
 import com.facebook.presto.block.BlockEncodingManager;
+import com.facebook.presto.common.function.OperatorType;
+import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.metadata.FunctionManager;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.type.TypeRegistry;
+
+import java.lang.invoke.MethodHandle;
+
+import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
 
 public class TestingEnvironment
 {
     private TestingEnvironment() {}
 
     public static final TypeManager TYPE_MANAGER = new TypeRegistry();
+    public static final FunctionManager FUNCTION_MANAGER = new FunctionManager(TYPE_MANAGER, new BlockEncodingManager(), new FeaturesConfig());
 
-    static {
-        // wire TYPE_MANAGER with function manager
-        new FunctionManager(TYPE_MANAGER, new BlockEncodingManager(), new FeaturesConfig());
+    public static MethodHandle getOperatorMethodHandle(OperatorType operatorType, Type... parameterTypes)
+    {
+        return FUNCTION_MANAGER.getBuiltInScalarFunctionImplementation(FUNCTION_MANAGER.resolveOperator(operatorType, fromTypes(parameterTypes))).getMethodHandle();
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/type/ArrayParametricType.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/ArrayParametricType.java
@@ -18,7 +18,6 @@ import com.facebook.presto.common.type.ParameterKind;
 import com.facebook.presto.common.type.ParametricType;
 import com.facebook.presto.common.type.StandardTypes;
 import com.facebook.presto.common.type.Type;
-import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.common.type.TypeParameter;
 
 import java.util.List;
@@ -41,7 +40,7 @@ public final class ArrayParametricType
     }
 
     @Override
-    public Type createType(TypeManager typeManager, List<TypeParameter> parameters)
+    public Type createType(List<TypeParameter> parameters)
     {
         checkArgument(parameters.size() == 1, "Array type expects exactly one type as a parameter, got %s", parameters);
         checkArgument(

--- a/presto-main/src/main/java/com/facebook/presto/type/CharParametricType.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/CharParametricType.java
@@ -17,7 +17,6 @@ import com.facebook.presto.common.InvalidFunctionArgumentException;
 import com.facebook.presto.common.type.ParametricType;
 import com.facebook.presto.common.type.StandardTypes;
 import com.facebook.presto.common.type.Type;
-import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.common.type.TypeParameter;
 import com.facebook.presto.spi.PrestoException;
 
@@ -38,7 +37,7 @@ public class CharParametricType
     }
 
     @Override
-    public Type createType(TypeManager typeManager, List<TypeParameter> parameters)
+    public Type createType(List<TypeParameter> parameters)
     {
         if (parameters.isEmpty()) {
             return createCharType(1);

--- a/presto-main/src/main/java/com/facebook/presto/type/DecimalParametricType.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/DecimalParametricType.java
@@ -18,7 +18,6 @@ import com.facebook.presto.common.type.DecimalType;
 import com.facebook.presto.common.type.ParametricType;
 import com.facebook.presto.common.type.StandardTypes;
 import com.facebook.presto.common.type.Type;
-import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.common.type.TypeParameter;
 import com.facebook.presto.spi.PrestoException;
 
@@ -38,7 +37,7 @@ public class DecimalParametricType
     }
 
     @Override
-    public Type createType(TypeManager typeManager, List<TypeParameter> parameters)
+    public Type createType(List<TypeParameter> parameters)
     {
         try {
             switch (parameters.size()) {

--- a/presto-main/src/main/java/com/facebook/presto/type/FunctionParametricType.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/FunctionParametricType.java
@@ -17,7 +17,6 @@ import com.facebook.presto.common.type.FunctionType;
 import com.facebook.presto.common.type.ParameterKind;
 import com.facebook.presto.common.type.ParametricType;
 import com.facebook.presto.common.type.Type;
-import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.common.type.TypeParameter;
 
 import java.util.List;
@@ -42,7 +41,7 @@ public final class FunctionParametricType
     }
 
     @Override
-    public Type createType(TypeManager typeManager, List<TypeParameter> parameters)
+    public Type createType(List<TypeParameter> parameters)
     {
         checkArgument(parameters.size() >= 1, "Function type must have at least one parameter, got %s", parameters);
         checkArgument(

--- a/presto-main/src/main/java/com/facebook/presto/type/RowParametricType.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/RowParametricType.java
@@ -20,7 +20,6 @@ import com.facebook.presto.common.type.RowFieldName;
 import com.facebook.presto.common.type.RowType;
 import com.facebook.presto.common.type.StandardTypes;
 import com.facebook.presto.common.type.Type;
-import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.common.type.TypeParameter;
 import com.facebook.presto.common.type.TypeSignature;
 import com.facebook.presto.common.type.TypeSignatureParameter;
@@ -46,7 +45,7 @@ public final class RowParametricType
     }
 
     @Override
-    public Type createType(TypeManager typeManager, List<TypeParameter> parameters)
+    public Type createType(List<TypeParameter> parameters)
     {
         checkArgument(!parameters.isEmpty(), "Row type must have at least one parameter");
         checkArgument(

--- a/presto-main/src/main/java/com/facebook/presto/type/VarcharParametricType.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/VarcharParametricType.java
@@ -16,7 +16,6 @@ package com.facebook.presto.type;
 import com.facebook.presto.common.type.ParametricType;
 import com.facebook.presto.common.type.StandardTypes;
 import com.facebook.presto.common.type.Type;
-import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.common.type.TypeParameter;
 import com.facebook.presto.common.type.VarcharType;
 
@@ -36,7 +35,7 @@ public class VarcharParametricType
     }
 
     @Override
-    public Type createType(TypeManager typeManager, List<TypeParameter> parameters)
+    public Type createType(List<TypeParameter> parameters)
     {
         if (parameters.isEmpty()) {
             return createUnboundedVarcharType();

--- a/presto-main/src/test/java/com/facebook/presto/block/BlockAssertions.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/BlockAssertions.java
@@ -24,7 +24,6 @@ import com.facebook.presto.common.type.DecimalType;
 import com.facebook.presto.common.type.MapType;
 import com.facebook.presto.common.type.RowType;
 import com.facebook.presto.common.type.Type;
-import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
 
 import java.lang.invoke.MethodHandle;
@@ -62,7 +61,7 @@ import static com.facebook.presto.common.type.TimestampWithTimeZoneType.TIMESTAM
 import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.testing.TestingConnectorSession.SESSION;
-import static com.facebook.presto.testing.TestingEnvironment.TYPE_MANAGER;
+import static com.facebook.presto.testing.TestingEnvironment.getOperatorMethodHandle;
 import static com.facebook.presto.util.StructuralTestUtil.appendToBlockBuilder;
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.slice.Slices.utf8Slice;
@@ -849,10 +848,9 @@ public final class BlockAssertions
 
     public static MapType createMapType(Type keyType, Type valueType)
     {
-        MethodHandle keyNativeEquals = TYPE_MANAGER.resolveOperator(OperatorType.EQUAL, ImmutableList.of(keyType, keyType));
-        MethodHandle keyBlockNativeEquals = compose(keyNativeEquals, nativeValueGetter(keyType));
+        MethodHandle keyNativeEquals = getOperatorMethodHandle(OperatorType.EQUAL, keyType, keyType);
         MethodHandle keyBlockEquals = compose(keyNativeEquals, nativeValueGetter(keyType), nativeValueGetter(keyType));
-        MethodHandle keyNativeHashCode = TYPE_MANAGER.resolveOperator(OperatorType.HASH_CODE, ImmutableList.of(keyType));
+        MethodHandle keyNativeHashCode = getOperatorMethodHandle(OperatorType.HASH_CODE, keyType);
         MethodHandle keyBlockHashCode = compose(keyNativeHashCode, nativeValueGetter(keyType));
         return new MapType(
                 keyType,

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestMergeQuantileDigestFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestMergeQuantileDigestFunction.java
@@ -57,7 +57,7 @@ public class TestMergeQuantileDigestFunction
     @Override
     public Block[] getSequenceBlocks(int start, int length)
     {
-        Type type = QDIGEST.createType(typeRegistry, ImmutableList.of(TypeParameter.of(DoubleType.DOUBLE)));
+        Type type = QDIGEST.createType(ImmutableList.of(TypeParameter.of(DoubleType.DOUBLE)));
         BlockBuilder blockBuilder = type.createBlockBuilder(null, length);
         for (int i = start; i < start + length; i++) {
             QuantileDigest qdigest = new QuantileDigest(0.0);

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestMergeTDigestFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestMergeTDigestFunction.java
@@ -68,7 +68,7 @@ public class TestMergeTDigestFunction
     @Override
     public Block[] getSequenceBlocks(int start, int length)
     {
-        Type type = TDIGEST.createType(typeRegistry, ImmutableList.of(TypeParameter.of(DoubleType.DOUBLE)));
+        Type type = TDIGEST.createType(ImmutableList.of(TypeParameter.of(DoubleType.DOUBLE)));
         BlockBuilder blockBuilder = type.createBlockBuilder(null, length);
         for (int i = start; i < start + length; i++) {
             TDigest tdigest = createTDigest(100);

--- a/presto-main/src/test/java/com/facebook/presto/operator/project/BenchmarkDictionaryBlockGetSizeInBytes.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/project/BenchmarkDictionaryBlockGetSizeInBytes.java
@@ -46,7 +46,7 @@ import static com.facebook.presto.block.BlockAssertions.createSlicesBlock;
 import static com.facebook.presto.common.block.MethodHandleUtil.compose;
 import static com.facebook.presto.common.block.MethodHandleUtil.nativeValueGetter;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
-import static com.facebook.presto.testing.TestingEnvironment.TYPE_MANAGER;
+import static com.facebook.presto.testing.TestingEnvironment.getOperatorMethodHandle;
 import static io.airlift.slice.Slices.utf8Slice;
 import static java.util.concurrent.TimeUnit.MICROSECONDS;
 
@@ -84,10 +84,9 @@ public class BenchmarkDictionaryBlockGetSizeInBytes
         {
             Type keyType = VARCHAR;
             Type valueType = VARCHAR;
-            MethodHandle keyNativeEquals = TYPE_MANAGER.resolveOperator(OperatorType.EQUAL, ImmutableList.of(keyType, keyType));
-            MethodHandle keyBlockNativeEquals = compose(keyNativeEquals, nativeValueGetter(keyType));
+            MethodHandle keyNativeEquals = getOperatorMethodHandle(OperatorType.EQUAL, keyType, keyType);
             MethodHandle keyBlockEquals = compose(keyNativeEquals, nativeValueGetter(keyType), nativeValueGetter(keyType));
-            MethodHandle keyNativeHashCode = TYPE_MANAGER.resolveOperator(OperatorType.HASH_CODE, ImmutableList.of(keyType));
+            MethodHandle keyNativeHashCode = getOperatorMethodHandle(OperatorType.HASH_CODE, keyType);
             MethodHandle keyBlockHashCode = compose(keyNativeHashCode, nativeValueGetter(keyType));
             MapType mapType = new MapType(
                     keyType,

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestQuantileDigestFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestQuantileDigestFunctions.java
@@ -26,7 +26,6 @@ import org.testng.annotations.Test;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.DoubleType.DOUBLE;
 import static com.facebook.presto.common.type.QuantileDigestParametricType.QDIGEST;
-import static com.facebook.presto.operator.aggregation.FloatingPointBitsConverterUtil.doubleToSortableLong;
 import static io.airlift.slice.Slices.wrappedBuffer;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
@@ -37,7 +36,7 @@ public class TestQuantileDigestFunctions
         extends AbstractTestFunctions
 {
     private static final TypeRegistry TYPE_REGISTRY = new TypeRegistry();
-    private static final Type QDIGEST_BIGINT = QDIGEST.createType(TYPE_REGISTRY, ImmutableList.of(TypeParameter.of(BIGINT)));
+    private static final Type QDIGEST_BIGINT = QDIGEST.createType(ImmutableList.of(TypeParameter.of(BIGINT)));
 
     @Test
     public void testNullQuantileDigestGetValueAtQuantile()

--- a/presto-main/src/test/java/com/facebook/presto/type/TestRowParametricType.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestRowParametricType.java
@@ -44,7 +44,7 @@ public class TestRowParametricType
         List<TypeParameter> parameters = typeSignature.getParameters().stream()
                 .map(parameter -> TypeParameter.of(parameter, typeManager))
                 .collect(Collectors.toList());
-        Type rowType = RowParametricType.ROW.createType(typeManager, parameters);
+        Type rowType = RowParametricType.ROW.createType(parameters);
 
         assertEquals(rowType.getTypeSignature(), typeSignature);
     }

--- a/presto-ml/src/main/java/com/facebook/presto/ml/type/ClassifierParametricType.java
+++ b/presto-ml/src/main/java/com/facebook/presto/ml/type/ClassifierParametricType.java
@@ -16,7 +16,6 @@ package com.facebook.presto.ml.type;
 import com.facebook.presto.common.type.ParameterKind;
 import com.facebook.presto.common.type.ParametricType;
 import com.facebook.presto.common.type.Type;
-import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.common.type.TypeParameter;
 
 import java.util.List;
@@ -35,7 +34,7 @@ public class ClassifierParametricType
     }
 
     @Override
-    public Type createType(TypeManager typeManager, List<TypeParameter> parameters)
+    public Type createType(List<TypeParameter> parameters)
     {
         checkArgument(parameters.size() == 1, "Expected only one type, got %s", parameters);
         checkArgument(

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcMapNullKey.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcMapNullKey.java
@@ -24,7 +24,6 @@ import com.facebook.presto.metadata.FunctionManager;
 import com.facebook.presto.orc.metadata.CompressionKind;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.type.TypeRegistry;
-import com.google.common.collect.ImmutableList;
 import org.apache.hadoop.hive.ql.exec.FileSinkOperator;
 import org.apache.hadoop.hive.ql.io.orc.OrcSerde;
 import org.apache.hadoop.hive.serde2.objectinspector.SettableStructObjectInspector;
@@ -48,6 +47,7 @@ import static com.facebook.presto.orc.OrcTester.createCustomOrcRecordReader;
 import static com.facebook.presto.orc.OrcTester.createCustomOrcSelectiveRecordReader;
 import static com.facebook.presto.orc.OrcTester.createOrcRecordWriter;
 import static com.facebook.presto.orc.OrcTester.createSettableStructObjectInspector;
+import static com.facebook.presto.testing.TestingEnvironment.getOperatorMethodHandle;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
@@ -153,10 +153,9 @@ public class TestOrcMapNullKey
 
     private static MapType createMapType(Type keyType, Type valueType)
     {
-        MethodHandle keyNativeEquals = TYPE_MANAGER.resolveOperator(OperatorType.EQUAL, ImmutableList.of(keyType, keyType));
-        MethodHandle keyBlockNativeEquals = compose(keyNativeEquals, nativeValueGetter(keyType));
+        MethodHandle keyNativeEquals = getOperatorMethodHandle(OperatorType.EQUAL, keyType, keyType);
         MethodHandle keyBlockEquals = compose(keyNativeEquals, nativeValueGetter(keyType), nativeValueGetter(keyType));
-        MethodHandle keyNativeHashCode = TYPE_MANAGER.resolveOperator(OperatorType.HASH_CODE, ImmutableList.of(keyType));
+        MethodHandle keyNativeHashCode = getOperatorMethodHandle(OperatorType.HASH_CODE, keyType);
         MethodHandle keyBlockHashCode = compose(keyNativeHashCode, nativeValueGetter(keyType));
 
         return new MapType(

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcReaderMemoryUsage.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcReaderMemoryUsage.java
@@ -24,7 +24,6 @@ import com.facebook.presto.orc.metadata.CompressionKind;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.type.TypeRegistry;
 import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableList;
 import org.apache.hadoop.hive.ql.exec.FileSinkOperator;
 import org.apache.hadoop.hive.ql.io.orc.OrcSerde;
 import org.apache.hadoop.hive.serde2.SerDeException;
@@ -50,6 +49,7 @@ import static com.facebook.presto.orc.OrcTester.Format.ORC_12;
 import static com.facebook.presto.orc.OrcTester.createCustomOrcRecordReader;
 import static com.facebook.presto.orc.OrcTester.createOrcRecordWriter;
 import static com.facebook.presto.orc.OrcTester.createSettableStructObjectInspector;
+import static com.facebook.presto.testing.TestingEnvironment.getOperatorMethodHandle;
 import static org.testng.Assert.assertEquals;
 
 public class TestOrcReaderMemoryUsage
@@ -163,10 +163,9 @@ public class TestOrcReaderMemoryUsage
         Type keyType = BIGINT;
         Type valueType = BIGINT;
 
-        MethodHandle keyNativeEquals = TYPE_MANAGER.resolveOperator(OperatorType.EQUAL, ImmutableList.of(keyType, keyType));
-        MethodHandle keyBlockNativeEquals = compose(keyNativeEquals, nativeValueGetter(keyType));
+        MethodHandle keyNativeEquals = getOperatorMethodHandle(OperatorType.EQUAL, keyType, keyType);
         MethodHandle keyBlockEquals = compose(keyNativeEquals, nativeValueGetter(keyType), nativeValueGetter(keyType));
-        MethodHandle keyNativeHashCode = TYPE_MANAGER.resolveOperator(OperatorType.HASH_CODE, ImmutableList.of(keyType));
+        MethodHandle keyNativeHashCode = getOperatorMethodHandle(OperatorType.HASH_CODE, keyType);
         MethodHandle keyBlockHashCode = compose(keyNativeHashCode, nativeValueGetter(keyType));
 
         MapType mapType = new MapType(


### PR DESCRIPTION
This API is a hack. TypeManager.resolveOperator internally will call
FunctionManager.resolveOperator. However, FunctionManager is not initialized
in TypeRegistry constructor, but set in FunctionManager's constructo, due to
cyclic dependency. So to be able to call this API, we see following hacky code
in test everywhere:
```
    TypeManager typeManager = new TypeRegistr();
    // associate typeManager with a function manager
    new FunctionManager(typeManager, ....);
```
The only reason that this API exists is because MapParametricType.createType
needs to use it. So we did
1) adding TypeManager to ParamatricType.createType
2) adding TypeManager.resolveOperator

just so MapParametricType could provide MethodHandle that would be used to
build hashtable in Map block, while no other API needs
TypeManager.resolveOperator, and no other ParametricType needs access to
TypeManager. Another problem is that the API directly returns a MethodHandle,
which means this API will not work once we support user defined types with
operator implementation that's not a Java MethodHandle.

Since the solution will not work for future generalized caase, removing it for
now, and directly check for MapParametricType in TypeRegistry to special handle
map types.

Test plan - travis
```
== NO RELEASE NOTE ==
```
