### PR TITLE
Disable broadcast join optimization for Presto on Spark

### DIFF
--- a/presto-spark-base/pom.xml
+++ b/presto-spark-base/pom.xml
@@ -35,6 +35,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.github.luben</groupId>
+            <artifactId>zstd-jni</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.facebook.presto.spark</groupId>
             <artifactId>spark-core</artifactId>
             <scope>provided</scope>

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkConfig.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkConfig.java
@@ -30,7 +30,6 @@ public class PrestoSparkConfig
     private int initialSparkPartitionCount = 16;
     private DataSize maxSplitsDataSizePerSparkPartition = new DataSize(2, GIGABYTE);
     private DataSize shuffleOutputTargetAverageRowSize = new DataSize(1, KILOBYTE);
-    private boolean nullifyingIteratorForBroadcastJoinEnabled = true;
 
     public boolean isSparkPartitionCountAutoTuneEnabled()
     {
@@ -108,19 +107,6 @@ public class PrestoSparkConfig
     public PrestoSparkConfig setShuffleOutputTargetAverageRowSize(DataSize shuffleOutputTargetAverageRowSize)
     {
         this.shuffleOutputTargetAverageRowSize = shuffleOutputTargetAverageRowSize;
-        return this;
-    }
-
-    public boolean isNullifyingIteratorForBroadcastJoinEnabled()
-    {
-        return nullifyingIteratorForBroadcastJoinEnabled;
-    }
-
-    @Config("spark.nullifying-iterator-for-broadcast-join-enabled")
-    @ConfigDescription("Enable nullifying iterator to optimize broadcast join memory footprint")
-    public PrestoSparkConfig setNullifyingIteratorForBroadcastJoinEnabled(boolean nullifyingIteratorForBroadcastJoinEnabled)
-    {
-        this.nullifyingIteratorForBroadcastJoinEnabled = nullifyingIteratorForBroadcastJoinEnabled;
         return this;
     }
 }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
@@ -140,6 +140,7 @@ import static com.facebook.presto.spark.SparkErrorCode.SPARK_EXECUTOR_LOST;
 import static com.facebook.presto.spark.SparkErrorCode.SPARK_EXECUTOR_OOM;
 import static com.facebook.presto.spark.classloader_interface.ScalaUtils.collectScalaIterator;
 import static com.facebook.presto.spark.classloader_interface.ScalaUtils.emptyScalaIterator;
+import static com.facebook.presto.spark.util.PrestoSparkUtils.createPagesSerde;
 import static com.facebook.presto.spark.util.PrestoSparkUtils.toSerializedPage;
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
@@ -323,7 +324,7 @@ public class PrestoSparkQueryExecutionFactory
                     rddFactory,
                     tableWriteInfo,
                     transactionManager,
-                    new PagesSerde(blockEncodingManager, Optional.empty(), Optional.empty(), Optional.empty()),
+                    createPagesSerde(blockEncodingManager),
                     executionExceptionFactory,
                     queryStatusInfoOutputPath,
                     queryDataOutputPath);

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
@@ -126,6 +126,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 
 import static com.facebook.airlift.concurrent.MoreFutures.getFutureValue;
+import static com.facebook.presto.ExceededMemoryLimitException.exceededLocalBroadcastMemoryLimit;
+import static com.facebook.presto.SystemSessionProperties.getQueryMaxBroadcastMemory;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.execution.QueryState.FAILED;
 import static com.facebook.presto.execution.QueryState.FINISHED;
@@ -160,6 +162,7 @@ import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.util.concurrent.Futures.getUnchecked;
 import static io.airlift.units.DataSize.succinctBytes;
 import static java.lang.Math.max;
+import static java.lang.String.format;
 import static java.nio.file.Files.notExists;
 import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
@@ -897,9 +900,29 @@ public class PrestoSparkQueryExecutionFactory
                 PlanFragment childFragment = child.getFragment();
                 if (childFragment.getPartitioningScheme().getPartitioning().getHandle().equals(FIXED_BROADCAST_DISTRIBUTION)) {
                     RddAndMore<PrestoSparkSerializedPage> childRdd = createRdd(child, PrestoSparkSerializedPage.class);
+
+                    // TODO: The driver might still OOM on a very large broadcast, think of how to prevent that from happening
                     List<PrestoSparkSerializedPage> broadcastPages = childRdd.collectAndDestroyDependencies().stream()
                             .map(Tuple2::_2)
                             .collect(toList());
+
+                    int compressedBroadcastSizeInBytes = broadcastPages.stream()
+                            .mapToInt(page -> page.getBytes().length)
+                            .sum();
+                    int uncompressedBroadcastSizeInBytes = broadcastPages.stream()
+                            .mapToInt(PrestoSparkSerializedPage::getUncompressedSizeInBytes)
+                            .sum();
+                    DataSize maxBroadcastSize = getQueryMaxBroadcastMemory(session);
+                    long maxBroadcastSizeInBytes = maxBroadcastSize.toBytes();
+
+                    if (compressedBroadcastSizeInBytes > maxBroadcastSizeInBytes) {
+                        throw exceededLocalBroadcastMemoryLimit(maxBroadcastSize, format("Compressed broadcast size: %s", succinctBytes(compressedBroadcastSizeInBytes)));
+                    }
+
+                    if (uncompressedBroadcastSizeInBytes > maxBroadcastSizeInBytes) {
+                        throw exceededLocalBroadcastMemoryLimit(maxBroadcastSize, format("Uncompressed broadcast size: %s", succinctBytes(compressedBroadcastSizeInBytes)));
+                    }
+
                     Broadcast<List<PrestoSparkSerializedPage>> broadcast = sparkContext.broadcast(broadcastPages);
                     broadcastInputs.put(childFragment.getId(), broadcast);
                     broadcastDependencies.add(broadcast);

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkPageOutputOperator.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkPageOutputOperator.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.spark.execution;
 
+import com.facebook.presto.block.BlockEncodingManager;
 import com.facebook.presto.common.Page;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.execution.buffer.PagesSerdeFactory;
@@ -32,6 +33,7 @@ import java.util.function.Function;
 
 import static com.facebook.presto.common.block.PageBuilderStatus.DEFAULT_MAX_PAGE_SIZE_IN_BYTES;
 import static com.facebook.presto.execution.buffer.PageSplitterUtil.splitPage;
+import static com.facebook.presto.spark.util.PrestoSparkUtils.createPagesSerde;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
@@ -43,14 +45,14 @@ public class PrestoSparkPageOutputOperator
             implements OutputFactory
     {
         private final PrestoSparkOutputBuffer<PrestoSparkBufferedSerializedPage> outputBuffer;
-        private final PagesSerde pagesSerde;
+        private final BlockEncodingManager blockEncodingManager;
 
         public PrestoSparkPageOutputFactory(
                 PrestoSparkOutputBuffer<PrestoSparkBufferedSerializedPage> outputBuffer,
-                PagesSerde pagesSerde)
+                BlockEncodingManager blockEncodingManager)
         {
             this.outputBuffer = requireNonNull(outputBuffer, "outputBuffer is null");
-            this.pagesSerde = requireNonNull(pagesSerde, "pagesSerde is null");
+            this.blockEncodingManager = requireNonNull(blockEncodingManager, "blockEncodingManager is null");
         }
 
         @Override
@@ -67,7 +69,8 @@ public class PrestoSparkPageOutputOperator
                     operatorId,
                     planNodeId,
                     outputBuffer,
-                    pagePreprocessor, pagesSerde);
+                    pagePreprocessor,
+                    blockEncodingManager);
         }
     }
 
@@ -78,20 +81,20 @@ public class PrestoSparkPageOutputOperator
         private final PlanNodeId planNodeId;
         private final PrestoSparkOutputBuffer<PrestoSparkBufferedSerializedPage> outputBuffer;
         private final Function<Page, Page> pagePreprocessor;
-        private final PagesSerde pagesSerde;
+        private final BlockEncodingManager blockEncodingManager;
 
         public PrestoSparkOutputOperatorFactory(
                 int operatorId,
                 PlanNodeId planNodeId,
                 PrestoSparkOutputBuffer<PrestoSparkBufferedSerializedPage> outputBuffer,
                 Function<Page, Page> pagePreprocessor,
-                PagesSerde pagesSerde)
+                BlockEncodingManager blockEncodingManager)
         {
             this.operatorId = operatorId;
             this.planNodeId = requireNonNull(planNodeId, "planNodeId is null");
             this.outputBuffer = requireNonNull(outputBuffer, "outputBuffer is null");
             this.pagePreprocessor = requireNonNull(pagePreprocessor, "pagePreprocessor is null");
-            this.pagesSerde = requireNonNull(pagesSerde, "pagesSerde is null");
+            this.blockEncodingManager = requireNonNull(blockEncodingManager, "blockEncodingManager is null");
         }
 
         @Override
@@ -102,7 +105,7 @@ public class PrestoSparkPageOutputOperator
                     operatorContext,
                     outputBuffer,
                     pagePreprocessor,
-                    pagesSerde);
+                    createPagesSerde(blockEncodingManager));
         }
 
         @Override
@@ -117,7 +120,8 @@ public class PrestoSparkPageOutputOperator
                     operatorId,
                     planNodeId,
                     outputBuffer,
-                    pagePreprocessor, pagesSerde);
+                    pagePreprocessor,
+                    blockEncodingManager);
         }
     }
 
@@ -131,7 +135,8 @@ public class PrestoSparkPageOutputOperator
     public PrestoSparkPageOutputOperator(
             OperatorContext operatorContext,
             PrestoSparkOutputBuffer<PrestoSparkBufferedSerializedPage> outputBuffer,
-            Function<Page, Page> pagePreprocessor, PagesSerde pagesSerde)
+            Function<Page, Page> pagePreprocessor,
+            PagesSerde pagesSerde)
     {
         this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
         this.outputBuffer = requireNonNull(outputBuffer, "outputBuffer is null");

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkTaskExecutorFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkTaskExecutorFactory.java
@@ -43,7 +43,6 @@ import com.facebook.presto.operator.OutputFactory;
 import com.facebook.presto.operator.TaskContext;
 import com.facebook.presto.operator.TaskStats;
 import com.facebook.presto.spark.PrestoSparkAuthenticatorProvider;
-import com.facebook.presto.spark.PrestoSparkConfig;
 import com.facebook.presto.spark.PrestoSparkTaskDescriptor;
 import com.facebook.presto.spark.classloader_interface.IPrestoSparkTaskExecutor;
 import com.facebook.presto.spark.classloader_interface.IPrestoSparkTaskExecutorFactory;
@@ -110,7 +109,6 @@ import static com.facebook.presto.spark.PrestoSparkSessionProperties.getShuffleO
 import static com.facebook.presto.spark.classloader_interface.PrestoSparkShuffleStats.Operation.WRITE;
 import static com.facebook.presto.spark.util.PrestoSparkUtils.compress;
 import static com.facebook.presto.spark.util.PrestoSparkUtils.decompress;
-import static com.facebook.presto.spark.util.PrestoSparkUtils.getNullifyingIterator;
 import static com.facebook.presto.spark.util.PrestoSparkUtils.toPrestoSparkSerializedPage;
 import static com.facebook.presto.sql.planner.SystemPartitioningHandle.FIXED_ARBITRARY_DISTRIBUTION;
 import static com.facebook.presto.util.Failures.toFailures;
@@ -158,8 +156,6 @@ public class PrestoSparkTaskExecutorFactory
     private final boolean perOperatorAllocationTrackingEnabled;
     private final boolean allocationTrackingEnabled;
 
-    private final boolean nullifyingIteratorForBroadcastJoinEnabled;
-
     @Inject
     public PrestoSparkTaskExecutorFactory(
             SessionPropertyManager sessionPropertyManager,
@@ -179,8 +175,7 @@ public class PrestoSparkTaskExecutorFactory
             FragmentResultCacheManager fragmentResultCacheManager,
             TaskManagerConfig taskManagerConfig,
             NodeMemoryConfig nodeMemoryConfig,
-            NodeSpillConfig nodeSpillConfig,
-            PrestoSparkConfig prestoSparkConfig)
+            NodeSpillConfig nodeSpillConfig)
     {
         this(
                 sessionPropertyManager,
@@ -205,8 +200,7 @@ public class PrestoSparkTaskExecutorFactory
                 requireNonNull(taskManagerConfig, "taskManagerConfig is null").isPerOperatorCpuTimerEnabled(),
                 requireNonNull(taskManagerConfig, "taskManagerConfig is null").isTaskCpuTimerEnabled(),
                 requireNonNull(taskManagerConfig, "taskManagerConfig is null").isPerOperatorAllocationTrackingEnabled(),
-                requireNonNull(taskManagerConfig, "taskManagerConfig is null").isTaskAllocationTrackingEnabled(),
-                requireNonNull(prestoSparkConfig, "prestoSparkConfig is null").isNullifyingIteratorForBroadcastJoinEnabled());
+                requireNonNull(taskManagerConfig, "taskManagerConfig is null").isTaskAllocationTrackingEnabled());
     }
 
     public PrestoSparkTaskExecutorFactory(
@@ -232,8 +226,7 @@ public class PrestoSparkTaskExecutorFactory
             boolean perOperatorCpuTimerEnabled,
             boolean cpuTimerEnabled,
             boolean perOperatorAllocationTrackingEnabled,
-            boolean allocationTrackingEnabled,
-            boolean nullifyingIteratorForBroadcastJoinEnabled)
+            boolean allocationTrackingEnabled)
     {
         this.sessionPropertyManager = requireNonNull(sessionPropertyManager, "sessionPropertyManager is null");
         this.blockEncodingManager = requireNonNull(blockEncodingManager, "blockEncodingManager is null");
@@ -258,7 +251,6 @@ public class PrestoSparkTaskExecutorFactory
         this.cpuTimerEnabled = cpuTimerEnabled;
         this.perOperatorAllocationTrackingEnabled = perOperatorAllocationTrackingEnabled;
         this.allocationTrackingEnabled = allocationTrackingEnabled;
-        this.nullifyingIteratorForBroadcastJoinEnabled = nullifyingIteratorForBroadcastJoinEnabled;
     }
 
     @Override
@@ -373,14 +365,11 @@ public class PrestoSparkTaskExecutorFactory
 
                 if (broadcastInput != null) {
                     checkArgument(inMemoryInput == null, "single remote source is not expected to accept different kind of inputs");
-                    if (nullifyingIteratorForBroadcastJoinEnabled) {
-                        // NullifyingIterator removes element from the list upon return
-                        // This allows GC to gradually reclaim the memory as the broadcast source is read
-                        remoteSourcePageInputs.add(getNullifyingIterator(broadcastInput.value()));
-                    }
-                    else {
-                        remoteSourcePageInputs.add(broadcastInput.value().iterator());
-                    }
+                    // TODO: Enable NullifyingIterator once migrated to one task per JVM model
+                    // NullifyingIterator removes element from the list upon return
+                    // This allows GC to gradually reclaim memory
+                    // remoteSourcePageInputs.add(getNullifyingIterator(broadcastInput.value()));
+                    remoteSourcePageInputs.add(broadcastInput.value().iterator());
                     continue;
                 }
 

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/util/PrestoSparkUtils.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/util/PrestoSparkUtils.java
@@ -15,7 +15,6 @@ package com.facebook.presto.spark.util;
 
 import com.facebook.presto.spark.classloader_interface.PrestoSparkSerializedPage;
 import com.facebook.presto.spi.page.SerializedPage;
-import com.google.common.collect.AbstractIterator;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 
@@ -23,8 +22,6 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.util.Iterator;
-import java.util.List;
 import java.util.zip.DeflaterInputStream;
 import java.util.zip.InflaterOutputStream;
 
@@ -55,26 +52,6 @@ public class PrestoSparkUtils
                 prestoSparkSerializedPage.getPageCodecMarkers(),
                 toIntExact(prestoSparkSerializedPage.getPositionCount()),
                 prestoSparkSerializedPage.getUncompressedSizeInBytes());
-    }
-
-    public static <T> Iterator<T> getNullifyingIterator(List<T> list)
-    {
-        return new AbstractIterator<T>()
-        {
-            private int index;
-
-            @Override
-            protected T computeNext()
-            {
-                if (index >= list.size()) {
-                    return endOfData();
-                }
-                T element = list.get(index);
-                list.set(index, null);
-                index++;
-                return element;
-            }
-        };
     }
 
     public static byte[] compress(byte[] bytes)

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/util/PrestoSparkUtils.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/util/PrestoSparkUtils.java
@@ -13,7 +13,9 @@
  */
 package com.facebook.presto.spark.util;
 
+import com.facebook.presto.block.BlockEncodingManager;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkSerializedPage;
+import com.facebook.presto.spi.page.PagesSerde;
 import com.facebook.presto.spi.page.SerializedPage;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
@@ -22,6 +24,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.Optional;
 import java.util.zip.DeflaterInputStream;
 import java.util.zip.InflaterOutputStream;
 
@@ -74,5 +77,14 @@ public class PrestoSparkUtils
             throw new UncheckedIOException(e);
         }
         return output.toByteArray();
+    }
+
+    public static PagesSerde createPagesSerde(BlockEncodingManager blockEncodingManager)
+    {
+        return new PagesSerde(
+                blockEncodingManager,
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty());
     }
 }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/util/PrestoSparkUtils.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/util/PrestoSparkUtils.java
@@ -15,8 +15,11 @@ package com.facebook.presto.spark.util;
 
 import com.facebook.presto.block.BlockEncodingManager;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkSerializedPage;
+import com.facebook.presto.spi.page.PageCompressor;
+import com.facebook.presto.spi.page.PageDecompressor;
 import com.facebook.presto.spi.page.PagesSerde;
 import com.facebook.presto.spi.page.SerializedPage;
+import com.github.luben.zstd.Zstd;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 
@@ -24,6 +27,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
 import java.util.Optional;
 import java.util.zip.DeflaterInputStream;
 import java.util.zip.InflaterOutputStream;
@@ -35,6 +39,8 @@ import static java.lang.Math.toIntExact;
 
 public class PrestoSparkUtils
 {
+    private static final int COMPRESSION_LEVEL = 3; // default level
+
     private PrestoSparkUtils() {}
 
     public static PrestoSparkSerializedPage toPrestoSparkSerializedPage(SerializedPage serializedPage)
@@ -83,8 +89,75 @@ public class PrestoSparkUtils
     {
         return new PagesSerde(
                 blockEncodingManager,
-                Optional.empty(),
-                Optional.empty(),
+                Optional.of(createPageCompressor()),
+                Optional.of(createPageDecompressor()),
                 Optional.empty());
+    }
+
+    private static PageCompressor createPageCompressor()
+    {
+        // based on ZstdJniCompressor
+        return new PageCompressor()
+        {
+            @Override
+            public int maxCompressedLength(int uncompressedSize)
+            {
+                return toIntExact(Zstd.compressBound(uncompressedSize));
+            }
+
+            @Override
+            public int compress(byte[] input, int inputOffset, int inputLength, byte[] output, int outputOffset, int maxOutputLength)
+            {
+                long size = Zstd.compressByteArray(output, outputOffset, maxOutputLength, input, inputOffset, inputLength, COMPRESSION_LEVEL);
+                if (Zstd.isError(size)) {
+                    throw new RuntimeException(Zstd.getErrorName(size));
+                }
+                return toIntExact(size);
+            }
+
+            @Override
+            public void compress(ByteBuffer input, ByteBuffer output)
+            {
+                if (input.isDirect() || output.isDirect() || !input.hasArray() || !output.hasArray()) {
+                    throw new IllegalArgumentException("Non-direct byte buffer backed by byte array required");
+                }
+                int inputOffset = input.arrayOffset() + input.position();
+                int outputOffset = output.arrayOffset() + output.position();
+
+                int written = compress(input.array(), inputOffset, input.remaining(), output.array(), outputOffset, output.remaining());
+                output.position(output.position() + written);
+            }
+        };
+    }
+
+    private static PageDecompressor createPageDecompressor()
+    {
+        // based on ZstdJniDecompressor
+        return new PageDecompressor()
+        {
+            @Override
+            public int decompress(byte[] input, int inputOffset, int inputLength, byte[] output, int outputOffset, int maxOutputLength)
+            {
+                long size = Zstd.decompressByteArray(output, 0, maxOutputLength, input, inputOffset, inputLength);
+                if (Zstd.isError(size)) {
+                    String errorName = Zstd.getErrorName(size);
+                    throw new RuntimeException("Zstd JNI decompressor failed with " + errorName);
+                }
+                return toIntExact(size);
+            }
+
+            @Override
+            public void decompress(ByteBuffer input, ByteBuffer output)
+            {
+                if (input.isDirect() || output.isDirect() || !input.hasArray() || !output.hasArray()) {
+                    throw new IllegalArgumentException("Non-direct byte buffer backed by byte array required");
+                }
+                int inputOffset = input.arrayOffset() + input.position();
+                int outputOffset = output.arrayOffset() + output.position();
+
+                int written = decompress(input.array(), inputOffset, input.remaining(), output.array(), outputOffset, output.remaining());
+                output.position(output.position() + written);
+            }
+        };
     }
 }

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
@@ -203,11 +203,7 @@ public class PrestoSparkQueryRunner
                 DRIVER,
                 ImmutableMap.of(
                         "presto.version", "testversion",
-                        "query.hash-partition-count", Integer.toString(NODE_COUNT * 2),
-                        // In the local query runner all pseudo distributed spark executors are
-                        // run in the same jvm and share the same broadcast variable, thus
-                        // gradually nullifying the broadcast variable elements is not possible
-                        "spark.nullifying-iterator-for-broadcast-join-enabled", "false"),
+                        "query.hash-partition-count", Integer.toString(NODE_COUNT * 2)),
                 ImmutableMap.of(),
                 Optional.empty(),
                 new SqlParserOptions(),

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkConfig.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkConfig.java
@@ -36,8 +36,7 @@ public class TestPrestoSparkConfig
                 .setMinSparkInputPartitionCountForAutoTune(100)
                 .setMaxSparkInputPartitionCountForAutoTune(1000)
                 .setMaxSplitsDataSizePerSparkPartition(new DataSize(2, GIGABYTE))
-                .setShuffleOutputTargetAverageRowSize(new DataSize(1, KILOBYTE))
-                .setNullifyingIteratorForBroadcastJoinEnabled(true));
+                .setShuffleOutputTargetAverageRowSize(new DataSize(1, KILOBYTE)));
     }
 
     @Test
@@ -50,7 +49,6 @@ public class TestPrestoSparkConfig
                 .put("spark.max-spark-input-partition-count-for-auto-tune", "2000")
                 .put("spark.max-splits-data-size-per-partition", "4GB")
                 .put("spark.shuffle-output-target-average-row-size", "10kB")
-                .put("spark.nullifying-iterator-for-broadcast-join-enabled", "false")
                 .build();
         PrestoSparkConfig expected = new PrestoSparkConfig()
                 .setSparkPartitionCountAutoTuneEnabled(false)
@@ -58,8 +56,7 @@ public class TestPrestoSparkConfig
                 .setMinSparkInputPartitionCountForAutoTune(200)
                 .setMaxSparkInputPartitionCountForAutoTune(2000)
                 .setMaxSplitsDataSizePerSparkPartition(new DataSize(4, GIGABYTE))
-                .setShuffleOutputTargetAverageRowSize(new DataSize(10, KILOBYTE))
-                .setNullifyingIteratorForBroadcastJoinEnabled(false);
+                .setShuffleOutputTargetAverageRowSize(new DataSize(10, KILOBYTE));
         assertFullMapping(properties, expected);
     }
 }


### PR DESCRIPTION
Nullifying iterator does not work if the executor containers are reused, as the broadcast variables persistent between tasks. Nullifying a broadcast variable will make it invalid for the next task run on the same executor.

As a workaround for increased broadcast memory on executors compression has been added and additional check for broadcast size is added.

```
== NO RELEASE NOTE ==
```
