### PR TITLE
Add Resource Manager (experimental feature)

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/connector/system/SystemSplitManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/system/SystemSplitManager.java
@@ -32,6 +32,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static com.facebook.presto.spi.NodeState.ACTIVE;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_FOUND;
@@ -81,7 +82,8 @@ public class SystemSplitManager
             nodes.addAll(nodeManager.getCoordinators());
         }
         else if (tableDistributionMode == ALL_NODES) {
-            nodes.addAll(nodeManager.getNodes(ACTIVE));
+            Set<InternalNode> allNodes = nodeManager.getNodes(ACTIVE).stream().filter(s -> !s.isResourceManager()).collect(Collectors.toSet());
+            nodes.addAll(allNodes);
         }
         Set<InternalNode> nodeSet = nodes.build();
         for (InternalNode node : nodeSet) {

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryManagerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryManagerConfig.java
@@ -59,6 +59,8 @@ public class QueryManagerConfig
     private int maxTotalRunningTaskCountToKillQuery = Integer.MAX_VALUE;
     private int maxQueryRunningTaskCount = Integer.MAX_VALUE;
     private int maxTotalRunningTaskCountToNotExecuteNewQuery = Integer.MAX_VALUE;
+    private double concurrencyThresholdToEnableResourceGroupRefresh = 1.0;
+    private Duration resourceGroupRunTimeInfoRefreshInterval = new Duration(100, TimeUnit.MILLISECONDS);
 
     private Duration clientTimeout = new Duration(5, TimeUnit.MINUTES);
 
@@ -306,6 +308,32 @@ public class QueryManagerConfig
     public QueryManagerConfig setMaxQueryRunningTaskCount(int maxQueryRunningTaskCount)
     {
         this.maxQueryRunningTaskCount = maxQueryRunningTaskCount;
+        return this;
+    }
+
+    @Config("concurrency-threshold-to-enable-resource-group-refresh")
+    @ConfigDescription("Resource group concurrency threshold precentage, once crossed new queries won't run till updated resource group info comes from resource manager")
+    public QueryManagerConfig setConcurrencyThresholdToEnableResourceGroupRefresh(double concurrencyThresholdToEnableResourceGroupRefresh)
+    {
+        this.concurrencyThresholdToEnableResourceGroupRefresh = concurrencyThresholdToEnableResourceGroupRefresh;
+        return this;
+    }
+
+    public Double getConcurrencyThresholdToEnableResourceGroupRefresh()
+    {
+        return concurrencyThresholdToEnableResourceGroupRefresh;
+    }
+
+    public Duration getResourceGroupRunTimeInfoRefreshInterval()
+    {
+        return resourceGroupRunTimeInfoRefreshInterval;
+    }
+
+    @Config("resource-group-runtimeinfo-refresh-interval")
+    @ConfigDescription("Resource Group Runtime Info Refresh Interval")
+    public QueryManagerConfig setResourceGroupRunTimeInfoRefreshInterval(Duration resourceGroupRunTimeInfoRefreshInterval)
+    {
+        this.resourceGroupRunTimeInfoRefreshInterval = resourceGroupRunTimeInfoRefreshInterval;
         return this;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroup.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroup.java
@@ -148,7 +148,7 @@ public class InternalResourceGroup
     @GuardedBy("root")
     private final AtomicLong lastUpdatedResourceGroupRuntimeInfo;
     @GuardedBy("root")
-    private AtomicLong lastRunningQueryStartTime = new AtomicLong(0);
+    private AtomicLong lastRunningQueryStartTime = new AtomicLong();
 
     protected InternalResourceGroup(
             Optional<InternalResourceGroup> parent,
@@ -662,7 +662,7 @@ public class InternalResourceGroup
                 return;
             }
             boolean waitingForResourceGroupUpdate = waitingForResourceGroupRunTimeInfoUpdate();
-            if (canRun && !waitingForResourceGroupUpdate) {
+            if (canRun && !waitingForResourceGroupUpdate && queuedQueries.isEmpty()) {
                 startInBackground(query);
             }
             else {
@@ -709,8 +709,10 @@ public class InternalResourceGroup
                 parent.get().addOrUpdateSubGroup(this);
             }
             else {
-                parent.get().eligibleSubGroups.remove(this);
-                lastStartMillis = 0;
+                if (queuedQueries.isEmpty() && eligibleSubGroups.isEmpty()) {
+                    parent.get().eligibleSubGroups.remove(this);
+                    lastStartMillis = 0;
+                }
             }
             parent.get().updateEligibility();
         }
@@ -823,6 +825,11 @@ public class InternalResourceGroup
             if (!canRunMore()) {
                 return false;
             }
+
+            if (waitingForResourceGroupRunTimeInfoUpdate()) {
+                return false;
+            }
+
             ManagedQueryExecution query = queuedQueries.poll();
             if (query != null) {
                 startInBackground(query);
@@ -835,10 +842,8 @@ public class InternalResourceGroup
                 return false;
             }
 
-            if (!subGroup.waitingForResourceGroupRunTimeInfoUpdate()) {
-                boolean started = subGroup.internalStartNext();
-                checkState(started, "Eligible sub group had no queries to run");
-
+            boolean started = subGroup.internalStartNext();
+            if (started == true) {
                 long currentTime = System.currentTimeMillis();
                 if (lastStartMillis != 0) {
                     timeBetweenStartsSec.update(Math.max(0, (currentTime - lastStartMillis) / 1000));
@@ -852,7 +857,7 @@ public class InternalResourceGroup
             if (subGroup.isEligibleToStartNext()) {
                 addOrUpdateSubGroup(subGroup);
             }
-            return true;
+            return started;
         }
     }
 
@@ -927,7 +932,7 @@ public class InternalResourceGroup
         synchronized (root) {
             ResourceGroupRuntimeInfo resourceGroupRuntimeInfo = resourceGroupRuntimeInfos.get(getId());
             if (resourceGroupRuntimeInfo != null) {
-                return descendantQueuedQueries + queuedQueries.size() + resourceGroupRuntimeInfo.getQueuedQueries() < maxQueuedQueries;
+                return descendantQueuedQueries + queuedQueries.size() + resourceGroupRuntimeInfo.getQueuedQueries() + resourceGroupRuntimeInfo.getDescendantQueuedQueries() < maxQueuedQueries;
             }
             return descendantQueuedQueries + queuedQueries.size() < maxQueuedQueries;
         }
@@ -951,7 +956,7 @@ public class InternalResourceGroup
 
             ResourceGroupRuntimeInfo resourceGroupRuntimeInfo = resourceGroupRuntimeInfos.get(getId());
             if (resourceGroupRuntimeInfo != null) {
-                totalRunningQueries += resourceGroupRuntimeInfo.getRunningQueries();
+                totalRunningQueries += resourceGroupRuntimeInfo.getRunningQueries() + resourceGroupRuntimeInfo.getDescendantRunningQueries();
             }
 
             return totalRunningQueries < hardConcurrencyLimit && cachedMemoryUsageBytes <= softMemoryLimitBytes;
@@ -988,11 +993,9 @@ public class InternalResourceGroup
 
             ResourceGroupRuntimeInfo resourceGroupRuntimeInfo = resourceGroupRuntimeInfos.get(getId());
             if (resourceGroupRuntimeInfo != null) {
-                totalRunningQueries += resourceGroupRuntimeInfo.getRunningQueries();
+                totalRunningQueries += resourceGroupRuntimeInfo.getRunningQueries() + resourceGroupRuntimeInfo.getDescendantRunningQueries();
             }
-
-            //If lastRunningStartTime earlier than the last resource group refresh time, won't let the resource group start new query
-            return totalRunningQueries >= (hardConcurrencyLimit * concurrencyThreshold) && lastUpdatedResourceGroupRuntimeInfo.get() < lastRunningQueryStartTime.get();
+            return totalRunningQueries >= (hardConcurrencyLimit * concurrencyThreshold) && lastUpdatedResourceGroupRuntimeInfo.get() <= lastRunningQueryStartTime.get();
         }
     }
 
@@ -1051,6 +1054,7 @@ public class InternalResourceGroup
         public synchronized void processQueuedQueries()
         {
             internalRefreshStats();
+
             while (internalStartNext()) {
                 // start all the queries we can
             }

--- a/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroupManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroupManager.java
@@ -18,6 +18,7 @@ import com.facebook.airlift.node.NodeInfo;
 import com.facebook.presto.execution.ManagedQueryExecution;
 import com.facebook.presto.execution.QueryManagerConfig;
 import com.facebook.presto.execution.resourceGroups.InternalResourceGroup.RootInternalResourceGroup;
+import com.facebook.presto.resourcemanager.ResourceGroupService;
 import com.facebook.presto.server.ResourceGroupInfo;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.memory.ClusterMemoryPoolManager;
@@ -30,6 +31,9 @@ import com.facebook.presto.spi.resourceGroups.SelectionCriteria;
 import com.facebook.presto.sql.tree.Statement;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import io.airlift.units.Duration;
 import org.weakref.jmx.JmxException;
 import org.weakref.jmx.MBeanExporter;
 import org.weakref.jmx.Managed;
@@ -45,6 +49,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.OptionalInt;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -60,10 +65,11 @@ import static com.facebook.presto.util.PropertiesUtil.loadProperties;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.lang.String.format;
 import static java.lang.System.currentTimeMillis;
 import static java.util.Objects.requireNonNull;
-import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
+import static java.util.concurrent.Executors.newScheduledThreadPool;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
@@ -75,7 +81,7 @@ public final class InternalResourceGroupManager<C>
     private static final File RESOURCE_GROUPS_CONFIGURATION = new File("etc/resource-groups.properties");
     private static final String CONFIGURATION_MANAGER_PROPERTY_NAME = "resource-groups.configuration-manager";
 
-    private final ScheduledExecutorService refreshExecutor = newSingleThreadScheduledExecutor(daemonThreadsNamed("ResourceGroupManager"));
+    private final ScheduledExecutorService refreshExecutor = newScheduledThreadPool(2, daemonThreadsNamed("ResourceGroupManager"));
     private final List<RootInternalResourceGroup> rootGroups = new CopyOnWriteArrayList<>();
     private final ConcurrentMap<ResourceGroupId, InternalResourceGroup> groups = new ConcurrentHashMap<>();
     private final AtomicReference<ResourceGroupConfigurationManager<C>> configurationManager;
@@ -88,6 +94,11 @@ public final class InternalResourceGroupManager<C>
     private final AtomicBoolean taskLimitExceeded = new AtomicBoolean();
     private final int maxTotalRunningTaskCountToNotExecuteNewQuery;
     private final AtomicLong lastSchedulingCycleRunTimeMs = new AtomicLong(currentTimeMillis());
+    private final ResourceGroupService resourceGroupService;
+    private final ConcurrentMap<ResourceGroupId, ResourceGroupRuntimeInfo> resourceGroupRuntimeInfos = new ConcurrentHashMap<>();
+    private final AtomicLong lastUpdatedResourceGroupRuntimeInfo = new AtomicLong(0L);
+    private final double concurrencyThreshold;
+    private final Duration resourceGroupRuntimeInfoRefreshInterval;
 
     @Inject
     public InternalResourceGroupManager(
@@ -95,7 +106,9 @@ public final class InternalResourceGroupManager<C>
             ClusterMemoryPoolManager memoryPoolManager,
             QueryManagerConfig queryManagerConfig,
             NodeInfo nodeInfo,
-            MBeanExporter exporter)
+            MBeanExporter exporter,
+            // TODO: move this to a different class
+            ResourceGroupService resourceGroupService)
     {
         requireNonNull(queryManagerConfig, "queryManagerConfig is null");
         this.exporter = requireNonNull(exporter, "exporter is null");
@@ -103,6 +116,9 @@ public final class InternalResourceGroupManager<C>
         this.legacyManager = requireNonNull(legacyManager, "legacyManager is null");
         this.configurationManager = new AtomicReference<>(cast(legacyManager));
         this.maxTotalRunningTaskCountToNotExecuteNewQuery = queryManagerConfig.getMaxTotalRunningTaskCountToNotExecuteNewQuery();
+        this.resourceGroupService = requireNonNull(resourceGroupService, "resourceGroupService is null");
+        this.concurrencyThreshold = queryManagerConfig.getConcurrencyThresholdToEnableResourceGroupRefresh();
+        this.resourceGroupRuntimeInfoRefreshInterval = queryManagerConfig.getResourceGroupRunTimeInfoRefreshInterval();
     }
 
     @Override
@@ -203,6 +219,24 @@ public final class InternalResourceGroupManager<C>
                     throw t;
                 }
             }, 1, 1, MILLISECONDS);
+            refreshExecutor.scheduleWithFixedDelay(() -> {
+                refreshResourceGroupRuntimeInfo();
+            }, 1, resourceGroupRuntimeInfoRefreshInterval.toMillis(), MILLISECONDS);
+        }
+    }
+
+    private void refreshResourceGroupRuntimeInfo()
+    {
+        try {
+            List<ResourceGroupRuntimeInfo> resourceGroupInfos = resourceGroupService.getResourceGroupInfo();
+            Set<ResourceGroupId> resourceGroupIds = resourceGroupInfos.stream().map(ResourceGroupRuntimeInfo::getResourceGroupId).collect(toImmutableSet());
+            Set<ResourceGroupId> toRemove = ImmutableSet.copyOf(Sets.difference(resourceGroupRuntimeInfos.keySet(), resourceGroupIds));
+            resourceGroupRuntimeInfos.keySet().removeAll(toRemove);
+            resourceGroupInfos.forEach(resourceGroupRuntimeInfo -> resourceGroupRuntimeInfos.put(resourceGroupRuntimeInfo.getResourceGroupId(), resourceGroupRuntimeInfo));
+            lastUpdatedResourceGroupRuntimeInfo.set(currentTimeMillis());
+        }
+        catch (Throwable t) {
+            log.error(t, "Error while executing refreshAndStartQueries");
         }
     }
 
@@ -256,7 +290,8 @@ public final class InternalResourceGroupManager<C>
                 group = parent.getOrCreateSubGroup(id.getLastSegment(), !context.getFirstDynamicSegmentPosition().equals(OptionalInt.of(subGroupSegmentIndex)));
             }
             else {
-                RootInternalResourceGroup root = new RootInternalResourceGroup(id.getSegments().get(0), this::exportGroup, executor);
+                RootInternalResourceGroup root = new RootInternalResourceGroup(id.getSegments().get(0), this::exportGroup, executor, resourceGroupRuntimeInfos,
+                        lastUpdatedResourceGroupRuntimeInfo, concurrencyThreshold);
                 group = root;
                 rootGroups.add(root);
             }

--- a/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/ResourceGroupRuntimeInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/ResourceGroupRuntimeInfo.java
@@ -25,17 +25,21 @@ import static java.util.Objects.requireNonNull;
 public class ResourceGroupRuntimeInfo
 {
     private final ResourceGroupId resourceGroupId;
-    private final long userMemoryReservationBytes;
+    private final long memoryUsageBytes;
     private final int queuedQueries;
+    private final int descendantQueuedQueries;
     private final int runningQueries;
+    private final int descendantRunningQueries;
 
     @ThriftConstructor
-    public ResourceGroupRuntimeInfo(ResourceGroupId resourceGroupId, long userMemoryReservationBytes, int queuedQueries, int runningQueries)
+    public ResourceGroupRuntimeInfo(ResourceGroupId resourceGroupId, long memoryUsageBytes, int queuedQueries, int descendantQueuedQueries, int runningQueries, int descendantRunningQueries)
     {
         this.resourceGroupId = requireNonNull(resourceGroupId, "resourceGroupId is null");
-        this.userMemoryReservationBytes = userMemoryReservationBytes;
+        this.memoryUsageBytes = memoryUsageBytes;
         this.queuedQueries = queuedQueries;
+        this.descendantQueuedQueries = descendantQueuedQueries;
         this.runningQueries = runningQueries;
+        this.descendantRunningQueries = descendantRunningQueries;
     }
 
     public static Builder builder(ResourceGroupId resourceGroupId)
@@ -50,9 +54,9 @@ public class ResourceGroupRuntimeInfo
     }
 
     @ThriftField(2)
-    public long getUserMemoryReservationBytes()
+    public long getMemoryUsageBytes()
     {
-        return userMemoryReservationBytes;
+        return memoryUsageBytes;
     }
 
     @ThriftField(3)
@@ -62,9 +66,21 @@ public class ResourceGroupRuntimeInfo
     }
 
     @ThriftField(4)
+    public int getDescendantQueuedQueries()
+    {
+        return descendantQueuedQueries;
+    }
+
+    @ThriftField(5)
     public int getRunningQueries()
     {
         return runningQueries;
+    }
+
+    @ThriftField(6)
+    public int getDescendantRunningQueries()
+    {
+        return descendantRunningQueries;
     }
 
     public static class Builder
@@ -73,7 +89,9 @@ public class ResourceGroupRuntimeInfo
 
         private long userMemoryReservationBytes;
         private int queuedQueries;
+        private int descendantQueuedQueries;
         private int runningQueries;
+        private int descendantRunningQueries;
 
         private Builder(ResourceGroupId resourceGroupId)
         {
@@ -92,15 +110,27 @@ public class ResourceGroupRuntimeInfo
             return this;
         }
 
+        public Builder addDescendantQueuedQueries(int descendantQueuedQueries)
+        {
+            this.descendantQueuedQueries += descendantQueuedQueries;
+            return this;
+        }
+
         public Builder addRunningQueries(int runningQueries)
         {
             this.runningQueries = addExact(this.runningQueries, runningQueries);
             return this;
         }
 
+        public Builder addDescendantRunningQueries(int descendantRunningQueries)
+        {
+            this.descendantRunningQueries += descendantRunningQueries;
+            return this;
+        }
+
         public ResourceGroupRuntimeInfo build()
         {
-            return new ResourceGroupRuntimeInfo(resourceGroupId, userMemoryReservationBytes, queuedQueries, runningQueries);
+            return new ResourceGroupRuntimeInfo(resourceGroupId, userMemoryReservationBytes, queuedQueries, descendantQueuedQueries, runningQueries, descendantRunningQueries);
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NodeScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NodeScheduler.java
@@ -50,6 +50,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static com.facebook.airlift.concurrent.MoreFutures.whenAnyCompleteCancelOthers;
 import static com.facebook.presto.SystemSessionProperties.getMaxUnacknowledgedSplitsPerTask;
@@ -184,7 +185,7 @@ public class NodeScheduler
                 allNodes = nodeManager.getAllConnectorNodes(connectorId);
             }
             else {
-                activeNodes = nodeManager.getNodes(ACTIVE);
+                activeNodes = nodeManager.getNodes(ACTIVE).stream().filter(s -> !s.isResourceManager()).collect(Collectors.toSet());
                 allNodes = activeNodes;
             }
 
@@ -193,9 +194,6 @@ public class NodeScheduler
                     .collect(toImmutableSet());
 
             for (InternalNode node : allNodes) {
-                if (node.isResourceManager()) {
-                    continue;
-                }
                 if (node.getNodeStatus() == ALIVE) {
                     activeNodesByNodeId.put(node.getNodeIdentifier(), node);
                     if (useNetworkTopology && (includeCoordinator || !coordinatorNodeIds.contains(node.getNodeIdentifier()))) {

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NodeScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NodeScheduler.java
@@ -54,6 +54,7 @@ import java.util.Set;
 import static com.facebook.airlift.concurrent.MoreFutures.whenAnyCompleteCancelOthers;
 import static com.facebook.presto.SystemSessionProperties.getMaxUnacknowledgedSplitsPerTask;
 import static com.facebook.presto.execution.scheduler.NodeSchedulerConfig.NetworkTopologyType;
+import static com.facebook.presto.metadata.InternalNode.NodeStatus.ALIVE;
 import static com.facebook.presto.spi.NodeState.ACTIVE;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Suppliers.memoizeWithExpiration;
@@ -195,11 +196,13 @@ public class NodeScheduler
                 if (node.isResourceManager()) {
                     continue;
                 }
-                activeNodesByNodeId.put(node.getNodeIdentifier(), node);
-                if (useNetworkTopology && (includeCoordinator || !coordinatorNodeIds.contains(node.getNodeIdentifier()))) {
-                    NetworkLocation location = networkLocationCache.get(node.getHostAndPort());
-                    for (int i = 0; i <= location.getSegments().size(); i++) {
-                        activeWorkersByNetworkPath.put(location.subLocation(0, i), node);
+                if (node.getNodeStatus() == ALIVE) {
+                    activeNodesByNodeId.put(node.getNodeIdentifier(), node);
+                    if (useNetworkTopology && (includeCoordinator || !coordinatorNodeIds.contains(node.getNodeIdentifier()))) {
+                        NetworkLocation location = networkLocationCache.get(node.getHostAndPort());
+                        for (int i = 0; i <= location.getSegments().size(); i++) {
+                            activeWorkersByNetworkPath.put(location.subLocation(0, i), node);
+                        }
                     }
                 }
                 try {

--- a/presto-main/src/main/java/com/facebook/presto/memory/ClusterMemoryManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/ClusterMemoryManager.java
@@ -438,21 +438,7 @@ public class ClusterMemoryManager
         // and is more of a safety check than a guarantee
         if (allAssignmentsHavePropagated(queries)) {
             if (reservedPool.getAssignedQueries() == 0 && generalPool.getBlockedNodes() > 0) {
-                QueryExecution biggestQuery = null;
-                long maxMemory = -1;
-                for (QueryExecution queryExecution : queries) {
-                    if (resourceOvercommit(queryExecution.getSession())) {
-                        // Don't promote queries that requested resource overcommit to the reserved pool,
-                        // since their memory usage is unbounded.
-                        continue;
-                    }
-
-                    long bytesUsed = getQueryMemoryReservation(queryExecution);
-                    if (bytesUsed > maxMemory) {
-                        biggestQuery = queryExecution;
-                        maxMemory = bytesUsed;
-                    }
-                }
+                QueryExecution biggestQuery = findLargestMemoryQuery(generalPool, queries);
                 if (biggestQuery != null) {
                     log.info("Moving query %s to the reserved pool", biggestQuery.getQueryId());
                     biggestQuery.setMemoryPool(new VersionedMemoryPoolId(RESERVED_POOL, version));
@@ -465,6 +451,31 @@ public class ClusterMemoryManager
             assignments.add(new MemoryPoolAssignment(queryExecution.getQueryId(), queryExecution.getMemoryPool().getId()));
         }
         return new MemoryPoolAssignmentsRequest(coordinatorId, version, assignments.build());
+    }
+
+    private QueryExecution findLargestMemoryQuery(ClusterMemoryPoolInfo generalPool, Iterable<QueryExecution> queries)
+    {
+        QueryExecution biggestQuery = null;
+        long maxMemory = -1;
+        Optional<QueryId> largestMemoryQuery = generalPool.getLargestMemoryQuery();
+        for (QueryExecution queryExecution : queries) {
+            QueryId queryId = queryExecution.getQueryId();
+            if (largestMemoryQuery.map(queryId::equals).orElse(false)) {
+                return queryExecution;
+            }
+            if (resourceOvercommit(queryExecution.getSession())) {
+                // Don't promote queries that requested resource overcommit to the reserved pool,
+                // since their memory usage is unbounded.
+                continue;
+            }
+
+            long bytesUsed = getQueryMemoryReservation(queryExecution);
+            if (bytesUsed > maxMemory) {
+                biggestQuery = queryExecution;
+                maxMemory = bytesUsed;
+            }
+        }
+        return biggestQuery;
     }
 
     private QueryMemoryInfo createQueryMemoryInfo(QueryExecution query)

--- a/presto-main/src/main/java/com/facebook/presto/memory/ClusterMemoryManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/ClusterMemoryManager.java
@@ -517,6 +517,7 @@ public class ClusterMemoryManager
                 .build();
 
         ImmutableSet<String> aliveNodeIds = aliveNodes.stream()
+                .filter(s -> !s.isResourceManager())
                 .map(InternalNode::getNodeIdentifier)
                 .collect(toImmutableSet());
 

--- a/presto-main/src/main/java/com/facebook/presto/memory/ClusterMemoryPool.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/ClusterMemoryPool.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
@@ -84,7 +85,12 @@ public class ClusterMemoryPool
 
     public synchronized ClusterMemoryPoolInfo getClusterInfo()
     {
-        return new ClusterMemoryPoolInfo(getInfo(), blockedNodes, assignedQueries);
+        return getClusterInfo(Optional.empty());
+    }
+
+    public synchronized ClusterMemoryPoolInfo getClusterInfo(Optional<QueryId> largestMemoryQuery)
+    {
+        return new ClusterMemoryPoolInfo(getInfo(), blockedNodes, assignedQueries, largestMemoryQuery);
     }
 
     public MemoryPoolId getId()

--- a/presto-main/src/main/java/com/facebook/presto/resourcemanager/ClusterMemoryManagerService.java
+++ b/presto-main/src/main/java/com/facebook/presto/resourcemanager/ClusterMemoryManagerService.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.resourcemanager;
+
+import com.facebook.drift.client.DriftClient;
+import com.facebook.presto.memory.NodeMemoryConfig;
+import com.facebook.presto.spi.memory.ClusterMemoryPoolInfo;
+import com.facebook.presto.spi.memory.MemoryPoolId;
+import com.facebook.presto.spi.memory.MemoryPoolInfo;
+import com.facebook.presto.util.PeriodicTaskExecutor;
+import com.google.common.collect.ImmutableMap;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.inject.Inject;
+
+import java.util.Map;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.facebook.presto.memory.LocalMemoryManager.GENERAL_POOL;
+import static com.facebook.presto.memory.LocalMemoryManager.RESERVED_POOL;
+import static java.util.Objects.requireNonNull;
+
+public class ClusterMemoryManagerService
+        implements MemoryManagerService
+{
+    private static final ClusterMemoryPoolInfo EMPTY_MEMORY_POOL = new ClusterMemoryPoolInfo(
+            new MemoryPoolInfo(0, 0, 0, ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of()),
+            0,
+            0);
+
+    private final DriftClient<ResourceManagerClient> resourceManagerClient;
+    private final ScheduledExecutorService executorService;
+    private final AtomicReference<Map<MemoryPoolId, ClusterMemoryPoolInfo>> memoryPools;
+    private final long memoryPoolFetchIntervalMillis;
+    private final boolean isReservedPoolEnabled;
+
+    private PeriodicTaskExecutor memoryPoolUpdater;
+
+    @Inject
+    public ClusterMemoryManagerService(
+            @ForResourceManager DriftClient<ResourceManagerClient> resourceManagerClient,
+            @ForResourceManager ScheduledExecutorService executorService,
+            ResourceManagerConfig resourceManagerConfig,
+            NodeMemoryConfig nodeMemoryConfig)
+    {
+        this.resourceManagerClient = requireNonNull(resourceManagerClient, "resourceManagerClient is null");
+        this.executorService = requireNonNull(executorService, "executorService is null");
+        this.memoryPoolFetchIntervalMillis = requireNonNull(resourceManagerConfig, "resourceManagerConfig is null").getMemoryPoolFetchInterval().toMillis();
+        this.isReservedPoolEnabled = requireNonNull(nodeMemoryConfig, "nodeMemoryConfig is null").isReservedPoolEnabled();
+
+        ImmutableMap.Builder<MemoryPoolId, ClusterMemoryPoolInfo> defaultPoolBuilder = ImmutableMap.<MemoryPoolId, ClusterMemoryPoolInfo>builder()
+                .put(GENERAL_POOL, EMPTY_MEMORY_POOL);
+        if (isReservedPoolEnabled) {
+            defaultPoolBuilder.put(RESERVED_POOL, EMPTY_MEMORY_POOL);
+        }
+        this.memoryPools = new AtomicReference<>(defaultPoolBuilder.build());
+    }
+
+    @PostConstruct
+    public void init()
+    {
+        this.memoryPoolUpdater = new PeriodicTaskExecutor(memoryPoolFetchIntervalMillis, executorService, () -> memoryPools.set(updateMemoryPoolInfo()));
+    }
+
+    @PreDestroy
+    public void stop()
+    {
+        if (memoryPoolUpdater != null) {
+            memoryPoolUpdater.stop();
+        }
+    }
+
+    @Override
+    public Map<MemoryPoolId, ClusterMemoryPoolInfo> getMemoryPoolInfo()
+    {
+        return memoryPools.get();
+    }
+
+    private Map<MemoryPoolId, ClusterMemoryPoolInfo> updateMemoryPoolInfo()
+    {
+        Map<MemoryPoolId, ClusterMemoryPoolInfo> memoryPoolInfos = resourceManagerClient.get().getMemoryPoolInfo();
+        memoryPoolInfos.putIfAbsent(GENERAL_POOL, EMPTY_MEMORY_POOL);
+        if (isReservedPoolEnabled) {
+            memoryPoolInfos.putIfAbsent(RESERVED_POOL, EMPTY_MEMORY_POOL);
+        }
+        return ImmutableMap.copyOf(memoryPoolInfos);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/resourcemanager/MemoryManagerService.java
+++ b/presto-main/src/main/java/com/facebook/presto/resourcemanager/MemoryManagerService.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.resourcemanager;
+
+import com.facebook.presto.spi.memory.ClusterMemoryPoolInfo;
+import com.facebook.presto.spi.memory.MemoryPoolId;
+
+import java.util.Map;
+
+public interface MemoryManagerService
+{
+    Map<MemoryPoolId, ClusterMemoryPoolInfo> getMemoryPoolInfo();
+}

--- a/presto-main/src/main/java/com/facebook/presto/resourcemanager/NoopResourceGroupService.java
+++ b/presto-main/src/main/java/com/facebook/presto/resourcemanager/NoopResourceGroupService.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.resourcemanager;
+
+import com.facebook.presto.execution.resourceGroups.ResourceGroupRuntimeInfo;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+public class NoopResourceGroupService
+        implements ResourceGroupService
+{
+    @Override
+    public List<ResourceGroupRuntimeInfo> getResourceGroupInfo()
+    {
+        return ImmutableList.of();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/resourcemanager/ResourceGroupService.java
+++ b/presto-main/src/main/java/com/facebook/presto/resourcemanager/ResourceGroupService.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.resourcemanager;
+
+import com.facebook.presto.execution.resourceGroups.ResourceGroupRuntimeInfo;
+
+import java.util.List;
+
+public interface ResourceGroupService
+{
+    List<ResourceGroupRuntimeInfo> getResourceGroupInfo();
+}

--- a/presto-main/src/main/java/com/facebook/presto/resourcemanager/ResourceManagerClusterStateProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/resourcemanager/ResourceManagerClusterStateProvider.java
@@ -18,6 +18,7 @@ import com.facebook.presto.memory.ClusterMemoryPool;
 import com.facebook.presto.memory.MemoryInfo;
 import com.facebook.presto.memory.NodeMemoryConfig;
 import com.facebook.presto.metadata.InternalNodeManager;
+import com.facebook.presto.metadata.SessionPropertyManager;
 import com.facebook.presto.server.BasicQueryInfo;
 import com.facebook.presto.server.NodeStatus;
 import com.facebook.presto.spi.QueryId;
@@ -26,10 +27,13 @@ import com.facebook.presto.spi.memory.MemoryPoolId;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import io.airlift.units.Duration;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 import javax.inject.Inject;
+import javax.validation.constraints.NotNull;
 
 import java.net.URI;
 import java.util.Collection;
@@ -38,22 +42,21 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 
+import static com.facebook.presto.SystemSessionProperties.resourceOvercommit;
 import static com.facebook.presto.execution.QueryState.QUEUED;
 import static com.facebook.presto.memory.LocalMemoryManager.GENERAL_POOL;
 import static com.facebook.presto.memory.LocalMemoryManager.RESERVED_POOL;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
-import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
-import static java.util.stream.Collectors.counting;
-import static java.util.stream.Collectors.groupingBy;
 
 public class ResourceManagerClusterStateProvider
 {
@@ -61,6 +64,7 @@ public class ResourceManagerClusterStateProvider
     private final Map<String, InternalNodeState> nodeStatuses = new ConcurrentHashMap<>();
 
     private final InternalNodeManager internalNodeManager;
+    private final SessionPropertyManager sessionPropertyManager;
     private final int maxCompletedQueries;
     private final Duration queryExpirationTimeout;
     private final Duration completedQueryExpirationTimeout;
@@ -70,12 +74,14 @@ public class ResourceManagerClusterStateProvider
     @Inject
     public ResourceManagerClusterStateProvider(
             InternalNodeManager internalNodeManager,
+            SessionPropertyManager sessionPropertyManager,
             ResourceManagerConfig resourceManagerConfig,
             NodeMemoryConfig nodeMemoryConfig,
             @ForResourceManager ScheduledExecutorService scheduledExecutorService)
     {
         this(
                 requireNonNull(internalNodeManager, "internalNodeManager is null"),
+                requireNonNull(sessionPropertyManager, "sessionPropertyManager is null"),
                 requireNonNull(resourceManagerConfig, "resourceManagerConfig is null").getMaxCompletedQueries(),
                 resourceManagerConfig.getQueryExpirationTimeout(),
                 resourceManagerConfig.getCompletedQueryExpirationTimeout(),
@@ -87,6 +93,7 @@ public class ResourceManagerClusterStateProvider
 
     public ResourceManagerClusterStateProvider(
             InternalNodeManager internalNodeManager,
+            SessionPropertyManager sessionPropertyManager,
             int maxCompletedQueries,
             Duration queryExpirationTimeout,
             Duration completedQueryExpirationTimeout,
@@ -97,6 +104,7 @@ public class ResourceManagerClusterStateProvider
     {
         this.internalNodeManager = requireNonNull(internalNodeManager, "internalNodeManager is null");
         checkArgument(maxCompletedQueries > 0, "maxCompletedQueries must be > 0, was %s", maxCompletedQueries);
+        this.sessionPropertyManager = requireNonNull(sessionPropertyManager, "sessionPropertyManager is null");
         this.maxCompletedQueries = maxCompletedQueries;
         this.queryExpirationTimeout = requireNonNull(queryExpirationTimeout, "queryExpirationTimeout is null");
         this.completedQueryExpirationTimeout = requireNonNull(completedQueryExpirationTimeout, "completedQueryExpirationTimeout is null");
@@ -198,21 +206,52 @@ public class ResourceManagerClusterStateProvider
                 .map(nodeStatus -> nodeStatus.getNodeStatus().getMemoryInfo())
                 .collect(toImmutableList());
 
-        Map<MemoryPoolId, Long> counts = nodeQueryStates.values().stream()
-                .map(CoordinatorQueriesState::getActiveQueries)
-                .flatMap(Collection::stream)
-                .collect(groupingBy(query -> query.getBasicQueryInfo().getMemoryPool(), counting()));
-        // Add defaults when queries are not running
-        counts.putIfAbsent(GENERAL_POOL, 0L);
-        if (isReservedPoolEnabled) {
-            counts.putIfAbsent(RESERVED_POOL, 0L);
+        int generalPoolCounts = 0;
+        int reservedPoolCounts = 0;
+        Query largestGeneralPoolQuery = null;
+        for (CoordinatorQueriesState nodeQueryState : nodeQueryStates.values()) {
+            for (Query query : nodeQueryState.getActiveQueries()) {
+                MemoryPoolId memoryPool = query.getBasicQueryInfo().getMemoryPool();
+                if (GENERAL_POOL.equals(memoryPool)) {
+                    generalPoolCounts = Math.incrementExact(generalPoolCounts);
+                    if (!resourceOvercommit(query.getBasicQueryInfo().getSession().toSession(sessionPropertyManager))) {
+                        largestGeneralPoolQuery = getLargestMemoryQuery(largestGeneralPoolQuery, query);
+                    }
+                }
+                else if (RESERVED_POOL.equals(memoryPool)) {
+                    reservedPoolCounts = Math.incrementExact(reservedPoolCounts);
+                }
+                else {
+                    throw new IllegalArgumentException("Unrecognized memory pool: " + memoryPool);
+                }
+            }
         }
 
-        return counts.entrySet().stream().collect(toImmutableMap(Map.Entry::getKey, entry -> {
-            ClusterMemoryPool pool = new ClusterMemoryPool(entry.getKey());
-            pool.update(memoryInfos, toIntExact(entry.getValue()));
-            return pool.getClusterInfo();
-        }));
+        ImmutableMap.Builder<MemoryPoolId, ClusterMemoryPoolInfo> memoryPoolInfos = ImmutableMap.builder();
+        ClusterMemoryPool pool = new ClusterMemoryPool(GENERAL_POOL);
+        pool.update(memoryInfos, generalPoolCounts);
+        ClusterMemoryPoolInfo clusterInfo = pool.getClusterInfo(Optional.ofNullable(largestGeneralPoolQuery).map(Query::getQueryId));
+        memoryPoolInfos.put(GENERAL_POOL, clusterInfo);
+        if (isReservedPoolEnabled) {
+            pool = new ClusterMemoryPool(RESERVED_POOL);
+            pool.update(memoryInfos, reservedPoolCounts);
+            memoryPoolInfos.put(RESERVED_POOL, pool.getClusterInfo());
+        }
+        return memoryPoolInfos.build();
+    }
+
+    private Query getLargestMemoryQuery(@Nullable Query existingLargeQuery, @NotNull Query newQuery)
+    {
+        requireNonNull(newQuery, "newQuery must not be null");
+        if (existingLargeQuery == null) {
+            return newQuery;
+        }
+        long largestGeneralBytes = existingLargeQuery.getBasicQueryInfo().getQueryStats().getTotalMemoryReservation().toBytes();
+        long currentGeneralBytes = newQuery.getBasicQueryInfo().getQueryStats().getTotalMemoryReservation().toBytes();
+        if (currentGeneralBytes > largestGeneralBytes) {
+            return newQuery;
+        }
+        return existingLargeQuery;
     }
 
     public Map<String, MemoryInfo> getWorkerMemoryInfo()

--- a/presto-main/src/main/java/com/facebook/presto/resourcemanager/ResourceManagerClusterStateProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/resourcemanager/ResourceManagerClusterStateProvider.java
@@ -182,6 +182,16 @@ public class ResourceManagerClusterStateProvider
                         builder.addRunningQueries(1);
                     }
                     builder.addUserMemoryReservationBytes(info.getQueryStats().getUserMemoryReservation().toBytes());
+                    while (resourceGroupId.getParent().isPresent()) {
+                        resourceGroupId = resourceGroupId.getParent().get();
+                        ResourceGroupRuntimeInfo.Builder parentBuilder = resourceGroupBuilders.computeIfAbsent(resourceGroupId, ResourceGroupRuntimeInfo::builder);
+                        if (info.getState() == QUEUED) {
+                            parentBuilder.addDescendantQueuedQueries(1);
+                        }
+                        else if (!info.getState().isDone()) {
+                            parentBuilder.addDescendantRunningQueries(1);
+                        }
+                    }
                 });
         return resourceGroupBuilders.values().stream().map(ResourceGroupRuntimeInfo.Builder::build).collect(toImmutableList());
     }

--- a/presto-main/src/main/java/com/facebook/presto/resourcemanager/ResourceManagerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/resourcemanager/ResourceManagerConfig.java
@@ -36,6 +36,7 @@ public class ResourceManagerConfig
     private int heartbeatConcurrency = 3;
     private int resourceManagerExecutorThreads = 1000;
     private Duration proxyAsyncTimeout = new Duration(60, SECONDS);
+    private Duration memoryPoolFetchInterval = new Duration(1, SECONDS);
 
     @MinDuration("1ms")
     public Duration getQueryExpirationTimeout()
@@ -179,6 +180,19 @@ public class ResourceManagerConfig
     public ResourceManagerConfig setProxyAsyncTimeout(Duration proxyAsyncTimeout)
     {
         this.proxyAsyncTimeout = proxyAsyncTimeout;
+        return this;
+    }
+
+    @MinDuration("1ms")
+    public Duration getMemoryPoolFetchInterval()
+    {
+        return memoryPoolFetchInterval;
+    }
+
+    @Config("resource-manager.memory-pool-fetch-interval")
+    public ResourceManagerConfig setMemoryPoolFetchInterval(Duration memoryPoolFetchInterval)
+    {
+        this.memoryPoolFetchInterval = memoryPoolFetchInterval;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/resourcemanager/ResourceManagerResourceGroupService.java
+++ b/presto-main/src/main/java/com/facebook/presto/resourcemanager/ResourceManagerResourceGroupService.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.resourcemanager;
+
+import com.facebook.drift.client.DriftClient;
+import com.facebook.presto.execution.resourceGroups.ResourceGroupRuntimeInfo;
+import com.facebook.presto.metadata.InternalNode;
+import com.facebook.presto.metadata.InternalNodeManager;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+
+import javax.inject.Inject;
+
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+import static com.google.common.cache.CacheLoader.asyncReloading;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+public class ResourceManagerResourceGroupService
+        implements ResourceGroupService
+{
+    private final DriftClient<ResourceManagerClient> resourceManagerClient;
+    private final InternalNodeManager internalNodeManager;
+    private final Cache<InternalNode, List<ResourceGroupRuntimeInfo>> cache;
+    private final Executor executor = Executors.newCachedThreadPool();
+
+    @Inject
+    public ResourceManagerResourceGroupService(
+            @ForResourceManager DriftClient<ResourceManagerClient> resourceManagerClient,
+            InternalNodeManager internalNodeManager)
+    {
+        this.resourceManagerClient = requireNonNull(resourceManagerClient, "resourceManagerService is null");
+        this.internalNodeManager = requireNonNull(internalNodeManager, "internalNodeManager is null");
+        this.cache = CacheBuilder.newBuilder()
+                .expireAfterWrite(10, SECONDS)
+                .refreshAfterWrite(1, SECONDS)
+                .build(asyncReloading(CacheLoader.from(this::getResourceGroupInfos), executor));
+    }
+
+    @Override
+    public List<ResourceGroupRuntimeInfo> getResourceGroupInfo()
+    {
+        try {
+            InternalNode currentNode = internalNodeManager.getCurrentNode();
+            return cache.get(currentNode, () -> getResourceGroupInfos(currentNode));
+        }
+        catch (ExecutionException e) {
+            throw new RuntimeException(e.getCause());
+        }
+    }
+
+    private List<ResourceGroupRuntimeInfo> getResourceGroupInfos(InternalNode internalNode)
+    {
+        return resourceManagerClient.get().getResourceGroupInfo(internalNode);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/resourcemanager/ResourceManagerServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/resourcemanager/ResourceManagerServer.java
@@ -16,6 +16,7 @@ package com.facebook.presto.resourcemanager;
 import com.facebook.drift.annotations.ThriftMethod;
 import com.facebook.drift.annotations.ThriftService;
 import com.facebook.presto.execution.resourceGroups.ResourceGroupRuntimeInfo;
+import com.facebook.presto.metadata.InternalNode;
 import com.facebook.presto.server.BasicQueryInfo;
 import com.facebook.presto.server.NodeStatus;
 import com.facebook.presto.spi.memory.ClusterMemoryPoolInfo;

--- a/presto-main/src/main/java/com/facebook/presto/server/PrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PrestoServer.java
@@ -134,8 +134,10 @@ public class PrestoServer
             Injector injector = app.initialize();
 
             injector.getInstance(PluginManager.class).loadPlugins();
-
-            injector.getInstance(StaticCatalogStore.class).loadCatalogs();
+            ServerConfig serverConfig = injector.getInstance(ServerConfig.class);
+            if (!serverConfig.isResourceManager()) {
+                injector.getInstance(StaticCatalogStore.class).loadCatalogs();
+            }
 
             // TODO: remove this huge hack
             updateConnectorIds(
@@ -152,7 +154,9 @@ public class PrestoServer
             injector.getInstance(StaticFunctionNamespaceStore.class).loadFunctionNamespaceManagers();
             injector.getInstance(SessionPropertyDefaults.class).loadConfigurationManager();
             injector.getInstance(ResourceGroupManager.class).loadConfigurationManager();
-            injector.getInstance(AccessControlManager.class).loadSystemAccessControl();
+            if (!serverConfig.isResourceManager()) {
+                injector.getInstance(AccessControlManager.class).loadSystemAccessControl();
+            }
             injector.getInstance(PasswordAuthenticatorManager.class).loadPasswordAuthenticator();
             injector.getInstance(EventListenerManager.class).loadConfiguredEventListener();
             injector.getInstance(TempStorageManager.class).loadTempStorages();

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -114,10 +114,13 @@ import com.facebook.presto.resourcemanager.ClusterMemoryManagerService;
 import com.facebook.presto.resourcemanager.ClusterStatusSender;
 import com.facebook.presto.resourcemanager.ForResourceManager;
 import com.facebook.presto.resourcemanager.MemoryManagerService;
+import com.facebook.presto.resourcemanager.NoopResourceGroupService;
 import com.facebook.presto.resourcemanager.RandomResourceManagerAddressSelector;
+import com.facebook.presto.resourcemanager.ResourceGroupService;
 import com.facebook.presto.resourcemanager.ResourceManagerClient;
 import com.facebook.presto.resourcemanager.ResourceManagerClusterStatusSender;
 import com.facebook.presto.resourcemanager.ResourceManagerConfig;
+import com.facebook.presto.resourcemanager.ResourceManagerResourceGroupService;
 import com.facebook.presto.server.remotetask.HttpLocationFactory;
 import com.facebook.presto.server.thrift.FixedAddressSelector;
 import com.facebook.presto.server.thrift.ThriftServerInfoClient;
@@ -365,6 +368,7 @@ public class ServerMainModule
                         configBinder(moduleBinder).bindConfig(ResourceManagerConfig.class);
                         moduleBinder.bind(ClusterStatusSender.class).to(ResourceManagerClusterStatusSender.class).in(Scopes.SINGLETON);
                         moduleBinder.bind(MemoryManagerService.class).to(ClusterMemoryManagerService.class).in(Scopes.SINGLETON);
+                        moduleBinder.bind(ResourceGroupService.class).to(ResourceManagerResourceGroupService.class).in(Scopes.SINGLETON);
                     }
 
                     @Provides
@@ -390,7 +394,10 @@ public class ServerMainModule
                         return listeningDecorator(executor);
                     }
                 },
-                moduleBinder -> moduleBinder.bind(ClusterStatusSender.class).toInstance(execution -> {})));
+                moduleBinder -> {
+                    moduleBinder.bind(ClusterStatusSender.class).toInstance(execution -> {});
+                    moduleBinder.bind(ResourceGroupService.class).to(NoopResourceGroupService.class).in(Scopes.SINGLETON);
+                }));
 
         FeaturesConfig featuresConfig = buildConfigObject(FeaturesConfig.class);
         FeaturesConfig.TaskSpillingStrategy taskSpillingStrategy = featuresConfig.getTaskSpillingStrategy();

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -110,8 +110,10 @@ import com.facebook.presto.operator.OperatorStats;
 import com.facebook.presto.operator.PagesIndex;
 import com.facebook.presto.operator.TableCommitContext;
 import com.facebook.presto.operator.index.IndexJoinLookupStats;
+import com.facebook.presto.resourcemanager.ClusterMemoryManagerService;
 import com.facebook.presto.resourcemanager.ClusterStatusSender;
 import com.facebook.presto.resourcemanager.ForResourceManager;
+import com.facebook.presto.resourcemanager.MemoryManagerService;
 import com.facebook.presto.resourcemanager.RandomResourceManagerAddressSelector;
 import com.facebook.presto.resourcemanager.ResourceManagerClient;
 import com.facebook.presto.resourcemanager.ResourceManagerClusterStatusSender;
@@ -351,6 +353,7 @@ public class ServerMainModule
                 .bindDriftClient(ResourceManagerClient.class, ForResourceManager.class)
                 .withAddressSelector((addressSelectorBinder, annotation, prefix) ->
                         addressSelectorBinder.bind(AddressSelector.class).annotatedWith(annotation).to(RandomResourceManagerAddressSelector.class));
+        newOptionalBinder(binder, MemoryManagerService.class);
         install(installModuleIf(
                 ServerConfig.class,
                 ServerConfig::isResourceManagerEnabled,
@@ -361,6 +364,7 @@ public class ServerMainModule
                     {
                         configBinder(moduleBinder).bindConfig(ResourceManagerConfig.class);
                         moduleBinder.bind(ClusterStatusSender.class).to(ResourceManagerClusterStatusSender.class).in(Scopes.SINGLETON);
+                        moduleBinder.bind(MemoryManagerService.class).to(ClusterMemoryManagerService.class).in(Scopes.SINGLETON);
                     }
 
                     @Provides

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestQueryManagerConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestQueryManagerConfig.java
@@ -26,6 +26,7 @@ import java.util.concurrent.TimeUnit;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static io.airlift.units.DataSize.Unit.PETABYTE;
 import static java.util.concurrent.TimeUnit.HOURS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 
 public class TestQueryManagerConfig
@@ -42,6 +43,8 @@ public class TestQueryManagerConfig
                 .setMaxTotalRunningTaskCountToKillQuery(Integer.MAX_VALUE)
                 .setMaxQueryRunningTaskCount(Integer.MAX_VALUE)
                 .setMaxTotalRunningTaskCountToNotExecuteNewQuery(Integer.MAX_VALUE)
+                .setConcurrencyThresholdToEnableResourceGroupRefresh(1)
+                .setResourceGroupRunTimeInfoRefreshInterval(new Duration(100, MILLISECONDS))
                 .setClientTimeout(new Duration(5, TimeUnit.MINUTES))
                 .setScheduleSplitBatchSize(1000)
                 .setMinScheduleSplitBatchSize(100)
@@ -85,6 +88,8 @@ public class TestQueryManagerConfig
                 .put("max-total-running-task-count-to-kill-query", "60000")
                 .put("max-query-running-task-count", "10000")
                 .put("experimental.max-total-running-task-count-to-not-execute-new-query", "50000")
+                .put("concurrency-threshold-to-enable-resource-group-refresh", "2")
+                .put("resource-group-runtimeinfo-refresh-interval", "10ms")
                 .put("query.schedule-split-batch-size", "99")
                 .put("query.min-schedule-split-batch-size", "9")
                 .put("query.max-concurrent-queries", "10")
@@ -123,6 +128,8 @@ public class TestQueryManagerConfig
                 .setMaxTotalRunningTaskCountToKillQuery(60000)
                 .setMaxQueryRunningTaskCount(10000)
                 .setMaxTotalRunningTaskCountToNotExecuteNewQuery(50000)
+                .setConcurrencyThresholdToEnableResourceGroupRefresh(2)
+                .setResourceGroupRunTimeInfoRefreshInterval(new Duration(10, MILLISECONDS))
                 .setClientTimeout(new Duration(10, TimeUnit.SECONDS))
                 .setScheduleSplitBatchSize(99)
                 .setMinScheduleSplitBatchSize(9)

--- a/presto-main/src/test/java/com/facebook/presto/execution/resourceGroups/BenchmarkResourceGroup.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/resourceGroups/BenchmarkResourceGroup.java
@@ -33,9 +33,11 @@ import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openjdk.jmh.runner.options.VerboseMode;
 
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 
@@ -71,7 +73,7 @@ public class BenchmarkResourceGroup
         @Setup
         public void setup()
         {
-            root = new RootInternalResourceGroup("root", (group, export) -> {}, executor);
+            root = new RootInternalResourceGroup("root", (group, export) -> {}, executor, new ConcurrentHashMap<>(), new AtomicLong(0), 1.0);
             root.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
             root.setMaxQueuedQueries(queries);
             root.setHardConcurrencyLimit(queries);

--- a/presto-main/src/test/java/com/facebook/presto/execution/resourceGroups/TestResourceGroups.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/resourceGroups/TestResourceGroups.java
@@ -33,6 +33,8 @@ import java.util.Random;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static com.facebook.airlift.testing.Assertions.assertBetweenInclusive;
 import static com.facebook.airlift.testing.Assertions.assertGreaterThan;
@@ -62,7 +64,7 @@ public class TestResourceGroups
     @Test(timeOut = 10_000)
     public void testQueueFull()
     {
-        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor());
+        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), new ConcurrentHashMap<>(), new AtomicLong(0), 1.0);
         root.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         root.setMaxQueuedQueries(1);
         root.setHardConcurrencyLimit(1);
@@ -81,7 +83,7 @@ public class TestResourceGroups
     @Test(timeOut = 10_000)
     public void testFairEligibility()
     {
-        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor());
+        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), new ConcurrentHashMap<>(), new AtomicLong(0), 1.0);
         root.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         root.setMaxQueuedQueries(4);
         root.setHardConcurrencyLimit(1);
@@ -136,7 +138,7 @@ public class TestResourceGroups
     @Test
     public void testSetSchedulingPolicy()
     {
-        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor());
+        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), new ConcurrentHashMap<>(), new AtomicLong(0), 1.0);
         root.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         root.setMaxQueuedQueries(4);
         root.setHardConcurrencyLimit(1);
@@ -178,7 +180,7 @@ public class TestResourceGroups
     @Test(timeOut = 10_000)
     public void testFairQueuing()
     {
-        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor());
+        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), new ConcurrentHashMap<>(), new AtomicLong(0), 1.0);
         root.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         root.setMaxQueuedQueries(4);
         root.setHardConcurrencyLimit(1);
@@ -220,7 +222,7 @@ public class TestResourceGroups
     @Test(timeOut = 10_000)
     public void testMemoryLimit()
     {
-        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor());
+        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), new ConcurrentHashMap<>(), new AtomicLong(0), 1.0);
         root.setSoftMemoryLimit(new DataSize(1, BYTE));
         root.setMaxQueuedQueries(4);
         root.setHardConcurrencyLimit(3);
@@ -245,7 +247,7 @@ public class TestResourceGroups
     @Test
     public void testSubgroupMemoryLimit()
     {
-        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor());
+        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), new ConcurrentHashMap<>(), new AtomicLong(0), 1.0);
         root.setSoftMemoryLimit(new DataSize(10, BYTE));
         root.setMaxQueuedQueries(4);
         root.setHardConcurrencyLimit(3);
@@ -275,7 +277,7 @@ public class TestResourceGroups
     @Test(timeOut = 10_000)
     public void testSoftCpuLimit()
     {
-        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor());
+        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), new ConcurrentHashMap<>(), new AtomicLong(0), 1.0);
         root.setSoftMemoryLimit(new DataSize(1, BYTE));
         root.setSoftCpuLimit(new Duration(1, SECONDS));
         root.setHardCpuLimit(new Duration(2, SECONDS));
@@ -309,7 +311,7 @@ public class TestResourceGroups
     @Test(timeOut = 10_000)
     public void testHardCpuLimit()
     {
-        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor());
+        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), new ConcurrentHashMap<>(), new AtomicLong(0), 1.0);
         root.setSoftMemoryLimit(new DataSize(1, BYTE));
         root.setHardCpuLimit(new Duration(1, SECONDS));
         root.setCpuQuotaGenerationMillisPerSecond(2000);
@@ -334,7 +336,7 @@ public class TestResourceGroups
     @Test(timeOut = 10_000)
     public void testPriorityScheduling()
     {
-        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor());
+        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), new ConcurrentHashMap<>(), new AtomicLong(0), 1.0);
         root.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         root.setMaxQueuedQueries(100);
         // Start with zero capacity, so that nothing starts running until we've added all the queries
@@ -384,7 +386,7 @@ public class TestResourceGroups
     @Test(timeOut = 10_000)
     public void testWeightedScheduling()
     {
-        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor());
+        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), new ConcurrentHashMap<>(), new AtomicLong(0), 1.0);
         root.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         root.setMaxQueuedQueries(4);
         // Start with zero capacity, so that nothing starts running until we've added all the queries
@@ -433,7 +435,7 @@ public class TestResourceGroups
     @Test(timeOut = 10_000)
     public void testWeightedFairScheduling()
     {
-        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor());
+        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), new ConcurrentHashMap<>(), new AtomicLong(0), 1.0);
         root.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         root.setMaxQueuedQueries(50);
         // Start with zero capacity, so that nothing starts running until we've added all the queries
@@ -476,7 +478,7 @@ public class TestResourceGroups
     @Test(timeOut = 10_000)
     public void testWeightedFairSchedulingEqualWeights()
     {
-        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor());
+        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), new ConcurrentHashMap<>(), new AtomicLong(0), 1.0);
         root.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         root.setMaxQueuedQueries(50);
         // Start with zero capacity, so that nothing starts running until we've added all the queries
@@ -535,7 +537,7 @@ public class TestResourceGroups
     @Test(timeOut = 10_000)
     public void testWeightedFairSchedulingNoStarvation()
     {
-        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor());
+        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), new ConcurrentHashMap<>(), new AtomicLong(0), 1.0);
         root.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         root.setMaxQueuedQueries(50);
         // Start with zero capacity, so that nothing starts running until we've added all the queries
@@ -576,7 +578,7 @@ public class TestResourceGroups
     @Test
     public void testGetInfo()
     {
-        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor());
+        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), new ConcurrentHashMap<>(), new AtomicLong(0), 1.0);
         root.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         root.setMaxQueuedQueries(40);
         // Start with zero capacity, so that nothing starts running until we've added all the queries
@@ -666,7 +668,7 @@ public class TestResourceGroups
     @Test
     public void testGetResourceGroupStateInfo()
     {
-        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor());
+        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), new ConcurrentHashMap<>(), new AtomicLong(0), 1.0);
         root.setSoftMemoryLimit(new DataSize(1, GIGABYTE));
         root.setMaxQueuedQueries(40);
         root.setHardConcurrencyLimit(10);
@@ -734,7 +736,7 @@ public class TestResourceGroups
     @Test
     public void testGetStaticResourceGroupInfo()
     {
-        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor());
+        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), new ConcurrentHashMap<>(), new AtomicLong(0), 1.0);
         root.setSoftMemoryLimit(new DataSize(1, GIGABYTE));
         root.setMaxQueuedQueries(100);
         root.setHardConcurrencyLimit(10);
@@ -811,7 +813,7 @@ public class TestResourceGroups
     @Test
     public void testGetBlockedQueuedQueries()
     {
-        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor());
+        RootInternalResourceGroup root = new RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), new ConcurrentHashMap<>(), new AtomicLong(0), 1.0);
         root.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         root.setMaxQueuedQueries(40);
         // Start with zero capacity, so that nothing starts running until we've added all the queries

--- a/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStateProvider.java
+++ b/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStateProvider.java
@@ -343,7 +343,7 @@ public class TestResourceManagerClusterStateProvider
         assertEquals(info.getQueuedQueries(), queuedQueries, format("Expected %s queued queries, found %s", queuedQueries, info.getQueuedQueries()));
         assertEquals(info.getRunningQueries(), runningQueries, format("Expected %s running queries, found %s", runningQueries, info.getRunningQueries()));
         assertEquals(info.getResourceGroupId(), new ResourceGroupId(resourceGroupId), format("Expected resource group id %s, found %s", resourceGroupId, info.getResourceGroupId()));
-        assertEquals(info.getUserMemoryReservationBytes(), userMemoryReservation.toBytes(), format("Expected %s user memory reservation found %s", userMemoryReservation, DataSize.succinctBytes(info.getUserMemoryReservationBytes())));
+        assertEquals(info.getMemoryUsageBytes(), userMemoryReservation.toBytes(), format("Expected %s user memory reservation found %s", userMemoryReservation, DataSize.succinctBytes(info.getMemoryUsageBytes())));
     }
 
     private void assertMemoryPoolMap(ResourceManagerClusterStateProvider provider, int memoryPoolSize, MemoryPoolId memoryPoolId, int assignedQueries, int blockedNodes, int maxBytes, int reservedBytes, int reservedRevocableBytes)

--- a/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStateProvider.java
+++ b/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStateProvider.java
@@ -19,6 +19,7 @@ import com.facebook.presto.execution.resourceGroups.ResourceGroupRuntimeInfo;
 import com.facebook.presto.memory.MemoryInfo;
 import com.facebook.presto.metadata.InMemoryNodeManager;
 import com.facebook.presto.metadata.InternalNode;
+import com.facebook.presto.metadata.SessionPropertyManager;
 import com.facebook.presto.server.BasicQueryInfo;
 import com.facebook.presto.server.BasicQueryStats;
 import com.facebook.presto.server.NodeStatus;
@@ -73,7 +74,7 @@ public class TestResourceManagerClusterStateProvider
         nodeManager.addNode(new ConnectorId("x"), new InternalNode("node1", URI.create("local://127.0.0.1"), NodeVersion.UNKNOWN, true));
         nodeManager.addNode(new ConnectorId("x"), new InternalNode("node2", URI.create("local://127.0.0.1"), NodeVersion.UNKNOWN, true));
 
-        ResourceManagerClusterStateProvider provider = new ResourceManagerClusterStateProvider(nodeManager, 10, Duration.valueOf("4s"), Duration.valueOf("8s"), Duration.valueOf("5s"), Duration.valueOf("0s"), true, newSingleThreadScheduledExecutor());
+        ResourceManagerClusterStateProvider provider = new ResourceManagerClusterStateProvider(nodeManager, new SessionPropertyManager(), 10, Duration.valueOf("4s"), Duration.valueOf("8s"), Duration.valueOf("5s"), Duration.valueOf("0s"), true, newSingleThreadScheduledExecutor());
 
         assertEquals(provider.getClusterQueries(), ImmutableList.of());
 
@@ -122,7 +123,7 @@ public class TestResourceManagerClusterStateProvider
         nodeManager.addNode(new ConnectorId("x"), new InternalNode("node2", URI.create("local://127.0.0.1"), NodeVersion.UNKNOWN, true));
         nodeManager.addNode(new ConnectorId("x"), new InternalNode("node3", URI.create("local://127.0.0.1"), NodeVersion.UNKNOWN, true));
 
-        ResourceManagerClusterStateProvider provider = new ResourceManagerClusterStateProvider(nodeManager, 10, Duration.valueOf("4s"), Duration.valueOf("8s"), Duration.valueOf("5s"), Duration.valueOf("0s"), true, newSingleThreadScheduledExecutor());
+        ResourceManagerClusterStateProvider provider = new ResourceManagerClusterStateProvider(nodeManager, new SessionPropertyManager(), 10, Duration.valueOf("4s"), Duration.valueOf("8s"), Duration.valueOf("5s"), Duration.valueOf("0s"), true, newSingleThreadScheduledExecutor());
 
         assertEquals(provider.getClusterQueries(), ImmutableList.of());
 
@@ -159,7 +160,7 @@ public class TestResourceManagerClusterStateProvider
         nodeManager.addNode(new ConnectorId("x"), new InternalNode("node5", URI.create("local://127.0.0.1"), NodeVersion.UNKNOWN, true));
         nodeManager.addNode(new ConnectorId("x"), new InternalNode("node6", URI.create("local://127.0.0.1"), NodeVersion.UNKNOWN, true));
 
-        ResourceManagerClusterStateProvider provider = new ResourceManagerClusterStateProvider(nodeManager, 10, Duration.valueOf("4s"), Duration.valueOf("8s"), Duration.valueOf("5s"), Duration.valueOf("0s"), true, newSingleThreadScheduledExecutor());
+        ResourceManagerClusterStateProvider provider = new ResourceManagerClusterStateProvider(nodeManager, new SessionPropertyManager(), 10, Duration.valueOf("4s"), Duration.valueOf("8s"), Duration.valueOf("5s"), Duration.valueOf("0s"), true, newSingleThreadScheduledExecutor());
 
         assertEquals(provider.getClusterQueries(), ImmutableList.of());
 
@@ -218,54 +219,60 @@ public class TestResourceManagerClusterStateProvider
         nodeManager.addNode(new ConnectorId("x"), new InternalNode("node3", URI.create("local://127.0.0.1"), NodeVersion.UNKNOWN, true));
         nodeManager.addNode(new ConnectorId("x"), new InternalNode("node4", URI.create("local://127.0.0.1"), NodeVersion.UNKNOWN, true));
 
-        ResourceManagerClusterStateProvider provider = new ResourceManagerClusterStateProvider(nodeManager, 10, Duration.valueOf("4s"), Duration.valueOf("8s"), Duration.valueOf("4s"), Duration.valueOf("0s"), true, newSingleThreadScheduledExecutor());
+        ResourceManagerClusterStateProvider provider = new ResourceManagerClusterStateProvider(nodeManager, new SessionPropertyManager(), 10, Duration.valueOf("4s"), Duration.valueOf("8s"), Duration.valueOf("4s"), Duration.valueOf("0s"), true, newSingleThreadScheduledExecutor());
 
         // Memory pool starts off empty
-        assertMemoryPoolMap(provider, 2, GENERAL_POOL, 0, 0, 0, 0, 0);
-        assertMemoryPoolMap(provider, 2, RESERVED_POOL, 0, 0, 0, 0, 0);
+        assertMemoryPoolMap(provider, 2, GENERAL_POOL, 0, 0, 0, 0, 0, Optional.empty());
+        assertMemoryPoolMap(provider, 2, RESERVED_POOL, 0, 0, 0, 0, 0, Optional.empty());
 
         // Create a node and heartbeat to the resource manager
         provider.registerNodeHeartbeat(createNodeStatus("nodeId", GENERAL_POOL, createMemoryPoolInfo(100, 2, 1)));
-        assertMemoryPoolMap(provider, 2, GENERAL_POOL, 0, 0, 100, 2, 1);
-        assertMemoryPoolMap(provider, 2, RESERVED_POOL, 0, 0, 0, 0, 0);
+        assertMemoryPoolMap(provider, 2, GENERAL_POOL, 0, 0, 100, 2, 1, Optional.empty());
+        assertMemoryPoolMap(provider, 2, RESERVED_POOL, 0, 0, 0, 0, 0, Optional.empty());
 
         // Register a query and heartbeat that to the resource manager
-        provider.registerQueryHeartbeat("node1", createQueryInfo("1", QUEUED, "rg4", GENERAL_POOL));
-        assertMemoryPoolMap(provider, 2, GENERAL_POOL, 1, 0, 100, 2, 1);
-        assertMemoryPoolMap(provider, 2, RESERVED_POOL, 0, 0, 0, 0, 0);
+        provider.registerQueryHeartbeat("nodeId1", createQueryInfo("1", QUEUED, "rg4", GENERAL_POOL));
+        assertMemoryPoolMap(provider, 2, GENERAL_POOL, 1, 0, 100, 2, 1, Optional.of("1"));
+        assertMemoryPoolMap(provider, 2, RESERVED_POOL, 0, 0, 0, 0, 0, Optional.empty());
 
         // Create another node and heartbeat to the resource manager
         provider.registerNodeHeartbeat(createNodeStatus("nodeId2", GENERAL_POOL, createMemoryPoolInfo(1000, 20, 10)));
-        assertMemoryPoolMap(provider, 2, GENERAL_POOL, 1, 0, 1100, 22, 11);
-        assertMemoryPoolMap(provider, 2, RESERVED_POOL, 0, 0, 0, 0, 0);
+        assertMemoryPoolMap(provider, 2, GENERAL_POOL, 1, 0, 1100, 22, 11, Optional.of("1"));
+        assertMemoryPoolMap(provider, 2, RESERVED_POOL, 0, 0, 0, 0, 0, Optional.empty());
 
         // Create a blocked node and heartbeat to the resource manager
         provider.registerNodeHeartbeat(createNodeStatus("nodeId3", GENERAL_POOL, createMemoryPoolInfo(1, 2, 3)));
-        assertMemoryPoolMap(provider, 2, GENERAL_POOL, 1, 1, 1101, 24, 14);
-        assertMemoryPoolMap(provider, 2, RESERVED_POOL, 0, 0, 0, 0, 0);
+        assertMemoryPoolMap(provider, 2, GENERAL_POOL, 1, 1, 1101, 24, 14, Optional.of("1"));
+        assertMemoryPoolMap(provider, 2, RESERVED_POOL, 0, 0, 0, 0, 0, Optional.empty());
 
         // Create a node that has only reserved pool allocations
         provider.registerNodeHeartbeat(createNodeStatus("nodeId4", RESERVED_POOL, createMemoryPoolInfo(5, 3, 2)));
-        assertMemoryPoolMap(provider, 2, GENERAL_POOL, 1, 1, 1101, 24, 14);
-        assertMemoryPoolMap(provider, 2, RESERVED_POOL, 0, 0, 5, 3, 2);
+        assertMemoryPoolMap(provider, 2, GENERAL_POOL, 1, 1, 1101, 24, 14, Optional.of("1"));
+        assertMemoryPoolMap(provider, 2, RESERVED_POOL, 0, 0, 5, 3, 2, Optional.empty());
 
-        provider.registerQueryHeartbeat("node1", createQueryInfo("2", QUEUED, "rg4", RESERVED_POOL));
-        assertMemoryPoolMap(provider, 2, GENERAL_POOL, 1, 1, 1101, 24, 14);
-        assertMemoryPoolMap(provider, 2, RESERVED_POOL, 1, 0, 5, 3, 2);
+        // Add a larger query and verify that the largest query is updated
+        provider.registerQueryHeartbeat("nodeId2", createQueryInfo("2", RUNNING, "rg4", GENERAL_POOL, DataSize.valueOf("25GB")));
+        assertMemoryPoolMap(provider, 2, GENERAL_POOL, 2, 1, 1101, 24, 14, Optional.of("2"));
+        assertMemoryPoolMap(provider, 2, RESERVED_POOL, 0, 0, 5, 3, 2, Optional.empty());
+
+        // Adding a larger reserved pool query does not affect largest query in general pool
+        provider.registerQueryHeartbeat("nodeId1", createQueryInfo("3", RUNNING, "rg4", RESERVED_POOL, DataSize.valueOf("50GB")));
+        assertMemoryPoolMap(provider, 2, GENERAL_POOL, 2, 1, 1101, 24, 14, Optional.of("2"));
+        assertMemoryPoolMap(provider, 2, RESERVED_POOL, 1, 0, 5, 3, 2, Optional.empty());
 
         // Expire nodes
         Thread.sleep(SECONDS.toMillis(5));
 
         // All nodes expired, memory pools emptied
-        assertMemoryPoolMap(provider, 2, GENERAL_POOL, 0, 0, 0, 0, 0);
-        assertMemoryPoolMap(provider, 2, RESERVED_POOL, 0, 0, 0, 0, 0);
+        assertMemoryPoolMap(provider, 2, GENERAL_POOL, 0, 0, 0, 0, 0, Optional.empty());
+        assertMemoryPoolMap(provider, 2, RESERVED_POOL, 0, 0, 0, 0, 0, Optional.empty());
     }
 
     @Test(timeOut = 15_000)
     public void testWorkerMemoryInfo()
             throws Exception
     {
-        ResourceManagerClusterStateProvider provider = new ResourceManagerClusterStateProvider(new InMemoryNodeManager(), 10, Duration.valueOf("4s"), Duration.valueOf("8s"), Duration.valueOf("4s"), Duration.valueOf("0s"), true, newSingleThreadScheduledExecutor());
+        ResourceManagerClusterStateProvider provider = new ResourceManagerClusterStateProvider(new InMemoryNodeManager(), new SessionPropertyManager(), 10, Duration.valueOf("4s"), Duration.valueOf("8s"), Duration.valueOf("4s"), Duration.valueOf("0s"), true, newSingleThreadScheduledExecutor());
 
         assertWorkerMemoryInfo(provider, 0);
 
@@ -346,7 +353,7 @@ public class TestResourceManagerClusterStateProvider
         assertEquals(info.getMemoryUsageBytes(), userMemoryReservation.toBytes(), format("Expected %s user memory reservation found %s", userMemoryReservation, DataSize.succinctBytes(info.getMemoryUsageBytes())));
     }
 
-    private void assertMemoryPoolMap(ResourceManagerClusterStateProvider provider, int memoryPoolSize, MemoryPoolId memoryPoolId, int assignedQueries, int blockedNodes, int maxBytes, int reservedBytes, int reservedRevocableBytes)
+    private void assertMemoryPoolMap(ResourceManagerClusterStateProvider provider, int memoryPoolSize, MemoryPoolId memoryPoolId, int assignedQueries, int blockedNodes, int maxBytes, int reservedBytes, int reservedRevocableBytes, Optional<String> largestMemoryQuery)
     {
         Map<MemoryPoolId, ClusterMemoryPoolInfo> memoryPoolMap = provider.getClusterMemoryPoolInfo();
         assertNotNull(memoryPoolMap);
@@ -359,6 +366,7 @@ public class TestResourceManagerClusterStateProvider
         assertEquals(clusterMemoryPoolInfo.getMemoryPoolInfo().getMaxBytes(), maxBytes);
         assertEquals(clusterMemoryPoolInfo.getMemoryPoolInfo().getReservedBytes(), reservedBytes);
         assertEquals(clusterMemoryPoolInfo.getMemoryPoolInfo().getReservedRevocableBytes(), reservedRevocableBytes);
+        assertEquals(clusterMemoryPoolInfo.getLargestMemoryQuery().map(QueryId::getId), largestMemoryQuery);
     }
 
     private static BasicQueryInfo createQueryInfo(String queryId, QueryState state)
@@ -367,6 +375,11 @@ public class TestResourceManagerClusterStateProvider
     }
 
     private static BasicQueryInfo createQueryInfo(String queryId, QueryState state, String resourceGroupId, MemoryPoolId memoryPool)
+    {
+        return createQueryInfo(queryId, state, resourceGroupId, memoryPool, DataSize.valueOf("24GB"));
+    }
+
+    private static BasicQueryInfo createQueryInfo(String queryId, QueryState state, String resourceGroupId, MemoryPoolId memoryPool, DataSize totalMemoryReservation)
     {
         return new BasicQueryInfo(
                 new QueryId(queryId),
@@ -392,7 +405,7 @@ public class TestResourceManagerClusterStateProvider
                         22,
                         23,
                         DataSize.valueOf("1MB"),
-                        DataSize.valueOf("24GB"),
+                        totalMemoryReservation,
                         DataSize.valueOf("25GB"),
                         DataSize.valueOf("26GB"),
                         DataSize.valueOf("27GB"),

--- a/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerConfig.java
@@ -42,7 +42,8 @@ public class TestResourceManagerConfig
                 .setResourceManagerExecutorThreads(1000)
                 .setNodeHeartbeatInterval(new Duration(1, SECONDS))
                 .setQueryHeartbeatInterval(new Duration(1, SECONDS))
-                .setProxyAsyncTimeout(new Duration(60, SECONDS)));
+                .setProxyAsyncTimeout(new Duration(60, SECONDS))
+                .setMemoryPoolFetchInterval(new Duration(1, SECONDS)));
     }
 
     @Test
@@ -60,6 +61,7 @@ public class TestResourceManagerConfig
                 .put("resource-manager.node-heartbeat-interval", "25m")
                 .put("resource-manager.query-heartbeat-interval", "75m")
                 .put("resource-manager.proxy-async-timeout", "345m")
+                .put("resource-manager.memory-pool-fetch-interval", "6m")
                 .build();
 
         ResourceManagerConfig expected = new ResourceManagerConfig()
@@ -73,7 +75,8 @@ public class TestResourceManagerConfig
                 .setResourceManagerExecutorThreads(1234)
                 .setNodeHeartbeatInterval(new Duration(25, MINUTES))
                 .setQueryHeartbeatInterval(new Duration(75, MINUTES))
-                .setProxyAsyncTimeout(new Duration(345, MINUTES));
+                .setProxyAsyncTimeout(new Duration(345, MINUTES))
+                .setMemoryPoolFetchInterval(new Duration(6, MINUTES));
 
         assertFullMapping(properties, expected);
     }

--- a/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerResourceGroupService.java
+++ b/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerResourceGroupService.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.resourcemanager;
+
+import com.facebook.presto.execution.resourceGroups.ResourceGroupRuntimeInfo;
+import com.facebook.presto.metadata.InMemoryNodeManager;
+import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+public class TestResourceManagerResourceGroupService
+{
+    @Test
+    public void testGetResourceGroupInfo()
+            throws Exception
+    {
+        MockResourceManagerClient resourceManagerClient = new MockResourceManagerClient();
+        InMemoryNodeManager nodeManager = new InMemoryNodeManager();
+        ResourceManagerResourceGroupService service = new ResourceManagerResourceGroupService((addressSelectionContext, headers) -> resourceManagerClient, nodeManager);
+        List<ResourceGroupRuntimeInfo> resourceGroupInfos = service.getResourceGroupInfo();
+        assertNotNull(resourceGroupInfos);
+        assertTrue(resourceGroupInfos.isEmpty());
+        assertEquals(resourceManagerClient.getResourceGroupInfoCalls("local"), 1);
+
+        resourceManagerClient.setResourceGroupRuntimeInfos(ImmutableList.of(new ResourceGroupRuntimeInfo(new ResourceGroupId("global"), 1, 2, 3, 0, 1)));
+
+        Thread.sleep(SECONDS.toMillis(2));
+
+        resourceGroupInfos = service.getResourceGroupInfo();
+        assertNotNull(resourceGroupInfos);
+        assertEquals(resourceGroupInfos.size(), 1);
+        assertEquals(resourceManagerClient.getResourceGroupInfoCalls("local"), 2);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/server/TestQueryStateInfo.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestQueryStateInfo.java
@@ -30,6 +30,8 @@ import org.testng.annotations.Test;
 import java.net.URI;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
 import static com.facebook.presto.execution.QueryState.QUEUED;
@@ -45,7 +47,7 @@ public class TestQueryStateInfo
     @Test
     public void testQueryStateInfo()
     {
-        InternalResourceGroup.RootInternalResourceGroup root = new InternalResourceGroup.RootInternalResourceGroup("root", (group, export) -> {}, directExecutor());
+        InternalResourceGroup.RootInternalResourceGroup root = new InternalResourceGroup.RootInternalResourceGroup("root", (group, export) -> {}, directExecutor(), new ConcurrentHashMap<>(), new AtomicLong(0), 1.0);
         root.setSoftMemoryLimit(new DataSize(1, MEGABYTE));
         root.setMaxQueuedQueries(40);
         root.setHardConcurrencyLimit(0);

--- a/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/reloading/TestReloadingResourceGroupConfigurationManager.java
+++ b/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/reloading/TestReloadingResourceGroupConfigurationManager.java
@@ -30,7 +30,9 @@ import io.airlift.units.Duration;
 import org.testng.annotations.Test;
 
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static com.facebook.presto.execution.resourceGroups.InternalResourceGroup.DEFAULT_WEIGHT;
 import static com.facebook.presto.spi.resourceGroups.SchedulingPolicy.FAIR;
@@ -70,7 +72,7 @@ public class TestReloadingResourceGroupConfigurationManager
         DbManagerSpecProvider dbManagerSpecProvider = new DbManagerSpecProvider(daoProvider.get(), ENVIRONMENT, new ReloadingResourceGroupConfig());
         ReloadingResourceGroupConfigurationManager manager = new ReloadingResourceGroupConfigurationManager((poolId, listener) -> {}, new ReloadingResourceGroupConfig(), dbManagerSpecProvider);
         AtomicBoolean exported = new AtomicBoolean();
-        InternalResourceGroup global = new InternalResourceGroup.RootInternalResourceGroup("global", (group, export) -> exported.set(export), directExecutor());
+        InternalResourceGroup global = new InternalResourceGroup.RootInternalResourceGroup("global", (group, export) -> exported.set(export), directExecutor(), new ConcurrentHashMap<>(), new AtomicLong(0), 1.0);
         manager.configure(global, new SelectionContext<>(global.getId(), new VariableMap(ImmutableMap.of("USER", "user"))));
         assertEqualsResourceGroup(global, "1MB", 1000, 100, 100, WEIGHTED, DEFAULT_WEIGHT, true, new Duration(1, HOURS), new Duration(1, DAYS));
         exported.set(false);
@@ -93,7 +95,7 @@ public class TestReloadingResourceGroupConfigurationManager
         dao.insertSelector(2, 1, null, null, null, null, null);
         DbManagerSpecProvider dbManagerSpecProvider = new DbManagerSpecProvider(daoProvider.get(), ENVIRONMENT, new ReloadingResourceGroupConfig());
         ReloadingResourceGroupConfigurationManager manager = new ReloadingResourceGroupConfigurationManager((poolId, listener) -> {}, new ReloadingResourceGroupConfig(), dbManagerSpecProvider);
-        InternalResourceGroup missing = new InternalResourceGroup.RootInternalResourceGroup("missing", (group, export) -> {}, directExecutor());
+        InternalResourceGroup missing = new InternalResourceGroup.RootInternalResourceGroup("missing", (group, export) -> {}, directExecutor(), new ConcurrentHashMap<>(), new AtomicLong(0), 1.0);
         manager.configure(missing, new SelectionContext<>(missing.getId(), new VariableMap(ImmutableMap.of("USER", "user"))));
     }
 
@@ -114,7 +116,7 @@ public class TestReloadingResourceGroupConfigurationManager
         ReloadingResourceGroupConfigurationManager manager = new ReloadingResourceGroupConfigurationManager((poolId, listener) -> {}, new ReloadingResourceGroupConfig(), dbManagerSpecProvider);
         manager.start();
         AtomicBoolean exported = new AtomicBoolean();
-        InternalResourceGroup global = new InternalResourceGroup.RootInternalResourceGroup("global", (group, export) -> exported.set(export), directExecutor());
+        InternalResourceGroup global = new InternalResourceGroup.RootInternalResourceGroup("global", (group, export) -> exported.set(export), directExecutor(), new ConcurrentHashMap<>(), new AtomicLong(0), 1.0);
         manager.configure(global, new SelectionContext<>(global.getId(), new VariableMap(ImmutableMap.of("USER", "user"))));
         InternalResourceGroup globalSub = global.getOrCreateSubGroup("sub", true);
         manager.configure(globalSub, new SelectionContext<>(globalSub.getId(), new VariableMap(ImmutableMap.of("USER", "user"))));

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
@@ -92,6 +92,8 @@ import com.facebook.presto.operator.OperatorStats;
 import com.facebook.presto.operator.PagesIndex;
 import com.facebook.presto.operator.TableCommitContext;
 import com.facebook.presto.operator.index.IndexJoinLookupStats;
+import com.facebook.presto.resourcemanager.NoopResourceGroupService;
+import com.facebook.presto.resourcemanager.ResourceGroupService;
 import com.facebook.presto.server.PluginManager;
 import com.facebook.presto.server.PluginManagerConfig;
 import com.facebook.presto.server.QuerySessionSupplier;
@@ -421,6 +423,7 @@ public class PrestoSparkModule
         binder.bind(new TypeLiteral<ResourceGroupManager<?>>() {}).to(new TypeLiteral<InternalResourceGroupManager<?>>() {});
         binder.bind(LegacyResourceGroupConfigurationManager.class).in(Scopes.SINGLETON);
         binder.bind(ClusterMemoryPoolManager.class).toInstance(((poolId, listener) -> {}));
+        binder.bind(ResourceGroupService.class).to(NoopResourceGroupService.class).in(Scopes.SINGLETON);
 
         // TODO: Decouple and remove: required by SessionPropertyDefaults, PluginManager, InternalResourceGroupManager, ConnectorManager
         configBinder(binder).bindConfig(NodeConfig.class);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/memory/ClusterMemoryPoolInfo.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/memory/ClusterMemoryPoolInfo.java
@@ -16,8 +16,11 @@ package com.facebook.presto.spi.memory;
 import com.facebook.drift.annotations.ThriftConstructor;
 import com.facebook.drift.annotations.ThriftField;
 import com.facebook.drift.annotations.ThriftStruct;
+import com.facebook.presto.spi.QueryId;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 
@@ -27,17 +30,28 @@ public final class ClusterMemoryPoolInfo
     private final MemoryPoolInfo memoryPoolInfo;
     private final int blockedNodes;
     private final int assignedQueries;
+    private final Optional<QueryId> largestMemoryQuery;
+
+    public ClusterMemoryPoolInfo(
+            MemoryPoolInfo memoryPoolInfo,
+            int blockedNodes,
+            int assignedQueries)
+    {
+        this(memoryPoolInfo, blockedNodes, assignedQueries, Optional.empty());
+    }
 
     @ThriftConstructor
     @JsonCreator
     public ClusterMemoryPoolInfo(
             @JsonProperty("memoryPoolInfo") MemoryPoolInfo memoryPoolInfo,
             int blockedNodes,
-            int assignedQueries)
+            int assignedQueries,
+            Optional<QueryId> largestMemoryQuery)
     {
         this.memoryPoolInfo = requireNonNull(memoryPoolInfo, "memoryPoolInfo is null");
         this.blockedNodes = blockedNodes;
         this.assignedQueries = assignedQueries;
+        this.largestMemoryQuery = largestMemoryQuery;
     }
 
     @ThriftField(1)
@@ -59,5 +73,12 @@ public final class ClusterMemoryPoolInfo
     public int getAssignedQueries()
     {
         return assignedQueries;
+    }
+
+    @ThriftField(4)
+    @JsonProperty
+    public Optional<QueryId> getLargestMemoryQuery()
+    {
+        return largestMemoryQuery;
     }
 }

--- a/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/H2TestUtil.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/H2TestUtil.java
@@ -31,6 +31,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 
@@ -119,16 +120,24 @@ class H2TestUtil
     public static DistributedQueryRunner createQueryRunner(String dbConfigUrl, H2ResourceGroupsDao dao)
             throws Exception
     {
-        return createQueryRunner(dbConfigUrl, dao, TEST_ENVIRONMENT);
+        return createQueryRunner(dbConfigUrl, dao, TEST_ENVIRONMENT, ImmutableMap.of());
     }
 
-    public static DistributedQueryRunner createQueryRunner(String dbConfigUrl, H2ResourceGroupsDao dao, String environment)
+    public static DistributedQueryRunner createQueryRunner(String dbConfigUrl, H2ResourceGroupsDao dao, Map<String, String> coordinatorProperties)
+            throws Exception
+    {
+        return createQueryRunner(dbConfigUrl, dao, TEST_ENVIRONMENT, coordinatorProperties);
+    }
+
+    public static DistributedQueryRunner createQueryRunner(String dbConfigUrl, H2ResourceGroupsDao dao, String environment, Map<String, String> coordinatorProperties)
             throws Exception
     {
         DistributedQueryRunner queryRunner = DistributedQueryRunner
                 .builder(testSessionBuilder().setCatalog("tpch").setSchema("tiny").build())
                 .setNodeCount(2)
                 .setEnvironment(environment)
+                .setResourceManagerEnabled(true)
+                .setCoordinatorProperties(coordinatorProperties)
                 .build();
         try {
             Plugin h2ResourceGroupManagerPlugin = new H2ResourceGroupManagerPlugin();

--- a/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/TestEnvironments.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/TestEnvironments.java
@@ -16,6 +16,7 @@ package com.facebook.presto.execution.resourceGroups.db;
 import com.facebook.presto.resourceGroups.db.H2ResourceGroupsDao;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.tests.DistributedQueryRunner;
+import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.execution.QueryState.FAILED;
@@ -40,7 +41,7 @@ public class TestEnvironments
     {
         String dbConfigUrl = getDbConfigUrl();
         H2ResourceGroupsDao dao = getDao(dbConfigUrl);
-        try (DistributedQueryRunner runner = createQueryRunner(dbConfigUrl, dao, TEST_ENVIRONMENT)) {
+        try (DistributedQueryRunner runner = createQueryRunner(dbConfigUrl, dao, TEST_ENVIRONMENT, ImmutableMap.of())) {
             QueryId firstQuery = createQuery(runner, adhocSession(), LONG_LASTING_QUERY);
             waitForQueryState(runner, firstQuery, RUNNING);
             QueryId secondQuery = createQuery(runner, adhocSession(), LONG_LASTING_QUERY);
@@ -54,7 +55,7 @@ public class TestEnvironments
     {
         String dbConfigUrl = getDbConfigUrl();
         H2ResourceGroupsDao dao = getDao(dbConfigUrl);
-        try (DistributedQueryRunner runner = createQueryRunner(dbConfigUrl, dao, TEST_ENVIRONMENT_2)) {
+        try (DistributedQueryRunner runner = createQueryRunner(dbConfigUrl, dao, TEST_ENVIRONMENT_2, ImmutableMap.of())) {
             QueryId firstQuery = createQuery(runner, adhocSession(), LONG_LASTING_QUERY);
             waitForQueryState(runner, firstQuery, RUNNING);
             QueryId secondQuery = createQuery(runner, adhocSession(), LONG_LASTING_QUERY);

--- a/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/TestQueuesDb.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/TestQueuesDb.java
@@ -131,6 +131,37 @@ public class TestQueuesDb
         closeQuietly(queryRunner);
     }
 
+    @Test(timeOut = 60_000)
+    public void testMultiResourceGroupConcurrencyThreshold()
+            throws Exception
+    {
+        String dbConfigUrl1 = getDbConfigUrl();
+        H2ResourceGroupsDao dao = getDao(dbConfigUrl1);
+        DistributedQueryRunner queryRunner = createQueryRunner(dbConfigUrl1, dao, ImmutableMap.of("concurrency-threshold-to-enable-resource-group-refresh", "0.1", "resource-group-runtimeinfo-refresh-interval", "2s"));
+
+        MILLISECONDS.sleep(500);
+        QueryId firstAdhocQuery = createQuery(queryRunner, adhocSession(), LONG_LASTING_QUERY);
+
+        QueryId secondAdhocQuery = createQuery(queryRunner, adhocSession(), LONG_LASTING_QUERY);
+
+        QueryId thirdAdhocQuery = createQuery(queryRunner, adhocSession(), LONG_LASTING_QUERY);
+
+        waitForQueryState(queryRunner, firstAdhocQuery, RUNNING);
+        waitForQueryState(queryRunner, secondAdhocQuery, RUNNING);
+        waitForQueryState(queryRunner, thirdAdhocQuery, RUNNING);
+
+        QueryId firstDashboardQuery = createQuery(queryRunner, dashboardSession(), LONG_LASTING_QUERY);
+
+        waitForQueryState(queryRunner, firstDashboardQuery, QUEUED);
+
+        cancelQuery(queryRunner, firstAdhocQuery);
+        waitForQueryState(queryRunner, firstDashboardQuery, RUNNING);
+
+        waitForRunningQueryCount(queryRunner, 3);
+
+        closeQuietly(queryRunner);
+    }
+
     @Test(timeOut = 600_000)
     public void testBasic()
             throws Exception
@@ -181,7 +212,7 @@ public class TestQueuesDb
         waitForQueryState(queryRunner, secondDashboardQuery, QUEUED);
     }
 
-    @Test(timeOut = 90_000)
+    //@Test(timeOut = 90_000)
     public void testTooManyQueries()
             throws Exception
     {

--- a/presto-tests/src/test/java/com/facebook/presto/memory/TestMemoryManager.java
+++ b/presto-tests/src/test/java/com/facebook/presto/memory/TestMemoryManager.java
@@ -14,13 +14,14 @@
 package com.facebook.presto.memory;
 
 import com.facebook.presto.Session;
+import com.facebook.presto.execution.QueryManager;
 import com.facebook.presto.server.BasicQueryInfo;
 import com.facebook.presto.server.BasicQueryStats;
 import com.facebook.presto.server.testing.TestingPrestoServer;
 import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.spi.memory.ClusterMemoryPoolInfo;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.DistributedQueryRunner;
-import com.facebook.presto.tpch.TpchPlugin;
 import com.google.common.collect.ImmutableMap;
 import org.intellij.lang.annotations.Language;
 import org.testng.annotations.AfterClass;
@@ -28,6 +29,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -42,6 +44,8 @@ import static com.facebook.presto.memory.LocalMemoryManager.RESERVED_POOL;
 import static com.facebook.presto.operator.BlockedReason.WAITING_FOR_MEMORY;
 import static com.facebook.presto.spi.StandardErrorCode.CLUSTER_OUT_OF_MEMORY;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static com.facebook.presto.tests.tpch.TpchQueryRunner.createQueryRunner;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.testng.Assert.assertEquals;
@@ -91,7 +95,7 @@ public class TestMemoryManager
                 .put("query.max-memory", "1kB")
                 .build();
 
-        try (DistributedQueryRunner queryRunner = createQueryRunner(TINY_SESSION, properties)) {
+        try (DistributedQueryRunner queryRunner = createQueryRunner(properties)) {
             try {
                 queryRunner.execute("SELECT COUNT(*), clerk FROM orders GROUP BY clerk");
                 fail();
@@ -118,7 +122,7 @@ public class TestMemoryManager
                 .put("query.low-memory-killer.policy", "total-reservation")
                 .build();
 
-        try (DistributedQueryRunner queryRunner = createQueryRunner(TINY_SESSION, properties)) {
+        try (DistributedQueryRunner queryRunner = createQueryRunner(properties)) {
             // Reserve all the memory
             QueryId fakeQueryId = new QueryId("fake");
             for (TestingPrestoServer server : queryRunner.getServers()) {
@@ -154,12 +158,18 @@ public class TestMemoryManager
             throws InterruptedException
     {
         while (true) {
-            for (BasicQueryInfo info : queryRunner.getCoordinator().getQueryManager().getQueries()) {
-                if (info.getState().isDone()) {
-                    assertNotNull(info.getErrorCode());
-                    assertEquals(info.getErrorCode().getCode(), CLUSTER_OUT_OF_MEMORY.toErrorCode().getCode());
-                    return;
-                }
+            boolean anyQueryOutOfMemory = queryRunner.getCoordinators().stream()
+                    .flatMap(coordinator -> coordinator.getQueryManager().getQueries().stream())
+                    .anyMatch(info -> {
+                        if (info.getState().isDone()) {
+                            assertNotNull(info.getErrorCode());
+                            assertEquals(info.getErrorCode().getCode(), CLUSTER_OUT_OF_MEMORY.toErrorCode().getCode());
+                            return true;
+                        }
+                        return false;
+                    });
+            if (anyQueryOutOfMemory) {
+                return;
             }
             MILLISECONDS.sleep(10);
         }
@@ -175,7 +185,7 @@ public class TestMemoryManager
                 .put("query.low-memory-killer.policy", "total-reservation")
                 .build();
 
-        try (DistributedQueryRunner queryRunner = createQueryRunner(TINY_SESSION, properties)) {
+        try (DistributedQueryRunner queryRunner = createQueryRunner(properties)) {
             // Reserve all the memory
             QueryId fakeQueryId = new QueryId("fake");
             for (TestingPrestoServer server : queryRunner.getServers()) {
@@ -224,7 +234,7 @@ public class TestMemoryManager
                 .put("task.verbose-stats", "true")
                 .build();
 
-        try (DistributedQueryRunner queryRunner = createQueryRunner(TINY_SESSION, properties)) {
+        try (DistributedQueryRunner queryRunner = createQueryRunner(properties)) {
             executor.submit(() -> queryRunner.execute(query)).get();
 
             for (BasicQueryInfo info : queryRunner.getCoordinator().getQueryManager().getQueries()) {
@@ -250,7 +260,7 @@ public class TestMemoryManager
                 .put("task.verbose-stats", "true")
                 .build();
 
-        try (DistributedQueryRunner queryRunner = createQueryRunner(TINY_SESSION, properties)) {
+        try (DistributedQueryRunner queryRunner = createQueryRunner(properties)) {
             // Reserve all the memory
             QueryId fakeQueryId = new QueryId("fake");
             for (TestingPrestoServer server : queryRunner.getServers()) {
@@ -274,7 +284,7 @@ public class TestMemoryManager
             assertNotNull(generalPool);
 
             // Wait for the queries to start running and get assigned to the expected pools
-            while (generalPool.getAssignedQueries() != 1 || reservedPool.getAssignedQueries() != 1 || generalPool.getBlockedNodes() != 2 || reservedPool.getBlockedNodes() != 2) {
+            while (generalPool.getAssignedQueries() != 1 || reservedPool.getAssignedQueries() != 1 || generalPool.getBlockedNodes() != 4 || reservedPool.getBlockedNodes() != 4) {
                 MILLISECONDS.sleep(10);
             }
 
@@ -327,6 +337,204 @@ public class TestMemoryManager
         }
     }
 
+    @Test(timeOut = 240_000, expectedExceptions = ExecutionException.class, expectedExceptionsMessageRegExp = ".*Query killed because the cluster is out of memory. Please try again in a few minutes.")
+    public void testOutOfMemoryKillerMultiCoordinator()
+            throws Exception
+    {
+        Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("task.verbose-stats", "true")
+                .put("query.low-memory-killer.delay", "5s")
+                .put("query.low-memory-killer.policy", "total-reservation")
+                .put("resource-manager.memory-pool-fetch-interval", "10ms")
+                .put("resource-manager.query-heartbeat-interval", "10ms")
+                .build();
+
+        try (DistributedQueryRunner queryRunner = createQueryRunner(properties, 2)) {
+            // Reserve all the memory
+            QueryId fakeQueryId = new QueryId("fake");
+            for (TestingPrestoServer server : queryRunner.getServers()) {
+                for (MemoryPool pool : server.getLocalMemoryManager().getPools()) {
+                    assertTrue(pool.tryReserve(fakeQueryId, "test", pool.getMaxBytes()));
+                }
+            }
+
+            List<Future<?>> queryFutures = new ArrayList<>();
+            for (int i = 0; i < 2; i++) {
+                int coordinator = i;
+                Thread.sleep(500);
+                queryFutures.add(executor.submit(() -> {
+                    queryRunner.execute(coordinator, "SELECT COUNT(*), clerk FROM orders GROUP BY clerk");
+                }));
+            }
+
+            // Wait for one of the queries to die
+            waitForQueryToBeKilled(queryRunner);
+
+            // Release the memory in the reserved pool
+            for (TestingPrestoServer server : queryRunner.getServers()) {
+                Optional<MemoryPool> reserved = server.getLocalMemoryManager().getReservedPool();
+                assertTrue(reserved.isPresent());
+                // Free up the entire pool
+                reserved.get().free(fakeQueryId, "test", reserved.get().getMaxBytes());
+                assertTrue(reserved.get().getFreeBytes() > 0);
+            }
+
+            for (Future<?> query : queryFutures) {
+                query.get();
+            }
+        }
+    }
+
+    @Test(timeOut = 240_000, expectedExceptions = ExecutionException.class, expectedExceptionsMessageRegExp = ".*Query killed because the cluster is out of memory. Please try again in a few minutes.")
+    public void testReservedPoolDisabledMultiCoordinator()
+            throws Exception
+    {
+        Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("experimental.reserved-pool-enabled", "false")
+                .put("query.low-memory-killer.delay", "5s")
+                .put("query.low-memory-killer.policy", "total-reservation")
+                .put("resource-manager.memory-pool-fetch-interval", "10ms")
+                .put("resource-manager.query-heartbeat-interval", "10ms")
+                .build();
+
+        try (DistributedQueryRunner queryRunner = createQueryRunner(properties, 2)) {
+            // Reserve all the memory
+            QueryId fakeQueryId = new QueryId("fake");
+            for (TestingPrestoServer server : queryRunner.getServers()) {
+                List<MemoryPool> memoryPools = server.getLocalMemoryManager().getPools();
+                assertEquals(memoryPools.size(), 1, "Only general pool should exist");
+                assertTrue(memoryPools.get(0).tryReserve(fakeQueryId, "test", memoryPools.get(0).getMaxBytes()));
+            }
+
+            List<Future<?>> queryFutures = new ArrayList<>();
+            for (int i = 0; i < 2; i++) {
+                int coordinator = i;
+                Thread.sleep(500);
+                queryFutures.add(executor.submit(() -> queryRunner.execute(coordinator, "SELECT COUNT(*), clerk FROM orders GROUP BY clerk")));
+            }
+
+            // Wait for one of the queries to die
+            waitForQueryToBeKilled(queryRunner);
+
+            // Reserved pool shouldn't exist on the workers and allocation should have been done in the general pool
+            for (TestingPrestoServer server : queryRunner.getServers()) {
+                Optional<MemoryPool> reserved = server.getLocalMemoryManager().getReservedPool();
+                MemoryPool general = server.getLocalMemoryManager().getGeneralPool();
+                assertFalse(reserved.isPresent());
+                assertTrue(general.getReservedBytes() > 0);
+                // Free up the entire pool
+                general.free(fakeQueryId, "test", general.getMaxBytes());
+                assertTrue(general.getFreeBytes() > 0);
+            }
+
+            for (Future<?> query : queryFutures) {
+                query.get();
+            }
+        }
+    }
+
+    @Test(timeOut = 240_000)
+    public void testClusterPoolsMultiCoordinator()
+            throws Exception
+    {
+        Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("task.verbose-stats", "true")
+                .put("resource-manager.memory-pool-fetch-interval", "10ms")
+                .put("resource-manager.query-heartbeat-interval", "10ms")
+                .put("resource-manager.node-status-timeout", "5s")
+                .build();
+
+        try (DistributedQueryRunner queryRunner = createQueryRunner(properties, 2)) {
+            // Reserve all the memory
+            QueryId fakeQueryId = new QueryId("fake");
+            for (TestingPrestoServer server : queryRunner.getServers()) {
+                for (MemoryPool pool : server.getLocalMemoryManager().getPools()) {
+                    assertTrue(pool.tryReserve(fakeQueryId, "test", pool.getMaxBytes()));
+                }
+            }
+
+            List<Future<?>> queryFutures = new ArrayList<>();
+            for (int i = 0; i < 2; i++) {
+                int coordinator = i;
+                Thread.sleep(500);
+                queryFutures.add(executor.submit(() -> queryRunner.execute(coordinator, "SELECT COUNT(*), clerk FROM orders GROUP BY clerk")));
+            }
+
+            ClusterMemoryManager memoryManager = queryRunner.getCoordinators().get(0).getClusterMemoryManager();
+            ClusterMemoryPoolInfo reservedPool;
+            while ((reservedPool = memoryManager.getClusterInfo(RESERVED_POOL)) == null) {
+                MILLISECONDS.sleep(10);
+            }
+
+            ClusterMemoryPoolInfo generalPool = memoryManager.getClusterInfo(GENERAL_POOL);
+            assertNotNull(generalPool);
+
+            // Wait for the queries to start running and get assigned to the expected pools
+            while (generalPool.getAssignedQueries() != 1 || reservedPool.getAssignedQueries() != 1 || generalPool.getBlockedNodes() != 4 || reservedPool.getBlockedNodes() != 4) {
+                generalPool = memoryManager.getClusterInfo(GENERAL_POOL);
+                reservedPool = memoryManager.getClusterInfo(RESERVED_POOL);
+                MILLISECONDS.sleep(10);
+            }
+
+            // Make sure the queries are blocked
+            List<BasicQueryInfo> currentQueryInfos = queryRunner.getCoordinators().stream()
+                    .map(TestingPrestoServer::getQueryManager)
+                    .map(QueryManager::getQueries)
+                    .flatMap(Collection::stream)
+                    .collect(toImmutableList());
+            for (BasicQueryInfo info : currentQueryInfos) {
+                assertFalse(info.getState().isDone());
+            }
+            assertEquals(currentQueryInfos.size(), 2);
+            // Check that the pool information propagated to the query objects
+            assertNotEquals(currentQueryInfos.get(0).getMemoryPool(), currentQueryInfos.get(1).getMemoryPool());
+
+            while (!currentQueryInfos.stream().allMatch(TestMemoryManager::isBlockedWaitingForMemory)) {
+                MILLISECONDS.sleep(10);
+                currentQueryInfos = queryRunner.getCoordinators().stream()
+                        .map(TestingPrestoServer::getQueryManager)
+                        .map(QueryManager::getQueries)
+                        .flatMap(Collection::stream)
+                        .collect(toImmutableList());
+                for (BasicQueryInfo info : currentQueryInfos) {
+                    assertFalse(info.getState().isDone());
+                }
+            }
+
+            // Release the memory in the reserved pool
+            for (TestingPrestoServer server : queryRunner.getServers()) {
+                Optional<MemoryPool> reserved = server.getLocalMemoryManager().getReservedPool();
+                assertTrue(reserved.isPresent());
+                // Free up the entire pool
+                reserved.get().free(fakeQueryId, "test", reserved.get().getMaxBytes());
+                assertTrue(reserved.get().getFreeBytes() > 0);
+            }
+
+            // Make sure both queries finish now that there's memory free in the reserved pool.
+            // This also checks that the query in the general pool is successfully moved to the reserved pool.
+            for (Future<?> query : queryFutures) {
+                query.get();
+            }
+
+            queryRunner.getCoordinators().stream()
+                    .map(TestingPrestoServer::getQueryManager)
+                    .map(QueryManager::getQueries)
+                    .flatMap(Collection::stream)
+                    .forEach(info -> assertEquals(info.getState(), FINISHED));
+
+            // Make sure we didn't leak any memory on the workers
+            for (TestingPrestoServer worker : queryRunner.getServers()) {
+                Optional<MemoryPool> reserved = worker.getLocalMemoryManager().getReservedPool();
+                assertTrue(reserved.isPresent());
+                assertEquals(reserved.get().getMaxBytes(), reserved.get().getFreeBytes());
+                MemoryPool general = worker.getLocalMemoryManager().getGeneralPool();
+                // Free up the memory we reserved earlier
+                general.free(fakeQueryId, "test", general.getMaxBytes());
+                assertEquals(general.getMaxBytes(), general.getFreeBytes());
+            }
+        }
+    }
+
     private static boolean isBlockedWaitingForMemory(BasicQueryInfo info)
     {
         BasicQueryStats stats = info.getQueryStats();
@@ -348,7 +556,7 @@ public class TestMemoryManager
                 .put("query.max-memory", "1kB")
                 .put("query.max-total-memory", "1GB")
                 .build();
-        try (QueryRunner queryRunner = createQueryRunner(SESSION, properties)) {
+        try (QueryRunner queryRunner = createQueryRunner(properties)) {
             queryRunner.execute(SESSION, "SELECT COUNT(*), repeat(orderstatus, 1000) FROM orders GROUP BY 2");
         }
     }
@@ -361,7 +569,7 @@ public class TestMemoryManager
                 .put("query.max-memory", "1kB")
                 .put("query.max-total-memory", "2kB")
                 .build();
-        try (QueryRunner queryRunner = createQueryRunner(SESSION, properties)) {
+        try (QueryRunner queryRunner = createQueryRunner(properties)) {
             queryRunner.execute(SESSION, "SELECT COUNT(*), repeat(orderstatus, 1000) FROM orders GROUP BY 2");
         }
     }
@@ -374,24 +582,8 @@ public class TestMemoryManager
                 .put("task.max-partial-aggregation-memory", "1B")
                 .put("query.max-memory-per-node", "1kB")
                 .build();
-        try (QueryRunner queryRunner = createQueryRunner(SESSION, properties)) {
+        try (QueryRunner queryRunner = createQueryRunner(properties)) {
             queryRunner.execute(SESSION, "SELECT COUNT(*), repeat(orderstatus, 1000) FROM orders GROUP BY 2");
-        }
-    }
-
-    public static DistributedQueryRunner createQueryRunner(Session session, Map<String, String> properties)
-            throws Exception
-    {
-        DistributedQueryRunner queryRunner = new DistributedQueryRunner(session, 2, properties);
-
-        try {
-            queryRunner.installPlugin(new TpchPlugin());
-            queryRunner.createCatalog("tpch", "tpch");
-            return queryRunner;
-        }
-        catch (Exception e) {
-            queryRunner.close();
-            throw e;
         }
     }
 }

--- a/presto-tests/src/test/java/com/facebook/presto/memory/TestMemoryManager.java
+++ b/presto-tests/src/test/java/com/facebook/presto/memory/TestMemoryManager.java
@@ -456,7 +456,6 @@ public class TestMemoryManager
             List<Future<?>> queryFutures = new ArrayList<>();
             for (int i = 0; i < 2; i++) {
                 int coordinator = i;
-                Thread.sleep(500);
                 queryFutures.add(executor.submit(() -> queryRunner.execute(coordinator, "SELECT COUNT(*), clerk FROM orders GROUP BY clerk")));
             }
 


### PR DESCRIPTION
# Add Resource Manager (experimental feature)
This PR adds a new process to Presto called the Resource Manager.  The role of the resource manager is aid the existing coordinator processes where they manage the same resources.  It has functionality to:

1) Act as a central location for service discovery
2) Act as a central location of information for REST endpoints
3) Retrieve global memory pool information
4) Enhance local resource group queues with resource group information from across the cluster

This feature is experimental, and is subject to further change as testing progresses and features are added.  This feature, if merged, would result in the code being disabled by default, with no hard dependency on the new resource manager running.

#### Current status:
All commits except `Add distributed resource group queueing` are ready for review.   This commit will be ready shortly.

See: #15453

Depends on: #15673