### PR TITLE
Refactor the OrcWriter Stats

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriter.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriter.java
@@ -27,7 +27,7 @@ import com.facebook.presto.orc.OrcEncoding;
 import com.facebook.presto.orc.OrcWriteValidation.OrcWriteValidationMode;
 import com.facebook.presto.orc.OrcWriter;
 import com.facebook.presto.orc.OrcWriterOptions;
-import com.facebook.presto.orc.OrcWriterStats;
+import com.facebook.presto.orc.WriterStats;
 import com.facebook.presto.orc.metadata.CompressionKind;
 import com.facebook.presto.spi.PrestoException;
 import com.google.common.collect.ImmutableList;
@@ -80,7 +80,7 @@ public class OrcFileWriter
             DateTimeZone hiveStorageTimeZone,
             Optional<Supplier<OrcDataSource>> validationInputFactory,
             OrcWriteValidationMode validationMode,
-            OrcWriterStats stats,
+            WriterStats stats,
             DwrfEncryptionProvider dwrfEncryptionProvider,
             Optional<DwrfWriterEncryption> dwrfWriterEncryption)
     {

--- a/presto-orc/src/main/java/com/facebook/presto/orc/WriterStats.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/WriterStats.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc;
+
+import com.facebook.presto.orc.metadata.StripeInformation;
+
+public interface WriterStats
+{
+    enum FlushReason
+    {
+        MAX_ROWS, MAX_BYTES, DICTIONARY_FULL, CLOSED
+    }
+
+    void recordStripeWritten(
+            int stripeMinBytes,
+            int stripeMaxBytes,
+            int dictionaryMaxMemoryBytes,
+            FlushReason flushReason,
+            int dictionaryBytes,
+            StripeInformation stripeInformation);
+
+    void updateSizeInBytes(long deltaInBytes);
+}

--- a/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
@@ -1503,7 +1503,7 @@ public class OrcTester
         writeOrcColumnsPresto(outputFile, format, compression, Optional.empty(), ImmutableList.of(type), ImmutableList.of(values), new OrcWriterStats());
     }
 
-    public static void writeOrcColumnsPresto(File outputFile, Format format, CompressionKind compression, Optional<DwrfWriterEncryption> dwrfWriterEncryption, List<Type> types, List<List<?>> values, OrcWriterStats stats)
+    public static void writeOrcColumnsPresto(File outputFile, Format format, CompressionKind compression, Optional<DwrfWriterEncryption> dwrfWriterEncryption, List<Type> types, List<List<?>> values, WriterStats stats)
             throws Exception
     {
         List<String> columnNames = makeColumnNames(types.size());

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcFileRewriter.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcFileRewriter.java
@@ -27,8 +27,8 @@ import com.facebook.presto.orc.OrcDataSource;
 import com.facebook.presto.orc.OrcReader;
 import com.facebook.presto.orc.OrcReaderOptions;
 import com.facebook.presto.orc.OrcWriter;
-import com.facebook.presto.orc.OrcWriterStats;
 import com.facebook.presto.orc.StripeMetadataSource;
+import com.facebook.presto.orc.WriterStats;
 import com.facebook.presto.orc.cache.OrcFileTailSource;
 import com.facebook.presto.orc.metadata.CompressionKind;
 import com.facebook.presto.raptor.RaptorOrcAggregatedMemoryContext;
@@ -74,7 +74,7 @@ public final class OrcFileRewriter
 
     private final ReaderAttributes readerAttributes;
     private final boolean validate;
-    private final OrcWriterStats stats;
+    private final WriterStats stats;
     private final TypeManager typeManager;
     private final CompressionKind compression;
     private final OrcDataEnvironment orcDataEnvironment;
@@ -84,7 +84,7 @@ public final class OrcFileRewriter
     OrcFileRewriter(
             ReaderAttributes readerAttributes,
             boolean validate,
-            OrcWriterStats stats,
+            WriterStats stats,
             TypeManager typeManager,
             OrcDataEnvironment orcDataEnvironment,
             CompressionKind compression,

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcFileWriter.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcFileWriter.java
@@ -22,7 +22,7 @@ import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.common.type.TypeSignature;
 import com.facebook.presto.orc.OrcWriter;
 import com.facebook.presto.orc.OrcWriterOptions;
-import com.facebook.presto.orc.OrcWriterStats;
+import com.facebook.presto.orc.WriterStats;
 import com.facebook.presto.orc.metadata.CompressionKind;
 import com.facebook.presto.spi.PrestoException;
 import com.google.common.annotations.VisibleForTesting;
@@ -59,7 +59,7 @@ public class OrcFileWriter
     private long rowCount;
     private long uncompressedSize;
 
-    public OrcFileWriter(List<Long> columnIds, List<Type> columnTypes, DataSink target, boolean validate, OrcWriterStats stats, TypeManager typeManager, CompressionKind compression)
+    public OrcFileWriter(List<Long> columnIds, List<Type> columnTypes, DataSink target, boolean validate, WriterStats stats, TypeManager typeManager, CompressionKind compression)
     {
         this(columnIds, columnTypes, target, true, validate, stats, typeManager, compression);
     }
@@ -71,7 +71,7 @@ public class OrcFileWriter
             DataSink target,
             boolean writeMetadata,
             boolean validate,
-            OrcWriterStats stats,
+            WriterStats stats,
             TypeManager typeManager,
             CompressionKind compression)
     {


### PR DESCRIPTION
Separate current OrcWriterStats into WriterStats abstraction. The new
WriterStats is able to send the metrics to a pub/sub system like Kafka.
Our current deployments are Storage constrained than CPU constrained.
This change can help to gather more IO metrics.

```
== NO RELEASE NOTE ==
```