### PR TITLE
Add memory.rows-per-split to control number of splits launched in memory connector

### DIFF
--- a/presto-memory/src/main/java/com/facebook/presto/plugin/memory/MemoryConfig.java
+++ b/presto-memory/src/main/java/com/facebook/presto/plugin/memory/MemoryConfig.java
@@ -16,12 +16,14 @@ package com.facebook.presto.plugin.memory;
 import com.facebook.airlift.configuration.Config;
 import io.airlift.units.DataSize;
 
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 public class MemoryConfig
 {
     private int splitsPerNode = Runtime.getRuntime().availableProcessors();
     private DataSize maxDataPerNode = new DataSize(128, DataSize.Unit.MEGABYTE);
+    private int rowsPerSplit = 1;
 
     @NotNull
     public int getSplitsPerNode()
@@ -46,6 +48,20 @@ public class MemoryConfig
     public MemoryConfig setMaxDataPerNode(DataSize maxDataPerNode)
     {
         this.maxDataPerNode = maxDataPerNode;
+        return this;
+    }
+
+    @NotNull
+    @Min(1)
+    public int getRowsPerSplit()
+    {
+        return rowsPerSplit;
+    }
+
+    @Config("memory.rows-per-split")
+    public MemoryConfig setRowsPerSplit(int rowsPerSplit)
+    {
+        this.rowsPerSplit = rowsPerSplit;
         return this;
     }
 }

--- a/presto-memory/src/main/java/com/facebook/presto/plugin/memory/MemorySplitManager.java
+++ b/presto-memory/src/main/java/com/facebook/presto/plugin/memory/MemorySplitManager.java
@@ -52,7 +52,7 @@ public final class MemorySplitManager
 
         ImmutableList.Builder<ConnectorSplit> splits = ImmutableList.builder();
         for (MemoryDataFragment dataFragment : dataFragments) {
-            int numSplits = (int) Math.min(splitsPerNode, dataFragment.getRows() / rowsPerSplit);
+            int numSplits = (int) Math.min(splitsPerNode, Math.max(1, dataFragment.getRows() / rowsPerSplit));
             for (int i = 0; i < numSplits; i++) {
                 splits.add(
                         new MemorySplit(

--- a/presto-memory/src/main/java/com/facebook/presto/plugin/memory/MemorySplitManager.java
+++ b/presto-memory/src/main/java/com/facebook/presto/plugin/memory/MemorySplitManager.java
@@ -30,11 +30,13 @@ public final class MemorySplitManager
         implements ConnectorSplitManager
 {
     private final int splitsPerNode;
+    private final int rowsPerSplit;
 
     @Inject
     public MemorySplitManager(MemoryConfig config)
     {
         this.splitsPerNode = config.getSplitsPerNode();
+        this.rowsPerSplit = config.getRowsPerSplit();
     }
 
     @Override
@@ -50,12 +52,13 @@ public final class MemorySplitManager
 
         ImmutableList.Builder<ConnectorSplit> splits = ImmutableList.builder();
         for (MemoryDataFragment dataFragment : dataFragments) {
-            for (int i = 0; i < splitsPerNode; i++) {
+            int numSplits = (int) Math.min(splitsPerNode, dataFragment.getRows() / rowsPerSplit);
+            for (int i = 0; i < numSplits; i++) {
                 splits.add(
                         new MemorySplit(
                                 layout.getTable(),
                                 i,
-                                splitsPerNode,
+                                numSplits,
                                 dataFragment.getHostAddress(),
                                 dataFragment.getRows()));
             }


### PR DESCRIPTION
A proposal solution to address: https://github.com/prestodb/presto/issues/15264
Launch splits base on number of rows in dataFragment. To avoid too many splits created on very small tables.

Tested create/insert/select table with memory connector.
Updated unit test case to cover new logic (remove a worker without data no longer impact table read; Must remove worker with table data to fail the read)


Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== RELEASE NOTES ==

General Changes
* In memory connector, the number of splits now base on data size.
* Add `memory.rows-per-split` to control how many splits to launch base on number of rows. It will use the smaller value between rows/rows-per-split and split-per-node

Hive Changes
* ...
* ...
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```
