### PR TITLE
Require min 30s query.min-expire-age

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryManagerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryManagerConfig.java
@@ -201,6 +201,7 @@ public class QueryManagerConfig
 
     @LegacyConfig("query.max-age")
     @Config("query.min-expire-age")
+    @MinDuration("30s")
     public QueryManagerConfig setMinQueryExpireAge(Duration minQueryExpireAge)
     {
         this.minQueryExpireAge = minQueryExpireAge;


### PR DESCRIPTION
Tested manually with TestQueryManagerConfig to make sure the minimum is enforced. 29 seconds fails, 30 seconds works.

This turns out to be important when clients are on higher latency connections. The client library may poll for status for a query that has completed and the coordinator may have expired the completed query causing the client library to generate an error.

```
== RELEASE NOTES ==
General Changes
* Add 30 second minimum to `query.min-expire-age` configuration parameter.
```

