### PR TITLE
Improve druid performance when split type is segment (not broker), other minor fixes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ benchmark_outputs
 .mvn/timing.properties
 .editorconfig
 node_modules
+# eclipse project
+.metadata

--- a/presto-druid/pom.xml
+++ b/presto-druid/pom.xml
@@ -17,6 +17,10 @@
 
     <dependencies>
         <dependency>
+             <groupId>org.roaringbitmap</groupId>
+             <artifactId>RoaringBitmap</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.druid</groupId>
             <artifactId>druid-processing</artifactId>
             <exclusions>

--- a/presto-druid/src/main/java/com/facebook/presto/druid/DruidClient.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/DruidClient.java
@@ -64,6 +64,7 @@ public class DruidClient
     private static final String LIST_TABLE_QUERY = "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = 'druid'";
     private static final String GET_COLUMN_TEMPLATE = "SELECT COLUMN_NAME, DATA_TYPE FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = 'druid' AND TABLE_NAME = '%s'";
     private static final String GET_SEGMENTS_ID_TEMPLATE = "SELECT segment_id FROM sys.segments WHERE datasource = '%s' AND is_published = 1";
+    private static final String GET_SEGMENTS_ID_TEMPLATE_WITH_FILTER = "SELECT segment_id FROM sys.segments WHERE datasource = '%s' AND is_published = 1 AND %s";
 
     private static final JsonCodec<List<DruidSegmentIdWrapper>> LIST_SEGMENT_ID_CODEC = listJsonCodec(DruidSegmentIdWrapper.class);
     private static final JsonCodec<List<DruidColumnInfo>> LIST_COLUMN_INFO_CODEC = listJsonCodec(DruidColumnInfo.class);
@@ -110,6 +111,13 @@ public class DruidClient
     public List<DruidColumnInfo> getColumnDataType(String tableName)
     {
         return httpClient.execute(prepareMetadataQuery(format(GET_COLUMN_TEMPLATE, tableName)), createJsonResponseHandler(LIST_COLUMN_INFO_CODEC));
+    }
+
+    public List<String> getDataSegmentId(String tableName, String segmentFilter)
+    {
+        return httpClient.execute(prepareMetadataQuery(format(GET_SEGMENTS_ID_TEMPLATE_WITH_FILTER, tableName, segmentFilter)), createJsonResponseHandler(LIST_SEGMENT_ID_CODEC)).stream()
+                .map(wrapper -> wrapper.getSegmentId())
+                .collect(toImmutableList());
     }
 
     public List<String> getDataSegmentId(String tableName)

--- a/presto-druid/src/main/java/com/facebook/presto/druid/DruidSplit.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/DruidSplit.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static com.facebook.presto.spi.schedule.NodeSelectionStrategy.NO_PREFERENCE;
@@ -36,18 +37,21 @@ public class DruidSplit
     private final Optional<DruidQueryGenerator.GeneratedDql> brokerDql;
     private final Optional<DruidSegmentInfo> segmentInfo;
     private final Optional<HostAddress> address;
+    private final Map<String, List<Object>> dimFilters;
 
     @JsonCreator
     public DruidSplit(
             @JsonProperty("splitType") SplitType splitType,
             @JsonProperty("brokerDql") Optional<DruidQueryGenerator.GeneratedDql> brokerDql,
             @JsonProperty("segmentInfo") Optional<DruidSegmentInfo> segmentInfo,
-            @JsonProperty("address") Optional<HostAddress> address)
+            @JsonProperty("address") Optional<HostAddress> address,
+            @JsonProperty("dimFilters") Map<String, List<Object>> dimFilters)
     {
         this.splitType = requireNonNull(splitType, "splitType id is null");
         this.brokerDql = requireNonNull(brokerDql, "brokerDql is null");
         this.segmentInfo = requireNonNull(segmentInfo, "segment info is null");
         this.address = requireNonNull(address, "address info is null");
+        this.dimFilters = requireNonNull(dimFilters, "dimFilters is null");
         if (splitType == SplitType.SEGMENT) {
             checkArgument(segmentInfo.isPresent(), "SegmentInfo is missing from split");
             checkArgument(address.isPresent(), "Address is missing from split");
@@ -63,16 +67,18 @@ public class DruidSplit
                 SplitType.BROKER,
                 Optional.of(requireNonNull(brokerDql, "brokerDql is null")),
                 Optional.empty(),
-                Optional.empty());
+                Optional.empty(),
+                null);
     }
 
-    public static DruidSplit createSegmentSplit(DruidSegmentInfo segmentInfo, HostAddress address)
+    public static DruidSplit createSegmentSplit(DruidSegmentInfo segmentInfo, HostAddress address, Map<String, List<Object>> dimFilters)
     {
         return new DruidSplit(
                 SplitType.SEGMENT,
                 Optional.empty(),
                 Optional.of(requireNonNull(segmentInfo, "segmentInfo are null")),
-                Optional.of(requireNonNull(address, "address is null")));
+                Optional.of(requireNonNull(address, "address is null")),
+                dimFilters);
     }
 
     @JsonProperty
@@ -91,6 +97,12 @@ public class DruidSplit
     public Optional<DruidSegmentInfo> getSegmentInfo()
     {
         return segmentInfo;
+    }
+
+    @JsonProperty
+    public Map<String, List<Object>> getDimFilters()
+    {
+        return dimFilters;
     }
 
     @JsonProperty
@@ -125,6 +137,7 @@ public class DruidSplit
                 .add("brokerDql", brokerDql)
                 .add("segmentInfo", segmentInfo)
                 .add("address", address)
+                .add("dimFilters", dimFilters)
                 .toString();
     }
 

--- a/presto-druid/src/main/java/com/facebook/presto/druid/DruidSplitManager.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/DruidSplitManager.java
@@ -13,6 +13,13 @@
  */
 package com.facebook.presto.druid;
 
+import com.facebook.presto.common.predicate.Domain;
+import com.facebook.presto.common.predicate.Marker.Bound;
+import com.facebook.presto.common.predicate.Range;
+import com.facebook.presto.common.predicate.SortedRangeSet;
+import com.facebook.presto.common.predicate.ValueSet;
+import com.facebook.presto.druid.metadata.DruidColumnType;
+import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ConnectorSplitSource;
 import com.facebook.presto.spi.ConnectorTableLayoutHandle;
@@ -21,21 +28,31 @@ import com.facebook.presto.spi.HostAddress;
 import com.facebook.presto.spi.connector.ConnectorSplitManager;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
 
 import javax.inject.Inject;
 
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static com.facebook.presto.druid.DruidSessionProperties.isComputePushdownEnabled;
 import static com.facebook.presto.druid.DruidSplit.createBrokerSplit;
 import static com.facebook.presto.druid.DruidSplit.createSegmentSplit;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public class DruidSplitManager
         implements ConnectorSplitManager
 {
     private final DruidClient druidClient;
+    // Druid stores segments times as strings in ISO-8601 format in UTC down to fractional seconds.
+    private DateTimeFormatter timeSegmentFormatter = new DateTimeFormatterBuilder().appendInstant(3).parseCaseInsensitive().toFormatter();
 
     @Inject
     public DruidSplitManager(DruidClient druidClient)
@@ -52,16 +69,119 @@ public class DruidSplitManager
     {
         DruidTableLayoutHandle layoutHandle = (DruidTableLayoutHandle) layout;
         DruidTableHandle table = layoutHandle.getTable();
-        if (isComputePushdownEnabled(session) || (table.getDql().isPresent() && table.getDql().get().getPushdown())) {
+        if (isComputePushdownEnabled(session) && (table.getDql().isPresent() && table.getDql().get().getPushdown())) {
             return new FixedSplitSource(ImmutableList.of(createBrokerSplit(table.getDql().get())));
         }
-        List<String> segmentIds = druidClient.getDataSegmentId(table.getTableName());
 
+        final List<String> segmentIds;
+        DruidTableLayoutHandle tableLayout = (DruidTableLayoutHandle) layout;
+        Map<String, List<Object>> dimFilters = new HashMap<>();
+        if (tableLayout.getTupleDomain().getDomains().isPresent()) {
+            String segmentFilter = null;
+            for (Map.Entry<ColumnHandle, Domain> entry : tableLayout.getTupleDomain().getDomains().get().entrySet()) {
+                DruidColumnHandle handle = (DruidColumnHandle) entry.getKey();
+                if (handle.getColumnName().equals("__time")) {
+                    Domain predicate = entry.getValue();
+                    segmentFilter = segmentFilter(predicate);
+                }
+                else {
+                    DruidColumnType dct = DruidColumnType.fromPrestoType(handle.getColumnType());
+                    if (dct == DruidColumnType.VARCHAR) {
+                        List<Object> values = stringDimensions(entry.getValue());
+                        if (values != null && !values.isEmpty()) {
+                            dimFilters.put(handle.getColumnName(), values);
+                        }
+                    }
+                }
+            }
+            if (segmentFilter != null) {
+                segmentIds = druidClient.getDataSegmentId(table.getTableName(), segmentFilter);
+            }
+            else {
+                segmentIds = druidClient.getDataSegmentId(table.getTableName());
+            }
+        }
+        else {
+            segmentIds = druidClient.getDataSegmentId(table.getTableName());
+        }
         List<DruidSplit> splits = segmentIds.stream()
                 .map(id -> druidClient.getSingleSegmentInfo(table.getTableName(), id))
-                .map(info -> createSegmentSplit(info, HostAddress.fromUri(druidClient.getDruidBroker())))
+                .map(info -> createSegmentSplit(info, HostAddress.fromUri(druidClient.getDruidBroker()), dimFilters))
                 .collect(toImmutableList());
 
         return new FixedSplitSource(splits);
+    }
+
+    private List<Object> stringDimensions(Domain predicate)
+    {
+        List<Object> dimensions = new ArrayList<>();
+        ValueSet values = predicate.getValues();
+        if (values instanceof SortedRangeSet) {
+            SortedRangeSet srs = (SortedRangeSet) values;
+            List<Range> ranges = srs.getOrderedRanges();
+            for (Range range : ranges) {
+                if (range.getLow().getValueBlock().isPresent() && range.getLow().getBound() == Bound.EXACTLY) {
+                    dimensions.add(((Slice) range.getLow().getValue()).toStringUtf8());
+                }
+            }
+        }
+        return dimensions;
+    }
+
+    private String segmentFilter(Domain predicate)
+    {
+        ValueSet values = predicate.getValues();
+        if (values instanceof SortedRangeSet) {
+            SortedRangeSet srs = (SortedRangeSet) values;
+            List<Range> ranges = srs.getOrderedRanges();
+            if (ranges.size() > 1) {
+                // In clause style predicate, we can't use IN because druid stores it as text.
+                List<String> filters = new ArrayList<>();
+                for (Range range : ranges) {
+                    String iso8601 = timeSegmentFormatter.format(Instant.ofEpochMilli((Long) range.getSingleValue()));
+                    String filter = format("((\"%s\" %s '%s') AND (\"%s\" %s '%s'))",
+                            "start", ">=", iso8601,
+                            "end", "<=", iso8601);
+                    filters.add(filter);
+                }
+                StringBuilder sb = new StringBuilder();
+                for (String filter : filters) {
+                    sb.append(filter);
+                    sb.append(" OR ");
+                }
+                return sb.substring(0, sb.length() - 4);
+            }
+            else {
+                // Greater, less, between etc. NOTE: Equals not supported in presto on timestmp.
+                Range range = ranges.iterator().next();
+                String highBoundFilter = null;
+                if (range.getHigh().getValueBlock().isPresent()) {
+                    highBoundFilter = format(
+                        "\"%s\" %s '%s'",
+                        "end",
+                        range.getHigh().getBound() == Bound.ABOVE ? ">=" : "<=",
+                        timeSegmentFormatter.format(Instant.ofEpochMilli((Long) range.getHigh().getValue())));
+                }
+
+                String lowBoundFilter = null;
+                if (range.getLow().getValueBlock().isPresent()) {
+                    lowBoundFilter = format(
+                        "\"%s\" %s '%s'",
+                        "start",
+                        range.getLow().getBound() == Bound.ABOVE ? ">=" : "<=",
+                        timeSegmentFormatter.format(Instant.ofEpochMilli((Long) range.getLow().getValue())));
+                }
+                if (highBoundFilter != null && lowBoundFilter != null) {
+                    return format("((%s) AND (%s))", lowBoundFilter, highBoundFilter);
+                }
+                else if (highBoundFilter != null) {
+                    return highBoundFilter;
+                }
+                else if (lowBoundFilter != null) {
+                    return lowBoundFilter;
+                }
+            }
+        }
+        return null;
     }
 }

--- a/presto-druid/src/main/java/com/facebook/presto/druid/column/StringColumnReader.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/column/StringColumnReader.java
@@ -40,7 +40,7 @@ public class StringColumnReader
         BlockBuilder builder = type.createBlockBuilder(null, batchSize);
         for (int i = 0; i < batchSize; i++) {
             String value = String.valueOf(valueSelector.getObject());
-            if (value != null) {
+            if (value != null && !value.equals("null")) {
                 type.writeSlice(builder, Slices.utf8Slice(value));
             }
             else {

--- a/presto-druid/src/main/java/com/facebook/presto/druid/segment/DruidSegmentReader.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/segment/DruidSegmentReader.java
@@ -19,17 +19,14 @@ import com.facebook.presto.druid.DruidColumnHandle;
 import com.facebook.presto.druid.column.ColumnReader;
 import com.facebook.presto.druid.column.SimpleReadableOffset;
 import com.facebook.presto.spi.ColumnHandle;
-import com.facebook.presto.spi.PrestoException;
 import com.google.common.collect.ImmutableMap;
 import org.apache.druid.segment.ColumnValueSelector;
 import org.apache.druid.segment.QueryableIndex;
 import org.apache.druid.segment.column.BaseColumn;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
-import static com.facebook.presto.druid.DruidErrorCode.DRUID_SEGMENT_LOAD_ERROR;
 import static com.facebook.presto.druid.column.ColumnReader.createColumnReader;
 import static java.lang.Math.min;
 import static java.lang.Math.toIntExact;
@@ -42,29 +39,22 @@ public class DruidSegmentReader
     private final Map<String, ColumnReader> columnValueSelectors;
     private final long totalRowCount;
 
-    private QueryableIndex queryableIndex;
     private long currentPosition;
     private int currentBatchSize;
 
-    public DruidSegmentReader(SegmentIndexSource segmentIndexSource, List<ColumnHandle> columns)
+    public DruidSegmentReader(QueryableIndex queryableIndex, List<ColumnHandle> columns)
     {
-        try {
-            queryableIndex = segmentIndexSource.loadIndex(columns);
-            totalRowCount = queryableIndex.getNumRows();
-            ImmutableMap.Builder<String, ColumnReader> selectorsBuilder = ImmutableMap.builder();
-            for (ColumnHandle column : columns) {
-                DruidColumnHandle druidColumn = (DruidColumnHandle) column;
-                String columnName = druidColumn.getColumnName();
-                Type type = druidColumn.getColumnType();
-                BaseColumn baseColumn = queryableIndex.getColumnHolder(columnName).getColumn();
-                ColumnValueSelector<?> valueSelector = baseColumn.makeColumnValueSelector(new SimpleReadableOffset());
-                selectorsBuilder.put(columnName, createColumnReader(type, valueSelector));
-            }
-            columnValueSelectors = selectorsBuilder.build();
+        totalRowCount = queryableIndex.getNumRows();
+        ImmutableMap.Builder<String, ColumnReader> selectorsBuilder = ImmutableMap.builder();
+        for (ColumnHandle column : columns) {
+            DruidColumnHandle druidColumn = (DruidColumnHandle) column;
+            String columnName = druidColumn.getColumnName();
+            Type type = druidColumn.getColumnType();
+            BaseColumn baseColumn = queryableIndex.getColumnHolder(columnName).getColumn();
+            ColumnValueSelector<?> valueSelector = baseColumn.makeColumnValueSelector(new SimpleReadableOffset());
+            selectorsBuilder.put(columnName, createColumnReader(type, valueSelector));
         }
-        catch (IOException e) {
-            throw new PrestoException(DRUID_SEGMENT_LOAD_ERROR, "failed to load druid segment");
-        }
+        columnValueSelectors = selectorsBuilder.build();
     }
 
     @Override

--- a/presto-druid/src/main/java/com/facebook/presto/druid/segment/SmooshedColumnSource.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/segment/SmooshedColumnSource.java
@@ -59,7 +59,7 @@ public class SmooshedColumnSource
     {
         SmooshFileMetadata metadata = columnSmoosh.get(name);
         if (metadata == null) {
-            throw new PrestoException(DRUID_SEGMENT_LOAD_ERROR, format("Internal file %s doesn't exist", name));
+            throw new PrestoException(DRUID_SEGMENT_LOAD_ERROR, format("Internal file \"%s\" doesn't exist", name));
         }
         String fileName = makeChunkFileName(metadata.getFileCount());
         int fileStart = metadata.getStartOffset();

--- a/presto-main/src/main/java/com/facebook/presto/testing/TestingConnectorSession.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/TestingConnectorSession.java
@@ -32,6 +32,7 @@ import java.util.Optional;
 
 import static com.facebook.presto.common.type.TimeZoneKey.UTC_KEY;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_SESSION_PROPERTY;
+import static com.facebook.presto.spi.session.PropertyMetadata.booleanProperty;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
@@ -40,7 +41,7 @@ public class TestingConnectorSession
         implements ConnectorSession
 {
     private static final QueryIdGenerator queryIdGenerator = new QueryIdGenerator();
-    public static final ConnectorSession SESSION = new TestingConnectorSession(ImmutableList.of());
+    public static final ConnectorSession SESSION = new TestingConnectorSession(ImmutableList.of(booleanProperty("compute_pushdown_enabled", "Mock pushdown", true, false)));
 
     private final String queryId;
     private final ConnectorIdentity identity;


### PR DESCRIPTION
Test plan - Local testing of various presto queries against local druid server.  More testing to be done. Looking for early feedback.

When druid goes to segment scanning take into account the queries predicates. If __time is provided then restrict the segments to be downloaded to be the ones that fall under the __time range. If its a string dimension, then leverage the segments dictionary to further filter before having presto handle the rows. 

Other fixes: 
- The connector will always attempt a broker style query even if the "compute_pushdown_enabled" is false. Fixing this allows segment approach to be enabled.
- NULL values on varchars were broken.