### PR TITLE
Reuse immutable partition fields in Glue partition conversion

### DIFF
--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/glue/converter/GlueToPrestoConverter.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/glue/converter/GlueToPrestoConverter.java
@@ -31,19 +31,20 @@ import com.facebook.presto.spi.security.PrincipalType;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 import static com.facebook.presto.hive.BucketFunctionType.HIVE_COMPATIBLE;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_INVALID_METADATA;
 import static com.facebook.presto.hive.metastore.PrestoTableType.OTHER;
-import static com.google.common.base.MoreObjects.firstNonNull;
+import static com.facebook.presto.hive.metastore.util.Memoizers.memoizeLast;
 import static com.google.common.base.Strings.nullToEmpty;
-import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
-import static java.util.stream.Collectors.toList;
 
 public final class GlueToPrestoConverter
 {
@@ -57,7 +58,7 @@ public final class GlueToPrestoConverter
                 .setDatabaseName(glueDb.getName())
                 .setLocation(Optional.ofNullable(glueDb.getLocationUri()))
                 .setComment(Optional.ofNullable(glueDb.getDescription()))
-                .setParameters(firstNonNull(glueDb.getParameters(), ImmutableMap.of()))
+                .setParameters(convertParameters(glueDb.getParameters()))
                 .setOwnerName(PUBLIC_OWNER)
                 .setOwnerType(PrincipalType.ROLE)
                 .build();
@@ -73,54 +74,20 @@ public final class GlueToPrestoConverter
                 .setTableName(glueTable.getName())
                 .setOwner(nullToEmpty(glueTable.getOwner()))
                 .setTableType(PrestoTableType.optionalValueOf(glueTable.getTableType()).orElse(OTHER))
-                .setDataColumns(sd.getColumns().stream()
-                        .map(GlueToPrestoConverter::convertColumn)
-                        .collect(toList()))
-                .setParameters(firstNonNull(glueTable.getParameters(), ImmutableMap.of()))
+                .setDataColumns(convertColumns(sd.getColumns()))
+                .setParameters(convertParameters(glueTable.getParameters()))
                 .setViewOriginalText(Optional.ofNullable(glueTable.getViewOriginalText()))
                 .setViewExpandedText(Optional.ofNullable(glueTable.getViewExpandedText()));
 
         if (glueTable.getPartitionKeys() != null) {
-            tableBuilder.setPartitionColumns(glueTable.getPartitionKeys().stream()
-                    .map(GlueToPrestoConverter::convertColumn)
-                    .collect(toList()));
+            tableBuilder.setPartitionColumns(convertColumns(glueTable.getPartitionKeys()));
         }
         else {
-            tableBuilder.setPartitionColumns(new ArrayList<>());
+            tableBuilder.setPartitionColumns(ImmutableList.of());
         }
 
-        setStorageBuilder(sd, tableBuilder.getStorageBuilder());
+        new StorageConverter().setConvertedStorage(sd, tableBuilder.getStorageBuilder());
         return tableBuilder.build();
-    }
-
-    private static void setStorageBuilder(StorageDescriptor sd, Storage.Builder storageBuilder)
-    {
-        requireNonNull(sd.getSerdeInfo(), "StorageDescriptor SerDeInfo is null");
-        SerDeInfo serdeInfo = sd.getSerdeInfo();
-
-        Optional<HiveBucketProperty> bucketProperty = Optional.empty();
-        if (sd.getNumberOfBuckets() > 0) {
-            if (isNullOrEmpty(sd.getBucketColumns())) {
-                throw new PrestoException(HIVE_INVALID_METADATA, "Table/partition metadata has 'numBuckets' set, but 'bucketCols' is not set");
-            }
-            List<SortingColumn> sortedBy = ImmutableList.of();
-            if (!isNullOrEmpty(sd.getSortColumns())) {
-                sortedBy = sd.getSortColumns().stream()
-                        .map(column -> new SortingColumn(
-                                column.getColumn(),
-                                Order.fromMetastoreApiOrder(column.getSortOrder(), "unknown")))
-                        .collect(toImmutableList());
-            }
-            bucketProperty = Optional.of(new HiveBucketProperty(sd.getBucketColumns(), sd.getNumberOfBuckets(), sortedBy, HIVE_COMPATIBLE, Optional.empty()));
-        }
-
-        storageBuilder.setStorageFormat(StorageFormat.createNullable(serdeInfo.getSerializationLibrary(), sd.getInputFormat(), sd.getOutputFormat()))
-                .setLocation(nullToEmpty(sd.getLocation()))
-                .setBucketProperty(bucketProperty)
-                .setSkewed(sd.getSkewedInfo() != null && !isNullOrEmpty(sd.getSkewedInfo().getSkewedColumnNames()))
-                .setSerdeParameters(firstNonNull(serdeInfo.getParameters(), ImmutableMap.of()))
-                .setParameters(firstNonNull(sd.getParameters(), ImmutableMap.of()))
-                .build();
     }
 
     private static Column convertColumn(com.amazonaws.services.glue.model.Column glueColumn)
@@ -128,26 +95,145 @@ public final class GlueToPrestoConverter
         return new Column(glueColumn.getName(), HiveType.valueOf(glueColumn.getType().toLowerCase(Locale.ENGLISH)), Optional.ofNullable(glueColumn.getComment()));
     }
 
-    public static Partition convertPartition(com.amazonaws.services.glue.model.Partition gluePartition)
+    private static List<Column> convertColumns(List<com.amazonaws.services.glue.model.Column> glueColumns)
     {
-        requireNonNull(gluePartition.getStorageDescriptor(), "Partition StorageDescriptor is null");
-        StorageDescriptor sd = gluePartition.getStorageDescriptor();
-
-        Partition.Builder partitionBuilder = Partition.builder()
-                .setDatabaseName(gluePartition.getDatabaseName())
-                .setTableName(gluePartition.getTableName())
-                .setValues(gluePartition.getValues())
-                .setColumns(sd.getColumns().stream()
-                        .map(GlueToPrestoConverter::convertColumn)
-                        .collect(toList()))
-                .setParameters(firstNonNull(gluePartition.getParameters(), ImmutableMap.of()));
-
-        setStorageBuilder(sd, partitionBuilder.getStorageBuilder());
-        return partitionBuilder.build();
+        return mappedCopy(glueColumns, GlueToPrestoConverter::convertColumn);
     }
 
-    private static boolean isNullOrEmpty(List list)
+    private static Map<String, String> convertParameters(Map<String, String> input)
+    {
+        if (input == null || input.isEmpty()) {
+            return ImmutableMap.of();
+        }
+        return ImmutableMap.copyOf(input);
+    }
+
+    private static Function<Map<String, String>, Map<String, String>> parametersConverter()
+    {
+        return memoizeLast(GlueToPrestoConverter::convertParameters);
+    }
+
+    private static boolean isNullOrEmpty(List<?> list)
     {
         return list == null || list.isEmpty();
+    }
+
+    public static final class GluePartitionConverter
+            implements Function<com.amazonaws.services.glue.model.Partition, Partition>
+    {
+        private final Function<List<com.amazonaws.services.glue.model.Column>, List<Column>> columnsConverter = memoizeLast(GlueToPrestoConverter::convertColumns);
+        private final Function<Map<String, String>, Map<String, String>> parametersConverter = parametersConverter();
+        private final StorageConverter storageConverter = new StorageConverter();
+        private final String databaseName;
+        private final String tableName;
+
+        public GluePartitionConverter(String databaseName, String tableName)
+        {
+            this.databaseName = requireNonNull(databaseName, "databaseName is null");
+            this.tableName = requireNonNull(tableName, "tableName is null");
+        }
+
+        @Override
+        public Partition apply(com.amazonaws.services.glue.model.Partition gluePartition)
+        {
+            requireNonNull(gluePartition.getStorageDescriptor(), "Partition StorageDescriptor is null");
+            StorageDescriptor sd = gluePartition.getStorageDescriptor();
+
+            if (!databaseName.equals(gluePartition.getDatabaseName())) {
+                throw new IllegalArgumentException(format("Unexpected databaseName, expected: %s, but found: %s", databaseName, gluePartition.getDatabaseName()));
+            }
+            if (!tableName.equals(gluePartition.getTableName())) {
+                throw new IllegalArgumentException(format("Unexpected tableName, expected: %s, but found: %s", tableName, gluePartition.getTableName()));
+            }
+
+            Partition.Builder partitionBuilder = Partition.builder()
+                    .setDatabaseName(databaseName)
+                    .setTableName(tableName)
+                    .setValues(gluePartition.getValues()) // No memoization benefit
+                    .setColumns(columnsConverter.apply(sd.getColumns()))
+                    .setParameters(parametersConverter.apply(gluePartition.getParameters()));
+
+            storageConverter.setConvertedStorage(sd, partitionBuilder.getStorageBuilder());
+
+            return partitionBuilder.build();
+        }
+    }
+
+    private static final class StorageConverter
+    {
+        private final Function<List<String>, List<String>> bucketColumns = memoizeLast(ImmutableList::copyOf);
+        private final Function<List<com.amazonaws.services.glue.model.Order>, List<SortingColumn>> sortColumns = memoizeLast(StorageConverter::createSortingColumns);
+        private final UnaryOperator<Optional<HiveBucketProperty>> bucketProperty = memoizeLast();
+        private final Function<Map<String, String>, Map<String, String>> serdeParametersConverter = parametersConverter();
+        private final Function<Map<String, String>, Map<String, String>> partitionParametersConverter = parametersConverter();
+        private final StorageFormatConverter storageFormatConverter = new StorageFormatConverter();
+
+        public void setConvertedStorage(StorageDescriptor sd, Storage.Builder storageBuilder)
+        {
+            requireNonNull(sd.getSerdeInfo(), "StorageDescriptor SerDeInfo is null");
+            SerDeInfo serdeInfo = sd.getSerdeInfo();
+
+            storageBuilder.setLocation(nullToEmpty(sd.getLocation()))
+                    .setBucketProperty(createBucketProperty(sd))
+                    .setSkewed(sd.getSkewedInfo() != null && !isNullOrEmpty(sd.getSkewedInfo().getSkewedColumnNames()))
+                    .setSerdeParameters(serdeParametersConverter.apply(serdeInfo.getParameters()))
+                    .setParameters(partitionParametersConverter.apply(sd.getParameters()))
+                    .setStorageFormat(storageFormatConverter.createStorageFormat(serdeInfo, sd));
+        }
+
+        private Optional<HiveBucketProperty> createBucketProperty(StorageDescriptor sd)
+        {
+            if (sd.getNumberOfBuckets() > 0) {
+                if (isNullOrEmpty(sd.getBucketColumns())) {
+                    throw new PrestoException(HIVE_INVALID_METADATA, "Table/partition metadata has 'numBuckets' set, but 'bucketCols' is not set");
+                }
+                List<String> bucketColumns = this.bucketColumns.apply(sd.getBucketColumns());
+                List<SortingColumn> sortedBy = this.sortColumns.apply(sd.getSortColumns());
+                return bucketProperty.apply(Optional.of(new HiveBucketProperty(bucketColumns, sd.getNumberOfBuckets(), sortedBy, HIVE_COMPATIBLE, Optional.empty())));
+            }
+            return Optional.empty();
+        }
+
+        private static List<SortingColumn> createSortingColumns(List<com.amazonaws.services.glue.model.Order> sortColumns)
+        {
+            if (isNullOrEmpty(sortColumns)) {
+                return ImmutableList.of();
+            }
+            return mappedCopy(sortColumns, column -> new SortingColumn(column.getColumn(), Order.fromMetastoreApiOrder(column.getSortOrder(), "unknown")));
+        }
+    }
+
+    private static final class StorageFormatConverter
+    {
+        private static final StorageFormat ALL_NULLS = StorageFormat.createNullable(null, null, null);
+        private final UnaryOperator<String> serializationLib = memoizeLast();
+        private final UnaryOperator<String> inputFormat = memoizeLast();
+        private final UnaryOperator<String> outputFormat = memoizeLast();
+        // Second phase to attempt memoization on the entire instance beyond just the fields
+        private final UnaryOperator<StorageFormat> storageFormat = memoizeLast();
+
+        public StorageFormat createStorageFormat(SerDeInfo serdeInfo, StorageDescriptor storageDescriptor)
+        {
+            String serializationLib = this.serializationLib.apply(serdeInfo.getSerializationLibrary());
+            String inputFormat = this.inputFormat.apply(storageDescriptor.getInputFormat());
+            String outputFormat = this.outputFormat.apply(storageDescriptor.getOutputFormat());
+            if (serializationLib == null && inputFormat == null && outputFormat == null) {
+                return ALL_NULLS;
+            }
+            return storageFormat.apply(StorageFormat.createNullable(serializationLib, inputFormat, outputFormat));
+        }
+    }
+
+    public static <T, R> List<R> mappedCopy(List<T> list, Function<T, R> mapper)
+    {
+        requireNonNull(list, "list is null");
+        requireNonNull(mapper, "mapper is null");
+        //  Uses a pre-sized builder to avoid intermediate allocations and copies, which is especially significant when the
+        //  number of elements is large and the size of the resulting list can be known in advance
+        ImmutableList.Builder<R> builder = ImmutableList.builderWithExpectedSize(list.size());
+        for (T item : list) {
+            builder.add(mapper.apply(item));
+        }
+        return builder.build();
     }
 }

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/util/Memoizers.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/util/Memoizers.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.metastore.util;
+
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
+
+import static java.util.Objects.requireNonNull;
+
+public final class Memoizers
+{
+    private Memoizers() {}
+
+    public static <T> UnaryOperator<T> memoizeLast()
+    {
+        return new Simple<>();
+    }
+
+    public static <I, O> Function<I, O> memoizeLast(Function<I, O> transform)
+    {
+        return new Transforming<>(transform);
+    }
+
+    private static final class Simple<T>
+            implements UnaryOperator<T>
+    {
+        private T lastInput;
+
+        @Override
+        public T apply(T input)
+        {
+            if (!Objects.equals(lastInput, input)) {
+                lastInput = input;
+            }
+            return lastInput;
+        }
+    }
+
+    private static final class Transforming<I, O>
+            implements Function<I, O>
+    {
+        private final Function<I, O> transform;
+        private boolean inputSeen;
+        private I lastInput;
+        private O lastOutput;
+
+        private Transforming(Function<I, O> transform)
+        {
+            this.transform = requireNonNull(transform, "transform is null");
+        }
+
+        @Override
+        public O apply(I input)
+        {
+            if (!inputSeen || !Objects.equals(lastInput, input)) {
+                lastOutput = transform.apply(input);
+                lastInput = input;
+                inputSeen = true;
+            }
+            return lastOutput;
+        }
+    }
+}


### PR DESCRIPTION
Extracted comparable changes from https://github.com/prestosql/presto/pull/5794

When loading a large number of partitions from Glue (and especially when storing the loaded values into a cache), partition
instances often share equivalent immutable field values (eg: their columns list) which can consume a large amount of coordinator heap space.

This change enables opportunistic reuse of some partition fields by memoizing values during transformation and opportunistically reusing equivalent shared instances for consecutive converted partitions.

```
== NO RELEASE NOTE ==
```
