### PR TITLE
Optimize TypedSet and map_concat, array_union

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/block/AbstractMapBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/AbstractMapBlock.java
@@ -284,6 +284,7 @@ public abstract class AbstractMapBlock
         int startEntryOffset = getOffset(position);
         int endEntryOffset = getOffset(position + 1);
         return new SingleMapBlock(
+                position,
                 startEntryOffset * 2,
                 (endEntryOffset - startEntryOffset) * 2,
                 this);
@@ -459,7 +460,7 @@ public abstract class AbstractMapBlock
 
         int startEntryOffset = getOffsets()[internalPosition];
         int endEntryOffset = getOffsets()[internalPosition + 1];
-        return new SingleMapBlock(startEntryOffset * 2, (endEntryOffset - startEntryOffset) * 2, this);
+        return new SingleMapBlock(internalPosition - getOffsetBase(), startEntryOffset * 2, (endEntryOffset - startEntryOffset) * 2, this);
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/block/SingleMapBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/SingleMapBlock.java
@@ -34,12 +34,14 @@ public class SingleMapBlock
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(SingleMapBlock.class).instanceSize();
 
+    private final int positionInMap;
     private final int offset;
     private final int positionCount;  // The number of keys in this single map * 2
     private final AbstractMapBlock mapBlock;
 
-    SingleMapBlock(int offset, int positionCount, AbstractMapBlock mapBlock)
+    SingleMapBlock(int positionInMap, int offset, int positionCount, AbstractMapBlock mapBlock)
     {
+        this.positionInMap = positionInMap;
         this.offset = offset;
         this.positionCount = positionCount;
         this.mapBlock = mapBlock;
@@ -120,9 +122,30 @@ public class SingleMapBlock
             return this;
         }
         return new SingleMapBlock(
+                positionInMap,
                 offset,
                 positionCount,
                 mapBlock);
+    }
+
+    public Block getKeyBlock()
+    {
+        return mapBlock.getRawKeyBlock().getRegion(mapBlock.getOffset(positionInMap), positionCount / 2);
+    }
+
+    public Block getValueBlock()
+    {
+        return mapBlock.getRawValueBlock().getRegion(positionInMap, positionCount / 2);
+    }
+
+    public Block getBaseMapBlock()
+    {
+        return mapBlock;
+    }
+
+    public int getPositionInMap()
+    {
+        return positionInMap;
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/block/SingleMapBlockEncoding.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/SingleMapBlockEncoding.java
@@ -89,6 +89,6 @@ public class SingleMapBlockEncoding
                 valueBlock,
                 new HashTables(Optional.ofNullable(hashTable), 1, hashTableLength));
 
-        return new SingleMapBlock(0, keyBlock.getPositionCount() * 2, mapBlock);
+        return new SingleMapBlock(0, 0, keyBlock.getPositionCount() * 2, mapBlock);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/OptimizedTypedSet.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/OptimizedTypedSet.java
@@ -1,0 +1,339 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.block.DictionaryBlock;
+import com.facebook.presto.common.block.DictionaryId;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.operator.project.SelectedPositions;
+import org.openjdk.jol.info.ClassLayout;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static com.facebook.presto.array.Arrays.ensureCapacity;
+import static com.facebook.presto.operator.project.SelectedPositions.positionsList;
+import static com.facebook.presto.type.TypeUtils.hashPosition;
+import static com.facebook.presto.type.TypeUtils.positionEqualsPosition;
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.slice.SizeOf.sizeOf;
+import static it.unimi.dsi.fastutil.HashCommon.arraySize;
+import static java.lang.Math.max;
+import static java.lang.Math.toIntExact;
+import static java.util.Objects.requireNonNull;
+
+public class OptimizedTypedSet
+{
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(TypedSet.class).instanceSize();
+    private static final int ARRAY_LIST_INSTANCE_SIZE = ClassLayout.parseClass(ArrayList.class).instanceSize();
+    private static final float FILL_RATIO = 0.75f;
+    private static final int EMPTY_SLOT = -1;
+    private static final int INVALID_POSITION = -1;
+    private static final int INITIAL_BLOCK_COUNT = 2;
+    private static final SelectedPositions EMPTY_SELECTED_POSITIONS = positionsList(new int[0], 0, 0);
+
+    private final Type elementType;
+    private final int hashCapacity;
+    private final int hashMask;
+
+    private int size;  // size is the number of elements added to the TypedSet (including null).
+    private Block[] blocks;   // Keeps track of the added blocks, even if the elements of the block was not inserted into the set. Array is used to get higher performance in getInsertPosition()
+    private List<SelectedPositions> positionsForBlocks;  // The selected positions for the added blocks, one for each added block
+    private long[] blockPositionByHash;  // Each 64-bit long is 32-bit index for blocks + 32-bit position within block
+    private int currentBlockIndex = -1;  // The index into the blocks array and positionsForBlocks list
+
+    public OptimizedTypedSet(Type elementType, int maxPositionCount)
+    {
+        this(elementType, INITIAL_BLOCK_COUNT, maxPositionCount);
+    }
+
+    public OptimizedTypedSet(Type elementType, int expectedBlockCount, int maxPositionCount)
+    {
+        checkArgument(expectedBlockCount >= 0, "expectedBlockCount must not be negative");
+        checkArgument(maxPositionCount >= 0, "maxPositionCount must not be negative");
+
+        this.elementType = requireNonNull(elementType, "elementType must not be null");
+        this.hashCapacity = arraySize(maxPositionCount, FILL_RATIO);
+        this.hashMask = hashCapacity - 1;
+
+        blocks = new Block[expectedBlockCount];
+        positionsForBlocks = new ArrayList<>(expectedBlockCount);
+        blockPositionByHash = initializeHashTable();
+    }
+
+    /**
+     * Union the set by adding the elements of the block, eliminating duplicates.
+     */
+    public void union(Block block)
+    {
+        currentBlockIndex++;
+        ensureBlocksCapacity(currentBlockIndex + 1);
+        blocks[currentBlockIndex] = block;
+
+        int positionCount = block.getPositionCount();
+        int[] positions = new int[positionCount];
+
+        // Add the elements to the hash table. Since union can only increase the set size, there is no need to create a separate hashtable.
+        int positionsIndex = 0;
+        for (int i = 0; i < positionCount; i++) {
+            int hashPosition = getInsertPosition(blockPositionByHash, getMaskedHash(hashPosition(elementType, block, i)), block, i);
+            if (hashPosition != INVALID_POSITION) {
+                // There is no need to test if adding element is successful since it's on the same hash table
+                addElement(blockPositionByHash, hashPosition, block, i);
+                positions[positionsIndex++] = i;
+            }
+        }
+
+        getPositionsForBlocks().add(positionsList(positions, 0, positionsIndex));
+        size += positionsIndex;
+    }
+
+    /**
+     * Intersect the set with the elements of the block, eliminating duplicates.
+     */
+    public void intersect(Block block)
+    {
+        currentBlockIndex++;
+        ensureBlocksCapacity(currentBlockIndex + 1);
+        blocks[currentBlockIndex] = block;
+
+        if (currentBlockIndex == 0) {
+            // This set was an empty set, so the result set should also be an empty set.
+            positionsForBlocks.add(EMPTY_SELECTED_POSITIONS);
+            return;
+        }
+
+        int positionCount = block.getPositionCount();
+        int[] positions = ensureCapacity(positionsForBlocks.get(currentBlockIndex - 1).getPositions(), positionCount);
+
+        // We need to create a new hash table because the elements in the set may be removed
+        long[] newBlockPositionByHash = initializeHashTable();
+
+        int positionsIndex = 0;
+        for (int i = 0; i < positionCount; i++) {
+            int hash = getMaskedHash(hashPosition(elementType, block, i));
+            int positionInBlockPositionByHash = getInsertPosition(blockPositionByHash, hash, block, i);
+            if (positionInBlockPositionByHash == INVALID_POSITION) {
+                // add to the hash table if it exists in blockPositionByHash
+                if (addElement(newBlockPositionByHash, hash, block, i)) {
+                    positions[positionsIndex++] = i;
+                }
+            }
+        }
+
+        blockPositionByHash = newBlockPositionByHash;
+        getPositionsForBlocks().add(positionsList(positions, 0, positionsIndex));
+        size = positionsIndex;
+
+        clearPreviousBlocks();
+    }
+
+    /**
+     * Add the elements of the block that do not exist in the set, eliminating duplicates, and remove all previously existing elements.
+     */
+    public void except(Block block)
+    {
+        int positionCount = block.getPositionCount();
+
+        if (currentBlockIndex == -1) {
+            // This set was an empty set. Call union() to remove duplicates.
+            union(block);
+            return;
+        }
+
+        currentBlockIndex++;
+        ensureBlocksCapacity(currentBlockIndex + 1);
+        blocks[currentBlockIndex] = block;
+
+        int[] positions = new int[positionCount];
+
+        // We need to create a new hash table because the elements in the set need be removed
+        long[] newBlockPositionByHash = initializeHashTable();
+
+        int positionsIndex = 0;
+        for (int i = 0; i < positionCount; i++) {
+            int hash = getMaskedHash(hashPosition(elementType, block, i));
+            int positionInBlockPositionByHash = getInsertPosition(blockPositionByHash, hash, block, i);
+
+            // add to the hash table if it does not exist in blockPositionByHash
+            if (positionInBlockPositionByHash != INVALID_POSITION) {
+                if (addElement(newBlockPositionByHash, hash, block, i)) {
+                    positions[positionsIndex++] = i;
+                }
+            }
+        }
+
+        blockPositionByHash = newBlockPositionByHash;
+        getPositionsForBlocks().add(positionsList(positions, 0, positionsIndex));
+        size = positionsIndex;
+
+        clearPreviousBlocks();
+    }
+
+    /**
+     * Build and return the block representing this set
+     */
+    public Block getBlock()
+    {
+        if (size == 0) {
+            return elementType.createBlockBuilder(null, 0).build();
+        }
+
+        if (currentBlockIndex == 0) {
+            // Just one block. Return a DictionaryBlock
+            Block block = blocks[currentBlockIndex];
+            SelectedPositions selectedPositions = getPositionsForBlocks().get(currentBlockIndex);
+
+            return new DictionaryBlock(
+                    selectedPositions.getOffset(),
+                    selectedPositions.size(),
+                    block,
+                    selectedPositions.getPositions(),
+                    false,
+                    DictionaryId.randomDictionaryId());
+        }
+
+        Block firstBlock = blocks[0];
+        BlockBuilder blockBuilder = elementType.createBlockBuilder(
+                null,
+                size,
+                toIntExact(firstBlock.getApproximateRegionLogicalSizeInBytes(0, firstBlock.getPositionCount()) / max(1, toIntExact(firstBlock.getPositionCount()))));
+        for (int i = 0; i <= currentBlockIndex; i++) {
+            Block block = blocks[i];
+            SelectedPositions selectedPositions = getPositionsForBlocks().get(i);
+            int positionCount = selectedPositions.size();
+
+            if (!selectedPositions.isList()) {
+                if (positionCount == block.getPositionCount()) {
+                    return block;
+                }
+                else {
+                    return block.getRegion(selectedPositions.getOffset(), positionCount);
+                }
+            }
+            int[] positions = selectedPositions.getPositions();
+            for (int j = 0; j < positionCount; j++) {
+                // offset is always 0
+                int position = positions[j];
+                if (block.isNull(position)) {
+                    blockBuilder.appendNull();
+                }
+                else {
+                    elementType.appendTo(block, position, blockBuilder);
+                }
+            }
+        }
+
+        return blockBuilder.build();
+    }
+
+    public List<SelectedPositions> getPositionsForBlocks()
+    {
+        return positionsForBlocks;
+    }
+
+    public long getRetainedSizeInBytes()
+    {
+        long sizeInBytes = INSTANCE_SIZE + ARRAY_LIST_INSTANCE_SIZE + sizeOf(blockPositionByHash);
+        for (int i = 0; i <= currentBlockIndex; i++) {
+            sizeInBytes += sizeOf(positionsForBlocks.get(i).getPositions());
+        }
+        return sizeInBytes;
+    }
+
+    private long[] initializeHashTable()
+    {
+        long[] newBlockPositionByHash = new long[hashCapacity]; // Create a new hashtable
+        Arrays.fill(newBlockPositionByHash, EMPTY_SLOT);
+        return newBlockPositionByHash;
+    }
+
+    private void ensureBlocksCapacity(int capacity)
+    {
+        if (blocks == null || blocks.length < capacity) {
+            blocks = Arrays.copyOf(blocks, capacity);
+        }
+    }
+
+    private int getMaskedHash(long rawHash)
+    {
+        return (int) (rawHash & hashMask);
+    }
+
+    /**
+     * Return the position in the hashtable the element at Block position should be inserted.
+     *
+     * @return The position of the hashtable to be inserted if the element does not exist, INVALID_POSITION otherwise.
+     * @hashPosition The position into the hashtable the linear probing starts
+     */
+    private int getInsertPosition(long[] hashtable, int hashPosition, Block block, int position)
+    {
+        while (true) {
+            long blockPosition = hashtable[hashPosition];
+            // Doesn't have this element
+            if (blockPosition == EMPTY_SLOT) {
+                // does not exist
+                return hashPosition;
+            }
+
+            // Already has this element
+            int blockIndex = (int) ((blockPosition & 0xffff_ffff_0000_0000L) >> 32);
+            int positionWithinBlock = (int) (blockPosition & 0xffff_ffff);
+            if (positionEqualsPosition(elementType, blocks[blockIndex], positionWithinBlock, block, position)) {
+                return INVALID_POSITION;
+            }
+
+            hashPosition = getMaskedHash(hashPosition + 1);
+        }
+    }
+
+    /**
+     * Add an element to the hash table if it's not already existed.
+     *
+     * @param hashtable The target hash table the element to be inserted into
+     * @param hashPosition The position into the hashtable the linear probing starts
+     * @return true of the element is inserted, false otherwise
+     */
+    private boolean addElement(long[] hashtable, int hashPosition, Block block, int position)
+    {
+        while (true) {
+            long blockPosition = hashtable[hashPosition];
+
+            // Doesn't have this element
+            if (blockPosition == EMPTY_SLOT) {
+                hashtable[hashPosition] = ((long) currentBlockIndex << 32) | position;
+                return true;
+            }
+
+            // Already has this element
+            int blockIndex = (int) ((blockPosition & 0xffff_ffff_0000_0000L) >> 32);
+            int positionWithinBlock = (int) (blockPosition & 0xffff_ffff);
+            if (positionEqualsPosition(elementType, blocks[blockIndex], positionWithinBlock, block, position)) {
+                return false;
+            }
+
+            hashPosition = getMaskedHash(hashPosition + 1);
+        }
+    }
+
+    private void clearPreviousBlocks()
+    {
+        for (int i = 0; i < currentBlockIndex; i++) {
+            positionsForBlocks.set(i, EMPTY_SELECTED_POSITIONS);
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapConcatFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapConcatFunction.java
@@ -18,6 +18,7 @@ import com.facebook.presto.common.PageBuilder;
 import com.facebook.presto.common.QualifiedObjectName;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.block.SingleMapBlock;
 import com.facebook.presto.common.type.MapType;
 import com.facebook.presto.common.type.StandardTypes;
 import com.facebook.presto.common.type.Type;
@@ -25,7 +26,8 @@ import com.facebook.presto.common.type.TypeSignatureParameter;
 import com.facebook.presto.metadata.BoundVariables;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
 import com.facebook.presto.metadata.SqlScalarFunction;
-import com.facebook.presto.operator.aggregation.TypedSet;
+import com.facebook.presto.operator.aggregation.OptimizedTypedSet;
+import com.facebook.presto.operator.project.SelectedPositions;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.function.FunctionKind;
 import com.facebook.presto.spi.function.Signature;
@@ -34,6 +36,7 @@ import com.facebook.presto.sql.gen.VarArgsToArrayAdapterGenerator.MethodHandleAn
 import com.google.common.collect.ImmutableList;
 
 import java.lang.invoke.MethodHandle;
+import java.util.List;
 import java.util.Optional;
 
 import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
@@ -139,42 +142,38 @@ public final class MapConcatFunction
             return maps[lastMapIndex];
         }
 
+        Type keyType = mapType.getKeyType();
+        Type valueType = mapType.getValueType();
+
+        // We need to divide the entries by 2 because the maps array is SingleMapBlocks and it had the positionCount twice as large as a normal Block
+        OptimizedTypedSet typedSet = new OptimizedTypedSet(keyType, maps.length, entries / 2);
+
+        for (int i = lastMapIndex; i >= firstMapIndex; i--) {
+            SingleMapBlock singleMapBlock = (SingleMapBlock) maps[i];
+            Block keyBlock = singleMapBlock.getKeyBlock();
+            typedSet.union(keyBlock);
+        }
+
+        List<SelectedPositions> selectedPositionsList = typedSet.getPositionsForBlocks();
+
         PageBuilder pageBuilder = (PageBuilder) state;
         if (pageBuilder.isFull()) {
             pageBuilder.reset();
         }
-
-        // TODO: we should move TypedSet into user state as well
-        Type keyType = mapType.getKeyType();
-        Type valueType = mapType.getValueType();
-        TypedSet typedSet = new TypedSet(keyType, entries / 2, FUNCTION_NAME);
         BlockBuilder mapBlockBuilder = pageBuilder.getBlockBuilder(0);
         BlockBuilder blockBuilder = mapBlockBuilder.beginBlockEntry();
 
-        // the last map
-        Block map = maps[lastMapIndex];
-        for (int i = 0; i < map.getPositionCount(); i += 2) {
-            typedSet.add(map, i);
-            keyType.appendTo(map, i, blockBuilder);
-            valueType.appendTo(map, i + 1, blockBuilder);
-        }
-        // the map between the last and the first
-        for (int idx = lastMapIndex - 1; idx > firstMapIndex; idx--) {
-            map = maps[idx];
-            for (int i = 0; i < map.getPositionCount(); i += 2) {
-                if (!typedSet.contains(map, i)) {
-                    typedSet.add(map, i);
-                    keyType.appendTo(map, i, blockBuilder);
-                    valueType.appendTo(map, i + 1, blockBuilder);
-                }
-            }
-        }
-        // the first map
-        map = maps[firstMapIndex];
-        for (int i = 0; i < map.getPositionCount(); i += 2) {
-            if (!typedSet.contains(map, i)) {
-                keyType.appendTo(map, i, blockBuilder);
-                valueType.appendTo(map, i + 1, blockBuilder);
+        for (int i = lastMapIndex; i >= firstMapIndex; i--) {
+            SingleMapBlock singleMapBlock = (SingleMapBlock) maps[i];
+            // selectedPositions was ordered by addUnion sequence therefore the order should be reversed.
+            SelectedPositions selectedPositions = selectedPositionsList.get(lastMapIndex - i);
+            assert selectedPositions.isList();
+
+            int[] positions = selectedPositions.getPositions();
+            for (int j = 0; j < selectedPositions.size(); j++) {
+                int position = positions[j];
+                keyType.appendTo(singleMapBlock, 2 * position, blockBuilder);
+                valueType.appendTo(singleMapBlock, 2 * position + 1, blockBuilder);
             }
         }
 

--- a/presto-main/src/test/java/com/facebook/presto/block/BlockAssertions.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/BlockAssertions.java
@@ -117,6 +117,11 @@ public final class BlockAssertions
         }
     }
 
+    public static Block createEmptyBlock(Type type)
+    {
+        return createAllNullsBlock(type, 0);
+    }
+
     public static Block createAllNullsBlock(Type type, int positionCount)
     {
         BlockBuilder blockBuilder = type.createBlockBuilder(null, 1);

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestOptimizedTypedSet.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestOptimizedTypedSet.java
@@ -1,0 +1,226 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.common.block.Block;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.block.BlockAssertions.assertBlockEquals;
+import static com.facebook.presto.block.BlockAssertions.createEmptyBlock;
+import static com.facebook.presto.block.BlockAssertions.createLongRepeatBlock;
+import static com.facebook.presto.block.BlockAssertions.createLongSequenceBlock;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static org.testng.Assert.fail;
+
+public class TestOptimizedTypedSet
+{
+    private static final String FUNCTION_NAME = "optimized_typed_set_test";
+    private static final int POSITIONS_PER_PAGE = 100;
+
+    @Test
+    public void testConstructor()
+    {
+        for (int i = -2; i <= -1; i++) {
+            try {
+                //noinspection ResultOfObjectAllocationIgnored
+                new OptimizedTypedSet(BIGINT, 2, i);
+                fail("Should throw exception if expectedSize < 0");
+            }
+            catch (IllegalArgumentException e) {
+                // ignored
+            }
+        }
+
+        try {
+            //noinspection ResultOfObjectAllocationIgnored
+            new OptimizedTypedSet(null, -1, 1);
+            fail("Should throw exception if expectedBlockCount is negative");
+        }
+        catch (NullPointerException | IllegalArgumentException e) {
+            // ignored
+        }
+
+        try {
+            //noinspection ResultOfObjectAllocationIgnored
+            new OptimizedTypedSet(null, 2, 1);
+            fail("Should throw exception if type is null");
+        }
+        catch (NullPointerException | IllegalArgumentException e) {
+            // ignored
+        }
+    }
+
+    @Test
+    public void testUnionWithDistinctValues()
+    {
+        OptimizedTypedSet typedSet = new OptimizedTypedSet(BIGINT, POSITIONS_PER_PAGE + 1);
+
+        Block block = createLongSequenceBlock(0, POSITIONS_PER_PAGE / 2);
+        testUnion(typedSet, block, block);
+
+        block = createLongSequenceBlock(0, POSITIONS_PER_PAGE);
+        testUnion(typedSet, createLongSequenceBlock(POSITIONS_PER_PAGE / 2, POSITIONS_PER_PAGE), block);
+
+        // Test adding a block with null
+        Block blockWithNull = block.appendNull();
+        testUnion(typedSet, blockWithNull, blockWithNull);
+    }
+
+    @Test
+    public void testUnionWithRepeatingValues()
+    {
+        OptimizedTypedSet typedSet = new OptimizedTypedSet(BIGINT, POSITIONS_PER_PAGE);
+
+        Block block = createLongRepeatBlock(0, POSITIONS_PER_PAGE);
+        Block expectedBlock = createLongRepeatBlock(0, 1);
+        testUnion(typedSet, block, expectedBlock);
+
+        // Test adding a block with null
+        Block blockWithNull = block.appendNull();
+        expectedBlock = expectedBlock.appendNull();
+        testUnion(typedSet, blockWithNull, expectedBlock);
+    }
+
+    @Test
+    public void testIntersectWithEmptySet()
+    {
+        OptimizedTypedSet typedSet = new OptimizedTypedSet(BIGINT, POSITIONS_PER_PAGE);
+        testIntersect(typedSet, createLongSequenceBlock(0, POSITIONS_PER_PAGE - 1).appendNull(), createEmptyBlock(BIGINT));
+    }
+
+    @Test
+    public void testIntersectWithDistinctValues()
+    {
+        OptimizedTypedSet typedSet = new OptimizedTypedSet(BIGINT, POSITIONS_PER_PAGE);
+
+        Block block = createLongSequenceBlock(0, POSITIONS_PER_PAGE - 1).appendNull();
+        typedSet.union(block);
+
+        testIntersect(typedSet, block, block);
+
+        block = createLongSequenceBlock(0, POSITIONS_PER_PAGE / 2 - 1).appendNull();
+        testIntersect(typedSet, block, block);
+
+        block = createLongSequenceBlock(0, 1).appendNull();
+        testIntersect(typedSet, block, block);
+    }
+
+    @Test
+    public void testIntersectWithNonDistinctValues()
+    {
+        OptimizedTypedSet typedSet = new OptimizedTypedSet(BIGINT, POSITIONS_PER_PAGE);
+
+        Block block = createLongSequenceBlock(0, POSITIONS_PER_PAGE - 1).appendNull();
+        typedSet.union(block);
+
+        block = createLongRepeatBlock(0, POSITIONS_PER_PAGE - 1).appendNull();
+        testIntersect(typedSet, block, createLongSequenceBlock(0, 1).appendNull());
+
+        block = createLongSequenceBlock(0, 0).appendNull();
+        testIntersect(typedSet, block, block);
+
+        block = createLongSequenceBlock(0, 0);
+        testIntersect(typedSet, block, block);
+    }
+
+    @Test
+    public void testExceptWithDistinctValues()
+    {
+        OptimizedTypedSet typedSet = new OptimizedTypedSet(BIGINT, POSITIONS_PER_PAGE);
+
+        Block block = createLongSequenceBlock(0, POSITIONS_PER_PAGE - 1).appendNull();
+        typedSet.union(block);
+
+        testExcept(typedSet, block, createEmptyBlock(BIGINT));
+        testExcept(typedSet, block, block);
+    }
+
+    @Test
+    public void testExceptWithRepeatingValues()
+    {
+        OptimizedTypedSet typedSet = new OptimizedTypedSet(BIGINT, POSITIONS_PER_PAGE);
+
+        Block block = createLongRepeatBlock(0, POSITIONS_PER_PAGE - 1).appendNull();
+        testExcept(typedSet, block, createLongSequenceBlock(0, 1).appendNull());
+    }
+
+    @Test
+    public void testMultipleOperations()
+    {
+        OptimizedTypedSet typedSet = new OptimizedTypedSet(BIGINT, POSITIONS_PER_PAGE + 1);
+
+        Block block = createLongSequenceBlock(0, POSITIONS_PER_PAGE / 2).appendNull();
+
+        testUnion(typedSet, block, block);
+        testIntersect(typedSet, block, block);
+
+        block = createLongSequenceBlock(POSITIONS_PER_PAGE / 2, POSITIONS_PER_PAGE);
+        testExcept(typedSet, block.appendNull(), block);
+        testExcept(typedSet, createLongSequenceBlock(0, POSITIONS_PER_PAGE), createLongSequenceBlock(0, POSITIONS_PER_PAGE / 2));
+
+        testUnion(typedSet, block, createLongSequenceBlock(0, POSITIONS_PER_PAGE));
+        testIntersect(typedSet, createEmptyBlock(BIGINT).appendNull(), createEmptyBlock(BIGINT));
+    }
+
+    @Test
+    public void testNulls()
+    {
+        OptimizedTypedSet typedSet = new OptimizedTypedSet(BIGINT, POSITIONS_PER_PAGE + 1);
+
+        // Empty block
+        Block emptyBlock = createLongSequenceBlock(0, 0);
+
+        testUnion(typedSet, emptyBlock, emptyBlock);
+
+        // Block with a single null
+        Block singleNullBlock = emptyBlock.appendNull();
+
+        testUnion(typedSet, singleNullBlock, singleNullBlock);
+        testIntersect(typedSet, singleNullBlock, singleNullBlock);
+        testIntersect(typedSet, emptyBlock, emptyBlock);
+        testExcept(typedSet, singleNullBlock, singleNullBlock);
+        testIntersect(typedSet, emptyBlock, emptyBlock);
+
+        // Block with a 0, and block with a 0 and a null
+        Block zero = createLongSequenceBlock(0, 0);
+        Block zeroAndNull = zero.appendNull();
+
+        testUnion(typedSet, zero, zero);
+        testUnion(typedSet, singleNullBlock, zeroAndNull);
+        testIntersect(typedSet, zero, zero);
+        testExcept(typedSet, singleNullBlock, singleNullBlock);
+        testUnion(typedSet, zero, zeroAndNull);
+    }
+
+    private void testUnion(OptimizedTypedSet typedSet, Block block, Block expectedBlock)
+    {
+        typedSet.union(block);
+        Block resultBlock = typedSet.getBlock();
+        assertBlockEquals(BIGINT, resultBlock, expectedBlock);
+    }
+
+    private void testIntersect(OptimizedTypedSet typedSet, Block block, Block expectedBlock)
+    {
+        typedSet.intersect(block);
+        Block resultBlock = typedSet.getBlock();
+        assertBlockEquals(BIGINT, resultBlock, expectedBlock);
+    }
+
+    private void testExcept(OptimizedTypedSet typedSet, Block block, Block expectedBlock)
+    {
+        typedSet.except(block);
+        Block resultBlock = typedSet.getBlock();
+        assertBlockEquals(BIGINT, resultBlock, expectedBlock);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkMapConcat.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkMapConcat.java
@@ -46,8 +46,10 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openjdk.jmh.runner.options.VerboseMode;
 import org.openjdk.jmh.runner.options.WarmupMode;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 
@@ -71,7 +73,7 @@ import static io.airlift.slice.Slices.utf8Slice;
 @BenchmarkMode(Mode.AverageTime)
 public class BenchmarkMapConcat
 {
-    private static final int POSITIONS = 10_000;
+    private static final int POSITIONS = 1000;
 
     @Benchmark
     @OperationsPerInvocation(POSITIONS)
@@ -92,7 +94,10 @@ public class BenchmarkMapConcat
         private String name = "map_concat";
 
         @Param({"left_empty", "right_empty", "both_empty", "non_empty"})
-        private String mapConfig = "left_empty";
+        private String mapConfig = "non_empty";
+
+        @Param({"10", "100", "1000"})
+        private int keyCount = 100;
 
         private Page page;
         private PageProcessor pageProcessor;
@@ -103,15 +108,18 @@ public class BenchmarkMapConcat
             MetadataManager metadata = createTestMetadataManager();
             ExpressionCompiler compiler = new ExpressionCompiler(metadata, new PageFunctionCompiler(metadata, 0));
 
+            List<String> keyList1 = createRandomStringListFromSet(keyCount);
+            List<String> keyList2 = createRandomStringListFromSet(keyCount);
+
             List<String> leftKeys;
             List<String> rightKeys;
             switch (mapConfig) {
                 case "left_empty":
                     leftKeys = ImmutableList.of();
-                    rightKeys = ImmutableList.of("a", "b", "c");
+                    rightKeys = keyList1;
                     break;
                 case "right_empty":
-                    leftKeys = ImmutableList.of("a", "b", "c");
+                    leftKeys = keyList1;
                     rightKeys = ImmutableList.of();
                     break;
                 case "both_empty":
@@ -119,8 +127,8 @@ public class BenchmarkMapConcat
                     rightKeys = ImmutableList.of();
                     break;
                 case "non_empty":
-                    leftKeys = ImmutableList.of("a", "b", "c");
-                    rightKeys = ImmutableList.of("d", "b", "c");
+                    leftKeys = keyList1;
+                    rightKeys = keyList2;
                     break;
                 default:
                     throw new UnsupportedOperationException();
@@ -197,6 +205,16 @@ public class BenchmarkMapConcat
                 sliceArray[i] = utf8Slice(keys.get(i));
             }
             return createSlicesBlock(sliceArray);
+        }
+
+        private static List<String> createRandomStringListFromSet(int keyCount)
+        {
+            Random random = new Random(0);
+            List<String> keyList = new ArrayList<>();
+            for (int i = 0; i < keyCount; i++) {
+                keyList.add(Integer.toString(random.nextInt(keyCount)));
+            }
+            return keyList;
         }
     }
 


### PR DESCRIPTION
This PR resolves the "Avoid block building inside" part in https://github.com/prestodb/presto/issues/15361. The optimizations included in this PR are
- Avoid block building inside.

  TypedSet has an internal BlockBuilder and appends each Block position being added to it. Block building using BlockBuilder is highly costly and inefficient operation. Here the BlockBuilder is needed to 1) resolve hash table probing collision 2) rehash. However, both are actually not a problem. In most use cases, whole blocks (instead of several positions of a block) are added to the TypedSet, and problem 1) can be resolved by keeping track of the blocks being added. 2) Rehashing is not needed since we can know the max number of entries before creating a TypedSet for most use cases. So we want to provide a method that adds a whole Block and just record the positions in the set using SelectedPositions objects. By providing this new interface, internal operations can be streamlined to more efficient loops. It also gives opportunity to get the result Block using more efficient APIs that allows encapsulated memory copying.

  In the new OptimizedTypedSet class, we offer several operations: union, intersect and except. The operations can be called multiple times, but user does need to specify the max set size when creating the OptimizedTypedSet.

- Avoid computing the hash positions multiple times
The previous TypedSet usage sometimes require calculating the hash position multiple times if there are multiple TypedSets. For example array_intersect and array_except. Such usages build one TypedSet R, and based on the probe result on R, insert new elements to another TypedSet B. It requires to calculate the hash position multiple times. This can be avoided if the new TypdedSet can encapsulate the operations inside. The hashPosition calculated in hashtable A can be reused by hashtable B if the size and hash functions are the same.

- JMH benchmark shows up to 40% improvement for `array_union`:

    Type       | Baseline  | Specialized Baseline | OptimizedTypedSet | Gain%
    -----------|-----------|----------------------|-------------------|----------
    BIGINT     |      5511 |                 3742 |            3320   |      40%
    VARCHAR    |     20414 |                 N/A  |            14155  |      31%

- JMH benchmark shows 82% improvement for non_empty case for `map_concat` when keyCount=100
    and POSITIONS=1000:

```
    Baseline

    Benchmark                     Mode  Cnt      Score      Error  Units
    BenchmarkMapConcat.mapConcat  avgt   20  26710.925 ± 2005.756  ns/op
    Retained Size: 1,402,374 bytes

    After
    Benchmark                     Mode  Cnt      Score      Error  Units
    BenchmarkMapConcat.mapConcat  avgt   20  14605.437 ± 1209.786  ns/op
    Retained Size: 1,373,273 bytes

```
 When keyCount=1000 and POSITIONS=1000, **the baseline just OOMed. The optimized version succeeded.**

- Array_intersect  showed up to 49% improvement in time and 72% savings in allocation rate. More detailed comparisons:
![Screen Shot 2020-11-05 at 1 59 55 AM](https://user-images.githubusercontent.com/33299678/98228163-14447a00-1f0d-11eb-9389-20df2a1ae3c6.png)
![Screen Shot 2020-11-05 at 2 00 02 AM](https://user-images.githubusercontent.com/33299678/98228174-173f6a80-1f0d-11eb-8ba0-a86cbdda2c6b.png)

- array_except JMH benchmark shows 40% improvement:

```
    Before
    Benchmark                               Mode  Cnt       Score        Error  Units
    BenchmarkArrayIntersect.arrayIntersect  avgt   10  618074.452 ± 119912.203  ns/op

    After
    Benchmark                               Mode  Cnt       Score       Error  Units
    BenchmarkArrayIntersect.arrayIntersect  avgt   10  376854.064 ± 21616.063  ns/op
```
Production testing:
Tested using verifier on 1220 queries with map_concat, array_union, array_intersect, array_except. No failures found.

```
== NO RELEASE NOTE ==
```
