### PR TITLE
Add config plugin.disabled-connectors to stop registration of disabled connectors

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/PluginManagerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PluginManagerConfig.java
@@ -14,8 +14,10 @@
 package com.facebook.presto.server;
 
 import com.facebook.airlift.configuration.Config;
+import com.facebook.airlift.configuration.ConfigDescription;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import io.airlift.resolver.ArtifactResolver;
 
 import javax.validation.constraints.NotNull;
@@ -30,6 +32,7 @@ public class PluginManagerConfig
     private File pluginConfigurationDir = new File("etc/");
     private String mavenLocalRepository = ArtifactResolver.USER_LOCAL_REPO;
     private List<String> mavenRemoteRepository = ImmutableList.of(ArtifactResolver.MAVEN_CENTRAL_URI);
+    private ImmutableSet<String> disabledConnectors = ImmutableSet.of();
 
     public File getInstalledPluginsDir()
     {
@@ -95,6 +98,20 @@ public class PluginManagerConfig
     public PluginManagerConfig setMavenRemoteRepository(String mavenRemoteRepository)
     {
         this.mavenRemoteRepository = ImmutableList.copyOf(Splitter.on(',').omitEmptyStrings().trimResults().split(mavenRemoteRepository));
+        return this;
+    }
+
+    @NotNull
+    public ImmutableSet<String> getDisabledConnectors()
+    {
+        return this.disabledConnectors;
+    }
+
+    @Config("plugin.disabled-connectors")
+    @ConfigDescription("Disabled connectors are not registered by PluginManager")
+    public PluginManagerConfig setDisabledConnectors(String disabledConnectors)
+    {
+        this.disabledConnectors = ImmutableSet.copyOf(Splitter.on(',').omitEmptyStrings().trimResults().split(disabledConnectors));
         return this;
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/server/TestPluginManagerConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestPluginManagerConfig.java
@@ -30,6 +30,7 @@ public class TestPluginManagerConfig
         ConfigAssertions.assertRecordedDefaults(ConfigAssertions.recordDefaults(PluginManagerConfig.class)
                 .setInstalledPluginsDir(new File("plugin"))
                 .setPlugins((String) null)
+                .setDisabledConnectors("")
                 .setMavenLocalRepository(ArtifactResolver.USER_LOCAL_REPO)
                 .setMavenRemoteRepository(ArtifactResolver.MAVEN_CENTRAL_URI));
     }
@@ -40,6 +41,7 @@ public class TestPluginManagerConfig
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("plugin.dir", "plugins-dir")
                 .put("plugin.bundles", "a,b,c")
+                .put("plugin.disabled-connectors", "scuba,prism")
                 .put("maven.repo.local", "local-repo")
                 .put("maven.repo.remote", "remote-a,remote-b")
                 .build();
@@ -47,6 +49,7 @@ public class TestPluginManagerConfig
         PluginManagerConfig expected = new PluginManagerConfig()
                 .setInstalledPluginsDir(new File("plugins-dir"))
                 .setPlugins(ImmutableList.of("a", "b", "c"))
+                .setDisabledConnectors("scuba,prism")
                 .setMavenLocalRepository("local-repo")
                 .setMavenRemoteRepository(ImmutableList.of("remote-a", "remote-b"));
 


### PR DESCRIPTION
plugin.disabled-connectors ensures disabled connectors are not registered.

Test plan - Deploy to test cluster to ensure "Skipping disabled connector" log is printed.

```
== NO RELEASE NOTE ==
```
