### PR TITLE
Improve byte and boolean stream readers

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/TupleDomainFilter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/TupleDomainFilter.java
@@ -51,7 +51,7 @@ public interface TupleDomainFilter
     /**
      * Used to apply is [not] null filters to complex types, e.g.
      * a[1] is null AND a[3] is not null, where a is an array(array(T)).
-     *
+     * <p>
      * In these case, the exact values are not known, but it is known whether they are
      * null or not. Furthermore, for some positions only nulls are allowed (a[1] is null),
      * for others only non-nulls (a[3] is not null), and for the rest both are allowed
@@ -69,6 +69,8 @@ public interface TupleDomainFilter
 
     boolean testBoolean(boolean value);
 
+    boolean testBoolean(byte value);
+
     boolean testBytes(byte[] buffer, int offset, int length);
 
     /**
@@ -83,6 +85,7 @@ public interface TupleDomainFilter
      * fail. To enable this functionality, the filter keeps track of the boundaries of
      * top-level positions and allows the caller to find out where the current top-level
      * position started and how far it continues.
+     *
      * @return number of positions from the start of the current top-level position up to
      * the current position (excluding current position)
      */
@@ -155,6 +158,12 @@ public interface TupleDomainFilter
 
         @Override
         public boolean testBoolean(boolean value)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean testBoolean(byte value)
         {
             throw new UnsupportedOperationException();
         }
@@ -235,6 +244,12 @@ public interface TupleDomainFilter
         }
 
         @Override
+        public boolean testBoolean(byte value)
+        {
+            return false;
+        }
+
+        @Override
         public boolean testBytes(byte[] buffer, int offset, int length)
         {
             return false;
@@ -293,6 +308,12 @@ public interface TupleDomainFilter
 
         @Override
         public boolean testBoolean(boolean value)
+        {
+            return false;
+        }
+
+        @Override
+        public boolean testBoolean(byte value)
         {
             return false;
         }
@@ -361,6 +382,12 @@ public interface TupleDomainFilter
         }
 
         @Override
+        public boolean testBoolean(byte value)
+        {
+            return true;
+        }
+
+        @Override
         public boolean testBytes(byte[] buffer, int offset, int length)
         {
             return true;
@@ -383,11 +410,13 @@ public interface TupleDomainFilter
             extends AbstractTupleDomainFilter
     {
         private final boolean value;
+        private final byte byteValue;
 
         private BooleanValue(boolean value, boolean nullAllowed)
         {
             super(true, nullAllowed);
             this.value = value;
+            this.byteValue = (byte) (value ? 1 : 0);
         }
 
         public static BooleanValue of(boolean value, boolean nullAllowed)
@@ -399,6 +428,12 @@ public interface TupleDomainFilter
         public boolean testBoolean(boolean value)
         {
             return this.value == value;
+        }
+
+        @Override
+        public boolean testBoolean(byte value)
+        {
+            return this.byteValue == value;
         }
 
         @Override
@@ -1660,6 +1695,18 @@ public interface TupleDomainFilter
         }
 
         @Override
+        public boolean testBoolean(byte value)
+        {
+            advance();
+            TupleDomainFilter filter = filters[filterIndex++];
+            if (filter == null) {
+                return true;
+            }
+
+            return recordTestResult(filter.testBoolean(value));
+        }
+
+        @Override
         public boolean testBytes(byte[] buffer, int offset, int length)
         {
             advance();
@@ -1730,6 +1777,11 @@ public interface TupleDomainFilter
         }
 
         public boolean testBoolean(boolean value)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        public boolean testBoolean(byte value)
         {
             throw new UnsupportedOperationException();
         }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/BooleanSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/BooleanSelectiveStreamReader.java
@@ -37,6 +37,9 @@ import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.orc.array.Arrays.ensureCapacity;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
+import static com.facebook.presto.orc.reader.ReaderUtils.packBytes;
+import static com.facebook.presto.orc.reader.ReaderUtils.packBytesAndNulls;
+import static com.facebook.presto.orc.reader.ReaderUtils.unpackByteNulls;
 import static com.facebook.presto.orc.reader.SelectiveStreamReaders.initializeOutputPositions;
 import static com.facebook.presto.orc.stream.MissingInputStreamSource.missingStreamSource;
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -160,7 +163,12 @@ public class BooleanSelectiveStreamReader
 
         allNulls = false;
 
-        if (outputRequired) {
+        if (useBatchMode()) {
+            // values need to be allocated for batch mode, because they need to be used for evaluating filters even when output is not required,
+            // nulls need to be allocated when presentStream != null, because values need to be unpacked with nulls
+            ensureValuesCapacity(positions[positionCount - 1] + 1, presentStream != null);
+        }
+        else if (outputRequired) {
             ensureValuesCapacity(positionCount, nullsAllowed && presentStream != null);
         }
 
@@ -181,6 +189,58 @@ public class BooleanSelectiveStreamReader
             streamPosition = readNoFilter(positions, positionCount);
         }
         else {
+            if (useBatchMode()) {
+                int totalPositionCount = positions[positionCount - 1] + 1;
+                int readCount = 0;
+
+                final int filteredPositionCount;
+
+                if (presentStream == null) {
+                    dataStream.getSetBits(totalPositionCount, values);
+
+                    filteredPositionCount = evaluateFilter(positions, positionCount);
+
+                    if (outputRequired && totalPositionCount > filteredPositionCount) {
+                        packBytes(values, outputPositions, filteredPositionCount);
+                    }
+                }
+                else {
+                    int nullCount = presentStream.getUnsetBits(totalPositionCount, nulls);
+                    if (nullCount == totalPositionCount) {
+                        // all nulls
+                        if ((nonDeterministicFilter && this.filter.testNull()) || nullsAllowed) {
+                            allNulls = true;
+                            filteredPositionCount = positionCount; // No positions were filtered out
+                        }
+                        else {
+                            filteredPositionCount = 0;
+                        }
+                    }
+                    else {
+                        // some nulls
+                        readCount = totalPositionCount - nullCount;
+                        dataStream.getSetBits(readCount, values);
+
+                        if (nullCount != 0) {
+                            // Note it should be totalPositionCount instead of positionCount
+                            unpackByteNulls(values, nulls, totalPositionCount, readCount);
+                        }
+
+                        filteredPositionCount = evaluateFilterWithNulls(positions, positionCount);
+
+                        if (outputRequired && totalPositionCount > filteredPositionCount) {
+                            // both values and nulls need to be packed
+                            packBytesAndNulls(values, nulls, outputPositions, filteredPositionCount);
+                        }
+                    }
+                }
+                outputPositionCount = filteredPositionCount;
+
+                // For this reader, should return filteredPositionCount instead of totalPositionCount
+                readOffset = offset + totalPositionCount;
+                return filteredPositionCount;
+            }
+
             // This branch is inlined because extracting this code into a helper method (readWithFilter)
             // results in performance regressions on BenchmarkSelectiveStreamReaders.readBooleanNoNull[withFilter]
             // benchmarks.
@@ -196,7 +256,7 @@ public class BooleanSelectiveStreamReader
                 }
 
                 if (presentStream != null && !presentStream.nextBit()) {
-                    if ((nonDeterministicFilter && filter.testNull()) || nullsAllowed) {
+                    if ((nonDeterministicFilter && this.filter.testNull()) || nullsAllowed) {
                         if (outputRequired) {
                             nulls[outputPositionCount] = true;
                         }
@@ -272,11 +332,41 @@ public class BooleanSelectiveStreamReader
             throws IOException
     {
         // filter == null implies outputRequired == true
-        if (presentStream == null && positions[positionCount - 1] == positionCount - 1) {
-            // contiguous chunk of rows, no nulls
-            dataStream.getSetBits(positionCount, values);
+
+        if (useBatchMode()) {
+            int totalPositionCount = positions[positionCount - 1] + 1;
+            if (presentStream == null) {
+                dataStream.getSetBits(totalPositionCount, values);
+
+                if (totalPositionCount > positionCount) {
+                    packBytes(values, positions, positionCount);
+                }
+            }
+            else {
+                int nullCount = presentStream.getUnsetBits(totalPositionCount, nulls);
+
+                if (nullCount == totalPositionCount) {
+                    // all nulls
+                    allNulls = true;
+                }
+                else {
+                    // some nulls
+                    dataStream.getSetBits(totalPositionCount - nullCount, values);
+
+                    if (outputRequired) {
+                        if (nullCount != 0) {
+                            unpackByteNulls(values, nulls, totalPositionCount, totalPositionCount - nullCount);
+                        }
+
+                        if (totalPositionCount > positionCount) {
+                            // Need to pack both values and nulls
+                            packBytesAndNulls(values, nulls, positions, positionCount);
+                        }
+                    }
+                }
+            }
             outputPositionCount = positionCount;
-            return positionCount;
+            return totalPositionCount;
         }
 
         int streamPosition = 0;
@@ -454,5 +544,57 @@ public class BooleanSelectiveStreamReader
         dataStreamSource = null;
 
         systemMemoryContext.close();
+    }
+
+    private boolean useBatchMode()
+    {
+        // JMH benchmark shows that batch read mode is better than skipping mode for all cases.
+        return true;
+    }
+
+    private int evaluateFilter(int[] positions, int positionCount)
+    {
+        int positionsIndex = 0;
+        for (int i = 0; i < positionCount; i++) {
+            int position = positions[i];
+            if (filter.testBoolean(values[position])) {
+                outputPositions[positionsIndex++] = position;  // compact positions on the fly
+            }
+            else {
+                i += filter.getSucceedingPositionsToFail();
+                positionsIndex -= filter.getPrecedingPositionsToFail();
+            }
+        }
+
+        return positionsIndex;
+    }
+
+    private int evaluateFilterWithNulls(int[] positions, int positionCount)
+    {
+        int positionsIndex = 0;
+        for (int i = 0; i < positionCount; i++) {
+            int position = positions[i];
+
+            if (nulls[position]) {
+                if ((nonDeterministicFilter && this.filter.testNull()) || nullsAllowed) {
+                    outputPositions[positionsIndex++] = position;
+                }
+                else {
+                    i += filter.getSucceedingPositionsToFail();
+                    positionsIndex -= filter.getPrecedingPositionsToFail();
+                }
+            }
+            else {
+                if (filter.testBoolean(values[position])) {
+                    outputPositions[positionsIndex++] = position;  // compact positions on the fly
+                }
+                else {
+                    i += filter.getSucceedingPositionsToFail();
+                    positionsIndex -= filter.getPrecedingPositionsToFail();
+                }
+            }
+        }
+
+        return positionsIndex;
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/ByteSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/ByteSelectiveStreamReader.java
@@ -566,8 +566,6 @@ public class ByteSelectiveStreamReader
 
     private int evaluateFilterWithNulls(int[] positions, int positionCount)
     {
-
-
         int positionsIndex = 0;
         for (int i = 0; i < positionCount; i++) {
             int position = positions[i];

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/ByteSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/ByteSelectiveStreamReader.java
@@ -38,6 +38,8 @@ import static com.facebook.presto.common.type.TinyintType.TINYINT;
 import static com.facebook.presto.orc.array.Arrays.ensureCapacity;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
+import static com.facebook.presto.orc.reader.ReaderUtils.packBytes;
+import static com.facebook.presto.orc.reader.ReaderUtils.packBytesAndNulls;
 import static com.facebook.presto.orc.reader.ReaderUtils.unpackByteNulls;
 import static com.facebook.presto.orc.reader.SelectiveStreamReaders.initializeOutputPositions;
 import static com.facebook.presto.orc.stream.MissingInputStreamSource.missingStreamSource;
@@ -144,7 +146,12 @@ public class ByteSelectiveStreamReader
 
         allNulls = false;
 
-        if (outputRequired) {
+        if (useBatchMode(positionCount, positions[positionCount - 1] + 1)) {
+            // values need to be allocated for batch mode, because they need to be used for evaluating filters even when output is not required,
+            // nulls need to be allocated when presentStream != null, because values need to be unpacked with nulls
+            ensureValuesCapacity(positions[positionCount - 1] + 1, presentStream != null);
+        }
+        else if (outputRequired) {
             ensureValuesCapacity(positionCount, nullsAllowed && presentStream != null);
         }
 
@@ -175,6 +182,56 @@ public class ByteSelectiveStreamReader
     private int readWithFilter(int[] positions, int positionCount)
             throws IOException
     {
+        int totalPositionCount = positions[positionCount - 1] + 1;
+        if (useBatchMode(positionCount, totalPositionCount)) {
+            int readCount = 0;
+
+            int filteredPositionCount;
+
+            if (presentStream == null) {
+                dataStream.next(values, totalPositionCount);
+
+                filteredPositionCount = evaluateFilter(positions, positionCount);
+
+                if (outputRequired && totalPositionCount > filteredPositionCount) {
+                    packBytes(values, outputPositions, filteredPositionCount);
+                }
+            }
+            else {
+                int nullCount = presentStream.getUnsetBits(totalPositionCount, nulls);
+                if (nullCount == totalPositionCount) {
+                    // all nulls
+                    if ((nonDeterministicFilter && this.filter.testNull()) || nullsAllowed) {
+                        allNulls = true;
+                        filteredPositionCount = positionCount; // No positions were filtered out
+                    }
+                    else {
+                        filteredPositionCount = 0;
+                    }
+                }
+                else {
+                    // some nulls
+                    readCount = totalPositionCount - nullCount;
+                    dataStream.next(values, readCount);
+
+                    if (nullCount != 0) {
+                        unpackByteNulls(values, nulls, totalPositionCount, readCount);
+                    }
+
+                    filteredPositionCount = evaluateFilterWithNulls(positions, positionCount);
+
+                    if (outputRequired && totalPositionCount > filteredPositionCount) {
+                        // both values and nulls need to be packed
+                        packBytesAndNulls(values, nulls, outputPositions, filteredPositionCount);
+                    }
+                }
+            }
+            outputPositionCount = filteredPositionCount;
+
+            // Should return totalPositionCount instead of readCount
+            return totalPositionCount;
+        }
+
         int streamPosition = 0;
         outputPositionCount = 0;
         for (int i = 0; i < positionCount; i++) {
@@ -185,7 +242,7 @@ public class ByteSelectiveStreamReader
             }
 
             if (presentStream != null && !presentStream.nextBit()) {
-                if ((nonDeterministicFilter && filter.testNull()) || nullsAllowed) {
+                if ((nonDeterministicFilter && this.filter.testNull()) || nullsAllowed) {
                     if (outputRequired) {
                         nulls[outputPositionCount] = true;
                     }
@@ -258,18 +315,40 @@ public class ByteSelectiveStreamReader
             throws IOException
     {
         // filter == null implies outputRequired == true
-        if (positions[positionCount - 1] == positionCount - 1) {
-            if (presentStream != null) {
-                int nonNullCount = positionCount - presentStream.getUnsetBits(positionCount, nulls);
-                dataStream.next(values, nonNullCount);
-                unpackByteNulls(values, nulls, positionCount, nonNullCount);
+
+        int totalPositionCount = positions[positionCount - 1] + 1;
+        if (useBatchMode(positionCount, totalPositionCount)) {
+            if (presentStream == null) {
+                dataStream.next(values, totalPositionCount);
+                if (totalPositionCount > positionCount) {
+                    packBytes(values, positions, positionCount);
+                }
             }
             else {
-                // contiguous chunk of rows, no nulls
-                dataStream.next(values, positionCount);
+                int nullCount = presentStream.getUnsetBits(totalPositionCount, nulls);
+
+                if (nullCount == totalPositionCount) {
+                    // all nulls
+                    allNulls = true;
+                }
+                else {
+                    // some nulls
+                    dataStream.next(values, totalPositionCount - nullCount);
+
+                    if (outputRequired) {
+                        if (nullCount != 0) {
+                            unpackByteNulls(values, nulls, totalPositionCount, totalPositionCount - nullCount);
+                        }
+
+                        if (totalPositionCount > positionCount) {
+                            // Need to pack both values and nulls
+                            packBytesAndNulls(values, nulls, positions, positionCount);
+                        }
+                    }
+                }
             }
             outputPositionCount = positionCount;
-            return positionCount;
+            return totalPositionCount;
         }
 
         int streamPosition = 0;
@@ -455,5 +534,64 @@ public class ByteSelectiveStreamReader
         dataStreamSource = null;
 
         systemMemoryContext.close();
+    }
+
+    private boolean useBatchMode(int positionCount, int totalPositionCount)
+    {
+        // JMH benchmark shows that when there is no null or no filter, the batch read mode was always better than the skipping mode.
+        // When there is filter and partial nulls, the batch read mode was better than the skipping mode when the input filter rate is less than 0.4
+        if (presentStream == null || filter == null || (double) (totalPositionCount - positionCount) / totalPositionCount <= 0.4) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private int evaluateFilter(int[] positions, int positionCount)
+    {
+        int positionsIndex = 0;
+        for (int i = 0; i < positionCount; i++) {
+            int position = positions[i];
+            if (filter.testLong(values[position])) {
+                outputPositions[positionsIndex++] = position;  // compact positions on the fly
+            }
+            else {
+                i += filter.getSucceedingPositionsToFail();
+                positionsIndex -= filter.getPrecedingPositionsToFail();
+            }
+        }
+
+        return positionsIndex;
+    }
+
+    private int evaluateFilterWithNulls(int[] positions, int positionCount)
+    {
+
+
+        int positionsIndex = 0;
+        for (int i = 0; i < positionCount; i++) {
+            int position = positions[i];
+
+            if (nulls[position]) {
+                if ((nonDeterministicFilter && this.filter.testNull()) || nullsAllowed) {
+                    outputPositions[positionsIndex++] = position;
+                }
+                else {
+                    i += filter.getSucceedingPositionsToFail();
+                    positionsIndex -= filter.getPrecedingPositionsToFail();
+                }
+            }
+            else {
+                if (filter.testLong(values[position])) {
+                    outputPositions[positionsIndex++] = position;  // compact positions on the fly
+                }
+                else {
+                    i += filter.getSucceedingPositionsToFail();
+                    positionsIndex -= filter.getPrecedingPositionsToFail();
+                }
+            }
+        }
+
+        return positionsIndex;
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/ReaderUtils.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/ReaderUtils.java
@@ -98,6 +98,24 @@ final class ReaderUtils
         }
     }
 
+    public static void packBytes(byte[] values, int[] positions, int positionCount)
+    {
+        for (int i = 0; i < positionCount; i++) {
+            values[i] = values[positions[i]];
+        }
+    }
+
+    public static void packBytesAndNulls(byte[] values, boolean[] nulls, int[] positions, int positionCount)
+    {
+        for (int i = 0; i < positionCount; i++) {
+            int position = positions[i];
+
+            // Pack nulls
+            nulls[i] = nulls[position];
+            values[i] = values[position];
+        }
+    }
+
     public static short[] unpackShortNulls(short[] values, boolean[] isNull)
     {
         short[] result = new short[isNull.length];

--- a/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkSelectiveStreamReaders.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkSelectiveStreamReaders.java
@@ -132,6 +132,8 @@ public class BenchmarkSelectiveStreamReaders
             }
         }
 
+        data.dataSource.close();
+
         return blocks;
     }
 
@@ -152,6 +154,7 @@ public class BenchmarkSelectiveStreamReaders
 
         private final Random random = new Random(0);
 
+        private OrcDataSource dataSource;
         private File temporaryDirectory;
         private File orcFile;
         private Type type;
@@ -279,7 +282,7 @@ public class BenchmarkSelectiveStreamReaders
         public OrcSelectiveRecordReader createRecordReader()
                 throws IOException
         {
-            OrcDataSource dataSource = new FileOrcDataSource(orcFile, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), true);
+            dataSource = new FileOrcDataSource(orcFile, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), true);
             OrcReader orcReader = new OrcReader(
                     dataSource,
                     ORC,

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestSelectiveOrcReader.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestSelectiveOrcReader.java
@@ -409,6 +409,13 @@ public class TestSelectiveOrcReader
         BigintRange negative = BigintRange.of(Integer.MIN_VALUE, 0, false);
         BigintRange nonNegative = BigintRange.of(0, Integer.MAX_VALUE, false);
 
+        // non-null arrays of TINYINT
+        tester.testRoundTrip(arrayType(TINYINT),
+                createList(NUM_ROWS, i -> randomBytes(8, random)),
+                ImmutableList.of(
+                        ImmutableMap.of(new Subfield("c[2]"), IS_NULL),
+                        ImmutableMap.of(new Subfield("c[2]"), nonNegative)));
+
         // non-empty non-null arrays of varying sizes
         tester.testRoundTrip(arrayType(INTEGER),
                 createList(NUM_ROWS, i -> randomIntegers(5 + random.nextInt(5), random)),
@@ -1214,6 +1221,11 @@ public class TestSelectiveOrcReader
     private static List<Integer> randomIntegers(int size, Random random)
     {
         return createList(size, i -> random.nextInt());
+    }
+
+    private static List<Byte> randomBytes(int size, Random random)
+    {
+        return createList(size, i -> (byte) random.nextInt(128));
     }
 
     private static List<SqlDecimal> decimalSequence(String start, String step, int items, int precision, int scale)

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestSelectiveOrcReader.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestSelectiveOrcReader.java
@@ -83,6 +83,7 @@ import static com.facebook.presto.orc.OrcTester.quickSelectiveOrcTester;
 import static com.facebook.presto.orc.OrcTester.rowType;
 import static com.facebook.presto.orc.OrcTester.writeOrcColumnsPresto;
 import static com.facebook.presto.orc.TestingOrcPredicate.createOrcPredicate;
+import static com.facebook.presto.orc.TupleDomainFilter.ALWAYS_FALSE;
 import static com.facebook.presto.orc.TupleDomainFilter.IS_NOT_NULL;
 import static com.facebook.presto.orc.TupleDomainFilter.IS_NULL;
 import static com.facebook.presto.orc.TupleDomainFilterUtils.toBigintValues;
@@ -415,6 +416,12 @@ public class TestSelectiveOrcReader
                 ImmutableList.of(
                         ImmutableMap.of(new Subfield("c[2]"), IS_NULL),
                         ImmutableMap.of(new Subfield("c[2]"), nonNegative)));
+
+        tester.testRoundTrip(arrayType(BOOLEAN),
+                createList(NUM_ROWS, i -> randomBooleans(8, random)),
+                ImmutableList.of(
+                        ImmutableMap.of(new Subfield("c[2]"), IS_NULL),
+                        ImmutableMap.of(new Subfield("c[2]"), ALWAYS_FALSE)));
 
         // non-empty non-null arrays of varying sizes
         tester.testRoundTrip(arrayType(INTEGER),
@@ -1226,6 +1233,11 @@ public class TestSelectiveOrcReader
     private static List<Byte> randomBytes(int size, Random random)
     {
         return createList(size, i -> (byte) random.nextInt(128));
+    }
+
+    private static List<Boolean> randomBooleans(int size, Random random)
+    {
+        return createList(size, i -> random.nextBoolean());
     }
 
     private static List<SqlDecimal> decimalSequence(String start, String step, int items, int precision, int scale)


### PR DESCRIPTION
BenchmarkSelectiveStreamReaders shows up to 3.8x for byte type, 3.4x for boolean type



```
== NO RELEASE NOTE ==
```
