### PR TITLE
Fix base column name not present error when dereference pushdown enabled

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/rule/HiveParquetDereferencePushDown.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/rule/HiveParquetDereferencePushDown.java
@@ -338,9 +338,8 @@ public class HiveParquetDereferencePushDown
                 return visitPlan(project, context);
             }
 
-            Map<String, HiveColumnHandle> regularHiveColumnHandles = tableScan.getAssignments().values().stream()
-                    .map(columnHandle -> (HiveColumnHandle) columnHandle)
-                    .collect(toMap(HiveColumnHandle::getName, identity()));
+            Map<String, HiveColumnHandle> regularHiveColumnHandles = tableScan.getAssignments().entrySet().stream()
+                    .collect(toMap(e -> e.getKey().getName(), e -> (HiveColumnHandle) e.getValue()));
 
             List<VariableReferenceExpression> newOutputVariables = new ArrayList<>(tableScan.getOutputVariables());
             Map<VariableReferenceExpression, ColumnHandle> newAssignments = new HashMap<>(tableScan.getAssignments());

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveLogicalPlanner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveLogicalPlanner.java
@@ -1146,6 +1146,14 @@ public class TestHiveLogicalPlanner
                                         withColumnDomains(ImmutableMap.of(pushdownColumnNameForSubfield(nestedColumn("x.a")), create(ofRanges(greaterThan(BIGINT, 10L)), false))),
                                         ImmutableSet.of(pushdownColumnNameForSubfield(nestedColumn("x.a"))),
                                         TRUE_CONSTANT)))));
+
+        // Self-Join and Table scan assignments
+        assertPlan(withParquetDereferencePushDownEnabled(), "SELECT t1.x.a, t2.x.a FROM test_pushdown_nestedcolumn_parquet t1, test_pushdown_nestedcolumn_parquet t2 where t1.id = t2.id",
+                anyTree(
+                        node(JoinNode.class,
+                                anyTree(tableScanParquetDeferencePushDowns("test_pushdown_nestedcolumn_parquet", nestedColumnMap("x.a"))),
+                                anyTree(tableScanParquetDeferencePushDowns("test_pushdown_nestedcolumn_parquet", nestedColumnMap("x_1.a"))))));
+
         // Aggregation
         assertParquetDereferencePushDown("SELECT id, min(x.a) FROM test_pushdown_nestedcolumn_parquet GROUP BY 1",
                 "test_pushdown_nestedcolumn_parquet",


### PR DESCRIPTION
We're seeing the error below when the dereference push down is enabled

`java.lang.IllegalArgumentException: nested column [SOME_COLUMN_455.SOME_SUBFIELD]'s base column SOME_COLUMN_455 is not present in table scan output
	at com.facebook.presto.hive.rule.HiveParquetDereferencePushDown$Visitor.visitProject(HiveParquetDereferencePushDown.java:357)
	at com.facebook.presto.hive.rule.HiveParquetDereferencePushDown$Visitor.visitProject(HiveParquetDereferencePushDown.java:288)
	at com.facebook.presto.spi.plan.ProjectNode.accept(ProjectNode.java:92)
	at com.facebook.presto.hive.rule.HiveParquetDereferencePushDown$Visitor.visitPlan(HiveParquetDereferencePushDown.java:308)
	at com.facebook.presto.hive.rule.HiveParquetDereferencePushDown$Visitor.visitProject(HiveParquetDereferencePushDown.java:325)
	at com.facebook.presto.hive.rule.HiveParquetDereferencePushDown$Visitor.visitProject(HiveParquetDereferencePushDown.java:288)
	at com.facebook.presto.spi.plan.ProjectNode.accept(ProjectNode.java:92)
	at com.facebook.presto.hive.rule.HiveParquetDereferencePushDown$Visitor.visitPlan(HiveParquetDereferencePushDown.java:308)
	at com.facebook.presto.hive.rule.HiveParquetDereferencePushDown$Visitor.visitPlan(HiveParquetDereferencePushDown.java:288)
	at com.facebook.presto.spi.plan.PlanVisitor.visitFilter(PlanVisitor.java:35)
	at com.facebook.presto.spi.plan.FilterNode.accept(FilterNode.java:80)
	at com.facebook.presto.hive.rule.HiveParquetDereferencePushDown$Visitor.visitPlan(HiveParquetDereferencePushDown.java:308)
	at com.facebook.presto.hive.rule.HiveParquetDereferencePushDown$Visitor.visitProject(HiveParquetDereferencePushDown.java:325)
	at com.facebook.presto.hive.rule.HiveParquetDereferencePushDown$Visitor.visitProject(HiveParquetDereferencePushDown.java:288)
	at com.facebook.presto.spi.plan.ProjectNode.accept(ProjectNode.java:92)
	at com.facebook.presto.hive.rule.HiveParquetDereferencePushDown$Visitor.visitPlan(HiveParquetDereferencePushDown.java:308)
	at com.facebook.presto.hive.rule.HiveParquetDereferencePushDown$Visitor.visitProject(HiveParquetDereferencePushDown.java:325)
	at com.facebook.presto.hive.rule.HiveParquetDereferencePushDown$Visitor.visitProject(HiveParquetDereferencePushDown.java:288)
	at com.facebook.presto.spi.plan.ProjectNode.accept(ProjectNode.java:92)
	at com.facebook.presto.hive.rule.HiveParquetDereferencePushDown$Visitor.visitPlan(HiveParquetDereferencePushDown.java:308)
	at com.facebook.presto.hive.rule.HiveParquetDereferencePushDown$Visitor.visitProject(HiveParquetDereferencePushDown.java:325)
	at com.facebook.presto.hive.rule.HiveParquetDereferencePushDown$Visitor.visitProject(HiveParquetDereferencePushDown.java:288)
	at com.facebook.presto.spi.plan.ProjectNode.accept(ProjectNode.java:92)
	at com.facebook.presto.hive.rule.HiveParquetDereferencePushDown.optimize(HiveParquetDereferencePushDown.java:175)
	at com.facebook.presto.sql.planner.optimizations.ApplyConnectorOptimization.optimize(ApplyConnectorOptimization.java:134)
	at com.facebook.presto.sql.planner.LogicalPlanner.plan(LogicalPlanner.java:187)
	at com.facebook.presto.sql.planner.LogicalPlanner.plan(LogicalPlanner.java:176)
	at com.facebook.presto.execution.SqlQueryExecution.doAnalyzeQuery(SqlQueryExecution.java:392)
	at com.facebook.presto.execution.SqlQueryExecution.analyzeQuery(SqlQueryExecution.java:378)
	at com.facebook.presto.execution.SqlQueryExecution.start(SqlQueryExecution.java:328)
	at com.facebook.presto.$gen.Presto_0_241_66578ef____20201121_034334_1.run(Unknown Source)
	at com.facebook.presto.execution.SqlQueryManager.createQuery(SqlQueryManager.java:242)
	at com.facebook.presto.dispatcher.LocalDispatchQuery.lambda$startExecution$5(LocalDispatchQuery.java:114)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)`


So I think we should use SOME_COLUMN_SOME_NUMBER instead of SOME_COLUMN as the key of the map regularHiveColumnHandles


@vkorukanti and @zhenxiao, could you guys help take a look? 

```
== NO RELEASE NOTE ==
```
