### PR TITLE
Support disabling strict config in PrestoServer

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/BootstrapConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/BootstrapConfig.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server;
+
+import com.facebook.airlift.configuration.Config;
+import com.facebook.airlift.configuration.ConfigDescription;
+
+public class BootstrapConfig
+{
+    private boolean quiet;
+    private boolean strictConfig = true;
+    private boolean requireExplicitBindings = true;
+
+    public boolean isQuiet()
+    {
+        return quiet;
+    }
+
+    @Config("bootstrap.quiet")
+    @ConfigDescription("Whether to require all specified configs to be used")
+    public BootstrapConfig setQuiet(boolean quiet)
+    {
+        this.quiet = quiet;
+        return this;
+    }
+
+    public boolean isStrictConfig()
+    {
+        return strictConfig;
+    }
+
+    @Config("bootstrap.strict-config")
+    @ConfigDescription("Whether to require all specified configs to be used")
+    public BootstrapConfig setStrictConfig(boolean strictConfig)
+    {
+        this.strictConfig = strictConfig;
+        return this;
+    }
+
+    public boolean isRequireExplicitBindings()
+    {
+        return requireExplicitBindings;
+    }
+
+    @Config("bootstrap.require-explicit-bindings")
+    public BootstrapConfig setRequireExplicitBindings(boolean requireExplicitBindings)
+    {
+        this.requireExplicitBindings = requireExplicitBindings;
+        return this;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/StrictConfigModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/StrictConfigModule.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+
+import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
+
+public class StrictConfigModule
+        implements Module
+{
+    @Override
+    public void configure(Binder binder)
+    {
+        configBinder(binder).bindConfig(BootstrapConfig.class);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/server/TestBootstrapConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestBootstrapConfig.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server;
+
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+
+public class TestBootstrapConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(BootstrapConfig.class)
+                .setQuiet(false)
+                .setStrictConfig(true)
+                .setRequireExplicitBindings(true));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("bootstrap.quiet", "false")
+                .put("bootstrap.strict-config", "false")
+                .put("bootstrap.require-explicit-bindings", "true")
+                .build();
+
+        BootstrapConfig expected = new BootstrapConfig()
+                .setQuiet(false)
+                .setStrictConfig(false)
+                .setRequireExplicitBindings(true);
+
+        assertFullMapping(properties, expected);
+    }
+}


### PR DESCRIPTION
This feature is useful for configuring test clusters.

Test plan:
- Run PrestoServer locally and verified.
- Hard to test via unit test because `PrestoServer` is not a class used by test. There is a testing version of PrestoServer, which is `TestingPrestoServer`, which mimics the logic of `PrestoServer`, rather than depending on it.

```
== RELEASE NOTES ==

General Changes
* Add configuration property ``strict-config`` to support disabling the requirement that all configuration properties must be used.
```
