### PR TITLE
Upgrade JTS to 1.18.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1692,13 +1692,13 @@
             <dependency>
                 <groupId>org.locationtech.jts</groupId>
                 <artifactId>jts-core</artifactId>
-                <version>1.17.0</version>
+                <version>1.18.0</version>
             </dependency>
 
             <dependency>
                 <groupId>org.locationtech.jts.io</groupId>
                 <artifactId>jts-io-common</artifactId>
-                <version>1.17.0</version>
+                <version>1.18.0</version>
                 <exclusions>
                     <exclusion>
                         <groupId>junit</groupId>


### PR DESCRIPTION
Relevant parts:
* Vastly improved overlay operations (intersection, union, etc).  This
  will allow us to use JTS operations (currently using ESRI).
  + TopologicalExceptions have been mostly eliminated.
  + Performance is improved.  For geometries that intersect in a small
    fraction of their area, performance is greatly improved.
  + More accurate in some cases.
  + https://locationtech.github.io/jts/javadoc/org/locationtech/jts/operation/overlayng/package-summary.html
* Fix for `buffer` and `DouglasPeuckerSimplifier`: in some cases, the
   majority of the polygon would be dropped:
  + https://github.com/locationtech/jts/pull/655
  + https://github.com/locationtech/jts/issues/498
* `WKBWriter` writes empty polygons in a fashion consistent with other
  libraries/tools.

More details: https://github.com/locationtech/jts/releases/tag/jts-1.18.0

Test plan -
All geospatial unit tests pass.

```
== RELEASE NOTES ==

Geospatial Changes
* Upgrade JTS to 1.18.0

```
