### PR TITLE
Fix SliceDirectSelectiveStreamReader for dataLength is 0

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDictionarySelectiveReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDictionarySelectiveReader.java
@@ -32,6 +32,7 @@ import com.facebook.presto.orc.stream.InputStreamSource;
 import com.facebook.presto.orc.stream.InputStreamSources;
 import com.facebook.presto.orc.stream.LongInputStream;
 import com.facebook.presto.orc.stream.RowGroupDictionaryLengthInputStream;
+import com.google.common.annotations.VisibleForTesting;
 import io.airlift.slice.Slice;
 import org.openjdk.jol.info.ClassLayout;
 
@@ -681,6 +682,12 @@ public class SliceDictionarySelectiveReader
                 sizeOf(evaluationStatus) +
                 sizeOf(valueWithPadding) +
                 dictionary.getRetainedSizeInBytes();
+    }
+
+    @VisibleForTesting
+    public void resetDataStream()
+    {
+        dataStream = null;
     }
 
     private void initiateEvaluationStatus(int positionCount)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDirectSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDirectSelectiveStreamReader.java
@@ -719,31 +719,30 @@ public class SliceDirectSelectiveStreamReader
 
     private boolean useBatchMode(int positionCount, int totalPositionCount)
     {
-        return true;
         // maxCodePointCount < 0 means it's unbounded varchar VARCHAR.
         // If the types are VARCHAR(N) or CHAR(N), the length of the string need to be calculated and truncated.
-//        if (lengthStream == null || maxCodePointCount >= 0) {
-//            return false;
-//        }
-//
-//        double inputFilterRate = (double) (totalPositionCount - positionCount) / totalPositionCount;
-//        if (filter == null) {  // readNoFilter
-//            // When there is no filter, batch mode performs better for almost all inputFilterRate.
-//            // But to limit data buffer size, we enable it for the range of [0.0f, 0.5f]
-//            if (inputFilterRate >= 0.0f && inputFilterRate <= 0.5f) {
-//                return true;
-//            }
-//
-//            return false;
-//        }
-//        else { // readWithFilter
-//            // When there is filter, batch mode performs better for almost all inputFilterRate except when inputFilterRate is around 0.1f.
-//            // To limit data buffer size, we enable it for the range of [0.0f, 0.05f] and [0.15f, 0.5f]
-//            if (inputFilterRate >= 0.0f && inputFilterRate <= 0.05f || inputFilterRate >= 0.15f && inputFilterRate <= 0.5f) {
-//                return true;
-//            }
-//
-//            return false;
-//        }
+        if (lengthStream == null || maxCodePointCount >= 0) {
+            return false;
+        }
+
+        double inputFilterRate = (double) (totalPositionCount - positionCount) / totalPositionCount;
+        if (filter == null) {  // readNoFilter
+            // When there is no filter, batch mode performs better for almost all inputFilterRate.
+            // But to limit data buffer size, we enable it for the range of [0.0f, 0.5f]
+            if (inputFilterRate >= 0.0f && inputFilterRate <= 0.5f) {
+                return true;
+            }
+
+            return false;
+        }
+        else { // readWithFilter
+            // When there is filter, batch mode performs better for almost all inputFilterRate except when inputFilterRate is around 0.1f.
+            // To limit data buffer size, we enable it for the range of [0.0f, 0.05f] and [0.15f, 0.5f]
+            if (inputFilterRate >= 0.0f && inputFilterRate <= 0.05f || inputFilterRate >= 0.15f && inputFilterRate <= 0.5f) {
+                return true;
+            }
+
+            return false;
+        }
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceSelectiveStreamReader.java
@@ -23,6 +23,7 @@ import com.facebook.presto.orc.StreamDescriptor;
 import com.facebook.presto.orc.TupleDomainFilter;
 import com.facebook.presto.orc.metadata.ColumnEncoding;
 import com.facebook.presto.orc.stream.InputStreamSources;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.io.Closer;
 import io.airlift.slice.Slice;
 import org.openjdk.jol.info.ClassLayout;
@@ -150,5 +151,12 @@ public class SliceSelectiveStreamReader
             return Varchars.byteCount(slice, offset, length, maxCodePointCount);
         }
         return length;
+    }
+
+    @VisibleForTesting
+    public void resetDataStream()
+    {
+        ((SliceDirectSelectiveStreamReader) directReader).resetDataStream();
+        ((SliceDictionarySelectiveReader) dictionaryReader).resetDataStream();
     }
 }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
@@ -1101,7 +1101,7 @@ public class OrcTester
             if (nestedType instanceof ArrayType) {
                 assertTrue(pathElement instanceof Subfield.LongSubscript);
                 if (nestedValue == null) {
-                    return filter == IS_NULL;
+                    return filter.testNull();
                 }
                 int index = toIntExact(((Subfield.LongSubscript) pathElement).getIndex()) - 1;
                 nestedType = ((ArrayType) nestedType).getElementType();

--- a/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
@@ -919,20 +919,21 @@ public class OrcTester
                 assertEquals(block.getPositionCount(), positionCount);
                 checkNullValues(type, block);
 
-                List<Object> data = new ArrayList<>(positionCount);
-                for (int position = 0; position < positionCount; position++) {
-                    data.add(type.getObjectValue(SESSION.getSqlFunctionProperties(), block, position));
-                }
-
-                for (int position = 0; position < positionCount; position++) {
-                    assertColumnValueEquals(type, data.get(position), expectedValues.get(i).get(rowsProcessed + position));
-                }
+                assertBlockEquals(type, block, expectedValues.get(i), rowsProcessed);
             }
 
             rowsProcessed += positionCount;
         }
 
         assertEquals(rowsProcessed, expectedValues.get(0).size());
+    }
+
+    static void assertBlockEquals(Type type, Block block, List<?> expectedValues, int offset)
+    {
+        int positionCount = block.getPositionCount();
+        for (int position = 0; position < positionCount; position++) {
+            assertColumnValueEquals(type, type.getObjectValue(SESSION.getSqlFunctionProperties(), block, position), expectedValues.get(offset + position));
+        }
     }
 
     private static Map<Integer, Map<Subfield, TupleDomainFilter>> addOrderTracking(Map<Integer, Map<Subfield, TupleDomainFilter>> filters, TupleDomainFilterOrderChecker orderChecker)
@@ -1042,14 +1043,7 @@ public class OrcTester
                         assertEquals(block.getPositionCount(), batchSize);
                         checkNullValues(type, block);
 
-                        List<Object> data = new ArrayList<>(block.getPositionCount());
-                        for (int position = 0; position < block.getPositionCount(); position++) {
-                            data.add(type.getObjectValue(SESSION.getSqlFunctionProperties(), block, position));
-                        }
-
-                        for (int position = 0; position < block.getPositionCount(); position++) {
-                            assertColumnValueEquals(type, data.get(position), expectedValues.get(i).get(rowsProcessed + position));
-                        }
+                        assertBlockEquals(type, block, expectedValues.get(i), rowsProcessed);
                     }
                 }
                 assertEquals(recordReader.getReaderPosition(), rowsProcessed);
@@ -1350,7 +1344,7 @@ public class OrcTester
         return builder.build();
     }
 
-    private static void assertColumnValueEquals(Type type, Object actual, Object expected)
+    public static void assertColumnValueEquals(Type type, Object actual, Object expected)
     {
         if (actual == null) {
             assertEquals(actual, expected);

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcSelectiveStreamReaders.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcSelectiveStreamReaders.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.orc;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.orc.metadata.CompressionKind;
+import com.facebook.presto.orc.reader.SelectiveStreamReader;
+import com.facebook.presto.orc.reader.SliceSelectiveStreamReader;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.IntStream;
+
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.orc.OrcTester.Format.DWRF;
+import static com.facebook.presto.orc.OrcTester.Format.ORC_11;
+import static com.facebook.presto.orc.OrcTester.Format.ORC_12;
+import static com.facebook.presto.orc.OrcTester.assertBlockEquals;
+import static com.facebook.presto.orc.OrcTester.createCustomOrcSelectiveRecordReader;
+import static com.facebook.presto.orc.OrcTester.writeOrcColumnsPresto;
+import static com.facebook.presto.orc.TestingOrcPredicate.createOrcPredicate;
+import static com.facebook.presto.orc.metadata.CompressionKind.LZ4;
+import static com.facebook.presto.orc.metadata.CompressionKind.NONE;
+import static com.facebook.presto.orc.metadata.CompressionKind.SNAPPY;
+import static com.facebook.presto.orc.metadata.CompressionKind.ZLIB;
+import static com.facebook.presto.orc.metadata.CompressionKind.ZSTD;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static java.lang.Math.min;
+import static org.testng.Assert.assertEquals;
+
+public class TestOrcSelectiveStreamReaders
+{
+    private Set<OrcTester.Format> formats = ImmutableSet.of(ORC_12, ORC_11, DWRF);
+    private Set<CompressionKind> compressions = ImmutableSet.of(NONE, SNAPPY, ZLIB, LZ4, ZSTD);
+
+    /**
+     * This test tests SliceDirectSelectiveStreamReader for the case where all elements to read are empty strings. The output Block should be a valid VariableWidthBlock with an
+     * empty Slice. It is to simulate a problem seen in production. The state of SliceDirectSelectiveStreamReader to reproduce the problem is:
+     * - dataStream: null
+     * - presentStream: null
+     * - lengthStream: not null
+     * - filter: null
+     * - outputRequired: true
+     * - offsets array: non zeros
+     * The test issues two reads, the first one reads a non-empty string and populates non-zero offsets. The second one reads the empty string with the above conditions met.
+     */
+    @Test
+    public void testEmptyStrings()
+            throws Exception
+    {
+        Type type = VARCHAR;
+        List<Type> types = ImmutableList.of(type);
+        List<List<?>> values = ImmutableList.of(ImmutableList.of("a", ""));
+
+        for (OrcTester.Format format : formats) {
+            if (!types.stream().allMatch(readType -> format.supportsType(readType))) {
+                return;
+            }
+
+            for (CompressionKind compression : compressions) {
+                TempFile tempFile = new TempFile();
+                writeOrcColumnsPresto(tempFile.getFile(), format, compression, Optional.empty(), types, values, new OrcWriterStats());
+
+                OrcPredicate orcPredicate = createOrcPredicate(types, values, DWRF, false);
+                Map<Integer, Type> includedColumns = IntStream.range(0, types.size())
+                        .boxed()
+                        .collect(toImmutableMap(Function.identity(), types::get));
+                List<Integer> outputColumns = IntStream.range(0, types.size())
+                        .boxed()
+                        .collect(toImmutableList());
+                OrcAggregatedMemoryContext systemMemoryUsage = new TestingHiveOrcAggregatedMemoryContext();
+                try (OrcSelectiveRecordReader recordReader = createCustomOrcSelectiveRecordReader(
+                        tempFile.getFile(),
+                        format.getOrcEncoding(),
+                        orcPredicate,
+                        types,
+                        1,
+                        ImmutableMap.of(),
+                        ImmutableList.of(),
+                        ImmutableMap.of(),
+                        OrcTester.OrcReaderSettings.builder().build().getRequiredSubfields(),
+                        ImmutableMap.of(),
+                        includedColumns,
+                        outputColumns,
+                        false,
+                        systemMemoryUsage)) {
+                    assertEquals(recordReader.getReaderPosition(), 0);
+                    assertEquals(recordReader.getFilePosition(), 0);
+
+                    SelectiveStreamReader streamReader = recordReader.getStreamReaders()[0];
+
+                    // Read the first non-empty element. Do not call streamReader.getBlock() to preserve the offsets array in SliceDirectSelectiveStreamReader.
+                    int batchSize = min(recordReader.prepareNextBatch(), 1);
+                    int[] positions = IntStream.range(0, batchSize).toArray();
+                    streamReader.read(0, positions, batchSize);
+                    recordReader.batchRead(batchSize);
+
+                    // Read the second element: an empty string. Set the dataStream in SliceDirectSelectiveStreamReader to null to simulate the conditions causing the problem.
+                    ((SliceSelectiveStreamReader) streamReader).resetDataStream();
+                    batchSize = min(recordReader.prepareNextBatch(), 1);
+                    positions = IntStream.range(0, batchSize).toArray();
+                    streamReader.read(0, positions, batchSize);
+                    recordReader.batchRead(batchSize);
+
+                    Block block = streamReader.getBlock(positions, batchSize);
+
+                    List<?> expectedValues = ImmutableList.of("");
+                    assertBlockEquals(type, block, expectedValues, 0);
+                    assertEquals(recordReader.getReaderPosition(), 1);
+                    assertEquals(recordReader.getFilePosition(), 1);
+                }
+            }
+        }
+    }
+}

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestSelectiveOrcReader.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestSelectiveOrcReader.java
@@ -412,6 +412,19 @@ public class TestSelectiveOrcReader
         BigintRange negative = BigintRange.of(Integer.MIN_VALUE, 0, false);
         BigintRange nonNegative = BigintRange.of(0, Integer.MAX_VALUE, false);
 
+        // arrays of strings
+        tester.testRoundTrip(arrayType(VARCHAR),
+                createList(1000, i -> randomStrings(5 + random.nextInt(5), random)),
+                ImmutableList.of(
+                        toSubfieldFilter("c[1]", IS_NULL),
+                        toSubfieldFilter("c[1]", stringIn(true, "a", "b", "c", "d"))));
+
+        tester.testRoundTrip(arrayType(VARCHAR),
+                createList(10, i -> randomStringsWithNulls(5 + random.nextInt(5), random)),
+                ImmutableList.of(
+                        toSubfieldFilter("c[1]", IS_NULL),
+                        toSubfieldFilter("c[1]", stringIn(true, "a", "b", "c", "d"))));
+
         // non-empty non-null arrays of varying sizes
         tester.testRoundTrip(arrayType(INTEGER),
                 createList(NUM_ROWS, i -> randomIntegers(5 + random.nextInt(5), random)),
@@ -1225,6 +1238,23 @@ public class TestSelectiveOrcReader
     private static List<Integer> randomIntegers(int size, Random random)
     {
         return createList(size, i -> random.nextInt());
+    }
+
+    private static List<String> randomStrings(int size, Random random)
+    {
+        return createList(size, i -> generateRandomStringWithLength(random, 10));
+    }
+
+    private static List<String> randomStringsWithNulls(int size, Random random)
+    {
+        return createList(size, i -> i % 2 == 0 ? null : generateRandomStringWithLength(random, 10));
+    }
+
+    private static String generateRandomStringWithLength(Random random, int length)
+    {
+        byte[] array = new byte[length];
+        random.nextBytes(array);
+        return new String(array, UTF_8);
     }
 
     private static List<SqlDecimal> decimalSequence(String start, String step, int items, int precision, int scale)


### PR DESCRIPTION
For batch read mode, when dataLength is 0 and offsets array was not
reset, the offsets array for previous batch would be used to create
the output Block. This causes IndexOutOfBoundsException for downstream
operators. This fix initializes the offsets array to 0 for the batch
read mode.

```
== NO RELEASE NOTE ==
```
