### PR TITLE
Support function namespace manager for Presto-on-Spark

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/StaticFunctionNamespaceStore.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/StaticFunctionNamespaceStore.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.metadata;
 
 import com.facebook.airlift.log.Logger;
-import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 
 import javax.inject.Inject;
@@ -27,12 +26,13 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.facebook.presto.util.PropertiesUtil.loadProperties;
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.io.Files.getNameWithoutExtension;
 
 public class StaticFunctionNamespaceStore
 {
     private static final Logger log = Logger.get(StaticFunctionNamespaceStore.class);
-    private static final Splitter SPLITTER = Splitter.on(',').trimResults().omitEmptyStrings();
+    private static final String FUNCTION_NAMESPACE_MANAGER_NAME = "function-namespace-manager.name";
 
     private final FunctionAndTypeManager functionAndTypeManager;
     private final File configDir;
@@ -54,20 +54,29 @@ public class StaticFunctionNamespaceStore
 
         for (File file : listFiles(configDir)) {
             if (file.isFile() && file.getName().endsWith(".properties")) {
-                loadFunctionNamespaceManager(file);
+                String catalogName = getNameWithoutExtension(file.getName());
+                Map<String, String> properties = loadProperties(file);
+                checkState(!isNullOrEmpty(properties.get(FUNCTION_NAMESPACE_MANAGER_NAME)),
+                        "Function namespace configuration %s does not contain %s",
+                        file.getAbsoluteFile(),
+                        FUNCTION_NAMESPACE_MANAGER_NAME);
+                loadFunctionNamespaceManager(catalogName, properties);
             }
         }
     }
 
-    private void loadFunctionNamespaceManager(File file)
-            throws Exception
+    public void loadFunctionNamespaceManagers(Map<String, Map<String, String>> catalogProperties)
     {
-        String catalogName = getNameWithoutExtension(file.getName());
-        log.info("-- Loading function namespace manager from %s --", file);
-        Map<String, String> properties = new HashMap<>(loadProperties(file));
+        catalogProperties.entrySet().stream()
+                .forEach(entry -> loadFunctionNamespaceManager(entry.getKey(), entry.getValue()));
+    }
 
-        String functionNamespaceManagerName = properties.remove("function-namespace-manager.name");
-        checkState(functionNamespaceManagerName != null, "Function namespace configuration %s does not contain function-namespace-manager.name", file.getAbsoluteFile());
+    private void loadFunctionNamespaceManager(String catalogName, Map<String, String> properties)
+    {
+        log.info("-- Loading function namespace manager for catalog %s --", catalogName);
+        properties = new HashMap<>(properties);
+        String functionNamespaceManagerName = properties.remove(FUNCTION_NAMESPACE_MANAGER_NAME);
+        checkState(!isNullOrEmpty(functionNamespaceManagerName), "%s property must be present", FUNCTION_NAMESPACE_MANAGER_NAME);
 
         functionAndTypeManager.loadFunctionNamespaceManager(functionNamespaceManagerName, catalogName, properties);
         log.info("-- Added function namespace manager [%s] --", catalogName);

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkServiceFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkServiceFactory.java
@@ -45,6 +45,7 @@ public class PrestoSparkServiceFactory
                 configuration.getEventListenerProperties(),
                 configuration.getAccessControlProperties(),
                 configuration.getSessionPropertyConfigurationProperties(),
+                configuration.getFunctionNamespaceProperties(),
                 getSqlParserOptions(),
                 getAdditionalModules());
 

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
@@ -203,6 +203,7 @@ public class PrestoSparkQueryRunner
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
+                Optional.empty(),
                 new SqlParserOptions(),
                 ImmutableList.of(),
                 true);

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkConfiguration.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkConfiguration.java
@@ -29,6 +29,7 @@ public class PrestoSparkConfiguration
     private final Optional<Map<String, String>> eventListenerProperties;
     private final Optional<Map<String, String>> accessControlProperties;
     private final Optional<Map<String, String>> sessionPropertyConfigurationProperties;
+    private final Optional<Map<String, Map<String, String>>> functionNamespaceProperties;
 
     public PrestoSparkConfiguration(
             Map<String, String> configProperties,
@@ -36,7 +37,8 @@ public class PrestoSparkConfiguration
             Map<String, Map<String, String>> catalogProperties,
             Optional<Map<String, String>> eventListenerProperties,
             Optional<Map<String, String>> accessControlProperties,
-            Optional<Map<String, String>> sessionPropertyConfigurationProperties)
+            Optional<Map<String, String>> sessionPropertyConfigurationProperties,
+            Optional<Map<String, Map<String, String>>> functionNamespaceProperties)
     {
         this.configProperties = unmodifiableMap(new HashMap<>(requireNonNull(configProperties, "configProperties is null")));
         this.pluginsDirectoryPath = requireNonNull(pluginsDirectoryPath, "pluginsDirectoryPath is null");
@@ -48,6 +50,9 @@ public class PrestoSparkConfiguration
                 .map(properties -> unmodifiableMap(new HashMap<>(properties)));
         this.sessionPropertyConfigurationProperties = requireNonNull(sessionPropertyConfigurationProperties, "sessionPropertyConfigurationProperties is null")
                 .map(properties -> unmodifiableMap(new HashMap<>(properties)));
+        this.functionNamespaceProperties = requireNonNull(functionNamespaceProperties, "functionNamespaceProperties is null")
+                .map(map -> map.entrySet().stream()
+                        .collect(toMap(Map.Entry::getKey, entry -> unmodifiableMap(new HashMap<>(entry.getValue())))));
     }
 
     public Map<String, String> getConfigProperties()
@@ -78,5 +83,10 @@ public class PrestoSparkConfiguration
     public Optional<Map<String, String>> getSessionPropertyConfigurationProperties()
     {
         return sessionPropertyConfigurationProperties;
+    }
+
+    public Optional<Map<String, Map<String, String>>> getFunctionNamespaceProperties()
+    {
+        return functionNamespaceProperties;
     }
 }

--- a/presto-spark-launcher/src/main/java/com/facebook/presto/spark/launcher/PrestoSparkDistribution.java
+++ b/presto-spark-launcher/src/main/java/com/facebook/presto/spark/launcher/PrestoSparkDistribution.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static java.util.Collections.unmodifiableMap;
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toMap;
 
 public class PrestoSparkDistribution
 {
@@ -33,6 +34,7 @@ public class PrestoSparkDistribution
     private final Optional<Map<String, String>> eventListenerProperties;
     private final Optional<Map<String, String>> accessControlProperties;
     private final Optional<Map<String, String>> sessionPropertyConfigurationProperties;
+    private final Optional<Map<String, Map<String, String>>> functionNamespaceProperties;
 
     public PrestoSparkDistribution(
             SparkContext sparkContext,
@@ -41,7 +43,8 @@ public class PrestoSparkDistribution
             Map<String, Map<String, String>> catalogProperties,
             Optional<Map<String, String>> eventListenerProperties,
             Optional<Map<String, String>> accessControlProperties,
-            Optional<Map<String, String>> sessionPropertyConfigurationProperties)
+            Optional<Map<String, String>> sessionPropertyConfigurationProperties,
+            Optional<Map<String, Map<String, String>>> functionNamespaceProperties)
     {
         this.sparkContext = requireNonNull(sparkContext, "sparkContext is null");
         this.packageSupplier = requireNonNull(packageSupplier, "packageSupplier is null");
@@ -54,6 +57,9 @@ public class PrestoSparkDistribution
                 .map(properties -> unmodifiableMap(new HashMap<>(properties)));
         this.sessionPropertyConfigurationProperties = requireNonNull(sessionPropertyConfigurationProperties, "sessionPropertyConfigurationProperties is null")
                 .map(properties -> unmodifiableMap(new HashMap<>(properties)));
+        this.functionNamespaceProperties = requireNonNull(functionNamespaceProperties, "functionNamespaceProperties is null")
+                .map(map -> map.entrySet().stream()
+                        .collect(toMap(Map.Entry::getKey, entry -> unmodifiableMap(new HashMap<>(entry.getValue())))));
     }
 
     public SparkContext getSparkContext()
@@ -89,5 +95,10 @@ public class PrestoSparkDistribution
     public Optional<Map<String, String>> getSessionPropertyConfigurationProperties()
     {
         return sessionPropertyConfigurationProperties;
+    }
+
+    public Optional<Map<String, Map<String, String>>> getFunctionNamespaceProperties()
+    {
+        return functionNamespaceProperties;
     }
 }

--- a/presto-spark-launcher/src/main/java/com/facebook/presto/spark/launcher/PrestoSparkLauncherCommand.java
+++ b/presto-spark-launcher/src/main/java/com/facebook/presto/spark/launcher/PrestoSparkLauncherCommand.java
@@ -60,6 +60,7 @@ public class PrestoSparkLauncherCommand
                 loadCatalogProperties(new File(clientOptions.catalogs)),
                 Optional.empty(),
                 Optional.empty(),
+                Optional.empty(),
                 Optional.empty());
 
         String query = readFileUtf8(checkFile(new File(clientOptions.file)));

--- a/presto-spark-launcher/src/main/java/com/facebook/presto/spark/launcher/PrestoSparkRunner.java
+++ b/presto-spark-launcher/src/main/java/com/facebook/presto/spark/launcher/PrestoSparkRunner.java
@@ -61,7 +61,8 @@ public class PrestoSparkRunner
                 distribution.getCatalogProperties(),
                 distribution.getEventListenerProperties(),
                 distribution.getAccessControlProperties(),
-                distribution.getSessionPropertyConfigurationProperties());
+                distribution.getSessionPropertyConfigurationProperties(),
+                distribution.getFunctionNamespaceProperties());
     }
 
     public void run(
@@ -152,7 +153,8 @@ public class PrestoSparkRunner
             Map<String, Map<String, String>> catalogProperties,
             Optional<Map<String, String>> eventListenerProperties,
             Optional<Map<String, String>> accessControlProperties,
-            Optional<Map<String, String>> sessionPropertyConfigurationProperties)
+            Optional<Map<String, String>> sessionPropertyConfigurationProperties,
+            Optional<Map<String, Map<String, String>>> functionNamespaceProperties)
     {
         String packagePath = getPackagePath(packageSupplier);
         File pluginsDirectory = checkDirectory(new File(packagePath, "plugin"));
@@ -162,7 +164,8 @@ public class PrestoSparkRunner
                 catalogProperties,
                 eventListenerProperties,
                 accessControlProperties,
-                sessionPropertyConfigurationProperties);
+                sessionPropertyConfigurationProperties,
+                functionNamespaceProperties);
         IPrestoSparkServiceFactory serviceFactory = createServiceFactory(checkDirectory(new File(packagePath, "lib")));
         return serviceFactory.createService(sparkProcessType, configuration);
     }
@@ -181,6 +184,7 @@ public class PrestoSparkRunner
         private final Map<String, String> eventListenerProperties;
         private final Map<String, String> accessControlProperties;
         private final Map<String, String> sessionPropertyConfigurationProperties;
+        private final Map<String, Map<String, String>> functionNamespaceProperties;
 
         public DistributionBasedPrestoSparkTaskExecutorFactoryProvider(PrestoSparkDistribution distribution)
         {
@@ -192,6 +196,7 @@ public class PrestoSparkRunner
             this.eventListenerProperties = distribution.getEventListenerProperties().orElse(null);
             this.accessControlProperties = distribution.getAccessControlProperties().orElse(null);
             this.sessionPropertyConfigurationProperties = distribution.getSessionPropertyConfigurationProperties().orElse(null);
+            this.functionNamespaceProperties = distribution.getFunctionNamespaceProperties().orElse(null);
         }
 
         @Override
@@ -209,6 +214,7 @@ public class PrestoSparkRunner
         private static Map<String, String> currentEventListenerProperties;
         private static Map<String, String> currentAccessControlProperties;
         private static Map<String, String> currentSessionPropertyConfigurationProperties;
+        private static Map<String, Map<String, String>> currentFunctionNamespaceProperties;
 
         private IPrestoSparkService getOrCreatePrestoSparkService()
         {
@@ -221,7 +227,8 @@ public class PrestoSparkRunner
                             catalogProperties,
                             Optional.ofNullable(eventListenerProperties),
                             Optional.ofNullable(accessControlProperties),
-                            Optional.ofNullable(sessionPropertyConfigurationProperties));
+                            Optional.ofNullable(sessionPropertyConfigurationProperties),
+                            Optional.ofNullable(functionNamespaceProperties));
 
                     currentPackagePath = getPackagePath(packageSupplier);
                     currentConfigProperties = configProperties;
@@ -229,6 +236,7 @@ public class PrestoSparkRunner
                     currentEventListenerProperties = eventListenerProperties;
                     currentAccessControlProperties = accessControlProperties;
                     currentSessionPropertyConfigurationProperties = sessionPropertyConfigurationProperties;
+                    currentFunctionNamespaceProperties = functionNamespaceProperties;
                 }
                 else {
                     checkEquals("packagePath", currentPackagePath, getPackagePath(packageSupplier));
@@ -239,6 +247,7 @@ public class PrestoSparkRunner
                     checkEquals("sessionPropertyConfigurationProperties",
                             currentSessionPropertyConfigurationProperties,
                             sessionPropertyConfigurationProperties);
+                    checkEquals("functionNamespaceProperties", currentFunctionNamespaceProperties, functionNamespaceProperties);
                 }
                 return service;
             }


### PR DESCRIPTION
Depended by https://github.com/facebookexternal/presto-facebook/pull/1303

Summary
- Similar to catalog configurations,  for `functionNamespaceProperties (Map<String, Map<String, String>>)` , key is namespace/catalog, value is properties

Test plan
- End to end test succeeded, see query result in facebookexternal/presto-facebook#1303


```
== NO RELEASE NOTE ==
```
