### PR TITLE
Add release notes for 0.246

### DIFF
--- a/presto-docs/src/main/sphinx/release.rst
+++ b/presto-docs/src/main/sphinx/release.rst
@@ -5,6 +5,7 @@ Release Notes
 .. toctree::
     :maxdepth: 1
 
+    release/release-0.246
     release/release-0.245.1
     release/release-0.245
     release/release-0.244.1

--- a/presto-docs/src/main/sphinx/release/release-0.246.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.246.rst
@@ -1,0 +1,33 @@
+=============
+Release 0.246
+=============
+
+**Details**
+===========
+
+General Changes
+_______________
+* Fix a bug introduced in :pr:`15313` that would cause queries to fail when using upper case in SQL function catalog schema names.
+* Fix a possible integer overflow error when spilling to temporary storage.
+* Fix an issue where prepared statements would allow some non-constant parameters.
+* Fix an error where Presto server can fail to start when using function namespace manager.
+* Add a minimum value of 30 seconds to the configuration property ``query.min-expire-age``.
+* Add listener-based revocation model for spilling strategy ``PER_TASK_MEMORY_THRESHOLD``.
+* Disable spill to disk for join queries where the probe side uses grouped execution and the build does not. Previously these queries would fail with ``GENERIC_INTERNAL_ERRORS``.
+* Disallow ``ORDER BY`` literals used with Window functions as it's not useful, expensive and most often used wrongly.
+* Add support for fragment result caching for queries with local exchange (e.g. intermediate aggregation).
+* Improve queries that have unnecessary limits and order bys.
+  This feature is enabled by default and can be disabled by using the configuration property ``optimizer.skip-redundant-sort`` or session property ``skip_redundant_sort``.
+
+Geospatial Changes
+__________________
+* Upgrade JTS to 1.18.0.
+
+Hive Changes
+____________
+* Fix dynamic pruning failures for joining on null keys in hive partition.
+
+**Contributors**
+================
+
+Andrii Rosa, Ariel Weisberg, Bhavani Hari, Bin Fan, Emy Sun, George Wang, James Gill, James Petty, James Sun, John Roll, Maria Basmanova, Moji Solgi, Nikhil Collooru, Rebecca Schlussel, Rohit Jain, Rongrong Zhong, Saksham Sachdev, Shixuan Fan, Sorin Stoiana, Sreeni Viswanadha, Vic Zhang, Wenlei Xie, Ying Su, Zhenyuan Zhao, fornaix


### PR DESCRIPTION
# Missing Release Notes
## Bhavani Hari
- [x] https://github.com/prestodb/presto/pull/15499 Add release notes for 0.245 (Merged by: Wenlei Xie)

## Emy Sun
- [ ] https://github.com/prestodb/presto/pull/15508 Port reverse(varbinary) from Prestosql to Prestodb (Merged by: Rongrong Zhong)

## George Wang
- [x] https://github.com/prestodb/presto/pull/14915 Avoid planning unnecessary LIMIT/TopN/Sort/DistinctLimit (Merged by: Rebecca Schlussel)
- [x] https://github.com/prestodb/presto/pull/14915 Avoid planning unnecessary LIMIT/TopN/Sort/DistinctLimit (Merged by: Rebecca Schlussel)

## shenh062326
- [x] d2cb24cd4cec630940463d8d8dc25806c774f00d Fix temporary table deletion for exchange materialization

# Extracted Release Notes
- #15322 (Author: Rebecca Schlussel): Only allow constants for prepared statement parameters
  - Fix an issue where prepared statements would allow some non-constant parameters.
- #15322 (Author: Rebecca Schlussel): Only allow constants for prepared statement parameters
  - Fix an issue where prepared statements would allow some non-constant parameters.
- #15470 (Author: George Wang): Ensure nullable partitioning column is handled properly
  - Fix dynamic pruning failures for joining on null keys in hive partition.
- #15485 (Author: Sreeni Viswanadha): Disallow ORDER BY literal in window functions
  - Disallow ORDER BY literals used with Window functions as it's not useful, expensive and most often used wrongly.
- #15501 (Author: Rongrong Zhong): Inject null provider when thrift execution is not needed
  - Fix injection issue when using function namespace manager.
- #15505 (Author: Saksham Sachdev): Add listener model for TaskThresholdMemoryRevokingScheduler
  - Add listener-based revocation model for spilling strategy PER_TASK_MEMORY_THRESHOLD.
- #15529 (Author: Rebecca Schlussel): Split large pages in TempSingleStreamSpiller
  - Fix a possible int overflow error when spilling to temp storage.
- #15550 (Author: Shixuan Fan): Support driver level plan in fragment result caching
  - Support fragment result caching for queries with local exchange (e.g. intermediate aggregation).
- #15550 (Author: Shixuan Fan): Support driver level plan in fragment result caching
  - Support fragment result caching for queries with local exchange (e.g. intermediate aggregation).
- #15555 (Author: Rongrong Zhong): Fix QualifiedObjectName instantiation in FunctionAndTypeManager
  - Fix a bug introduced in :pr:`15313` that would cause queries to fail when using upper case in SQL function catalog schema names.
- #15560 (Author: James Gill): Upgrade JTS to 1.18.0
  - Upgrade JTS to 1.18.0.
- #15585 (Author: Ariel Weisberg): Require min 30s query.min-expire-age
  - Add 30 second minimum to `query.min-expire-age` configuration parameter.
- #15592 (Author: Rebecca Schlussel): Disable spill for probe only grouped execution
  - Disable spill to disk for join queries where the probe side uses grouped execution and the build does not.  Previously these queries would fail with generic_internal_errors.

# All Commits
- dc00b9ff1df66f932326194b1303e677a5278f04 Disable spill for probe only grouped execution (Rebecca Schlussel)
- 8148cb3f329bca8cc13226e19fac34d25e4a0ecc Dereference SerializedPageReferences in batches (James Petty)
- 7ce6c1f1c80d3b39fce75a756bae47e63745ca96 Avoid unnecessary synchronization in LazyOutputBuffer (James Petty)
- ca9466572da066f29c894d6b2ee5600aeab2dffa Add listener model for TaskThresholdMemoryRevokingScheduler (Saksham Sachdev)
- ca7610b70370dbfa7b4a7cc7df6a03381e50cb36 Require min 30s query.min-expire-age (Ariel Weisberg)
- ab78e27d92221a616133027ef88b3385948ec8b3 Fix SliceDirectSelectiveStreamReader for ARRAY of VARCHAR (Ying Su)
- c3d0a4d762b387ab3c2f576e478a84527c9dc6d8 Fix testSubfieldValue in OrcTester (Ying Su)
- 27fc29b9a7d0b2e8704dfb3a42b00851535d1212 Limit batch read mode to certain conditions for SliceDirectSelectiveStreamReader (Ying Su)
- 70f379dd2b0287cdb4a92de59faadc71813d9a84 Fix SliceDirectSelectiveStreamReader for dataLength is 0 (Ying Su)
- 18cbfa78167df5d9e18172886d452a3bda4feda1 Extract assertBlockEquals() in OrcTester (Ying Su)
- 6f4e4443a21f82e1cd5014f641387dabc1e2623a Upgrade JTS to 1.18.0 (James Gill)
- cebe0c29aa14ce7c84d40c70684c3cc76bc990f9 Store manifest only when they are preferred and file renaming is enabled (Nikhil Collooru)
- aa1fd64545ee5be5bdfd0081a20107dad5b145a7 Track compressed manifest size when file_renaming is enabled (Nikhil Collooru)
- 6a47cf2557087b3d0aff4af154d8f4da53928297 Add containsNumberedFileNames to PartitionUpdate (Nikhil Collooru)
- f538920ae958a51961e0d1b2f134b40445844b5d Fix sorting file names for bucketed splits (Nikhil Collooru)
- effd0ea39af14f737b6b09d96df5f19d8fe66ddc Disallow ORDER BY literal (ordinal) in window functions as this may be a misunderstood feature. (Sreeni Viswanadha)
- 844dbebc2cd417835e4506fac31a7da600cf7e13 Avoid planning unnecessary Sort (George Wang)
- 90cd1d004cf458d397dd50c40bb57cc85ac53be9 Avoid planning unnecessary LIMIT/TopN/Sort/DistinctLimit (George Wang)
- b1846c1bae374a0bc70675166fa1903b2b1ddd83 Support driver level plan in fragment result caching (Shixuan Fan)
- b950aec7a5d4ebc12f56aad0a127f53c3601592c Remove unused method in LocalExecutionPlanner (Shixuan Fan)
- 8a005811dc02be9474c220a47c648a9c173b5e83 Provide more detail in MULTI_CATALOG_WRITE_CONFLICT (Wenlei Xie)
- abdbd68f56011b439f71e5657f56b721620b0ee0 Fix javadoc method reference (James Petty)
- 13be472fd60ef9a4d3a5a0b2620793515404e40a Fix typo in ConcurrentHashMap creation (James Petty)
- f5a5af4b6e9d741e4d893a407b53b3a2ee9bb757 Avoid repeatedly setting memory limits in QueryContext (James Petty)
- 1bb85b03c76ee564685d7dc0b6d32f5ce23b4aaf Fix QualifiedObjectName instantiation in FunctionAndTypeManager (Rongrong Zhong)
- f31b960020d39189c65220a8aa2fc41e5ff40568 Minor fix to Hive temporary table location (Wenlei Xie)
- adc7a640faf6263033fce8ea083ae3799f39ddce Avoid costly resizes of the addresses dynamic array in PagesIndex (Andrii Rosa)
- 9dd4b7766c461c3b717ea6636569733aee6e53be Remove redundant setter in TestHiveClientConfig (Shixuan Fan)
- 8d6ac0ee73f2bbc859f66e667c1b3a8ba99bac0a Reuse decompression buffer between multiple OrcInputStream's (Andrii Rosa)
- 47a39d4d5252da11aabab5bdc43c89d04e15d907 Shrink cached buffers in OrcInputStream (Andrii Rosa)
- 69b12d3bf1290cdc4bea01c6533dcab7999335c5 Improve OrcInputStream memory tracking (Andrii Rosa)
- 839007f9b78b8fc1159ea1c14f4f23ceddd57e54 Upgrade Drift to 1.32 (Andrii Rosa)
- bb3a2b78f97fd97b3ae005d5dbf8f46552309fcf Add PrestoThriftPage (Rongrong Zhong)
- 7561c121a28de44ad632cfbd28b189b04553fb0d Add flag to set cache eviction retries (Bin Fan)
- 7f3e6940da9cf187f30d8c79f5106d7b2c09db44 Improve error handling for spill (Rebecca Schlussel)
- 6d77b0a868647d93e035ca93d160aaab8d60cbc8 Make AbstractTestXQueries classes abstract (Rebecca Schlussel)
- 28f787bcd6b41ba2e2ff4bce4111018b3da2404d Add config to stop installation of disabled connectors (Saksham Sachdev)
- a68b96b06f24496ababb21018d82edd5091ee74b Split large pages in TempSingleStreamSpiller (Rebecca Schlussel)
- ab243b6ce24ac150bac4821c4a11342e89daa88a Refactor JoinBridgeProvider (Rebecca Schlussel)
- a2939dc3afea1d407a9777f027ab3da113d6dd4a Make getExpectedOrdersTableDescription protected (Rohit Jain)
- 382c83dc271617e7a33affb97228d2af5e84c2b4 Revert "Fix temporary table deletion for exchange materialization" (Wenlei Xie)
- cfe964254b14c684beeb6d795975a14842b1b704 Replace Joda-Time libraries with java.time in Presto MongoDB (Sorin Stoiana)
- 772621530a4b67f34f93bdeba9c29c86a4a5c978 Refactor AbstractTestQueryFramework to supply expectedQueryRunner (John Roll)
- 1acb585f0195315fc55dc9c6e83d4405ef06fb30 Release notes for 0.244.1 (Bhavani Hari)
- d2cb24cd4cec630940463d8d8dc25806c774f00d Fix temporary table deletion for exchange materialization (shenh062326)
- 25c03ccad1758ee2a3d0336e73e49874e7f29ede Fix accidental per-instance logger in SerializedPageWriteListener (James Petty)
- a4d7abded6aefddbe3526ad8ee0f01bbc55cb51f Set broadcast memory limit for Presto on Spark (Vic Zhang)
- 3feecf3743ffd8c81c21b08ed89402ca45fe8c05 Fix broadcast memory update in RootAggregatedMemoryContext (Vic Zhang)
- 4d5afceed18cc4f71a1574adafcd506db6e33e83 Support Serialized Presto Page in Thrift UDF service (Rongrong Zhong)
- b49294b10a72654d6bc5a1f44d88979e1fd2f286 Move BlockEncodingManager to presto-common (Rongrong Zhong)
- b3d92fcef735b6cce29ade81a452d5b5ba968dd6 Remove redundant code in EchoFirstInputThriftUdfService (Rongrong Zhong)
- 8bea180fdc31be1f2c31b9e9d2b3b6f83ec47c63 Prefer default parallelism to avoid adding extra local exchange (Andrii Rosa)
- 1eb7024d34b597367a6c4be071a8cbe0e35418bf Support different concurrency settings for table writer (Andrii Rosa)
- b7d1a76eb2d443f65ada17357e169e7bdda6c8be Add reverse function for varbinary (Emy Sun)
- 22efd1acfdf0f1c33aa8e3a3a2a9ead87905b8e8 Deprecating Joda library in Presto Cassandra (Moji Solgi)
- 222b0df79bd9c0dc2799451ddb49c15643d8bfed Inject null provider when thrift execution is not needed (Rongrong Zhong)
- 60f4d6891e28cb78665a4e9f736977b19623bae7 Fix incompatible reflection for modifying static final fields since JDK 12 (fornaix)
- bf7bec4438accdde7bd60ec94845de7a1696be4b handle nulls properly in flatmap reader (Zhenyuan Zhao)
- 9b3690acaf956a4e8f79dc2d6b504078400c9079 Clean up parameters related code (Rebecca Schlussel)
- 457aa86c620f150a0837ddc0cdb456473c991c32 Only allow constants in prepared statement parameters (Rebecca Schlussel)
- 729554d3a5b83909322417703992f8cc5e764497 Fix dynamic pruning for null keys in hive partition (George Wang)
- 6913ec9a25187748dea95f991a139667d876526a Minor fix for memory property removal in Presto verifier (Wenlei Xie)