### PR TITLE
Add clientInfo triggered session property rules

### DIFF
--- a/presto-docs/src/main/sphinx/admin/session-property-managers.rst
+++ b/presto-docs/src/main/sphinx/admin/session-property-managers.rst
@@ -46,6 +46,8 @@ Match Rules
 * ``group`` (optional): regex to match against the fully qualified name of the resource group the query is
   routed to.
 
+* ``clientInfo`` (optional): regex to match against the client info text supplied by the client
+
 * ``sessionProperties``: map with string keys and values. Each entry is a system or catalog property name and
   corresponding value. Values must be specified as strings, no matter the actual data type.
 

--- a/presto-main/src/main/java/com/facebook/presto/server/SessionPropertyDefaults.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/SessionPropertyDefaults.java
@@ -116,7 +116,8 @@ public class SessionPropertyDefaults
                 session.getSource(),
                 session.getClientTags(),
                 queryType,
-                resourceGroupId);
+                resourceGroupId,
+                session.getClientInfo());
 
         Map<String, String> systemPropertyOverrides = configurationManager.getSystemSessionProperties(context);
         Map<String, Map<String, String>> catalogPropertyOverrides = configurationManager.getCatalogSessionProperties(context);

--- a/presto-session-property-managers/src/main/java/com/facebook/presto/session/SessionMatchSpec.java
+++ b/presto-session-property-managers/src/main/java/com/facebook/presto/session/SessionMatchSpec.java
@@ -35,6 +35,7 @@ public class SessionMatchSpec
     private final Optional<Pattern> sourceRegex;
     private final Set<String> clientTags;
     private final Optional<String> queryType;
+    private final Optional<Pattern> clientInfoRegex;
     private final Optional<Pattern> resourceGroupRegex;
     private final Map<String, String> sessionProperties;
 
@@ -45,6 +46,7 @@ public class SessionMatchSpec
             @JsonProperty("clientTags") Optional<List<String>> clientTags,
             @JsonProperty("queryType") Optional<String> queryType,
             @JsonProperty("group") Optional<Pattern> resourceGroupRegex,
+            @JsonProperty("clientInfo") Optional<Pattern> clientInfoRegex,
             @JsonProperty("sessionProperties") Map<String, String> sessionProperties)
     {
         this.userRegex = requireNonNull(userRegex, "userRegex is null");
@@ -53,6 +55,7 @@ public class SessionMatchSpec
         this.clientTags = ImmutableSet.copyOf(clientTags.orElse(ImmutableList.of()));
         this.queryType = requireNonNull(queryType, "queryType is null");
         this.resourceGroupRegex = requireNonNull(resourceGroupRegex, "resourceGroupRegex is null");
+        this.clientInfoRegex = requireNonNull(clientInfoRegex, "clientInfoRegex is null");
         requireNonNull(sessionProperties, "sessionProperties is null");
         this.sessionProperties = ImmutableMap.copyOf(sessionProperties);
     }
@@ -75,6 +78,13 @@ public class SessionMatchSpec
         if (queryType.isPresent()) {
             String contextQueryType = context.getQueryType().orElse("");
             if (!queryType.get().equalsIgnoreCase(contextQueryType)) {
+                return ImmutableMap.of();
+            }
+        }
+
+        if (clientInfoRegex.isPresent()) {
+            String clientInfo = context.getClientInfo().orElse("");
+            if (!clientInfoRegex.get().matcher(clientInfo).matches()) {
                 return ImmutableMap.of();
             }
         }
@@ -117,6 +127,12 @@ public class SessionMatchSpec
     public Optional<Pattern> getResourceGroupRegex()
     {
         return resourceGroupRegex;
+    }
+
+    @JsonProperty
+    public Optional<Pattern> getClientInfoRegex()
+    {
+        return clientInfoRegex;
     }
 
     @JsonProperty

--- a/presto-session-property-managers/src/test/java/com/facebook/presto/session/TestFileSessionPropertyManager.java
+++ b/presto-session-property-managers/src/test/java/com/facebook/presto/session/TestFileSessionPropertyManager.java
@@ -42,7 +42,8 @@ public class TestFileSessionPropertyManager
             Optional.of("source"),
             ImmutableSet.of("tag1", "tag2"),
             Optional.of(QueryType.DATA_DEFINITION.toString()),
-            Optional.of(new ResourceGroupId(ImmutableList.of("global", "pipeline", "user_foo", "bar"))));
+            Optional.of(new ResourceGroupId(ImmutableList.of("global", "pipeline", "user_foo", "bar"))),
+            Optional.of("bar"));
 
     @Test
     public void testResourceGroupMatch()
@@ -55,6 +56,7 @@ public class TestFileSessionPropertyManager
                 Optional.empty(),
                 Optional.empty(),
                 Optional.of(Pattern.compile("global.pipeline.user_.*")),
+                Optional.empty(),
                 properties);
 
         assertProperties(properties, spec);
@@ -69,6 +71,7 @@ public class TestFileSessionPropertyManager
                 Optional.empty(),
                 Optional.empty(),
                 Optional.of(ImmutableList.of("tag2")),
+                Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
                 properties);
@@ -86,11 +89,13 @@ public class TestFileSessionPropertyManager
                 Optional.of(ImmutableList.of("tag2")),
                 Optional.empty(),
                 Optional.empty(),
+                Optional.empty(),
                 ImmutableMap.of("PROPERTY1", "VALUE1"));
         SessionMatchSpec spec2 = new SessionMatchSpec(
                 Optional.empty(),
                 Optional.empty(),
                 Optional.of(ImmutableList.of("tag1", "tag2")),
+                Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
                 ImmutableMap.of("PROPERTY1", "VALUE1", "PROPERTY2", "VALUE2"));
@@ -108,9 +113,27 @@ public class TestFileSessionPropertyManager
                 Optional.empty(),
                 Optional.empty(),
                 Optional.of(Pattern.compile("global.interactive.user_.*")),
+                Optional.empty(),
                 ImmutableMap.of("PROPERTY", "VALUE"));
 
         assertProperties(ImmutableMap.of(), spec);
+    }
+
+    @Test
+    public void testClientInfoMatch()
+            throws IOException
+    {
+        ImmutableMap<String, String> properties = ImmutableMap.of("PROPERTY", "VALUE");
+        SessionMatchSpec spec = new SessionMatchSpec(
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.of(Pattern.compile("bar")),
+                properties);
+
+        assertProperties(properties, spec);
     }
 
     private static void assertProperties(Map<String, String> properties, SessionMatchSpec... spec)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/session/SessionConfigurationContext.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/session/SessionConfigurationContext.java
@@ -29,19 +29,22 @@ public final class SessionConfigurationContext
     private final Set<String> clientTags;
     private final Optional<String> queryType;
     private final Optional<ResourceGroupId> resourceGroupId;
+    private final Optional<String> clientInfo;
 
     public SessionConfigurationContext(
             String user,
             Optional<String> source,
             Set<String> clientTags,
             Optional<String> queryType,
-            Optional<ResourceGroupId> resourceGroupId)
+            Optional<ResourceGroupId> resourceGroupId,
+            Optional<String> clientInfo)
     {
         this.user = requireNonNull(user, "user is null");
         this.source = requireNonNull(source, "source is null");
         this.clientTags = unmodifiableSet(new HashSet<>(requireNonNull(clientTags, "clientTags is null")));
         this.queryType = requireNonNull(queryType, "queryType is null");
         this.resourceGroupId = requireNonNull(resourceGroupId, "resourceGroupId");
+        this.clientInfo = requireNonNull(clientInfo, "clientInfo is null");
     }
 
     public String getUser()
@@ -67,5 +70,10 @@ public final class SessionConfigurationContext
     public Optional<ResourceGroupId> getResourceGroupId()
     {
         return resourceGroupId;
+    }
+
+    public Optional<String> getClientInfo()
+    {
+        return clientInfo;
     }
 }


### PR DESCRIPTION
Just letting Travis run it right now

Test plan - Unit tests. Will deploy a custom build with this to make sure it works.

```
== RELEASE NOTES ==

General Changes
* Add support for specifying session properties via regex matching on client info using :doc:`/admin/session-property-managers`
```

depended by https://github.com/facebookexternal/presto-facebook/pull/1392