### PR TITLE
Add thrift serde support for TaskStatus

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <air.maven.version>3.3.9</air.maven.version>
 
         <dep.antlr.version>4.7.1</dep.antlr.version>
-        <dep.airlift.version>0.194</dep.airlift.version>
+        <dep.airlift.version>0.195</dep.airlift.version>
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
         <dep.slice.version>0.38</dep.slice.version>
         <dep.testing-mysql-server-5.version>0.6</dep.testing-mysql-server-5.version>
@@ -53,7 +53,7 @@
         <dep.okhttp.version>3.9.0</dep.okhttp.version>
         <dep.jdbi3.version>3.4.0</dep.jdbi3.version>
         <dep.oracle.version>19.3.0.0</dep.oracle.version>
-        <dep.drift.version>1.28</dep.drift.version>
+        <dep.drift.version>1.29</dep.drift.version>
         <dep.joda.version>2.10.5</dep.joda.version>
         <dep.tempto.version>1.50</dep.tempto.version>
         <dep.testng.version>6.10</dep.testng.version>

--- a/presto-accumulo/pom.xml
+++ b/presto-accumulo/pom.xml
@@ -276,6 +276,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
             <scope>provided</scope>

--- a/presto-atop/pom.xml
+++ b/presto-atop/pom.xml
@@ -99,6 +99,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>slice</artifactId>
             <scope>provided</scope>

--- a/presto-blackhole/pom.xml
+++ b/presto-blackhole/pom.xml
@@ -48,6 +48,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>slice</artifactId>
             <scope>provided</scope>

--- a/presto-cache/pom.xml
+++ b/presto-cache/pom.xml
@@ -96,6 +96,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>slice</artifactId>
             <scope>provided</scope>

--- a/presto-cassandra/pom.xml
+++ b/presto-cassandra/pom.xml
@@ -101,6 +101,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>slice</artifactId>
             <scope>provided</scope>

--- a/presto-client/pom.xml
+++ b/presto-client/pom.xml
@@ -57,6 +57,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-api</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>units</artifactId>
         </dependency>

--- a/presto-client/src/main/java/com/facebook/presto/client/ErrorLocation.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/ErrorLocation.java
@@ -13,6 +13,9 @@
  */
 package com.facebook.presto.client;
 
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -22,12 +25,14 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 
 @Immutable
+@ThriftStruct
 public class ErrorLocation
 {
     private final int lineNumber;
     private final int columnNumber;
 
     @JsonCreator
+    @ThriftConstructor
     public ErrorLocation(
             @JsonProperty("lineNumber") int lineNumber,
             @JsonProperty("columnNumber") int columnNumber)
@@ -40,12 +45,14 @@ public class ErrorLocation
     }
 
     @JsonProperty
+    @ThriftField(1)
     public int getLineNumber()
     {
         return lineNumber;
     }
 
     @JsonProperty
+    @ThriftField(2)
     public int getColumnNumber()
     {
         return columnNumber;

--- a/presto-druid/pom.xml
+++ b/presto-druid/pom.xml
@@ -257,6 +257,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-expressions</artifactId>
         </dependency>

--- a/presto-elasticsearch/pom.xml
+++ b/presto-elasticsearch/pom.xml
@@ -206,6 +206,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
             <scope>provided</scope>

--- a/presto-example-http/pom.xml
+++ b/presto-example-http/pom.xml
@@ -75,6 +75,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>slice</artifactId>
             <scope>provided</scope>

--- a/presto-function-namespace-managers/pom.xml
+++ b/presto-function-namespace-managers/pom.xml
@@ -41,6 +41,7 @@
         <dependency>
             <groupId>com.facebook.drift</groupId>
             <artifactId>drift-api</artifactId>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/presto-geospatial/pom.xml
+++ b/presto-geospatial/pom.xml
@@ -57,6 +57,12 @@
             <artifactId>presto-spi</artifactId>
             <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
         
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/presto-hive-hadoop2/pom.xml
+++ b/presto-hive-hadoop2/pom.xml
@@ -52,6 +52,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>slice</artifactId>
             <scope>provided</scope>

--- a/presto-i18n-functions/pom.xml
+++ b/presto-i18n-functions/pom.xml
@@ -40,6 +40,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>slice</artifactId>
             <scope>provided</scope>

--- a/presto-jdbc/pom.xml
+++ b/presto-jdbc/pom.xml
@@ -228,6 +228,10 @@
                                     <shadedPattern>${shadeBase}.common</shadedPattern>
                                 </relocation>
                                 <relocation>
+                                    <pattern>com.facebook.drift</pattern>
+                                    <shadedPattern>${shadeBase}.drift</shadedPattern>
+                                </relocation>
+                                <relocation>
                                     <pattern>com.fasterxml.jackson</pattern>
                                     <shadedPattern>${shadeBase}.jackson</shadedPattern>
                                 </relocation>

--- a/presto-jmx/pom.xml
+++ b/presto-jmx/pom.xml
@@ -86,6 +86,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>slice</artifactId>
             <scope>provided</scope>

--- a/presto-kafka/pom.xml
+++ b/presto-kafka/pom.xml
@@ -114,6 +114,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>slice</artifactId>
             <scope>provided</scope>

--- a/presto-kudu/pom.xml
+++ b/presto-kudu/pom.xml
@@ -103,6 +103,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>slice</artifactId>
             <scope>provided</scope>

--- a/presto-local-file/pom.xml
+++ b/presto-local-file/pom.xml
@@ -71,6 +71,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>slice</artifactId>
             <scope>provided</scope>

--- a/presto-main/pom.xml
+++ b/presto-main/pom.xml
@@ -208,6 +208,11 @@
 
         <dependency>
             <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-protocol</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.drift</groupId>
             <artifactId>drift-codec</artifactId>
         </dependency>
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/ExecutionFailureInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/ExecutionFailureInfo.java
@@ -13,6 +13,9 @@
  */
 package com.facebook.presto.execution;
 
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
 import com.facebook.presto.client.ErrorLocation;
 import com.facebook.presto.client.FailureInfo;
 import com.facebook.presto.spi.ErrorCode;
@@ -28,10 +31,13 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static com.facebook.drift.annotations.ThriftField.Recursiveness.TRUE;
+import static com.facebook.drift.annotations.ThriftField.Requiredness.OPTIONAL;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
 
 @Immutable
+@ThriftStruct
 public class ExecutionFailureInfo
 {
     private static final Pattern STACK_TRACE_PATTERN = Pattern.compile("(.*)\\.(.*)\\(([^:]*)(?::(.*))?\\)");
@@ -47,6 +53,7 @@ public class ExecutionFailureInfo
     private final HostAddress remoteHost;
 
     @JsonCreator
+    @ThriftConstructor
     public ExecutionFailureInfo(
             @JsonProperty("type") String type,
             @JsonProperty("message") String message,
@@ -72,6 +79,7 @@ public class ExecutionFailureInfo
     }
 
     @JsonProperty
+    @ThriftField(1)
     public String getType()
     {
         return type;
@@ -79,6 +87,7 @@ public class ExecutionFailureInfo
 
     @Nullable
     @JsonProperty
+    @ThriftField(2)
     public String getMessage()
     {
         return message;
@@ -86,18 +95,21 @@ public class ExecutionFailureInfo
 
     @Nullable
     @JsonProperty
+    @ThriftField(value = 3, isRecursive = TRUE, requiredness = OPTIONAL)
     public ExecutionFailureInfo getCause()
     {
         return cause;
     }
 
     @JsonProperty
+    @ThriftField(4)
     public List<ExecutionFailureInfo> getSuppressed()
     {
         return suppressed;
     }
 
     @JsonProperty
+    @ThriftField(5)
     public List<String> getStack()
     {
         return stack;
@@ -105,6 +117,7 @@ public class ExecutionFailureInfo
 
     @Nullable
     @JsonProperty
+    @ThriftField(6)
     public ErrorLocation getErrorLocation()
     {
         return errorLocation;
@@ -112,6 +125,7 @@ public class ExecutionFailureInfo
 
     @Nullable
     @JsonProperty
+    @ThriftField(7)
     public ErrorCode getErrorCode()
     {
         return errorCode;
@@ -119,6 +133,7 @@ public class ExecutionFailureInfo
 
     @Nullable
     @JsonProperty
+    @ThriftField(8)
     public HostAddress getRemoteHost()
     {
         return remoteHost;

--- a/presto-main/src/main/java/com/facebook/presto/execution/Lifespan.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/Lifespan.java
@@ -14,6 +14,9 @@
 
 package com.facebook.presto.execution;
 
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
@@ -23,6 +26,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static java.lang.Integer.parseInt;
 
+@ThriftStruct
 public class Lifespan
 {
     private static final Lifespan TASK_WIDE = new Lifespan(false, 0);
@@ -40,8 +44,10 @@ public class Lifespan
         return new Lifespan(true, id);
     }
 
-    private Lifespan(boolean grouped, int groupId)
+    @ThriftConstructor
+    public Lifespan(boolean grouped, int groupId)
     {
+        checkArgument(grouped || groupId == 0);
         this.grouped = grouped;
         this.groupId = groupId;
     }
@@ -51,9 +57,16 @@ public class Lifespan
         return !grouped;
     }
 
+    @ThriftField(1)
+    public boolean isGrouped()
+    {
+        return grouped;
+    }
+
+    @ThriftField(value = 2, name = "groupId")
     public int getId()
     {
-        checkState(grouped);
+        checkState(grouped || groupId == 0);
         return groupId;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskState.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskState.java
@@ -13,11 +13,15 @@
  */
 package com.facebook.presto.execution;
 
+import com.facebook.drift.annotations.ThriftEnum;
+import com.facebook.drift.annotations.ThriftEnumValue;
+
 import java.util.Set;
 import java.util.stream.Stream;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 
+@ThriftEnum
 public enum TaskState
 {
     /**
@@ -25,35 +29,37 @@ public enum TaskState
      * be in the planned state until, the dependencies of the task
      * have begun producing output.
      */
-    PLANNED(false),
+    PLANNED(0, false),
     /**
      * Task is running.
      */
-    RUNNING(false),
+    RUNNING(1, false),
     /**
      * Task has finished executing and all output has been consumed.
      */
-    FINISHED(true),
+    FINISHED(2, true),
     /**
      * Task was canceled by a user.
      */
-    CANCELED(true),
+    CANCELED(3, true),
     /**
      * Task was aborted due to a failure in the query.  The failure
      * was not in this task.
      */
-    ABORTED(true),
+    ABORTED(4, true),
     /**
      * Task execution failed.
      */
-    FAILED(true);
+    FAILED(5, true);
 
     public static final Set<TaskState> TERMINAL_TASK_STATES = Stream.of(TaskState.values()).filter(TaskState::isDone).collect(toImmutableSet());
 
+    private final int code;
     private final boolean doneState;
 
-    TaskState(boolean doneState)
+    TaskState(int code, boolean doneState)
     {
+        this.code = code;
         this.doneState = doneState;
     }
 
@@ -63,5 +69,11 @@ public enum TaskState
     public boolean isDone()
     {
         return doneState;
+    }
+
+    @ThriftEnumValue
+    public int getCode()
+    {
+        return code;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskStatus.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskStatus.java
@@ -13,6 +13,9 @@
  */
 package com.facebook.presto.execution;
 
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
@@ -28,6 +31,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
+@ThriftStruct
 public class TaskStatus
 {
     /**
@@ -70,6 +74,7 @@ public class TaskStatus
     private final List<ExecutionFailureInfo> failures;
 
     @JsonCreator
+    @ThriftConstructor
     public TaskStatus(
             @JsonProperty("taskInstanceIdLeastSignificantBits") long taskInstanceIdLeastSignificantBits,
             @JsonProperty("taskInstanceIdMostSignificantBits") long taskInstanceIdMostSignificantBits,
@@ -117,96 +122,112 @@ public class TaskStatus
     }
 
     @JsonProperty
+    @ThriftField(1)
     public long getTaskInstanceIdLeastSignificantBits()
     {
         return taskInstanceIdLeastSignificantBits;
     }
 
     @JsonProperty
+    @ThriftField(2)
     public long getTaskInstanceIdMostSignificantBits()
     {
         return taskInstanceIdMostSignificantBits;
     }
 
     @JsonProperty
+    @ThriftField(3)
     public long getVersion()
     {
         return version;
     }
 
     @JsonProperty
+    @ThriftField(4)
     public TaskState getState()
     {
         return state;
     }
 
     @JsonProperty
+    @ThriftField(5)
     public URI getSelf()
     {
         return self;
     }
 
     @JsonProperty
+    @ThriftField(6)
     public Set<Lifespan> getCompletedDriverGroups()
     {
         return completedDriverGroups;
     }
 
     @JsonProperty
+    @ThriftField(7)
     public List<ExecutionFailureInfo> getFailures()
     {
         return failures;
     }
 
     @JsonProperty
+    @ThriftField(8)
     public int getQueuedPartitionedDrivers()
     {
         return queuedPartitionedDrivers;
     }
 
     @JsonProperty
+    @ThriftField(9)
     public int getRunningPartitionedDrivers()
     {
         return runningPartitionedDrivers;
     }
 
     @JsonProperty
+    @ThriftField(10)
     public double getOutputBufferUtilization()
     {
         return outputBufferUtilization;
     }
 
     @JsonProperty
+    @ThriftField(11)
     public boolean isOutputBufferOverutilized()
     {
         return outputBufferOverutilized;
     }
 
     @JsonProperty
+    @ThriftField(12)
     public long getPhysicalWrittenDataSizeInBytes()
     {
         return physicalWrittenDataSizeInBytes;
     }
 
     @JsonProperty
+    @ThriftField(13)
     public long getMemoryReservationInBytes()
     {
         return memoryReservationInBytes;
     }
 
     @JsonProperty
+    @ThriftField(14)
     public long getSystemMemoryReservationInBytes()
     {
         return systemMemoryReservationInBytes;
     }
 
     @JsonProperty
+    @ThriftField(15)
     public long getFullGcCount()
     {
         return fullGcCount;
     }
 
     @JsonProperty
+    @ThriftField(16)
     public long getFullGcTimeInMillis()
     {
         return fullGcTimeInMillis;

--- a/presto-main/src/main/java/com/facebook/presto/server/PluginManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PluginManager.java
@@ -80,6 +80,9 @@ public class PluginManager
             .add("io.airlift.units.")
             .add("org.openjdk.jol.")
             .add("com.facebook.presto.common")
+            .add("com.facebook.drift.annotations.")
+            .add("com.facebook.drift.TException")
+            .add("com.facebook.drift.TApplicationException")
             .build();
 
     private static final Logger log = Logger.get(PluginManager.class);

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestThriftTaskStatus.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestThriftTaskStatus.java
@@ -1,0 +1,209 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution;
+
+import com.facebook.drift.codec.ThriftCodec;
+import com.facebook.drift.codec.ThriftCodecManager;
+import com.facebook.drift.codec.internal.compiler.CompilerThriftCodecFactory;
+import com.facebook.drift.codec.internal.reflection.ReflectionThriftCodecFactory;
+import com.facebook.drift.protocol.TBinaryProtocol;
+import com.facebook.drift.protocol.TCompactProtocol;
+import com.facebook.drift.protocol.TFacebookCompactProtocol;
+import com.facebook.drift.protocol.TMemoryBuffer;
+import com.facebook.drift.protocol.TProtocol;
+import com.facebook.drift.protocol.TTransport;
+import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.PrestoTransportException;
+import com.facebook.presto.sql.parser.ParsingException;
+import com.facebook.presto.sql.tree.NodeLocation;
+import com.facebook.presto.util.Failures;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
+
+import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static com.facebook.presto.spi.StandardErrorCode.REMOTE_TASK_ERROR;
+import static com.facebook.presto.spi.StandardErrorCode.SYNTAX_ERROR;
+import static com.facebook.presto.spi.StandardErrorCode.TOO_MANY_REQUESTS_FAILED;
+import static org.testng.Assert.assertEquals;
+
+public class TestThriftTaskStatus
+{
+    private static final ThriftCodecManager COMPILER_READ_CODEC_MANAGER = new ThriftCodecManager(new CompilerThriftCodecFactory(false));
+    private static final ThriftCodecManager COMPILER_WRITE_CODEC_MANAGER = new ThriftCodecManager(new CompilerThriftCodecFactory(false));
+    private static final ThriftCodec<TaskStatus> COMPILER_READ_CODEC = COMPILER_READ_CODEC_MANAGER.getCodec(TaskStatus.class);
+    private static final ThriftCodec<TaskStatus> COMPILER_WRITE_CODEC = COMPILER_WRITE_CODEC_MANAGER.getCodec(TaskStatus.class);
+    private static final ThriftCodecManager REFLECTION_READ_CODEC_MANAGER = new ThriftCodecManager(new ReflectionThriftCodecFactory());
+    private static final ThriftCodecManager REFLECTION_WRITE_CODEC_MANAGER = new ThriftCodecManager(new ReflectionThriftCodecFactory());
+    private static final ThriftCodec<TaskStatus> REFLECTION_READ_CODEC = REFLECTION_READ_CODEC_MANAGER.getCodec(TaskStatus.class);
+    private static final ThriftCodec<TaskStatus> REFLECTION_WRITE_CODEC = REFLECTION_WRITE_CODEC_MANAGER.getCodec(TaskStatus.class);
+    private static final TMemoryBuffer transport = new TMemoryBuffer(100 * 1024);
+    public static final long TASK_INSTANCE_ID_LEAST_SIGNIFICANT_BITS = 123L;
+    public static final long TASK_INSTANCE_ID_MOST_SIGNIFICANT_BITS = 456L;
+    public static final long VERSION = 789L;
+    public static final TaskState RUNNING = TaskState.RUNNING;
+    public static final URI SELF_URI = java.net.URI.create("fake://task/" + "1");
+    public static final Set<Lifespan> LIFESPANS = ImmutableSet.of(Lifespan.taskWide(), Lifespan.driverGroup(100));
+    public static final int QUEUED_PARTITIONED_DRIVERS = 100;
+    public static final int RUNNING_PARTITIONED_DRIVERS = 200;
+    public static final double OUTPUT_BUFFER_UTILIZATION = 99.9;
+    public static final boolean OUTPUT_BUFFER_OVERUTILIZED = true;
+    public static final int PHYSICAL_WRITTEN_DATA_SIZE_IN_BYTES = 1024 * 1024;
+    public static final int MEMORY_RESERVATION_IN_BYTES = 1024 * 1024 * 1024;
+    public static final int SYSTEM_MEMORY_RESERVATION_IN_BYTES = 2 * 1024 * 1024 * 1024;
+    public static final int FULL_GC_COUNT = 10;
+    public static final int FULL_GC_TIME_IN_MILLIS = 1001;
+    public static final HostAddress REMOTE_HOST = HostAddress.fromParts("www.fake.invalid", 8080);
+    private TaskStatus taskStatus;
+
+    @BeforeMethod
+    public void setUp()
+    {
+        taskStatus = getTaskStatus();
+    }
+
+    @DataProvider
+    public Object[][] codecCombinations()
+    {
+        return new Object[][] {
+                {COMPILER_READ_CODEC, COMPILER_WRITE_CODEC},
+                {COMPILER_READ_CODEC, REFLECTION_WRITE_CODEC},
+                {REFLECTION_READ_CODEC, COMPILER_WRITE_CODEC},
+                {REFLECTION_READ_CODEC, REFLECTION_WRITE_CODEC}
+        };
+    }
+
+    @Test(dataProvider = "codecCombinations")
+    public void testRoundTripSerializeBinaryProtocol(ThriftCodec<TaskStatus> readCodec, ThriftCodec<TaskStatus> writeCodec)
+            throws Exception
+    {
+        TaskStatus taskStatus = getRoundTripSerialize(readCodec, writeCodec, TBinaryProtocol::new);
+        assertSerde(taskStatus);
+    }
+
+    @Test(dataProvider = "codecCombinations")
+    public void testRoundTripSerializeTCompactProtocol(ThriftCodec<TaskStatus> readCodec, ThriftCodec<TaskStatus> writeCodec)
+            throws Exception
+    {
+        TaskStatus taskStatus = getRoundTripSerialize(readCodec, writeCodec, TCompactProtocol::new);
+        assertSerde(taskStatus);
+    }
+
+    @Test(dataProvider = "codecCombinations")
+    public void testRoundTripSerializeTFacebookCompactProtocol(ThriftCodec<TaskStatus> readCodec, ThriftCodec<TaskStatus> writeCodec)
+            throws Exception
+    {
+        TaskStatus taskStatus = getRoundTripSerialize(readCodec, writeCodec, TFacebookCompactProtocol::new);
+        assertSerde(taskStatus);
+    }
+
+    private void assertSerde(TaskStatus taskStatus)
+    {
+        assertEquals(taskStatus.getTaskInstanceIdLeastSignificantBits(), 123L);
+        assertEquals(taskStatus.getTaskInstanceIdMostSignificantBits(), 456L);
+        assertEquals(taskStatus.getVersion(), 789L);
+        assertEquals(taskStatus.getState(), TaskState.RUNNING);
+        assertEquals(taskStatus.getSelf(), SELF_URI);
+        assertEquals(taskStatus.getCompletedDriverGroups(), LIFESPANS);
+        assertEquals(taskStatus.getQueuedPartitionedDrivers(), QUEUED_PARTITIONED_DRIVERS);
+        assertEquals(taskStatus.getRunningPartitionedDrivers(), RUNNING_PARTITIONED_DRIVERS);
+        assertEquals(taskStatus.getOutputBufferUtilization(), OUTPUT_BUFFER_UTILIZATION);
+        assertEquals(taskStatus.isOutputBufferOverutilized(), OUTPUT_BUFFER_OVERUTILIZED);
+        assertEquals(taskStatus.getPhysicalWrittenDataSizeInBytes(), PHYSICAL_WRITTEN_DATA_SIZE_IN_BYTES);
+        assertEquals(taskStatus.getSystemMemoryReservationInBytes(), SYSTEM_MEMORY_RESERVATION_IN_BYTES);
+        assertEquals(taskStatus.getFullGcCount(), FULL_GC_COUNT);
+        assertEquals(taskStatus.getFullGcTimeInMillis(), FULL_GC_TIME_IN_MILLIS);
+
+        List<ExecutionFailureInfo> failures = taskStatus.getFailures();
+        assertEquals(failures.size(), 3);
+
+        ExecutionFailureInfo firstFailure = failures.get(0);
+        assertEquals(firstFailure.getType(), IOException.class.getName());
+        assertEquals(firstFailure.getMessage(), "Remote call timed out");
+        assertEquals(firstFailure.getErrorCode(), GENERIC_INTERNAL_ERROR.toErrorCode());
+        List<ExecutionFailureInfo> suppressedFailures = firstFailure.getSuppressed();
+        assertEquals(suppressedFailures.size(), 1);
+        ExecutionFailureInfo suppressedFailure = suppressedFailures.get(0);
+        assertEquals(suppressedFailure.getType(), IOException.class.getName());
+        assertEquals(suppressedFailure.getMessage(), "Thrift call timed out");
+        assertEquals(suppressedFailure.getErrorCode(), GENERIC_INTERNAL_ERROR.toErrorCode());
+
+        ExecutionFailureInfo secondFailure = failures.get(1);
+        assertEquals(secondFailure.getType(), PrestoTransportException.class.getName());
+        assertEquals(secondFailure.getMessage(), "Too many requests failed");
+        assertEquals(secondFailure.getRemoteHost(), REMOTE_HOST);
+        assertEquals(secondFailure.getErrorCode(), TOO_MANY_REQUESTS_FAILED.toErrorCode());
+        ExecutionFailureInfo cause = secondFailure.getCause();
+        assertEquals(cause.getType(), PrestoException.class.getName());
+        assertEquals(cause.getMessage(), "Remote Task Error");
+        assertEquals(cause.getErrorCode(), REMOTE_TASK_ERROR.toErrorCode());
+
+        ExecutionFailureInfo thirdFailure = failures.get(2);
+        assertEquals(thirdFailure.getType(), ParsingException.class.getName());
+        assertEquals(thirdFailure.getErrorCode(), SYNTAX_ERROR.toErrorCode());
+        assertEquals(thirdFailure.getErrorLocation().getLineNumber(), 100);
+        assertEquals(thirdFailure.getErrorLocation().getColumnNumber(), 3);
+    }
+
+    private TaskStatus getRoundTripSerialize(ThriftCodec<TaskStatus> readCodec, ThriftCodec<TaskStatus> writeCodec, Function<TTransport, TProtocol> protocolFactory)
+            throws Exception
+    {
+        TProtocol protocol = protocolFactory.apply(transport);
+        writeCodec.write(taskStatus, protocol);
+        return readCodec.read(protocol);
+    }
+
+    private TaskStatus getTaskStatus()
+    {
+        List<ExecutionFailureInfo> executionFailureInfos = getExecutionFailureInfos();
+        return new TaskStatus(
+                TASK_INSTANCE_ID_LEAST_SIGNIFICANT_BITS,
+                TASK_INSTANCE_ID_MOST_SIGNIFICANT_BITS,
+                VERSION,
+                RUNNING,
+                SELF_URI,
+                LIFESPANS,
+                executionFailureInfos,
+                QUEUED_PARTITIONED_DRIVERS,
+                RUNNING_PARTITIONED_DRIVERS,
+                OUTPUT_BUFFER_UTILIZATION,
+                OUTPUT_BUFFER_OVERUTILIZED,
+                PHYSICAL_WRITTEN_DATA_SIZE_IN_BYTES,
+                MEMORY_RESERVATION_IN_BYTES,
+                SYSTEM_MEMORY_RESERVATION_IN_BYTES,
+                FULL_GC_COUNT,
+                FULL_GC_TIME_IN_MILLIS);
+    }
+
+    private List<ExecutionFailureInfo> getExecutionFailureInfos()
+    {
+        IOException ioException = new IOException("Remote call timed out");
+        ioException.addSuppressed(new IOException("Thrift call timed out"));
+        PrestoTransportException prestoTransportException = new PrestoTransportException(TOO_MANY_REQUESTS_FAILED,
+                REMOTE_HOST,
+                "Too many requests failed",
+                new PrestoException(REMOTE_TASK_ERROR, "Remote Task Error"));
+        ParsingException parsingException = new ParsingException("Parsing Exception", new NodeLocation(100, 1));
+        return Failures.toFailures(ImmutableList.of(ioException, prestoTransportException, parsingException));
+    }
+}

--- a/presto-memory/pom.xml
+++ b/presto-memory/pom.xml
@@ -72,6 +72,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>slice</artifactId>
             <scope>provided</scope>

--- a/presto-ml/pom.xml
+++ b/presto-ml/pom.xml
@@ -70,6 +70,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
             <scope>provided</scope>

--- a/presto-mongodb/pom.xml
+++ b/presto-mongodb/pom.xml
@@ -99,6 +99,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>slice</artifactId>
             <scope>provided</scope>

--- a/presto-mysql/pom.xml
+++ b/presto-mysql/pom.xml
@@ -66,6 +66,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>slice</artifactId>
             <scope>provided</scope>

--- a/presto-oracle/pom.xml
+++ b/presto-oracle/pom.xml
@@ -80,6 +80,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>slice</artifactId>
             <scope>provided</scope>

--- a/presto-password-authenticators/pom.xml
+++ b/presto-password-authenticators/pom.xml
@@ -71,6 +71,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>slice</artifactId>
             <scope>provided</scope>

--- a/presto-pinot-toolkit/pom.xml
+++ b/presto-pinot-toolkit/pom.xml
@@ -99,6 +99,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.openjdk.jol</groupId>
             <artifactId>jol-core</artifactId>
             <scope>provided</scope>

--- a/presto-pinot/pom.xml
+++ b/presto-pinot/pom.xml
@@ -43,6 +43,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.openjdk.jol</groupId>
             <artifactId>jol-core</artifactId>
             <scope>provided</scope>

--- a/presto-postgresql/pom.xml
+++ b/presto-postgresql/pom.xml
@@ -61,6 +61,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>slice</artifactId>
             <scope>provided</scope>

--- a/presto-raptor/pom.xml
+++ b/presto-raptor/pom.xml
@@ -184,6 +184,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>slice</artifactId>
             <scope>provided</scope>

--- a/presto-redshift/pom.xml
+++ b/presto-redshift/pom.xml
@@ -63,6 +63,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>slice</artifactId>
             <scope>provided</scope>

--- a/presto-spi/pom.xml
+++ b/presto-spi/pom.xml
@@ -23,6 +23,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-api</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>slice</artifactId>
         </dependency>

--- a/presto-spi/src/main/java/com/facebook/presto/spi/ErrorCode.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ErrorCode.java
@@ -13,6 +13,9 @@
  */
 package com.facebook.presto.spi;
 
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -20,6 +23,7 @@ import java.util.Objects;
 
 import static java.util.Objects.requireNonNull;
 
+@ThriftStruct
 public final class ErrorCode
 {
     private final int code;
@@ -27,6 +31,7 @@ public final class ErrorCode
     private final ErrorType type;
 
     @JsonCreator
+    @ThriftConstructor
     public ErrorCode(
             @JsonProperty("code") int code,
             @JsonProperty("name") String name,
@@ -41,18 +46,21 @@ public final class ErrorCode
     }
 
     @JsonProperty
+    @ThriftField(1)
     public int getCode()
     {
         return code;
     }
 
     @JsonProperty
+    @ThriftField(2)
     public String getName()
     {
         return name;
     }
 
     @JsonProperty
+    @ThriftField(3)
     public ErrorType getType()
     {
         return type;

--- a/presto-spi/src/main/java/com/facebook/presto/spi/ErrorType.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ErrorType.java
@@ -13,10 +13,27 @@
  */
 package com.facebook.presto.spi;
 
+import com.facebook.drift.annotations.ThriftEnum;
+import com.facebook.drift.annotations.ThriftEnumValue;
+
+@ThriftEnum
 public enum ErrorType
 {
-    USER_ERROR,
-    INTERNAL_ERROR,
-    INSUFFICIENT_RESOURCES,
-    EXTERNAL
+    USER_ERROR(0),
+    INTERNAL_ERROR(1),
+    INSUFFICIENT_RESOURCES(2),
+    EXTERNAL(3);
+
+    private final int code;
+
+    ErrorType(int code)
+    {
+        this.code = code;
+    }
+
+    @ThriftEnumValue
+    public int getCode()
+    {
+        return code;
+    }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/HostAddress.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/HostAddress.java
@@ -13,6 +13,9 @@
  */
 package com.facebook.presto.spi;
 
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
@@ -56,6 +59,7 @@ import static java.util.Objects.requireNonNull;
  * @author Paul Marks
  * @since 10.0
  */
+@ThriftStruct
 public class HostAddress
 {
     /**
@@ -73,7 +77,8 @@ public class HostAddress
      */
     private final int port;
 
-    private HostAddress(String host, int port)
+    @ThriftConstructor
+    public HostAddress(String host, int port)
     {
         this.host = host;
         this.port = port;
@@ -86,6 +91,7 @@ public class HostAddress
      * <p>A successful parse does not imply any degree of sanity in this field.
      * For additional validation, see the {@link com.google.common.net.HostSpecifier} class.
      */
+    @ThriftField(value = 1, name = "host")
     public String getHostText()
     {
         return host;
@@ -106,6 +112,7 @@ public class HostAddress
      * @throws IllegalStateException if no port is defined.  You can use
      * {@link #withDefaultPort(int)} to prevent this from occurring.
      */
+    @ThriftField(2)
     public int getPort()
     {
         if (!hasPort()) {

--- a/presto-sqlserver/pom.xml
+++ b/presto-sqlserver/pom.xml
@@ -76,6 +76,12 @@
             <scope>provided</scope>
         </dependency>
 
+        <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- for testing -->
         <dependency>
             <groupId>org.testng</groupId>

--- a/presto-teradata-functions/pom.xml
+++ b/presto-teradata-functions/pom.xml
@@ -50,6 +50,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>slice</artifactId>
             <scope>provided</scope>

--- a/presto-thrift-connector/pom.xml
+++ b/presto-thrift-connector/pom.xml
@@ -24,11 +24,6 @@
 
         <dependency>
             <groupId>com.facebook.drift</groupId>
-            <artifactId>drift-api</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.facebook.drift</groupId>
             <artifactId>drift-client</artifactId>
         </dependency>
 
@@ -120,6 +115,12 @@
         <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-common</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-api</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/presto-tpcds/pom.xml
+++ b/presto-tpcds/pom.xml
@@ -60,6 +60,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>slice</artifactId>
             <scope>provided</scope>

--- a/presto-tpch/pom.xml
+++ b/presto-tpch/pom.xml
@@ -40,6 +40,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>io.airlift</groupId>
             <artifactId>slice</artifactId>
             <scope>provided</scope>


### PR DESCRIPTION
depended by facebookexternal/presto-facebook#1231

Add thrift serde support for TaskStatus.

Added Drift annotations to TaskStatus and related classes to support thrift serde.

Test plan - Unit tests
Verifier tests : https://www.internalfb.com/intern/presto/verifier/results/?test_id=46590
```
== NO RELEASE NOTE ==
```