### PR TITLE
Handle query level timeouts in Presto on Spark

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
@@ -98,6 +98,7 @@ import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import org.apache.spark.SparkContext;
 import org.apache.spark.SparkException;
+import org.apache.spark.api.java.JavaFutureAction;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.broadcast.Broadcast;
@@ -115,6 +116,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -123,11 +125,14 @@ import java.util.OptionalLong;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import static com.facebook.airlift.concurrent.MoreFutures.getFutureValue;
 import static com.facebook.presto.ExceededMemoryLimitException.exceededLocalBroadcastMemoryLimit;
 import static com.facebook.presto.SystemSessionProperties.getQueryMaxBroadcastMemory;
+import static com.facebook.presto.SystemSessionProperties.getQueryMaxExecutionTime;
+import static com.facebook.presto.SystemSessionProperties.getQueryMaxRunTime;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.execution.QueryState.FAILED;
 import static com.facebook.presto.execution.QueryState.FINISHED;
@@ -144,6 +149,7 @@ import static com.facebook.presto.spark.classloader_interface.ScalaUtils.collect
 import static com.facebook.presto.spark.classloader_interface.ScalaUtils.emptyScalaIterator;
 import static com.facebook.presto.spark.util.PrestoSparkUtils.createPagesSerde;
 import static com.facebook.presto.spark.util.PrestoSparkUtils.toSerializedPage;
+import static com.facebook.presto.spi.StandardErrorCode.EXCEEDED_TIME_LIMIT;
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.spi.connector.ConnectorCapabilities.SUPPORTS_PAGE_SINK_COMMIT;
@@ -276,6 +282,15 @@ public class PrestoSparkQueryExecutionFactory
         TransactionId transactionId = transactionManager.beginTransaction(true);
         session = session.beginTransactionId(transactionId, transactionManager, accessControl);
 
+        // including queueing time
+        Duration queryMaxRunTime = getQueryMaxRunTime(session);
+        // excluding queueing time
+        Duration queryMaxExecutionTime = getQueryMaxExecutionTime(session);
+        // pick a smaller one as we are not tracking queueing for Presto on Spark
+        Duration queryTimeout = queryMaxRunTime.compareTo(queryMaxExecutionTime) < 0 ? queryMaxRunTime : queryMaxExecutionTime;
+
+        long queryCompletionDeadline = System.currentTimeMillis() + queryTimeout.toMillis();
+
         queryMonitor.queryCreatedEvent(
                 new BasicQueryInfo(createQueryInfo(
                         session,
@@ -329,6 +344,8 @@ public class PrestoSparkQueryExecutionFactory
                     transactionManager,
                     createPagesSerde(blockEncodingManager),
                     executionExceptionFactory,
+                    queryTimeout,
+                    queryCompletionDeadline,
                     queryStatusInfoOutputPath,
                     queryDataOutputPath);
         }
@@ -676,8 +693,11 @@ public class PrestoSparkQueryExecutionFactory
         private final TransactionManager transactionManager;
         private final PagesSerde pagesSerde;
         private final PrestoSparkExecutionExceptionFactory executionExceptionFactory;
+        private final Duration queryTimeout;
         private final Optional<Path> queryStatusInfoOutputPath;
         private final Optional<Path> queryDataOutputPath;
+
+        private final long queryCompletionDeadline;
 
         private PrestoSparkQueryExecution(
                 JavaSparkContext sparkContext,
@@ -702,6 +722,8 @@ public class PrestoSparkQueryExecutionFactory
                 TransactionManager transactionManager,
                 PagesSerde pagesSerde,
                 PrestoSparkExecutionExceptionFactory executionExceptionFactory,
+                Duration queryTimeout,
+                long queryCompletionDeadline,
                 Optional<Path> queryStatusInfoOutputPath,
                 Optional<Path> queryDataOutputPath)
         {
@@ -728,6 +750,8 @@ public class PrestoSparkQueryExecutionFactory
             this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
             this.pagesSerde = requireNonNull(pagesSerde, "pagesSerde is null");
             this.executionExceptionFactory = requireNonNull(executionExceptionFactory, "executionExceptionFactory is null");
+            this.queryTimeout = requireNonNull(queryTimeout, "queryTimeout is null");
+            this.queryCompletionDeadline = queryCompletionDeadline;
             this.queryStatusInfoOutputPath = requireNonNull(queryStatusInfoOutputPath, "queryStatusInfoOutputPath is null");
             this.queryDataOutputPath = requireNonNull(queryDataOutputPath, "queryDataOutputPath is null");
         }
@@ -780,6 +804,9 @@ public class PrestoSparkQueryExecutionFactory
                 }
                 else if (executionException instanceof PrestoSparkExecutionException) {
                     failureInfo = executionExceptionFactory.extractExecutionFailureInfo((PrestoSparkExecutionException) executionException);
+                }
+                else if (executionException instanceof TimeoutException) {
+                    failureInfo = Optional.of(toFailure(new PrestoException(EXCEEDED_TIME_LIMIT, "Query exceeded maximum time limit of " + queryTimeout, executionException)));
                 }
 
                 if (!failureInfo.isPresent()) {
@@ -855,7 +882,7 @@ public class PrestoSparkQueryExecutionFactory
         }
 
         private List<Tuple2<MutablePartitionId, PrestoSparkSerializedPage>> doExecute(SubPlan root)
-                throws SparkException
+                throws SparkException, TimeoutException
         {
             PlanFragment rootFragment = root.getFragment();
 
@@ -867,13 +894,15 @@ public class PrestoSparkQueryExecutionFactory
                         tableWriteInfo);
                 SerializedPrestoSparkTaskDescriptor serializedTaskDescriptor = new SerializedPrestoSparkTaskDescriptor(sparkTaskDescriptorJsonCodec.toJsonBytes(taskDescriptor));
 
-                Map<PlanFragmentId, RddAndMore<PrestoSparkSerializedPage>> inputRdds = root.getChildren().stream()
-                        .collect(toImmutableMap(child -> child.getFragment().getId(), child -> createRdd(child, PrestoSparkSerializedPage.class)));
+                Map<PlanFragmentId, RddAndMore<PrestoSparkSerializedPage>> inputRdds = new HashMap<>();
+                for (SubPlan child : root.getChildren()) {
+                    inputRdds.put(child.getFragment().getId(), createRdd(child, PrestoSparkSerializedPage.class));
+                }
 
-                Map<String, Future<List<Tuple2<MutablePartitionId, PrestoSparkSerializedPage>>>> inputFutures = inputRdds.entrySet().stream()
+                Map<String, JavaFutureAction<List<Tuple2<MutablePartitionId, PrestoSparkSerializedPage>>>> inputFutures = inputRdds.entrySet().stream()
                         .collect(toImmutableMap(entry -> entry.getKey().toString(), entry -> entry.getValue().getRdd().collectAsync()));
 
-                waitFor(inputFutures.values());
+                waitForActionsCompletionWithTimeout(inputFutures.values(), computeNextTimeout(), MILLISECONDS);
 
                 Map<String, List<PrestoSparkSerializedPage>> inputs = inputFutures.entrySet().stream()
                         .collect(toImmutableMap(
@@ -893,10 +922,11 @@ public class PrestoSparkQueryExecutionFactory
             }
 
             RddAndMore<PrestoSparkSerializedPage> rootRdd = createRdd(root, PrestoSparkSerializedPage.class);
-            return rootRdd.collectAndDestroyDependencies();
+            return rootRdd.collectAndDestroyDependenciesWithTimeout(computeNextTimeout(), MILLISECONDS);
         }
 
         private <T extends PrestoSparkTaskOutput> RddAndMore<T> createRdd(SubPlan subPlan, Class<T> outputType)
+                throws SparkException, TimeoutException
         {
             ImmutableMap.Builder<PlanFragmentId, JavaPairRDD<MutablePartitionId, PrestoSparkMutableRow>> rddInputs = ImmutableMap.builder();
             ImmutableMap.Builder<PlanFragmentId, Broadcast<List<PrestoSparkSerializedPage>>> broadcastInputs = ImmutableMap.builder();
@@ -908,7 +938,7 @@ public class PrestoSparkQueryExecutionFactory
                     RddAndMore<PrestoSparkSerializedPage> childRdd = createRdd(child, PrestoSparkSerializedPage.class);
 
                     // TODO: The driver might still OOM on a very large broadcast, think of how to prevent that from happening
-                    List<PrestoSparkSerializedPage> broadcastPages = childRdd.collectAndDestroyDependencies().stream()
+                    List<PrestoSparkSerializedPage> broadcastPages = childRdd.collectAndDestroyDependenciesWithTimeout(computeNextTimeout(), MILLISECONDS).stream()
                             .map(Tuple2::_2)
                             .collect(toList());
 
@@ -1047,31 +1077,75 @@ public class PrestoSparkQueryExecutionFactory
                     DataSize.succinctBytes(bytesPerSecond));
         }
 
-        private static <T> void waitFor(Collection<Future<T>> futures)
-                throws SparkException
+        private long computeNextTimeout()
+                throws TimeoutException
         {
-            try {
-                for (Future<?> future : futures) {
-                    future.get();
+            long timeout = queryCompletionDeadline - System.currentTimeMillis();
+            if (timeout <= 0) {
+                throw new TimeoutException();
+            }
+            return timeout;
+        }
+    }
+
+    private static <T> void waitForActionsCompletionWithTimeout(Collection<JavaFutureAction<T>> actions, long timeout, TimeUnit timeUnit)
+            throws SparkException, TimeoutException
+    {
+        long deadline = System.currentTimeMillis() + timeUnit.toMillis(timeout);
+
+        try {
+            for (JavaFutureAction<?> action : actions) {
+                long nextTimeoutInMillis = deadline - System.currentTimeMillis();
+                if (nextTimeoutInMillis <= 0) {
+                    throw new TimeoutException();
+                }
+                getActionResultWithTimeout(action, nextTimeoutInMillis, MILLISECONDS);
+            }
+        }
+        finally {
+            for (JavaFutureAction<?> action : actions) {
+                if (!action.isDone()) {
+                    action.cancel(true);
                 }
             }
-            catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                throw new RuntimeException(e);
-            }
-            catch (ExecutionException e) {
-                propagateIfPossible(e.getCause(), SparkException.class);
-                propagateIfPossible(e.getCause(), RuntimeException.class);
+        }
+    }
 
-                // this should never happen
-                throw new UncheckedExecutionException(e.getCause());
-            }
-            finally {
-                for (Future<?> future : futures) {
-                    if (!future.isDone()) {
-                        future.cancel(true);
+    private static <T> T getActionResultWithTimeout(JavaFutureAction<T> action, long timeout, TimeUnit timeUnit)
+            throws SparkException, TimeoutException
+    {
+        long deadline = System.currentTimeMillis() + timeUnit.toMillis(timeout);
+        try {
+            while (true) {
+                long nextTimeoutInMillis = deadline - System.currentTimeMillis();
+                if (nextTimeoutInMillis <= 0) {
+                    throw new TimeoutException();
+                }
+                try {
+                    return action.get(nextTimeoutInMillis, MILLISECONDS);
+                }
+                catch (TimeoutException e) {
+                    // guard against spurious wakeup
+                    if (deadline - System.currentTimeMillis() <= 0) {
+                        throw e;
                     }
                 }
+            }
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+        catch (ExecutionException e) {
+            propagateIfPossible(e.getCause(), SparkException.class);
+            propagateIfPossible(e.getCause(), RuntimeException.class);
+
+            // this should never happen
+            throw new UncheckedExecutionException(e.getCause());
+        }
+        finally {
+            if (!action.isDone()) {
+                action.cancel(true);
             }
         }
     }
@@ -1089,11 +1163,12 @@ public class PrestoSparkQueryExecutionFactory
             this.broadcastDependencies = ImmutableList.copyOf(requireNonNull(broadcastDependencies, "broadcastDependencies is null"));
         }
 
-        public List<Tuple2<MutablePartitionId, T>> collectAndDestroyDependencies()
+        public List<Tuple2<MutablePartitionId, T>> collectAndDestroyDependenciesWithTimeout(long timeout, TimeUnit timeUnit)
+                throws SparkException, TimeoutException
         {
             checkState(!collected, "already collected");
             collected = true;
-            List<Tuple2<MutablePartitionId, T>> result = rdd.collect();
+            List<Tuple2<MutablePartitionId, T>> result = getActionResultWithTimeout(rdd.collectAsync(), timeout, timeUnit);
             broadcastDependencies.forEach(Broadcast::destroy);
             return result;
         }


### PR DESCRIPTION
```
== NO RELEASE NOTE ==
```
