### PR TITLE
Support different concurrency

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddLocalExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddLocalExchanges.java
@@ -549,7 +549,7 @@ public class AddLocalExchanges
                 }
             }
             else {
-                PlanWithProperties source = originalTableWriterNode.getSource().accept(this, fixedParallelism());
+                PlanWithProperties source = originalTableWriterNode.getSource().accept(this, defaultParallelism(session));
                 PlanWithProperties exchange = deriveProperties(
                         partitionedExchange(
                                 idAllocator.getNextId(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddLocalExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddLocalExchanges.java
@@ -508,21 +508,45 @@ public class AddLocalExchanges
             PlanWithProperties tableWriter;
 
             if (!originalTableWriterNode.getTablePartitioningScheme().isPresent()) {
-                tableWriter = planAndEnforceChildren(
-                        new TableWriterNode(
-                                originalTableWriterNode.getId(),
-                                originalTableWriterNode.getSource(),
-                                originalTableWriterNode.getTarget(),
-                                variableAllocator.newVariable("partialrowcount", BIGINT),
-                                variableAllocator.newVariable("partialfragments", VARBINARY),
-                                variableAllocator.newVariable("partialcontext", VARBINARY),
-                                originalTableWriterNode.getColumns(),
-                                originalTableWriterNode.getColumnNames(),
-                                originalTableWriterNode.getTablePartitioningScheme(),
-                                originalTableWriterNode.getPreferredShufflePartitioningScheme(),
-                                statisticAggregations.map(StatisticAggregations.Parts::getPartialAggregation)),
-                        fixedParallelism(),
-                        fixedParallelism());
+                int taskWriterCount = getTaskWriterCount(session);
+                int taskConcurrency = getTaskConcurrency(session);
+                if (taskWriterCount == taskConcurrency) {
+                    tableWriter = planAndEnforceChildren(
+                            new TableWriterNode(
+                                    originalTableWriterNode.getId(),
+                                    originalTableWriterNode.getSource(),
+                                    originalTableWriterNode.getTarget(),
+                                    variableAllocator.newVariable("partialrowcount", BIGINT),
+                                    variableAllocator.newVariable("partialfragments", VARBINARY),
+                                    variableAllocator.newVariable("partialcontext", VARBINARY),
+                                    originalTableWriterNode.getColumns(),
+                                    originalTableWriterNode.getColumnNames(),
+                                    originalTableWriterNode.getTablePartitioningScheme(),
+                                    originalTableWriterNode.getPreferredShufflePartitioningScheme(),
+                                    statisticAggregations.map(StatisticAggregations.Parts::getPartialAggregation)),
+                            fixedParallelism(),
+                            fixedParallelism());
+                }
+                else {
+                    PlanWithProperties source = originalTableWriterNode.getSource().accept(this, defaultParallelism(session));
+                    PlanWithProperties exchange = deriveProperties(
+                            roundRobinExchange(idAllocator.getNextId(), LOCAL, source.getNode()),
+                            source.getProperties());
+                    tableWriter = deriveProperties(
+                            new TableWriterNode(
+                                    originalTableWriterNode.getId(),
+                                    exchange.getNode(),
+                                    originalTableWriterNode.getTarget(),
+                                    variableAllocator.newVariable("partialrowcount", BIGINT),
+                                    variableAllocator.newVariable("partialfragments", VARBINARY),
+                                    variableAllocator.newVariable("partialcontext", VARBINARY),
+                                    originalTableWriterNode.getColumns(),
+                                    originalTableWriterNode.getColumnNames(),
+                                    originalTableWriterNode.getTablePartitioningScheme(),
+                                    originalTableWriterNode.getPreferredShufflePartitioningScheme(),
+                                    statisticAggregations.map(StatisticAggregations.Parts::getPartialAggregation)),
+                            exchange.getProperties());
+                }
             }
             else {
                 PlanWithProperties source = originalTableWriterNode.getSource().accept(this, fixedParallelism());


### PR DESCRIPTION
If TableWriter input is fixed distributed (e.g.: aggregation or join) the actual aggregation or join concurrency will be set to the table writer concurrency
```
== NO RELEASE NOTE ==
```
