### PR TITLE
to #15385 Fix bug in HiveNodePartitioningProvider.getBucketNodeMap

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveNodePartitioningProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveNodePartitioningProvider.java
@@ -68,6 +68,10 @@ public class HiveNodePartitioningProvider
         HivePartitioningHandle handle = (HivePartitioningHandle) partitioningHandle;
         NodeSelectionStrategy nodeSelectionStrategy = getNodeSelectionStrategy(session);
         int bucketCount = handle.getBucketCount();
+        if (sortedNodes.size() == 0) {
+            return createBucketNodeMap(bucketCount);
+        }
+
         switch (nodeSelectionStrategy) {
             case HARD_AFFINITY:
             case SOFT_AFFINITY:


### PR DESCRIPTION
When I test exchange materialization and grouped execution, some query will hold forever. The jstack is
![image](https://user-images.githubusercontent.com/9527867/97966282-97bf7780-1df6-11eb-94e8-5e1e69df5683.png)

The reason is LocalExchange.createPartitionFunction call HiveNodePartitioningProvider.getBucketNodeMap, the sortedNodes is ImmutableList.of(), it will cause Stream.generate(() -> sortedNodes).flatMap(List::stream).limit(bucketCount) hold forever. 

LocalExchange.createPartitionFunction:
```java
        ConnectorBucketNodeMap connectorBucketNodeMap = partitioningProvider.getBucketNodeMap(
                partitioning.getTransactionHandle().orElse(null),
                session.toConnectorSession(partitioning.getConnectorId().get()),
                partitioning.getConnectorHandle(),
                ImmutableList.of());
```

HiveNodePartitioningProvider.getBucketNodeMap
```java
    @Override
    public ConnectorBucketNodeMap getBucketNodeMap(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorPartitioningHandle partitioningHandle, List<Node> sortedNodes)
    {
        HivePartitioningHandle handle = (HivePartitioningHandle) partitioningHandle;
        NodeSelectionStrategy nodeSelectionStrategy = getNodeSelectionStrategy(session);
        int bucketCount = handle.getBucketCount();
        switch (nodeSelectionStrategy) {
            case HARD_AFFINITY:
            case SOFT_AFFINITY:
                return createBucketNodeMap(Stream.generate(() -> sortedNodes).flatMap(List::stream).limit(bucketCount).collect(toImmutableList()), nodeSelectionStrategy);
            case NO_PREFERENCE:
                return createBucketNodeMap(bucketCount);
            default:
                throw new PrestoException(NODE_SELECTION_NOT_SUPPORTED, format("Unsupported node selection strategy %s", nodeSelectionStrategy));
        }
    }
```