### PR TITLE
Build and test on arm64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: java
 
+jobs:
+  include:
+    - name: arm64
+      arch: arm64
+  
 env:
   global:
     - MAVEN_OPTS="-Xmx1024M -XX:+ExitOnOutOfMemoryError"


### PR DESCRIPTION
More and more server side software runs on ARM64 CPU architecture.
It would be good if PrestoDB is being regularly tested on ARM64.

This PR adds an additional TravisCI job that builds all Presto modules on Linux ARM64. 