### PR TITLE
Add @Consumes and @Produces annotations for resources

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/ClusterStatsResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ClusterStatsResource.java
@@ -34,6 +34,7 @@ import static com.facebook.presto.server.security.RoleType.ADMIN;
 import static com.facebook.presto.server.security.RoleType.USER;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
 @Path("/v1/cluster")
 @RolesAllowed({ADMIN, USER})
@@ -101,6 +102,7 @@ public class ClusterStatsResource
 
     @GET
     @Path("memory")
+    @Produces(APPLICATION_JSON)
     public Response getClusterMemoryPoolInfo()
     {
         return Response.ok()
@@ -110,6 +112,7 @@ public class ClusterStatsResource
 
     @GET
     @Path("workerMemory")
+    @Produces(APPLICATION_JSON)
     public Response getWorkerMemoryInfo()
     {
         return Response.ok()

--- a/presto-main/src/main/java/com/facebook/presto/server/NodeResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/NodeResource.java
@@ -20,11 +20,13 @@ import javax.annotation.security.RolesAllowed;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
 
 import java.util.Collection;
 
 import static com.facebook.presto.server.security.RoleType.INTERNAL;
 import static com.google.common.base.Predicates.in;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
 @Path("/v1/node")
 @RolesAllowed(INTERNAL)
@@ -39,6 +41,7 @@ public class NodeResource
     }
 
     @GET
+    @Produces(APPLICATION_JSON)
     public Collection<HeartbeatFailureDetector.Stats> getNodeStats()
     {
         return failureDetector.getStats().values();
@@ -46,6 +49,7 @@ public class NodeResource
 
     @GET
     @Path("failed")
+    @Produces(APPLICATION_JSON)
     public Collection<HeartbeatFailureDetector.Stats> getFailed()
     {
         return Maps.filterKeys(failureDetector.getStats(), in(failureDetector.getFailed())).values();

--- a/presto-main/src/main/java/com/facebook/presto/server/QueryResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/QueryResource.java
@@ -24,11 +24,13 @@ import com.google.common.collect.ImmutableList;
 
 import javax.annotation.security.RolesAllowed;
 import javax.inject.Inject;
+import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
@@ -42,6 +44,7 @@ import static com.facebook.presto.connector.system.KillQueryProcedure.createPree
 import static com.facebook.presto.server.security.RoleType.ADMIN;
 import static com.facebook.presto.server.security.RoleType.USER;
 import static java.util.Objects.requireNonNull;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 
 /**
  * Manage queries scheduled on this node
@@ -62,6 +65,7 @@ public class QueryResource
     }
 
     @GET
+    @Produces(APPLICATION_JSON)
     public List<BasicQueryInfo> getAllQueryInfo(@QueryParam("state") String stateFilter)
     {
         QueryState expectedState = stateFilter == null ? null : QueryState.valueOf(stateFilter.toUpperCase(Locale.ENGLISH));
@@ -76,6 +80,7 @@ public class QueryResource
 
     @GET
     @Path("{queryId}")
+    @Produces(APPLICATION_JSON)
     public Response getQueryInfo(@PathParam("queryId") QueryId queryId)
     {
         requireNonNull(queryId, "queryId is null");
@@ -105,6 +110,8 @@ public class QueryResource
 
     @PUT
     @Path("{queryId}/killed")
+    @Consumes(APPLICATION_JSON)
+    @Produces(APPLICATION_JSON)
     public Response killQuery(@PathParam("queryId") QueryId queryId, String message)
     {
         return failQuery(queryId, createKillQueryException(message));
@@ -112,6 +119,8 @@ public class QueryResource
 
     @PUT
     @Path("{queryId}/preempted")
+    @Consumes(APPLICATION_JSON)
+    @Produces(APPLICATION_JSON)
     public Response preemptQuery(@PathParam("queryId") QueryId queryId, String message)
     {
         return failQuery(queryId, createPreemptQueryException(message));

--- a/presto-main/src/main/java/com/facebook/presto/server/WebUiResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/WebUiResource.java
@@ -17,6 +17,7 @@ import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
 import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
@@ -24,6 +25,7 @@ import javax.ws.rs.core.UriInfo;
 import static com.facebook.presto.server.security.RoleType.ADMIN;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.net.HttpHeaders.X_FORWARDED_PROTO;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.Response.Status.MOVED_PERMANENTLY;
 
 @Path("/")
@@ -31,6 +33,7 @@ import static javax.ws.rs.core.Response.Status.MOVED_PERMANENTLY;
 public class WebUiResource
 {
     @GET
+    @Produces(APPLICATION_JSON)
     public Response redirectIndexHtml(
             @HeaderParam(X_FORWARDED_PROTO) String proto,
             @Context UriInfo uriInfo)

--- a/presto-main/src/main/java/com/facebook/presto/server/WorkerResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/WorkerResource.java
@@ -25,6 +25,7 @@ import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 
@@ -57,6 +58,7 @@ public class WorkerResource
 
     @GET
     @Path("{nodeId}/status")
+    @Produces(APPLICATION_JSON)
     public Response getStatus(@PathParam("nodeId") String nodeId)
     {
         return proxyJsonResponse(nodeId, "v1/status");
@@ -64,6 +66,7 @@ public class WorkerResource
 
     @GET
     @Path("{nodeId}/thread")
+    @Produces(APPLICATION_JSON)
     public Response getThreads(@PathParam("nodeId") String nodeId)
     {
         return proxyJsonResponse(nodeId, "v1/thread");


### PR DESCRIPTION
Add `@Consumes` and `@Produces` annotations for resources

Without specifying a specific media type, the content
negotiation mechanism can choose any valid type. Since
we need a JSON response type adding these annotations
for the resources would help the server to choose JSON
as the correct response type.


Test plan - Unit tests

```
== NO RELEASE NOTE ==
```