### PR TITLE
Allow qualified names in types

### DIFF
--- a/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
+++ b/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
@@ -452,7 +452,7 @@ baseType
     : TIME_WITH_TIME_ZONE
     | TIMESTAMP_WITH_TIME_ZONE
     | DOUBLE_PRECISION
-    | identifier
+    | qualifiedName
     ;
 
 whenClause

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestEnums.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestEnums.java
@@ -42,12 +42,12 @@ public class TestEnums
 {
     private static final Long BIG_VALUE = Integer.MAX_VALUE + 10L; // 2147483657
 
-    private static final LongEnumParametricType MOOD_ENUM = new LongEnumParametricType("Mood", new LongEnumMap(ImmutableMap.of(
+    private static final LongEnumParametricType MOOD_ENUM = new LongEnumParametricType("test.enum.Mood", new LongEnumMap(ImmutableMap.of(
             "HAPPY", 0L,
             "SAD", 1L,
             "MELLOW", BIG_VALUE,
             "curious", -2L)));
-    private static final VarcharEnumParametricType COUNTRY_ENUM = new VarcharEnumParametricType("Country", new VarcharEnumMap(ImmutableMap.of(
+    private static final VarcharEnumParametricType COUNTRY_ENUM = new VarcharEnumParametricType("test.enum.Country", new VarcharEnumMap(ImmutableMap.of(
             "US", "United States",
             "BAHAMAS", "The Bahamas",
             "FRANCE", "France",
@@ -104,100 +104,100 @@ public class TestEnums
     public void testEnumLiterals()
     {
         assertQueryResultUnordered(
-                "SELECT Mood.HAPPY, mood.happY, \"mood\".SAD, \"mood\".\"mellow\"",
+                "SELECT test.enum.mood.HAPPY, test.enum.mood.happY, \"test.enum.mood\".SAD, \"test.enum.mood\".\"mellow\"",
                 singletonList(ImmutableList.of(0L, 0L, 1L, BIG_VALUE)));
 
         assertQueryResultUnordered(
-                "SELECT Country.us, country.\"CHINA\", Country.\"भारत\"",
+                "SELECT test.enum.country.us, test.enum.country.\"CHINA\", test.enum.country.\"भारत\"",
                 singletonList(ImmutableList.of("United States", "中国", "India")));
 
         assertQueryResultUnordered(
                 "SELECT testEnum.TEST, testEnum.TEST2, testEnum.TEST3, array[testEnum.TEST4]",
                 singletonList(ImmutableList.of("\"}\"", "", " ", ImmutableList.of(")))\"\""))));
 
-        assertQueryFails("SELECT mood.hello", ".*No key 'HELLO' in enum 'Mood'");
+        assertQueryFails("SELECT test.enum.mood.hello", ".*No key 'HELLO' in enum 'test.enum.Mood'");
     }
 
     @Test
     public void testEnumCasts()
     {
-        assertSingleValue("CAST(CAST(1 AS TINYINT) AS Mood)", 1L);
-        assertSingleValue("CAST('The Bahamas' AS COUNTRY)", "The Bahamas");
-        assertSingleValue("CAST(row(1, 1) as row(x BIGINT, y Mood))", ImmutableList.of(1L, 1L));
-        assertSingleValue("CAST(mood.MELLOW AS BIGINT)", BIG_VALUE);
+        assertSingleValue("CAST(CAST(1 AS TINYINT) AS test.enum.mood)", 1L);
+        assertSingleValue("CAST('The Bahamas' AS test.enum.country)", "The Bahamas");
+        assertSingleValue("CAST(row(1, 1) as row(x BIGINT, y test.enum.mood))", ImmutableList.of(1L, 1L));
+        assertSingleValue("CAST(test.enum.mood.MELLOW AS BIGINT)", BIG_VALUE);
         assertSingleValue(
-                "cast(map(array[country.FRANCE], array[array[mood.HAPPY]]) as JSON)",
+                "cast(map(array[test.enum.country.FRANCE], array[array[test.enum.mood.HAPPY]]) as JSON)",
                 "{\"France\":[0]}");
         assertSingleValue(
-                "map_filter(MAP(ARRAY[country.FRANCE, country.US], ARRAY[mood.HAPPY, mood.SAD]), (k,v) -> CAST(v AS BIGINT) > 0)",
+                "map_filter(MAP(ARRAY[test.enum.country.FRANCE, test.enum.country.US], ARRAY[test.enum.mood.HAPPY, test.enum.mood.SAD]), (k,v) -> CAST(v AS BIGINT) > 0)",
                 ImmutableMap.of("United States", 1L));
         assertSingleValue(
-                "cast(JSON '{\"France\": [0]}' as MAP<Country,ARRAY<Mood>>)",
+                "cast(JSON '{\"France\": [0]}' as MAP<test.enum.country,ARRAY<test.enum.mood>>)",
                 ImmutableMap.of("France", singletonList(0L)));
-        assertQueryFails("select cast(7 as mood)", ".*No value '7' in enum 'Mood'");
+        assertQueryFails("select cast(7 as test.enum.mood)", ".*No value '7' in enum 'test.enum.Mood'");
     }
 
     @Test
     public void testVarcharEnumComparisonOperators()
     {
-        assertSingleValue("country.US = CAST('United States' AS country)", true);
-        assertSingleValue("country.FRANCE = country.BAHAMAS", false);
+        assertSingleValue("test.enum.country.US = CAST('United States' AS test.enum.country)", true);
+        assertSingleValue("test.enum.country.FRANCE = test.enum.country.BAHAMAS", false);
 
-        assertSingleValue("country.FRANCE != country.US", true);
-        assertSingleValue("array[country.FRANCE, country.BAHAMAS] != array[country.US, country.BAHAMAS]", true);
+        assertSingleValue("test.enum.country.FRANCE != test.enum.country.US", true);
+        assertSingleValue("array[test.enum.country.FRANCE, test.enum.country.BAHAMAS] != array[test.enum.country.US, test.enum.country.BAHAMAS]", true);
 
-        assertSingleValue("country.CHINA IN (country.US, null, country.BAHAMAS, country.China)", true);
-        assertSingleValue("country.BAHAMAS IN (country.US, country.FRANCE)", false);
+        assertSingleValue("test.enum.country.CHINA IN (test.enum.country.US, null, test.enum.country.BAHAMAS, test.enum.country.China)", true);
+        assertSingleValue("test.enum.country.BAHAMAS IN (test.enum.country.US, test.enum.country.FRANCE)", false);
 
-        assertSingleValue("country.BAHAMAS < country.US", true);
-        assertSingleValue("country.BAHAMAS < country.BAHAMAS", false);
+        assertSingleValue("test.enum.country.BAHAMAS < test.enum.country.US", true);
+        assertSingleValue("test.enum.country.BAHAMAS < test.enum.country.BAHAMAS", false);
 
-        assertSingleValue("country.\"भारत\" <= country.\"भारत\"", true);
-        assertSingleValue("country.\"भारत\" <= country.FRANCE", false);
+        assertSingleValue("test.enum.country.\"भारत\" <= test.enum.country.\"भारत\"", true);
+        assertSingleValue("test.enum.country.\"भारत\" <= test.enum.country.FRANCE", false);
 
-        assertSingleValue("country.\"भारत\" >= country.FRANCE", true);
-        assertSingleValue("country.BAHAMAS >= country.US", false);
+        assertSingleValue("test.enum.country.\"भारत\" >= test.enum.country.FRANCE", true);
+        assertSingleValue("test.enum.country.BAHAMAS >= test.enum.country.US", false);
 
-        assertSingleValue("country.\"भारत\" > country.FRANCE", true);
-        assertSingleValue("country.CHINA > country.CHINA", false);
+        assertSingleValue("test.enum.country.\"भारत\" > test.enum.country.FRANCE", true);
+        assertSingleValue("test.enum.country.CHINA > test.enum.country.CHINA", false);
 
-        assertSingleValue("country.\"भारत\" between country.FRANCE and country.BAHAMAS", true);
-        assertSingleValue("country.US between country.FRANCE and country.\"भारत\"", false);
+        assertSingleValue("test.enum.country.\"भारत\" between test.enum.country.FRANCE and test.enum.country.BAHAMAS", true);
+        assertSingleValue("test.enum.country.US between test.enum.country.FRANCE and test.enum.country.\"भारत\"", false);
 
-        assertQueryFails("select country.US = mood.HAPPY", ".* '=' cannot be applied to Country.*, Mood.*");
-        assertQueryFails("select country.US IN (country.CHINA, mood.SAD)", ".* All IN list values must be the same type.*");
-        assertQueryFails("select country.US IN (mood.HAPPY, mood.SAD)", ".* IN value and list items must be the same type: Country");
-        assertQueryFails("select country.US > 2", ".* '>' cannot be applied to Country.*, integer");
+        assertQueryFails("select test.enum.country.US = test.enum.mood.HAPPY", ".* '=' cannot be applied to test.enum.Country.*, test.enum.Mood.*");
+        assertQueryFails("select test.enum.country.US IN (test.enum.country.CHINA, test.enum.mood.SAD)", ".* All IN list values must be the same type.*");
+        assertQueryFails("select test.enum.country.US IN (test.enum.mood.HAPPY, test.enum.mood.SAD)", ".* IN value and list items must be the same type: test.enum.Country");
+        assertQueryFails("select test.enum.country.US > 2", ".* '>' cannot be applied to test.enum.Country.*, integer");
     }
 
     @Test
     public void testLongEnumComparisonOperators()
     {
-        assertSingleValue("mood.HAPPY = CAST(0 AS mood)", true);
-        assertSingleValue("mood.HAPPY = mood.SAD", false);
+        assertSingleValue("test.enum.mood.HAPPY = CAST(0 AS test.enum.mood)", true);
+        assertSingleValue("test.enum.mood.HAPPY = test.enum.mood.SAD", false);
 
-        assertSingleValue("mood.SAD != mood.MELLOW", true);
-        assertSingleValue("array[mood.HAPPY, mood.SAD] != array[mood.SAD, mood.HAPPY]", true);
+        assertSingleValue("test.enum.mood.SAD != test.enum.mood.MELLOW", true);
+        assertSingleValue("array[test.enum.mood.HAPPY, test.enum.mood.SAD] != array[test.enum.mood.SAD, test.enum.mood.HAPPY]", true);
 
-        assertSingleValue("mood.SAD IN (mood.HAPPY, null, mood.SAD)", true);
-        assertSingleValue("mood.HAPPY IN (mood.SAD, mood.MELLOW)", false);
+        assertSingleValue("test.enum.mood.SAD IN (test.enum.mood.HAPPY, null, test.enum.mood.SAD)", true);
+        assertSingleValue("test.enum.mood.HAPPY IN (test.enum.mood.SAD, test.enum.mood.MELLOW)", false);
 
-        assertSingleValue("mood.CURIOUS < mood.MELLOW", true);
-        assertSingleValue("mood.SAD < mood.HAPPY", false);
+        assertSingleValue("test.enum.mood.CURIOUS < test.enum.mood.MELLOW", true);
+        assertSingleValue("test.enum.mood.SAD < test.enum.mood.HAPPY", false);
 
-        assertSingleValue("mood.HAPPY <= mood.HAPPY", true);
-        assertSingleValue("mood.HAPPY <= mood.CURIOUS", false);
+        assertSingleValue("test.enum.mood.HAPPY <= test.enum.mood.HAPPY", true);
+        assertSingleValue("test.enum.mood.HAPPY <= test.enum.mood.CURIOUS", false);
 
-        assertSingleValue("mood.MELLOW >= mood.SAD", true);
-        assertSingleValue("mood.HAPPY >= mood.SAD", false);
+        assertSingleValue("test.enum.mood.MELLOW >= test.enum.mood.SAD", true);
+        assertSingleValue("test.enum.mood.HAPPY >= test.enum.mood.SAD", false);
 
-        assertSingleValue("mood.SAD > mood.HAPPY", true);
-        assertSingleValue("mood.HAPPY > mood.HAPPY", false);
+        assertSingleValue("test.enum.mood.SAD > test.enum.mood.HAPPY", true);
+        assertSingleValue("test.enum.mood.HAPPY > test.enum.mood.HAPPY", false);
 
-        assertSingleValue("mood.HAPPY between mood.CURIOUS and mood.SAD ", true);
-        assertSingleValue("mood.MELLOW between mood.SAD and mood.HAPPY", false);
+        assertSingleValue("test.enum.mood.HAPPY between test.enum.mood.CURIOUS and test.enum.mood.SAD ", true);
+        assertSingleValue("test.enum.mood.MELLOW between test.enum.mood.SAD and test.enum.mood.HAPPY", false);
 
-        assertQueryFails("select mood.HAPPY = 3", ".* '=' cannot be applied to Mood.*, integer");
+        assertQueryFails("select test.enum.mood.HAPPY = 3", ".* '=' cannot be applied to test.enum.Mood.*, integer");
     }
 
     @Test
@@ -205,23 +205,23 @@ public class TestEnums
     {
         assertQueryResultUnordered(
                 "SELECT DISTINCT x " +
-                        "FROM (VALUES mood.happy, mood.sad, mood.sad, mood.happy) t(x)",
+                        "FROM (VALUES test.enum.mood.happy, test.enum.mood.sad, test.enum.mood.sad, test.enum.mood.happy) t(x)",
                 ImmutableList.of(
                         ImmutableList.of(0L),
                         ImmutableList.of(1L)));
 
         assertQueryResultUnordered(
                 "SELECT DISTINCT x " +
-                        "FROM (VALUES country.FRANCE, country.FRANCE, country.\"भारत\") t(x)",
+                        "FROM (VALUES test.enum.country.FRANCE, test.enum.country.FRANCE, test.enum.country.\"भारत\") t(x)",
                 ImmutableList.of(
                         ImmutableList.of("France"),
                         ImmutableList.of("India")));
 
         assertQueryResultUnordered(
                 "SELECT APPROX_DISTINCT(x), APPROX_DISTINCT(y)" +
-                        "FROM (VALUES (country.FRANCE, mood.HAPPY), " +
-                        "             (country.FRANCE, mood.SAD)," +
-                        "             (country.US, mood.HAPPY)) t(x, y)",
+                        "FROM (VALUES (test.enum.country.FRANCE, test.enum.mood.HAPPY), " +
+                        "             (test.enum.country.FRANCE, test.enum.mood.SAD)," +
+                        "             (test.enum.country.US, test.enum.mood.HAPPY)) t(x, y)",
                 ImmutableList.of(
                         ImmutableList.of(2L, 2L)));
     }
@@ -231,10 +231,10 @@ public class TestEnums
     {
         assertQueryResultUnordered(
                 "  SELECT a, ARRAY_AGG(DISTINCT b) " +
-                        "FROM (VALUES (mood.happy, country.us), " +
-                        "             (mood.happy, country.china)," +
-                        "             (mood.happy, country.CHINA)," +
-                        "             (mood.sad, country.us)) t(a, b)" +
+                        "FROM (VALUES (test.enum.mood.happy, test.enum.country.us), " +
+                        "             (test.enum.mood.happy, test.enum.country.china)," +
+                        "             (test.enum.mood.happy, test.enum.country.CHINA)," +
+                        "             (test.enum.mood.sad, test.enum.country.us)) t(a, b)" +
                         "GROUP BY a",
                 ImmutableList.of(
                         ImmutableList.of(0L, ImmutableList.of("United States", "中国")),
@@ -246,8 +246,8 @@ public class TestEnums
     {
         assertQueryResultUnordered(
                 "  SELECT t1.a, t2.b " +
-                        "FROM (VALUES mood.happy, mood.sad, mood.mellow) t1(a) " +
-                        "JOIN (VALUES (mood.sad, 'hello'), (mood.happy, 'world')) t2(a, b) " +
+                        "FROM (VALUES test.enum.mood.happy, test.enum.mood.sad, test.enum.mood.mellow) t1(a) " +
+                        "JOIN (VALUES (test.enum.mood.sad, 'hello'), (test.enum.mood.happy, 'world')) t2(a, b) " +
                         "ON t1.a = t2.a",
                 ImmutableList.of(
                         ImmutableList.of(1L, "hello"),
@@ -259,7 +259,7 @@ public class TestEnums
     {
         assertQueryResultUnordered(
                 "  SELECT first_value(b) OVER (PARTITION BY a ORDER BY a) AS rnk " +
-                        "FROM (VALUES (mood.happy, 1), (mood.happy, 3), (mood.sad, 5)) t(a, b)",
+                        "FROM (VALUES (test.enum.mood.happy, 1), (test.enum.mood.happy, 3), (test.enum.mood.sad, 5)) t(a, b)",
                 ImmutableList.of(singletonList(1), singletonList(1), singletonList(5)));
     }
 }


### PR DESCRIPTION
Currently, type names used in CREATE TABLE or CAST statements are expected to be `identifiers`.
Instead, we want them to be `qualifiedNames` so that we can use user-defined types with a namespace, like `testing.test.mytype`.
