### PR TITLE
Add cpu and memory stats to NodeTaskMap

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/NodeTaskMap.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/NodeTaskMap.java
@@ -17,14 +17,18 @@ import com.facebook.airlift.log.Logger;
 import com.facebook.presto.metadata.InternalNode;
 import com.facebook.presto.util.FinalizerService;
 import com.google.common.collect.Sets;
+import io.airlift.units.Duration;
+import it.unimi.dsi.fastutil.longs.Long2LongRBTreeMap;
+import it.unimi.dsi.fastutil.longs.Long2LongSortedMap;
 
 import javax.annotation.concurrent.ThreadSafe;
 import javax.inject.Inject;
 
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.IntConsumer;
+import java.util.function.LongConsumer;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
@@ -35,11 +39,19 @@ public class NodeTaskMap
     private static final Logger log = Logger.get(NodeTaskMap.class);
     private final ConcurrentHashMap<InternalNode, NodeTasks> nodeTasksMap = new ConcurrentHashMap<>();
     private final FinalizerService finalizerService;
+    private final long cpuStatsWindowSizeInMillis;
 
     @Inject
-    public NodeTaskMap(FinalizerService finalizerService)
+    public NodeTaskMap(FinalizerService finalizerService, TaskManagerConfig taskConfig)
     {
         this.finalizerService = requireNonNull(finalizerService, "finalizerService is null");
+        this.cpuStatsWindowSizeInMillis = taskConfig.getStatusRefreshMaxWait().toMillis() * 2;
+    }
+
+    public NodeTaskMap(FinalizerService finalizerService, Duration statusRefreshMaxWait)
+    {
+        this.finalizerService = requireNonNull(finalizerService, "finalizerService is null");
+        this.cpuStatsWindowSizeInMillis = requireNonNull(statusRefreshMaxWait, "statusRefreshMaxWait is null").toMillis();
     }
 
     public void addTask(InternalNode node, RemoteTask task)
@@ -52,44 +64,54 @@ public class NodeTaskMap
         return createOrGetNodeTasks(node).getPartitionedSplitCount();
     }
 
-    public PartitionedSplitCountTracker createPartitionedSplitCountTracker(InternalNode node, TaskId taskId)
+    public long getNodeTotalMemoryUsageInBytes(InternalNode node)
     {
-        return createOrGetNodeTasks(node).createPartitionedSplitCountTracker(taskId);
+        return createOrGetNodeTasks(node).getTotalMemoryUsageInBytes();
+    }
+
+    public long getNodeCpuUtilizationPercentage(InternalNode node)
+    {
+        return createOrGetNodeTasks(node).getTotalCpuTimePerMillis();
+    }
+
+    public NodeStatsTracker createTaskStatsTracker(InternalNode node, TaskId taskId)
+    {
+        return createOrGetNodeTasks(node).createTaskStatsTrackers(taskId);
     }
 
     private NodeTasks createOrGetNodeTasks(InternalNode node)
     {
-        NodeTasks nodeTasks = nodeTasksMap.get(node);
-        if (nodeTasks == null) {
-            nodeTasks = addNodeTask(node);
-        }
-        return nodeTasks;
-    }
-
-    private NodeTasks addNodeTask(InternalNode node)
-    {
-        NodeTasks newNodeTasks = new NodeTasks(finalizerService);
-        NodeTasks nodeTasks = nodeTasksMap.putIfAbsent(node, newNodeTasks);
-        if (nodeTasks == null) {
-            return newNodeTasks;
-        }
-        return nodeTasks;
+        return nodeTasksMap.computeIfAbsent(node, key -> new NodeTasks(finalizerService, cpuStatsWindowSizeInMillis));
     }
 
     private static class NodeTasks
     {
         private final Set<RemoteTask> remoteTasks = Sets.newConcurrentHashSet();
-        private final AtomicInteger nodeTotalPartitionedSplitCount = new AtomicInteger();
+        private final AtomicLong nodeTotalPartitionedSplitCount = new AtomicLong();
+        private final AtomicLong nodeTotalMemoryUsageInBytes = new AtomicLong();
+        private final AtomicLong nodeTotalCpuTimePerMillis = new AtomicLong();
         private final FinalizerService finalizerService;
+        private final long windowSizeInMilis;
 
-        public NodeTasks(FinalizerService finalizerService)
+        public NodeTasks(FinalizerService finalizerService, long windowSizeInMilis)
         {
             this.finalizerService = requireNonNull(finalizerService, "finalizerService is null");
+            this.windowSizeInMilis = windowSizeInMilis;
         }
 
         private int getPartitionedSplitCount()
         {
-            return nodeTotalPartitionedSplitCount.get();
+            return nodeTotalPartitionedSplitCount.intValue();
+        }
+
+        private long getTotalMemoryUsageInBytes()
+        {
+            return nodeTotalMemoryUsageInBytes.get();
+        }
+
+        private long getTotalCpuTimePerMillis()
+        {
+            return nodeTotalCpuTimePerMillis.get();
         }
 
         private void addTask(RemoteTask task)
@@ -108,56 +130,65 @@ public class NodeTaskMap
             }
         }
 
-        public PartitionedSplitCountTracker createPartitionedSplitCountTracker(TaskId taskId)
+        public NodeStatsTracker createTaskStatsTrackers(TaskId taskId)
         {
             requireNonNull(taskId, "taskId is null");
 
-            TaskPartitionedSplitCountTracker tracker = new TaskPartitionedSplitCountTracker(taskId);
-            PartitionedSplitCountTracker partitionedSplitCountTracker = new PartitionedSplitCountTracker(tracker::setPartitionedSplitCount);
+            TaskStatsTracker splitTracker = new TaskStatsTracker("SplitTracker", taskId, nodeTotalPartitionedSplitCount);
+            TaskStatsTracker memoryUsageTracker = new TaskStatsTracker("MemoryTracker", taskId, nodeTotalMemoryUsageInBytes);
+            AccumulatedTaskStatsTracker cpuUtilizationPercentageTracker = new AccumulatedTaskStatsTracker("CpuTracker", taskId, nodeTotalCpuTimePerMillis, windowSizeInMilis);
+            NodeStatsTracker nodeStatsTracker = new NodeStatsTracker(splitTracker::setValue, memoryUsageTracker::setValue, cpuUtilizationPercentageTracker::setValue);
 
-            // when partitionedSplitCountTracker is garbage collected, run the cleanup method on the tracker
-            // Note: tracker can not have a reference to partitionedSplitCountTracker
-            finalizerService.addFinalizer(partitionedSplitCountTracker, tracker::cleanup);
+            // when nodeStatsTracker is garbage collected, run the cleanup method on the tracker
+            // Note: tracker can not have a reference to nodeStatsTracker
+            finalizerService.addFinalizer(nodeStatsTracker, splitTracker::cleanup);
+            finalizerService.addFinalizer(memoryUsageTracker, memoryUsageTracker::cleanup);
+            finalizerService.addFinalizer(cpuUtilizationPercentageTracker, cpuUtilizationPercentageTracker::cleanup);
 
-            return partitionedSplitCountTracker;
+            return nodeStatsTracker;
         }
 
         @ThreadSafe
-        private class TaskPartitionedSplitCountTracker
+        private class TaskStatsTracker
         {
+            private final String stat;
             private final TaskId taskId;
-            private final AtomicInteger localPartitionedSplitCount = new AtomicInteger();
+            private final AtomicLong totalValue;
+            private final AtomicLong value = new AtomicLong();
 
-            public TaskPartitionedSplitCountTracker(TaskId taskId)
+            public TaskStatsTracker(String stat, TaskId taskId, AtomicLong totalValue)
             {
+                this.stat = requireNonNull(stat, "stat is null");
                 this.taskId = requireNonNull(taskId, "taskId is null");
+                this.totalValue = requireNonNull(totalValue, "totalValue is null");
             }
 
-            public synchronized void setPartitionedSplitCount(int partitionedSplitCount)
+            public synchronized void setValue(long value)
             {
-                if (partitionedSplitCount < 0) {
-                    int oldValue = localPartitionedSplitCount.getAndSet(0);
-                    nodeTotalPartitionedSplitCount.addAndGet(-oldValue);
-                    throw new IllegalArgumentException("partitionedSplitCount is negative");
+                if (value < 0) {
+                    long oldValue = this.value.getAndSet(0L);
+                    totalValue.addAndGet(-oldValue);
+                    throw new IllegalArgumentException(stat + " is negative");
                 }
 
-                int oldValue = localPartitionedSplitCount.getAndSet(partitionedSplitCount);
-                nodeTotalPartitionedSplitCount.addAndGet(partitionedSplitCount - oldValue);
+                long oldValue = this.value.getAndSet(value);
+                totalValue.addAndGet(value - oldValue);
             }
 
             public void cleanup()
             {
-                int leakedSplits = localPartitionedSplitCount.getAndSet(0);
-                if (leakedSplits == 0) {
+                long leakedValues = value.getAndSet(0);
+                if (leakedValues == 0) {
                     return;
                 }
 
-                log.error("BUG! %s for %s leaked with %s partitioned splits.  Cleaning up so server can continue to function.",
+                log.error("BUG! %s for %s leaked with %s %s.  Cleaning up so server can continue to function.",
                         getClass().getName(),
                         taskId,
-                        leakedSplits);
+                        leakedValues,
+                        stat);
 
-                nodeTotalPartitionedSplitCount.addAndGet(-leakedSplits);
+                totalValue.addAndGet(-leakedValues);
             }
 
             @Override
@@ -165,19 +196,60 @@ public class NodeTaskMap
             {
                 return toStringHelper(this)
                         .add("taskId", taskId)
-                        .add("splits", localPartitionedSplitCount)
+                        .add(stat, value)
                         .toString();
+            }
+        }
+
+        // tracks stats which are passed as accumulated (cpu time) by calculating delta / duration.
+        @ThreadSafe
+        private class AccumulatedTaskStatsTracker
+                extends TaskStatsTracker
+        {
+            private final long windowSizeInMillis;
+            private final Long2LongSortedMap values = new Long2LongRBTreeMap();
+
+            AccumulatedTaskStatsTracker(String stat, TaskId taskId, AtomicLong totalValue, long windowSizeInMillis)
+            {
+                super(stat, taskId, totalValue);
+                this.windowSizeInMillis = windowSizeInMillis;
+            }
+
+            private long getDeltaPerSecond(long taskAgeInMillis, long value)
+            {
+                if (value > 0) {
+                    values.put(taskAgeInMillis, value);
+                    // this clears the map and make items eligible for GC
+                    values.headMap(values.lastKey() - windowSizeInMillis).clear();
+                    if (values.size() > 1) {
+                        long lastLongKey = values.lastLongKey();
+                        long firstLongKey = values.firstLongKey();
+                        long deltaValue = (values.get(lastLongKey) - values.get(firstLongKey)) * 100;
+                        long deltaDuration = lastLongKey - firstLongKey;
+                        return deltaDuration >= 0 && deltaValue > 0 ? deltaValue / deltaDuration : 0;
+                    }
+                }
+                return 0;
+            }
+
+            public synchronized void setValue(long taskAgeInMillis, long value)
+            {
+                super.setValue(getDeltaPerSecond(taskAgeInMillis, value));
             }
         }
     }
 
-    public static class PartitionedSplitCountTracker
+    public static class NodeStatsTracker
     {
         private final IntConsumer splitSetter;
+        private final LongConsumer memoryUsageSetter;
+        private final CumulativeStatsConsumer cpuUsageSetter;
 
-        public PartitionedSplitCountTracker(IntConsumer splitSetter)
+        public NodeStatsTracker(IntConsumer splitSetter, LongConsumer memoryUsageSetter, CumulativeStatsConsumer cpuUsageSetter)
         {
             this.splitSetter = requireNonNull(splitSetter, "splitSetter is null");
+            this.memoryUsageSetter = requireNonNull(memoryUsageSetter, "memoryUsageSetter is null");
+            this.cpuUsageSetter = requireNonNull(cpuUsageSetter, "cpuUsageSetter is null");
         }
 
         public void setPartitionedSplitCount(int partitionedSplitCount)
@@ -185,10 +257,29 @@ public class NodeTaskMap
             splitSetter.accept(partitionedSplitCount);
         }
 
+        public void setMemoryUsage(long memoryUsage)
+        {
+            memoryUsageSetter.accept(memoryUsage);
+        }
+
+        public void setCpuUsage(long age, long cpuUsage)
+        {
+            cpuUsageSetter.accept(age, cpuUsage);
+        }
+
         @Override
         public String toString()
         {
-            return splitSetter.toString();
+            return toStringHelper(this)
+                    .add("splitSetter", splitSetter.toString())
+                    .add("memoryUsageSetter", memoryUsageSetter.toString())
+                    .add("cpuUsageSetter", cpuUsageSetter.toString())
+                    .toString();
         }
+    }
+
+    public interface CumulativeStatsConsumer
+    {
+        void accept(long age, long value);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/RemoteTaskFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/RemoteTaskFactory.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.execution;
 
 import com.facebook.presto.Session;
-import com.facebook.presto.execution.NodeTaskMap.PartitionedSplitCountTracker;
 import com.facebook.presto.execution.buffer.OutputBuffers;
 import com.facebook.presto.execution.scheduler.TableWriteInfo;
 import com.facebook.presto.metadata.InternalNode;
@@ -22,6 +21,8 @@ import com.facebook.presto.metadata.Split;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.sql.planner.PlanFragment;
 import com.google.common.collect.Multimap;
+
+import static com.facebook.presto.execution.NodeTaskMap.NodeStatsTracker;
 
 public interface RemoteTaskFactory
 {
@@ -31,7 +32,7 @@ public interface RemoteTaskFactory
             PlanFragment fragment,
             Multimap<PlanNodeId, Split> initialSplits,
             OutputBuffers outputBuffers,
-            PartitionedSplitCountTracker partitionedSplitCountTracker,
+            NodeStatsTracker nodeStatsTracker,
             boolean summarizeTaskInfo,
             TableWriteInfo tableWriteInfo);
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlStageExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlStageExecution.java
@@ -518,7 +518,7 @@ public final class SqlStageExecution
                 planFragment,
                 initialSplits.build(),
                 outputBuffers,
-                nodeTaskMap.createPartitionedSplitCountTracker(node, taskId),
+                nodeTaskMap.createTaskStatsTracker(node, taskId),
                 summarizeTaskInfo,
                 tableWriteInfo);
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlTask.java
@@ -65,6 +65,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.util.concurrent.Futures.immediateFuture;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 public class SqlTask
 {
@@ -86,6 +87,7 @@ public class SqlTask
 
     private final AtomicReference<TaskHolder> taskHolderReference = new AtomicReference<>(new TaskHolder());
     private final AtomicBoolean needsPlan = new AtomicBoolean(true);
+    private final long creationTime = System.nanoTime();
 
     public static SqlTask createSqlTask(
             TaskId taskId,
@@ -237,6 +239,7 @@ public class SqlTask
 
     private TaskStatus createTaskStatus(TaskHolder taskHolder)
     {
+        long taskStatusAgeInMilis = NANOSECONDS.toMillis(System.nanoTime() - creationTime);
         // Always return a new TaskInfo with a larger version number;
         // otherwise a client will not accept the update
         long versionNumber = nextTaskInfoVersion.getAndIncrement();
@@ -256,6 +259,7 @@ public class SqlTask
         Set<Lifespan> completedDriverGroups = ImmutableSet.of();
         long fullGcCount = 0;
         long fullGcTimeInMillis = 0L;
+        long totalCpuTimeInNanos = 0L;
         if (taskHolder.getFinalTaskInfo() != null) {
             TaskStats taskStats = taskHolder.getFinalTaskInfo().getStats();
             queuedPartitionedDrivers = taskStats.getQueuedPartitionedDrivers();
@@ -265,6 +269,7 @@ public class SqlTask
             systemMemoryReservationInBytes = taskStats.getSystemMemoryReservationInBytes();
             fullGcCount = taskStats.getFullGcCount();
             fullGcTimeInMillis = taskStats.getFullGcTimeInMillis();
+            totalCpuTimeInNanos = taskStats.getTotalCpuTimeInNanos();
         }
         else if (taskHolder.getTaskExecution() != null) {
             long physicalWrittenBytes = 0;
@@ -274,6 +279,7 @@ public class SqlTask
                 queuedPartitionedDrivers += pipelineStatus.getQueuedPartitionedDrivers();
                 runningPartitionedDrivers += pipelineStatus.getRunningPartitionedDrivers();
                 physicalWrittenBytes += pipelineContext.getPhysicalWrittenDataSize();
+                totalCpuTimeInNanos += pipelineContext.getPipelineStats().getTotalCpuTimeInNanos();
             }
             physicalWrittenDataSizeInBytes = physicalWrittenBytes;
             userMemoryReservationInBytes = taskContext.getMemoryReservation().toBytes();
@@ -300,7 +306,9 @@ public class SqlTask
                 systemMemoryReservationInBytes,
                 queryContext.getPeakNodeTotalMemory(),
                 fullGcCount,
-                fullGcTimeInMillis);
+                fullGcTimeInMillis,
+                totalCpuTimeInNanos,
+                taskStatusAgeInMilis);
     }
 
     private TaskStats getTaskStats(TaskHolder taskHolder)

--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskStatus.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskStatus.java
@@ -74,6 +74,9 @@ public class TaskStatus
 
     private final List<ExecutionFailureInfo> failures;
 
+    private final long totalCpuTimeInNanos;
+    private final long taskAgeInMillis;
+
     @JsonCreator
     @ThriftConstructor
     public TaskStatus(
@@ -93,7 +96,9 @@ public class TaskStatus
             @JsonProperty("systemMemoryReservationInBytes") long systemMemoryReservationInBytes,
             @JsonProperty("peakNodeTotalMemoryReservationInBytes") long peakNodeTotalMemoryReservationInBytes,
             @JsonProperty("fullGcCount") long fullGcCount,
-            @JsonProperty("fullGcTimeInMillis") long fullGcTimeInMillis)
+            @JsonProperty("fullGcTimeInMillis") long fullGcTimeInMillis,
+            @JsonProperty("totalCpuTimeInNanos") long totalCpuTimeInNanos,
+            @JsonProperty("taskAgeInMillis") long taskAgeInMillis)
     {
         this.taskInstanceIdLeastSignificantBits = taskInstanceIdLeastSignificantBits;
         this.taskInstanceIdMostSignificantBits = taskInstanceIdMostSignificantBits;
@@ -122,6 +127,8 @@ public class TaskStatus
         checkArgument(fullGcCount >= 0, "fullGcCount is negative");
         this.fullGcCount = fullGcCount;
         this.fullGcTimeInMillis = fullGcTimeInMillis;
+        this.totalCpuTimeInNanos = totalCpuTimeInNanos;
+        this.taskAgeInMillis = taskAgeInMillis;
     }
 
     @JsonProperty
@@ -243,6 +250,20 @@ public class TaskStatus
         return peakNodeTotalMemoryReservationInBytes;
     }
 
+    @JsonProperty
+    @ThriftField(18)
+    public long getTotalCpuTimeInNanos()
+    {
+        return totalCpuTimeInNanos;
+    }
+
+    @JsonProperty
+    @ThriftField(19)
+    public long getTaskAgeInMillis()
+    {
+        return taskAgeInMillis;
+    }
+
     @Override
     public String toString()
     {
@@ -270,6 +291,8 @@ public class TaskStatus
                 0,
                 0,
                 0,
+                0,
+                0,
                 0);
     }
 
@@ -292,6 +315,8 @@ public class TaskStatus
                 taskStatus.getSystemMemoryReservationInBytes(),
                 taskStatus.getPeakNodeTotalMemoryReservationInBytes(),
                 taskStatus.getFullGcCount(),
-                taskStatus.getFullGcTimeInMillis());
+                taskStatus.getFullGcTimeInMillis(),
+                taskStatus.getTotalCpuTimeInNanos(),
+                taskStatus.getTaskAgeInMillis());
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/TrackingRemoteTaskFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TrackingRemoteTaskFactory.java
@@ -14,7 +14,7 @@
 package com.facebook.presto.execution;
 
 import com.facebook.presto.Session;
-import com.facebook.presto.execution.NodeTaskMap.PartitionedSplitCountTracker;
+import com.facebook.presto.execution.NodeTaskMap.NodeStatsTracker;
 import com.facebook.presto.execution.StateMachine.StateChangeListener;
 import com.facebook.presto.execution.buffer.OutputBuffers;
 import com.facebook.presto.execution.scheduler.TableWriteInfo;
@@ -47,7 +47,7 @@ public class TrackingRemoteTaskFactory
             PlanFragment fragment,
             Multimap<PlanNodeId, Split> initialSplits,
             OutputBuffers outputBuffers,
-            PartitionedSplitCountTracker partitionedSplitCountTracker,
+            NodeStatsTracker nodeStatsTracker,
             boolean summarizeTaskInfo,
             TableWriteInfo tableWriteInfo)
     {
@@ -57,7 +57,7 @@ public class TrackingRemoteTaskFactory
                 fragment,
                 initialSplits,
                 outputBuffers,
-                partitionedSplitCountTracker,
+                nodeStatsTracker,
                 summarizeTaskInfo,
                 tableWriteInfo);
 

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTask.java
@@ -24,7 +24,7 @@ import com.facebook.drift.transport.netty.codec.Protocol;
 import com.facebook.presto.Session;
 import com.facebook.presto.execution.FutureStateChange;
 import com.facebook.presto.execution.Lifespan;
-import com.facebook.presto.execution.NodeTaskMap.PartitionedSplitCountTracker;
+import com.facebook.presto.execution.NodeTaskMap.NodeStatsTracker;
 import com.facebook.presto.execution.QueryManager;
 import com.facebook.presto.execution.RemoteTask;
 import com.facebook.presto.execution.ScheduledSplit;
@@ -188,7 +188,7 @@ public final class HttpRemoteTask
     private final AtomicBoolean needsUpdate = new AtomicBoolean(true);
     private final AtomicBoolean sendPlan = new AtomicBoolean(true);
 
-    private final PartitionedSplitCountTracker partitionedSplitCountTracker;
+    private final NodeStatsTracker nodeStatsTracker;
 
     private final AtomicBoolean aborting = new AtomicBoolean(false);
 
@@ -222,7 +222,7 @@ public final class HttpRemoteTask
             Codec<TaskUpdateRequest> taskUpdateRequestCodec,
             Codec<PlanFragment> planFragmentCodec,
             Codec<MetadataUpdates> metadataUpdatesCodec,
-            PartitionedSplitCountTracker partitionedSplitCountTracker,
+            NodeStatsTracker nodeStatsTracker,
             RemoteTaskStats stats,
             boolean binaryTransportEnabled,
             boolean thriftTransportEnabled,
@@ -245,7 +245,7 @@ public final class HttpRemoteTask
         requireNonNull(taskInfoCodec, "taskInfoCodec is null");
         requireNonNull(taskUpdateRequestCodec, "taskUpdateRequestCodec is null");
         requireNonNull(planFragmentCodec, "planFragmentCodec is null");
-        requireNonNull(partitionedSplitCountTracker, "partitionedSplitCountTracker is null");
+        requireNonNull(nodeStatsTracker, "nodeStatsTracker is null");
         requireNonNull(maxErrorDuration, "maxErrorDuration is null");
         requireNonNull(stats, "stats is null");
         requireNonNull(taskInfoRefreshMaxWait, "taskInfoRefreshMaxWait is null");
@@ -270,7 +270,7 @@ public final class HttpRemoteTask
             this.taskUpdateRequestCodec = taskUpdateRequestCodec;
             this.planFragmentCodec = planFragmentCodec;
             this.updateErrorTracker = taskRequestErrorTracker(taskId, location, maxErrorDuration, errorScheduledExecutor, "updating task");
-            this.partitionedSplitCountTracker = requireNonNull(partitionedSplitCountTracker, "partitionedSplitCountTracker is null");
+            this.nodeStatsTracker = requireNonNull(nodeStatsTracker, "nodeStatsTracker is null");
             this.maxErrorDuration = maxErrorDuration;
             this.stats = stats;
             this.binaryTransportEnabled = binaryTransportEnabled;
@@ -340,12 +340,12 @@ public final class HttpRemoteTask
                     cleanUpTask();
                 }
                 else {
-                    partitionedSplitCountTracker.setPartitionedSplitCount(getPartitionedSplitCount());
+                    updateTaskStats();
                     updateSplitQueueSpace();
                 }
             });
 
-            partitionedSplitCountTracker.setPartitionedSplitCount(getPartitionedSplitCount());
+            updateTaskStats();
             updateSplitQueueSpace();
         }
     }
@@ -416,7 +416,7 @@ public final class HttpRemoteTask
             }
             if (tableScanPlanNodeIds.contains(sourceId)) {
                 pendingSourceSplitCount += added;
-                partitionedSplitCountTracker.setPartitionedSplitCount(getPartitionedSplitCount());
+                updateTaskStats();
             }
             needsUpdate = true;
         }
@@ -602,6 +602,21 @@ public final class HttpRemoteTask
         }
     }
 
+    private void updateTaskStats()
+    {
+        TaskStatus taskStatus = getTaskStatus();
+        if (taskStatus.getState().isDone()) {
+            nodeStatsTracker.setPartitionedSplitCount(0);
+            nodeStatsTracker.setMemoryUsage(0);
+            nodeStatsTracker.setCpuUsage(taskStatus.getTaskAgeInMillis(), 0);
+        }
+        else {
+            nodeStatsTracker.setPartitionedSplitCount(getPartitionedSplitCount());
+            nodeStatsTracker.setMemoryUsage(taskStatus.getMemoryReservationInBytes() + taskStatus.getSystemMemoryReservationInBytes());
+            nodeStatsTracker.setCpuUsage(taskStatus.getTaskAgeInMillis(), taskStatus.getTotalCpuTimeInNanos());
+        }
+    }
+
     private synchronized void processTaskUpdate(TaskInfo newValue, List<TaskSource> sources)
     {
         updateTaskInfo(newValue);
@@ -627,7 +642,7 @@ public final class HttpRemoteTask
         }
         updateSplitQueueSpace();
 
-        partitionedSplitCountTracker.setPartitionedSplitCount(getPartitionedSplitCount());
+        updateTaskStats();
     }
 
     private void updateTaskInfo(TaskInfo taskInfo)
@@ -765,7 +780,7 @@ public final class HttpRemoteTask
         // clear pending splits to free memory
         pendingSplits.clear();
         pendingSourceSplitCount = 0;
-        partitionedSplitCountTracker.setPartitionedSplitCount(getPartitionedSplitCount());
+        updateTaskStats();
         splitQueueHasSpace = true;
         whenSplitQueueHasSpace.complete(null, executor);
 

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTaskFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTaskFactory.java
@@ -21,7 +21,7 @@ import com.facebook.drift.codec.ThriftCodec;
 import com.facebook.drift.transport.netty.codec.Protocol;
 import com.facebook.presto.Session;
 import com.facebook.presto.execution.LocationFactory;
-import com.facebook.presto.execution.NodeTaskMap.PartitionedSplitCountTracker;
+import com.facebook.presto.execution.NodeTaskMap;
 import com.facebook.presto.execution.QueryManager;
 import com.facebook.presto.execution.QueryManagerConfig;
 import com.facebook.presto.execution.RemoteTask;
@@ -181,7 +181,7 @@ public class HttpRemoteTaskFactory
             PlanFragment fragment,
             Multimap<PlanNodeId, Split> initialSplits,
             OutputBuffers outputBuffers,
-            PartitionedSplitCountTracker partitionedSplitCountTracker,
+            NodeTaskMap.NodeStatsTracker nodeStatsTracker,
             boolean summarizeTaskInfo,
             TableWriteInfo tableWriteInfo)
     {
@@ -208,7 +208,7 @@ public class HttpRemoteTaskFactory
                 taskUpdateRequestCodec,
                 planFragmentCodec,
                 metadataUpdatesCodec,
-                partitionedSplitCountTracker,
+                nodeStatsTracker,
                 stats,
                 binaryTransportEnabled,
                 thriftTransportEnabled,

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -326,7 +326,7 @@ public class LocalQueryRunner
                 nodeManager,
                 new NodeSelectionStats(),
                 nodeSchedulerConfig,
-                new NodeTaskMap(finalizerService));
+                new NodeTaskMap(finalizerService, Duration.valueOf("10s")));
         this.pageSinkManager = new PageSinkManager();
         CatalogManager catalogManager = new CatalogManager();
         this.transactionManager = InMemoryTransactionManager.create(

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestCostCalculator.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestCostCalculator.java
@@ -64,6 +64,7 @@ import com.facebook.presto.util.FinalizerService;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import io.airlift.units.Duration;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -134,7 +135,7 @@ public class TestCostCalculator
                 new InMemoryNodeManager(),
                 new NodeSelectionStats(),
                 new NodeSchedulerConfig().setIncludeCoordinator(true),
-                new NodeTaskMap(finalizerService));
+                new NodeTaskMap(finalizerService, Duration.valueOf("10s")));
         PartitioningProviderManager partitioningProviderManager = new PartitioningProviderManager();
         nodePartitioningManager = new NodePartitioningManager(nodeScheduler, partitioningProviderManager);
         planFragmenter = new PlanFragmenter(metadata, nodePartitioningManager, new QueryManagerConfig(), new SqlParser(), new FeaturesConfig());

--- a/presto-main/src/test/java/com/facebook/presto/execution/BenchmarkNodeScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/BenchmarkNodeScheduler.java
@@ -37,6 +37,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Multimap;
+import io.airlift.units.Duration;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -145,7 +146,7 @@ public class BenchmarkNodeScheduler
             TestingTransactionHandle transactionHandle = TestingTransactionHandle.create();
 
             finalizerService.start();
-            NodeTaskMap nodeTaskMap = new NodeTaskMap(finalizerService);
+            NodeTaskMap nodeTaskMap = new NodeTaskMap(finalizerService, Duration.valueOf("10s"));
 
             ImmutableList.Builder<InternalNode> nodeBuilder = ImmutableList.builder();
             for (int i = 0; i < NODES; i++) {
@@ -162,7 +163,7 @@ public class BenchmarkNodeScheduler
                     initialSplits.add(new Split(CONNECTOR_ID, transactionHandle, new TestSplitRemote(i)));
                 }
                 TaskId taskId = new TaskId("test", 1, 0, i);
-                MockRemoteTaskFactory.MockRemoteTask remoteTask = remoteTaskFactory.createTableScanTask(taskId, node, initialSplits.build(), nodeTaskMap.createPartitionedSplitCountTracker(node, taskId));
+                MockRemoteTaskFactory.MockRemoteTask remoteTask = remoteTaskFactory.createTableScanTask(taskId, node, initialSplits.build(), nodeTaskMap.createTaskStatsTracker(node, taskId));
                 nodeTaskMap.addTask(node, remoteTask);
                 taskMap.put(node, remoteTask);
             }

--- a/presto-main/src/test/java/com/facebook/presto/execution/MockRemoteTaskFactory.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/MockRemoteTaskFactory.java
@@ -17,7 +17,7 @@ import com.facebook.airlift.stats.TestingGcMonitor;
 import com.facebook.presto.Session;
 import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.cost.StatsAndCosts;
-import com.facebook.presto.execution.NodeTaskMap.PartitionedSplitCountTracker;
+import com.facebook.presto.execution.NodeTaskMap.NodeStatsTracker;
 import com.facebook.presto.execution.buffer.LazyOutputBuffer;
 import com.facebook.presto.execution.buffer.OutputBuffer;
 import com.facebook.presto.execution.buffer.OutputBuffers;
@@ -104,7 +104,7 @@ public class MockRemoteTaskFactory
         this.scheduledExecutor = scheduledExecutor;
     }
 
-    public MockRemoteTask createTableScanTask(TaskId taskId, InternalNode newNode, List<Split> splits, PartitionedSplitCountTracker partitionedSplitCountTracker)
+    public MockRemoteTask createTableScanTask(TaskId taskId, InternalNode newNode, List<Split> splits, NodeTaskMap.NodeStatsTracker nodeStatsTracker)
     {
         VariableReferenceExpression variable = new VariableReferenceExpression("column", VARCHAR);
         PlanNodeId sourceId = new PlanNodeId("sourceId");
@@ -137,7 +137,7 @@ public class MockRemoteTaskFactory
                 testFragment,
                 initialSplits.build(),
                 createInitialEmptyOutputBuffers(BROADCAST),
-                partitionedSplitCountTracker,
+                nodeStatsTracker,
                 true,
                 new TableWriteInfo(Optional.empty(), Optional.empty(), Optional.empty()));
     }
@@ -150,17 +150,18 @@ public class MockRemoteTaskFactory
             PlanFragment fragment,
             Multimap<PlanNodeId, Split> initialSplits,
             OutputBuffers outputBuffers,
-            PartitionedSplitCountTracker partitionedSplitCountTracker,
+            NodeTaskMap.NodeStatsTracker nodeStatsTracker,
             boolean summarizeTaskInfo,
             TableWriteInfo tableWriteInfo)
     {
-        return new MockRemoteTask(taskId, fragment, node.getNodeIdentifier(), executor, scheduledExecutor, initialSplits, partitionedSplitCountTracker);
+        return new MockRemoteTask(taskId, fragment, node.getNodeIdentifier(), executor, scheduledExecutor, initialSplits, nodeStatsTracker);
     }
 
     public static final class MockRemoteTask
             implements RemoteTask
     {
         private final AtomicLong nextTaskInfoVersion = new AtomicLong(TaskStatus.STARTING_VERSION);
+        private final AtomicLong nextAgeOffset = new AtomicLong(0);
 
         private final URI location;
         private final TaskStateMachine taskStateMachine;
@@ -182,7 +183,7 @@ public class MockRemoteTaskFactory
         @GuardedBy("this")
         private SettableFuture<?> whenSplitQueueHasSpace = SettableFuture.create();
 
-        private final PartitionedSplitCountTracker partitionedSplitCountTracker;
+        private final NodeStatsTracker nodeStatsTracker;
 
         public MockRemoteTask(TaskId taskId,
                 PlanFragment fragment,
@@ -190,7 +191,7 @@ public class MockRemoteTaskFactory
                 Executor executor,
                 ScheduledExecutorService scheduledExecutor,
                 Multimap<PlanNodeId, Split> initialSplits,
-                PartitionedSplitCountTracker partitionedSplitCountTracker)
+                NodeTaskMap.NodeStatsTracker nodeStatsTracker)
         {
             this.taskStateMachine = new TaskStateMachine(requireNonNull(taskId, "taskId is null"), requireNonNull(executor, "executor is null"));
 
@@ -228,8 +229,8 @@ public class MockRemoteTaskFactory
             this.fragment = requireNonNull(fragment, "fragment is null");
             this.nodeId = requireNonNull(nodeId, "nodeId is null");
             splits.putAll(initialSplits);
-            this.partitionedSplitCountTracker = requireNonNull(partitionedSplitCountTracker, "partitionedSplitCountTracker is null");
-            partitionedSplitCountTracker.setPartitionedSplitCount(getPartitionedSplitCount());
+            this.nodeStatsTracker = requireNonNull(nodeStatsTracker, "nodeStatsTracker is null");
+            updateTaskStats();
             updateSplitQueueSpace();
         }
 
@@ -248,6 +249,7 @@ public class MockRemoteTaskFactory
         @Override
         public TaskInfo getTaskInfo()
         {
+            TaskStats stats = taskContext.getTaskStats();
             TaskState state = taskStateMachine.getState();
             List<ExecutionFailureInfo> failures = ImmutableList.of();
             if (state == TaskState.FAILED) {
@@ -273,7 +275,9 @@ public class MockRemoteTaskFactory
                             0,
                             0,
                             0,
-                            0),
+                            0,
+                            0,
+                            System.currentTimeMillis() + 100 - stats.getCreateTime().getMillis()),
                     DateTime.now(),
                     outputBuffer.getInfo(),
                     ImmutableSet.of(),
@@ -309,7 +313,27 @@ public class MockRemoteTaskFactory
                     stats.getSystemMemoryReservationInBytes(),
                     stats.getPeakNodeTotalMemoryInBytes(),
                     0,
-                    0);
+                    0,
+                    stats.getTotalCpuTimeInNanos(),
+                    // Adding 100 millis to make sure task age > 0 for testing
+                    System.currentTimeMillis() + 100 - stats.getCreateTime().getMillis());
+        }
+
+        private void updateTaskStats()
+        {
+            TaskStatus taskStatus = getTaskStatus();
+            if (taskStatus.getState().isDone()) {
+                nodeStatsTracker.setPartitionedSplitCount(0);
+                nodeStatsTracker.setMemoryUsage(0);
+                nodeStatsTracker.setCpuUsage(taskStatus.getTaskAgeInMillis(), 0);
+            }
+            else {
+                nodeStatsTracker.setPartitionedSplitCount(getPartitionedSplitCount());
+                // setting some values for testing
+                nodeStatsTracker.setMemoryUsage(100);
+                long ageOffset = nextAgeOffset.addAndGet(1);
+                nodeStatsTracker.setCpuUsage(taskStatus.getTaskAgeInMillis() + ageOffset, taskStatus.getTaskAgeInMillis() + ageOffset);
+            }
         }
 
         private synchronized void updateSplitQueueSpace()
@@ -342,7 +366,7 @@ public class MockRemoteTaskFactory
         public synchronized void clearSplits()
         {
             splits.clear();
-            partitionedSplitCountTracker.setPartitionedSplitCount(getPartitionedSplitCount());
+            updateTaskStats();
             runningDrivers = 0;
             updateSplitQueueSpace();
         }
@@ -370,7 +394,7 @@ public class MockRemoteTaskFactory
             synchronized (this) {
                 this.splits.putAll(splits);
             }
-            partitionedSplitCountTracker.setPartitionedSplitCount(getPartitionedSplitCount());
+            updateTaskStats();
             updateSplitQueueSpace();
         }
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
@@ -68,6 +68,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import io.airlift.units.Duration;
 
 import java.util.List;
 import java.util.Optional;
@@ -135,7 +136,7 @@ public final class TaskTestUtils
                 new InMemoryNodeManager(),
                 new NodeSelectionStats(),
                 new NodeSchedulerConfig().setIncludeCoordinator(true),
-                new NodeTaskMap(finalizerService));
+                new NodeTaskMap(finalizerService, Duration.valueOf("10s")));
         PartitioningProviderManager partitioningProviderManager = new PartitioningProviderManager();
         NodePartitioningManager nodePartitioningManager = new NodePartitioningManager(nodeScheduler, partitioningProviderManager);
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestNodeScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestNodeScheduler.java
@@ -88,7 +88,7 @@ public class TestNodeScheduler
     public void setUp()
     {
         finalizerService = new FinalizerService();
-        nodeTaskMap = new NodeTaskMap(finalizerService);
+        nodeTaskMap = new NodeTaskMap(finalizerService, Duration.valueOf("100s"));
         nodeManager = new InMemoryNodeManager();
 
         ImmutableList.Builder<InternalNode> nodeBuilder = ImmutableList.builder();
@@ -136,7 +136,7 @@ public class TestNodeScheduler
             throws Exception
     {
         TestingTransactionHandle transactionHandle = TestingTransactionHandle.create();
-        NodeTaskMap nodeTaskMap = new NodeTaskMap(finalizerService);
+        NodeTaskMap nodeTaskMap = new NodeTaskMap(finalizerService, Duration.valueOf("10s"));
         InMemoryNodeManager nodeManager = new InMemoryNodeManager();
 
         ImmutableList.Builder<InternalNode> nodeBuilder = ImmutableList.builder();
@@ -184,7 +184,7 @@ public class TestNodeScheduler
         for (InternalNode node : assignments.keySet()) {
             TaskId taskId = new TaskId("test", 1, 0, task);
             task++;
-            MockRemoteTaskFactory.MockRemoteTask remoteTask = remoteTaskFactory.createTableScanTask(taskId, node, ImmutableList.copyOf(assignments.get(node)), nodeTaskMap.createPartitionedSplitCountTracker(node, taskId));
+            MockRemoteTaskFactory.MockRemoteTask remoteTask = remoteTaskFactory.createTableScanTask(taskId, node, ImmutableList.copyOf(assignments.get(node)), nodeTaskMap.createTaskStatsTracker(node, taskId));
             remoteTask.startSplits(25);
             nodeTaskMap.addTask(node, remoteTask);
             taskMap.put(node, remoteTask);
@@ -297,7 +297,7 @@ public class TestNodeScheduler
     @Test
     public void testAffinityAssignmentNotSupported()
     {
-        NodeTaskMap nodeTaskMap = new NodeTaskMap(finalizerService);
+        NodeTaskMap nodeTaskMap = new NodeTaskMap(finalizerService, Duration.valueOf("10s"));
         TestingTransactionHandle transactionHandle = TestingTransactionHandle.create();
         NodeSchedulerConfig nodeSchedulerConfig = new NodeSchedulerConfig()
                 .setMaxSplitsPerNode(20)
@@ -320,7 +320,7 @@ public class TestNodeScheduler
     @Test
     public void testAffinityAssignment()
     {
-        NodeTaskMap nodeTaskMap = new NodeTaskMap(finalizerService);
+        NodeTaskMap nodeTaskMap = new NodeTaskMap(finalizerService, Duration.valueOf("10s"));
         TestingTransactionHandle transactionHandle = TestingTransactionHandle.create();
         NodeSchedulerConfig nodeSchedulerConfig = new NodeSchedulerConfig()
                 .setMaxSplitsPerNode(20)
@@ -358,7 +358,7 @@ public class TestNodeScheduler
     @Test
     public void testHardAffinityAssignment()
     {
-        NodeTaskMap nodeTaskMap = new NodeTaskMap(finalizerService);
+        NodeTaskMap nodeTaskMap = new NodeTaskMap(finalizerService, Duration.valueOf("10s"));
         TestingTransactionHandle transactionHandle = TestingTransactionHandle.create();
         NodeSchedulerConfig nodeSchedulerConfig = new NodeSchedulerConfig()
                 .setMaxSplitsPerNode(20)
@@ -396,11 +396,11 @@ public class TestNodeScheduler
         MockRemoteTaskFactory remoteTaskFactory = new MockRemoteTaskFactory(remoteTaskExecutor, remoteTaskScheduledExecutor);
         // Max out number of splits on node
         TaskId taskId1 = new TaskId("test", 1, 0, 1);
-        RemoteTask remoteTask1 = remoteTaskFactory.createTableScanTask(taskId1, newNode, initialSplits.build(), nodeTaskMap.createPartitionedSplitCountTracker(newNode, taskId1));
+        RemoteTask remoteTask1 = remoteTaskFactory.createTableScanTask(taskId1, newNode, initialSplits.build(), nodeTaskMap.createTaskStatsTracker(newNode, taskId1));
         nodeTaskMap.addTask(newNode, remoteTask1);
 
         TaskId taskId2 = new TaskId("test", 1, 0, 2);
-        RemoteTask remoteTask2 = remoteTaskFactory.createTableScanTask(taskId2, newNode, initialSplits.build(), nodeTaskMap.createPartitionedSplitCountTracker(newNode, taskId2));
+        RemoteTask remoteTask2 = remoteTaskFactory.createTableScanTask(taskId2, newNode, initialSplits.build(), nodeTaskMap.createTaskStatsTracker(newNode, taskId2));
         nodeTaskMap.addTask(newNode, remoteTask2);
 
         Set<Split> splits = new HashSet<>();
@@ -436,13 +436,13 @@ public class TestNodeScheduler
         for (InternalNode node : nodeManager.getActiveConnectorNodes(CONNECTOR_ID)) {
             // Max out number of splits on node
             TaskId taskId = new TaskId("test", 1, 0, 1);
-            RemoteTask remoteTask = remoteTaskFactory.createTableScanTask(taskId, node, initialSplits.build(), nodeTaskMap.createPartitionedSplitCountTracker(node, taskId));
+            RemoteTask remoteTask = remoteTaskFactory.createTableScanTask(taskId, node, initialSplits.build(), nodeTaskMap.createTaskStatsTracker(node, taskId));
             nodeTaskMap.addTask(node, remoteTask);
             tasks.add(remoteTask);
         }
 
         TaskId taskId = new TaskId("test", 1, 0, 2);
-        RemoteTask newRemoteTask = remoteTaskFactory.createTableScanTask(taskId, newNode, initialSplits.build(), nodeTaskMap.createPartitionedSplitCountTracker(newNode, taskId));
+        RemoteTask newRemoteTask = remoteTaskFactory.createTableScanTask(taskId, newNode, initialSplits.build(), nodeTaskMap.createTaskStatsTracker(newNode, taskId));
         // Max out pending splits on new node
         taskMap.put(newNode, newRemoteTask);
         nodeTaskMap.addTask(newNode, newRemoteTask);
@@ -476,7 +476,7 @@ public class TestNodeScheduler
                 taskId,
                 chosenNode,
                 ImmutableList.of(new Split(CONNECTOR_ID, TestingTransactionHandle.create(), new TestSplitRemote())),
-                nodeTaskMap.createPartitionedSplitCountTracker(chosenNode, taskId));
+                nodeTaskMap.createTaskStatsTracker(chosenNode, taskId));
         nodeTaskMap.addTask(chosenNode, remoteTask);
         assertEquals(nodeTaskMap.getPartitionedSplitsOnNode(chosenNode), 1);
         remoteTask.abort();
@@ -499,14 +499,14 @@ public class TestNodeScheduler
                 ImmutableList.of(
                         new Split(CONNECTOR_ID, TestingTransactionHandle.create(), new TestSplitRemote()),
                         new Split(CONNECTOR_ID, TestingTransactionHandle.create(), new TestSplitRemote())),
-                nodeTaskMap.createPartitionedSplitCountTracker(chosenNode, taskId1));
+                nodeTaskMap.createTaskStatsTracker(chosenNode, taskId1));
 
         TaskId taskId2 = new TaskId("test", 1, 0, 2);
         RemoteTask remoteTask2 = remoteTaskFactory.createTableScanTask(
                 taskId2,
                 chosenNode,
                 ImmutableList.of(new Split(CONNECTOR_ID, TestingTransactionHandle.create(), new TestSplitRemote())),
-                nodeTaskMap.createPartitionedSplitCountTracker(chosenNode, taskId2));
+                nodeTaskMap.createTaskStatsTracker(chosenNode, taskId2));
 
         nodeTaskMap.addTask(chosenNode, remoteTask1);
         nodeTaskMap.addTask(chosenNode, remoteTask2);
@@ -519,9 +519,89 @@ public class TestNodeScheduler
     }
 
     @Test
+    public void testCpuUsage()
+    {
+        MockRemoteTaskFactory remoteTaskFactory = new MockRemoteTaskFactory(remoteTaskExecutor, remoteTaskScheduledExecutor);
+        InternalNode chosenNode = Iterables.get(nodeManager.getActiveConnectorNodes(CONNECTOR_ID), 0);
+
+        TaskId taskId1 = new TaskId("test", 1, 0, 1);
+        ImmutableList<Split> splits = ImmutableList.of(
+                new Split(CONNECTOR_ID, TestingTransactionHandle.create(), new TestSplitRemote()),
+                new Split(CONNECTOR_ID, TestingTransactionHandle.create(), new TestSplitRemote()));
+        RemoteTask remoteTask1 = remoteTaskFactory.createTableScanTask(taskId1,
+                chosenNode,
+                splits,
+                nodeTaskMap.createTaskStatsTracker(chosenNode, taskId1));
+
+        TaskId taskId2 = new TaskId("test", 1, 0, 2);
+        RemoteTask remoteTask2 = remoteTaskFactory.createTableScanTask(
+                taskId2,
+                chosenNode,
+                ImmutableList.of(new Split(CONNECTOR_ID, TestingTransactionHandle.create(), new TestSplitRemote())),
+                nodeTaskMap.createTaskStatsTracker(chosenNode, taskId2));
+
+        nodeTaskMap.addTask(chosenNode, remoteTask1);
+        nodeTaskMap.addTask(chosenNode, remoteTask2);
+
+        remoteTask2.addSplits(ImmutableMultimap.<PlanNodeId, Split>builder()
+                .putAll(new PlanNodeId("sourceId"), splits)
+                .build());
+
+        assertEquals(nodeTaskMap.getNodeCpuUtilizationPercentage(chosenNode), 100);
+        remoteTask1.addSplits(ImmutableMultimap.<PlanNodeId, Split>builder()
+                .putAll(new PlanNodeId("sourceId"), splits)
+                .build());
+        assertEquals(nodeTaskMap.getNodeCpuUtilizationPercentage(chosenNode), 200);
+        remoteTask1.abort();
+        assertEquals(nodeTaskMap.getNodeCpuUtilizationPercentage(chosenNode), 100);
+        remoteTask2.abort();
+        assertEquals(nodeTaskMap.getNodeCpuUtilizationPercentage(chosenNode), 0);
+    }
+
+    @Test
+    public void testMemoryUsage()
+    {
+        MockRemoteTaskFactory remoteTaskFactory = new MockRemoteTaskFactory(remoteTaskExecutor, remoteTaskScheduledExecutor);
+        InternalNode chosenNode = Iterables.get(nodeManager.getActiveConnectorNodes(CONNECTOR_ID), 0);
+
+        TaskId taskId1 = new TaskId("test", 1, 0, 1);
+        ImmutableList<Split> splits = ImmutableList.of(
+                new Split(CONNECTOR_ID, TestingTransactionHandle.create(), new TestSplitRemote()),
+                new Split(CONNECTOR_ID, TestingTransactionHandle.create(), new TestSplitRemote()));
+        RemoteTask remoteTask1 = remoteTaskFactory.createTableScanTask(taskId1,
+                chosenNode,
+                splits,
+                nodeTaskMap.createTaskStatsTracker(chosenNode, taskId1));
+
+        TaskId taskId2 = new TaskId("test", 1, 0, 2);
+        RemoteTask remoteTask2 = remoteTaskFactory.createTableScanTask(
+                taskId2,
+                chosenNode,
+                ImmutableList.of(new Split(CONNECTOR_ID, TestingTransactionHandle.create(), new TestSplitRemote())),
+                nodeTaskMap.createTaskStatsTracker(chosenNode, taskId2));
+
+        nodeTaskMap.addTask(chosenNode, remoteTask1);
+        nodeTaskMap.addTask(chosenNode, remoteTask2);
+
+        remoteTask2.addSplits(ImmutableMultimap.<PlanNodeId, Split>builder()
+                .putAll(new PlanNodeId("sourceId"), splits)
+                .build());
+
+        assertEquals(nodeTaskMap.getNodeTotalMemoryUsageInBytes(chosenNode), 200);
+        remoteTask1.addSplits(ImmutableMultimap.<PlanNodeId, Split>builder()
+                .putAll(new PlanNodeId("sourceId"), splits)
+                .build());
+        assertEquals(nodeTaskMap.getNodeTotalMemoryUsageInBytes(chosenNode), 200);
+        remoteTask1.abort();
+        assertEquals(nodeTaskMap.getNodeTotalMemoryUsageInBytes(chosenNode), 100);
+        remoteTask2.abort();
+        assertEquals(nodeTaskMap.getNodeTotalMemoryUsageInBytes(chosenNode), 0);
+    }
+
+    @Test
     public void testMaxTasksPerStageWittLimit()
     {
-        NodeTaskMap nodeTaskMap = new NodeTaskMap(finalizerService);
+        NodeTaskMap nodeTaskMap = new NodeTaskMap(finalizerService, Duration.valueOf("10s"));
         TestingTransactionHandle transactionHandle = TestingTransactionHandle.create();
         NodeSchedulerConfig nodeSchedulerConfig = new NodeSchedulerConfig()
                 .setMaxSplitsPerNode(20)
@@ -557,7 +637,7 @@ public class TestNodeScheduler
     {
         InMemoryNodeManager nodeManager = new InMemoryNodeManager();
 
-        NodeTaskMap nodeTaskMap = new NodeTaskMap(finalizerService);
+        NodeTaskMap nodeTaskMap = new NodeTaskMap(finalizerService, Duration.valueOf("10s"));
         TestingTransactionHandle transactionHandle = TestingTransactionHandle.create();
         NodeSchedulerConfig nodeSchedulerConfig = new NodeSchedulerConfig()
                 .setMaxSplitsPerNode(20)
@@ -601,7 +681,7 @@ public class TestNodeScheduler
         for (InternalNode node : assignments.keySet()) {
             TaskId taskId = new TaskId("test", 1, 1, task);
             task++;
-            MockRemoteTaskFactory.MockRemoteTask remoteTask = remoteTaskFactory.createTableScanTask(taskId, node, ImmutableList.copyOf(assignments.get(node)), nodeTaskMap.createPartitionedSplitCountTracker(node, taskId));
+            MockRemoteTaskFactory.MockRemoteTask remoteTask = remoteTaskFactory.createTableScanTask(taskId, node, ImmutableList.copyOf(assignments.get(node)), nodeTaskMap.createTaskStatsTracker(node, taskId));
             remoteTask.startSplits(25);
             nodeTaskMap.addTask(node, remoteTask);
             taskMap.put(node, remoteTask);

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSqlStageExecution.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSqlStageExecution.java
@@ -33,6 +33,7 @@ import com.facebook.presto.util.FinalizerService;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.SettableFuture;
+import io.airlift.units.Duration;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -95,7 +96,7 @@ public class TestSqlStageExecution
     private void testFinalStageInfoInternal()
             throws Exception
     {
-        NodeTaskMap nodeTaskMap = new NodeTaskMap(new FinalizerService());
+        NodeTaskMap nodeTaskMap = new NodeTaskMap(new FinalizerService(), Duration.valueOf("10s"));
 
         StageId stageId = new StageId(new QueryId("query"), 0);
         SqlStageExecution stage = createSqlStageExecution(

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestThriftTaskStatus.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestThriftTaskStatus.java
@@ -74,6 +74,8 @@ public class TestThriftTaskStatus
     public static final int PEAK_NODE_TOTAL_MEMORY_RESERVATION_IN_BYTES = 42 * 1024 * 1024;
     public static final int FULL_GC_COUNT = 10;
     public static final int FULL_GC_TIME_IN_MILLIS = 1001;
+    public static final int TOTAL_CPU_TIME_IN_NANOS = 1002;
+    public static final int TASK_AGE = 1003;
     public static final HostAddress REMOTE_HOST = HostAddress.fromParts("www.fake.invalid", 8080);
     private TaskStatus taskStatus;
 
@@ -135,6 +137,8 @@ public class TestThriftTaskStatus
         assertEquals(taskStatus.getPeakNodeTotalMemoryReservationInBytes(), PEAK_NODE_TOTAL_MEMORY_RESERVATION_IN_BYTES);
         assertEquals(taskStatus.getFullGcCount(), FULL_GC_COUNT);
         assertEquals(taskStatus.getFullGcTimeInMillis(), FULL_GC_TIME_IN_MILLIS);
+        assertEquals(taskStatus.getTotalCpuTimeInNanos(), TOTAL_CPU_TIME_IN_NANOS);
+        assertEquals(taskStatus.getTaskAgeInMillis(), TASK_AGE);
 
         List<ExecutionFailureInfo> failures = taskStatus.getFailures();
         assertEquals(failures.size(), 3);
@@ -195,7 +199,9 @@ public class TestThriftTaskStatus
                 SYSTEM_MEMORY_RESERVATION_IN_BYTES,
                 PEAK_NODE_TOTAL_MEMORY_RESERVATION_IN_BYTES,
                 FULL_GC_COUNT,
-                FULL_GC_TIME_IN_MILLIS);
+                FULL_GC_TIME_IN_MILLIS,
+                TOTAL_CPU_TIME_IN_NANOS,
+                TASK_AGE);
     }
 
     private List<ExecutionFailureInfo> getExecutionFailureInfos()

--- a/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestFixedCountScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestFixedCountScheduler.java
@@ -15,7 +15,7 @@ package com.facebook.presto.execution.scheduler;
 
 import com.facebook.presto.client.NodeVersion;
 import com.facebook.presto.execution.MockRemoteTaskFactory;
-import com.facebook.presto.execution.NodeTaskMap.PartitionedSplitCountTracker;
+import com.facebook.presto.execution.NodeTaskMap;
 import com.facebook.presto.execution.RemoteTask;
 import com.facebook.presto.execution.TaskId;
 import com.facebook.presto.metadata.InternalNode;
@@ -63,7 +63,7 @@ public class TestFixedCountScheduler
                 (node, partition) -> Optional.of(taskFactory.createTableScanTask(
                         new TaskId("test", 1, 0, 1),
                         node, ImmutableList.of(),
-                        new PartitionedSplitCountTracker(delta -> {}))),
+                        new NodeTaskMap.NodeStatsTracker(delta -> {}, delta -> {}, (age, delta) -> {}))),
                 generateRandomNodes(1));
 
         ScheduleResult result = nodeScheduler.schedule();
@@ -80,7 +80,7 @@ public class TestFixedCountScheduler
                 (node, partition) -> Optional.of(taskFactory.createTableScanTask(
                         new TaskId("test", 1, 0, 1),
                         node, ImmutableList.of(),
-                        new PartitionedSplitCountTracker(delta -> {}))),
+                        new NodeTaskMap.NodeStatsTracker(delta -> {}, delta -> {}, (age, delta) -> {}))),
                 generateRandomNodes(5));
 
         ScheduleResult result = nodeScheduler.schedule();

--- a/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestSourcePartitionedScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestSourcePartitionedScheduler.java
@@ -61,6 +61,7 @@ import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import io.airlift.units.Duration;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -134,7 +135,7 @@ public class TestSourcePartitionedScheduler
     public void testScheduleNoSplits()
     {
         SubPlan plan = createPlan();
-        NodeTaskMap nodeTaskMap = new NodeTaskMap(finalizerService);
+        NodeTaskMap nodeTaskMap = new NodeTaskMap(finalizerService, Duration.valueOf("10s"));
         SqlStageExecution stage = createSqlStageExecution(plan, nodeTaskMap);
 
         StageScheduler scheduler = getSourcePartitionedScheduler(createFixedSplitSource(0, TestingSplit::createRemoteSplit), stage, nodeManager, nodeTaskMap, 1);
@@ -151,7 +152,7 @@ public class TestSourcePartitionedScheduler
     public void testScheduleSplitsOneAtATime()
     {
         SubPlan plan = createPlan();
-        NodeTaskMap nodeTaskMap = new NodeTaskMap(finalizerService);
+        NodeTaskMap nodeTaskMap = new NodeTaskMap(finalizerService, Duration.valueOf("10s"));
         SqlStageExecution stage = createSqlStageExecution(plan, nodeTaskMap);
 
         StageScheduler scheduler = getSourcePartitionedScheduler(createFixedSplitSource(60, TestingSplit::createRemoteSplit), stage, nodeManager, nodeTaskMap, 1);
@@ -188,7 +189,7 @@ public class TestSourcePartitionedScheduler
     public void testScheduleSplitsBatched()
     {
         SubPlan plan = createPlan();
-        NodeTaskMap nodeTaskMap = new NodeTaskMap(finalizerService);
+        NodeTaskMap nodeTaskMap = new NodeTaskMap(finalizerService, Duration.valueOf("10s"));
         SqlStageExecution stage = createSqlStageExecution(plan, nodeTaskMap);
 
         StageScheduler scheduler = getSourcePartitionedScheduler(createFixedSplitSource(60, TestingSplit::createRemoteSplit), stage, nodeManager, nodeTaskMap, 7);
@@ -225,7 +226,7 @@ public class TestSourcePartitionedScheduler
     public void testScheduleSplitsBlock()
     {
         SubPlan plan = createPlan();
-        NodeTaskMap nodeTaskMap = new NodeTaskMap(finalizerService);
+        NodeTaskMap nodeTaskMap = new NodeTaskMap(finalizerService, Duration.valueOf("10s"));
         SqlStageExecution stage = createSqlStageExecution(plan, nodeTaskMap);
 
         StageScheduler scheduler = getSourcePartitionedScheduler(createFixedSplitSource(80, TestingSplit::createRemoteSplit), stage, nodeManager, nodeTaskMap, 1);
@@ -290,7 +291,7 @@ public class TestSourcePartitionedScheduler
     {
         QueuedSplitSource queuedSplitSource = new QueuedSplitSource(TestingSplit::createRemoteSplit);
         SubPlan plan = createPlan();
-        NodeTaskMap nodeTaskMap = new NodeTaskMap(finalizerService);
+        NodeTaskMap nodeTaskMap = new NodeTaskMap(finalizerService, Duration.valueOf("10s"));
         SqlStageExecution stage = createSqlStageExecution(plan, nodeTaskMap);
 
         StageScheduler scheduler = getSourcePartitionedScheduler(queuedSplitSource, stage, nodeManager, nodeTaskMap, 1);
@@ -310,7 +311,7 @@ public class TestSourcePartitionedScheduler
     public void testNoNodes()
     {
         try {
-            NodeTaskMap nodeTaskMap = new NodeTaskMap(finalizerService);
+            NodeTaskMap nodeTaskMap = new NodeTaskMap(finalizerService, Duration.valueOf("10s"));
             InMemoryNodeManager nodeManager = new InMemoryNodeManager();
             NodeScheduler nodeScheduler = new NodeScheduler(
                     new LegacyNetworkTopology(),
@@ -346,7 +347,7 @@ public class TestSourcePartitionedScheduler
                 new InternalNode("other1", URI.create("http://127.0.0.1:11"), NodeVersion.UNKNOWN, false),
                 new InternalNode("other2", URI.create("http://127.0.0.1:12"), NodeVersion.UNKNOWN, false),
                 new InternalNode("other3", URI.create("http://127.0.0.1:13"), NodeVersion.UNKNOWN, false));
-        NodeTaskMap nodeTaskMap = new NodeTaskMap(finalizerService);
+        NodeTaskMap nodeTaskMap = new NodeTaskMap(finalizerService, Duration.valueOf("10s"));
 
         // Schedule 15 splits - there are 3 nodes, each node should get 5 splits
         SubPlan firstPlan = createPlan();
@@ -386,7 +387,7 @@ public class TestSourcePartitionedScheduler
     @Test
     public void testBlockCausesFullSchedule()
     {
-        NodeTaskMap nodeTaskMap = new NodeTaskMap(finalizerService);
+        NodeTaskMap nodeTaskMap = new NodeTaskMap(finalizerService, Duration.valueOf("10s"));
 
         // Schedule 60 splits - filling up all nodes
         SubPlan firstPlan = createPlan();

--- a/presto-main/src/test/java/com/facebook/presto/server/remotetask/TestHttpRemoteTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/remotetask/TestHttpRemoteTask.java
@@ -238,7 +238,7 @@ public class TestHttpRemoteTask
                 createPlanFragment(),
                 ImmutableMultimap.of(),
                 createInitialEmptyOutputBuffers(OutputBuffers.BufferType.BROADCAST),
-                new NodeTaskMap.PartitionedSplitCountTracker(i -> {}),
+                new NodeTaskMap.NodeStatsTracker(i -> {}, i -> {}, (age, i) -> {}),
                 true,
                 new TableWriteInfo(Optional.empty(), Optional.empty(), Optional.empty()));
     }
@@ -547,7 +547,9 @@ public class TestHttpRemoteTask
                     initialTaskStatus.getSystemMemoryReservationInBytes(),
                     initialTaskStatus.getPeakNodeTotalMemoryReservationInBytes(),
                     initialTaskStatus.getFullGcCount(),
-                    initialTaskStatus.getFullGcTimeInMillis());
+                    initialTaskStatus.getFullGcTimeInMillis(),
+                    initialTaskStatus.getTotalCpuTimeInNanos(),
+                    initialTaskStatus.getTaskAgeInMillis());
         }
     }
 }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkTaskExecutorFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkTaskExecutorFactory.java
@@ -677,7 +677,9 @@ public class PrestoSparkTaskExecutorFactory
                     taskStats.getSystemMemoryReservationInBytes(),
                     taskStats.getPeakNodeTotalMemoryInBytes(),
                     taskStats.getFullGcCount(),
-                    taskStats.getFullGcTimeInMillis());
+                    taskStats.getFullGcTimeInMillis(),
+                    taskStats.getTotalCpuTimeInNanos(),
+                    System.currentTimeMillis() - taskStats.getCreateTime().getMillis());
 
             OutputBufferInfo outputBufferInfo = new OutputBufferInfo(
                     outputBufferType.name(),

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/node/PrestoSparkNodeScheduler.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/node/PrestoSparkNodeScheduler.java
@@ -44,7 +44,7 @@ public class PrestoSparkNodeScheduler
                 new InMemoryNodeManager(),
                 new NodeSelectionStats(),
                 new NodeSchedulerConfig(),
-                new NodeTaskMap(new FinalizerService()),
+                new NodeTaskMap(new FinalizerService(), Duration.valueOf("10s")),
                 new Duration(5, SECONDS));
     }
 


### PR DESCRIPTION
NodeTaskMap holds the worker level aggregated split stats which is used by NodeSelectors. NodeSelector accesses to NodeTaskMap via NodeAssignmentStats. CPU and Memory stats are added to NodeTaskMap. CPU and Memory stats will used in planed new feature "workload placement".