### PR TITLE
Improve Float and Double StreamReaders using batch read mode

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/DoubleSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/DoubleSelectiveStreamReader.java
@@ -38,6 +38,9 @@ import static com.facebook.presto.common.type.DoubleType.DOUBLE;
 import static com.facebook.presto.orc.array.Arrays.ensureCapacity;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
+import static com.facebook.presto.orc.reader.ReaderUtils.packLongs;
+import static com.facebook.presto.orc.reader.ReaderUtils.packLongsAndNulls;
+import static com.facebook.presto.orc.reader.ReaderUtils.unpackLongsWithNulls;
 import static com.facebook.presto.orc.reader.SelectiveStreamReaders.initializeOutputPositions;
 import static com.facebook.presto.orc.stream.MissingInputStreamSource.missingStreamSource;
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -45,6 +48,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.Double.doubleToLongBits;
+import static java.lang.Double.longBitsToDouble;
 import static java.util.Objects.requireNonNull;
 
 public class DoubleSelectiveStreamReader
@@ -161,7 +165,12 @@ public class DoubleSelectiveStreamReader
 
         allNulls = false;
 
-        if (outputRequired) {
+        if (useBatchMode()) {
+            // values need to be allocated for batch mode, because they need to be used for evaluating filters even when output is not required,
+            // nulls need to be allocated when presentStream != null, because values need to be unpacked with nulls
+            ensureValuesCapacity(positions[positionCount - 1] + 1, presentStream != null);
+        }
+        else if (outputRequired) {
             ensureValuesCapacity(positionCount, nullsAllowed && presentStream != null);
         }
 
@@ -221,6 +230,42 @@ public class DoubleSelectiveStreamReader
             throws IOException
     {
         // filter == null implies outputRequired == true
+
+        if (useBatchMode()) {
+            int totalPositionCount = positions[positionCount - 1] + 1;
+            if (presentStream == null) {
+                dataStream.next(values, totalPositionCount);
+                if (totalPositionCount > positionCount) {
+                    packLongs(values, positions, positionCount);
+                }
+            }
+            else {
+                int nullCount = presentStream.getUnsetBits(totalPositionCount, nulls);
+
+                if (nullCount == totalPositionCount) {
+                    // all nulls
+                    allNulls = true;
+                }
+                else {
+                    // some nulls
+                    dataStream.next(values, totalPositionCount - nullCount);
+
+                    if (outputRequired) {
+                        if (nullCount != 0) {
+                            unpackLongsWithNulls(values, nulls, totalPositionCount, totalPositionCount - nullCount);
+                        }
+
+                        if (totalPositionCount > positionCount) {
+                            // Need to pack both values and nulls
+                            packLongsAndNulls(values, nulls, positions, positionCount);
+                        }
+                    }
+                }
+            }
+            outputPositionCount = positionCount;
+            return totalPositionCount;
+        }
+
         int streamPosition = 0;
         for (int i = 0; i < positionCount; i++) {
             int position = positions[i];
@@ -247,6 +292,58 @@ public class DoubleSelectiveStreamReader
     private int readWithFilter(int[] positions, int positionCount)
             throws IOException
     {
+        if (useBatchMode()) {
+            int totalPositionCount = positions[positionCount - 1] + 1;
+            int readCount = 0;
+
+            int filteredPositionCount;
+
+            if (presentStream == null) {
+                dataStream.next(values, totalPositionCount);
+
+                filteredPositionCount = evaluateFilter(positions, positionCount);
+
+                if (outputRequired && totalPositionCount > filteredPositionCount) {
+                    packLongs(values, outputPositions, filteredPositionCount);
+                }
+            }
+            else {
+                int nullCount = presentStream.getUnsetBits(totalPositionCount, nulls);
+
+                if (nullCount == totalPositionCount) {
+                    // all nulls
+                    if ((nonDeterministicFilter && this.filter.testNull()) || nullsAllowed) {
+                        allNulls = true;
+                        filteredPositionCount = positionCount; // No positions were filtered out
+                    }
+                    else {
+                        filteredPositionCount = 0;
+                    }
+                }
+                else {
+                    // some nulls
+                    readCount = totalPositionCount - nullCount;
+                    dataStream.next(values, readCount);
+
+                    if (nullCount != 0) {
+                        // Note it should be totalPositionCount instead of positionCount
+                        unpackLongsWithNulls(values, nulls, totalPositionCount, readCount);
+                    }
+
+                    filteredPositionCount = evaluateFilterWithNulls(positions, positionCount);
+
+                    if (outputRequired && totalPositionCount > filteredPositionCount) {
+                        // both values and nulls need to be packed
+                        packLongsAndNulls(values, nulls, outputPositions, filteredPositionCount);
+                    }
+                }
+            }
+            outputPositionCount = filteredPositionCount;
+
+            // Should return totalPositionCount instead of readCount
+            return totalPositionCount;
+        }
+
         int streamPosition = 0;
         outputPositionCount = 0;
         for (int i = 0; i < positionCount; i++) {
@@ -257,7 +354,7 @@ public class DoubleSelectiveStreamReader
             }
 
             if (presentStream != null && !presentStream.nextBit()) {
-                if ((nonDeterministicFilter && filter.testNull()) || nullsAllowed) {
+                if ((nonDeterministicFilter && this.filter.testNull()) || nullsAllowed) {
                     if (outputRequired) {
                         nulls[outputPositionCount] = true;
                     }
@@ -450,5 +547,56 @@ public class DoubleSelectiveStreamReader
         dataStreamSource = null;
 
         systemMemoryContext.close();
+    }
+
+    private boolean useBatchMode()
+    {
+        // When there are no nulls, the batch read mode is better than skipping mode for all cases
+        return presentStream == null;
+    }
+
+    private int evaluateFilter(int[] positions, int positionCount)
+    {
+        int positionsIndex = 0;
+        for (int i = 0; i < positionCount; i++) {
+            int position = positions[i];
+            if (filter.testDouble(longBitsToDouble(values[position]))) {
+                outputPositions[positionsIndex++] = position;  // compact positions on the fly
+            }
+            else {
+                i += filter.getSucceedingPositionsToFail();
+                positionsIndex -= filter.getPrecedingPositionsToFail();
+            }
+        }
+        return positionsIndex;
+    }
+
+    private int evaluateFilterWithNulls(int[] positions, int positionCount)
+    {
+        int positionsIndex = 0;
+        for (int i = 0; i < positionCount; i++) {
+            int position = positions[i];
+
+            // Note it should not be nulls[position] && testNull
+            if (nulls[position]) {
+                if ((nonDeterministicFilter && this.filter.testNull()) || nullsAllowed) {
+                    outputPositions[positionsIndex++] = position;
+                }
+                else {
+                    i += filter.getSucceedingPositionsToFail();
+                    positionsIndex -= filter.getPrecedingPositionsToFail();
+                }
+            }
+            else {
+                if (filter.testDouble(longBitsToDouble(values[position]))) {
+                    outputPositions[positionsIndex++] = position;  // compact positions on the fly
+                }
+                else {
+                    i += filter.getSucceedingPositionsToFail();
+                    positionsIndex -= filter.getPrecedingPositionsToFail();
+                }
+            }
+        }
+        return positionsIndex;
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/ReaderUtils.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/ReaderUtils.java
@@ -98,6 +98,86 @@ final class ReaderUtils
         }
     }
 
+    public static void unpackLongsWithNulls(long[] values, boolean[] isNull, int positionCount, int nonNullCount)
+    {
+        int position = nonNullCount - 1;
+        for (int i = positionCount - 1; i >= 0; i--) {
+            if (!isNull[i]) {
+                values[i] = values[position--];
+            }
+            else {
+                values[i] = 0;
+            }
+        }
+    }
+
+    public static void packBytes(byte[] values, int[] positions, int positionCount)
+    {
+        for (int i = 0; i < positionCount; i++) {
+            values[i] = values[positions[i]];
+        }
+    }
+
+    public static void packBytesAndNulls(byte[] values, boolean[] nulls, int[] positions, int positionCount)
+    {
+        for (int i = 0; i < positionCount; i++) {
+            int position = positions[i];
+
+            // Pack nulls
+            nulls[i] = nulls[position];
+            values[i] = values[position];
+        }
+    }
+
+    public static void packInts(int[] values, int[] positions, int positionCount)
+    {
+        for (int i = 0; i < positionCount; i++) {
+            values[i] = values[positions[i]];
+        }
+    }
+
+    public static void packIntsAndNulls(int[] values, boolean[] nulls, int[] positions, int positionCount)
+    {
+        for (int i = 0; i < positionCount; i++) {
+            int position = positions[i];
+
+            // Pack nulls
+            nulls[i] = nulls[position];
+            values[i] = values[position];
+        }
+    }
+
+    public static void packLongs(long[] values, int[] positions, int positionCount)
+    {
+        for (int i = 0; i < positionCount; i++) {
+            values[i] = values[positions[i]];
+        }
+    }
+
+    public static void packLongsAndNulls(long[] values, boolean[] nulls, int[] positions, int positionCount)
+    {
+        for (int i = 0; i < positionCount; i++) {
+            int position = positions[i];
+
+            // Pack nulls
+            nulls[i] = nulls[position];
+            values[i] = values[position];
+        }
+    }
+
+    public static void unpackIntsWithNulls(int[] values, boolean[] isNull, int positionCount, int nonNullCount)
+    {
+        int position = nonNullCount - 1;
+        for (int i = positionCount - 1; i >= 0; i--) {
+            if (!isNull[i]) {
+                values[i] = values[position--];
+            }
+            else {
+                values[i] = 0;
+            }
+        }
+    }
+
     public static short[] unpackShortNulls(short[] values, boolean[] isNull)
     {
         short[] result = new short[isNull.length];

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/DoubleInputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/DoubleInputStream.java
@@ -65,4 +65,10 @@ public class DoubleInputStream
             type.writeDouble(builder, next());
         }
     }
+
+    public void next(long[] values, int items)
+            throws IOException
+    {
+        input.readDoubles(values, items);
+    }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/FloatInputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/FloatInputStream.java
@@ -66,4 +66,10 @@ public class FloatInputStream
             type.writeLong(builder, floatToRawIntBits(next()));
         }
     }
+
+    public void next(int[] values, int items)
+            throws IOException
+    {
+        input.readFloats(values, items);
+    }
 }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestSelectiveOrcReader.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestSelectiveOrcReader.java
@@ -406,6 +406,14 @@ public class TestSelectiveOrcReader
                 createList(NUM_ROWS, i -> randomIntegers(random.nextInt(10), random)),
                 IS_NULL, IS_NOT_NULL);
 
+        tester.testRoundTrip(arrayType(REAL),
+                createList(NUM_ROWS, i -> randomFloats(5 + random.nextInt(5), random)),
+                ImmutableList.of(ImmutableMap.of(new Subfield("c[2]"), IS_NOT_NULL)));
+
+        tester.testRoundTrip(arrayType(DOUBLE),
+                createList(NUM_ROWS, i -> randomDoubles(5 + random.nextInt(5), random)),
+                ImmutableList.of(ImmutableMap.of(new Subfield("c[2]"), IS_NOT_NULL)));
+
         BigintRange negative = BigintRange.of(Integer.MIN_VALUE, 0, false);
         BigintRange nonNegative = BigintRange.of(0, Integer.MAX_VALUE, false);
 
@@ -1214,6 +1222,16 @@ public class TestSelectiveOrcReader
     private static List<Integer> randomIntegers(int size, Random random)
     {
         return createList(size, i -> random.nextInt());
+    }
+
+    private static List<Float> randomFloats(int size, Random random)
+    {
+        return createList(size, i -> random.nextFloat());
+    }
+
+    private static List<Double> randomDoubles(int size, Random random)
+    {
+        return createList(size, i -> random.nextDouble());
     }
 
     private static List<SqlDecimal> decimalSequence(String start, String step, int items, int precision, int scale)


### PR DESCRIPTION
BenchmarkSelectiveStreamReaders shows up to 2.2x improvement for float, and 1.6x for double:

```
== NO RELEASE NOTE ==
```
