### PR TITLE
Fix client-info test-name output

### DIFF
--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/prestoaction/ClientInfo.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/prestoaction/ClientInfo.java
@@ -13,17 +13,18 @@
  */
 package com.facebook.presto.verifier.prestoaction;
 
+import com.facebook.airlift.json.JsonCodec;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.util.Optional;
 
+import static com.facebook.airlift.json.JsonCodec.jsonCodec;
 import static java.util.Objects.requireNonNull;
 
 public class ClientInfo
 {
     private static final String CLIENT_INFO_TYPE = "VERIFIER";
+    private static final JsonCodec<ClientInfo> CLIENT_INFO_JSON_CODEC = jsonCodec(ClientInfo.class);
 
     private final String testId;
     private final Optional<String> testName;
@@ -70,11 +71,6 @@ public class ClientInfo
 
     public String serialize()
     {
-        try {
-            return new ObjectMapper().writeValueAsString(this);
-        }
-        catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
-        }
+        return CLIENT_INFO_JSON_CODEC.toJson(this).replaceAll("\\n", "");
     }
 }


### PR DESCRIPTION
The serialization of the Optional test-name field was outputting an
object with its only key value pair being "Present". We want the
actual test-name string to be serialized to json instead. Airlift's
toJson seems to handle serialization a bit better than ObjectMapper's

Test plan - Ran verifier with a test-name and found it correctly serializes without putting in "Present". 

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== NO RELEASE NOTE ==
```
