### PR TITLE
Remove never used variable in PluginManagrConfig

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/PluginManagerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PluginManagerConfig.java
@@ -27,7 +27,6 @@ public class PluginManagerConfig
 {
     private File installedPluginsDir = new File("plugin");
     private List<String> plugins;
-    private File pluginConfigurationDir = new File("etc/");
     private String mavenLocalRepository = ArtifactResolver.USER_LOCAL_REPO;
     private List<String> mavenRemoteRepository = ImmutableList.of(ArtifactResolver.MAVEN_CENTRAL_URI);
 


### PR DESCRIPTION
`pluginConfigurationDir ` is never used, so delete it

```
== NO RELEASE NOTE ==
```
