### PR TITLE
Disable MergingPageOutput for ScanFilterAndProjectOperator before repartitioning

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestOrcBatchPageSourceMemoryTracking.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestOrcBatchPageSourceMemoryTracking.java
@@ -555,7 +555,8 @@ public class TestOrcBatchPageSourceMemoryTracking
                     types,
                     Optional.empty(),
                     new DataSize(0, BYTE),
-                    0);
+                    0,
+                    false);
             SourceOperator operator = sourceOperatorFactory.createOperator(driverContext);
             operator.addSplit(new Split(new ConnectorId("test"), TestingTransactionHandle.create(), TestingSplit.createLocalSplit()));
             return operator;

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -171,6 +171,7 @@ public final class SystemSessionProperties
     public static final String LEGACY_TYPE_COERCION_WARNING_ENABLED = "legacy_type_coercion_warning_enabled";
     public static final String INLINE_SQL_FUNCTIONS = "inline_sql_functions";
     public static final String REMOTE_FUNCTIONS_ENABLED = "remote_functions_enabled";
+    public static final String DISABLE_MERGING_PAGE_OUTPUT = "disable_merging_page_output";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -905,6 +906,11 @@ public final class SystemSessionProperties
                         REMOTE_FUNCTIONS_ENABLED,
                         "Allow remote functions",
                         false,
+                        false),
+                booleanProperty(
+                        DISABLE_MERGING_PAGE_OUTPUT,
+                        "Experimental: Disable MergingPageOutput if the stage has only ScanFilterAndProjectOperator",
+                        featuresConfig.isDisableMergingPageOutput(),
                         false));
     }
 
@@ -1525,5 +1531,10 @@ public final class SystemSessionProperties
     public static boolean isRemoteFunctionsEnabled(Session session)
     {
         return session.getSystemProperty(REMOTE_FUNCTIONS_ENABLED, Boolean.class);
+    }
+
+    public static boolean isDisableMergingPageOutput(Session session)
+    {
+        return session.getSystemProperty(DISABLE_MERGING_PAGE_OUTPUT, Boolean.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -173,6 +173,8 @@ public class FeaturesConfig
 
     private PartitioningPrecisionStrategy partitioningPrecisionStrategy = PartitioningPrecisionStrategy.AUTOMATIC;
 
+    private boolean disableMergingPageOutput = true;
+
     public enum PartitioningPrecisionStrategy
     {
         // Let Presto decide when to repartition
@@ -1455,5 +1457,18 @@ public class FeaturesConfig
     {
         this.inlineSqlFunctions = inlineSqlFunctions;
         return this;
+    }
+
+    @Config("experimental.disable-merging-page-output")
+    @ConfigDescription("Experimental: disable MergingPageOutput")
+    public FeaturesConfig setDisableMergingPageOutput(boolean disableMergingPageOutput)
+    {
+        this.disableMergingPageOutput = disableMergingPageOutput;
+        return this;
+    }
+
+    public boolean isDisableMergingPageOutput()
+    {
+        return disableMergingPageOutput;
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestScanFilterAndProjectOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestScanFilterAndProjectOperator.java
@@ -128,7 +128,8 @@ public class TestScanFilterAndProjectOperator
                 ImmutableList.of(VARCHAR),
                 Optional.empty(),
                 new DataSize(0, BYTE),
-                0);
+                0,
+                false);
 
         SourceOperator operator = factory.createOperator(driverContext);
         operator.addSplit(new Split(new ConnectorId("test"), TestingTransactionHandle.create(), TestingSplit.createLocalSplit()));
@@ -173,7 +174,8 @@ public class TestScanFilterAndProjectOperator
                 ImmutableList.of(BIGINT),
                 Optional.empty(),
                 new DataSize(64, KILOBYTE),
-                2);
+                2,
+                false);
 
         SourceOperator operator = factory.createOperator(newDriverContext());
         operator.addSplit(new Split(new ConnectorId("test"), TestingTransactionHandle.create(), TestingSplit.createLocalSplit()));
@@ -218,7 +220,8 @@ public class TestScanFilterAndProjectOperator
                 ImmutableList.of(BIGINT),
                 Optional.empty(),
                 new DataSize(0, BYTE),
-                0);
+                0,
+                false);
 
         SourceOperator operator = factory.createOperator(driverContext);
         operator.addSplit(new Split(new ConnectorId("test"), TestingTransactionHandle.create(), TestingSplit.createLocalSplit()));
@@ -257,7 +260,8 @@ public class TestScanFilterAndProjectOperator
                 ImmutableList.of(BIGINT),
                 Optional.empty(),
                 new DataSize(0, BYTE),
-                0);
+                0,
+                false);
 
         SourceOperator operator = factory.createOperator(driverContext);
         operator.addSplit(new Split(new ConnectorId("test"), TestingTransactionHandle.create(), TestingSplit.createLocalSplit()));
@@ -302,7 +306,8 @@ public class TestScanFilterAndProjectOperator
                 ImmutableList.of(VARCHAR),
                 Optional.empty(),
                 new DataSize(0, BYTE),
-                0);
+                0,
+                false);
 
         SourceOperator operator = factory.createOperator(driverContext);
         operator.addSplit(new Split(new ConnectorId("test"), TestingTransactionHandle.create(), TestingSplit.createLocalSplit()));
@@ -356,7 +361,8 @@ public class TestScanFilterAndProjectOperator
                 ImmutableList.of(BIGINT),
                 Optional.empty(),
                 new DataSize(0, BYTE),
-                0);
+                0,
+                false);
 
         SourceOperator operator = factory.createOperator(driverContext);
         operator.addSplit(new Split(new ConnectorId("test"), TestingTransactionHandle.create(), TestingSplit.createLocalSplit()));
@@ -424,7 +430,8 @@ public class TestScanFilterAndProjectOperator
                 ImmutableList.of(BIGINT),
                 Optional.empty(),
                 new DataSize(0, BYTE),
-                0);
+                0,
+                false);
 
         SourceOperator operator = factory.createOperator(driverContext);
         operator.addSplit(new Split(new ConnectorId("test"), TestingTransactionHandle.create(), TestingSplit.createLocalSplit()));

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/FunctionAssertions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/FunctionAssertions.java
@@ -976,7 +976,8 @@ public final class FunctionAssertions
                     ImmutableList.of(projection.getType()),
                     Optional.empty(),
                     new DataSize(0, BYTE),
-                    0);
+                    0,
+                    false);
         }
         catch (Throwable e) {
             if (e instanceof UncheckedExecutionException) {

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -149,7 +149,8 @@ public class TestFeaturesConfig
                 .setPreferDistributedUnion(true)
                 .setOptimizeNullsInJoin(false)
                 .setWarnOnNoTableLayoutFilter("")
-                .setInlineSqlFunctions(true));
+                .setInlineSqlFunctions(true)
+                .setDisableMergingPageOutput(true));
     }
 
     @Test
@@ -253,6 +254,7 @@ public class TestFeaturesConfig
                 .put("optimize-nulls-in-join", "true")
                 .put("warn-on-no-table-layout-filter", "ry@nlikestheyankees,ds")
                 .put("inline-sql-functions", "false")
+                .put("experimental.disable-merging-page-output", "false")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -352,7 +354,8 @@ public class TestFeaturesConfig
                 .setPreferDistributedUnion(false)
                 .setOptimizeNullsInJoin(true)
                 .setWarnOnNoTableLayoutFilter("ry@nlikestheyankees,ds")
-                .setInlineSqlFunctions(false);
+                .setInlineSqlFunctions(false)
+                .setDisableMergingPageOutput(false);
         assertFullMapping(properties, expected);
     }
 


### PR DESCRIPTION
If the downstream operator for the projection (pageProcessor.process) in
ScanFilterAndProjectOperator is (Optimized)PartitionedOutputOperator,
 there is no need to run MergingPageOutput since the
(Optimized)PartitionedOutputOperator will merge the pages in a more
efficient way. Simple query on TPCH 100GB shows 22% CPU reduction:


```
== NO RELEASE NOTE ==
```
