### PR TITLE
Generate presto-internal.thrift file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -164,6 +164,7 @@
         <module>presto-druid</module>
         <module>presto-common</module>
         <module>presto-thrift-testing-udf-server</module>
+        <module>presto-thrift-spec</module>
     </modules>
 
     <dependencyManagement>

--- a/presto-thrift-spec/pom.xml
+++ b/presto-thrift-spec/pom.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.facebook.presto</groupId>
+        <artifactId>presto-root</artifactId>
+        <version>0.247-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>presto-thrift-spec</artifactId>
+
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-main</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <configuration>
+                    <ignoredDependencies>
+                        <ignoredDependency>com.facebook.presto:presto-main</ignoredDependency>
+                    </ignoredDependencies>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>com.facebook.drift</groupId>
+                <artifactId>drift-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>execution</id>
+                        <goals>
+                            <goal>generate-thrift-idl</goal>
+                        </goals>
+                        <phase>process-classes</phase>
+                        <configuration>
+                            <classes>
+                                <class>com.facebook.presto.execution.TaskStatus</class>
+                            </classes>
+                            <recursive>true</recursive>
+                            <outputFile>target/presto-internal-${project.version}.thrift</outputFile>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-artifacts</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>attach-artifact</goal>
+                        </goals>
+                        <configuration>
+                            <artifacts>
+                                <artifact>
+                                    <file>target/presto-internal-${project.version}.thrift</file>
+                                    <type>thrift</type>
+                                </artifact>
+                            </artifacts>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>


### PR DESCRIPTION
Test plan - 

run 
```
mvn process-classes -DskipTests -T1C
```

inspect presto-thrift-spec/target/presto-internal-0.247-SNAPSHOT.thrift

```
mvn clean install -DskipTests -T1C -pl '!presto-docs,!presto-server-rpm'
jroll@fb : ls -l ~/.m2/repository/com/facebook/presto/presto-thrift-spec/0.247-SNAPSHOT/presto-thrift-spec-0.247-SNAPSHOT.thrift
-rw-r--r--  1 jroll  staff  1371 Jan 22 09:29 /Users/jroll/.m2/repository/com/facebook/presto/presto-thrift-spec/0.247-SNAPSHOT/presto-thrift-spec-0.247-SNAPSHOT.thrift
```
== RELEASE NOTES ==

General Changes
* Add maven plugin for drift to generate the Thrift spec for a list of classes, current class list is **TaskStatus**


