### PR TITLE
Avoid costly resizes of the addresses dynamic array in PagesIndex

### DIFF
--- a/presto-array/src/main/java/com/facebook/presto/array/AdaptiveLongBigArray.java
+++ b/presto-array/src/main/java/com/facebook/presto/array/AdaptiveLongBigArray.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.array;
+
+import org.openjdk.jol.info.ClassLayout;
+
+import java.util.Arrays;
+
+import static io.airlift.slice.SizeOf.sizeOf;
+import static io.airlift.slice.SizeOf.sizeOfLongArray;
+
+/**
+ * This variation of BigArray is designed to expand segments up to some reasonable extend
+ * and add more segments if the maximum segment capacity is reached
+ * This implementation allows to keep the redirection table small so it does fit into L1 CPU cache
+ */
+public class AdaptiveLongBigArray
+{
+    // visible for testing
+    static final int INSTANCE_SIZE = ClassLayout.parseClass(AdaptiveLongBigArray.class).instanceSize();
+
+    // settings are constants due to efficiency considerations
+    static final int INITIAL_SEGMENT_LENGTH = 16 * 1024; // 128KB
+    static final int MAX_SEGMENT_LENGTH = 32 * 1024 * 1024; // 256MB
+    static final long MAX_SEGMENT_SIZE_IN_BYTES = sizeOfLongArray(MAX_SEGMENT_LENGTH);
+    static final int INITIAL_SEGMENTS = 10;
+    static final int SEGMENT_SHIFT = 25;
+    static final int SEGMENT_MASK = MAX_SEGMENT_LENGTH - 1;
+
+    // segments are allocated lazily in ensureCapacity
+    // The first segment is allocated initially with INITIAL_SEGMENT_LENGTH
+    // and then gradually expanded until it reaches MAX_SEGMENT_LENGTH
+    // Second and subsequent segments are directly allocated with MAX_SEGMENT_LENGTH
+    private long[][] array;
+    // number of allocated segments
+    private int segments;
+    // number of elements that currently can be stored in the container
+    private int capacity;
+
+    public AdaptiveLongBigArray()
+    {
+        array = new long[INITIAL_SEGMENTS][];
+    }
+
+    public long getRetainedSizeInBytes()
+    {
+        long result = INSTANCE_SIZE + sizeOf(array);
+        if (segments == 1) {
+            result += sizeOfLongArray(array[0].length);
+        }
+        else if (segments > 1) {
+            result += segments * MAX_SEGMENT_SIZE_IN_BYTES;
+        }
+        return result;
+    }
+
+    public long get(int index)
+    {
+        return array[segment(index)][offset(index)];
+    }
+
+    public void set(int index, long value)
+    {
+        array[segment(index)][offset(index)] = value;
+    }
+
+    public void swap(int first, int second)
+    {
+        long[] firstSegment = array[segment(first)];
+        int firstOffset = offset(first);
+
+        long[] secondSegment = array[segment(first)];
+        int secondOffset = offset(second);
+
+        long tmp = firstSegment[firstOffset];
+        firstSegment[firstOffset] = secondSegment[secondOffset];
+        secondSegment[secondOffset] = tmp;
+    }
+
+    public void ensureCapacity(int length)
+    {
+        if (capacity >= length) {
+            return;
+        }
+
+        int lastIndex = length - 1;
+        int segment = segment(lastIndex);
+        int offset = offset(lastIndex);
+
+        // expand segments array if needed
+        if (segment >= array.length) {
+            array = Arrays.copyOf(array, array.length * 2);
+        }
+
+        if (segment == 0) {
+            if (array[0] == null) {
+                array[0] = new long[INITIAL_SEGMENT_LENGTH];
+            }
+            // expand segment if needed
+            if (offset >= array[0].length) {
+                int segmentLength = array[0].length;
+                while (offset >= segmentLength) {
+                    segmentLength *= 2;
+                }
+                array[0] = Arrays.copyOf(array[0], segmentLength);
+            }
+        }
+        else {
+            for (int i = 0; i <= segment; i++) {
+                if (array[i] == null) {
+                    array[i] = new long[MAX_SEGMENT_LENGTH];
+                }
+            }
+        }
+
+        segments = segment + 1;
+        capacity = segments == 1 ? array[0].length : MAX_SEGMENT_LENGTH * segments;
+    }
+
+    private static int segment(int index)
+    {
+        return index >>> SEGMENT_SHIFT;
+    }
+
+    private static int offset(int index)
+    {
+        return index & SEGMENT_MASK;
+    }
+
+    public void clear()
+    {
+        array = new long[INITIAL_SEGMENTS][];
+        segments = 0;
+        capacity = 0;
+    }
+}

--- a/presto-array/src/test/java/com/facebook/presto/array/TestAdaptiveLongBigArray.java
+++ b/presto-array/src/test/java/com/facebook/presto/array/TestAdaptiveLongBigArray.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.array;
+
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.array.AdaptiveLongBigArray.INITIAL_SEGMENTS;
+import static com.facebook.presto.array.AdaptiveLongBigArray.INITIAL_SEGMENT_LENGTH;
+import static com.facebook.presto.array.AdaptiveLongBigArray.MAX_SEGMENT_LENGTH;
+import static com.facebook.presto.array.AdaptiveLongBigArray.MAX_SEGMENT_SIZE_IN_BYTES;
+import static io.airlift.slice.SizeOf.sizeOfLongArray;
+import static io.airlift.slice.SizeOf.sizeOfObjectArray;
+import static org.testng.Assert.assertEquals;
+
+public class TestAdaptiveLongBigArray
+{
+    @Test
+    public void test()
+    {
+        AdaptiveLongBigArray array = new AdaptiveLongBigArray();
+        array.ensureCapacity(0);
+        assertEquals(array.getRetainedSizeInBytes(), expectedRetainedMemorySize(0, 0));
+
+        array.ensureCapacity(1);
+        array.set(0, 0xDEADBEAF);
+        assertEquals(array.get(0), 0xDEADBEAF);
+        assertEquals(array.getRetainedSizeInBytes(), expectedRetainedMemorySize(1, INITIAL_SEGMENT_LENGTH));
+
+        array.ensureCapacity(INITIAL_SEGMENT_LENGTH);
+        array.set(INITIAL_SEGMENT_LENGTH - 1, 0xDEADBEAF);
+        assertEquals(array.get(INITIAL_SEGMENT_LENGTH - 1), 0xDEADBEAF);
+        assertEquals(array.getRetainedSizeInBytes(), expectedRetainedMemorySize(1, INITIAL_SEGMENT_LENGTH));
+
+        array.ensureCapacity(INITIAL_SEGMENT_LENGTH + 1);
+        array.set(INITIAL_SEGMENT_LENGTH, 0xDEADBEAF);
+        assertEquals(array.get(INITIAL_SEGMENT_LENGTH), 0xDEADBEAF);
+        assertEquals(array.getRetainedSizeInBytes(), expectedRetainedMemorySize(1, INITIAL_SEGMENT_LENGTH * 2));
+
+        array.ensureCapacity(2 * INITIAL_SEGMENT_LENGTH + 1);
+        array.set(2 * INITIAL_SEGMENT_LENGTH, 0xDEADBEAF);
+        assertEquals(array.get(2 * INITIAL_SEGMENT_LENGTH), 0xDEADBEAF);
+        assertEquals(array.getRetainedSizeInBytes(), expectedRetainedMemorySize(1, INITIAL_SEGMENT_LENGTH * 4));
+
+        array.ensureCapacity(4 * INITIAL_SEGMENT_LENGTH + 1);
+        array.set(4 * INITIAL_SEGMENT_LENGTH, 0xDEADBEAF);
+        assertEquals(array.get(4 * INITIAL_SEGMENT_LENGTH), 0xDEADBEAF);
+        assertEquals(array.getRetainedSizeInBytes(), expectedRetainedMemorySize(1, INITIAL_SEGMENT_LENGTH * 8));
+
+        array.ensureCapacity(MAX_SEGMENT_LENGTH);
+        array.set(MAX_SEGMENT_LENGTH - 1, 0xDEADBEAF);
+        assertEquals(array.get(MAX_SEGMENT_LENGTH - 1), 0xDEADBEAF);
+        assertEquals(array.getRetainedSizeInBytes(), expectedRetainedMemorySize(1, MAX_SEGMENT_LENGTH));
+
+        array.ensureCapacity(MAX_SEGMENT_LENGTH + 1);
+        array.set(MAX_SEGMENT_LENGTH, 0xDEADBEAF);
+        assertEquals(array.get(MAX_SEGMENT_LENGTH), 0xDEADBEAF);
+        assertEquals(array.getRetainedSizeInBytes(), expectedRetainedMemorySize(2, MAX_SEGMENT_LENGTH));
+
+        // expand directly to the second segment
+        array = new AdaptiveLongBigArray();
+        array.ensureCapacity(MAX_SEGMENT_LENGTH + 1);
+        array.set(4 * INITIAL_SEGMENT_LENGTH, 0xBEAFDEAD);
+        assertEquals(array.get(4 * INITIAL_SEGMENT_LENGTH), 0xBEAFDEAD);
+        array.set(MAX_SEGMENT_LENGTH, 0xDEADBEAF);
+        assertEquals(array.get(MAX_SEGMENT_LENGTH), 0xDEADBEAF);
+        assertEquals(array.getRetainedSizeInBytes(), expectedRetainedMemorySize(2, MAX_SEGMENT_LENGTH));
+
+        array = new AdaptiveLongBigArray();
+        array.ensureCapacity(MAX_SEGMENT_LENGTH + 3 * INITIAL_SEGMENT_LENGTH + 1);
+        array.set(MAX_SEGMENT_LENGTH + 3 * INITIAL_SEGMENT_LENGTH, 0xBEAFDEAD);
+        assertEquals(array.get(MAX_SEGMENT_LENGTH + 3 * INITIAL_SEGMENT_LENGTH), 0xBEAFDEAD);
+        assertEquals(array.getRetainedSizeInBytes(), expectedRetainedMemorySize(2, MAX_SEGMENT_LENGTH));
+    }
+
+    private static long expectedRetainedMemorySize(int segments, int lastSegmentLength)
+    {
+        return AdaptiveLongBigArray.INSTANCE_SIZE +
+                sizeOfObjectArray(INITIAL_SEGMENTS) +
+                (segments > 0 ? (segments - 1) * MAX_SEGMENT_SIZE_IN_BYTES + sizeOfLongArray(lastSegmentLength) : 0);
+    }
+}

--- a/presto-geospatial/pom.xml
+++ b/presto-geospatial/pom.xml
@@ -88,11 +88,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <dependency>
-            <groupId>it.unimi.dsi</groupId>
-            <artifactId>fastutil</artifactId>
-        </dependency>
-
         <!-- for testing -->
         <dependency>
             <groupId>com.facebook.presto.hadoop</groupId>

--- a/presto-main/src/main/java/com/facebook/presto/PagesIndexPageSorter.java
+++ b/presto-main/src/main/java/com/facebook/presto/PagesIndexPageSorter.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto;
 
+import com.facebook.presto.array.AdaptiveLongBigArray;
 import com.facebook.presto.common.Page;
 import com.facebook.presto.common.block.SortOrder;
 import com.facebook.presto.common.type.Type;
@@ -45,7 +46,14 @@ public class PagesIndexPageSorter
         pages.forEach(pagesIndex::addPage);
         pagesIndex.sort(sortChannels, sortOrders);
 
-        return pagesIndex.getValueAddresses().toLongArray(null);
+        int positionCount = pagesIndex.getPositionCount();
+        AdaptiveLongBigArray valueAddresses = pagesIndex.getValueAddresses();
+        long[] result = new long[positionCount];
+        for (int i = 0; i < positionCount; i++) {
+            result[i] = valueAddresses.get(i);
+        }
+
+        return result;
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/JoinHashSupplier.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/JoinHashSupplier.java
@@ -14,11 +14,11 @@
 package com.facebook.presto.operator;
 
 import com.facebook.presto.Session;
+import com.facebook.presto.array.AdaptiveLongBigArray;
 import com.facebook.presto.common.Page;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.sql.gen.JoinFilterFunctionCompiler.JoinFilterFunctionFactory;
 import com.google.common.collect.ImmutableList;
-import it.unimi.dsi.fastutil.longs.LongArrayList;
 
 import java.util.List;
 import java.util.Optional;
@@ -34,7 +34,7 @@ public class JoinHashSupplier
 {
     private final Session session;
     private final PagesHash pagesHash;
-    private final LongArrayList addresses;
+    private final AdaptiveLongBigArray addresses;
     private final List<Page> pages;
     private final Optional<PositionLinks.Factory> positionLinks;
     private final Optional<JoinFilterFunctionFactory> filterFunctionFactory;
@@ -43,7 +43,8 @@ public class JoinHashSupplier
     public JoinHashSupplier(
             Session session,
             PagesHashStrategy pagesHashStrategy,
-            LongArrayList addresses,
+            AdaptiveLongBigArray addresses,
+            int positionCount,
             List<List<Block>> channels,
             Optional<JoinFilterFunctionFactory> filterFunctionFactory,
             Optional<Integer> sortChannel,
@@ -61,16 +62,16 @@ public class JoinHashSupplier
                 isFastInequalityJoin(session)) {
             checkArgument(filterFunctionFactory.isPresent(), "filterFunctionFactory not set while sortChannel set");
             positionLinksFactoryBuilder = SortedPositionLinks.builder(
-                    addresses.size(),
+                    positionCount,
                     pagesHashStrategy,
                     addresses);
         }
         else {
-            positionLinksFactoryBuilder = ArrayPositionLinks.builder(addresses.size());
+            positionLinksFactoryBuilder = ArrayPositionLinks.builder(positionCount);
         }
 
         this.pages = channelsToPages(channels);
-        this.pagesHash = new PagesHash(addresses, pagesHashStrategy, positionLinksFactoryBuilder);
+        this.pagesHash = new PagesHash(addresses, positionCount, pagesHashStrategy, positionLinksFactoryBuilder);
         this.positionLinks = positionLinksFactoryBuilder.isEmpty() ? Optional.empty() : Optional.of(positionLinksFactoryBuilder.build());
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/PagesIndex.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PagesIndex.java
@@ -15,6 +15,7 @@ package com.facebook.presto.operator;
 
 import com.facebook.airlift.log.Logger;
 import com.facebook.presto.Session;
+import com.facebook.presto.array.AdaptiveLongBigArray;
 import com.facebook.presto.common.Page;
 import com.facebook.presto.common.PageBuilder;
 import com.facebook.presto.common.block.Block;
@@ -37,7 +38,6 @@ import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
 import io.airlift.units.DataSize;
 import it.unimi.dsi.fastutil.Swapper;
-import it.unimi.dsi.fastutil.longs.LongArrayList;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import org.openjdk.jol.info.ClassLayout;
 
@@ -84,7 +84,7 @@ public class PagesIndex
     private final boolean groupByUsesEqualTo;
 
     private final List<Type> types;
-    private final LongArrayList valueAddresses;
+    private final AdaptiveLongBigArray valueAddresses;
     private final ObjectArrayList<Block>[] channels;
     private final boolean eagerCompact;
 
@@ -107,7 +107,8 @@ public class PagesIndex
         this.functionAndTypeManager = requireNonNull(functionAndTypeManager, "functionManager is null");
         this.groupByUsesEqualTo = groupByUsesEqualTo;
         this.types = ImmutableList.copyOf(requireNonNull(types, "types is null"));
-        this.valueAddresses = new LongArrayList(expectedPositions);
+        this.valueAddresses = new AdaptiveLongBigArray();
+        this.valueAddresses.ensureCapacity(expectedPositions);
         this.eagerCompact = eagerCompact;
 
         //noinspection rawtypes
@@ -180,7 +181,7 @@ public class PagesIndex
         return positionCount;
     }
 
-    public LongArrayList getValueAddresses()
+    public AdaptiveLongBigArray getValueAddresses()
     {
         return valueAddresses;
     }
@@ -197,7 +198,6 @@ public class PagesIndex
             channel.trim();
         }
         valueAddresses.clear();
-        valueAddresses.trim();
         positionCount = 0;
         nextBlockToCompact = 0;
         pagesMemorySize = 0;
@@ -212,8 +212,6 @@ public class PagesIndex
             return;
         }
 
-        positionCount += page.getPositionCount();
-
         int pageIndex = (channels.length > 0) ? channels[0].size() : 0;
         for (int i = 0; i < channels.length; i++) {
             Block block = page.getBlock(i);
@@ -224,9 +222,11 @@ public class PagesIndex
             pagesMemorySize += block.getRetainedSizeInBytes();
         }
 
+        valueAddresses.ensureCapacity(positionCount + page.getPositionCount());
         for (int position = 0; position < page.getPositionCount(); position++) {
             long sliceAddress = encodeSyntheticAddress(pageIndex, position);
-            valueAddresses.add(sliceAddress);
+            valueAddresses.set(positionCount, sliceAddress);
+            positionCount++;
         }
         estimatedSize = calculateEstimatedSize();
     }
@@ -261,7 +261,7 @@ public class PagesIndex
     {
         long elementsSize = (channels.length > 0) ? sizeOf(channels[0].elements()) : 0;
         long channelsArraySize = elementsSize * channels.length;
-        long addressesArraySize = sizeOf(valueAddresses.elements());
+        long addressesArraySize = valueAddresses.getRetainedSizeInBytes();
         return INSTANCE_SIZE + pagesMemorySize + channelsArraySize + addressesArraySize;
     }
 
@@ -273,16 +273,13 @@ public class PagesIndex
     @Override
     public void swap(int a, int b)
     {
-        long[] elements = valueAddresses.elements();
-        long temp = elements[a];
-        elements[a] = elements[b];
-        elements[b] = temp;
+        valueAddresses.swap(a, b);
     }
 
     public int buildPage(int position, int[] outputChannels, PageBuilder pageBuilder)
     {
         while (!pageBuilder.isFull() && position < positionCount) {
-            long pageAddress = valueAddresses.getLong(position);
+            long pageAddress = valueAddresses.get(position);
             int blockIndex = decodeSliceIndex(pageAddress);
             int blockPosition = decodePosition(pageAddress);
 
@@ -303,7 +300,7 @@ public class PagesIndex
 
     public void appendTo(int channel, int position, BlockBuilder output)
     {
-        long pageAddress = valueAddresses.getLong(position);
+        long pageAddress = valueAddresses.get(position);
 
         Type type = types.get(channel);
         Block block = channels[channel].get(decodeSliceIndex(pageAddress));
@@ -313,7 +310,7 @@ public class PagesIndex
 
     public boolean isNull(int channel, int position)
     {
-        long pageAddress = valueAddresses.getLong(position);
+        long pageAddress = valueAddresses.get(position);
 
         Block block = channels[channel].get(decodeSliceIndex(pageAddress));
         int blockPosition = decodePosition(pageAddress);
@@ -322,7 +319,7 @@ public class PagesIndex
 
     public boolean getBoolean(int channel, int position)
     {
-        long pageAddress = valueAddresses.getLong(position);
+        long pageAddress = valueAddresses.get(position);
 
         Block block = channels[channel].get(decodeSliceIndex(pageAddress));
         int blockPosition = decodePosition(pageAddress);
@@ -331,7 +328,7 @@ public class PagesIndex
 
     public long getLong(int channel, int position)
     {
-        long pageAddress = valueAddresses.getLong(position);
+        long pageAddress = valueAddresses.get(position);
 
         Block block = channels[channel].get(decodeSliceIndex(pageAddress));
         int blockPosition = decodePosition(pageAddress);
@@ -340,7 +337,7 @@ public class PagesIndex
 
     public double getDouble(int channel, int position)
     {
-        long pageAddress = valueAddresses.getLong(position);
+        long pageAddress = valueAddresses.get(position);
 
         Block block = channels[channel].get(decodeSliceIndex(pageAddress));
         int blockPosition = decodePosition(pageAddress);
@@ -349,7 +346,7 @@ public class PagesIndex
 
     public Slice getSlice(int channel, int position)
     {
-        long pageAddress = valueAddresses.getLong(position);
+        long pageAddress = valueAddresses.get(position);
 
         Block block = channels[channel].get(decodeSliceIndex(pageAddress));
         int blockPosition = decodePosition(pageAddress);
@@ -358,7 +355,7 @@ public class PagesIndex
 
     public Object getObject(int channel, int position)
     {
-        long pageAddress = valueAddresses.getLong(position);
+        long pageAddress = valueAddresses.get(position);
 
         Block block = channels[channel].get(decodeSliceIndex(pageAddress));
         int blockPosition = decodePosition(pageAddress);
@@ -367,7 +364,7 @@ public class PagesIndex
 
     public Block getSingleValueBlock(int channel, int position)
     {
-        long pageAddress = valueAddresses.getLong(position);
+        long pageAddress = valueAddresses.get(position);
 
         Block block = channels[channel].get(decodeSliceIndex(pageAddress));
         int blockPosition = decodePosition(pageAddress);
@@ -386,11 +383,11 @@ public class PagesIndex
 
     public boolean positionEqualsPosition(PagesHashStrategy partitionHashStrategy, int leftPosition, int rightPosition)
     {
-        long leftAddress = valueAddresses.getLong(leftPosition);
+        long leftAddress = valueAddresses.get(leftPosition);
         int leftPageIndex = decodeSliceIndex(leftAddress);
         int leftPagePosition = decodePosition(leftAddress);
 
-        long rightAddress = valueAddresses.getLong(rightPosition);
+        long rightAddress = valueAddresses.get(rightPosition);
         int rightPageIndex = decodeSliceIndex(rightAddress);
         int rightPagePosition = decodePosition(rightAddress);
 
@@ -399,7 +396,7 @@ public class PagesIndex
 
     public boolean positionEqualsRow(PagesHashStrategy pagesHashStrategy, int indexPosition, int rightPosition, Page rightPage)
     {
-        long pageAddress = valueAddresses.getLong(indexPosition);
+        long pageAddress = valueAddresses.get(indexPosition);
         int pageIndex = decodeSliceIndex(pageAddress);
         int pagePosition = decodePosition(pageAddress);
 
@@ -470,7 +467,7 @@ public class PagesIndex
     {
         // TODO probably shouldn't copy to reduce memory and for memory accounting's sake
         List<List<Block>> channels = ImmutableList.copyOf(this.channels);
-        return new PagesSpatialIndexSupplier(session, valueAddresses, types, outputChannels, channels, geometryChannel, radiusChannel, partitionChannel, spatialRelationshipTest, filterFunctionFactory, partitions, localUserMemoryContext);
+        return new PagesSpatialIndexSupplier(session, valueAddresses, positionCount, types, outputChannels, channels, geometryChannel, radiusChannel, partitionChannel, spatialRelationshipTest, filterFunctionFactory, partitions, localUserMemoryContext);
     }
 
     public LookupSourceSupplier createLookupSourceSupplier(
@@ -493,6 +490,7 @@ public class PagesIndex
                 return lookupSourceFactory.createLookupSourceSupplier(
                         session,
                         valueAddresses,
+                        positionCount,
                         channels,
                         hashChannel,
                         filterFunctionFactory,
@@ -519,6 +517,7 @@ public class PagesIndex
                 session,
                 hashStrategy,
                 valueAddresses,
+                positionCount,
                 channels,
                 filterFunctionFactory,
                 sortChannel,

--- a/presto-main/src/main/java/com/facebook/presto/operator/PagesRTreeIndex.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PagesRTreeIndex.java
@@ -15,6 +15,7 @@ package com.facebook.presto.operator;
 
 import com.esri.core.geometry.ogc.OGCGeometry;
 import com.facebook.presto.Session;
+import com.facebook.presto.array.AdaptiveLongBigArray;
 import com.facebook.presto.common.Page;
 import com.facebook.presto.common.PageBuilder;
 import com.facebook.presto.common.block.Block;
@@ -27,7 +28,6 @@ import com.facebook.presto.operator.SpatialIndexBuilderOperator.SpatialPredicate
 import com.facebook.presto.sql.gen.JoinFilterFunctionCompiler.JoinFilterFunctionFactory;
 import io.airlift.slice.Slice;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
-import it.unimi.dsi.fastutil.longs.LongArrayList;
 import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
@@ -51,7 +51,7 @@ public class PagesRTreeIndex
 {
     private static final int[] EMPTY_ADDRESSES = new int[0];
 
-    private final LongArrayList addresses;
+    private final AdaptiveLongBigArray addresses;
     private final List<Type> types;
     private final List<Integer> outputChannels;
     private final List<List<Block>> channels;
@@ -114,7 +114,7 @@ public class PagesRTreeIndex
 
     public PagesRTreeIndex(
             Session session,
-            LongArrayList addresses,
+            AdaptiveLongBigArray addresses,
             List<Type> types,
             List<Integer> outputChannels,
             List<List<Block>> channels,
@@ -195,7 +195,7 @@ public class PagesRTreeIndex
 
     private double getRadius(int joinPosition)
     {
-        long joinAddress = addresses.getLong(joinPosition);
+        long joinAddress = addresses.get(joinPosition);
         int blockIndex = decodeSliceIndex(joinAddress);
         int blockPosition = decodePosition(joinAddress);
 
@@ -211,7 +211,7 @@ public class PagesRTreeIndex
     @Override
     public void appendTo(int joinPosition, PageBuilder pageBuilder, int outputChannelOffset)
     {
-        long joinAddress = addresses.getLong(joinPosition);
+        long joinAddress = addresses.get(joinPosition);
         int blockIndex = decodeSliceIndex(joinAddress);
         int blockPosition = decodePosition(joinAddress);
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/SimplePagesIndexComparator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/SimplePagesIndexComparator.java
@@ -44,11 +44,11 @@ public class SimplePagesIndexComparator
     @Override
     public int compareTo(PagesIndex pagesIndex, int leftPosition, int rightPosition)
     {
-        long leftPageAddress = pagesIndex.getValueAddresses().getLong(leftPosition);
+        long leftPageAddress = pagesIndex.getValueAddresses().get(leftPosition);
         int leftBlockIndex = decodeSliceIndex(leftPageAddress);
         int leftBlockPosition = decodePosition(leftPageAddress);
 
-        long rightPageAddress = pagesIndex.getValueAddresses().getLong(rightPosition);
+        long rightPageAddress = pagesIndex.getValueAddresses().get(rightPosition);
         int rightBlockIndex = decodeSliceIndex(rightPageAddress);
         int rightBlockPosition = decodePosition(rightPageAddress);
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/SortedPositionLinks.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/SortedPositionLinks.java
@@ -13,13 +13,13 @@
  */
 package com.facebook.presto.operator;
 
+import com.facebook.presto.array.AdaptiveLongBigArray;
 import com.facebook.presto.common.Page;
 import com.google.common.collect.ImmutableList;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntComparator;
-import it.unimi.dsi.fastutil.longs.LongArrayList;
 import org.openjdk.jol.info.ClassLayout;
 
 import java.util.List;
@@ -48,9 +48,9 @@ public final class SortedPositionLinks
         private final int size;
         private final IntComparator comparator;
         private final PagesHashStrategy pagesHashStrategy;
-        private final LongArrayList addresses;
+        private final AdaptiveLongBigArray addresses;
 
-        public FactoryBuilder(int size, PagesHashStrategy pagesHashStrategy, LongArrayList addresses)
+        public FactoryBuilder(int size, PagesHashStrategy pagesHashStrategy, AdaptiveLongBigArray addresses)
         {
             this.size = size;
             this.comparator = new PositionComparator(pagesHashStrategy, addresses);
@@ -96,7 +96,7 @@ public final class SortedPositionLinks
 
         private boolean isNull(int position)
         {
-            long pageAddress = addresses.getLong(position);
+            long pageAddress = addresses.get(position);
             int blockIndex = decodeSliceIndex(pageAddress);
             int blockPosition = decodePosition(pageAddress);
             return pagesHashStrategy.isSortChannelPositionNull(blockIndex, blockPosition);
@@ -184,7 +184,7 @@ public final class SortedPositionLinks
         return retainedSize;
     }
 
-    public static FactoryBuilder builder(int size, PagesHashStrategy pagesHashStrategy, LongArrayList addresses)
+    public static FactoryBuilder builder(int size, PagesHashStrategy pagesHashStrategy, AdaptiveLongBigArray addresses)
     {
         return new FactoryBuilder(size, pagesHashStrategy, addresses);
     }
@@ -295,9 +295,9 @@ public final class SortedPositionLinks
             implements IntComparator
     {
         private final PagesHashStrategy pagesHashStrategy;
-        private final LongArrayList addresses;
+        private final AdaptiveLongBigArray addresses;
 
-        PositionComparator(PagesHashStrategy pagesHashStrategy, LongArrayList addresses)
+        PositionComparator(PagesHashStrategy pagesHashStrategy, AdaptiveLongBigArray addresses)
         {
             this.pagesHashStrategy = pagesHashStrategy;
             this.addresses = addresses;
@@ -306,11 +306,11 @@ public final class SortedPositionLinks
         @Override
         public int compare(int leftPosition, int rightPosition)
         {
-            long leftPageAddress = addresses.getLong(leftPosition);
+            long leftPageAddress = addresses.get(leftPosition);
             int leftBlockIndex = decodeSliceIndex(leftPageAddress);
             int leftBlockPosition = decodePosition(leftPageAddress);
 
-            long rightPageAddress = addresses.getLong(rightPosition);
+            long rightPageAddress = addresses.get(rightPosition);
             int rightBlockIndex = decodeSliceIndex(rightPageAddress);
             int rightBlockPosition = decodePosition(rightPageAddress);
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/StandardJoinFilterFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/StandardJoinFilterFunction.java
@@ -13,9 +13,9 @@
  */
 package com.facebook.presto.operator;
 
+import com.facebook.presto.array.AdaptiveLongBigArray;
 import com.facebook.presto.common.Page;
 import com.google.common.collect.ImmutableList;
-import it.unimi.dsi.fastutil.longs.LongArrayList;
 
 import java.util.List;
 
@@ -29,10 +29,10 @@ public class StandardJoinFilterFunction
     private static final Page EMPTY_PAGE = new Page(0);
 
     private final InternalJoinFilterFunction filterFunction;
-    private final LongArrayList addresses;
+    private final AdaptiveLongBigArray addresses;
     private final List<Page> pages;
 
-    public StandardJoinFilterFunction(InternalJoinFilterFunction filterFunction, LongArrayList addresses, List<Page> pages)
+    public StandardJoinFilterFunction(InternalJoinFilterFunction filterFunction, AdaptiveLongBigArray addresses, List<Page> pages)
     {
         this.filterFunction = requireNonNull(filterFunction, "filterFunction can not be null");
         this.addresses = requireNonNull(addresses, "addresses is null");
@@ -42,7 +42,7 @@ public class StandardJoinFilterFunction
     @Override
     public boolean filter(int leftPosition, int rightPosition, Page rightPage)
     {
-        long pageAddress = addresses.getLong(leftPosition);
+        long pageAddress = addresses.get(leftPosition);
         int pageIndex = decodeSliceIndex(pageAddress);
         int pagePosition = decodePosition(pageAddress);
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/JoinCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/JoinCompiler.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.sql.gen;
 
 import com.facebook.presto.Session;
+import com.facebook.presto.array.AdaptiveLongBigArray;
 import com.facebook.presto.bytecode.BytecodeBlock;
 import com.facebook.presto.bytecode.BytecodeNode;
 import com.facebook.presto.bytecode.ClassDefinition;
@@ -51,7 +52,6 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
-import it.unimi.dsi.fastutil.longs.LongArrayList;
 import org.openjdk.jol.info.ClassLayout;
 import org.weakref.jmx.Managed;
 import org.weakref.jmx.Nested;
@@ -906,7 +906,7 @@ public class JoinCompiler
         {
             this.pagesHashStrategyFactory = pagesHashStrategyFactory;
             try {
-                constructor = joinHashSupplierClass.getConstructor(Session.class, PagesHashStrategy.class, LongArrayList.class, List.class, Optional.class, Optional.class, List.class);
+                constructor = joinHashSupplierClass.getConstructor(Session.class, PagesHashStrategy.class, AdaptiveLongBigArray.class, int.class, List.class, Optional.class, Optional.class, List.class);
             }
             catch (NoSuchMethodException e) {
                 throw new RuntimeException(e);
@@ -915,7 +915,8 @@ public class JoinCompiler
 
         public LookupSourceSupplier createLookupSourceSupplier(
                 Session session,
-                LongArrayList addresses,
+                AdaptiveLongBigArray addresses,
+                int positionCount,
                 List<List<Block>> channels,
                 OptionalInt hashChannel,
                 Optional<JoinFilterFunctionFactory> filterFunctionFactory,
@@ -924,7 +925,7 @@ public class JoinCompiler
         {
             PagesHashStrategy pagesHashStrategy = pagesHashStrategyFactory.createPagesHashStrategy(channels, hashChannel);
             try {
-                return constructor.newInstance(session, pagesHashStrategy, addresses, channels, filterFunctionFactory, sortChannel, searchFunctionFactories);
+                return constructor.newInstance(session, pagesHashStrategy, addresses, positionCount, channels, filterFunctionFactory, sortChannel, searchFunctionFactories);
             }
             catch (ReflectiveOperationException e) {
                 throw new RuntimeException(e);

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/JoinFilterFunctionCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/JoinFilterFunctionCompiler.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.gen;
 
+import com.facebook.presto.array.AdaptiveLongBigArray;
 import com.facebook.presto.bytecode.BytecodeBlock;
 import com.facebook.presto.bytecode.BytecodeNode;
 import com.facebook.presto.bytecode.ClassDefinition;
@@ -38,7 +39,6 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableList;
-import it.unimi.dsi.fastutil.longs.LongArrayList;
 import org.weakref.jmx.Managed;
 import org.weakref.jmx.Nested;
 
@@ -221,7 +221,7 @@ public class JoinFilterFunctionCompiler
 
     public interface JoinFilterFunctionFactory
     {
-        JoinFilterFunction create(SqlFunctionProperties properties, LongArrayList addresses, List<Page> pages);
+        JoinFilterFunction create(SqlFunctionProperties properties, AdaptiveLongBigArray addresses, List<Page> pages);
     }
 
     private static RowExpressionVisitor<BytecodeNode, Scope> fieldReferenceCompiler(
@@ -319,7 +319,7 @@ public class JoinFilterFunctionCompiler
                         new DynamicClassLoader(getClass().getClassLoader()),
                         JoinFilterFunction.class,
                         StandardJoinFilterFunction.class);
-                isolatedJoinFilterFunctionConstructor = isolatedJoinFilterFunction.getConstructor(InternalJoinFilterFunction.class, LongArrayList.class, List.class);
+                isolatedJoinFilterFunctionConstructor = isolatedJoinFilterFunction.getConstructor(InternalJoinFilterFunction.class, AdaptiveLongBigArray.class, List.class);
             }
             catch (NoSuchMethodException e) {
                 throw new RuntimeException(e);
@@ -327,7 +327,7 @@ public class JoinFilterFunctionCompiler
         }
 
         @Override
-        public JoinFilterFunction create(SqlFunctionProperties properties, LongArrayList addresses, List<Page> pages)
+        public JoinFilterFunction create(SqlFunctionProperties properties, AdaptiveLongBigArray addresses, List<Page> pages)
         {
             try {
                 InternalJoinFilterFunction internalJoinFilterFunction = internalJoinFilterFunctionConstructor.newInstance(properties);

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/OrderingCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/OrderingCompiler.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.sql.gen;
 
 import com.facebook.airlift.log.Logger;
+import com.facebook.presto.array.AdaptiveLongBigArray;
 import com.facebook.presto.bytecode.BytecodeBlock;
 import com.facebook.presto.bytecode.ClassDefinition;
 import com.facebook.presto.bytecode.MethodDefinition;
@@ -38,7 +39,6 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableList;
-import it.unimi.dsi.fastutil.longs.LongArrayList;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import org.weakref.jmx.Managed;
 import org.weakref.jmx.Nested;
@@ -143,17 +143,17 @@ public class OrderingCompiler
         MethodDefinition compareToMethod = classDefinition.declareMethod(a(PUBLIC), "compareTo", type(int.class), pagesIndex, leftPosition, rightPosition);
         Scope scope = compareToMethod.getScope();
 
-        Variable valueAddresses = scope.declareVariable(LongArrayList.class, "valueAddresses");
+        Variable valueAddresses = scope.declareVariable(AdaptiveLongBigArray.class, "valueAddresses");
         compareToMethod
                 .getBody()
-                .comment("LongArrayList valueAddresses = pagesIndex.valueAddresses")
-                .append(valueAddresses.set(pagesIndex.invoke("getValueAddresses", LongArrayList.class)));
+                .comment("AdaptiveLongBigArray valueAddresses = pagesIndex.valueAddresses")
+                .append(valueAddresses.set(pagesIndex.invoke("getValueAddresses", AdaptiveLongBigArray.class)));
 
         Variable leftPageAddress = scope.declareVariable(long.class, "leftPageAddress");
         compareToMethod
                 .getBody()
-                .comment("long leftPageAddress = valueAddresses.getLong(leftPosition)")
-                .append(leftPageAddress.set(valueAddresses.invoke("getLong", long.class, leftPosition)));
+                .comment("long leftPageAddress = valueAddresses.get(leftPosition)")
+                .append(leftPageAddress.set(valueAddresses.invoke("get", long.class, leftPosition)));
 
         Variable leftBlockIndex = scope.declareVariable(int.class, "leftBlockIndex");
         compareToMethod
@@ -170,8 +170,8 @@ public class OrderingCompiler
         Variable rightPageAddress = scope.declareVariable(long.class, "rightPageAddress");
         compareToMethod
                 .getBody()
-                .comment("long rightPageAddress = valueAddresses.getLong(rightPosition);")
-                .append(rightPageAddress.set(valueAddresses.invoke("getLong", long.class, rightPosition)));
+                .comment("long rightPageAddress = valueAddresses.get(rightPosition);")
+                .append(rightPageAddress.set(valueAddresses.invoke("get", long.class, rightPosition)));
 
         Variable rightBlockIndex = scope.declareVariable(int.class, "rightBlockIndex");
         compareToMethod

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestPositionLinks.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestPositionLinks.java
@@ -14,11 +14,11 @@
 package com.facebook.presto.operator;
 
 import com.facebook.presto.RowPagesBuilder;
+import com.facebook.presto.array.AdaptiveLongBigArray;
 import com.facebook.presto.common.Page;
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.google.common.collect.ImmutableList;
-import it.unimi.dsi.fastutil.longs.LongArrayList;
 import org.testng.annotations.Test;
 
 import java.util.Optional;
@@ -319,11 +319,12 @@ public class TestPositionLinks
                 new FeaturesConfig().isGroupByUsesEqualTo());
     }
 
-    private static LongArrayList addresses()
+    private static AdaptiveLongBigArray addresses()
     {
-        LongArrayList addresses = new LongArrayList();
+        AdaptiveLongBigArray addresses = new AdaptiveLongBigArray();
+        addresses.ensureCapacity(TEST_PAGE.getPositionCount());
         for (int i = 0; i < TEST_PAGE.getPositionCount(); ++i) {
-            addresses.add(encodeSyntheticAddress(0, i));
+            addresses.set(i, encodeSyntheticAddress(0, i));
         }
         return addresses;
     }


### PR DESCRIPTION
On memory constraint environments resizing the `valueAddresses` can cause OOM. Also given the high expansion factor it may end up causing significant memory overhead.

For example if the current size of `valueAddresses` is ~2GB (260m elements) trying to expand it to 4GB can cause a premature OOM, as there might not be enough memory to accommodate 2 strongly reachable arrays (2GB + 4GB).
Also it is very likely to result in a significant memory waste if the expansion happens just to accommodate only a few overflowing elements. 

This patch replaces a contiguous `LongArrayList` with the `AdaptiveLongBigArray`. `AdaptiveLongBigArray` allocates memory gradually. It is implemented by employing another level of indirection:

```
[1,2,3,4,5] -> [block1 -> [1,2,3], block2->[4,5]] 
```

This allows more gradual memory allocation, and eliminates the need of expensive array expansions. 

However everything comes at a price. Another indirection adds a cost of additional memory lookup. In theory that may negatively impact CPU cache locality and decrease performance.

To decrease the effects of the indirection the `AdaptiveLongBigArray` employs both techniques. It is expanding linear array (segment) up to 256MB, and only then adds another segment. With large segments the first table (array of long arrays) should be very small (~5 - 10 elements, 40 - 80 bytes)* and should easily fit into L1 CPU cache.


```
== NO RELEASE NOTE ==
```
