### PR TITLE
Instrument the Orc ReadType

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/HdfsOrcDataSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/HdfsOrcDataSource.java
@@ -57,7 +57,7 @@ public class HdfsOrcDataSource
     }
 
     @Override
-    protected void readInternal(long position, byte[] buffer, int bufferOffset, int bufferLength)
+    protected void readInternal(long position, byte[] buffer, int bufferOffset, int bufferLength, ReadType type)
     {
         try {
             long readStart = System.nanoTime();

--- a/presto-orc/src/main/java/com/facebook/presto/orc/CachingStripeMetadataSource.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/CachingStripeMetadataSource.java
@@ -65,11 +65,11 @@ public class CachingStripeMetadataSource
     }
 
     @Override
-    public Map<StreamId, OrcDataSourceInput> getInputs(OrcDataSource orcDataSource, StripeId stripeId, Map<StreamId, DiskRange> diskRanges, boolean cacheable)
+    public Map<StreamId, OrcDataSourceInput> getInputs(OrcDataSource orcDataSource, StripeId stripeId, Map<StreamId, DiskRange> diskRanges, boolean cacheable, OrcDataSource.ReadType readType)
             throws IOException
     {
         if (!cacheable) {
-            return delegate.getInputs(orcDataSource, stripeId, diskRanges, cacheable);
+            return delegate.getInputs(orcDataSource, stripeId, diskRanges, cacheable, readType);
         }
 
         // Fetch existing stream slice from cache
@@ -91,7 +91,7 @@ public class CachingStripeMetadataSource
         }
 
         // read ranges and update cache
-        Map<StreamId, OrcDataSourceInput> uncachedInputs = delegate.getInputs(orcDataSource, stripeId, uncachedDiskRangesBuilder.build(), cacheable);
+        Map<StreamId, OrcDataSourceInput> uncachedInputs = delegate.getInputs(orcDataSource, stripeId, uncachedDiskRangesBuilder.build(), cacheable, readType);
         for (Entry<StreamId, OrcDataSourceInput> entry : uncachedInputs.entrySet()) {
             if (isCachedStream(entry.getKey().getStreamKind())) {
                 // We need to rewind the input after eagerly reading the slice.

--- a/presto-orc/src/main/java/com/facebook/presto/orc/FileOrcDataSource.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/FileOrcDataSource.java
@@ -40,7 +40,7 @@ public class FileOrcDataSource
     }
 
     @Override
-    protected void readInternal(long position, byte[] buffer, int bufferOffset, int bufferLength)
+    protected void readInternal(long position, byte[] buffer, int bufferOffset, int bufferLength, ReadType type)
             throws IOException
     {
         input.seek(position);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcDataSource.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcDataSource.java
@@ -20,6 +20,14 @@ import java.util.Map;
 public interface OrcDataSource
         extends Closeable
 {
+    enum ReadType{
+        Header,
+        Stream,
+        StripeFooter,
+        FileFooter,
+        Tail
+    };
+
     OrcDataSourceId getId();
 
     long getReadBytes();
@@ -28,13 +36,15 @@ public interface OrcDataSource
 
     long getSize();
 
-    void readFully(long position, byte[] buffer)
+    int getReadCount();
+
+    void readFully(long position, byte[] buffer, ReadType readType)
             throws IOException;
 
-    void readFully(long position, byte[] buffer, int bufferOffset, int bufferLength)
+    void readFully(long position, byte[] buffer, int bufferOffset, int bufferLength, ReadType readType)
             throws IOException;
 
-    <K> Map<K, OrcDataSourceInput> readFully(Map<K, DiskRange> diskRanges)
+    <K> Map<K, OrcDataSourceInput> readFully(Map<K, DiskRange> diskRanges, ReadType readType)
             throws IOException;
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcReader.java
@@ -185,7 +185,7 @@ public class OrcReader
             writeValidation.get().validateStripeStatistics(orcDataSource.getId(), footer.getStripes(), metadata.getStripeStatsList());
         }
 
-        this.cacheable = requireNonNull(cacheable, "hiveFileContext is null");
+        this.cacheable = cacheable;
     }
 
     @VisibleForTesting

--- a/presto-orc/src/main/java/com/facebook/presto/orc/StorageStripeMetadataSource.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/StorageStripeMetadataSource.java
@@ -29,12 +29,12 @@ public class StorageStripeMetadataSource
             throws IOException
     {
         byte[] tailBuffer = new byte[footerLength];
-        orcDataSource.readFully(footerOffset, tailBuffer);
+        orcDataSource.readFully(footerOffset, tailBuffer, OrcDataSource.ReadType.StripeFooter);
         return Slices.wrappedBuffer(tailBuffer);
     }
 
     @Override
-    public Map<StreamId, OrcDataSourceInput> getInputs(OrcDataSource orcDataSource, StripeId stripeId, Map<StreamId, DiskRange> diskRanges, boolean cacheable)
+    public Map<StreamId, OrcDataSourceInput> getInputs(OrcDataSource orcDataSource, StripeId stripeId, Map<StreamId, DiskRange> diskRanges, boolean cacheable, OrcDataSource.ReadType readType)
             throws IOException
     {
         //
@@ -50,6 +50,6 @@ public class StorageStripeMetadataSource
         diskRanges = diskRangesBuilder.build();
 
         // read ranges
-        return orcDataSource.readFully(diskRanges);
+        return orcDataSource.readFully(diskRanges, readType);
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/StripeMetadataSource.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/StripeMetadataSource.java
@@ -28,6 +28,7 @@ public interface StripeMetadataSource
             OrcDataSource orcDataSource,
             StripeId stripeId,
             Map<StreamId, DiskRange> diskRanges,
-            boolean cacheable)
+            boolean cacheable,
+            OrcDataSource.ReadType readType)
             throws IOException;
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/cache/StorageOrcFileTailSource.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/cache/StorageOrcFileTailSource.java
@@ -56,7 +56,7 @@ public class StorageOrcFileTailSource
 
         // Read the tail of the file
         byte[] buffer = new byte[toIntExact(min(size, EXPECTED_FOOTER_SIZE))];
-        orcDataSource.readFully(size - buffer.length, buffer);
+        orcDataSource.readFully(size - buffer.length, buffer, OrcDataSource.ReadType.Tail);
 
         // get length of PostScript - last byte of the file
         int postScriptSize = buffer[buffer.length - SIZE_OF_BYTE] & 0xff;
@@ -101,7 +101,7 @@ public class StorageOrcFileTailSource
             completeFooterSlice = Slices.wrappedBuffer(newBuffer);
 
             // initial read was not large enough, so read missing section
-            orcDataSource.readFully(size - completeFooterSize, newBuffer, 0, completeFooterSize - buffer.length);
+            orcDataSource.readFully(size - completeFooterSize, newBuffer, 0, completeFooterSize - buffer.length, OrcDataSource.ReadType.FileFooter);
 
             // copy already read bytes into the new buffer
             completeFooterSlice.setBytes(completeFooterSize - buffer.length, buffer);
@@ -124,7 +124,7 @@ public class StorageOrcFileTailSource
             throws IOException
     {
         byte[] headerMagic = new byte[MAGIC.length()];
-        source.readFully(0, headerMagic);
+        source.readFully(0, headerMagic, OrcDataSource.ReadType.Header);
 
         return MAGIC.equals(Slices.wrappedBuffer(headerMagic));
     }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestListFilter.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestListFilter.java
@@ -251,17 +251,23 @@ public class TestListFilter
         }
 
         @Override
-        public void readFully(long position, byte[] buffer)
+        public final int getReadCount()
+        {
+            return 0;
+        }
+
+        @Override
+        public void readFully(long position, byte[] buffer, ReadType readType)
         {
         }
 
         @Override
-        public void readFully(long position, byte[] buffer, int bufferOffset, int bufferLength)
+        public void readFully(long position, byte[] buffer, int bufferOffset, int bufferLength, ReadType readType)
         {
         }
 
         @Override
-        public <K> Map<K, OrcDataSourceInput> readFully(Map<K, DiskRange> diskRanges)
+        public <K> Map<K, OrcDataSourceInput> readFully(Map<K, DiskRange> diskRanges, ReadType readType)
         {
             return null;
         }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcLz4.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcLz4.java
@@ -113,7 +113,7 @@ public class TestOrcLz4
         }
 
         @Override
-        protected void readInternal(long position, byte[] buffer, int bufferOffset, int bufferLength)
+        protected void readInternal(long position, byte[] buffer, int bufferOffset, int bufferLength, ReadType type)
         {
             System.arraycopy(data, toIntExact(position), buffer, bufferOffset, bufferLength);
         }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcWriter.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcWriter.java
@@ -124,7 +124,7 @@ public class TestOrcWriter
             for (StripeInformation stripe : footer.getStripes()) {
                 // read the footer
                 byte[] tailBuffer = new byte[toIntExact(stripe.getFooterLength())];
-                orcDataSource.readFully(stripe.getOffset() + stripe.getIndexLength() + stripe.getDataLength(), tailBuffer);
+                orcDataSource.readFully(stripe.getOffset() + stripe.getIndexLength() + stripe.getDataLength(), tailBuffer, OrcDataSource.ReadType.StripeFooter);
                 try (InputStream inputStream = new OrcInputStream(
                         orcDataSource.getId(),
                         new SharedBuffer(NOOP_ORC_LOCAL_MEMORY_CONTEXT),

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/filesystem/HdfsOrcDataSource.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/filesystem/HdfsOrcDataSource.java
@@ -51,7 +51,7 @@ public class HdfsOrcDataSource
     }
 
     @Override
-    protected void readInternal(long position, byte[] buffer, int bufferOffset, int bufferLength)
+    protected void readInternal(long position, byte[] buffer, int bufferOffset, int bufferLength, ReadType type)
     {
         try {
             inputStream.readFully(position, buffer, bufferOffset, bufferLength);


### PR DESCRIPTION
OrcReader issues Read to the storage for several reasons.

1. Reading the tail (PostScript + FileFooter)
2. Reading the FileFooter (if Tail did not completely fetch the FileFooter)
3. Reading the StripeFooter.
4. Reading the Stripe Streams.
5. Reading the header if the file failed to parse.

We want to collect metrics on how much each IO is issued for each type and
optimize the IO parameters for our use case.

Also OrcDataSource now contains total IO issued (readCount)
in addition to the readBytes and readTimeNanos.

For my use case, I plan to implement the derived class of OrcDataSource and capture
this metric and Ultimately I want to reduce the number of IOs and increase the size
of each IO.


Test plan - (Please fill in how you tested your changes)
I added tests in the TestCachingOrcDataSource, but other than than this change
is just plumbing the readType from the source of the read to the OrcDataSource.
This change is not very useful by itself, but a custom implementation of OrcDataSource now can extract more metrics.

we plan to use this change in our deployment to tune the IO Sizes (Tail, Stream and other parameters).


Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines. Don't forget to follow our [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution) for any code copied from other projects.

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== RELEASE NOTES ==

General Changes
* Instrument the OrcDataSource readType.
```

