### PR TITLE
Improve SliceDirectSelectiveStreamReader

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDirectSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDirectSelectiveStreamReader.java
@@ -646,7 +646,7 @@ public class SliceDirectSelectiveStreamReader
         if (lengthStream != null) {
             int nonNullCount = totalPositions - nullCount;
             lengthVector = ensureCapacity(lengthVector, nonNullCount);
-            lengthStream.nextIntVector(nonNullCount, lengthVector, 0);
+            lengthStream.next(lengthVector, nonNullCount);
 
             if (useBatchMode(positionCount, totalPositions)) {
                 for (int i = 0; i < nonNullCount; i++) {

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDirectSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDirectSelectiveStreamReader.java
@@ -43,6 +43,9 @@ import static com.facebook.presto.orc.array.Arrays.ensureCapacity;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.LENGTH;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
+import static com.facebook.presto.orc.reader.ReaderUtils.convertLengthVectorToOffsetVector;
+import static com.facebook.presto.orc.reader.ReaderUtils.packByteArrayAndOffsets;
+import static com.facebook.presto.orc.reader.ReaderUtils.packByteArrayOffsetsAndNulls;
 import static com.facebook.presto.orc.reader.SelectiveStreamReaders.initializeOutputPositions;
 import static com.facebook.presto.orc.reader.SliceSelectiveStreamReader.computeTruncatedLength;
 import static com.facebook.presto.orc.stream.MissingInputStreamSource.missingStreamSource;
@@ -129,7 +132,7 @@ public class SliceDirectSelectiveStreamReader
             skip(offset - readOffset);
         }
 
-        prepareForNextRead(positionCount, positions);
+        int dataLength = prepareForNextRead(positionCount, positions);
 
         int streamPosition;
 
@@ -137,19 +140,51 @@ public class SliceDirectSelectiveStreamReader
             streamPosition = readAllNulls(positions, positionCount);
         }
         else if (filter == null) {
-            streamPosition = readNoFilter(positions, positionCount);
+            streamPosition = readNoFilter(positions, positionCount, dataLength);
         }
         else {
-            streamPosition = readWithFilter(positions, positionCount);
+            streamPosition = readWithFilter(positions, positionCount, dataLength);
         }
 
         readOffset = offset + streamPosition;
         return outputPositionCount;
     }
 
-    private int readNoFilter(int[] positions, int positionCount)
+    private int readNoFilter(int[] positions, int positionCount, int dataLength)
             throws IOException
     {
+        // filter == null implies outputRequired == true
+
+        int totalPositionCount = positions[positionCount - 1] + 1;
+        if (useBatchMode(positionCount, totalPositionCount)) {
+            if (presentStream == null) {
+                if (dataStream != null) {
+                    dataStream.next(data, 0, dataLength);
+                    convertLengthVectorToOffsetVector(lengthVector, totalPositionCount, offsets);
+
+                    if (totalPositionCount > positionCount) {
+                        packByteArrayAndOffsets(data, offsets, positions, positionCount);
+                    }
+                }
+            }
+            else {
+                if (dataStream != null) {
+                    dataStream.next(data, 0, dataLength);
+                    convertLengthVectorToOffsetVector(lengthVector, isNullVector, totalPositionCount, offsets);
+                }
+
+                if (totalPositionCount > positionCount) {
+                    packByteArrayOffsetsAndNulls(data, offsets, isNullVector, positions, positionCount);
+                }
+
+                if (nullsAllowed) {
+                    System.arraycopy(isNullVector, 0, nulls, 0, positionCount);
+                }
+            }
+            outputPositionCount = positionCount;
+            return totalPositionCount;
+        }
+
         int streamPosition = 0;
         for (int i = 0; i < positionCount; i++) {
             int position = positions[i];
@@ -184,9 +219,43 @@ public class SliceDirectSelectiveStreamReader
         return streamPosition;
     }
 
-    private int readWithFilter(int[] positions, int positionCount)
+    private int readWithFilter(int[] positions, int positionCount, int dataLength)
             throws IOException
     {
+        int totalPositionCount = positions[positionCount - 1] + 1;
+        if (useBatchMode(positionCount, totalPositionCount)) {
+            if (dataStream != null) {
+                dataStream.next(data, 0, dataLength);
+            }
+
+            final int filteredPositionCount;
+            if (presentStream == null) {
+                filteredPositionCount = evaluateFilter(positions, positionCount);
+
+                if (outputRequired && totalPositionCount > filteredPositionCount && filteredPositionCount > 0 && dataStream != null) {
+                    packByteArrayAndOffsets(data, offsets, outputPositions, filteredPositionCount);
+                }
+            }
+            else {
+                filteredPositionCount = evaluateFilterWithNull(positions, positionCount);
+
+                if (outputRequired) {
+                    if (filteredPositionCount > 0) {
+                        if (outputRequired && totalPositionCount > filteredPositionCount) {
+                            packByteArrayOffsetsAndNulls(data, offsets, isNullVector, outputPositions, filteredPositionCount);
+                        }
+
+                        if (nullsAllowed) {
+                            System.arraycopy(isNullVector, 0, nulls, 0, filteredPositionCount);
+                        }
+                    }
+                }
+            }
+
+            outputPositionCount = filteredPositionCount;
+            return totalPositionCount;
+        }
+
         int streamPosition = 0;
         int dataToSkip = 0;
 
@@ -329,6 +398,79 @@ public class SliceDirectSelectiveStreamReader
         if (dataStream != null) {
             dataStream.skip(dataToSkip);
         }
+    }
+
+    // No nulls
+    private int evaluateFilter(int[] positions, int positionCount)
+    {
+        int positionsIndex = 0;
+        for (int i = 0; i < positionCount; i++) {
+            int position = positions[i];
+            if (filter.testLength(lengthVector[position])) {
+                outputPositions[positionsIndex++] = position;  // compact positions on the fly
+            }
+        }
+
+        int filteredPositionCount = 0;
+        if (positionsIndex > 0) {
+            if (dataStream == null) {
+                // The length check has passed and there is no need to run testBytes because there is no data
+                filteredPositionCount = positionsIndex;
+            }
+            else {
+                int totalPositionCount = outputPositions[positionsIndex - 1] + 1;
+                convertLengthVectorToOffsetVector(lengthVector, totalPositionCount, offsets);
+                filteredPositionCount = testBytes(outputPositions, positionsIndex);
+            }
+        }
+
+        return filteredPositionCount;
+    }
+
+    private int evaluateFilterWithNull(int[] positions, int positionCount)
+    {
+        if (dataStream != null) {
+            int totalPositionCount = positions[positionCount - 1] + 1;
+            convertLengthVectorToOffsetVector(lengthVector, isNullVector, totalPositionCount, offsets);
+        }
+
+        boolean testNull = (nonDeterministicFilter && filter.testNull()) || nullsAllowed;
+
+        int positionsIndex = 0;
+        for (int i = 0; i < positionCount; i++) {
+            int position = positions[i];
+
+            if (isNullVector[position]) {
+                if (testNull) {
+                    outputPositions[positionsIndex++] = position;
+                }
+            }
+            else {
+                int dataOffset = offsets[position];
+                int length = offsets[position + 1] - dataOffset;
+
+                if (filter.testLength(length) && filter.testBytes(data, dataOffset, length)) {
+                    outputPositions[positionsIndex++] = position;  // compact positions on the fly
+                }
+            }
+        }
+
+        return positionsIndex;
+    }
+
+    private int testBytes(int[] positions, int positionCount)
+    {
+        int positionsIndex = 0;
+        for (int i = 0; i < positionCount; i++) {
+            int position = positions[i];
+
+            int dataOffset = offsets[position];
+            int length = offsets[position + 1] - dataOffset;
+            if (filter.testBytes(data, dataOffset, length)) {
+                positions[positionsIndex++] = position;
+            }
+        }
+        return positionsIndex;
     }
 
     @Override
@@ -484,7 +626,7 @@ public class SliceDirectSelectiveStreamReader
         return INSTANCE_SIZE + sizeOf(offsets) + sizeOf(outputPositions) + sizeOf(data) + sizeOf(nulls) + sizeOf(lengthVector) + sizeOf(isNullVector);
     }
 
-    private void prepareForNextRead(int positionCount, int[] positions)
+    private int prepareForNextRead(int positionCount, int[] positions)
             throws IOException
     {
         lengthIndex = 0;
@@ -492,6 +634,7 @@ public class SliceDirectSelectiveStreamReader
 
         int totalLength = 0;
         int maxLength = 0;
+        int dataLength = 0;
 
         int totalPositions = positions[positionCount - 1] + 1;
         int nullCount = 0;
@@ -505,20 +648,28 @@ public class SliceDirectSelectiveStreamReader
             lengthVector = ensureCapacity(lengthVector, nonNullCount);
             lengthStream.nextIntVector(nonNullCount, lengthVector, 0);
 
-            int positionIndex = 0;
-            int lengthIndex = 0;
-            for (int i = 0; i < totalPositions; i++) {
-                boolean isNotNull = nullCount == 0 || !isNullVector[i];
-                if (i == positions[positionIndex]) {
-                    if (isNotNull) {
-                        totalLength += lengthVector[lengthIndex];
-                        maxLength = Math.max(maxLength, lengthVector[lengthIndex]);
+            if (useBatchMode(positionCount, totalPositions)) {
+                for (int i = 0; i < nonNullCount; i++) {
+                    totalLength += lengthVector[i];
+                    maxLength = Math.max(maxLength, lengthVector[i]);
+                }
+            }
+            else {
+                int positionIndex = 0;
+                int lengthIndex = 0;
+                for (int i = 0; i < totalPositions; i++) {
+                    boolean isNotNull = nullCount == 0 || !isNullVector[i];
+                    if (i == positions[positionIndex]) {
+                        if (isNotNull) {
+                            totalLength += lengthVector[lengthIndex];
+                            maxLength = Math.max(maxLength, lengthVector[lengthIndex]);
+                            lengthIndex++;
+                        }
+                        positionIndex++;
+                    }
+                    else if (isNotNull) {
                         lengthIndex++;
                     }
-                    positionIndex++;
-                }
-                else if (isNotNull) {
-                    lengthIndex++;
                 }
             }
 
@@ -535,13 +686,55 @@ public class SliceDirectSelectiveStreamReader
             if (presentStream != null && nullsAllowed) {
                 nulls = ensureCapacity(nulls, positionCount);
             }
+            dataLength = totalLength;
             data = ensureCapacity(data, totalLength);
             offsets = ensureCapacity(offsets, totalPositions + 1);
         }
         else {
-            data = ensureCapacity(data, maxLength);
+            if (useBatchMode(positionCount, totalPositions)) {
+                dataLength = totalLength;
+                if (filter != null) {
+                    offsets = ensureCapacity(offsets, totalPositions + 1);
+                }
+            }
+            else {
+                dataLength = maxLength;
+            }
+
+            data = ensureCapacity(data, dataLength);
         }
 
         dataAsSlice = Slices.wrappedBuffer(data);
+        return dataLength;
+    }
+
+    private boolean useBatchMode(int positionCount, int totalPositionCount)
+    {
+        return true;
+        // maxCodePointCount < 0 means it's unbounded varchar VARCHAR.
+        // If the types are VARCHAR(N) or CHAR(N), the length of the string need to be calculated and truncated.
+//        if (lengthStream == null || maxCodePointCount >= 0) {
+//            return false;
+//        }
+//
+//        double inputFilterRate = (double) (totalPositionCount - positionCount) / totalPositionCount;
+//        if (filter == null) {  // readNoFilter
+//            // When there is no filter, batch mode performs better for almost all inputFilterRate.
+//            // But to limit data buffer size, we enable it for the range of [0.0f, 0.5f]
+//            if (inputFilterRate >= 0.0f && inputFilterRate <= 0.5f) {
+//                return true;
+//            }
+//
+//            return false;
+//        }
+//        else { // readWithFilter
+//            // When there is filter, batch mode performs better for almost all inputFilterRate except when inputFilterRate is around 0.1f.
+//            // To limit data buffer size, we enable it for the range of [0.0f, 0.05f] and [0.15f, 0.5f]
+//            if (inputFilterRate >= 0.0f && inputFilterRate <= 0.05f || inputFilterRate >= 0.15f && inputFilterRate <= 0.5f) {
+//                return true;
+//            }
+//
+//            return false;
+//        }
     }
 }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkSelectiveStreamReaders.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkSelectiveStreamReaders.java
@@ -100,7 +100,7 @@ import static org.joda.time.DateTimeZone.UTC;
 
 @SuppressWarnings("MethodMayBeStatic")
 @State(Scope.Thread)
-@OutputTimeUnit(TimeUnit.SECONDS)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
 @Fork(2)
 @Warmup(iterations = 10, time = 1000, timeUnit = MILLISECONDS)
 @Measurement(iterations = 10, time = 1000, timeUnit = MILLISECONDS)
@@ -216,6 +216,19 @@ public class BenchmarkSelectiveStreamReaders
                 "0.8|-1",
                 "0.9|-1",
                 "1|-1",
+                "0|0.5",
+                "0.1|0.5",
+                "0.2|0.5",
+                "0.3|0.5",
+                "0.4|0.5",
+                "0.5|0.5",
+                "0.6|0.5",
+                "0.7|0.5",
+                "0.8|0.5",
+                "0.9|0.5",
+                "1|0.5",
+                "-1|-1",
+                "1|1",
         })
         private String filterRateSignature = "0.1|-1";
 


### PR DESCRIPTION
This PR improves reading unbounded varchar  by 1) introducing the batch read 
mode in SliceDirectSelectiveStreamReader; and 2) reading the lengthVector with 
more efficient `next()` API. 

BenchmarkSelectiveStreamReaders shows improvements for almost all input
filter rates for both `readNoFilter` and `readWithFilter` except only one
case, where filter rate = 0.1. The
improvement ratio is up to 2.36x for reading one column and 2.1x for reading two columns.
To make a overall good balance between performance and memory
I set the batch mode threshold on filter rate to be in the range of [0, 0.5] for readNoFilter,
[0, 0.05] and [0.15, 0.5] for readWithFilter.

No Nulls
<img width="274" alt="Screen Shot 2020-11-13 at 12 36 52 PM" src="https://user-images.githubusercontent.com/33299678/99118793-01851180-25ad-11eb-8164-246cbe1e87a4.png">

With Partial Nulls
<img width="278" alt="Screen Shot 2020-11-13 at 12 36 59 PM" src="https://user-images.githubusercontent.com/33299678/99118798-04800200-25ad-11eb-8d6f-d5b098d8779f.png">


```
== NO RELEASE NOTE ==
```
