### PR TITLE
Support driver level plan in fragment result caching

### DIFF
--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/AbstractOperatorBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/AbstractOperatorBenchmark.java
@@ -289,8 +289,7 @@ public abstract class AbstractOperatorBenchmark
                         false,
                         false,
                         false,
-                        false,
-                        Optional.empty());
+                        false);
 
         CpuTimer cpuTimer = new CpuTimer();
         Map<String, Long> executionStats = execute(taskContext);

--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/AbstractSimpleOperatorBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/AbstractSimpleOperatorBenchmark.java
@@ -28,6 +28,7 @@ import com.google.common.collect.ImmutableList;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.OptionalInt;
 
 import static com.facebook.presto.operator.PipelineExecutionStrategy.UNGROUPED_EXECUTION;
@@ -54,7 +55,7 @@ public abstract class AbstractSimpleOperatorBenchmark
 
         operatorFactories.add(new NullOutputOperatorFactory(999, new PlanNodeId("test")));
 
-        return new DriverFactory(0, true, true, operatorFactories, OptionalInt.empty(), UNGROUPED_EXECUTION);
+        return new DriverFactory(0, true, true, operatorFactories, OptionalInt.empty(), UNGROUPED_EXECUTION, Optional.empty());
     }
 
     @Override

--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashBuildAndJoinBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashBuildAndJoinBenchmark.java
@@ -115,7 +115,7 @@ public class HashBuildAndJoinBenchmark
                 SingleStreamSpillerFactory.unsupportedSingleStreamSpillerFactory(),
                 false);
         driversBuilder.add(hashBuilder);
-        DriverFactory hashBuildDriverFactory = new DriverFactory(0, true, false, driversBuilder.build(), OptionalInt.empty(), UNGROUPED_EXECUTION);
+        DriverFactory hashBuildDriverFactory = new DriverFactory(0, true, false, driversBuilder.build(), OptionalInt.empty(), UNGROUPED_EXECUTION, Optional.empty());
 
         // join
         ImmutableList.Builder<OperatorFactory> joinDriversBuilder = ImmutableList.builder();
@@ -143,7 +143,7 @@ public class HashBuildAndJoinBenchmark
                 unsupportedPartitioningSpillerFactory());
         joinDriversBuilder.add(joinOperator);
         joinDriversBuilder.add(new NullOutputOperatorFactory(3, new PlanNodeId("test")));
-        DriverFactory joinDriverFactory = new DriverFactory(1, true, true, joinDriversBuilder.build(), OptionalInt.empty(), UNGROUPED_EXECUTION);
+        DriverFactory joinDriverFactory = new DriverFactory(1, true, true, joinDriversBuilder.build(), OptionalInt.empty(), UNGROUPED_EXECUTION, Optional.empty());
 
         Driver hashBuildDriver = hashBuildDriverFactory.createDriver(taskContext.addPipelineContext(0, true, false, false).addDriverContext());
         hashBuildDriverFactory.noMoreDrivers();

--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashBuildBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashBuildBenchmark.java
@@ -85,7 +85,7 @@ public class HashBuildBenchmark
                 false,
                 SingleStreamSpillerFactory.unsupportedSingleStreamSpillerFactory(),
                 false);
-        DriverFactory hashBuildDriverFactory = new DriverFactory(0, true, true, ImmutableList.of(ordersTableScan, hashBuilder), OptionalInt.empty(), UNGROUPED_EXECUTION);
+        DriverFactory hashBuildDriverFactory = new DriverFactory(0, true, true, ImmutableList.of(ordersTableScan, hashBuilder), OptionalInt.empty(), UNGROUPED_EXECUTION, Optional.empty());
 
         // empty join so build finishes
         ImmutableList.Builder<OperatorFactory> joinDriversBuilder = ImmutableList.builder();
@@ -102,7 +102,7 @@ public class HashBuildBenchmark
                 unsupportedPartitioningSpillerFactory());
         joinDriversBuilder.add(joinOperator);
         joinDriversBuilder.add(new NullOutputOperatorFactory(3, new PlanNodeId("test")));
-        DriverFactory joinDriverFactory = new DriverFactory(1, true, true, joinDriversBuilder.build(), OptionalInt.empty(), UNGROUPED_EXECUTION);
+        DriverFactory joinDriverFactory = new DriverFactory(1, true, true, joinDriversBuilder.build(), OptionalInt.empty(), UNGROUPED_EXECUTION, Optional.empty());
 
         Driver hashBuildDriver = hashBuildDriverFactory.createDriver(taskContext.addPipelineContext(0, true, true, false).addDriverContext());
         hashBuildDriverFactory.noMoreDrivers();

--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashJoinBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashJoinBenchmark.java
@@ -96,13 +96,13 @@ public class HashJoinBenchmark
                     false);
 
             DriverContext driverContext = taskContext.addPipelineContext(0, false, false, false).addDriverContext();
-            DriverFactory buildDriverFactory = new DriverFactory(0, false, false, ImmutableList.of(ordersTableScan, hashBuilder), OptionalInt.empty(), UNGROUPED_EXECUTION);
+            DriverFactory buildDriverFactory = new DriverFactory(0, false, false, ImmutableList.of(ordersTableScan, hashBuilder), OptionalInt.empty(), UNGROUPED_EXECUTION, Optional.empty());
 
             List<Type> lineItemTypes = getColumnTypes("lineitem", "orderkey", "quantity");
             OperatorFactory lineItemTableScan = createTableScanOperator(0, new PlanNodeId("test"), "lineitem", "orderkey", "quantity");
             OperatorFactory joinOperator = LOOKUP_JOIN_OPERATORS.innerJoin(1, new PlanNodeId("test"), lookupSourceFactoryManager, lineItemTypes, Ints.asList(0), OptionalInt.empty(), Optional.empty(), OptionalInt.empty(), unsupportedPartitioningSpillerFactory());
             NullOutputOperatorFactory output = new NullOutputOperatorFactory(2, new PlanNodeId("test"));
-            this.probeDriverFactory = new DriverFactory(1, true, true, ImmutableList.of(lineItemTableScan, joinOperator, output), OptionalInt.empty(), UNGROUPED_EXECUTION);
+            this.probeDriverFactory = new DriverFactory(1, true, true, ImmutableList.of(lineItemTableScan, joinOperator, output), OptionalInt.empty(), UNGROUPED_EXECUTION, Optional.empty());
 
             Driver driver = buildDriverFactory.createDriver(driverContext);
             Future<LookupSourceProvider> lookupSourceProvider = lookupSourceFactoryManager.getJoinBridge(Lifespan.taskWide()).createLookupSourceProvider();

--- a/presto-benchmark/src/test/java/com/facebook/presto/benchmark/MemoryLocalQueryRunner.java
+++ b/presto-benchmark/src/test/java/com/facebook/presto/benchmark/MemoryLocalQueryRunner.java
@@ -95,8 +95,7 @@ public class MemoryLocalQueryRunner
                         false,
                         false,
                         false,
-                        false,
-                        Optional.empty());
+                        false);
 
         // Use NullOutputFactory to avoid coping out results to avoid affecting benchmark results
         ImmutableList.Builder<Page> output = ImmutableList.builder();

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskExecution.java
@@ -934,7 +934,7 @@ public class SqlTaskExecution
             status.incrementPendingCreation(pipelineContext.getPipelineId(), lifespan);
             // create driver context immediately so the driver existence is recorded in the stats
             // the number of drivers is used to balance work across nodes
-            DriverContext driverContext = pipelineContext.addDriverContext(lifespan);
+            DriverContext driverContext = pipelineContext.addDriverContext(lifespan, driverFactory.getFragmentResultCacheContext());
             return new DriverSplitRunner(this, driverContext, partitionedSplit, lifespan);
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskExecutionFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskExecutionFactory.java
@@ -21,7 +21,6 @@ import com.facebook.presto.execution.buffer.OutputBuffer;
 import com.facebook.presto.execution.executor.TaskExecutor;
 import com.facebook.presto.execution.scheduler.TableWriteInfo;
 import com.facebook.presto.memory.QueryContext;
-import com.facebook.presto.operator.FragmentResultCacheManager;
 import com.facebook.presto.operator.TaskContext;
 import com.facebook.presto.operator.TaskExchangeClientManager;
 import com.facebook.presto.sql.gen.OrderingCompiler;
@@ -29,14 +28,11 @@ import com.facebook.presto.sql.planner.HttpRemoteSourceFactory;
 import com.facebook.presto.sql.planner.LocalExecutionPlanner;
 import com.facebook.presto.sql.planner.LocalExecutionPlanner.LocalExecutionPlan;
 import com.facebook.presto.sql.planner.PlanFragment;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.util.List;
 import java.util.concurrent.Executor;
 
-import static com.facebook.presto.execution.FragmentResultCacheContext.createFragmentResultCacheContext;
 import static com.facebook.presto.execution.SqlTaskExecution.createSqlTaskExecution;
-import static com.fasterxml.jackson.databind.SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS;
 import static com.google.common.base.Throwables.throwIfUnchecked;
 import static java.util.Objects.requireNonNull;
 
@@ -50,8 +46,6 @@ public class SqlTaskExecutionFactory
     private final BlockEncodingSerde blockEncodingSerde;
     private final OrderingCompiler orderingCompiler;
     private final SplitMonitor splitMonitor;
-    private final FragmentResultCacheManager fragmentResultCacheManager;
-    private final ObjectMapper objectMapper;
     private final boolean perOperatorCpuTimerEnabled;
     private final boolean cpuTimerEnabled;
     private final boolean perOperatorAllocationTrackingEnabled;
@@ -65,8 +59,6 @@ public class SqlTaskExecutionFactory
             BlockEncodingSerde blockEncodingSerde,
             OrderingCompiler orderingCompiler,
             SplitMonitor splitMonitor,
-            FragmentResultCacheManager fragmentResultCacheManager,
-            ObjectMapper objectMapper,
             TaskManagerConfig config)
     {
         this.taskNotificationExecutor = requireNonNull(taskNotificationExecutor, "taskNotificationExecutor is null");
@@ -75,9 +67,6 @@ public class SqlTaskExecutionFactory
         this.blockEncodingSerde = requireNonNull(blockEncodingSerde, "blockEncodingSerde is null");
         this.orderingCompiler = requireNonNull(orderingCompiler, "orderingCompiler is null");
         this.splitMonitor = requireNonNull(splitMonitor, "splitMonitor is null");
-        this.fragmentResultCacheManager = requireNonNull(fragmentResultCacheManager, "fragmentResultCacheManager is null");
-        // Ordering is needed to make sure serialized plans are consistent for the same map
-        this.objectMapper = objectMapper.copy().configure(ORDER_MAP_ENTRIES_BY_KEYS, true);
         requireNonNull(config, "config is null");
         this.perOperatorCpuTimerEnabled = config.isPerOperatorCpuTimerEnabled();
         this.cpuTimerEnabled = config.isTaskCpuTimerEnabled();
@@ -103,8 +92,7 @@ public class SqlTaskExecutionFactory
                 cpuTimerEnabled,
                 perOperatorAllocationTrackingEnabled,
                 allocationTrackingEnabled,
-                legacyLifespanCompletionCondition,
-                createFragmentResultCacheContext(fragmentResultCacheManager, fragment.getRoot(), fragment.getPartitioningScheme(), session, objectMapper));
+                legacyLifespanCompletionCondition);
 
         LocalExecutionPlan localExecutionPlan;
         try (SetThreadName ignored = new SetThreadName("Task-%s", taskStateMachine.getTaskId())) {

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskManager.java
@@ -158,8 +158,6 @@ public class SqlTaskManager
                 blockEncodingSerde,
                 orderingCompiler,
                 splitMonitor,
-                fragmentResultCacheManager,
-                objectMapper,
                 config);
 
         this.localMemoryManager = requireNonNull(localMemoryManager, "localMemoryManager is null");

--- a/presto-main/src/main/java/com/facebook/presto/memory/QueryContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/QueryContext.java
@@ -15,7 +15,6 @@ package com.facebook.presto.memory;
 
 import com.facebook.airlift.stats.GcMonitor;
 import com.facebook.presto.Session;
-import com.facebook.presto.execution.FragmentResultCacheContext;
 import com.facebook.presto.execution.TaskId;
 import com.facebook.presto.execution.TaskStateMachine;
 import com.facebook.presto.memory.context.MemoryReservationHandler;
@@ -34,7 +33,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
@@ -306,8 +304,7 @@ public class QueryContext
             boolean cpuTimerEnabled,
             boolean perOperatorAllocationTrackingEnabled,
             boolean allocationTrackingEnabled,
-            boolean legacyLifespanCompletionCondition,
-            Optional<FragmentResultCacheContext> fragmentResultCacheContext)
+            boolean legacyLifespanCompletionCondition)
     {
         TaskContext taskContext = TaskContext.createTaskContext(
                 this,
@@ -321,8 +318,7 @@ public class QueryContext
                 cpuTimerEnabled,
                 perOperatorAllocationTrackingEnabled,
                 allocationTrackingEnabled,
-                legacyLifespanCompletionCondition,
-                fragmentResultCacheContext);
+                legacyLifespanCompletionCondition);
         taskContexts.put(taskStateMachine.getTaskId(), taskContext);
         return taskContext;
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/Driver.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/Driver.java
@@ -129,7 +129,7 @@ public class Driver
     private Driver(DriverContext driverContext, List<Operator> operators)
     {
         this.driverContext = requireNonNull(driverContext, "driverContext is null");
-        this.fragmentResultCacheContext = driverContext.getPipelineContext().getTaskContext().getFragmentResultCacheContext();
+        this.fragmentResultCacheContext = driverContext.getFragmentResultCacheContext();
         this.allOperators = ImmutableList.copyOf(requireNonNull(operators, "operators is null"));
         checkArgument(allOperators.size() > 1, "At least two operators are required");
         this.activeOperators = new ArrayList<>(operators);

--- a/presto-main/src/main/java/com/facebook/presto/operator/DriverContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/DriverContext.java
@@ -15,6 +15,7 @@ package com.facebook.presto.operator;
 
 import com.facebook.airlift.stats.CounterStat;
 import com.facebook.presto.Session;
+import com.facebook.presto.execution.FragmentResultCacheContext;
 import com.facebook.presto.execution.Lifespan;
 import com.facebook.presto.execution.TaskId;
 import com.facebook.presto.memory.QueryContextVisitor;
@@ -30,6 +31,7 @@ import io.airlift.units.Duration;
 import org.joda.time.DateTime;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
@@ -81,19 +83,22 @@ public class DriverContext
 
     private final List<OperatorContext> operatorContexts = new CopyOnWriteArrayList<>();
     private final Lifespan lifespan;
+    private final Optional<FragmentResultCacheContext> fragmentResultCacheContext;
 
     public DriverContext(
             PipelineContext pipelineContext,
             Executor notificationExecutor,
             ScheduledExecutorService yieldExecutor,
             MemoryTrackingContext driverMemoryContext,
-            Lifespan lifespan)
+            Lifespan lifespan,
+            Optional<FragmentResultCacheContext> fragmentResultCacheContext)
     {
         this.pipelineContext = requireNonNull(pipelineContext, "pipelineContext is null");
         this.notificationExecutor = requireNonNull(notificationExecutor, "notificationExecutor is null");
         this.yieldExecutor = requireNonNull(yieldExecutor, "scheduler is null");
         this.driverMemoryContext = requireNonNull(driverMemoryContext, "driverMemoryContext is null");
         this.lifespan = requireNonNull(lifespan, "lifespan is null");
+        this.fragmentResultCacheContext = requireNonNull(fragmentResultCacheContext, "fragmentResultCacheContext is null");
         this.yieldSignal = new DriverYieldSignal();
     }
 
@@ -421,6 +426,11 @@ public class DriverContext
     public Lifespan getLifespan()
     {
         return lifespan;
+    }
+
+    public Optional<FragmentResultCacheContext> getFragmentResultCacheContext()
+    {
+        return fragmentResultCacheContext;
     }
 
     public ScheduledExecutorService getYieldExecutor()

--- a/presto-main/src/main/java/com/facebook/presto/operator/DriverFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/DriverFactory.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.operator;
 
+import com.facebook.presto.execution.FragmentResultCacheContext;
 import com.facebook.presto.execution.Lifespan;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import com.google.common.collect.ImmutableList;
@@ -39,6 +40,7 @@ public class DriverFactory
     private final Optional<PlanNodeId> sourceId;
     private final OptionalInt driverInstances;
     private final PipelineExecutionStrategy pipelineExecutionStrategy;
+    private final Optional<FragmentResultCacheContext> fragmentResultCacheContext;
 
     private boolean closed;
     private final Set<Lifespan> encounteredLifespans = new HashSet<>();
@@ -50,7 +52,8 @@ public class DriverFactory
             boolean outputDriver,
             List<OperatorFactory> operatorFactories,
             OptionalInt driverInstances,
-            PipelineExecutionStrategy pipelineExecutionStrategy)
+            PipelineExecutionStrategy pipelineExecutionStrategy,
+            Optional<FragmentResultCacheContext> fragmentResultCacheContext)
     {
         this.pipelineId = pipelineId;
         this.inputDriver = inputDriver;
@@ -59,6 +62,7 @@ public class DriverFactory
         checkArgument(!operatorFactories.isEmpty(), "There must be at least one operator");
         this.driverInstances = requireNonNull(driverInstances, "driverInstances is null");
         this.pipelineExecutionStrategy = requireNonNull(pipelineExecutionStrategy, "pipelineExecutionStrategy is null");
+        this.fragmentResultCacheContext = requireNonNull(fragmentResultCacheContext, "fragmentResultCacheContext is null");
 
         List<PlanNodeId> sourceIds = operatorFactories.stream()
                 .filter(SourceOperatorFactory.class::isInstance)
@@ -102,6 +106,11 @@ public class DriverFactory
     public PipelineExecutionStrategy getPipelineExecutionStrategy()
     {
         return pipelineExecutionStrategy;
+    }
+
+    public Optional<FragmentResultCacheContext> getFragmentResultCacheContext()
+    {
+        return fragmentResultCacheContext;
     }
 
     public List<OperatorFactory> getOperatorFactories()

--- a/presto-main/src/main/java/com/facebook/presto/operator/PipelineContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PipelineContext.java
@@ -16,6 +16,7 @@ package com.facebook.presto.operator;
 import com.facebook.airlift.stats.CounterStat;
 import com.facebook.airlift.stats.Distribution;
 import com.facebook.presto.Session;
+import com.facebook.presto.execution.FragmentResultCacheContext;
 import com.facebook.presto.execution.Lifespan;
 import com.facebook.presto.execution.TaskId;
 import com.facebook.presto.memory.QueryContextVisitor;
@@ -35,6 +36,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
@@ -139,17 +141,18 @@ public class PipelineContext
 
     public DriverContext addDriverContext()
     {
-        return addDriverContext(Lifespan.taskWide());
+        return addDriverContext(Lifespan.taskWide(), Optional.empty());
     }
 
-    public DriverContext addDriverContext(Lifespan lifespan)
+    public DriverContext addDriverContext(Lifespan lifespan, Optional<FragmentResultCacheContext> fragmentResultCacheContext)
     {
         DriverContext driverContext = new DriverContext(
                 this,
                 notificationExecutor,
                 yieldExecutor,
                 pipelineMemoryContext.newMemoryTrackingContext(),
-                lifespan);
+                lifespan,
+                fragmentResultCacheContext);
         drivers.add(driverContext);
         return driverContext;
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/TaskContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TaskContext.java
@@ -16,7 +16,6 @@ package com.facebook.presto.operator;
 import com.facebook.airlift.stats.CounterStat;
 import com.facebook.airlift.stats.GcMonitor;
 import com.facebook.presto.Session;
-import com.facebook.presto.execution.FragmentResultCacheContext;
 import com.facebook.presto.execution.Lifespan;
 import com.facebook.presto.execution.TaskId;
 import com.facebook.presto.execution.TaskMetadataContext;
@@ -40,7 +39,6 @@ import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executor;
@@ -95,8 +93,6 @@ public class TaskContext
 
     private final boolean legacyLifespanCompletionCondition;
 
-    private final Optional<FragmentResultCacheContext> fragmentResultCacheContext;
-
     private final Object cumulativeMemoryLock = new Object();
     private final AtomicDouble cumulativeUserMemory = new AtomicDouble(0.0);
 
@@ -125,8 +121,7 @@ public class TaskContext
             boolean cpuTimerEnabled,
             boolean perOperatorAllocationTrackingEnabled,
             boolean allocationTrackingEnabled,
-            boolean legacyLifespanCompletionCondition,
-            Optional<FragmentResultCacheContext> fragmentResultCacheContext)
+            boolean legacyLifespanCompletionCondition)
     {
         TaskContext taskContext = new TaskContext(
                 queryContext,
@@ -140,8 +135,7 @@ public class TaskContext
                 cpuTimerEnabled,
                 perOperatorAllocationTrackingEnabled,
                 allocationTrackingEnabled,
-                legacyLifespanCompletionCondition,
-                fragmentResultCacheContext);
+                legacyLifespanCompletionCondition);
         taskContext.initialize();
         return taskContext;
     }
@@ -157,8 +151,7 @@ public class TaskContext
             boolean cpuTimerEnabled,
             boolean perOperatorAllocationTrackingEnabled,
             boolean allocationTrackingEnabled,
-            boolean legacyLifespanCompletionCondition,
-            Optional<FragmentResultCacheContext> fragmentResultCacheContext)
+            boolean legacyLifespanCompletionCondition)
     {
         this.taskStateMachine = requireNonNull(taskStateMachine, "taskStateMachine is null");
         this.gcMonitor = requireNonNull(gcMonitor, "gcMonitor is null");
@@ -174,7 +167,6 @@ public class TaskContext
         this.perOperatorAllocationTrackingEnabled = perOperatorAllocationTrackingEnabled;
         this.allocationTrackingEnabled = allocationTrackingEnabled;
         this.legacyLifespanCompletionCondition = legacyLifespanCompletionCondition;
-        this.fragmentResultCacheContext = requireNonNull(fragmentResultCacheContext, "fragmentResultCacheContext is null");
         this.taskMetadataContext = new TaskMetadataContext();
     }
 
@@ -344,11 +336,6 @@ public class TaskContext
     public boolean isLegacyLifespanCompletionCondition()
     {
         return legacyLifespanCompletionCondition;
-    }
-
-    public Optional<FragmentResultCacheContext> getFragmentResultCacheContext()
-    {
-        return fragmentResultCacheContext;
     }
 
     public CounterStat getInputDataSize()

--- a/presto-main/src/main/java/com/facebook/presto/operator/index/IndexBuildDriverFactoryProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/index/IndexBuildDriverFactoryProvider.java
@@ -85,7 +85,8 @@ public class IndexBuildDriverFactoryProvider
                         .add(new PagesIndexBuilderOperatorFactory(outputOperatorId, planNodeId, indexSnapshotBuilder))
                         .build(),
                 OptionalInt.empty(),
-                UNGROUPED_EXECUTION);
+                UNGROUPED_EXECUTION,
+                Optional.empty());
     }
 
     public DriverFactory createStreaming(PageBuffer pageBuffer, Page indexKeyTuple)
@@ -100,6 +101,6 @@ public class IndexBuildDriverFactoryProvider
 
         operatorFactories.add(new PageBufferOperatorFactory(outputOperatorId, planNodeId, pageBuffer));
 
-        return new DriverFactory(pipelineId, inputDriver, false, operatorFactories.build(), OptionalInt.empty(), UNGROUPED_EXECUTION);
+        return new DriverFactory(pipelineId, inputDriver, false, operatorFactories.build(), OptionalInt.empty(), UNGROUPED_EXECUTION, Optional.empty());
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/CanonicalPlanGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/CanonicalPlanGenerator.java
@@ -57,6 +57,9 @@ public class CanonicalPlanGenerator
     {
         Map<VariableReferenceExpression, VariableReferenceExpression> originalToNewVariableNames = new HashMap<>();
         Optional<PlanNode> canonicalPlan = root.accept(new CanonicalPlanGenerator(), originalToNewVariableNames);
+        if (!originalToNewVariableNames.keySet().containsAll(partitioningScheme.getOutputLayout())) {
+            return Optional.empty();
+        }
         return canonicalPlan.map(planNode -> new CanonicalPlanFragment(planNode, getCanonicalPartitioningScheme(partitioningScheme, originalToNewVariableNames)));
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -583,16 +583,6 @@ public class LocalExecutionPlanner
         return new LocalExecutionPlan(context.getDriverFactories(), partitionedSourceOrder, stageExecutionDescriptor);
     }
 
-    private static boolean isOnlyScanFilterProject(PlanNode planNode)
-    {
-        if (planNode instanceof TableScanNode ||
-                planNode instanceof FilterNode ||
-                planNode instanceof ProjectNode) {
-            return planNode.getSources().stream().allMatch(LocalExecutionPlanner::isOnlyScanFilterProject);
-        }
-        return false;
-    }
-
     private static void addLookupOuterDrivers(LocalExecutionPlanContext context)
     {
         // For an outer join on the lookup side (RIGHT or FULL) add an additional

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -99,6 +99,7 @@ import com.facebook.presto.operator.Driver;
 import com.facebook.presto.operator.DriverContext;
 import com.facebook.presto.operator.DriverFactory;
 import com.facebook.presto.operator.LookupJoinOperators;
+import com.facebook.presto.operator.NoOpFragmentResultCacheManager;
 import com.facebook.presto.operator.OperatorContext;
 import com.facebook.presto.operator.OutputFactory;
 import com.facebook.presto.operator.PagesIndex;
@@ -184,6 +185,7 @@ import com.facebook.presto.transaction.InMemoryTransactionManager;
 import com.facebook.presto.transaction.TransactionManager;
 import com.facebook.presto.transaction.TransactionManagerConfig;
 import com.facebook.presto.util.FinalizerService;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -793,7 +795,9 @@ public class LocalQueryRunner
                 new LookupJoinOperators(),
                 new OrderingCompiler(),
                 jsonCodec(TableCommitContext.class),
-                new RowExpressionDeterminismEvaluator(metadata));
+                new RowExpressionDeterminismEvaluator(metadata),
+                new NoOpFragmentResultCacheManager(),
+                new ObjectMapper());
 
         // plan query
         StageExecutionDescriptor stageExecutionDescriptor = subplan.getFragment().getStageExecutionDescriptor();
@@ -804,7 +808,7 @@ public class LocalQueryRunner
                 taskContext,
                 stageExecutionDescriptor,
                 subplan.getFragment().getRoot(),
-                subplan.getFragment().getPartitioningScheme().getOutputLayout(),
+                subplan.getFragment().getPartitioningScheme(),
                 subplan.getFragment().getTableScanSchedulingOrder(),
                 outputFactory,
                 Optional.empty(),

--- a/presto-main/src/test/java/com/facebook/presto/execution/MockRemoteTaskFactory.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/MockRemoteTaskFactory.java
@@ -214,8 +214,7 @@ public class MockRemoteTaskFactory
                     true,
                     true,
                     true,
-                    false,
-                    Optional.empty());
+                    false);
 
             this.location = URI.create("fake://task/" + taskId);
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
@@ -31,6 +31,7 @@ import com.facebook.presto.metadata.InMemoryNodeManager;
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.metadata.Split;
 import com.facebook.presto.operator.LookupJoinOperators;
+import com.facebook.presto.operator.NoOpFragmentResultCacheManager;
 import com.facebook.presto.operator.PagesIndex;
 import com.facebook.presto.operator.StageExecutionDescriptor;
 import com.facebook.presto.operator.TableCommitContext;
@@ -63,6 +64,7 @@ import com.facebook.presto.testing.TestingMetadata.TestingTableHandle;
 import com.facebook.presto.testing.TestingSplit;
 import com.facebook.presto.testing.TestingTransactionHandle;
 import com.facebook.presto.util.FinalizerService;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -167,7 +169,9 @@ public final class TaskTestUtils
                 new LookupJoinOperators(),
                 new OrderingCompiler(),
                 jsonCodec(TableCommitContext.class),
-                new RowExpressionDeterminismEvaluator(metadata));
+                new RowExpressionDeterminismEvaluator(metadata),
+                new NoOpFragmentResultCacheManager(),
+                new ObjectMapper());
     }
 
     public static TaskInfo updateTask(SqlTask sqlTask, List<TaskSource> taskSources, OutputBuffers outputBuffers)

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestMemoryRevokingScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestMemoryRevokingScheduler.java
@@ -27,7 +27,6 @@ import com.facebook.presto.memory.QueryContext;
 import com.facebook.presto.memory.context.LocalMemoryContext;
 import com.facebook.presto.memory.context.MemoryTrackingContext;
 import com.facebook.presto.operator.DriverContext;
-import com.facebook.presto.operator.NoOpFragmentResultCacheManager;
 import com.facebook.presto.operator.OperatorContext;
 import com.facebook.presto.operator.PipelineContext;
 import com.facebook.presto.operator.TaskContext;
@@ -39,7 +38,6 @@ import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.gen.OrderingCompiler;
 import com.facebook.presto.sql.planner.LocalExecutionPlanner;
 import com.facebook.presto.testing.TestingSession;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Functions;
 import com.google.common.base.Ticker;
 import com.google.common.collect.ImmutableList;
@@ -119,8 +117,6 @@ public class TestMemoryRevokingScheduler
                 new BlockEncodingManager(),
                 new OrderingCompiler(),
                 createTestSplitMonitor(),
-                new NoOpFragmentResultCacheManager(),
-                new ObjectMapper(),
                 new TaskManagerConfig()
                         .setPerOperatorAllocationTrackingEnabled(true)
                         .setTaskCpuTimerEnabled(true)
@@ -146,7 +142,7 @@ public class TestMemoryRevokingScheduler
         SqlTask sqlTask1 = newSqlTask();
         SqlTask sqlTask2 = newSqlTask();
 
-        TaskContext taskContext1 = sqlTask1.getQueryContext().addTaskContext(new TaskStateMachine(new TaskId("q1", 1, 0, 1), executor), session, false, false, false, false, false, Optional.empty());
+        TaskContext taskContext1 = sqlTask1.getQueryContext().addTaskContext(new TaskStateMachine(new TaskId("q1", 1, 0, 1), executor), session, false, false, false, false, false);
         PipelineContext pipelineContext11 = taskContext1.addPipelineContext(0, false, false, false);
         DriverContext driverContext111 = pipelineContext11.addDriverContext();
         OperatorContext operatorContext1 = driverContext111.addOperatorContext(1, new PlanNodeId("na"), "na");
@@ -154,7 +150,7 @@ public class TestMemoryRevokingScheduler
         DriverContext driverContext112 = pipelineContext11.addDriverContext();
         OperatorContext operatorContext3 = driverContext112.addOperatorContext(3, new PlanNodeId("na"), "na");
 
-        TaskContext taskContext2 = sqlTask2.getQueryContext().addTaskContext(new TaskStateMachine(new TaskId("q2", 1, 0, 1), executor), session, false, false, false, false, false, Optional.empty());
+        TaskContext taskContext2 = sqlTask2.getQueryContext().addTaskContext(new TaskStateMachine(new TaskId("q2", 1, 0, 1), executor), session, false, false, false, false, false);
         PipelineContext pipelineContext21 = taskContext2.addPipelineContext(1, false, false, false);
         DriverContext driverContext211 = pipelineContext21.addDriverContext();
         OperatorContext operatorContext4 = driverContext211.addOperatorContext(4, new PlanNodeId("na"), "na");
@@ -392,7 +388,7 @@ public class TestMemoryRevokingScheduler
 
     private OperatorContext createContexts(SqlTask sqlTask)
     {
-        TaskContext taskContext = sqlTask.getQueryContext().addTaskContext(new TaskStateMachine(new TaskId("q", 1, 0, 1), executor), session, false, false, false, false, false, Optional.empty());
+        TaskContext taskContext = sqlTask.getQueryContext().addTaskContext(new TaskStateMachine(new TaskId("q", 1, 0, 1), executor), session, false, false, false, false, false);
         PipelineContext pipelineContext = taskContext.addPipelineContext(0, false, false, false);
         DriverContext driverContext = pipelineContext.addDriverContext();
         OperatorContext operatorContext = driverContext.addOperatorContext(1, new PlanNodeId("na"), "na");

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTask.java
@@ -25,13 +25,11 @@ import com.facebook.presto.execution.executor.TaskExecutor;
 import com.facebook.presto.execution.scheduler.TableWriteInfo;
 import com.facebook.presto.memory.MemoryPool;
 import com.facebook.presto.memory.QueryContext;
-import com.facebook.presto.operator.NoOpFragmentResultCacheManager;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.memory.MemoryPoolId;
 import com.facebook.presto.spiller.SpillSpaceTracker;
 import com.facebook.presto.sql.gen.OrderingCompiler;
 import com.facebook.presto.sql.planner.LocalExecutionPlanner;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Functions;
 import com.google.common.base.Ticker;
 import com.google.common.collect.ImmutableList;
@@ -100,8 +98,6 @@ public class TestSqlTask
                 new BlockEncodingManager(),
                 new OrderingCompiler(),
                 createTestSplitMonitor(),
-                new NoOpFragmentResultCacheManager(),
-                new ObjectMapper(),
                 new TaskManagerConfig());
     }
 
@@ -323,7 +319,7 @@ public class TestSqlTask
                 new DataSize(1, MEGABYTE),
                 new SpillSpaceTracker(new DataSize(1, GIGABYTE)));
 
-        queryContext.addTaskContext(new TaskStateMachine(taskId, taskNotificationExecutor), testSessionBuilder().build(), false, false, false, false, false, Optional.empty());
+        queryContext.addTaskContext(new TaskStateMachine(taskId, taskNotificationExecutor), testSessionBuilder().build(), false, false, false, false, false);
 
         return createSqlTask(
                 taskId,

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskExecution.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskExecution.java
@@ -169,7 +169,8 @@ public class TestSqlTaskExecution
                             true,
                             ImmutableList.of(testingScanOperatorFactory, taskOutputOperatorFactory),
                             OptionalInt.empty(),
-                            executionStrategy)),
+                            executionStrategy,
+                            Optional.empty())),
                     ImmutableList.of(TABLE_SCAN_NODE_ID),
                     executionStrategy == GROUPED_EXECUTION
                             ? StageExecutionDescriptor.fixedLifespanScheduleGroupedExecution(ImmutableList.of(TABLE_SCAN_NODE_ID), 8)
@@ -406,28 +407,32 @@ public class TestSqlTaskExecution
                                     true,
                                     ImmutableList.of(scanOperatorFactory0, joinOperatorFactoryA, joinOperatorFactoryC, taskOutputOperatorFactory),
                                     OptionalInt.empty(),
-                                    executionStrategy),
+                                    executionStrategy,
+                                    Optional.empty()),
                             new DriverFactory(
                                     1,
                                     false,
                                     false,
                                     ImmutableList.of(valuesOperatorFactory1, joinOperatorFactoryB, buildOperatorFactoryA),
                                     OptionalInt.empty(),
-                                    executionStrategy),
+                                    executionStrategy,
+                                    Optional.empty()),
                             new DriverFactory(
                                     2,
                                     true,
                                     false,
                                     ImmutableList.of(scanOperatorFactory2, buildOperatorFactoryB),
                                     OptionalInt.empty(),
-                                    executionStrategy),
+                                    executionStrategy,
+                                    Optional.empty()),
                             new DriverFactory(
                                     3,
                                     false,
                                     false,
                                     ImmutableList.of(valuesOperatorFactory3, buildOperatorFactoryC),
                                     OptionalInt.empty(),
-                                    UNGROUPED_EXECUTION)),
+                                    UNGROUPED_EXECUTION,
+                                    Optional.empty())),
                     ImmutableList.of(scan2NodeId, scan0NodeId),
                     executionStrategy == GROUPED_EXECUTION
                             ? StageExecutionDescriptor.fixedLifespanScheduleGroupedExecution(ImmutableList.of(scan0NodeId, scan2NodeId), 4)
@@ -621,7 +626,7 @@ public class TestSqlTaskExecution
                 driverYieldExecutor,
                 new DataSize(1, MEGABYTE),
                 new SpillSpaceTracker(new DataSize(1, GIGABYTE)));
-        return queryContext.addTaskContext(taskStateMachine, TEST_SESSION, false, false, false, false, false, Optional.empty());
+        return queryContext.addTaskContext(taskStateMachine, TEST_SESSION, false, false, false, false, false);
     }
 
     private PartitionedOutputBuffer newTestingOutputBuffer(ScheduledExecutorService taskNotificationExecutor)

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskManager.java
@@ -278,8 +278,7 @@ public class TestSqlTaskManager
                         false,
                         false,
                         false,
-                        false,
-                        Optional.empty());
+                        false);
         return sqlTaskManager.updateTask(
                 TEST_SESSION,
                 taskId,

--- a/presto-main/src/test/java/com/facebook/presto/memory/TestMemoryTracking.java
+++ b/presto-main/src/test/java/com/facebook/presto/memory/TestMemoryTracking.java
@@ -37,7 +37,6 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Consumer;
@@ -117,8 +116,7 @@ public class TestMemoryTracking
                 true,
                 true,
                 true,
-                false,
-                Optional.empty());
+                false);
         pipelineContext = taskContext.addPipelineContext(0, true, true, false);
         driverContext = pipelineContext.addDriverContext();
         operatorContext = driverContext.addOperatorContext(1, new PlanNodeId("a"), "test-operator");

--- a/presto-main/src/test/java/com/facebook/presto/memory/TestQueryContext.java
+++ b/presto-main/src/test/java/com/facebook/presto/memory/TestQueryContext.java
@@ -31,7 +31,6 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.ScheduledExecutorService;
 
 import static com.facebook.airlift.concurrent.Threads.threadsNamed;
@@ -115,7 +114,7 @@ public class TestQueryContext
         QueryId queryId = new QueryId("query");
         QueryContext queryContext = createQueryContext(queryId, generalPool);
         TaskStateMachine taskStateMachine = new TaskStateMachine(TaskId.valueOf("queryid.0.0.0"), TEST_EXECUTOR);
-        TaskContext taskContext = queryContext.addTaskContext(taskStateMachine, TEST_SESSION, false, false, false, false, false, Optional.empty());
+        TaskContext taskContext = queryContext.addTaskContext(taskStateMachine, TEST_SESSION, false, false, false, false, false);
         DriverContext driverContext = taskContext.addPipelineContext(0, false, false, false).addDriverContext();
         OperatorContext operatorContext = driverContext.addOperatorContext(0, new PlanNodeId("test"), "test");
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestDriver.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestDriver.java
@@ -17,6 +17,7 @@ import com.facebook.presto.common.Page;
 import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.execution.FragmentResultCacheContext;
+import com.facebook.presto.execution.Lifespan;
 import com.facebook.presto.execution.ScheduledSplit;
 import com.facebook.presto.execution.TaskSource;
 import com.facebook.presto.memory.context.LocalMemoryContext;
@@ -134,7 +135,7 @@ public class TestDriver
         driverContext = createTaskContext(executor, scheduledExecutor, TEST_SESSION)
                 .addPipelineContext(0, true, true, false)
                 .addDriverContext();
-        driverContextWithFragmentResultCacheContext = createTaskContext(executor, scheduledExecutor, TEST_SESSION, TESTING_FRAGMENT_RESULT_CACHE_CONTEXT)
+        driverContextWithFragmentResultCacheContext = createTaskContext(executor, scheduledExecutor, TEST_SESSION)
                 .addPipelineContext(0, true, true, false)
                 .addDriverContext();
     }
@@ -418,9 +419,9 @@ public class TestDriver
         processSourceDriver(driverContextWithFragmentResultCacheContext);
 
         // Create a new driver and test cache hit
-        driverContextWithFragmentResultCacheContext = createTaskContext(executor, scheduledExecutor, TEST_SESSION, TESTING_FRAGMENT_RESULT_CACHE_CONTEXT)
+        driverContextWithFragmentResultCacheContext = createTaskContext(executor, scheduledExecutor, TEST_SESSION)
                 .addPipelineContext(0, true, true, false)
-                .addDriverContext();
+                .addDriverContext(Lifespan.taskWide(), Optional.of(TESTING_FRAGMENT_RESULT_CACHE_CONTEXT));
         processSourceDriver(driverContextWithFragmentResultCacheContext);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestingOperatorContext.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestingOperatorContext.java
@@ -20,6 +20,7 @@ import com.facebook.presto.testing.TestingSession;
 import com.facebook.presto.testing.TestingTaskContext;
 import com.google.common.util.concurrent.MoreExecutors;
 
+import java.util.Optional;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -53,7 +54,8 @@ public class TestingOperatorContext
                 executor,
                 scheduledExecutor,
                 pipelineMemoryContext,
-                Lifespan.taskWide());
+                Lifespan.taskWide(),
+                Optional.empty());
 
         OperatorContext operatorContext = driverContext.addOperatorContext(
                 1,

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestLocalExecutionPlanner.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestLocalExecutionPlanner.java
@@ -13,30 +13,74 @@
  */
 package com.facebook.presto.sql.planner;
 
+import com.facebook.presto.Session;
+import com.facebook.presto.common.block.SortOrder;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.execution.FragmentResultCacheContext;
+import com.facebook.presto.execution.Lifespan;
+import com.facebook.presto.execution.StateMachine;
+import com.facebook.presto.execution.buffer.BufferResult;
+import com.facebook.presto.execution.buffer.BufferState;
+import com.facebook.presto.execution.buffer.OutputBuffer;
+import com.facebook.presto.execution.buffer.OutputBufferInfo;
+import com.facebook.presto.execution.buffer.OutputBuffers;
+import com.facebook.presto.execution.scheduler.TableWriteInfo;
+import com.facebook.presto.operator.DriverContext;
+import com.facebook.presto.operator.SourceOperator;
+import com.facebook.presto.operator.SourceOperatorFactory;
 import com.facebook.presto.spi.ErrorCodeSupplier;
 import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.page.SerializedPage;
+import com.facebook.presto.spi.plan.PlanNodeId;
+import com.facebook.presto.sql.planner.LocalExecutionPlanner.LocalExecutionPlan;
 import com.facebook.presto.testing.LocalQueryRunner;
+import com.facebook.presto.tpch.TpchConnectorFactory;
 import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.ListenableFuture;
+import io.airlift.units.DataSize;
 import org.intellij.lang.annotations.Language;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Consumer;
+
+import static com.facebook.airlift.concurrent.Threads.daemonThreadsNamed;
 import static com.facebook.airlift.testing.Closeables.closeAllRuntimeException;
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
+import static com.facebook.presto.SystemSessionProperties.ENABLE_INTERMEDIATE_AGGREGATIONS;
+import static com.facebook.presto.SystemSessionProperties.FRAGMENT_RESULT_CACHING_ENABLED;
+import static com.facebook.presto.execution.TaskTestUtils.createTestingPlanner;
 import static com.facebook.presto.spi.StandardErrorCode.COMPILER_ERROR;
+import static com.facebook.presto.sql.planner.LogicalPlanner.Stage.OPTIMIZED_AND_VALIDATED;
+import static com.facebook.presto.testing.TestingTaskContext.createTaskContext;
 import static java.util.Collections.nCopies;
+import static java.util.concurrent.Executors.newCachedThreadPool;
+import static java.util.concurrent.Executors.newScheduledThreadPool;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 public class TestLocalExecutionPlanner
 {
+    private static final ExecutorService EXECUTOR = newCachedThreadPool(daemonThreadsNamed("test-%s"));
+    private static final ScheduledExecutorService SCHEDULED_EXECUTOR = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%s"));
+
     private LocalQueryRunner runner;
 
     @BeforeClass
     public void setUp()
     {
         runner = new LocalQueryRunner(TEST_SESSION);
+        runner.createCatalog(runner.getDefaultSession().getCatalog().get(),
+                new TpchConnectorFactory(1),
+                ImmutableMap.of());
     }
 
     @AfterClass(alwaysRun = true)
@@ -63,6 +107,208 @@ public class TestLocalExecutionPlanner
         }
         catch (PrestoException e) {
             assertEquals(e.getErrorCode(), supplier.toErrorCode());
+        }
+    }
+
+    @Test
+    public void testCreatingFragmentResultCacheContext()
+    {
+        Session session = Session.builder(runner.getDefaultSession())
+                .setSystemProperty(FRAGMENT_RESULT_CACHING_ENABLED, "true")
+                .build();
+        LocalExecutionPlan planWithoutIntermediateAggregation = getLocalExecutionPlan(session);
+        // Expect one driver factory: partial aggregation
+        assertEquals(planWithoutIntermediateAggregation.getDriverFactories().size(), 1);
+        Optional<FragmentResultCacheContext> contextWithoutIntermediateAggregation = planWithoutIntermediateAggregation.getDriverFactories().get(0).getFragmentResultCacheContext();
+        assertTrue(contextWithoutIntermediateAggregation.isPresent());
+
+        session = Session.builder(runner.getDefaultSession())
+                .setSystemProperty(FRAGMENT_RESULT_CACHING_ENABLED, "true")
+                .setSystemProperty(ENABLE_INTERMEDIATE_AGGREGATIONS, "true")
+                .build();
+        LocalExecutionPlan planWithIntermediateAggregation = getLocalExecutionPlan(session);
+        // Expect twp driver factories: partial aggregation and intermediate aggregation
+        assertEquals(planWithIntermediateAggregation.getDriverFactories().size(), 2);
+        Optional<FragmentResultCacheContext> contextWithIntermediateAggregation = planWithIntermediateAggregation.getDriverFactories().get(0).getFragmentResultCacheContext();
+        assertTrue(contextWithIntermediateAggregation.isPresent());
+
+        assertEquals(contextWithIntermediateAggregation.get().getHashedCanonicalPlanFragment(), contextWithoutIntermediateAggregation.get().getHashedCanonicalPlanFragment());
+    }
+
+    private LocalExecutionPlan getLocalExecutionPlan(Session session)
+    {
+        SubPlan subPlan = runner.inTransaction(session, transactionSession -> {
+            Plan plan = runner.createPlan(transactionSession, "SELECT avg(totalprice) FROM orders", OPTIMIZED_AND_VALIDATED, false, WarningCollector.NOOP);
+            return runner.createSubPlans(transactionSession, plan, false);
+        });
+        // Expect only one child sub plan doing partial aggregation.
+        assertEquals(subPlan.getChildren().size(), 1);
+
+        PlanFragment leafFragment = subPlan.getChildren().get(0).getFragment();
+        return createTestingPlanner().plan(
+                createTaskContext(EXECUTOR, SCHEDULED_EXECUTOR, session),
+                leafFragment.getRoot(),
+                leafFragment.getPartitioningScheme(),
+                leafFragment.getStageExecutionDescriptor(),
+                leafFragment.getTableScanSchedulingOrder(),
+                new TestingOutputBuffer(),
+                new TestingRemoteSourceFactory(),
+                new TableWriteInfo(Optional.empty(), Optional.empty(), Optional.empty()));
+    }
+
+    private static class TestingOutputBuffer
+            implements OutputBuffer
+    {
+        @Override
+        public OutputBufferInfo getInfo()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isFinished()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public double getUtilization()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isOverutilized()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void addStateChangeListener(StateMachine.StateChangeListener<BufferState> stateChangeListener)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void setOutputBuffers(OutputBuffers newOutputBuffers)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ListenableFuture<BufferResult> get(OutputBuffers.OutputBufferId bufferId, long token, DataSize maxSize)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void acknowledge(OutputBuffers.OutputBufferId bufferId, long token)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void abort(OutputBuffers.OutputBufferId bufferId)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ListenableFuture<?> isFull()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void enqueue(Lifespan lifespan, List<SerializedPage> pages)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void enqueue(Lifespan lifespan, int partition, List<SerializedPage> pages)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void setNoMorePages()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void destroy()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void fail()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void setNoMorePagesForLifespan(Lifespan lifespan)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void registerLifespanCompletionCallback(Consumer<Lifespan> callback)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean isFinishedForLifespan(Lifespan lifespan)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public long getPeakMemoryUsage()
+        {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private static class TestingRemoteSourceFactory
+            implements RemoteSourceFactory
+    {
+        @Override
+        public SourceOperatorFactory createRemoteSource(Session session, int operatorId, PlanNodeId planNodeId, List<Type> types)
+        {
+            return new TestingSourceOperatorFactory();
+        }
+
+        @Override
+        public SourceOperatorFactory createMergeRemoteSource(Session session, int operatorId, PlanNodeId planNodeId, List<Type> types, List<Integer> outputChannels, List<Integer> sortChannels, List<SortOrder> sortOrder)
+        {
+            throw new UnsupportedOperationException();
+        }
+    }
+
+    private static class TestingSourceOperatorFactory
+            implements SourceOperatorFactory
+    {
+        @Override
+        public PlanNodeId getSourceId()
+        {
+            return new PlanNodeId("test");
+        }
+
+        @Override
+        public SourceOperator createOperator(DriverContext driverContext)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void noMoreOperators()
+        {
+            throw new UnsupportedOperationException();
         }
     }
 }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkTaskExecution.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkTaskExecution.java
@@ -339,7 +339,7 @@ public class PrestoSparkTaskExecution
             pendingCreation.incrementAndGet();
             // create driver context immediately so the driver existence is recorded in the stats
             // the number of drivers is used to balance work across nodes
-            DriverContext driverContext = pipelineContext.addDriverContext(Lifespan.taskWide());
+            DriverContext driverContext = pipelineContext.addDriverContext(Lifespan.taskWide(), driverFactory.getFragmentResultCacheContext());
             return new DriverSplitRunner(this, driverContext, partitionedSplit);
         }
 


### PR DESCRIPTION
Test plan - Added unit test. Will also do verifier correctness test

```
== RELEASE NOTES ==

General Changes
* Support fragment result caching for queries with local exchange (e.g. intermediate aggregation).
```
