### PR TITLE
Catch all possible failures for Presto-on-Spark

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
@@ -332,7 +332,7 @@ public class PrestoSparkQueryExecutionFactory
                     queryStatusInfoOutputPath,
                     queryDataOutputPath);
         }
-        catch (RuntimeException executionFailure) {
+        catch (Throwable executionFailure) {
             queryStateTimer.beginFinishing();
             try {
                 rollback(session, transactionManager);
@@ -738,7 +738,7 @@ public class PrestoSparkQueryExecutionFactory
                 commit(session, transactionManager);
                 queryStateTimer.endQuery();
             }
-            catch (Exception executionException) {
+            catch (Throwable executionException) {
                 queryStateTimer.beginFinishing();
                 try {
                     rollback(session, transactionManager);


### PR DESCRIPTION
The goal is to let all failed queries have query completion events logged.

```
== NO RELEASE NOTE ==
```
