### PR TITLE
Add UDF to map enum value to key

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/type/EnumType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/EnumType.java
@@ -14,11 +14,14 @@
 package com.facebook.presto.common.type;
 
 import java.util.Map;
+import java.util.Optional;
 
 public interface EnumType<T>
         extends Type
 {
     Map<String, T> getEnumMap();
+
+    Optional<String> getEnumKeyForValue(T value);
 
     Type getValueType();
 }

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestEnums.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestEnums.java
@@ -265,4 +265,17 @@ public class TestEnums
         assertSingleValue("CAST(' ' as test.enum.TestEnum)", " ");
         assertSingleValue("CAST(8 as test.enum.TestLongEnum)", 8L);
     }
+
+    @Test
+    public void testEnumKey()
+    {
+        assertSingleValue("enum_key(test.enum.mood.curious)", "CURIOUS");
+        assertSingleValue("enum_key(test.enum.country.CHINA)", "CHINA");
+
+        assertSingleValue("enum_key(cast(1 as test.enum.mood))", "SAD");
+        assertSingleValue("enum_key(cast('中国' as test.enum.country))", "CHINA");
+
+        assertSingleValue("enum_key(try_cast(7 as test.enum.mood))", null);
+        assertSingleValue("enum_key(try_cast('invalid_value' as test.enum.country))", null);
+    }
 }


### PR DESCRIPTION
Adds a UDF to get the enum key for an enum as a string value.
This is useful in the case of integer enums in particular, to inspect data via clients that do not support enum pretty-printing, and would just show the enum value as a number.

```
== RELEASE NOTES ==

General Changes
* Added a UDF to get the key corresponding to an enum value
```
