### PR TITLE
Fix order inconsistency between Hive Metastore partition information and actual partition values

### DIFF
--- a/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/TestHiveMetastoreUtil.java
+++ b/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/TestHiveMetastoreUtil.java
@@ -35,6 +35,7 @@ import static com.facebook.presto.hive.HiveType.HIVE_DATE;
 import static com.facebook.presto.hive.HiveType.HIVE_DOUBLE;
 import static com.facebook.presto.hive.HiveType.HIVE_INT;
 import static com.facebook.presto.hive.HiveType.HIVE_STRING;
+import static com.facebook.presto.hive.metastore.MetastoreUtil.extractPartitionValues;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.getHiveSchema;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.reconstructPartitionSchema;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -196,5 +197,16 @@ public class TestHiveMetastoreUtil
                 .isInstanceOf(IllegalArgumentException.class);
         assertThatThrownBy(() -> reconstructPartitionSchema(ImmutableList.of(c1), 2, ImmutableMap.of(0, c2)))
                 .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void testExtractPartitionValues()
+    {
+        String p1 = "date_str";
+        String p2 = "20201221";
+        assertEquals(extractPartitionValues("p1=date_str/p2=20201221", Optional.of(ImmutableList.of("p1", "p2"))), ImmutableList.of(p1, p2));
+        assertEquals(extractPartitionValues("p2=20201221/p1=date_str", Optional.of(ImmutableList.of("p1", "p2"))), ImmutableList.of(p1, p2));
+        assertEquals(extractPartitionValues("p1=date_str/p2=20201221"), ImmutableList.of(p1, p2));
+        assertEquals(extractPartitionValues("p2=20201221/p1=date_str"), ImmutableList.of(p2, p1));
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePartitionManager.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePartitionManager.java
@@ -44,6 +44,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static com.facebook.presto.hive.HiveBucketing.getHiveBucketFilter;
 import static com.facebook.presto.hive.HiveBucketing.getHiveBucketHandle;
@@ -395,7 +396,10 @@ public class HivePartitionManager
             List<Type> partitionColumnTypes,
             DateTimeZone timeZone)
     {
-        List<String> partitionValues = extractPartitionValues(partitionName);
+        List<String> partitionColumnNames = partitionColumns.stream()
+                .map(HiveColumnHandle::getName)
+                .collect(Collectors.toList());
+        List<String> partitionValues = extractPartitionValues(partitionName, Optional.of(partitionColumnNames));
         ImmutableMap.Builder<ColumnHandle, NullableValue> builder = ImmutableMap.builder();
         for (int i = 0; i < partitionColumns.size(); i++) {
             HiveColumnHandle column = partitionColumns.get(i);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/ManifestPartitionLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/ManifestPartitionLoader.java
@@ -156,7 +156,7 @@ public class ManifestPartitionLoader
         int partitionDataColumnCount = partition.getPartition()
                 .map(p -> p.getColumns().size())
                 .orElse(table.getDataColumns().size());
-        List<HivePartitionKey> partitionKeys = getPartitionKeys(table, partition.getPartition());
+        List<HivePartitionKey> partitionKeys = getPartitionKeys(table, partition.getPartition(), partitionName);
         Path path = new Path(getPartitionLocation(table, partition.getPartition()));
         Configuration configuration = hdfsEnvironment.getConfiguration(hdfsContext, path);
         InputFormat<?, ?> inputFormat = getInputFormat(configuration, inputFormatName, false);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/PartitionLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/PartitionLoader.java
@@ -23,10 +23,13 @@ import com.google.common.util.concurrent.ListenableFuture;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_INVALID_METADATA;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_INVALID_PARTITION_VALUE;
+import static com.facebook.presto.hive.HiveUtil.getPartitionKeyColumnHandles;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.checkCondition;
+import static com.facebook.presto.hive.metastore.MetastoreUtil.extractPartitionValues;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static java.lang.String.format;
 
@@ -35,14 +38,19 @@ public abstract class PartitionLoader
     public abstract ListenableFuture<?> loadPartition(HivePartitionMetadata partition, HiveSplitSource hiveSplitSource, boolean stopped)
             throws IOException;
 
-    public List<HivePartitionKey> getPartitionKeys(Table table, Optional<Partition> partition)
+    public List<HivePartitionKey> getPartitionKeys(Table table, Optional<Partition> partition, String partitionName)
     {
         if (!partition.isPresent()) {
             return ImmutableList.of();
         }
         ImmutableList.Builder<HivePartitionKey> partitionKeys = ImmutableList.builder();
+        // partition information provided by Hive Metastore is out of order
         List<Column> keys = table.getPartitionColumns();
-        List<String> values = partition.get().getValues();
+        List<HiveColumnHandle> partitionColumns = getPartitionKeyColumnHandles(table);
+        List<String> partitionColumnNames = partitionColumns.stream()
+                .map(HiveColumnHandle::getName)
+                .collect(Collectors.toList());
+        List<String> values = extractPartitionValues(partitionName, Optional.of(partitionColumnNames));
         checkCondition(keys.size() == values.size(), HIVE_INVALID_METADATA, "Expected %s partition key values, but got %s", keys.size(), values.size());
         for (int i = 0; i < keys.size(); i++) {
             String name = keys.get(i).getName();

--- a/presto-hive/src/main/java/com/facebook/presto/hive/StoragePartitionLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/StoragePartitionLoader.java
@@ -143,7 +143,7 @@ public class StoragePartitionLoader
         int partitionDataColumnCount = partition.getPartition()
                 .map(p -> p.getColumns().size())
                 .orElse(table.getDataColumns().size());
-        List<HivePartitionKey> partitionKeys = getPartitionKeys(table, partition.getPartition());
+        List<HivePartitionKey> partitionKeys = getPartitionKeys(table, partition.getPartition(), partitionName);
         Path path = new Path(getPartitionLocation(table, partition.getPartition()));
         Configuration configuration = hdfsEnvironment.getConfiguration(hdfsContext, path);
         InputFormat<?, ?> inputFormat = getInputFormat(configuration, inputFormatName, false);


### PR DESCRIPTION

```
== NO RELEASE NOTE ==
```
