### PR TITLE
Fix local exchanges when materializing remote exchanges

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/HiveQueryRunner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/HiveQueryRunner.java
@@ -38,6 +38,7 @@ import org.joda.time.DateTimeZone;
 import java.io.File;
 import java.net.URI;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiFunction;
@@ -215,6 +216,27 @@ public final class HiveQueryRunner
                         "query.hash-partition-count", "11",
                         "colocated-joins-enabled", "true",
                         "grouped-execution-enabled", "true"),
+                Optional.empty());
+    }
+
+    public static DistributedQueryRunner createMaterializingAndSpillingQueryRunner(Iterable<TpchTable<?>> tables)
+            throws Exception
+    {
+        return createQueryRunner(
+                tables,
+                ImmutableMap.<String, String>builder()
+                        .put("query.partitioning-provider-catalog", "hive")
+                        .put("query.exchange-materialization-strategy", "ALL")
+                        .put("query.hash-partition-count", "11")
+                        .put("colocated-joins-enabled", "true")
+                        .put("grouped-execution-enabled", "true")
+                        .put("experimental.spill-enabled", "true")
+                        .put("experimental.join-spill-enabled", "true")
+                        .put("experimental.spiller-spill-path", Paths.get(System.getProperty("java.io.tmpdir"), "presto", "spills").toString())
+                        .put("experimental.spiller-max-used-space-threshold", "1.0")
+                        .put("experimental.memory-revoking-threshold", "0.0") // revoke always
+                        .put("experimental.memory-revoking-target", "0.0")
+                        .build(),
                 Optional.empty());
     }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSpillingWithExchangeMaterialization.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSpillingWithExchangeMaterialization.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.hive.HiveQueryRunner.createMaterializingAndSpillingQueryRunner;
+import static com.facebook.presto.testing.MaterializedResult.resultBuilder;
+import static com.facebook.presto.testing.assertions.Assert.assertEquals;
+import static io.airlift.tpch.TpchTable.getTables;
+
+public class TestHiveSpillingWithExchangeMaterialization
+        extends AbstractTestQueryFramework
+{
+    public TestHiveSpillingWithExchangeMaterialization()
+    {
+        super(() -> createMaterializingAndSpillingQueryRunner(getTables()));
+    }
+
+    @Test
+    public void testJoin()
+    {
+        assertQuery("SELECT orderstatus FROM lineitem JOIN orders on lineitem.orderkey = orders.orderkey");
+    }
+
+    @Test
+    public void testOrderBy()
+    {
+        assertQueryOrdered("SELECT orderstatus FROM orders ORDER BY orderstatus");
+    }
+
+    @Test
+    public void testAggregation()
+    {
+        assertQuery("SELECT custkey, orderpriority, sum(custkey), array_agg(DISTINCT orderpriority ORDER BY orderpriority) FROM orders GROUP BY custkey, orderpriority ORDER BY 1, 2");
+    }
+
+    @Test
+    public void testWindow()
+    {
+        MaterializedResult actual = computeActual(
+                "SELECT RANK() OVER (PARTITION BY orderdate ORDER BY COUNT(DISTINCT clerk)) rnk " +
+                        "FROM orders " +
+                        "GROUP BY orderdate, custkey " +
+                        "ORDER BY rnk " +
+                        "LIMIT 1");
+        MaterializedResult expected = resultBuilder(getSession(), BIGINT).row(1L).build();
+        assertEquals(actual, expected);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/StreamPropertyDerivations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/StreamPropertyDerivations.java
@@ -81,6 +81,7 @@ import static com.facebook.presto.sql.planner.optimizations.PropertyDerivations.
 import static com.facebook.presto.sql.planner.optimizations.StreamPropertyDerivations.StreamProperties.StreamDistribution.FIXED;
 import static com.facebook.presto.sql.planner.optimizations.StreamPropertyDerivations.StreamProperties.StreamDistribution.MULTIPLE;
 import static com.facebook.presto.sql.planner.optimizations.StreamPropertyDerivations.StreamProperties.StreamDistribution.SINGLE;
+import static com.facebook.presto.sql.planner.plan.ExchangeNode.Scope.REMOTE_MATERIALIZED;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
@@ -296,6 +297,11 @@ public final class StreamPropertyDerivations
         {
             if (node.isEnsureSourceOrdering() || node.getOrderingScheme().isPresent()) {
                 return StreamProperties.ordered();
+            }
+
+            if (node.getScope() == REMOTE_MATERIALIZED) {
+                // remote materialized exchanges get converted to table scans. Return the properties that the table scan would have
+                return new StreamProperties(MULTIPLE, Optional.empty(), false);
             }
 
             if (node.getScope().isRemote()) {


### PR DESCRIPTION
Remote streaming exchanges enforce a "fixed" distribution, but table scans
only enforce a "multiple" distribution.  This meant we were missing local
exchanges in some cases when we materialized exchanges but required a fixed
distribution.  In particular this fixes join spilling when using
materialized exchanges, since in that case the probe side requires a
fixed distribution.

Test plan - Added test for spill + materialized exchanges.  Also increased general join spill test coverage.

```
== RELEASE NOTES ==

General Changes
* Add support for spilling joins when using materialized exchanges.
```

```
