### PR TITLE
Add release notes for 0.242

### DIFF
--- a/presto-docs/src/main/sphinx/release.rst
+++ b/presto-docs/src/main/sphinx/release.rst
@@ -5,6 +5,7 @@ Release Notes
 .. toctree::
     :maxdepth: 1
 
+    release/release-0.242
     release/release-0.241
     release/release-0.240
     release/release-0.239.2

--- a/presto-docs/src/main/sphinx/release/release-0.242.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.242.rst
@@ -1,0 +1,63 @@
+=============
+Release 0.242
+=============
+
+**Highlights**
+==============
+* Add configuration property ``experimental.spiller.task-spilling-strategy`` for choosing different spilling strategy to use.
+* Add support for fragment result caching.
+* Add support for partition versioning.
+* Add support for caching HiveMetastore calls at a more granular level.
+
+**Details**
+===========
+
+General Changes
+_______________
+* Fix compiler error in ``LambdaBytecodeGenerator`` when common sub-expression optimization is enabled and multiple SQL functions contain lambda expressions.
+* Fix possible permanently stucked queries when memory limit is exceeded during shuffle.
+* Fix a bug where ``IS DISTINCT FROM NULL`` produces wrong results for columns with null values.
+* Add configuration property ``experimental.spiller.task-spilling-strategy`` for choosing different spilling strategy to use.
+* Add session property ``query_max_output_bytes`` and configuration property ``query.max-output-bytes`` to control how much data a query can output.
+* Add support for fragment result caching. This can be enabled by ``fragment-result-cache.enabled`` and ``experimental.fragment-result-caching-enabled``.
+
+Hive Changes
+____________
+* Fix a bug where DWRF encryption would fail for large uncompressed column values.
+* Fix a bug where non-Presto readers could not read encrypted DWRF files written by Presto if the encryption group listed columns out of order.
+* Fix a performance regression for String field handling in GenericHiveRecordCursor when the SerDe does not provide an efficient Writable implementation.
+* Improve split loading efficiency by only using as many threads as are required.
+* Add support for file renaming for Hive connector. This can be enabled with the ``hive.file_renaming_enabled`` configuration property.
+* Add support to query parquet files written by parquet-avro library that uses ``TIMESTAMP_MICROS`` as the ``OriginalType`` to represent timestamp.
+* Add support for partition versioning. This can be enabled with ``hive.partition-versioning-enabled`` configuration property
+* Add support for caching HiveMetastore calls at a more granular level. This can be specified by the ``hive.metastore-cache-scope`` configuration property.
+
+Pinot Changes
+_____________
+* Add configuration property ``pinot.pushdown-topn-broker-queries`` to allow pushing down TOPN queries to Pinot.
+
+Cassandra Change
+________________
+* Add ``SMALLINT``, ``TINYINT``, and ``DATE`` type support.
+
+Verifier Changes
+________________
+* Fix an issue in determinism analysis which would indicate failing due to data being changed while the data is not changed.
+* Improve JSON plan comparison for explain verification. (:pr:`15198`).
+* Add application-name config to override source passed in ClientInfo.
+* Add support to fetch the list of queries to be verified by running a Presto query.
+* Add support to run explain verification. (:pr:`15101`). This can be enabled by configuration property ``explain``.
+
+SPI Changes
+___________
+* Add ``getIdentifier`` to ``ConnectorTableLayoutHandle``. Layout identifier is used in fragment result caching to construct canonical plan.
+* Add ``getSplitIdentifier`` to ``ConnectorSplit``. Split identifier is used in fragment result caching to identify if splits are identical.
+
+Geospatial Changes
+__________________
+* Upgrade Esri to [2.2.4](https://github.com/Esri/geometry-api-java/releases/tag/v2.2.4). This includes two fixes for bug (https://github.com/Esri/geometry-api-java/issues/266 and https://github.com/Esri/geometry-api-java/issues/247) that were seen in production.
+
+**Contributors**
+================
+
+Andrii Rosa, Ariel Weisberg, Bin Fan, Daniel Ohayon, Dharak Kharod, James Gill, James Petty, James Sun, Ke Wang, Leiqing Cai, Masha Basmanova, Mayank Garg, Nikhil Collooru, Palash Goel, Rebecca Schlussel, Rongrong Zhong, Saksham Sachdev, Sanjay Sundaresan, Saumitra Shahapure, Shixuan Fan, Sreeni Viswanadha, Tim Meehan, Vic Zhang, Vivek, Weidong Duan, Wenlei Xie, Xiang Fu, Ying Su, Yuya Ebihara, Zhenxiao Luo, ankit0811, asdf2014, fornaix


### PR DESCRIPTION
# Missing Release Notes
## Ariel Weisberg
- [x] https://github.com/prestodb/presto/pull/15243 Link to attribution guidelines in PR template (Merged by: Andrii Rosa)

## Daniel Ohayon
- [x] https://github.com/prestodb/presto/pull/15219 Core support for enums, take #2 (Merged by: Rongrong Zhong)

## Mayank Garg
- [x] https://github.com/prestodb/presto/pull/15187 Consider predicate columns for encryption (Merged by: Rebecca Schlussel)

## Nikhil Collooru
- [x] https://github.com/prestodb/presto/pull/15044 Add support for versioning metastore API (Merged by: Shixuan Fan)

## Rongrong Zhong
- [x] https://github.com/prestodb/presto/pull/14012 Remote plan execution (Merged by: Rongrong Zhong)

## Saumitra Shahapure
- [x] https://github.com/prestodb/presto/pull/15128 Fixing bug: IS DISTINCT FROM NULL should work for NULL column values (Merged by: Rongrong Zhong)

## Xiang Fu
- [x] https://github.com/prestodb/presto/pull/15135 Pinot Connector: Adding limit to push down order by for broker query (Merged by: Zhenxiao Luo)

## Yuya Ebihara
- [x] https://github.com/prestodb/presto/pull/15147 Support smallint, tinyint, date type of Cassandra (Merged by: James Sun)

## asdf2014
- [x] https://github.com/prestodb/presto/pull/15148 Bump Apache Druid to 0.19.0 (Merged by: Zhenxiao Luo)

# Extracted Release Notes
- #14974 (Author: Nikhil Collooru): Rename files written by PageSink
  - Add support for file renaming for Hive connector. This can be enabled with ``hive.file_renaming_enabled`` configuration property.
- #15074 (Author: Sanjay Sundaresan): Add support in parquet reader for reading TIMESTAMP_MICROS type.
  - Parquet files written by parquet-avro library that uses TIMESTAMP_MICROS as the OriginalType to represent timestamp can now be queried by presto.
- #15101 (Author: Leiqing Cai): Support explain verification
  - Add support to run explain verification. (:pr:`15101`). This can be enabled by configuration property ``explain``.
- #15108 (Author: Mayank Garg): Add property to limit output size of a query
  - Add session property ``query_max_output_bytes`` and configuration property ``query.max-output-bytes`` to control how much data a query can output.
- #15132 (Author: Leiqing Cai): Support fetching queries to be verified using a Presto query
  - Add support to fetch the list of queries to be verified by running a Presto query.
- #15155 (Author: Shixuan Fan): Support fragment result caching
  - Add support for fragment result caching. When enabled, if the same plan fragment and same connector split hit the same worker, engine would directly fetch result from cache and skip computation. Currently only partial aggregation is supported. Cache could be enabled by setting ``fragment-result-cache.enabled`` to ``true`` and tuned by other configs started with ``fragment-result-cache``. Query could use fragment result cache by setting config ``experimental.fragment-result-caching-enabled`` or session property ``fragment_result_caching_enabled`` to ``true``.
  - Add ``getSplitIdentifier`` to ``ConnectorSplit``. Split identifier is used in fragment result caching to identify if splits are identical.
  - Add ``getIdentifier`` to ``ConnectorTableLayoutHandle``. Layout identifier is used in fragment result caching to construct canonical plan.
- #15163 (Author: James Petty): Fix performance regression when hive SerDe doesn't prefer Writables
  - Fix a performance regression for String field handling in GenericHiveRecordCursor when the SerDe does not provide an efficient Writable implementation.
- #15173 (Author: Saksham Sachdev): Implement Spilling Strategies
  - Add config `experimental.spiller.task-spilling-strategy` for choosing different spilling strategy to use.
- #15181 (Author: Leiqing Cai): Fix LimitQueryDeterminismAnalyzer
  - Fix an issue in determinism analysis would indicate failing due to data being changed while the data is not changed.
- #15183 (Author: Rongrong Zhong): Fix compiler error in LambdaBytecodeGenerator
  - Fix compiler error in LambdaBytecodeGenerator when CSE is enabled and multiple SQL functions contain lambda expressions.
- #15191 (Author: Palash Goel): [Verifier] Add application-name config
  - Add application-name config to override source passed in ClientInfo.
- #15198 (Author: Leiqing Cai): Improve plan comparison for explain verification
  - Improve JSON plan comparison for explain verification. (:pr:`15198`).
- #15199 (Author: Rebecca Schlussel): Fix encrypt large value
  - Fix a bug where DWRF encryption would fail for large uncompressed column values.
- #15200 (Author: James Gill): Upgrade Esri to 2.2.4
  - Upgrade Esri to [2.2.4](https://github.com/Esri/geometry-api-java/releases/tag/v2.2.4).  This includes two fixes for bug (https://github.com/Esri/geometry-api-java/issues/266 and https://github.com/Esri/geometry-api-java/issues/247) that were seen in production.
- #15208 (Author: James Petty): Clamp BackgroundHiveSplitLoader concurrency to usable parallelism
  - Improve split loading thread utilization by reducing the number of tasks submitted for small scans.
- #15214 (Author: Rebecca Schlussel): Fix order of dwrf encryption group stats
  - Fix a bug where non-Presto readers could not read encrypted DWRF files written by Presto if the encryption group listed columns out of order.
- #15220 (Author: James Petty): Fix potential deadlock when PageBufferClient exceeds memory limit
  - Fix possible permanent stuck queries when memory limit exceeded during shuffle.

# All Commits
- 4cd2141ab8b3f7d596568b9acebe247941528789 Add integration tests for file renaming (Nikhil Collooru)
- d3ef69a8796f25f8773b95fef8addd5a55646df3 Add config parameters to enable hive file renaming (Nikhil Collooru)
- a78669969ae212476c6f8301d4fb14f88e8528f5 POST the metadata results to worker (Nikhil Collooru)
- c2b2b0d9cc80f08edb931a849edfd2ebe55d5352 Rename files written by HivePageSink (Nikhil Collooru)
- a74b034525bfe1541a510eaa408a97cacb1a77b0 Add new POST {taskId}/metadataresults endpoint on worker (Nikhil Collooru)
- f15fe1f678751dff123f2920c2996d6d90e498f6 Piggyback MetadataUpdateRequests to coordinator as part of TaskInfo (Nikhil Collooru)
- 9eaa655ac8f7719898abd5fea6923dc3d408f0d6 Support fragment result caching (Shixuan Fan)
- 99445d9d1f56b0701cc1b5e18cdbd09aa6bcf089 Use static import and lambda in TestDriver (Shixuan Fan)
- 1489cac84ee7332493113bd5f849e74cf637a54e Introduce fragment result cache manager (Shixuan Fan)
- 069629bae15bca84a4c9128c8eb46ba595dd0380 Introduce split identifier (Shixuan Fan)
- a1b91767c69a48d2e57d0d287b64bdef172d4b9e Introduce CanonicalPlanGenerator (Shixuan Fan)
- 53aa7f67c8156a904c9114e4faae2586c630968c Reserve memory before projecting rows (Ying Su)
- 00e61e4ff38bb9ec0782f57db11f81156a689f7b Do not ignore table bucketing when query uses bucket column (Vic Zhang)
- d57ce0f0ed34647883daeb821dfd92196893072c Remove TypeManager.resolveOperator (Rongrong Zhong)
- e6ad497de2d3fba67be46a018878e7648154cd1a Collapse nested DEREF expressions into a single one. (Sreeni Viswanadha)
- d8be70d5fc70731e292d1a101d9213cb77bae802 Add extra config and session property to toggle join spilling (Saksham Sachdev)
- 9a1190801eb856db518d2e673a1481d9f65b7453 Use newer Alluxio client (Bin Fan)
- 544b5a4313fac313ddf6534e7740c2ddfd0c0bd5 Introduce TaskSpillingStrategy and multiple spilling strategies (Saksham Sachdev)
- 30e46063c0b3872a7d1422a1a83855ecbfe98911 Link to attribution guidelines in PR template (Ariel Weisberg)
- cef58ff2037ed4445d7871c8dae1b75a5d14b4ef Add enum operators (Daniel Ohayon)
- 9fe32b502815daa67d52ccd084e662aa9f0782d4 Support enum literals in queries (Daniel Ohayon)
- 7e880e6de3fc41b5585da0ae6c502bc75a508f77 Support type bound in TypeVariableConstraint (Daniel Ohayon)
- 5e209739f57bcb0924a5b4725a1af20e0960f981 Add long and varchar enum types (Daniel Ohayon)
- 2dfb7cd69c3b2a321e169f4f248446d62c33e1b8 Remove BlockEncodingManager's dependency on TypeManager (Rongrong Zhong)
- ef5843ad6b1c44743909ba0f81f0c9ad510cb9f0 Make TestQueryManager#testFailQueryPrerun more reliable (Tim Meehan)
- b57f7ff9d1c6de6f00e3f9f43b8e4a3f04f3f467 Upgrade Esri to 2.2.4 (James Gill)
- 139f15aad6b3dd0d77e32a959f6ac28a3aecd13b [Verifier] Add application-name config (Palash Goel)
- e2ff32eb8e15a7efe8f34d9ad3015dd004eda923 Simplify PinotQueryGenerator pushdown logic (Zhenxiao Luo)
- 2d1416eb77e5dc06f0398b054216b54bd278f2cd Pinot Connector: Adding config to push down order by for broker query (Xiang Fu)
- bb0d04ada5c72a24d99494630f54a11203340ab2 Add docs for exchange materialization (Wenlei Xie)
- 6b97e58656d7c102dce0649eb41128bad7634562 Update peak memory in TaskContext for Presto-on-Spark task (Wenlei Xie)
- c9e550bf49d35bf426e43feb131b8d5921259c96 Minor tweak in Presto-on-Spark peak task user memory report (Wenlei Xie)
- ebf428a76a4a862e681546b16ff4805c2fba7d4c Add peak task user memory to TaskStats (Wenlei Xie)
- 46bcc6314a41f42aa756fbdaa05b3dcd003857d9 Add comment to SerializedTaskInfo (Wenlei Xie)
- 746824c1c0331f1449b5b0b97f21bf9a7f55fd5d Fix potential deadlock when PageBufferClient exceeds memory limit (James Petty)
- 35f267df72b8140fcc9610a92dcc787daa22753b Disable Elasticsearch connector flaky test (Zhenxiao Luo)
- 8ae554dc9c1434c3e22b1c6c94fc45ed478012fa Enable nullifying iterator for broadcast join (Andrii Rosa)
- 77bfa04063ef5b7d636b3b3034c9292f4ce730ca Cassandra connector ccreate table (Yuya Ebihara)
- c857741afb79f656e0ec21d5b1cb1d7366fc439e Fix order of dwrf encryption group stats (Rebecca Schlussel)
- d57bbfda5fcf839246e169a134c44947a768dbda Implement pass through mode UNION ALL on Presto-on-Spark (Vic Zhang)
- 4d91a6016c8bfeb77a80c59fd7aa1cac91df2a4b Improve plan matching for explain verification (Leiqing Cai)
- fdfd9bec9140be74ed2d4b92907fcc4b98609a51 Remove special rule to skip control queries for explain verification (Leiqing Cai)
- 1fc69dcce88e596fd9232c5696ead3bd1df78025 Handle storage connection exceptions correctly (Nikhil Collooru)
- 6bb12b633eec281d0619b84d2851219511cbc018 Fix error message formatting (Rebecca Schlussel)
- da0d5c2945610e3aa8a88aa3108784bc72eebcea Fix dwrf encryption for large column values (Rebecca Schlussel)
- 913be2838e939cdba851a978dbfc46b018bcea94 Clamp BackgroundHiveSplitLoader concurrency to usable parallelism (James Petty)
- 79c3a3f26e4e771eed3f568d0ead36f41131d72c Improve Elasticsearch connector documentation (fornaix)
- 00fbb9b371b6676129403ff48cafb2f0b89def43 Update default Presto Pinot Connector Configs (Xiang Fu)
- 14ba79ce5c811636e2281b4fc1e7e519e01b16c8 Refactor more operators to use applicate Page method helpers (James Petty)
- 20a6c406baf2a4cb5facc2b13925dc42d66cea09 Add Page#extractChannel(int) to enable efficient single channel extraction (James Petty)
- fa513e2fe824845676c2299f12754853a83547e4 Consider predicate columns for encryption (Mayank Garg)
- c0b38fe9c9e9c1b5b194c359f3f63eeb13c671b8 Disallow partial aggregation pushdown when (Vivek)
- c065b1ddd8b618b6471250197f00a2e2a2fe7ff3 Do not support dynamic filtering with grouped-execution (Ke Wang)
- 244d8804f26f7c43ffebdf118656e33b56e5db14 Update drift library to 1.28 (Vic Zhang)
- 95bcfcda9b6d42de7233f2f9a779813f463b4202 Include storage format name to temporary table name (Vic Zhang)
- 28bd920dd26c1de4336bb7986a5cf8dc6434af36 Use PAGEFILE format for hive unsupported type (Vic Zhang)
- 2d228dba8ca5203e33818a12ca8d7c806c9c45d1 Add session property to automatically use PAGEFILE (Vic Zhang)
- 20b72bdc27d410397f0ebe0db4acf6765286a80a Parquet code cleanup (Zhenxiao Luo)
- 4b8021ff468b089eb4abef521c2bd1628a18317c Add unit tests for partition versioning enabled Metastore (Nikhil Collooru)
- 584fd8cb9b02479f8042be4e016aebb5aa3b9f87 Add new getPartitionNamesWithVersionByFilter metastore api (Nikhil Collooru)
- cdbd17701c5575c357ac84fe2cad9b20ee86da49 Add config to enable Partition versioning (Nikhil Collooru)
- 9dcc558428e282cd34378e66787da034a096420e Add optional version parameter to metastore Partition (Nikhil Collooru)
- 9ae10f0fbc5e2daa2108a75a4f0dd8b06edbed35 Skip unsupported types when pushing down in Cassandra (Yuya Ebihara)
- ad2a1c7b913a9d3eb3f137eca07953f97779025a Add support in parquet reader for reading TIMESTAMP_MICROS type. (Sanjay Sundaresan)
- d9c8807bb75c4abe8c95e50866e824b78482d5f2 Remove unused Parquet classes (Vivek)
- b88a9a91b24500d3c46df8cd613783effdc9d70c Fix compiler error in LambdaBytecodeGenerator (Rongrong Zhong)
- 30d258803edab0d22d8725344d120515611cab52 Remove unused configuration property from properties.rst (Ying Su)
- 4ea4139e5fd9893e350a2af710c5ccadbbc2fa73 Revert "Add long and varchar enum types" (Ying Su)
- 748e69eee4358eb9ba10d0685a4c942b20ce45ec Revert "Support type bound in TypeVariableConstraint" (Ying Su)
- 93bf9be6b0e511578ab801a31e64d41a8c3021b7 Revert "Support enum literals in queries" (Ying Su)
- 923d3ed904882deb2b15de3cc8ad6e37ae93e326 Revert "Add enum operators" (Ying Su)
- 77c442cf6b64c3d57d10da186310ef735baa3222 Revert "Fix IllegalArgumentException in RelationPlanner" (Ying Su)
- d79804dc483ade179834fef2c5469632a41e0416 Fixing bug: IS DISTINCT FROM NULL should work for NULL column values (Saumitra Shahapure)
- ee1627e0fd74ab65446213d5fcac6ed1ab101fd7 Bug fix in LimitQueryDeterminismAnalyzer (Leiqing Cai)
- 600c15755840cd3ff4857ded1c06934b2eb7ff98 Avoid DateTimeZone.getDefault() in GenericHiveRecordCursor hot path (James Petty)
- e7e8ecc97f720cdc94386a5e892e9dea65370b5a Fix performance regression when Hive SerDe doesn't prefer Writables (James Petty)
- 06d5f49a22845d3f923dd1259ca8fcd1a9869ba1 Support smallint, tinyint, date type of Cassandra (Yuya Ebihara)
- 5bdb41d3c8d003290affac6f179b030b9de41a20 Parser warnings when the query contains mixed AND/OR operator without proper parenthesis. (ankit0811)
- df8228fe7265ced46c1dc2ed92371d37998212e6 Fix wrong group by column definition in druid connector (Weidong Duan)
- af273e1a86b5f161d2f8402bd3ae052af2eb9a65 Fix broken link in presto-verifier README (Palash Goel)
- faebf2a918196895a6929069346c9cc249329cda Add more functions to TestHiveExternalWorkersQueries (Masha Basmanova)
- 2108955ddce372cfe76275370e04988f8c08dab3 Add waitForMinimumCoordinators to ClusterSizeMonitor (Tim Meehan)
- dd7dad97aaf9e4b03d8ac87bac71feb9ae7a96e4 Fix IllegalArgumentException in RelationPlanner (Rongrong Zhong)
- aaeff3f8360a09c1f64c8feb05354e1ca527d37d Support Remote function execution (Rongrong Zhong)
- 3825bdb0078665a12e2671468589f59e977fbdb8 Remote function execution with thrift executor (Rongrong Zhong)
- b1b5e8f276485d8faf73f3fe3abf5812a9e09b34 Fix ProjectNode locality in PlanFragmenter (Rongrong Zhong)
- 219c7d76eb42df406213e3ff4f9e8428028fc54e Introduce large dictionary mode in SliceDictionarySelectiveReader (Ying Su)
- 0006741cc9a2ed8474a15c8e7556bd20f9b8c0f7 Remove stripeDictionaryData buffer in SliceDictionarySelectiveReader (Ying Su)
- 79947540306b3ccc774102c6ca069d9147ea0352 Defer the creation of dictionary in SliceDictionarySelectiveReader (Ying Su)
- 93d1b046a53d72b101bd2bba5cb21e78a5737849 Bump Apache Druid to 0.19.0 (asdf2014)
- 405ebe6f8c4af2d0ee9aa4717c0da2d57bc2e42c Adding multivalued column support in Pinot connector (Dharak Kharod)
- ec9b5cf8177ff3bfb63a5a4c9a52c77d9986fa33 Add tests for sum, min, max and avg queries running on native workers (Masha Basmanova)
- 926df095ab79752545d61eba0513362415736ca3 TupleDomain cleanup (Zhenxiao Luo)
- a7bf06f81b37364fecaf242fdc2cc2f3342ab7fc Add property to limit output size of a query (Mayank Garg)
- 1bc26f0c8223d5fe52957b7b3778b626fb0fddd6 Dynamic partition pruning on workers (Ke Wang)
- 710f04e002587a7617db107b76b60bd3ebb67c41 Support explain verification (Leiqing Cai)
- b388a1bca8e98e403dcbe332d43510ba3c2dfe9d Extract class QueryBundle (Leiqing Cai)
- d3855832408038a07a6cb39597646d574ee78143 Extract interface MatchResult (Leiqing Cai)
- f2d19cff05a3687fe8c80f3a4a4d80c4eb682283 Extract determinism analysis from AbstractVerification (Leiqing Cai)
- b050fc1ba814f7093066766b670578199c8caab7 Extract query rewrite from AbstractVerification (Leiqing Cai)
- aae01573a3e9d2e40061d84fead33ed665b62a47 Minor fixes in Verifier (Leiqing Cai)
- f3a43a8cc0a3e3cdb65deb48a24b949f5b999600 Add test infrastructure to run queries using native workers (Masha Basmanova)
- 2e179d3ff936ab790baf23beaa6908385cbc3d8e Support fetching queries to be verified using a Presto query (Leiqing Cai)
- 6a763b274c161a783c1fca1eedea277f8c990346 Cleanup of partial aggregation pushdown for ORC/Parquet (Zhenxiao Luo)
- b66f1028ecaac6f0475ea04dd761ffff3b375be1 Remove dependency on javafx (Vivek)
- baece53fc9cb467052dab7538f8703102665d819 Restore commented out tests (Ying Su)