### PR TITLE
Replace Joda-Time libraries with java.time

### DIFF
--- a/presto-kafka/pom.xml
+++ b/presto-kafka/pom.xml
@@ -69,10 +69,6 @@
             <artifactId>kafka-clients</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-        </dependency>
 
         <dependency>
             <groupId>javax.inject</groupId>

--- a/presto-kafka/src/test/java/com/facebook/presto/kafka/util/KafkaLoader.java
+++ b/presto-kafka/src/test/java/com/facebook/presto/kafka/util/KafkaLoader.java
@@ -27,9 +27,9 @@ import com.facebook.presto.tests.ResultsSession;
 import com.google.common.collect.ImmutableMap;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
-import org.joda.time.format.DateTimeFormatter;
-import org.joda.time.format.ISODateTimeFormat;
 
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -55,7 +55,7 @@ import static java.util.Objects.requireNonNull;
 public class KafkaLoader
         extends AbstractTestingPrestoClient<Void>
 {
-    private static final DateTimeFormatter ISO8601_FORMATTER = ISODateTimeFormat.dateTime();
+    private static final DateTimeFormatter ISO8601_FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
 
     private final String topicName;
     private final KafkaProducer<Long, Object> producer;
@@ -147,13 +147,13 @@ public class KafkaLoader
                 return value;
             }
             if (TIME.equals(type)) {
-                return ISO8601_FORMATTER.print(parseTimeLiteral(timeZoneKey, (String) value));
+                return ISO8601_FORMATTER.format(Instant.ofEpochMilli(parseTimeLiteral(timeZoneKey, (String) value)));
             }
             if (TIMESTAMP.equals(type)) {
-                return ISO8601_FORMATTER.print(parseTimestampWithoutTimeZone(timeZoneKey, (String) value));
+                return ISO8601_FORMATTER.format(Instant.ofEpochMilli(parseTimestampWithoutTimeZone(timeZoneKey, (String) value)));
             }
             if (TIME_WITH_TIME_ZONE.equals(type) || TIMESTAMP_WITH_TIME_ZONE.equals(type)) {
-                return ISO8601_FORMATTER.print(unpackMillisUtc(parseTimestampWithTimeZone(timeZoneKey, (String) value)));
+                return ISO8601_FORMATTER.format(Instant.ofEpochMilli(unpackMillisUtc(parseTimestampWithTimeZone(timeZoneKey, (String) value))));
             }
             throw new AssertionError("unhandled type: " + type);
         }


### PR DESCRIPTION
Since Java 8 we have java.time packages which are equivalent to Joda and
the recommendation from the author of the Joda-Time is to migrate to
java.time(JSR-310) library.

Test plan - 
Run unit test using 
mvn  install -pl presto-kafka  -T1C
All unit test passed

```
== NO RELEASE NOTE ==
```