### PR TITLE
Fix NPE in enum key lookup

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/type/LongEnumType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/LongEnumType.java
@@ -23,7 +23,6 @@ import java.util.Comparator;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
@@ -81,15 +80,15 @@ public class LongEnumType
     public static class LongEnumMap
     {
         private final Map<String, Long> enumMap;
-        private Map<Long, String> flippedEnumMap;
-        private final AtomicBoolean isFlippedEnumComputed = new AtomicBoolean();
+        private final Map<Long, String> flippedEnumMap;
 
         @JsonCreator
         public LongEnumMap(@JsonProperty("enumMap") Map<String, Long> enumMap)
         {
             validateEnumMap(enumMap);
             this.enumMap = normalizeEnumMap(enumMap);
-            this.flippedEnumMap = null;
+            this.flippedEnumMap = this.enumMap.entrySet().stream()
+                    .collect(toMap(Map.Entry::getValue, Map.Entry::getKey));
         }
 
         @JsonProperty
@@ -100,10 +99,6 @@ public class LongEnumType
 
         public Optional<String> getKeyForValue(Long value)
         {
-            if (!isFlippedEnumComputed.getAndSet(true)) {
-                this.flippedEnumMap = this.enumMap.entrySet().stream()
-                        .collect(toMap(Map.Entry::getValue, Map.Entry::getKey));
-            }
             return Optional.ofNullable(flippedEnumMap.get(value));
         }
 

--- a/presto-common/src/main/java/com/facebook/presto/common/type/VarcharEnumType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/VarcharEnumType.java
@@ -22,7 +22,6 @@ import java.util.Comparator;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 import static com.facebook.presto.common.type.TypeUtils.normalizeEnumMap;
@@ -70,15 +69,15 @@ public class VarcharEnumType
     public static class VarcharEnumMap
     {
         private final Map<String, String> enumMap;
-        private Map<String, String> flippedEnumMap;
-        private final AtomicBoolean isFlippedEnumComputed = new AtomicBoolean();
+        private final Map<String, String> flippedEnumMap;
 
         @JsonCreator
         public VarcharEnumMap(@JsonProperty("enumMap") Map<String, String> enumMap)
         {
             validateEnumMap(enumMap);
             this.enumMap = normalizeEnumMap(enumMap);
-            this.flippedEnumMap = null;
+            this.flippedEnumMap = this.enumMap.entrySet().stream()
+                    .collect(toMap(Map.Entry::getValue, Map.Entry::getKey));
         }
 
         @JsonProperty
@@ -89,10 +88,6 @@ public class VarcharEnumType
 
         public Optional<String> getKeyForValue(String value)
         {
-            if (!isFlippedEnumComputed.getAndSet(true)) {
-                this.flippedEnumMap = this.enumMap.entrySet().stream()
-                        .collect(toMap(Map.Entry::getValue, Map.Entry::getKey));
-            }
             return Optional.ofNullable(flippedEnumMap.get(value));
         }
 


### PR DESCRIPTION
There is a race condition in the enum key lookup logic because we set `isFlippedEnumComputed` to `true` before actually setting `this.flippedEnum`. This only reproduces during distributed query execution.

The added tests fail on master and pass on this branch.


```
== RELEASE NOTES ==

General Changes
* Fixed a race condition in enum key lookup which caused queries using the `ENUM_KEY` UDF to crash occasionally with an internal error #15607

```
