### PR TITLE
Minor fix to Hive temporary table location

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveLocationService.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveLocationService.java
@@ -81,7 +81,7 @@ public class HiveLocationService
         String schemaName = table.getDatabaseName();
         String tableName = table.getTableName();
         HdfsContext context = new HdfsContext(session, schemaName, tableName);
-        Path targetPath = new Path(getTableDefaultLocation(context, metastore, hdfsEnvironment, schemaName, tableName), randomUUID().toString().replaceAll("-", "_"));
+        Path targetPath = getTableDefaultLocation(context, metastore, hdfsEnvironment, schemaName, tableName);
         return new LocationHandle(
                 targetPath,
                 targetPath,


### PR DESCRIPTION
Temporary table name is unique and already contains UUID, doesn't need
to append the extra UUID sub-directory.

See https://github.com/prestodb/presto/pull/15532 and https://github.com/prestodb/presto/pull/15486

Test plan - Travis


```
== NO RELEASE NOTE ==
```
