### PR TITLE
Add release notes for 0.245

### DIFF
--- a/presto-docs/src/main/sphinx/release.rst
+++ b/presto-docs/src/main/sphinx/release.rst
@@ -5,6 +5,7 @@ Release Notes
 .. toctree::
     :maxdepth: 1
 
+    release/release-0.244.1
     release/release-0.244
     release/release-0.243.4
     release/release-0.243.3

--- a/presto-docs/src/main/sphinx/release.rst
+++ b/presto-docs/src/main/sphinx/release.rst
@@ -5,6 +5,7 @@ Release Notes
 .. toctree::
     :maxdepth: 1
 
+    release/release-0.245
     release/release-0.244.1
     release/release-0.244
     release/release-0.243.4

--- a/presto-docs/src/main/sphinx/release/release-0.242.1.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.242.1.rst
@@ -2,6 +2,9 @@
 Release 0.242.1
 ===============
 
+.. warning::
+    There is a bug causing failure at startup if function namespace manager is enabled and Thrift is not configured (:pr:`15501`).
+
 Hive Changes
 ------------
 * Fix a bug with reading encrypted DWRF tables where queries could fail with a NullPointerException.

--- a/presto-docs/src/main/sphinx/release/release-0.242.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.242.rst
@@ -5,6 +5,9 @@ Release 0.242
 .. warning::
     There is a bug in LambdaDefinitionExpression canonicalization introduced since 0.238. For more details, go to :issue:`15424`.
 
+.. warning::
+    There is a bug causing failure at startup if function namespace manager is enabled and Thrift is not configured. Fixed in :pr:`15501`.
+
 **Highlights**
 ==============
 * Add configuration property ``experimental.spiller.task-spilling-strategy`` for choosing different spilling strategy to use.

--- a/presto-docs/src/main/sphinx/release/release-0.243.1.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.243.1.rst
@@ -2,6 +2,9 @@
 Release 0.243.1
 ===============
 
+.. warning::
+    There is a bug causing failure at startup if function namespace manager is enabled and Thrift is not configured (:pr:`15501`).
+
 Hive Changes
 ------------
 * Fix a bug with reading encrypted DWRF tables where queries could fail with a NullPointerException.

--- a/presto-docs/src/main/sphinx/release/release-0.243.2.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.243.2.rst
@@ -2,6 +2,9 @@
 Release 0.243.2
 ===============
 
+.. warning::
+    There is a bug causing failure at startup if function namespace manager is enabled and Thrift is not configured (:pr:`15501`).
+
 General Changes
 ---------------
 * Fix LambdaDefinitionExpression canonicalization to correctly canonicalize Block constant (:issue:`15424`).

--- a/presto-docs/src/main/sphinx/release/release-0.243.3.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.243.3.rst
@@ -2,6 +2,9 @@
 Release 0.243.3
 ===============
 
+.. warning::
+    There is a bug causing failure at startup if function namespace manager is enabled and Thrift is not configured (:pr:`15501`).
+
 General Changes
 ---------------
 * Fix access control checks for columns in ``USING`` clause (:pr:`15333`).

--- a/presto-docs/src/main/sphinx/release/release-0.243.4.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.243.4.rst
@@ -2,6 +2,9 @@
 Release 0.243.4
 ===============
 
+.. warning::
+    There is a bug causing failure at startup if function namespace manager is enabled and Thrift is not configured (:pr:`15501`).
+
 Hive Changes
 ____________
 * Fix reading ORC files having MAP columns with MAP_FLAT encoding where all entries are empty maps (:pr:`15468`).

--- a/presto-docs/src/main/sphinx/release/release-0.243.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.243.rst
@@ -11,6 +11,9 @@ Release 0.243
 .. warning::
     There is a bug that causes a failure in reading ORC files having MAP columns with MAP_FLAT encoding where all the entries in the column are empty maps (:pr:`15468`).
 
+.. warning::
+    There is a bug causing failure at startup if function namespace manager is enabled and Thrift is not configured (:pr:`15501`).
+
 **Highlights**
 ==============
 * Add :func:`approx_most_frequent` aggregation function.

--- a/presto-docs/src/main/sphinx/release/release-0.244.1.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.244.1.rst
@@ -2,6 +2,9 @@
 Release 0.244.1
 ===============
 
+.. warning::
+    There is a bug causing failure at startup if function namespace manager is enabled and Thrift is not configured (:pr:`15501`).
+
 Hive Changes
 ____________
 * Fix reading ORC files having MAP columns with MAP_FLAT encoding where all entries are empty maps (:pr:`15468`).

--- a/presto-docs/src/main/sphinx/release/release-0.244.1.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.244.1.rst
@@ -1,0 +1,7 @@
+===============
+Release 0.244.1
+===============
+
+Hive Changes
+____________
+* Fix reading ORC files having MAP columns with MAP_FLAT encoding where all entries are empty maps (:pr:`15468`).

--- a/presto-docs/src/main/sphinx/release/release-0.244.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.244.rst
@@ -2,6 +2,9 @@
 Release 0.244
 =============
 
+.. warning::
+    There is a bug that causes a failure in reading ORC files having MAP columns with MAP_FLAT encoding where all the entries in the column are empty maps (:pr:`15468`).
+
 **Highlights**
 ==============
 * Improve performance of cross joins.

--- a/presto-docs/src/main/sphinx/release/release-0.244.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.244.rst
@@ -5,6 +5,9 @@ Release 0.244
 .. warning::
     There is a bug that causes a failure in reading ORC files having MAP columns with MAP_FLAT encoding where all the entries in the column are empty maps (:pr:`15468`).
 
+.. warning::
+    There is a bug causing failure at startup if function namespace manager is enabled and Thrift is not configured (:pr:`15501`).
+
 **Highlights**
 ==============
 * Improve performance of cross joins.

--- a/presto-docs/src/main/sphinx/release/release-0.245.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.245.rst
@@ -1,0 +1,37 @@
+=============
+Release 0.245
+=============
+
+.. warning::
+    There is a bug causing failure at startup if function namespace manager is enabled and Thrift is not configured (:pr:`15501`).
+
+**Highlights**
+==============
+* New ``enum_key`` UDF to get the key for an enum value.
+* Configurable query result compression.
+
+**Details**
+===========
+
+General Changes
+_______________
+* Fix wrong results issue for queries with multiple lambda expressions that differ only in array/map/row constants that have the same length (:issue:`15424`).
+* Fix serialization bug causing maps with string-valued enum keys to be displayed as illegible strings in Presto CLI.
+* Fix parsing logic for prepared statements to be consistent with regular statements.
+* Improve memory usage for fragment result caching.
+* Add support for disabling query result compression via client and server-side configuration properties. Clients can disable compressed responses using the ``--disable-compression`` flag or ``disableCompression`` driver property. Compression can be disabled server-wide by using the configuration property: ``query-results.compression-enabled=false``
+* Add support in affinity scheduler to enable cache for bucketed table scan that has remote source.
+* Add ``enum_key`` to get the key corresponding to an enum value: `ENUM_KEY(EnumType) -> VARCHAR`.
+
+Hive Connector Changes
+______________________
+* Improve parquet metadata reader by preloading data and reducing the number of reads (:pr:`15421`).
+
+SPI Changes
+____________
+* Add ``getSchema`` to ``ConnectorSession``.
+
+**Contributors**
+================
+
+Andrii Rosa, Beinan Wang, Bhavani Hari, Daniel Ohayon, Dong Shi, Ge Gao, James Petty, James Sun, Ke Wang, Leiqing Cai, Masha Basmanova, Mayank Garg, Nikhil Collooru, Rebecca Schlussel, Rongrong Zhong, Saksham Sachdev, Shixuan Fan, Timothy Meehan, Vic Zhang, Wenlei Xie, Ying Su, Zhenxiao Luo


### PR DESCRIPTION
# Missing Release Notes
## Mayank Garg
- [x] https://github.com/prestodb/presto/pull/15495 Add query schema to ConnectorSession (Merged by: Timothy Meehan)

# Extracted Release Notes
- #15349 (Author: Dong Shi): Changes to pass through sqlparser options
  - Pass SqlParserOptions to prepared statement handler so that parsing logic is consistent with regular requests.
- #15393 (Author: James Petty): Make query result HTTP response compression configurable
  - Add support for disabling query result compression via client and server-side configuration properties.
- #15393 (Author: James Petty): Make query result HTTP response compression configurable
  - Add support for disabling query result compression via client and server-side configuration properties.
- #15414 (Author: Rongrong Zhong): Fix LambdaDefinitionExpression canonicalization
  - Fix LambdaDefinitionExpression canonicalization to correctly canonicalize Block constant (:issue:`15424`).
- #15414 (Author: Rongrong Zhong): Fix LambdaDefinitionExpression canonicalization
  - Fix LambdaDefinitionExpression canonicalization to correctly canonicalize Block constant (:issue:`15424`).
- #15421 (Author: James Petty): Reduce parquet metadata read request count
  - Improve parquet metadata reader by pre-loading 16KiB from the end of the file. When the metadata section is smaller than the prefetch size, only a single read is performed compared to the previous two.
- #15428 (Author: Shixuan Fan): Use serialized plan hash for fragment result caching
  - Reduce memory usage for fragment result caching.
- #15444 (Author: Daniel Ohayon): Add UDF to map enum value to key
  - Added a UDF to get the key corresponding to an enum value.
- #15450 (Author: Daniel Ohayon): Fix LongEnum deserialization in map keys
  - Fix enum deserialization bug in map keys.
- #15464 (Author: Ke Wang): Fix split cacheable setting for affinity scheduling
  - Add support in affinity scheduler to enable cache for bucketed table scan that has remote source.

# All Commits
- b2c7ab82fe10cf9103d7239897a448fada15f22a Load function managers for Presto-on-Spark driver only (Vic Zhang)
- 8e1384e2fe241f6b28ae8b0ad4a78b3f217c4343 Add query schema to ConnectorSession (Mayank Garg)
- 27ab25b538642fec4c4b96430013b877a9753d7f Fix tests for prefer_manifests_to_list_files property (Nikhil Collooru)
- 996738a178d4b872ef26e83c39d20c1815637c84 Fix NPE when a FlatMap column is all empty (Bhavani Hari)
- 388055f1c46d0481aa5f0d7d57c1968bde10cf6b Add more filter rates to BenchmarkSelectiveStreamReaders (Ying Su)
- 297b089ea5fd786114d3944554d507470af25e76 Improve reading the lengthVector in SliceDirectSelectiveStreamReader (Ying Su)
- 02e09811ff09d9f27ab5d99394e6b1cdc513a792 Improve reading unbounded varchar with batch read mode (Ying Su)
- dc2d50bc51984e0e46577b3792eceabf33a679cb Make query result HTTP compression server configurable (James Petty)
- d0c739356ee99e4da453477c14a935cfd76262eb Make query result HTTP compression client configurable (James Petty)
- 1e00009c582c36ce585e85e9ea583450a59c02d5 Optimize array_intersect by using OptimizedTypedSet (Ying Su)
- 87c776600afb054364e78ed155bc6076a16f14ae Optimize array_except by using OptimizedTypedSet (Ying Su)
- aabf9d6314cd1dcf25284df3f634ee5b777d5961 Optimize array_union using OptimizedTypedSet (Ying Su)
- 23e1ba71a6acf0e37b2147b18ec13bca7b6cbba2 Optimize map_concat using OptimizedTypedSet (Ying Su)
- 30cacee442adf246b38b9fc986e2fea51aa454b0 Introducing OptimizedTypedSet (Ying Su)
- ec7336d8a8302992cbce3dab1047f13f7ecc65ee Add self join and table scan assignment tests for dereference pushdown (Beinan Wang)
- 130527265fd8aebee395ed2412f4058d0e269f51 Fix base column name not present error when dereference pushdown enabled (Beinan Wang)
- 1a804ac9e5f34316af2b27793624990b5f6c5bf4 Fixes for prefer_manifests_to_list_files property (Nikhil Collooru)
- cba87b4f111983b5483ab2ecf580573ac0afa595 Add syntax support for CREATE MATERIALIZED VIEW (Ge Gao)
- fe1bc57c9442a368276be3a4536ae760104efaf0 Add verifier flag for removing memory related session property (Wenlei Xie)
- ca64162a0c43482b75e8dd41313472ddba8f9d86 Update to airlift 0.198 and airbase 100 (Leiqing Cai)
- 7b41e69c40eb9815e13dce6b41f9a2545c97c60d Add session property manifest_verification_enabled (Nikhil Collooru)
- ce41e2f7af8815b96da95b5be389d5d57377e887 Add PartitionLoader to load partitions (Nikhil Collooru)
- 04c9ef6307faf35d2fa04563f52002586010a63c Add new session property prefer_manifests_to_list_files (Nikhil Collooru)
- 951ec9dfbbf66fb68c3df77d20274cf9f500d38c Build presto-docs in Travis (Leiqing Cai)
- 1918b624f74aa069610a998a0187b2c79209ac41 Do not treat warning as errors when making presto-docs (Leiqing Cai)
- 817d50ac5091cdb5d71e5e90a4c9e57875bb5805 Fix split cacheable setting for affinity scheduling (Ke Wang)
- c0e24ec7b32d0361ef741d7430e255edfaf75ab9 Add UDF to map enum value to key (Daniel Ohayon)
- 59e88dc9e1d441593868080897b44c2b93873db5 Fix LongEnum deserialization in map keys (Daniel Ohayon)
- 9d5db3c1c4b809a8a0a503ef22039d334ffd3898 Fix extracting logic in dynamic filtering when integrated with filter pushdown (Ke Wang)
- c96938bf960b62da8fb4700c752b61979753303c Store file names and sizes in partition parameters (Nikhil Collooru)
- 36fdd4072cf09c4686762702b90f0d4de3fa1867 Add getFileSize() to retrieve the size of the file (Nikhil Collooru)
- faee0a05677d0453832a7ad8cf35fd959c670d2a Add filter pushdown tests for native worker (Masha Basmanova)
- 566b0d84827fc1c85af4c88b7a060970913a9897 Change task threshold revoking config type to DataSize (Saksham Sachdev)
- 0bb6d8dac2fb4cf0c2bcfa3b5777940185e0f397 Null unused array elements in SpillableFinalOnlyGroupedAccumulator (Saksham Sachdev)
- 2e67116d263b02b97ef507e8ca978af731747d06 Use serialized plan for fragment result caching (Shixuan Fan)
- 15b0ea204136c1dc14ecffb109b81102bb385c69 Minor refactor to SingleStreamSpillerChoice (Wenlei Xie)
- aef9bfc29149418b4014974c7db4bda5aabc5ee3 Fix not registering TempStorage in PluginManager (Wenlei Xie)
- 6970b6da9f392a8f6eb41c974c7eeb15f69c62da Refactor TempStorage related interfaces (Wenlei Xie)
- 548457ab4e63c9b045bfffa6f6d9a8fb8d6a7bb3 Pass in SqlParserOptions to HttpRequestSessionContext for Prepared Statements. (Dong Shi)
- 2499b40de1599a99eea4f898c5e1cb24aefae9ea Add per-node revocable memory limit (Saksham Sachdev)
- 32e32af04f82b2791a6c9e42ccd67f4794c3f7e5 Add warning for Presto on Spark (Vic Zhang)
- 68b3c78fc6b189c56a5d96a2e932e204b9464605 Reuse immutable partition fields in Glue partition conversion (James Petty)
- 1b842223640f2e6595e72e5f8b26d0f74662b8f8 Add pre-read hueristic to parquet MetadataReader (James Petty)
- b23ce2e00046f108ebfd47497da7d6095f939f6e Remove spill-enabled requirement for enabling join spill (Rebecca Schlussel)
- b2208ec92a3119f8365440cdcc8206781a215987 Fix the check to correctly capture NULL positions (Bhavani Hari)
- 63d85a3c4998370738e0a859c1bda1061ee316cb Add ParametricType APIs to FunctionNamespaceManager (Rongrong Zhong)
- a6d77a63e29adaaff1047c73f8448c66aebac479 Add QualifiedObjectName to TypeSignature (Rongrong Zhong)
- b411d77178848abfa31d903d3d0c1a4fe1024390 Merge BuiltInTypeRegistry and BuiltinFunctionNamespaceManager (Rongrong Zhong)
- 0ffe6dfca5a0220aeb54afe9d043ad6a19bb4574 Move QualifiedObjectName to presto-common (Rongrong Zhong)
- bde30f6ba348ad20b729cdba4c0d54a574bb1cf2 Refactor type coercion logic to TypeCoercer (Rongrong Zhong)
- d8da5bc2cbcf8fade280e57ffa4893abdffff240 Rename TypeRegistry to BuiltInTypeRegistry (Rongrong Zhong)
- cd44d2409d5413385ade194eefd539ca017d639e Clean up TypeManager APIs (Rongrong Zhong)
- ae66246ebbb9bcf4f1deabc399543d26beadebd3 Remove Metadata.getTypeManager (Rongrong Zhong)
- e24dcc2b6411164812773667f2d385d5208a477e Support function namespace manager for Presto-on-Spark (Vic Zhang)
- be1e61cdaea3f86e4433ba9728e1ac5d674c698e Refactor StaticFunctionNamespaceStore to load properties map (Vic Zhang)
- 11535d41414a13709cf811e0aab3fbefa0bbaaf2 Chage Block's toString to be unique with respect to hashCode (Rongrong Zhong)
- 5e1687b9f716c8fd32a3a7ef10840161e96e2b44 Fix LambdaDefinitionExpression canonicalization (Rongrong Zhong)
- 455cd6c11cd08498caede087dd9f21f5b5a2eddc Load configuration manager for Presto-on-Spark driver (Vic Zhang)