### PR TITLE
Disable listFiles call to underlying storage

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
@@ -14,112 +14,39 @@
 package com.facebook.presto.hive;
 
 import com.facebook.presto.common.predicate.Domain;
-import com.facebook.presto.hive.HiveBucketing.HiveBucketFilter;
-import com.facebook.presto.hive.HiveSplit.BucketConversion;
-import com.facebook.presto.hive.filesystem.ExtendedFileSystem;
-import com.facebook.presto.hive.metastore.Column;
-import com.facebook.presto.hive.metastore.Partition;
-import com.facebook.presto.hive.metastore.Storage;
+import com.facebook.presto.hive.StoragePartitionLoader.BucketSplitInfo;
 import com.facebook.presto.hive.metastore.Table;
-import com.facebook.presto.hive.util.HiveFileIterator.NestedDirectoryNotAllowedException;
-import com.facebook.presto.hive.util.InternalHiveSplitFactory;
 import com.facebook.presto.hive.util.ResumableTask;
 import com.facebook.presto.hive.util.ResumableTasks;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.PrestoException;
-import com.facebook.presto.spi.SchemaTableName;
-import com.google.common.base.Suppliers;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Iterators;
-import com.google.common.io.CharStreams;
 import com.google.common.util.concurrent.ListenableFuture;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileStatus;
-import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.fs.PathFilter;
-import org.apache.hadoop.hive.ql.io.SymlinkTextInputFormat;
-import org.apache.hadoop.mapred.FileInputFormat;
-import org.apache.hadoop.mapred.FileSplit;
-import org.apache.hadoop.mapred.InputFormat;
-import org.apache.hadoop.mapred.InputSplit;
-import org.apache.hadoop.mapred.JobConf;
-import org.apache.hadoop.mapred.TextInputFormat;
-import org.apache.hudi.hadoop.HoodieParquetInputFormat;
-import org.apache.hudi.hadoop.HoodieROTablePathFilter;
-import org.apache.hudi.hadoop.realtime.HoodieParquetRealtimeInputFormat;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.lang.annotation.Annotation;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Deque;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Optional;
-import java.util.Properties;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.Executor;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-import java.util.function.IntPredicate;
-import java.util.function.Supplier;
 
-import static com.facebook.presto.hive.HiveBucketing.getVirtualBucketNumber;
-import static com.facebook.presto.hive.HiveColumnHandle.pathColumnHandle;
-import static com.facebook.presto.hive.HiveErrorCode.HIVE_BAD_DATA;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_FILESYSTEM_ERROR;
-import static com.facebook.presto.hive.HiveErrorCode.HIVE_INVALID_BUCKET_FILES;
-import static com.facebook.presto.hive.HiveErrorCode.HIVE_INVALID_METADATA;
-import static com.facebook.presto.hive.HiveErrorCode.HIVE_INVALID_PARTITION_VALUE;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_UNKNOWN_ERROR;
-import static com.facebook.presto.hive.HiveSessionProperties.getMaxInitialSplitSize;
-import static com.facebook.presto.hive.HiveSessionProperties.getNodeSelectionStrategy;
-import static com.facebook.presto.hive.HiveSessionProperties.isUseListDirectoryCache;
-import static com.facebook.presto.hive.HiveUtil.getFooterCount;
-import static com.facebook.presto.hive.HiveUtil.getHeaderCount;
-import static com.facebook.presto.hive.HiveUtil.getInputFormat;
-import static com.facebook.presto.hive.NestedDirectoryPolicy.FAIL;
-import static com.facebook.presto.hive.NestedDirectoryPolicy.IGNORED;
-import static com.facebook.presto.hive.NestedDirectoryPolicy.RECURSE;
-import static com.facebook.presto.hive.S3SelectPushdown.shouldEnablePushdownForTable;
-import static com.facebook.presto.hive.metastore.MetastoreUtil.checkCondition;
-import static com.facebook.presto.hive.metastore.MetastoreUtil.getHiveSchema;
-import static com.facebook.presto.hive.metastore.MetastoreUtil.getPartitionLocation;
-import static com.facebook.presto.hive.util.ConfigurationUtils.toJobConf;
-import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
-import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.google.common.collect.Streams.stream;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
-import static java.lang.Math.max;
-import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
-import static org.apache.hadoop.hive.common.FileUtils.HIDDEN_FILES_PATH_FILTER;
 
 public class BackgroundHiveSplitLoader
         implements HiveSplitLoader
 {
     private static final ListenableFuture<?> COMPLETED_FUTURE = immediateFuture(null);
 
-    private final Table table;
-    private final Optional<Domain> pathDomain;
-    private final Optional<BucketSplitInfo> tableBucketInfo;
-    private final HdfsEnvironment hdfsEnvironment;
-    private final HdfsContext hdfsContext;
-    private final NamenodeStats namenodeStats;
-    private final DirectoryLister directoryLister;
     private final int loaderConcurrency;
-    private final boolean recursiveDirWalkerEnabled;
     private final Executor executor;
-    private final ConnectorSession session;
     private final ConcurrentLazyQueue<HivePartitionMetadata> partitions;
     private final Deque<Iterator<InternalHiveSplit>> fileIterators = new ConcurrentLinkedDeque<>();
-    private final boolean schedulerUsesHostAddresses;
-    private final Supplier<HoodieROTablePathFilter> hoodiePathFilterSupplier;
-    private final boolean partialAggregationsPushedDown;
+    private final PartitionLoader delegatingPartitionLoader;
 
     // Purpose of this lock:
     // * Write lock: when you need a consistent view across partitions, fileIterators, and hiveSplitSource.
@@ -156,22 +83,11 @@ public class BackgroundHiveSplitLoader
             boolean schedulerUsesHostAddresses,
             boolean partialAggregationsPushedDown)
     {
-        this.table = requireNonNull(table, "table is null");
-        this.pathDomain = requireNonNull(pathDomain, "pathDomain is null");
-        this.tableBucketInfo = requireNonNull(tableBucketInfo, "tableBucketInfo is null");
         this.loaderConcurrency = loaderConcurrency;
         checkArgument(loaderConcurrency > 0, "loaderConcurrency must be > 0, found: %s", loaderConcurrency);
-        this.session = requireNonNull(session, "session is null");
-        this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
-        this.namenodeStats = requireNonNull(namenodeStats, "namenodeStats is null");
-        this.directoryLister = requireNonNull(directoryLister, "directoryLister is null");
-        this.recursiveDirWalkerEnabled = recursiveDirWalkerEnabled;
         this.executor = requireNonNull(executor, "executor is null");
         this.partitions = new ConcurrentLazyQueue<>(requireNonNull(partitions, "partitions is null"));
-        this.hdfsContext = new HdfsContext(session, table.getDatabaseName(), table.getTableName());
-        this.schedulerUsesHostAddresses = schedulerUsesHostAddresses;
-        this.hoodiePathFilterSupplier = Suppliers.memoize(HoodieROTablePathFilter::new)::get;
-        this.partialAggregationsPushedDown = partialAggregationsPushedDown;
+        this.delegatingPartitionLoader = new DelegatingPartitionLoader(table, pathDomain, tableBucketInfo, session, hdfsEnvironment, namenodeStats, directoryLister, fileIterators, recursiveDirWalkerEnabled, schedulerUsesHostAddresses, partialAggregationsPushedDown);
     }
 
     @Override
@@ -273,7 +189,7 @@ public class BackgroundHiveSplitLoader
             if (partition == null) {
                 return COMPLETED_FUTURE;
             }
-            return loadPartition(partition);
+            return delegatingPartitionLoader.loadPartition(partition, hiveSplitSource, stopped);
         }
 
         while (splits.hasNext() && !stopped) {
@@ -286,386 +202,5 @@ public class BackgroundHiveSplitLoader
 
         // No need to put the iterator back, since it's either empty or we've stopped
         return COMPLETED_FUTURE;
-    }
-
-    private ListenableFuture<?> loadPartition(HivePartitionMetadata partition)
-            throws IOException
-    {
-        String partitionName = partition.getHivePartition().getPartitionId();
-        Storage storage = partition.getPartition().map(Partition::getStorage).orElse(table.getStorage());
-        String inputFormatName = storage.getStorageFormat().getInputFormat();
-        int partitionDataColumnCount = partition.getPartition()
-                .map(p -> p.getColumns().size())
-                .orElse(table.getDataColumns().size());
-        List<HivePartitionKey> partitionKeys = getPartitionKeys(table, partition.getPartition());
-        Path path = new Path(getPartitionLocation(table, partition.getPartition()));
-        Configuration configuration = hdfsEnvironment.getConfiguration(hdfsContext, path);
-        InputFormat<?, ?> inputFormat = getInputFormat(configuration, inputFormatName, false);
-        ExtendedFileSystem fs = hdfsEnvironment.getFileSystem(hdfsContext, path);
-        boolean s3SelectPushdownEnabled = shouldEnablePushdownForTable(session, table, path.toString(), partition.getPartition());
-
-        if (inputFormat instanceof SymlinkTextInputFormat) {
-            if (tableBucketInfo.isPresent()) {
-                throw new PrestoException(NOT_SUPPORTED, "Bucketed table in SymlinkTextInputFormat is not yet supported");
-            }
-
-            // TODO: This should use an iterator like the HiveFileIterator
-            ListenableFuture<?> lastResult = COMPLETED_FUTURE;
-            for (Path targetPath : getTargetPathsFromSymlink(fs, path)) {
-                // The input should be in TextInputFormat.
-                TextInputFormat targetInputFormat = new TextInputFormat();
-                // the splits must be generated using the file system for the target path
-                // get the configuration for the target path -- it may be a different hdfs instance
-                ExtendedFileSystem targetFilesystem = hdfsEnvironment.getFileSystem(hdfsContext, targetPath);
-                JobConf targetJob = toJobConf(targetFilesystem.getConf());
-                targetJob.setInputFormat(TextInputFormat.class);
-                targetInputFormat.configure(targetJob);
-                FileInputFormat.setInputPaths(targetJob, targetPath);
-                InputSplit[] targetSplits = targetInputFormat.getSplits(targetJob, 0);
-
-                InternalHiveSplitFactory splitFactory = new InternalHiveSplitFactory(
-                        targetFilesystem,
-                        inputFormat,
-                        pathDomain,
-                        getNodeSelectionStrategy(session),
-                        getMaxInitialSplitSize(session),
-                        s3SelectPushdownEnabled,
-                        new HiveSplitPartitionInfo(storage, path.toUri(), partitionKeys, partitionName, partitionDataColumnCount, partition.getPartitionSchemaDifference(), Optional.empty()),
-                        schedulerUsesHostAddresses,
-                        partition.getEncryptionInformation());
-                lastResult = addSplitsToSource(targetSplits, splitFactory);
-                if (stopped) {
-                    return COMPLETED_FUTURE;
-                }
-            }
-            return lastResult;
-        }
-
-        Optional<BucketConversion> bucketConversion = Optional.empty();
-        boolean bucketConversionRequiresWorkerParticipation = false;
-        if (partition.getPartition().isPresent()) {
-            Optional<HiveBucketProperty> partitionBucketProperty = partition.getPartition().get().getStorage().getBucketProperty();
-            if (tableBucketInfo.isPresent() && partitionBucketProperty.isPresent()) {
-                int tableBucketCount = tableBucketInfo.get().getTableBucketCount();
-                int partitionBucketCount = partitionBucketProperty.get().getBucketCount();
-                // Validation was done in HiveSplitManager#getPartitionMetadata.
-                // Here, it's just trying to see if its needs the BucketConversion.
-                if (tableBucketCount != partitionBucketCount) {
-                    bucketConversion = Optional.of(new BucketConversion(tableBucketCount, partitionBucketCount, tableBucketInfo.get().getBucketColumns()));
-                    if (tableBucketCount > partitionBucketCount) {
-                        bucketConversionRequiresWorkerParticipation = true;
-                    }
-                }
-            }
-        }
-        InternalHiveSplitFactory splitFactory = new InternalHiveSplitFactory(
-                fs,
-                inputFormat,
-                pathDomain,
-                getNodeSelectionStrategy(session),
-                getMaxInitialSplitSize(session),
-                s3SelectPushdownEnabled,
-                new HiveSplitPartitionInfo(
-                        storage,
-                        path.toUri(),
-                        partitionKeys,
-                        partitionName,
-                        partitionDataColumnCount,
-                        partition.getPartitionSchemaDifference(),
-                        bucketConversionRequiresWorkerParticipation ? bucketConversion : Optional.empty()),
-                schedulerUsesHostAddresses,
-                partition.getEncryptionInformation());
-
-        if (!isHudiParquetInputFormat(inputFormat) && shouldUseFileSplitsFromInputFormat(inputFormat)) {
-            if (tableBucketInfo.isPresent()) {
-                throw new PrestoException(NOT_SUPPORTED, "Presto cannot read bucketed partition in an input format with UseFileSplitsFromInputFormat annotation: " + inputFormat.getClass().getSimpleName());
-            }
-            JobConf jobConf = toJobConf(configuration);
-            FileInputFormat.setInputPaths(jobConf, path);
-            InputSplit[] splits = inputFormat.getSplits(jobConf, 0);
-
-            return addSplitsToSource(splits, splitFactory);
-        }
-        PathFilter pathFilter = isHudiParquetInputFormat(inputFormat) ? hoodiePathFilterSupplier.get() : path1 -> true;
-        // S3 Select pushdown works at the granularity of individual S3 objects,
-        // Partial aggregation pushdown works at the granularity of individual files
-        // therefore we must not split files when either is enabled.
-        Properties schema = getHiveSchema(storage.getSerdeParameters(), table.getParameters());
-        // Skip header / footer lines are not splittable except for a special case when skip.header.line.count=1
-        boolean splittable = !s3SelectPushdownEnabled && !partialAggregationsPushedDown && getFooterCount(schema) == 0 && getHeaderCount(schema) <= 1;
-
-        // Bucketed partitions are fully loaded immediately since all files must be loaded to determine the file to bucket mapping
-        if (tableBucketInfo.isPresent()) {
-            if (tableBucketInfo.get().isVirtuallyBucketed()) {
-                // For virtual bucket, bucket conversion must not be present because there is no physical partition bucket count
-                checkState(!bucketConversion.isPresent(), "Virtually bucketed table must not have partitions that are physically bucketed");
-                checkState(
-                        tableBucketInfo.get().getTableBucketCount() == tableBucketInfo.get().getReadBucketCount(),
-                        "Table and read bucket count should be the same for virtual bucket");
-                return hiveSplitSource.addToQueue(getVirtuallyBucketedSplits(path, fs, splitFactory, tableBucketInfo.get().getReadBucketCount(), splittable, pathFilter));
-            }
-            return hiveSplitSource.addToQueue(getBucketedSplits(path, fs, splitFactory, tableBucketInfo.get(), bucketConversion, partitionName, splittable, pathFilter));
-        }
-
-        fileIterators.addLast(createInternalHiveSplitIterator(path, fs, splitFactory, splittable, pathFilter, partition.getPartition()));
-        return COMPLETED_FUTURE;
-    }
-
-    private ListenableFuture<?> addSplitsToSource(InputSplit[] targetSplits, InternalHiveSplitFactory splitFactory)
-            throws IOException
-    {
-        ListenableFuture<?> lastResult = COMPLETED_FUTURE;
-        for (InputSplit inputSplit : targetSplits) {
-            Optional<InternalHiveSplit> internalHiveSplit = splitFactory.createInternalHiveSplit((FileSplit) inputSplit);
-            if (internalHiveSplit.isPresent()) {
-                lastResult = hiveSplitSource.addToQueue(internalHiveSplit.get());
-            }
-            if (stopped) {
-                return COMPLETED_FUTURE;
-            }
-        }
-        return lastResult;
-    }
-
-    private static boolean isHudiParquetInputFormat(InputFormat<?, ?> inputFormat)
-    {
-        if (inputFormat instanceof HoodieParquetRealtimeInputFormat) {
-            return false;
-        }
-        return inputFormat instanceof HoodieParquetInputFormat;
-    }
-
-    private static boolean shouldUseFileSplitsFromInputFormat(InputFormat<?, ?> inputFormat)
-    {
-        return Arrays.stream(inputFormat.getClass().getAnnotations())
-                .map(Annotation::annotationType)
-                .map(Class::getSimpleName)
-                .anyMatch(name -> name.equals("UseFileSplitsFromInputFormat"));
-    }
-
-    private Iterator<InternalHiveSplit> createInternalHiveSplitIterator(Path path, ExtendedFileSystem fileSystem, InternalHiveSplitFactory splitFactory, boolean splittable, PathFilter pathFilter, Optional<Partition> partition)
-    {
-        boolean cacheable = isUseListDirectoryCache(session);
-        if (partition.isPresent()) {
-            // Use cache only for sealed partitions
-            cacheable &= partition.get().isSealedPartition();
-        }
-
-        HiveDirectoryContext hiveDirectoryContext = new HiveDirectoryContext(recursiveDirWalkerEnabled ? RECURSE : IGNORED, cacheable);
-        return stream(directoryLister.list(fileSystem, table, path, namenodeStats, pathFilter, hiveDirectoryContext))
-                .map(status -> splitFactory.createInternalHiveSplit(status, splittable))
-                .filter(Optional::isPresent)
-                .map(Optional::get)
-                .iterator();
-    }
-
-    private List<InternalHiveSplit> getBucketedSplits(
-            Path path,
-            ExtendedFileSystem fileSystem,
-            InternalHiveSplitFactory splitFactory,
-            BucketSplitInfo bucketSplitInfo,
-            Optional<BucketConversion> bucketConversion,
-            String partitionName,
-            boolean splittable,
-            PathFilter pathFilter)
-    {
-        int readBucketCount = bucketSplitInfo.getReadBucketCount();
-        int tableBucketCount = bucketSplitInfo.getTableBucketCount();
-        int partitionBucketCount = bucketConversion.map(BucketConversion::getPartitionBucketCount).orElse(tableBucketCount);
-
-        checkState(readBucketCount <= tableBucketCount, "readBucketCount(%s) should be less than or equal to tableBucketCount(%s)", readBucketCount, tableBucketCount);
-
-        // list all files in the partition
-        List<HiveFileInfo> fileInfos = new ArrayList<>(partitionBucketCount);
-        try {
-            Iterators.addAll(fileInfos, directoryLister.list(fileSystem, table, path, namenodeStats, pathFilter, new HiveDirectoryContext(FAIL, isUseListDirectoryCache(session))));
-        }
-        catch (NestedDirectoryNotAllowedException e) {
-            // Fail here to be on the safe side. This seems to be the same as what Hive does
-            throw new PrestoException(
-                    HIVE_INVALID_BUCKET_FILES,
-                    format("Hive table '%s' is corrupt. Found sub-directory in bucket directory for partition: %s",
-                            new SchemaTableName(table.getDatabaseName(), table.getTableName()),
-                            partitionName));
-        }
-
-        // verify we found one file per bucket
-        if (fileInfos.size() != partitionBucketCount) {
-            throw new PrestoException(
-                    HIVE_INVALID_BUCKET_FILES,
-                    format("Hive table '%s' is corrupt. The number of files in the directory (%s) does not match the declared bucket count (%s) for partition: %s",
-                            new SchemaTableName(table.getDatabaseName(), table.getTableName()),
-                            fileInfos.size(),
-                            partitionBucketCount,
-                            partitionName));
-        }
-
-        // Sort FileStatus objects (instead of, e.g., fileStatus.getPath().toString). This matches org.apache.hadoop.hive.ql.metadata.Table.getSortedPaths
-        fileInfos.sort(null);
-
-        // convert files internal splits
-        List<InternalHiveSplit> splitList = new ArrayList<>();
-        for (int bucketNumber = 0; bucketNumber < max(readBucketCount, partitionBucketCount); bucketNumber++) {
-            // Physical bucket #. This determine file name. It also determines the order of splits in the result.
-            int partitionBucketNumber = bucketNumber % partitionBucketCount;
-            // Logical bucket #. Each logical bucket corresponds to a "bucket" from engine's perspective.
-            int readBucketNumber = bucketNumber % readBucketCount;
-
-            boolean containsIneligibleTableBucket = false;
-            List<Integer> eligibleTableBucketNumbers = new ArrayList<>();
-            for (int tableBucketNumber = bucketNumber % tableBucketCount; tableBucketNumber < tableBucketCount; tableBucketNumber += max(readBucketCount, partitionBucketCount)) {
-                // table bucket number: this is used for evaluating "$bucket" filters.
-                if (bucketSplitInfo.isTableBucketEnabled(tableBucketNumber)) {
-                    eligibleTableBucketNumbers.add(tableBucketNumber);
-                }
-                else {
-                    containsIneligibleTableBucket = true;
-                }
-            }
-
-            if (!eligibleTableBucketNumbers.isEmpty() && containsIneligibleTableBucket) {
-                throw new PrestoException(
-                        NOT_SUPPORTED,
-                        "The bucket filter cannot be satisfied. There are restrictions on the bucket filter when all the following is true: " +
-                                "1. a table has a different buckets count as at least one of its partitions that is read in this query; " +
-                                "2. the table has a different but compatible bucket number with another table in the query; " +
-                                "3. some buckets of the table is filtered out from the query, most likely using a filter on \"$bucket\". " +
-                                "(table name: " + table.getTableName() + ", table bucket count: " + tableBucketCount + ", " +
-                                "partition bucket count: " + partitionBucketCount + ", effective reading bucket count: " + readBucketCount + ")");
-            }
-            if (!eligibleTableBucketNumbers.isEmpty()) {
-                HiveFileInfo fileInfo = fileInfos.get(partitionBucketNumber);
-                eligibleTableBucketNumbers.stream()
-                        .map(tableBucketNumber -> splitFactory.createInternalHiveSplit(fileInfo, readBucketNumber, tableBucketNumber, splittable))
-                        .forEach(optionalSplit -> optionalSplit.ifPresent(splitList::add));
-            }
-        }
-        return splitList;
-    }
-
-    private List<InternalHiveSplit> getVirtuallyBucketedSplits(Path path, ExtendedFileSystem fileSystem, InternalHiveSplitFactory splitFactory, int bucketCount, boolean splittable, PathFilter pathFilter)
-    {
-        // List all files recursively in the partition and assign virtual bucket number to each of them
-        HiveDirectoryContext hiveDirectoryContext = new HiveDirectoryContext(recursiveDirWalkerEnabled ? RECURSE : IGNORED, isUseListDirectoryCache(session));
-        return stream(directoryLister.list(fileSystem, table, path, namenodeStats, pathFilter, hiveDirectoryContext))
-                .map(fileInfo -> {
-                    int virtualBucketNumber = getVirtualBucketNumber(bucketCount, fileInfo.getPath());
-                    return splitFactory.createInternalHiveSplit(fileInfo, virtualBucketNumber, virtualBucketNumber, splittable);
-                })
-                .filter(Optional::isPresent)
-                .map(Optional::get)
-                .collect(toImmutableList());
-    }
-
-    private static List<Path> getTargetPathsFromSymlink(ExtendedFileSystem fileSystem, Path symlinkDir)
-    {
-        try {
-            FileStatus[] symlinks = fileSystem.listStatus(symlinkDir, HIDDEN_FILES_PATH_FILTER);
-            List<Path> targets = new ArrayList<>();
-
-            for (FileStatus symlink : symlinks) {
-                try (BufferedReader reader = new BufferedReader(new InputStreamReader(fileSystem.open(symlink.getPath()), StandardCharsets.UTF_8))) {
-                    CharStreams.readLines(reader).stream()
-                            .map(Path::new)
-                            .forEach(targets::add);
-                }
-            }
-            return targets;
-        }
-        catch (IOException e) {
-            throw new PrestoException(HIVE_BAD_DATA, "Error parsing symlinks from: " + symlinkDir, e);
-        }
-    }
-
-    private static List<HivePartitionKey> getPartitionKeys(Table table, Optional<Partition> partition)
-    {
-        if (!partition.isPresent()) {
-            return ImmutableList.of();
-        }
-        ImmutableList.Builder<HivePartitionKey> partitionKeys = ImmutableList.builder();
-        List<Column> keys = table.getPartitionColumns();
-        List<String> values = partition.get().getValues();
-        checkCondition(keys.size() == values.size(), HIVE_INVALID_METADATA, "Expected %s partition key values, but got %s", keys.size(), values.size());
-        for (int i = 0; i < keys.size(); i++) {
-            String name = keys.get(i).getName();
-            HiveType hiveType = keys.get(i).getType();
-            if (!hiveType.isSupportedType()) {
-                throw new PrestoException(NOT_SUPPORTED, format("Unsupported Hive type %s found in partition keys of table %s.%s", hiveType, table.getDatabaseName(), table.getTableName()));
-            }
-            String value = values.get(i);
-            checkCondition(value != null, HIVE_INVALID_PARTITION_VALUE, "partition key value cannot be null for field: %s", name);
-            partitionKeys.add(new HivePartitionKey(name, value));
-        }
-        return partitionKeys.build();
-    }
-
-    public static class BucketSplitInfo
-    {
-        private final List<HiveColumnHandle> bucketColumns;
-        private final int tableBucketCount;
-        private final int readBucketCount;
-        private final IntPredicate bucketFilter;
-
-        public static Optional<BucketSplitInfo> createBucketSplitInfo(Optional<HiveBucketHandle> bucketHandle, Optional<HiveBucketFilter> bucketFilter)
-        {
-            requireNonNull(bucketHandle, "bucketHandle is null");
-            requireNonNull(bucketFilter, "buckets is null");
-
-            if (!bucketHandle.isPresent()) {
-                checkArgument(!bucketFilter.isPresent(), "bucketHandle must be present if bucketFilter is present");
-                return Optional.empty();
-            }
-
-            int tableBucketCount = bucketHandle.get().getTableBucketCount();
-            int readBucketCount = bucketHandle.get().getReadBucketCount();
-
-            List<HiveColumnHandle> bucketColumns = bucketHandle.get().getColumns();
-            IntPredicate predicate = bucketFilter
-                    .<IntPredicate>map(filter -> filter.getBucketsToKeep()::contains)
-                    .orElse(bucket -> true);
-            return Optional.of(new BucketSplitInfo(bucketColumns, tableBucketCount, readBucketCount, predicate));
-        }
-
-        private BucketSplitInfo(List<HiveColumnHandle> bucketColumns, int tableBucketCount, int readBucketCount, IntPredicate bucketFilter)
-        {
-            this.bucketColumns = ImmutableList.copyOf(requireNonNull(bucketColumns, "bucketColumns is null"));
-            this.tableBucketCount = tableBucketCount;
-            this.readBucketCount = readBucketCount;
-            this.bucketFilter = requireNonNull(bucketFilter, "bucketFilter is null");
-        }
-
-        public List<HiveColumnHandle> getBucketColumns()
-        {
-            return bucketColumns;
-        }
-
-        public int getTableBucketCount()
-        {
-            return tableBucketCount;
-        }
-
-        public int getReadBucketCount()
-        {
-            return readBucketCount;
-        }
-
-        public boolean isVirtuallyBucketed()
-        {
-            return bucketColumns.size() == 1 && bucketColumns.get(0).equals(pathColumnHandle());
-        }
-
-        /**
-         * Evaluates whether the provided table bucket number passes the bucket predicate.
-         * A bucket predicate can be present in two cases:
-         * <ul>
-         * <li>Filter on "$bucket" column. e.g. {@code "$bucket" between 0 and 100}
-         * <li>Single-value equality filter on all bucket columns. e.g. for a table with two bucketing columns,
-         * {@code bucketCol1 = 'a' AND bucketCol2 = 123}
-         * </ul>
-         */
-        public boolean isTableBucketEnabled(int tableBucketNumber)
-        {
-            return bucketFilter.test(tableBucketNumber);
-        }
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/DelegatingPartitionLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/DelegatingPartitionLoader.java
@@ -52,7 +52,7 @@ public class DelegatingPartitionLoader
     {
         this.session = requireNonNull(session, "session is null");
         this.storagePartitionLoader = new StoragePartitionLoader(table, pathDomain, tableBucketInfo, session, hdfsEnvironment, namenodeStats, directoryLister, fileIterators, recursiveDirWalkerEnabled, schedulerUsesHostAddresses, partialAggregationsPushedDown);
-        this.manifestPartitionLoader = new ManifestPartitionLoader(table, pathDomain, session, hdfsEnvironment, schedulerUsesHostAddresses);
+        this.manifestPartitionLoader = new ManifestPartitionLoader(table, pathDomain, session, hdfsEnvironment, namenodeStats, directoryLister, recursiveDirWalkerEnabled, schedulerUsesHostAddresses);
     }
 
     @Override

--- a/presto-hive/src/main/java/com/facebook/presto/hive/DelegatingPartitionLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/DelegatingPartitionLoader.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.common.predicate.Domain;
+import com.facebook.presto.hive.StoragePartitionLoader.BucketSplitInfo;
+import com.facebook.presto.hive.metastore.Partition;
+import com.facebook.presto.hive.metastore.Table;
+import com.facebook.presto.spi.ConnectorSession;
+import com.google.common.util.concurrent.ListenableFuture;
+
+import java.io.IOException;
+import java.util.Deque;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.presto.hive.HiveManifestUtils.MANIFEST_VERSION;
+import static com.facebook.presto.hive.HiveSessionProperties.isPreferManifestsToListFiles;
+import static java.util.Objects.requireNonNull;
+
+public class DelegatingPartitionLoader
+        extends PartitionLoader
+{
+    private final ConnectorSession session;
+    private final PartitionLoader storagePartitionLoader;
+    private final PartitionLoader manifestPartitionLoader;
+
+    public DelegatingPartitionLoader(
+            Table table,
+            Optional<Domain> pathDomain,
+            Optional<BucketSplitInfo> tableBucketInfo,
+            ConnectorSession session,
+            HdfsEnvironment hdfsEnvironment,
+            NamenodeStats namenodeStats,
+            DirectoryLister directoryLister,
+            Deque<Iterator<InternalHiveSplit>> fileIterators,
+            boolean recursiveDirWalkerEnabled,
+            boolean schedulerUsesHostAddresses,
+            boolean partialAggregationsPushedDown)
+    {
+        this.session = requireNonNull(session, "session is null");
+        this.storagePartitionLoader = new StoragePartitionLoader(table, pathDomain, tableBucketInfo, session, hdfsEnvironment, namenodeStats, directoryLister, fileIterators, recursiveDirWalkerEnabled, schedulerUsesHostAddresses, partialAggregationsPushedDown);
+        this.manifestPartitionLoader = new ManifestPartitionLoader(table, pathDomain, session, hdfsEnvironment, schedulerUsesHostAddresses);
+    }
+
+    @Override
+    public ListenableFuture<?> loadPartition(HivePartitionMetadata partition, HiveSplitSource hiveSplitSource, boolean stopped)
+            throws IOException
+    {
+        if (isListFilesLoadedPartition(session, partition.getPartition())) {
+            // Partition has list of file names and sizes. We can avoid the listFiles() call to underlying storage.
+            return manifestPartitionLoader.loadPartition(partition, hiveSplitSource, stopped);
+        }
+
+        return storagePartitionLoader.loadPartition(partition, hiveSplitSource, stopped);
+    }
+
+    private static boolean isListFilesLoadedPartition(ConnectorSession session, Optional<Partition> partition)
+    {
+        if (partition.isPresent() && isPreferManifestsToListFiles(session)) {
+            Map<String, String> parameters = partition.get().getParameters();
+            return parameters.containsKey(MANIFEST_VERSION);
+        }
+
+        return false;
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -182,6 +182,7 @@ public class HiveClientConfig
     private boolean isPartialAggregationPushdownForVariableLengthDatatypesEnabled;
 
     private boolean fileRenamingEnabled;
+    private boolean preferManifestToListFiles;
 
     public int getMaxInitialSplits()
     {
@@ -1523,5 +1524,18 @@ public class HiveClientConfig
     public boolean isFileRenamingEnabled()
     {
         return this.fileRenamingEnabled;
+    }
+
+    @Config("hive.prefer-manifests-to-list-files")
+    @ConfigDescription("Prefer to fetch the list of file names and sizes from manifests rather than storage")
+    public HiveClientConfig setPreferManifestsToListFiles(boolean preferManifestToListFiles)
+    {
+        this.preferManifestToListFiles = preferManifestToListFiles;
+        return this;
+    }
+
+    public boolean isPreferManifestsToListFiles()
+    {
+        return this.preferManifestToListFiles;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -183,6 +183,7 @@ public class HiveClientConfig
 
     private boolean fileRenamingEnabled;
     private boolean preferManifestToListFiles;
+    private boolean manifestVerificationEnabled;
 
     public int getMaxInitialSplits()
     {
@@ -1537,5 +1538,18 @@ public class HiveClientConfig
     public boolean isPreferManifestsToListFiles()
     {
         return this.preferManifestToListFiles;
+    }
+
+    @Config("hive.manifest-verification-enabled")
+    @ConfigDescription("Enable verification of file names and sizes in manifest / partition parameters")
+    public HiveClientConfig setManifestVerificationEnabled(boolean manifestVerificationEnabled)
+    {
+        this.manifestVerificationEnabled = manifestVerificationEnabled;
+        return this;
+    }
+
+    public boolean isManifestVerificationEnabled()
+    {
+        return this.manifestVerificationEnabled;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveManifestUtils.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveManifestUtils.java
@@ -48,10 +48,10 @@ public class HiveManifestUtils
     private static final int ROW_COUNT_CHANNEL = 1;
     private static final int COMPRESSION_LEVEL = 7; // default level
     private static final String COMMA = ",";
-    private static final String MANIFEST_VERSION = "MANIFEST_VERSION";
 
     public static final String FILE_NAMES = "FILE_NAMES";
     public static final String FILE_SIZES = "FILE_SIZES";
+    public static final String MANIFEST_VERSION = "MANIFEST_VERSION";
     public static final String VERSION_1 = "V1";
 
     private HiveManifestUtils()

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
@@ -111,6 +111,7 @@ public final class HiveSessionProperties
     public static final String PARTIAL_AGGREGATION_PUSHDOWN_ENABLED = "partial_aggregation_pushdown_enabled";
     public static final String PARTIAL_AGGREGATION_PUSHDOWN_FOR_VARIABLE_LENGTH_DATATYPES_ENABLED = "partial_aggregation_pushdown_for_variable_length_datatypes_enabled";
     public static final String FILE_RENAMING_ENABLED = "file_renaming_enabled";
+    public static final String PREFER_MANIFESTS_TO_LIST_FILES = "prefer_manifests_to_list_files";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -520,6 +521,11 @@ public final class HiveSessionProperties
                         FILE_RENAMING_ENABLED,
                         "Enable renaming the files written by writers",
                         hiveClientConfig.isFileRenamingEnabled(),
+                        false),
+                booleanProperty(
+                        PREFER_MANIFESTS_TO_LIST_FILES,
+                        "Prefer to fetch the list of file names and sizes from manifest",
+                        hiveClientConfig.isPreferManifestsToListFiles(),
                         false));
     }
 
@@ -909,5 +915,10 @@ public final class HiveSessionProperties
     public static boolean isFileRenamingEnabled(ConnectorSession session)
     {
         return session.getProperty(FILE_RENAMING_ENABLED, Boolean.class);
+    }
+
+    public static boolean isPreferManifestsToListFiles(ConnectorSession session)
+    {
+        return session.getProperty(PREFER_MANIFESTS_TO_LIST_FILES, Boolean.class);
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
@@ -112,6 +112,7 @@ public final class HiveSessionProperties
     public static final String PARTIAL_AGGREGATION_PUSHDOWN_FOR_VARIABLE_LENGTH_DATATYPES_ENABLED = "partial_aggregation_pushdown_for_variable_length_datatypes_enabled";
     public static final String FILE_RENAMING_ENABLED = "file_renaming_enabled";
     public static final String PREFER_MANIFESTS_TO_LIST_FILES = "prefer_manifests_to_list_files";
+    public static final String MANIFEST_VERIFICATION_ENABLED = "manifest_verification_enabled";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -526,6 +527,11 @@ public final class HiveSessionProperties
                         PREFER_MANIFESTS_TO_LIST_FILES,
                         "Prefer to fetch the list of file names and sizes from manifest",
                         hiveClientConfig.isPreferManifestsToListFiles(),
+                        false),
+                booleanProperty(
+                        MANIFEST_VERIFICATION_ENABLED,
+                        "Enable manifest verification",
+                        hiveClientConfig.isManifestVerificationEnabled(),
                         false));
     }
 
@@ -920,5 +926,10 @@ public final class HiveSessionProperties
     public static boolean isPreferManifestsToListFiles(ConnectorSession session)
     {
         return session.getProperty(PREFER_MANIFESTS_TO_LIST_FILES, Boolean.class);
+    }
+
+    public static boolean isManifestVerificationEnabled(ConnectorSession session)
+    {
+        return session.getProperty(MANIFEST_VERIFICATION_ENABLED, Boolean.class);
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitManager.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitManager.java
@@ -61,7 +61,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.stream.Stream;
 
-import static com.facebook.presto.hive.BackgroundHiveSplitLoader.BucketSplitInfo.createBucketSplitInfo;
 import static com.facebook.presto.hive.HiveColumnHandle.ColumnType.REGULAR;
 import static com.facebook.presto.hive.HiveColumnHandle.isPathColumnHandle;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_INVALID_METADATA;
@@ -72,6 +71,7 @@ import static com.facebook.presto.hive.HivePartition.UNPARTITIONED_ID;
 import static com.facebook.presto.hive.HiveSessionProperties.isOfflineDataDebugModeEnabled;
 import static com.facebook.presto.hive.HiveSessionProperties.shouldIgnoreUnreadablePartition;
 import static com.facebook.presto.hive.HiveWarningCode.PARTITION_NOT_READABLE;
+import static com.facebook.presto.hive.StoragePartitionLoader.BucketSplitInfo.createBucketSplitInfo;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.getProtectMode;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.makePartName;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.verifyOnline;

--- a/presto-hive/src/main/java/com/facebook/presto/hive/ManifestPartitionLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/ManifestPartitionLoader.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.common.predicate.Domain;
+import com.facebook.presto.hive.filesystem.ExtendedFileSystem;
+import com.facebook.presto.hive.metastore.Partition;
+import com.facebook.presto.hive.metastore.Storage;
+import com.facebook.presto.hive.metastore.Table;
+import com.facebook.presto.hive.util.InternalHiveSplitFactory;
+import com.facebook.presto.spi.ConnectorSession;
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.ListenableFuture;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.BlockLocation;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.LocatedFileStatus;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapred.InputFormat;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.presto.hive.HiveManifestUtils.FILE_NAMES;
+import static com.facebook.presto.hive.HiveManifestUtils.FILE_SIZES;
+import static com.facebook.presto.hive.HiveManifestUtils.MANIFEST_VERSION;
+import static com.facebook.presto.hive.HiveManifestUtils.VERSION_1;
+import static com.facebook.presto.hive.HiveManifestUtils.decompressFileNames;
+import static com.facebook.presto.hive.HiveManifestUtils.decompressFileSizes;
+import static com.facebook.presto.hive.HiveSessionProperties.getMaxInitialSplitSize;
+import static com.facebook.presto.hive.HiveSessionProperties.getMaxSplitSize;
+import static com.facebook.presto.hive.HiveSessionProperties.getNodeSelectionStrategy;
+import static com.facebook.presto.hive.HiveUtil.getInputFormat;
+import static com.facebook.presto.hive.metastore.MetastoreUtil.getPartitionLocation;
+import static com.google.common.base.Verify.verify;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class ManifestPartitionLoader
+        extends PartitionLoader
+{
+    // The following constants are referred from FileSystem.getFileBlockLocations in Hadoop
+    private static final String[] BLOCK_LOCATION_NAMES = new String[] {"localhost:50010"};
+    private static final String[] BLOCK_LOCATION_HOSTS = new String[] {"localhost"};
+
+    private final Table table;
+    private final Optional<Domain> pathDomain;
+    private final ConnectorSession session;
+    private final HdfsEnvironment hdfsEnvironment;
+    private final HdfsContext hdfsContext;
+    private final boolean schedulerUsesHostAddresses;
+
+    public ManifestPartitionLoader(
+            Table table,
+            Optional<Domain> pathDomain,
+            ConnectorSession session,
+            HdfsEnvironment hdfsEnvironment,
+            boolean schedulerUsesHostAddresses)
+    {
+        this.table = requireNonNull(table, "table is null");
+        this.pathDomain = requireNonNull(pathDomain, "pathDomain is null");
+        this.session = requireNonNull(session, "session is null");
+        this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
+        this.hdfsContext = new HdfsContext(session, table.getDatabaseName(), table.getTableName());
+        this.schedulerUsesHostAddresses = schedulerUsesHostAddresses;
+    }
+
+    public ListenableFuture<?> loadPartition(HivePartitionMetadata partition, HiveSplitSource hiveSplitSource, boolean stopped)
+            throws IOException
+    {
+        Path path = new Path(getPartitionLocation(table, partition.getPartition()));
+        Map<String, String> parameters = partition.getPartition().get().getParameters();
+
+        // TODO: Add support for more manifest versions
+        // Verify the manifest version
+        verify(VERSION_1.equals(parameters.get(MANIFEST_VERSION)), format("Manifest version is not equal to %s", VERSION_1));
+
+        List<String> fileNames = decompressFileNames(parameters.get(FILE_NAMES));
+        List<Long> fileSizes = decompressFileSizes(parameters.get(FILE_SIZES));
+
+        // Verify that the count of fileNames and fileSizes are same
+        verify(fileNames.size() == fileSizes.size(), "List of fileNames and fileSizes differ in length");
+
+        ImmutableList.Builder<HiveFileInfo> fileListBuilder = ImmutableList.builder();
+        for (int i = 0; i < fileNames.size(); i++) {
+            Path filePath = new Path(path, fileNames.get(i));
+            FileStatus fileStatus = new FileStatus(fileSizes.get(i), false, 1, getMaxSplitSize(session).toBytes(), 0, filePath);
+            try {
+                BlockLocation[] locations = new BlockLocation[] {new BlockLocation(BLOCK_LOCATION_NAMES, BLOCK_LOCATION_HOSTS, 0, fileSizes.get(i))};
+
+                // It is safe to set extraFileContext as empty because downstream code always checks if its present before proceeding.
+                fileListBuilder.add(HiveFileInfo.createHiveFileInfo(new LocatedFileStatus(fileStatus, locations), Optional.empty()));
+            }
+            catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+
+        InternalHiveSplitFactory splitFactory = createInternalHiveSplitFactory(table, partition, session, pathDomain, hdfsEnvironment, hdfsContext, schedulerUsesHostAddresses);
+
+        return hiveSplitSource.addToQueue(fileListBuilder.build().stream()
+                .map(status -> splitFactory.createInternalHiveSplit(status, true))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(toImmutableList()));
+    }
+
+    private InternalHiveSplitFactory createInternalHiveSplitFactory(
+            Table table,
+            HivePartitionMetadata partition,
+            ConnectorSession session,
+            Optional<Domain> pathDomain,
+            HdfsEnvironment hdfsEnvironment,
+            HdfsContext hdfsContext,
+            boolean schedulerUsesHostAddresses)
+            throws IOException
+    {
+        String partitionName = partition.getHivePartition().getPartitionId();
+        Storage storage = partition.getPartition().map(Partition::getStorage).orElse(table.getStorage());
+        String inputFormatName = storage.getStorageFormat().getInputFormat();
+        int partitionDataColumnCount = partition.getPartition()
+                .map(p -> p.getColumns().size())
+                .orElse(table.getDataColumns().size());
+        List<HivePartitionKey> partitionKeys = getPartitionKeys(table, partition.getPartition());
+        Path path = new Path(getPartitionLocation(table, partition.getPartition()));
+        Configuration configuration = hdfsEnvironment.getConfiguration(hdfsContext, path);
+        InputFormat<?, ?> inputFormat = getInputFormat(configuration, inputFormatName, false);
+        ExtendedFileSystem fileSystem = hdfsEnvironment.getFileSystem(hdfsContext, path);
+
+        return new InternalHiveSplitFactory(
+                fileSystem,
+                inputFormat,
+                pathDomain,
+                getNodeSelectionStrategy(session),
+                getMaxInitialSplitSize(session),
+                false,
+                new HiveSplitPartitionInfo(
+                        storage,
+                        path.toUri(),
+                        partitionKeys,
+                        partitionName,
+                        partitionDataColumnCount,
+                        partition.getPartitionSchemaDifference(),
+                        Optional.empty()),
+                schedulerUsesHostAddresses,
+                partition.getEncryptionInformation());
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/PartitionLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/PartitionLoader.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.hive.metastore.Column;
+import com.facebook.presto.hive.metastore.Partition;
+import com.facebook.presto.hive.metastore.Table;
+import com.facebook.presto.spi.PrestoException;
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.ListenableFuture;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+import static com.facebook.presto.hive.HiveErrorCode.HIVE_INVALID_METADATA;
+import static com.facebook.presto.hive.HiveErrorCode.HIVE_INVALID_PARTITION_VALUE;
+import static com.facebook.presto.hive.metastore.MetastoreUtil.checkCondition;
+import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
+import static java.lang.String.format;
+
+public abstract class PartitionLoader
+{
+    public abstract ListenableFuture<?> loadPartition(HivePartitionMetadata partition, HiveSplitSource hiveSplitSource, boolean stopped)
+            throws IOException;
+
+    public List<HivePartitionKey> getPartitionKeys(Table table, Optional<Partition> partition)
+    {
+        if (!partition.isPresent()) {
+            return ImmutableList.of();
+        }
+        ImmutableList.Builder<HivePartitionKey> partitionKeys = ImmutableList.builder();
+        List<Column> keys = table.getPartitionColumns();
+        List<String> values = partition.get().getValues();
+        checkCondition(keys.size() == values.size(), HIVE_INVALID_METADATA, "Expected %s partition key values, but got %s", keys.size(), values.size());
+        for (int i = 0; i < keys.size(); i++) {
+            String name = keys.get(i).getName();
+            HiveType hiveType = keys.get(i).getType();
+            if (!hiveType.isSupportedType()) {
+                throw new PrestoException(NOT_SUPPORTED, format("Unsupported Hive type %s found in partition keys of table %s.%s", hiveType, table.getDatabaseName(), table.getTableName()));
+            }
+            String value = values.get(i);
+            checkCondition(value != null, HIVE_INVALID_PARTITION_VALUE, "partition key value cannot be null for field: %s", name);
+            partitionKeys.add(new HivePartitionKey(name, value));
+        }
+        return partitionKeys.build();
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/StoragePartitionLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/StoragePartitionLoader.java
@@ -1,0 +1,495 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.common.predicate.Domain;
+import com.facebook.presto.hive.filesystem.ExtendedFileSystem;
+import com.facebook.presto.hive.metastore.Partition;
+import com.facebook.presto.hive.metastore.Storage;
+import com.facebook.presto.hive.metastore.Table;
+import com.facebook.presto.hive.util.HiveFileIterator;
+import com.facebook.presto.hive.util.InternalHiveSplitFactory;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.SchemaTableName;
+import com.google.common.base.Suppliers;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterators;
+import com.google.common.io.CharStreams;
+import com.google.common.util.concurrent.ListenableFuture;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.PathFilter;
+import org.apache.hadoop.hive.ql.io.SymlinkTextInputFormat;
+import org.apache.hadoop.mapred.FileInputFormat;
+import org.apache.hadoop.mapred.FileSplit;
+import org.apache.hadoop.mapred.InputFormat;
+import org.apache.hadoop.mapred.InputSplit;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.TextInputFormat;
+import org.apache.hudi.hadoop.HoodieParquetInputFormat;
+import org.apache.hudi.hadoop.HoodieROTablePathFilter;
+import org.apache.hudi.hadoop.realtime.HoodieParquetRealtimeInputFormat;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.lang.annotation.Annotation;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Deque;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.function.IntPredicate;
+import java.util.function.Supplier;
+
+import static com.facebook.presto.hive.HiveBucketing.getVirtualBucketNumber;
+import static com.facebook.presto.hive.HiveColumnHandle.pathColumnHandle;
+import static com.facebook.presto.hive.HiveErrorCode.HIVE_BAD_DATA;
+import static com.facebook.presto.hive.HiveErrorCode.HIVE_INVALID_BUCKET_FILES;
+import static com.facebook.presto.hive.HiveSessionProperties.getMaxInitialSplitSize;
+import static com.facebook.presto.hive.HiveSessionProperties.getNodeSelectionStrategy;
+import static com.facebook.presto.hive.HiveSessionProperties.isUseListDirectoryCache;
+import static com.facebook.presto.hive.HiveUtil.getFooterCount;
+import static com.facebook.presto.hive.HiveUtil.getHeaderCount;
+import static com.facebook.presto.hive.HiveUtil.getInputFormat;
+import static com.facebook.presto.hive.NestedDirectoryPolicy.FAIL;
+import static com.facebook.presto.hive.NestedDirectoryPolicy.IGNORED;
+import static com.facebook.presto.hive.NestedDirectoryPolicy.RECURSE;
+import static com.facebook.presto.hive.S3SelectPushdown.shouldEnablePushdownForTable;
+import static com.facebook.presto.hive.metastore.MetastoreUtil.getHiveSchema;
+import static com.facebook.presto.hive.metastore.MetastoreUtil.getPartitionLocation;
+import static com.facebook.presto.hive.util.ConfigurationUtils.toJobConf;
+import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.Streams.stream;
+import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static java.lang.Math.max;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+import static org.apache.hadoop.hive.common.FileUtils.HIDDEN_FILES_PATH_FILTER;
+
+public class StoragePartitionLoader
+        extends PartitionLoader
+{
+    private static final ListenableFuture<?> COMPLETED_FUTURE = immediateFuture(null);
+
+    private final Table table;
+    private final Optional<Domain> pathDomain;
+    private final Optional<BucketSplitInfo> tableBucketInfo;
+    private final HdfsEnvironment hdfsEnvironment;
+    private final HdfsContext hdfsContext;
+    private final NamenodeStats namenodeStats;
+    private final DirectoryLister directoryLister;
+    private final boolean recursiveDirWalkerEnabled;
+    private final ConnectorSession session;
+    private final Deque<Iterator<InternalHiveSplit>> fileIterators;
+    private final boolean schedulerUsesHostAddresses;
+    private final Supplier<HoodieROTablePathFilter> hoodiePathFilterSupplier;
+    private final boolean partialAggregationsPushedDown;
+
+    public StoragePartitionLoader(
+            Table table,
+            Optional<Domain> pathDomain,
+            Optional<BucketSplitInfo> tableBucketInfo,
+            ConnectorSession session,
+            HdfsEnvironment hdfsEnvironment,
+            NamenodeStats namenodeStats,
+            DirectoryLister directoryLister,
+            Deque<Iterator<InternalHiveSplit>> fileIterators,
+            boolean recursiveDirWalkerEnabled,
+            boolean schedulerUsesHostAddresses,
+            boolean partialAggregationsPushedDown)
+    {
+        this.table = requireNonNull(table, "table is null");
+        this.pathDomain = requireNonNull(pathDomain, "pathDomain is null");
+        this.tableBucketInfo = requireNonNull(tableBucketInfo, "tableBucketInfo is null");
+        this.session = requireNonNull(session, "session is null");
+        this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
+        this.namenodeStats = requireNonNull(namenodeStats, "namenodeStats is null");
+        this.directoryLister = requireNonNull(directoryLister, "directoryLister is null");
+        this.recursiveDirWalkerEnabled = recursiveDirWalkerEnabled;
+        this.hdfsContext = new HdfsContext(session, table.getDatabaseName(), table.getTableName());
+        this.fileIterators = requireNonNull(fileIterators, "fileIterators is null");
+        this.schedulerUsesHostAddresses = schedulerUsesHostAddresses;
+        this.hoodiePathFilterSupplier = Suppliers.memoize(HoodieROTablePathFilter::new)::get;
+        this.partialAggregationsPushedDown = partialAggregationsPushedDown;
+    }
+
+    @Override
+    public ListenableFuture<?> loadPartition(HivePartitionMetadata partition, HiveSplitSource hiveSplitSource, boolean stopped)
+            throws IOException
+    {
+        String partitionName = partition.getHivePartition().getPartitionId();
+        Storage storage = partition.getPartition().map(Partition::getStorage).orElse(table.getStorage());
+        String inputFormatName = storage.getStorageFormat().getInputFormat();
+        int partitionDataColumnCount = partition.getPartition()
+                .map(p -> p.getColumns().size())
+                .orElse(table.getDataColumns().size());
+        List<HivePartitionKey> partitionKeys = getPartitionKeys(table, partition.getPartition());
+        Path path = new Path(getPartitionLocation(table, partition.getPartition()));
+        Configuration configuration = hdfsEnvironment.getConfiguration(hdfsContext, path);
+        InputFormat<?, ?> inputFormat = getInputFormat(configuration, inputFormatName, false);
+        ExtendedFileSystem fs = hdfsEnvironment.getFileSystem(hdfsContext, path);
+        boolean s3SelectPushdownEnabled = shouldEnablePushdownForTable(session, table, path.toString(), partition.getPartition());
+
+        if (inputFormat instanceof SymlinkTextInputFormat) {
+            if (tableBucketInfo.isPresent()) {
+                throw new PrestoException(NOT_SUPPORTED, "Bucketed table in SymlinkTextInputFormat is not yet supported");
+            }
+
+            // TODO: This should use an iterator like the HiveFileIterator
+            ListenableFuture<?> lastResult = COMPLETED_FUTURE;
+            for (Path targetPath : getTargetPathsFromSymlink(fs, path)) {
+                // The input should be in TextInputFormat.
+                TextInputFormat targetInputFormat = new TextInputFormat();
+                // the splits must be generated using the file system for the target path
+                // get the configuration for the target path -- it may be a different hdfs instance
+                ExtendedFileSystem targetFilesystem = hdfsEnvironment.getFileSystem(hdfsContext, targetPath);
+                JobConf targetJob = toJobConf(targetFilesystem.getConf());
+                targetJob.setInputFormat(TextInputFormat.class);
+                targetInputFormat.configure(targetJob);
+                FileInputFormat.setInputPaths(targetJob, targetPath);
+                InputSplit[] targetSplits = targetInputFormat.getSplits(targetJob, 0);
+
+                InternalHiveSplitFactory splitFactory = new InternalHiveSplitFactory(
+                        targetFilesystem,
+                        inputFormat,
+                        pathDomain,
+                        getNodeSelectionStrategy(session),
+                        getMaxInitialSplitSize(session),
+                        s3SelectPushdownEnabled,
+                        new HiveSplitPartitionInfo(storage, path.toUri(), partitionKeys, partitionName, partitionDataColumnCount, partition.getPartitionSchemaDifference(), Optional.empty()),
+                        schedulerUsesHostAddresses,
+                        partition.getEncryptionInformation());
+                lastResult = addSplitsToSource(targetSplits, splitFactory, hiveSplitSource, stopped);
+                if (stopped) {
+                    return COMPLETED_FUTURE;
+                }
+            }
+            return lastResult;
+        }
+
+        Optional<HiveSplit.BucketConversion> bucketConversion = Optional.empty();
+        boolean bucketConversionRequiresWorkerParticipation = false;
+        if (partition.getPartition().isPresent()) {
+            Optional<HiveBucketProperty> partitionBucketProperty = partition.getPartition().get().getStorage().getBucketProperty();
+            if (tableBucketInfo.isPresent() && partitionBucketProperty.isPresent()) {
+                int tableBucketCount = tableBucketInfo.get().getTableBucketCount();
+                int partitionBucketCount = partitionBucketProperty.get().getBucketCount();
+                // Validation was done in HiveSplitManager#getPartitionMetadata.
+                // Here, it's just trying to see if its needs the BucketConversion.
+                if (tableBucketCount != partitionBucketCount) {
+                    bucketConversion = Optional.of(new HiveSplit.BucketConversion(tableBucketCount, partitionBucketCount, tableBucketInfo.get().getBucketColumns()));
+                    if (tableBucketCount > partitionBucketCount) {
+                        bucketConversionRequiresWorkerParticipation = true;
+                    }
+                }
+            }
+        }
+        InternalHiveSplitFactory splitFactory = new InternalHiveSplitFactory(
+                fs,
+                inputFormat,
+                pathDomain,
+                getNodeSelectionStrategy(session),
+                getMaxInitialSplitSize(session),
+                s3SelectPushdownEnabled,
+                new HiveSplitPartitionInfo(
+                        storage,
+                        path.toUri(),
+                        partitionKeys,
+                        partitionName,
+                        partitionDataColumnCount,
+                        partition.getPartitionSchemaDifference(),
+                        bucketConversionRequiresWorkerParticipation ? bucketConversion : Optional.empty()),
+                schedulerUsesHostAddresses,
+                partition.getEncryptionInformation());
+
+        if (!isHudiParquetInputFormat(inputFormat) && shouldUseFileSplitsFromInputFormat(inputFormat)) {
+            if (tableBucketInfo.isPresent()) {
+                throw new PrestoException(NOT_SUPPORTED, "Presto cannot read bucketed partition in an input format with UseFileSplitsFromInputFormat annotation: " + inputFormat.getClass().getSimpleName());
+            }
+            JobConf jobConf = toJobConf(configuration);
+            FileInputFormat.setInputPaths(jobConf, path);
+            InputSplit[] splits = inputFormat.getSplits(jobConf, 0);
+
+            return addSplitsToSource(splits, splitFactory, hiveSplitSource, stopped);
+        }
+        PathFilter pathFilter = isHudiParquetInputFormat(inputFormat) ? hoodiePathFilterSupplier.get() : path1 -> true;
+        // S3 Select pushdown works at the granularity of individual S3 objects,
+        // Partial aggregation pushdown works at the granularity of individual files
+        // therefore we must not split files when either is enabled.
+        Properties schema = getHiveSchema(storage.getSerdeParameters(), table.getParameters());
+        // Skip header / footer lines are not splittable except for a special case when skip.header.line.count=1
+        boolean splittable = !s3SelectPushdownEnabled && !partialAggregationsPushedDown && getFooterCount(schema) == 0 && getHeaderCount(schema) <= 1;
+
+        // Bucketed partitions are fully loaded immediately since all files must be loaded to determine the file to bucket mapping
+        if (tableBucketInfo.isPresent()) {
+            if (tableBucketInfo.get().isVirtuallyBucketed()) {
+                // For virtual bucket, bucket conversion must not be present because there is no physical partition bucket count
+                checkState(!bucketConversion.isPresent(), "Virtually bucketed table must not have partitions that are physically bucketed");
+                checkState(
+                        tableBucketInfo.get().getTableBucketCount() == tableBucketInfo.get().getReadBucketCount(),
+                        "Table and read bucket count should be the same for virtual bucket");
+                return hiveSplitSource.addToQueue(getVirtuallyBucketedSplits(path, fs, splitFactory, tableBucketInfo.get().getReadBucketCount(), splittable, pathFilter));
+            }
+            return hiveSplitSource.addToQueue(getBucketedSplits(path, fs, splitFactory, tableBucketInfo.get(), bucketConversion, partitionName, splittable, pathFilter));
+        }
+
+        fileIterators.addLast(createInternalHiveSplitIterator(path, fs, splitFactory, splittable, pathFilter, partition.getPartition()));
+        return COMPLETED_FUTURE;
+    }
+
+    private ListenableFuture<?> addSplitsToSource(InputSplit[] targetSplits, InternalHiveSplitFactory splitFactory, HiveSplitSource hiveSplitSource, boolean stopped)
+            throws IOException
+    {
+        ListenableFuture<?> lastResult = COMPLETED_FUTURE;
+        for (InputSplit inputSplit : targetSplits) {
+            Optional<InternalHiveSplit> internalHiveSplit = splitFactory.createInternalHiveSplit((FileSplit) inputSplit);
+            if (internalHiveSplit.isPresent()) {
+                lastResult = hiveSplitSource.addToQueue(internalHiveSplit.get());
+            }
+            if (stopped) {
+                return COMPLETED_FUTURE;
+            }
+        }
+        return lastResult;
+    }
+
+    private static boolean isHudiParquetInputFormat(InputFormat<?, ?> inputFormat)
+    {
+        if (inputFormat instanceof HoodieParquetRealtimeInputFormat) {
+            return false;
+        }
+        return inputFormat instanceof HoodieParquetInputFormat;
+    }
+
+    private static boolean shouldUseFileSplitsFromInputFormat(InputFormat<?, ?> inputFormat)
+    {
+        return Arrays.stream(inputFormat.getClass().getAnnotations())
+                .map(Annotation::annotationType)
+                .map(Class::getSimpleName)
+                .anyMatch(name -> name.equals("UseFileSplitsFromInputFormat"));
+    }
+
+    private Iterator<InternalHiveSplit> createInternalHiveSplitIterator(Path path, ExtendedFileSystem fileSystem, InternalHiveSplitFactory splitFactory, boolean splittable, PathFilter pathFilter, Optional<Partition> partition)
+    {
+        boolean cacheable = isUseListDirectoryCache(session);
+        if (partition.isPresent()) {
+            // Use cache only for sealed partitions
+            cacheable &= partition.get().isSealedPartition();
+        }
+
+        HiveDirectoryContext hiveDirectoryContext = new HiveDirectoryContext(recursiveDirWalkerEnabled ? RECURSE : IGNORED, cacheable);
+        return stream(directoryLister.list(fileSystem, table, path, namenodeStats, pathFilter, hiveDirectoryContext))
+                .map(status -> splitFactory.createInternalHiveSplit(status, splittable))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .iterator();
+    }
+
+    private List<InternalHiveSplit> getBucketedSplits(
+            Path path,
+            ExtendedFileSystem fileSystem,
+            InternalHiveSplitFactory splitFactory,
+            BucketSplitInfo bucketSplitInfo,
+            Optional<HiveSplit.BucketConversion> bucketConversion,
+            String partitionName,
+            boolean splittable,
+            PathFilter pathFilter)
+    {
+        int readBucketCount = bucketSplitInfo.getReadBucketCount();
+        int tableBucketCount = bucketSplitInfo.getTableBucketCount();
+        int partitionBucketCount = bucketConversion.map(HiveSplit.BucketConversion::getPartitionBucketCount).orElse(tableBucketCount);
+
+        checkState(readBucketCount <= tableBucketCount, "readBucketCount(%s) should be less than or equal to tableBucketCount(%s)", readBucketCount, tableBucketCount);
+
+        // list all files in the partition
+        List<HiveFileInfo> fileInfos = new ArrayList<>(partitionBucketCount);
+        try {
+            Iterators.addAll(fileInfos, directoryLister.list(fileSystem, table, path, namenodeStats, pathFilter, new HiveDirectoryContext(FAIL, isUseListDirectoryCache(session))));
+        }
+        catch (HiveFileIterator.NestedDirectoryNotAllowedException e) {
+            // Fail here to be on the safe side. This seems to be the same as what Hive does
+            throw new PrestoException(
+                    HIVE_INVALID_BUCKET_FILES,
+                    format("Hive table '%s' is corrupt. Found sub-directory in bucket directory for partition: %s",
+                            new SchemaTableName(table.getDatabaseName(), table.getTableName()),
+                            partitionName));
+        }
+
+        // verify we found one file per bucket
+        if (fileInfos.size() != partitionBucketCount) {
+            throw new PrestoException(
+                    HIVE_INVALID_BUCKET_FILES,
+                    format("Hive table '%s' is corrupt. The number of files in the directory (%s) does not match the declared bucket count (%s) for partition: %s",
+                            new SchemaTableName(table.getDatabaseName(), table.getTableName()),
+                            fileInfos.size(),
+                            partitionBucketCount,
+                            partitionName));
+        }
+
+        // Sort FileStatus objects (instead of, e.g., fileStatus.getPath().toString). This matches org.apache.hadoop.hive.ql.metadata.Table.getSortedPaths
+        fileInfos.sort(null);
+
+        // convert files internal splits
+        List<InternalHiveSplit> splitList = new ArrayList<>();
+        for (int bucketNumber = 0; bucketNumber < max(readBucketCount, partitionBucketCount); bucketNumber++) {
+            // Physical bucket #. This determine file name. It also determines the order of splits in the result.
+            int partitionBucketNumber = bucketNumber % partitionBucketCount;
+            // Logical bucket #. Each logical bucket corresponds to a "bucket" from engine's perspective.
+            int readBucketNumber = bucketNumber % readBucketCount;
+
+            boolean containsIneligibleTableBucket = false;
+            List<Integer> eligibleTableBucketNumbers = new ArrayList<>();
+            for (int tableBucketNumber = bucketNumber % tableBucketCount; tableBucketNumber < tableBucketCount; tableBucketNumber += max(readBucketCount, partitionBucketCount)) {
+                // table bucket number: this is used for evaluating "$bucket" filters.
+                if (bucketSplitInfo.isTableBucketEnabled(tableBucketNumber)) {
+                    eligibleTableBucketNumbers.add(tableBucketNumber);
+                }
+                else {
+                    containsIneligibleTableBucket = true;
+                }
+            }
+
+            if (!eligibleTableBucketNumbers.isEmpty() && containsIneligibleTableBucket) {
+                throw new PrestoException(
+                        NOT_SUPPORTED,
+                        "The bucket filter cannot be satisfied. There are restrictions on the bucket filter when all the following is true: " +
+                                "1. a table has a different buckets count as at least one of its partitions that is read in this query; " +
+                                "2. the table has a different but compatible bucket number with another table in the query; " +
+                                "3. some buckets of the table is filtered out from the query, most likely using a filter on \"$bucket\". " +
+                                "(table name: " + table.getTableName() + ", table bucket count: " + tableBucketCount + ", " +
+                                "partition bucket count: " + partitionBucketCount + ", effective reading bucket count: " + readBucketCount + ")");
+            }
+            if (!eligibleTableBucketNumbers.isEmpty()) {
+                HiveFileInfo fileInfo = fileInfos.get(partitionBucketNumber);
+                eligibleTableBucketNumbers.stream()
+                        .map(tableBucketNumber -> splitFactory.createInternalHiveSplit(fileInfo, readBucketNumber, tableBucketNumber, splittable))
+                        .forEach(optionalSplit -> optionalSplit.ifPresent(splitList::add));
+            }
+        }
+        return splitList;
+    }
+
+    private List<InternalHiveSplit> getVirtuallyBucketedSplits(Path path, ExtendedFileSystem fileSystem, InternalHiveSplitFactory splitFactory, int bucketCount, boolean splittable, PathFilter pathFilter)
+    {
+        // List all files recursively in the partition and assign virtual bucket number to each of them
+        HiveDirectoryContext hiveDirectoryContext = new HiveDirectoryContext(recursiveDirWalkerEnabled ? RECURSE : IGNORED, isUseListDirectoryCache(session));
+        return stream(directoryLister.list(fileSystem, table, path, namenodeStats, pathFilter, hiveDirectoryContext))
+                .map(fileInfo -> {
+                    int virtualBucketNumber = getVirtualBucketNumber(bucketCount, fileInfo.getPath());
+                    return splitFactory.createInternalHiveSplit(fileInfo, virtualBucketNumber, virtualBucketNumber, splittable);
+                })
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .collect(toImmutableList());
+    }
+
+    private static List<Path> getTargetPathsFromSymlink(ExtendedFileSystem fileSystem, Path symlinkDir)
+    {
+        try {
+            FileStatus[] symlinks = fileSystem.listStatus(symlinkDir, HIDDEN_FILES_PATH_FILTER);
+            List<Path> targets = new ArrayList<>();
+
+            for (FileStatus symlink : symlinks) {
+                try (BufferedReader reader = new BufferedReader(new InputStreamReader(fileSystem.open(symlink.getPath()), StandardCharsets.UTF_8))) {
+                    CharStreams.readLines(reader).stream()
+                            .map(Path::new)
+                            .forEach(targets::add);
+                }
+            }
+            return targets;
+        }
+        catch (IOException e) {
+            throw new PrestoException(HIVE_BAD_DATA, "Error parsing symlinks from: " + symlinkDir, e);
+        }
+    }
+
+    public static class BucketSplitInfo
+    {
+        private final List<HiveColumnHandle> bucketColumns;
+        private final int tableBucketCount;
+        private final int readBucketCount;
+        private final IntPredicate bucketFilter;
+
+        public static Optional<BucketSplitInfo> createBucketSplitInfo(Optional<HiveBucketHandle> bucketHandle, Optional<HiveBucketing.HiveBucketFilter> bucketFilter)
+        {
+            requireNonNull(bucketHandle, "bucketHandle is null");
+            requireNonNull(bucketFilter, "buckets is null");
+
+            if (!bucketHandle.isPresent()) {
+                checkArgument(!bucketFilter.isPresent(), "bucketHandle must be present if bucketFilter is present");
+                return Optional.empty();
+            }
+
+            int tableBucketCount = bucketHandle.get().getTableBucketCount();
+            int readBucketCount = bucketHandle.get().getReadBucketCount();
+
+            List<HiveColumnHandle> bucketColumns = bucketHandle.get().getColumns();
+            IntPredicate predicate = bucketFilter
+                    .<IntPredicate>map(filter -> filter.getBucketsToKeep()::contains)
+                    .orElse(bucket -> true);
+            return Optional.of(new BucketSplitInfo(bucketColumns, tableBucketCount, readBucketCount, predicate));
+        }
+
+        private BucketSplitInfo(List<HiveColumnHandle> bucketColumns, int tableBucketCount, int readBucketCount, IntPredicate bucketFilter)
+        {
+            this.bucketColumns = ImmutableList.copyOf(requireNonNull(bucketColumns, "bucketColumns is null"));
+            this.tableBucketCount = tableBucketCount;
+            this.readBucketCount = readBucketCount;
+            this.bucketFilter = requireNonNull(bucketFilter, "bucketFilter is null");
+        }
+
+        public List<HiveColumnHandle> getBucketColumns()
+        {
+            return bucketColumns;
+        }
+
+        public int getTableBucketCount()
+        {
+            return tableBucketCount;
+        }
+
+        public int getReadBucketCount()
+        {
+            return readBucketCount;
+        }
+
+        public boolean isVirtuallyBucketed()
+        {
+            return bucketColumns.size() == 1 && bucketColumns.get(0).equals(pathColumnHandle());
+        }
+
+        /**
+         * Evaluates whether the provided table bucket number passes the bucket predicate.
+         * A bucket predicate can be present in two cases:
+         * <ul>
+         * <li>Filter on "$bucket" column. e.g. {@code "$bucket" between 0 and 100}
+         * <li>Single-value equality filter on all bucket columns. e.g. for a table with two bucketing columns,
+         * {@code bucketCol1 = 'a' AND bucketCol2 = 123}
+         * </ul>
+         */
+        public boolean isTableBucketEnabled(int tableBucketNumber)
+        {
+            return bucketFilter.test(tableBucketNumber);
+        }
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestBackgroundHiveSplitLoader.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestBackgroundHiveSplitLoader.java
@@ -67,7 +67,6 @@ import java.util.concurrent.TimeUnit;
 import static com.facebook.airlift.concurrent.Threads.daemonThreadsNamed;
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
-import static com.facebook.presto.hive.BackgroundHiveSplitLoader.BucketSplitInfo.createBucketSplitInfo;
 import static com.facebook.presto.hive.BucketFunctionType.HIVE_COMPATIBLE;
 import static com.facebook.presto.hive.CacheQuotaScope.GLOBAL;
 import static com.facebook.presto.hive.HiveSessionProperties.getMaxInitialSplitSize;
@@ -75,6 +74,7 @@ import static com.facebook.presto.hive.HiveTestUtils.SESSION;
 import static com.facebook.presto.hive.HiveType.HIVE_INT;
 import static com.facebook.presto.hive.HiveType.HIVE_STRING;
 import static com.facebook.presto.hive.HiveUtil.getRegularColumnHandles;
+import static com.facebook.presto.hive.StoragePartitionLoader.BucketSplitInfo.createBucketSplitInfo;
 import static com.facebook.presto.hive.metastore.PrestoTableType.MANAGED_TABLE;
 import static com.facebook.presto.spi.connector.NotPartitionedPartitionHandle.NOT_PARTITIONED;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -443,9 +443,9 @@ public class TestBackgroundHiveSplitLoader
     {
         ConnectorSession connectorSession = new TestingConnectorSession(
                 new HiveSessionProperties(
-                    new HiveClientConfig().setMaxSplitSize(new DataSize(1.0, GIGABYTE)),
-                    new OrcFileWriterConfig(),
-                    new ParquetFileWriterConfig()).getSessionProperties());
+                        new HiveClientConfig().setMaxSplitSize(new DataSize(1.0, GIGABYTE)),
+                        new OrcFileWriterConfig(),
+                        new ParquetFileWriterConfig()).getSessionProperties());
         return backgroundHiveSplitLoader(connectorSession, files, pathDomain, hiveBucketFilter, table, bucketHandle);
     }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
@@ -145,7 +145,8 @@ public class TestHiveClientConfig
                 .setMaxMetadataUpdaterThreads(100)
                 .setPartialAggregationPushdownEnabled(false)
                 .setPartialAggregationPushdownForVariableLengthDatatypesEnabled(false)
-                .setFileRenamingEnabled(false));
+                .setFileRenamingEnabled(false)
+                .setPreferManifestsToListFiles(false));
     }
 
     @Test
@@ -252,6 +253,7 @@ public class TestHiveClientConfig
                 .put("hive.partial_aggregation_pushdown_enabled", "true")
                 .put("hive.partial_aggregation_pushdown_for_variable_length_datatypes_enabled", "true")
                 .put("hive.file_renaming_enabled", "true")
+                .put("hive.prefer-manifests-to-list-files", "true")
                 .build();
 
         HiveClientConfig expected = new HiveClientConfig()
@@ -355,7 +357,8 @@ public class TestHiveClientConfig
                 .setMaxMetadataUpdaterThreads(1000)
                 .setPartialAggregationPushdownEnabled(true)
                 .setPartialAggregationPushdownForVariableLengthDatatypesEnabled(true)
-                .setFileRenamingEnabled(true);
+                .setFileRenamingEnabled(true)
+                .setPreferManifestsToListFiles(true);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
@@ -146,7 +146,8 @@ public class TestHiveClientConfig
                 .setPartialAggregationPushdownEnabled(false)
                 .setPartialAggregationPushdownForVariableLengthDatatypesEnabled(false)
                 .setFileRenamingEnabled(false)
-                .setPreferManifestsToListFiles(false));
+                .setPreferManifestsToListFiles(false)
+                .setManifestVerificationEnabled(false));
     }
 
     @Test
@@ -254,6 +255,7 @@ public class TestHiveClientConfig
                 .put("hive.partial_aggregation_pushdown_for_variable_length_datatypes_enabled", "true")
                 .put("hive.file_renaming_enabled", "true")
                 .put("hive.prefer-manifests-to-list-files", "true")
+                .put("hive.manifest-verification-enabled", "true")
                 .build();
 
         HiveClientConfig expected = new HiveClientConfig()
@@ -358,7 +360,8 @@ public class TestHiveClientConfig
                 .setPartialAggregationPushdownEnabled(true)
                 .setPartialAggregationPushdownForVariableLengthDatatypesEnabled(true)
                 .setFileRenamingEnabled(true)
-                .setPreferManifestsToListFiles(true);
+                .setPreferManifestsToListFiles(true)
+                .setManifestVerificationEnabled(true);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -100,6 +100,7 @@ import static com.facebook.presto.hive.HiveQueryRunner.createBucketedSession;
 import static com.facebook.presto.hive.HiveQueryRunner.createMaterializeExchangesSession;
 import static com.facebook.presto.hive.HiveQueryRunner.createQueryRunner;
 import static com.facebook.presto.hive.HiveSessionProperties.FILE_RENAMING_ENABLED;
+import static com.facebook.presto.hive.HiveSessionProperties.MANIFEST_VERIFICATION_ENABLED;
 import static com.facebook.presto.hive.HiveSessionProperties.PREFER_MANIFESTS_TO_LIST_FILES;
 import static com.facebook.presto.hive.HiveSessionProperties.PUSHDOWN_FILTER_ENABLED;
 import static com.facebook.presto.hive.HiveSessionProperties.RCFILE_OPTIMIZED_WRITER_ENABLED;
@@ -2401,6 +2402,7 @@ public class TestHiveIntegrationSmokeTest
                     Session.builder(getSession())
                             .setCatalogSessionProperty(catalog, FILE_RENAMING_ENABLED, "true")
                             .setCatalogSessionProperty(catalog, PREFER_MANIFESTS_TO_LIST_FILES, "true")
+                            .setCatalogSessionProperty(catalog, MANIFEST_VERIFICATION_ENABLED, "true")
                             .build(),
                     "SELECT orderkey, custkey, totalprice, orderdate FROM partitioned_ordering_table",
                     "SELECT orderkey, custkey, totalprice, orderdate FROM orders where orderstatus = 'O'");
@@ -2422,6 +2424,7 @@ public class TestHiveIntegrationSmokeTest
                     Session.builder(getSession())
                             .setCatalogSessionProperty(catalog, FILE_RENAMING_ENABLED, "true")
                             .setCatalogSessionProperty(catalog, PREFER_MANIFESTS_TO_LIST_FILES, "true")
+                            .setCatalogSessionProperty(catalog, MANIFEST_VERIFICATION_ENABLED, "true")
                             .build(),
                     "SELECT orderkey, custkey, totalprice, orderdate FROM partitioned_ordering_table",
                     "SELECT orderkey, custkey, totalprice, orderdate FROM orders where orderstatus = 'O' OR orderstatus = 'P'");
@@ -2450,6 +2453,7 @@ public class TestHiveIntegrationSmokeTest
                     Session.builder(getSession())
                             .setCatalogSessionProperty(catalog, FILE_RENAMING_ENABLED, "true")
                             .setCatalogSessionProperty(catalog, PREFER_MANIFESTS_TO_LIST_FILES, "true")
+                            .setCatalogSessionProperty(catalog, MANIFEST_VERIFICATION_ENABLED, "true")
                             .build(),
                     "SELECT orderkey, custkey, totalprice, orderdate FROM unpartitioned_ordering_table",
                     "SELECT orderkey, custkey, totalprice, orderdate FROM orders where orderstatus = 'O'");
@@ -2469,6 +2473,7 @@ public class TestHiveIntegrationSmokeTest
                     Session.builder(getSession())
                             .setCatalogSessionProperty(catalog, FILE_RENAMING_ENABLED, "true")
                             .setCatalogSessionProperty(catalog, PREFER_MANIFESTS_TO_LIST_FILES, "true")
+                            .setCatalogSessionProperty(catalog, MANIFEST_VERIFICATION_ENABLED, "true")
                             .build(),
                     "SELECT orderkey, custkey, totalprice, orderdate FROM unpartitioned_ordering_table",
                     "SELECT orderkey, custkey, totalprice, orderdate FROM orders where orderstatus = 'O' OR orderstatus = 'P'");


### PR DESCRIPTION
Get the filenames and filesizes from Metastore partition object and use them to create splits. 
This way we can avoid list directory call to underlying storage.

```
== NO RELEASE NOTE ==
```
