### PR TITLE
replacing map keyset calls with entryset to obtain O(n) performance 

### DIFF
--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/alluxio/AlluxioHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/alluxio/AlluxioHiveMetastore.java
@@ -49,6 +49,7 @@ import com.google.inject.Inject;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
@@ -176,8 +177,9 @@ public class AlluxioHiveMetastore
                         entry -> groupStatisticsByColumn(entry.getValue(), partitionRowCounts.getOrDefault(entry.getKey(), OptionalLong.empty()))));
 
         ImmutableMap.Builder<String, PartitionStatistics> result = ImmutableMap.builder();
-        for (String partitionName : partitionBasicStatistics.keySet()) {
-            HiveBasicStatistics basicStatistics = partitionBasicStatistics.get(partitionName);
+        for (Map.Entry<String, HiveBasicStatistics> partitionBasicStatisticsEntry : partitionBasicStatistics.entrySet()) {
+            String partitionName = partitionBasicStatisticsEntry.getKey();
+            HiveBasicStatistics basicStatistics = partitionBasicStatisticsEntry.getValue();
             Map<String, HiveColumnStatistics> columnStatistics = partitionColumnStatistics.getOrDefault(partitionName, ImmutableMap.of());
             result.put(partitionName, new PartitionStatistics(basicStatistics, columnStatistics));
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/TextRenderer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/TextRenderer.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 
@@ -140,8 +141,9 @@ public class TextRenderer
 
         Map<String, String> translatedOperatorTypes = translateOperatorTypes(stats.getOperatorTypes());
 
-        for (String operator : translatedOperatorTypes.keySet()) {
-            String translatedOperatorType = translatedOperatorTypes.get(operator);
+        for (Map.Entry<String, String> translatedOperatorTypesEntry : translatedOperatorTypes.entrySet()) {
+            String operator = translatedOperatorTypesEntry.getKey();
+            String translatedOperatorType = translatedOperatorTypesEntry.getValue();
             double inputAverage = inputAverages.get(operator);
 
             output.append(translatedOperatorType);

--- a/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoIndex.java
+++ b/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoIndex.java
@@ -19,6 +19,7 @@ import com.mongodb.client.ListIndexesIterable;
 import org.bson.Document;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 
@@ -53,9 +54,9 @@ public class MongoIndex
     {
         ImmutableList.Builder<MongodbIndexKey> builder = ImmutableList.builder();
 
-        for (Map.Entry<String,Object> keyEntry : key.entrySet()) {
-            String name = key.getKey();
-            Object value = key.getValue();
+        for (Map.Entry<String, Object> keyEntry : key.entrySet()) {
+            String name = keyEntry.getKey();
+            Object value = keyEntry.getValue();
             if (value instanceof Number) {
                 int order = ((Number) value).intValue();
                 checkState(order == 1 || order == -1, "Unknown index sort order");

--- a/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoIndex.java
+++ b/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoIndex.java
@@ -19,6 +19,7 @@ import com.mongodb.client.ListIndexesIterable;
 import org.bson.Document;
 
 import java.util.List;
+import java.util.Map.Entry;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkState;
@@ -52,8 +53,9 @@ public class MongoIndex
     {
         ImmutableList.Builder<MongodbIndexKey> builder = ImmutableList.builder();
 
-        for (String name : key.keySet()) {
-            Object value = key.get(name);
+        for (Map.Entry<String,Object> keyEntry : key.entrySet()) {
+            String name = key.getKey();
+            Object value = key.getValue();
             if (value instanceof Number) {
                 int order = ((Number) value).intValue();
                 checkState(order == 1 || order == -1, "Unknown index sort order");

--- a/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoSession.java
+++ b/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoSession.java
@@ -473,9 +473,9 @@ public class MongoSession
 
         ImmutableList.Builder<Document> builder = ImmutableList.builder();
 
-        for (Map.Entry<String,Object> docEntry : doc.entrySet()) {
-            key = doc.getKey();
-            Object value = doc.getValue();
+        for (Map.Entry<String, Object> docEntry : doc.entrySet()) {
+            String key = docEntry.getKey();
+            Object value = docEntry.getValue();
             Optional<TypeSignature> fieldType = guessFieldType(value);
             if (fieldType.isPresent()) {
                 Document metadata = new Document();

--- a/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoSession.java
+++ b/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoSession.java
@@ -53,6 +53,7 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -472,8 +473,9 @@ public class MongoSession
 
         ImmutableList.Builder<Document> builder = ImmutableList.builder();
 
-        for (String key : doc.keySet()) {
-            Object value = doc.get(key);
+        for (Map.Entry<String,Object> docEntry : doc.entrySet()) {
+            key = doc.getKey();
+            Object value = doc.getValue();
             Optional<TypeSignature> fieldType = guessFieldType(value);
             if (fieldType.isPresent()) {
                 Document metadata = new Document();


### PR DESCRIPTION
replacing map keyset calls with entryset to obtain O(n) performance improvement from O(N^2)

Test plan - I ran mvn clean install -DskipTests   **** Unit tests failed on my macbook pro before and after making changes the same way **** I'm a first time contributor so I'm sure best practice is to rerun these tests on a machine where the tests do run to completion anyway but I'm flagging all this trying to be a good member of the community.

Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines. Don't forget to follow our [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution) for any code copied from other projects.

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== RELEASE NOTES ==

General Changes
* Four keySet() iterators that then performed .get on the map to obtain the entry were replaced by entrySet() iterators
```
