### PR TITLE
Fix druid reading issue

### DIFF
--- a/presto-druid/src/main/java/com/facebook/presto/druid/DruidBrokerPageSource.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/DruidBrokerPageSource.java
@@ -28,8 +28,6 @@ import com.facebook.presto.spi.ConnectorPageSource;
 import com.facebook.presto.spi.PrestoException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
@@ -123,17 +121,10 @@ public class DruidBrokerPageSource
                 }
                 else {
                     JsonNode rootNode = OBJECT_MAPPER.readTree(readLine);
-                    if (!(rootNode instanceof ArrayNode)) {
-                        if (rootNode instanceof ObjectNode) {
-                            throw new PrestoException(DRUID_BROKER_RESULT_ERROR, ((ObjectNode) rootNode).findValue("errorMessage").asText());
-                        }
-                        throw new PrestoException(DRUID_BROKER_RESULT_ERROR, rootNode.toString());
-                    }
-                    ArrayNode arrayNode = (ArrayNode) rootNode;
                     for (int i = 0; i < columnHandles.size(); i++) {
                         Type type = columnTypes.get(i);
                         BlockBuilder blockBuilder = pageBuilder.getBlockBuilder(i);
-                        JsonNode value = arrayNode.get(i);
+                        JsonNode value = rootNode.get(((DruidColumnHandle) columnHandles.get(i)).getColumnName());
                         if (value == null) {
                             blockBuilder.appendNull();
                             continue;

--- a/presto-druid/src/main/java/com/facebook/presto/druid/DruidBrokerPageSource.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/DruidBrokerPageSource.java
@@ -60,7 +60,6 @@ public class DruidBrokerPageSource
     private BufferedReader responseStream;
     private final PageBuilder pageBuilder;
     private List<Type> columnTypes;
-    private boolean columnHandlesHasErrorMessageField;
 
     public DruidBrokerPageSource(
             GeneratedDql brokerDql,
@@ -78,8 +77,6 @@ public class DruidBrokerPageSource
                 .map(DruidColumnHandle::getColumnType)
                 .collect(toImmutableList());
         this.pageBuilder = new PageBuilder(this.columnTypes);
-        this.columnHandlesHasErrorMessageField = columnHandles.stream().anyMatch(
-                handle -> ((DruidColumnHandle)handle).getColumnName().equals("errorMessage"));
     }
 
     @Override
@@ -114,6 +111,8 @@ public class DruidBrokerPageSource
         }
 
         long start = System.nanoTime();
+        boolean columnHandlesHasErrorMessageField = columnHandles.stream().anyMatch(
+                handle -> ((DruidColumnHandle) handle).getColumnName().equals("errorMessage"));
         try {
             String readLine;
             while ((readLine = responseStream.readLine()) != null) {

--- a/presto-druid/src/main/java/com/facebook/presto/druid/DruidClient.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/DruidClient.java
@@ -46,8 +46,8 @@ import static com.facebook.airlift.http.client.StaticBodyGenerator.createStaticB
 import static com.facebook.airlift.json.JsonCodec.jsonCodec;
 import static com.facebook.airlift.json.JsonCodec.listJsonCodec;
 import static com.facebook.presto.druid.DruidErrorCode.DRUID_BROKER_RESULT_ERROR;
-import static com.facebook.presto.druid.DruidResultFormat.ARRAY_LINES;
 import static com.facebook.presto.druid.DruidResultFormat.OBJECT;
+import static com.facebook.presto.druid.DruidResultFormat.OBJECT_LINES;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
 import static com.google.common.net.MediaType.JSON_UTF_8;
@@ -169,7 +169,7 @@ public class DruidClient
 
         return setContentTypeHeaders(preparePost())
                 .setUri(uriBuilder.build())
-                .setBodyGenerator(createStaticBodyGenerator(createRequestBody(query, ARRAY_LINES, false)))
+                .setBodyGenerator(createStaticBodyGenerator(createRequestBody(query, OBJECT_LINES, false)))
                 .build();
     }
 


### PR DESCRIPTION
This PR solves the problem of reading from druid caused by using the ARRAY_LINES result format. When applying any unsupported transformation(expression) to one of the selected columns and filtering on other columns, this will cause the dql to be build and sent to druid with all the columns in select and filter statements, leading to a larger number of columns returned to be processed, hence, parsing the wrong column if we are depending on the column indices (since columnHandles size differ from the returned data array size).

Test plan:
Applying the following query on wikipedia test dataset provided by druid, before and after the change:
```
select if(cityname = '', 'hi', cityname), count
from druid.wikipedia
where __time > timestamp '2016-06-27 13:00:00';
```

```
== RELEASE NOTES ==

Druid Changes
* Fix druid reading issue
```
