### PR TITLE
Improve error handling for spill

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/Driver.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/Driver.java
@@ -47,8 +47,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
 
-import static com.facebook.airlift.concurrent.MoreFutures.getFutureValue;
 import static com.facebook.presto.operator.Operator.NOT_BLOCKED;
+import static com.facebook.presto.operator.SpillingUtils.checkSpillSucceeded;
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.schedule.NodeSelectionStrategy.NO_PREFERENCE;
 import static com.facebook.presto.util.MoreUninterruptibles.tryLockUninterruptibly;
@@ -539,7 +539,7 @@ public class Driver
     {
         ListenableFuture<?> future = revokingOperators.get(operator);
         if (future.isDone()) {
-            getFutureValue(future); // propagate exception if there was some
+            checkSpillSucceeded(future); // propagate exception if there was some
             revokingOperators.remove(operator);
             operator.finishMemoryRevoke();
             operator.getOperatorContext().resetMemoryRevokingRequested();

--- a/presto-main/src/main/java/com/facebook/presto/operator/HashBuilderOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/HashBuilderOperator.java
@@ -38,8 +38,8 @@ import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.Queue;
 
-import static com.facebook.airlift.concurrent.MoreFutures.checkSuccess;
 import static com.facebook.airlift.concurrent.MoreFutures.getDone;
+import static com.facebook.presto.operator.SpillingUtils.checkSpillSucceeded;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
@@ -360,7 +360,7 @@ public class HashBuilderOperator
     private void spillInput(Page page)
     {
         checkState(spillInProgress.isDone(), "Previous spill still in progress");
-        checkSuccess(spillInProgress, "spilling failed");
+        checkSpillSucceeded(spillInProgress);
         spillInProgress = getSpiller().spill(page);
     }
 
@@ -525,7 +525,7 @@ public class HashBuilderOperator
             // Not ready to handle finish() yet
             return;
         }
-        checkSuccess(spillInProgress, "spilling failed");
+        checkSpillSucceeded(spillInProgress);
         state = State.INPUT_SPILLED;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperator.java
@@ -40,10 +40,10 @@ import java.util.function.IntPredicate;
 import java.util.function.Supplier;
 
 import static com.facebook.airlift.concurrent.MoreFutures.addSuccessCallback;
-import static com.facebook.airlift.concurrent.MoreFutures.checkSuccess;
 import static com.facebook.airlift.concurrent.MoreFutures.getDone;
 import static com.facebook.presto.operator.LookupJoinOperators.JoinType.FULL_OUTER;
 import static com.facebook.presto.operator.LookupJoinOperators.JoinType.PROBE_OUTER;
+import static com.facebook.presto.operator.SpillingUtils.checkSpillSucceeded;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
 import static java.lang.String.format;
@@ -146,7 +146,7 @@ public class LookupJoinOperator
             return;
         }
 
-        checkSuccess(spillInProgress, "spilling failed");
+        checkSpillSucceeded(spillInProgress);
         finishing = true;
     }
 
@@ -237,7 +237,7 @@ public class LookupJoinOperator
     private Page spillAndMaskSpilledPositions(Page page, IntPredicate spillMask)
     {
         checkState(spillInProgress.isDone(), "Previous spill still in progress");
-        checkSuccess(spillInProgress, "spilling failed");
+        checkSpillSucceeded(spillInProgress);
 
         if (!spiller.isPresent()) {
             spiller = Optional.of(partitioningSpillerFactory.create(
@@ -272,7 +272,8 @@ public class LookupJoinOperator
              */
             return null;
         }
-        checkSuccess(spillInProgress, "spilling failed");
+
+        checkSpillSucceeded(spillInProgress);
 
         if (probe == null && pageBuilder.isEmpty() && !finishing) {
             return null;

--- a/presto-main/src/main/java/com/facebook/presto/operator/SpillingUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/SpillingUtils.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.spi.PrestoException;
+
+import java.util.concurrent.Future;
+
+import static com.facebook.airlift.concurrent.MoreFutures.getFutureValue;
+import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
+import static java.lang.String.format;
+
+public class SpillingUtils
+{
+    private SpillingUtils() {}
+
+    /**
+     * We use this instead of checkSuccess in airlift so we can propagate the error message
+     * and so that we throw a PrestoException rather than an IllegalArgumentException.
+     *
+     * @param spillInProgress
+     */
+    public static void checkSpillSucceeded(Future spillInProgress)
+    {
+        try {
+            getFutureValue(spillInProgress);
+        }
+        catch (PrestoException prestoException) {
+            throw new PrestoException(prestoException::getErrorCode, prestoException.getMessage(), prestoException);
+        }
+        catch (RuntimeException runtimeException) {
+            throw new PrestoException(GENERIC_INTERNAL_ERROR, format("Spilling failed: %s", runtimeException.getMessage()), runtimeException);
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/WindowOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/WindowOperator.java
@@ -44,8 +44,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiPredicate;
 import java.util.stream.Stream;
 
-import static com.facebook.airlift.concurrent.MoreFutures.checkSuccess;
 import static com.facebook.presto.common.block.SortOrder.ASC_NULLS_LAST;
+import static com.facebook.presto.operator.SpillingUtils.checkSpillSucceeded;
 import static com.facebook.presto.operator.WorkProcessor.TransformationState.needsMoreData;
 import static com.facebook.presto.util.MergeSortedPages.mergeSortedPages;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -705,7 +705,7 @@ public class WindowOperator
                 return;
             }
 
-            checkSuccess(spillInProgress.get(), "spilling failed");
+            checkSpillSucceeded(spillInProgress.get());
             spillInProgress = Optional.empty();
 
             // No memory to reclaim
@@ -824,8 +824,8 @@ public class WindowOperator
 
     /**
      * @param startPosition - inclusive
-     * @param endPosition - exclusive
-     * @param comparator - returns true if positions given as parameters are equal
+     * @param endPosition   - exclusive
+     * @param comparator    - returns true if positions given as parameters are equal
      * @return the end of the group position exclusive (the position the very next group starts)
      */
     @VisibleForTesting

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/builder/SpillableHashAggregationBuilder.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/builder/SpillableHashAggregationBuilder.java
@@ -35,8 +35,8 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 
-import static com.facebook.airlift.concurrent.MoreFutures.getFutureValue;
 import static com.facebook.presto.operator.Operator.NOT_BLOCKED;
+import static com.facebook.presto.operator.SpillingUtils.checkSpillSucceeded;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -151,7 +151,7 @@ public class SpillableHashAggregationBuilder
     {
         if (spillInProgress.isDone()) {
             // check for exception from previous spill for early failure
-            getFutureValue(spillInProgress);
+            checkSpillSucceeded(spillInProgress);
             return true;
         }
         else {
@@ -200,7 +200,7 @@ public class SpillableHashAggregationBuilder
                 localRevocableMemoryContext.setBytes(currentRevocableBytes);
                 // spill since revocable memory could not be converted to user memory immediately
                 // TODO: this should be asynchronous
-                getFutureValue(spillToDisk());
+                checkSpillSucceeded(spillToDisk());
                 updateMemory();
             }
         }
@@ -213,7 +213,7 @@ public class SpillableHashAggregationBuilder
             return mergeFromDiskAndMemory();
         }
         else {
-            getFutureValue(spillToDisk());
+            checkSpillSucceeded(spillToDisk());
             return mergeFromDisk();
         }
     }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestJoinQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestJoinQueries.java
@@ -35,7 +35,7 @@ import static com.google.common.collect.Iterables.getOnlyElement;
 import static java.lang.String.format;
 import static org.testng.Assert.assertTrue;
 
-public class AbstractTestJoinQueries
+public abstract class AbstractTestJoinQueries
         extends AbstractTestQueryFramework
 {
     protected AbstractTestJoinQueries(QueryRunnerSupplier supplier)

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestOrderByQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestOrderByQueries.java
@@ -25,7 +25,7 @@ import static com.facebook.presto.testing.assertions.Assert.assertEquals;
 import static com.facebook.presto.tests.QueryTemplate.parameter;
 import static com.facebook.presto.tests.QueryTemplate.queryTemplate;
 
-public class AbstractTestOrderByQueries
+public abstract class AbstractTestOrderByQueries
         extends AbstractTestQueryFramework
 {
     public AbstractTestOrderByQueries(QueryRunnerSupplier supplier)

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestWindowQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestWindowQueries.java
@@ -26,7 +26,7 @@ import static com.facebook.presto.testing.assertions.Assert.assertEquals;
 import static com.facebook.presto.tests.QueryAssertions.assertEqualsIgnoreOrder;
 import static com.facebook.presto.tests.StructuralTestUtil.mapType;
 
-public class AbstractTestWindowQueries
+public abstract class AbstractTestWindowQueries
         extends AbstractTestQueryFramework
 {
     public AbstractTestWindowQueries(QueryRunnerSupplier supplier)


### PR DESCRIPTION
checkSuccess wrapped exceptions in an IllegalArgumentException, which
meant the actual error was buried in the stacktrace. getFutureValue
wrapped the source exception in a runtime exception, but only included
the error stacktrace and not the stack to the  getFutureValue call.
Without the other stack trace, you don't know where in the operator
execution spill failed, which can make debugging harder.

Test Plan - Ran tests with max spilled bytes set to 1B and looked at the
errors.

```
== NO RELEASE NOTE ==
```
