### PR TITLE
Add peak [node] total memory to returned stats

### DIFF
--- a/presto-benchmark-runner/src/test/java/com/facebook/presto/benchmark/prestoaction/TestPrestoExceptionClassifier.java
+++ b/presto-benchmark-runner/src/test/java/com/facebook/presto/benchmark/prestoaction/TestPrestoExceptionClassifier.java
@@ -42,7 +42,7 @@ import static com.facebook.presto.testing.assertions.Assert.assertEquals;
 
 public class TestPrestoExceptionClassifier
 {
-    private static final QueryStats QUERY_STATS = new QueryStats("id", "", false, false, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, Optional.empty());
+    private static final QueryStats QUERY_STATS = new QueryStats("id", "", false, false, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, Optional.empty());
 
     private final SqlExceptionClassifier classifier = new PrestoExceptionClassifier(ImmutableSet.of());
 

--- a/presto-cli/src/main/java/com/facebook/presto/cli/StatusPrinter.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/StatusPrinter.java
@@ -210,6 +210,8 @@ Spilled: 20GB
             reprintLine("Peak Total Memory: " + formatDataSize(bytes(stats.getPeakTotalMemoryBytes()), true));
             // Peak Task Total Memory: 1.99GB
             reprintLine("Peak Task Total Memory: " + formatDataSize(bytes(stats.getPeakTaskTotalMemoryBytes()), true));
+            // Peak Node Total Memory: 2.00GB
+            reprintLine("Peak Node Total Memory: " + formatDataSize(bytes(stats.getPeakNodeTotalMemoryBytes()), true));
 
             // Spilled Data: 20GB
             if (stats.getSpilledBytes() > 0) {
@@ -310,6 +312,8 @@ Spilled: 20GB
                 reprintLine("Peak Total Memory: " + formatDataSize(bytes(stats.getPeakTotalMemoryBytes()), true));
                 // Peak Task Total Memory: 1.99GB
                 reprintLine("Peak Task Total Memory: " + formatDataSize(bytes(stats.getPeakTaskTotalMemoryBytes()), true));
+                // Peak Node Total Memory: 2.00GB
+                reprintLine("Peak Node Total Memory: " + formatDataSize(bytes(stats.getPeakNodeTotalMemoryBytes()), true));
 
                 // Spilled Data: 20GB
                 if (stats.getSpilledBytes() > 0) {

--- a/presto-client/src/main/java/com/facebook/presto/client/StatementStats.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/StatementStats.java
@@ -45,6 +45,7 @@ public class StatementStats
     private final long peakMemoryBytes;
     private final long peakTotalMemoryBytes;
     private final long peakTaskTotalMemoryBytes;
+    private final long peakNodeTotalMemoryBytes;
     private final long spilledBytes;
     private final StageStats rootStage;
 
@@ -67,6 +68,7 @@ public class StatementStats
             @JsonProperty("peakMemoryBytes") long peakMemoryBytes,
             @JsonProperty("peakTotalMemoryBytes") long peakTotalMemoryBytes,
             @JsonProperty("peakTaskTotalMemoryBytes") long peakTaskTotalMemoryBytes,
+            @JsonProperty("peakNodeTotalMemoryBytes") long peakNodeTotalMemoryBytes,
             @JsonProperty("spilledBytes") long spilledBytes,
             @JsonProperty("rootStage") StageStats rootStage)
     {
@@ -87,6 +89,7 @@ public class StatementStats
         this.peakMemoryBytes = peakMemoryBytes;
         this.peakTotalMemoryBytes = peakTotalMemoryBytes;
         this.peakTaskTotalMemoryBytes = peakTaskTotalMemoryBytes;
+        this.peakNodeTotalMemoryBytes = peakNodeTotalMemoryBytes;
         this.spilledBytes = spilledBytes;
         this.rootStage = rootStage;
     }
@@ -193,6 +196,12 @@ public class StatementStats
         return peakTaskTotalMemoryBytes;
     }
 
+    @JsonProperty
+    public long getPeakNodeTotalMemoryBytes()
+    {
+        return peakNodeTotalMemoryBytes;
+    }
+
     @Nullable
     @JsonProperty
     public StageStats getRootStage()
@@ -236,6 +245,7 @@ public class StatementStats
                 .add("peakMemoryBytes", peakMemoryBytes)
                 .add("peakTotalMemoryBytes", peakTotalMemoryBytes)
                 .add("peakTaskTotalMemoryBytes", peakTaskTotalMemoryBytes)
+                .add("peakNodeTotalMemoryBytes", peakNodeTotalMemoryBytes)
                 .add("spilledBytes", spilledBytes)
                 .add("rootStage", rootStage)
                 .toString();
@@ -265,6 +275,7 @@ public class StatementStats
         private long peakMemoryBytes;
         private long peakTotalMemoryBytes;
         private long peakTaskTotalMemoryBytes;
+        private long peakNodeTotalMemoryBytes;
         private long spilledBytes;
         private StageStats rootStage;
 
@@ -372,6 +383,12 @@ public class StatementStats
             return this;
         }
 
+        public Builder setPeakNodeTotalMemoryBytes(long peakNodeTotalMemoryBytes)
+        {
+            this.peakNodeTotalMemoryBytes = peakNodeTotalMemoryBytes;
+            return this;
+        }
+
         public Builder setSpilledBytes(long spilledBytes)
         {
             this.spilledBytes = spilledBytes;
@@ -404,6 +421,7 @@ public class StatementStats
                     peakMemoryBytes,
                     peakTotalMemoryBytes,
                     peakTaskTotalMemoryBytes,
+                    peakNodeTotalMemoryBytes,
                     spilledBytes,
                     rootStage);
         }

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/QueryStats.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/QueryStats.java
@@ -41,6 +41,7 @@ public final class QueryStats
     private final long peakMemoryBytes;
     private final long peakTotalMemoryBytes;
     private final long peakTaskTotalMemoryBytes;
+    private final long peakNodeTotalMemoryBytes;
     private final Optional<StageStats> rootStage;
 
     public QueryStats(
@@ -62,6 +63,7 @@ public final class QueryStats
             long peakMemoryBytes,
             long peakTotalMemoryBytes,
             long peakTaskTotalMemoryBytes,
+            long peakNodeTotalMemoryBytes,
             Optional<StageStats> rootStage)
     {
         this.queryId = requireNonNull(queryId, "queryId is null");
@@ -82,6 +84,7 @@ public final class QueryStats
         this.peakMemoryBytes = peakMemoryBytes;
         this.peakTotalMemoryBytes = peakTotalMemoryBytes;
         this.peakTaskTotalMemoryBytes = peakTaskTotalMemoryBytes;
+        this.peakNodeTotalMemoryBytes = peakNodeTotalMemoryBytes;
         this.rootStage = requireNonNull(rootStage, "rootStage is null");
     }
 
@@ -106,6 +109,7 @@ public final class QueryStats
                 stats.getPeakMemoryBytes(),
                 stats.getPeakTotalMemoryBytes(),
                 stats.getPeakTaskTotalMemoryBytes(),
+                stats.getPeakNodeTotalMemoryBytes(),
                 Optional.ofNullable(stats.getRootStage()).map(StageStats::create));
     }
 
@@ -197,6 +201,11 @@ public final class QueryStats
     public long getPeakTaskTotalMemoryBytes()
     {
         return peakTaskTotalMemoryBytes;
+    }
+
+    public long getPeakNodeTotalMemoryBytes()
+    {
+        return peakNodeTotalMemoryBytes;
     }
 
     public Optional<StageStats> getRootStage()

--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestProgressMonitor.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestProgressMonitor.java
@@ -89,7 +89,7 @@ public class TestProgressMonitor
                 nextUriId == null ? null : server.url(format("/v1/statement/%s/%s", queryId, nextUriId)).uri(),
                 responseColumns,
                 data,
-                new StatementStats(state, state.equals("QUEUED"), true, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, null),
+                new StatementStats(state, state.equals("QUEUED"), true, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, null),
                 null,
                 ImmutableList.of(),
                 null,

--- a/presto-main/src/main/java/com/facebook/presto/server/BasicQueryStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/BasicQueryStats.java
@@ -308,7 +308,7 @@ public class BasicQueryStats
     }
 
     @JsonProperty
-    public DataSize getPeakNodeTotalMemorReservation()
+    public DataSize getPeakNodeTotalMemoryReservation()
     {
         return peakNodeTotalMemoryReservation;
     }

--- a/presto-main/src/main/java/com/facebook/presto/server/QueryProgressStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/QueryProgressStats.java
@@ -31,6 +31,7 @@ public class QueryProgressStats
     private final long peakMemoryBytes;
     private final long peakTotalMemoryBytes;
     private final long peakTaskTotalMemoryBytes;
+    private final long peakNodeTotalMemoryBytes;
     private final long inputRows;
     private final long inputBytes;
     private final OptionalDouble progressPercentage;
@@ -46,6 +47,7 @@ public class QueryProgressStats
             @JsonProperty("peakMemoryBytes") long peakMemoryBytes,
             @JsonProperty("peakTotalMemoryBytes") long peakTotalMemoryBytes,
             @JsonProperty("peakTaskTotalMemoryBytes") long peakTaskTotalMemoryBytes,
+            @JsonProperty("peakNodeTotalMemoryBytes") long peakNodeTotalMemoryBytes,
             @JsonProperty("inputRows") long inputRows,
             @JsonProperty("inputBytes") long inputBytes,
             @JsonProperty("blocked") boolean blocked,
@@ -59,6 +61,7 @@ public class QueryProgressStats
         this.peakMemoryBytes = peakMemoryBytes;
         this.peakTotalMemoryBytes = peakTotalMemoryBytes;
         this.peakTaskTotalMemoryBytes = peakTaskTotalMemoryBytes;
+        this.peakNodeTotalMemoryBytes = peakNodeTotalMemoryBytes;
         this.inputRows = inputRows;
         this.inputBytes = inputBytes;
         this.blocked = blocked;
@@ -76,6 +79,7 @@ public class QueryProgressStats
                 queryStats.getPeakUserMemoryReservation().toBytes(),
                 queryStats.getPeakTotalMemoryReservation().toBytes(),
                 queryStats.getPeakTaskTotalMemoryReservation().toBytes(),
+                queryStats.getPeakNodeTotalMemoryReservation().toBytes(),
                 queryStats.getRawInputPositions(),
                 queryStats.getRawInputDataSize().toBytes(),
                 queryStats.isFullyBlocked(),
@@ -128,6 +132,12 @@ public class QueryProgressStats
     public long getPeakTaskTotalMemoryBytes()
     {
         return peakTaskTotalMemoryBytes;
+    }
+
+    @JsonProperty
+    public long getPeakNodeTotalMemoryBytes()
+    {
+        return peakNodeTotalMemoryBytes;
     }
 
     @JsonProperty

--- a/presto-main/src/test/java/com/facebook/presto/server/TestBasicQueryInfo.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestBasicQueryInfo.java
@@ -154,7 +154,7 @@ public class TestBasicQueryInfo
         assertEquals(basicInfo.getQueryStats().getPeakUserMemoryReservation(), DataSize.valueOf("23GB"));
         assertEquals(basicInfo.getQueryStats().getPeakTotalMemoryReservation(), DataSize.valueOf("24GB"));
         assertEquals(basicInfo.getQueryStats().getPeakTaskTotalMemoryReservation(), DataSize.valueOf("26GB"));
-        assertEquals(basicInfo.getQueryStats().getPeakNodeTotalMemorReservation(), DataSize.valueOf("42GB"));
+        assertEquals(basicInfo.getQueryStats().getPeakNodeTotalMemoryReservation(), DataSize.valueOf("42GB"));
 
         assertEquals(basicInfo.getQueryStats().getTotalCpuTime(), Duration.valueOf("24m"));
 

--- a/presto-main/src/test/java/com/facebook/presto/server/TestQueryProgressStats.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestQueryProgressStats.java
@@ -35,6 +35,7 @@ public class TestQueryProgressStats
                 34230492,
                 34230493,
                 34230494,
+                34230495,
                 1000,
                 100000,
                 false,
@@ -52,6 +53,7 @@ public class TestQueryProgressStats
         assertEquals(actual.getPeakMemoryBytes(), 34230492);
         assertEquals(actual.getPeakTotalMemoryBytes(), 34230493);
         assertEquals(actual.getPeakTaskTotalMemoryBytes(), 34230494);
+        assertEquals(actual.getPeakTaskTotalMemoryBytes(), 34230495);
         assertEquals(actual.getInputRows(), 1000);
         assertEquals(actual.getInputBytes(), 100000);
         assertFalse(actual.isBlocked());

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestLimitQueryDeterminismAnalyzer.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestLimitQueryDeterminismAnalyzer.java
@@ -80,7 +80,7 @@ public class TestLimitQueryDeterminismAnalyzer
 
     private static final long ROW_COUNT_WITH_LIMIT = 1000;
     private static final QueryActionStats QUERY_STATS = new QueryActionStats(
-            Optional.of(new QueryStats("id", "", false, false, 1, 2, 3, 4, 5, 0, 7, 8, 9, 10, 11, 0, 0, 0, Optional.empty())),
+            Optional.of(new QueryStats("id", "", false, false, 1, 2, 3, 4, 5, 0, 7, 8, 9, 10, 11, 0, 0, 0, 0, Optional.empty())),
             Optional.empty());
     private static final ParsingOptions PARSING_OPTIONS = ParsingOptions.builder().setDecimalLiteralTreatment(AS_DOUBLE).build();
     private static final SqlParser sqlParser = new SqlParser(new SqlParserOptions().allowIdentifierSymbol(COLON, AT_SIGN));

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/prestoaction/TestPrestoExceptionClassifier.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/prestoaction/TestPrestoExceptionClassifier.java
@@ -57,7 +57,7 @@ public class TestPrestoExceptionClassifier
 {
     private static final QueryStage QUERY_STAGE = CONTROL_MAIN;
     private static final QueryActionStats QUERY_ACTION_STATS = new QueryActionStats(
-            Optional.of(new QueryStats("id", "", false, false, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, Optional.empty())),
+            Optional.of(new QueryStats("id", "", false, false, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, Optional.empty())),
             Optional.empty());
 
     private final SqlExceptionClassifier classifier = PrestoExceptionClassifier.defaultBuilder().build();

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/resolver/AbstractTestPrestoQueryFailureResolver.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/resolver/AbstractTestPrestoQueryFailureResolver.java
@@ -105,7 +105,7 @@ public class AbstractTestPrestoQueryFailureResolver
 
     protected static QueryStats createQueryStats(long cpuTimeMillis, long peakTotalMemoryBytes)
     {
-        return new QueryStats("id", "", false, false, 1, 2, 3, 4, 5, cpuTimeMillis, 7, 8, 9, 10, 11, 12, peakTotalMemoryBytes, 13, Optional.empty());
+        return new QueryStats("id", "", false, false, 1, 2, 3, 4, 5, cpuTimeMillis, 7, 8, 9, 10, 11, 12, peakTotalMemoryBytes, 13, 14, Optional.empty());
     }
 
     protected static QueryActionStats createQueryActionStats(long cpuTimeMillis, long peakTotalMemoryBytes)


### PR DESCRIPTION
Discussed with @aweisberg. Added peak node total memory to returned stats so that the information can be extracted downstream in Presto client 

Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines. Don't forget to follow our [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution) for any code copied from other projects.

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== RELEASE NOTES ==

General Changes
* Added peak node total memory to returned stats so that the information can be extracted downstream in Presto client 