### PR TITLE
Add warning for Presto on Spark

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkInjectorFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkInjectorFactory.java
@@ -18,6 +18,7 @@ import com.facebook.airlift.json.JsonModule;
 import com.facebook.presto.eventlistener.EventListenerManager;
 import com.facebook.presto.eventlistener.EventListenerModule;
 import com.facebook.presto.execution.resourceGroups.ResourceGroupManager;
+import com.facebook.presto.execution.warnings.WarningCollectorModule;
 import com.facebook.presto.metadata.StaticCatalogStore;
 import com.facebook.presto.metadata.StaticFunctionNamespaceStore;
 import com.facebook.presto.security.AccessControl;
@@ -120,7 +121,8 @@ public class PrestoSparkInjectorFactory
         modules.add(
                 new JsonModule(),
                 new EventListenerModule(),
-                new PrestoSparkModule(sparkProcessType, sqlParserOptions));
+                new PrestoSparkModule(sparkProcessType, sqlParserOptions),
+                new WarningCollectorModule());
 
         if (useAccessControlForTesting) {
             modules.add(


### PR DESCRIPTION
Test
- Get expected warning in a real query. ` "warnings": [
        {
            "warningCode": {
                "code": 3,
                "name": "PERFORMANCE_WARNING"
            },
            "message": "COUNT(DISTINCT xxx) can be a very expensive operation when the cardinality is high for xxx. In most scenarios, using approx_distinct instead would be enough"
        }
    ]`
```
== NO RELEASE NOTE ==
```
