### PR TITLE
Add local cache for Parquet Metadata

### DIFF
--- a/presto-hive-common/pom.xml
+++ b/presto-hive-common/pom.xml
@@ -38,5 +38,9 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.weakref</groupId>
+            <artifactId>jmxutils</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/presto-hive-common/src/main/java/com/facebook/presto/hive/CacheStatsMBean.java
+++ b/presto-hive-common/src/main/java/com/facebook/presto/hive/CacheStatsMBean.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.google.common.cache.Cache;
+import org.weakref.jmx.Managed;
+
+import static java.util.Objects.requireNonNull;
+
+public class CacheStatsMBean
+{
+    private final Cache<?, ?> cache;
+
+    public CacheStatsMBean(Cache<?, ?> cache)
+    {
+        this.cache = requireNonNull(cache, "cache is null");
+    }
+
+    @Managed
+    public long getSize()
+    {
+        return cache.size();
+    }
+
+    @Managed
+    public long getHitCount()
+    {
+        return cache.stats().hitCount();
+    }
+
+    @Managed
+    public long getMissCount()
+    {
+        return cache.stats().missCount();
+    }
+
+    @Managed
+    public double getHitRate()
+    {
+        return cache.stats().hitRate();
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientModule.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientModule.java
@@ -35,7 +35,6 @@ import com.facebook.presto.hive.parquet.ParquetPageSourceFactory;
 import com.facebook.presto.hive.rcfile.RcFilePageSourceFactory;
 import com.facebook.presto.hive.rule.HivePlanOptimizerProvider;
 import com.facebook.presto.hive.s3.PrestoS3ClientFactory;
-import com.facebook.presto.orc.CacheStatsMBean;
 import com.facebook.presto.orc.CachingStripeMetadataSource;
 import com.facebook.presto.orc.EncryptionLibrary;
 import com.facebook.presto.orc.OrcDataSourceId;
@@ -49,6 +48,12 @@ import com.facebook.presto.orc.cache.OrcCacheConfig;
 import com.facebook.presto.orc.cache.OrcFileTailSource;
 import com.facebook.presto.orc.cache.StorageOrcFileTailSource;
 import com.facebook.presto.orc.metadata.OrcFileTail;
+import com.facebook.presto.parquet.ParquetDataSourceId;
+import com.facebook.presto.parquet.cache.CachingParquetMetadataSource;
+import com.facebook.presto.parquet.cache.MetadataReader;
+import com.facebook.presto.parquet.cache.ParquetCacheConfig;
+import com.facebook.presto.parquet.cache.ParquetFileMetadata;
+import com.facebook.presto.parquet.cache.ParquetMetadataSource;
 import com.facebook.presto.spi.connector.ConnectorMetadataUpdaterProvider;
 import com.facebook.presto.spi.connector.ConnectorNodePartitioningProvider;
 import com.facebook.presto.spi.connector.ConnectorPageSinkProvider;
@@ -70,7 +75,6 @@ import org.weakref.jmx.MBeanExporter;
 import javax.inject.Singleton;
 
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
 import static com.facebook.airlift.concurrent.Threads.daemonThreadsNamed;
@@ -81,6 +85,7 @@ import static com.google.inject.multibindings.Multibinder.newSetBinder;
 import static java.lang.Math.toIntExact;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static java.util.concurrent.Executors.newFixedThreadPool;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.weakref.jmx.ObjectNames.generatedNameOf;
 import static org.weakref.jmx.guice.ExportBinder.newExporter;
 
@@ -159,6 +164,7 @@ public class HiveClientModule
         binder.bind(EncryptionLibrary.class).annotatedWith(ForUnknown.class).to(UnsupportedEncryptionLibrary.class).in(Scopes.SINGLETON);
         binder.bind(HiveDwrfEncryptionProvider.class).in(Scopes.SINGLETON);
 
+        configBinder(binder).bindConfig(ParquetCacheConfig.class, connectorId);
         Multibinder<HiveBatchPageSourceFactory> pageSourceFactoryBinder = newSetBinder(binder, HiveBatchPageSourceFactory.class);
         pageSourceFactoryBinder.addBinding().to(OrcBatchPageSourceFactory.class).in(Scopes.SINGLETON);
         pageSourceFactoryBinder.addBinding().to(DwrfBatchPageSourceFactory.class).in(Scopes.SINGLETON);
@@ -257,7 +263,7 @@ public class HiveClientModule
             Cache<OrcDataSourceId, OrcFileTail> cache = CacheBuilder.newBuilder()
                     .maximumWeight(orcCacheConfig.getFileTailCacheSize().toBytes())
                     .weigher((id, tail) -> ((OrcFileTail) tail).getFooterSize() + ((OrcFileTail) tail).getMetadataSize())
-                    .expireAfterAccess(orcCacheConfig.getFileTailCacheTtlSinceLastAccess().toMillis(), TimeUnit.MILLISECONDS)
+                    .expireAfterAccess(orcCacheConfig.getFileTailCacheTtlSinceLastAccess().toMillis(), MILLISECONDS)
                     .recordStats()
                     .build();
             CacheStatsMBean cacheStatsMBean = new CacheStatsMBean(cache);
@@ -276,13 +282,13 @@ public class HiveClientModule
             Cache<StripeId, Slice> footerCache = CacheBuilder.newBuilder()
                     .maximumWeight(orcCacheConfig.getStripeFooterCacheSize().toBytes())
                     .weigher((id, footer) -> toIntExact(((Slice) footer).getRetainedSize()))
-                    .expireAfterAccess(orcCacheConfig.getStripeFooterCacheTtlSinceLastAccess().toMillis(), TimeUnit.MILLISECONDS)
+                    .expireAfterAccess(orcCacheConfig.getStripeFooterCacheTtlSinceLastAccess().toMillis(), MILLISECONDS)
                     .recordStats()
                     .build();
             Cache<StripeStreamId, Slice> streamCache = CacheBuilder.newBuilder()
                     .maximumWeight(orcCacheConfig.getStripeStreamCacheSize().toBytes())
                     .weigher((id, stream) -> toIntExact(((Slice) stream).getRetainedSize()))
-                    .expireAfterAccess(orcCacheConfig.getStripeStreamCacheTtlSinceLastAccess().toMillis(), TimeUnit.MILLISECONDS)
+                    .expireAfterAccess(orcCacheConfig.getStripeStreamCacheTtlSinceLastAccess().toMillis(), MILLISECONDS)
                     .recordStats()
                     .build();
             CacheStatsMBean footerCacheStatsMBean = new CacheStatsMBean(footerCache);
@@ -292,5 +298,24 @@ public class HiveClientModule
             exporter.export(generatedNameOf(CacheStatsMBean.class, connectorId + "_StripeStream"), streamCacheStatsMBean);
         }
         return stripeMetadataSource;
+    }
+
+    @Singleton
+    @Provides
+    public ParquetMetadataSource createParquetMetadataSource(ParquetCacheConfig parquetCacheConfig, MBeanExporter exporter)
+    {
+        ParquetMetadataSource parquetMetadataSource = new MetadataReader();
+        if (parquetCacheConfig.isMetadataCacheEnabled()) {
+            Cache<ParquetDataSourceId, ParquetFileMetadata> cache = CacheBuilder.newBuilder()
+                    .maximumWeight(parquetCacheConfig.getMetadataCacheSize().toBytes())
+                    .weigher((id, metadata) -> ((ParquetFileMetadata) metadata).getMetadataSize())
+                    .expireAfterAccess(parquetCacheConfig.getMetadataCacheTtlSinceLastAccess().toMillis(), MILLISECONDS)
+                    .recordStats()
+                    .build();
+            CacheStatsMBean cacheStatsMBean = new CacheStatsMBean(cache);
+            parquetMetadataSource = new CachingParquetMetadataSource(cache, parquetMetadataSource);
+            exporter.export(generatedNameOf(CacheStatsMBean.class, connectorId + "_ParquetMetadata"), cacheStatsMBean);
+        }
+        return parquetMetadataSource;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/TupleDomainFilterCache.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/TupleDomainFilterCache.java
@@ -14,7 +14,7 @@
 package com.facebook.presto.hive.orc;
 
 import com.facebook.presto.common.predicate.Domain;
-import com.facebook.presto.orc.CacheStatsMBean;
+import com.facebook.presto.hive.CacheStatsMBean;
 import com.facebook.presto.orc.TupleDomainFilter;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;

--- a/presto-hive/src/test/java/com/facebook/presto/hive/HiveTestUtils.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/HiveTestUtils.java
@@ -47,6 +47,7 @@ import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.operator.PagesIndex;
 import com.facebook.presto.orc.StorageStripeMetadataSource;
 import com.facebook.presto.orc.cache.StorageOrcFileTailSource;
+import com.facebook.presto.parquet.cache.MetadataReader;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.PageSorter;
@@ -146,7 +147,7 @@ public final class HiveTestUtils
                 .add(new RcFilePageSourceFactory(FUNCTION_AND_TYPE_MANAGER, testHdfsEnvironment, stats))
                 .add(new OrcBatchPageSourceFactory(FUNCTION_AND_TYPE_MANAGER, FUNCTION_RESOLUTION, hiveClientConfig, testHdfsEnvironment, stats, new StorageOrcFileTailSource(), new StorageStripeMetadataSource()))
                 .add(new DwrfBatchPageSourceFactory(FUNCTION_AND_TYPE_MANAGER, FUNCTION_RESOLUTION, hiveClientConfig, testHdfsEnvironment, stats, new StorageOrcFileTailSource(), new StorageStripeMetadataSource(), NO_ENCRYPTION))
-                .add(new ParquetPageSourceFactory(FUNCTION_AND_TYPE_MANAGER, FUNCTION_RESOLUTION, testHdfsEnvironment, stats))
+                .add(new ParquetPageSourceFactory(FUNCTION_AND_TYPE_MANAGER, FUNCTION_RESOLUTION, testHdfsEnvironment, stats, new MetadataReader()))
                 .add(new PageFilePageSourceFactory(testHdfsEnvironment, new BlockEncodingManager()))
                 .build();
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/benchmark/FileFormat.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/benchmark/FileFormat.java
@@ -46,6 +46,7 @@ import com.facebook.presto.orc.OrcWriterStats;
 import com.facebook.presto.orc.OutputStreamDataSink;
 import com.facebook.presto.orc.StorageStripeMetadataSource;
 import com.facebook.presto.orc.cache.StorageOrcFileTailSource;
+import com.facebook.presto.parquet.cache.MetadataReader;
 import com.facebook.presto.parquet.writer.ParquetWriter;
 import com.facebook.presto.parquet.writer.ParquetWriterOptions;
 import com.facebook.presto.rcfile.AircompressorCodecFactory;
@@ -259,7 +260,7 @@ public enum FileFormat
         @Override
         public ConnectorPageSource createFileFormatReader(ConnectorSession session, HdfsEnvironment hdfsEnvironment, File targetFile, List<String> columnNames, List<Type> columnTypes)
         {
-            HiveBatchPageSourceFactory pageSourceFactory = new ParquetPageSourceFactory(FUNCTION_AND_TYPE_MANAGER, FUNCTION_RESOLUTION, hdfsEnvironment, new FileFormatDataSourceStats());
+            HiveBatchPageSourceFactory pageSourceFactory = new ParquetPageSourceFactory(FUNCTION_AND_TYPE_MANAGER, FUNCTION_RESOLUTION, hdfsEnvironment, new FileFormatDataSourceStats(), new MetadataReader());
             return createPageSource(pageSourceFactory, session, targetFile, columnNames, columnTypes, HiveStorageFormat.PARQUET);
         }
 
@@ -366,7 +367,7 @@ public enum FileFormat
         @Override
         public ConnectorPageSource createFileFormatReader(ConnectorSession session, HdfsEnvironment hdfsEnvironment, File targetFile, List<String> columnNames, List<Type> columnTypes)
         {
-            HiveBatchPageSourceFactory pageSourceFactory = new ParquetPageSourceFactory(FUNCTION_AND_TYPE_MANAGER, FUNCTION_RESOLUTION, hdfsEnvironment, new FileFormatDataSourceStats());
+            HiveBatchPageSourceFactory pageSourceFactory = new ParquetPageSourceFactory(FUNCTION_AND_TYPE_MANAGER, FUNCTION_RESOLUTION, hdfsEnvironment, new FileFormatDataSourceStats(), new MetadataReader());
             return createPageSource(pageSourceFactory, session, targetFile, columnNames, columnTypes, HiveStorageFormat.PARQUET);
         }
 
@@ -414,7 +415,7 @@ public enum FileFormat
         return true;
     }
 
-    private static ConnectorPageSource createPageSource(
+    public static ConnectorPageSource createPageSource(
             HiveRecordCursorProvider cursorProvider,
             ConnectorSession session, File targetFile, List<String> columnNames, List<Type> columnTypes, HiveStorageFormat format)
     {
@@ -445,7 +446,7 @@ public enum FileFormat
         return new RecordPageSource(columnTypes, recordCursor);
     }
 
-    private static ConnectorPageSource createPageSource(
+    public static ConnectorPageSource createPageSource(
             HiveBatchPageSourceFactory pageSourceFactory,
             ConnectorSession session,
             File targetFile,

--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/AbstractTestParquetReader.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/AbstractTestParquetReader.java
@@ -20,6 +20,13 @@ import com.facebook.presto.common.type.SqlDecimal;
 import com.facebook.presto.common.type.SqlTimestamp;
 import com.facebook.presto.common.type.SqlVarbinary;
 import com.facebook.presto.common.type.Type;
+import com.facebook.presto.parquet.ParquetDataSourceId;
+import com.facebook.presto.parquet.cache.CachingParquetMetadataSource;
+import com.facebook.presto.parquet.cache.MetadataReader;
+import com.facebook.presto.parquet.cache.ParquetFileMetadata;
+import com.facebook.presto.parquet.cache.ParquetMetadataSource;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.AbstractSequentialIterator;
 import com.google.common.collect.ContiguousSet;
@@ -28,6 +35,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Range;
 import com.google.common.primitives.Shorts;
 import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
 import org.apache.hadoop.hive.common.type.HiveDecimal;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.JavaHiveDecimalObjectInspector;
@@ -38,6 +46,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import parquet.hadoop.ParquetOutputFormat;
 import parquet.hadoop.codec.CodecConfig;
+import parquet.hadoop.metadata.CompressionCodecName;
 import parquet.schema.MessageType;
 
 import java.math.BigDecimal;
@@ -77,6 +86,8 @@ import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.common.type.VarcharType.createUnboundedVarcharType;
 import static com.facebook.presto.hive.parquet.ParquetTester.HIVE_STORAGE_TIME_ZONE;
 import static com.facebook.presto.hive.parquet.ParquetTester.insertNullEvery;
+import static com.facebook.presto.hive.parquet.ParquetTester.testSingleRead;
+import static com.facebook.presto.hive.parquet.ParquetTester.writeParquetColumnPresto;
 import static com.facebook.presto.testing.DateTimeTestingUtils.sqlTimestampOf;
 import static com.facebook.presto.testing.TestingConnectorSession.SESSION;
 import static com.facebook.presto.tests.StructuralTestUtil.mapType;
@@ -86,10 +97,14 @@ import static com.google.common.collect.Iterables.concat;
 import static com.google.common.collect.Iterables.cycle;
 import static com.google.common.collect.Iterables.limit;
 import static com.google.common.collect.Iterables.transform;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
+import static java.util.Arrays.stream;
 import static java.util.Collections.singletonList;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory.getStandardListObjectInspector;
 import static org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory.getStandardMapObjectInspector;
 import static org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory.getStandardStructObjectInspector;
@@ -1557,6 +1572,75 @@ public abstract class AbstractTestParquetReader
         DataSize maxReadBlockSize = new DataSize(1_000, DataSize.Unit.BYTE);
         Iterable<Map<String, Long>> values = createFixedTestMaps(Collections.nCopies(5_000, String.join("", Collections.nCopies(33, "test"))), longsBetween(0, 5_000));
         tester.testMaxReadBytes(getStandardMapObjectInspector(javaStringObjectInspector, javaLongObjectInspector), values, values, mapType(VARCHAR, BIGINT), maxReadBlockSize);
+    }
+
+    @Test
+    public void testCaching()
+            throws Exception
+    {
+        Cache<ParquetDataSourceId, ParquetFileMetadata> parquetFileMetadataCache = CacheBuilder.newBuilder()
+                .maximumWeight(new DataSize(1, MEGABYTE).toBytes())
+                .weigher((id, metadata) -> ((ParquetFileMetadata) metadata).getMetadataSize())
+                .expireAfterAccess(new Duration(10, MINUTES).toMillis(), MILLISECONDS)
+                .recordStats()
+                .build();
+        ParquetMetadataSource parquetMetadataSource = new CachingParquetMetadataSource(parquetFileMetadataCache, new MetadataReader());
+
+        try (ParquetTester.TempFile tempFile = new ParquetTester.TempFile("test", "parquet")) {
+            Iterable<Integer> values = intsBetween(0, 10);
+            Iterator<?>[] readValues = stream(new Iterable<?>[] {values}).map(Iterable::iterator).toArray(size -> new Iterator<?>[size]);
+
+            List<String> columnNames = singletonList("column1");
+            List<Type> columnTypes = singletonList(INTEGER);
+            writeParquetColumnPresto(tempFile.getFile(),
+                    columnTypes,
+                    columnNames,
+                    readValues,
+                    10,
+                    CompressionCodecName.GZIP);
+
+            testSingleRead(new Iterable<?>[] {values},
+                    columnNames,
+                    columnTypes,
+                    parquetMetadataSource,
+                    tempFile.getFile());
+            assertEquals(parquetFileMetadataCache.stats().missCount(), 1);
+            assertEquals(parquetFileMetadataCache.stats().hitCount(), 0);
+
+            testSingleRead(new Iterable<?>[] {values},
+                    columnNames,
+                    columnTypes,
+                    parquetMetadataSource,
+                    tempFile.getFile());
+            assertEquals(parquetFileMetadataCache.stats().missCount(), 1);
+            assertEquals(parquetFileMetadataCache.stats().hitCount(), 1);
+
+            testSingleRead(new Iterable<?>[] {values},
+                    columnNames,
+                    columnTypes,
+                    parquetMetadataSource,
+                    tempFile.getFile());
+            assertEquals(parquetFileMetadataCache.stats().missCount(), 1);
+            assertEquals(parquetFileMetadataCache.stats().hitCount(), 2);
+
+            parquetFileMetadataCache.invalidateAll();
+
+            testSingleRead(new Iterable<?>[] {values},
+                    columnNames,
+                    columnTypes,
+                    parquetMetadataSource,
+                    tempFile.getFile());
+            assertEquals(parquetFileMetadataCache.stats().missCount(), 2);
+            assertEquals(parquetFileMetadataCache.stats().hitCount(), 2);
+
+            testSingleRead(new Iterable<?>[] {values},
+                    columnNames,
+                    columnTypes,
+                    parquetMetadataSource,
+                    tempFile.getFile());
+            assertEquals(parquetFileMetadataCache.stats().missCount(), 2);
+            assertEquals(parquetFileMetadataCache.stats().hitCount(), 3);
+        }
     }
 
     private static <T> Iterable<T> repeatEach(int n, Iterable<T> iterable)

--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/TestParquetPageSourceFactory.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/TestParquetPageSourceFactory.java
@@ -23,6 +23,7 @@ import com.facebook.presto.hive.MetastoreClientConfig;
 import com.facebook.presto.hive.authentication.NoHdfsAuthentication;
 import com.facebook.presto.hive.metastore.Storage;
 import com.facebook.presto.hive.metastore.StorageFormat;
+import com.facebook.presto.parquet.cache.MetadataReader;
 import com.facebook.presto.spi.ConnectorPageSource;
 import com.facebook.presto.spi.function.StandardFunctionResolution;
 import com.facebook.presto.sql.relational.FunctionResolution;
@@ -51,7 +52,7 @@ public class TestParquetPageSourceFactory
     {
         HiveHdfsConfiguration hiveHdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationInitializer(new HiveClientConfig(), new MetastoreClientConfig()), ImmutableSet.of());
         HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(hiveHdfsConfiguration, new MetastoreClientConfig(), new NoHdfsAuthentication());
-        parquetPageSourceFactory = new ParquetPageSourceFactory(new TestingTypeManager(), functionResolution, hdfsEnvironment, new FileFormatDataSourceStats());
+        parquetPageSourceFactory = new ParquetPageSourceFactory(new TestingTypeManager(), functionResolution, hdfsEnvironment, new FileFormatDataSourceStats(), new MetadataReader());
     }
 
     @AfterClass(alwaysRun = true)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/cache/OrcCacheConfig.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/cache/OrcCacheConfig.java
@@ -69,7 +69,7 @@ public class OrcCacheConfig
     }
 
     @Config("orc.file-tail-cache-ttl-since-last-access")
-    @ConfigDescription("Time-to-live for file tail cache entry after last access")
+    @ConfigDescription("Time-to-live for orc file tail cache entry after last access")
     public OrcCacheConfig setFileTailCacheTtlSinceLastAccess(Duration fileTailCacheTtlSinceLastAccess)
     {
         this.fileTailCacheTtlSinceLastAccess = fileTailCacheTtlSinceLastAccess;

--- a/presto-parquet/pom.xml
+++ b/presto-parquet/pom.xml
@@ -17,6 +17,10 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>configuration</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-memory-context</artifactId>
         </dependency>

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/cache/CachingParquetMetadataSource.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/cache/CachingParquetMetadataSource.java
@@ -1,0 +1,55 @@
+
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.parquet.cache;
+
+import com.facebook.presto.parquet.ParquetDataSourceId;
+import com.google.common.cache.Cache;
+import com.google.common.util.concurrent.UncheckedExecutionException;
+import org.apache.hadoop.fs.FSDataInputStream;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+
+import static com.google.common.base.Throwables.throwIfInstanceOf;
+import static java.util.Objects.requireNonNull;
+
+public class CachingParquetMetadataSource
+        implements ParquetMetadataSource
+{
+    private final Cache<ParquetDataSourceId, ParquetFileMetadata> cache;
+    private final ParquetMetadataSource delegate;
+
+    public CachingParquetMetadataSource(Cache<ParquetDataSourceId, ParquetFileMetadata> cache, ParquetMetadataSource delegate)
+    {
+        this.cache = requireNonNull(cache, "cache is null");
+        this.delegate = requireNonNull(delegate, "delegate is null");
+    }
+
+    @Override
+    public ParquetFileMetadata getParquetMetadata(FSDataInputStream inputStream, ParquetDataSourceId parquetDataSourceId, long fileSize, boolean cacheable)
+            throws IOException
+    {
+        try {
+            if (cacheable) {
+                return cache.get(parquetDataSourceId, () -> delegate.getParquetMetadata(inputStream, parquetDataSourceId, fileSize, cacheable));
+            }
+            return delegate.getParquetMetadata(inputStream, parquetDataSourceId, fileSize, cacheable);
+        }
+        catch (ExecutionException | UncheckedExecutionException e) {
+            throwIfInstanceOf(e.getCause(), IOException.class);
+            throw new IOException("Unexpected error in parquet metadata reading after cache miss", e.getCause());
+        }
+    }
+}

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/cache/ParquetCacheConfig.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/cache/ParquetCacheConfig.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.parquet.cache;
+
+import com.facebook.airlift.configuration.Config;
+import com.facebook.airlift.configuration.ConfigDescription;
+import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
+import io.airlift.units.MinDataSize;
+import io.airlift.units.MinDuration;
+
+import static io.airlift.units.DataSize.Unit.BYTE;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+public class ParquetCacheConfig
+{
+    private boolean metadataCacheEnabled;
+    private DataSize metadataCacheSize = new DataSize(0, BYTE);
+    private Duration metadataCacheTtlSinceLastAccess = new Duration(0, SECONDS);
+
+    public boolean isMetadataCacheEnabled()
+    {
+        return metadataCacheEnabled;
+    }
+
+    @Config("parquet.metadata-cache-enabled")
+    @ConfigDescription("Enable cache for parquet metadata")
+    public ParquetCacheConfig setMetadataCacheEnabled(boolean metadataCacheEnabled)
+    {
+        this.metadataCacheEnabled = metadataCacheEnabled;
+        return this;
+    }
+
+    @MinDataSize("0B")
+    public DataSize getMetadataCacheSize()
+    {
+        return metadataCacheSize;
+    }
+
+    @Config("parquet.metadata-cache-size")
+    @ConfigDescription("Size of the parquet metadata cache")
+    public ParquetCacheConfig setMetadataCacheSize(DataSize metadataCacheSize)
+    {
+        this.metadataCacheSize = metadataCacheSize;
+        return this;
+    }
+
+    @MinDuration("0s")
+    public Duration getMetadataCacheTtlSinceLastAccess()
+    {
+        return metadataCacheTtlSinceLastAccess;
+    }
+
+    @Config("parquet.metadata-cache-ttl-since-last-access")
+    @ConfigDescription("Time-to-live for parquet metadata cache entry after last access")
+    public ParquetCacheConfig setMetadataCacheTtlSinceLastAccess(Duration metadataCacheTtlSinceLastAccess)
+    {
+        this.metadataCacheTtlSinceLastAccess = metadataCacheTtlSinceLastAccess;
+        return this;
+    }
+}

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/cache/ParquetFileMetadata.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/cache/ParquetFileMetadata.java
@@ -11,43 +11,30 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.orc;
+package com.facebook.presto.parquet.cache;
 
-import com.google.common.cache.Cache;
-import org.weakref.jmx.Managed;
+import org.apache.parquet.hadoop.metadata.ParquetMetadata;
 
 import static java.util.Objects.requireNonNull;
 
-public class CacheStatsMBean
+public class ParquetFileMetadata
 {
-    private final Cache<?, ?> cache;
+    private final ParquetMetadata parquetMetadata;
+    private final int metadataSize;
 
-    public CacheStatsMBean(Cache<?, ?> cache)
+    public ParquetFileMetadata(ParquetMetadata parquetMetadata, int metadataSize)
     {
-        this.cache = requireNonNull(cache, "cache is null");
+        this.parquetMetadata = requireNonNull(parquetMetadata, "parquetMetadata is null");
+        this.metadataSize = metadataSize;
     }
 
-    @Managed
-    public long getSize()
+    public int getMetadataSize()
     {
-        return cache.size();
+        return metadataSize;
     }
 
-    @Managed
-    public long getHitCount()
+    public ParquetMetadata getParquetMetadata()
     {
-        return cache.stats().hitCount();
-    }
-
-    @Managed
-    public long getMissCount()
-    {
-        return cache.stats().missCount();
-    }
-
-    @Managed
-    public double getHitRate()
-    {
-        return cache.stats().hitRate();
+        return parquetMetadata;
     }
 }

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/cache/ParquetMetadataSource.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/cache/ParquetMetadataSource.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.parquet.cache;
+
+import com.facebook.presto.parquet.ParquetDataSourceId;
+import org.apache.hadoop.fs.FSDataInputStream;
+
+import java.io.IOException;
+
+public interface ParquetMetadataSource
+{
+    ParquetFileMetadata getParquetMetadata(FSDataInputStream inputStream, ParquetDataSourceId parquetDataSourceId, long fileSize, boolean cacheable)
+            throws IOException;
+}

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/reader/ParquetColumnChunk.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/reader/ParquetColumnChunk.java
@@ -18,6 +18,7 @@ import com.facebook.presto.parquet.DataPageV1;
 import com.facebook.presto.parquet.DataPageV2;
 import com.facebook.presto.parquet.DictionaryPage;
 import com.facebook.presto.parquet.ParquetCorruptionException;
+import com.facebook.presto.parquet.cache.MetadataReader;
 import io.airlift.slice.Slice;
 import org.apache.parquet.column.Encoding;
 import org.apache.parquet.format.DataPageHeader;

--- a/presto-parquet/src/test/java/com/facebook/presto/parquet/BenchmarkParquetReader.java
+++ b/presto-parquet/src/test/java/com/facebook/presto/parquet/BenchmarkParquetReader.java
@@ -18,7 +18,7 @@ import com.facebook.presto.common.type.ArrayType;
 import com.facebook.presto.common.type.RowType;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.VarcharType;
-import com.facebook.presto.parquet.reader.MetadataReader;
+import com.facebook.presto.parquet.cache.MetadataReader;
 import com.facebook.presto.parquet.reader.ParquetReader;
 import com.google.common.base.Strings;
 import io.airlift.units.DataSize;
@@ -275,7 +275,7 @@ public class BenchmarkParquetReader
                 throws IOException
         {
             FileParquetDataSource dataSource = new FileParquetDataSource(file);
-            ParquetMetadata parquetMetadata = MetadataReader.readFooter(FileSystem.getLocal(new Configuration()), new Path(file.getAbsolutePath()), file.length());
+            ParquetMetadata parquetMetadata = MetadataReader.readFooter(FileSystem.getLocal(new Configuration()), new Path(file.getAbsolutePath()), file.length()).getParquetMetadata();
             MessageType schema = parquetMetadata.getFileMetaData().getSchema();
             MessageColumnIO messageColumnIO = getColumnIO(schema, schema);
 

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/StorageModule.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/StorageModule.java
@@ -13,7 +13,7 @@
  */
 package com.facebook.presto.raptor.storage;
 
-import com.facebook.presto.orc.CacheStatsMBean;
+import com.facebook.presto.hive.CacheStatsMBean;
 import com.facebook.presto.orc.CachingStripeMetadataSource;
 import com.facebook.presto.orc.OrcDataSourceId;
 import com.facebook.presto.orc.StorageStripeMetadataSource;


### PR DESCRIPTION
Test plan - TravisCI and unit tests in AbstractTestParquetReader

Fixes #13921

```
== RELEASE NOTES ==

Hive Changes
* Add caching module for Parquet metadata
```
