### PR TITLE
Close Parquet page InputSteam in error cases

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSourceFactory.java
@@ -216,9 +216,10 @@ public class ParquetPageSourceFactory
     {
         AggregatedMemoryContext systemMemoryContext = newSimpleAggregatedMemoryContext();
 
+        FSDataInputStream inputStream = null;
         ParquetDataSource dataSource = null;
         try {
-            FSDataInputStream inputStream = hdfsEnvironment.getFileSystem(user, path, configuration).openFile(path, hiveFileContext);
+            inputStream = hdfsEnvironment.getFileSystem(user, path, configuration).openFile(path, hiveFileContext);
             dataSource = buildHdfsParquetDataSource(inputStream, path, stats);
             ParquetMetadata parquetMetadata = parquetMetadataSource.getParquetMetadata(inputStream, dataSource.getId(), fileSize, hiveFileContext.isCacheable()).getParquetMetadata();
 
@@ -305,8 +306,12 @@ public class ParquetPageSourceFactory
                 if (dataSource != null) {
                     dataSource.close();
                 }
+                else if (inputStream != null) {
+                    inputStream.close();
+                }
             }
-            catch (IOException ignored) {
+            catch (IOException ioException) {
+                e.addSuppressed(ioException);
             }
             if (e instanceof PrestoException) {
                 throw (PrestoException) e;


### PR DESCRIPTION
Close the inputStream in error cases to avoid potential leak in InputStream.

The leak could happen when current thread running openFile() while the query aborted from another thread. In that case, the dataSource is not initialized in current thread and inputStream will not be closed.


Test plan 
```
Create a parquet table and break its schema so that reading the table will throw schema errors.
com.facebook.presto.spi.PrestoException: The column context is declared as type struct .... but the Parquet file declares the column as type optional group context

Add debug counters in PrestoS3InputStream for unclosed inputStream
Start a simple select from the broken parquet table to reproduce/verify the leak.
```


```
== NO RELEASE NOTE ==
```
