### PR TITLE
Add session property remote_functions_enabled

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -170,6 +170,7 @@ public final class SystemSessionProperties
     public static final String FRAGMENT_RESULT_CACHING_ENABLED = "fragment_result_caching_enabled";
     public static final String LEGACY_TYPE_COERCION_WARNING_ENABLED = "legacy_type_coercion_warning_enabled";
     public static final String INLINE_SQL_FUNCTIONS = "inline_sql_functions";
+    public static final String REMOTE_FUNCTIONS_ENABLED = "remote_functions_enabled";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -899,6 +900,11 @@ public final class SystemSessionProperties
                         INLINE_SQL_FUNCTIONS,
                         "Inline SQL function definition at plan time",
                         featuresConfig.isInlineSqlFunctions(),
+                        false),
+                booleanProperty(
+                        REMOTE_FUNCTIONS_ENABLED,
+                        "Allow remote functions",
+                        false,
                         false));
     }
 
@@ -1514,5 +1520,10 @@ public final class SystemSessionProperties
     public static boolean isInlineSqlFunctions(Session session)
     {
         return session.getSystemProperty(INLINE_SQL_FUNCTIONS, Boolean.class);
+    }
+
+    public static boolean isRemoteFunctionsEnabled(Session session)
+    {
+        return session.getSystemProperty(REMOTE_FUNCTIONS_ENABLED, Boolean.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PlanRemotePojections.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PlanRemotePojections.java
@@ -16,6 +16,7 @@ package com.facebook.presto.sql.planner.iterative.rule;
 import com.facebook.presto.matching.Captures;
 import com.facebook.presto.matching.Pattern;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.function.FunctionMetadata;
 import com.facebook.presto.spi.plan.Assignments;
 import com.facebook.presto.spi.plan.PlanNode;
@@ -41,6 +42,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import static com.facebook.presto.SystemSessionProperties.isRemoteFunctionsEnabled;
+import static com.facebook.presto.spi.StandardErrorCode.GENERIC_USER_ERROR;
 import static com.facebook.presto.spi.function.FunctionImplementationType.THRIFT;
 import static com.facebook.presto.spi.plan.ProjectNode.Locality.LOCAL;
 import static com.facebook.presto.spi.plan.ProjectNode.Locality.REMOTE;
@@ -82,6 +85,9 @@ public class PlanRemotePojections
         if (node.getAssignments().getExpressions().stream().noneMatch(expression -> expression.accept(new ExternalCallExpressionChecker(functionAndTypeManager), null))) {
             // No remote function
             return Result.ofPlanNode(new ProjectNode(node.getId(), node.getSource(), node.getAssignments(), LOCAL));
+        }
+        if (!isRemoteFunctionsEnabled(context.getSession())) {
+            throw new PrestoException(GENERIC_USER_ERROR, "Remote functions are not enabled");
         }
         List<ProjectionContext> projectionContexts = planRemoteAssignments(node.getAssignments(), context.getVariableAllocator());
         checkState(!projectionContexts.isEmpty(), "Expect non-empty projectionContexts");

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestSqlFunctions.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestSqlFunctions.java
@@ -48,6 +48,7 @@ public class TestSqlFunctions
             Session session = testSessionBuilder()
                     .setCatalog("tpch")
                     .setSchema(TINY_SCHEMA_NAME)
+                    .setSystemProperty("remote_functions_enabled", "true")
                     .build();
             DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(session)
                     .setExtraProperties(ImmutableMap.of("inline-sql-functions", "false"))


### PR DESCRIPTION
Test plan - travis
```
== RELEASE NOTES ==

General Changes
* Add session property ``remote_functions_enabled`` to configure whether remote functions are allowed.
```
