### PR TITLE
Prefer verifier cluster memory limits

### DIFF
--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/prestoaction/QueryActionUtil.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/prestoaction/QueryActionUtil.java
@@ -23,6 +23,8 @@ import java.util.Map;
 import static com.facebook.presto.SystemSessionProperties.QUERY_MAX_BROADCAST_MEMORY;
 import static com.facebook.presto.SystemSessionProperties.QUERY_MAX_EXECUTION_TIME;
 import static com.facebook.presto.SystemSessionProperties.QUERY_MAX_RUN_TIME;
+import static com.facebook.presto.SystemSessionProperties.QUERY_MAX_TOTAL_MEMORY;
+import static com.facebook.presto.SystemSessionProperties.QUERY_MAX_TOTAL_MEMORY_PER_NODE;
 import static com.facebook.presto.verifier.framework.QueryStage.DETERMINISM_ANALYSIS_MAIN;
 
 public class QueryActionUtil
@@ -47,8 +49,11 @@ public class QueryActionUtil
         // Remove query max run time to respect execution time limit.
         sessionProperties.remove(QUERY_MAX_RUN_TIME);
 
-        // Remove broadcast memory limit, since CBO may choose to broadcast on a smaller verifier cluster
+        // Allow verifier clusters to provide their own memory limits to reduce noise from
+        // CBO making different decisions based on cluster size
         sessionProperties.remove(QUERY_MAX_BROADCAST_MEMORY);
+        sessionProperties.remove(QUERY_MAX_TOTAL_MEMORY_PER_NODE);
+        sessionProperties.remove(QUERY_MAX_TOTAL_MEMORY);
 
         return ImmutableMap.copyOf(sessionProperties);
     }


### PR DESCRIPTION
Verifier unit tests

```
== RELEASE NOTES ==

Verifier
* Improve verifier handling of memory limits by using the limits from the verifier cluster which are frequently better matched to the queries picked to be run in the verifier suite
```