### PR TITLE
Replace Joda-Time libraries with java.time in Presto MongoDB

### DIFF
--- a/presto-mongodb/pom.xml
+++ b/presto-mongodb/pom.xml
@@ -31,11 +31,6 @@
         </dependency>
 
         <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
         </dependency>

--- a/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoPageSource.java
+++ b/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoPageSource.java
@@ -27,8 +27,10 @@ import io.airlift.slice.Slice;
 import org.bson.Document;
 import org.bson.types.Binary;
 import org.bson.types.ObjectId;
-import org.joda.time.chrono.ISOChronology;
 
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoField;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -56,7 +58,7 @@ import static java.util.stream.Collectors.toList;
 public class MongoPageSource
         implements ConnectorPageSource
 {
-    private static final ISOChronology UTC_CHRONOLOGY = ISOChronology.getInstanceUTC();
+    private static final ZoneId UTC_ZONE_ID = ZoneId.of("UTC");
     private static final int ROWS_PER_REQUEST = 1024;
 
     private final MongoCursor<Document> cursor;
@@ -164,7 +166,7 @@ public class MongoPageSource
                     type.writeLong(output, TimeUnit.MILLISECONDS.toDays(utcMillis));
                 }
                 else if (type.equals(TIME)) {
-                    type.writeLong(output, UTC_CHRONOLOGY.millisOfDay().get(((Date) value).getTime()));
+                    type.writeLong(output, ZonedDateTime.ofInstant(((Date) value).toInstant(), UTC_ZONE_ID).get(ChronoField.MILLI_OF_DAY));
                 }
                 else if (type.equals(TIMESTAMP)) {
                     type.writeLong(output, ((Date) value).getTime());

--- a/presto-mongodb/src/test/java/com/facebook/presto/mongodb/TestMongoIntegrationSmokeTest.java
+++ b/presto-mongodb/src/test/java/com/facebook/presto/mongodb/TestMongoIntegrationSmokeTest.java
@@ -25,6 +25,7 @@ import org.testng.annotations.Test;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.Arrays;
 
 import static com.facebook.presto.mongodb.MongoQueryRunner.createMongoQueryRunner;
@@ -105,6 +106,7 @@ public class TestMongoIntegrationSmokeTest
                 ", b boolean" +
                 ", dt  date" +
                 ", ts  timestamp" +
+                ", tm time" +
                 ", objid objectid" +
                 ")";
         getQueryRunner().execute(getSession(), createSql);
@@ -119,6 +121,7 @@ public class TestMongoIntegrationSmokeTest
                 ", true _boolean" +
                 ", DATE '1980-05-07' _date" +
                 ", TIMESTAMP '1980-05-07 11:22:33.456' _timestamp" +
+                ", TIME '11:22:33.456' _time" +
                 ", ObjectId('ffffffffffffffffffffffff') _objectid";
         getQueryRunner().execute(getSession(), insertSql);
 
@@ -132,6 +135,7 @@ public class TestMongoIntegrationSmokeTest
         assertEquals(row.getField(4), true);
         assertEquals(row.getField(5), LocalDate.of(1980, 5, 7));
         assertEquals(row.getField(6), LocalDateTime.of(1980, 5, 7, 11, 22, 33, 456_000_000));
+        assertEquals(row.getField(7), LocalTime.of(11, 22, 33, 456_000_000));
         assertUpdate("DROP TABLE test_insert_types_table");
         assertFalse(getQueryRunner().tableExists(getSession(), "test_insert_types_table"));
     }


### PR DESCRIPTION
Replace Joda-Time libraries with java.time in Presto MongoDB
    
    Since Java 8 we have java.time packages which are equivalent to Joda and
    the recommendation from the author of the Joda-Time is to migrate to
    java.time(JSR-310) library.

Test plan
* I updated TestMongoIntegrationSmokeTest.java to include TIME
* mvn test

```
== NO RELEASE NOTE ==
```
