### PR TITLE
Optimization for removing lossless join

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -197,6 +197,7 @@ public final class SystemSessionProperties
     public static final String PARTIAL_RESULTS_MAX_EXECUTION_TIME_MULTIPLIER = "partial_results_max_execution_time_multiplier";
     public static final String OFFSET_CLAUSE_ENABLED = "offset_clause_enabled";
     public static final String VERBOSE_EXCEEDED_MEMORY_LIMIT_ERRORS_ENABLED = "verbose_exceeded_memory_limit_errors_enabled";
+    public static final String ENABLE_REMOVE_UNREFERENCED_JOIN = "enable_remove_unreferneced_join";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -972,6 +973,11 @@ public final class SystemSessionProperties
                         CHECK_ACCESS_CONTROL_ON_UTILIZED_COLUMNS_ONLY,
                         "Apply access control rules on only those columns that are required to produce the query output",
                         featuresConfig.isCheckAccessControlOnUtilizedColumnsOnly(),
+                        false),
+                booleanProperty(
+                        ENABLE_REMOVE_UNREFERENCED_JOIN,
+                        "Enable optimization to remove unreferenced join",
+                        featuresConfig.isEnableRemoveUnreferencedJoin(),
                         false),
                 booleanProperty(
                         ALLOW_WINDOW_ORDER_BY_LITERALS,
@@ -1778,5 +1784,10 @@ public final class SystemSessionProperties
     public static boolean isVerboseExceededMemoryLimitErrorsEnabled(Session session)
     {
         return session.getSystemProperty(VERBOSE_EXCEEDED_MEMORY_LIMIT_ERRORS_ENABLED, Boolean.class);
+    }
+
+    public static boolean isEnableRemoveUnreferencedJoin(Session session)
+    {
+        return session.getSystemProperty(ENABLE_REMOVE_UNREFERENCED_JOIN, Boolean.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -183,6 +183,7 @@ public class FeaturesConfig
     private boolean checkAccessControlOnUtilizedColumnsOnly;
     private boolean skipRedundantSort = true;
     private boolean isAllowWindowOrderByLiterals = true;
+    private boolean isEnableRemoveUnreferencedJoin = true;
 
     private boolean spoolingOutputBufferEnabled;
     private DataSize spoolingOutputBufferThreshold = new DataSize(8, MEGABYTE);
@@ -1755,6 +1756,18 @@ public class FeaturesConfig
     public FeaturesConfig setOffsetClauseEnabled(boolean offsetClauseEnabled)
     {
         this.offsetClauseEnabled = offsetClauseEnabled;
+        return this;
+    }
+
+    public boolean isEnableRemoveUnreferencedJoin()
+    {
+        return isEnableRemoveUnreferencedJoin;
+    }
+
+    @Config("enable-remove-unreferenced-join")
+    public FeaturesConfig setEnableRemoveUnreferencedJoin(boolean value)
+    {
+        this.isEnableRemoveUnreferencedJoin = value;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -93,6 +93,7 @@ import com.facebook.presto.sql.planner.iterative.rule.RemoveEmptyDelete;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveFullSample;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveRedundantIdentityProjections;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveTrivialFilters;
+import com.facebook.presto.sql.planner.iterative.rule.RemoveUnreferencedJoin;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveUnreferencedScalarApplyNodes;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveUnreferencedScalarLateralNodes;
 import com.facebook.presto.sql.planner.iterative.rule.RemoveUnsupportedDynamicFilters;
@@ -458,6 +459,7 @@ public class PlanOptimizers
                         estimatedExchangesCostCalculator,
                         ImmutableSet.<Rule<?>>builder()
                                 .addAll(new PushDownDereferences(metadata).rules())
+                                .addAll(new RemoveUnreferencedJoin().rules())
                                 .build()),
                 new PruneUnreferencedOutputs());
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RemoveUnreferencedJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RemoveUnreferencedJoin.java
@@ -1,0 +1,278 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.matching.Capture;
+import com.facebook.presto.matching.Captures;
+import com.facebook.presto.matching.Pattern;
+import com.facebook.presto.spi.plan.AggregationNode;
+import com.facebook.presto.spi.plan.Assignments;
+import com.facebook.presto.spi.plan.DistinctLimitNode;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.iterative.Rule;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.List;
+import java.util.Set;
+
+import static com.facebook.presto.SystemSessionProperties.isEnableRemoveUnreferencedJoin;
+import static com.facebook.presto.sql.planner.plan.JoinNode.Type.LEFT;
+import static com.facebook.presto.sql.planner.plan.JoinNode.Type.RIGHT;
+import static com.facebook.presto.sql.planner.plan.Patterns.Join.type;
+import static com.facebook.presto.sql.planner.plan.Patterns.aggregation;
+import static com.facebook.presto.sql.planner.plan.Patterns.distinctLimit;
+import static com.facebook.presto.sql.planner.plan.Patterns.join;
+import static com.facebook.presto.sql.planner.plan.Patterns.source;
+
+/**
+ * LEFT-JOIN by definition is "lossless", this optimization rule enforces JOIN operation to be removed if the project output is no columns
+ * of the table are referenced in the output of the JOIN
+ */
+public class RemoveUnreferencedJoin
+{
+    public Set<Rule<?>> rules()
+    {
+        return ImmutableSet.of(
+                new RemoveJoinFromDistinctLimit(),
+                new RemoveJoinFromAggregation());
+    }
+
+    /**
+     * DistinctLimit enforces the uniqueness of the output symbols. If there is no output columns from right table to reference in the output of the parent,
+     * it is safe to remove the right table of the LEFT-JOIN
+     */
+    public static final class RemoveJoinFromDistinctLimit
+            implements Rule<DistinctLimitNode>
+    {
+        private static final Capture<JoinNode> JOIN = Capture.newCapture();
+        private static final Pattern<DistinctLimitNode> PATTERN =
+                distinctLimit()
+                        .with(source().matching(
+                                join()
+                                        .with(type().matching(type -> type == LEFT || type == RIGHT))
+                                        .capturedAs(JOIN)));
+
+        @Override
+        public boolean isEnabled(Session session)
+        {
+            return isEnableRemoveUnreferencedJoin(session);
+        }
+
+        @Override
+        public Pattern<DistinctLimitNode> getPattern()
+        {
+            return PATTERN;
+        }
+
+        @Override
+        public Result apply(DistinctLimitNode node, Captures captures, Context context)
+        {
+            JoinNode childJoin = captures.get(JOIN);
+
+            if (childJoin.getType() == LEFT) {
+                return pruneJoinFromDistinctLimit(
+                        childJoin.getRight().getOutputVariables(),
+                        childJoin.getLeft().getOutputVariables(),
+                        node,
+                        childJoin.getLeft(),
+                        context);
+            }
+            else {
+                return pruneJoinFromDistinctLimit(
+                        childJoin.getLeft().getOutputVariables(),
+                        childJoin.getRight().getOutputVariables(),
+                        node,
+                        childJoin.getRight(),
+                        context);
+            }
+        }
+    }
+
+    private static Rule.Result pruneJoinFromDistinctLimit(
+            List<VariableReferenceExpression> unreferencedJoinOutput,
+            List<VariableReferenceExpression> referencedJoinOutput,
+            DistinctLimitNode distinctLimitNode,
+            PlanNode source,
+            Rule.Context context)
+    {
+        Assignments.Builder newAssignments = Assignments.builder();
+        if (!distinctLimitNode.getDistinctVariables().containsAll(unreferencedJoinOutput)) {
+            for (VariableReferenceExpression outputVariable : referencedJoinOutput) {
+                newAssignments.put(outputVariable, outputVariable);
+            }
+
+            return Rule.Result.ofPlanNode(
+                    new DistinctLimitNode(
+                            context.getIdAllocator().getNextId(),
+                            new ProjectNode(
+                                    context.getIdAllocator().getNextId(),
+                                    source,
+                                    newAssignments.build()),
+                            distinctLimitNode.getLimit(),
+                            distinctLimitNode.isPartial(),
+                            distinctLimitNode.getDistinctVariables(),
+                            distinctLimitNode.getHashVariable()));
+        }
+        return Rule.Result.empty();
+    }
+
+    /**
+     * Aggregation enforces the uniqueness of the output symbols too, check to prune JOIN if possible
+     */
+    public static final class RemoveJoinFromAggregation
+            implements Rule<AggregationNode>
+    {
+        private static final Capture<JoinNode> JOIN = Capture.newCapture();
+        private static final Pattern<AggregationNode> PATTERN =
+                aggregation()
+                        .with(source().matching(
+                                join()
+                                        .with(type().matching(type -> type == LEFT || type == RIGHT))
+                                        .capturedAs(JOIN)));
+
+        @Override
+        public boolean isEnabled(Session session)
+        {
+            return isEnableRemoveUnreferencedJoin(session);
+        }
+
+        @Override
+        public Pattern<AggregationNode> getPattern()
+        {
+            return PATTERN;
+        }
+
+        @Override
+        public Result apply(AggregationNode node, Captures captures, Context context)
+        {
+            JoinNode childJoin = captures.get(JOIN);
+
+            if (childJoin.getType() == LEFT) {
+                return pruneJoinFromAggregation(
+                        childJoin.getRight().getOutputVariables(),
+                        childJoin.getLeft().getOutputVariables(),
+                        node,
+                        childJoin.getLeft(),
+                        context);
+            }
+            else {
+                return pruneJoinFromAggregation(
+                        childJoin.getLeft().getOutputVariables(),
+                        childJoin.getRight().getOutputVariables(),
+                        node,
+                        childJoin.getRight(),
+                        context);
+            }
+        }
+
+        private static Rule.Result pruneJoinFromAggregation(
+                List<VariableReferenceExpression> unreferencedJoinOutput,
+                List<VariableReferenceExpression> referencedJoinOutput,
+                AggregationNode aggregationNode,
+                PlanNode source,
+                Rule.Context context)
+        {
+            Assignments.Builder newAssignments = Assignments.builder();
+            if (checkDistinctColumnToPruneJoin(aggregationNode, unreferencedJoinOutput, referencedJoinOutput)) {
+                for (VariableReferenceExpression outputVariable : referencedJoinOutput) {
+                    newAssignments.put(outputVariable, outputVariable);
+                }
+
+                return Result.ofPlanNode(
+                        new AggregationNode(
+                                context.getIdAllocator().getNextId(),
+                                new ProjectNode(context.getIdAllocator().getNextId(),
+                                        source,
+                                        newAssignments.build()),
+                                aggregationNode.getAggregations(),
+                                aggregationNode.getGroupingSets(),
+                                aggregationNode.getPreGroupedVariables(),
+                                aggregationNode.getStep(),
+                                aggregationNode.getHashVariable(),
+                                aggregationNode.getGroupIdVariable()));
+            }
+            return Rule.Result.empty();
+        }
+
+        /**
+         * @param node - AggregationNode input
+         * @param unreferencedOutput - List of unreferenced Output
+         * @param referencedJoinOutput - List of referenced Output
+         * @return - true if ok to prune Joinnode
+         * - false if not qualified to prune JoinNode
+         */
+        private static boolean checkDistinctColumnToPruneJoin(
+                AggregationNode node,
+                List<VariableReferenceExpression> unreferencedOutput,
+                List<VariableReferenceExpression> referencedJoinOutput)
+        {
+            if (node.getAggregations().isEmpty()) {
+                if (!node.getOutputVariables().containsAll(unreferencedOutput)) {
+                    return true;
+                }
+                else {
+                    return false;
+                }
+            }
+            else {
+                if (node.getAggregations().values().stream().anyMatch(aggregation -> aggregation.getCall().getArguments().stream().anyMatch(arg -> unreferencedOutput.contains(arg))) ||
+                        checkMultiOutputAgg(node.getGroupingKeys(), node.getOutputVariables(), unreferencedOutput, referencedJoinOutput)) {
+                    return false;
+                }
+                else {
+                    return true;
+                }
+            }
+        }
+
+        /**
+         * @param groupingKeys
+         * @param aggOutput
+         * @param unreferencedOutput
+         * @param referencedJoinOutput
+         * @return true if not ok to prune Joinnode
+         * false if qualified to prune JoinNode
+         */
+        private static boolean checkMultiOutputAgg(
+                List<VariableReferenceExpression> groupingKeys,
+                List<VariableReferenceExpression> aggOutput,
+                List<VariableReferenceExpression> unreferencedOutput,
+                List<VariableReferenceExpression> referencedJoinOutput)
+        {
+            // if no grouping key, uniqueness is not guaranteed, so cannot prune joinNode
+            if (groupingKeys.isEmpty()) {
+                if (aggOutput.stream().anyMatch(variable -> unreferencedOutput.contains(variable)) ||
+                        !aggOutput.stream().anyMatch(variable -> referencedJoinOutput.contains(variable))) {
+                    return true;
+                }
+                else {
+                    return false;
+                }
+            }
+            else {
+                if (aggOutput.stream().anyMatch(variable -> groupingKeys.contains(variable)) &&
+                        aggOutput.size() > groupingKeys.size()) {
+                    return true;
+                }
+                else {
+                    return false;
+                }
+            }
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/JoinNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/JoinNode.java
@@ -333,6 +333,11 @@ public class JoinNode
         return criteria.isEmpty() && !filter.isPresent() && type == INNER;
     }
 
+    public boolean isLeftJoin()
+    {
+        return type == LEFT;
+    }
+
     public static class EquiJoinClause
     {
         private final VariableReferenceExpression left;

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/Patterns.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/Patterns.java
@@ -16,6 +16,7 @@ package com.facebook.presto.sql.planner.plan;
 import com.facebook.presto.matching.Pattern;
 import com.facebook.presto.matching.Property;
 import com.facebook.presto.spi.plan.AggregationNode;
+import com.facebook.presto.spi.plan.DistinctLimitNode;
 import com.facebook.presto.spi.plan.FilterNode;
 import com.facebook.presto.spi.plan.IntersectNode;
 import com.facebook.presto.spi.plan.LimitNode;
@@ -168,6 +169,11 @@ public class Patterns
     public static Pattern<IntersectNode> intersect()
     {
         return typeOf(IntersectNode.class);
+    }
+
+    public static Pattern<DistinctLimitNode> distinctLimit()
+    {
+        return typeOf(DistinctLimitNode.class);
     }
 
     public static Pattern<ValuesNode> values()

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -172,6 +172,7 @@ public class TestFeaturesConfig
                 .setPartialResultsEnabled(false)
                 .setPartialResultsCompletionRatioThreshold(0.5)
                 .setOffsetClauseEnabled(false)
+                .setEnableRemoveUnreferencedJoin(true)
                 .setPartialResultsMaxExecutionTimeMultiplier(2.0));
     }
 
@@ -297,6 +298,7 @@ public class TestFeaturesConfig
                 .put("partial-results-completion-ratio-threshold", "0.9")
                 .put("partial-results-max-execution-time-multiplier", "1.5")
                 .put("offset-clause-enabled", "true")
+                .put("enable-remove-unreferenced-join", "false")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -418,6 +420,7 @@ public class TestFeaturesConfig
                 .setPartialResultsEnabled(true)
                 .setPartialResultsCompletionRatioThreshold(0.9)
                 .setOffsetClauseEnabled(true)
+                .setEnableRemoveUnreferencedJoin(false)
                 .setPartialResultsMaxExecutionTimeMultiplier(1.5);
         assertFullMapping(properties, expected);
     }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/DistinctLimitMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/DistinctLimitMatcher.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.assertions;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.cost.StatsProvider;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.plan.DistinctLimitNode;
+import com.facebook.presto.spi.plan.PlanNode;
+
+import static com.google.common.base.Preconditions.checkState;
+
+public class DistinctLimitMatcher
+        implements Matcher
+{
+    private final long limit;
+    private final boolean partial;
+
+    public DistinctLimitMatcher(long limit, boolean partial)
+    {
+        this.limit = limit;
+        this.partial = partial;
+    }
+
+    @Override
+    public boolean shapeMatches(PlanNode node)
+    {
+        if (!(node instanceof DistinctLimitNode)) {
+            return false;
+        }
+        DistinctLimitNode distinctLimitNode = (DistinctLimitNode) node;
+        return distinctLimitNode.getLimit() == limit && distinctLimitNode.isPartial() == partial;
+    }
+
+    @Override
+    public MatchResult detailMatches(PlanNode node, StatsProvider stats, Session session, Metadata metadata, SymbolAliases symbolAliases)
+    {
+        checkState(shapeMatches(node));
+        return MatchResult.match();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
@@ -20,6 +20,7 @@ import com.facebook.presto.cost.StatsProvider;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.spi.plan.AggregationNode;
 import com.facebook.presto.spi.plan.AggregationNode.Step;
+import com.facebook.presto.spi.plan.DistinctLimitNode;
 import com.facebook.presto.spi.plan.ExceptNode;
 import com.facebook.presto.spi.plan.FilterNode;
 import com.facebook.presto.spi.plan.IntersectNode;
@@ -547,6 +548,11 @@ public final class PlanMatchPattern
     public static PlanMatchPattern limit(long limit, boolean partial, PlanMatchPattern source)
     {
         return node(LimitNode.class, source).with(new LimitMatcher(limit, partial));
+    }
+
+    public static PlanMatchPattern distinctLimit(long limit, boolean partial, PlanMatchPattern source)
+    {
+        return node(DistinctLimitNode.class, source).with(new DistinctLimitMatcher(limit, partial));
     }
 
     public static PlanMatchPattern enforceSingleRow(PlanMatchPattern source)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestRemoveUnreferencedJoin.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestRemoveUnreferencedJoin.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.iterative.rule;
+
+import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.aggregation;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.distinctLimit;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.expression;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.functionCall;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
+
+public class TestRemoveUnreferencedJoin
+        extends BaseRuleTest
+{
+    @Test
+    public void testAggLeftJoin()
+    {
+        tester().assertThat(new RemoveUnreferencedJoin.RemoveJoinFromAggregation())
+                .on(p -> p.aggregation(a -> a
+                        .source(p.join(
+                                JoinNode.Type.LEFT,
+                                p.values(p.variable("COL1")),
+                                p.values(p.variable("COL2")),
+                                ImmutableList.of(new JoinNode.EquiJoinClause(p.variable("COL1"), p.variable("COL2"))),
+                                ImmutableList.of(p.variable("COL1")),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.empty()))
+                        .addAggregation(
+                                p.variable(p.variable("COL1")),
+                                p.rowExpression("count(COL1)"))
+                        .globalGrouping()))
+                .matches(
+                        aggregation(
+                                ImmutableMap.of("count", functionCall("count", ImmutableList.of("COL1"))),
+                                project(ImmutableMap.of("COL1", expression("COL1")),
+                                        values("COL1"))));
+    }
+
+    @Test
+    public void testAggRightJoin()
+    {
+        tester().assertThat(new RemoveUnreferencedJoin.RemoveJoinFromAggregation())
+                .on(p -> p.aggregation(a -> a
+                        .source(p.join(
+                                JoinNode.Type.RIGHT,
+                                p.values(p.variable("COL1")),
+                                p.values(p.variable("COL2")),
+                                ImmutableList.of(new JoinNode.EquiJoinClause(p.variable("COL1"), p.variable("COL2"))),
+                                ImmutableList.of(p.variable("COL1"), p.variable("COL2")),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.empty()))
+                        .addAggregation(
+                                p.variable(p.variable("COL2")),
+                                p.rowExpression("count(COL2)"))
+                        .globalGrouping()))
+                .matches(
+                        aggregation(
+                                ImmutableMap.of("count", functionCall("count", ImmutableList.of("COL2"))),
+                                project(ImmutableMap.of("COL2", expression("COL2")),
+                                        values("COL2"))));
+    }
+
+    @Test
+    public void testDistinctLimitLeftJoin()
+    {
+        tester().assertThat(new RemoveUnreferencedJoin.RemoveJoinFromDistinctLimit())
+                .on(p -> p.distinctLimit(
+                        1,
+                        ImmutableList.of(p.variable("COL1")),
+                        p.join(
+                                JoinNode.Type.LEFT,
+                                p.values(p.variable("COL1")),
+                                p.values(p.variable("COL2")),
+                                ImmutableList.of(new JoinNode.EquiJoinClause(p.variable("COL1"), p.variable("COL2"))),
+                                ImmutableList.of(p.variable("COL1")),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.empty())))
+                .matches(
+                        distinctLimit(1,
+                                false,
+                                project(ImmutableMap.of("COL1", expression("COL1")),
+                                        values("COL1"))));
+    }
+
+    @Test
+    public void testDistinctLimitRightJoin()
+    {
+        tester().assertThat(new RemoveUnreferencedJoin.RemoveJoinFromDistinctLimit())
+                .on(p -> p.distinctLimit(
+                        1,
+                        ImmutableList.of(p.variable("COL2")),
+                        p.join(
+                                JoinNode.Type.RIGHT,
+                                p.values(p.variable("COL1")),
+                                p.values(p.variable("COL2")),
+                                ImmutableList.of(new JoinNode.EquiJoinClause(p.variable("COL1"), p.variable("COL2"))),
+                                ImmutableList.of(p.variable("COL2")),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.empty())))
+                .matches(
+                        distinctLimit(1,
+                                false,
+                                project(ImmutableMap.of("COL2", expression("COL2")),
+                                        values("COL2"))));
+    }
+
+    @Test
+    public void testDistinctLimitLeftJoinNotFire()
+    {
+        tester().assertThat(new RemoveUnreferencedJoin.RemoveJoinFromDistinctLimit())
+                .on(p -> p.distinctLimit(
+                        1,
+                        ImmutableList.of(p.variable("COL2")),
+                        p.join(
+                                JoinNode.Type.LEFT,
+                                p.values(p.variable("COL1")),
+                                p.values(p.variable("COL2")),
+                                ImmutableList.of(new JoinNode.EquiJoinClause(p.variable("COL1"), p.variable("COL2"))),
+                                ImmutableList.of(p.variable("COL1")),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.empty())))
+                .doesNotFire();
+    }
+
+    @Test
+    public void testDistinctLimitRightJoinNotFire()
+    {
+        tester().assertThat(new RemoveUnreferencedJoin.RemoveJoinFromDistinctLimit())
+                .on(p -> p.distinctLimit(
+                        1,
+                        ImmutableList.of(p.variable("COL1")),
+                        p.join(
+                                JoinNode.Type.RIGHT,
+                                p.values(p.variable("COL1")),
+                                p.values(p.variable("COL2")),
+                                ImmutableList.of(new JoinNode.EquiJoinClause(p.variable("COL1"), p.variable("COL2"))),
+                                ImmutableList.of(p.variable("COL2")),
+                                Optional.empty(),
+                                Optional.empty(),
+                                Optional.empty())))
+                .doesNotFire();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -30,6 +30,7 @@ import com.facebook.presto.spi.plan.AggregationNode;
 import com.facebook.presto.spi.plan.AggregationNode.Aggregation;
 import com.facebook.presto.spi.plan.AggregationNode.Step;
 import com.facebook.presto.spi.plan.Assignments;
+import com.facebook.presto.spi.plan.DistinctLimitNode;
 import com.facebook.presto.spi.plan.ExceptNode;
 import com.facebook.presto.spi.plan.FilterNode;
 import com.facebook.presto.spi.plan.IntersectNode;
@@ -277,6 +278,22 @@ public class PlanBuilder
     public ProjectNode project(Assignments assignments, PlanNode source)
     {
         return new ProjectNode(idAllocator.getNextId(), source, assignments);
+    }
+
+    public DistinctLimitNode distinctLimit(long count, List<VariableReferenceExpression> distinctSymbols, PlanNode source)
+    {
+        return distinctLimit(count, distinctSymbols, Optional.empty(), source);
+    }
+
+    public DistinctLimitNode distinctLimit(long count, List<VariableReferenceExpression> distinctSymbols, Optional<VariableReferenceExpression> hashSymbol, PlanNode source)
+    {
+        return new DistinctLimitNode(
+                idAllocator.getNextId(),
+                source,
+                count,
+                false,
+                distinctSymbols,
+                hashSymbol);
     }
 
     public MarkDistinctNode markDistinct(VariableReferenceExpression markerVariable, List<VariableReferenceExpression> distinctVariables, PlanNode source)


### PR DESCRIPTION
This PR adds a new optimization rule to remove redundant join if following criterias are satisfied:

 - If the join's output column only references from the inner side (right) side of left outer join; or there is no output columns from the inner side of the right outer join.

  - If the output is unique. 

An example will be...

```
  SELECT DISTINCT left.key
  FROM left
  LEFT JOIN right
  ON
  left.key=right.key
```

  This will become...

```
  SELECT DISTINCT left.key
  FROM left
```
![image](https://user-images.githubusercontent.com/32091981/103499734-ff497180-4dfd-11eb-8913-aebaa2d025d0.png)


resolve #15576 

Test plan - Add UT coverage, and test the feature locally
```
== RELEASE NOTES ==

Add support to remove redundant lossless Leftjoin. This feature can be disabled by setting the session property ``enable_remove_unreferneced_join`` or configuration property  ``enable-remove-unreferenced-join`` to false.

```
