### PR TITLE
Use serialized plan hash for fragment result caching

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskManager.java
@@ -44,6 +44,7 @@ import com.facebook.presto.spiller.NodeSpillConfig;
 import com.facebook.presto.sql.gen.OrderingCompiler;
 import com.facebook.presto.sql.planner.LocalExecutionPlanner;
 import com.facebook.presto.sql.planner.PlanFragment;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
@@ -134,7 +135,8 @@ public class SqlTaskManager
             GcMonitor gcMonitor,
             BlockEncodingSerde blockEncodingSerde,
             OrderingCompiler orderingCompiler,
-            FragmentResultCacheManager fragmentResultCacheManager)
+            FragmentResultCacheManager fragmentResultCacheManager,
+            ObjectMapper objectMapper)
     {
         requireNonNull(nodeInfo, "nodeInfo is null");
         requireNonNull(config, "config is null");
@@ -157,6 +159,7 @@ public class SqlTaskManager
                 orderingCompiler,
                 splitMonitor,
                 fragmentResultCacheManager,
+                objectMapper,
                 config);
 
         this.localMemoryManager = requireNonNull(localMemoryManager, "localMemoryManager is null");

--- a/presto-main/src/main/java/com/facebook/presto/operator/Driver.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/Driver.java
@@ -260,7 +260,7 @@ public class Driver
 
             if (fragmentResultCacheContext.isPresent() && !(split.getConnectorSplit() instanceof RemoteSplit)) {
                 checkState(!this.cachedResult.get().isPresent());
-                this.cachedResult.set(fragmentResultCacheContext.get().getFragmentResultCacheManager().get(fragmentResultCacheContext.get().getCanonicalPlanFragment(), split));
+                this.cachedResult.set(fragmentResultCacheContext.get().getFragmentResultCacheManager().get(fragmentResultCacheContext.get().getHashedCanonicalPlanFragment(), split));
                 this.split.set(split);
             }
 
@@ -458,7 +458,7 @@ public class Driver
                     if (shouldUseFragmentResultCache() && outputOperatorFinished && !cachedResult.get().isPresent()) {
                         checkState(split.get() != null);
                         checkState(fragmentResultCacheContext.isPresent());
-                        fragmentResultCacheContext.get().getFragmentResultCacheManager().put(fragmentResultCacheContext.get().getCanonicalPlanFragment(), split.get(), outputPages);
+                        fragmentResultCacheContext.get().getFragmentResultCacheManager().put(fragmentResultCacheContext.get().getHashedCanonicalPlanFragment(), split.get(), outputPages);
                     }
 
                     // Finish the next operator, which is now the first operator.

--- a/presto-main/src/main/java/com/facebook/presto/operator/FragmentResultCacheManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/FragmentResultCacheManager.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator;
 
 import com.facebook.presto.common.Page;
 import com.facebook.presto.metadata.Split;
-import com.facebook.presto.sql.planner.CanonicalPlanFragment;
 
 import java.util.Iterator;
 import java.util.List;
@@ -24,7 +23,7 @@ import java.util.concurrent.Future;
 
 public interface FragmentResultCacheManager
 {
-    Future<?> put(CanonicalPlanFragment plan, Split split, List<Page> result);
+    Future<?> put(String serializedPlan, Split split, List<Page> result);
 
-    Optional<Iterator<Page>> get(CanonicalPlanFragment plan, Split split);
+    Optional<Iterator<Page>> get(String serializedPlan, Split split);
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/NoOpFragmentResultCacheManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/NoOpFragmentResultCacheManager.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator;
 
 import com.facebook.presto.common.Page;
 import com.facebook.presto.metadata.Split;
-import com.facebook.presto.sql.planner.CanonicalPlanFragment;
 
 import java.util.Iterator;
 import java.util.List;
@@ -28,13 +27,13 @@ public class NoOpFragmentResultCacheManager
         implements FragmentResultCacheManager
 {
     @Override
-    public Future<?> put(CanonicalPlanFragment plan, Split split, List<Page> result)
+    public Future<?> put(String serializedPlan, Split split, List<Page> result)
     {
         return immediateFuture(null);
     }
 
     @Override
-    public Optional<Iterator<Page>> get(CanonicalPlanFragment plan, Split split)
+    public Optional<Iterator<Page>> get(String serializedPlan, Split split)
     {
         return Optional.empty();
     }

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -16,6 +16,7 @@ package com.facebook.presto.server;
 import com.facebook.airlift.concurrent.BoundedExecutor;
 import com.facebook.airlift.configuration.AbstractConfigurationAwareModule;
 import com.facebook.airlift.http.server.TheServlet;
+import com.facebook.airlift.json.ObjectMapperProvider;
 import com.facebook.airlift.stats.GcMonitor;
 import com.facebook.airlift.stats.JmxGcMonitor;
 import com.facebook.airlift.stats.PauseMeter;
@@ -167,6 +168,7 @@ import com.facebook.presto.type.TypeDeserializer;
 import com.facebook.presto.util.FinalizerService;
 import com.facebook.presto.util.GcStatusMonitor;
 import com.facebook.presto.version.EmbedVersion;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Binder;
 import com.google.inject.Key;
@@ -461,6 +463,7 @@ public class ServerMainModule
 
         // handle resolver
         binder.install(new HandleJsonModule());
+        binder.bind(ObjectMapper.class).toProvider(ObjectMapperProvider.class);
 
         // connector
         binder.bind(ScalarStatsCalculator.class).in(Scopes.SINGLETON);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/CanonicalPartitioningScheme.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/CanonicalPartitioningScheme.java
@@ -17,6 +17,8 @@ import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.connector.ConnectorPartitioningHandle;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
@@ -50,11 +52,12 @@ public class CanonicalPartitioningScheme
                         .collect(toImmutableList()));
     }
 
-    private CanonicalPartitioningScheme(
-            Optional<ConnectorId> connectorId,
-            ConnectorPartitioningHandle connectorHandle,
-            List<RowExpression> arguments,
-            List<VariableReferenceExpression> outputLayout)
+    @JsonCreator
+    CanonicalPartitioningScheme(
+            @JsonProperty("connectorId") Optional<ConnectorId> connectorId,
+            @JsonProperty("connectorHandle") ConnectorPartitioningHandle connectorHandle,
+            @JsonProperty("arguments") List<RowExpression> arguments,
+            @JsonProperty("outputLayout") List<VariableReferenceExpression> outputLayout)
     {
         this.connectorId = requireNonNull(connectorId, "connectorId is null");
         this.connectorHandle = requireNonNull(connectorHandle, "connectorHandle is null");
@@ -62,21 +65,25 @@ public class CanonicalPartitioningScheme
         this.outputLayout = ImmutableList.copyOf(requireNonNull(outputLayout, "outputLayout is null"));
     }
 
+    @JsonProperty
     public Optional<ConnectorId> getConnectorId()
     {
         return connectorId;
     }
 
+    @JsonProperty
     public ConnectorPartitioningHandle getConnectorHandle()
     {
         return connectorHandle;
     }
 
+    @JsonProperty
     public List<RowExpression> getArguments()
     {
         return arguments;
     }
 
+    @JsonProperty
     public List<VariableReferenceExpression> getOutputLayout()
     {
         return outputLayout;

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/CanonicalPlanFragment.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/CanonicalPlanFragment.java
@@ -14,6 +14,8 @@
 package com.facebook.presto.sql.planner;
 
 import com.facebook.presto.spi.plan.PlanNode;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Objects;
 
@@ -25,17 +27,22 @@ public class CanonicalPlanFragment
     private final PlanNode plan;
     private final CanonicalPartitioningScheme partitioningScheme;
 
-    public CanonicalPlanFragment(PlanNode plan, CanonicalPartitioningScheme partitioningScheme)
+    @JsonCreator
+    public CanonicalPlanFragment(
+            @JsonProperty("plan") PlanNode plan,
+            @JsonProperty("partitionScheme") CanonicalPartitioningScheme partitioningScheme)
     {
         this.plan = requireNonNull(plan, "plan is null");
         this.partitioningScheme = requireNonNull(partitioningScheme, "partitioningScheme is null");
     }
 
+    @JsonProperty
     public PlanNode getPlan()
     {
         return plan;
     }
 
+    @JsonProperty
     public CanonicalPartitioningScheme getPartitioningScheme()
     {
         return partitioningScheme;

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/CanonicalTableScanNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/CanonicalTableScanNode.java
@@ -21,6 +21,8 @@ import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.HashMap;
 import java.util.List;
@@ -41,11 +43,12 @@ public class CanonicalTableScanNode
     private final Map<VariableReferenceExpression, ColumnHandle> assignments;
     private final List<VariableReferenceExpression> outputVariables;
 
+    @JsonCreator
     public CanonicalTableScanNode(
-            PlanNodeId id,
-            CanonicalTableHandle table,
-            List<VariableReferenceExpression> outputVariables,
-            Map<VariableReferenceExpression, ColumnHandle> assignments)
+            @JsonProperty("id") PlanNodeId id,
+            @JsonProperty("table") CanonicalTableHandle table,
+            @JsonProperty("outputVariables") List<VariableReferenceExpression> outputVariables,
+            @JsonProperty("assignments") Map<VariableReferenceExpression, ColumnHandle> assignments)
     {
         super(id);
         this.table = requireNonNull(table, "table is null");
@@ -61,6 +64,7 @@ public class CanonicalTableScanNode
     }
 
     @Override
+    @JsonProperty
     public List<VariableReferenceExpression> getOutputVariables()
     {
         return outputVariables;
@@ -73,11 +77,13 @@ public class CanonicalTableScanNode
         return this;
     }
 
+    @JsonProperty
     public CanonicalTableHandle getTable()
     {
         return table;
     }
 
+    @JsonProperty
     public Map<VariableReferenceExpression, ColumnHandle> getAssignments()
     {
         return assignments;
@@ -113,29 +119,33 @@ public class CanonicalTableScanNode
 
         public static CanonicalTableHandle getCanonicalTableHandle(TableHandle tableHandle)
         {
-            return new CanonicalTableHandle(tableHandle.getConnectorId(), tableHandle.getConnectorHandle(), tableHandle.getLayout());
+            return new CanonicalTableHandle(tableHandle.getConnectorId(), tableHandle.getConnectorHandle(), tableHandle.getLayout().map(ConnectorTableLayoutHandle::getIdentifier));
         }
 
-        private CanonicalTableHandle(
-                ConnectorId connectorId,
-                ConnectorTableHandle connectorHandle,
-                Optional<ConnectorTableLayoutHandle> layout)
+        @JsonCreator
+        public CanonicalTableHandle(
+                @JsonProperty("coonectorId") ConnectorId connectorId,
+                @JsonProperty("connectorHandle") ConnectorTableHandle connectorHandle,
+                @JsonProperty("layoutIdentifier") Optional<Object> layoutIdentifier)
         {
             this.connectorId = requireNonNull(connectorId, "connectorId is null");
             this.connectorHandle = requireNonNull(connectorHandle, "connectorHandle is null");
-            this.layoutIdentifier = requireNonNull(layout, "layout is null").map(ConnectorTableLayoutHandle::getIdentifier);
+            this.layoutIdentifier = requireNonNull(layoutIdentifier, "layoutIdentifier is null");
         }
 
+        @JsonProperty
         public ConnectorId getConnectorId()
         {
             return connectorId;
         }
 
+        @JsonProperty
         public ConnectorTableHandle getConnectorHandle()
         {
             return connectorHandle;
         }
 
+        @JsonProperty
         public Optional<Object> getLayoutIdentifier()
         {
             return layoutIdentifier;

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestMemoryRevokingScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestMemoryRevokingScheduler.java
@@ -39,6 +39,7 @@ import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.gen.OrderingCompiler;
 import com.facebook.presto.sql.planner.LocalExecutionPlanner;
 import com.facebook.presto.testing.TestingSession;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Functions;
 import com.google.common.base.Ticker;
 import com.google.common.collect.ImmutableList;
@@ -119,6 +120,7 @@ public class TestMemoryRevokingScheduler
                 new OrderingCompiler(),
                 createTestSplitMonitor(),
                 new NoOpFragmentResultCacheManager(),
+                new ObjectMapper(),
                 new TaskManagerConfig()
                         .setPerOperatorAllocationTrackingEnabled(true)
                         .setTaskCpuTimerEnabled(true)

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTask.java
@@ -31,6 +31,7 @@ import com.facebook.presto.spi.memory.MemoryPoolId;
 import com.facebook.presto.spiller.SpillSpaceTracker;
 import com.facebook.presto.sql.gen.OrderingCompiler;
 import com.facebook.presto.sql.planner.LocalExecutionPlanner;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Functions;
 import com.google.common.base.Ticker;
 import com.google.common.collect.ImmutableList;
@@ -100,6 +101,7 @@ public class TestSqlTask
                 new OrderingCompiler(),
                 createTestSplitMonitor(),
                 new NoOpFragmentResultCacheManager(),
+                new ObjectMapper(),
                 new TaskManagerConfig());
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskManager.java
@@ -33,6 +33,7 @@ import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spiller.LocalSpillManager;
 import com.facebook.presto.spiller.NodeSpillConfig;
 import com.facebook.presto.sql.gen.OrderingCompiler;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Ticker;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -253,7 +254,8 @@ public class TestSqlTaskManager
                 new TestingGcMonitor(),
                 new BlockEncodingManager(),
                 new OrderingCompiler(),
-                new NoOpFragmentResultCacheManager());
+                new NoOpFragmentResultCacheManager(),
+                new ObjectMapper());
     }
 
     private TaskInfo createTask(SqlTaskManager sqlTaskManager, TaskId taskId, ImmutableSet<ScheduledSplit> splits, OutputBuffers outputBuffers)

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestDriver.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestDriver.java
@@ -25,23 +25,22 @@ import com.facebook.presto.operator.FileFragmentResultCacheManager.CacheKey;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.ConnectorSplit;
-import com.facebook.presto.spi.ConnectorTableHandle;
 import com.facebook.presto.spi.FixedPageSource;
 import com.facebook.presto.spi.HostAddress;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.TableHandle;
-import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.facebook.presto.spi.plan.AggregationNode;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.spi.plan.TableScanNode;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.facebook.presto.split.PageSourceProvider;
-import com.facebook.presto.sql.planner.CanonicalPlanFragment;
 import com.facebook.presto.sql.planner.Partitioning;
 import com.facebook.presto.sql.planner.PartitioningScheme;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.PageConsumerOperator;
+import com.facebook.presto.testing.TestingMetadata.TestingTableHandle;
 import com.facebook.presto.testing.TestingTransactionHandle;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -58,6 +57,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -96,8 +96,8 @@ public class TestDriver
 {
     private static final TableHandle TESTING_TABLE_HANDLE = new TableHandle(
             new ConnectorId("test"),
-            new ConnectorTableHandle() {},
-            new ConnectorTransactionHandle() {},
+            new TestingTableHandle(),
+            new TestingTransactionHandle(UUID.randomUUID()),
             Optional.empty());
 
     private static final FragmentResultCacheContext TESTING_FRAGMENT_RESULT_CACHE_CONTEXT = createFragmentResultCacheContext(
@@ -117,7 +117,8 @@ public class TestDriver
                     Optional.empty(),
                     Optional.empty()),
             new PartitioningScheme(Partitioning.create(FIXED_HASH_DISTRIBUTION, ImmutableList.of()), ImmutableList.of()),
-            testSessionBuilder().setSystemProperty(FRAGMENT_RESULT_CACHING_ENABLED, "true").build()).get();
+            testSessionBuilder().setSystemProperty(FRAGMENT_RESULT_CACHING_ENABLED, "true").build(),
+            new ObjectMapper()).get();
 
     private ExecutorService executor;
     private ScheduledExecutorService scheduledExecutor;
@@ -668,14 +669,14 @@ public class TestDriver
         private final Map<CacheKey, List<Page>> cache = new HashMap<>();
 
         @Override
-        public Future<?> put(CanonicalPlanFragment plan, Split split, List<Page> result)
+        public Future<?> put(String plan, Split split, List<Page> result)
         {
             cache.put(new CacheKey(plan, split.getSplitIdentifier()), result);
             return immediateFuture(null);
         }
 
         @Override
-        public Optional<Iterator<Page>> get(CanonicalPlanFragment plan, Split split)
+        public Optional<Iterator<Page>> get(String plan, Split split)
         {
             CacheKey key = new CacheKey(plan, split.getSplitIdentifier());
             if (cache.containsKey(key)) {

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestFileFragmentResultCacheManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestFileFragmentResultCacheManager.java
@@ -18,18 +18,10 @@ import com.facebook.presto.common.block.TestingBlockEncodingSerde;
 import com.facebook.presto.metadata.Split;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.ConnectorSplit;
-import com.facebook.presto.spi.ConnectorTableHandle;
 import com.facebook.presto.spi.HostAddress;
-import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
-import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
-import com.facebook.presto.sql.planner.CanonicalPlanFragment;
-import com.facebook.presto.sql.planner.CanonicalTableScanNode;
-import com.facebook.presto.sql.planner.Partitioning;
-import com.facebook.presto.sql.planner.PartitioningScheme;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -47,9 +39,6 @@ import java.util.concurrent.ExecutorService;
 import static com.facebook.airlift.concurrent.Threads.daemonThreadsNamed;
 import static com.facebook.presto.block.BlockAssertions.createStringsBlock;
 import static com.facebook.presto.spi.schedule.NodeSelectionStrategy.NO_PREFERENCE;
-import static com.facebook.presto.sql.planner.CanonicalPartitioningScheme.getCanonicalPartitioningScheme;
-import static com.facebook.presto.sql.planner.CanonicalTableScanNode.CanonicalTableHandle.getCanonicalTableHandle;
-import static com.facebook.presto.sql.planner.SystemPartitioningHandle.FIXED_HASH_DISTRIBUTION;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkState;
 import static java.nio.file.Files.createTempDirectory;
@@ -60,32 +49,8 @@ import static org.testng.Assert.assertTrue;
 
 public class TestFileFragmentResultCacheManager
 {
-    private static final CanonicalPlanFragment PLAN_FRAGMENT_1 = new CanonicalPlanFragment(
-            new CanonicalTableScanNode(
-                    new PlanNodeId("1"),
-                    getCanonicalTableHandle(new TableHandle(
-                            new ConnectorId("test1"),
-                            new ConnectorTableHandle() {},
-                            new ConnectorTransactionHandle() {},
-                            Optional.empty())),
-                    ImmutableList.of(),
-                    ImmutableMap.of()),
-            getCanonicalPartitioningScheme(
-                    new PartitioningScheme(Partitioning.create(FIXED_HASH_DISTRIBUTION, ImmutableList.of()), ImmutableList.of()),
-                    ImmutableMap.of()));
-    private static final CanonicalPlanFragment PLAN_FRAGMENT_2 = new CanonicalPlanFragment(
-            new CanonicalTableScanNode(
-                    new PlanNodeId("1"),
-                    getCanonicalTableHandle(new TableHandle(
-                            new ConnectorId("test-2"),
-                            new ConnectorTableHandle() {},
-                            new ConnectorTransactionHandle() {},
-                            Optional.empty())),
-                    ImmutableList.of(),
-                    ImmutableMap.of()),
-            getCanonicalPartitioningScheme(
-                    new PartitioningScheme(Partitioning.create(FIXED_HASH_DISTRIBUTION, ImmutableList.of()), ImmutableList.of()),
-                    ImmutableMap.of()));
+    private static final String SERIALIZED_PLAN_FRAGMENT_1 = "test plan fragment 1";
+    private static final String SERIALIZED_PLAN_FRAGMENT_2 = "test plan fragment 2";
     private static final Split SPLIT_1 = new Split(new ConnectorId("test"), new ConnectorTransactionHandle() {}, new TestingSplit(1));
     private static final Split SPLIT_2 = new Split(new ConnectorId("test"), new ConnectorTransactionHandle() {}, new TestingSplit(2));
 
@@ -96,7 +61,7 @@ public class TestFileFragmentResultCacheManager
 
     @BeforeClass
     public void setup()
-            throws IOException
+            throws Exception
     {
         this.cacheDirectory = createTempDirectory("cache").toUri();
     }
@@ -126,13 +91,13 @@ public class TestFileFragmentResultCacheManager
         FragmentResultCacheManager cacheManager = fileFragmentResultCacheManager(stats);
 
         // Test fetching new fragment. Current cache status: empty
-        assertFalse(cacheManager.get(PLAN_FRAGMENT_1, SPLIT_1).isPresent());
+        assertFalse(cacheManager.get(SERIALIZED_PLAN_FRAGMENT_1, SPLIT_1).isPresent());
         assertEquals(stats.getCacheMiss(), 1);
         assertEquals(stats.getCacheHit(), 0);
 
         // Test empty page. Current cache status: empty
-        cacheManager.put(PLAN_FRAGMENT_1, SPLIT_1, ImmutableList.of()).get();
-        Optional<Iterator<Page>> result = cacheManager.get(PLAN_FRAGMENT_1, SPLIT_1);
+        cacheManager.put(SERIALIZED_PLAN_FRAGMENT_1, SPLIT_1, ImmutableList.of()).get();
+        Optional<Iterator<Page>> result = cacheManager.get(SERIALIZED_PLAN_FRAGMENT_1, SPLIT_1);
         assertTrue(result.isPresent());
         assertFalse(result.get().hasNext());
         assertEquals(stats.getCacheMiss(), 1);
@@ -140,18 +105,18 @@ public class TestFileFragmentResultCacheManager
 
         // Test non-empty page. Current cache status: { (plan1, split1) -> [] }
         List<Page> pages = ImmutableList.of(new Page(createStringsBlock("plan-1-split-2")));
-        cacheManager.put(PLAN_FRAGMENT_2, SPLIT_2, pages).get();
-        result = cacheManager.get(PLAN_FRAGMENT_2, SPLIT_2);
+        cacheManager.put(SERIALIZED_PLAN_FRAGMENT_2, SPLIT_2, pages).get();
+        result = cacheManager.get(SERIALIZED_PLAN_FRAGMENT_2, SPLIT_2);
         assertTrue(result.isPresent());
         assertPagesEqual(result.get(), pages.iterator());
         assertEquals(stats.getCacheMiss(), 1);
         assertEquals(stats.getCacheHit(), 2);
 
         // Test cache miss for plan mismatch and split mismatch. Current cache status: { (plan1, split1) -> [], (plan2, split2) -> ["plan-1-split-2"] }
-        cacheManager.get(PLAN_FRAGMENT_1, SPLIT_2);
+        cacheManager.get(SERIALIZED_PLAN_FRAGMENT_1, SPLIT_2);
         assertEquals(stats.getCacheMiss(), 2);
         assertEquals(stats.getCacheHit(), 2);
-        cacheManager.get(PLAN_FRAGMENT_2, SPLIT_1);
+        cacheManager.get(SERIALIZED_PLAN_FRAGMENT_2, SPLIT_1);
         assertEquals(stats.getCacheMiss(), 3);
         assertEquals(stats.getCacheHit(), 2);
     }

--- a/presto-spark-base/pom.xml
+++ b/presto-spark-base/pom.xml
@@ -97,6 +97,11 @@
         </dependency>
 
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkTaskExecutorFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkTaskExecutorFactory.java
@@ -72,6 +72,7 @@ import com.facebook.presto.sql.planner.PlanFragment;
 import com.facebook.presto.sql.planner.plan.PlanFragmentId;
 import com.facebook.presto.sql.planner.plan.RemoteSourceNode;
 import com.facebook.presto.sql.planner.planPrinter.PlanPrinter;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -111,6 +112,7 @@ import static com.facebook.presto.spark.util.PrestoSparkUtils.decompress;
 import static com.facebook.presto.spark.util.PrestoSparkUtils.toPrestoSparkSerializedPage;
 import static com.facebook.presto.sql.planner.SystemPartitioningHandle.FIXED_ARBITRARY_DISTRIBUTION;
 import static com.facebook.presto.util.Failures.toFailures;
+import static com.fasterxml.jackson.databind.SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Throwables.propagateIfPossible;
@@ -143,6 +145,7 @@ public class PrestoSparkTaskExecutorFactory
     private final Set<PrestoSparkAuthenticatorProvider> authenticatorProviders;
 
     private final FragmentResultCacheManager fragmentResultCacheManager;
+    private final ObjectMapper objectMapper;
 
     private final DataSize maxUserMemory;
     private final DataSize maxTotalMemory;
@@ -172,6 +175,7 @@ public class PrestoSparkTaskExecutorFactory
             SplitMonitor splitMonitor,
             Set<PrestoSparkAuthenticatorProvider> authenticatorProviders,
             FragmentResultCacheManager fragmentResultCacheManager,
+            ObjectMapper objectMapper,
             TaskManagerConfig taskManagerConfig,
             NodeMemoryConfig nodeMemoryConfig,
             NodeSpillConfig nodeSpillConfig)
@@ -192,6 +196,7 @@ public class PrestoSparkTaskExecutorFactory
                 splitMonitor,
                 authenticatorProviders,
                 fragmentResultCacheManager,
+                objectMapper,
                 requireNonNull(nodeMemoryConfig, "nodeMemoryConfig is null").getMaxQueryMemoryPerNode(),
                 requireNonNull(nodeMemoryConfig, "nodeMemoryConfig is null").getMaxQueryTotalMemoryPerNode(),
                 requireNonNull(nodeSpillConfig, "nodeSpillConfig is null").getMaxSpillPerNode(),
@@ -218,6 +223,7 @@ public class PrestoSparkTaskExecutorFactory
             SplitMonitor splitMonitor,
             Set<PrestoSparkAuthenticatorProvider> authenticatorProviders,
             FragmentResultCacheManager fragmentResultCacheManager,
+            ObjectMapper objectMapper,
             DataSize maxUserMemory,
             DataSize maxTotalMemory,
             DataSize maxSpillMemory,
@@ -242,6 +248,8 @@ public class PrestoSparkTaskExecutorFactory
         this.splitMonitor = requireNonNull(splitMonitor, "splitMonitor is null");
         this.authenticatorProviders = ImmutableSet.copyOf(requireNonNull(authenticatorProviders, "authenticatorProviders is null"));
         this.fragmentResultCacheManager = requireNonNull(fragmentResultCacheManager, "fragmentResultCacheManager is null");
+        // Ordering is needed to make sure serialized plans are consistent for the same map
+        this.objectMapper = objectMapper.copy().configure(ORDER_MAP_ENTRIES_BY_KEYS, true);
         this.maxUserMemory = requireNonNull(maxUserMemory, "maxUserMemory is null");
         this.maxTotalMemory = requireNonNull(maxTotalMemory, "maxTotalMemory is null");
         this.maxSpillMemory = requireNonNull(maxSpillMemory, "maxSpillMemory is null");
@@ -343,7 +351,7 @@ public class PrestoSparkTaskExecutorFactory
                 perOperatorAllocationTrackingEnabled,
                 allocationTrackingEnabled,
                 false,
-                createFragmentResultCacheContext(fragmentResultCacheManager, fragment.getRoot(), fragment.getPartitioningScheme(), session));
+                createFragmentResultCacheContext(fragmentResultCacheManager, fragment.getRoot(), fragment.getPartitioningScheme(), session, objectMapper));
 
         ImmutableMap.Builder<PlanNodeId, List<PrestoSparkShuffleInput>> shuffleInputs = ImmutableMap.builder();
         ImmutableMap.Builder<PlanNodeId, List<java.util.Iterator<PrestoSparkSerializedPage>>> pageInputs = ImmutableMap.builder();


### PR DESCRIPTION
Test plan - Enhanced existing unit test. Verifier run for internal queries passed.

```
== RELEASE NOTES ==

General Changes
* Reduce memory usage for fragment result caching.
```
