### PR TITLE
Reserve memory for nested BlockBuilders in projection

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/block/ArrayBlockBuilder.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/ArrayBlockBuilder.java
@@ -26,6 +26,7 @@ import static com.facebook.presto.common.block.ArrayBlock.createArrayBlockIntern
 import static com.facebook.presto.common.block.BlockUtil.calculateBlockResetSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.Math.max;
+import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class ArrayBlockBuilder
@@ -290,6 +291,14 @@ public class ArrayBlockBuilder
     {
         int newSize = calculateBlockResetSize(getPositionCount());
         return new ArrayBlockBuilder(blockBuilderStatus, values.newBlockBuilderLike(blockBuilderStatus), newSize);
+    }
+
+    @Override
+    public BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus, int expectedEntries)
+    {
+        int newSize = max(calculateBlockResetSize(positionCount), expectedEntries);
+        int valueExpectedEntries = positionCount == 0 ? expectedEntries : toIntExact((long) offsets[positionCount] * newSize / positionCount);
+        return new ArrayBlockBuilder(blockBuilderStatus, values.newBlockBuilderLike(blockBuilderStatus, valueExpectedEntries), newSize);
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/block/BlockBuilder.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/BlockBuilder.java
@@ -118,4 +118,9 @@ public interface BlockBuilder
      * Creates a new block builder of the same type based on the current usage statistics of this block builder.
      */
     BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus);
+
+    /**
+     * Creates a new block builder of the same type based on the expectedEntries and the current usage statistics of this block builder.
+     */
+    BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus, int expectedEntries);
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/block/ByteArrayBlockBuilder.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/ByteArrayBlockBuilder.java
@@ -114,6 +114,12 @@ public class ByteArrayBlockBuilder
         return new ByteArrayBlockBuilder(blockBuilderStatus, calculateBlockResetSize(positionCount));
     }
 
+    @Override
+    public BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus, int expectedEntries)
+    {
+        return new ByteArrayBlockBuilder(blockBuilderStatus, max(calculateBlockResetSize(positionCount), expectedEntries));
+    }
+
     private void growCapacity()
     {
         int newSize;

--- a/presto-common/src/main/java/com/facebook/presto/common/block/Int128ArrayBlockBuilder.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/Int128ArrayBlockBuilder.java
@@ -133,6 +133,12 @@ public class Int128ArrayBlockBuilder
         return new Int128ArrayBlockBuilder(blockBuilderStatus, calculateBlockResetSize(positionCount));
     }
 
+    @Override
+    public BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus, int expectedEntries)
+    {
+        return new Int128ArrayBlockBuilder(blockBuilderStatus, max(calculateBlockResetSize(positionCount), expectedEntries));
+    }
+
     private void growCapacity()
     {
         int newSize;

--- a/presto-common/src/main/java/com/facebook/presto/common/block/IntArrayBlockBuilder.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/IntArrayBlockBuilder.java
@@ -114,6 +114,12 @@ public class IntArrayBlockBuilder
         return new IntArrayBlockBuilder(blockBuilderStatus, calculateBlockResetSize(positionCount));
     }
 
+    @Override
+    public BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus, int expectedEntries)
+    {
+        return new IntArrayBlockBuilder(blockBuilderStatus, max(calculateBlockResetSize(positionCount), expectedEntries));
+    }
+
     private void growCapacity()
     {
         int newSize;

--- a/presto-common/src/main/java/com/facebook/presto/common/block/LongArrayBlockBuilder.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/LongArrayBlockBuilder.java
@@ -56,7 +56,6 @@ public class LongArrayBlockBuilder
     {
         this.blockBuilderStatus = blockBuilderStatus;
         this.initialEntryCount = max(expectedEntries, 1);
-
         updateDataSize();
     }
 
@@ -113,6 +112,12 @@ public class LongArrayBlockBuilder
     public BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus)
     {
         return new LongArrayBlockBuilder(blockBuilderStatus, calculateBlockResetSize(positionCount));
+    }
+
+    @Override
+    public BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus, int expectedEntries)
+    {
+        return new LongArrayBlockBuilder(blockBuilderStatus, max(calculateBlockResetSize(positionCount), expectedEntries));
     }
 
     private void growCapacity()

--- a/presto-common/src/main/java/com/facebook/presto/common/block/ShortArrayBlockBuilder.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/ShortArrayBlockBuilder.java
@@ -114,6 +114,12 @@ public class ShortArrayBlockBuilder
         return new ShortArrayBlockBuilder(blockBuilderStatus, calculateBlockResetSize(positionCount));
     }
 
+    @Override
+    public BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus, int expectedEntries)
+    {
+        return new ShortArrayBlockBuilder(blockBuilderStatus, max(calculateBlockResetSize(positionCount), expectedEntries));
+    }
+
     private void growCapacity()
     {
         int newSize;

--- a/presto-common/src/main/java/com/facebook/presto/common/block/SingleArrayBlockWriter.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/SingleArrayBlockWriter.java
@@ -168,6 +168,12 @@ public class SingleArrayBlockWriter
     }
 
     @Override
+    public BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus, int expectedEntries)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public String toString()
     {
         return format("SingleArrayBlockWriter{positionCount=%d}", getPositionCount());

--- a/presto-common/src/main/java/com/facebook/presto/common/block/SingleMapBlockWriter.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/SingleMapBlockWriter.java
@@ -250,6 +250,12 @@ public class SingleMapBlockWriter
     }
 
     @Override
+    public BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus, int expectedEntries)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public String toString()
     {
         return format("SingleMapBlockWriter{positionCount=%d}", getPositionCount());

--- a/presto-common/src/main/java/com/facebook/presto/common/block/SingleRowBlockWriter.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/SingleRowBlockWriter.java
@@ -230,6 +230,12 @@ public class SingleRowBlockWriter
     }
 
     @Override
+    public BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus, int expectedEntries)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public String toString()
     {
         if (!fieldBlockBuilderReturned) {

--- a/presto-common/src/main/java/com/facebook/presto/common/block/VariableWidthBlockBuilder.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/VariableWidthBlockBuilder.java
@@ -44,7 +44,9 @@ import static io.airlift.slice.SizeOf.SIZE_OF_INT;
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
 import static io.airlift.slice.SizeOf.SIZE_OF_SHORT;
 import static io.airlift.slice.SizeOf.sizeOf;
+import static java.lang.Math.max;
 import static java.lang.Math.min;
+import static java.lang.Math.toIntExact;
 
 public class VariableWidthBlockBuilder
         extends AbstractVariableWidthBlock
@@ -379,6 +381,16 @@ public class VariableWidthBlockBuilder
     {
         int currentSizeInBytes = positions == 0 ? positions : (getOffset(positions) - getOffset(0));
         return new VariableWidthBlockBuilder(blockBuilderStatus, calculateBlockResetSize(positions), calculateBlockResetBytes(currentSizeInBytes));
+    }
+
+    @Override
+    public BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus, int expectedEntries)
+    {
+        int newSize = max(calculateBlockResetSize(positions), expectedEntries);
+        int currentSizeInBytes = offsets[positions];
+        return new VariableWidthBlockBuilder(blockBuilderStatus,
+                newSize,
+                max(calculateBlockResetBytes(currentSizeInBytes), positions == 0 ? currentSizeInBytes : toIntExact((long) currentSizeInBytes * newSize / positions)));
     }
 
     private int getOffset(int position)

--- a/presto-main/src/main/java/com/facebook/presto/operator/project/GeneratedPageProjection.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/project/GeneratedPageProjection.java
@@ -17,7 +17,6 @@ import com.facebook.presto.common.Page;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockBuilder;
 import com.facebook.presto.common.function.SqlFunctionProperties;
-import com.facebook.presto.common.type.Type;
 import com.facebook.presto.operator.DriverYieldSignal;
 import com.facebook.presto.operator.Work;
 import com.facebook.presto.spi.relation.RowExpression;
@@ -37,7 +36,8 @@ public class GeneratedPageProjection
     private final boolean isDeterministic;
     private final InputChannels inputChannels;
     private final MethodHandle pageProjectionWorkFactory;
-    private List<Type> types;
+
+    private List<BlockBuilder> blockBuilders;
 
     public GeneratedPageProjection(List<RowExpression> projections, boolean isDeterministic, InputChannels inputChannels, MethodHandle pageProjectionWorkFactory)
     {
@@ -45,7 +45,7 @@ public class GeneratedPageProjection
         this.isDeterministic = isDeterministic;
         this.inputChannels = requireNonNull(inputChannels, "inputChannels is null");
         this.pageProjectionWorkFactory = requireNonNull(pageProjectionWorkFactory, "pageProjectionWorkFactory is null");
-        this.types = projections.stream().map(RowExpression::getType).collect(toImmutableList());
+        this.blockBuilders = projections.stream().map(RowExpression::getType).map(type -> type.createBlockBuilder(null, 1)).collect(toImmutableList());
     }
 
     @Override
@@ -63,9 +63,7 @@ public class GeneratedPageProjection
     @Override
     public Work<List<Block>> project(SqlFunctionProperties properties, DriverYieldSignal yieldSignal, Page page, SelectedPositions selectedPositions)
     {
-        List<BlockBuilder> blockBuilders = types.stream()
-                .map(type -> type.createBlockBuilder(null, selectedPositions.size()))
-                .collect(toImmutableList());
+        blockBuilders = blockBuilders.stream().map(blockBuilder -> blockBuilder.newBlockBuilderLike(null, selectedPositions.size())).collect(toImmutableList());
         try {
             return (Work<List<Block>>) pageProjectionWorkFactory.invoke(blockBuilders, properties, page, selectedPositions);
         }


### PR DESCRIPTION
In bf4bf6a610 "Reserve memory before projecting rows" we created the
    BlockBuilders new every time. However, nested BlockBuilders for complex
    types would lose the status from previously created BlockBuilders such
    that memory growth increased. For example, for an ARRAY(BIGINT)
    BlockBuilder, the nested LongArrayBlockBuilder would just have the same
    expectedEntries as the ArrayBlockBuilder although the entries in the
    LongArrayBlockBuilder could be a lot more.

This commit uses the newly introduced newBlockBuilderLike() method that
    estimates the expectedEntries for nested BlockBuilders from previously
    created BlockBuilders. The following simple ArrayTransform query shows
    the allocated long[] reduced from 118GB to 93GB on TPCH 100GB.

```
    select transform(l_array, x-> x+1) from lineitem_map_array;
```

```
== NO RELEASE NOTE ==
```
