### PR TITLE
Add setter for BlockEncodingSerde in remote function executor

### DIFF
--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/AbstractSqlInvokedFunctionNamespaceManager.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/AbstractSqlInvokedFunctionNamespaceManager.java
@@ -17,6 +17,7 @@ import com.facebook.presto.common.CatalogSchemaName;
 import com.facebook.presto.common.Page;
 import com.facebook.presto.common.QualifiedObjectName;
 import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockEncodingSerde;
 import com.facebook.presto.common.type.ParametricType;
 import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.common.type.TypeSignature;
@@ -133,6 +134,12 @@ public abstract class AbstractSqlInvokedFunctionNamespaceManager
     protected abstract FunctionMetadata fetchFunctionMetadataDirect(SqlFunctionHandle functionHandle);
 
     protected abstract ScalarFunctionImplementation fetchFunctionImplementationDirect(SqlFunctionHandle functionHandle);
+
+    @Override
+    public void setBlockEncodingSerde(BlockEncodingSerde blockEncodingSerde)
+    {
+        sqlFunctionExecutors.setBlockEncodingSerde(blockEncodingSerde);
+    }
 
     @Override
     public final FunctionNamespaceTransactionHandle beginTransaction()

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/execution/SqlFunctionExecutors.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/execution/SqlFunctionExecutors.java
@@ -15,6 +15,7 @@ package com.facebook.presto.functionNamespace.execution;
 
 import com.facebook.presto.common.Page;
 import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockEncodingSerde;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.functionNamespace.execution.thrift.ThriftSqlFunctionExecutor;
 import com.facebook.presto.spi.function.FunctionImplementationType;
@@ -46,6 +47,11 @@ public class SqlFunctionExecutors
     {
         this.supportedLanguages = requireNonNull(supportedLanguages, "supportedLanguages is null");
         this.thriftSqlFunctionExecutor = Optional.ofNullable(thriftSqlFunctionExecutor);
+    }
+
+    public void setBlockEncodingSerde(BlockEncodingSerde blockEncodingSerde)
+    {
+        thriftSqlFunctionExecutor.ifPresent(executor -> executor.setBlockEncodingSerde(blockEncodingSerde));
     }
 
     public Set<Language> getSupportedLanguages()

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/execution/thrift/SimpleAddressThriftSqlFunctionExecutionModule.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/execution/thrift/SimpleAddressThriftSqlFunctionExecutionModule.java
@@ -14,8 +14,6 @@
 package com.facebook.presto.functionNamespace.execution.thrift;
 
 import com.facebook.drift.client.address.SimpleAddressSelectorConfig;
-import com.facebook.presto.common.block.BlockEncodingManager;
-import com.facebook.presto.common.block.BlockEncodingSerde;
 import com.facebook.presto.spi.function.RoutineCharacteristics.Language;
 import com.facebook.presto.thrift.api.udf.ThriftUdfService;
 import com.google.inject.Binder;
@@ -48,8 +46,6 @@ public class SimpleAddressThriftSqlFunctionExecutionModule
             return;
         }
         binder.bind(ThriftSqlFunctionExecutor.class).in(SINGLETON);
-        binder.bind(BlockEncodingManager.class).in(SINGLETON);
-        binder.bind(BlockEncodingSerde.class).to(BlockEncodingManager.class).in(SINGLETON);
 
         driftClientBinder(binder)
                 .bindDriftClient(ThriftUdfService.class)

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/testing/InMemoryFunctionNamespaceManager.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/testing/InMemoryFunctionNamespaceManager.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.functionNamespace.testing;
 
 import com.facebook.presto.common.QualifiedObjectName;
+import com.facebook.presto.common.block.BlockEncodingSerde;
 import com.facebook.presto.common.type.ParametricType;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeSignature;
@@ -55,6 +56,12 @@ public class InMemoryFunctionNamespaceManager
     public InMemoryFunctionNamespaceManager(String catalogName, SqlFunctionExecutors sqlFunctionExecutors, SqlInvokedFunctionNamespaceManagerConfig config)
     {
         super(catalogName, sqlFunctionExecutors, config);
+    }
+
+    @Override
+    public void setBlockEncodingSerde(BlockEncodingSerde blockEncodingSerde)
+    {
+        // Do not need to do anything here since InMemoryFunctionNamespaceManager cannot execute functions
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
@@ -850,6 +850,12 @@ public class BuiltInTypeAndFunctionNamespaceManager
     }
 
     @Override
+    public void setBlockEncodingSerde(BlockEncodingSerde blockEncodingSerde)
+    {
+        // Do not need to do anything here since BlockEncodingSerde is passed in constructor
+    }
+
+    @Override
     public void createFunction(SqlInvokedFunction function, boolean replace)
     {
         throw new PrestoException(GENERIC_USER_ERROR, format("Cannot create function in built-in function namespace: %s", function.getSignature().getName()));

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionAndTypeManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionAndTypeManager.java
@@ -104,6 +104,7 @@ public class FunctionAndTypeManager
         implements FunctionMetadataManager, TypeManager
 {
     private final TransactionManager transactionManager;
+    private final BlockEncodingSerde blockEncodingSerde;
     private final BuiltInTypeAndFunctionNamespaceManager builtInTypeAndFunctionNamespaceManager;
     private final FunctionInvokerProvider functionInvokerProvider;
     private final Map<String, FunctionNamespaceManagerFactory> functionNamespaceManagerFactories = new ConcurrentHashMap<>();
@@ -124,6 +125,7 @@ public class FunctionAndTypeManager
             Set<Type> types)
     {
         this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
+        this.blockEncodingSerde = requireNonNull(blockEncodingSerde, "blockEncodingSerde is null");
         this.builtInTypeAndFunctionNamespaceManager = new BuiltInTypeAndFunctionNamespaceManager(blockEncodingSerde, featuresConfig, types, this);
         this.functionNamespaceManagers.put(DEFAULT_NAMESPACE.getCatalogName(), builtInTypeAndFunctionNamespaceManager);
         this.functionInvokerProvider = new FunctionInvokerProvider(this);
@@ -164,6 +166,7 @@ public class FunctionAndTypeManager
         FunctionNamespaceManagerFactory factory = functionNamespaceManagerFactories.get(functionNamespaceManagerName);
         checkState(factory != null, "No factory for function namespace manager %s", functionNamespaceManagerName);
         FunctionNamespaceManager<?> functionNamespaceManager = factory.create(catalogName, properties);
+        functionNamespaceManager.setBlockEncodingSerde(blockEncodingSerde);
 
         transactionManager.registerFunctionNamespaceManager(catalogName, functionNamespaceManager);
         if (functionNamespaceManagers.putIfAbsent(catalogName, functionNamespaceManager) != null) {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/FunctionNamespaceManager.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/FunctionNamespaceManager.java
@@ -16,6 +16,7 @@ package com.facebook.presto.spi.function;
 import com.facebook.presto.common.Page;
 import com.facebook.presto.common.QualifiedObjectName;
 import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockEncodingSerde;
 import com.facebook.presto.common.type.ParametricType;
 import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.common.type.TypeSignature;
@@ -29,6 +30,11 @@ import java.util.concurrent.CompletableFuture;
 @Experimental
 public interface FunctionNamespaceManager<F extends SqlFunction>
 {
+    /**
+     * BlockEncodingSerde might be needed to serialize/deserialize Presto pages when running external functions.
+     */
+    void setBlockEncodingSerde(BlockEncodingSerde blockEncodingSerde);
+
     /**
      * Start a transaction.
      */


### PR DESCRIPTION
Remote function executor should use the same BlockEncodingSerde as the
main module rather than creating their own because plugins can register
BlockEncoding.

This is a follow up to issues brought up in #15457

Test plan - Travis

```
== NO RELEASE NOTE ==
```
