### PR TITLE
Support formatting Use statement

### DIFF
--- a/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
@@ -107,6 +107,7 @@ import com.facebook.presto.sql.tree.TransactionAccessMode;
 import com.facebook.presto.sql.tree.TransactionMode;
 import com.facebook.presto.sql.tree.Union;
 import com.facebook.presto.sql.tree.Unnest;
+import com.facebook.presto.sql.tree.Use;
 import com.facebook.presto.sql.tree.Values;
 import com.facebook.presto.sql.tree.With;
 import com.facebook.presto.sql.tree.WithQuery;
@@ -781,6 +782,19 @@ public final class SqlFormatter
             node.getEscape().ifPresent(value ->
                     builder.append(" ESCAPE ")
                             .append(formatStringLiteral(value)));
+
+            return null;
+        }
+
+        @Override
+        protected Void visitUse(Use node, Integer context)
+        {
+            builder.append("USE ");
+            if (node.getCatalog().isPresent()) {
+                builder.append(formatExpression(node.getCatalog().get(), Optional.empty()))
+                        .append(".");
+            }
+            builder.append(formatExpression(node.getSchema(), Optional.empty()));
 
             return null;
         }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Use.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Use.java
@@ -100,6 +100,9 @@ public final class Use
     @Override
     public String toString()
     {
-        return toStringHelper(this).toString();
+        return toStringHelper(this)
+                .add("catalog", catalog)
+                .add("schema", schema)
+                .toString();
     }
 }

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -140,6 +140,7 @@ import com.facebook.presto.sql.tree.TimestampLiteral;
 import com.facebook.presto.sql.tree.TransactionAccessMode;
 import com.facebook.presto.sql.tree.Union;
 import com.facebook.presto.sql.tree.Unnest;
+import com.facebook.presto.sql.tree.Use;
 import com.facebook.presto.sql.tree.Values;
 import com.facebook.presto.sql.tree.Window;
 import com.facebook.presto.sql.tree.With;
@@ -2439,6 +2440,16 @@ public class TestSqlParser
                         false,
                         false,
                         ImmutableList.of(new Identifier("x"), new LongLiteral("1"))));
+    }
+
+    @Test
+    public void testUse()
+    {
+        assertStatement("Use test_schema", new Use(Optional.empty(), identifier("test_schema")));
+        assertStatement("Use test_catalog.test_schema", new Use(Optional.of(identifier("test_catalog")), new Identifier("test_schema")));
+
+        assertStatement("Use \"test_schema\"", new Use(Optional.empty(), quotedIdentifier("test_schema")));
+        assertStatement("Use \"test_catalog\".\"test_schema\"", new Use(Optional.of(quotedIdentifier("test_catalog")), quotedIdentifier("test_schema")));
     }
 
     private static void assertCast(String type)


### PR DESCRIPTION
Before the fix, `explain use catalog.schema` would fail with generic internal error.

```
== RELEASE NOTES ==

General Changes
* Fix query failure when explaining ``Use`` statement.
```
