### PR TITLE
Fix maven scope for airlift units library

### DIFF
--- a/presto-memory-context/pom.xml
+++ b/presto-memory-context/pom.xml
@@ -28,21 +28,22 @@
             <artifactId>guava</artifactId>
         </dependency>
 
-        <dependency>
-            <groupId>io.airlift</groupId>
-            <artifactId>units</artifactId>
-        </dependency>
-
         <!-- for testing -->
         <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>testing</artifactId>
             <scope>test</scope>
         </dependency>
 
         <dependency>
-            <groupId>com.facebook.airlift</groupId>
-            <artifactId>testing</artifactId>
+            <groupId>io.airlift</groupId>
+            <artifactId>units</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Airlift units library is only used from TestMemoryContexts.
Therefore a test scope should be sufficient.


Test plan
mvn clean install -Dmaven.test.skip=true
runs without any depepency-analyze errors

```
== NO RELEASE NOTE ==
```