### PR TITLE
Reduce output buffer lock contention

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/buffer/ArbitraryOutputBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/buffer/ArbitraryOutputBuffer.java
@@ -18,6 +18,7 @@ import com.facebook.presto.execution.StateMachine;
 import com.facebook.presto.execution.StateMachine.StateChangeListener;
 import com.facebook.presto.execution.buffer.ClientBuffer.PagesSupplier;
 import com.facebook.presto.execution.buffer.OutputBuffers.OutputBufferId;
+import com.facebook.presto.execution.buffer.SerializedPageReference.PagesReleasedListener;
 import com.facebook.presto.memory.context.LocalMemoryContext;
 import com.facebook.presto.spi.page.SerializedPage;
 import com.google.common.annotations.VisibleForTesting;
@@ -35,7 +36,6 @@ import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executor;
@@ -52,6 +52,7 @@ import static com.facebook.presto.execution.buffer.BufferState.NO_MORE_PAGES;
 import static com.facebook.presto.execution.buffer.BufferState.OPEN;
 import static com.facebook.presto.execution.buffer.OutputBuffers.BufferType.ARBITRARY;
 import static com.facebook.presto.execution.buffer.OutputBuffers.createInitialEmptyOutputBuffers;
+import static com.facebook.presto.execution.buffer.SerializedPageReference.dereferencePages;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
@@ -82,9 +83,7 @@ public class ArbitraryOutputBuffer
     private final AtomicLong totalPagesAdded = new AtomicLong();
     private final AtomicLong totalRowsAdded = new AtomicLong();
 
-    private final ConcurrentMap<Lifespan, AtomicLong> outstandingPageCountPerLifespan = new ConcurrentHashMap<>();
-    private final Set<Lifespan> noMorePagesForLifespan = ConcurrentHashMap.newKeySet();
-    private volatile Consumer<Lifespan> lifespanCompletionCallback;
+    private final LifespanSerializedPageTracker pageTracker;
 
     public ArbitraryOutputBuffer(
             String taskInstanceId,
@@ -101,7 +100,8 @@ public class ArbitraryOutputBuffer
                 maxBufferSize.toBytes(),
                 requireNonNull(systemMemoryContextSupplier, "systemMemoryContextSupplier is null"),
                 requireNonNull(notificationExecutor, "notificationExecutor is null"));
-        this.masterBuffer = new MasterBuffer();
+        this.pageTracker = new LifespanSerializedPageTracker(memoryManager);
+        this.masterBuffer = new MasterBuffer(pageTracker);
     }
 
     @Override
@@ -213,8 +213,7 @@ public class ArbitraryOutputBuffer
     @Override
     public void registerLifespanCompletionCallback(Consumer<Lifespan> callback)
     {
-        checkState(lifespanCompletionCallback == null, "lifespanCompletionCallback is already set");
-        this.lifespanCompletionCallback = requireNonNull(callback, "callback is null");
+        pageTracker.registerLifespanCompletionCallback(callback);
     }
 
     @Override
@@ -223,11 +222,11 @@ public class ArbitraryOutputBuffer
         checkState(!Thread.holdsLock(this), "Can not enqueue pages while holding a lock on this");
         requireNonNull(lifespan, "lifespan is null");
         requireNonNull(pages, "page is null");
-        checkState(lifespanCompletionCallback != null, "lifespanCompletionCallback must be set before enqueueing data");
+        checkState(pageTracker.isLifespanCompletionCallbackRegistered(), "lifespanCompletionCallback must be set before enqueueing data");
 
         // ignore pages after "no more pages" is set
         // this can happen with a limit query
-        if (!state.get().canAddPages() || noMorePagesForLifespan.contains(lifespan)) {
+        if (!state.get().canAddPages() || pageTracker.isNoMorePagesForLifespan(lifespan)) {
             return;
         }
 
@@ -239,7 +238,7 @@ public class ArbitraryOutputBuffer
             bytesAdded += retainedSize;
             rowCount += page.getPositionCount();
             // create page reference counts with an initial single reference
-            references.add(new SerializedPageReference(page, 1, () -> dereferencePage(page, lifespan)));
+            references.add(new SerializedPageReference(page, 1, lifespan));
         }
         List<SerializedPageReference> serializedPageReferences = references.build();
 
@@ -249,7 +248,7 @@ public class ArbitraryOutputBuffer
         // update stats
         totalRowsAdded.addAndGet(rowCount);
         totalPagesAdded.addAndGet(serializedPageReferences.size());
-        outstandingPageCountPerLifespan.computeIfAbsent(lifespan, ignored -> new AtomicLong()).addAndGet(serializedPageReferences.size());
+        pageTracker.incrementLifespanPageCount(lifespan, serializedPageReferences.size());
 
         // add pages to the buffer (this will increase the reference count by one)
         masterBuffer.addPages(serializedPageReferences);
@@ -359,19 +358,13 @@ public class ArbitraryOutputBuffer
     @Override
     public void setNoMorePagesForLifespan(Lifespan lifespan)
     {
-        requireNonNull(lifespan, "lifespan is null");
-        noMorePagesForLifespan.add(lifespan);
+        pageTracker.setNoMorePagesForLifespan(lifespan);
     }
 
     @Override
     public boolean isFinishedForLifespan(Lifespan lifespan)
     {
-        if (!noMorePagesForLifespan.contains(lifespan)) {
-            return false;
-        }
-
-        AtomicLong outstandingPageCount = outstandingPageCountPerLifespan.get(lifespan);
-        return outstandingPageCount == null || outstandingPageCount.get() == 0;
+        return pageTracker.isFinishedForLifespan(lifespan);
     }
 
     @Override
@@ -400,7 +393,7 @@ public class ArbitraryOutputBuffer
 
         // NOTE: buffers are allowed to be created before they are explicitly declared by setOutputBuffers
         // When no-more-buffers is set, we verify that all created buffers have been declared
-        buffer = new ClientBuffer(taskInstanceId, id);
+        buffer = new ClientBuffer(taskInstanceId, id, pageTracker);
 
         // buffer may have finished immediately before calling this method
         if (state.get() == FINISHED) {
@@ -443,6 +436,8 @@ public class ArbitraryOutputBuffer
     private static class MasterBuffer
             implements PagesSupplier
     {
+        private final PagesReleasedListener onPagesReleased;
+
         @GuardedBy("this")
         private final LinkedList<SerializedPageReference> masterBuffer = new LinkedList<>();
 
@@ -450,6 +445,11 @@ public class ArbitraryOutputBuffer
         private boolean noMorePages;
 
         private final AtomicInteger bufferedPages = new AtomicInteger();
+
+        private MasterBuffer(PagesReleasedListener onPagesReleased)
+        {
+            this.onPagesReleased = requireNonNull(onPagesReleased, "onPagesReleased is null");
+        }
 
         public synchronized void addPages(List<SerializedPageReference> pages)
         {
@@ -511,7 +511,7 @@ public class ArbitraryOutputBuffer
             }
 
             // dereference outside of synchronized to avoid making a callback while holding a lock
-            pages.forEach(SerializedPageReference::dereferencePage);
+            dereferencePages(pages, onPagesReleased);
         }
 
         public int getBufferedPages()
@@ -532,16 +532,5 @@ public class ArbitraryOutputBuffer
     OutputBufferMemoryManager getMemoryManager()
     {
         return memoryManager;
-    }
-
-    private void dereferencePage(SerializedPage pageSplit, Lifespan lifespan)
-    {
-        long outstandingPageCount = outstandingPageCountPerLifespan.get(lifespan).decrementAndGet();
-        if (outstandingPageCount == 0 && noMorePagesForLifespan.contains(lifespan)) {
-            checkState(lifespanCompletionCallback != null, "lifespanCompletionCallback is not null");
-            lifespanCompletionCallback.accept(lifespan);
-        }
-
-        memoryManager.updateMemoryUsage(-pageSplit.getRetainedSizeInBytes());
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/buffer/LifespanSerializedPageTracker.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/buffer/LifespanSerializedPageTracker.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.buffer;
+
+import com.facebook.presto.execution.Lifespan;
+import com.facebook.presto.execution.buffer.SerializedPageReference.PagesReleasedListener;
+
+import javax.annotation.Nullable;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+final class LifespanSerializedPageTracker
+        implements PagesReleasedListener
+{
+    private final OutputBufferMemoryManager memoryManager;
+    @Nullable
+    private final PagesReleasedListener childListener;
+    private final ConcurrentMap<Lifespan, AtomicLong> outstandingPageCountPerLifespan = new ConcurrentHashMap<>();
+    private final Set<Lifespan> noMorePagesForLifespan = ConcurrentHashMap.newKeySet();
+    private volatile Consumer<Lifespan> lifespanCompletionCallback;
+
+    public LifespanSerializedPageTracker(OutputBufferMemoryManager memoryManager)
+    {
+        this(memoryManager, Optional.empty());
+    }
+
+    public LifespanSerializedPageTracker(OutputBufferMemoryManager memoryManager, Optional<PagesReleasedListener> childListener)
+    {
+        this.memoryManager = requireNonNull(memoryManager, "memoryManager is null");
+        this.childListener = requireNonNull(childListener, "childListener is null").orElse(null);
+    }
+
+    public boolean isLifespanCompletionCallbackRegistered()
+    {
+        return lifespanCompletionCallback != null;
+    }
+
+    public void registerLifespanCompletionCallback(Consumer<Lifespan> callback)
+    {
+        checkState(lifespanCompletionCallback == null, "lifespanCompletionCallback is already set");
+        this.lifespanCompletionCallback = requireNonNull(callback, "callback is null");
+    }
+
+    public void incrementLifespanPageCount(Lifespan lifespan, int pagesAdded)
+    {
+        // JDK-8 acquires the write lock unconditionally in computeIfAbsent
+        // TODO: Remove this extra get call once Presto no longer supports JDK-8
+        AtomicLong counter = outstandingPageCountPerLifespan.get(lifespan);
+        if (counter == null) {
+            counter = outstandingPageCountPerLifespan.computeIfAbsent(lifespan, ignore -> new AtomicLong());
+        }
+        counter.addAndGet(pagesAdded);
+    }
+
+    public void setNoMorePagesForLifespan(Lifespan lifespan)
+    {
+        requireNonNull(lifespan, "lifespan is null");
+        noMorePagesForLifespan.add(lifespan);
+    }
+
+    public boolean isNoMorePagesForLifespan(Lifespan lifespan)
+    {
+        return noMorePagesForLifespan.contains(lifespan);
+    }
+
+    public boolean isFinishedForLifespan(Lifespan lifespan)
+    {
+        if (!noMorePagesForLifespan.contains(lifespan)) {
+            return false;
+        }
+
+        AtomicLong outstandingPageCount = outstandingPageCountPerLifespan.get(lifespan);
+        return outstandingPageCount == null || outstandingPageCount.get() == 0;
+    }
+
+    @Override
+    public void onPagesReleased(Lifespan lifespan, int releasedPageCount, long releasedSizeInBytes)
+    {
+        long outstandingPageCount = outstandingPageCountPerLifespan.get(lifespan).addAndGet(-releasedPageCount);
+        if (outstandingPageCount == 0 && noMorePagesForLifespan.contains(lifespan)) {
+            Consumer<Lifespan> lifespanCompletionCallback = this.lifespanCompletionCallback;
+            checkState(lifespanCompletionCallback != null, "lifespanCompletionCallback is not null");
+            lifespanCompletionCallback.accept(lifespan);
+        }
+        memoryManager.updateMemoryUsage(-releasedSizeInBytes);
+        if (childListener != null) {
+            childListener.onPagesReleased(lifespan, releasedPageCount, releasedSizeInBytes);
+        }
+    }
+}


### PR DESCRIPTION
Two commits attempting to reduce lock contention related to output buffers:
- Refactors `LazyOutputBuffer` to attempt to read the delegate `OutputBuffer` reference before synchronizing
- Refactors `SerializedPageReference` and usages to perform dereferencing in batches to avoid synchronizing on memory manager locks for each individual page.

```
== NO RELEASE NOTE ==
```
