### PR TITLE
Add verifier flag for removing memory related session property

### DIFF
--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/prestoaction/JdbcPrestoAction.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/prestoaction/JdbcPrestoAction.java
@@ -64,6 +64,7 @@ public class JdbcPrestoAction
     private final String testId;
     private final Optional<String> testName;
     private final String applicationName;
+    private final boolean removeMemoryRelatedSessionProperties;
 
     private final RetryDriver<QueryException> networkRetry;
     private final RetryDriver<QueryException> prestoRetry;
@@ -87,6 +88,7 @@ public class JdbcPrestoAction
 
         this.queryTimeout = requireNonNull(prestoActionConfig.getQueryTimeout(), "queryTimeout is null");
         this.applicationName = requireNonNull(prestoActionConfig.getApplicationName(), "applicationName is null");
+        this.removeMemoryRelatedSessionProperties = prestoActionConfig.isRemoveMemoryRelatedSessionProperties();
         this.metadataTimeout = requireNonNull(metadataTimeout, "metadataTimeout is null");
         this.checksumTimeout = requireNonNull(checksumTimeout, "checksumTimeout is null");
         this.testId = requireNonNull(verifierConfig.getTestId(), "testId is null");
@@ -165,7 +167,11 @@ public class JdbcPrestoAction
             // Do nothing
         }
 
-        Map<String, String> sessionProperties = mangleSessionProperties(queryConfiguration.getSessionProperties(), queryStage, getTimeout(queryStage));
+        Map<String, String> sessionProperties = mangleSessionProperties(
+                queryConfiguration.getSessionProperties(),
+                queryStage,
+                getTimeout(queryStage),
+                removeMemoryRelatedSessionProperties);
         for (Entry<String, String> entry : sessionProperties.entrySet()) {
             connection.setSessionProperty(entry.getKey(), entry.getValue());
         }

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/prestoaction/PrestoActionConfig.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/prestoaction/PrestoActionConfig.java
@@ -45,6 +45,7 @@ public class PrestoActionConfig
     private Map<String, String> jdbcUrlParameters = ImmutableMap.of();
     private Duration queryTimeout = new Duration(60, MINUTES);
     private String applicationName = "verifier-test";
+    private boolean removeMemoryRelatedSessionProperties = true;
 
     @Override
     @NotNull
@@ -138,6 +139,18 @@ public class PrestoActionConfig
     public PrestoActionConfig setApplicationName(String applicationName)
     {
         this.applicationName = applicationName;
+        return this;
+    }
+
+    public boolean isRemoveMemoryRelatedSessionProperties()
+    {
+        return removeMemoryRelatedSessionProperties;
+    }
+
+    @Config("remove-memory-related-session-properties")
+    public PrestoActionConfig setRemoveMemoryRelatedSessionProperties(boolean removeMemoryRelatedSessionProperties)
+    {
+        this.removeMemoryRelatedSessionProperties = removeMemoryRelatedSessionProperties;
         return this;
     }
 }

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/prestoaction/QueryActionUtil.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/prestoaction/QueryActionUtil.java
@@ -36,7 +36,8 @@ public class QueryActionUtil
     public static Map<String, String> mangleSessionProperties(
             Map<String, String> mainQuerySessionProperty,
             QueryStage queryStage,
-            Duration queryTimeout)
+            Duration queryTimeout,
+            boolean removeMemoryRelatedSessionProperty)
     {
         // configure session properties
         Map<String, String> sessionProperties = queryStage.isMain() || queryStage == DETERMINISM_ANALYSIS_MAIN
@@ -49,11 +50,13 @@ public class QueryActionUtil
         // Remove query max run time to respect execution time limit.
         sessionProperties.remove(QUERY_MAX_RUN_TIME);
 
-        // Allow verifier clusters to provide their own memory limits to reduce noise from
-        // CBO making different decisions based on cluster size
-        sessionProperties.remove(QUERY_MAX_BROADCAST_MEMORY);
-        sessionProperties.remove(QUERY_MAX_TOTAL_MEMORY_PER_NODE);
-        sessionProperties.remove(QUERY_MAX_TOTAL_MEMORY);
+        if (removeMemoryRelatedSessionProperty) {
+            // Allow verifier clusters to provide their own memory limits to reduce noise from
+            // CBO making different decisions based on cluster size
+            sessionProperties.remove(QUERY_MAX_BROADCAST_MEMORY);
+            sessionProperties.remove(QUERY_MAX_TOTAL_MEMORY_PER_NODE);
+            sessionProperties.remove(QUERY_MAX_TOTAL_MEMORY);
+        }
 
         return ImmutableMap.copyOf(sessionProperties);
     }

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/prestoaction/TestPrestoActionConfig.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/prestoaction/TestPrestoActionConfig.java
@@ -39,6 +39,7 @@ public class TestPrestoActionConfig
                 .setHttpPort(null)
                 .setJdbcUrlParameters(null)
                 .setApplicationName("verifier-test")
+                .setRemoveMemoryRelatedSessionProperties(true)
                 .setQueryTimeout(new Duration(60, MINUTES)));
     }
 
@@ -52,6 +53,7 @@ public class TestPrestoActionConfig
                 .put("jdbc-url-parameters", "{\"SSL\": false}")
                 .put("query-timeout", "2h")
                 .put("application-name", "verifier")
+                .put("remove-memory-related-session-properties", "false")
                 .build();
         PrestoActionConfig expected = new PrestoActionConfig()
                 .setHosts("proxy.presto.fbinfra.net")
@@ -59,7 +61,8 @@ public class TestPrestoActionConfig
                 .setHttpPort(7777)
                 .setJdbcUrlParameters("{\"SSL\": false}")
                 .setQueryTimeout(new Duration(2, HOURS))
-                .setApplicationName("verifier");
+                .setApplicationName("verifier")
+                .setRemoveMemoryRelatedSessionProperties(false);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
Depended by https://github.com/facebookexternal/presto-facebook/pull/1330

In some cases we want to remove these session property when run verifier
test on smaller cluster. While in certain other cases we want to keep or
add them to test memory related improvements (while not changing the
cluster config).

Test plan - Travis

```
== NO RELEASE NOTE ==
```
