### PR TITLE
Add session property configuraiton manager for Presto-on-Spark

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/dispatcher/DispatchManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/dispatcher/DispatchManager.java
@@ -193,7 +193,7 @@ public class DispatchManager
                     queryType.map(Enum::name)));
 
             // apply system default session properties (does not override user set properties)
-            session = sessionPropertyDefaults.newSessionWithDefaultProperties(session, queryType.map(Enum::name), selectionContext.getResourceGroupId());
+            session = sessionPropertyDefaults.newSessionWithDefaultProperties(session, queryType.map(Enum::name), Optional.of(selectionContext.getResourceGroupId()));
 
             // mark existing transaction as active
             transactionManager.activateTransaction(session, isTransactionControlStatement(preparedQuery.getStatement()), accessControl);

--- a/presto-main/src/main/java/com/facebook/presto/server/SessionPropertyDefaults.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/SessionPropertyDefaults.java
@@ -101,7 +101,10 @@ public class SessionPropertyDefaults
         log.info("-- Loaded session property configuration manager %s --", configManagerName);
     }
 
-    public Session newSessionWithDefaultProperties(Session session, Optional<String> queryType, ResourceGroupId resourceGroupId)
+    public Session newSessionWithDefaultProperties(
+            Session session,
+            Optional<String> queryType,
+            Optional<ResourceGroupId> resourceGroupId)
     {
         SessionPropertyConfigurationManager configurationManager = delegate.get();
         if (configurationManager == null) {

--- a/presto-main/src/test/java/com/facebook/presto/server/TestSessionPropertyDefaults.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestSessionPropertyDefaults.java
@@ -76,7 +76,7 @@ public class TestSessionPropertyDefaults
                                 .put("explicit_set", "explicit_set")
                                 .build()));
 
-        session = sessionPropertyDefaults.newSessionWithDefaultProperties(session, Optional.empty(), TEST_RESOURCE_GROUP_ID);
+        session = sessionPropertyDefaults.newSessionWithDefaultProperties(session, Optional.empty(), Optional.of(TEST_RESOURCE_GROUP_ID));
 
         assertEquals(session.getSystemProperties(), ImmutableMap.<String, String>builder()
                 .put(QUERY_MAX_MEMORY, "1GB")

--- a/presto-session-property-managers/src/main/java/com/facebook/presto/session/SessionMatchSpec.java
+++ b/presto-session-property-managers/src/main/java/com/facebook/presto/session/SessionMatchSpec.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.session;
 
+import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
 import com.facebook.presto.spi.session.SessionConfigurationContext;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -78,8 +79,11 @@ public class SessionMatchSpec
             }
         }
 
-        if (resourceGroupRegex.isPresent() && !resourceGroupRegex.get().matcher(context.getResourceGroupId().toString()).matches()) {
-            return ImmutableMap.of();
+        if (resourceGroupRegex.isPresent()) {
+            String resourceGroupId = context.getResourceGroupId().map(ResourceGroupId::toString).orElse("");
+            if (!resourceGroupRegex.get().matcher(resourceGroupId).matches()) {
+                return ImmutableMap.of();
+            }
         }
 
         return sessionProperties;

--- a/presto-session-property-managers/src/test/java/com/facebook/presto/session/TestFileSessionPropertyManager.java
+++ b/presto-session-property-managers/src/test/java/com/facebook/presto/session/TestFileSessionPropertyManager.java
@@ -42,7 +42,7 @@ public class TestFileSessionPropertyManager
             Optional.of("source"),
             ImmutableSet.of("tag1", "tag2"),
             Optional.of(QueryType.DATA_DEFINITION.toString()),
-            new ResourceGroupId(ImmutableList.of("global", "pipeline", "user_foo", "bar")));
+            Optional.of(new ResourceGroupId(ImmutableList.of("global", "pipeline", "user_foo", "bar"))));
 
     @Test
     public void testResourceGroupMatch()

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
@@ -47,6 +47,7 @@ import com.facebook.presto.security.AccessControl;
 import com.facebook.presto.server.BasicQueryInfo;
 import com.facebook.presto.server.QuerySessionSupplier;
 import com.facebook.presto.server.SessionContext;
+import com.facebook.presto.server.SessionPropertyDefaults;
 import com.facebook.presto.spark.classloader_interface.IPrestoSparkQueryExecution;
 import com.facebook.presto.spark.classloader_interface.IPrestoSparkQueryExecutionFactory;
 import com.facebook.presto.spark.classloader_interface.IPrestoSparkTaskExecutor;
@@ -198,6 +199,7 @@ public class PrestoSparkQueryExecutionFactory
     private final PrestoSparkSettingsRequirements settingsRequirements;
     private final PrestoSparkExecutionExceptionFactory executionExceptionFactory;
     private final PrestoSparkTaskExecutorFactory prestoSparkTaskExecutorFactory;
+    private final SessionPropertyDefaults sessionPropertyDefaults;
 
     private final Set<PrestoSparkCredentialsProvider> credentialsProviders;
     private final Set<PrestoSparkAuthenticatorProvider> authenticatorProviders;
@@ -222,6 +224,7 @@ public class PrestoSparkQueryExecutionFactory
             PrestoSparkSettingsRequirements settingsRequirements,
             PrestoSparkExecutionExceptionFactory executionExceptionFactory,
             PrestoSparkTaskExecutorFactory prestoSparkTaskExecutorFactory,
+            SessionPropertyDefaults sessionPropertyDefaults,
             Set<PrestoSparkCredentialsProvider> credentialsProviders,
             Set<PrestoSparkAuthenticatorProvider> authenticatorProviders)
     {
@@ -243,6 +246,7 @@ public class PrestoSparkQueryExecutionFactory
         this.settingsRequirements = requireNonNull(settingsRequirements, "settingsRequirements is null");
         this.executionExceptionFactory = requireNonNull(executionExceptionFactory, "executionExceptionFactory is null");
         this.prestoSparkTaskExecutorFactory = requireNonNull(prestoSparkTaskExecutorFactory, "prestoSparkTaskExecutorFactory is null");
+        this.sessionPropertyDefaults = requireNonNull(sessionPropertyDefaults, "sessionPropertyDefaults is null");
         this.credentialsProviders = ImmutableSet.copyOf(requireNonNull(credentialsProviders, "credentialsProviders is null"));
         this.authenticatorProviders = ImmutableSet.copyOf(requireNonNull(authenticatorProviders, "authenticatorProviders is null"));
     }
@@ -277,6 +281,8 @@ public class PrestoSparkQueryExecutionFactory
         WarningCollector warningCollector = WarningCollector.NOOP;
 
         Session session = sessionSupplier.createSession(queryId, sessionContext);
+
+        session = sessionPropertyDefaults.newSessionWithDefaultProperties(session, Optional.empty(), Optional.empty());
 
         TransactionId transactionId = transactionManager.beginTransaction(true);
         session = session.beginTransactionId(transactionId, transactionManager, accessControl);

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkServiceFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkServiceFactory.java
@@ -44,6 +44,7 @@ public class PrestoSparkServiceFactory
                 configuration.getCatalogProperties(),
                 configuration.getEventListenerProperties(),
                 configuration.getAccessControlProperties(),
+                configuration.getSessionPropertyConfigurationProperties(),
                 getSqlParserOptions(),
                 getAdditionalModules());
 

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
@@ -202,6 +202,7 @@ public class PrestoSparkQueryRunner
                 ImmutableMap.of(),
                 Optional.empty(),
                 Optional.empty(),
+                Optional.empty(),
                 new SqlParserOptions(),
                 ImmutableList.of(),
                 true);

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkConfiguration.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkConfiguration.java
@@ -28,13 +28,15 @@ public class PrestoSparkConfiguration
     private final Map<String, Map<String, String>> catalogProperties;
     private final Optional<Map<String, String>> eventListenerProperties;
     private final Optional<Map<String, String>> accessControlProperties;
+    private final Optional<Map<String, String>> sessionPropertyConfigurationProperties;
 
     public PrestoSparkConfiguration(
             Map<String, String> configProperties,
             String pluginsDirectoryPath,
             Map<String, Map<String, String>> catalogProperties,
             Optional<Map<String, String>> eventListenerProperties,
-            Optional<Map<String, String>> accessControlProperties)
+            Optional<Map<String, String>> accessControlProperties,
+            Optional<Map<String, String>> sessionPropertyConfigurationProperties)
     {
         this.configProperties = unmodifiableMap(new HashMap<>(requireNonNull(configProperties, "configProperties is null")));
         this.pluginsDirectoryPath = requireNonNull(pluginsDirectoryPath, "pluginsDirectoryPath is null");
@@ -43,6 +45,8 @@ public class PrestoSparkConfiguration
         this.eventListenerProperties = requireNonNull(eventListenerProperties, "eventListenerProperties is null")
                 .map(properties -> unmodifiableMap(new HashMap<>(properties)));
         this.accessControlProperties = requireNonNull(accessControlProperties, "accessControlProperties is null")
+                .map(properties -> unmodifiableMap(new HashMap<>(properties)));
+        this.sessionPropertyConfigurationProperties = requireNonNull(sessionPropertyConfigurationProperties, "sessionPropertyConfigurationProperties is null")
                 .map(properties -> unmodifiableMap(new HashMap<>(properties)));
     }
 
@@ -69,5 +73,10 @@ public class PrestoSparkConfiguration
     public Optional<Map<String, String>> getAccessControlProperties()
     {
         return accessControlProperties;
+    }
+
+    public Optional<Map<String, String>> getSessionPropertyConfigurationProperties()
+    {
+        return sessionPropertyConfigurationProperties;
     }
 }

--- a/presto-spark-launcher/src/main/java/com/facebook/presto/spark/launcher/PrestoSparkDistribution.java
+++ b/presto-spark-launcher/src/main/java/com/facebook/presto/spark/launcher/PrestoSparkDistribution.java
@@ -32,6 +32,7 @@ public class PrestoSparkDistribution
     private final Map<String, Map<String, String>> catalogProperties;
     private final Optional<Map<String, String>> eventListenerProperties;
     private final Optional<Map<String, String>> accessControlProperties;
+    private final Optional<Map<String, String>> sessionPropertyConfigurationProperties;
 
     public PrestoSparkDistribution(
             SparkContext sparkContext,
@@ -39,7 +40,8 @@ public class PrestoSparkDistribution
             Map<String, String> configProperties,
             Map<String, Map<String, String>> catalogProperties,
             Optional<Map<String, String>> eventListenerProperties,
-            Optional<Map<String, String>> accessControlProperties)
+            Optional<Map<String, String>> accessControlProperties,
+            Optional<Map<String, String>> sessionPropertyConfigurationProperties)
     {
         this.sparkContext = requireNonNull(sparkContext, "sparkContext is null");
         this.packageSupplier = requireNonNull(packageSupplier, "packageSupplier is null");
@@ -49,6 +51,8 @@ public class PrestoSparkDistribution
         this.eventListenerProperties = requireNonNull(eventListenerProperties, "eventListenerProperties is null")
                 .map(properties -> unmodifiableMap(new HashMap<>(properties)));
         this.accessControlProperties = requireNonNull(accessControlProperties, "accessControlProperties is null")
+                .map(properties -> unmodifiableMap(new HashMap<>(properties)));
+        this.sessionPropertyConfigurationProperties = requireNonNull(sessionPropertyConfigurationProperties, "sessionPropertyConfigurationProperties is null")
                 .map(properties -> unmodifiableMap(new HashMap<>(properties)));
     }
 
@@ -80,5 +84,10 @@ public class PrestoSparkDistribution
     public Optional<Map<String, String>> getAccessControlProperties()
     {
         return accessControlProperties;
+    }
+
+    public Optional<Map<String, String>> getSessionPropertyConfigurationProperties()
+    {
+        return sessionPropertyConfigurationProperties;
     }
 }

--- a/presto-spark-launcher/src/main/java/com/facebook/presto/spark/launcher/PrestoSparkLauncherCommand.java
+++ b/presto-spark-launcher/src/main/java/com/facebook/presto/spark/launcher/PrestoSparkLauncherCommand.java
@@ -59,6 +59,7 @@ public class PrestoSparkLauncherCommand
                 loadProperties(checkFile(new File(clientOptions.config))),
                 loadCatalogProperties(new File(clientOptions.catalogs)),
                 Optional.empty(),
+                Optional.empty(),
                 Optional.empty());
 
         String query = readFileUtf8(checkFile(new File(clientOptions.file)));

--- a/presto-spark-launcher/src/main/java/com/facebook/presto/spark/launcher/PrestoSparkRunner.java
+++ b/presto-spark-launcher/src/main/java/com/facebook/presto/spark/launcher/PrestoSparkRunner.java
@@ -60,7 +60,8 @@ public class PrestoSparkRunner
                 distribution.getConfigProperties(),
                 distribution.getCatalogProperties(),
                 distribution.getEventListenerProperties(),
-                distribution.getAccessControlProperties());
+                distribution.getAccessControlProperties(),
+                distribution.getSessionPropertyConfigurationProperties());
     }
 
     public void run(
@@ -150,7 +151,8 @@ public class PrestoSparkRunner
             Map<String, String> configProperties,
             Map<String, Map<String, String>> catalogProperties,
             Optional<Map<String, String>> eventListenerProperties,
-            Optional<Map<String, String>> accessControlProperties)
+            Optional<Map<String, String>> accessControlProperties,
+            Optional<Map<String, String>> sessionPropertyConfigurationProperties)
     {
         String packagePath = getPackagePath(packageSupplier);
         File pluginsDirectory = checkDirectory(new File(packagePath, "plugin"));
@@ -159,7 +161,8 @@ public class PrestoSparkRunner
                 pluginsDirectory.getAbsolutePath(),
                 catalogProperties,
                 eventListenerProperties,
-                accessControlProperties);
+                accessControlProperties,
+                sessionPropertyConfigurationProperties);
         IPrestoSparkServiceFactory serviceFactory = createServiceFactory(checkDirectory(new File(packagePath, "lib")));
         return serviceFactory.createService(sparkProcessType, configuration);
     }
@@ -177,6 +180,7 @@ public class PrestoSparkRunner
         private final Map<String, Map<String, String>> catalogProperties;
         private final Map<String, String> eventListenerProperties;
         private final Map<String, String> accessControlProperties;
+        private final Map<String, String> sessionPropertyConfigurationProperties;
 
         public DistributionBasedPrestoSparkTaskExecutorFactoryProvider(PrestoSparkDistribution distribution)
         {
@@ -187,6 +191,7 @@ public class PrestoSparkRunner
             // Optional is not Serializable
             this.eventListenerProperties = distribution.getEventListenerProperties().orElse(null);
             this.accessControlProperties = distribution.getAccessControlProperties().orElse(null);
+            this.sessionPropertyConfigurationProperties = distribution.getSessionPropertyConfigurationProperties().orElse(null);
         }
 
         @Override
@@ -203,6 +208,7 @@ public class PrestoSparkRunner
         private static Map<String, Map<String, String>> currentCatalogProperties;
         private static Map<String, String> currentEventListenerProperties;
         private static Map<String, String> currentAccessControlProperties;
+        private static Map<String, String> currentSessionPropertyConfigurationProperties;
 
         private IPrestoSparkService getOrCreatePrestoSparkService()
         {
@@ -214,12 +220,15 @@ public class PrestoSparkRunner
                             configProperties,
                             catalogProperties,
                             Optional.ofNullable(eventListenerProperties),
-                            Optional.ofNullable(accessControlProperties));
+                            Optional.ofNullable(accessControlProperties),
+                            Optional.ofNullable(sessionPropertyConfigurationProperties));
+
                     currentPackagePath = getPackagePath(packageSupplier);
                     currentConfigProperties = configProperties;
                     currentCatalogProperties = catalogProperties;
                     currentEventListenerProperties = eventListenerProperties;
                     currentAccessControlProperties = accessControlProperties;
+                    currentSessionPropertyConfigurationProperties = sessionPropertyConfigurationProperties;
                 }
                 else {
                     checkEquals("packagePath", currentPackagePath, getPackagePath(packageSupplier));
@@ -227,6 +236,9 @@ public class PrestoSparkRunner
                     checkEquals("catalogProperties", currentCatalogProperties, catalogProperties);
                     checkEquals("eventListenerProperties", currentEventListenerProperties, eventListenerProperties);
                     checkEquals("accessControlProperties", currentAccessControlProperties, accessControlProperties);
+                    checkEquals("sessionPropertyConfigurationProperties",
+                            currentSessionPropertyConfigurationProperties,
+                            sessionPropertyConfigurationProperties);
                 }
                 return service;
             }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/session/SessionConfigurationContext.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/session/SessionConfigurationContext.java
@@ -28,9 +28,14 @@ public final class SessionConfigurationContext
     private final Optional<String> source;
     private final Set<String> clientTags;
     private final Optional<String> queryType;
-    private final ResourceGroupId resourceGroupId;
+    private final Optional<ResourceGroupId> resourceGroupId;
 
-    public SessionConfigurationContext(String user, Optional<String> source, Set<String> clientTags, Optional<String> queryType, ResourceGroupId resourceGroupId)
+    public SessionConfigurationContext(
+            String user,
+            Optional<String> source,
+            Set<String> clientTags,
+            Optional<String> queryType,
+            Optional<ResourceGroupId> resourceGroupId)
     {
         this.user = requireNonNull(user, "user is null");
         this.source = requireNonNull(source, "source is null");
@@ -59,7 +64,7 @@ public final class SessionConfigurationContext
         return queryType;
     }
 
-    public ResourceGroupId getResourceGroupId()
+    public Optional<ResourceGroupId> getResourceGroupId()
     {
         return resourceGroupId;
     }


### PR DESCRIPTION
Depended by https://github.com/facebookexternal/presto-facebook/pull/1294

Goal
- Support session property override
- Presto on Spark doesn't have resource group, make regex matching rule for resource group optional

Test
- End to end test done. See details in https://github.com/facebookexternal/presto-facebook/pull/1294


```
== NO RELEASE NOTE ==
```
