### PR TITLE
Fix temporary table path not delete

### DIFF
--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/SemiTransactionalHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/SemiTransactionalHiveMetastore.java
@@ -1622,7 +1622,11 @@ public class SemiTransactionalHiveMetastore
     {
         for (DeclaredIntentionToWrite declaredIntentionToWrite : declaredIntentionsToWrite) {
             if (declaredIntentionToWrite.isTemporaryTable()) {
-                deleteRecursivelyIfExists(declaredIntentionToWrite.getContext(), hdfsEnvironment, declaredIntentionToWrite.getStagingPathRoot());
+                String tableName = declaredIntentionToWrite.getSchemaTableName().getTableName();
+                // table path is set to _presto_temporary_table_${uuid}/${uuid}/ for temporary table
+                Path tablePath = declaredIntentionToWrite.getStagingPathRoot().getParent();
+                checkState(tablePath.getName().equalsIgnoreCase(tableName));
+                deleteRecursivelyIfExists(declaredIntentionToWrite.getContext(), hdfsEnvironment, tablePath);
             }
         }
     }


### PR DESCRIPTION
When I turn on grouped_execution_for_aggregation and set partitioning_provider_catalog=hive, I found when the query finished, the table path still remains. It because in HiveLocationService.forTemporaryTable, the tablePath is set to "__presto_temporary_table_6818bf60_b7f7_4eb1_998f_7c96437f3f02/${uuid}/", and the SemiTransactionalHiveMetastore.deleteTemporaryTableDirectories will only delete the uuid path, the presto temporary table path has not delete.

```
public LocationHandle forTemporaryTable(SemiTransactionalHiveMetastore metastore, ConnectorSession session, Table table, boolean tempPathRequired)
    {
        String schemaName = table.getDatabaseName();
        String tableName = table.getTableName();
        HdfsContext context = new HdfsContext(session, schemaName, tableName);
        Path targetPath = new Path(getTableDefaultLocation(context, metastore, hdfsEnvironment, schemaName, tableName), randomUUID().toString().replaceAll("-", "_"));
        return new LocationHandle(
                targetPath,
                targetPath,
                tempPathRequired ? Optional.of(createTemporaryPath(session, context, hdfsEnvironment, targetPath)) : Optional.empty(),
                TEMPORARY,
                DIRECT_TO_TARGET_NEW_DIRECTORY);
    }
```

```
    private static void deleteTemporaryTableDirectories(List<DeclaredIntentionToWrite> declaredIntentionsToWrite, HdfsEnvironment hdfsEnvironment)
    {
        for (DeclaredIntentionToWrite declaredIntentionToWrite : declaredIntentionsToWrite) {
            if (declaredIntentionToWrite.isTemporaryTable()) {
                deleteRecursivelyIfExists(declaredIntentionToWrite.getContext(), hdfsEnvironment, declaredIntentionToWrite.getStagingPathRoot());
            }
        }
    }
```