### PR TITLE
Fix double counting of charPositionInLine

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/execution/TestThriftTaskStatus.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestThriftTaskStatus.java
@@ -162,7 +162,7 @@ public class TestThriftTaskStatus
         assertEquals(thirdFailure.getType(), ParsingException.class.getName());
         assertEquals(thirdFailure.getErrorCode(), SYNTAX_ERROR.toErrorCode());
         assertEquals(thirdFailure.getErrorLocation().getLineNumber(), 100);
-        assertEquals(thirdFailure.getErrorLocation().getColumnNumber(), 3);
+        assertEquals(thirdFailure.getErrorLocation().getColumnNumber(), 2);
     }
 
     private TaskStatus getRoundTripSerialize(ThriftCodec<TaskStatus> readCodec, ThriftCodec<TaskStatus> writeCodec, Function<TTransport, TProtocol> protocolFactory)

--- a/presto-parser/src/main/java/com/facebook/presto/sql/parser/ParsingException.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/parser/ParsingException.java
@@ -39,7 +39,9 @@ public class ParsingException
 
     public ParsingException(String message, NodeLocation nodeLocation)
     {
-        this(message, null, nodeLocation.getLineNumber(), nodeLocation.getColumnNumber());
+        // charPositionInLine is 0-based whereas columnNumber is 1-based.
+        // We need to decrement the columnNumber by 1 here since we are storing charPositionInLine.
+        this(message, null, nodeLocation.getLineNumber(), nodeLocation.getColumnNumber() - 1);
     }
 
     public int getLineNumber()

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/ParsingExceptionTest.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/ParsingExceptionTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.parser;
+
+import com.facebook.presto.sql.tree.NodeLocation;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public class ParsingExceptionTest
+{
+    private ParsingException parsingException;
+
+    @BeforeMethod
+    public void setUp()
+    {
+        parsingException = new ParsingException("ParsingException", new NodeLocation(100, 1));
+    }
+
+    @Test
+    public void testParsingExceptionFields()
+    {
+        assertEquals(parsingException.getColumnNumber(), 2);
+        assertEquals(parsingException.getLineNumber(), 100);
+        assertEquals(parsingException.getErrorMessage(), "ParsingException");
+        assertEquals(parsingException.getMessage(), "line 100:2: ParsingException");
+    }
+}


### PR DESCRIPTION
Fix double counting of charPositionInLine

ParsingException when constructed through the NodeLocation
constructor ends up double counting the column number. This
commit tries to fix that by decrementing the column number
while constructing the object.

Test plan - unit testing and travis tests.

fixes https://github.com/prestodb/presto/issues/15254
```
== NO RELEASE NOTE ==
```