### PR TITLE
Add query schema to ConnectorSession

### DIFF
--- a/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraConnector.java
+++ b/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraConnector.java
@@ -87,6 +87,7 @@ public class TestCassandraConnector
             new CassandraSessionProperties(new CassandraClientConfig()).getSessionProperties(),
             ImmutableMap.of(),
             true,
+            Optional.empty(),
             Optional.empty());
     protected String database;
     protected SchemaTableName table;

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -1095,6 +1095,12 @@ public abstract class AbstractTestHiveClient
 
                 return session.getProperty(name, type);
             }
+
+            @Override
+            public Optional<String> getSchema()
+            {
+                return Optional.empty();
+            }
         };
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/FullConnectorSession.java
+++ b/presto-main/src/main/java/com/facebook/presto/FullConnectorSession.java
@@ -133,6 +133,12 @@ public class FullConnectorSession
     }
 
     @Override
+    public Optional<String> getSchema()
+    {
+        return session.getSchema();
+    }
+
+    @Override
     public String toString()
     {
         return toStringHelper(this)

--- a/presto-main/src/main/java/com/facebook/presto/testing/TestingConnectorSession.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/TestingConnectorSession.java
@@ -52,10 +52,16 @@ public class TestingConnectorSession
     private final Map<String, Object> propertyValues;
     private final Optional<String> clientInfo;
     private final SqlFunctionProperties sqlFunctionProperties;
+    private final Optional<String> schema;
 
     public TestingConnectorSession(List<PropertyMetadata<?>> properties)
     {
-        this("user", Optional.of("test"), Optional.empty(), UTC_KEY, ENGLISH, System.currentTimeMillis(), properties, ImmutableMap.of(), new FeaturesConfig().isLegacyTimestamp(), Optional.empty());
+        this("user", Optional.of("test"), Optional.empty(), UTC_KEY, ENGLISH, System.currentTimeMillis(), properties, ImmutableMap.of(), new FeaturesConfig().isLegacyTimestamp(), Optional.empty(), Optional.empty());
+    }
+
+    public TestingConnectorSession(List<PropertyMetadata<?>> properties, Optional<String> schema)
+    {
+        this("user", Optional.of("test"), Optional.empty(), UTC_KEY, ENGLISH, System.currentTimeMillis(), properties, ImmutableMap.of(), new FeaturesConfig().isLegacyTimestamp(), Optional.empty(), schema);
     }
 
     public TestingConnectorSession(
@@ -68,7 +74,8 @@ public class TestingConnectorSession
             List<PropertyMetadata<?>> propertyMetadatas,
             Map<String, Object> propertyValues,
             boolean isLegacyTimestamp,
-            Optional<String> clientInfo)
+            Optional<String> clientInfo,
+            Optional<String> schema)
     {
         this.queryId = queryIdGenerator.createNextQueryId().toString();
         this.identity = new ConnectorIdentity(requireNonNull(user, "user is null"), Optional.empty(), Optional.empty());
@@ -86,6 +93,7 @@ public class TestingConnectorSession
                 .setSessionLocale(locale)
                 .setSessionUser(user)
                 .build();
+        this.schema = requireNonNull(schema, "schema is null");
     }
 
     @Override
@@ -148,6 +156,12 @@ public class TestingConnectorSession
             return type.cast(metadata.getDefaultValue());
         }
         return type.cast(metadata.decode(value));
+    }
+
+    @Override
+    public Optional<String> getSchema()
+    {
+        return schema;
     }
 
     @Override

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestDateTimeFunctionsBase.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestDateTimeFunctionsBase.java
@@ -159,7 +159,19 @@ public abstract class TestDateTimeFunctionsBase
     private void assertCurrentDateAtInstant(TimeZoneKey timeZoneKey, long instant)
     {
         long expectedDays = epochDaysInZone(timeZoneKey, instant);
-        long dateTimeCalculation = currentDate(new TestingConnectorSession("test", Optional.empty(), Optional.empty(), timeZoneKey, US, instant, ImmutableList.of(), ImmutableMap.of(), isLegacyTimestamp(session), Optional.empty()).getSqlFunctionProperties());
+        long dateTimeCalculation = currentDate(
+                new TestingConnectorSession(
+                        "test",
+                        Optional.empty(),
+                        Optional.empty(),
+                        timeZoneKey,
+                        US,
+                        instant,
+                        ImmutableList.of(),
+                        ImmutableMap.of(),
+                        isLegacyTimestamp(session),
+                        Optional.empty(),
+                        Optional.empty()).getSqlFunctionProperties());
         assertEquals(dateTimeCalculation, expectedDays);
     }
 

--- a/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotSplitManager.java
+++ b/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotSplitManager.java
@@ -156,6 +156,7 @@ public class TestPinotSplitManager
                         PinotSessionProperties.FORBID_SEGMENT_QUERIES,
                         forbidSegmentQueries),
                 new FeaturesConfig().isLegacyTimestamp(),
+                Optional.empty(),
                 Optional.empty());
     }
 

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/TestRaptorConnector.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/TestRaptorConnector.java
@@ -228,6 +228,7 @@ public class TestRaptorConnector
                 new RaptorSessionProperties(new StorageManagerConfig()).getSessionProperties(),
                 ImmutableMap.of(),
                 true,
+                Optional.empty(),
                 Optional.empty());
 
         ConnectorTransactionHandle transaction = connector.beginTransaction(READ_COMMITTED, false);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorSession.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorSession.java
@@ -43,4 +43,6 @@ public interface ConnectorSession
     SqlFunctionProperties getSqlFunctionProperties();
 
     <T> T getProperty(String name, Class<T> type);
+
+    Optional<String> getSchema();
 }

--- a/presto-spi/src/test/java/com/facebook/presto/spi/TestingSession.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/TestingSession.java
@@ -86,6 +86,12 @@ public final class TestingSession
         {
             throw new PrestoException(INVALID_SESSION_PROPERTY, "Unknown session property " + name);
         }
+
+        @Override
+        public Optional<String> getSchema()
+        {
+            return Optional.empty();
+        }
     };
 
     private TestingSession() {}


### PR DESCRIPTION
Having access to this information will allow us to make decisions based on the schema
in the metadata layers

Test plan - This is a simple change that flows the schema to the connector. Just ensured that
the current tests continue to succeed.

```
== RELEASE NOTES ==

SPI Changes
* Add ``getSchema`` to ``ConnectorSession``
```

Depended by https://github.com/facebookexternal/presto-facebook/pull/1341
