### PR TITLE
Add QueryInterceptor to presto-jdbc

### DIFF
--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/ConnectionProperties.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/ConnectionProperties.java
@@ -18,12 +18,14 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.net.HostAndPort;
 
 import java.io.File;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.function.Predicate;
 
+import static com.facebook.presto.jdbc.AbstractConnectionProperty.ClassListConverter.CLASS_LIST_CONVERTER;
 import static com.facebook.presto.jdbc.AbstractConnectionProperty.StringMapConverter.STRING_MAP_CONVERTER;
 import static com.facebook.presto.jdbc.AbstractConnectionProperty.checkedPredicate;
 import static java.util.Collections.unmodifiableMap;
@@ -52,6 +54,7 @@ final class ConnectionProperties
     public static final ConnectionProperty<String> ACCESS_TOKEN = new AccessToken();
     public static final ConnectionProperty<Map<String, String>> EXTRA_CREDENTIALS = new ExtraCredentials();
     public static final ConnectionProperty<Map<String, String>> SESSION_PROPERTIES = new SessionProperties();
+    public static final ConnectionProperty<List<QueryInterceptor>> QUERY_INTERCEPTORS = new QueryInterceptors();
 
     private static final Set<ConnectionProperty<?>> ALL_PROPERTIES = ImmutableSet.<ConnectionProperty<?>>builder()
             .add(USER)
@@ -74,6 +77,7 @@ final class ConnectionProperties
             .add(ACCESS_TOKEN)
             .add(EXTRA_CREDENTIALS)
             .add(SESSION_PROPERTIES)
+            .add(QUERY_INTERCEPTORS)
             .build();
 
     private static final Map<String, ConnectionProperty<?>> KEY_LOOKUP = unmodifiableMap(ALL_PROPERTIES.stream()
@@ -306,6 +310,15 @@ final class ConnectionProperties
         public SessionProperties()
         {
             super("sessionProperties", NOT_REQUIRED, ALLOWED, STRING_MAP_CONVERTER);
+        }
+    }
+
+    private static class QueryInterceptors
+            extends AbstractConnectionProperty<List<QueryInterceptor>>
+    {
+        public QueryInterceptors()
+        {
+            super("queryInterceptors", NOT_REQUIRED, ALLOWED, CLASS_LIST_CONVERTER);
         }
     }
 }

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoDriverUri.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoDriverUri.java
@@ -16,6 +16,7 @@ package com.facebook.presto.jdbc;
 import com.facebook.presto.client.ClientException;
 import com.facebook.presto.client.OkHttpUtil;
 import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.net.HostAndPort;
@@ -54,6 +55,7 @@ import static com.facebook.presto.jdbc.ConnectionProperties.KERBEROS_PRINCIPAL;
 import static com.facebook.presto.jdbc.ConnectionProperties.KERBEROS_REMOTE_SERVICE_NAME;
 import static com.facebook.presto.jdbc.ConnectionProperties.KERBEROS_USE_CANONICAL_HOSTNAME;
 import static com.facebook.presto.jdbc.ConnectionProperties.PASSWORD;
+import static com.facebook.presto.jdbc.ConnectionProperties.QUERY_INTERCEPTORS;
 import static com.facebook.presto.jdbc.ConnectionProperties.SESSION_PROPERTIES;
 import static com.facebook.presto.jdbc.ConnectionProperties.SOCKS_PROXY;
 import static com.facebook.presto.jdbc.ConnectionProperties.SSL;
@@ -154,6 +156,12 @@ final class PrestoDriverUri
             throws SQLException
     {
         return SESSION_PROPERTIES.getValue(properties).orElse(ImmutableMap.of());
+    }
+
+    public List<QueryInterceptor> getQueryInterceptors()
+            throws SQLException
+    {
+        return QUERY_INTERCEPTORS.getValue(properties).orElse(ImmutableList.of());
     }
 
     public boolean isCompressionDisabled()

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoStatement.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoStatement.java
@@ -35,6 +35,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 import static com.facebook.presto.jdbc.PrestoResultSet.resultsException;
+import static com.google.common.base.Verify.verifyNotNull;
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
@@ -54,6 +55,7 @@ public class PrestoStatement
     private final AtomicReference<String> currentUpdateType = new AtomicReference<>();
     private final AtomicReference<Optional<Consumer<QueryStats>>> progressCallback = new AtomicReference<>(Optional.empty());
     private final Consumer<QueryStats> progressConsumer = value -> progressCallback.get().ifPresent(callback -> callback.accept(value));
+    private final AtomicInteger statementDepth = new AtomicInteger(0);
 
     PrestoStatement(PrestoConnection connection)
     {
@@ -236,26 +238,52 @@ public class PrestoStatement
 
         StatementClient client = null;
         PrestoResultSet resultSet = null;
+        boolean intercepted = false;
+
         try {
-            client = connection().startQuery(sql, getStatementSessionProperties());
-            if (client.isFinished()) {
-                QueryStatusInfo finalStatusInfo = client.finalStatusInfo();
-                if (finalStatusInfo.getError() != null) {
-                    throw resultsException(finalStatusInfo);
-                }
-            }
-            executingClient.set(client);
             WarningsManager warningsManager = new WarningsManager();
             currentWarningsManager.set(Optional.of(warningsManager));
-            resultSet = new PrestoResultSet(this, client, maxRows.get(), progressConsumer, warningsManager);
 
-            for (Map.Entry<String, SelectedRole> entry : client.getSetRoles().entrySet()) {
-                connection.get().setRole(entry.getKey(), entry.getValue());
+            int statementDepth = this.statementDepth.incrementAndGet();
+            boolean shouldIntercept = !connection().getQueryInterceptorInstances().isEmpty() && statementDepth == 1;
+
+            if (shouldIntercept) {
+                Optional<PrestoResultSet> newResultSet = connection().invokeQueryInterceptorsPre(sql, this);
+                if (newResultSet.isPresent()) {
+                    resultSet = newResultSet.get();
+                }
+            }
+
+            // Check if no resultSet is returned from an interceptor
+            if (resultSet != null) {
+                currentResult.set(resultSet);
+                intercepted = true;
+            }
+            else {
+                client = connection().startQuery(sql, getStatementSessionProperties());
+                if (client.isFinished()) {
+                    QueryStatusInfo finalStatusInfo = client.finalStatusInfo();
+                    if (finalStatusInfo.getError() != null) {
+                        throw resultsException(finalStatusInfo);
+                    }
+                }
+                executingClient.set(client);
+
+                resultSet = new PrestoResultSet(this, client, maxRows.get(), progressConsumer, warningsManager);
+
+                for (Map.Entry<String, SelectedRole> entry : client.getSetRoles().entrySet()) {
+                    connection.get().setRole(entry.getKey(), entry.getValue());
+                }
             }
 
             // check if this is a query
-            if (client.currentStatusInfo().getUpdateType() == null) {
+            if (intercepted || client.currentStatusInfo().getUpdateType() == null) {
                 currentResult.set(resultSet);
+                if (shouldIntercept) {
+                    resultSet = connection().invokeQueryInterceptorsPost(sql, this, resultSet);
+                    verifyNotNull(resultSet, "invokeQueryInterceptorsPost should never return a null ResultSet");
+                    currentResult.set(resultSet);
+                }
                 return true;
             }
 
@@ -279,6 +307,7 @@ public class PrestoStatement
             throw new SQLException("Error executing query", e);
         }
         finally {
+            this.statementDepth.decrementAndGet();
             executingClient.set(null);
             if (currentResult.get() == null) {
                 if (resultSet != null) {
@@ -292,8 +321,12 @@ public class PrestoStatement
     }
 
     private void clearCurrentResults()
+            throws SQLException
     {
-        currentResult.set(null);
+        PrestoResultSet rs = currentResult.getAndSet(null);
+        if (rs != null) {
+            rs.close();
+        }
         currentUpdateCount.set(-1);
         currentUpdateType.set(null);
         currentWarningsManager.set(Optional.empty());

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/QueryInterceptor.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/QueryInterceptor.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.jdbc;
+
+import java.sql.Statement;
+import java.util.Map;
+import java.util.Optional;
+
+public interface QueryInterceptor
+{
+    /**
+     * Called once per {@link PrestoConnection} at instantiation.
+     *
+     * @param properties the session properties supplied in the URI
+     */
+    default void init(Map<String, String> properties)
+    {
+    }
+
+    /**
+     * Called once to release any resources when {@link PrestoConnection} is closing.
+     */
+    default void destroy()
+    {
+    }
+
+    /**
+     * Called before the query has been sent to the server. This method is only called on
+     * top-level queries i.e. a query executed by a {@link QueryInterceptor} is not intercepted.
+     *
+     * This method can optionally return a {@link PrestoResultSet}. If a <code>PrestoResultSet</code> is returned from
+     * from <code>preProcess</code> then the intercepted query is not executed and that <code>PrestoResultSet</code> is
+     * returned instead. If there are multiple  <code>QueryInterceptors</code>, <code>preProcess</code> will be called
+     * on each and the last <code>PrestoResultSet</code> is returned.
+     *
+     * @param sql the SQL string of the query.
+     * @param interceptedStatement the Statement being executed.
+     * @return optional <code>PrestoResultSet</code> to be returned
+     */
+    default Optional<PrestoResultSet> preProcess(String sql, Statement interceptedStatement)
+    {
+        return Optional.empty();
+    }
+
+    /**
+     * Called after the query has been sent to the server. This method is only called on
+     * top-level queries i.e. a query executed by a {@link QueryInterceptor} is not intercepted.
+     *
+     * This method can optionally return a {@link PrestoResultSet}. If a <code>PrestoResultSet</code> is returned
+     * from postProcess then that <code>PrestoResultSet</code>  is returned instead. If there are multiple
+     *  <code>QueryInterceptors</code>, <code>postProcess</code> will be called on each and the last <code>PrestoResultSet</code> is returned.
+     *
+     * @param sql the SQL string of the query.
+     * @param interceptedStatement the {@link Statement} being executed.
+     * @param interceptedResultSet the intercepted <code>PrestoResultSet</code>
+     * @return optional <code>PrestoResultSet</code> to be returned instead of the original <code>PrestoResultSet</code>
+     */
+    default Optional<PrestoResultSet> postProcess(String sql, Statement interceptedStatement, PrestoResultSet interceptedResultSet)
+    {
+        return Optional.empty();
+    }
+}

--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestJdbcConnection.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestJdbcConnection.java
@@ -40,6 +40,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -226,6 +227,27 @@ public class TestJdbcConnection
         PrestoConnection prestoConnection = connection.unwrap(PrestoConnection.class);
         assertEquals(prestoConnection.getExtraCredentials(), credentials);
         assertEquals(listExtraCredentials(connection), credentials);
+    }
+
+    @Test
+    public void testQueryInterceptors()
+            throws SQLException
+    {
+        String extra = "queryInterceptors=" + TestNoopQueryInterceptor.class.getName();
+        try (PrestoConnection connection = createConnection(extra).unwrap(PrestoConnection.class)) {
+            List<QueryInterceptor> queryInterceptorInstances = connection.getQueryInterceptorInstances();
+            assertEquals(queryInterceptorInstances.size(), 1);
+            assertEquals(queryInterceptorInstances.get(0).getClass().getName(), TestNoopQueryInterceptor.class.getName());
+        }
+    }
+
+    public static class TestNoopQueryInterceptor
+            implements QueryInterceptor
+    {
+        @Override
+        public void init(Map<String, String> properties)
+        {
+        }
     }
 
     private Connection createConnection()

--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestPrestoDriverUri.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestPrestoDriverUri.java
@@ -25,6 +25,7 @@ import java.util.Properties;
 import static com.facebook.presto.jdbc.ConnectionProperties.DISABLE_COMPRESSION;
 import static com.facebook.presto.jdbc.ConnectionProperties.EXTRA_CREDENTIALS;
 import static com.facebook.presto.jdbc.ConnectionProperties.HTTP_PROXY;
+import static com.facebook.presto.jdbc.ConnectionProperties.QUERY_INTERCEPTORS;
 import static com.facebook.presto.jdbc.ConnectionProperties.SESSION_PROPERTIES;
 import static com.facebook.presto.jdbc.ConnectionProperties.SOCKS_PROXY;
 import static com.facebook.presto.jdbc.ConnectionProperties.SSL_TRUST_STORE_PASSWORD;
@@ -263,6 +264,20 @@ public class TestPrestoDriverUri
         Properties properties = parameters.getProperties();
         assertEquals(properties.getProperty(SESSION_PROPERTIES.getKey()), sessionProperties);
     }
+
+    @Test
+    public void testUriWithQueryInterceptors()
+            throws SQLException
+    {
+        String queryInterceptor = TestForUriQueryInterceptor.class.getName();
+        PrestoDriverUri parameters = createDriverUri("presto://localhost:8080?queryInterceptors=" + queryInterceptor);
+        Properties properties = parameters.getProperties();
+        assertEquals(properties.getProperty(QUERY_INTERCEPTORS.getKey()), queryInterceptor);
+    }
+
+    public static class TestForUriQueryInterceptor
+                implements QueryInterceptor
+    {}
 
     private static void assertUriPortScheme(PrestoDriverUri parameters, int port, String scheme)
     {

--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestQueryInterceptor.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestQueryInterceptor.java
@@ -1,0 +1,263 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.jdbc;
+
+import com.facebook.airlift.log.Logging;
+import com.facebook.presto.Session;
+import com.facebook.presto.execution.QueryManager;
+import com.facebook.presto.execution.QueryState;
+import com.facebook.presto.server.BasicQueryInfo;
+import com.facebook.presto.server.testing.TestingPrestoServer;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import com.facebook.presto.tpch.TpchPlugin;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+import java.util.Optional;
+
+import static com.facebook.presto.jdbc.TestPrestoDriver.closeQuietly;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static java.lang.String.format;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+@Test(singleThreaded = true)
+public class TestQueryInterceptor
+{
+    private TestingPrestoServer server;
+    private QueryManager qm;
+
+    @BeforeClass
+    public void setup()
+            throws Exception
+    {
+        Logging.initialize();
+    }
+
+    @BeforeMethod
+    public void setupServer()
+            throws Exception
+    {
+        DistributedQueryRunner distributedQueryRunner = createTpchQueryRunner();
+        server = distributedQueryRunner.getCoordinator();
+        qm = server.getQueryManager();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void teardownServer()
+    {
+        closeQuietly(server);
+    }
+
+    public static DistributedQueryRunner createTpchQueryRunner()
+            throws Exception
+    {
+        Session session = testSessionBuilder()
+                .setCatalog("tpch")
+                .setSchema("tiny")
+                .build();
+
+        DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(session).build();
+        try {
+            queryRunner.installPlugin(new TpchPlugin());
+            queryRunner.createCatalog("tpch", "tpch", ImmutableMap.of());
+            return queryRunner;
+        }
+        catch (Exception e) {
+            queryRunner.close();
+            throw e;
+        }
+    }
+
+    @Test
+    public void testBasicPrePreprocess()
+                throws Exception
+    {
+        String extra = "queryInterceptors=" + TestPreProcess1QueryInterceptor.class.getName();
+        try (Connection connection = createConnection(extra);
+                Statement statement = connection.createStatement()) {
+            try (ResultSet rs = statement.executeQuery("SELECT 123")) {
+                assertEquals(qm.getQueries().size(), 1);
+                assertTrue(rs.next());
+                assertEquals(rs.getLong(1), 456);
+                assertFalse(rs.next());
+            }
+        }
+    }
+
+    @Test
+    public void testMultiplePrePreprocess()
+            throws Exception
+    {
+        String extra = "queryInterceptors=" + TestPreProcess1QueryInterceptor.class.getName() + ";" + TestPreProcess2QueryInterceptor.class.getName();
+        try (Connection connection = createConnection(extra);
+                Statement statement = connection.createStatement()) {
+            try (ResultSet rs = statement.executeQuery("SELECT 123")) {
+                assertEquals(qm.getQueries().size(), 2);
+                assertTrue(rs.next());
+                assertEquals(rs.getLong(1), 789);
+                assertFalse(rs.next());
+            }
+        }
+    }
+
+    public static class TestPreProcess1QueryInterceptor
+                implements QueryInterceptor
+    {
+        @Override
+        public Optional<PrestoResultSet> preProcess(String sql, Statement interceptedStatement)
+        {
+            try {
+                ResultSet rs = interceptedStatement.executeQuery("SELECT 456");
+                return Optional.ofNullable((PrestoResultSet) rs);
+            }
+            catch (SQLException ex) {
+                throw new RuntimeException("Failed at ", ex);
+            }
+        }
+    }
+
+    public static class TestPreProcess2QueryInterceptor
+                implements QueryInterceptor
+    {
+        @Override
+        public Optional<PrestoResultSet> preProcess(String sql, Statement interceptedStatement)
+        {
+            try {
+                ResultSet rs = interceptedStatement.executeQuery("SELECT 789");
+                return Optional.ofNullable((PrestoResultSet) rs);
+            }
+            catch (SQLException ex) {
+                throw new RuntimeException("Failed at ", ex);
+            }
+        }
+    }
+
+    @Test
+    public void testBasicPostPreprocess()
+            throws Exception
+    {
+        String extra = "queryInterceptors=" + TestPostProcess1QueryInterceptor.class.getName();
+        try (Connection connection = createConnection(extra)) {
+            try (Statement statement = connection.createStatement()) {
+                try (ResultSet ignored = statement.executeQuery("select * from tpch.sf1000.orders")) {
+                    assertEquals(qm.getQueries().size(), 2);
+                }
+            }
+        }
+
+        // Add sleep because deletes are sent async
+        Thread.sleep(1000);
+        List<BasicQueryInfo> queries = qm.getQueries();
+        assertEquals(queries.stream().filter(query -> query.getState() == QueryState.FAILED).count(), 2);
+    }
+
+    @Test
+    public void testMultiplePostPreprocess()
+            throws Exception
+    {
+        String extra = "queryInterceptors=" + TestPostProcess1QueryInterceptor.class.getName() + ";" + TestPostProcess1QueryInterceptor.class.getName();
+        try (Connection connection = createConnection(extra)) {
+            try (Statement statement = connection.createStatement()) {
+                try (ResultSet ignored = statement.executeQuery("select * from tpch.sf1000.orders")) {
+                    assertEquals(qm.getQueries().size(), 3);
+                }
+            }
+        }
+
+        // Add sleep because deletes are sent async
+        Thread.sleep(1000);
+        List<BasicQueryInfo> queries = qm.getQueries();
+        assertEquals(queries.stream().filter(query -> query.getState() == QueryState.FAILED).count(), 3);
+    }
+
+    public static class TestPostProcess1QueryInterceptor
+                implements QueryInterceptor
+    {
+        @Override
+        public Optional<PrestoResultSet> postProcess(String sql, Statement interceptedStatement, PrestoResultSet originalResultSet)
+        {
+            try {
+                ResultSet rs = interceptedStatement.executeQuery("select * from tpch.sf1001.orders");
+                return Optional.ofNullable((PrestoResultSet) rs);
+            }
+            catch (SQLException ex) {
+                throw new RuntimeException("Failed at ", ex);
+            }
+        }
+    }
+
+    @Test
+    public void testPreAndPostProcess()
+            throws Exception
+    {
+        String extra = "queryInterceptors=" + TestPrePostQueryInterceptor.class.getName();
+        try (Connection connection = createConnection(extra)) {
+            try (Statement statement = connection.createStatement()) {
+                try (ResultSet ignored = statement.executeQuery("SELECT 123")) {
+                    List<BasicQueryInfo> queries = qm.getQueries();
+
+                    assertEquals(queries.size(), 2);
+                    assertEquals(queries.stream().filter(query -> query.getQuery().contains("456")).count(), 1);
+                    assertEquals(queries.stream().filter(query -> query.getQuery().contains("789")).count(), 1);
+                }
+            }
+        }
+    }
+
+    public static class TestPrePostQueryInterceptor
+            implements QueryInterceptor
+    {
+        @Override
+        public Optional<PrestoResultSet> preProcess(String sql, Statement interceptedStatement)
+        {
+            try {
+                ResultSet rs = interceptedStatement.executeQuery("SELECT 456");
+                return Optional.ofNullable((PrestoResultSet) rs);
+            }
+            catch (SQLException ex) {
+                throw new RuntimeException("Failed at ", ex);
+            }
+        }
+
+        @Override
+        public Optional<PrestoResultSet> postProcess(String sql, Statement interceptedStatement, PrestoResultSet originalResultSet)
+        {
+            try {
+                ResultSet rs = interceptedStatement.executeQuery("SELECT 789");
+                return Optional.ofNullable((PrestoResultSet) rs);
+            }
+            catch (SQLException ex) {
+                throw new RuntimeException("Failed at ", ex);
+            }
+        }
+    }
+
+    private Connection createConnection(String extra)
+            throws SQLException
+    {
+        String url = format("jdbc:presto://%s/?%s", server.getAddress(), extra);
+        return DriverManager.getConnection(url, "test", null);
+    }
+}


### PR DESCRIPTION
Introduce chainable [query interceptors](https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-interceptors.html) to Presto JDBC. QueryInterceptors can modify the behavior of a query or perform side effects. QueryInterceptors' `preProcess()` and `postProcess()` methods are run before and after the query is executed in the server, respectively. If more than one QueryInterceptor classname is provided separated by a semicolon, each will be called one-by-one from left to right in the classnames provided in the connection string. Both methods can optionally return a PrestoResultSet to override the ResultSet returned by the query.

Addresses issue #15142 

Test plan - Run new tests in TestQueryInterceptor, TestPrestoDriverUri, and TestJdbcConnection

```
== RELEASE NOTES ==

JDBC changes
* Add the interface `QueryInterceptor` to allow for custom logic to be executed before or after query execution. (:pr:`15565`)