### PR TITLE
Implement MAP_UNION_SUM aggregation

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/type/TypeUtils.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TypeUtils.java
@@ -23,6 +23,12 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.common.type.RealType.REAL;
+import static com.facebook.presto.common.type.SmallintType.SMALLINT;
+import static com.facebook.presto.common.type.TinyintType.TINYINT;
 import static java.util.Locale.ENGLISH;
 import static java.util.stream.Collectors.toMap;
 import static java.util.stream.Collectors.toSet;
@@ -33,6 +39,26 @@ public final class TypeUtils
 
     private TypeUtils()
     {
+    }
+
+    public static boolean isNumericType(Type type)
+    {
+        return isNonDecimalNumericType(type) || type instanceof DecimalType;
+    }
+
+    public static boolean isNonDecimalNumericType(Type type)
+    {
+        return isExactNumericType(type) || isApproximateNumericType(type);
+    }
+
+    public static boolean isExactNumericType(Type type)
+    {
+        return type.equals(BIGINT) || type.equals(INTEGER) || type.equals(SMALLINT) || type.equals(TINYINT);
+    }
+
+    public static boolean isApproximateNumericType(Type type)
+    {
+        return type.equals(DOUBLE) || type.equals(REAL);
     }
 
     /**

--- a/presto-docs/src/main/sphinx/functions/aggregate.rst
+++ b/presto-docs/src/main/sphinx/functions/aggregate.rst
@@ -193,6 +193,11 @@ Map Aggregate Functions
    Returns the union of all the input maps. If a key is found in multiple
    input maps, that key's value in the resulting map comes from an arbitrary input map.
 
+.. function:: map_union_sum(x(K,V)) -> map(K,V)
+
+      Returns the union of all the input maps summing the values of matching keys in all
+      the maps. All null values in the original maps are coalesced to 0.
+
 .. function:: multimap_agg(key, value) -> map(K,array(V))
 
     Returns a multimap created from the input ``key`` / ``value`` pairs.

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/MetastoreUtil.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/MetastoreUtil.java
@@ -82,17 +82,12 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
-import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.common.type.Chars.isCharType;
 import static com.facebook.presto.common.type.Chars.padSpaces;
 import static com.facebook.presto.common.type.DateType.DATE;
-import static com.facebook.presto.common.type.DoubleType.DOUBLE;
-import static com.facebook.presto.common.type.IntegerType.INTEGER;
-import static com.facebook.presto.common.type.RealType.REAL;
-import static com.facebook.presto.common.type.SmallintType.SMALLINT;
 import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
-import static com.facebook.presto.common.type.TinyintType.TINYINT;
+import static com.facebook.presto.common.type.TypeUtils.isNumericType;
 import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.common.type.Varchars.isVarcharType;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_FILESYSTEM_ERROR;
@@ -759,13 +754,6 @@ public class MetastoreUtil
             return nonNullsCount;
         }
         return distinctValuesCount;
-    }
-
-    public static boolean isNumericType(Type type)
-    {
-        return type.equals(BIGINT) || type.equals(INTEGER) || type.equals(SMALLINT) || type.equals(TINYINT) ||
-                type.equals(DOUBLE) || type.equals(REAL) ||
-                type instanceof DecimalType;
     }
 
     public static Set<ColumnStatisticType> getSupportedColumnStatistics(Type type)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -149,6 +149,7 @@ import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.common.type.Chars.isCharType;
 import static com.facebook.presto.common.type.DateType.DATE;
 import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.common.type.TypeUtils.isNumericType;
 import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.common.type.VarcharType.createUnboundedVarcharType;
@@ -267,7 +268,6 @@ import static com.facebook.presto.hive.metastore.MetastoreUtil.PRESTO_QUERY_ID_N
 import static com.facebook.presto.hive.metastore.MetastoreUtil.PRESTO_VIEW_FLAG;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.getHiveSchema;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.getProtectMode;
-import static com.facebook.presto.hive.metastore.MetastoreUtil.isNumericType;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.toPartitionValues;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.verifyOnline;
 import static com.facebook.presto.hive.metastore.PrestoTableType.EXTERNAL_TABLE;

--- a/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
@@ -288,6 +288,7 @@ import static com.facebook.presto.operator.aggregation.DecimalAverageAggregation
 import static com.facebook.presto.operator.aggregation.DecimalSumAggregation.DECIMAL_SUM_AGGREGATION;
 import static com.facebook.presto.operator.aggregation.MapAggregationFunction.MAP_AGG;
 import static com.facebook.presto.operator.aggregation.MapUnionAggregation.MAP_UNION;
+import static com.facebook.presto.operator.aggregation.MapUnionSumAggregation.MAP_UNION_SUM;
 import static com.facebook.presto.operator.aggregation.MaxAggregationFunction.MAX_AGGREGATION;
 import static com.facebook.presto.operator.aggregation.MaxNAggregationFunction.MAX_N_AGGREGATION;
 import static com.facebook.presto.operator.aggregation.MinAggregationFunction.MIN_AGGREGATION;
@@ -781,7 +782,7 @@ public class BuiltInTypeAndFunctionNamespaceManager
                 .function(new ArrayAggregationFunction(featuresConfig.isLegacyArrayAgg(), featuresConfig.getArrayAggGroupImplementation()))
                 .functions(new MapSubscriptOperator(featuresConfig.isLegacyMapSubscript()))
                 .functions(MAP_CONSTRUCTOR, MAP_TO_JSON, JSON_TO_MAP, JSON_STRING_TO_MAP)
-                .functions(MAP_AGG, MAP_UNION)
+                .functions(MAP_AGG, MAP_UNION, MAP_UNION_SUM)
                 .function(REDUCE_AGG)
                 .function(new MultimapAggregationFunction(featuresConfig.getMultimapAggGroupImplementation()))
                 .functions(DECIMAL_TO_VARCHAR_CAST, DECIMAL_TO_INTEGER_CAST, DECIMAL_TO_BIGINT_CAST, DECIMAL_TO_DOUBLE_CAST, DECIMAL_TO_REAL_CAST, DECIMAL_TO_BOOLEAN_CAST, DECIMAL_TO_TINYINT_CAST, DECIMAL_TO_SMALLINT_CAST)

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/Adder.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/Adder.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.Type;
+
+public interface Adder
+{
+    // Sum the two non-null values - value1[position1] and value2[position2] and write the result to the blockBuilder
+    void writeSum(Type type, Block block1, int position1, Block block2, int position2, BlockBuilder blockBuilder);
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/MapUnionSumAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/MapUnionSumAggregation.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.bytecode.DynamicClassLoader;
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.MapType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.TypeSignatureParameter;
+import com.facebook.presto.metadata.BoundVariables;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.metadata.SqlAggregationFunction;
+import com.facebook.presto.operator.aggregation.AggregationMetadata.AccumulatorStateDescriptor;
+import com.facebook.presto.operator.aggregation.state.MapUnionSumState;
+import com.facebook.presto.operator.aggregation.state.MapUnionSumStateFactory;
+import com.facebook.presto.operator.aggregation.state.MapUnionSumStateSerializer;
+import com.google.common.collect.ImmutableList;
+
+import java.lang.invoke.MethodHandle;
+import java.util.List;
+
+import static com.facebook.presto.common.type.StandardTypes.MAP;
+import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata;
+import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.INPUT_CHANNEL;
+import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata.ParameterType.STATE;
+import static com.facebook.presto.operator.aggregation.AggregationUtils.generateAggregationName;
+import static com.facebook.presto.spi.function.Signature.comparableTypeParameter;
+import static com.facebook.presto.spi.function.Signature.nonDecimalNumericTypeParameter;
+import static com.facebook.presto.util.Reflection.methodHandle;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+public class MapUnionSumAggregation
+        extends SqlAggregationFunction
+{
+    public static final String NAME = "map_union_sum";
+    public static final MapUnionSumAggregation MAP_UNION_SUM = new MapUnionSumAggregation();
+
+    private static final MethodHandle INPUT_FUNCTION = methodHandle(MapUnionSumAggregation.class, "input", Type.class, Type.class, MapUnionSumState.class, Block.class);
+    private static final MethodHandle COMBINE_FUNCTION = methodHandle(MapUnionSumAggregation.class, "combine", MapUnionSumState.class, MapUnionSumState.class);
+    private static final MethodHandle OUTPUT_FUNCTION = methodHandle(MapUnionSumAggregation.class, "output", MapUnionSumState.class, BlockBuilder.class);
+
+    public MapUnionSumAggregation()
+    {
+        super(NAME,
+                ImmutableList.of(comparableTypeParameter("K"), nonDecimalNumericTypeParameter("V")),
+                ImmutableList.of(),
+                parseTypeSignature("map<K,V>"),
+                ImmutableList.of(parseTypeSignature("map<K,V>")));
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "Aggregate all the maps into a single map summing the values for matching keys";
+    }
+
+    @Override
+    public InternalAggregationFunction specialize(BoundVariables boundVariables, int arity, FunctionAndTypeManager functionAndTypeManager)
+    {
+        Type keyType = boundVariables.getTypeVariable("K");
+        Type valueType = boundVariables.getTypeVariable("V");
+        MapType outputType = (MapType) functionAndTypeManager.getParameterizedType(MAP, ImmutableList.of(
+                TypeSignatureParameter.of(keyType.getTypeSignature()),
+                TypeSignatureParameter.of(valueType.getTypeSignature())));
+
+        return generateAggregation(keyType, valueType, outputType);
+    }
+
+    private static InternalAggregationFunction generateAggregation(Type keyType, Type valueType, MapType outputType)
+    {
+        DynamicClassLoader classLoader = new DynamicClassLoader(MapUnionSumAggregation.class.getClassLoader());
+        List<Type> inputTypes = ImmutableList.of(outputType);
+        MapUnionSumStateSerializer stateSerializer = new MapUnionSumStateSerializer(outputType);
+        Type intermediateType = stateSerializer.getSerializedType();
+
+        AggregationMetadata metadata = new AggregationMetadata(
+                generateAggregationName(NAME, outputType.getTypeSignature(), inputTypes.stream().map(Type::getTypeSignature).collect(toImmutableList())),
+                createInputParameterMetadata(outputType),
+                INPUT_FUNCTION.bindTo(keyType).bindTo(valueType),
+                COMBINE_FUNCTION,
+                OUTPUT_FUNCTION,
+                ImmutableList.of(new AccumulatorStateDescriptor(
+                        MapUnionSumState.class,
+                        stateSerializer,
+                        new MapUnionSumStateFactory(keyType, valueType))),
+                outputType);
+
+        GenericAccumulatorFactoryBinder factory = AccumulatorCompiler.generateAccumulatorFactoryBinder(metadata, classLoader);
+        return new InternalAggregationFunction(NAME, inputTypes, ImmutableList.of(intermediateType), outputType, true, false, factory);
+    }
+
+    private static List<ParameterMetadata> createInputParameterMetadata(Type inputType)
+    {
+        return ImmutableList.of(
+                new ParameterMetadata(STATE),
+                new ParameterMetadata(INPUT_CHANNEL, inputType));
+    }
+
+    public static void input(Type keyType, Type valueType, MapUnionSumState state, Block mapBlock)
+    {
+        MapUnionSumResult mapUnionSumResult = state.get();
+        long startSize;
+
+        if (mapUnionSumResult == null) {
+            startSize = 0;
+            mapUnionSumResult = MapUnionSumResult.create(keyType, valueType, state.getAdder(), mapBlock);
+            state.set(mapUnionSumResult);
+        }
+        else {
+            startSize = mapUnionSumResult.getRetainedSizeInBytes();
+            state.set(state.get().unionSum(mapBlock));
+        }
+
+        state.addMemoryUsage(mapUnionSumResult.getRetainedSizeInBytes() - startSize);
+    }
+
+    public static void combine(MapUnionSumState state, MapUnionSumState otherState)
+    {
+        if (state.get() == null) {
+            state.set(otherState.get());
+            return;
+        }
+
+        long startSize = state.get().getRetainedSizeInBytes();
+        state.set(state.get().unionSum(otherState.get()));
+        state.addMemoryUsage(state.get().getRetainedSizeInBytes() - startSize);
+    }
+
+    public static void output(MapUnionSumState state, BlockBuilder out)
+    {
+        MapUnionSumResult mapUnionSumResult = state.get();
+        if (mapUnionSumResult == null) {
+            out.appendNull();
+        }
+        else {
+            mapUnionSumResult.serialize(out);
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/MapUnionSumResult.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/MapUnionSumResult.java
@@ -1,0 +1,321 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.Type;
+import org.openjdk.jol.info.ClassLayout;
+
+import static com.facebook.presto.common.type.TypeUtils.isExactNumericType;
+import static com.facebook.presto.type.TypeUtils.expectedValueSize;
+import static com.google.common.base.Preconditions.checkState;
+import static java.lang.Math.max;
+import static java.util.Objects.requireNonNull;
+
+public abstract class MapUnionSumResult
+{
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(MapUnionSumResult.class).instanceSize();
+    private static final int EXPECTED_ENTRIES = 10;
+    private static final int EXPECTED_ENTRY_SIZE = 16;
+
+    protected final Type keyType;
+    protected final Type valueType;
+    protected final Adder adder;
+
+    public MapUnionSumResult(Type keyType, Type valueType, Adder adder)
+    {
+        this.keyType = requireNonNull(keyType, "keyType is null");
+        this.valueType = requireNonNull(valueType, "valueType is null");
+        this.adder = adder;
+    }
+
+    abstract int size();
+    abstract void addKey(int i, BlockBuilder out);
+    abstract void appendValue(int i, BlockBuilder blockBuilder);
+    abstract boolean isValueNull(int i);
+    public abstract long getRetainedSizeInBytes();
+    abstract void addKeyToSet(TypedSet keySet, int i);
+    abstract int getPosition(TypedSet otherKeySet, int keyPosition);
+    abstract TypedSet getKeySet();
+    abstract Block getValueBlock();
+    abstract int getValueBlockIndex(int i);
+
+    public static MapUnionSumResult create(Type keyType, Type valueType, Adder adder, Block mapBlock)
+    {
+        return new SingleMapBlock(keyType, valueType, adder, mapBlock);
+    }
+
+    public Type getKeyType()
+    {
+        return keyType;
+    }
+
+    public void serialize(BlockBuilder out)
+    {
+        BlockBuilder mapBlockBuilder = out.beginBlockEntry();
+        for (int i = 0; i < size(); i++) {
+            addKey(i, mapBlockBuilder);
+            appendValue(i, mapBlockBuilder);
+        }
+        out.closeEntry();
+    }
+
+    static void appendValue(Type valueType, Block block, int position, BlockBuilder blockBuilder)
+    {
+        if (block.isNull(position)) {
+            if (isExactNumericType(valueType)) {
+                valueType.writeLong(blockBuilder, 0L);
+            }
+            else {
+                valueType.writeDouble(blockBuilder, 0);
+            }
+        }
+        else {
+            valueType.appendTo(block, position, blockBuilder);
+        }
+    }
+
+    /**
+     * Add the values for corresponding keys from other to this.
+     */
+    public MapUnionSumResult unionSum(MapUnionSumResult other)
+    {
+        if (other instanceof KeySetAndValues &&
+                (this instanceof SingleMapBlock || size() < other.size())) {
+            // We can avoid creating a new set by merging the keys from this into the other one.
+            return other.unionSum(this);
+        }
+
+        TypedSet resultKeySet = getKeySet();
+
+        int size = size();
+        int otherSize = other.size();
+        int[] otherKeyIndex = new int[size];
+        boolean[] toAppend = new boolean[otherSize];
+        boolean[] common = new boolean[size];
+        boolean remaining = false;
+        BlockBuilder resultValueBlockBuilder = valueType.createBlockBuilder(null, max(size(), other.size()), expectedValueSize(valueType, EXPECTED_ENTRY_SIZE));
+        for (int i = 0; i < otherSize; i++) {
+            int position = other.getPosition(resultKeySet, i);
+            if (position >= 0) {
+                otherKeyIndex[position] = i;
+                common[position] = true;
+            }
+            else {
+                toAppend[i] = true;
+                if (!remaining) {
+                    remaining = true;
+                }
+            }
+        }
+
+        for (int i = 0; i < size; i++) {
+            if (common[i]) {
+                if (!isValueNull(i) && !other.isValueNull(otherKeyIndex[i])) {
+                    // common key. So SUM the values from both.
+                    adder.writeSum(
+                            valueType,
+                            getValueBlock(),
+                            getValueBlockIndex(i),
+                            other.getValueBlock(),
+                            other.getValueBlockIndex(otherKeyIndex[i]),
+                            resultValueBlockBuilder);
+                }
+                else if (!isValueNull(i)) {
+                    this.appendValue(i, resultValueBlockBuilder);
+                }
+                else {
+                    other.appendValue(otherKeyIndex[i], resultValueBlockBuilder);
+                }
+            }
+            else {
+                this.appendValue(i, resultValueBlockBuilder);
+            }
+        }
+
+        // Now the remaining entries from other that are not in the current keyset
+        if (remaining) {
+            for (int i = 0; i < otherSize; i++) {
+                if (toAppend[i]) {
+                    other.addKeyToSet(resultKeySet, i);
+                    other.appendValue(i, resultValueBlockBuilder);
+                }
+            }
+        }
+
+        checkState(resultKeySet.size() == resultValueBlockBuilder.getPositionCount());
+        return new KeySetAndValues(keyType, valueType, adder, resultKeySet, resultValueBlockBuilder.build());
+    }
+
+    public MapUnionSumResult unionSum(Block mapBlock)
+    {
+        MapUnionSumResult mapUnionSumResult = new SingleMapBlock(keyType, valueType, adder, mapBlock);
+        return unionSum(mapUnionSumResult);
+    }
+
+    /**
+     * Holds the input map block to avoid unnecessary typeset creation for the first map.
+     */
+    private static class SingleMapBlock
+            extends MapUnionSumResult
+    {
+        private final Block mapBlock;
+
+        public SingleMapBlock(Type keyType, Type valueType, Adder adder, Block mapBlock)
+        {
+            super(keyType, valueType, adder);
+            this.mapBlock = mapBlock;
+        }
+
+        @Override
+        int size()
+        {
+            return mapBlock.getPositionCount() / 2;
+        }
+
+        @Override
+        void addKeyToSet(TypedSet keySet, int i)
+        {
+            keySet.add(mapBlock, 2 * i);
+        }
+        @Override
+        void addKey(int i, BlockBuilder out)
+        {
+            keyType.appendTo(mapBlock, 2 * i, out);
+        }
+
+        @Override
+        void appendValue(int i, BlockBuilder blockBuilder)
+        {
+            appendValue(valueType, mapBlock, 2 * i + 1, blockBuilder);
+        }
+
+        @Override
+        boolean isValueNull(int i)
+        {
+            return mapBlock.isNull(2 * i + 1);
+        }
+
+        @Override
+        public long getRetainedSizeInBytes()
+        {
+            return INSTANCE_SIZE;
+        }
+
+        @Override
+        int getPosition(TypedSet otherKeySet, int keyPosition)
+        {
+            return otherKeySet.positionOf(mapBlock, 2 * keyPosition);
+        }
+
+        TypedSet getKeySet()
+        {
+            TypedSet resultKeySet = new TypedSet(keyType, mapBlock.getPositionCount() / 2, "MAP_UNION_SUM");
+            for (int i = 0; i < mapBlock.getPositionCount(); i += 2) {
+                resultKeySet.add(mapBlock, i);
+            }
+
+            return resultKeySet;
+        }
+
+        @Override
+        Block getValueBlock()
+        {
+            return mapBlock;
+        }
+
+        @Override
+        int getValueBlockIndex(int i)
+        {
+            return 2 * i + 1;
+        }
+    }
+
+    /**
+     * Holds the result of aggregating two or more maps.
+     */
+    private static class KeySetAndValues
+            extends MapUnionSumResult
+    {
+        private final TypedSet keySet;
+        private final Block valueBlock;
+
+        KeySetAndValues(Type keyType, Type valueType, Adder adder, TypedSet keySet, Block valueBlock)
+        {
+            super(keyType, valueType, adder);
+            this.keySet = keySet;
+            this.valueBlock = valueBlock;
+        }
+
+        @Override
+        int size()
+        {
+            return keySet.size();
+        }
+
+        @Override
+        void addKeyToSet(TypedSet keySet, int i)
+        {
+            keySet.add(keySet.getBlockBuilder(), i);
+        }
+
+        @Override
+        void addKey(int i, BlockBuilder out)
+        {
+            keyType.appendTo(keySet.getBlockBuilder(), i, out);
+        }
+
+        @Override
+        void appendValue(int i, BlockBuilder blockBuilder)
+        {
+            appendValue(valueType, valueBlock, i, blockBuilder);
+        }
+
+        @Override
+        boolean isValueNull(int i)
+        {
+            return valueBlock.isNull(i);
+        }
+
+        @Override
+        public long getRetainedSizeInBytes()
+        {
+            return INSTANCE_SIZE + keySet.getRetainedSizeInBytes() + valueBlock.getRetainedSizeInBytes();
+        }
+
+        @Override
+        int getPosition(TypedSet otherKeySet, int keyPosition)
+        {
+            return otherKeySet.positionOf(keySet.getBlockBuilder(), keyPosition);
+        }
+
+        TypedSet getKeySet()
+        {
+            return keySet;
+        }
+
+        @Override
+        Block getValueBlock()
+        {
+            return valueBlock;
+        }
+
+        @Override
+        int getValueBlockIndex(int i)
+        {
+            return i;
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/TypedSet.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/TypedSet.java
@@ -157,6 +157,11 @@ public class TypedSet
         return blockPositionByHash.get(getHashPositionOfElement(block, position));
     }
 
+    public BlockBuilder getBlockBuilder()
+    {
+        return elementBlock;
+    }
+
     /**
      * Get slot position of element at {@code position} of {@code block}
      */

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/MapUnionSumState.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/MapUnionSumState.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.state;
+
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.operator.aggregation.Adder;
+import com.facebook.presto.operator.aggregation.MapUnionSumResult;
+import com.facebook.presto.spi.function.AccumulatorState;
+import com.facebook.presto.spi.function.AccumulatorStateMetadata;
+
+@AccumulatorStateMetadata(stateFactoryClass = MapUnionSumStateFactory.class, stateSerializerClass = MapUnionSumStateSerializer.class)
+public interface MapUnionSumState
+        extends AccumulatorState
+{
+    MapUnionSumResult get();
+
+    void set(MapUnionSumResult value);
+
+    void addMemoryUsage(long memory);
+
+    Type getKeyType();
+
+    Type getValueType();
+
+    Adder getAdder();
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/MapUnionSumStateFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/MapUnionSumStateFactory.java
@@ -1,0 +1,250 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.state;
+
+import com.facebook.presto.array.ObjectBigArray;
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.operator.aggregation.Adder;
+import com.facebook.presto.operator.aggregation.MapUnionSumResult;
+import com.facebook.presto.spi.function.AccumulatorStateFactory;
+import com.facebook.presto.type.BigintOperators;
+import com.facebook.presto.type.DoubleOperators;
+import com.facebook.presto.type.RealOperators;
+import org.openjdk.jol.info.ClassLayout;
+
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.RealType.REAL;
+import static com.facebook.presto.common.type.TypeUtils.isExactNumericType;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+public class MapUnionSumStateFactory
+        implements AccumulatorStateFactory<MapUnionSumState>
+{
+    private final Type keyType;
+    private final Type valueType;
+    private final Adder adder;
+
+    public MapUnionSumStateFactory(Type keyType, Type valueType)
+    {
+        this.keyType = keyType;
+        this.valueType = valueType;
+        this.adder = getAdder(valueType);
+    }
+
+    @Override
+    public MapUnionSumState createSingleState()
+    {
+        return new SingleState(keyType, valueType, adder);
+    }
+
+    @Override
+    public Class<? extends MapUnionSumState> getSingleStateClass()
+    {
+        return SingleState.class;
+    }
+
+    @Override
+    public MapUnionSumState createGroupedState()
+    {
+        return new GroupedState(keyType, valueType, adder);
+    }
+
+    @Override
+    public Class<? extends MapUnionSumState> getGroupedStateClass()
+    {
+        return GroupedState.class;
+    }
+
+    public static class GroupedState
+            extends AbstractGroupedAccumulatorState
+            implements MapUnionSumState
+    {
+        private static final int INSTANCE_SIZE = ClassLayout.parseClass(GroupedState.class).instanceSize();
+        private final Type keyType;
+        private final Type valueType;
+        private final Adder adder;
+        private final ObjectBigArray<MapUnionSumResult> pairs = new ObjectBigArray<>();
+        private long size;
+
+        public GroupedState(Type keyType, Type valueType, Adder adder)
+        {
+            this.keyType = keyType;
+            this.valueType = valueType;
+            this.adder = adder;
+        }
+
+        @Override
+        public void ensureCapacity(long size)
+        {
+            pairs.ensureCapacity(size);
+        }
+
+        @Override
+        public MapUnionSumResult get()
+        {
+            return pairs.get(getGroupId());
+        }
+
+        @Override
+        public void set(MapUnionSumResult value)
+        {
+            requireNonNull(value, "value is null");
+
+            MapUnionSumResult previous = get();
+            if (previous != null) {
+                size -= previous.getRetainedSizeInBytes();
+            }
+
+            pairs.set(getGroupId(), value);
+            size += value.getRetainedSizeInBytes();
+        }
+
+        @Override
+        public void addMemoryUsage(long memory)
+        {
+            size += memory;
+        }
+
+        @Override
+        public Type getKeyType()
+        {
+            return keyType;
+        }
+
+        @Override
+        public Type getValueType()
+        {
+            return valueType;
+        }
+
+        @Override
+        public long getEstimatedSize()
+        {
+            return INSTANCE_SIZE + size + pairs.sizeOf();
+        }
+
+        @Override
+        public Adder getAdder()
+        {
+            return adder;
+        }
+    }
+
+    public static class SingleState
+            implements MapUnionSumState
+    {
+        private static final int INSTANCE_SIZE = ClassLayout.parseClass(SingleState.class).instanceSize();
+        private final Type keyType;
+        private final Type valueType;
+        private final Adder adder;
+        private MapUnionSumResult pair;
+
+        public SingleState(Type keyType, Type valueType, Adder adder)
+        {
+            this.keyType = keyType;
+            this.valueType = valueType;
+            this.adder = adder;
+        }
+
+        @Override
+        public MapUnionSumResult get()
+        {
+            return pair;
+        }
+
+        @Override
+        public void set(MapUnionSumResult value)
+        {
+            pair = value;
+        }
+
+        @Override
+        public void addMemoryUsage(long memory)
+        {
+        }
+
+        @Override
+        public Type getKeyType()
+        {
+            return keyType;
+        }
+
+        @Override
+        public Type getValueType()
+        {
+            return valueType;
+        }
+
+        @Override
+        public long getEstimatedSize()
+        {
+            long estimatedSize = INSTANCE_SIZE;
+            if (pair != null) {
+                estimatedSize += pair.getRetainedSizeInBytes();
+            }
+            return estimatedSize;
+        }
+
+        @Override
+        public Adder getAdder()
+        {
+            return adder;
+        }
+    }
+
+    private static final Adder LONG_ADDER = new Adder() {
+        @Override
+        public void writeSum(Type type, Block block1, int position1, Block block2, int position2, BlockBuilder blockBuilder)
+        {
+            type.writeLong(blockBuilder, BigintOperators.add(type.getLong(block1, position1), type.getLong(block2, position2)));
+        }
+    };
+
+    private static final Adder DOUBLE_ADDER = new Adder() {
+        @Override
+        public void writeSum(Type type, Block block1, int position1, Block block2, int position2, BlockBuilder blockBuilder)
+        {
+            type.writeDouble(blockBuilder, DoubleOperators.add(type.getDouble(block1, position1), type.getDouble(block2, position2)));
+        }
+    };
+
+    private static final Adder FLOAT_ADDER = new Adder() {
+        @Override
+        public void writeSum(Type type, Block block1, int position1, Block block2, int position2, BlockBuilder blockBuilder)
+        {
+            type.writeLong(blockBuilder, RealOperators.add(type.getLong(block1, position1), type.getLong(block2, position2)));
+        }
+    };
+
+    private static Adder getAdder(Type type)
+    {
+        if (isExactNumericType(type)) {
+            return LONG_ADDER;
+        }
+
+        if (DOUBLE.equals(type)) {
+            return DOUBLE_ADDER;
+        }
+
+        if (REAL.equals(type)) {
+            return FLOAT_ADDER;
+        }
+
+        checkState(false);
+        return null;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/MapUnionSumStateSerializer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/MapUnionSumStateSerializer.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.state;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.MapType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.operator.aggregation.MapUnionSumResult;
+import com.facebook.presto.spi.function.AccumulatorStateSerializer;
+
+public class MapUnionSumStateSerializer
+        implements AccumulatorStateSerializer<MapUnionSumState>
+{
+    private final MapType mapType;
+
+    public MapUnionSumStateSerializer(MapType mapType)
+    {
+        this.mapType = mapType;
+    }
+
+    @Override
+    public Type getSerializedType()
+    {
+        return mapType;
+    }
+
+    @Override
+    public void serialize(MapUnionSumState state, BlockBuilder out)
+    {
+        if (state.get() == null) {
+            out.appendNull();
+        }
+        else {
+            state.get().serialize(out);
+        }
+    }
+
+    @Override
+    public void deserialize(Block block, int index, MapUnionSumState state)
+    {
+        MapUnionSumResult mapUnionSumResult = MapUnionSumResult.create(state.getKeyType(), state.getValueType(), state.getAdder(), mapType.getObject(block, index));
+        state.set(mapUnionSumResult);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/annotations/FunctionsParserHelper.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/annotations/FunctionsParserHelper.java
@@ -109,13 +109,13 @@ public class FunctionsParserHelper
         for (TypeParameter typeParameter : typeParameters) {
             String name = typeParameter.value();
             if (orderableRequired.contains(name)) {
-                typeVariableConstraints.add(new TypeVariableConstraint(name, false, true, null, typeParameter.boundedBy()));
+                typeVariableConstraints.add(new TypeVariableConstraint(name, false, true, null, false, typeParameter.boundedBy()));
             }
             else if (comparableRequired.contains(name)) {
-                typeVariableConstraints.add(new TypeVariableConstraint(name, true, false, null, typeParameter.boundedBy()));
+                typeVariableConstraints.add(new TypeVariableConstraint(name, true, false, null, false, typeParameter.boundedBy()));
             }
             else {
-                typeVariableConstraints.add(new TypeVariableConstraint(name, false, false, null, typeParameter.boundedBy()));
+                typeVariableConstraints.add(new TypeVariableConstraint(name, false, false, null, false, typeParameter.boundedBy()));
             }
         }
         return typeVariableConstraints.build();

--- a/presto-main/src/test/java/com/facebook/presto/metadata/TestSignatureBinder.java
+++ b/presto-main/src/test/java/com/facebook/presto/metadata/TestSignatureBinder.java
@@ -428,8 +428,8 @@ public class TestSignatureBinder
                 .returnType(parseTypeSignature("T2"))
                 .argumentTypes(parseTypeSignature("T1"))
                 .typeVariableConstraints(ImmutableList.of(
-                        new TypeVariableConstraint("T1", true, false, "varchar"),
-                        new TypeVariableConstraint("T2", true, false, "varchar")))
+                        new TypeVariableConstraint("T1", true, false, "varchar", false),
+                        new TypeVariableConstraint("T2", true, false, "varchar", false)))
                 .build();
 
         assertThat(function)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/Signature.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/Signature.java
@@ -161,32 +161,37 @@ public final class Signature
      */
     public static TypeVariableConstraint withVariadicBound(String name, String variadicBound)
     {
-        return new TypeVariableConstraint(name, false, false, variadicBound);
+        return new TypeVariableConstraint(name, false, false, variadicBound, false);
     }
 
     public static TypeVariableConstraint comparableWithVariadicBound(String name, String variadicBound)
     {
-        return new TypeVariableConstraint(name, true, false, variadicBound);
+        return new TypeVariableConstraint(name, true, false, variadicBound, false);
     }
 
     public static TypeVariableConstraint typeVariable(String name)
     {
-        return new TypeVariableConstraint(name, false, false, null);
+        return new TypeVariableConstraint(name, false, false, null, false);
     }
 
     public static TypeVariableConstraint comparableTypeParameter(String name)
     {
-        return new TypeVariableConstraint(name, true, false, null);
+        return new TypeVariableConstraint(name, true, false, null, false);
     }
 
     public static TypeVariableConstraint orderableWithVariadicBound(String name, String variadicBound)
     {
-        return new TypeVariableConstraint(name, false, true, variadicBound);
+        return new TypeVariableConstraint(name, false, true, variadicBound, false);
     }
 
     public static TypeVariableConstraint orderableTypeParameter(String name)
     {
-        return new TypeVariableConstraint(name, false, true, null);
+        return new TypeVariableConstraint(name, false, true, null, false);
+    }
+
+    public static TypeVariableConstraint nonDecimalNumericTypeParameter(String name)
+    {
+        return new TypeVariableConstraint(name, false, false, null, true);
     }
 
     public static LongVariableConstraint longVariableExpression(String variable, String expression)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/TypeVariableConstraint.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/TypeVariableConstraint.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.spi.function;
 
 import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.TypeUtils;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -29,6 +30,7 @@ public class TypeVariableConstraint
     private final boolean comparableRequired;
     private final boolean orderableRequired;
     private final String variadicBound;
+    private final boolean nonDecimalNumericRequired;
     private final Class<? extends Type> typeBound;
 
     @JsonCreator
@@ -37,12 +39,14 @@ public class TypeVariableConstraint
             @JsonProperty("comparableRequired") boolean comparableRequired,
             @JsonProperty("orderableRequired") boolean orderableRequired,
             @JsonProperty("variadicBound") @Nullable String variadicBound,
+            @JsonProperty("nonDecimalNumericRequired") boolean nonDecimalNumericRequired,
             @JsonProperty("boundedBy") Class<? extends Type> typeBound)
     {
         this.name = name;
         this.comparableRequired = comparableRequired;
         this.orderableRequired = orderableRequired;
         this.variadicBound = variadicBound;
+        this.nonDecimalNumericRequired = nonDecimalNumericRequired;
         this.typeBound = typeBound;
     }
 
@@ -50,9 +54,10 @@ public class TypeVariableConstraint
             @JsonProperty("name") String name,
             @JsonProperty("comparableRequired") boolean comparableRequired,
             @JsonProperty("orderableRequired") boolean orderableRequired,
-            @JsonProperty("variadicBound") @Nullable String variadicBound)
+            @JsonProperty("variadicBound") @Nullable String variadicBound,
+            @JsonProperty("nonDecimalNumericRequired") boolean nonDecimalNumericRequired)
     {
-        this(name, comparableRequired, orderableRequired, variadicBound, Type.class);
+        this(name, comparableRequired, orderableRequired, variadicBound, nonDecimalNumericRequired, Type.class);
     }
 
     @JsonProperty
@@ -80,6 +85,12 @@ public class TypeVariableConstraint
     }
 
     @JsonProperty
+    public boolean isNonDecimalNumericRequired()
+    {
+        return nonDecimalNumericRequired;
+    }
+
+    @JsonProperty
     public Class<? extends Type> getTypeBound()
     {
         return typeBound;
@@ -97,6 +108,9 @@ public class TypeVariableConstraint
             return false;
         }
         if (variadicBound != null && !UNKNOWN.equals(type) && !variadicBound.equals(type.getTypeSignature().getBase())) {
+            return false;
+        }
+        if (nonDecimalNumericRequired && !TypeUtils.isNonDecimalNumericType(type)) {
             return false;
         }
         return true;
@@ -118,6 +132,9 @@ public class TypeVariableConstraint
         if (!typeBound.equals(Type.class)) {
             value += " extends " + typeBound.getSimpleName();
         }
+        if (nonDecimalNumericRequired) {
+            value += ":nonDecimalNumeric";
+        }
         return value;
     }
 
@@ -133,6 +150,7 @@ public class TypeVariableConstraint
         TypeVariableConstraint that = (TypeVariableConstraint) o;
         return comparableRequired == that.comparableRequired &&
                 orderableRequired == that.orderableRequired &&
+                nonDecimalNumericRequired == that.nonDecimalNumericRequired &&
                 Objects.equals(name, that.name) &&
                 Objects.equals(variadicBound, that.variadicBound) &&
                 Objects.equals(typeBound, that.typeBound);
@@ -141,6 +159,6 @@ public class TypeVariableConstraint
     @Override
     public int hashCode()
     {
-        return Objects.hash(name, comparableRequired, orderableRequired, variadicBound, typeBound);
+        return Objects.hash(name, comparableRequired, orderableRequired, variadicBound, nonDecimalNumericRequired, typeBound);
     }
 }


### PR DESCRIPTION
This is a heavily used aggregation that aggregates maps into one by adding values for matching keys. SQL/lambda versions are inefficient. So we implement them natively.

Test plan - Added tests

```
== RELEASE NOTES ==

General Changes
*  :func `map_union_sum`
 
```
