### PR TITLE
Fix broadcast memory bytes update

### DIFF
--- a/presto-memory-context/src/main/java/com/facebook/presto/memory/context/RootAggregatedMemoryContext.java
+++ b/presto-memory-context/src/main/java/com/facebook/presto/memory/context/RootAggregatedMemoryContext.java
@@ -36,7 +36,9 @@ class RootAggregatedMemoryContext
         checkState(!isClosed(), "RootAggregatedMemoryContext is already closed");
         ListenableFuture<?> future = reservationHandler.reserveMemory(allocationTag, bytes, enforceBroadcastMemoryLimit);
         addBytes(bytes);
-        addBroadcastBytes(bytes);
+        if (enforceBroadcastMemoryLimit) {
+            addBroadcastBytes(bytes);
+        }
         // make sure we never block queries below guaranteedMemory
         if (getBytes() < guaranteedMemory) {
             future = NOT_BLOCKED;
@@ -49,7 +51,9 @@ class RootAggregatedMemoryContext
     {
         if (reservationHandler.tryReserveMemory(allocationTag, delta, enforceBroadcastMemoryLimit)) {
             addBytes(delta);
-            addBroadcastBytes(delta);
+            if (enforceBroadcastMemoryLimit) {
+                addBroadcastBytes(delta);
+            }
             return true;
         }
         return false;

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkTaskExecutorFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkTaskExecutorFactory.java
@@ -149,6 +149,7 @@ public class PrestoSparkTaskExecutorFactory
 
     private final DataSize maxUserMemory;
     private final DataSize maxTotalMemory;
+    private final DataSize maxBroadcastMemory;
     private final DataSize maxRevocableMemory;
     private final DataSize maxSpillMemory;
     private final DataSize sinkMaxBufferSize;
@@ -200,6 +201,7 @@ public class PrestoSparkTaskExecutorFactory
                 objectMapper,
                 requireNonNull(nodeMemoryConfig, "nodeMemoryConfig is null").getMaxQueryMemoryPerNode(),
                 requireNonNull(nodeMemoryConfig, "nodeMemoryConfig is null").getMaxQueryTotalMemoryPerNode(),
+                requireNonNull(nodeMemoryConfig, "nodeSpillConfig is null").getMaxQueryBroadcastMemory(),
                 requireNonNull(nodeSpillConfig, "nodeSpillConfig is null").getMaxRevocableMemoryPerNode(),
                 requireNonNull(nodeSpillConfig, "nodeSpillConfig is null").getMaxSpillPerNode(),
                 requireNonNull(taskManagerConfig, "taskManagerConfig is null").getSinkMaxBufferSize(),
@@ -228,6 +230,7 @@ public class PrestoSparkTaskExecutorFactory
             ObjectMapper objectMapper,
             DataSize maxUserMemory,
             DataSize maxTotalMemory,
+            DataSize maxBroadcastMemory,
             DataSize maxRevocableMemory,
             DataSize maxSpillMemory,
             DataSize sinkMaxBufferSize,
@@ -255,6 +258,7 @@ public class PrestoSparkTaskExecutorFactory
         this.objectMapper = objectMapper.copy().configure(ORDER_MAP_ENTRIES_BY_KEYS, true);
         this.maxUserMemory = requireNonNull(maxUserMemory, "maxUserMemory is null");
         this.maxTotalMemory = requireNonNull(maxTotalMemory, "maxTotalMemory is null");
+        this.maxBroadcastMemory = requireNonNull(maxBroadcastMemory, "maxBroadcastMemory is null");
         this.maxRevocableMemory = requireNonNull(maxRevocableMemory, "maxRevocableMemory is null");
         this.maxSpillMemory = requireNonNull(maxSpillMemory, "maxSpillMemory is null");
         this.sinkMaxBufferSize = requireNonNull(sinkMaxBufferSize, "sinkMaxBufferSize is null");
@@ -338,7 +342,7 @@ public class PrestoSparkTaskExecutorFactory
                 session.getQueryId(),
                 maxUserMemory,
                 maxTotalMemory,
-                maxUserMemory,
+                maxBroadcastMemory,
                 maxRevocableMemory,
                 memoryPool,
                 new TestingGcMonitor(),


### PR DESCRIPTION
- It is not necessary to update broadcast memory bytes if the query has no broadcast join. This PR fixed it.
- When a query exceeds max broadcast memory bytes, query will only be killed after verifying that the query has broadcast join,  therefore, no query is badly affected, this PR only fixed unnecessary update.

- Max broadcast memory bytes for Presto on Spark is now correctly set.


```
== NO RELEASE NOTE ==
```
