### PR TITLE
Revert "Fix temporary table deletion for exchange materialization"

### DIFF
--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/SemiTransactionalHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/SemiTransactionalHiveMetastore.java
@@ -1622,11 +1622,7 @@ public class SemiTransactionalHiveMetastore
     {
         for (DeclaredIntentionToWrite declaredIntentionToWrite : declaredIntentionsToWrite) {
             if (declaredIntentionToWrite.isTemporaryTable()) {
-                String tableName = declaredIntentionToWrite.getSchemaTableName().getTableName();
-                // table path is set to _presto_temporary_table_${uuid}/${uuid}/ for temporary table
-                Path tablePath = declaredIntentionToWrite.getStagingPathRoot().getParent();
-                checkState(tablePath.getName().equalsIgnoreCase(tableName));
-                deleteRecursivelyIfExists(declaredIntentionToWrite.getContext(), hdfsEnvironment, tablePath);
+                deleteRecursivelyIfExists(declaredIntentionToWrite.getContext(), hdfsEnvironment, declaredIntentionToWrite.getStagingPathRoot());
             }
         }
     }


### PR DESCRIPTION
This reverts commit d2cb24cd4cec630940463d8d8dc25806c774f00d.

Different LocationService might implement the different convention for
temporary table location and not necessarily always follow the
"_presto_temporary_table_${uuid}/${uuid}/" pattern.

Test plan - Travis

```
== NO RELEASE NOTE ==
```
