### PR TITLE
Fix QualifiedObjectName instantiation in FunctionAndTypeManager

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionAndTypeManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionAndTypeManager.java
@@ -302,7 +302,7 @@ public class FunctionAndTypeManager
         if (name.getOriginalParts().size() != 3) {
             throw new PrestoException(FUNCTION_NOT_FOUND, format("Non-builtin functions must be referenced by 'catalog.schema.function_name', found: %s", name));
         }
-        return QualifiedObjectName.valueOf(name.getOriginalParts().get(0), name.getOriginalParts().get(1), name.getOriginalParts().get(2));
+        return QualifiedObjectName.valueOf(name.getParts().get(0), name.getParts().get(1), name.getParts().get(2));
     }
 
     /**

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestSqlFunctions.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestSqlFunctions.java
@@ -110,7 +110,7 @@ public class TestSqlFunctions
     @Test
     public void testCreateFunction()
     {
-        assertQuerySucceeds("CREATE FUNCTION testing.test.tan (x int) RETURNS double RETURN sin(x) / cos(x)");
+        assertQuerySucceeds("CREATE FUNCTION TESTING.TEST.TAN (x int) RETURNS double RETURN sin(x) / cos(x)");
         assertQuerySucceeds("CREATE FUNCTION testing.test.tan (x double) RETURNS double LANGUAGE JAVA RETURN sin(x) / cos(x)");
 
         // external function


### PR DESCRIPTION
QualifiedObjectName expect catalog and schema to be lowercase.
Use QualifiedName.parts instead of QualifiedName.originalParts when
instantiating the object in FunctionAndTypeManager.

Test plan - travis

```
== RELEASE NOTES ==

General Changes
* Fix a bug introduced in :pr:`15313` that would cause queries to fail when using upper case in SQL function catalog schema names.
```