### PR TITLE
Change warning to ignore unreadable partitions to be a digest

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientFileMetastore.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientFileMetastore.java
@@ -55,6 +55,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static org.apache.hadoop.hive.common.FileUtils.makePartName;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 public class TestHiveClientFileMetastore
@@ -152,6 +153,8 @@ public class TestHiveClientFileMetastore
                 splitManager.getSplits(transaction.getTransactionHandle(), session, tableLayout.getHandle(), SPLIT_SCHEDULING_CONTEXT);
                 assertNotNull(SPLIT_SCHEDULING_CONTEXT.getWarningCollector());
                 assertEquals(SPLIT_SCHEDULING_CONTEXT.getWarningCollector().getWarnings().size(), 1);
+                assertTrue(SPLIT_SCHEDULING_CONTEXT.getWarningCollector().getWarnings().get(0).getMessage().contains("has 1 out of 3 partitions unreadable: ds=2020-01-03... are due to Testing Unreadable Partition. "));
+                assertEquals(SPLIT_SCHEDULING_CONTEXT.getWarningCollector().getWarnings().get(0).getWarningCode().getName(), "PARTITION_NOT_READABLE");
             }
         }
         catch (Exception e) {


### PR DESCRIPTION
This PR is for issue [#15285](https://github.com/prestodb/presto/issues/15285)

HiveSplitManager creates a PrestoWarning for each unreadable partition within a partitionBatch:

```
Table <table name> partition <partition name> is not readable: <reason>
Table <table name> partition <partition name> is not readable: <reason>
Table <table name> partition <partition name> is not readable: <reason>
```
This is excessive and can result in memory/readability issues for a large number of unreadable partitions. With the changes in this PR,
1 PrestoWarning is added to the warningCollector for each partitionBatch. The warning message for the PrestoWarning follows this general format:

```
Table <table name> has <number of unreadable partitions> out of <total partitions> partitions unreadable: 
<reason_a>: <partition name> <partition name>  <"..." if more than 2 unreadable partitions have this error>
<reason_b>: <partition name> <partition name>  <"..." if more than 2 unreadable partitions have this error>
<"..." if more than 2 types of errors>
```
A partition can be unreadable for more than one reason (**in theory**). If there is only 1 reason, a maximum of 2 partitions will be displayed, and if there are 2 reasons, a maximum of 4 partitions will be displayed. If there are more than 2 partitions that are unreadable for the same reason, `<partition name> <partition name> ...`

**In practice**, the PrestoWarning message will likely follow:
```
Table <table name> has <number of unreadable partitions> out of <total partitions> partitions unreadable: 
<reason>: <partition name> <partition name> ...
```
(I think..)

Other changes: Strings partName and partitionNotReadable changed to partitionName and reason to be more descriptive. MetastoreUtil.makePartName() should also be modified. Tests added in TestHiveClientFileMetastore to validate the new format of the PrestoWarning message.
