### PR TITLE
Fix bug where MemoryRevokingSchedulers stopped being installed

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -318,11 +318,11 @@ public class ServerMainModule
         binder.bind(TaskManager.class).to(Key.get(SqlTaskManager.class));
 
         // memory revoking scheduler
-        installModuleIf(
+        install(installModuleIf(
                 FeaturesConfig.class,
                 config -> config.getTaskSpillingStrategy() == PER_TASK_MEMORY_THRESHOLD,
                 moduleBinder -> moduleBinder.bind(TaskThresholdMemoryRevokingScheduler.class).in(Scopes.SINGLETON),
-                moduleBinder -> moduleBinder.bind(MemoryRevokingScheduler.class).in(Scopes.SINGLETON));
+                moduleBinder -> moduleBinder.bind(MemoryRevokingScheduler.class).in(Scopes.SINGLETON)));
 
         // Add monitoring for JVM pauses
         binder.bind(PauseMeter.class).in(Scopes.SINGLETON);


### PR DESCRIPTION
Test plan - None, fixed bug that prevented spilling schedulers from being bound.

```
== NO RELEASE NOTE ==
```
