### PR TITLE
Only allow constants for prepared statement parameters

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryPreparer.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryPreparer.java
@@ -27,6 +27,7 @@ import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.Statement;
 import com.facebook.presto.util.StatementUtils;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 import javax.inject.Inject;
 
@@ -42,7 +43,6 @@ import static com.facebook.presto.sql.ParsingUtil.createParsingOptions;
 import static com.facebook.presto.sql.analyzer.ConstantExpressionVerifier.verifyExpressionIsConstant;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.INVALID_PARAMETER_USAGE;
 import static java.lang.String.format;
-import static java.util.Collections.emptySet;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
 
@@ -105,7 +105,7 @@ public class QueryPreparer
             throw new SemanticException(INVALID_PARAMETER_USAGE, node, "Incorrect number of parameters: expected %s but found %s", parameterCount, parameterValues.size());
         }
         for (Expression expression : parameterValues) {
-            verifyExpressionIsConstant(emptySet(), expression);
+            verifyExpressionIsConstant(ImmutableSet.of(), expression);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ConstantExpressionVerifier.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ConstantExpressionVerifier.java
@@ -13,12 +13,14 @@
  */
 package com.facebook.presto.sql.analyzer;
 
+import com.facebook.presto.sql.tree.AllColumns;
 import com.facebook.presto.sql.tree.DefaultTraversalVisitor;
 import com.facebook.presto.sql.tree.DereferenceExpression;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.FieldReference;
 import com.facebook.presto.sql.tree.Identifier;
 import com.facebook.presto.sql.tree.NodeRef;
+import com.facebook.presto.sql.tree.Table;
 
 import java.util.Set;
 
@@ -66,6 +68,18 @@ public final class ConstantExpressionVerifier
         protected Void visitFieldReference(FieldReference node, Void context)
         {
             throw new SemanticException(EXPRESSION_NOT_CONSTANT, expression, "Constant expression cannot contain column references");
+        }
+
+        @Override
+        protected Void visitAllColumns(AllColumns node, Void context)
+        {
+            throw new SemanticException(EXPRESSION_NOT_CONSTANT, expression, "Constant expression cannot contain column references");
+        }
+
+        @Override
+        protected Void visitTable(Table node, Void context)
+        {
+            throw new SemanticException(EXPRESSION_NOT_CONSTANT, expression, "Constant expression cannot contain table references");
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/ParameterRewriter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/ParameterRewriter.java
@@ -34,9 +34,7 @@ public class ParameterRewriter
 
     public ParameterRewriter(List<Expression> parameterValues)
     {
-        requireNonNull(parameterValues, "parameterValues is null");
-        this.parameterValues = parameterValues;
-        this.analysis = null;
+        this(parameterValues, null);
     }
 
     public ParameterRewriter(List<Expression> parameterValues, Analysis analysis)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanBuilder.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanBuilder.java
@@ -23,7 +23,6 @@ import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.SymbolReference;
 import com.google.common.collect.ImmutableMap;
 
-import java.util.List;
 import java.util.Map;
 
 import static com.facebook.presto.sql.relational.OriginalExpressionUtils.castToRowExpression;
@@ -32,18 +31,15 @@ import static java.util.Objects.requireNonNull;
 class PlanBuilder
 {
     private final TranslationMap translations;
-    private final List<Expression> parameters;
     private final PlanNode root;
 
-    public PlanBuilder(TranslationMap translations, PlanNode root, List<Expression> parameters)
+    public PlanBuilder(TranslationMap translations, PlanNode root)
     {
         requireNonNull(translations, "translations is null");
         requireNonNull(root, "root is null");
-        requireNonNull(parameters, "parameterRewriter is null");
 
         this.translations = translations;
         this.root = root;
-        this.parameters = parameters;
     }
 
     public TranslationMap copyTranslations()
@@ -60,7 +56,7 @@ class PlanBuilder
 
     public PlanBuilder withNewRoot(PlanNode root)
     {
-        return new PlanBuilder(translations, root, parameters);
+        return new PlanBuilder(translations, root);
     }
 
     public RelationPlan getRelationPlan()
@@ -120,6 +116,6 @@ class PlanBuilder
             translations.put(entry.getValue(), entry.getKey());
         }
 
-        return new PlanBuilder(translations, new ProjectNode(idAllocator.getNextId(), getRoot(), projections.build()), parameters);
+        return new PlanBuilder(translations, new ProjectNode(idAllocator.getNextId(), getRoot(), projections.build()));
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/QueryPlanner.java
@@ -232,7 +232,7 @@ class QueryPlanner
         TranslationMap translations = new TranslationMap(relationPlan, analysis, lambdaDeclarationToVariableMap);
         translations.setFieldMappings(relationPlan.getFieldMappings());
 
-        PlanBuilder builder = new PlanBuilder(translations, relationPlan.getRoot(), analysis.getParameters());
+        PlanBuilder builder = new PlanBuilder(translations, relationPlan.getRoot());
 
         if (node.getWhere().isPresent()) {
             builder = filter(builder, node.getWhere().get(), node);
@@ -303,7 +303,7 @@ class QueryPlanner
         // This makes it possible to rewrite FieldOrExpressions that reference fields from the FROM clause directly
         translations.setFieldMappings(relationPlan.getFieldMappings());
 
-        return new PlanBuilder(translations, relationPlan.getRoot(), analysis.getParameters());
+        return new PlanBuilder(translations, relationPlan.getRoot());
     }
 
     private RelationPlan planImplicitTable()
@@ -355,8 +355,7 @@ class QueryPlanner
         return new PlanBuilder(outputTranslations, new ProjectNode(
                 idAllocator.getNextId(),
                 subPlan.getRoot(),
-                projections.build()),
-                analysis.getParameters());
+                projections.build()));
     }
 
     private Map<VariableReferenceExpression, RowExpression> coerce(Iterable<? extends Expression> expressions, PlanBuilder subPlan, TranslationMap translations)
@@ -408,8 +407,7 @@ class QueryPlanner
                 idAllocator.getNextId(),
                 subPlan.getRoot(),
                 projections.build(),
-                LOCAL),
-                analysis.getParameters());
+                LOCAL));
     }
 
     private PlanBuilder explicitCoercionVariables(PlanBuilder subPlan, List<VariableReferenceExpression> alreadyCoerced, Iterable<? extends Expression> uncoerced)
@@ -425,8 +423,7 @@ class QueryPlanner
                 idAllocator.getNextId(),
                 subPlan.getRoot(),
                 assignments,
-                LOCAL),
-                analysis.getParameters());
+                LOCAL));
     }
 
     private PlanBuilder aggregate(PlanBuilder subPlan, QuerySpecification node)
@@ -537,7 +534,7 @@ class QueryPlanner
         if (groupingSets.size() > 1) {
             groupIdVariable = Optional.of(variableAllocator.newVariable("groupId", BIGINT));
             GroupIdNode groupId = new GroupIdNode(idAllocator.getNextId(), subPlan.getRoot(), groupingSets, groupingSetMappings, aggregationArguments, groupIdVariable.get());
-            subPlan = new PlanBuilder(groupingTranslations, groupId, analysis.getParameters());
+            subPlan = new PlanBuilder(groupingTranslations, groupId);
         }
         else {
             Assignments.Builder assignments = Assignments.builder();
@@ -545,7 +542,7 @@ class QueryPlanner
             groupingSetMappings.forEach((key, value) -> assignments.put(key, castToRowExpression(asSymbolReference(value))));
 
             ProjectNode project = new ProjectNode(idAllocator.getNextId(), subPlan.getRoot(), assignments.build(), LOCAL);
-            subPlan = new PlanBuilder(groupingTranslations, project, analysis.getParameters());
+            subPlan = new PlanBuilder(groupingTranslations, project);
         }
 
         TranslationMap aggregationTranslations = new TranslationMap(subPlan.getRelationPlan(), analysis, lambdaDeclarationToVariableMap);
@@ -608,7 +605,7 @@ class QueryPlanner
                 Optional.empty(),
                 groupIdVariable);
 
-        subPlan = new PlanBuilder(aggregationTranslations, aggregationNode, analysis.getParameters());
+        subPlan = new PlanBuilder(aggregationTranslations, aggregationNode);
 
         // 3. Post-projection
         // Add back the implicit casts that we removed in 2.a
@@ -704,7 +701,7 @@ class QueryPlanner
             newTranslations.put(groupingOperation, variable);
         }
 
-        return new PlanBuilder(newTranslations, new ProjectNode(idAllocator.getNextId(), subPlan.getRoot(), projections.build(), LOCAL), analysis.getParameters());
+        return new PlanBuilder(newTranslations, new ProjectNode(idAllocator.getNextId(), subPlan.getRoot(), projections.build(), LOCAL));
     }
 
     private PlanBuilder window(PlanBuilder subPlan, OrderBy node)
@@ -850,8 +847,7 @@ class QueryPlanner
                             ImmutableMap.of(newVariable, function),
                             Optional.empty(),
                             ImmutableSet.of(),
-                            0),
-                    analysis.getParameters());
+                            0));
 
             if (needCoercion) {
                 subPlan = explicitCoercionVariables(subPlan, subPlan.getRoot().getOutputVariables(), ImmutableList.of(windowFunction));

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
@@ -392,7 +392,7 @@ class RelationPlanner
 
         if (node.getType() == INNER) {
             // rewrite all the other conditions using output variables from left + right plan node.
-            PlanBuilder rootPlanBuilder = new PlanBuilder(translationMap, root, analysis.getParameters());
+            PlanBuilder rootPlanBuilder = new PlanBuilder(translationMap, root);
             rootPlanBuilder = subqueryPlanner.handleSubqueries(rootPlanBuilder, complexJoinExpressions, node);
 
             for (Expression expression : complexJoinExpressions) {
@@ -690,7 +690,8 @@ class RelationPlanner
     private RowExpression rewriteRow(Expression row)
     {
         // resolve enum literals
-        Expression expression = ExpressionTreeRewriter.rewriteWith(new ExpressionRewriter<Void>() {
+        Expression expression = ExpressionTreeRewriter.rewriteWith(new ExpressionRewriter<Void>()
+        {
             @Override
             public Expression rewriteDereferenceExpression(DereferenceExpression node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
             {
@@ -901,7 +902,7 @@ class RelationPlanner
         // This makes it possible to rewrite FieldOrExpressions that reference fields from the underlying tuple directly
         translations.setFieldMappings(relationPlan.getFieldMappings());
 
-        return new PlanBuilder(translations, relationPlan.getRoot(), analysis.getParameters());
+        return new PlanBuilder(translations, relationPlan.getRoot());
     }
 
     private PlanNode distinct(PlanNode node)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/SubqueryPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/SubqueryPlanner.java
@@ -255,8 +255,7 @@ class SubqueryPlanner
                         subqueryNode,
                         ImmutableList.copyOf(VariablesExtractor.extractUnique(correlation.values(), variableAllocator.getTypes())),
                         type,
-                        subQueryNotSupportedError(query, "Given correlated subquery")),
-                analysis.getParameters());
+                        subQueryNotSupportedError(query, "Given correlated subquery")));
     }
 
     private PlanBuilder appendExistsSubqueryApplyNodes(PlanBuilder builder, Set<ExistsPredicate> existsPredicates, boolean correlationAllowed)
@@ -450,8 +449,7 @@ class SubqueryPlanner
                         subqueryNode,
                         subqueryAssignments,
                         ImmutableList.copyOf(VariablesExtractor.extractUnique(correlation.values(), variableAllocator.getTypes())),
-                        subQueryNotSupportedError(subquery, "Given correlated subquery")),
-                analysis.getParameters());
+                        subQueryNotSupportedError(subquery, "Given correlated subquery")));
     }
 
     private Map<Expression, Expression> extractCorrelation(PlanBuilder subPlan, PlanNode subquery)
@@ -493,7 +491,7 @@ class SubqueryPlanner
             translations.put((Expression) node, getOnlyElement(relationPlan.getFieldMappings()));
         }
 
-        return new PlanBuilder(translations, relationPlan.getRoot(), analysis.getParameters());
+        return new PlanBuilder(translations, relationPlan.getRoot());
     }
 
     /**

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkAbstractTestQueries.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkAbstractTestQueries.java
@@ -125,6 +125,12 @@ public class TestPrestoSparkAbstractTestQueries
         // prepared statement is not supported by Presto on Spark
     }
 
+    @Override
+    public void testExecuteUsingWithDifferentDatatypes()
+    {
+        // prepared statement is not supported by Presto on Spark
+    }
+
     public void testExecuteUsingComplexJoinCriteria()
     {
         // prepared statement is not supported by Presto on Spark
@@ -143,6 +149,30 @@ public class TestPrestoSparkAbstractTestQueries
 
     @Override
     public void testExecuteWithParametersInGroupBy()
+    {
+        // prepared statement is not supported by Presto on Spark
+    }
+
+    @Override
+    public void testExecuteUsingFunction()
+    {
+        // prepared statement is not supported by Presto on Spark
+    }
+
+    @Override
+    public void testExecuteUsingSubqueryFails()
+    {
+        // prepared statement is not supported by Presto on Spark
+    }
+
+    @Override
+    public void testExecuteUsingSelectStarFails()
+    {
+        // prepared statement is not supported by Presto on Spark
+    }
+
+    @Override
+    public void testExecuteUsingColumnReferenceFails()
     {
         // prepared statement is not supported by Presto on Spark
     }


### PR DESCRIPTION
We were allowing anything without an explicit column reference, which
included SELECT * from table and SELECT 1 from table.  Now only
expressions that reference neither tables nor columns (nor *) will be
allowed.

Test plan -  unit tests

Fixes #15297 

```
== RELEASE NOTES ==

General Changes
* Fix an issue where prepared statements would allow some non-constant parameters.
```
