### PR TITLE
Fix the check to correctly capture NULL positions when presentStream is null and filter allows NULLs

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDirectSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDirectSelectiveStreamReader.java
@@ -220,7 +220,7 @@ public class SliceDirectSelectiveStreamReader
                             if (outputRequired) {
                                 int truncatedLength = computeTruncatedLength(dataAsSlice, dataOffset, length, maxCodePointCount, isCharType);
                                 offsets[outputPositionCount + 1] = offset + truncatedLength;
-                                if (nullsAllowed && isNullVector != null) {
+                                if (nullsAllowed && presentStream != null) {
                                     nulls[outputPositionCount] = false;
                                 }
                             }
@@ -233,7 +233,7 @@ public class SliceDirectSelectiveStreamReader
                         if (filter.testBytes("".getBytes(), 0, 0)) {
                             if (outputRequired) {
                                 offsets[outputPositionCount + 1] = offset;
-                                if (nullsAllowed && isNullVector != null) {
+                                if (nullsAllowed && presentStream != null) {
                                     nulls[outputPositionCount] = false;
                                 }
                             }


### PR DESCRIPTION
```
== NO RELEASE NOTE ==
When the presentStream is null, we do not initialize the nulls member variable. During readWithFilter we were checking the inNullVector instead of presentStream, which is causing an NPE. The isNullVector is reused across stripes and is not null. Updated the if condition to use presentStream
```
