### PR TITLE
Adding array functions pushdown to pinot

### DIFF
--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/query/PinotFilterExpressionConverter.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/query/PinotFilterExpressionConverter.java
@@ -201,6 +201,24 @@ public class PinotFilterExpressionConverter
         return Optional.of(timeValueString);
     }
 
+    private PinotExpression handleContains(
+            CallExpression contains,
+            Function<VariableReferenceExpression, Selection> context)
+    {
+        if (contains.getArguments().size() != 2) {
+            throw new PinotException(PINOT_UNSUPPORTED_EXPRESSION, Optional.empty(), format("Contains operator not supported: %s", contains));
+        }
+        RowExpression left = contains.getArguments().get(0);
+        RowExpression right = contains.getArguments().get(1);
+        if (!(right instanceof ConstantExpression)) {
+            throw new PinotException(PINOT_UNSUPPORTED_EXPRESSION, Optional.empty(), format("Contains operator can not push down non-literal value: %s", right));
+        }
+        return derived(format(
+                "(%s = %s)",
+                left.accept(this, context).getDefinition(),
+                right.accept(this, context).getDefinition()));
+    }
+
     private PinotExpression handleBetween(
             CallExpression between,
             Function<VariableReferenceExpression, Selection> context)
@@ -293,6 +311,9 @@ public class PinotFilterExpressionConverter
             if (operatorType.isComparisonOperator()) {
                 return handleLogicalBinary(operatorType.getOperator(), call, context);
             }
+        }
+        if ("contains".equals(functionMetadata.getName().getFunctionName())) {
+            return handleContains(call, context);
         }
         // Handle queries like `eventTimestamp < 1391126400000`.
         // Otherwise TypeManager.canCoerce(...) will return false and directly fail this query.

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/query/PinotQueryGenerator.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/query/PinotQueryGenerator.java
@@ -299,7 +299,7 @@ public class PinotQueryGenerator
                 RowExpression expression = node.getAssignments().get(variable);
                 PinotExpression pinotExpression = expression.accept(
                         contextIn.getVariablesInAggregation().contains(variable) ?
-                                new PinotAggregationProjectConverter(typeManager, functionMetadataManager, standardFunctionResolution, session) :
+                                new PinotAggregationProjectConverter(typeManager, functionMetadataManager, standardFunctionResolution, session, variable) :
                                 pinotProjectExpressionConverter,
                         context.getSelections());
                 newSelections.put(

--- a/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotQueryBase.java
+++ b/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotQueryBase.java
@@ -98,6 +98,7 @@ public class TestPinotQueryBase
     protected static PinotColumnHandle regionId = new PinotColumnHandle("regionId", BIGINT, REGULAR);
     protected static PinotColumnHandle city = new PinotColumnHandle("city", VARCHAR, REGULAR);
     protected static final PinotColumnHandle fare = new PinotColumnHandle("fare", DOUBLE, REGULAR);
+    protected static final PinotColumnHandle scores = array(DOUBLE, "scores");
     protected static final PinotColumnHandle secondsSinceEpoch = new PinotColumnHandle("secondsSinceEpoch", BIGINT, REGULAR);
     protected static final PinotColumnHandle daysSinceEpoch = new PinotColumnHandle("daysSinceEpoch", DATE, REGULAR);
     protected static final PinotColumnHandle millisSinceEpoch = new PinotColumnHandle("millisSinceEpoch", TIMESTAMP, REGULAR);
@@ -111,10 +112,15 @@ public class TestPinotQueryBase
                     .put(new VariableReferenceExpression("regionid", BIGINT), new PinotQueryGeneratorContext.Selection("regionId", TABLE_COLUMN)) // direct column reference
                     .put(new VariableReferenceExpression("regionid$distinct", BIGINT), new PinotQueryGeneratorContext.Selection("regionId", TABLE_COLUMN)) // distinct column reference
                     .put(new VariableReferenceExpression("city", VARCHAR), new PinotQueryGeneratorContext.Selection("city", TABLE_COLUMN)) // direct column reference
+                    .put(new VariableReferenceExpression("scores", new ArrayType(DOUBLE)), new PinotQueryGeneratorContext.Selection("scores", TABLE_COLUMN)) // direct column reference
                     .put(new VariableReferenceExpression("fare", DOUBLE), new PinotQueryGeneratorContext.Selection("fare", TABLE_COLUMN)) // direct column reference
                     .put(new VariableReferenceExpression("totalfare", DOUBLE), new PinotQueryGeneratorContext.Selection("(fare + trip)", DERIVED)) // derived column
                     .put(new VariableReferenceExpression("count_regionid", BIGINT), new PinotQueryGeneratorContext.Selection("count(regionid)", DERIVED))// derived column
                     .put(new VariableReferenceExpression("sum_fare", BIGINT), new PinotQueryGeneratorContext.Selection("sum(fare)", DERIVED))// derived column
+                    .put(new VariableReferenceExpression("array_min_0", DOUBLE), new PinotQueryGeneratorContext.Selection("array_min(scores)", DERIVED)) // derived column
+                    .put(new VariableReferenceExpression("array_max_0", DOUBLE), new PinotQueryGeneratorContext.Selection("array_max(scores)", DERIVED)) // derived column
+                    .put(new VariableReferenceExpression("array_sum_0", DOUBLE), new PinotQueryGeneratorContext.Selection("reduce(scores, cast(0 as double), (s, x) -> s + x, s -> s)", DERIVED)) // derived column
+                    .put(new VariableReferenceExpression("array_average_0", DOUBLE), new PinotQueryGeneratorContext.Selection("reduce(scores, CAST(ROW(0.0, 0) AS ROW(sum DOUBLE, count INTEGER)), (s,x) -> CAST(ROW(x + s.sum, s.count + 1) AS ROW(sum DOUBLE, count INTEGER)), s -> IF(s.count = 0, NULL, s.sum / s.count))", DERIVED)) // derived column
                     .put(new VariableReferenceExpression("secondssinceepoch", BIGINT), new PinotQueryGeneratorContext.Selection("secondsSinceEpoch", TABLE_COLUMN)) // column for datetime functions
                     .put(new VariableReferenceExpression("dayssinceepoch", DATE), new PinotQueryGeneratorContext.Selection("daysSinceEpoch", TABLE_COLUMN)) // column for date functions
                     .put(new VariableReferenceExpression("millissinceepoch", TIMESTAMP), new PinotQueryGeneratorContext.Selection("millisSinceEpoch", TABLE_COLUMN)) // column for timestamp functions


### PR DESCRIPTION
Support pushing down Array functions to Pinot.
- Array functions(`array_sum`, `array_min`, `array_max`, `array_average`) inside aggregation functions or group by clause  to Pinot.
- Boolean functions in Predicate: `contains`

E.g. For Presto query: `SELECT sum(array_max(col)) FROM myTable WHERE contains(col, 1)` , the pushdown pinot query is: `SELECT sum(arrayMax(col)) FROM myTable WHERE col = 1`


Test plan:
Unit tests and tested with local setup for array functions(`array_sum`, `array_min`, `array_max`, `array_average`, `contains`) pushdown to Pinot:


```
== RELEASE NOTES ==

Pinot Changes
* Support pushing down array functions `array_sum`, `array_min`, `array_max`, `array_average`, and `contains` to Pinot connector.
```

