### PR TITLE
Display enum keys in Presto CLI

### DIFF
--- a/presto-cli/src/main/java/com/facebook/presto/cli/OutputHandler.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/OutputHandler.java
@@ -13,15 +13,28 @@
  */
 package com.facebook.presto.cli;
 
+import com.facebook.presto.client.ClientTypeSignature;
+import com.facebook.presto.client.ClientTypeSignatureParameter;
+import com.facebook.presto.client.Column;
 import com.facebook.presto.client.StatementClient;
+import com.facebook.presto.common.type.NamedTypeSignature;
+import com.facebook.presto.common.type.ParameterKind;
+import com.google.common.collect.ImmutableList;
 import io.airlift.units.Duration;
 
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
 
+import static com.facebook.presto.client.ClientTypeSignature.hasEnum;
+import static com.facebook.presto.common.type.StandardTypes.ARRAY;
+import static com.facebook.presto.common.type.StandardTypes.MAP;
+import static com.facebook.presto.common.type.StandardTypes.ROW;
 import static io.airlift.units.Duration.nanosSince;
 import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
@@ -44,17 +57,30 @@ public final class OutputHandler
         this.printer = requireNonNull(printer, "printer is null");
     }
 
-    public void processRow(List<?> row)
+    public void processRow(List<?> row, Map<Integer, ColumnDataTransformer> transformers)
             throws IOException
     {
         if (rowBuffer.isEmpty()) {
             bufferStart = System.nanoTime();
         }
 
-        rowBuffer.add(row);
+        rowBuffer.add(transformers.isEmpty() ? row : transformRow(row, transformers));
         if (rowBuffer.size() >= MAX_BUFFERED_ROWS) {
             flush(false);
         }
+    }
+
+    private List<?> transformRow(List<?> row, Map<Integer, ColumnDataTransformer> transformers)
+    {
+        ImmutableList.Builder<Object> builder = new ImmutableList.Builder<>();
+        for (int i = 0; i < row.size(); i++) {
+            if (!transformers.containsKey(i)) {
+                builder.add(row.get(i));
+                continue;
+            }
+            builder.add(transformers.get(i).transformValue(row.get(i)));
+        }
+        return builder.build();
     }
 
     @Override
@@ -74,7 +100,7 @@ public final class OutputHandler
             Iterable<List<Object>> data = client.currentData().getData();
             if (data != null) {
                 for (List<Object> row : data) {
-                    processRow(unmodifiableList(row));
+                    processRow(unmodifiableList(row), getColumnTransformers(client.currentData().getColumns()));
                 }
             }
 
@@ -86,12 +112,101 @@ public final class OutputHandler
         }
     }
 
+    // Column transformers are used for pretty-printing of values in the CLI output.
+    // Returns a map of column index to column transformers
+    private Map<Integer, ColumnDataTransformer> getColumnTransformers(List<Column> columns)
+    {
+        Map<Integer, ColumnDataTransformer> transformers = new HashMap<>();
+        for (int i = 0; i < columns.size(); i++) {
+            Column column = columns.get(i);
+            if (!hasEnum(column.getTypeSignature())) {
+                continue;
+            }
+            transformers.put(i, new EnumLiteralTransformer(column.getTypeSignature()));
+        }
+        return transformers;
+    }
+
     private void flush(boolean complete)
             throws IOException
     {
         if (!rowBuffer.isEmpty()) {
             printer.printRows(unmodifiableList(rowBuffer), complete);
             rowBuffer.clear();
+        }
+    }
+
+    private interface ColumnDataTransformer
+    {
+        Object transformValue(Object value);
+    }
+
+    private static class EnumLiteralTransformer
+            implements ColumnDataTransformer
+    {
+        private final ClientTypeSignature columnSignature;
+
+        EnumLiteralTransformer(ClientTypeSignature columnSignature)
+        {
+            this.columnSignature = columnSignature;
+        }
+
+        @Override
+        public Object transformValue(Object value)
+        {
+            return transformValue(columnSignature, value);
+        }
+
+        private static Object transformValue(ClientTypeSignature signature, Object value)
+        {
+            if (value == null) {
+                return null;
+            }
+
+            if (signature.getRawType().equals(ARRAY)) {
+                return ((List<?>) value).stream()
+                        .map(v -> transformValue(signature.getArguments().get(0).getTypeSignature(), v))
+                        .collect(Collectors.toList());
+            }
+
+            if (signature.getRawType().equals(MAP)) {
+                ClientTypeSignature keySignature = signature.getArguments().get(0).getTypeSignature();
+                ClientTypeSignature valueSignature = signature.getArguments().get(1).getTypeSignature();
+                return ((Map<?, ?>) value).entrySet().stream()
+                        .collect(Collectors.toMap(
+                                e -> transformValue(keySignature, e.getKey()),
+                                e -> transformValue(valueSignature, e.getValue())));
+            }
+
+            if (signature.getRawType().equals(ROW)) {
+                Map<String, ClientTypeSignature> fieldSignatures = new HashMap<>();
+                List<ClientTypeSignatureParameter> arguments = signature.getArguments();
+                for (int i = 0; i < arguments.size(); i++) {
+                    NamedTypeSignature namedTypeSignature = arguments.get(i).getNamedTypeSignature();
+                    fieldSignatures.put(
+                            namedTypeSignature.getName().orElse("field" + i),
+                            new ClientTypeSignature(namedTypeSignature.getTypeSignature()));
+                }
+                return ((Map<?, ?>) value).entrySet().stream()
+                        .collect(Collectors.toMap(
+                                Map.Entry::getKey,
+                                e -> transformValue(fieldSignatures.get(e.getKey()), e.getValue())));
+            }
+
+            if (!signature.isEnum()) {
+                return value;
+            }
+
+            ClientTypeSignatureParameter parameter = signature.getArguments().get(0);
+            if (ParameterKind.LONG_ENUM.equals(parameter.getKind())) {
+                return parameter.getLongEnumMap().getEnumMapFlipped().getOrDefault(
+                        ((Number) value).longValue(), value.toString());
+            }
+            if (ParameterKind.VARCHAR_ENUM.equals(parameter.getKind())) {
+                return parameter.getVarcharEnumMap().getEnumMapFlipped().getOrDefault(
+                        (String) value, (String) value);
+            }
+            return value;
         }
     }
 }

--- a/presto-client/src/main/java/com/facebook/presto/client/ClientTypeSignatureParameter.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/ClientTypeSignatureParameter.java
@@ -110,6 +110,16 @@ public class ClientTypeSignatureParameter
         return getValue(ParameterKind.NAMED_TYPE, NamedTypeSignature.class);
     }
 
+    public LongEnumMap getLongEnumMap()
+    {
+        return getValue(ParameterKind.LONG_ENUM, LongEnumMap.class);
+    }
+
+    public VarcharEnumMap getVarcharEnumMap()
+    {
+        return getValue(ParameterKind.VARCHAR_ENUM, VarcharEnumMap.class);
+    }
+
     @Override
     public String toString()
     {

--- a/presto-client/src/main/java/com/facebook/presto/client/FixJsonDataUtils.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/FixJsonDataUtils.java
@@ -127,6 +127,14 @@ final class FixJsonDataUtils
         if (signature.isVarcharEnum()) {
             return String.class.cast(value);
         }
+        if (signature.isLongEnum()) {
+            if (value instanceof String) {
+                // this happens for map keys
+                return Long.parseLong((String) value);
+            }
+            return ((Number) value).longValue();
+        }
+
         switch (signature.getBase()) {
             case BIGINT:
                 if (value instanceof String) {

--- a/presto-client/src/main/java/com/facebook/presto/client/QueryData.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/QueryData.java
@@ -18,4 +18,6 @@ import java.util.List;
 public interface QueryData
 {
     Iterable<List<Object>> getData();
+
+    List<Column> getColumns();
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/type/LongEnumType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/LongEnumType.java
@@ -24,6 +24,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.TypeUtils.flipMap;
 import static com.facebook.presto.common.type.TypeUtils.normalizeEnumMap;
 import static com.facebook.presto.common.type.TypeUtils.validateEnumMap;
 import static java.lang.String.format;
@@ -71,18 +72,26 @@ public class LongEnumType
     public static class LongEnumMap
     {
         private final Map<String, Long> enumMap;
+        private final Map<Long, String> flippedEnumMap;
 
         @JsonCreator
         public LongEnumMap(@JsonProperty("enumMap") Map<String, Long> enumMap)
         {
             validateEnumMap(enumMap);
             this.enumMap = normalizeEnumMap(enumMap);
+            this.flippedEnumMap = flipMap(this.enumMap);
         }
 
         @JsonProperty
         public Map<String, Long> getEnumMap()
         {
             return enumMap;
+        }
+
+        @JsonProperty
+        public Map<Long, String> getEnumMapFlipped()
+        {
+            return flippedEnumMap;
         }
 
         @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/type/TypeUtils.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TypeUtils.java
@@ -131,4 +131,10 @@ public final class TypeUtils
         return entries.entrySet().stream()
                 .collect(toMap(e -> e.getKey().toUpperCase(ENGLISH), Map.Entry::getValue));
     }
+
+    static <K, V> Map<V, K> flipMap(Map<K, V> map)
+    {
+        return map.entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getValue, Map.Entry::getKey));
+    }
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/type/VarcharEnumType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/VarcharEnumType.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import static com.facebook.presto.common.type.TypeUtils.flipMap;
 import static com.facebook.presto.common.type.TypeUtils.normalizeEnumMap;
 import static com.facebook.presto.common.type.TypeUtils.validateEnumMap;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
@@ -59,18 +60,25 @@ public class VarcharEnumType
     public static class VarcharEnumMap
     {
         private final Map<String, String> enumMap;
+        private final Map<String, String> flippedEnumMap;
 
         @JsonCreator
         public VarcharEnumMap(@JsonProperty("enumMap") Map<String, String> enumMap)
         {
             validateEnumMap(enumMap);
             this.enumMap = normalizeEnumMap(enumMap);
+            this.flippedEnumMap = flipMap(this.enumMap);
         }
 
         @JsonProperty
         public Map<String, String> getEnumMap()
         {
             return enumMap;
+        }
+
+        public Map<String, String> getEnumMapFlipped()
+        {
+            return flippedEnumMap;
         }
 
         @Override


### PR DESCRIPTION
Enum keys are usually more meaningful than values for end-users reading query results, so we're displaying them in the CLI output.

The main logic is in the OutputHandler class, to traverse data simultaneously with type signatures to replace enum values by keys. We need this recursive logic to properly render enum keys within complex types, like `row(array(map(enum, enum)), ...)`
