### PR TITLE
Improve float  and double stream readers

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/ByteArrayUtils.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/ByteArrayUtils.java
@@ -17,8 +17,13 @@ import sun.misc.Unsafe;
 
 import java.lang.reflect.Field;
 
+import static io.airlift.slice.SizeOf.SIZE_OF_DOUBLE;
+import static io.airlift.slice.SizeOf.SIZE_OF_FLOAT;
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
+import static java.lang.Double.doubleToLongBits;
+import static java.lang.Float.floatToRawIntBits;
 import static java.lang.Math.min;
+import static java.lang.String.format;
 import static sun.misc.Unsafe.ARRAY_BYTE_BASE_OFFSET;
 
 public class ByteArrayUtils
@@ -108,5 +113,32 @@ public class ByteArrayUtils
             lastWord = bytes[offset + i] | (lastWord << 8);
         }
         return (seed * M * lastWord) ^ (seed << 27);
+    }
+
+    public static void getDoubles(byte[] bytes, int bytesIndex, long[] values, int valuesIndex, int numOfDoubles)
+    {
+        checkValidRange(bytesIndex, SIZE_OF_DOUBLE * numOfDoubles, bytes.length);
+
+        for (int i = 0; i < numOfDoubles; i++) {
+            double readDouble = unsafe.getDouble(bytes, (long) bytesIndex + i * SIZE_OF_DOUBLE + ARRAY_BYTE_BASE_OFFSET);
+            values[valuesIndex++] = doubleToLongBits(readDouble);
+        }
+    }
+
+    public static void getFloats(byte[] bytes, int bytesIndex, int[] values, int valuesIndex, int numOfDoubles)
+    {
+        checkValidRange(bytesIndex, SIZE_OF_FLOAT * numOfDoubles, bytes.length);
+
+        for (int i = 0; i < numOfDoubles; i++) {
+            float readFloat = unsafe.getFloat(bytes, (long) bytesIndex + i * SIZE_OF_FLOAT + ARRAY_BYTE_BASE_OFFSET);
+            values[valuesIndex++] = floatToRawIntBits(readFloat);
+        }
+    }
+
+    public static void checkValidRange(int start, int length, int size)
+    {
+        if (start < 0 || length < 0 || start + length > size) {
+            throw new IndexOutOfBoundsException(format("Invalid start %s and length %s with array size %s", start, length, size));
+        }
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/TupleDomainFilter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/TupleDomainFilter.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.orc;
 
+import com.facebook.presto.common.NotSupportedException;
 import com.google.common.annotations.VisibleForTesting;
 
 import java.util.Arrays;
@@ -51,7 +52,7 @@ public interface TupleDomainFilter
     /**
      * Used to apply is [not] null filters to complex types, e.g.
      * a[1] is null AND a[3] is not null, where a is an array(array(T)).
-     *
+     * <p>
      * In these case, the exact values are not known, but it is known whether they are
      * null or not. Furthermore, for some positions only nulls are allowed (a[1] is null),
      * for others only non-nulls (a[3] is not null), and for the rest both are allowed
@@ -69,6 +70,11 @@ public interface TupleDomainFilter
 
     boolean testBoolean(boolean value);
 
+    default boolean testBoolean(byte value)
+    {
+        throw new NotSupportedException("testBoolean(value) is not supported");
+    }
+
     boolean testBytes(byte[] buffer, int offset, int length);
 
     /**
@@ -83,6 +89,7 @@ public interface TupleDomainFilter
      * fail. To enable this functionality, the filter keeps track of the boundaries of
      * top-level positions and allows the caller to find out where the current top-level
      * position started and how far it continues.
+     *
      * @return number of positions from the start of the current top-level position up to
      * the current position (excluding current position)
      */
@@ -235,6 +242,12 @@ public interface TupleDomainFilter
         }
 
         @Override
+        public boolean testBoolean(byte value)
+        {
+            return false;
+        }
+
+        @Override
         public boolean testBytes(byte[] buffer, int offset, int length)
         {
             return false;
@@ -293,6 +306,12 @@ public interface TupleDomainFilter
 
         @Override
         public boolean testBoolean(boolean value)
+        {
+            return false;
+        }
+
+        @Override
+        public boolean testBoolean(byte value)
         {
             return false;
         }
@@ -361,6 +380,12 @@ public interface TupleDomainFilter
         }
 
         @Override
+        public boolean testBoolean(byte value)
+        {
+            return true;
+        }
+
+        @Override
         public boolean testBytes(byte[] buffer, int offset, int length)
         {
             return true;
@@ -383,11 +408,13 @@ public interface TupleDomainFilter
             extends AbstractTupleDomainFilter
     {
         private final boolean value;
+        private final byte byteValue;
 
         private BooleanValue(boolean value, boolean nullAllowed)
         {
             super(true, nullAllowed);
             this.value = value;
+            this.byteValue = (byte) (value ? 1 : 0);
         }
 
         public static BooleanValue of(boolean value, boolean nullAllowed)
@@ -399,6 +426,12 @@ public interface TupleDomainFilter
         public boolean testBoolean(boolean value)
         {
             return this.value == value;
+        }
+
+        @Override
+        public boolean testBoolean(byte value)
+        {
+            return this.byteValue == value;
         }
 
         @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/BooleanSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/BooleanSelectiveStreamReader.java
@@ -37,6 +37,9 @@ import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.orc.array.Arrays.ensureCapacity;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
+import static com.facebook.presto.orc.reader.ReaderUtils.packBytes;
+import static com.facebook.presto.orc.reader.ReaderUtils.packBytesAndNulls;
+import static com.facebook.presto.orc.reader.ReaderUtils.unpackByteNulls;
 import static com.facebook.presto.orc.reader.SelectiveStreamReaders.initializeOutputPositions;
 import static com.facebook.presto.orc.stream.MissingInputStreamSource.missingStreamSource;
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -160,7 +163,13 @@ public class BooleanSelectiveStreamReader
 
         allNulls = false;
 
-        if (outputRequired) {
+        if (useBatchMode()) {
+            // values need to be totalPositionCount,
+            // and nulls need to be allocated even nullsAllowed == false, and whether there is filter or not, or outputRequired == true or not,
+            // because values need to be unpacked with nulls
+            ensureValuesCapacity(positions[positionCount - 1] + 1, presentStream != null);
+        }
+        else if (outputRequired) {
             ensureValuesCapacity(positionCount, nullsAllowed && presentStream != null);
         }
 
@@ -181,6 +190,54 @@ public class BooleanSelectiveStreamReader
             streamPosition = readNoFilter(positions, positionCount);
         }
         else {
+            if (useBatchMode()) {
+                int totalPositionCount = positions[positionCount - 1] + 1;
+                int readCount = 0;
+
+                final int filteredPositionCount;
+
+                if (presentStream == null) {
+                    dataStream.getSetBits(totalPositionCount, values);
+
+                    filteredPositionCount = evaluateFilter(positions, positionCount);
+
+                    if (outputRequired && totalPositionCount > filteredPositionCount) {
+                        packBytes(values, outputPositions, filteredPositionCount);
+                    }
+                }
+                else {
+                    int nullCount = presentStream.getUnsetBits(totalPositionCount, nulls);
+
+                    if (nullCount == totalPositionCount) {
+                        // all nulls
+                        allNulls = true;
+                        filteredPositionCount = positionCount; // No positions were filtered out
+                    }
+                    else {
+                        // some nulls
+                        readCount = totalPositionCount - nullCount;
+                        dataStream.getSetBits(readCount, values);
+
+                        if (nullCount != 0) {
+                            // Note it should be totalPositionCount instead of positionCound
+                            unpackByteNulls(values, nulls, totalPositionCount, readCount);
+                        }
+
+                        filteredPositionCount = evaluateFilterWithNulls(positions, positionCount);
+
+                        if (outputRequired && totalPositionCount > filteredPositionCount) {
+                            // both values and nulls need to be packed
+                            packBytesAndNulls(values, nulls, outputPositions, filteredPositionCount);
+                        }
+                    }
+                }
+                outputPositionCount = filteredPositionCount;
+
+                // For this reader, should return filteredPositionCount instead of totalPositionCount
+                readOffset = offset + totalPositionCount;
+                return filteredPositionCount;
+            }
+
             // This branch is inlined because extracting this code into a helper method (readWithFilter)
             // results in performance regressions on BenchmarkSelectiveStreamReaders.readBooleanNoNull[withFilter]
             // benchmarks.
@@ -272,11 +329,41 @@ public class BooleanSelectiveStreamReader
             throws IOException
     {
         // filter == null implies outputRequired == true
-        if (presentStream == null && positions[positionCount - 1] == positionCount - 1) {
-            // contiguous chunk of rows, no nulls
-            dataStream.getSetBits(positionCount, values);
+
+        if (useBatchMode()) {
+            int totalPositionCount = positions[positionCount - 1] + 1;
+            if (presentStream == null) {
+                dataStream.getSetBits(totalPositionCount, values);
+
+                if (totalPositionCount > positionCount) {
+                    packBytes(values, positions, positionCount);
+                }
+            }
+            else {
+                int nullCount = presentStream.getUnsetBits(totalPositionCount, nulls);
+
+                if (nullCount == totalPositionCount) {
+                    // all nulls
+                    allNulls = true;
+                }
+                else {
+                    // some nulls
+                    dataStream.getSetBits(totalPositionCount - nullCount, values);
+
+                    if (outputRequired) {
+                        if (nullCount != 0) {
+                            unpackByteNulls(values, nulls, totalPositionCount, totalPositionCount - nullCount);
+                        }
+
+                        if (totalPositionCount > positionCount) {
+                            // Need to pack both values and nulls
+                            packBytesAndNulls(values, nulls, positions, positionCount);
+                        }
+                    }
+                }
+            }
             outputPositionCount = positionCount;
-            return positionCount;
+            return totalPositionCount;
         }
 
         int streamPosition = 0;
@@ -454,5 +541,58 @@ public class BooleanSelectiveStreamReader
         dataStreamSource = null;
 
         systemMemoryContext.close();
+    }
+
+    private boolean useBatchMode()
+    {
+        // JMH benchmark shows that batch read mode is better than skipping mode for all cases.
+        return true;
+    }
+
+    private int evaluateFilter(int[] positions, int positionCount)
+    {
+        int positionsIndex = 0;
+        int i = 0;
+        while (i < positionCount) {
+            int position = positions[i];
+            if (filter.testBoolean(values[position])) {
+                outputPositions[positionsIndex++] = position;  // compact positions on the fly
+                i++;
+            }
+            else {
+                i += filter.getSucceedingPositionsToFail() + 1;
+                positionsIndex -= filter.getPrecedingPositionsToFail();
+            }
+        }
+        return positionsIndex;
+    }
+
+    private int evaluateFilterWithNulls(int[] positions, int positionCount)
+    {
+        boolean testNull = (nonDeterministicFilter && filter.testNull()) || nullsAllowed;
+
+        int positionsIndex = 0;
+        int i = 0;
+        while (i < positionCount) {
+            int position = positions[i];
+
+            // Note it should not be nulls[position] && testNull
+            if (nulls[position]) {
+                if (testNull) {
+                    outputPositions[positionsIndex++] = position;
+                }
+            }
+            else {
+                if (filter.testBoolean(values[position])) {
+                    outputPositions[positionsIndex++] = position;  // compact positions on the fly
+                }
+                else {
+                    i += filter.getSucceedingPositionsToFail();
+                    positionsIndex -= filter.getPrecedingPositionsToFail();
+                }
+            }
+            i++;
+        }
+        return positionsIndex;
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/ByteSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/ByteSelectiveStreamReader.java
@@ -38,6 +38,8 @@ import static com.facebook.presto.common.type.TinyintType.TINYINT;
 import static com.facebook.presto.orc.array.Arrays.ensureCapacity;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
+import static com.facebook.presto.orc.reader.ReaderUtils.packBytes;
+import static com.facebook.presto.orc.reader.ReaderUtils.packBytesAndNulls;
 import static com.facebook.presto.orc.reader.ReaderUtils.unpackByteNulls;
 import static com.facebook.presto.orc.reader.SelectiveStreamReaders.initializeOutputPositions;
 import static com.facebook.presto.orc.stream.MissingInputStreamSource.missingStreamSource;
@@ -144,7 +146,12 @@ public class ByteSelectiveStreamReader
 
         allNulls = false;
 
-        if (outputRequired) {
+        if (useBatchMode(positionCount, positions[positionCount - 1] + 1)) {
+            // values need to be allocated for batch mode, because they need to be used for evaluating filters even when output is not required,
+            // nulls need to be allocated when presentStream != null, because values need to be unpacked with nulls
+            ensureValuesCapacity(positions[positionCount - 1] + 1, presentStream != null);
+        }
+        else if (outputRequired) {
             ensureValuesCapacity(positionCount, nullsAllowed && presentStream != null);
         }
 
@@ -175,6 +182,53 @@ public class ByteSelectiveStreamReader
     private int readWithFilter(int[] positions, int positionCount)
             throws IOException
     {
+        int totalPositionCount = positions[positionCount - 1] + 1;
+        if (useBatchMode(positionCount, totalPositionCount)) {
+            int readCount = 0;
+
+            final int filteredPositionCount;
+
+            if (presentStream == null) {
+                dataStream.next(values, totalPositionCount);
+
+                filteredPositionCount = evaluateFilter(positions, positionCount);
+
+                if (outputRequired && totalPositionCount > filteredPositionCount) {
+                    packBytes(values, outputPositions, filteredPositionCount);
+                }
+            }
+            else {
+                int nullCount = presentStream.getUnsetBits(totalPositionCount, nulls);
+
+                if (nullCount == totalPositionCount) {
+                    // all nulls
+                    allNulls = true;
+                    filteredPositionCount = positionCount; // No positions were filtered out
+                }
+                else {
+                    // some nulls
+                    readCount = totalPositionCount - nullCount;
+                    dataStream.next(values, readCount);
+
+                    if (nullCount != 0) {
+                        // Note it should be totalPositionCount instead of positionCound
+                        unpackByteNulls(values, nulls, totalPositionCount, readCount);
+                    }
+
+                    filteredPositionCount = evaluateFilterWithNulls(positions, positionCount);
+
+                    if (outputRequired && totalPositionCount > filteredPositionCount) {
+                        // both values and nulls need to be packed
+                        packBytesAndNulls(values, nulls, outputPositions, filteredPositionCount);
+                    }
+                }
+            }
+            outputPositionCount = filteredPositionCount;
+
+            // Should return totalPositionCount instead of readCount
+            return totalPositionCount;
+        }
+
         int streamPosition = 0;
         outputPositionCount = 0;
         for (int i = 0; i < positionCount; i++) {
@@ -258,18 +312,40 @@ public class ByteSelectiveStreamReader
             throws IOException
     {
         // filter == null implies outputRequired == true
-        if (positions[positionCount - 1] == positionCount - 1) {
-            if (presentStream != null) {
-                int nonNullCount = positionCount - presentStream.getUnsetBits(positionCount, nulls);
-                dataStream.next(values, nonNullCount);
-                unpackByteNulls(values, nulls, positionCount, nonNullCount);
+
+        int totalPositionCount = positions[positionCount - 1] + 1;
+        if (useBatchMode(positionCount, totalPositionCount)) {
+            if (presentStream == null) {
+                dataStream.next(values, totalPositionCount);
+                if (totalPositionCount > positionCount) {
+                    packBytes(values, positions, positionCount);
+                }
             }
             else {
-                // contiguous chunk of rows, no nulls
-                dataStream.next(values, positionCount);
+                int nullCount = presentStream.getUnsetBits(totalPositionCount, nulls);
+
+                if (nullCount == totalPositionCount) {
+                    // all nulls
+                    allNulls = true;
+                }
+                else {
+                    // some nulls
+                    dataStream.next(values, totalPositionCount - nullCount);
+
+                    if (outputRequired) {
+                        if (nullCount != 0) {
+                            unpackByteNulls(values, nulls, totalPositionCount, totalPositionCount - nullCount);
+                        }
+
+                        if (totalPositionCount > positionCount) {
+                            // Need to pack both values and nulls
+                            packBytesAndNulls(values, nulls, positions, positionCount);
+                        }
+                    }
+                }
             }
             outputPositionCount = positionCount;
-            return positionCount;
+            return totalPositionCount;
         }
 
         int streamPosition = 0;
@@ -455,5 +531,63 @@ public class ByteSelectiveStreamReader
         dataStreamSource = null;
 
         systemMemoryContext.close();
+    }
+
+    private boolean useBatchMode(int positionCount, int totalPositionCount)
+    {
+        // JMH benchmark shows that when there is no null or no filter, the batch read mode was always better than the skipping mode.
+        // When there is filter and partial nulls, the batch read mode was better than the skipping mode when the input filter rate is less than 0.4
+        if (presentStream == null || filter == null || (double) (totalPositionCount - positionCount) / totalPositionCount <= 0.4) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private int evaluateFilter(int[] positions, int positionCount)
+    {
+        int positionsIndex = 0;
+        int i = 0;
+        while (i < positionCount) {
+            int position = positions[i];
+            if (filter.testLong(values[position])) {
+                outputPositions[positionsIndex++] = position;  // compact positions on the fly
+                i++;
+            }
+            else {
+                i += filter.getSucceedingPositionsToFail() + 1;
+                positionsIndex -= filter.getPrecedingPositionsToFail();
+            }
+        }
+        return positionsIndex;
+    }
+
+    private int evaluateFilterWithNulls(int[] positions, int positionCount)
+    {
+        boolean testNull = (nonDeterministicFilter && filter.testNull()) || nullsAllowed;
+
+        int positionsIndex = 0;
+        int i = 0;
+        while (i < positionCount) {
+            int position = positions[i];
+
+            // Note it should not be nulls[position] && testNull
+            if (nulls[position]) {
+                if (testNull) {
+                    outputPositions[positionsIndex++] = position;
+                }
+            }
+            else {
+                if (filter.testLong(values[position])) {
+                    outputPositions[positionsIndex++] = position;  // compact positions on the fly
+                }
+                else {
+                    i += filter.getSucceedingPositionsToFail();
+                    positionsIndex -= filter.getPrecedingPositionsToFail();
+                }
+            }
+            i++;
+        }
+        return positionsIndex;
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/FloatSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/FloatSelectiveStreamReader.java
@@ -36,6 +36,9 @@ import static com.facebook.presto.common.type.RealType.REAL;
 import static com.facebook.presto.orc.array.Arrays.ensureCapacity;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
+import static com.facebook.presto.orc.reader.ReaderUtils.packInts;
+import static com.facebook.presto.orc.reader.ReaderUtils.packIntsAndNulls;
+import static com.facebook.presto.orc.reader.ReaderUtils.unpackIntsWithNulls;
 import static com.facebook.presto.orc.reader.SelectiveStreamReaders.initializeOutputPositions;
 import static com.facebook.presto.orc.stream.MissingInputStreamSource.missingStreamSource;
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -43,6 +46,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.Float.floatToRawIntBits;
+import static java.lang.Float.intBitsToFloat;
 import static java.util.Objects.requireNonNull;
 
 public class FloatSelectiveStreamReader
@@ -136,7 +140,13 @@ public class FloatSelectiveStreamReader
 
         allNulls = false;
 
-        if (outputRequired) {
+        int totalPositionCount = positions[positionCount - 1] + 1;
+        if (useBatchMode(positionCount, totalPositionCount)) {
+            // values need to be allocated for batch mode, because they need to be used for evaluating filters even when output is not required,
+            // nulls need to be allocated when presentStream != null, because values need to be unpacked with nulls
+            ensureValuesCapacity(totalPositionCount, presentStream != null);
+        }
+        else if (outputRequired) {
             ensureValuesCapacity(positionCount, nullsAllowed && presentStream != null);
         }
 
@@ -167,6 +177,53 @@ public class FloatSelectiveStreamReader
     private int readWithFilter(int[] positions, int positionCount)
             throws IOException
     {
+        int totalPositionCount = positions[positionCount - 1] + 1;
+        if (useBatchMode(positionCount, totalPositionCount)) {
+            int readCount = 0;
+
+            final int filteredPositionCount;
+
+            if (presentStream == null) {
+                dataStream.next(values, totalPositionCount);
+
+                filteredPositionCount = evaluateFilter(positions, positionCount);
+
+                if (outputRequired && totalPositionCount > filteredPositionCount) {
+                    packInts(values, outputPositions, filteredPositionCount);
+                }
+            }
+            else {
+                int nullCount = presentStream.getUnsetBits(totalPositionCount, nulls);
+
+                if (nullCount == totalPositionCount) {
+                    // all nulls
+                    allNulls = true;
+                    filteredPositionCount = positionCount; // No positions were filtered out
+                }
+                else {
+                    // some nulls
+                    readCount = totalPositionCount - nullCount;
+                    dataStream.next(values, readCount);
+
+                    if (nullCount != 0) {
+                        // Note it should be totalPositionCount instead of positionCound
+                        unpackIntsWithNulls(values, nulls, totalPositionCount, readCount);
+                    }
+
+                    filteredPositionCount = evaluateFilterWithNulls(positions, positionCount);
+
+                    if (outputRequired && totalPositionCount > filteredPositionCount) {
+                        // both values and nulls need to be packed
+                        packIntsAndNulls(values, nulls, outputPositions, filteredPositionCount);
+                    }
+                }
+            }
+            outputPositionCount = filteredPositionCount;
+
+            // Should return totalPositionCount instead of readCount
+            return totalPositionCount;
+        }
+
         int streamPosition = 0;
         outputPositionCount = 0;
         for (int i = 0; i < positionCount; i++) {
@@ -250,6 +307,41 @@ public class FloatSelectiveStreamReader
     private int readNoFilter(int[] positions, int positionCount)
             throws IOException
     {
+        int totalPositionCount = positions[positionCount - 1] + 1;
+        if (useBatchMode(positionCount, totalPositionCount)) {
+            if (presentStream == null) {
+                dataStream.next(values, totalPositionCount);
+                if (totalPositionCount > positionCount) {
+                    packInts(values, positions, positionCount);
+                }
+            }
+            else {
+                int nullCount = presentStream.getUnsetBits(totalPositionCount, nulls);
+
+                if (nullCount == totalPositionCount) {
+                    // all nulls
+                    allNulls = true;
+                }
+                else {
+                    // some nulls
+                    dataStream.next(values, totalPositionCount - nullCount);
+
+                    if (outputRequired) {
+                        if (nullCount != 0) {
+                            unpackIntsWithNulls(values, nulls, totalPositionCount, totalPositionCount - nullCount);
+                        }
+
+                        if (totalPositionCount > positionCount) {
+                            // Need to pack both values and nulls
+                            packIntsAndNulls(values, nulls, positions, positionCount);
+                        }
+                    }
+                }
+            }
+            outputPositionCount = positionCount;
+            return totalPositionCount;
+        }
+
         if (positions[positionCount - 1] == positionCount - 1) {
             // no skipping
             if (presentStream != null) {
@@ -459,5 +551,63 @@ public class FloatSelectiveStreamReader
         return toStringHelper(this)
                 .addValue(streamDescriptor)
                 .toString();
+    }
+
+    private boolean useBatchMode(int positionCount, int totalPositionCount)
+    {
+        // JMH benchmark shows that when there is no null or no filter, the batch read mode was always better than the skipping mode.
+        // When there is filter and partial nulls, the batch read mode was better than the skipping mode when the input filter rate is less than 0.4
+        if (presentStream == null || filter == null || (double) (totalPositionCount - positionCount) / totalPositionCount <= 0.4) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private int evaluateFilter(int[] positions, int positionCount)
+    {
+        int positionsIndex = 0;
+        int i = 0;
+        while (i < positionCount) {
+            int position = positions[i];
+            if (filter.testFloat(intBitsToFloat(values[position]))) {
+                outputPositions[positionsIndex++] = position;  // compact positions on the fly
+                i++;
+            }
+            else {
+                i += filter.getSucceedingPositionsToFail() + 1;
+                positionsIndex -= filter.getPrecedingPositionsToFail();
+            }
+        }
+        return positionsIndex;
+    }
+
+    private int evaluateFilterWithNulls(int[] positions, int positionCount)
+    {
+        boolean testNull = (nonDeterministicFilter && filter.testNull()) || nullsAllowed;
+
+        int positionsIndex = 0;
+        int i = 0;
+        while (i < positionCount) {
+            int position = positions[i];
+
+            // Note it should not be nulls[position] && testNull
+            if (nulls[position]) {
+                if (testNull) {
+                    outputPositions[positionsIndex++] = position;
+                }
+            }
+            else {
+                if (filter.testFloat(intBitsToFloat(values[position]))) {
+                    outputPositions[positionsIndex++] = position;  // compact positions on the fly
+                }
+                else {
+                    i += filter.getSucceedingPositionsToFail();
+                    positionsIndex -= filter.getPrecedingPositionsToFail();
+                }
+            }
+            i++;
+        }
+        return positionsIndex;
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/ReaderUtils.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/ReaderUtils.java
@@ -72,6 +72,19 @@ final class ReaderUtils
         }
     }
 
+    public static void unpackLongsWithNulls(long[] values, boolean[] isNull, int positionCount, int nonNullCount)
+    {
+        int position = nonNullCount - 1;
+        for (int i = positionCount - 1; i >= 0; i--) {
+            if (!isNull[i]) {
+                values[i] = values[position--];
+            }
+            else {
+                values[i] = 0;
+            }
+        }
+    }
+
     public static void packBytes(byte[] values, int[] positions, int positionCount)
     {
         for (int i = 0; i < positionCount; i++) {
@@ -87,6 +100,55 @@ final class ReaderUtils
             // Pack nulls
             nulls[i] = nulls[position];
             values[i] = values[position];
+        }
+    }
+
+    public static void packInts(int[] values, int[] positions, int positionCount)
+    {
+        for (int i = 0; i < positionCount; i++) {
+            values[i] = values[positions[i]];
+        }
+    }
+
+    public static void packIntsAndNulls(int[] values, boolean[] nulls, int[] positions, int positionCount)
+    {
+        for (int i = 0; i < positionCount; i++) {
+            int position = positions[i];
+
+            // Pack nulls
+            nulls[i] = nulls[position];
+            values[i] = values[position];
+        }
+    }
+
+    public static void packLongs(long[] values, int[] positions, int positionCount)
+    {
+        for (int i = 0; i < positionCount; i++) {
+            values[i] = values[positions[i]];
+        }
+    }
+
+    public static void packLongsAndNulls(long[] values, boolean[] nulls, int[] positions, int positionCount)
+    {
+        for (int i = 0; i < positionCount; i++) {
+            int position = positions[i];
+
+            // Pack nulls
+            nulls[i] = nulls[position];
+            values[i] = values[position];
+        }
+    }
+
+    public static void unpackIntsWithNulls(int[] values, boolean[] isNull, int positionCount, int nonNullCount)
+    {
+        int position = nonNullCount - 1;
+        for (int i = positionCount - 1; i >= 0; i--) {
+            if (!isNull[i]) {
+                values[i] = values[position--];
+            }
+            else {
+                values[i] = 0;
+            }
         }
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/ReaderUtils.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/ReaderUtils.java
@@ -72,6 +72,24 @@ final class ReaderUtils
         }
     }
 
+    public static void packBytes(byte[] values, int[] positions, int positionCount)
+    {
+        for (int i = 0; i < positionCount; i++) {
+            values[i] = values[positions[i]];
+        }
+    }
+
+    public static void packBytesAndNulls(byte[] values, boolean[] nulls, int[] positions, int positionCount)
+    {
+        for (int i = 0; i < positionCount; i++) {
+            int position = positions[i];
+
+            // Pack nulls
+            nulls[i] = nulls[position];
+            values[i] = values[position];
+        }
+    }
+
     public static short[] unpackShortNulls(short[] values, boolean[] isNull)
     {
         short[] result = new short[isNull.length];

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/DoubleInputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/DoubleInputStream.java
@@ -65,4 +65,10 @@ public class DoubleInputStream
             type.writeDouble(builder, next());
         }
     }
+
+    public void next(long[] values, int items)
+            throws IOException
+    {
+        input.readDoubles(values, items);
+    }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/FloatInputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/FloatInputStream.java
@@ -66,4 +66,10 @@ public class FloatInputStream
             type.writeLong(builder, floatToRawIntBits(next()));
         }
     }
+
+    public void next(int[] values, int items)
+            throws IOException
+    {
+        input.readFloats(values, items);
+    }
 }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
@@ -1518,8 +1518,9 @@ public class OrcTester
         metadata.put("columns", String.join(", ", columnNames));
         metadata.put("columns.types", createSettableStructObjectInspector(types).getTypeName());
 
+        FileOutputStream fileOutputStream = new FileOutputStream(outputFile);
         OrcWriter writer = new OrcWriter(
-                new OutputStreamDataSink(new FileOutputStream(outputFile)),
+                new OutputStreamDataSink(fileOutputStream),
                 columnNames,
                 types,
                 format.getOrcEncoding(),
@@ -1551,6 +1552,8 @@ public class OrcTester
                 new DataSize(1, MEGABYTE),
                 new DataSize(1, MEGABYTE),
                 true));
+
+        fileOutputStream.close();
     }
 
     private static DwrfWriterEncryption generateWriterEncryption()


### PR DESCRIPTION
BenchmarkSelectiveStreamReaders shows up to 3.8x for byte type, 3.4x for boolean type, 2.2x for float, and 1.6x for double.


```
== NO RELEASE NOTE ==
```
