### PR TITLE
Initialize memory limits once

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/memory/QueryContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/QueryContext.java
@@ -142,7 +142,7 @@ public class QueryContext
     public synchronized void setResourceOvercommit()
     {
         resourceOverCommit = true;
-        // Allow the query to use the entire pool. This way the worker will kill the query, if it uses the entire local general pool.
+        // Allow the query to use the entire pool. This way the worker will kill the query, if it uses the entire local memory pool.
         // The coordinator will kill the query if the cluster runs out of memory.
         maxUserMemory = memoryPool.getMaxBytes();
         maxTotalMemory = memoryPool.getMaxBytes();
@@ -168,7 +168,7 @@ public class QueryContext
      * Deadlock is possible for concurrent user and system allocations when updateSystemMemory()/updateUserMemory
      * calls queryMemoryContext.getUserMemory()/queryMemoryContext.getSystemMemory(), respectively.
      *
-     * @see this##updateSystemMemory(long) for details.
+     * @see this#updateSystemMemory(String, long) for details.
      */
     private synchronized ListenableFuture<?> updateUserMemory(String allocationTag, long delta)
     {

--- a/presto-main/src/main/java/com/facebook/presto/memory/QueryContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/QueryContext.java
@@ -72,7 +72,7 @@ public class QueryContext
     private final ScheduledExecutorService yieldExecutor;
     private final long maxSpill;
     private final SpillSpaceTracker spillSpaceTracker;
-    private final Map<TaskId, TaskContext> taskContexts = new ConcurrentHashMap();
+    private final Map<TaskId, TaskContext> taskContexts = new ConcurrentHashMap<>();
 
     @GuardedBy("this")
     private boolean resourceOverCommit;


### PR DESCRIPTION
Synchronizing on the `QueryContext` as part of every task update adds contention to the already heavily contended `QueryContext` instance lock (since each memory tracking update must synchronize as well). This change checks whether the memory limit initialization is necessary before synchronizing to avoid adding the extra contention after they
have been set at least once successfully.

```
== NO RELEASE NOTE ==
```
