### PR TITLE
Support distribution of broadcast table using disk storage in Presto-on-Spark

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/spiller/LocalTempStorage.java
+++ b/presto-main/src/main/java/com/facebook/presto/spiller/LocalTempStorage.java
@@ -18,6 +18,7 @@ import com.facebook.presto.common.io.DataOutput;
 import com.facebook.presto.common.io.DataSink;
 import com.facebook.presto.common.io.OutputStreamDataSink;
 import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.storage.StorageCapabilities;
 import com.facebook.presto.spi.storage.TempDataOperationContext;
 import com.facebook.presto.spi.storage.TempDataSink;
 import com.facebook.presto.spi.storage.TempStorage;
@@ -31,6 +32,8 @@ import javax.annotation.concurrent.GuardedBy;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.FileStore;
 import java.nio.file.Files;
@@ -43,6 +46,7 @@ import static com.facebook.presto.spi.StandardErrorCode.OUT_OF_SPILL_SPACE;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.lang.String.format;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.Files.createDirectories;
 import static java.nio.file.Files.delete;
 import static java.nio.file.Files.getFileStore;
@@ -118,6 +122,31 @@ public class LocalTempStorage
         Files.delete(((LocalTempStorageHandle) handle).getFilePath());
     }
 
+    @Override
+    public byte[] serializeHandle(TempStorageHandle storageHandle)
+    {
+        URI uri = ((LocalTempStorageHandle) storageHandle).getFilePath().toUri();
+        return uri.toString().getBytes(UTF_8);
+    }
+
+    @Override
+    public TempStorageHandle deserialize(byte[] serializedStorageHandle)
+    {
+        String uriString = new String(serializedStorageHandle, UTF_8);
+        try {
+            return new LocalTempStorageHandle(Paths.get(new URI(uriString)));
+        }
+        catch (URISyntaxException e) {
+            throw new IllegalArgumentException("Invalid URI: " + uriString, e);
+        }
+    }
+
+    @Override
+    public List<StorageCapabilities> getStorageCapabilities()
+    {
+        return ImmutableList.of();
+    }
+
     private static void cleanupOldSpillFiles(Path path)
     {
         try (DirectoryStream<Path> stream = newDirectoryStream(path, SPILL_FILE_GLOB)) {
@@ -177,6 +206,12 @@ public class LocalTempStorage
         public Path getFilePath()
         {
             return filePath;
+        }
+
+        @Override
+        public String toString()
+        {
+            return filePath.toString();
         }
     }
 

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkBroadcastDependency.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkBroadcastDependency.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark;
+
+import com.facebook.presto.spark.classloader_interface.PrestoSparkTaskOutput;
+import org.apache.spark.SparkException;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.broadcast.Broadcast;
+
+import java.util.List;
+import java.util.concurrent.TimeoutException;
+
+public interface PrestoSparkBroadcastDependency<T extends PrestoSparkTaskOutput>
+{
+    Broadcast<List<T>> executeBroadcast(JavaSparkContext sparkContext)
+            throws SparkException, TimeoutException;
+
+    void destroy();
+}

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkConfig.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkConfig.java
@@ -21,6 +21,7 @@ import javax.validation.constraints.NotNull;
 
 import static io.airlift.units.DataSize.Unit.GIGABYTE;
 import static io.airlift.units.DataSize.Unit.KILOBYTE;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
 
 public class PrestoSparkConfig
 {
@@ -30,6 +31,9 @@ public class PrestoSparkConfig
     private int initialSparkPartitionCount = 16;
     private DataSize maxSplitsDataSizePerSparkPartition = new DataSize(2, GIGABYTE);
     private DataSize shuffleOutputTargetAverageRowSize = new DataSize(1, KILOBYTE);
+    private boolean storageBasedBroadcastJoinEnabled;
+    private DataSize storageBasedBroadcastJoinWriteBufferSize = new DataSize(24, MEGABYTE);
+    private String storageBasedBroadcastJoinStorage = "local";
 
     public boolean isSparkPartitionCountAutoTuneEnabled()
     {
@@ -107,6 +111,45 @@ public class PrestoSparkConfig
     public PrestoSparkConfig setShuffleOutputTargetAverageRowSize(DataSize shuffleOutputTargetAverageRowSize)
     {
         this.shuffleOutputTargetAverageRowSize = shuffleOutputTargetAverageRowSize;
+        return this;
+    }
+
+    public boolean isStorageBasedBroadcastJoinEnabled()
+    {
+        return storageBasedBroadcastJoinEnabled;
+    }
+
+    @Config("spark.storage-based-broadcast-join-enabled")
+    @ConfigDescription("Distribute broadcast hashtable to workers using storage")
+    public PrestoSparkConfig setStorageBasedBroadcastJoinEnabled(boolean storageBasedBroadcastJoinEnabled)
+    {
+        this.storageBasedBroadcastJoinEnabled = storageBasedBroadcastJoinEnabled;
+        return this;
+    }
+
+    public DataSize getStorageBasedBroadcastJoinWriteBufferSize()
+    {
+        return storageBasedBroadcastJoinWriteBufferSize;
+    }
+
+    @Config("spark.storage-based-broadcast-join-write-buffer-size")
+    @ConfigDescription("Maximum size in bytes to buffer before flushing pages to disk")
+    public PrestoSparkConfig setStorageBasedBroadcastJoinWriteBufferSize(DataSize storageBasedBroadcastJoinWriteBufferSize)
+    {
+        this.storageBasedBroadcastJoinWriteBufferSize = storageBasedBroadcastJoinWriteBufferSize;
+        return this;
+    }
+
+    public String getStorageBasedBroadcastJoinStorage()
+    {
+        return storageBasedBroadcastJoinStorage;
+    }
+
+    @Config("spark.storage-based-broadcast-join-storage")
+    @ConfigDescription("TempStorage to use for dumping broadcast table")
+    public PrestoSparkConfig setStorageBasedBroadcastJoinStorage(String storageBasedBroadcastJoinStorage)
+    {
+        this.storageBasedBroadcastJoinStorage = storageBasedBroadcastJoinStorage;
         return this;
     }
 }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkMemoryBasedBroadcastDependency.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkMemoryBasedBroadcastDependency.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark;
+
+import com.facebook.presto.spark.classloader_interface.PrestoSparkSerializedPage;
+import io.airlift.units.DataSize;
+import org.apache.spark.SparkException;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.broadcast.Broadcast;
+import scala.Tuple2;
+
+import java.util.List;
+import java.util.concurrent.TimeoutException;
+
+import static com.facebook.presto.ExceededMemoryLimitException.exceededLocalBroadcastMemoryLimit;
+import static com.facebook.presto.spark.util.PrestoSparkUtils.computeNextTimeout;
+import static io.airlift.units.DataSize.succinctBytes;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.stream.Collectors.toList;
+
+public class PrestoSparkMemoryBasedBroadcastDependency
+        implements PrestoSparkBroadcastDependency<PrestoSparkSerializedPage>
+{
+    private final RddAndMore<PrestoSparkSerializedPage> broadcastDependency;
+    private final DataSize maxBroadcastSize;
+    private final long queryCompletionDeadline;
+    private Broadcast<List<PrestoSparkSerializedPage>> broadcastVariable;
+
+    public PrestoSparkMemoryBasedBroadcastDependency(RddAndMore<PrestoSparkSerializedPage> broadcastDependency, DataSize maxBroadcastSize, long queryCompletionDeadline)
+    {
+        this.broadcastDependency = requireNonNull(broadcastDependency, "broadcastDependency cannot be null");
+        this.maxBroadcastSize = requireNonNull(maxBroadcastSize, "maxBroadcastSize cannot be null");
+        this.queryCompletionDeadline = queryCompletionDeadline;
+    }
+
+    @Override
+    public Broadcast<List<PrestoSparkSerializedPage>> executeBroadcast(JavaSparkContext sparkContext)
+            throws SparkException, TimeoutException
+    {
+        List<PrestoSparkSerializedPage> broadcastValue = broadcastDependency.collectAndDestroyDependenciesWithTimeout(computeNextTimeout(queryCompletionDeadline), MILLISECONDS).stream()
+                .map(Tuple2::_2)
+                .collect(toList());
+
+        long compressedBroadcastSizeInBytes = broadcastValue.stream()
+                .mapToInt(page -> page.getBytes().length)
+                .sum();
+        long uncompressedBroadcastSizeInBytes = broadcastValue.stream()
+                .mapToInt(page -> page.getUncompressedSizeInBytes())
+                .sum();
+
+        long maxBroadcastSizeInBytes = maxBroadcastSize.toBytes();
+
+        if (compressedBroadcastSizeInBytes > maxBroadcastSizeInBytes) {
+            throw exceededLocalBroadcastMemoryLimit(maxBroadcastSize, format("Compressed broadcast size: %s", succinctBytes(compressedBroadcastSizeInBytes)));
+        }
+
+        if (uncompressedBroadcastSizeInBytes > maxBroadcastSizeInBytes) {
+            throw exceededLocalBroadcastMemoryLimit(maxBroadcastSize, format("Uncompressed broadcast size: %s", succinctBytes(uncompressedBroadcastSizeInBytes)));
+        }
+
+        broadcastVariable = sparkContext.broadcast(broadcastValue);
+        return broadcastVariable;
+    }
+
+    @Override
+    public void destroy()
+    {
+        if (broadcastVariable != null) {
+            broadcastVariable.destroy();
+        }
+    }
+}

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
@@ -96,6 +96,7 @@ import com.facebook.presto.server.ServerConfig;
 import com.facebook.presto.server.SessionPropertyDefaults;
 import com.facebook.presto.server.security.ServerSecurityModule;
 import com.facebook.presto.spark.classloader_interface.SparkProcessType;
+import com.facebook.presto.spark.execution.PrestoSparkBroadcastTableCacheManager;
 import com.facebook.presto.spark.execution.PrestoSparkExecutionExceptionFactory;
 import com.facebook.presto.spark.execution.PrestoSparkTaskExecutorFactory;
 import com.facebook.presto.spark.node.PrestoSparkInternalNodeManager;
@@ -423,6 +424,7 @@ public class PrestoSparkModule
         binder.bind(PrestoSparkTaskExecutorFactory.class).in(Scopes.SINGLETON);
         binder.bind(PrestoSparkQueryExecutionFactory.class).in(Scopes.SINGLETON);
         binder.bind(PrestoSparkService.class).in(Scopes.SINGLETON);
+        binder.bind(PrestoSparkBroadcastTableCacheManager.class).in(Scopes.SINGLETON);
 
         // extra credentials and authenticator for Presto-on-Spark
         newSetBinder(binder, PrestoSparkCredentialsProvider.class);

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkSessionProperties.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkSessionProperties.java
@@ -34,6 +34,8 @@ public class PrestoSparkSessionProperties
     public static final String SPARK_INITIAL_PARTITION_COUNT = "spark_initial_partition_count";
     public static final String MAX_SPLITS_DATA_SIZE_PER_SPARK_PARTITION = "max_splits_data_size_per_spark_partition";
     public static final String SHUFFLE_OUTPUT_TARGET_AVERAGE_ROW_SIZE = "shuffle_output_target_average_row_size";
+    public static final String STORAGE_BASED_BROADCAST_JOIN_ENABLED = "storage_based_broadcast_join_enabled";
+    public static final String STORAGE_BASED_BROADCAST_JOIN_WRITE_BUFFER_SIZE = "storage_based_broadcast_join_write_buffer_size";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -70,6 +72,16 @@ public class PrestoSparkSessionProperties
                         SHUFFLE_OUTPUT_TARGET_AVERAGE_ROW_SIZE,
                         "Target average size for row entries produced by Presto on Spark for shuffle",
                         prestoSparkConfig.getShuffleOutputTargetAverageRowSize(),
+                        false),
+                booleanProperty(
+                        STORAGE_BASED_BROADCAST_JOIN_ENABLED,
+                        "Use storage for distributing broadcast table",
+                        prestoSparkConfig.isStorageBasedBroadcastJoinEnabled(),
+                        false),
+                dataSizeProperty(
+                        STORAGE_BASED_BROADCAST_JOIN_WRITE_BUFFER_SIZE,
+                        "Maximum size in bytes to buffer before flushing pages to disk",
+                        prestoSparkConfig.getStorageBasedBroadcastJoinWriteBufferSize(),
                         false));
     }
 
@@ -106,5 +118,15 @@ public class PrestoSparkSessionProperties
     public static DataSize getShuffleOutputTargetAverageRowSize(Session session)
     {
         return session.getSystemProperty(SHUFFLE_OUTPUT_TARGET_AVERAGE_ROW_SIZE, DataSize.class);
+    }
+
+    public static boolean isStorageBasedBroadcastJoinEnabled(Session session)
+    {
+        return session.getSystemProperty(STORAGE_BASED_BROADCAST_JOIN_ENABLED, Boolean.class);
+    }
+
+    public static DataSize getStorageBasedBroadcastJoinWriteBufferSize(Session session)
+    {
+        return session.getSystemProperty(STORAGE_BASED_BROADCAST_JOIN_WRITE_BUFFER_SIZE, DataSize.class);
     }
 }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkStorageBasedBroadcastDependency.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkStorageBasedBroadcastDependency.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark;
+
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.spark.classloader_interface.PrestoSparkStorageHandle;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.storage.TempDataOperationContext;
+import com.facebook.presto.spi.storage.TempStorage;
+import com.facebook.presto.spi.storage.TempStorageHandle;
+import io.airlift.units.DataSize;
+import org.apache.spark.SparkException;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.broadcast.Broadcast;
+import scala.Tuple2;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.TimeoutException;
+
+import static com.facebook.presto.ExceededMemoryLimitException.exceededLocalBroadcastMemoryLimit;
+import static com.facebook.presto.spark.SparkErrorCode.STORAGE_ERROR;
+import static com.facebook.presto.spark.util.PrestoSparkUtils.computeNextTimeout;
+import static io.airlift.units.DataSize.succinctBytes;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.stream.Collectors.toList;
+
+public class PrestoSparkStorageBasedBroadcastDependency
+        implements PrestoSparkBroadcastDependency<PrestoSparkStorageHandle>
+{
+    private static final Logger log = Logger.get(PrestoSparkStorageBasedBroadcastDependency.class);
+
+    private final RddAndMore<PrestoSparkStorageHandle> broadcastDependency;
+    private final DataSize maxBroadcastSize;
+    private final long queryCompletionDeadline;
+    private final TempStorage tempStorage;
+    private final TempDataOperationContext tempDataOperationContext;
+
+    private Broadcast<List<PrestoSparkStorageHandle>> broadcastVariable;
+
+    public PrestoSparkStorageBasedBroadcastDependency(RddAndMore<PrestoSparkStorageHandle> broadcastDependency, DataSize maxBroadcastSize, long queryCompletionDeadline, TempStorage tempStorage, TempDataOperationContext tempDataOperationContext)
+    {
+        this.broadcastDependency = requireNonNull(broadcastDependency, "broadcastDependency cannot be null");
+        this.maxBroadcastSize = requireNonNull(maxBroadcastSize, "maxBroadcastSize cannot be null");
+        this.queryCompletionDeadline = queryCompletionDeadline;
+        this.tempStorage = requireNonNull(tempStorage, "tempStorage cannot be null");
+        this.tempDataOperationContext = requireNonNull(tempDataOperationContext, "tempDataOperationContext cannot be null");
+    }
+
+    @Override
+    public Broadcast<List<PrestoSparkStorageHandle>> executeBroadcast(JavaSparkContext sparkContext)
+            throws SparkException, TimeoutException
+    {
+        List<PrestoSparkStorageHandle> broadcastValue = broadcastDependency.collectAndDestroyDependenciesWithTimeout(computeNextTimeout(queryCompletionDeadline), MILLISECONDS).stream()
+                .map(Tuple2::_2)
+                .collect(toList());
+
+        long compressedBroadcastSizeInBytes = broadcastValue.stream()
+                .mapToLong(metadata -> metadata.getCompressedSizeInBytes())
+                .sum();
+        long uncompressedBroadcastSizeInBytes = broadcastValue.stream()
+                .mapToLong(metadata -> metadata.getUncompressedSizeInBytes())
+                .sum();
+
+        log.info("Got back %d pages. compressedBroadcastSizeInBytes: %d; uncompressedBroadcastSizeInBytes: %d",
+                broadcastValue.size(),
+                compressedBroadcastSizeInBytes,
+                uncompressedBroadcastSizeInBytes);
+
+        long maxBroadcastSizeInBytes = maxBroadcastSize.toBytes();
+
+        if (compressedBroadcastSizeInBytes > maxBroadcastSizeInBytes) {
+            throw exceededLocalBroadcastMemoryLimit(maxBroadcastSize, format("Compressed broadcast size: %s", succinctBytes(compressedBroadcastSizeInBytes)));
+        }
+
+        if (uncompressedBroadcastSizeInBytes > maxBroadcastSizeInBytes) {
+            throw exceededLocalBroadcastMemoryLimit(maxBroadcastSize, format("Uncompressed broadcast size: %s", succinctBytes(uncompressedBroadcastSizeInBytes)));
+        }
+
+        broadcastVariable = sparkContext.broadcast(broadcastValue);
+        return broadcastVariable;
+    }
+
+    @Override
+    public void destroy()
+    {
+        if (broadcastVariable == null) {
+            return;
+        }
+
+        try {
+            // Delete the files
+            for (PrestoSparkStorageHandle diskPage : broadcastVariable.getValue()) {
+                TempStorageHandle storageHandle = tempStorage.deserialize(diskPage.getSerializedStorageHandle());
+                tempStorage.remove(tempDataOperationContext, storageHandle);
+                log.info("Deleted broadcast spill file: " + storageHandle.toString());
+            }
+        }
+        catch (IOException e) {
+            throw new PrestoException(STORAGE_ERROR, "Unable to delete broadcast spill file", e);
+        }
+
+        // Destroy broadcast variable
+        broadcastVariable.destroy();
+    }
+}

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/RddAndMore.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/RddAndMore.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark;
+
+import com.facebook.presto.spark.classloader_interface.MutablePartitionId;
+import com.facebook.presto.spark.classloader_interface.PrestoSparkTaskOutput;
+import com.google.common.collect.ImmutableList;
+import org.apache.spark.SparkException;
+import org.apache.spark.api.java.JavaPairRDD;
+import scala.Tuple2;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static com.facebook.presto.spark.util.PrestoSparkUtils.getActionResultWithTimeout;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+public class RddAndMore<T extends PrestoSparkTaskOutput>
+{
+    private final JavaPairRDD<MutablePartitionId, T> rdd;
+    private final List<PrestoSparkBroadcastDependency> broadcastDependencies;
+
+    private boolean collected;
+
+    public RddAndMore(
+            JavaPairRDD<MutablePartitionId, T> rdd,
+            List<PrestoSparkBroadcastDependency> broadcastDependencies)
+    {
+        this.rdd = requireNonNull(rdd, "rdd is null");
+        this.broadcastDependencies = ImmutableList.copyOf(requireNonNull(broadcastDependencies, "broadcastDependencies is null"));
+    }
+
+    public List<Tuple2<MutablePartitionId, T>> collectAndDestroyDependenciesWithTimeout(long timeout, TimeUnit timeUnit)
+            throws SparkException, TimeoutException
+    {
+        checkState(!collected, "already collected");
+        collected = true;
+        List<Tuple2<MutablePartitionId, T>> result = getActionResultWithTimeout(rdd.collectAsync(), timeout, timeUnit);
+        broadcastDependencies.forEach(PrestoSparkBroadcastDependency::destroy);
+        return result;
+    }
+
+    public JavaPairRDD<MutablePartitionId, T> getRdd()
+    {
+        return rdd;
+    }
+
+    public List<PrestoSparkBroadcastDependency> getBroadcastDependencies()
+    {
+        return broadcastDependencies;
+    }
+}

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkBroadcastTableCacheManager.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkBroadcastTableCacheManager.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark.execution;
+
+import com.facebook.presto.common.Page;
+import com.facebook.presto.execution.StageId;
+import com.facebook.presto.spi.plan.PlanNodeId;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+
+public class PrestoSparkBroadcastTableCacheManager
+{
+    // Currently we cache HT from a single stage. When a task from another stage is scheduled, the cache will be cleared
+    private final Map<BroadcastTableCacheKey, List<List<Page>>> cache = new HashMap<>();
+    private long cacheSizeInBytes;
+
+    public synchronized void removeCachedTablesForStagesOtherThan(StageId stageId)
+    {
+        Iterator<Map.Entry<BroadcastTableCacheKey, List<List<Page>>>> iterator = cache.entrySet().iterator();
+        while (iterator.hasNext()) {
+            Map.Entry<BroadcastTableCacheKey, List<List<Page>>> entry = iterator.next();
+            if (!entry.getKey().getStageId().equals(stageId)) {
+                cacheSizeInBytes -= entry.getValue().stream().mapToLong(pageList -> pageList.stream().mapToLong(Page::getRetainedSizeInBytes).sum()).sum();
+                iterator.remove();
+            }
+        }
+    }
+
+    public synchronized List<List<Page>> getCachedBroadcastTable(StageId stageId, PlanNodeId planNodeId)
+    {
+        return cache.get(new BroadcastTableCacheKey(stageId, planNodeId));
+    }
+
+    public synchronized void cache(StageId stageId, PlanNodeId planNodeId, List<List<Page>> broadcastTable)
+    {
+        cache.put(new BroadcastTableCacheKey(stageId, planNodeId), broadcastTable);
+        cacheSizeInBytes += broadcastTable.stream().mapToLong(pageList -> pageList.stream().mapToLong(Page::getRetainedSizeInBytes).sum()).sum();
+    }
+
+    public synchronized long getCacheSizeInBytes()
+    {
+        return cacheSizeInBytes;
+    }
+
+    private static class BroadcastTableCacheKey
+    {
+        private final StageId stageId;
+        private final PlanNodeId planNodeId;
+
+        public BroadcastTableCacheKey(StageId stageId, PlanNodeId planNodeId)
+        {
+            this.stageId = requireNonNull(stageId, "stageId is null");
+            this.planNodeId = requireNonNull(planNodeId, "planNodeId is null");
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            BroadcastTableCacheKey that = (BroadcastTableCacheKey) o;
+            return Objects.equals(stageId, that.stageId) &&
+                    Objects.equals(planNodeId, that.planNodeId);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(stageId, planNodeId);
+        }
+
+        public StageId getStageId()
+        {
+            return stageId;
+        }
+    }
+}

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkDiskPageInput.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkDiskPageInput.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark.execution;
+
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.common.Page;
+import com.facebook.presto.execution.StageId;
+import com.facebook.presto.spark.classloader_interface.PrestoSparkStorageHandle;
+import com.facebook.presto.spark.classloader_interface.PrestoSparkTaskOutput;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.page.PagesSerde;
+import com.facebook.presto.spi.page.SerializedPage;
+import com.facebook.presto.spi.plan.PlanNodeId;
+import com.facebook.presto.spi.storage.TempDataOperationContext;
+import com.facebook.presto.spi.storage.TempStorage;
+import com.facebook.presto.spi.storage.TempStorageHandle;
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.InputStreamSliceInput;
+
+import javax.annotation.concurrent.GuardedBy;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.zip.CRC32;
+
+import static com.facebook.presto.spark.SparkErrorCode.STORAGE_ERROR;
+import static com.facebook.presto.spi.page.PagesSerdeUtil.readSerializedPages;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Collections.shuffle;
+import static java.util.Objects.requireNonNull;
+
+public class PrestoSparkDiskPageInput
+        implements PrestoSparkPageInput
+{
+    private static final Logger log = Logger.get(PrestoSparkDiskPageInput.class);
+
+    private final PagesSerde pagesSerde;
+    private final TempStorage tempStorage;
+    private final TempDataOperationContext tempDataOperationContext;
+    private final PrestoSparkBroadcastTableCacheManager prestoSparkBroadcastTableCacheManager;
+    private final StageId stageId;
+    private final PlanNodeId planNodeId;
+    private final List<List<PrestoSparkStorageHandle>> broadcastTableFilesInfo;
+
+    @GuardedBy("this")
+    private List<Iterator<Page>> pageIterators;
+    @GuardedBy("this")
+    private int currentIteratorIndex;
+
+    public PrestoSparkDiskPageInput(
+            PagesSerde pagesSerde,
+            TempStorage tempStorage,
+            TempDataOperationContext tempDataOperationContext,
+            PrestoSparkBroadcastTableCacheManager prestoSparkBroadcastTableCacheManager,
+            StageId stageId,
+            PlanNodeId planNodeId,
+            List<List<PrestoSparkStorageHandle>> broadcastTableFilesInfo)
+    {
+        this.pagesSerde = requireNonNull(pagesSerde, "pagesSerde is null");
+        this.tempStorage = requireNonNull(tempStorage, "tempStorage is null");
+        this.tempDataOperationContext = requireNonNull(tempDataOperationContext, "tempDataOperationContext is null");
+        this.prestoSparkBroadcastTableCacheManager = requireNonNull(prestoSparkBroadcastTableCacheManager, "prestoSparkBroadcastTableCacheManager is null");
+        this.stageId = requireNonNull(stageId, "stageId is null");
+        this.planNodeId = requireNonNull(planNodeId, "planNodeId is null");
+        this.broadcastTableFilesInfo = requireNonNull(broadcastTableFilesInfo, "broadcastTableFilesInfo is null");
+    }
+
+    @Override
+    public Page getNextPage()
+    {
+        Page page = null;
+        synchronized (this) {
+            while (page == null) {
+                if (currentIteratorIndex >= getPageIterators().size()) {
+                    return null;
+                }
+                Iterator<Page> currentIterator = getPageIterators().get(currentIteratorIndex);
+                if (currentIterator.hasNext()) {
+                    page = currentIterator.next();
+                }
+                else {
+                    currentIteratorIndex++;
+                }
+            }
+        }
+        return page;
+    }
+
+    private List<Iterator<Page>> getPageIterators()
+    {
+        if (pageIterators == null) {
+            pageIterators = getPages(broadcastTableFilesInfo, tempStorage, tempDataOperationContext, prestoSparkBroadcastTableCacheManager, stageId, planNodeId);
+        }
+        return pageIterators;
+    }
+
+    private List<Iterator<Page>> getPages(
+            List<List<PrestoSparkStorageHandle>> broadcastTableFilesInfo,
+            TempStorage tempStorage,
+            TempDataOperationContext tempDataOperationContext,
+            PrestoSparkBroadcastTableCacheManager prestoSparkBroadcastTableCacheManager,
+            StageId stageId,
+            PlanNodeId planNodeId)
+    {
+        // Try to get table from cache
+        List<List<Page>> pages = prestoSparkBroadcastTableCacheManager.getCachedBroadcastTable(stageId, planNodeId);
+        if (pages == null) {
+            pages = broadcastTableFilesInfo.stream()
+                    .map(tableFiles -> {
+                        List<SerializedPage> serializedPages = loadBroadcastTable(tableFiles, tempStorage, tempDataOperationContext);
+                        return serializedPages.stream().map(serializedPage -> pagesSerde.deserialize(serializedPage)).collect(toImmutableList());
+                    }).collect(toImmutableList());
+
+            // Cache deserialized pages
+            prestoSparkBroadcastTableCacheManager.cache(stageId, planNodeId, pages);
+        }
+
+        return pages.stream().map(List::iterator).collect(toImmutableList());
+    }
+
+    private List<SerializedPage> loadBroadcastTable(
+            List<PrestoSparkStorageHandle> broadcastTaskFilesInfo,
+            TempStorage tempStorage,
+            TempDataOperationContext tempDataOperationContext)
+    {
+        try {
+            CRC32 checksum = new CRC32();
+            ImmutableList.Builder<SerializedPage> pages = ImmutableList.builder();
+            List<PrestoSparkStorageHandle> broadcastTaskFilesInfoCopy = new ArrayList<>(broadcastTaskFilesInfo);
+            shuffle(broadcastTaskFilesInfoCopy);
+            for (PrestoSparkTaskOutput taskFileInfo : broadcastTaskFilesInfoCopy) {
+                checksum.reset();
+                PrestoSparkStorageHandle prestoSparkStorageHandle = (PrestoSparkStorageHandle) taskFileInfo;
+                TempStorageHandle tempStorageHandle = tempStorage.deserialize(prestoSparkStorageHandle.getSerializedStorageHandle());
+                log.info("Reading path: " + tempStorageHandle.toString());
+                try (InputStream inputStream = tempStorage.open(tempDataOperationContext, tempStorageHandle);
+                        InputStreamSliceInput inputStreamSliceInput = new InputStreamSliceInput(inputStream)) {
+                    Iterator<SerializedPage> pagesIterator = readSerializedPages(inputStreamSliceInput);
+                    while (pagesIterator.hasNext()) {
+                        SerializedPage page = pagesIterator.next();
+                        checksum.update(page.getSlice().byteArray(), page.getSlice().byteArrayOffset(), page.getSlice().length());
+                        pages.add(page);
+                    }
+                }
+
+                if (checksum.getValue() != prestoSparkStorageHandle.getChecksum()) {
+                    throw new PrestoException(STORAGE_ERROR, "Disk page checksum does not match. " +
+                            "Data seems to be corrupted on disk for file " + tempStorageHandle.toString());
+                }
+            }
+            return pages.build();
+        }
+        catch (IOException e) {
+            throw new PrestoException(STORAGE_ERROR, "Unable to read data from disk: ", e);
+        }
+    }
+
+    public long getRetainedSizeInBytes()
+    {
+        return prestoSparkBroadcastTableCacheManager.getCacheSizeInBytes();
+    }
+}

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkRemoteSourceFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkRemoteSourceFactory.java
@@ -17,11 +17,15 @@ import com.facebook.presto.Session;
 import com.facebook.presto.common.block.BlockEncodingManager;
 import com.facebook.presto.common.block.SortOrder;
 import com.facebook.presto.common.type.Type;
+import com.facebook.presto.execution.StageId;
 import com.facebook.presto.operator.SourceOperatorFactory;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkSerializedPage;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkShuffleStats;
+import com.facebook.presto.spark.classloader_interface.PrestoSparkStorageHandle;
 import com.facebook.presto.spark.execution.PrestoSparkRemoteSourceOperator.SparkRemoteSourceOperatorFactory;
 import com.facebook.presto.spi.plan.PlanNodeId;
+import com.facebook.presto.spi.storage.TempDataOperationContext;
+import com.facebook.presto.spi.storage.TempStorage;
 import com.facebook.presto.sql.planner.RemoteSourceFactory;
 import com.google.common.collect.ImmutableMap;
 import org.apache.spark.util.CollectionAccumulator;
@@ -30,8 +34,10 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import static com.facebook.presto.spark.PrestoSparkSessionProperties.isStorageBasedBroadcastJoinEnabled;
 import static com.facebook.presto.spark.util.PrestoSparkUtils.createPagesSerde;
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
 
 public class PrestoSparkRemoteSourceFactory
@@ -40,21 +46,36 @@ public class PrestoSparkRemoteSourceFactory
     private final BlockEncodingManager blockEncodingManager;
     private final Map<PlanNodeId, List<PrestoSparkShuffleInput>> shuffleInputsMap;
     private final Map<PlanNodeId, List<java.util.Iterator<PrestoSparkSerializedPage>>> pageInputsMap;
+    private final Map<PlanNodeId, List<List<?>>> broadcastInputsMap;
     private final int taskId;
     private final CollectionAccumulator<PrestoSparkShuffleStats> shuffleStatsCollector;
+    private final TempStorage tempStorage;
+    private final TempDataOperationContext tempDataOperationContext;
+    private final PrestoSparkBroadcastTableCacheManager prestoSparkBroadcastTableCacheManager;
+    private final StageId stageId;
 
     public PrestoSparkRemoteSourceFactory(
             BlockEncodingManager blockEncodingManager,
             Map<PlanNodeId, List<PrestoSparkShuffleInput>> shuffleInputsMap,
             Map<PlanNodeId, List<Iterator<PrestoSparkSerializedPage>>> pageInputsMap,
+            Map<PlanNodeId, List<List<?>>> broadcastInputsMap,
             int taskId,
-            CollectionAccumulator<PrestoSparkShuffleStats> shuffleStatsCollector)
+            CollectionAccumulator<PrestoSparkShuffleStats> shuffleStatsCollector,
+            TempStorage tempStorage,
+            TempDataOperationContext tempDataOperationContext,
+            PrestoSparkBroadcastTableCacheManager prestoSparkBroadcastTableCacheManager,
+            StageId stageId)
     {
         this.blockEncodingManager = requireNonNull(blockEncodingManager, "blockEncodingManager is null");
         this.shuffleInputsMap = ImmutableMap.copyOf(requireNonNull(shuffleInputsMap, "shuffleInputsMap is null"));
         this.pageInputsMap = ImmutableMap.copyOf(requireNonNull(pageInputsMap, "pageInputs is null"));
+        this.broadcastInputsMap = ImmutableMap.copyOf(requireNonNull(broadcastInputsMap, "broadcastInputsMap is null"));
         this.taskId = taskId;
         this.shuffleStatsCollector = requireNonNull(shuffleStatsCollector, "shuffleStatsCollector is null");
+        this.tempDataOperationContext = requireNonNull(tempDataOperationContext, "tempDataOperationContext is null");
+        this.tempStorage = requireNonNull(tempStorage, "tempStorage is null");
+        this.prestoSparkBroadcastTableCacheManager = requireNonNull(prestoSparkBroadcastTableCacheManager, "prestoSparkBroadcastTableCacheManager is null");
+        this.stageId = requireNonNull(stageId, "stageId is null");
     }
 
     @Override
@@ -62,8 +83,34 @@ public class PrestoSparkRemoteSourceFactory
     {
         List<PrestoSparkShuffleInput> shuffleInputs = shuffleInputsMap.get(planNodeId);
         List<java.util.Iterator<PrestoSparkSerializedPage>> pageInputs = pageInputsMap.get(planNodeId);
-        checkArgument(shuffleInputs != null || pageInputs != null, "input not found for plan node with id %s", planNodeId);
+        List<List<?>> broadcastInputs = broadcastInputsMap.get(planNodeId);
+        checkArgument(shuffleInputs != null || pageInputs != null || broadcastInputs != null, "input not found for plan node with id %s", planNodeId);
         checkArgument(shuffleInputs == null || pageInputs == null, "single remote source cannot accept both, shuffle and page inputs");
+        if (broadcastInputs != null) {
+            if (isStorageBasedBroadcastJoinEnabled(session)) {
+                List<List<PrestoSparkStorageHandle>> diskPageInputs =
+                        broadcastInputs.stream().map(input -> ((List<PrestoSparkStorageHandle>) input)).collect(toImmutableList());
+                return new SparkRemoteSourceOperatorFactory(
+                        operatorId,
+                        planNodeId,
+                        new PrestoSparkDiskPageInput(
+                                createPagesSerde(blockEncodingManager),
+                                tempStorage,
+                                tempDataOperationContext,
+                                prestoSparkBroadcastTableCacheManager,
+                                stageId,
+                                planNodeId,
+                                diskPageInputs));
+            }
+            else {
+                List<Iterator<PrestoSparkSerializedPage>> serializedPageInputs =
+                        broadcastInputs.stream().map(input -> ((List<PrestoSparkSerializedPage>) input).iterator()).collect(toImmutableList());
+                return new SparkRemoteSourceOperatorFactory(
+                        operatorId,
+                        planNodeId,
+                        new PrestoSparkSerializedPageInput(createPagesSerde(blockEncodingManager), serializedPageInputs));
+            }
+        }
 
         if (pageInputs != null) {
             return new SparkRemoteSourceOperatorFactory(

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/planner/PrestoSparkRddFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/planner/PrestoSparkRddFactory.java
@@ -24,7 +24,6 @@ import com.facebook.presto.spark.PrestoSparkTaskDescriptor;
 import com.facebook.presto.spark.classloader_interface.MutablePartitionId;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkMutableRow;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkPartitioner;
-import com.facebook.presto.spark.classloader_interface.PrestoSparkSerializedPage;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkShuffleSerializer;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkShuffleStats;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkTaskExecutorFactoryProvider;
@@ -140,7 +139,7 @@ public class PrestoSparkRddFactory
             Session session,
             PlanFragment fragment,
             Map<PlanFragmentId, JavaPairRDD<MutablePartitionId, PrestoSparkMutableRow>> rddInputs,
-            Map<PlanFragmentId, Broadcast<List<PrestoSparkSerializedPage>>> broadcastInputs,
+            Map<PlanFragmentId, Broadcast<List<T>>> broadcastInputs,
             PrestoSparkTaskExecutorFactoryProvider executorFactoryProvider,
             CollectionAccumulator<SerializedTaskInfo> taskInfoCollector,
             CollectionAccumulator<PrestoSparkShuffleStats> shuffleStatsCollector,
@@ -260,7 +259,7 @@ public class PrestoSparkRddFactory
             CollectionAccumulator<PrestoSparkShuffleStats> shuffleStatsCollector,
             TableWriteInfo tableWriteInfo,
             Map<PlanFragmentId, JavaPairRDD<MutablePartitionId, PrestoSparkMutableRow>> rddInputs,
-            Map<PlanFragmentId, Broadcast<List<PrestoSparkSerializedPage>>> broadcastInputs,
+            Map<PlanFragmentId, Broadcast<List<T>>> broadcastInputs,
             Class<T> outputType)
     {
         checkInputs(fragment.getRemoteSourceNodes(), rddInputs, broadcastInputs);
@@ -545,16 +544,16 @@ public class PrestoSparkRddFactory
                 .findAll();
     }
 
-    private static Map<String, Broadcast<List<PrestoSparkSerializedPage>>> toTaskProcessorBroadcastInputs(Map<PlanFragmentId, Broadcast<List<PrestoSparkSerializedPage>>> broadcastInputs)
+    private static <T extends PrestoSparkTaskOutput> Map<String, Broadcast<List<T>>> toTaskProcessorBroadcastInputs(Map<PlanFragmentId, Broadcast<List<T>>> broadcastInputs)
     {
         return broadcastInputs.entrySet().stream()
                 .collect(toImmutableMap(entry -> entry.getKey().toString(), Map.Entry::getValue));
     }
 
-    private static void checkInputs(
+    private static <T extends PrestoSparkTaskOutput> void checkInputs(
             List<RemoteSourceNode> remoteSources,
             Map<PlanFragmentId, JavaPairRDD<MutablePartitionId, PrestoSparkMutableRow>> rddInputs,
-            Map<PlanFragmentId, Broadcast<List<PrestoSparkSerializedPage>>> broadcastInputs)
+            Map<PlanFragmentId, Broadcast<List<T>>> broadcastInputs)
     {
         Set<PlanFragmentId> expectedInputs = remoteSources.stream()
                 .map(RemoteSourceNode::getSourceFragmentIds)

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkConfig.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkConfig.java
@@ -24,6 +24,7 @@ import static com.facebook.airlift.configuration.testing.ConfigAssertions.assert
 import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static io.airlift.units.DataSize.Unit.GIGABYTE;
 import static io.airlift.units.DataSize.Unit.KILOBYTE;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
 
 public class TestPrestoSparkConfig
 {
@@ -36,7 +37,10 @@ public class TestPrestoSparkConfig
                 .setMinSparkInputPartitionCountForAutoTune(100)
                 .setMaxSparkInputPartitionCountForAutoTune(1000)
                 .setMaxSplitsDataSizePerSparkPartition(new DataSize(2, GIGABYTE))
-                .setShuffleOutputTargetAverageRowSize(new DataSize(1, KILOBYTE)));
+                .setShuffleOutputTargetAverageRowSize(new DataSize(1, KILOBYTE))
+                .setStorageBasedBroadcastJoinEnabled(false)
+                .setStorageBasedBroadcastJoinStorage("local")
+                .setStorageBasedBroadcastJoinWriteBufferSize(new DataSize(24, MEGABYTE)));
     }
 
     @Test
@@ -49,6 +53,9 @@ public class TestPrestoSparkConfig
                 .put("spark.max-spark-input-partition-count-for-auto-tune", "2000")
                 .put("spark.max-splits-data-size-per-partition", "4GB")
                 .put("spark.shuffle-output-target-average-row-size", "10kB")
+                .put("spark.storage-based-broadcast-join-enabled", "true")
+                .put("spark.storage-based-broadcast-join-storage", "tempfs")
+                .put("spark.storage-based-broadcast-join-write-buffer-size", "4MB")
                 .build();
         PrestoSparkConfig expected = new PrestoSparkConfig()
                 .setSparkPartitionCountAutoTuneEnabled(false)
@@ -56,7 +63,10 @@ public class TestPrestoSparkConfig
                 .setMinSparkInputPartitionCountForAutoTune(200)
                 .setMaxSparkInputPartitionCountForAutoTune(2000)
                 .setMaxSplitsDataSizePerSparkPartition(new DataSize(4, GIGABYTE))
-                .setShuffleOutputTargetAverageRowSize(new DataSize(10, KILOBYTE));
+                .setShuffleOutputTargetAverageRowSize(new DataSize(10, KILOBYTE))
+                .setStorageBasedBroadcastJoinEnabled(true)
+                .setStorageBasedBroadcastJoinStorage("tempfs")
+                .setStorageBasedBroadcastJoinWriteBufferSize(new DataSize(4, MEGABYTE));
         assertFullMapping(properties, expected);
     }
 }

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkConfInitializer.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkConfInitializer.java
@@ -39,7 +39,8 @@ public class PrestoSparkConfInitializer
                 PrestoSparkSerializedPage.class,
                 SerializedPrestoSparkTaskDescriptor.class,
                 SerializedTaskInfo.class,
-                PrestoSparkShuffleStats.class
+                PrestoSparkShuffleStats.class,
+                PrestoSparkStorageHandle.class
         });
     }
 

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkStorageHandle.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkStorageHandle.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark.classloader_interface;
+
+import java.io.Serializable;
+
+import static java.util.Objects.requireNonNull;
+
+public class PrestoSparkStorageHandle
+        implements Serializable, PrestoSparkTaskOutput
+{
+    private final byte[] serializedStorageHandle;
+    private final long uncompressedSizeInBytes;
+    private final long compressedSizeInBytes;
+    private final long checksum;
+    private final int positionCount;
+
+    public PrestoSparkStorageHandle(
+            byte[] serializedStorageHandle,
+            long uncompressedSizeInBytes,
+            long compressedSizeInBytes,
+            long checksum,
+            int positionCount)
+    {
+        this.serializedStorageHandle = requireNonNull(serializedStorageHandle, "serializedStorageHandle is null");
+        this.uncompressedSizeInBytes = uncompressedSizeInBytes;
+        this.compressedSizeInBytes = compressedSizeInBytes;
+        this.checksum = requireNonNull(checksum, "checksum is null");
+        this.positionCount = positionCount;
+    }
+
+    public long getUncompressedSizeInBytes()
+    {
+        return uncompressedSizeInBytes;
+    }
+
+    public long getCompressedSizeInBytes()
+    {
+        return compressedSizeInBytes;
+    }
+
+    public byte[] getSerializedStorageHandle()
+    {
+        return serializedStorageHandle;
+    }
+
+    public long getChecksum()
+    {
+        return checksum;
+    }
+
+    @Override
+    public long getPositionCount()
+    {
+        return positionCount;
+    }
+
+    @Override
+    public long getSize()
+    {
+        return uncompressedSizeInBytes;
+    }
+}

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkTaskInputs.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkTaskInputs.java
@@ -24,17 +24,17 @@ import java.util.Map;
 import static java.util.Collections.unmodifiableMap;
 import static java.util.Objects.requireNonNull;
 
-public class PrestoSparkTaskInputs
+public class PrestoSparkTaskInputs<T extends PrestoSparkTaskOutput>
 {
     // fragmentId -> Iterator<[partitionId, page]>
     private final Map<String, Iterator<Tuple2<MutablePartitionId, PrestoSparkMutableRow>>> shuffleInputs;
-    private final Map<String, Broadcast<List<PrestoSparkSerializedPage>>> broadcastInputs;
+    private final Map<String, Broadcast<List<T>>> broadcastInputs;
     // For the COORDINATOR_ONLY fragment we first collect the inputs on the Driver
     private final Map<String, List<PrestoSparkSerializedPage>> inMemoryInputs;
 
     public PrestoSparkTaskInputs(
             Map<String, Iterator<Tuple2<MutablePartitionId, PrestoSparkMutableRow>>> shuffleInputs,
-            Map<String, Broadcast<List<PrestoSparkSerializedPage>>> broadcastInputs,
+            Map<String, Broadcast<List<T>>> broadcastInputs,
             Map<String, List<PrestoSparkSerializedPage>> inMemoryInputs)
     {
         this.shuffleInputs = unmodifiableMap(new HashMap<>(requireNonNull(shuffleInputs, "shuffleInputs is null")));
@@ -47,7 +47,7 @@ public class PrestoSparkTaskInputs
         return shuffleInputs;
     }
 
-    public Map<String, Broadcast<List<PrestoSparkSerializedPage>>> getBroadcastInputs()
+    public Map<String, Broadcast<List<T>>> getBroadcastInputs()
     {
         return broadcastInputs;
     }

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkTaskProcessor.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkTaskProcessor.java
@@ -35,7 +35,7 @@ public class PrestoSparkTaskProcessor<T extends PrestoSparkTaskOutput>
     private final CollectionAccumulator<SerializedTaskInfo> taskInfoCollector;
     private final CollectionAccumulator<PrestoSparkShuffleStats> shuffleStatsCollector;
     // fragmentId -> Broadcast
-    private final Map<String, Broadcast<List<PrestoSparkSerializedPage>>> broadcastInputs;
+    private final Map<String, Broadcast<List<T>>> broadcastInputs;
     private final Class<T> outputType;
 
     public PrestoSparkTaskProcessor(
@@ -43,7 +43,7 @@ public class PrestoSparkTaskProcessor<T extends PrestoSparkTaskOutput>
             SerializedPrestoSparkTaskDescriptor serializedTaskDescriptor,
             CollectionAccumulator<SerializedTaskInfo> taskInfoCollector,
             CollectionAccumulator<PrestoSparkShuffleStats> shuffleStatsCollector,
-            Map<String, Broadcast<List<PrestoSparkSerializedPage>>> broadcastInputs,
+            Map<String, Broadcast<List<T>>> broadcastInputs,
             Class<T> outputType)
     {
         this.taskExecutorFactoryProvider = requireNonNull(taskExecutorFactoryProvider, "taskExecutorFactoryProvider is null");

--- a/presto-spark-common/src/main/java/com/facebook/presto/spark/SparkErrorCode.java
+++ b/presto-spark-common/src/main/java/com/facebook/presto/spark/SparkErrorCode.java
@@ -17,6 +17,7 @@ import com.facebook.presto.spi.ErrorCode;
 import com.facebook.presto.spi.ErrorCodeSupplier;
 import com.facebook.presto.spi.ErrorType;
 
+import static com.facebook.presto.spi.ErrorType.EXTERNAL;
 import static com.facebook.presto.spi.ErrorType.INSUFFICIENT_RESOURCES;
 import static com.facebook.presto.spi.ErrorType.INTERNAL_ERROR;
 
@@ -26,7 +27,9 @@ public enum SparkErrorCode
     GENERIC_SPARK_ERROR(0, INTERNAL_ERROR),
     SPARK_EXECUTOR_OOM(1, INTERNAL_ERROR),
     SPARK_EXECUTOR_LOST(2, INTERNAL_ERROR),
-    EXCEEDED_SPARK_DRIVER_MAX_RESULT_SIZE(3, INSUFFICIENT_RESOURCES)
+    EXCEEDED_SPARK_DRIVER_MAX_RESULT_SIZE(3, INSUFFICIENT_RESOURCES),
+    UNSUPPORTED_STORAGE_TYPE(4, INTERNAL_ERROR),
+    STORAGE_ERROR(5, EXTERNAL)
     /**/;
 
     private final ErrorCode errorCode;

--- a/presto-spi/src/main/java/com/facebook/presto/spi/storage/StorageCapabilities.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/storage/StorageCapabilities.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.storage;
+
+public enum StorageCapabilities
+{
+    REMOTELY_ACCESSIBLE,
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/storage/TempStorage.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/storage/TempStorage.java
@@ -15,6 +15,7 @@ package com.facebook.presto.spi.storage;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.List;
 
 public interface TempStorage
 {
@@ -26,4 +27,10 @@ public interface TempStorage
 
     void remove(TempDataOperationContext context, TempStorageHandle handle)
             throws IOException;
+
+    byte[] serializeHandle(TempStorageHandle storageHandle);
+
+    TempStorageHandle deserialize(byte[] serializedStorageHandle);
+
+    List<StorageCapabilities> getStorageCapabilities();
 }


### PR DESCRIPTION
== Test plan ==
- Added unit tests to trigger broadcast join using disk.
- Ran verifier for around 100 broadcast join queries.

== RELEASE NOTES ==
General Changes
- Add support for distributing broadcast table using permanent storage, thereby removing spark driver from the distribution flow
This feature can be enabled/disabled using 'distribute_broadcast_table_using_disk' session property

Hive Changes
- None
