### PR TITLE
replacing map keyset calls with entryset to obtain O(n) performance i…

### DIFF
--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/alluxio/AlluxioHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/alluxio/AlluxioHiveMetastore.java
@@ -176,8 +176,9 @@ public class AlluxioHiveMetastore
                         entry -> groupStatisticsByColumn(entry.getValue(), partitionRowCounts.getOrDefault(entry.getKey(), OptionalLong.empty()))));
 
         ImmutableMap.Builder<String, PartitionStatistics> result = ImmutableMap.builder();
-        for (String partitionName : partitionBasicStatistics.keySet()) {
-            HiveBasicStatistics basicStatistics = partitionBasicStatistics.get(partitionName);
+        for (java.util.Map.Entry<String, HiveBasicStatistics> partitionBasicStatisticsEntry : partitionBasicStatistics.entrySet()) {
+            String partitionName = partitionBasicStatisticsEntry.getKey();
+            HiveBasicStatistics basicStatistics = partitionBasicStatisticsEntry.getValue();
             Map<String, HiveColumnStatistics> columnStatistics = partitionColumnStatistics.getOrDefault(partitionName, ImmutableMap.of());
             result.put(partitionName, new PartitionStatistics(basicStatistics, columnStatistics));
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/TextRenderer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/TextRenderer.java
@@ -140,8 +140,9 @@ public class TextRenderer
 
         Map<String, String> translatedOperatorTypes = translateOperatorTypes(stats.getOperatorTypes());
 
-        for (String operator : translatedOperatorTypes.keySet()) {
-            String translatedOperatorType = translatedOperatorTypes.get(operator);
+        for (java.util.Map.Entry<String, String> translatedOperatorTypesEntry : translatedOperatorTypes.entrySet()) {
+            String operator = translatedOperatorTypesEntry.getKey();
+            String translatedOperatorType = translatedOperatorTypesEntry.getValue();
             double inputAverage = inputAverages.get(operator);
 
             output.append(translatedOperatorType);

--- a/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoIndex.java
+++ b/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoIndex.java
@@ -52,8 +52,9 @@ public class MongoIndex
     {
         ImmutableList.Builder<MongodbIndexKey> builder = ImmutableList.builder();
 
-        for (String name : key.keySet()) {
-            Object value = key.get(name);
+        for (java.util.Map.Entry<String, Object> keyEntry : key.entrySet()) {
+            String name = keyEntry.getKey();
+            Object value = keyEntry.getValue();
             if (value instanceof Number) {
                 int order = ((Number) value).intValue();
                 checkState(order == 1 || order == -1, "Unknown index sort order");

--- a/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoSession.java
+++ b/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoSession.java
@@ -472,8 +472,9 @@ public class MongoSession
 
         ImmutableList.Builder<Document> builder = ImmutableList.builder();
 
-        for (String key : doc.keySet()) {
-            Object value = doc.get(key);
+        for (java.util.Map.Entry<String, Object> docEntry : doc.entrySet()) {
+            String key = docEntry.getKey();
+            Object value = docEntry.getValue();
             Optional<TypeSignature> fieldType = guessFieldType(value);
             if (fieldType.isPresent()) {
                 Document metadata = new Document();


### PR DESCRIPTION
replacing map keyset calls with entryset to obtain O(n) performance improvement from O(N^2)

Test plan - I used the existing tests.   There are new new features in this commit, this is purely performance boosts

Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines. Don't forget to follow our [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution) for any code copied from other projects.

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== RELEASE NOTES ==

General Changes
* Four keySet() iterators that then performed .get on the map to obtain the entry were replaced by entrySet() iterators

```
