### PR TITLE
Make PageTransportErrorException extends PageTransportException

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/PageTransportErrorException.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PageTransportErrorException.java
@@ -13,20 +13,21 @@
  */
 package com.facebook.presto.operator;
 
-import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.PrestoTransportException;
 
 import static com.facebook.presto.spi.StandardErrorCode.PAGE_TRANSPORT_ERROR;
 
 public class PageTransportErrorException
-        extends PrestoException
+        extends PrestoTransportException
 {
-    public PageTransportErrorException(String message)
+    public PageTransportErrorException(HostAddress remoteHost, String message)
     {
-        super(PAGE_TRANSPORT_ERROR, message);
+        super(PAGE_TRANSPORT_ERROR, remoteHost, message);
     }
 
-    public PageTransportErrorException(String message, Throwable cause)
+    public PageTransportErrorException(HostAddress remoteHost, String message, Throwable cause)
     {
-        super(PAGE_TRANSPORT_ERROR, message, cause);
+        super(PAGE_TRANSPORT_ERROR, remoteHost, message, cause);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestPageBufferClient.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestPageBufferClient.java
@@ -411,7 +411,7 @@ public class TestPageBufferClient
     public void testErrorCodes()
     {
         assertEquals(new PageTooLargeException(null).getErrorCode(), PAGE_TOO_LARGE.toErrorCode());
-        assertEquals(new PageTransportErrorException("").getErrorCode(), PAGE_TRANSPORT_ERROR.toErrorCode());
+        assertEquals(new PageTransportErrorException(HostAddress.fromParts("127.0.0.1", 8080), "").getErrorCode(), PAGE_TRANSPORT_ERROR.toErrorCode());
         assertEquals(new PageTransportTimeoutException(HostAddress.fromParts("127.0.0.1", 8080), "", null).getErrorCode(), PAGE_TRANSPORT_TIMEOUT.toErrorCode());
     }
 


### PR DESCRIPTION
This allows coordinator re-categorize the Page transport error into
REMOTE_HOST_GONE by looking at the error host.

It is possible for PageTransportErrorException to caused by worker
restart, such as 503 Service Unavailable.

Test plan - Travis


```
== NO RELEASE NOTE ==
```
