### PR TITLE
Add flag to set cache eviction retries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <dep.nexus-staging-plugin.version>1.6.8</dep.nexus-staging-plugin.version>
         <dep.asm.version>9.0</dep.asm.version>
         <dep.gcs.version>1.9.17</dep.gcs.version>
-        <dep.alluxio.version>2.3.0-2</dep.alluxio.version>
+        <dep.alluxio.version>2.4.1-1</dep.alluxio.version>
         <dep.kafka.version>2.3.1</dep.kafka.version>
         <dep.druid.version>0.19.0</dep.druid.version>
         <dep.jaxb.version>2.3.1</dep.jaxb.version>

--- a/presto-cache/src/main/java/com/facebook/presto/cache/alluxio/AlluxioCacheConfig.java
+++ b/presto-cache/src/main/java/com/facebook/presto/cache/alluxio/AlluxioCacheConfig.java
@@ -32,6 +32,7 @@ public class AlluxioCacheConfig
     private boolean timeoutEnabled;
     private Duration timeoutDuration = new Duration(60, SECONDS);
     private int timeoutThreads = 64;
+    private int evictionRetries;
 
     public boolean isMetricsCollectionEnabled()
     {
@@ -147,6 +148,19 @@ public class AlluxioCacheConfig
     public AlluxioCacheConfig setTimeoutEnabled(boolean timeoutEnabled)
     {
         this.timeoutEnabled = timeoutEnabled;
+        return this;
+    }
+
+    public int getEvictionRetries()
+    {
+        return evictionRetries;
+    }
+
+    @Config("cache.alluxio.eviction-retries")
+    @ConfigDescription("The maximum number of eviction retries")
+    public AlluxioCacheConfig setEvictionRetries(int evictionRetries)
+    {
+        this.evictionRetries = evictionRetries;
         return this;
     }
 }

--- a/presto-cache/src/main/java/com/facebook/presto/cache/alluxio/AlluxioCachingConfigurationProvider.java
+++ b/presto-cache/src/main/java/com/facebook/presto/cache/alluxio/AlluxioCachingConfigurationProvider.java
@@ -48,6 +48,7 @@ public class AlluxioCachingConfigurationProvider
             configuration.set("alluxio.user.client.cache.size", alluxioCacheConfig.getMaxCacheSize().toString());
             configuration.set("alluxio.user.client.cache.async.write.enabled", String.valueOf(alluxioCacheConfig.isAsyncWriteEnabled()));
             configuration.set("alluxio.user.metrics.collection.enabled", String.valueOf(alluxioCacheConfig.isMetricsCollectionEnabled()));
+            configuration.set("alluxio.user.client.cache.eviction.retries", String.valueOf(alluxioCacheConfig.getEvictionRetries()));
             configuration.set("sink.jmx.class", alluxioCacheConfig.getJmxClass());
             configuration.set("sink.jmx.domain", alluxioCacheConfig.getMetricsDomain());
             configuration.set("alluxio.conf.validation.enabled", String.valueOf(alluxioCacheConfig.isConfigValidationEnabled()));

--- a/presto-cache/src/test/java/com/facebook/presto/cache/alluxio/TestAlluxioCacheConfig.java
+++ b/presto-cache/src/test/java/com/facebook/presto/cache/alluxio/TestAlluxioCacheConfig.java
@@ -35,6 +35,7 @@ public class TestAlluxioCacheConfig
         assertRecordedDefaults(recordDefaults(AlluxioCacheConfig.class)
                 .setAsyncWriteEnabled(false)
                 .setConfigValidationEnabled(false)
+                .setEvictionRetries(0)
                 .setJmxClass("alluxio.metrics.sink.JmxSink")
                 .setMaxCacheSize(new DataSize(2, GIGABYTE))
                 .setMetricsCollectionEnabled(true)
@@ -50,6 +51,7 @@ public class TestAlluxioCacheConfig
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("cache.alluxio.async-write-enabled", "true")
                 .put("cache.alluxio.config-validation-enabled", "true")
+                .put("cache.alluxio.eviction-retries", "5")
                 .put("cache.alluxio.jmx-class", "test.TestJmxSink")
                 .put("cache.alluxio.max-cache-size", "42MB")
                 .put("cache.alluxio.metrics-domain", "test.alluxio")
@@ -61,6 +63,7 @@ public class TestAlluxioCacheConfig
 
         AlluxioCacheConfig expected = new AlluxioCacheConfig()
                 .setAsyncWriteEnabled(true)
+                .setEvictionRetries(5)
                 .setMaxCacheSize(new DataSize(42, MEGABYTE))
                 .setMetricsCollectionEnabled(false)
                 .setMetricsDomain("test.alluxio")


### PR DESCRIPTION
Add a flag to enable retries when Alluxio cache eviction failed.
This feature is particularly helpful if there are a lot of small files cached

Test plan - unit tests added

```
== NO RELEASE NOTE ==
```
