### PR TITLE
Improve identity projection when the selectedPositions is a list

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/Page.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/Page.java
@@ -102,6 +102,22 @@ public final class Page
         return logicalSizeInBytes;
     }
 
+    /**
+     * Returns the approximate logical size of the page if logicalSizeInBytes was not calculated before.
+     */
+    public long getApproximateLogicalSizeInBytes()
+    {
+        if (logicalSizeInBytes < 0) {
+            long approximateLogicalSizeInBytes = 0;
+            for (Block block : blocks) {
+                approximateLogicalSizeInBytes += block.getApproximateRegionLogicalSizeInBytes(0, block.getPositionCount());
+            }
+            return approximateLogicalSizeInBytes;
+        }
+
+        return logicalSizeInBytes;
+    }
+
     public long getRetainedSizeInBytes()
     {
         long retainedSizeInBytes = this.retainedSizeInBytes;

--- a/presto-common/src/main/java/com/facebook/presto/common/block/AbstractArrayBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/AbstractArrayBlock.java
@@ -122,6 +122,18 @@ public abstract class AbstractArrayBlock
     }
 
     @Override
+    public long getApproximateRegionLogicalSizeInBytes(int position, int length)
+    {
+        int positionCount = getPositionCount();
+        checkValidRegion(positionCount, position, length);
+
+        int valueStart = getOffset(position);
+        int valueEnd = getOffset(position + length);
+
+        return getRawElementBlock().getApproximateRegionLogicalSizeInBytes(valueStart, valueEnd - valueStart) + (Integer.BYTES + Byte.BYTES) * length;
+    }
+
+    @Override
     public long getPositionsSizeInBytes(boolean[] positions)
     {
         checkValidPositions(positions, getPositionCount());

--- a/presto-common/src/main/java/com/facebook/presto/common/block/AbstractMapBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/AbstractMapBlock.java
@@ -195,6 +195,22 @@ public abstract class AbstractMapBlock
     }
 
     @Override
+    public long getApproximateRegionLogicalSizeInBytes(int position, int length)
+    {
+        int positionCount = getPositionCount();
+        checkValidRegion(positionCount, position, length);
+
+        int entriesStart = getOffset(position);
+        int entriesEnd = getOffset(position + length);
+        int entryCount = entriesEnd - entriesStart;
+
+        return getRawKeyBlock().getApproximateRegionLogicalSizeInBytes(entriesStart, entryCount) +
+                getRawValueBlock().getApproximateRegionLogicalSizeInBytes(entriesStart, entryCount) +
+                (Integer.BYTES + Byte.BYTES) * length +         // offsets and mapIsNull
+                Integer.BYTES * HASH_MULTIPLIER * entryCount;   // hashtables
+    }
+
+    @Override
     public long getPositionsSizeInBytes(boolean[] positions)
     {
         // We can use either the getRegionSizeInBytes or getPositionsSizeInBytes

--- a/presto-common/src/main/java/com/facebook/presto/common/block/AbstractRowBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/AbstractRowBlock.java
@@ -131,6 +131,23 @@ public abstract class AbstractRowBlock
     }
 
     @Override
+    public long getApproximateRegionLogicalSizeInBytes(int position, int length)
+    {
+        int positionCount = getPositionCount();
+        checkValidRegion(positionCount, position, length);
+
+        int startFieldBlockOffset = getFieldBlockOffset(position);
+        int fieldBlockLength = getFieldBlockOffset(position + length) - startFieldBlockOffset;
+
+        long approximateLogicalSizeInBytes = (Integer.BYTES + Byte.BYTES) * length; // offsets and rowIsNull
+        for (int i = 0; i < numFields; i++) {
+            approximateLogicalSizeInBytes += getRawFieldBlocks()[i].getApproximateRegionLogicalSizeInBytes(startFieldBlockOffset, fieldBlockLength);
+        }
+
+        return approximateLogicalSizeInBytes;
+    }
+
+    @Override
     public long getPositionsSizeInBytes(boolean[] positions)
     {
         checkValidPositions(positions, getPositionCount());

--- a/presto-common/src/main/java/com/facebook/presto/common/block/Block.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/Block.java
@@ -215,6 +215,20 @@ public interface Block
     }
 
     /**
+     * Returns the approximate logical size of {@code block.getRegion(position, length)}.
+     * This method is faster than getRegionLogicalSizeInBytes().
+     * For dictionary blocks, this counts the amortized flattened size of the included positions.
+     * For example, for a DictionaryBlock with 5 ids [1, 1, 1, 1, 1] and a dictionary of
+     * VariableWidthBlock with 3 elements of sizes [9, 5, 7], the result of
+     * getApproximateRegionLogicalSizeInBytes(0, 5) would be (9 + 5 + 7) / 3 * 5 = 35,
+     * while getRegionLogicalSizeInBytes(0, 5) would be 5 * 5 = 25.
+     */
+    default long getApproximateRegionLogicalSizeInBytes(int position, int length)
+    {
+        return getRegionSizeInBytes(position, length);
+    }
+
+    /**
      * Returns the size of of all positions marked true in the positions array.
      * This is equivalent to multiple calls of {@code block.getRegionSizeInBytes(position, length)}
      * where you mark all positions for the regions first.

--- a/presto-common/src/main/java/com/facebook/presto/common/block/DictionaryBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/DictionaryBlock.java
@@ -281,6 +281,13 @@ public class DictionaryBlock
     }
 
     @Override
+    public long getApproximateRegionLogicalSizeInBytes(int position, int length)
+    {
+        int dictionaryPositionCount = dictionary.getPositionCount();
+        return dictionaryPositionCount == 0 ? 0 : dictionary.getApproximateRegionLogicalSizeInBytes(0, dictionaryPositionCount) * length / dictionaryPositionCount;
+    }
+
+    @Override
     public long getPositionsSizeInBytes(boolean[] positions)
     {
         checkValidPositions(positions, positionCount);

--- a/presto-common/src/main/java/com/facebook/presto/common/block/RunLengthEncodedBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/RunLengthEncodedBlock.java
@@ -154,6 +154,12 @@ public class RunLengthEncodedBlock
     }
 
     @Override
+    public long getApproximateRegionLogicalSizeInBytes(int position, int length)
+    {
+        return positionCount * value.getApproximateRegionLogicalSizeInBytes(0, 1);
+    }
+
+    @Override
     public long getPositionsSizeInBytes(boolean[] positions)
     {
         return value.getSizeInBytes();

--- a/presto-main/src/main/java/com/facebook/presto/operator/project/InputPageProjection.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/project/InputPageProjection.java
@@ -15,6 +15,8 @@ package com.facebook.presto.operator.project;
 
 import com.facebook.presto.common.Page;
 import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.DictionaryBlock;
+import com.facebook.presto.common.block.DictionaryId;
 import com.facebook.presto.common.function.SqlFunctionProperties;
 import com.facebook.presto.operator.CompletedWork;
 import com.facebook.presto.operator.DriverYieldSignal;
@@ -55,7 +57,13 @@ public class InputPageProjection
 
         Block result;
         if (selectedPositions.isList()) {
-            result = block.copyPositions(selectedPositions.getPositions(), selectedPositions.getOffset(), selectedPositions.size());
+            result = new DictionaryBlock(
+                    selectedPositions.getOffset(),
+                    selectedPositions.size(),
+                    block.getLoadedBlock(),
+                    selectedPositions.getPositions(),
+                    false,
+                    DictionaryId.randomDictionaryId());
         }
         else if (selectedPositions.getOffset() == 0 && selectedPositions.size() == page.getPositionCount()) {
             result = block.getLoadedBlock();

--- a/presto-main/src/test/java/com/facebook/presto/block/AbstractTestBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/AbstractTestBlock.java
@@ -18,6 +18,7 @@ import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockBuilder;
 import com.facebook.presto.common.block.BlockBuilderStatus;
 import com.facebook.presto.common.block.BlockEncodingSerde;
+import com.facebook.presto.common.block.DictionaryBlock;
 import com.facebook.presto.common.block.DictionaryId;
 import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.metadata.FunctionManager;
@@ -41,6 +42,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.function.Supplier;
 
+import static com.facebook.airlift.testing.Assertions.assertBetweenInclusive;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
@@ -49,6 +51,8 @@ import static io.airlift.slice.SizeOf.SIZE_OF_INT;
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
 import static io.airlift.slice.SizeOf.SIZE_OF_SHORT;
 import static io.airlift.slice.SizeOf.sizeOf;
+import static java.lang.Math.max;
+import static java.lang.Math.min;
 import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.util.Arrays.fill;
@@ -225,41 +229,107 @@ public abstract class AbstractTestBlock
     {
         // Asserting on `block` is not very effective because most blocks passed to this method is compact.
         // Therefore, we split the `block` into two and assert again.
+        //------------------Test Whole Block Sizes---------------------------------------------------
+        // Assert sizeInBytes for the whole block.
         long expectedBlockSize = copyBlockViaBlockSerde(block).getSizeInBytes();
         assertEquals(block.getSizeInBytes(), expectedBlockSize);
         assertEquals(block.getRegionSizeInBytes(0, block.getPositionCount()), expectedBlockSize);
 
+        // Assert logicalSize for the whole block. Note that copyBlockViaBlockSerde would flatten DictionaryBlock or RleBlock
+        long logicalSizeInBytes = block.getLogicalSizeInBytes();
+
         long expectedLogicalBlockSize = copyBlockViaBlockSerde(block).getLogicalSizeInBytes();
-        assertEquals(block.getLogicalSizeInBytes(), expectedLogicalBlockSize);
+        assertEquals(logicalSizeInBytes, expectedLogicalBlockSize);
         assertEquals(block.getRegionLogicalSizeInBytes(0, block.getPositionCount()), expectedLogicalBlockSize);
 
+        // Assert approximateLogicalSize for the whole block
+        long approximateLogicalSizeInBytes = block.getApproximateRegionLogicalSizeInBytes(0, block.getPositionCount());
+
+        long expectedApproximateLogicalBlockSize = expectedLogicalBlockSize;
+        if (block instanceof DictionaryBlock) {
+            int dictionaryPositionCount = ((DictionaryBlock) block).getDictionary().getPositionCount();
+            expectedApproximateLogicalBlockSize = ((DictionaryBlock) block).getDictionary().getApproximateRegionLogicalSizeInBytes(0, dictionaryPositionCount) * block.getPositionCount() / dictionaryPositionCount;
+        }
+        assertEquals(approximateLogicalSizeInBytes, expectedApproximateLogicalBlockSize);
+
+        //------------------Test First Half Sizes---------------------------------------------------
         List<Block> splitBlock = splitBlock(block, 2);
         Block firstHalf = splitBlock.get(0);
+        int firstHalfPositionCount = firstHalf.getPositionCount();
 
+        // Assert sizeInBytes for the firstHalf block.
         long expectedFirstHalfSize = copyBlockViaBlockSerde(firstHalf).getSizeInBytes();
         assertEquals(firstHalf.getSizeInBytes(), expectedFirstHalfSize);
-        assertEquals(block.getRegionSizeInBytes(0, firstHalf.getPositionCount()), expectedFirstHalfSize);
+        assertEquals(block.getRegionSizeInBytes(0, firstHalfPositionCount), expectedFirstHalfSize);
 
+        // Assert logicalSize for the firstHalf block
+        long firstHalfLogicalSizeInBytes = firstHalf.getLogicalSizeInBytes();
         long expectedFirstHalfLogicalSize = copyBlockViaBlockSerde(firstHalf).getLogicalSizeInBytes();
-        assertEquals(firstHalf.getLogicalSizeInBytes(), expectedFirstHalfLogicalSize);
-        assertEquals(firstHalf.getRegionLogicalSizeInBytes(0, firstHalf.getPositionCount()), expectedFirstHalfLogicalSize);
+        assertEquals(firstHalfLogicalSizeInBytes, expectedFirstHalfLogicalSize);
+        assertEquals(firstHalf.getRegionLogicalSizeInBytes(0, firstHalfPositionCount), expectedFirstHalfLogicalSize);
 
+        // Assert approximateLogicalSize for the firstHalf block using logicalSize
+        long approximateFirstHalfLogicalSize = firstHalf.getApproximateRegionLogicalSizeInBytes(0, firstHalfPositionCount);
+
+        long expectedApproximateFirstHalfLogicalSize = expectedFirstHalfLogicalSize;
+        if (firstHalf instanceof DictionaryBlock) {
+            int dictionaryPositionCount = ((DictionaryBlock) firstHalf).getDictionary().getPositionCount();
+            expectedApproximateFirstHalfLogicalSize = ((DictionaryBlock) firstHalf).getDictionary().getApproximateRegionLogicalSizeInBytes(0, dictionaryPositionCount) * firstHalfPositionCount / dictionaryPositionCount;
+        }
+        assertEquals(approximateFirstHalfLogicalSize, expectedApproximateFirstHalfLogicalSize);
+
+        // Assert approximateLogicalSize for the firstHalf block using the ratio of firstHalf logicalSize vs whole block logicalSize
+        long expectedApproximateFirstHalfLogicalSizeFromUnsplittedBlock = logicalSizeInBytes == 0 ?
+                approximateLogicalSizeInBytes :
+                approximateLogicalSizeInBytes * firstHalfLogicalSizeInBytes / logicalSizeInBytes;
+        assertBetweenInclusive(
+                approximateFirstHalfLogicalSize,
+                // Allow for some error margins due to skew in blocks
+                min(expectedApproximateFirstHalfLogicalSizeFromUnsplittedBlock - 3, (long) (expectedApproximateFirstHalfLogicalSizeFromUnsplittedBlock * 0.7)),
+                max(expectedApproximateFirstHalfLogicalSizeFromUnsplittedBlock + 3, (long) (expectedApproximateFirstHalfLogicalSizeFromUnsplittedBlock * 1.3)));
+
+        //------------------Test Second Half Sizes---------------------------------------------------
         Block secondHalf = splitBlock.get(1);
+        int secondHalfPositionCount = secondHalf.getPositionCount();
 
+        // Assert sizeInBytes for the secondHalf block.
         long expectedSecondHalfSize = copyBlockViaBlockSerde(secondHalf).getSizeInBytes();
         assertEquals(secondHalf.getSizeInBytes(), expectedSecondHalfSize);
-        assertEquals(block.getRegionSizeInBytes(firstHalf.getPositionCount(), secondHalf.getPositionCount()), expectedSecondHalfSize);
+        assertEquals(block.getRegionSizeInBytes(firstHalfPositionCount, secondHalfPositionCount), expectedSecondHalfSize);
 
+        // Assert logicalSize for the secondHalf block.
+        long secondHalfLogicalSizeInBytes = secondHalf.getLogicalSizeInBytes();
         long expectedSecondHalfLogicalSize = copyBlockViaBlockSerde(secondHalf).getLogicalSizeInBytes();
-        assertEquals(secondHalf.getLogicalSizeInBytes(), expectedSecondHalfLogicalSize);
-        assertEquals(secondHalf.getRegionLogicalSizeInBytes(0, secondHalf.getPositionCount()), expectedSecondHalfLogicalSize);
+        assertEquals(secondHalfLogicalSizeInBytes, expectedSecondHalfLogicalSize);
+        assertEquals(secondHalf.getRegionLogicalSizeInBytes(0, secondHalfPositionCount), expectedSecondHalfLogicalSize);
 
+        // Assert approximateLogicalSize for the secondHalf block using logicalSize
+        long approximateSecondHalfLogicalSize = secondHalf.getApproximateRegionLogicalSizeInBytes(0, secondHalfPositionCount);
+
+        long expectedApproximateSecondHalfLogicalSize = copyBlockViaBlockSerde(secondHalf).getApproximateRegionLogicalSizeInBytes(0, secondHalfPositionCount);
+        if (secondHalf instanceof DictionaryBlock) {
+            int dictionaryPositionCount = ((DictionaryBlock) secondHalf).getDictionary().getPositionCount();
+            expectedApproximateSecondHalfLogicalSize = ((DictionaryBlock) secondHalf).getDictionary().getApproximateRegionLogicalSizeInBytes(0, dictionaryPositionCount) * secondHalfPositionCount / dictionaryPositionCount;
+        }
+        assertEquals(approximateSecondHalfLogicalSize, expectedApproximateSecondHalfLogicalSize);
+
+        // Assert approximateLogicalSize for the secondHalf block using the ratio of firstHalf logicalSize vs whole block logicalSize
+        long expectedApproximateSecondHalfLogicalSizeFromUnsplittedBlock = logicalSizeInBytes == 0 ?
+                approximateLogicalSizeInBytes :
+                approximateLogicalSizeInBytes * secondHalfLogicalSizeInBytes / logicalSizeInBytes;
+        assertBetweenInclusive(
+                approximateSecondHalfLogicalSize,
+                // Allow for some error margins due to skew in blocks
+                min(expectedApproximateSecondHalfLogicalSizeFromUnsplittedBlock - 3, (long) (expectedApproximateSecondHalfLogicalSizeFromUnsplittedBlock * 0.7)),
+                max(expectedApproximateSecondHalfLogicalSizeFromUnsplittedBlock + 3, (long) (expectedApproximateSecondHalfLogicalSizeFromUnsplittedBlock * 1.3)));
+
+        //----------------Test getPositionsSizeInBytes----------------------------------------
         boolean[] positions = new boolean[block.getPositionCount()];
-        fill(positions, 0, firstHalf.getPositionCount(), true);
+        fill(positions, 0, firstHalfPositionCount, true);
         assertEquals(block.getPositionsSizeInBytes(positions), expectedFirstHalfSize);
         fill(positions, true);
         assertEquals(block.getPositionsSizeInBytes(positions), expectedBlockSize);
-        fill(positions, 0, firstHalf.getPositionCount(), false);
+        fill(positions, 0, firstHalfPositionCount, false);
         assertEquals(block.getPositionsSizeInBytes(positions), expectedSecondHalfSize);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/project/TestPageProcessor.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/project/TestPageProcessor.java
@@ -14,11 +14,13 @@
 package com.facebook.presto.operator.project;
 
 import com.facebook.airlift.testing.TestingTicker;
+import com.facebook.presto.block.BlockAssertions;
 import com.facebook.presto.common.Page;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.LazyBlock;
 import com.facebook.presto.common.block.VariableWidthBlock;
 import com.facebook.presto.common.function.SqlFunctionProperties;
+import com.facebook.presto.common.type.ArrayType;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.memory.context.AggregatedMemoryContext;
 import com.facebook.presto.memory.context.LocalMemoryContext;
@@ -48,18 +50,24 @@ import java.util.stream.IntStream;
 
 import static com.facebook.airlift.concurrent.Threads.daemonThreadsNamed;
 import static com.facebook.presto.block.BlockAssertions.createLongSequenceBlock;
+import static com.facebook.presto.block.BlockAssertions.createMapType;
 import static com.facebook.presto.block.BlockAssertions.createSlicesBlock;
 import static com.facebook.presto.block.BlockAssertions.createStringsBlock;
 import static com.facebook.presto.common.function.OperatorType.ADD;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.common.type.RealType.REAL;
+import static com.facebook.presto.common.type.RowType.withDefaultFieldNames;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.execution.executor.PrioritizedSplitRunner.SPLIT_RUN_QUANTA;
 import static com.facebook.presto.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static com.facebook.presto.metadata.MetadataManager.createTestMetadataManager;
 import static com.facebook.presto.operator.PageAssertions.assertPageEquals;
+import static com.facebook.presto.operator.PageAssertions.createPageWithRandomData;
 import static com.facebook.presto.operator.project.PageProcessor.MAX_BATCH_SIZE;
 import static com.facebook.presto.operator.project.PageProcessor.MAX_PAGE_SIZE_IN_BYTES;
 import static com.facebook.presto.operator.project.PageProcessor.MIN_PAGE_SIZE_IN_BYTES;
+import static com.facebook.presto.operator.project.SelectedPositions.positionsList;
 import static com.facebook.presto.operator.project.SelectedPositions.positionsRange;
 import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
 import static com.facebook.presto.sql.relational.Expressions.call;
@@ -135,6 +143,34 @@ public class TestPageProcessor
     }
 
     @Test
+    public void testPartialFilterAsList()
+    {
+        // Primitive types
+
+        testPartialFilterAsList(BOOLEAN, 100, 0.5f, 0.5f, false, ImmutableList.of());
+        testPartialFilterAsList(REAL, 100, 0.5f, 0.5f, false, ImmutableList.of());
+        testPartialFilterAsList(BIGINT, 100, 0.5f, 0.5f, false, ImmutableList.of());
+        testPartialFilterAsList(VARCHAR, 100, 0.5f, 0.5f, false, ImmutableList.of());
+
+        testPartialFilterAsList(BOOLEAN, 100, 0.5f, 0.5f, true, ImmutableList.of());
+        testPartialFilterAsList(REAL, 100, 0.5f, 0.5f, true, ImmutableList.of());
+        testPartialFilterAsList(BIGINT, 100, 0.5f, 0.5f, true, ImmutableList.of());
+        testPartialFilterAsList(VARCHAR, 100, 0.5f, 0.5f, true, ImmutableList.of());
+
+        // Complext types
+
+        testPartialFilterAsList(new ArrayType(BIGINT), 100, 0.5f, 0.5f, false, ImmutableList.of());
+        testPartialFilterAsList(new ArrayType(VARCHAR), 100, 0.5f, 0.5f, false, ImmutableList.of());
+        testPartialFilterAsList(createMapType(BIGINT, VARCHAR), 100, 0.5f, 0.5f, false, ImmutableList.of());
+        testPartialFilterAsList(withDefaultFieldNames(ImmutableList.of(BIGINT, withDefaultFieldNames(ImmutableList.of(BOOLEAN, VARCHAR)))), 100, 0.5f, 0.5f, false, ImmutableList.of());
+
+        testPartialFilterAsList(new ArrayType(BIGINT), 100, 0.5f, 0.5f, true, ImmutableList.of());
+        testPartialFilterAsList(new ArrayType(VARCHAR), 100, 0.5f, 0.5f, true, ImmutableList.of());
+        testPartialFilterAsList(createMapType(BIGINT, VARCHAR), 100, 0.5f, 0.5f, true, ImmutableList.of());
+        testPartialFilterAsList(withDefaultFieldNames(ImmutableList.of(BIGINT, withDefaultFieldNames(ImmutableList.of(BOOLEAN, VARCHAR)))), 100, 0.5f, 0.5f, true, ImmutableList.of());
+    }
+
+    @Test
     public void testSelectAllFilter()
     {
         PageProcessor pageProcessor = new PageProcessor(Optional.of(new SelectAllFilter()), ImmutableList.of(createInputPageProjectionWithOutputs(0, BIGINT, 0)), OptionalInt.of(MAX_BATCH_SIZE));
@@ -199,7 +235,8 @@ public class TestPageProcessor
     @Test
     public void testProjectLazyLoad()
     {
-        PageProcessor pageProcessor = new PageProcessor(Optional.of(new SelectAllFilter()), ImmutableList.of(new PageProjectionWithOutputs(new LazyPagePageProjection(), new int[] {0})), OptionalInt.of(MAX_BATCH_SIZE));
+        PageProcessor pageProcessor = new PageProcessor(Optional.of(new SelectAllFilter()), ImmutableList.of(new PageProjectionWithOutputs(new LazyPagePageProjection(), new int[] {
+                0})), OptionalInt.of(MAX_BATCH_SIZE));
 
         // if channel 1 is loaded, test will fail
         Page inputPage = new Page(createLongSequenceBlock(0, 100), new LazyBlock(100, lazyBlock -> {
@@ -278,7 +315,8 @@ public class TestPageProcessor
     {
         InvocationCountPageProjection firstProjection = new InvocationCountPageProjection(new InputPageProjection(0));
         InvocationCountPageProjection secondProjection = new InvocationCountPageProjection(new InputPageProjection(0));
-        PageProcessor pageProcessor = new PageProcessor(Optional.empty(), ImmutableList.of(new PageProjectionWithOutputs(firstProjection, new int[] {0}), new PageProjectionWithOutputs(secondProjection, new int[] {1})), OptionalInt.of(MAX_BATCH_SIZE));
+        PageProcessor pageProcessor = new PageProcessor(Optional.empty(), ImmutableList.of(new PageProjectionWithOutputs(firstProjection, new int[] {
+                0}), new PageProjectionWithOutputs(secondProjection, new int[] {1})), OptionalInt.of(MAX_BATCH_SIZE));
 
         // process large page which will reduce batch size
         Slice[] slices = new Slice[(int) (MAX_BATCH_SIZE * 2.5)];
@@ -510,6 +548,23 @@ public class TestPageProcessor
                 inputPage);
         assertEquals(memoryContext.getBytes(), 0);
         return output;
+    }
+
+    private void testPartialFilterAsList(Type type, int positionCount, float primitiveNullRate, float nestedNullRate, boolean useBlockView, List<BlockAssertions.Encoding> wrappings)
+    {
+        int[] positions = IntStream.range(0, positionCount / 2).map(x -> x * 2).toArray();
+        PageProcessor pageProcessor = new PageProcessor(
+                Optional.of(new TestingPageFilter(positionsList(positions, 0, positionCount / 2))),
+                ImmutableList.of(createInputPageProjectionWithOutputs(0, BIGINT, 0)),
+                OptionalInt.of(MAX_BATCH_SIZE));
+
+        Page inputPage = createPageWithRandomData(ImmutableList.of(type), positionCount, false, false, primitiveNullRate, nestedNullRate, useBlockView, wrappings);
+
+        Iterator<Optional<Page>> output = processAndAssertRetainedPageSize(pageProcessor, inputPage);
+
+        List<Optional<Page>> outputPages = ImmutableList.copyOf(output);
+        assertEquals(outputPages.size(), 1);
+        assertPageEquals(ImmutableList.of(type), outputPages.get(0).orElse(null), new Page(inputPage.getBlock(0).copyPositions(positions, 0, positionCount / 2)));
     }
 
     private static class InvocationCountPageProjection


### PR DESCRIPTION
This PR optimizes identity projection with two ways:

1. Create DictionaryBlock when the selectedPositions is a list;
2. Use a faster and more memory efficient block size calculation.

BenchmarkPageProcessor shows 21x improvement in throughput, 46x reduction in gc.alloc.rate.norm, and 9x reduction in
GC count and time:

Before

```
    Benchmark                                                                    Mode  Cnt       Score      Error   Units
    BenchmarkPageProcessor.identityProjection                                   thrpt   50  125261.816 ± 5342.200   ops/s
    BenchmarkPageProcessor.identityProjection:·gc.alloc.rate                    thrpt   50    2439.004 ±  103.990  MB/sec
    BenchmarkPageProcessor.identityProjection:·gc.alloc.rate.norm               thrpt   50   40832.029 ±    0.033    B/op
    BenchmarkPageProcessor.identityProjection:·gc.churn.PS_Eden_Space           thrpt   50    2461.428 ±  364.315  MB/sec
    BenchmarkPageProcessor.identityProjection:·gc.churn.PS_Eden_Space.norm      thrpt   50   41439.660 ± 6521.978    B/op
    BenchmarkPageProcessor.identityProjection:·gc.churn.PS_Survivor_Space       thrpt   50       0.016 ±    0.016  MB/sec
    BenchmarkPageProcessor.identityProjection:·gc.churn.PS_Survivor_Space.norm  thrpt   50       0.257 ±    0.267    B/op
    BenchmarkPageProcessor.identityProjection:·gc.count                         thrpt   50      46.000             counts
    BenchmarkPageProcessor.identityProjection:·gc.time                          thrpt   50     181.000                 ms
```

After

```
    Benchmark                                                                    Mode  Cnt        Score        Error   Units
    BenchmarkPageProcessor.identityProjection                                   thrpt   10  2687127.250 ± 337956.918   ops/s
    BenchmarkPageProcessor.identityProjection:·gc.alloc.rate                    thrpt   10     1118.285 ±    141.900  MB/sec
    BenchmarkPageProcessor.identityProjection:·gc.alloc.rate.norm               thrpt   10      872.001 ±      0.005    B/op
    BenchmarkPageProcessor.identityProjection:·gc.churn.PS_Eden_Space           thrpt   10     1050.013 ±   1683.604  MB/sec
    BenchmarkPageProcessor.identityProjection:·gc.churn.PS_Eden_Space.norm      thrpt   10      827.947 ±   1329.288    B/op
    BenchmarkPageProcessor.identityProjection:·gc.churn.PS_Survivor_Space       thrpt   10        0.012 ±      0.040  MB/sec
    BenchmarkPageProcessor.identityProjection:·gc.churn.PS_Survivor_Space.norm  thrpt   10        0.011 ±      0.034    B/op
    BenchmarkPageProcessor.identityProjection:·gc.count                         thrpt   10        5.000               counts
    BenchmarkPageProcessor.identityProjection:·gc.time                          thrpt   10       21.000                   ms
```


```
== NO RELEASE NOTE ==
```
