### PR TITLE
Add coordinator REST endpoint for TaskInfo

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/StageInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/StageInfo.java
@@ -126,4 +126,15 @@ public class StageInfo
     {
         return stageInfo.map(StageInfo::getAllStages).orElse(ImmutableList.of());
     }
+
+    public Optional<StageInfo> getStageWithStageId(StageId stageId)
+    {
+        Iterable<StageInfo> iterableStageInfo = forTree(StageInfo::getSubStages).depthFirstPreOrder(this);
+        for (StageInfo stageInfo : iterableStageInfo) {
+            if (stageInfo.getStageId().equals(stageId)) {
+                return Optional.of(stageInfo);
+            }
+        }
+        return Optional.empty();
+    }
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
@@ -236,6 +236,8 @@ public class CoordinatorModule
 
         binder.bind(LocalQueryProvider.class).in(Scopes.SINGLETON);
 
+        jaxrsBinder(binder).bind(TaskInfoResource.class);
+
         // dispatcher
         binder.bind(DispatchManager.class).in(Scopes.SINGLETON);
         binder.bind(FailedDispatchQueryFactory.class).in(Scopes.SINGLETON);

--- a/presto-main/src/main/java/com/facebook/presto/server/TaskInfoResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/TaskInfoResource.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server;
+
+import com.facebook.presto.execution.QueryManager;
+import com.facebook.presto.execution.StageInfo;
+import com.facebook.presto.execution.TaskId;
+import com.facebook.presto.execution.TaskInfo;
+import com.facebook.presto.spi.QueryId;
+import com.google.inject.Inject;
+
+import javax.annotation.security.RolesAllowed;
+import javax.ws.rs.GET;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+@Path("v1/taskInfo")
+@RolesAllowed("ADMIN")
+public class TaskInfoResource
+{
+    private final QueryManager queryManager;
+
+    @Inject
+    public TaskInfoResource(QueryManager queryManager)
+    {
+        this.queryManager = requireNonNull(queryManager, "queryManager is null");
+    }
+
+    @GET
+    @Path("{taskId}")
+    public TaskInfo getTaskInfo(@PathParam("taskId") TaskId taskId)
+            throws NotFoundException
+    {
+        QueryId queryId = taskId.getQueryId();
+        try {
+            Optional<StageInfo> stageInfo = queryManager.getFullQueryInfo(queryId).getOutputStage();
+
+            if (stageInfo.isPresent()) {
+                Optional<StageInfo> stage = stageInfo.get().getStageWithStageId(taskId.getStageExecutionId().getStageId());
+                if (stage.isPresent()) {
+                    Optional<TaskInfo> taskInfo = stage.get().getLatestAttemptExecutionInfo().getTasks().stream()
+                            .filter(info -> info.getTaskId().equals(taskId))
+                            .findFirst();
+
+                    if (taskInfo.isPresent()) {
+                        return taskInfo.get();
+                    }
+                }
+            }
+            throw new NotFoundException("TaskInfo not found for task id " + taskId.toString());
+        }
+        catch (Exception e) {
+            throw new NotFoundException(e);
+        }
+    }
+}

--- a/presto-main/src/main/resources/webapp/src/components/QueryDetail.jsx
+++ b/presto-main/src/main/resources/webapp/src/components/QueryDetail.jsx
@@ -117,7 +117,7 @@ class TaskList extends React.Component {
             return (
                 <Tr key={task.taskId}>
                     <Td column="id" value={task.taskId}>
-                        <a href={task.taskStatus.self + "?pretty"}>
+                        <a href={"/v1/taskInfo/" + task.taskId + "?pretty"}>
                             {getTaskIdSuffix(task.taskId)}
                         </a>
                     </Td>

--- a/presto-tests/src/test/java/com/facebook/presto/execution/TestStageInfo.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TestStageInfo.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution;
+
+import com.facebook.presto.server.testing.TestingPrestoServer;
+import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import com.facebook.presto.tests.ResultWithQueryId;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.facebook.airlift.testing.Closeables.closeQuietly;
+import static com.facebook.presto.tests.tpch.TpchQueryRunner.createQueryRunner;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+public class TestStageInfo
+{
+    private TestingPrestoServer server;
+    private DistributedQueryRunner queryRunner;
+
+    @BeforeClass
+    public void setup()
+            throws Exception
+    {
+        queryRunner = createQueryRunner(ImmutableMap.of("query.client.timeout", "10s"));
+        server = queryRunner.getCoordinator();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void teardown()
+    {
+        closeQuietly(server);
+        server = null;
+    }
+
+    @Test
+    public void testGetStageWithStageId()
+    {
+        String sql = "SELECT nationkey AS nationkey, count(*) AS count FROM tpch.sf1.supplier GROUP BY nationkey";
+        ResultWithQueryId<MaterializedResult> result = queryRunner.executeWithQueryId(queryRunner.getDefaultSession(), sql);
+        QueryId queryId = result.getQueryId();
+        Optional<StageInfo> stageInfo = server.getQueryManager().getFullQueryInfo(queryId).getOutputStage();
+
+        if (stageInfo.isPresent()) {
+            List<StageInfo> allStages = stageInfo.get().getAllStages();
+
+            for (StageInfo expectedStage : allStages) {
+                Optional<StageInfo> actualStage = stageInfo.get().getStageWithStageId(expectedStage.getStageId());
+                if (!actualStage.isPresent()) {
+                    fail("StageInfo with id " + expectedStage.getStageId() + "not found");
+                }
+                assertEquals(expectedStage.getStageId(), actualStage.get().getStageId());
+            }
+        }
+    }
+}

--- a/presto-tests/src/test/java/com/facebook/presto/server/TestTaskInfoResource.java
+++ b/presto-tests/src/test/java/com/facebook/presto/server/TestTaskInfoResource.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server;
+
+import com.facebook.airlift.http.client.HttpClient;
+import com.facebook.airlift.http.client.HttpUriBuilder;
+import com.facebook.airlift.http.client.Request;
+import com.facebook.airlift.http.client.StringResponseHandler;
+import com.facebook.airlift.http.client.jetty.JettyHttpClient;
+import com.facebook.presto.execution.QueryIdGenerator;
+import com.facebook.presto.execution.StageInfo;
+import com.facebook.presto.execution.TaskInfo;
+import com.facebook.presto.server.testing.TestingPrestoServer;
+import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import com.facebook.presto.tests.ResultWithQueryId;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.net.URI;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static com.facebook.airlift.http.client.JsonResponseHandler.createJsonResponseHandler;
+import static com.facebook.airlift.http.client.Request.Builder.prepareGet;
+import static com.facebook.airlift.http.client.StringResponseHandler.createStringResponseHandler;
+import static com.facebook.airlift.json.JsonCodec.jsonCodec;
+import static com.facebook.airlift.testing.Closeables.closeQuietly;
+import static com.facebook.presto.tests.tpch.TpchQueryRunner.createQueryRunner;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+public class TestTaskInfoResource
+{
+    private QueryIdGenerator queryIdGenerator = new QueryIdGenerator();
+    private TestingPrestoServer server;
+    private DistributedQueryRunner queryRunner;
+    private HttpClient client;
+
+    @BeforeClass
+    public void setup()
+            throws Exception
+    {
+        this.client = new JettyHttpClient();
+        this.queryRunner = createQueryRunner(ImmutableMap.of("query.client.timeout", "10s"));
+        this.server = queryRunner.getCoordinator();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void teardown()
+    {
+        closeQuietly(server);
+        closeQuietly(client);
+        server = null;
+        client = null;
+    }
+
+    @Test
+    public void testGetTaskInfo()
+    {
+        String sql = "SELECT * FROM tpch.sf1.customer WHERE tpch.sf1.customer.nationkey = 1";
+        ResultWithQueryId<MaterializedResult> result = queryRunner.executeWithQueryId(queryRunner.getDefaultSession(), sql);
+        QueryId queryId = result.getQueryId();
+        Optional<StageInfo> stageInfo = server.getQueryManager().getFullQueryInfo(queryId).getOutputStage();
+
+        if (stageInfo.isPresent()) {
+            Stream<TaskInfo> latestTaskInfo = stageInfo.get().getAllStages().stream()
+                    .flatMap(stage -> stage.getLatestAttemptExecutionInfo().getTasks().stream());
+            Iterable<TaskInfo> iterableTaskInfo = latestTaskInfo::iterator;
+
+            for (TaskInfo taskInfo : iterableTaskInfo) {
+                URI taskURI = taskUri("v1/taskInfo/", taskInfo.getTaskId().toString());
+                Request taskInfoRequest = prepareGet().setUri(taskURI).build();
+                TaskInfo responseTaskInfo = client.execute(taskInfoRequest, createJsonResponseHandler(jsonCodec(TaskInfo.class)));
+                compareTasks(taskInfo, responseTaskInfo);
+            }
+        }
+        else {
+            fail("StageInfo not present");
+        }
+    }
+
+    @Test
+    public void testInvalidQueryId()
+    {
+        String invalidTaskId = queryIdGenerator.createNextQueryId().toString() + ".0.0.0";
+        URI invalidTaskURI = taskUri("v1/taskInfo/", invalidTaskId);
+        Request taskInfoRequest = prepareGet().setUri(invalidTaskURI).build();
+        StringResponseHandler.StringResponse stringResponse = client.execute(taskInfoRequest, createStringResponseHandler());
+        assertEquals(stringResponse.getStatusCode(), 404);
+    }
+
+    public void compareTasks(TaskInfo expectedTask, TaskInfo actualTask)
+    {
+        assertEquals(expectedTask.getTaskId(), actualTask.getTaskId());
+        assertEquals(expectedTask.getTaskStatus().getState(), actualTask.getTaskStatus().getState());
+        assertEquals(expectedTask.getTaskStatus().getSelf(), actualTask.getTaskStatus().getSelf());
+        assertEquals(expectedTask.getStats().getCreateTime(), actualTask.getStats().getCreateTime());
+    }
+
+    public URI taskUri(String path, String taskId)
+    {
+        String taskUri = path + taskId;
+        return HttpUriBuilder.uriBuilderFrom(server.getBaseUrl()).replacePath(taskUri).build();
+    }
+}


### PR DESCRIPTION
Test plan -

Added TestTaskInfoResource.java to validate the response from the new endpoint for retrieving TaskInfo.

Fixes #15192 
```
== RELEASE NOTES ==

General Changes
* Added a REST endpoint to get TaskInfo without directly going to worker endpoint
