### PR TITLE
Proactively enforce memory limits in distincting accumulators

### DIFF
--- a/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestSpatialPartitioningInternalAggregation.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestSpatialPartitioningInternalAggregation.java
@@ -24,6 +24,7 @@ import com.facebook.presto.common.block.BlockBuilder;
 import com.facebook.presto.geospatial.KdbTreeUtils;
 import com.facebook.presto.geospatial.Rectangle;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.operator.UpdateMemory;
 import com.facebook.presto.operator.aggregation.Accumulator;
 import com.facebook.presto.operator.aggregation.AccumulatorFactory;
 import com.facebook.presto.operator.aggregation.GroupedAccumulator;
@@ -84,12 +85,12 @@ public class TestSpatialPartitioningInternalAggregation
         AccumulatorFactory accumulatorFactory = function.bind(Ints.asList(0, 1, 2), Optional.empty());
         Page page = new Page(geometryBlock, partitionCountBlock);
 
-        Accumulator accumulator = accumulatorFactory.createAccumulator();
+        Accumulator accumulator = accumulatorFactory.createAccumulator(UpdateMemory.NOOP);
         accumulator.addInput(page);
         String aggregation = (String) BlockAssertions.getOnlyValue(accumulator.getFinalType(), getFinalBlock(accumulator));
         assertEquals(aggregation, expectedValue);
 
-        GroupedAccumulator groupedAggregation = accumulatorFactory.createGroupedAccumulator();
+        GroupedAccumulator groupedAggregation = accumulatorFactory.createGroupedAccumulator(UpdateMemory.NOOP);
         groupedAggregation.addInput(createGroupByIdBlock(0, page.getPositionCount()), page);
         String groupValue = (String) getGroupValue(groupedAggregation, 0);
         assertEquals(groupValue, expectedValue);
@@ -105,7 +106,7 @@ public class TestSpatialPartitioningInternalAggregation
         Page page = new Page(geometryBlock, partitionCountBlock);
 
         AccumulatorFactory accumulatorFactory = function.bind(Ints.asList(0, 1, 2), Optional.empty());
-        Accumulator accumulator = accumulatorFactory.createAccumulator();
+        Accumulator accumulator = accumulatorFactory.createAccumulator(UpdateMemory.NOOP);
         accumulator.addInput(page);
         try {
             getFinalBlock(accumulator);

--- a/presto-main/src/main/java/com/facebook/presto/operator/Aggregator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/Aggregator.java
@@ -28,11 +28,11 @@ class Aggregator
     private final AggregationNode.Step step;
     private final int intermediateChannel;
 
-    Aggregator(AccumulatorFactory accumulatorFactory, AggregationNode.Step step)
+    Aggregator(AccumulatorFactory accumulatorFactory, AggregationNode.Step step, UpdateMemory updateMemory)
     {
         if (step.isInputRaw()) {
             intermediateChannel = -1;
-            aggregation = accumulatorFactory.createAccumulator();
+            aggregation = accumulatorFactory.createAccumulator(updateMemory);
         }
         else {
             checkArgument(accumulatorFactory.getInputChannels().size() == 1, "expected 1 input channel for intermediate aggregation");

--- a/presto-main/src/main/java/com/facebook/presto/operator/HashAggregationOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/HashAggregationOperator.java
@@ -508,7 +508,8 @@ public class HashAggregationOperator
     private Page getGlobalAggregationOutput()
     {
         List<Accumulator> accumulators = accumulatorFactories.stream()
-                .map(AccumulatorFactory::createAccumulator)
+                // No input will be added to the accumulators, it is ok not to specify the memory callback
+                .map(accumulatorFactory -> accumulatorFactory.createAccumulator(UpdateMemory.NOOP))
                 .collect(Collectors.toList());
 
         // global aggregation output page will only be constructed once,

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AccumulatorFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AccumulatorFactory.java
@@ -13,19 +13,21 @@
  */
 package com.facebook.presto.operator.aggregation;
 
+import com.facebook.presto.operator.UpdateMemory;
+
 import java.util.List;
 
 public interface AccumulatorFactory
 {
     List<Integer> getInputChannels();
 
-    Accumulator createAccumulator();
+    Accumulator createAccumulator(UpdateMemory updateMemory);
 
     Accumulator createIntermediateAccumulator();
 
-    GroupedAccumulator createGroupedAccumulator();
+    GroupedAccumulator createGroupedAccumulator(UpdateMemory updateMemory);
 
-    GroupedAccumulator createGroupedIntermediateAccumulator();
+    GroupedAccumulator createGroupedIntermediateAccumulator(UpdateMemory updateMemory);
 
     boolean hasOrderBy();
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/window/AggregateWindowFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/window/AggregateWindowFunction.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.operator.window;
 
 import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.operator.UpdateMemory;
 import com.facebook.presto.operator.aggregation.Accumulator;
 import com.facebook.presto.operator.aggregation.AccumulatorFactory;
 import com.facebook.presto.operator.aggregation.InternalAggregationFunction;
@@ -82,7 +83,10 @@ public class AggregateWindowFunction
     private void resetAccumulator()
     {
         if (currentStart >= 0) {
-            accumulator = accumulatorFactory.createAccumulator();
+            // updateMemory callback is used by distinct and ordering accumulators
+            // since window functions do not support distinct and ordering accumulators
+            // it is ok not to provide the memory reservation callback
+            accumulator = accumulatorFactory.createAccumulator(UpdateMemory.NOOP);
             currentStart = -1;
             currentEnd = -1;
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/BenchmarkArrayAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/BenchmarkArrayAggregation.java
@@ -19,6 +19,7 @@ import com.facebook.presto.common.block.BlockBuilder;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
 import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.operator.UpdateMemory;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slices;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -105,7 +106,7 @@ public class BenchmarkArrayAggregation
 
             InternalAggregationFunction function = functionAndTypeManager.getAggregateFunctionImplementation(
                     functionAndTypeManager.lookupFunction(name, fromTypes(elementType)));
-            accumulator = function.bind(ImmutableList.of(0), Optional.empty()).createAccumulator();
+            accumulator = function.bind(ImmutableList.of(0), Optional.empty()).createAccumulator(UpdateMemory.NOOP);
 
             block = createChannel(ARRAY_SIZE, elementType);
             page = new Page(block);

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/BenchmarkGroupedTypedHistogram.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/BenchmarkGroupedTypedHistogram.java
@@ -18,6 +18,7 @@ import com.facebook.presto.common.block.Block;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.operator.GroupByIdBlock;
+import com.facebook.presto.operator.UpdateMemory;
 import com.facebook.presto.operator.aggregation.groupByAggregations.GroupByAggregationTestUtils;
 import com.facebook.presto.operator.aggregation.histogram.HistogramGroupImplementation;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
@@ -134,7 +135,7 @@ public class BenchmarkGroupedTypedHistogram
             int[] args = GroupByAggregationTestUtils.createArgs(function);
 
             return function.bind(Ints.asList(args), Optional.empty())
-                    .createGroupedAccumulator();
+                    .createGroupedAccumulator(UpdateMemory.NOOP);
         }
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestArrayAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestArrayAggregation.java
@@ -20,6 +20,7 @@ import com.facebook.presto.common.type.SqlDate;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
 import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.operator.UpdateMemory;
 import com.facebook.presto.operator.aggregation.groupByAggregations.AggregationTestInput;
 import com.facebook.presto.operator.aggregation.groupByAggregations.AggregationTestInputBuilder;
 import com.facebook.presto.operator.aggregation.groupByAggregations.AggregationTestOutput;
@@ -136,7 +137,7 @@ public class TestArrayAggregation
     {
         InternalAggregationFunction bigIntAgg = getAggregation(BIGINT);
         GroupedAccumulator groupedAccumulator = bigIntAgg.bind(Ints.asList(new int[] {}), Optional.empty())
-                .createGroupedAccumulator();
+                .createGroupedAccumulator(UpdateMemory.NOOP);
         BlockBuilder blockBuilder = groupedAccumulator.getFinalType().createBlockBuilder(null, 1000);
 
         groupedAccumulator.evaluateFinal(0, blockBuilder);
@@ -218,7 +219,7 @@ public class TestArrayAggregation
         int[] args = GroupByAggregationTestUtils.createArgs(function);
 
         return function.bind(Ints.asList(args), Optional.empty())
-                .createGroupedAccumulator();
+                .createGroupedAccumulator(UpdateMemory.NOOP);
     }
 
     private InternalAggregationFunction getAggregation(Type... arguments)

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDoubleHistogramAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDoubleHistogramAggregation.java
@@ -19,6 +19,7 @@ import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.type.MapType;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
 import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.operator.UpdateMemory;
 import com.facebook.presto.spi.PrestoException;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
@@ -53,15 +54,15 @@ public class TestDoubleHistogramAggregation
     @Test
     public void test()
     {
-        Accumulator singleStep = factory.createAccumulator();
+        Accumulator singleStep = factory.createAccumulator(UpdateMemory.NOOP);
         singleStep.addInput(input);
         Block expected = getFinalBlock(singleStep);
 
-        Accumulator partialStep = factory.createAccumulator();
+        Accumulator partialStep = factory.createAccumulator(UpdateMemory.NOOP);
         partialStep.addInput(input);
         Block partialBlock = getIntermediateBlock(partialStep);
 
-        Accumulator finalStep = factory.createAccumulator();
+        Accumulator finalStep = factory.createAccumulator(UpdateMemory.NOOP);
         finalStep.addIntermediate(partialBlock);
         Block actual = getFinalBlock(finalStep);
 
@@ -71,15 +72,15 @@ public class TestDoubleHistogramAggregation
     @Test
     public void testMerge()
     {
-        Accumulator singleStep = factory.createAccumulator();
+        Accumulator singleStep = factory.createAccumulator(UpdateMemory.NOOP);
         singleStep.addInput(input);
         Block singleStepResult = getFinalBlock(singleStep);
 
-        Accumulator partialStep = factory.createAccumulator();
+        Accumulator partialStep = factory.createAccumulator(UpdateMemory.NOOP);
         partialStep.addInput(input);
         Block intermediate = getIntermediateBlock(partialStep);
 
-        Accumulator finalStep = factory.createAccumulator();
+        Accumulator finalStep = factory.createAccumulator(UpdateMemory.NOOP);
 
         finalStep.addIntermediate(intermediate);
         finalStep.addIntermediate(intermediate);
@@ -93,7 +94,7 @@ public class TestDoubleHistogramAggregation
     @Test
     public void testNull()
     {
-        Accumulator accumulator = factory.createAccumulator();
+        Accumulator accumulator = factory.createAccumulator(UpdateMemory.NOOP);
         Block result = getFinalBlock(accumulator);
 
         assertTrue(result.getPositionCount() == 1);
@@ -103,7 +104,7 @@ public class TestDoubleHistogramAggregation
     @Test(expectedExceptions = PrestoException.class)
     public void testBadNumberOfBuckets()
     {
-        Accumulator singleStep = factory.createAccumulator();
+        Accumulator singleStep = factory.createAccumulator(UpdateMemory.NOOP);
         singleStep.addInput(makeInput(0));
         getFinalBlock(singleStep);
     }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestHistogram.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestHistogram.java
@@ -24,6 +24,7 @@ import com.facebook.presto.common.type.TimeZoneKey;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
 import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.operator.UpdateMemory;
 import com.facebook.presto.operator.aggregation.groupByAggregations.AggregationTestInput;
 import com.facebook.presto.operator.aggregation.groupByAggregations.AggregationTestInputBuilder;
 import com.facebook.presto.operator.aggregation.groupByAggregations.AggregationTestOutput;
@@ -222,7 +223,7 @@ public class TestHistogram
     {
         InternalAggregationFunction function = getInternalDefaultVarCharAggregationn();
         GroupedAccumulator groupedAccumulator = function.bind(Ints.asList(new int[] {}), Optional.empty())
-                .createGroupedAccumulator();
+                .createGroupedAccumulator(UpdateMemory.NOOP);
         BlockBuilder blockBuilder = groupedAccumulator.getFinalType().createBlockBuilder(null, 1000);
 
         groupedAccumulator.evaluateFinal(0, blockBuilder);
@@ -313,7 +314,7 @@ public class TestHistogram
         int[] args = GroupByAggregationTestUtils.createArgs(function);
 
         return function.bind(Ints.asList(args), Optional.empty())
-                .createGroupedAccumulator();
+                .createGroupedAccumulator(UpdateMemory.NOOP);
     }
 
     private void testSharedGroupByWithOverlappingValuesPerGroupRunner(InternalAggregationFunction aggregationFunction)

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestMultimapAggAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestMultimapAggAggregation.java
@@ -21,6 +21,7 @@ import com.facebook.presto.common.type.ArrayType;
 import com.facebook.presto.common.type.RowType;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.operator.UpdateMemory;
 import com.facebook.presto.operator.aggregation.groupByAggregations.AggregationTestInput;
 import com.facebook.presto.operator.aggregation.groupByAggregations.AggregationTestInputBuilder;
 import com.facebook.presto.operator.aggregation.groupByAggregations.AggregationTestOutput;
@@ -166,7 +167,7 @@ public class TestMultimapAggAggregation
     public void testEmptyStateOutputIsNull()
     {
         InternalAggregationFunction aggregationFunction = getInternalAggregationFunction(BIGINT, BIGINT);
-        GroupedAccumulator groupedAccumulator = aggregationFunction.bind(Ints.asList(), Optional.empty()).createGroupedAccumulator();
+        GroupedAccumulator groupedAccumulator = aggregationFunction.bind(Ints.asList(), Optional.empty()).createGroupedAccumulator(UpdateMemory.NOOP);
         BlockBuilder blockBuilder = groupedAccumulator.getFinalType().createBlockBuilder(null, 1);
         groupedAccumulator.evaluateFinal(0, blockBuilder);
         assertTrue(blockBuilder.isNull(0));
@@ -229,6 +230,6 @@ public class TestMultimapAggAggregation
 
     private GroupedAccumulator getGroupedAccumulator(InternalAggregationFunction aggFunction)
     {
-        return aggFunction.bind(Ints.asList(GroupByAggregationTestUtils.createArgs(aggFunction)), Optional.empty()).createGroupedAccumulator();
+        return aggFunction.bind(Ints.asList(GroupByAggregationTestUtils.createArgs(aggFunction)), Optional.empty()).createGroupedAccumulator(UpdateMemory.NOOP);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestRealHistogramAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestRealHistogramAggregation.java
@@ -18,6 +18,7 @@ import com.facebook.presto.common.PageBuilder;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.type.MapType;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.operator.UpdateMemory;
 import com.facebook.presto.spi.PrestoException;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
@@ -54,15 +55,15 @@ public class TestRealHistogramAggregation
     @Test
     public void test()
     {
-        Accumulator singleStep = factory.createAccumulator();
+        Accumulator singleStep = factory.createAccumulator(UpdateMemory.NOOP);
         singleStep.addInput(input);
         Block expected = getFinalBlock(singleStep);
 
-        Accumulator partialStep = factory.createAccumulator();
+        Accumulator partialStep = factory.createAccumulator(UpdateMemory.NOOP);
         partialStep.addInput(input);
         Block partialBlock = getIntermediateBlock(partialStep);
 
-        Accumulator finalStep = factory.createAccumulator();
+        Accumulator finalStep = factory.createAccumulator(UpdateMemory.NOOP);
         finalStep.addIntermediate(partialBlock);
         Block actual = getFinalBlock(finalStep);
 
@@ -72,15 +73,15 @@ public class TestRealHistogramAggregation
     @Test
     public void testMerge()
     {
-        Accumulator singleStep = factory.createAccumulator();
+        Accumulator singleStep = factory.createAccumulator(UpdateMemory.NOOP);
         singleStep.addInput(input);
         Block singleStepResult = getFinalBlock(singleStep);
 
-        Accumulator partialStep = factory.createAccumulator();
+        Accumulator partialStep = factory.createAccumulator(UpdateMemory.NOOP);
         partialStep.addInput(input);
         Block intermediate = getIntermediateBlock(partialStep);
 
-        Accumulator finalStep = factory.createAccumulator();
+        Accumulator finalStep = factory.createAccumulator(UpdateMemory.NOOP);
 
         finalStep.addIntermediate(intermediate);
         finalStep.addIntermediate(intermediate);
@@ -94,7 +95,7 @@ public class TestRealHistogramAggregation
     @Test
     public void testNull()
     {
-        Accumulator accumulator = factory.createAccumulator();
+        Accumulator accumulator = factory.createAccumulator(UpdateMemory.NOOP);
         Block result = getFinalBlock(accumulator);
 
         assertTrue(result.getPositionCount() == 1);
@@ -104,7 +105,7 @@ public class TestRealHistogramAggregation
     @Test(expectedExceptions = PrestoException.class)
     public void testBadNumberOfBuckets()
     {
-        Accumulator singleStep = factory.createAccumulator();
+        Accumulator singleStep = factory.createAccumulator(UpdateMemory.NOOP);
         singleStep.addInput(makeInput(0));
         getFinalBlock(singleStep);
     }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/groupByAggregations/AggregationTestInput.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/groupByAggregations/AggregationTestInput.java
@@ -16,6 +16,7 @@ package com.facebook.presto.operator.aggregation.groupByAggregations;
 
 import com.facebook.presto.common.Page;
 import com.facebook.presto.operator.GroupByIdBlock;
+import com.facebook.presto.operator.UpdateMemory;
 import com.facebook.presto.operator.aggregation.AggregationTestUtils;
 import com.facebook.presto.operator.aggregation.GroupedAccumulator;
 import com.facebook.presto.operator.aggregation.InternalAggregationFunction;
@@ -94,6 +95,6 @@ public class AggregationTestInput
     public GroupedAccumulator createGroupedAccumulator()
     {
         return function.bind(Ints.asList(args), Optional.empty())
-                .createGroupedAccumulator();
+                .createGroupedAccumulator(UpdateMemory.NOOP);
     }
 }

--- a/presto-ml/src/test/java/com/facebook/presto/ml/TestEvaluateClassifierPredictions.java
+++ b/presto-ml/src/test/java/com/facebook/presto/ml/TestEvaluateClassifierPredictions.java
@@ -19,6 +19,7 @@ import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockBuilder;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
 import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.operator.UpdateMemory;
 import com.facebook.presto.operator.aggregation.Accumulator;
 import com.facebook.presto.operator.aggregation.InternalAggregationFunction;
 import com.google.common.base.Splitter;
@@ -45,7 +46,7 @@ public class TestEvaluateClassifierPredictions
         metadata.registerBuiltInFunctions(extractFunctions(new MLPlugin().getFunctions()));
         InternalAggregationFunction aggregation = functionAndTypeManager.getAggregateFunctionImplementation(
                 functionAndTypeManager.lookupFunction("evaluate_classifier_predictions", fromTypes(BIGINT, BIGINT)));
-        Accumulator accumulator = aggregation.bind(ImmutableList.of(0, 1), Optional.empty()).createAccumulator();
+        Accumulator accumulator = aggregation.bind(ImmutableList.of(0, 1), Optional.empty()).createAccumulator(UpdateMemory.NOOP);
         accumulator.addInput(getPage());
         BlockBuilder finalOut = accumulator.getFinalType().createBlockBuilder(null, 1);
         accumulator.evaluateFinal(finalOut);

--- a/presto-ml/src/test/java/com/facebook/presto/ml/TestLearnAggregations.java
+++ b/presto-ml/src/test/java/com/facebook/presto/ml/TestLearnAggregations.java
@@ -27,6 +27,7 @@ import com.facebook.presto.ml.type.ClassifierParametricType;
 import com.facebook.presto.ml.type.ClassifierType;
 import com.facebook.presto.ml.type.ModelType;
 import com.facebook.presto.ml.type.RegressorType;
+import com.facebook.presto.operator.UpdateMemory;
 import com.facebook.presto.operator.aggregation.Accumulator;
 import com.facebook.presto.operator.aggregation.AggregationFromAnnotationsParser;
 import com.facebook.presto.operator.aggregation.InternalAggregationFunction;
@@ -62,7 +63,7 @@ public class TestLearnAggregations
     {
         Type mapType = functionAndTypeManager.getParameterizedType("map", ImmutableList.of(TypeSignatureParameter.of(parseTypeSignature(StandardTypes.BIGINT)), TypeSignatureParameter.of(parseTypeSignature(StandardTypes.DOUBLE))));
         InternalAggregationFunction aggregation = generateInternalAggregationFunction(LearnClassifierAggregation.class, ClassifierType.BIGINT_CLASSIFIER.getTypeSignature(), ImmutableList.of(BIGINT.getTypeSignature(), mapType.getTypeSignature()), functionAndTypeManager);
-        assertLearnClassifer(aggregation.bind(ImmutableList.of(0, 1), Optional.empty()).createAccumulator());
+        assertLearnClassifer(aggregation.bind(ImmutableList.of(0, 1), Optional.empty()).createAccumulator(UpdateMemory.NOOP));
     }
 
     @Test
@@ -74,7 +75,7 @@ public class TestLearnAggregations
                 ClassifierType.BIGINT_CLASSIFIER.getTypeSignature(),
                 ImmutableList.of(BIGINT.getTypeSignature(), mapType.getTypeSignature(), VarcharType.getParametrizedVarcharSignature("x"))
         ).specialize(BoundVariables.builder().setLongVariable("x", (long) Integer.MAX_VALUE).build(), 3, functionAndTypeManager);
-        assertLearnClassifer(aggregation.bind(ImmutableList.of(0, 1, 2), Optional.empty()).createAccumulator());
+        assertLearnClassifer(aggregation.bind(ImmutableList.of(0, 1, 2), Optional.empty()).createAccumulator(UpdateMemory.NOOP));
     }
 
     private static void assertLearnClassifer(Accumulator accumulator)


### PR DESCRIPTION
GroupByHash allows to specify a memory accounting callback to enforce memory limits before the
hash table expansion happens.

Unfortunately distincting accumulators weren't providing a callback, so the memory limits for
distincting accumulators were enforced post factum, triggering out of memory errors on memory
constrained environments.

This patch provides a callback, so the task memory limit can be enforced.

This patch doesn't implement yield semantics for accumulators, thus the distincting accumulators
will not wait for the memory to become available in the pool. Although it is not ideal, it is
an improvement over the previous version, as at least the task memory limits will be enforced
proactively.

Test plan:

travis + verifier

```
== NO RELEASE NOTE ==
```
