### PR TITLE
Allow nullable cache base directory

### DIFF
--- a/presto-cache/src/main/java/com/facebook/presto/cache/CacheConfig.java
+++ b/presto-cache/src/main/java/com/facebook/presto/cache/CacheConfig.java
@@ -18,6 +18,8 @@ import com.facebook.airlift.configuration.ConfigDescription;
 import com.facebook.presto.hive.CacheQuotaScope;
 import io.airlift.units.DataSize;
 
+import javax.annotation.Nullable;
+
 import java.net.URI;
 import java.util.Optional;
 
@@ -32,6 +34,7 @@ public class CacheConfig
     private CacheQuotaScope cacheQuotaScope = GLOBAL;
     private Optional<DataSize> defaultCacheQuota = Optional.empty();
 
+    @Nullable
     public URI getBaseDirectory()
     {
         return baseDirectory;

--- a/presto-cache/src/main/java/com/facebook/presto/cache/alluxio/AlluxioCachingConfigurationProvider.java
+++ b/presto-cache/src/main/java/com/facebook/presto/cache/alluxio/AlluxioCachingConfigurationProvider.java
@@ -42,7 +42,9 @@ public class AlluxioCachingConfigurationProvider
     {
         if (cacheConfig.isCachingEnabled() && cacheConfig.getCacheType() == ALLUXIO) {
             configuration.set("alluxio.user.local.cache.enabled", String.valueOf(cacheConfig.isCachingEnabled()));
-            configuration.set("alluxio.user.client.cache.dir", cacheConfig.getBaseDirectory().getPath());
+            if (cacheConfig.getBaseDirectory() != null) {
+                configuration.set("alluxio.user.client.cache.dir", cacheConfig.getBaseDirectory().getPath());
+            }
             configuration.set("alluxio.user.client.cache.size", alluxioCacheConfig.getMaxCacheSize().toString());
             configuration.set("alluxio.user.client.cache.async.write.enabled", String.valueOf(alluxioCacheConfig.isAsyncWriteEnabled()));
             configuration.set("alluxio.user.metrics.collection.enabled", String.valueOf(alluxioCacheConfig.isMetricsCollectionEnabled()));

--- a/presto-cache/src/test/java/com/facebook/presto/cache/alluxio/TestAlluxioCachingFileSystem.java
+++ b/presto-cache/src/test/java/com/facebook/presto/cache/alluxio/TestAlluxioCachingFileSystem.java
@@ -364,7 +364,9 @@ public class TestAlluxioCachingFileSystem
         Configuration configuration = new Configuration();
         if (cacheConfig.isCachingEnabled() && cacheConfig.getCacheType() == ALLUXIO) {
             configuration.set("alluxio.user.local.cache.enabled", String.valueOf(cacheConfig.isCachingEnabled()));
-            configuration.set("alluxio.user.client.cache.dir", cacheConfig.getBaseDirectory().getPath());
+            if (cacheConfig.getBaseDirectory() != null) {
+                configuration.set("alluxio.user.client.cache.dir", cacheConfig.getBaseDirectory().getPath());
+            }
             configuration.set("alluxio.user.client.cache.size", alluxioCacheConfig.getMaxCacheSize().toString());
             configuration.set("alluxio.user.client.cache.page.size", Integer.toString(PAGE_SIZE));
             configuration.set("alluxio.user.metrics.collection.enabled", String.valueOf(alluxioCacheConfig.isMetricsCollectionEnabled()));


### PR DESCRIPTION
Test plan - Tested locally

Avoid throwing NPE when user didn't set `cache.base-directory`. In this case, cache base directory will  be the default value set by `alluxio.user.client.cache.dir` property in Alluxio 


```
== NO RELEASE NOTE ==
```
