### PR TITLE
Add scalar function DESTRUCTURE_TDIGEST

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/TDigestFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/TDigestFunctions.java
@@ -15,14 +15,20 @@ package com.facebook.presto.operator.scalar;
 
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.RowType;
 import com.facebook.presto.common.type.StandardTypes;
 import com.facebook.presto.spi.function.Description;
 import com.facebook.presto.spi.function.ScalarFunction;
 import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.tdigest.Centroid;
 import com.facebook.presto.tdigest.TDigest;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
 
 import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static com.facebook.presto.spi.function.SqlFunctionVisibility.EXPERIMENTAL;
 import static com.facebook.presto.tdigest.TDigest.createTDigest;
@@ -31,6 +37,17 @@ import static com.facebook.presto.util.Failures.checkCondition;
 public final class TDigestFunctions
 {
     public static final double DEFAULT_COMPRESSION = 100;
+
+    @VisibleForTesting
+    static final RowType TDIGEST_CENTROIDS_ROW_TYPE = RowType.from(
+            ImmutableList.of(
+                    RowType.field("centroid_means", new ArrayType(DOUBLE)),
+                    RowType.field("centroid_weights", new ArrayType(INTEGER)),
+                    RowType.field("compression", DOUBLE),
+                    RowType.field("min", DOUBLE),
+                    RowType.field("max", DOUBLE),
+                    RowType.field("sum", DOUBLE),
+                    RowType.field("count", INTEGER)));
 
     private TDigestFunctions() {}
 
@@ -85,5 +102,39 @@ public final class TDigestFunctions
         TDigest digest = createTDigest(input);
         digest.scale(scale);
         return digest.serialize();
+    }
+
+    @ScalarFunction(value = "destructure_tdigest", visibility = EXPERIMENTAL)
+    @Description("Return the raw TDigest, including arrays of centroid means and weights, as well as min, max, sum, count, and compression factor.")
+    @SqlType("row(centroid_means array(double), centroid_weights array(integer), compression double, min double, max double, sum double, count integer)")
+    public static Block destructureTDigest(@SqlType("tdigest(double)") Slice input)
+    {
+        TDigest tDigest = createTDigest(input);
+
+        BlockBuilder blockBuilder = TDIGEST_CENTROIDS_ROW_TYPE.createBlockBuilder(null, 1);
+        BlockBuilder rowBuilder = blockBuilder.beginBlockEntry();
+
+        // Centroid means / weights
+        BlockBuilder meansBuilder = DOUBLE.createBlockBuilder(null, tDigest.centroidCount());
+        BlockBuilder weightsBuilder = INTEGER.createBlockBuilder(null, tDigest.centroidCount());
+        int count = 0;
+        for (Centroid centroid : tDigest.centroids()) {
+            int weight = centroid.getWeight();
+            DOUBLE.writeDouble(meansBuilder, centroid.getMean());
+            INTEGER.writeLong(weightsBuilder, weight);
+            count += weight;
+        }
+        rowBuilder.appendStructure(meansBuilder);
+        rowBuilder.appendStructure(weightsBuilder);
+
+        // Compression, min, max, sum, count
+        DOUBLE.writeDouble(rowBuilder, tDigest.getCompressionFactor());
+        DOUBLE.writeDouble(rowBuilder, tDigest.getMin());
+        DOUBLE.writeDouble(rowBuilder, tDigest.getMax());
+        DOUBLE.writeDouble(rowBuilder, tDigest.getSum());
+        INTEGER.writeLong(rowBuilder, count);
+
+        blockBuilder.closeEntry();
+        return TDIGEST_CENTROIDS_ROW_TYPE.getObject(blockBuilder, blockBuilder.getPositionCount() - 1);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/tdigest/TDigest.java
+++ b/presto-main/src/main/java/com/facebook/presto/tdigest/TDigest.java
@@ -61,6 +61,7 @@ import static io.airlift.slice.SizeOf.SIZE_OF_INT;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static io.airlift.slice.Slices.wrappedDoubleArray;
 import static java.lang.Double.isNaN;
+import static java.lang.Double.sum;
 import static java.lang.Math.ceil;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
@@ -98,6 +99,7 @@ public class TDigest
 
     private double min = Double.POSITIVE_INFINITY;
     private double max = Double.NEGATIVE_INFINITY;
+    private double sum;
 
     private final Random gen = ThreadLocalRandom.current();
 
@@ -166,14 +168,16 @@ public class TDigest
         SliceInput sliceInput = new BasicSliceInput(slice);
         try {
             byte format = sliceInput.readByte();
-            checkArgument(format == 0, "Invalid serialization format for TDigest; expected '0'");
+            checkArgument(format == 0 || format == 1, "Invalid serialization format for TDigest; expected '0' or '1'");
             byte type = sliceInput.readByte();
             checkArgument(type == 0, "Invalid type for TDigest; expected '0' (type double)");
             double min = sliceInput.readDouble();
             double max = sliceInput.readDouble();
+            double sum = format == 1 ? sliceInput.readDouble() : 0.0;
             double publicCompression = max(10, sliceInput.readDouble());
             TDigest r = new TDigest(publicCompression);
             r.setMinMax(min, max);
+            r.setSum(sum);
             r.totalWeight = sliceInput.readDouble();
             r.activeCentroids = sliceInput.readInt();
             r.weight = new double[r.activeCentroids];
@@ -218,6 +222,7 @@ public class TDigest
         if (x > max) {
             max = x;
         }
+        sum += (x * w);
     }
 
     public void merge(TDigest other)
@@ -324,12 +329,12 @@ public class TDigest
         }
 
         // sanity check
-        double sum = 0;
+        double sumWeights = 0;
         for (int i = 0; i < activeCentroids; i++) {
-            sum += weight[i];
+            sumWeights += weight[i];
         }
 
-        checkArgument(sum == totalWeight, "Sum must equal the total weight, but sum:%s != totalWeight:%s", sum, totalWeight);
+        checkArgument(sumWeights == totalWeight, "Sum must equal the total weight, but sum:%s != totalWeight:%s", sumWeights, totalWeight);
         if (runBackwards) {
             reverse(mean, 0, activeCentroids);
             reverse(weight, 0, activeCentroids);
@@ -621,6 +626,7 @@ public class TDigest
                 + SIZE_OF_BYTE                          // type (e.g double, float, bigint)
                 + SIZE_OF_DOUBLE                        // min
                 + SIZE_OF_DOUBLE                        // max
+                + SIZE_OF_DOUBLE                        // sum
                 + SIZE_OF_DOUBLE                        // compression factor
                 + SIZE_OF_DOUBLE                        // total weight
                 + SIZE_OF_INT                           // number of centroids
@@ -637,10 +643,11 @@ public class TDigest
     {
         SliceOutput sliceOutput = new DynamicSliceOutput(toIntExact(estimatedSerializedSizeInBytes()));
 
-        sliceOutput.writeByte(0); // version 0 of T-Digest serialization
+        sliceOutput.writeByte(1); // version 1 of T-Digest serialization
         sliceOutput.writeByte(0); // represents the underlying data type of the distribution
         sliceOutput.writeDouble(min);
         sliceOutput.writeDouble(max);
+        sliceOutput.writeDouble(sum);
         sliceOutput.writeDouble(publicCompression);
         sliceOutput.writeDouble(totalWeight);
         sliceOutput.writeInt(activeCentroids);
@@ -655,6 +662,11 @@ public class TDigest
         this.max = max;
     }
 
+    private void setSum(double sum)
+    {
+        this.sum = sum;
+    }
+
     public double getMin()
     {
         return min;
@@ -663,6 +675,11 @@ public class TDigest
     public double getMax()
     {
         return max;
+    }
+
+    public double getSum()
+    {
+        return sum;
     }
 
     /**

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestMergeTDigestFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestMergeTDigestFunction.java
@@ -31,6 +31,7 @@ import static io.airlift.slice.Slices.wrappedBuffer;
 import static java.lang.Math.abs;
 import static java.lang.Math.max;
 import static java.util.Objects.requireNonNull;
+import static org.testng.Assert.assertEquals;
 
 public class TestMergeTDigestFunction
         extends TestMergeStatisticalDigestFunction
@@ -52,6 +53,8 @@ public class TestMergeTDigestFunction
                 return false;
             }
         }
+
+        assertEquals(actual.getSum(), expected.getSum(), 0.0001);
 
         return actual.getSize() == expected.getSize() &&
                 actual.getMin() == expected.getMin() &&

--- a/presto-main/src/test/java/com/facebook/presto/tdigest/TestTDigest.java
+++ b/presto-main/src/test/java/com/facebook/presto/tdigest/TestTDigest.java
@@ -40,10 +40,12 @@ import org.testng.annotations.Test;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static com.facebook.presto.tdigest.TDigest.createTDigest;
 import static java.lang.String.format;
 import static java.util.Collections.sort;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
 public class TestTDigest
@@ -65,6 +67,8 @@ public class TestTDigest
             list.add(i);
         }
 
+        assertSumInts(list, tDigest);
+
         for (int i = 0; i < quantile.length; i++) {
             assertDiscreteWithinBound(quantile[i], STANDARD_ERROR, list, tDigest);
         }
@@ -85,6 +89,7 @@ public class TestTDigest
         }
 
         tDigest1.merge(tDigest2);
+        assertSumInts(list, tDigest1);
         sort(list);
 
         for (int i = 0; i < quantile.length; i++) {
@@ -107,6 +112,7 @@ public class TestTDigest
         }
 
         tDigest2.merge(tDigest1);
+        assertSumInts(list, tDigest2);
         sort(list);
 
         for (int i = 0; i < quantile.length; i++) {
@@ -125,6 +131,8 @@ public class TestTDigest
             tDigest.add(value);
             list.add(value);
         }
+
+        assertSum(list, tDigest);
 
         sort(list);
 
@@ -146,6 +154,8 @@ public class TestTDigest
             list.add(value);
         }
 
+        assertSum(list, tDigest);
+
         sort(list);
 
         for (int i = 0; i < quantile.length; i++) {
@@ -165,6 +175,8 @@ public class TestTDigest
             tDigest.add(value);
             list.add(value);
         }
+
+        assertSum(list, tDigest);
 
         sort(list);
 
@@ -191,6 +203,7 @@ public class TestTDigest
         }
 
         tDigest1.merge(tDigest2);
+        assertSum(list, tDigest1);
         sort(list);
 
         for (int i = 0; i < quantile.length; i++) {
@@ -215,6 +228,8 @@ public class TestTDigest
             }
             tDigest.merge(current);
         }
+
+        assertSum(list, tDigest);
 
         sort(list);
 
@@ -241,6 +256,8 @@ public class TestTDigest
             tDigest.merge(current);
         }
 
+        assertSum(list, tDigest);
+
         sort(list);
 
         for (int i = 0; i < quantile.length; i++) {
@@ -263,6 +280,8 @@ public class TestTDigest
                 tDigest.add(sample);
                 list.add(sample);
             }
+
+            assertSumInts(list, tDigest);
 
             Collections.sort(list);
 
@@ -287,6 +306,8 @@ public class TestTDigest
                 list.add(sample);
             }
 
+            assertSumInts(list, tDigest);
+
             Collections.sort(list);
 
             for (int i = 0; i < quantile.length; i++) {
@@ -309,6 +330,8 @@ public class TestTDigest
                 tDigest.add(sample);
                 list.add(sample);
             }
+
+            assertSumInts(list, tDigest);
 
             Collections.sort(list);
 
@@ -365,5 +388,16 @@ public class TestTDigest
         // we use Math.rint to round to the nearest integer, since casting as (int) always rounds down and no casting results in error > 1%
         assertTrue(Math.rint(tDigest.getQuantile(quantile)) >= lowerBound && Math.rint(tDigest.getQuantile(quantile)) <= upperBound,
                 format("Value %s is outside bound [%s, %s] for quantile %s", tDigest.getQuantile(quantile), lowerBound, upperBound, quantile));
+    }
+
+    private void assertSumInts(List<Integer> values, TDigest tDigest)
+    {
+        assertSum(values.stream().map(Double::new).collect(Collectors.toList()), tDigest);
+    }
+
+    private void assertSum(List<Double> values, TDigest tDigest)
+    {
+        double expectedSum = values.stream().reduce(0.0d, Double::sum);
+        assertEquals(tDigest.getSum(), expectedSum, 0.0001);
     }
 }


### PR DESCRIPTION
* Add `sum` to TDigest and update serialization version to handle new field
* Add new scalar function on TDigest type to expose the "raw" TDigest data
structure. The prototype of the new function is:
```
DESTRUCTURE_TDIGEST(column: TDIGEST) ->

ROW(
  centroid_means: ARRAY[DOUBLE],
  centroid_weights: ARRAY[INTEGER],
  compression: DOUBLE,
  min: DOUBLE,
  max: DOUBLE,
  sum: DOUBLE,
  count: INTEGER
)
```

Test plan

`mvn -Dtest="TestTDigest,TestTDigestFunctions,TestMergeTDigestFunction" test`

```
== RELEASE NOTES ==

General Changes
* Add new scalar function on TDigest type to expose the "raw" TDigest data
structure. The prototype of the new function is:

DESTRUCTURE_TDIGEST(column: TDIGEST) ->

ROW(
  centroid_means: ARRAY[DOUBLE],
  centroid_weights: ARRAY[INTEGER],
  compression: DOUBLE,
  min: DOUBLE,
  max: DOUBLE,
  sum: DOUBLE,
  count: INTEGER
)
```