### PR TITLE
Make query result HTTP response compression configurable

### DIFF
--- a/presto-benchmark-driver/src/main/java/com/facebook/presto/benchmark/driver/BenchmarkDriverOptions.java
+++ b/presto-benchmark-driver/src/main/java/com/facebook/presto/benchmark/driver/BenchmarkDriverOptions.java
@@ -85,6 +85,9 @@ public class BenchmarkDriverOptions
     @Option(name = "--client-request-timeout", title = "client request timeout", description = "Client request timeout (default: 2m)")
     public Duration clientRequestTimeout = new Duration(2, MINUTES);
 
+    @Option(name = "--disable-compression", title = "disable response compression", description = "Disable compression of query results")
+    public boolean disableCompression;
+
     public ClientSession getClientSession()
     {
         return new ClientSession(
@@ -104,7 +107,8 @@ public class BenchmarkDriverOptions
                 ImmutableMap.of(),
                 ImmutableMap.of(),
                 null,
-                clientRequestTimeout);
+                clientRequestTimeout,
+                disableCompression);
     }
 
     private static URI parseServer(String server)

--- a/presto-cli/src/main/java/com/facebook/presto/cli/ClientOptions.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/ClientOptions.java
@@ -140,6 +140,9 @@ public class ClientOptions
     @Option(name = "--ignore-errors", title = "ignore errors", description = "Continue processing in batch mode when an error occurs (default is to exit immediately)")
     public boolean ignoreErrors;
 
+    @Option(name = "--disable-compression", title = "disable response compression", description = "Disable compression of query results")
+    public boolean disableCompression;
+
     public enum OutputFormat
     {
         ALIGNED,
@@ -170,7 +173,8 @@ public class ClientOptions
                 emptyMap(),
                 toExtraCredentials(extraCredentials),
                 null,
-                clientRequestTimeout);
+                clientRequestTimeout,
+                disableCompression);
     }
 
     public static URI parseServer(String server)

--- a/presto-cli/src/test/java/com/facebook/presto/cli/TestClientOptions.java
+++ b/presto-cli/src/test/java/com/facebook/presto/cli/TestClientOptions.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 
 import static io.airlift.airline.SingleCommand.singleCommand;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 public class TestClientOptions
 {
@@ -123,6 +124,14 @@ public class TestClientOptions
 
         // empty values are allowed
         assertEquals(new ClientSessionProperty("foo="), new ClientSessionProperty(Optional.empty(), "foo", ""));
+    }
+
+    @Test
+    public void testDisableCompression()
+    {
+        Console console = singleCommand(Console.class).parse("--disable-compression");
+        assertTrue(console.clientOptions.disableCompression);
+        assertTrue(console.clientOptions.toClientSession().isCompressionDisabled());
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class)

--- a/presto-cli/src/test/java/com/facebook/presto/cli/TestQueryRunner.java
+++ b/presto-cli/src/test/java/com/facebook/presto/cli/TestQueryRunner.java
@@ -99,7 +99,8 @@ public class TestQueryRunner
                         ImmutableMap.of(),
                         ImmutableMap.of(),
                         null,
-                        new Duration(2, MINUTES)));
+                        new Duration(2, MINUTES),
+                        true));
         try (Query query = queryRunner.startQuery("first query will introduce a cookie")) {
             query.renderOutput(new PrintStream(nullOutputStream()), CSV, false);
         }

--- a/presto-client/src/main/java/com/facebook/presto/client/ClientSession.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/ClientSession.java
@@ -51,6 +51,7 @@ public class ClientSession
     private final Map<String, String> extraCredentials;
     private final String transactionId;
     private final Duration clientRequestTimeout;
+    private final boolean compressionDisabled;
 
     public static Builder builder(ClientSession clientSession)
     {
@@ -81,7 +82,8 @@ public class ClientSession
             Map<String, SelectedRole> roles,
             Map<String, String> extraCredentials,
             String transactionId,
-            Duration clientRequestTimeout)
+            Duration clientRequestTimeout,
+            boolean compressionDisabled)
     {
         this.server = requireNonNull(server, "server is null");
         this.user = user;
@@ -100,6 +102,7 @@ public class ClientSession
         this.roles = ImmutableMap.copyOf(requireNonNull(roles, "roles is null"));
         this.extraCredentials = ImmutableMap.copyOf(requireNonNull(extraCredentials, "extraCredentials is null"));
         this.clientRequestTimeout = clientRequestTimeout;
+        this.compressionDisabled = compressionDisabled;
 
         for (String clientTag : clientTags) {
             checkArgument(!clientTag.contains(","), "client tag cannot contain ','");
@@ -223,6 +226,11 @@ public class ClientSession
         return clientRequestTimeout;
     }
 
+    public boolean isCompressionDisabled()
+    {
+        return compressionDisabled;
+    }
+
     @Override
     public String toString()
     {
@@ -261,6 +269,7 @@ public class ClientSession
         private Map<String, String> credentials;
         private String transactionId;
         private Duration clientRequestTimeout;
+        private boolean compressionDisabled;
 
         private Builder(ClientSession clientSession)
         {
@@ -282,6 +291,7 @@ public class ClientSession
             credentials = clientSession.getExtraCredentials();
             transactionId = clientSession.getTransactionId();
             clientRequestTimeout = clientSession.getClientRequestTimeout();
+            compressionDisabled = clientSession.isCompressionDisabled();
         }
 
         public Builder withCatalog(String catalog)
@@ -332,6 +342,12 @@ public class ClientSession
             return this;
         }
 
+        public Builder withCompressionDisabled(boolean compressionDisabled)
+        {
+            this.compressionDisabled = compressionDisabled;
+            return this;
+        }
+
         public ClientSession build()
         {
             return new ClientSession(
@@ -351,7 +367,8 @@ public class ClientSession
                     roles,
                     credentials,
                     transactionId,
-                    clientRequestTimeout);
+                    clientRequestTimeout,
+                    compressionDisabled);
         }
     }
 }

--- a/presto-client/src/main/java/com/facebook/presto/client/StatementClientV1.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/StatementClientV1.java
@@ -72,6 +72,7 @@ import static com.facebook.presto.client.PrestoHeaders.PRESTO_TRANSACTION_ID;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_USER;
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.net.HttpHeaders.ACCEPT_ENCODING;
 import static com.google.common.net.HttpHeaders.USER_AGENT;
 import static java.lang.String.format;
 import static java.net.HttpURLConnection.HTTP_OK;
@@ -107,6 +108,7 @@ class StatementClientV1
     private final TimeZoneKey timeZone;
     private final Duration requestTimeoutNanos;
     private final String user;
+    private final boolean compressionDisabled;
 
     private final AtomicReference<State> state = new AtomicReference<>(State.RUNNING);
 
@@ -121,6 +123,7 @@ class StatementClientV1
         this.query = query;
         this.requestTimeoutNanos = session.getClientRequestTimeout();
         this.user = session.getUser();
+        this.compressionDisabled = session.isCompressionDisabled();
 
         Request request = buildQueryRequest(session, query);
 
@@ -313,10 +316,14 @@ class StatementClientV1
 
     private Request.Builder prepareRequest(HttpUrl url)
     {
-        return new Request.Builder()
+        Request.Builder builder = new Request.Builder()
                 .addHeader(PRESTO_USER, user)
                 .addHeader(USER_AGENT, USER_AGENT_VALUE)
                 .url(url);
+        if (compressionDisabled) {
+            builder.header(ACCEPT_ENCODING, "identity");
+        }
+        return builder;
     }
 
     @Override

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/ConnectionProperties.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/ConnectionProperties.java
@@ -37,6 +37,7 @@ final class ConnectionProperties
     public static final ConnectionProperty<HostAndPort> SOCKS_PROXY = new SocksProxy();
     public static final ConnectionProperty<HostAndPort> HTTP_PROXY = new HttpProxy();
     public static final ConnectionProperty<String> APPLICATION_NAME_PREFIX = new ApplicationNamePrefix();
+    public static final ConnectionProperty<Boolean> DISABLE_COMPRESSION = new DisableCompression();
     public static final ConnectionProperty<Boolean> SSL = new Ssl();
     public static final ConnectionProperty<String> SSL_KEY_STORE_PATH = new SslKeyStorePath();
     public static final ConnectionProperty<String> SSL_KEY_STORE_PASSWORD = new SslKeyStorePassword();
@@ -58,6 +59,7 @@ final class ConnectionProperties
             .add(SOCKS_PROXY)
             .add(HTTP_PROXY)
             .add(APPLICATION_NAME_PREFIX)
+            .add(DISABLE_COMPRESSION)
             .add(SSL)
             .add(SSL_KEY_STORE_PATH)
             .add(SSL_KEY_STORE_PASSWORD)
@@ -152,6 +154,15 @@ final class ConnectionProperties
         public ApplicationNamePrefix()
         {
             super("applicationNamePrefix", NOT_REQUIRED, ALLOWED, STRING_CONVERTER);
+        }
+    }
+
+    private static class DisableCompression
+            extends AbstractConnectionProperty<Boolean>
+    {
+        public DisableCompression()
+        {
+            super("disableCompression", NOT_REQUIRED, ALLOWED, BOOLEAN_CONVERTER);
         }
     }
 

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoConnection.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoConnection.java
@@ -84,6 +84,7 @@ public class PrestoConnection
     private final URI jdbcUri;
     private final URI httpUri;
     private final String user;
+    private final boolean compressionDisabled;
     private final Map<String, String> extraCredentials;
     private final Map<String, String> sessionProperties;
     private final Optional<String> applicationNamePrefix;
@@ -104,6 +105,7 @@ public class PrestoConnection
         this.catalog.set(uri.getCatalog());
         this.user = uri.getUser();
         this.applicationNamePrefix = uri.getApplicationNamePrefix();
+        this.compressionDisabled = uri.isCompressionDisabled();
 
         this.extraCredentials = uri.getExtraCredentials();
         this.sessionProperties = new ConcurrentHashMap<>(uri.getSessionProperties());
@@ -709,7 +711,8 @@ public class PrestoConnection
                 ImmutableMap.copyOf(roles),
                 extraCredentials,
                 transactionId.get(),
-                timeout);
+                timeout,
+                compressionDisabled);
 
         return queryExecutor.startQuery(session, sql);
     }

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoDriverUri.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoDriverUri.java
@@ -44,6 +44,7 @@ import static com.facebook.presto.client.OkHttpUtil.setupSsl;
 import static com.facebook.presto.client.OkHttpUtil.tokenAuth;
 import static com.facebook.presto.jdbc.ConnectionProperties.ACCESS_TOKEN;
 import static com.facebook.presto.jdbc.ConnectionProperties.APPLICATION_NAME_PREFIX;
+import static com.facebook.presto.jdbc.ConnectionProperties.DISABLE_COMPRESSION;
 import static com.facebook.presto.jdbc.ConnectionProperties.EXTRA_CREDENTIALS;
 import static com.facebook.presto.jdbc.ConnectionProperties.HTTP_PROXY;
 import static com.facebook.presto.jdbc.ConnectionProperties.KERBEROS_CONFIG_PATH;
@@ -153,6 +154,12 @@ final class PrestoDriverUri
             throws SQLException
     {
         return SESSION_PROPERTIES.getValue(properties).orElse(ImmutableMap.of());
+    }
+
+    public boolean isCompressionDisabled()
+            throws SQLException
+    {
+        return DISABLE_COMPRESSION.getValue(properties).orElse(false);
     }
 
     public void setupClient(OkHttpClient.Builder builder)

--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestPrestoDriverUri.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestPrestoDriverUri.java
@@ -22,6 +22,7 @@ import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.util.Properties;
 
+import static com.facebook.presto.jdbc.ConnectionProperties.DISABLE_COMPRESSION;
 import static com.facebook.presto.jdbc.ConnectionProperties.EXTRA_CREDENTIALS;
 import static com.facebook.presto.jdbc.ConnectionProperties.HTTP_PROXY;
 import static com.facebook.presto.jdbc.ConnectionProperties.SESSION_PROPERTIES;
@@ -32,6 +33,7 @@ import static java.lang.String.format;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 public class TestPrestoDriverUri
@@ -162,6 +164,15 @@ public class TestPrestoDriverUri
 
         Properties properties = parameters.getProperties();
         assertEquals(properties.getProperty(HTTP_PROXY.getKey()), "localhost:5678");
+    }
+
+    @Test
+    public void testUriWithoutCompression()
+            throws SQLException
+    {
+        PrestoDriverUri parameters = createDriverUri("presto://localhost:8080/blackhole?disableCompression=true");
+        assertTrue(parameters.isCompressionDisabled());
+        assertEquals(parameters.getProperties().getProperty(DISABLE_COMPRESSION.getKey()), "true");
     }
 
     @Test

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerConfig.java
@@ -28,6 +28,7 @@ public class ServerConfig
     private boolean includeExceptionInResponse = true;
     private Duration gracePeriod = new Duration(2, MINUTES);
     private boolean enhancedErrorReporting = true;
+    private boolean queryResultsCompressionEnabled = true;
 
     public boolean isCoordinator()
     {
@@ -104,6 +105,18 @@ public class ServerConfig
     public ServerConfig setEnhancedErrorReporting(boolean value)
     {
         this.enhancedErrorReporting = value;
+        return this;
+    }
+
+    public boolean isQueryResultsCompressionEnabled()
+    {
+        return queryResultsCompressionEnabled;
+    }
+
+    @Config("query-results.compression-enabled")
+    public ServerConfig setQueryResultsCompressionEnabled(boolean queryResultsCompressionEnabled)
+    {
+        this.queryResultsCompressionEnabled = queryResultsCompressionEnabled;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/protocol/QueryResourceUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/protocol/QueryResourceUtil.java
@@ -49,7 +49,7 @@ public final class QueryResourceUtil
 {
     private QueryResourceUtil() {}
 
-    public static Response toResponse(Query query, QueryResults queryResults)
+    public static Response toResponse(Query query, QueryResults queryResults, boolean compressionEnabled)
     {
         Response.ResponseBuilder response = Response.ok(queryResults);
 
@@ -88,6 +88,10 @@ public final class QueryResourceUtil
         // add clear transaction ID directive
         if (query.isClearTransactionId()) {
             response.header(PRESTO_CLEAR_TRANSACTION_ID, true);
+        }
+
+        if (!compressionEnabled) {
+            response.encoding("identity");
         }
 
         return response.build();

--- a/presto-main/src/test/java/com/facebook/presto/server/TestServerConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestServerConfig.java
@@ -35,7 +35,8 @@ public class TestServerConfig
                 .setDataSources(null)
                 .setIncludeExceptionInResponse(true)
                 .setGracePeriod(new Duration(2, MINUTES))
-                .setEnhancedErrorReporting(true));
+                .setEnhancedErrorReporting(true)
+                .setQueryResultsCompressionEnabled(true));
     }
 
     @Test
@@ -48,6 +49,7 @@ public class TestServerConfig
                 .put("http.include-exception-in-response", "false")
                 .put("shutdown.grace-period", "5m")
                 .put("sql.parser.enhanced-error-reporting", "false")
+                .put("query-results.compression-enabled", "false")
                 .build();
 
         ServerConfig expected = new ServerConfig()
@@ -56,7 +58,8 @@ public class TestServerConfig
                 .setDataSources("jmx")
                 .setIncludeExceptionInResponse(false)
                 .setGracePeriod(new Duration(5, MINUTES))
-                .setEnhancedErrorReporting(false);
+                .setEnhancedErrorReporting(false)
+                .setQueryResultsCompressionEnabled(false);
 
         assertFullMapping(properties, expected);
     }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestingPrestoClient.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestingPrestoClient.java
@@ -155,7 +155,8 @@ public abstract class AbstractTestingPrestoClient<T>
                 session.getIdentity().getRoles(),
                 session.getIdentity().getExtraCredentials(),
                 session.getTransactionId().map(Object::toString).orElse(null),
-                clientRequestTimeout);
+                clientRequestTimeout,
+                true);
     }
 
     public List<QualifiedObjectName> listTables(Session session, String catalog, String schema)

--- a/presto-tests/src/test/java/com/facebook/presto/execution/TestFinalQueryInfo.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TestFinalQueryInfo.java
@@ -79,7 +79,8 @@ public class TestFinalQueryInfo
                     ImmutableMap.of(),
                     ImmutableMap.of(),
                     null,
-                    new Duration(2, MINUTES));
+                    new Duration(2, MINUTES),
+                    true);
 
             // start query
             StatementClient client = newStatementClient(httpClient, clientSession, sql);


### PR DESCRIPTION
Before this change, query result JSON responses were generally compressed (assuming the response met the minimum size threshold and passed the user agent checks), so that behavior is still the default. However, disabling GZIP compression can significantly improve throughput of sending query results, especially over localhost links where the overhead of compressing the response and then uncompressing it again on the client side is never worth the bandwidth savings.

Clients are allowed to *opt-out* of compression, but not request compression from a server which has decided to disable compressed query result responses. Both sides ultimately negotiate the result based on their `Accept-Encoding` or `Content-Encoding` headers and the way that the gzip compression middleware interprets them.

For queries that are bound only by result processing throughput (eg: `SELECT * FROM <large table>`) execution time can reduced by 20-50% when submitted over a localhost connection with compression disabled.

```
== RELEASE NOTES ==

General Changes
* Add support for disabling query result compression via client and server-side configuration properties.
```
