### PR TITLE
Fix time types in MongoDB connector

### DIFF
--- a/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoSession.java
+++ b/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoSession.java
@@ -17,9 +17,11 @@ import com.facebook.airlift.log.Logger;
 import com.facebook.presto.common.predicate.Domain;
 import com.facebook.presto.common.predicate.Range;
 import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.common.type.DateType;
 import com.facebook.presto.common.type.NamedTypeSignature;
 import com.facebook.presto.common.type.RowFieldName;
 import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.common.type.TimestampType;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.common.type.TypeSignature;
@@ -55,6 +57,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -332,6 +335,12 @@ public class MongoSession
             else {
                 return ((Slice) source).toStringUtf8();
             }
+        }
+        else if (type instanceof TimestampType) {
+            return new Date((Long) source);
+        }
+        else if (type instanceof DateType) {
+            return new Date(TimeUnit.DAYS.toMillis((Long) source));
         }
 
         return source;

--- a/presto-mongodb/src/test/java/com/facebook/presto/mongodb/TestMongoIntegrationSmokeTest.java
+++ b/presto-mongodb/src/test/java/com/facebook/presto/mongodb/TestMongoIntegrationSmokeTest.java
@@ -237,6 +237,14 @@ public class TestMongoIntegrationSmokeTest
         assertOneNotNullResult("SELECT id FROM tmp_objectid WHERE id = ObjectId('ffffffffffffffffffffffff')");
     }
 
+    @Test
+    public void testDateTimeTypes()
+    {
+        assertUpdate("CREATE TABLE tmp_date AS SELECT DATE '1980-05-07' AS _date, TIMESTAMP '1980-05-07 11:22:33.456' _timestamp", 1);
+        assertOneNotNullResult("SELECT _date FROM tmp_date WHERE _date = DATE '1980-05-07'");
+        assertOneNotNullResult("SELECT _timestamp FROM tmp_date WHERE _timestamp = TIMESTAMP '1980-05-07 11:22:33.456'");
+    }
+
     private void assertOneNotNullResult(String query)
     {
         MaterializedResult results = getQueryRunner().execute(getSession(), query).toTestTypes();


### PR DESCRIPTION
Fix #15429 15429
Test plan -  added new test in TestMongoIntegrationSmokeTest


```
== RELEASE NOTES ==

General Changes
* Fix Mongodb filtering by Date and Timestamp types. (:issue:`15429`)

```
