### PR TITLE
Fix access control checks for USING clause

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/AggregationAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/AggregationAnalyzer.java
@@ -63,11 +63,12 @@ import com.facebook.presto.sql.tree.WhenClause;
 import com.facebook.presto.sql.tree.Window;
 import com.facebook.presto.sql.tree.WindowFrame;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Multimap;
 
 import javax.annotation.Nullable;
 
+import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -75,6 +76,7 @@ import java.util.Set;
 import static com.facebook.presto.spi.StandardWarningCode.PERFORMANCE_WARNING;
 import static com.facebook.presto.spi.function.FunctionKind.AGGREGATE;
 import static com.facebook.presto.sql.NodeUtils.getSortItemsFromOrderBy;
+import static com.facebook.presto.sql.analyzer.ExpressionTreeUtils.checkAndGetColumnReferenceField;
 import static com.facebook.presto.sql.analyzer.ExpressionTreeUtils.extractAggregateFunctions;
 import static com.facebook.presto.sql.analyzer.ExpressionTreeUtils.extractWindowFunctions;
 import static com.facebook.presto.sql.analyzer.FreeLambdaReferenceExtractor.hasFreeReferencesToLambdaArgument;
@@ -103,7 +105,7 @@ class AggregationAnalyzer
     // fields and expressions in the group by clause
     private final Set<FieldId> groupingFields;
     private final List<Expression> expressions;
-    private final Map<NodeRef<Expression>, FieldId> columnReferences;
+    private final Multimap<NodeRef<Expression>, FieldId> columnReferences;
 
     private final Metadata metadata;
     private final Analysis analysis;
@@ -163,6 +165,7 @@ class AggregationAnalyzer
                 .map(NodeRef::of)
                 .filter(columnReferences::containsKey)
                 .map(columnReferences::get)
+                .flatMap(Collection::stream)
                 .collect(toImmutableSet());
 
         this.groupingFields.forEach(fieldId -> {
@@ -360,9 +363,11 @@ class AggregationAnalyzer
                                     .map(NodeRef::of)
                                     .map(columnReferences::get)
                                     .filter(Objects::nonNull)
+                                    .flatMap(Collection::stream)
                                     .collect(toImmutableList());
                             for (Expression sortKey : sortKeys) {
-                                if (!node.getArguments().contains(sortKey) && !fieldIds.contains(columnReferences.get(NodeRef.of(sortKey)))) {
+                                if (!node.getArguments().contains(sortKey)
+                                        && !(columnReferences.containsKey(NodeRef.of(sortKey)) && fieldIds.containsAll(columnReferences.get(NodeRef.of(sortKey))))) {
                                     throw new SemanticException(
                                             ORDER_BY_MUST_BE_IN_AGGREGATE,
                                             sortKey,
@@ -499,8 +504,7 @@ class AggregationAnalyzer
 
         private boolean isGroupingKey(Expression node)
         {
-            FieldId fieldId = columnReferences.get(NodeRef.of(node));
-            requireNonNull(fieldId, () -> "No FieldId for " + node);
+            FieldId fieldId = checkAndGetColumnReferenceField(node, columnReferences);
 
             if (orderByScope.isPresent() && isFieldFromScope(fieldId, orderByScope.get())) {
                 return true;
@@ -516,7 +520,7 @@ class AggregationAnalyzer
                 return true;
             }
 
-            FieldId fieldId = requireNonNull(columnReferences.get(NodeRef.<Expression>of(node)), "No FieldId for FieldReference");
+            FieldId fieldId = checkAndGetColumnReferenceField(node, columnReferences);
             boolean inGroup = groupingFields.contains(fieldId);
             if (!inGroup) {
                 Field field = sourceScope.getRelationType().getFieldByIndex(node.getFieldIndex());

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionTreeUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionTreeUtils.java
@@ -27,6 +27,7 @@ import com.facebook.presto.sql.tree.Node;
 import com.facebook.presto.sql.tree.NodeRef;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Multimap;
 
 import java.util.List;
 import java.util.Map;
@@ -36,6 +37,7 @@ import java.util.function.Predicate;
 import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.spi.function.FunctionKind.AGGREGATE;
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Predicates.alwaysTrue;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.slice.Slices.utf8Slice;
@@ -168,5 +170,13 @@ public final class ExpressionTreeUtils
         checkArgument(enumType.getEnumMap().containsKey(enumKey), format("No key '%s' in enum '%s'", enumKey, nodeType.getDisplayName()));
         Object enumValue = enumType.getEnumMap().get(enumKey);
         return enumValue instanceof String ? Optional.of(utf8Slice((String) enumValue)) : Optional.of(enumValue);
+    }
+
+    public static FieldId checkAndGetColumnReferenceField(Expression expression, Multimap<NodeRef<Expression>, FieldId> columnReferences)
+    {
+        checkState(columnReferences.containsKey(NodeRef.of(expression)), "Missing field reference for expression");
+        checkState(columnReferences.get(NodeRef.of(expression)).size() == 1, "Multiple field references for expression");
+
+        return columnReferences.get(NodeRef.of(expression)).iterator().next();
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestUtilizedColumnsAnalyzer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestUtilizedColumnsAnalyzer.java
@@ -120,9 +120,9 @@ public class TestUtilizedColumnsAnalyzer
         assertUtilizedTableColumns("SELECT w FROM (SELECT * FROM t1 LEFT JOIN t2 ON t1.a = t2.a AND t1.b = t2.b) AS t(u, v, w, x, y, z)",
                 ImmutableMap.of(QualifiedObjectName.valueOf("tpch.s1.t1"), ImmutableSet.of("a", "b", "c"), QualifiedObjectName.valueOf("tpch.s1.t2"), ImmutableSet.of("a", "b")));
 
-        // TODO: Columns in join criteria with USING should be checked
-        //assertUtilizedTableColumns("SELECT t1.c FROM t1 JOIN t2 USING (a, b)",
-        //        ImmutableMap.of(QualifiedObjectName.valueOf("tpch.s1.t1"), ImmutableSet.of("a", "b", "c"), QualifiedObjectName.valueOf("tpch.s1.t2"), ImmutableSet.of("a", "b")));
+        // Join with USING clause
+        assertUtilizedTableColumns("SELECT t1.c FROM t1 JOIN t2 USING (a, b)",
+                ImmutableMap.of(QualifiedObjectName.valueOf("tpch.s1.t1"), ImmutableSet.of("a", "b", "c"), QualifiedObjectName.valueOf("tpch.s1.t2"), ImmutableSet.of("a", "b")));
     }
 
     @Test

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -4600,6 +4600,8 @@ public abstract class AbstractTestQueries
         assertAccessAllowed("SELECT name AS my_alias FROM nation", privilege("my_alias", SELECT_COLUMN));
         assertAccessAllowed("SELECT my_alias from (SELECT name AS my_alias FROM nation)", privilege("my_alias", SELECT_COLUMN));
         assertAccessDenied("SELECT name AS my_alias FROM nation", "Cannot select from columns \\[name\\] in table .*.nation.*", privilege("name", SELECT_COLUMN));
+        assertAccessDenied("SELECT nation.name FROM nation JOIN region USING (regionkey)", "Cannot select from columns \\[regionkey, name\\] in table .*", privilege("regionkey", SELECT_COLUMN));
+        assertAccessDenied("SELECT array_agg(regionkey ORDER BY regionkey) FROM nation JOIN region USING (regionkey)", "Cannot select from columns \\[regionkey\\] in table .*", privilege("regionkey", SELECT_COLUMN));
     }
 
     @Test


### PR DESCRIPTION
This change fixes a bug where columns referenced in the USING clause of
a join were not checked for column access permissions. Since an
identifier in a USING clause refers to multiple columns, the
``columnReferences`` field in Analysis is changed to a Multimap.

Test plan - 
Added unit tests 

```
== NO RELEASE NOTE ==
```
