### PR TITLE
Fix accidental per-instance logger in SerializedPageWriteListener

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/SerializedPageWriteListener.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/SerializedPageWriteListener.java
@@ -35,7 +35,7 @@ import static sun.misc.Unsafe.ARRAY_BYTE_BASE_OFFSET;
 public class SerializedPageWriteListener
         implements WriteListener
 {
-    private final Logger log = Logger.get(SerializedPageWriteListener.class);
+    private static final Logger log = Logger.get(SerializedPageWriteListener.class);
 
     public static final int PAGE_METADATA_SIZE = SIZE_OF_INT * 3 + SIZE_OF_BYTE;
     private final ArrayDeque<SerializedPage> serializedPages;


### PR DESCRIPTION
Identified as a contention bottleneck due to calling `java.util.logging.Logger.getLogger` under the hood on each request.

```
== NO RELEASE NOTE ==
```
