### PR TITLE
Load function managers for Presto-on-Spark driver only

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkInjectorFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkInjectorFactory.java
@@ -28,6 +28,7 @@ import com.facebook.presto.server.PluginManager;
 import com.facebook.presto.server.SessionPropertyDefaults;
 import com.facebook.presto.server.security.PasswordAuthenticatorManager;
 import com.facebook.presto.spark.classloader_interface.SparkProcessType;
+import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.parser.SqlParserOptions;
 import com.facebook.presto.storage.TempStorageManager;
 import com.facebook.presto.storage.TempStorageModule;
@@ -160,12 +161,6 @@ public class PrestoSparkInjectorFactory
         try {
             injector.getInstance(PluginManager.class).loadPlugins();
             injector.getInstance(StaticCatalogStore.class).loadCatalogs(catalogProperties);
-            if (functionNamespaceProperties.isPresent()) {
-                injector.getInstance(StaticFunctionNamespaceStore.class).loadFunctionNamespaceManagers(functionNamespaceProperties.get());
-            }
-            else {
-                injector.getInstance(StaticFunctionNamespaceStore.class).loadFunctionNamespaceManagers();
-            }
             injector.getInstance(ResourceGroupManager.class).loadConfigurationManager();
             injector.getInstance(PasswordAuthenticatorManager.class).loadPasswordAuthenticator();
             eventListenerProperties.ifPresent(properties -> injector.getInstance(EventListenerManager.class).loadConfiguredEventListener(properties));
@@ -187,6 +182,16 @@ public class PrestoSparkInjectorFactory
                 }
                 else {
                     injector.getInstance(SessionPropertyDefaults.class).loadConfigurationManager();
+                }
+            }
+
+            if (sparkProcessType.equals(DRIVER) ||
+                    !injector.getInstance(FeaturesConfig.class).isInlineSqlFunctions()) {
+                if (functionNamespaceProperties.isPresent()) {
+                    injector.getInstance(StaticFunctionNamespaceStore.class).loadFunctionNamespaceManagers(functionNamespaceProperties.get());
+                }
+                else {
+                    injector.getInstance(StaticFunctionNamespaceStore.class).loadFunctionNamespaceManagers();
                 }
             }
         }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkSettingsRequirements.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkSettingsRequirements.java
@@ -88,6 +88,7 @@ public class PrestoSparkSettingsRequirements
         config.setScaleWriters(false);
         config.setPreferDistributedUnion(true);
         config.setForceSingleNodeOutput(false);
+        config.setInlineSqlFunctions(true);
     }
 
     public static void setDefaults(QueryManagerConfig config)


### PR DESCRIPTION
When inline sql function is enabled, no need to load
function managers for executors.

Issue
- Loading function managers for PoS executor is not free,  reliability issue such as transportation error is observed when fetching client certificate

Test plan 
- Build a package and query succeeds 20201130_212659_00000_ts7k9 when inline sql function is enabled.


```
== NO RELEASE NOTE ==
```
