### PR TITLE
Add listener model for TaskThresholdMemoryRevokingScheduler

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/MemoryRevokingScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/MemoryRevokingScheduler.java
@@ -40,6 +40,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 
+import static com.facebook.presto.execution.MemoryRevokingUtils.getMemoryPools;
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.TaskSpillingStrategy.PER_TASK_MEMORY_THRESHOLD;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
@@ -109,15 +110,6 @@ public class MemoryRevokingScheduler
         requireNonNull(valueName, "valueName is null");
         checkArgument(0 <= value && value <= 1, "%s should be within [0, 1] range, got %s", valueName, value);
         return value;
-    }
-
-    private static List<MemoryPool> getMemoryPools(LocalMemoryManager localMemoryManager)
-    {
-        requireNonNull(localMemoryManager, "localMemoryManager can not be null");
-        ImmutableList.Builder<MemoryPool> builder = new ImmutableList.Builder<>();
-        builder.add(localMemoryManager.getGeneralPool());
-        localMemoryManager.getReservedPool().ifPresent(builder::add);
-        return builder.build();
     }
 
     @PostConstruct

--- a/presto-main/src/main/java/com/facebook/presto/execution/MemoryRevokingUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/MemoryRevokingUtils.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution;
+
+import com.facebook.presto.memory.LocalMemoryManager;
+import com.facebook.presto.memory.MemoryPool;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+public class MemoryRevokingUtils
+{
+    private MemoryRevokingUtils() {}
+
+    public static List<MemoryPool> getMemoryPools(LocalMemoryManager localMemoryManager)
+    {
+        requireNonNull(localMemoryManager, "localMemoryManager can not be null");
+        ImmutableList.Builder<MemoryPool> builder = new ImmutableList.Builder<>();
+        builder.add(localMemoryManager.getGeneralPool());
+        localMemoryManager.getReservedPool().ifPresent(builder::add);
+        return builder.build();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskManager.java
@@ -316,6 +316,11 @@ public class SqlTaskManager
         return ImmutableList.copyOf(tasks.asMap().values());
     }
 
+    public SqlTask getTask(TaskId taskId)
+    {
+        return tasks.getUnchecked(taskId);
+    }
+
     @Override
     public List<TaskInfo> getAllTaskInfo()
     {

--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskThresholdMemoryRevokingScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskThresholdMemoryRevokingScheduler.java
@@ -14,11 +14,15 @@
 package com.facebook.presto.execution;
 
 import com.facebook.airlift.log.Logger;
+import com.facebook.presto.memory.LocalMemoryManager;
+import com.facebook.presto.memory.MemoryPool;
 import com.facebook.presto.memory.QueryContext;
+import com.facebook.presto.memory.TaskRevocableMemoryListener;
 import com.facebook.presto.memory.VoidTraversingQueryContextVisitor;
 import com.facebook.presto.operator.OperatorContext;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 
 import javax.annotation.Nullable;
 import javax.annotation.PostConstruct;
@@ -31,8 +35,10 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
+import static com.facebook.presto.execution.MemoryRevokingUtils.getMemoryPools;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -40,7 +46,8 @@ public class TaskThresholdMemoryRevokingScheduler
 {
     private static final Logger log = Logger.get(TaskThresholdMemoryRevokingScheduler.class);
 
-    private final Supplier<List<SqlTask>> currentTasksSupplier;
+    private final Supplier<List<SqlTask>> allTasksSupplier;
+    private final Function<TaskId, SqlTask> taskSupplier;
     private final ScheduledExecutorService taskManagementExecutor;
     private final long maxRevocableMemoryPerTask;
 
@@ -50,15 +57,20 @@ public class TaskThresholdMemoryRevokingScheduler
     private ScheduledFuture<?> scheduledFuture;
 
     private final AtomicBoolean checkPending = new AtomicBoolean();
+    private final List<MemoryPool> memoryPools;
+    private final TaskRevocableMemoryListener taskRevocableMemoryListener = TaskRevocableMemoryListener.onMemoryReserved(this::onMemoryReserved);
 
     @Inject
     public TaskThresholdMemoryRevokingScheduler(
+            LocalMemoryManager localMemoryManager,
             SqlTaskManager sqlTaskManager,
             TaskManagementExecutor taskManagementExecutor,
             FeaturesConfig config)
     {
         this(
+                ImmutableList.copyOf(getMemoryPools(localMemoryManager)),
                 requireNonNull(sqlTaskManager, "sqlTaskManager cannot be null")::getAllTasks,
+                requireNonNull(sqlTaskManager, "sqlTaskManager cannot be null")::getTask,
                 requireNonNull(taskManagementExecutor, "taskManagementExecutor cannot be null").getExecutor(),
                 requireNonNull(config.getMaxRevocableMemoryPerTask(), "maxRevocableMemoryPerTask cannot be null").toBytes());
         log.debug("Using TaskThresholdMemoryRevokingScheduler spilling strategy");
@@ -66,11 +78,15 @@ public class TaskThresholdMemoryRevokingScheduler
 
     @VisibleForTesting
     TaskThresholdMemoryRevokingScheduler(
-            Supplier<List<SqlTask>> currentTasksSupplier,
+            List<MemoryPool> memoryPools,
+            Supplier<List<SqlTask>> allTasksSupplier,
+            Function<TaskId, SqlTask> taskSupplier,
             ScheduledExecutorService taskManagementExecutor,
             long maxRevocableMemoryPerTask)
     {
-        this.currentTasksSupplier = requireNonNull(currentTasksSupplier, "currentTasksSupplier is null");
+        this.memoryPools = ImmutableList.copyOf(requireNonNull(memoryPools, "memoryPools is null"));
+        this.allTasksSupplier = requireNonNull(allTasksSupplier, "allTasksSupplier is null");
+        this.taskSupplier = requireNonNull(taskSupplier, "taskSupplier is null");
         this.taskManagementExecutor = requireNonNull(taskManagementExecutor, "taskManagementExecutor is null");
         this.maxRevocableMemoryPerTask = maxRevocableMemoryPerTask;
     }
@@ -79,6 +95,7 @@ public class TaskThresholdMemoryRevokingScheduler
     public void start()
     {
         registerTaskMemoryPeriodicCheck();
+        registerPoolListeners();
     }
 
     private void registerTaskMemoryPeriodicCheck()
@@ -100,6 +117,14 @@ public class TaskThresholdMemoryRevokingScheduler
             scheduledFuture.cancel(true);
             scheduledFuture = null;
         }
+
+        memoryPools.forEach(memoryPool -> memoryPool.removeTaskRevocableMemoryListener(taskRevocableMemoryListener));
+    }
+
+    @VisibleForTesting
+    void registerPoolListeners()
+    {
+        memoryPools.forEach(memoryPool -> memoryPool.addTaskRevocableMemoryListener(taskRevocableMemoryListener));
     }
 
     @VisibleForTesting
@@ -110,15 +135,51 @@ public class TaskThresholdMemoryRevokingScheduler
         }
     }
 
+    private void onMemoryReserved(TaskId taskId, MemoryPool memoryPool)
+    {
+        try {
+            SqlTask task = taskSupplier.apply(taskId);
+            if (!memoryRevokingNeeded(task)) {
+                return;
+            }
+
+            if (checkPending.compareAndSet(false, true)) {
+                log.debug("Scheduling check for %s", memoryPool);
+                scheduleRevoking();
+            }
+        }
+        catch (Throwable e) {
+            log.error(e, "Error when acting on memory pool reservation");
+        }
+    }
+
+    private void scheduleRevoking()
+    {
+        taskManagementExecutor.execute(() -> {
+            try {
+                revokeHighMemoryTasks();
+            }
+            catch (Throwable e) {
+                log.error(e, "Error requesting memory revoking");
+            }
+        });
+    }
+
+    private boolean memoryRevokingNeeded(SqlTask task)
+    {
+        return task.getTaskInfo().getStats().getRevocableMemoryReservationInBytes() >= maxRevocableMemoryPerTask;
+    }
+
     private synchronized void revokeHighMemoryTasks()
     {
         if (checkPending.getAndSet(false)) {
-            Collection<SqlTask> sqlTasks = requireNonNull(currentTasksSupplier.get());
+            Collection<SqlTask> sqlTasks = requireNonNull(allTasksSupplier.get());
             for (SqlTask task : sqlTasks) {
-                long currentTaskRevocableMemory = task.getTaskInfo().getStats().getRevocableMemoryReservationInBytes();
-                if (currentTaskRevocableMemory < maxRevocableMemoryPerTask) {
+                if (!memoryRevokingNeeded(task)) {
                     continue;
                 }
+
+                long currentTaskRevocableMemory = task.getTaskInfo().getStats().getRevocableMemoryReservationInBytes();
 
                 AtomicLong remainingBytesToRevokeAtomic = new AtomicLong(currentTaskRevocableMemory - maxRevocableMemoryPerTask);
                 task.getQueryContext().accept(new VoidTraversingQueryContextVisitor<AtomicLong>()

--- a/presto-main/src/main/java/com/facebook/presto/memory/MemoryPool.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/MemoryPool.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.memory;
 
+import com.facebook.presto.execution.TaskId;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.memory.MemoryAllocation;
 import com.facebook.presto.spi.memory.MemoryPoolId;
@@ -71,6 +72,8 @@ public class MemoryPool
 
     private final List<MemoryPoolListener> listeners = new CopyOnWriteArrayList<>();
 
+    private final List<TaskRevocableMemoryListener> taskRevocableMemoryListeners = new CopyOnWriteArrayList<>();
+
     public MemoryPool(MemoryPoolId id, DataSize size)
     {
         this.id = requireNonNull(id, "name is null");
@@ -106,6 +109,16 @@ public class MemoryPool
         listeners.remove(requireNonNull(listener, "listener cannot be null"));
     }
 
+    public void addTaskRevocableMemoryListener(TaskRevocableMemoryListener listener)
+    {
+        taskRevocableMemoryListeners.add(requireNonNull(listener, "listener cannot be null"));
+    }
+
+    public void removeTaskRevocableMemoryListener(TaskRevocableMemoryListener listener)
+    {
+        taskRevocableMemoryListeners.remove(requireNonNull(listener, "listener cannot be null"));
+    }
+
     /**
      * Reserves the given number of bytes. Caller should wait on the returned future, before allocating more memory.
      */
@@ -139,6 +152,11 @@ public class MemoryPool
     private void onMemoryReserved()
     {
         listeners.forEach(listener -> listener.onMemoryReserved(this));
+    }
+
+    public void onTaskMemoryReserved(TaskId taskId)
+    {
+        taskRevocableMemoryListeners.forEach(listener -> listener.onMemoryReserved(taskId, this));
     }
 
     public ListenableFuture<?> reserveRevocable(QueryId queryId, long bytes)

--- a/presto-main/src/main/java/com/facebook/presto/memory/TaskRevocableMemoryListener.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/TaskRevocableMemoryListener.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.memory;
+
+import com.facebook.presto.execution.TaskId;
+
+import java.util.function.BiConsumer;
+
+public interface TaskRevocableMemoryListener
+{
+    /**
+     * Listener function that is called when a Task reserves
+     * memory in a given MemoryPool successfully
+     *
+     * @param taskId the {@link TaskId} of the task that reserved the memory
+     * @param memoryPool the {@link MemoryPool} where the reservation took place
+     */
+    void onMemoryReserved(TaskId taskId, MemoryPool memoryPool);
+
+    static TaskRevocableMemoryListener onMemoryReserved(BiConsumer<TaskId, ? super MemoryPool> action)
+    {
+        return action::accept;
+    }
+}


### PR DESCRIPTION
Test plan - deployed to cluster, travis, wrote tests

Previously, TaskThresholdMemoryRevokingScheduler had only a polling based model for when a task allocates too much memory. This introduces a listener-based model instead which ensures that we do not have to wait for the polling thread to be scheduled.  Instead, we immediately schedule revoking.

```
== RELEASE NOTES ==

General Changes
* Add listener-based revocation model for spilling strategy PER_TASK_MEMORY_THRESHOLD
```