### PR TITLE
Fix hamming_distance to handle code point zero

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/StringFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/StringFunctions.java
@@ -814,8 +814,8 @@ public final class StringFunctions
                 distance++;
             }
 
-            leftPosition += codePointLeft > 0 ? lengthOfCodePoint(codePointLeft) : -codePointLeft;
-            rightPosition += codePointRight > 0 ? lengthOfCodePoint(codePointRight) : -codePointRight;
+            leftPosition += codePointLeft >= 0 ? lengthOfCodePoint(codePointLeft) : -codePointLeft;
+            rightPosition += codePointRight >= 0 ? lengthOfCodePoint(codePointRight) : -codePointRight;
         }
 
         checkCondition(

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestStringFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestStringFunctions.java
@@ -195,6 +195,7 @@ public class TestStringFunctions
         assertFunction("HAMMING_DISTANCE('hello', 'jello')", BIGINT, 1L);
         assertFunction("HAMMING_DISTANCE('like', 'hate')", BIGINT, 3L);
         assertFunction("HAMMING_DISTANCE('hello', 'world')", BIGINT, 4L);
+        assertFunction("HAMMING_DISTANCE('\u0000', '\u0001')", BIGINT, 1L);
         assertFunction("HAMMING_DISTANCE(NULL, NULL)", BIGINT, null);
         assertFunction("HAMMING_DISTANCE('hello', NULL)", BIGINT, null);
         assertFunction("HAMMING_DISTANCE(NULL, 'world')", BIGINT, null);


### PR DESCRIPTION
Currently when code point zero is encountered in hamming_distance,
we treat it as 0-length, which would fail the position check for
legit comparison.

Test plan - Added unit test

```
== RELEASE NOTES ==

General Changes
* Fix hamming_distance to handle code point zero correctly.
```
