### PR TITLE
Fix integer overflow in newBlockBuilderLike()

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/block/ArrayBlockBuilder.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/ArrayBlockBuilder.java
@@ -26,7 +26,6 @@ import static com.facebook.presto.common.block.ArrayBlock.createArrayBlockIntern
 import static com.facebook.presto.common.block.BlockUtil.calculateBlockResetSize;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.Math.max;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class ArrayBlockBuilder
@@ -297,7 +296,7 @@ public class ArrayBlockBuilder
     public BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus, int expectedEntries)
     {
         int newSize = max(calculateBlockResetSize(positionCount), expectedEntries);
-        int valueExpectedEntries = positionCount == 0 ? expectedEntries : toIntExact((long) offsets[positionCount] * newSize / positionCount);
+        int valueExpectedEntries = BlockUtil.calculateNestedStructureResetSize(offsets[positionCount], positionCount, newSize);
         return new ArrayBlockBuilder(blockBuilderStatus, values.newBlockBuilderLike(blockBuilderStatus, valueExpectedEntries), newSize);
     }
 

--- a/presto-common/src/main/java/com/facebook/presto/common/block/BlockUtil.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/BlockUtil.java
@@ -119,15 +119,6 @@ public final class BlockUtil
         return toIntExact(newSize);
     }
 
-    static int calculateBlockResetBytes(int currentBytes)
-    {
-        long newBytes = (long) ceil(currentBytes * BLOCK_RESET_SKEW);
-        if (newBytes > MAX_ARRAY_SIZE) {
-            return MAX_ARRAY_SIZE;
-        }
-        return (int) newBytes;
-    }
-
     /**
      * Recalculate the <code>offsets</code> array for the specified range.
      * The returned <code>offsets</code> array contains <code>length + 1</code> integers

--- a/presto-common/src/main/java/com/facebook/presto/common/block/BlockUtil.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/BlockUtil.java
@@ -22,6 +22,8 @@ import java.util.Arrays;
 
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
 import static java.lang.Math.ceil;
+import static java.lang.Math.max;
+import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -104,6 +106,17 @@ public final class BlockUtil
             newSize = MAX_ARRAY_SIZE;
         }
         return (int) newSize;
+    }
+
+    static int calculateNestedStructureResetSize(int currentNestedStructureSize, int currentNestedStructurePositionCount, int expectedPositionCount)
+    {
+        long newSize = max(
+                (long) ceil(currentNestedStructureSize * BLOCK_RESET_SKEW),
+                currentNestedStructurePositionCount == 0 ? currentNestedStructureSize : (long) currentNestedStructureSize * expectedPositionCount / currentNestedStructurePositionCount);
+        if (newSize > MAX_ARRAY_SIZE) {
+            return MAX_ARRAY_SIZE;
+        }
+        return toIntExact(newSize);
     }
 
     static int calculateBlockResetBytes(int currentBytes)

--- a/presto-common/src/main/java/com/facebook/presto/common/block/MapBlockBuilder.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/MapBlockBuilder.java
@@ -30,7 +30,6 @@ import static com.facebook.presto.common.block.BlockUtil.calculateBlockResetSize
 import static com.facebook.presto.common.block.MapBlock.createMapBlockInternal;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.Math.max;
-import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -461,7 +460,7 @@ public class MapBlockBuilder
     public BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus, int expectedEntries)
     {
         int newSize = max(calculateBlockResetSize(getPositionCount()), expectedEntries);
-        int nestedExpectedEntries = positionCount == 0 ? expectedEntries : toIntExact((long) offsets[positionCount] * newSize / positionCount);
+        int nestedExpectedEntries = BlockUtil.calculateNestedStructureResetSize(offsets[positionCount], positionCount, expectedEntries);
         return new MapBlockBuilder(
                 keyBlockEquals,
                 keyBlockHashCode,

--- a/presto-common/src/main/java/com/facebook/presto/common/block/RowBlockBuilder.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/RowBlockBuilder.java
@@ -28,7 +28,6 @@ import static com.facebook.presto.common.block.BlockUtil.calculateBlockResetSize
 import static com.facebook.presto.common.block.RowBlock.createRowBlockInternal;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.Math.max;
-import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -306,7 +305,8 @@ public class RowBlockBuilder
     {
         int newSize = max(calculateBlockResetSize(getPositionCount()), expectedEntries);
         BlockBuilder[] newBlockBuilders = new BlockBuilder[numFields];
-        int nestedExpectedEntries = positionCount == 0 ? expectedEntries : toIntExact((long) fieldBlockOffsets[positionCount] * newSize / positionCount);
+        // We still calculate the new expected fieldBlockBuilders sizes because the positions could be null.
+        int nestedExpectedEntries = BlockUtil.calculateNestedStructureResetSize(fieldBlockOffsets[positionCount], positionCount, expectedEntries);
         for (int i = 0; i < numFields; i++) {
             newBlockBuilders[i] = fieldBlockBuilders[i].newBlockBuilderLike(blockBuilderStatus, nestedExpectedEntries);
         }

--- a/presto-common/src/main/java/com/facebook/presto/common/block/VariableWidthBlockBuilder.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/VariableWidthBlockBuilder.java
@@ -29,7 +29,6 @@ import java.util.Arrays;
 import java.util.function.BiConsumer;
 
 import static com.facebook.presto.common.block.BlockUtil.MAX_ARRAY_SIZE;
-import static com.facebook.presto.common.block.BlockUtil.calculateBlockResetBytes;
 import static com.facebook.presto.common.block.BlockUtil.calculateBlockResetSize;
 import static com.facebook.presto.common.block.BlockUtil.checkArrayRange;
 import static com.facebook.presto.common.block.BlockUtil.checkValidPosition;
@@ -379,7 +378,7 @@ public class VariableWidthBlockBuilder
     public BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus)
     {
         int currentSizeInBytes = positions == 0 ? positions : (getOffset(positions) - getOffset(0));
-        return new VariableWidthBlockBuilder(blockBuilderStatus, calculateBlockResetSize(positions), calculateBlockResetBytes(currentSizeInBytes));
+        return new VariableWidthBlockBuilder(blockBuilderStatus, calculateBlockResetSize(positions), calculateBlockResetSize(currentSizeInBytes));
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/block/VariableWidthBlockBuilder.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/VariableWidthBlockBuilder.java
@@ -46,7 +46,6 @@ import static io.airlift.slice.SizeOf.SIZE_OF_SHORT;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
-import static java.lang.Math.toIntExact;
 
 public class VariableWidthBlockBuilder
         extends AbstractVariableWidthBlock
@@ -388,9 +387,7 @@ public class VariableWidthBlockBuilder
     {
         int newSize = max(calculateBlockResetSize(positions), expectedEntries);
         int currentSizeInBytes = offsets[positions];
-        return new VariableWidthBlockBuilder(blockBuilderStatus,
-                newSize,
-                max(calculateBlockResetBytes(currentSizeInBytes), positions == 0 ? currentSizeInBytes : toIntExact((long) currentSizeInBytes * newSize / positions)));
+        return new VariableWidthBlockBuilder(blockBuilderStatus, newSize, BlockUtil.calculateNestedStructureResetSize(currentSizeInBytes, positions, newSize));
     }
 
     private int getOffset(int position)


### PR DESCRIPTION
When `newBlockBuilderLike()` is called on BlockBuilders for complex types,
`toIntExact()` could throw "Integer Overflow" exception when the expected
new size exceeds integer boundary. Example stack trace is as follows:
```
java.lang.ArithmeticException: integer overflow
at java.base/java.lang.Math.toIntExact(Math.java:1071)
at com.facebook.presto.common.block.VariableWidthBlockBuilder.newBlockBuilderLike(VariableWidthBlockBuilder.java:393)
```
This commit fixes the problem by introducing a new method
`calculateBlockResetSize()` that calculates the new size and bound it
by `MAX_ARRAY_SIZE`.

```
== NO RELEASE NOTE ==
```
