### PR TITLE
Support access control for Presto-on-Spark

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/security/AccessControlManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/AccessControlManager.java
@@ -110,17 +110,26 @@ public class AccessControlManager
             throws Exception
     {
         if (ACCESS_CONTROL_CONFIGURATION.exists()) {
-            Map<String, String> properties = new HashMap<>(loadProperties(ACCESS_CONTROL_CONFIGURATION));
+            Map<String, String> properties = loadProperties(ACCESS_CONTROL_CONFIGURATION);
+            checkArgument(!isNullOrEmpty(properties.get(ACCESS_CONTROL_PROPERTY_NAME)),
+                    "Access control configuration %s does not contain %s",
+                    ACCESS_CONTROL_CONFIGURATION.getAbsoluteFile(),
+                    ACCESS_CONTROL_PROPERTY_NAME);
 
-            String accessControlName = properties.remove(ACCESS_CONTROL_PROPERTY_NAME);
-            checkArgument(!isNullOrEmpty(accessControlName),
-                    "Access control configuration %s does not contain %s", ACCESS_CONTROL_CONFIGURATION.getAbsoluteFile(), ACCESS_CONTROL_PROPERTY_NAME);
-
-            setSystemAccessControl(accessControlName, properties);
+            loadSystemAccessControl(properties);
         }
         else {
             setSystemAccessControl(AllowAllSystemAccessControl.NAME, ImmutableMap.of());
         }
+    }
+
+    public void loadSystemAccessControl(Map<String, String> properties)
+    {
+        properties = new HashMap<>(properties);
+        String accessControlName = properties.remove(ACCESS_CONTROL_PROPERTY_NAME);
+        checkArgument(!isNullOrEmpty(accessControlName), "%s property must be present", ACCESS_CONTROL_PROPERTY_NAME);
+
+        setSystemAccessControl(accessControlName, properties);
     }
 
     @VisibleForTesting

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkServiceFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkServiceFactory.java
@@ -43,6 +43,7 @@ public class PrestoSparkServiceFactory
                 properties.build(),
                 configuration.getCatalogProperties(),
                 configuration.getEventListenerProperties(),
+                configuration.getAccessControlProperties(),
                 getSqlParserOptions(),
                 getAdditionalModules());
 

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
@@ -35,8 +35,6 @@ import com.facebook.presto.metadata.CatalogManager;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.QualifiedObjectName;
 import com.facebook.presto.metadata.SessionPropertyManager;
-import com.facebook.presto.security.AccessControl;
-import com.facebook.presto.security.AccessControlManager;
 import com.facebook.presto.server.PluginManager;
 import com.facebook.presto.spark.PrestoSparkQueryExecutionFactory.PrestoSparkQueryExecution;
 import com.facebook.presto.spark.classloader_interface.IPrestoSparkQueryExecutionFactory;
@@ -62,10 +60,7 @@ import com.facebook.presto.transaction.TransactionManager;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.google.inject.Binder;
 import com.google.inject.Injector;
-import com.google.inject.Module;
-import com.google.inject.Scopes;
 import io.airlift.tpch.TpchTable;
 import org.apache.spark.SparkConf;
 import org.apache.spark.SparkContext;
@@ -206,9 +201,10 @@ public class PrestoSparkQueryRunner
                         "query.hash-partition-count", Integer.toString(NODE_COUNT * 2)),
                 ImmutableMap.of(),
                 Optional.empty(),
+                Optional.empty(),
                 new SqlParserOptions(),
                 ImmutableList.of(),
-                Optional.of(new TestingAccessControlModule()));
+                true);
 
         Injector injector = injectorFactory.create();
 
@@ -505,18 +501,6 @@ public class PrestoSparkQueryRunner
                 .setOwnerName("public")
                 .setOwnerType(PrincipalType.ROLE)
                 .build();
-    }
-
-    private static class TestingAccessControlModule
-            implements Module
-    {
-        @Override
-        public void configure(Binder binder)
-        {
-            binder.bind(TestingAccessControlManager.class).in(Scopes.SINGLETON);
-            binder.bind(AccessControlManager.class).to(TestingAccessControlManager.class).in(Scopes.SINGLETON);
-            binder.bind(AccessControl.class).to(AccessControlManager.class).in(Scopes.SINGLETON);
-        }
     }
 
     private static class SparkContextHolder

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkConfiguration.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkConfiguration.java
@@ -27,18 +27,22 @@ public class PrestoSparkConfiguration
     private final String pluginsDirectoryPath;
     private final Map<String, Map<String, String>> catalogProperties;
     private final Optional<Map<String, String>> eventListenerProperties;
+    private final Optional<Map<String, String>> accessControlProperties;
 
     public PrestoSparkConfiguration(
             Map<String, String> configProperties,
             String pluginsDirectoryPath,
             Map<String, Map<String, String>> catalogProperties,
-            Optional<Map<String, String>> eventListenerProperties)
+            Optional<Map<String, String>> eventListenerProperties,
+            Optional<Map<String, String>> accessControlProperties)
     {
         this.configProperties = unmodifiableMap(new HashMap<>(requireNonNull(configProperties, "configProperties is null")));
         this.pluginsDirectoryPath = requireNonNull(pluginsDirectoryPath, "pluginsDirectoryPath is null");
         this.catalogProperties = unmodifiableMap(requireNonNull(catalogProperties, "catalogProperties is null").entrySet().stream()
                 .collect(toMap(Map.Entry::getKey, entry -> unmodifiableMap(new HashMap<>(entry.getValue())))));
         this.eventListenerProperties = requireNonNull(eventListenerProperties, "eventListenerProperties is null")
+                .map(properties -> unmodifiableMap(new HashMap<>(properties)));
+        this.accessControlProperties = requireNonNull(accessControlProperties, "accessControlProperties is null")
                 .map(properties -> unmodifiableMap(new HashMap<>(properties)));
     }
 
@@ -60,5 +64,10 @@ public class PrestoSparkConfiguration
     public Optional<Map<String, String>> getEventListenerProperties()
     {
         return eventListenerProperties;
+    }
+
+    public Optional<Map<String, String>> getAccessControlProperties()
+    {
+        return accessControlProperties;
     }
 }

--- a/presto-spark-launcher/src/main/java/com/facebook/presto/spark/launcher/PrestoSparkDistribution.java
+++ b/presto-spark-launcher/src/main/java/com/facebook/presto/spark/launcher/PrestoSparkDistribution.java
@@ -31,13 +31,15 @@ public class PrestoSparkDistribution
     private final Map<String, String> configProperties;
     private final Map<String, Map<String, String>> catalogProperties;
     private final Optional<Map<String, String>> eventListenerProperties;
+    private final Optional<Map<String, String>> accessControlProperties;
 
     public PrestoSparkDistribution(
             SparkContext sparkContext,
             PackageSupplier packageSupplier,
             Map<String, String> configProperties,
             Map<String, Map<String, String>> catalogProperties,
-            Optional<Map<String, String>> eventListenerProperties)
+            Optional<Map<String, String>> eventListenerProperties,
+            Optional<Map<String, String>> accessControlProperties)
     {
         this.sparkContext = requireNonNull(sparkContext, "sparkContext is null");
         this.packageSupplier = requireNonNull(packageSupplier, "packageSupplier is null");
@@ -45,6 +47,8 @@ public class PrestoSparkDistribution
         this.catalogProperties = requireNonNull(catalogProperties, "catalogProperties is null").entrySet().stream()
                 .collect(toImmutableMap(Map.Entry::getKey, entry -> ImmutableMap.copyOf(entry.getValue())));
         this.eventListenerProperties = requireNonNull(eventListenerProperties, "eventListenerProperties is null")
+                .map(properties -> unmodifiableMap(new HashMap<>(properties)));
+        this.accessControlProperties = requireNonNull(accessControlProperties, "accessControlProperties is null")
                 .map(properties -> unmodifiableMap(new HashMap<>(properties)));
     }
 
@@ -71,5 +75,10 @@ public class PrestoSparkDistribution
     public Optional<Map<String, String>> getEventListenerProperties()
     {
         return eventListenerProperties;
+    }
+
+    public Optional<Map<String, String>> getAccessControlProperties()
+    {
+        return accessControlProperties;
     }
 }

--- a/presto-spark-launcher/src/main/java/com/facebook/presto/spark/launcher/PrestoSparkLauncherCommand.java
+++ b/presto-spark-launcher/src/main/java/com/facebook/presto/spark/launcher/PrestoSparkLauncherCommand.java
@@ -58,6 +58,7 @@ public class PrestoSparkLauncherCommand
                 packageSupplier,
                 loadProperties(checkFile(new File(clientOptions.config))),
                 loadCatalogProperties(new File(clientOptions.catalogs)),
+                Optional.empty(),
                 Optional.empty());
 
         String query = readFileUtf8(checkFile(new File(clientOptions.file)));


### PR DESCRIPTION
- The default value for config `allow-unsecured-access` is true. Need to configure Presto-on-Spark after this is merged.

- `TestingAccessControlModule` is removed.

Depended by https://github.com/facebookexternal/presto-facebook/pull/1257

```
== NO RELEASE NOTE ==
```
