### PR TITLE
Refactor AbstractTestQueryFramework to supply expectedQueryRunner

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/testing/ExpectedQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/ExpectedQueryRunner.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.testing;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.common.type.Type;
+import org.intellij.lang.annotations.Language;
+
+import java.io.Closeable;
+import java.util.List;
+
+public interface ExpectedQueryRunner
+        extends Closeable
+{
+    @Override
+    void close();
+    MaterializedResult execute(Session session, @Language("SQL") String sql, List<? extends Type> resultTypes);
+}

--- a/presto-main/src/main/java/com/facebook/presto/testing/QueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/QueryRunner.java
@@ -15,6 +15,7 @@ package com.facebook.presto.testing;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.common.QualifiedObjectName;
+import com.facebook.presto.common.type.Type;
 import com.facebook.presto.cost.StatsCalculator;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spi.Plugin;
@@ -28,18 +29,14 @@ import com.facebook.presto.sql.planner.Plan;
 import com.facebook.presto.transaction.TransactionManager;
 import org.intellij.lang.annotations.Language;
 
-import java.io.Closeable;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.locks.Lock;
 
 public interface QueryRunner
-        extends Closeable
+        extends ExpectedQueryRunner
 {
-    @Override
-    void close();
-
     int getNodeCount();
 
     Session getDefaultSession();
@@ -65,6 +62,11 @@ public interface QueryRunner
     MaterializedResult execute(@Language("SQL") String sql);
 
     MaterializedResult execute(Session session, @Language("SQL") String sql);
+
+    default MaterializedResult execute(Session session, @Language("SQL") String sql, List<? extends Type> resultTypes)
+    {
+        return this.execute(session, sql);
+    }
 
     default MaterializedResultWithPlan executeWithPlan(Session session, @Language("SQL") String sql, WarningCollector warningCollector)
     {

--- a/presto-tests/src/main/java/com/facebook/presto/tests/H2QueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/H2QueryRunner.java
@@ -26,6 +26,7 @@ import com.facebook.presto.spi.ConnectorTableMetadata;
 import com.facebook.presto.spi.RecordCursor;
 import com.facebook.presto.spi.RecordSet;
 import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.testing.ExpectedQueryRunner;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.MaterializedRow;
 import com.facebook.presto.tpch.TpchMetadata;
@@ -42,7 +43,6 @@ import org.jdbi.v3.core.statement.SqlParser;
 import org.jdbi.v3.core.statement.StatementContext;
 import org.joda.time.DateTimeZone;
 
-import java.io.Closeable;
 import java.math.BigDecimal;
 import java.math.MathContext;
 import java.sql.Array;
@@ -92,7 +92,7 @@ import static java.lang.String.format;
 import static java.util.Collections.nCopies;
 
 public class H2QueryRunner
-        implements Closeable
+        implements ExpectedQueryRunner
 {
     private final Handle handle;
 

--- a/presto-tests/src/main/java/com/facebook/presto/tests/QueryAssertions.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/QueryAssertions.java
@@ -18,6 +18,7 @@ import com.facebook.presto.Session;
 import com.facebook.presto.common.QualifiedObjectName;
 import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.sql.planner.Plan;
+import com.facebook.presto.testing.ExpectedQueryRunner;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.testing.MaterializedRow;
 import com.facebook.presto.testing.QueryRunner;
@@ -98,32 +99,32 @@ public final class QueryAssertions
             QueryRunner actualQueryRunner,
             Session session,
             @Language("SQL") String actual,
-            H2QueryRunner h2QueryRunner,
+            ExpectedQueryRunner expectedQueryRunner,
             @Language("SQL") String expected,
             boolean ensureOrdering,
             boolean compareUpdate)
     {
-        assertQuery(actualQueryRunner, session, actual, h2QueryRunner, expected, ensureOrdering, compareUpdate, Optional.empty());
+        assertQuery(actualQueryRunner, session, actual, expectedQueryRunner, expected, ensureOrdering, compareUpdate, Optional.empty());
     }
 
     public static void assertQuery(
             QueryRunner actualQueryRunner,
             Session session,
             @Language("SQL") String actual,
-            H2QueryRunner h2QueryRunner,
+            ExpectedQueryRunner expectedQueryRunner,
             @Language("SQL") String expected,
             boolean ensureOrdering,
             boolean compareUpdate,
             Consumer<Plan> planAssertion)
     {
-        assertQuery(actualQueryRunner, session, actual, h2QueryRunner, expected, ensureOrdering, compareUpdate, Optional.of(planAssertion));
+        assertQuery(actualQueryRunner, session, actual, expectedQueryRunner, expected, ensureOrdering, compareUpdate, Optional.of(planAssertion));
     }
 
     private static void assertQuery(
             QueryRunner actualQueryRunner,
             Session session,
             @Language("SQL") String actual,
-            H2QueryRunner h2QueryRunner,
+            ExpectedQueryRunner expectedQueryRunner,
             @Language("SQL") String expected,
             boolean ensureOrdering,
             boolean compareUpdate,
@@ -158,14 +159,14 @@ public final class QueryAssertions
         long expectedStart = System.nanoTime();
         MaterializedResult expectedResults = null;
         try {
-            expectedResults = h2QueryRunner.execute(session, expected, actualResults.getTypes());
+            expectedResults = expectedQueryRunner.execute(session, expected, actualResults.getTypes());
         }
         catch (RuntimeException ex) {
             fail("Execution of 'expected' query failed: " + expected, ex);
         }
         Duration totalTime = nanosSince(start);
         if (totalTime.compareTo(Duration.succinctDuration(1, SECONDS)) > 0) {
-            log.info("FINISHED in presto: %s, h2: %s, total: %s", actualTime, nanosSince(expectedStart), totalTime);
+            log.info("FINISHED in presto: %s, expected: %s, total: %s", actualTime, nanosSince(expectedStart), totalTime);
         }
 
         if (actualResults.getUpdateType().isPresent() || actualResults.getUpdateCount().isPresent()) {


### PR DESCRIPTION
Test plan - 

Travis

Refactor AbstractTestQueryFramework to allow an expectedQueryRunnerSupplier to be provided in the 
constructor instead of the hard coded H2QueryRunner.  H2 is still the default for the current constructor.  
This will allow presto_cpp to use AbstractTestQueryFramework and QueryAssertions to directly compare 
query results from the Java and C++ workers.

This is used by presto_cpp here : https://github.com/facebookexternal/presto_cpp/pull/239
```
== NO RELEASE NOTE ==
```
