### PR TITLE
Enable reading of FileStatistics in presto-orc

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcSelectivePageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcSelectivePageSourceFactory.java
@@ -36,6 +36,7 @@ import com.facebook.presto.hive.HiveType;
 import com.facebook.presto.hive.SubfieldExtractor;
 import com.facebook.presto.hive.metastore.Storage;
 import com.facebook.presto.orc.DwrfEncryptionProvider;
+import com.facebook.presto.orc.DwrfKeyProvider;
 import com.facebook.presto.orc.FilterFunction;
 import com.facebook.presto.orc.OrcAggregatedMemoryContext;
 import com.facebook.presto.orc.OrcDataSource;
@@ -69,7 +70,6 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.UncheckedExecutionException;
-import io.airlift.slice.Slice;
 import io.airlift.units.DataSize;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
@@ -321,6 +321,9 @@ public class OrcSelectivePageSourceFactory
 
         OrcAggregatedMemoryContext systemMemoryUsage = new HiveOrcAggregatedMemoryContext();
         try {
+            checkArgument(!domainPredicate.isNone(), "Unexpected NONE domain");
+
+            DwrfKeyProvider dwrfKeyProvider = new ProjectionBasedDwrfKeyProvider(encryptionInformation, columns, useOrcColumnNames, path);
             OrcReader reader = new OrcReader(
                     orcDataSource,
                     orcEncoding,
@@ -329,11 +332,10 @@ public class OrcSelectivePageSourceFactory
                     systemMemoryUsage,
                     orcReaderOptions,
                     hiveFileContext.isCacheable(),
-                    dwrfEncryptionProvider);
+                    dwrfEncryptionProvider,
+                    dwrfKeyProvider);
 
-            checkArgument(!domainPredicate.isNone(), "Unexpected NONE domain");
-
-            List<HiveColumnHandle> physicalColumns = getPhysicalHiveColumnHandles(columns, useOrcColumnNames, reader, path);
+            List<HiveColumnHandle> physicalColumns = getPhysicalHiveColumnHandles(columns, useOrcColumnNames, reader.getTypes(), path);
 
             if (!physicalColumns.isEmpty() && physicalColumns.stream().allMatch(hiveColumnHandle -> hiveColumnHandle.getColumnType() == AGGREGATED)) {
                 return new AggregatedOrcPageSource(physicalColumns, reader.getFooter(), typeManager, functionResolution);
@@ -386,11 +388,6 @@ public class OrcSelectivePageSourceFactory
 
             List<FilterFunction> filterFunctions = toFilterFunctions(replaceExpression(remainingPredicate, variableToInput), bucketAdapter, session, rowExpressionService.getDeterminismEvaluator(), rowExpressionService.getPredicateCompiler());
 
-            Map<Integer, Slice> keyMap = ImmutableMap.of();
-            if (encryptionInformation.isPresent() && encryptionInformation.get().getDwrfEncryptionMetadata().isPresent()) {
-                keyMap = encryptionInformation.get().getDwrfEncryptionMetadata().get().toKeyMap(reader.getTypes(), physicalColumns);
-            }
-
             OrcSelectiveRecordReader recordReader = reader.createSelectiveRecordReader(
                     columnTypes,
                     outputIndices,
@@ -407,8 +404,7 @@ public class OrcSelectivePageSourceFactory
                     session.getSqlFunctionProperties().isLegacyMapSubscript(),
                     systemMemoryUsage,
                     Optional.empty(),
-                    INITIAL_BATCH_SIZE,
-                    keyMap);
+                    INITIAL_BATCH_SIZE);
 
             return new OrcSelectivePageSource(
                     recordReader,

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/ProjectionBasedDwrfKeyProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/ProjectionBasedDwrfKeyProvider.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.orc;
+
+import com.facebook.presto.hive.EncryptionInformation;
+import com.facebook.presto.hive.HiveColumnHandle;
+import com.facebook.presto.orc.DwrfKeyProvider;
+import com.facebook.presto.orc.metadata.OrcType;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.slice.Slice;
+import org.apache.hadoop.fs.Path;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.presto.hive.HiveUtil.getPhysicalHiveColumnHandles;
+
+/**
+ * Builds the node to the intermediate encryption key map based on the requested Hive columns.
+ */
+public class ProjectionBasedDwrfKeyProvider
+        implements DwrfKeyProvider
+{
+    private final List<HiveColumnHandle> columns;
+    private final boolean useOrcColumnNames;
+    private final Path path;
+    private final Optional<EncryptionInformation> encryptionInformation;
+    private Map<Integer, Slice> keys;
+
+    public ProjectionBasedDwrfKeyProvider(Optional<EncryptionInformation> encryptionInformation, List<HiveColumnHandle> columns, boolean useOrcColumnNames, Path path)
+    {
+        this.encryptionInformation = encryptionInformation;
+        this.columns = ImmutableList.copyOf(columns);
+        this.useOrcColumnNames = useOrcColumnNames;
+        this.path = path;
+    }
+
+    @Override
+    public Map<Integer, Slice> getIntermediateKeys(List<OrcType> types)
+    {
+        if (keys == null) {
+            if (encryptionInformation.isPresent() && encryptionInformation.get().getDwrfEncryptionMetadata().isPresent()) {
+                List<HiveColumnHandle> physicalColumns = getPhysicalHiveColumnHandles(columns, useOrcColumnNames, types, path);
+                keys = encryptionInformation.get().getDwrfEncryptionMetadata().get().toKeyMap(types, physicalColumns);
+            }
+            else {
+                keys = ImmutableMap.of();
+            }
+        }
+
+        return keys;
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/util/TempFileReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/util/TempFileReader.java
@@ -17,6 +17,7 @@ import com.facebook.presto.common.Page;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.hive.HiveOrcAggregatedMemoryContext;
+import com.facebook.presto.orc.DwrfKeyProvider;
 import com.facebook.presto.orc.OrcBatchRecordReader;
 import com.facebook.presto.orc.OrcDataSource;
 import com.facebook.presto.orc.OrcPredicate;
@@ -26,7 +27,6 @@ import com.facebook.presto.orc.StorageStripeMetadataSource;
 import com.facebook.presto.orc.cache.StorageOrcFileTailSource;
 import com.facebook.presto.spi.PrestoException;
 import com.google.common.collect.AbstractIterator;
-import com.google.common.collect.ImmutableMap;
 import io.airlift.units.DataSize;
 
 import java.io.IOException;
@@ -67,7 +67,8 @@ public class TempFileReader
                             new DataSize(16, MEGABYTE),
                             false),
                     false,
-                    NO_ENCRYPTION);
+                    NO_ENCRYPTION,
+                    DwrfKeyProvider.EMPTY);
 
             Map<Integer, Type> includedColumns = new HashMap<>();
             for (int i = 0; i < types.size(); i++) {
@@ -79,8 +80,7 @@ public class TempFileReader
                     OrcPredicate.TRUE,
                     UTC,
                     new HiveOrcAggregatedMemoryContext(),
-                    INITIAL_BATCH_SIZE,
-                    ImmutableMap.of());
+                    INITIAL_BATCH_SIZE);
         }
         catch (IOException e) {
             throw new PrestoException(HIVE_WRITER_DATA_ERROR, "Failed to read temporary data");

--- a/presto-orc/src/main/java/com/facebook/presto/orc/AbstractOrcRecordReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/AbstractOrcRecordReader.java
@@ -19,6 +19,7 @@ import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.type.FixedWidthType;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.orc.metadata.ColumnEncoding;
+import com.facebook.presto.orc.metadata.DwrfEncryption;
 import com.facebook.presto.orc.metadata.MetadataReader;
 import com.facebook.presto.orc.metadata.OrcType;
 import com.facebook.presto.orc.metadata.PostScript;
@@ -137,6 +138,7 @@ abstract class AbstractOrcRecordReader<T extends StreamReader>
             Optional<EncryptionLibrary> encryptionLibrary,
             Map<Integer, Integer> dwrfEncryptionGroupMap,
             Map<Integer, Slice> columnToIntermediateKeyMap,
+            Optional<DwrfEncryption> dwrfEncryption,
             int rowsInRowGroup,
             DateTimeZone hiveStorageTimeZone,
             PostScript.HiveWriterVersion hiveWriterVersion,

--- a/presto-orc/src/main/java/com/facebook/presto/orc/DwrfKeyProvider.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/DwrfKeyProvider.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc;
+
+import com.facebook.presto.orc.metadata.OrcType;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.slice.Slice;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Returns intermediate encryption keys in exchange for node types.
+ */
+public interface DwrfKeyProvider
+{
+    DwrfKeyProvider EMPTY = types -> ImmutableMap.of();
+
+    /**
+     * Construct a DwrfKeyProvider that always returns the same keys.
+     */
+    static DwrfKeyProvider of(Map<Integer, Slice> keys)
+    {
+        ImmutableMap<Integer, Slice> iek = ImmutableMap.copyOf(keys);
+        return types -> iek;
+    }
+
+    /**
+     * Get a node to the intermediate encryption key mapping.
+     */
+    Map<Integer, Slice> getIntermediateKeys(List<OrcType> types);
+}

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcBatchRecordReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcBatchRecordReader.java
@@ -16,6 +16,7 @@ package com.facebook.presto.orc;
 import com.facebook.presto.common.Page;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.type.Type;
+import com.facebook.presto.orc.metadata.DwrfEncryption;
 import com.facebook.presto.orc.metadata.MetadataReader;
 import com.facebook.presto.orc.metadata.OrcType;
 import com.facebook.presto.orc.metadata.PostScript.HiveWriterVersion;
@@ -54,6 +55,7 @@ public class OrcBatchRecordReader
             Optional<EncryptionLibrary> encryptionLibrary,
             Map<Integer, Integer> dwrfEncryptionGroupMap,
             Map<Integer, Slice> intermediateKeyMetadata,
+            Optional<DwrfEncryption> dwrfEncryption,
             int rowsInRowGroup,
             DateTimeZone hiveStorageTimeZone,
             OrcRecordReaderOptions options,
@@ -89,6 +91,7 @@ public class OrcBatchRecordReader
                 encryptionLibrary,
                 dwrfEncryptionGroupMap,
                 intermediateKeyMetadata,
+                dwrfEncryption,
                 rowsInRowGroup,
                 hiveStorageTimeZone,
                 hiveWriterVersion,

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcSelectiveRecordReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcSelectiveRecordReader.java
@@ -27,6 +27,7 @@ import com.facebook.presto.orc.TupleDomainFilter.BigintMultiRange;
 import com.facebook.presto.orc.TupleDomainFilter.BigintRange;
 import com.facebook.presto.orc.TupleDomainFilter.BigintValuesUsingBitmask;
 import com.facebook.presto.orc.TupleDomainFilter.BigintValuesUsingHashTable;
+import com.facebook.presto.orc.metadata.DwrfEncryption;
 import com.facebook.presto.orc.metadata.MetadataReader;
 import com.facebook.presto.orc.metadata.OrcType;
 import com.facebook.presto.orc.metadata.PostScript;
@@ -167,6 +168,7 @@ public class OrcSelectiveRecordReader
             Optional<EncryptionLibrary> encryptionLibrary,
             Map<Integer, Integer> dwrfEncryptionGroupMap,
             Map<Integer, Slice> intermediateKeyMetadata,
+            Optional<DwrfEncryption> dwrfEncryption,
             int rowsInRowGroup,
             DateTimeZone hiveStorageTimeZone,
             OrcRecordReaderOptions options,
@@ -208,6 +210,7 @@ public class OrcSelectiveRecordReader
                 encryptionLibrary,
                 dwrfEncryptionGroupMap,
                 intermediateKeyMetadata,
+                dwrfEncryption,
                 rowsInRowGroup,
                 hiveStorageTimeZone,
                 hiveWriterVersion,

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriteValidation.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriteValidation.java
@@ -179,10 +179,6 @@ public class OrcWriteValidation
     public void validateFileStatistics(OrcDataSourceId orcDataSourceId, List<ColumnStatistics> actualFileStatistics)
             throws OrcCorruptionException
     {
-        if (actualFileStatistics.isEmpty()) {
-            // DWRF file statistics are disabled
-            return;
-        }
         validateColumnStatisticsEquivalent(orcDataSourceId, "file", actualFileStatistics, fileStatistics);
     }
 
@@ -362,6 +358,7 @@ public class OrcWriteValidation
         if (actualColumnStatistics.getNumberOfValues() != expectedColumnStatistics.getNumberOfValues()) {
             throw new OrcCorruptionException(orcDataSourceId, "Write validation failed: unexpected number of values in %s statistics", name);
         }
+
         if (!Objects.equals(actualColumnStatistics.getBooleanStatistics(), expectedColumnStatistics.getBooleanStatistics())) {
             throw new OrcCorruptionException(orcDataSourceId, "Write validation failed: unexpected boolean counts in %s statistics", name);
         }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
@@ -742,8 +742,8 @@ public class OrcWriter
                 hiveStorageTimeZone,
                 orcEncoding,
                 new OrcReaderOptions(new DataSize(1, MEGABYTE), new DataSize(8, MEGABYTE), new DataSize(16, MEGABYTE), false),
-                intermediateKeyMetadata.build(),
-                dwrfEncryptionProvider);
+                dwrfEncryptionProvider,
+                DwrfKeyProvider.of(intermediateKeyMetadata.build()));
     }
 
     private int estimateAverageLogicalSizePerRow(Page page)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/ExceptionWrappingMetadataReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/ExceptionWrappingMetadataReader.java
@@ -13,14 +13,19 @@
  */
 package com.facebook.presto.orc.metadata;
 
+import com.facebook.presto.orc.DwrfEncryptionProvider;
+import com.facebook.presto.orc.DwrfKeyProvider;
 import com.facebook.presto.orc.OrcCorruptionException;
+import com.facebook.presto.orc.OrcDataSource;
 import com.facebook.presto.orc.OrcDataSourceId;
+import com.facebook.presto.orc.OrcDecompressor;
 import com.facebook.presto.orc.metadata.PostScript.HiveWriterVersion;
 import com.facebook.presto.orc.metadata.statistics.HiveBloomFilter;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
+import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
@@ -63,11 +68,16 @@ public class ExceptionWrappingMetadataReader
     }
 
     @Override
-    public Footer readFooter(HiveWriterVersion hiveWriterVersion, InputStream inputStream)
+    public Footer readFooter(HiveWriterVersion hiveWriterVersion,
+            InputStream inputStream,
+            DwrfEncryptionProvider dwrfEncryptionProvider,
+            DwrfKeyProvider dwrfKeyProvider,
+            OrcDataSource orcDataSource,
+            Optional<OrcDecompressor> decompressor)
             throws OrcCorruptionException
     {
         try {
-            return delegate.readFooter(hiveWriterVersion, inputStream);
+            return delegate.readFooter(hiveWriterVersion, inputStream, dwrfEncryptionProvider, dwrfKeyProvider, orcDataSource, decompressor);
         }
         catch (IOException | RuntimeException e) {
             throw propagate(e, "Invalid file footer");

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/MetadataReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/MetadataReader.java
@@ -13,12 +13,17 @@
  */
 package com.facebook.presto.orc.metadata;
 
+import com.facebook.presto.orc.DwrfEncryptionProvider;
+import com.facebook.presto.orc.DwrfKeyProvider;
+import com.facebook.presto.orc.OrcDataSource;
+import com.facebook.presto.orc.OrcDecompressor;
 import com.facebook.presto.orc.metadata.PostScript.HiveWriterVersion;
 import com.facebook.presto.orc.metadata.statistics.HiveBloomFilter;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
+import java.util.Optional;
 
 public interface MetadataReader
 {
@@ -28,7 +33,12 @@ public interface MetadataReader
     Metadata readMetadata(HiveWriterVersion hiveWriterVersion, InputStream inputStream)
             throws IOException;
 
-    Footer readFooter(HiveWriterVersion hiveWriterVersion, InputStream inputStream)
+    Footer readFooter(HiveWriterVersion hiveWriterVersion,
+            InputStream inputStream,
+            DwrfEncryptionProvider dwrfEncryptionProvider,
+            DwrfKeyProvider dwrfKeyProvider,
+            OrcDataSource orcDataSource,
+            Optional<OrcDecompressor> decompressor)
             throws IOException;
 
     StripeFooter readStripeFooter(List<OrcType> types, InputStream inputStream)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcMetadataReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcMetadataReader.java
@@ -13,6 +13,10 @@
  */
 package com.facebook.presto.orc.metadata;
 
+import com.facebook.presto.orc.DwrfEncryptionProvider;
+import com.facebook.presto.orc.DwrfKeyProvider;
+import com.facebook.presto.orc.OrcDataSource;
+import com.facebook.presto.orc.OrcDecompressor;
 import com.facebook.presto.orc.metadata.ColumnEncoding.ColumnEncodingKind;
 import com.facebook.presto.orc.metadata.OrcType.OrcTypeKind;
 import com.facebook.presto.orc.metadata.PostScript.HiveWriterVersion;
@@ -123,7 +127,12 @@ public class OrcMetadataReader
     }
 
     @Override
-    public Footer readFooter(HiveWriterVersion hiveWriterVersion, InputStream inputStream)
+    public Footer readFooter(HiveWriterVersion hiveWriterVersion,
+            InputStream inputStream,
+            DwrfEncryptionProvider dwrfEncryptionProvider,
+            DwrfKeyProvider dwrfKeyProvider,
+            OrcDataSource orcDataSource,
+            Optional<OrcDecompressor> decompressor)
             throws IOException
     {
         CodedInputStream input = CodedInputStream.newInstance(inputStream);

--- a/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkBatchStreamReaders.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkBatchStreamReaders.java
@@ -211,14 +211,14 @@ public class BenchmarkBatchStreamReaders
                     NOOP_ORC_AGGREGATED_MEMORY_CONTEXT,
                     OrcReaderTestingUtils.createDefaultTestConfig(),
                     false,
-                    NO_ENCRYPTION);
+                    NO_ENCRYPTION,
+                    DwrfKeyProvider.EMPTY);
             return orcReader.createBatchRecordReader(
                     ImmutableMap.of(0, type),
                     OrcPredicate.TRUE,
                     UTC, // arbitrary
                     new TestingHiveOrcAggregatedMemoryContext(),
-                    INITIAL_BATCH_SIZE,
-                    ImmutableMap.of());
+                    INITIAL_BATCH_SIZE);
         }
 
         private static String randomAsciiString(Random random)

--- a/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkBatchStreamReadersWithZstd.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkBatchStreamReadersWithZstd.java
@@ -223,14 +223,14 @@ public class BenchmarkBatchStreamReadersWithZstd
                     NOOP_ORC_AGGREGATED_MEMORY_CONTEXT,
                     OrcReaderTestingUtils.createTestingReaderOptions(zstdJniDecompressionEnabled),
                     false,
-                    NO_ENCRYPTION);
+                    NO_ENCRYPTION,
+                    DwrfKeyProvider.EMPTY);
             return orcReader.createBatchRecordReader(
                     ImmutableMap.of(0, type),
                     OrcPredicate.TRUE,
                     UTC, // arbitrary
                     new TestingHiveOrcAggregatedMemoryContext(),
-                    INITIAL_BATCH_SIZE,
-                    ImmutableMap.of());
+                    INITIAL_BATCH_SIZE);
         }
 
         private static String randomAsciiString(Random random)

--- a/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkSelectiveStreamReaders.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkSelectiveStreamReaders.java
@@ -275,7 +275,8 @@ public class BenchmarkSelectiveStreamReaders
                     NOOP_ORC_AGGREGATED_MEMORY_CONTEXT,
                     OrcReaderTestingUtils.createDefaultTestConfig(),
                     false,
-                    NO_ENCRYPTION);
+                    NO_ENCRYPTION,
+                    DwrfKeyProvider.EMPTY);
 
             return orcReader.createSelectiveRecordReader(
                     IntStream.range(0, channelCount).boxed().collect(Collectors.toMap(Function.identity(), i -> type)),
@@ -295,8 +296,7 @@ public class BenchmarkSelectiveStreamReaders
                     true,
                     new TestingHiveOrcAggregatedMemoryContext(),
                     Optional.empty(),
-                    INITIAL_BATCH_SIZE,
-                    ImmutableMap.of());
+                    INITIAL_BATCH_SIZE);
         }
 
         private Optional<TupleDomainFilter> getFilter(Type type, float filterRate, boolean filterAllowNull, float selectionRateForNonNull)

--- a/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
@@ -1467,6 +1467,33 @@ public class OrcTester
         return orcReader.createBatchRecordReader(columnTypes, predicate, HIVE_STORAGE_TIME_ZONE, new TestingHiveOrcAggregatedMemoryContext(), initialBatchSize);
     }
 
+    static OrcReader createCustomOrcReader(
+            TempFile tempFile,
+            OrcEncoding orcEncoding,
+            boolean mapNullKeysEnabled,
+            Map<Integer, Slice> intermediateEncryptionKeys)
+            throws IOException
+    {
+        OrcDataSource orcDataSource = new FileOrcDataSource(tempFile.getFile(), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), true);
+        OrcReader orcReader = new OrcReader(
+                orcDataSource,
+                orcEncoding,
+                new StorageOrcFileTailSource(),
+                new StorageStripeMetadataSource(),
+                NOOP_ORC_AGGREGATED_MEMORY_CONTEXT,
+                new OrcReaderOptions(
+                        new DataSize(1, MEGABYTE),
+                        new DataSize(1, MEGABYTE),
+                        MAX_BLOCK_SIZE,
+                        false,
+                        mapNullKeysEnabled,
+                        false),
+                false,
+                new DwrfEncryptionProvider(new UnsupportedEncryptionLibrary(), new TestingEncryptionLibrary()),
+                DwrfKeyProvider.of(intermediateEncryptionKeys));
+        return orcReader;
+    }
+
     public static void writeOrcColumnPresto(File outputFile, Format format, CompressionKind compression, Type type, List<?> values)
             throws Exception
     {

--- a/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
@@ -1455,7 +1455,8 @@ public class OrcTester
                         mapNullKeysEnabled,
                         false),
                 cacheable,
-                new DwrfEncryptionProvider(new UnsupportedEncryptionLibrary(), new TestingEncryptionLibrary()));
+                new DwrfEncryptionProvider(new UnsupportedEncryptionLibrary(), new TestingEncryptionLibrary()),
+                DwrfKeyProvider.of(intermediateEncryptionKeys));
 
         assertEquals(orcReader.getFooter().getRowsInRowGroup(), 10_000);
 
@@ -1463,7 +1464,7 @@ public class OrcTester
                 .boxed()
                 .collect(toImmutableMap(Functions.identity(), types::get));
 
-        return orcReader.createBatchRecordReader(columnTypes, predicate, HIVE_STORAGE_TIME_ZONE, new TestingHiveOrcAggregatedMemoryContext(), initialBatchSize, intermediateEncryptionKeys);
+        return orcReader.createBatchRecordReader(columnTypes, predicate, HIVE_STORAGE_TIME_ZONE, new TestingHiveOrcAggregatedMemoryContext(), initialBatchSize);
     }
 
     public static void writeOrcColumnPresto(File outputFile, Format format, CompressionKind compression, Type type, List<?> values)
@@ -1584,7 +1585,8 @@ public class OrcTester
                         mapNullKeysEnabled,
                         false),
                 false,
-                new DwrfEncryptionProvider(new UnsupportedEncryptionLibrary(), new TestingEncryptionLibrary()));
+                new DwrfEncryptionProvider(new UnsupportedEncryptionLibrary(), new TestingEncryptionLibrary()),
+                DwrfKeyProvider.of(intermediateEncryptionKeys));
 
         assertEquals(orcReader.getColumnNames().subList(0, types.size()), makeColumnNames(types.size()));
         assertEquals(orcReader.getFooter().getRowsInRowGroup(), 10_000);
@@ -1605,8 +1607,7 @@ public class OrcTester
                 LEGACY_MAP_SUBSCRIPT,
                 systemMemoryUsage,
                 Optional.empty(),
-                initialBatchSize,
-                intermediateEncryptionKeys);
+                initialBatchSize);
     }
 
     private static void writeValue(Type type, BlockBuilder blockBuilder, Object value)

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestCachingOrcDataSource.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestCachingOrcDataSource.java
@@ -240,7 +240,8 @@ public class TestCachingOrcDataSource
                 NOOP_ORC_AGGREGATED_MEMORY_CONTEXT,
                 new OrcReaderOptions(maxMergeDistance, tinyStripeThreshold, new DataSize(1, Unit.MEGABYTE), false),
                 false,
-                NO_ENCRYPTION);
+                NO_ENCRYPTION,
+                DwrfKeyProvider.EMPTY);
         // 1 for reading file footer
         assertEquals(orcDataSource.getReadCount(), 1);
         List<StripeInformation> stripes = orcReader.getFooter().getStripes();
@@ -254,8 +255,7 @@ public class TestCachingOrcDataSource
                 (numberOfRows, statisticsByColumnIndex) -> true,
                 HIVE_STORAGE_TIME_ZONE,
                 new TestingHiveOrcAggregatedMemoryContext(),
-                INITIAL_BATCH_SIZE,
-                ImmutableMap.of());
+                INITIAL_BATCH_SIZE);
         int positionCount = 0;
         while (true) {
             int batchSize = orcRecordReader.nextBatch();

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestMapFlatBatchStreamReader.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestMapFlatBatchStreamReader.java
@@ -404,7 +404,8 @@ public class TestMapFlatBatchStreamReader
                 NOOP_ORC_AGGREGATED_MEMORY_CONTEXT,
                 OrcReaderTestingUtils.createDefaultTestConfig(),
                 false,
-                NO_ENCRYPTION);
+                NO_ENCRYPTION,
+                DwrfKeyProvider.EMPTY);
         Type mapType = FUNCTION_AND_TYPE_MANAGER.getParameterizedType(
                 StandardTypes.MAP,
                 ImmutableList.of(
@@ -416,8 +417,7 @@ public class TestMapFlatBatchStreamReader
                 createOrcPredicate(0, mapType, expectedValues, OrcTester.Format.DWRF, true),
                 HIVE_STORAGE_TIME_ZONE,
                 new TestingHiveOrcAggregatedMemoryContext(),
-                1024,
-                ImmutableMap.of())) {
+                1024)) {
             Iterator<?> expectedValuesIterator = expectedValues.iterator();
 
             boolean isFirst = true;

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcLz4.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcLz4.java
@@ -60,7 +60,8 @@ public class TestOrcLz4
                         SIZE,
                         false),
                 false,
-                NO_ENCRYPTION);
+                NO_ENCRYPTION,
+                DwrfKeyProvider.EMPTY);
 
         assertEquals(orcReader.getCompressionKind(), LZ4);
         assertEquals(orcReader.getFooter().getNumberOfRows(), 10_000);
@@ -76,8 +77,7 @@ public class TestOrcLz4
                 OrcPredicate.TRUE,
                 DateTimeZone.UTC,
                 new TestingHiveOrcAggregatedMemoryContext(),
-                INITIAL_BATCH_SIZE,
-                ImmutableMap.of());
+                INITIAL_BATCH_SIZE);
 
         int rows = 0;
         while (true) {

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcReaderPositions.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcReaderPositions.java
@@ -309,7 +309,8 @@ public class TestOrcReaderPositions
                     NOOP_ORC_AGGREGATED_MEMORY_CONTEXT,
                     OrcReaderTestingUtils.createDefaultTestConfig(),
                     false,
-                    NO_ENCRYPTION);
+                    NO_ENCRYPTION,
+                    DwrfKeyProvider.EMPTY);
             Footer footer = orcReader.getFooter();
             Map<String, String> readMetadata = Maps.transformValues(footer.getUserMetadata(), Slice::toStringAscii);
             assertEquals(readMetadata, metadata);

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcWriter.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcWriter.java
@@ -115,7 +115,8 @@ public class TestOrcWriter
                             dataSize,
                             false),
                     false,
-                    NO_ENCRYPTION
+                    NO_ENCRYPTION,
+                    DwrfKeyProvider.EMPTY
             ).getFooter();
 
             for (StripeInformation stripe : footer.getStripes()) {

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestReadBloomFilter.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestReadBloomFilter.java
@@ -122,12 +122,13 @@ public class TestReadBloomFilter
                 NOOP_ORC_AGGREGATED_MEMORY_CONTEXT,
                 OrcReaderTestingUtils.createDefaultTestConfig(),
                 false,
-                NO_ENCRYPTION);
+                NO_ENCRYPTION,
+                DwrfKeyProvider.EMPTY);
 
         assertEquals(orcReader.getColumnNames(), ImmutableList.of("test"));
         assertEquals(orcReader.getFooter().getRowsInRowGroup(), 10_000);
 
-        return orcReader.createBatchRecordReader(ImmutableMap.of(0, type), predicate, HIVE_STORAGE_TIME_ZONE, new TestingHiveOrcAggregatedMemoryContext(), MAX_BATCH_SIZE, ImmutableMap.of());
+        return orcReader.createBatchRecordReader(ImmutableMap.of(0, type), predicate, HIVE_STORAGE_TIME_ZONE, new TestingHiveOrcAggregatedMemoryContext(), MAX_BATCH_SIZE);
     }
 
     private static <T> TupleDomainOrcPredicate<String> makeOrcPredicate(Type type, T value, boolean bloomFilterEnabled)

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestStructBatchStreamReader.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestStructBatchStreamReader.java
@@ -280,7 +280,8 @@ public class TestStructBatchStreamReader
                         dataSize,
                         false),
                 false,
-                NO_ENCRYPTION);
+                NO_ENCRYPTION,
+                DwrfKeyProvider.EMPTY);
 
         Map<Integer, Type> includedColumns = new HashMap<>();
         includedColumns.put(0, readerType);
@@ -290,8 +291,7 @@ public class TestStructBatchStreamReader
                 OrcPredicate.TRUE,
                 UTC,
                 new TestingHiveOrcAggregatedMemoryContext(),
-                OrcReader.INITIAL_BATCH_SIZE,
-                ImmutableMap.of());
+                OrcReader.INITIAL_BATCH_SIZE);
 
         recordReader.nextBatch();
         RowBlock block = (RowBlock) recordReader.readBlock(0);

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestingOrcPredicate.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestingOrcPredicate.java
@@ -83,7 +83,7 @@ public final class TestingOrcPredicate
     {
         List<Object> expectedValues = newArrayList(values);
         if (BOOLEAN.equals(type)) {
-            return new BooleanOrcPredicate(columnIndex, expectedValues, format == DWRF);
+            return new BooleanOrcPredicate(columnIndex, expectedValues, false);
         }
         if (TINYINT.equals(type) || SMALLINT.equals(type) || INTEGER.equals(type) || BIGINT.equals(type)) {
             return new LongOrcPredicate(true,
@@ -91,7 +91,7 @@ public final class TestingOrcPredicate
                     expectedValues.stream()
                             .map(value -> value == null ? null : ((Number) value).longValue())
                             .collect(toList()),
-                    format == DWRF);
+                    false);
         }
         if (TIMESTAMP.equals(type)) {
             return new LongOrcPredicate(false,
@@ -99,7 +99,7 @@ public final class TestingOrcPredicate
                     expectedValues.stream()
                             .map(value -> value == null ? null : ((SqlTimestamp) value).getMillisUtc())
                             .collect(toList()),
-                    format == DWRF);
+                    false);
         }
         if (DATE.equals(type)) {
             return new DateOrcPredicate(
@@ -107,7 +107,7 @@ public final class TestingOrcPredicate
                     expectedValues.stream()
                             .map(value -> value == null ? null : (long) ((SqlDate) value).getDays())
                             .collect(toList()),
-                    format == DWRF);
+                    false);
         }
         if (REAL.equals(type) || DOUBLE.equals(type)) {
             return new DoubleOrcPredicate(
@@ -115,25 +115,25 @@ public final class TestingOrcPredicate
                     expectedValues.stream()
                             .map(value -> value == null ? null : ((Number) value).doubleValue())
                             .collect(toList()),
-                    format == DWRF);
+                    false);
         }
         if (type instanceof VarbinaryType) {
             // binary does not have stats
-            return new BasicOrcPredicate<>(columnIndex, expectedValues, Object.class, format == DWRF);
+            return new BasicOrcPredicate<>(columnIndex, expectedValues, Object.class, false);
         }
         if (type instanceof VarcharType) {
             return new StringOrcPredicate(columnIndex, expectedValues, format, isHiveWriter);
         }
         if (type instanceof CharType) {
-            return new CharOrcPredicate(columnIndex, expectedValues, format == DWRF);
+            return new CharOrcPredicate(columnIndex, expectedValues, false);
         }
         if (type instanceof DecimalType) {
-            return new DecimalOrcPredicate(columnIndex, expectedValues, format == DWRF);
+            return new DecimalOrcPredicate(columnIndex, expectedValues, false);
         }
 
         String baseType = type.getTypeSignature().getBase();
         if (ARRAY.equals(baseType) || MAP.equals(baseType) || ROW.equals(baseType)) {
-            return new BasicOrcPredicate<>(columnIndex, expectedValues, Object.class, format == DWRF);
+            return new BasicOrcPredicate<>(columnIndex, expectedValues, Object.class, false);
         }
         throw new IllegalArgumentException("Unsupported type " + type);
     }
@@ -178,9 +178,7 @@ public final class TestingOrcPredicate
         public boolean matches(long numberOfRows, Map<Integer, ColumnStatistics> statisticsByColumnIndex)
         {
             ColumnStatistics columnStatistics = statisticsByColumnIndex.get(columnIndex);
-
-            // todo enable file stats when DWRF team verifies that the stats are correct
-            // assertTrue(columnStatistics.hasNumberOfValues());
+            assertTrue(columnStatistics.hasNumberOfValues());
             if (noFileStats && numberOfRows == expectedValues.size()) {
                 assertNull(columnStatistics);
                 return true;
@@ -405,7 +403,7 @@ public final class TestingOrcPredicate
 
         public StringOrcPredicate(int columnIndex, Iterable<?> expectedValues, Format format, boolean isHiveWriter)
         {
-            super(columnIndex, expectedValues, String.class, format == DWRF);
+            super(columnIndex, expectedValues, String.class, false);
             this.format = format;
             this.isHiveWriter = isHiveWriter;
         }

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcFileRewriter.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcFileRewriter.java
@@ -21,6 +21,7 @@ import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.common.type.TypeSignature;
+import com.facebook.presto.orc.DwrfKeyProvider;
 import com.facebook.presto.orc.OrcBatchRecordReader;
 import com.facebook.presto.orc.OrcDataSource;
 import com.facebook.presto.orc.OrcReader;
@@ -113,7 +114,8 @@ public final class OrcFileRewriter
                     new RaptorOrcAggregatedMemoryContext(),
                     new OrcReaderOptions(readerAttributes.getMaxMergeDistance(), readerAttributes.getTinyStripeThreshold(), HUGE_MAX_READ_BLOCK_SIZE, readerAttributes.isZstdJniDecompressionEnabled()),
                     false,
-                    NO_ENCRYPTION);
+                    NO_ENCRYPTION,
+                    DwrfKeyProvider.EMPTY);
 
             if (reader.getFooter().getNumberOfRows() < rowsToDelete.length()) {
                 throw new IOException("File has fewer rows than deletion vector");
@@ -181,8 +183,7 @@ public final class OrcFileRewriter
                             TRUE,
                             DEFAULT_STORAGE_TIMEZONE,
                             new RaptorOrcAggregatedMemoryContext(),
-                            INITIAL_BATCH_SIZE,
-                            ImmutableMap.of()),
+                            INITIAL_BATCH_SIZE),
                     OrcBatchRecordReader::close);
                     Closer<OrcWriter, IOException> writer = closer(new OrcWriter(
                                     orcDataEnvironment.createOrcDataSink(fileSystem, output),

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcStorageManager.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcStorageManager.java
@@ -32,6 +32,7 @@ import com.facebook.presto.common.type.TypeSignature;
 import com.facebook.presto.common.type.TypeSignatureParameter;
 import com.facebook.presto.hive.HdfsContext;
 import com.facebook.presto.hive.HiveFileContext;
+import com.facebook.presto.orc.DwrfKeyProvider;
 import com.facebook.presto.orc.OrcAggregatedMemoryContext;
 import com.facebook.presto.orc.OrcBatchRecordReader;
 import com.facebook.presto.orc.OrcDataSource;
@@ -296,7 +297,8 @@ public class OrcStorageManager
                     new RaptorOrcAggregatedMemoryContext(),
                     new OrcReaderOptions(readerAttributes.getMaxMergeDistance(), readerAttributes.getTinyStripeThreshold(), HUGE_MAX_READ_BLOCK_SIZE, readerAttributes.isZstdJniDecompressionEnabled()),
                     hiveFileContext.isCacheable(),
-                    NO_ENCRYPTION);
+                    NO_ENCRYPTION,
+                    DwrfKeyProvider.EMPTY);
 
             Map<Long, Integer> indexMap = columnIdIndex(reader.getColumnNames());
             ImmutableMap.Builder<Integer, Type> includedColumns = ImmutableMap.builder();
@@ -327,8 +329,7 @@ public class OrcStorageManager
                     predicate,
                     DEFAULT_STORAGE_TIMEZONE,
                     systemMemoryUsage,
-                    INITIAL_BATCH_SIZE,
-                    ImmutableMap.of());
+                    INITIAL_BATCH_SIZE);
 
             Optional<ShardRewriter> shardRewriter = Optional.empty();
             if (transactionId.isPresent()) {
@@ -391,7 +392,8 @@ public class OrcStorageManager
                             HUGE_MAX_READ_BLOCK_SIZE,
                             defaultReaderAttributes.isZstdJniDecompressionEnabled()),
                     false,
-                    NO_ENCRYPTION);
+                    NO_ENCRYPTION,
+                    DwrfKeyProvider.EMPTY);
 
             if (reader.getFooter().getNumberOfRows() >= Integer.MAX_VALUE) {
                 throw new IOException("File has too many rows");
@@ -402,8 +404,7 @@ public class OrcStorageManager
                     OrcPredicate.TRUE,
                     DEFAULT_STORAGE_TIMEZONE,
                     systemMemoryUsage,
-                    INITIAL_BATCH_SIZE,
-                    ImmutableMap.of())) {
+                    INITIAL_BATCH_SIZE)) {
                 BitSet bitSet = new BitSet();
                 while (recordReader.nextBatch() > 0) {
                     Block block = recordReader.readBlock(0);
@@ -556,7 +557,8 @@ public class OrcStorageManager
                     new RaptorOrcAggregatedMemoryContext(),
                     new OrcReaderOptions(defaultReaderAttributes.getMaxMergeDistance(), defaultReaderAttributes.getTinyStripeThreshold(), HUGE_MAX_READ_BLOCK_SIZE, defaultReaderAttributes.isZstdJniDecompressionEnabled()),
                     false,
-                    NO_ENCRYPTION);
+                    NO_ENCRYPTION,
+                    DwrfKeyProvider.EMPTY);
 
             ImmutableList.Builder<ColumnStats> list = ImmutableList.builder();
             for (ColumnInfo info : getColumnInfo(reader)) {

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/ShardStats.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/ShardStats.java
@@ -77,8 +77,7 @@ public final class ShardStats
                 OrcPredicate.TRUE,
                 UTC,
                 new RaptorOrcAggregatedMemoryContext(),
-                INITIAL_BATCH_SIZE,
-                ImmutableMap.of());
+                INITIAL_BATCH_SIZE);
 
         if (type.equals(BOOLEAN)) {
             return indexBoolean(reader, columnIndex, columnId);

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/OrcTestingUtil.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/OrcTestingUtil.java
@@ -18,6 +18,7 @@ import com.facebook.presto.common.type.Type;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.orc.DwrfKeyProvider;
 import com.facebook.presto.orc.FileOrcDataSource;
 import com.facebook.presto.orc.OrcBatchRecordReader;
 import com.facebook.presto.orc.OrcCorruptionException;
@@ -29,7 +30,6 @@ import com.facebook.presto.orc.OrcWriterStats;
 import com.facebook.presto.orc.StorageStripeMetadataSource;
 import com.facebook.presto.orc.cache.StorageOrcFileTailSource;
 import com.facebook.presto.raptor.RaptorOrcAggregatedMemoryContext;
-import com.google.common.collect.ImmutableMap;
 import io.airlift.units.DataSize;
 import org.joda.time.DateTimeZone;
 
@@ -71,7 +71,8 @@ final class OrcTestingUtil
                 new RaptorOrcAggregatedMemoryContext(),
                 createDefaultTestConfig(),
                 false,
-                NO_ENCRYPTION);
+                NO_ENCRYPTION,
+                DwrfKeyProvider.EMPTY);
 
         List<String> columnNames = orcReader.getColumnNames();
         assertEquals(columnNames.size(), columnIds.size());
@@ -98,8 +99,7 @@ final class OrcTestingUtil
                 OrcPredicate.TRUE,
                 DateTimeZone.UTC,
                 new RaptorOrcAggregatedMemoryContext(),
-                MAX_BATCH_SIZE,
-                ImmutableMap.of());
+                MAX_BATCH_SIZE);
     }
 
     public static byte[] octets(int... values)

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestOrcFileRewriter.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestOrcFileRewriter.java
@@ -25,6 +25,7 @@ import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeSignature;
 import com.facebook.presto.common.type.TypeSignatureParameter;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.orc.DwrfKeyProvider;
 import com.facebook.presto.orc.OrcBatchRecordReader;
 import com.facebook.presto.orc.OrcDataSource;
 import com.facebook.presto.orc.OrcReader;
@@ -502,7 +503,8 @@ public class TestOrcFileRewriter
                 new RaptorOrcAggregatedMemoryContext(),
                 OrcTestingUtil.createDefaultTestConfig(),
                 false,
-                NO_ENCRYPTION);
+                NO_ENCRYPTION,
+                DwrfKeyProvider.EMPTY);
         orcReader.getColumnNames().equals(ImmutableList.of("7"));
 
         // Add a column with the different ID with different type


### PR DESCRIPTION
Move intermediate encryption keys from the OrcRecordReader to the OrcReader's constructor.
Enable reading of FileStatistics for both encrypted and unencrypted ORC files.

== Test plan ==
```
mvn clean install -DskipTests
mvn clean install -pl presto-orc -pl presto-hive -pl presto-raptor
```

== RELEASE NOTES ==

General Changes
* Move IEK from OrcRecordReader to OrcReader's constructor
* Enable reading of FileStatistics for ORC files
