### PR TITLE
Bump Alluxio client version to 2.3.0-2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <dep.nexus-staging-plugin.version>1.6.8</dep.nexus-staging-plugin.version>
         <dep.asm.version>6.2.1</dep.asm.version>
         <dep.gcs.version>1.9.17</dep.gcs.version>
-        <dep.alluxio.version>2.3.0-1</dep.alluxio.version>
+        <dep.alluxio.version>2.3.0-2</dep.alluxio.version>
         <dep.kafka.version>2.3.1</dep.kafka.version>
         <dep.druid.version>0.19.0</dep.druid.version>
         <dep.jaxb.version>2.3.1</dep.jaxb.version>

--- a/presto-cache/src/main/java/com/facebook/presto/cache/alluxio/AlluxioCacheConfig.java
+++ b/presto-cache/src/main/java/com/facebook/presto/cache/alluxio/AlluxioCacheConfig.java
@@ -16,8 +16,10 @@ package com.facebook.presto.cache.alluxio;
 import com.facebook.airlift.configuration.Config;
 import com.facebook.airlift.configuration.ConfigDescription;
 import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
 
 import static io.airlift.units.DataSize.Unit.GIGABYTE;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class AlluxioCacheConfig
 {
@@ -27,6 +29,9 @@ public class AlluxioCacheConfig
     private String metricsDomain = "com.facebook.alluxio";
     private DataSize maxCacheSize = new DataSize(2, GIGABYTE);
     private boolean configValidationEnabled;
+    private boolean timeoutEnabled;
+    private Duration timeoutDuration = new Duration(60, SECONDS);
+    private int timeoutThreads = 64;
 
     public boolean isMetricsCollectionEnabled()
     {
@@ -104,5 +109,44 @@ public class AlluxioCacheConfig
     public boolean isConfigValidationEnabled()
     {
         return configValidationEnabled;
+    }
+
+    public int getTimeoutThreads()
+    {
+        return timeoutThreads;
+    }
+
+    @Config("cache.alluxio.timeout-threads")
+    @ConfigDescription("Number of threads used to handle timeouts in alluxio caching")
+    public AlluxioCacheConfig setTimeoutThreads(int timeoutThreads)
+    {
+        this.timeoutThreads = timeoutThreads;
+        return this;
+    }
+
+    public Duration getTimeoutDuration()
+    {
+        return timeoutDuration;
+    }
+
+    @Config("cache.alluxio.timeout-duration")
+    @ConfigDescription("Timeout duration for alluxio caching operations")
+    public AlluxioCacheConfig setTimeoutDuration(Duration timeoutDuration)
+    {
+        this.timeoutDuration = timeoutDuration;
+        return this;
+    }
+
+    public boolean getTimeoutEnabled()
+    {
+        return timeoutEnabled;
+    }
+
+    @Config("cache.alluxio.timeout-enabled")
+    @ConfigDescription("Whether to enable timeout for alluxio caching operations")
+    public AlluxioCacheConfig setTimeoutEnabled(boolean timeoutEnabled)
+    {
+        this.timeoutEnabled = timeoutEnabled;
+        return this;
     }
 }

--- a/presto-cache/src/main/java/com/facebook/presto/cache/alluxio/AlluxioCachingConfigurationProvider.java
+++ b/presto-cache/src/main/java/com/facebook/presto/cache/alluxio/AlluxioCachingConfigurationProvider.java
@@ -51,6 +51,13 @@ public class AlluxioCachingConfigurationProvider
             configuration.set("sink.jmx.class", alluxioCacheConfig.getJmxClass());
             configuration.set("sink.jmx.domain", alluxioCacheConfig.getMetricsDomain());
             configuration.set("alluxio.conf.validation.enabled", String.valueOf(alluxioCacheConfig.isConfigValidationEnabled()));
+            if (alluxioCacheConfig.getTimeoutEnabled()) {
+                configuration.set("alluxio.user.client.cache.timeout.duration", String.valueOf(alluxioCacheConfig.getTimeoutDuration().toMillis()));
+                configuration.set("alluxio.user.client.cache.timeout.threads", String.valueOf(alluxioCacheConfig.getTimeoutThreads()));
+            }
+            else {
+                configuration.set("alluxio.user.client.cache.timeout.duration", "-1");
+            }
         }
     }
 }

--- a/presto-cache/src/test/java/com/facebook/presto/cache/alluxio/TestAlluxioCacheConfig.java
+++ b/presto-cache/src/test/java/com/facebook/presto/cache/alluxio/TestAlluxioCacheConfig.java
@@ -15,6 +15,7 @@ package com.facebook.presto.cache.alluxio;
 
 import com.google.common.collect.ImmutableMap;
 import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
 import org.testng.annotations.Test;
 
 import java.util.Map;
@@ -24,6 +25,7 @@ import static com.facebook.airlift.configuration.testing.ConfigAssertions.assert
 import static com.facebook.airlift.configuration.testing.ConfigAssertions.recordDefaults;
 import static io.airlift.units.DataSize.Unit.GIGABYTE;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class TestAlluxioCacheConfig
 {
@@ -32,11 +34,14 @@ public class TestAlluxioCacheConfig
     {
         assertRecordedDefaults(recordDefaults(AlluxioCacheConfig.class)
                 .setAsyncWriteEnabled(false)
+                .setConfigValidationEnabled(false)
+                .setJmxClass("alluxio.metrics.sink.JmxSink")
                 .setMaxCacheSize(new DataSize(2, GIGABYTE))
                 .setMetricsCollectionEnabled(true)
                 .setMetricsDomain("com.facebook.alluxio")
-                .setJmxClass("alluxio.metrics.sink.JmxSink")
-                .setConfigValidationEnabled(false));
+                .setTimeoutDuration(new Duration(60, SECONDS))
+                .setTimeoutEnabled(false)
+                .setTimeoutThreads(64));
     }
 
     @Test
@@ -44,11 +49,14 @@ public class TestAlluxioCacheConfig
     {
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("cache.alluxio.async-write-enabled", "true")
-                .put("cache.alluxio.max-cache-size", "42MB")
-                .put("cache.alluxio.metrics-enabled", "false")
-                .put("cache.alluxio.metrics-domain", "test.alluxio")
-                .put("cache.alluxio.jmx-class", "test.TestJmxSink")
                 .put("cache.alluxio.config-validation-enabled", "true")
+                .put("cache.alluxio.jmx-class", "test.TestJmxSink")
+                .put("cache.alluxio.max-cache-size", "42MB")
+                .put("cache.alluxio.metrics-domain", "test.alluxio")
+                .put("cache.alluxio.metrics-enabled", "false")
+                .put("cache.alluxio.timeout-duration", "120s")
+                .put("cache.alluxio.timeout-enabled", "true")
+                .put("cache.alluxio.timeout-threads", "512")
                 .build();
 
         AlluxioCacheConfig expected = new AlluxioCacheConfig()
@@ -57,7 +65,10 @@ public class TestAlluxioCacheConfig
                 .setMetricsCollectionEnabled(false)
                 .setMetricsDomain("test.alluxio")
                 .setJmxClass("test.TestJmxSink")
-                .setConfigValidationEnabled(true);
+                .setConfigValidationEnabled(true)
+                .setTimeoutDuration(new Duration(120, SECONDS))
+                .setTimeoutEnabled(true)
+                .setTimeoutThreads(512);
 
         assertFullMapping(properties, expected);
     }

--- a/presto-cache/src/test/java/com/facebook/presto/cache/alluxio/TestAlluxioCachingFileSystem.java
+++ b/presto-cache/src/test/java/com/facebook/presto/cache/alluxio/TestAlluxioCachingFileSystem.java
@@ -374,6 +374,13 @@ public class TestAlluxioCachingFileSystem
             configuration.set("alluxio.user.client.cache.async.restore.enabled", String.valueOf(false));
             configuration.set("sink.jmx.class", alluxioCacheConfig.getJmxClass());
             configuration.set("sink.jmx.domain", alluxioCacheConfig.getMetricsDomain());
+            if (alluxioCacheConfig.getTimeoutEnabled()) {
+                configuration.set("alluxio.user.client.cache.timeout.duration", String.valueOf(alluxioCacheConfig.getTimeoutDuration().toMillis()));
+                configuration.set("alluxio.user.client.cache.timeout.threads", String.valueOf(alluxioCacheConfig.getTimeoutThreads()));
+            }
+            else {
+                configuration.set("alluxio.user.client.cache.timeout.duration", "-1");
+            }
         }
         return configuration;
     }


### PR DESCRIPTION
After bumping Alluxio client version to 2.3.0-2, we aim to 

- Enable calling openFile with hiveFileContext in local cache
- Enable timeout for cache operations to fall back normally in case of hitting OS or hardware issues

Test plan - (Please fill in how you tested your changes)


```
== NO RELEASE NOTE ==
```
