### PR TITLE
Support custom types in HiveType

### DIFF
--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/ExtendedFieldSchema.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/ExtendedFieldSchema.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+
+/*
+ * A regular Hive FieldSchema object only stores the column type as a string, which must
+ * be a valid built-in Hive type signature, that can be parsed by Hive's TypeInfoUtils.getTypeInfoFromTypeString.
+ * This is why use this class to pass non-builtin Hive types to Presto (eg enums, distinct types).
+ */
+public class ExtendedFieldSchema
+        extends FieldSchema
+{
+    private final TypeInfo typeInfo;
+
+    public ExtendedFieldSchema(String name, String type, String comment, TypeInfo typeInfo)
+    {
+        super(name, type, comment);
+        this.typeInfo = typeInfo;
+    }
+
+    public TypeInfo getTypeInfo()
+    {
+        return typeInfo;
+    }
+
+    @Override
+    public FieldSchema deepCopy()
+    {
+        return new ExtendedFieldSchema(getName(), getType(), getComment(), getTypeInfo());
+    }
+}

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/ExtendedTypeInfo.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/ExtendedTypeInfo.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.common.type.TypeSignature;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+
+import java.util.Objects;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+public class ExtendedTypeInfo
+        extends TypeInfo
+{
+    private final TypeSignature signature;
+    private final TypeInfo typeInfo;
+
+    public ExtendedTypeInfo(TypeSignature signature, TypeInfo typeInfo)
+    {
+        checkArgument(!(typeInfo instanceof ExtendedTypeInfo), "typeInfo cannot be an ExtendedTypeInfo");
+        this.typeInfo = typeInfo;
+        this.signature = signature;
+    }
+
+    public TypeSignature getSignature()
+    {
+        return signature;
+    }
+
+    public TypeInfo getTypeInfo()
+    {
+        return typeInfo;
+    }
+
+    @Override
+    public ObjectInspector.Category getCategory()
+    {
+        return typeInfo.getCategory();
+    }
+
+    @Override
+    public String getTypeName()
+    {
+        return typeInfo.getTypeName();
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (!(o instanceof ExtendedTypeInfo)) {
+            return false;
+        }
+        ExtendedTypeInfo other = (ExtendedTypeInfo) o;
+        return Objects.equals(other.getTypeInfo(), typeInfo)
+                && Objects.equals(other.getSignature(), signature);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(typeInfo, signature);
+    }
+}

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/HiveType.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/HiveType.java
@@ -162,6 +162,10 @@ public final class HiveType
 
     public static boolean isSupportedType(TypeInfo typeInfo)
     {
+        if (typeInfo instanceof ExtendedTypeInfo) {
+            return isSupportedType(((ExtendedTypeInfo) typeInfo).getTypeInfo());
+        }
+
         switch (typeInfo.getCategory()) {
             case PRIMITIVE:
                 return getPrimitiveType((PrimitiveTypeInfo) typeInfo) != null;
@@ -194,7 +198,7 @@ public final class HiveType
                 .collect(toList()));
     }
 
-    private static HiveType toHiveType(TypeInfo typeInfo)
+    public static HiveType toHiveType(TypeInfo typeInfo)
     {
         requireNonNull(typeInfo, "typeInfo is null");
         return new HiveType(typeInfo);
@@ -220,6 +224,9 @@ public final class HiveType
 
     private static TypeSignature getTypeSignature(TypeInfo typeInfo)
     {
+        if (typeInfo instanceof ExtendedTypeInfo) {
+            return ((ExtendedTypeInfo) typeInfo).getSignature();
+        }
         switch (typeInfo.getCategory()) {
             case PRIMITIVE:
                 Type primitiveType = getPrimitiveType((PrimitiveTypeInfo) typeInfo);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
@@ -111,6 +111,7 @@ public final class HiveSessionProperties
     public static final String PARTIAL_AGGREGATION_PUSHDOWN_ENABLED = "partial_aggregation_pushdown_enabled";
     public static final String PARTIAL_AGGREGATION_PUSHDOWN_FOR_VARIABLE_LENGTH_DATATYPES_ENABLED = "partial_aggregation_pushdown_for_variable_length_datatypes_enabled";
     public static final String FILE_RENAMING_ENABLED = "file_renaming_enabled";
+    public static final String SEMANTIC_TYPES_ENABLED = "semantic_types_enabled";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -520,6 +521,11 @@ public final class HiveSessionProperties
                         FILE_RENAMING_ENABLED,
                         "Enable renaming the files written by writers",
                         hiveClientConfig.isFileRenamingEnabled(),
+                        false),
+                booleanProperty(
+                        SEMANTIC_TYPES_ENABLED,
+                        "Override Hive physical types with semantic types",
+                        true,
                         false));
     }
 
@@ -909,5 +915,10 @@ public final class HiveSessionProperties
     public static boolean isFileRenamingEnabled(ConnectorSession session)
     {
         return session.getProperty(FILE_RENAMING_ENABLED, Boolean.class);
+    }
+
+    public static boolean isSemanticTypesEnabled(ConnectorSession session)
+    {
+        return session.getProperty(SEMANTIC_TYPES_ENABLED, Boolean.class);
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveTypeTranslator.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveTypeTranslator.java
@@ -15,9 +15,11 @@ package com.facebook.presto.hive;
 
 import com.facebook.presto.common.type.CharType;
 import com.facebook.presto.common.type.DecimalType;
+import com.facebook.presto.common.type.LongEnumType;
 import com.facebook.presto.common.type.NamedTypeSignature;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeSignatureParameter;
+import com.facebook.presto.common.type.VarcharEnumType;
 import com.facebook.presto.common.type.VarcharType;
 import com.facebook.presto.spi.PrestoException;
 import com.google.common.collect.ImmutableList;
@@ -119,6 +121,12 @@ public class HiveTypeTranslator
         }
         if (TIMESTAMP.equals(type)) {
             return HIVE_TIMESTAMP.getTypeInfo();
+        }
+        if (type instanceof LongEnumType) {
+            return new ExtendedTypeInfo(type.getTypeSignature(), HIVE_LONG.getTypeInfo());
+        }
+        if (type instanceof VarcharEnumType) {
+            return new ExtendedTypeInfo(type.getTypeSignature(), HIVE_STRING.getTypeInfo());
         }
         if (type instanceof DecimalType) {
             DecimalType decimalType = (DecimalType) type;

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriteUtils.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriteUtils.java
@@ -447,6 +447,10 @@ public final class HiveWriteUtils
 
     private static boolean isWritableType(TypeInfo typeInfo)
     {
+        if (typeInfo instanceof ExtendedTypeInfo) {
+            return isWritableType(((ExtendedTypeInfo) typeInfo).getTypeInfo());
+        }
+
         switch (typeInfo.getCategory()) {
             case PRIMITIVE:
                 PrimitiveCategory primitiveCategory = ((PrimitiveTypeInfo) typeInfo).getPrimitiveCategory();

--- a/presto-main/src/main/java/com/facebook/presto/type/TypeRegistry.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/TypeRegistry.java
@@ -16,6 +16,8 @@ package com.facebook.presto.type;
 import com.facebook.presto.common.type.ArrayType;
 import com.facebook.presto.common.type.CharType;
 import com.facebook.presto.common.type.DecimalType;
+import com.facebook.presto.common.type.LongEnumParametricType;
+import com.facebook.presto.common.type.LongEnumType;
 import com.facebook.presto.common.type.MapType;
 import com.facebook.presto.common.type.ParametricType;
 import com.facebook.presto.common.type.RowType;
@@ -24,6 +26,8 @@ import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeParameter;
 import com.facebook.presto.common.type.TypeSignature;
 import com.facebook.presto.common.type.TypeSignatureParameter;
+import com.facebook.presto.common.type.VarcharEnumParametricType;
+import com.facebook.presto.common.type.VarcharEnumType;
 import com.facebook.presto.common.type.VarcharType;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
@@ -33,6 +37,7 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.util.concurrent.UncheckedExecutionException;
 
 import javax.annotation.concurrent.ThreadSafe;
@@ -149,6 +154,16 @@ public final class TypeRegistry
         addParametricType(FUNCTION);
         addParametricType(QDIGEST);
         addParametricType(TDIGEST);
+
+        addParametricType(new LongEnumParametricType("test.Hello", new LongEnumType.LongEnumMap(
+                ImmutableMap.of(
+                        "HAPPY", 0L,
+                        "SAD", 1L))));
+
+        addParametricType(new VarcharEnumParametricType("test.Country", new VarcharEnumType.VarcharEnumMap(
+                ImmutableMap.of(
+                        "FR", "France",
+                        "US", "United States"))));
 
         for (Type type : types) {
             addType(type);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDictionaryBatchStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDictionaryBatchStreamReader.java
@@ -18,6 +18,7 @@ import com.facebook.presto.common.block.BlockBuilder;
 import com.facebook.presto.common.type.BigintType;
 import com.facebook.presto.common.type.DateType;
 import com.facebook.presto.common.type.IntegerType;
+import com.facebook.presto.common.type.LongEnumType;
 import com.facebook.presto.common.type.SmallintType;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.orc.OrcCorruptionException;
@@ -81,7 +82,7 @@ public class LongDictionaryBatchStreamReader
             throws OrcCorruptionException
     {
         requireNonNull(type, "type is null");
-        verifyStreamType(streamDescriptor, type, t -> t instanceof BigintType || t instanceof IntegerType || t instanceof SmallintType || t instanceof DateType);
+        verifyStreamType(streamDescriptor, type, t -> t instanceof BigintType || t instanceof IntegerType || t instanceof SmallintType || t instanceof DateType || t instanceof LongEnumType);
         this.type = type;
         this.streamDescriptor = requireNonNull(streamDescriptor, "stream is null");
         this.systemMemoryContext = requireNonNull(systemMemoryContext, "systemMemoryContext is null");

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDirectBatchStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDirectBatchStreamReader.java
@@ -21,6 +21,7 @@ import com.facebook.presto.common.block.ShortArrayBlock;
 import com.facebook.presto.common.type.BigintType;
 import com.facebook.presto.common.type.DateType;
 import com.facebook.presto.common.type.IntegerType;
+import com.facebook.presto.common.type.LongEnumType;
 import com.facebook.presto.common.type.SmallintType;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.orc.OrcCorruptionException;
@@ -84,7 +85,7 @@ public class LongDirectBatchStreamReader
             throws OrcCorruptionException
     {
         requireNonNull(type, "type is null");
-        verifyStreamType(streamDescriptor, type, t -> t instanceof BigintType || t instanceof IntegerType || t instanceof SmallintType || t instanceof DateType);
+        verifyStreamType(streamDescriptor, type, t -> t instanceof BigintType || t instanceof IntegerType || t instanceof SmallintType || t instanceof DateType || t instanceof LongEnumType);
         this.type = type;
         this.streamDescriptor = requireNonNull(streamDescriptor, "stream is null");
         this.systemMemoryContext = requireNonNull(systemMemoryContext, "systemMemoryContext is null");
@@ -153,7 +154,7 @@ public class LongDirectBatchStreamReader
             throws IOException
     {
         verify(dataStream != null);
-        if (type instanceof BigintType) {
+        if (type instanceof BigintType || type instanceof LongEnumType) {
             long[] values = new long[nextBatchSize];
             dataStream.next(values, nextBatchSize);
             return new LongArrayBlock(nextBatchSize, Optional.empty(), values);
@@ -174,7 +175,7 @@ public class LongDirectBatchStreamReader
     private Block readNullBlock(boolean[] isNull, int nonNullCount)
             throws IOException
     {
-        if (type instanceof BigintType) {
+        if (type instanceof BigintType || type instanceof LongEnumType) {
             return longReadNullBlock(isNull, nonNullCount);
         }
         if (type instanceof IntegerType || type instanceof DateType) {

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SelectiveStreamReaders.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SelectiveStreamReaders.java
@@ -30,6 +30,7 @@ import com.facebook.presto.common.type.TimestampType;
 import com.facebook.presto.common.type.TinyintType;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.VarbinaryType;
+import com.facebook.presto.common.type.VarcharEnumType;
 import com.facebook.presto.common.type.VarcharType;
 import com.facebook.presto.orc.OrcAggregatedMemoryContext;
 import com.facebook.presto.orc.OrcRecordReaderOptions;
@@ -98,7 +99,7 @@ public final class SelectiveStreamReaders
             case VARCHAR:
             case CHAR:
                 checkArgument(requiredSubfields.isEmpty(), "Primitive stream reader doesn't support subfields");
-                verifyStreamType(streamDescriptor, outputType, t -> t instanceof VarcharType || t instanceof CharType || t instanceof VarbinaryType);
+                verifyStreamType(streamDescriptor, outputType, t -> t instanceof VarcharType || t instanceof CharType || t instanceof VarbinaryType || t instanceof VarcharEnumType);
                 return new SliceSelectiveStreamReader(streamDescriptor, getOptionalOnlyFilter(type, filters), outputType, systemMemoryContext);
             case TIMESTAMP: {
                 checkArgument(requiredSubfields.isEmpty(), "Timestamp stream reader doesn't support subfields");

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceBatchStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceBatchStreamReader.java
@@ -17,6 +17,7 @@ import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.type.CharType;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.VarbinaryType;
+import com.facebook.presto.common.type.VarcharEnumType;
 import com.facebook.presto.common.type.VarcharType;
 import com.facebook.presto.orc.OrcAggregatedMemoryContext;
 import com.facebook.presto.orc.OrcCorruptionException;
@@ -60,7 +61,7 @@ public class SliceBatchStreamReader
             throws OrcCorruptionException
     {
         requireNonNull(type, "type is null");
-        verifyStreamType(streamDescriptor, type, t -> t instanceof VarcharType || t instanceof CharType || t instanceof VarbinaryType);
+        verifyStreamType(streamDescriptor, type, t -> t instanceof VarcharType || t instanceof CharType || t instanceof VarbinaryType || t instanceof VarcharEnumType);
         this.streamDescriptor = requireNonNull(streamDescriptor, "stream is null");
         this.directReader = new SliceDirectBatchStreamReader(streamDescriptor, getMaxCodePointCount(type), isCharType(type));
         this.dictionaryReader = new SliceDictionaryBatchStreamReader(streamDescriptor, getMaxCodePointCount(type), isCharType(type), systemMemoryContext.newOrcLocalMemoryContext(SliceBatchStreamReader.class.getSimpleName()));
@@ -123,7 +124,7 @@ public class SliceBatchStreamReader
         if (isCharType(type)) {
             return ((CharType) type).getLength();
         }
-        if (isVarbinaryType(type)) {
+        if (isVarbinaryType(type) || type instanceof VarcharEnumType) {
             return -1;
         }
         throw new IllegalArgumentException("Unsupported encoding " + type.getDisplayName());


### PR DESCRIPTION
When fetching metadata for Hive tables while analyzing a query, we go through the following codepath:
```
HiveMetadata.getViews -> ConnectorViewDefinition
SemiTransactionalHiveMetastore -> presto.hive.Table
...
ThriftMetastoreUtil.fromMetastoreApiTable -> presto.hive.Table
HiveMetastore.getTable -> hadoop.Table
```

Currently, the `presto.hive.Table` object can only describe types supported by open-source Hive, but not potential user-defined types.

This PR adds support for those.
