### PR TITLE
Add release notes for 0.243

### DIFF
--- a/presto-docs/src/main/sphinx/release.rst
+++ b/presto-docs/src/main/sphinx/release.rst
@@ -5,6 +5,7 @@ Release Notes
 .. toctree::
     :maxdepth: 1
 
+    release/release-0.243
     release/release-0.242
     release/release-0.241
     release/release-0.240

--- a/presto-docs/src/main/sphinx/release/release-0.243.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.243.rst
@@ -1,0 +1,50 @@
+=============
+Release 0.243
+=============
+
+**Highlights**
+==============
+* Add :func:`approx_most_frequent` aggregation function.
+* Add support to :func:`truncate` function for specifying the number of digits to the right of the decimal point in the truncated result.
+* Add support for ignoring access checks on columns that are referenced in the query, but are not required to compute the query results. This can be enabled with the ``check_access_control_on_utilized_columns_only`` session property.
+* Add support in verifier to verify ``CREATE VIEW`` and ``CREATE TABLE`` queries.
+
+**Details**
+===========
+
+General Changes
+_______________
+* Fix query failure when using ``EXPLAIN`` with a ``USE`` statement.
+* Add :func:`approx_most_frequent` aggregation function.
+* Add support to :func:`truncate` function for specifying the number of digits to the right of the decimal point in the truncated result.
+* Remove configuration property ``optimizer.optimize-full-outer-join-with-coalesce`` and the corresponding session property ``optimize_full_outer_join_with_coalesce``. The feature will always be enabled.
+* Remove deprecated configuration properties ``grouped-execution-for-aggregation-enabled`` and ``grouped-execution-for-join-enabled`` and their corresponding session properties ``grouped_execution_for_aggregation`` and ``grouped_execution_for_join``.  These have been replaced by a single configuration property ``grouped-execution-enabled`` and session property ``grouped_execution``.
+* Remove deprecated configuration property ``dynamic-schedule-for-grouped-execution`` and session property ``dynamic_schedule_for_grouped_execution``.
+
+Security Changes
+________________
+* Add support for ignoring access checks on columns that are referenced in the query, but are not required to compute the query results. This can be enabled with the ``check_access_control_on_utilized_columns_only`` session property.
+
+Geospatial Changes
+__________________
+* Add support to allow geometries outside of the spatial partitioning to match in a partitioned spatial join.
+
+Hive Changes
+____________
+* Improve metadata query optimizer.
+* Add support for Parquet file metadata caching.
+
+Pinot Changes
+_____________
+* Add support for pushing down aggregation function ``approx_distinct(x, e)``.
+* Add support for pushing down array functions ``array_sum``, ``array_min``, ``array_max``, ``array_average`` and ``contains``.
+
+Verifier Changes
+________________
+* Add support for removing explicitly set broadcast memory limits.
+* Add support to verify ``CREATE VIEW`` and ``CREATE TABLE`` queries.
+
+**Contributors**
+================
+
+Ajay George, Andrii Rosa, Ariel Weisberg, Ashish Tadose, Bin Fan, Daniel Ohayon, George Wang, James A. Gill, James Sun, Ke, Leiqing Cai, Maria Basmanova, Mayank Garg, Nikhil Collooru, Rebecca Schlussel, Rongrong Zhong, Shixuan Fan, Timothy Meehan, Vivek, Wenlei Xie, Xiang Fu, Ying Su, Zhenxiao Luo, Zhenyuan Zhao, ankit0811, leonpanokarren, prithvip


### PR DESCRIPTION
# Missing Release Notes
## Daniel Ohayon
- [x] https://github.com/prestodb/presto/pull/15302 Allow qualified names in types (Merged by: Rongrong Zhong)

## George Wang
- [x] https://github.com/prestodb/presto/pull/14783 Fix #14693: support TRUNCATE function for DOUBLE and REAL (Merged by: Rongrong Zhong)

## Ke
- [x] https://github.com/prestodb/presto/pull/15289 Revert "GC issue fixes in SliceDictionarySelectiveReader" (Merged by: Leiqing Cai)

## ankit0811
- [x] https://github.com/prestodb/presto/pull/15216 Adding approxMostFrequent aggregate from prestoSQL (Merged by: Rongrong Zhong)

# Extracted Release Notes
- #14485 (Author: James A. Gill): Fix partitioned spatial joins with small spatial index
  - Allow geometries outside of the spatial partitioning to match in a partitioned spatial join.
- #15195 (Author: Leiqing Cai): Support CREATE VIEW and CREATE TABLE verification
  - Add support to verify ``CREATE VIEW`` and ``CREATE TABLE`` queries.
- #15227 (Author: Shixuan Fan): Optimize MetadataQueryOptimizer with filter pushdown enabled
  - Optimize metadata query optimizer so that it does not fetch all partitions from metastore when hive filter pushdown is enabled.
- #15231 (Author: Xiang Fu): Support pushdown approx_distinct(x, e) into pinot
  - Support pushing down aggregation function `approx_distinct(x, e)` to Pinot connector.
- #15260 (Author: Xiang Fu): Adding array functions pushdown to pinot
  - Support pushing down array functions `array_sum`, `array_min`, `array_max`, `array_average`, and `contains` to Pinot connector.
- #15269 (Author: prithvip): Add option to do more precise ACL checks
  - Add session property ``check_access_control_on_utilized_columns_only``, which, when enabled, only performs access control checks on columns that would actually be required to produce the query output, ignoring columns that are referenced in the query, but are not required to compute the query results.
- #15271 (Author: Rongrong Zhong): Remove unnecessary config and session property
  - Remove config property `optimizer.optimize-full-outer-join-with-coalesce` and the corresponding session property `optimize_full_outer_join_with_coalesce`. The feature will always be enabled.
- #15276 (Author: Vivek): Add local cache for Parquet Metadata
  - Add caching module for Parquet metadata.
- #15281 (Author: Ariel Weisberg): Ignore broadcast memory limit in verifier
  - Improve verifier handling of broadcast memory limit by removing it if it is set via session property to avoid CBO broadcast induced failures on smaller verifier clusters.
- #15293 (Author: Leiqing Cai): Support formatting Use statement
  - Fix query failure when explaining ``Use`` statement.
- #15305 (Author: Rongrong Zhong): Add session property remote_functions_enabled
  - Add session property ``remote_functions_enabled`` to configure whether remote functions are allowed.
- #15317 (Author: Rebecca Schlussel): Remove deprecated grouped execution properties
  - Remove deprecated configuration properties ``grouped-execution-for-aggregation-enabled`` and ``grouped-execution-for-join-enabled`` and their corresponding session properties ``grouped_execution_for_aggregation`` and ``grouped_execution_for_join``.  These have been replaced by a single configuration property ``grouped-execution-enabled`` and session property ``grouped-execution``.
  - Remove deprecated configuration property ``dynamic-schedule-for-grouped-execution`` and session property ``dynamic_schedule_for_grouped_execution``.  No replacement is needed.

# All Commits
- d5773063bb5fda35bcd974ef1ac73fff6fbca9a8 Move PageDataOutput to presto-spi (Wenlei Xie)
- d879d7f5e3eb9621ac8ca133ed9132a2de4a4cfd Move DataSink/DataOutput to presto-common (Wenlei Xie)
- bef17e674ead757b28a1042a5d7b909d2274548d Add option to do more precise ACL checks (prithvip)
- 4479fb8749ea913a12361de5d012785659a27ce5 Remove deprecated grouped execution properties (Rebecca Schlussel)
- 061f432fd3f4f1bc2f5b79687909d98f569a5151 Allow qualified names in types parsing (Daniel Ohayon)
- 4fdfb89574b0e9d82b71e28cda5887de83c30028 Add sealedPartition flag to HivePartition (Nikhil Collooru)
- 029ae8d9962fffcbc793e46c10ed6481d27a19b0 Add a test for adding a new column (Mayank Garg)
- 84ade36f51c10c449f62aa840426fa798d4c078d Refactor ParquetPageSource (Zhenxiao Luo)
- 2e0c44f9a2438909dcf8d1e1e845d83902880408 Add scale_tdigest function (leonpanokarren)
- d3bd4ec0840c349ec91f938244e468824f595ab6 Bug fixes for file_renaming feature (Nikhil Collooru)
- 7a122bb50b63426c64551a02a3ce62e082e4f023 Handle cases when flat map doesn't have dummy encoding for sequence 0 (Zhenyuan Zhao)
- ee74e4bdcdb13ef0414506dccee058d4f1e2bbc9 Use getApproximateLogicalSizeInBytes() in PageProcessor (Ying Su)
- 7bffeb531fdab7a1982130f4bc74ea61c2bae4c1 Add getApproximateRegionLogicalSizeInBytes() to Block (Ying Su)
- 465644ca69ea57f76fc5b8f5b7e312c6800c0716 Create DictionaryBlock for identity projections (Ying Su)
- 57a1b204f542344f1607e478744100fa78dd1138 Update drift-api module's scope to provided (Ajay George)
- 118b48a2c95eef21e0051a2a28443b19453119cf Add thrift serde support for TaskStatus (Ajay George)
- 213660bceff1f5f1b16c89a71406b7c9d6538d5b Add local cache for Parquet Metadata (Vivek)
- f2965f681745b4054d2c62134f828cb9ffaec609 Add support for TRUNCATE function for DOUBLE and REAL (George Wang)
- 4631b6d104b810b5dbe7400bb0a0bd4c6cfd4667 Add session property remote_functions_enabled (Rongrong Zhong)
- 321c8b633d98220753564bce48cf5c5eed222633 Adding approxMostFrequent aggregate from prestoSQL (ankit0811)
- f1fb2e045232df0ac9f4f89ce1e699855bc9e4d1 Remove setFunctionAndTypeManager from TypeRegistry (Rongrong Zhong)
- ac735dbd270d3ef435102f2061818b92dcd9090e Use FunctionAndTypeManager instead of TypeRegistry (Rongrong Zhong)
- 7fffbd80b8ca42bb0e6c8381d1edfd066825f9da Remove TypeManager from BuiltInFunctionNamespaceManager (Rongrong Zhong)
- ca07a42e351af0863b8b29d7b397d86baf2b9328 Remove TypeManager from APIs when FunctionAndTypeManager is available (Rongrong Zhong)
- 63af9357ae7e1aaf951d7da01833a2427ab262a7 Change FunctionManager to FunctionAndTypeManager (Rongrong Zhong)
- 4720be3b94b1c8d97d83d98895934c5705cb09a3 Allow PrestoS3FileSystem and GlueHiveMetastore to assume an aws role (Ashish Tadose)
- 8cbf330cda791a86dfe3c219b5a89b976b152b34 Allow PrestoS3FileSystem and GlueHiveMetastore to assume an aws role (Ashish Tadose)
- 3ec373e05c77079dc000865bf82dc5720418779f bump aws-sdk to 1.11.697 (Ashish Tadose)
- ac60c7560103ce0a08acf3bdbfbe77c2bbf7e391 Support formatting Use statement (Leiqing Cai)
- ce96d881e74b3bb98c142e0c1c255d83769a3979 Fix a potential NPE by allowing nulllable cache base directory (Bin Fan)
- 4de1f4d1a6c34aafa7d6fe0b6197d0e7c3e9364a Optimize MetadataQueryOptimizer with filter pushdown enabled (Shixuan Fan)
- 05f387555515cf7fedfa2f9b723f40dea4095706 Fix ValuesMatcher (Shixuan Fan)
- 8ab725f37277ae91e7218d156ba8158778e86704 Revert "Defer the creation of dictionary in SliceDictionarySelectiveReader" (Ke)
- 460a4d064bc9ac547e938a98267f651b7e0dd638 Revert "Remove stripeDictionaryData buffer in SliceDictionarySelectiveReader" (Ke)
- a8825abcfd380f3a948e3a43c1544aa169ea1e8a Revert "Introduce large dictionary mode in SliceDictionarySelectiveReader" (Ke)
- 83e4afc56e97764a276dc69e8789d53731425676 Add a new deployment example (Bin Fan)
- 03fb2f6a992d244ed867b27086caf8ea64a025f0 Ignore broadcast memory limit in verifier (Ariel Weisberg)
- 9870fb8319b38b609239015f123b20eaff209a0c Rename PartitionVersionFetcher to PartitionMutator (James Sun)
- 55508dfadb0cb4bd7b5d83563befdf4c9926976b Remove unnecessary config and session property (Rongrong Zhong)
- 63565a9381adf51422d083a64e2602bed11f733f Improve spatial join tests (James A. Gill)
- 4cd357c4b97e9eda45929d035387a37f1ac3edad Assign partition index to geometries outside of KdbTree (James A. Gill)
- 89c399680986651d38b4d325d561131abe7f8e1f Add eligibleToIgnore flag to Hive partitions (James Sun)
- ca06ed5756b56c7c43cdf898e6944c6877618e61 Allow partial filter failures in BenchmarkPageProcessor (Ying Su)
- c0455e93f2a8e79fe0ff2398942e4d37f85cba69 Add identity projection to BenchmarkPageProcessor (Ying Su)
- 883e88322b229b01a790c12a37fd2ee2ab51b26e Support CREATE TABLE verification (Leiqing Cai)
- a50fb09da6a576d8c2e17d9401d8c9b625a2d966 Support CREATE VIEW verification (Leiqing Cai)
- 2f6965dbfa4c67772339a56becc606f42667408e Fix injection error when failure resolvers are disabled (Leiqing Cai)
- facde22ff8c2b6958ecdf7e983c973fc2dec2f11 Rename DataQueryBundle to QueryObjectBundle (Leiqing Cai)
- a81016cb84fde647f91ce6ecf88a20c6a05050b3 Remove unsupported query types (Leiqing Cai)
- 79a8c8f5d30878e60e1baca06d5e1f4e7c457ec5 Enforce broadcast memory limits in Presto on Spark (Andrii Rosa)
- 13a8f649f87c4fc26cda51ba356b6cdcc55c72d4 Compress broadcast pages in Presto on Spark to save memory (Andrii Rosa)
- d87cee599ed7cc3682bc9be26ad7eac1f697d961 Make sure PagesSerde is not used in a non thread safe manner (Andrii Rosa)
- 322321d2cb7e07c93908c0f854d3e33d8a06ed7e Revert "Enable nullifying iterator for broadcast join" (Andrii Rosa)
- 299f751df9e8858b7621a599c1748d89c137acab Support for CSV format in hive (Ashish Tadose)
- 9f4203ed016f0e1df551aeb5fd8b880023bcd492 Support pushdown approx_distinct(x, e) into pinot (Xiang Fu)
- 5c29aa2d06d2c9e2634b56611355226a7bc5b881 Adding array functions pushdown to pinot (Xiang Fu)
- a93082917f2a62a8fd525b733ba9a849ef649180 Add unit tests on async cache restore (Bin Fan)
- 6ff3052e9df1a04613157746e7e779fd54c0c2a1 Add BIGINT benchmark for projection (Ying Su)
- 3a44824409b8f66fe5b8081573e0401b4cd14c90 Add GCProfilter to BenchmarkPageProcessor (Ying Su)
- 186ee27aa9e7667c140925351e18f950410f9610 Add verify methods for BenchmarkPageProcessor (Ying Su)
- 632c403a9e33816533739b884b4f045109bd4b78 Allow 100% filter pass rate in BenchmarkPageProcessor (Ying Su)
- 1d3ef17c190ff928a3beb7cbb1e89cbe7c866cb0 Move data preparation to BenchmarkData for BenchmarkPageProcessor (Ying Su)