### PR TITLE
Use long for {Primitive}BigArray#capacity

### DIFF
--- a/presto-array/src/main/java/com/facebook/presto/array/BooleanBigArray.java
+++ b/presto-array/src/main/java/com/facebook/presto/array/BooleanBigArray.java
@@ -34,7 +34,7 @@ public final class BooleanBigArray
     private final boolean initialValue;
 
     private boolean[][] array;
-    private int capacity;
+    private long capacity;
     private int segments;
 
     /**

--- a/presto-array/src/main/java/com/facebook/presto/array/ByteBigArray.java
+++ b/presto-array/src/main/java/com/facebook/presto/array/ByteBigArray.java
@@ -34,7 +34,7 @@ public final class ByteBigArray
     private final byte initialValue;
 
     private byte[][] array;
-    private int capacity;
+    private long capacity;
     private int segments;
 
     /**

--- a/presto-array/src/main/java/com/facebook/presto/array/DoubleBigArray.java
+++ b/presto-array/src/main/java/com/facebook/presto/array/DoubleBigArray.java
@@ -34,7 +34,7 @@ public final class DoubleBigArray
     private final double initialValue;
 
     private double[][] array;
-    private int capacity;
+    private long capacity;
     private int segments;
 
     /**

--- a/presto-array/src/main/java/com/facebook/presto/array/IntBigArray.java
+++ b/presto-array/src/main/java/com/facebook/presto/array/IntBigArray.java
@@ -34,7 +34,7 @@ public final class IntBigArray
     private final int initialValue;
 
     private int[][] array;
-    private int capacity;
+    private long capacity;
     private int segments;
 
     /**

--- a/presto-array/src/main/java/com/facebook/presto/array/LongBigArray.java
+++ b/presto-array/src/main/java/com/facebook/presto/array/LongBigArray.java
@@ -34,7 +34,7 @@ public final class LongBigArray
     private final long initialValue;
 
     private long[][] array;
-    private int capacity;
+    private long capacity;
     private int segments;
 
     /**

--- a/presto-array/src/main/java/com/facebook/presto/array/ObjectBigArray.java
+++ b/presto-array/src/main/java/com/facebook/presto/array/ObjectBigArray.java
@@ -34,7 +34,7 @@ public final class ObjectBigArray<T>
     private final Object initialValue;
 
     private Object[][] array;
-    private int capacity;
+    private long capacity;
     private int segments;
 
     /**

--- a/presto-array/src/main/java/com/facebook/presto/array/ShortBigArray.java
+++ b/presto-array/src/main/java/com/facebook/presto/array/ShortBigArray.java
@@ -34,7 +34,7 @@ public final class ShortBigArray
     private final short initialValue;
 
     private short[][] array;
-    private int capacity;
+    private long capacity;
     private int segments;
 
     /**


### PR DESCRIPTION
Previous implementations supported accesses by `long` index, but used `int` as the capacity field which could overflow. Overflowing was mostly benign but would cause `#ensureCapacity(long capacity)` to proceed down the slow-path unnecessarily.

```
== NO RELEASE NOTE ==
```
