### PR TITLE
Configurable ZSTD compression level for ORC Writer

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/pagefile/PageFileWriterFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/pagefile/PageFileWriterFactory.java
@@ -45,6 +45,7 @@ import javax.inject.Inject;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.Properties;
 import java.util.concurrent.Callable;
 
@@ -150,11 +151,11 @@ public class PageFileWriterFactory
                 pageDecompressor = new AirliftDecompressorAdapter(new Lz4Decompressor());
                 break;
             case GZIP:
-                pageCompressor = new AirliftCompressorAdapter(new DeflateCompressor());
+                pageCompressor = new AirliftCompressorAdapter(new DeflateCompressor(OptionalInt.empty()));
                 pageDecompressor = new AirliftDecompressorAdapter(new InflateDecompressor());
                 break;
             case ZSTD:
-                pageCompressor = new AirliftCompressorAdapter(new ZstdJniCompressor());
+                pageCompressor = new AirliftCompressorAdapter(new ZstdJniCompressor(OptionalInt.empty()));
                 pageDecompressor = new AirliftDecompressorAdapter(new ZstdJniDecompressor());
                 break;
             default:

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
@@ -24,6 +24,7 @@ import com.facebook.presto.orc.WriterStats.FlushReason;
 import com.facebook.presto.orc.metadata.ColumnEncoding;
 import com.facebook.presto.orc.metadata.CompressedMetadataWriter;
 import com.facebook.presto.orc.metadata.CompressionKind;
+import com.facebook.presto.orc.metadata.CompressionParameters;
 import com.facebook.presto.orc.metadata.DwrfEncryption;
 import com.facebook.presto.orc.metadata.EncryptionGroup;
 import com.facebook.presto.orc.metadata.Footer;
@@ -111,13 +112,12 @@ public class OrcWriter
     private final DataSink dataSink;
     private final List<Type> types;
     private final OrcEncoding orcEncoding;
-    private final CompressionKind compression;
+    private final CompressionParameters compressionParameters;
     private final int stripeMinBytes;
     private final int stripeMaxBytes;
     private final int chunkMaxLogicalBytes;
     private final int stripeMaxRowCount;
     private final int rowGroupMaxRowCount;
-    private final int maxCompressionBufferSize;
     private final Map<String, String> userMetadata;
     private final CompressedMetadataWriter metadataWriter;
     private final DateTimeZone hiveStorageTimeZone;
@@ -148,7 +148,7 @@ public class OrcWriter
             List<String> columnNames,
             List<Type> types,
             OrcEncoding orcEncoding,
-            CompressionKind compression,
+            CompressionKind compressionKind,
             Optional<DwrfWriterEncryption> encryption,
             DwrfEncryptionProvider dwrfEncryptionProvider,
             OrcWriterOptions options,
@@ -163,8 +163,11 @@ public class OrcWriter
         this.dataSink = requireNonNull(dataSink, "dataSink is null");
         this.types = ImmutableList.copyOf(requireNonNull(types, "types is null"));
         this.orcEncoding = requireNonNull(orcEncoding, "orcEncoding is null");
-        this.compression = requireNonNull(compression, "compression is null");
-        recordValidation(validation -> validation.setCompression(compression));
+
+        requireNonNull(compressionKind, "compressionKind is null");
+        int maxCompressionBufferSize = toIntExact(options.getMaxCompressionBufferSize().toBytes());
+        this.compressionParameters = new CompressionParameters(compressionKind, options.getCompressionLevel(), maxCompressionBufferSize);
+        recordValidation(validation -> validation.setCompression(compressionKind));
 
         requireNonNull(options, "options is null");
         checkArgument(options.getStripeMaxSize().compareTo(options.getStripeMinSize()) >= 0, "stripeMaxSize must be greater than stripeMinSize");
@@ -174,13 +177,12 @@ public class OrcWriter
         this.stripeMaxRowCount = options.getStripeMaxRowCount();
         this.rowGroupMaxRowCount = options.getRowGroupMaxRowCount();
         recordValidation(validation -> validation.setRowGroupMaxRowCount(rowGroupMaxRowCount));
-        this.maxCompressionBufferSize = toIntExact(options.getMaxCompressionBufferSize().toBytes());
 
         this.userMetadata = ImmutableMap.<String, String>builder()
                 .putAll(requireNonNull(userMetadata, "userMetadata is null"))
                 .put(PRESTO_ORC_WRITER_VERSION_METADATA_KEY, PRESTO_ORC_WRITER_VERSION)
                 .build();
-        this.metadataWriter = new CompressedMetadataWriter(orcEncoding.createMetadataWriter(), compression, Optional.empty(), maxCompressionBufferSize);
+        this.metadataWriter = new CompressedMetadataWriter(orcEncoding.createMetadataWriter(), compressionParameters, Optional.empty());
         this.hiveStorageTimeZone = requireNonNull(hiveStorageTimeZone, "hiveStorageTimeZone is null");
         this.stats = requireNonNull(stats, "stats is null");
 
@@ -234,8 +236,7 @@ public class OrcWriter
                     fieldColumnIndex,
                     orcTypes,
                     fieldType,
-                    compression,
-                    maxCompressionBufferSize,
+                    compressionParameters,
                     orcEncoding,
                     hiveStorageTimeZone,
                     options.getMaxStringStatisticsLimit(),
@@ -560,7 +561,7 @@ public class OrcWriter
                     .filter(entry -> dwrfEncryptionInfo.getGroupByNodeId(entry.getKey()).orElseThrow(() -> new VerifyError("missing group for encryptedColumn")) == groupId)
                     .collect(toImmutableMap(Entry::getKey, Entry::getValue));
             DwrfDataEncryptor dwrfDataEncryptor = dwrfEncryptionInfo.getEncryptorByGroupId(i);
-            OrcOutputBuffer buffer = new OrcOutputBuffer(compression, Optional.of(dwrfDataEncryptor), maxCompressionBufferSize);
+            OrcOutputBuffer buffer = new OrcOutputBuffer(compressionParameters, Optional.of(dwrfDataEncryptor));
             toStripeEncryptionGroup(
                     new StripeEncryptionGroup(
                             ImmutableList.copyOf(encryptedStreams.get(i)),
@@ -664,7 +665,7 @@ public class OrcWriter
         outputData.add(createDataOutput(footerSlice));
 
         recordValidation(validation -> validation.setVersion(metadataWriter.getOrcMetadataVersion()));
-        Slice postscriptSlice = metadataWriter.writePostscript(footerSlice.length(), metadataSlice.length(), compression, maxCompressionBufferSize);
+        Slice postscriptSlice = metadataWriter.writePostscript(footerSlice.length(), metadataSlice.length(), compressionParameters.getKind(), compressionParameters.getMaxBufferSize());
         outputData.add(createDataOutput(postscriptSlice));
         outputData.add(createDataOutput(Slices.wrappedBuffer((byte) postscriptSlice.length())));
         return outputData;
@@ -715,7 +716,7 @@ public class OrcWriter
     {
         DwrfProto.FileStatistics fileStatistics = toFileStatistics(statsFromRoot);
         DwrfDataEncryptor dwrfDataEncryptor = dwrfEncryptionInfo.getEncryptorByGroupId(groupId);
-        OrcOutputBuffer buffer = new OrcOutputBuffer(compression, Optional.of(dwrfDataEncryptor), maxCompressionBufferSize);
+        OrcOutputBuffer buffer = new OrcOutputBuffer(compressionParameters, Optional.of(dwrfDataEncryptor));
         fileStatistics.writeTo(buffer);
         buffer.close();
         DynamicSliceOutput output = new DynamicSliceOutput(toIntExact(buffer.getOutputDataSize()));

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriterOptions.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriterOptions.java
@@ -16,6 +16,8 @@ package com.facebook.presto.orc;
 import com.google.common.annotations.VisibleForTesting;
 import io.airlift.units.DataSize;
 
+import java.util.OptionalInt;
+
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.units.DataSize.Unit.BYTE;
@@ -44,6 +46,7 @@ public class OrcWriterOptions
     private final DataSize dictionaryMaxMemory;
     private final DataSize maxStringStatisticsLimit;
     private final DataSize maxCompressionBufferSize;
+    private final OptionalInt compressionLevel;
 
     public OrcWriterOptions()
     {
@@ -54,7 +57,8 @@ public class OrcWriterOptions
                 DEFAULT_ROW_GROUP_MAX_ROW_COUNT,
                 DEFAULT_DICTIONARY_MAX_MEMORY,
                 DEFAULT_MAX_STRING_STATISTICS_LIMIT,
-                DEFAULT_MAX_COMPRESSION_BUFFER_SIZE);
+                DEFAULT_MAX_COMPRESSION_BUFFER_SIZE,
+                OptionalInt.empty());
     }
 
     private OrcWriterOptions(
@@ -64,7 +68,8 @@ public class OrcWriterOptions
             int rowGroupMaxRowCount,
             DataSize dictionaryMaxMemory,
             DataSize maxStringStatisticsLimit,
-            DataSize maxCompressionBufferSize)
+            DataSize maxCompressionBufferSize,
+            OptionalInt compressionLevel)
     {
         requireNonNull(stripeMinSize, "stripeMinSize is null");
         requireNonNull(stripeMaxSize, "stripeMaxSize is null");
@@ -73,6 +78,7 @@ public class OrcWriterOptions
         requireNonNull(dictionaryMaxMemory, "dictionaryMaxMemory is null");
         requireNonNull(maxStringStatisticsLimit, "maxStringStatisticsLimit is null");
         requireNonNull(maxCompressionBufferSize, "maxCompressionBufferSize is null");
+        requireNonNull(compressionLevel, "zstdCompressionLevel is null");
 
         this.stripeMinSize = stripeMinSize;
         this.stripeMaxSize = stripeMaxSize;
@@ -81,6 +87,7 @@ public class OrcWriterOptions
         this.dictionaryMaxMemory = dictionaryMaxMemory;
         this.maxStringStatisticsLimit = maxStringStatisticsLimit;
         this.maxCompressionBufferSize = maxCompressionBufferSize;
+        this.compressionLevel = compressionLevel;
     }
 
     public DataSize getStripeMinSize()
@@ -118,39 +125,113 @@ public class OrcWriterOptions
         return maxCompressionBufferSize;
     }
 
+    public OptionalInt getCompressionLevel()
+    {
+        return compressionLevel;
+    }
+
     public OrcWriterOptions withStripeMinSize(DataSize stripeMinSize)
     {
-        return new OrcWriterOptions(stripeMinSize, stripeMaxSize, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, maxStringStatisticsLimit, maxCompressionBufferSize);
+        return new OrcWriterOptions(
+                stripeMinSize,
+                stripeMaxSize,
+                stripeMaxRowCount,
+                rowGroupMaxRowCount,
+                dictionaryMaxMemory,
+                maxStringStatisticsLimit,
+                maxCompressionBufferSize,
+                compressionLevel);
     }
 
     public OrcWriterOptions withStripeMaxSize(DataSize stripeMaxSize)
     {
-        return new OrcWriterOptions(stripeMinSize, stripeMaxSize, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, maxStringStatisticsLimit, maxCompressionBufferSize);
+        return new OrcWriterOptions(
+                stripeMinSize,
+                stripeMaxSize,
+                stripeMaxRowCount,
+                rowGroupMaxRowCount,
+                dictionaryMaxMemory,
+                maxStringStatisticsLimit,
+                maxCompressionBufferSize,
+                compressionLevel);
     }
 
     public OrcWriterOptions withStripeMaxRowCount(int stripeMaxRowCount)
     {
-        return new OrcWriterOptions(stripeMinSize, stripeMaxSize, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, maxStringStatisticsLimit, maxCompressionBufferSize);
+        return new OrcWriterOptions(
+                stripeMinSize,
+                stripeMaxSize,
+                stripeMaxRowCount,
+                rowGroupMaxRowCount,
+                dictionaryMaxMemory,
+                maxStringStatisticsLimit,
+                maxCompressionBufferSize,
+                compressionLevel);
     }
 
     public OrcWriterOptions withRowGroupMaxRowCount(int rowGroupMaxRowCount)
     {
-        return new OrcWriterOptions(stripeMinSize, stripeMaxSize, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, maxStringStatisticsLimit, maxCompressionBufferSize);
+        return new OrcWriterOptions(
+                stripeMinSize,
+                stripeMaxSize,
+                stripeMaxRowCount,
+                rowGroupMaxRowCount,
+                dictionaryMaxMemory,
+                maxStringStatisticsLimit,
+                maxCompressionBufferSize,
+                compressionLevel);
     }
 
     public OrcWriterOptions withDictionaryMaxMemory(DataSize dictionaryMaxMemory)
     {
-        return new OrcWriterOptions(stripeMinSize, stripeMaxSize, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, maxStringStatisticsLimit, maxCompressionBufferSize);
+        return new OrcWriterOptions(
+                stripeMinSize,
+                stripeMaxSize,
+                stripeMaxRowCount,
+                rowGroupMaxRowCount,
+                dictionaryMaxMemory,
+                maxStringStatisticsLimit,
+                maxCompressionBufferSize,
+                compressionLevel);
     }
 
     public OrcWriterOptions withMaxStringStatisticsLimit(DataSize maxStringStatisticsLimit)
     {
-        return new OrcWriterOptions(stripeMinSize, stripeMaxSize, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, maxStringStatisticsLimit, maxCompressionBufferSize);
+        return new OrcWriterOptions(
+                stripeMinSize,
+                stripeMaxSize,
+                stripeMaxRowCount,
+                rowGroupMaxRowCount,
+                dictionaryMaxMemory,
+                maxStringStatisticsLimit,
+                maxCompressionBufferSize,
+                compressionLevel);
     }
 
     public OrcWriterOptions withMaxCompressionBufferSize(DataSize maxCompressionBufferSize)
     {
-        return new OrcWriterOptions(stripeMinSize, stripeMaxSize, stripeMaxRowCount, rowGroupMaxRowCount, dictionaryMaxMemory, maxStringStatisticsLimit, maxCompressionBufferSize);
+        return new OrcWriterOptions(
+                stripeMinSize,
+                stripeMaxSize,
+                stripeMaxRowCount,
+                rowGroupMaxRowCount,
+                dictionaryMaxMemory,
+                maxStringStatisticsLimit,
+                maxCompressionBufferSize,
+                compressionLevel);
+    }
+
+    public OrcWriterOptions withCompressionLevel(OptionalInt compressionLevel)
+    {
+        return new OrcWriterOptions(
+                stripeMinSize,
+                stripeMaxSize,
+                stripeMaxRowCount,
+                rowGroupMaxRowCount,
+                dictionaryMaxMemory,
+                maxStringStatisticsLimit,
+                maxCompressionBufferSize,
+                compressionLevel);
     }
 
     @Override
@@ -164,6 +245,7 @@ public class OrcWriterOptions
                 .add("dictionaryMaxMemory", dictionaryMaxMemory)
                 .add("maxStringStatisticsLimit", maxStringStatisticsLimit)
                 .add("maxCompressionBufferSize", maxCompressionBufferSize)
+                .add("compressionLevel", compressionLevel)
                 .toString();
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/CompressedMetadataWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/CompressedMetadataWriter.java
@@ -30,10 +30,10 @@ public class CompressedMetadataWriter
     private final MetadataWriter metadataWriter;
     private final OrcOutputBuffer buffer;
 
-    public CompressedMetadataWriter(MetadataWriter metadataWriter, CompressionKind compression, Optional<DwrfDataEncryptor> dwrfEncryptor, int bufferSize)
+    public CompressedMetadataWriter(MetadataWriter metadataWriter, CompressionParameters compressionParameters, Optional<DwrfDataEncryptor> dwrfEncryptor)
     {
         this.metadataWriter = requireNonNull(metadataWriter, "metadataWriter is null");
-        this.buffer = new OrcOutputBuffer(compression, dwrfEncryptor, bufferSize);
+        this.buffer = new OrcOutputBuffer(compressionParameters, dwrfEncryptor);
     }
 
     public List<Integer> getOrcMetadataVersion()

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/CompressionParameters.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/CompressionParameters.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.metadata;
+
+import java.util.OptionalInt;
+
+import static java.util.Objects.requireNonNull;
+
+public class CompressionParameters
+{
+    private final CompressionKind kind;
+    private final OptionalInt level;
+    private final int maxBufferSize;
+
+    public CompressionParameters(CompressionKind kind, OptionalInt level, int maxBufferSize)
+    {
+        this.kind = requireNonNull(kind, "kind is null");
+        this.level = requireNonNull(level, "level is null");
+        this.maxBufferSize = maxBufferSize;
+    }
+
+    public CompressionKind getKind()
+    {
+        return kind;
+    }
+
+    public OptionalInt getLevel()
+    {
+        return level;
+    }
+
+    public int getMaxBufferSize()
+    {
+        return maxBufferSize;
+    }
+}

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/BooleanOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/BooleanOutputStream.java
@@ -17,7 +17,7 @@ import com.facebook.presto.orc.DwrfDataEncryptor;
 import com.facebook.presto.orc.OrcOutputBuffer;
 import com.facebook.presto.orc.checkpoint.BooleanStreamCheckpoint;
 import com.facebook.presto.orc.checkpoint.ByteStreamCheckpoint;
-import com.facebook.presto.orc.metadata.CompressionKind;
+import com.facebook.presto.orc.metadata.CompressionParameters;
 import com.google.common.collect.ImmutableList;
 import org.openjdk.jol.info.ClassLayout;
 
@@ -40,9 +40,9 @@ public class BooleanOutputStream
     private int data;
     private boolean closed;
 
-    public BooleanOutputStream(CompressionKind compression, Optional<DwrfDataEncryptor> dwrfEncryptor, int bufferSize)
+    public BooleanOutputStream(CompressionParameters compressionParameters, Optional<DwrfDataEncryptor> dwrfEncryptor)
     {
-        this(new ByteOutputStream(compression, dwrfEncryptor, bufferSize));
+        this(new ByteOutputStream(compressionParameters, dwrfEncryptor));
     }
 
     public BooleanOutputStream(OrcOutputBuffer buffer)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/ByteArrayOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/ByteArrayOutputStream.java
@@ -16,7 +16,7 @@ package com.facebook.presto.orc.stream;
 import com.facebook.presto.orc.DwrfDataEncryptor;
 import com.facebook.presto.orc.OrcOutputBuffer;
 import com.facebook.presto.orc.checkpoint.ByteArrayStreamCheckpoint;
-import com.facebook.presto.orc.metadata.CompressionKind;
+import com.facebook.presto.orc.metadata.CompressionParameters;
 import com.facebook.presto.orc.metadata.Stream;
 import com.facebook.presto.orc.metadata.Stream.StreamKind;
 import com.google.common.collect.ImmutableList;
@@ -44,14 +44,14 @@ public class ByteArrayOutputStream
 
     private boolean closed;
 
-    public ByteArrayOutputStream(CompressionKind compression, Optional<DwrfDataEncryptor> dwrfEncryptor, int bufferSize)
+    public ByteArrayOutputStream(CompressionParameters compressionParameters, Optional<DwrfDataEncryptor> dwrfEncryptor)
     {
-        this(compression, dwrfEncryptor, bufferSize, DATA);
+        this(compressionParameters, dwrfEncryptor, DATA);
     }
 
-    public ByteArrayOutputStream(CompressionKind compression, Optional<DwrfDataEncryptor> dwrfEncryptor, int bufferSize, StreamKind streamKind)
+    public ByteArrayOutputStream(CompressionParameters compressionParameters, Optional<DwrfDataEncryptor> dwrfEncryptor, StreamKind streamKind)
     {
-        this.buffer = new OrcOutputBuffer(compression, dwrfEncryptor, bufferSize);
+        this.buffer = new OrcOutputBuffer(compressionParameters, dwrfEncryptor);
         this.streamKind = streamKind;
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/ByteOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/ByteOutputStream.java
@@ -16,7 +16,7 @@ package com.facebook.presto.orc.stream;
 import com.facebook.presto.orc.DwrfDataEncryptor;
 import com.facebook.presto.orc.OrcOutputBuffer;
 import com.facebook.presto.orc.checkpoint.ByteStreamCheckpoint;
-import com.facebook.presto.orc.metadata.CompressionKind;
+import com.facebook.presto.orc.metadata.CompressionParameters;
 import com.facebook.presto.orc.metadata.Stream;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.SizeOf;
@@ -50,9 +50,9 @@ public class ByteOutputStream
 
     private boolean closed;
 
-    public ByteOutputStream(CompressionKind compression, Optional<DwrfDataEncryptor> dwrfEncryptor, int bufferSize)
+    public ByteOutputStream(CompressionParameters compressionParameters, Optional<DwrfDataEncryptor> dwrfEncryptor)
     {
-        this(new OrcOutputBuffer(compression, dwrfEncryptor, bufferSize));
+        this(new OrcOutputBuffer(compressionParameters, dwrfEncryptor));
     }
 
     public ByteOutputStream(OrcOutputBuffer buffer)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/DecimalOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/DecimalOutputStream.java
@@ -16,7 +16,7 @@ package com.facebook.presto.orc.stream;
 import com.facebook.presto.common.type.Decimals;
 import com.facebook.presto.orc.OrcOutputBuffer;
 import com.facebook.presto.orc.checkpoint.DecimalStreamCheckpoint;
-import com.facebook.presto.orc.metadata.CompressionKind;
+import com.facebook.presto.orc.metadata.CompressionParameters;
 import com.facebook.presto.orc.metadata.Stream;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
@@ -44,9 +44,9 @@ public class DecimalOutputStream
 
     private boolean closed;
 
-    public DecimalOutputStream(CompressionKind compression, int bufferSize)
+    public DecimalOutputStream(CompressionParameters compressionParameters)
     {
-        this.buffer = new OrcOutputBuffer(compression, Optional.empty(), bufferSize);
+        this.buffer = new OrcOutputBuffer(compressionParameters, Optional.empty());
     }
 
     // todo rewrite without BigInteger

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/DoubleOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/DoubleOutputStream.java
@@ -16,7 +16,7 @@ package com.facebook.presto.orc.stream;
 import com.facebook.presto.orc.DwrfDataEncryptor;
 import com.facebook.presto.orc.OrcOutputBuffer;
 import com.facebook.presto.orc.checkpoint.DoubleStreamCheckpoint;
-import com.facebook.presto.orc.metadata.CompressionKind;
+import com.facebook.presto.orc.metadata.CompressionParameters;
 import com.facebook.presto.orc.metadata.Stream;
 import com.google.common.collect.ImmutableList;
 import org.openjdk.jol.info.ClassLayout;
@@ -38,9 +38,9 @@ public class DoubleOutputStream
 
     private boolean closed;
 
-    public DoubleOutputStream(CompressionKind compression, Optional<DwrfDataEncryptor> dwrfEncryptor, int bufferSize)
+    public DoubleOutputStream(CompressionParameters compressionParameters, Optional<DwrfDataEncryptor> dwrfEncryptor)
     {
-        this.buffer = new OrcOutputBuffer(compression, dwrfEncryptor, bufferSize);
+        this.buffer = new OrcOutputBuffer(compressionParameters, dwrfEncryptor);
     }
 
     public void writeDouble(double value)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/FloatOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/FloatOutputStream.java
@@ -16,7 +16,7 @@ package com.facebook.presto.orc.stream;
 import com.facebook.presto.orc.DwrfDataEncryptor;
 import com.facebook.presto.orc.OrcOutputBuffer;
 import com.facebook.presto.orc.checkpoint.FloatStreamCheckpoint;
-import com.facebook.presto.orc.metadata.CompressionKind;
+import com.facebook.presto.orc.metadata.CompressionParameters;
 import com.facebook.presto.orc.metadata.Stream;
 import com.google.common.collect.ImmutableList;
 import org.openjdk.jol.info.ClassLayout;
@@ -38,9 +38,9 @@ public class FloatOutputStream
 
     private boolean closed;
 
-    public FloatOutputStream(CompressionKind compression, Optional<DwrfDataEncryptor> dwrfEncryptor, int bufferSize)
+    public FloatOutputStream(CompressionParameters compressionParameters, Optional<DwrfDataEncryptor> dwrfEncryptor)
     {
-        this.buffer = new OrcOutputBuffer(compression, dwrfEncryptor, bufferSize);
+        this.buffer = new OrcOutputBuffer(compressionParameters, dwrfEncryptor);
     }
 
     public void writeFloat(float value)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStream.java
@@ -16,7 +16,7 @@ package com.facebook.presto.orc.stream;
 import com.facebook.presto.orc.DwrfDataEncryptor;
 import com.facebook.presto.orc.OrcEncoding;
 import com.facebook.presto.orc.checkpoint.LongStreamCheckpoint;
-import com.facebook.presto.orc.metadata.CompressionKind;
+import com.facebook.presto.orc.metadata.CompressionParameters;
 
 import java.util.Optional;
 
@@ -26,13 +26,13 @@ import static com.facebook.presto.orc.metadata.Stream.StreamKind.LENGTH;
 public interface LongOutputStream
         extends ValueOutputStream<LongStreamCheckpoint>
 {
-    static LongOutputStream createLengthOutputStream(CompressionKind compression, Optional<DwrfDataEncryptor> dwrfEncryptor, int bufferSize, OrcEncoding orcEncoding)
+    static LongOutputStream createLengthOutputStream(CompressionParameters compressionParameters, Optional<DwrfDataEncryptor> dwrfEncryptor, OrcEncoding orcEncoding)
     {
         if (orcEncoding == DWRF) {
-            return new LongOutputStreamV1(compression, dwrfEncryptor, bufferSize, false, LENGTH);
+            return new LongOutputStreamV1(compressionParameters, dwrfEncryptor, false, LENGTH);
         }
         else {
-            return new LongOutputStreamV2(compression, bufferSize, false, LENGTH);
+            return new LongOutputStreamV2(compressionParameters, false, LENGTH);
         }
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamDwrf.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamDwrf.java
@@ -17,7 +17,7 @@ import com.facebook.presto.orc.DwrfDataEncryptor;
 import com.facebook.presto.orc.OrcOutputBuffer;
 import com.facebook.presto.orc.checkpoint.LongStreamCheckpoint;
 import com.facebook.presto.orc.checkpoint.LongStreamDwrfCheckpoint;
-import com.facebook.presto.orc.metadata.CompressionKind;
+import com.facebook.presto.orc.metadata.CompressionParameters;
 import com.facebook.presto.orc.metadata.Stream;
 import com.facebook.presto.orc.metadata.Stream.StreamKind;
 import com.google.common.collect.ImmutableList;
@@ -43,10 +43,10 @@ public class LongOutputStreamDwrf
 
     private boolean closed;
 
-    public LongOutputStreamDwrf(CompressionKind compression, Optional<DwrfDataEncryptor> dwrfEncryptor, int bufferSize, boolean signed, StreamKind streamKind)
+    public LongOutputStreamDwrf(CompressionParameters compressionParameters, Optional<DwrfDataEncryptor> dwrfEncryptor, boolean signed, StreamKind streamKind)
     {
         this.streamKind = requireNonNull(streamKind, "streamKind is null");
-        this.buffer = new OrcOutputBuffer(compression, dwrfEncryptor, bufferSize);
+        this.buffer = new OrcOutputBuffer(compressionParameters, dwrfEncryptor);
         this.signed = signed;
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamV1.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamV1.java
@@ -17,7 +17,7 @@ import com.facebook.presto.orc.DwrfDataEncryptor;
 import com.facebook.presto.orc.OrcOutputBuffer;
 import com.facebook.presto.orc.checkpoint.LongStreamCheckpoint;
 import com.facebook.presto.orc.checkpoint.LongStreamV1Checkpoint;
-import com.facebook.presto.orc.metadata.CompressionKind;
+import com.facebook.presto.orc.metadata.CompressionParameters;
 import com.facebook.presto.orc.metadata.Stream;
 import com.facebook.presto.orc.metadata.Stream.StreamKind;
 import com.google.common.collect.ImmutableList;
@@ -57,10 +57,10 @@ public class LongOutputStreamV1
 
     private boolean closed;
 
-    public LongOutputStreamV1(CompressionKind compression, Optional<DwrfDataEncryptor> dwrfEncryptor, int bufferSize, boolean signed, StreamKind streamKind)
+    public LongOutputStreamV1(CompressionParameters compressionParameters, Optional<DwrfDataEncryptor> dwrfEncryptor, boolean signed, StreamKind streamKind)
     {
         this.streamKind = requireNonNull(streamKind, "streamKind is null");
-        this.buffer = new OrcOutputBuffer(compression, dwrfEncryptor, bufferSize);
+        this.buffer = new OrcOutputBuffer(compressionParameters, dwrfEncryptor);
         this.signed = signed;
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamV2.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamV2.java
@@ -16,7 +16,7 @@ package com.facebook.presto.orc.stream;
 import com.facebook.presto.orc.OrcOutputBuffer;
 import com.facebook.presto.orc.checkpoint.LongStreamCheckpoint;
 import com.facebook.presto.orc.checkpoint.LongStreamV2Checkpoint;
-import com.facebook.presto.orc.metadata.CompressionKind;
+import com.facebook.presto.orc.metadata.CompressionParameters;
 import com.facebook.presto.orc.metadata.Stream;
 import com.facebook.presto.orc.metadata.Stream.StreamKind;
 import com.google.common.collect.ImmutableList;
@@ -89,10 +89,10 @@ public class LongOutputStreamV2
 
     private boolean closed;
 
-    public LongOutputStreamV2(CompressionKind compression, int bufferSize, boolean signed, StreamKind streamKind)
+    public LongOutputStreamV2(CompressionParameters compressionParameters, boolean signed, StreamKind streamKind)
     {
         this.streamKind = requireNonNull(streamKind, "streamKind is null");
-        this.buffer = new OrcOutputBuffer(compression, Optional.empty(), bufferSize);
+        this.buffer = new OrcOutputBuffer(compressionParameters, Optional.empty());
         this.signed = signed;
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/PresentOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/PresentOutputStream.java
@@ -16,7 +16,7 @@ package com.facebook.presto.orc.stream;
 import com.facebook.presto.orc.DwrfDataEncryptor;
 import com.facebook.presto.orc.OrcOutputBuffer;
 import com.facebook.presto.orc.checkpoint.BooleanStreamCheckpoint;
-import com.facebook.presto.orc.metadata.CompressionKind;
+import com.facebook.presto.orc.metadata.CompressionParameters;
 import com.facebook.presto.orc.metadata.Stream;
 import org.openjdk.jol.info.ClassLayout;
 
@@ -45,9 +45,9 @@ public class PresentOutputStream
 
     private boolean closed;
 
-    public PresentOutputStream(CompressionKind compression, Optional<DwrfDataEncryptor> dwrfEncryptor, int bufferSize)
+    public PresentOutputStream(CompressionParameters compressionParameters, Optional<DwrfDataEncryptor> dwrfEncryptor)
     {
-        this.buffer = new OrcOutputBuffer(compression, dwrfEncryptor, bufferSize);
+        this.buffer = new OrcOutputBuffer(compressionParameters, dwrfEncryptor);
     }
 
     public void writeBoolean(boolean value)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/BooleanColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/BooleanColumnWriter.java
@@ -19,7 +19,7 @@ import com.facebook.presto.orc.DwrfDataEncryptor;
 import com.facebook.presto.orc.checkpoint.BooleanStreamCheckpoint;
 import com.facebook.presto.orc.metadata.ColumnEncoding;
 import com.facebook.presto.orc.metadata.CompressedMetadataWriter;
-import com.facebook.presto.orc.metadata.CompressionKind;
+import com.facebook.presto.orc.metadata.CompressionParameters;
 import com.facebook.presto.orc.metadata.MetadataWriter;
 import com.facebook.presto.orc.metadata.RowGroupIndex;
 import com.facebook.presto.orc.metadata.Stream;
@@ -69,20 +69,20 @@ public class BooleanColumnWriter
     public BooleanColumnWriter(
             int column,
             Type type,
-            CompressionKind compression,
+            CompressionParameters compressionParameters,
             Optional<DwrfDataEncryptor> dwrfEncryptor,
-            int bufferSize,
             MetadataWriter metadataWriter)
     {
         checkArgument(column >= 0, "column is negative");
+        requireNonNull(compressionParameters, "compressionParameters is null");
         requireNonNull(dwrfEncryptor, "dwrfEncryptor is null");
         requireNonNull(metadataWriter, "metadataWriter is null");
         this.column = column;
         this.type = requireNonNull(type, "type is null");
-        this.compressed = requireNonNull(compression, "compression is null") != NONE;
-        this.dataStream = new BooleanOutputStream(compression, dwrfEncryptor, bufferSize);
-        this.presentStream = new PresentOutputStream(compression, dwrfEncryptor, bufferSize);
-        this.metadataWriter = new CompressedMetadataWriter(metadataWriter, compression, dwrfEncryptor, bufferSize);
+        this.compressed = compressionParameters.getKind() != NONE;
+        this.dataStream = new BooleanOutputStream(compressionParameters, dwrfEncryptor);
+        this.presentStream = new PresentOutputStream(compressionParameters, dwrfEncryptor);
+        this.metadataWriter = new CompressedMetadataWriter(metadataWriter, compressionParameters, dwrfEncryptor);
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/ByteColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/ByteColumnWriter.java
@@ -20,7 +20,7 @@ import com.facebook.presto.orc.checkpoint.BooleanStreamCheckpoint;
 import com.facebook.presto.orc.checkpoint.ByteStreamCheckpoint;
 import com.facebook.presto.orc.metadata.ColumnEncoding;
 import com.facebook.presto.orc.metadata.CompressedMetadataWriter;
-import com.facebook.presto.orc.metadata.CompressionKind;
+import com.facebook.presto.orc.metadata.CompressionParameters;
 import com.facebook.presto.orc.metadata.MetadataWriter;
 import com.facebook.presto.orc.metadata.RowGroupIndex;
 import com.facebook.presto.orc.metadata.Stream;
@@ -66,17 +66,18 @@ public class ByteColumnWriter
 
     private boolean closed;
 
-    public ByteColumnWriter(int column, Type type, CompressionKind compression, Optional<DwrfDataEncryptor> dwrfEncryptor, int bufferSize, MetadataWriter metadataWriter)
+    public ByteColumnWriter(int column, Type type, CompressionParameters compressionParameters, Optional<DwrfDataEncryptor> dwrfEncryptor, MetadataWriter metadataWriter)
     {
         checkArgument(column >= 0, "column is negative");
+        requireNonNull(compressionParameters, "compressionParameters is null");
         requireNonNull(dwrfEncryptor, "dwrfEncryptor is null");
         requireNonNull(metadataWriter, "metadataWriter is null");
         this.column = column;
         this.type = requireNonNull(type, "type is null");
-        this.compressed = requireNonNull(compression, "compression is null") != NONE;
-        this.dataStream = new ByteOutputStream(compression, dwrfEncryptor, bufferSize);
-        this.presentStream = new PresentOutputStream(compression, dwrfEncryptor, bufferSize);
-        this.metadataWriter = new CompressedMetadataWriter(metadataWriter, compression, dwrfEncryptor, bufferSize);
+        this.compressed = compressionParameters.getKind() != NONE;
+        this.dataStream = new ByteOutputStream(compressionParameters, dwrfEncryptor);
+        this.presentStream = new PresentOutputStream(compressionParameters, dwrfEncryptor);
+        this.metadataWriter = new CompressedMetadataWriter(metadataWriter, compressionParameters, dwrfEncryptor);
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/DoubleColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/DoubleColumnWriter.java
@@ -20,7 +20,7 @@ import com.facebook.presto.orc.checkpoint.BooleanStreamCheckpoint;
 import com.facebook.presto.orc.checkpoint.DoubleStreamCheckpoint;
 import com.facebook.presto.orc.metadata.ColumnEncoding;
 import com.facebook.presto.orc.metadata.CompressedMetadataWriter;
-import com.facebook.presto.orc.metadata.CompressionKind;
+import com.facebook.presto.orc.metadata.CompressionParameters;
 import com.facebook.presto.orc.metadata.MetadataWriter;
 import com.facebook.presto.orc.metadata.RowGroupIndex;
 import com.facebook.presto.orc.metadata.Stream;
@@ -67,17 +67,18 @@ public class DoubleColumnWriter
 
     private boolean closed;
 
-    public DoubleColumnWriter(int column, Type type, CompressionKind compression, Optional<DwrfDataEncryptor> dwrfEncryptor, int bufferSize, MetadataWriter metadataWriter)
+    public DoubleColumnWriter(int column, Type type, CompressionParameters compressionParameters, Optional<DwrfDataEncryptor> dwrfEncryptor, MetadataWriter metadataWriter)
     {
         checkArgument(column >= 0, "column is negative");
+        requireNonNull(compressionParameters, "compressionParameters is null");
         requireNonNull(dwrfEncryptor, "dwrfEncryptor is null");
         requireNonNull(metadataWriter, "metadataWriter is null");
         this.column = column;
         this.type = requireNonNull(type, "type is null");
-        this.compressed = requireNonNull(compression, "compression is null") != NONE;
-        this.dataStream = new DoubleOutputStream(compression, dwrfEncryptor, bufferSize);
-        this.presentStream = new PresentOutputStream(compression, dwrfEncryptor, bufferSize);
-        this.metadataWriter = new CompressedMetadataWriter(metadataWriter, compression, dwrfEncryptor, bufferSize);
+        this.compressed = compressionParameters.getKind() != NONE;
+        this.dataStream = new DoubleOutputStream(compressionParameters, dwrfEncryptor);
+        this.presentStream = new PresentOutputStream(compressionParameters, dwrfEncryptor);
+        this.metadataWriter = new CompressedMetadataWriter(metadataWriter, compressionParameters, dwrfEncryptor);
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/FloatColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/FloatColumnWriter.java
@@ -20,7 +20,7 @@ import com.facebook.presto.orc.checkpoint.BooleanStreamCheckpoint;
 import com.facebook.presto.orc.checkpoint.FloatStreamCheckpoint;
 import com.facebook.presto.orc.metadata.ColumnEncoding;
 import com.facebook.presto.orc.metadata.CompressedMetadataWriter;
-import com.facebook.presto.orc.metadata.CompressionKind;
+import com.facebook.presto.orc.metadata.CompressionParameters;
 import com.facebook.presto.orc.metadata.MetadataWriter;
 import com.facebook.presto.orc.metadata.RowGroupIndex;
 import com.facebook.presto.orc.metadata.Stream;
@@ -68,17 +68,18 @@ public class FloatColumnWriter
 
     private boolean closed;
 
-    public FloatColumnWriter(int column, Type type, CompressionKind compression, Optional<DwrfDataEncryptor> dwrfEncryptor, int bufferSize, MetadataWriter metadataWriter)
+    public FloatColumnWriter(int column, Type type, CompressionParameters compressionParameters, Optional<DwrfDataEncryptor> dwrfEncryptor, MetadataWriter metadataWriter)
     {
         checkArgument(column >= 0, "column is negative");
+        requireNonNull(compressionParameters, "compressionParameters is null");
         requireNonNull(dwrfEncryptor, "dwrfEncryptor is null");
         requireNonNull(metadataWriter, "metadataWriter is null");
         this.column = column;
         this.type = requireNonNull(type, "type is null");
-        this.compressed = requireNonNull(compression, "compression is null") != NONE;
-        this.dataStream = new FloatOutputStream(compression, dwrfEncryptor, bufferSize);
-        this.presentStream = new PresentOutputStream(compression, dwrfEncryptor, bufferSize);
-        this.metadataWriter = new CompressedMetadataWriter(metadataWriter, compression, dwrfEncryptor, bufferSize);
+        this.compressed = compressionParameters.getKind() != NONE;
+        this.dataStream = new FloatOutputStream(compressionParameters, dwrfEncryptor);
+        this.presentStream = new PresentOutputStream(compressionParameters, dwrfEncryptor);
+        this.metadataWriter = new CompressedMetadataWriter(metadataWriter, compressionParameters, dwrfEncryptor);
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/LongColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/LongColumnWriter.java
@@ -21,7 +21,7 @@ import com.facebook.presto.orc.checkpoint.BooleanStreamCheckpoint;
 import com.facebook.presto.orc.checkpoint.LongStreamCheckpoint;
 import com.facebook.presto.orc.metadata.ColumnEncoding;
 import com.facebook.presto.orc.metadata.CompressedMetadataWriter;
-import com.facebook.presto.orc.metadata.CompressionKind;
+import com.facebook.presto.orc.metadata.CompressionParameters;
 import com.facebook.presto.orc.metadata.MetadataWriter;
 import com.facebook.presto.orc.metadata.RowGroupIndex;
 import com.facebook.presto.orc.metadata.Stream;
@@ -77,29 +77,29 @@ public class LongColumnWriter
     public LongColumnWriter(
             int column,
             Type type,
-            CompressionKind compression,
+            CompressionParameters compressionParameters,
             Optional<DwrfDataEncryptor> dwrfEncryptor,
-            int bufferSize,
             OrcEncoding orcEncoding,
             Supplier<LongValueStatisticsBuilder> statisticsBuilderSupplier,
             MetadataWriter metadataWriter)
     {
         checkArgument(column >= 0, "column is negative");
+        requireNonNull(compressionParameters, "compressionParameters is null");
         requireNonNull(dwrfEncryptor, "dwrfEncryptor is null");
         requireNonNull(metadataWriter, "metadataWriter is null");
         this.column = column;
         this.type = requireNonNull(type, "type is null");
-        this.compressed = requireNonNull(compression, "compression is null") != NONE;
+        this.compressed = compressionParameters.getKind() != NONE;
         if (orcEncoding == DWRF) {
             this.columnEncoding = new ColumnEncoding(DIRECT, 0);
-            this.dataStream = new LongOutputStreamDwrf(compression, dwrfEncryptor, bufferSize, true, DATA);
+            this.dataStream = new LongOutputStreamDwrf(compressionParameters, dwrfEncryptor, true, DATA);
         }
         else {
             this.columnEncoding = new ColumnEncoding(DIRECT_V2, 0);
-            this.dataStream = new LongOutputStreamV2(compression, bufferSize, true, DATA);
+            this.dataStream = new LongOutputStreamV2(compressionParameters, true, DATA);
         }
-        this.presentStream = new PresentOutputStream(compression, dwrfEncryptor, bufferSize);
-        this.metadataWriter = new CompressedMetadataWriter(metadataWriter, compression, dwrfEncryptor, bufferSize);
+        this.presentStream = new PresentOutputStream(compressionParameters, dwrfEncryptor);
+        this.metadataWriter = new CompressedMetadataWriter(metadataWriter, compressionParameters, dwrfEncryptor);
         this.statisticsBuilderSupplier = requireNonNull(statisticsBuilderSupplier, "statisticsBuilderSupplier is null");
         this.statisticsBuilder = statisticsBuilderSupplier.get();
     }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/MapColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/MapColumnWriter.java
@@ -21,7 +21,7 @@ import com.facebook.presto.orc.checkpoint.BooleanStreamCheckpoint;
 import com.facebook.presto.orc.checkpoint.LongStreamCheckpoint;
 import com.facebook.presto.orc.metadata.ColumnEncoding;
 import com.facebook.presto.orc.metadata.CompressedMetadataWriter;
-import com.facebook.presto.orc.metadata.CompressionKind;
+import com.facebook.presto.orc.metadata.CompressionParameters;
 import com.facebook.presto.orc.metadata.MetadataWriter;
 import com.facebook.presto.orc.metadata.RowGroupIndex;
 import com.facebook.presto.orc.metadata.Stream;
@@ -71,17 +71,18 @@ public class MapColumnWriter
 
     private boolean closed;
 
-    public MapColumnWriter(int column, CompressionKind compression, Optional<DwrfDataEncryptor> dwrfEncryptor, int bufferSize, OrcEncoding orcEncoding, ColumnWriter keyWriter, ColumnWriter valueWriter, MetadataWriter metadataWriter)
+    public MapColumnWriter(int column, CompressionParameters compressionParameters, Optional<DwrfDataEncryptor> dwrfEncryptor, OrcEncoding orcEncoding, ColumnWriter keyWriter, ColumnWriter valueWriter, MetadataWriter metadataWriter)
     {
         checkArgument(column >= 0, "column is negative");
+        requireNonNull(compressionParameters, "compressionParameters is null");
         this.column = column;
-        this.compressed = requireNonNull(compression, "compression is null") != NONE;
+        this.compressed = compressionParameters.getKind() != NONE;
         this.columnEncoding = new ColumnEncoding(orcEncoding == DWRF ? DIRECT : DIRECT_V2, 0);
         this.keyWriter = requireNonNull(keyWriter, "keyWriter is null");
         this.valueWriter = requireNonNull(valueWriter, "valueWriter is null");
-        this.lengthStream = createLengthOutputStream(compression, dwrfEncryptor, bufferSize, orcEncoding);
-        this.presentStream = new PresentOutputStream(compression, dwrfEncryptor, bufferSize);
-        this.metadataWriter = new CompressedMetadataWriter(metadataWriter, compression, dwrfEncryptor, bufferSize);
+        this.lengthStream = createLengthOutputStream(compressionParameters, dwrfEncryptor, orcEncoding);
+        this.presentStream = new PresentOutputStream(compressionParameters, dwrfEncryptor);
+        this.metadataWriter = new CompressedMetadataWriter(metadataWriter, compressionParameters, dwrfEncryptor);
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/StructColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/StructColumnWriter.java
@@ -19,7 +19,7 @@ import com.facebook.presto.orc.DwrfDataEncryptor;
 import com.facebook.presto.orc.checkpoint.BooleanStreamCheckpoint;
 import com.facebook.presto.orc.metadata.ColumnEncoding;
 import com.facebook.presto.orc.metadata.CompressedMetadataWriter;
-import com.facebook.presto.orc.metadata.CompressionKind;
+import com.facebook.presto.orc.metadata.CompressionParameters;
 import com.facebook.presto.orc.metadata.MetadataWriter;
 import com.facebook.presto.orc.metadata.RowGroupIndex;
 import com.facebook.presto.orc.metadata.Stream;
@@ -64,14 +64,15 @@ public class StructColumnWriter
 
     private boolean closed;
 
-    public StructColumnWriter(int column, CompressionKind compression, Optional<DwrfDataEncryptor> dwrfEncryptor, int bufferSize, List<ColumnWriter> structFields, MetadataWriter metadataWriter)
+    public StructColumnWriter(int column, CompressionParameters compressionParameters, Optional<DwrfDataEncryptor> dwrfEncryptor, List<ColumnWriter> structFields, MetadataWriter metadataWriter)
     {
         checkArgument(column >= 0, "column is negative");
+        requireNonNull(compressionParameters, "compressionParameters is null");
         this.column = column;
-        this.compressed = requireNonNull(compression, "compression is null") != NONE;
+        this.compressed = compressionParameters.getKind() != NONE;
         this.structFields = ImmutableList.copyOf(requireNonNull(structFields, "structFields is null"));
-        this.presentStream = new PresentOutputStream(compression, dwrfEncryptor, bufferSize);
-        this.metadataWriter = new CompressedMetadataWriter(metadataWriter, compression, dwrfEncryptor, bufferSize);
+        this.presentStream = new PresentOutputStream(compressionParameters, dwrfEncryptor);
+        this.metadataWriter = new CompressedMetadataWriter(metadataWriter, compressionParameters, dwrfEncryptor);
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/TimestampColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/TimestampColumnWriter.java
@@ -21,7 +21,7 @@ import com.facebook.presto.orc.checkpoint.BooleanStreamCheckpoint;
 import com.facebook.presto.orc.checkpoint.LongStreamCheckpoint;
 import com.facebook.presto.orc.metadata.ColumnEncoding;
 import com.facebook.presto.orc.metadata.CompressedMetadataWriter;
-import com.facebook.presto.orc.metadata.CompressionKind;
+import com.facebook.presto.orc.metadata.CompressionParameters;
 import com.facebook.presto.orc.metadata.MetadataWriter;
 import com.facebook.presto.orc.metadata.RowGroupIndex;
 import com.facebook.presto.orc.metadata.Stream;
@@ -80,26 +80,27 @@ public class TimestampColumnWriter
 
     private boolean closed;
 
-    public TimestampColumnWriter(int column, Type type, CompressionKind compression, Optional<DwrfDataEncryptor> dwrfEncryptor, int bufferSize, OrcEncoding orcEncoding, DateTimeZone hiveStorageTimeZone, MetadataWriter metadataWriter)
+    public TimestampColumnWriter(int column, Type type, CompressionParameters compressionParameters, Optional<DwrfDataEncryptor> dwrfEncryptor, OrcEncoding orcEncoding, DateTimeZone hiveStorageTimeZone, MetadataWriter metadataWriter)
     {
         checkArgument(column >= 0, "column is negative");
+        requireNonNull(compressionParameters, "compression is null");
         requireNonNull(dwrfEncryptor, "dwrfEncryptor is null");
         requireNonNull(metadataWriter, "metadataWriter is null");
         this.column = column;
         this.type = requireNonNull(type, "type is null");
-        this.compressed = requireNonNull(compression, "compression is null") != NONE;
+        this.compressed = compressionParameters.getKind() != NONE;
         if (orcEncoding == DWRF) {
             this.columnEncoding = new ColumnEncoding(DIRECT, 0);
-            this.secondsStream = new LongOutputStreamV1(compression, dwrfEncryptor, bufferSize, true, DATA);
-            this.nanosStream = new LongOutputStreamV1(compression, dwrfEncryptor, bufferSize, false, SECONDARY);
+            this.secondsStream = new LongOutputStreamV1(compressionParameters, dwrfEncryptor, true, DATA);
+            this.nanosStream = new LongOutputStreamV1(compressionParameters, dwrfEncryptor, false, SECONDARY);
         }
         else {
             this.columnEncoding = new ColumnEncoding(DIRECT_V2, 0);
-            this.secondsStream = new LongOutputStreamV2(compression, bufferSize, true, DATA);
-            this.nanosStream = new LongOutputStreamV2(compression, bufferSize, false, SECONDARY);
+            this.secondsStream = new LongOutputStreamV2(compressionParameters, true, DATA);
+            this.nanosStream = new LongOutputStreamV2(compressionParameters, false, SECONDARY);
         }
-        this.presentStream = new PresentOutputStream(compression, dwrfEncryptor, bufferSize);
-        this.metadataWriter = new CompressedMetadataWriter(metadataWriter, compression, dwrfEncryptor, bufferSize);
+        this.presentStream = new PresentOutputStream(compressionParameters, dwrfEncryptor);
+        this.metadataWriter = new CompressedMetadataWriter(metadataWriter, compressionParameters, dwrfEncryptor);
         this.baseTimestampInSeconds = new DateTime(2015, 1, 1, 0, 0, requireNonNull(hiveStorageTimeZone, "hiveStorageTimeZone is null")).getMillis() / MILLIS_PER_SECOND;
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/zlib/DeflateCompressor.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/zlib/DeflateCompressor.java
@@ -16,15 +16,25 @@ package com.facebook.presto.orc.zlib;
 import io.airlift.compress.Compressor;
 
 import java.nio.ByteBuffer;
+import java.util.OptionalInt;
 import java.util.zip.Deflater;
 
+import static java.util.Objects.requireNonNull;
 import static java.util.zip.Deflater.FULL_FLUSH;
 
 public class DeflateCompressor
         implements Compressor
 {
     private static final int EXTRA_COMPRESSION_SPACE = 16;
-    private static final int COMPRESSION_LEVEL = 4;
+    private static final int DEFAULT_COMPRESSION_LEVEL = 4;
+
+    private final int compressionLevel;
+
+    public DeflateCompressor(OptionalInt compressionLevel)
+    {
+        requireNonNull(compressionLevel, "compressionLevel is null");
+        this.compressionLevel = compressionLevel.orElse(DEFAULT_COMPRESSION_LEVEL);
+    }
 
     @Override
     public int maxCompressedLength(int uncompressedSize)
@@ -41,7 +51,7 @@ public class DeflateCompressor
             throw new IllegalArgumentException("Output buffer must be at least " + maxCompressedLength + " bytes");
         }
 
-        Deflater deflater = new Deflater(COMPRESSION_LEVEL, true);
+        Deflater deflater = new Deflater(compressionLevel, true);
         try {
             deflater.setInput(input, inputOffset, inputLength);
             deflater.finish();

--- a/presto-orc/src/main/java/com/facebook/presto/orc/zstd/ZstdJniCompressor.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/zstd/ZstdJniCompressor.java
@@ -17,13 +17,23 @@ import com.github.luben.zstd.Zstd;
 import io.airlift.compress.Compressor;
 
 import java.nio.ByteBuffer;
+import java.util.OptionalInt;
 
 import static java.lang.Math.toIntExact;
+import static java.util.Objects.requireNonNull;
 
 public class ZstdJniCompressor
         implements Compressor
 {
-    private static final int COMPRESSION_LEVEL = 3; // default level
+    private static final int DEFAULT_COMPRESSION_LEVEL = 3; // default level
+
+    private final int compressionLevel;
+
+    public ZstdJniCompressor(OptionalInt compressionLevel)
+    {
+        requireNonNull(compressionLevel, "compressionLevel is null");
+        this.compressionLevel = compressionLevel.orElse(DEFAULT_COMPRESSION_LEVEL);
+    }
 
     @Override
     public int maxCompressedLength(int uncompressedSize)
@@ -34,7 +44,7 @@ public class ZstdJniCompressor
     @Override
     public int compress(byte[] input, int inputOffset, int inputLength, byte[] output, int outputOffset, int maxOutputLength)
     {
-        long size = Zstd.compressByteArray(output, outputOffset, maxOutputLength, input, inputOffset, inputLength, COMPRESSION_LEVEL);
+        long size = Zstd.compressByteArray(output, outputOffset, maxOutputLength, input, inputOffset, inputLength, compressionLevel);
         if (Zstd.isError(size)) {
             throw new RuntimeException(Zstd.getErrorName(size));
         }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkZstdJniDecompression.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkZstdJniDecompression.java
@@ -26,6 +26,7 @@ import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 
 import java.util.List;
+import java.util.OptionalInt;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.testng.Assert.assertEquals;
@@ -40,7 +41,7 @@ import static org.testng.Assert.assertEquals;
 
 public class BenchmarkZstdJniDecompression
 {
-    private static final ZstdJniCompressor compressor = new ZstdJniCompressor();
+    private static final ZstdJniCompressor compressor = new ZstdJniCompressor(OptionalInt.empty());
     private static final List<Unit> list = generateWorkload();
     private static final int sourceLength = 256 * 1024;
     private static byte[] decompressedBytes = new byte[sourceLength];

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcOutputBuffer.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcOutputBuffer.java
@@ -14,11 +14,13 @@
 package com.facebook.presto.orc;
 
 import com.facebook.presto.orc.metadata.CompressionKind;
+import com.facebook.presto.orc.metadata.CompressionParameters;
 import io.airlift.slice.DynamicSliceOutput;
 import org.testng.annotations.Test;
 
 import java.util.Arrays;
 import java.util.Optional;
+import java.util.OptionalInt;
 
 import static io.airlift.slice.Slices.wrappedBuffer;
 import static org.testng.Assert.assertEquals;
@@ -31,7 +33,8 @@ public class TestOrcOutputBuffer
         int size = 1024 * 1024;
         byte[] largeByteArray = new byte[size];
         Arrays.fill(largeByteArray, (byte) 0xA);
-        OrcOutputBuffer sliceOutput = new OrcOutputBuffer(CompressionKind.NONE, Optional.empty(), 256 * 1024);
+        CompressionParameters compressionParameters = new CompressionParameters(CompressionKind.NONE, OptionalInt.empty(), 256 * 1024);
+        OrcOutputBuffer sliceOutput = new OrcOutputBuffer(compressionParameters, Optional.empty());
 
         DynamicSliceOutput output = new DynamicSliceOutput(size);
         sliceOutput.writeBytes(largeByteArray, 10, size - 10);
@@ -49,7 +52,8 @@ public class TestOrcOutputBuffer
     public void testGrowCapacity()
     {
         byte[] largeByteArray = new byte[4096];
-        OrcOutputBuffer sliceOutput = new OrcOutputBuffer(CompressionKind.NONE, Optional.empty(), 3000);
+        CompressionParameters compressionParameters = new CompressionParameters(CompressionKind.NONE, OptionalInt.empty(), 3000);
+        OrcOutputBuffer sliceOutput = new OrcOutputBuffer(compressionParameters, Optional.empty());
 
         // write some data that can fit the initial capacity = 256
         sliceOutput.writeBytes(largeByteArray, 0, 200);

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestSliceDictionaryColumnWriter.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestSliceDictionaryColumnWriter.java
@@ -16,12 +16,14 @@ package com.facebook.presto.orc;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.RunLengthEncodedBlock;
 import com.facebook.presto.orc.metadata.CompressionKind;
+import com.facebook.presto.orc.metadata.CompressionParameters;
 import com.facebook.presto.orc.writer.SliceDictionaryColumnWriter;
 import io.airlift.slice.Slices;
 import io.airlift.units.DataSize;
 import org.testng.annotations.Test;
 
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
@@ -36,12 +38,15 @@ public class TestSliceDictionaryColumnWriter
     @Test
     public void testDirectConversion()
     {
+        CompressionParameters compressionParameters = new CompressionParameters(
+                CompressionKind.NONE,
+                OptionalInt.empty(),
+                toIntExact(DEFAULT_MAX_COMPRESSION_BUFFER_SIZE.toBytes()));
         SliceDictionaryColumnWriter writer = new SliceDictionaryColumnWriter(
                 0,
                 VARCHAR,
-                CompressionKind.NONE,
+                compressionParameters,
                 Optional.empty(),
-                toIntExact(DEFAULT_MAX_COMPRESSION_BUFFER_SIZE.toBytes()),
                 OrcEncoding.ORC,
                 DEFAULT_MAX_STRING_STATISTICS_LIMIT,
                 OrcEncoding.ORC.createMetadataWriter());

--- a/presto-orc/src/test/java/com/facebook/presto/orc/stream/TestBooleanOutputStream.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/stream/TestBooleanOutputStream.java
@@ -16,6 +16,7 @@ package com.facebook.presto.orc.stream;
 import com.facebook.presto.orc.OrcOutputBuffer;
 import com.facebook.presto.orc.checkpoint.BooleanStreamCheckpoint;
 import com.facebook.presto.orc.checkpoint.ByteStreamCheckpoint;
+import com.facebook.presto.orc.metadata.CompressionParameters;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.DynamicSliceOutput;
 import io.airlift.slice.Slice;
@@ -23,6 +24,7 @@ import org.testng.annotations.Test;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalInt;
 
 import static com.facebook.presto.orc.metadata.CompressionKind.NONE;
 import static org.testng.Assert.assertEquals;
@@ -42,7 +44,8 @@ public class TestBooleanOutputStream
                 ImmutableList.of(14000, 1, 2));
 
         for (List<Integer> counts : testGroups) {
-            OrcOutputBuffer buffer = new OrcOutputBuffer(NONE, Optional.empty(), 1024);
+            CompressionParameters compressionParameters = new CompressionParameters(NONE, OptionalInt.empty(), 1024);
+            OrcOutputBuffer buffer = new OrcOutputBuffer(compressionParameters, Optional.empty());
             BooleanOutputStream output = new BooleanOutputStream(buffer);
 
             // write multiple booleans together

--- a/presto-orc/src/test/java/com/facebook/presto/orc/stream/TestBooleanStream.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/stream/TestBooleanStream.java
@@ -17,6 +17,7 @@ import com.facebook.presto.orc.OrcCorruptionException;
 import com.facebook.presto.orc.OrcDecompressor;
 import com.facebook.presto.orc.TestingHiveOrcAggregatedMemoryContext;
 import com.facebook.presto.orc.checkpoint.BooleanStreamCheckpoint;
+import com.facebook.presto.orc.metadata.CompressionParameters;
 import com.facebook.presto.orc.metadata.Stream;
 import com.facebook.presto.orc.metadata.Stream.StreamKind;
 import io.airlift.slice.DynamicSliceOutput;
@@ -30,6 +31,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalInt;
 
 import static com.facebook.presto.orc.OrcDecompressor.createOrcDecompressor;
 import static com.facebook.presto.orc.metadata.CompressionKind.SNAPPY;
@@ -149,7 +151,11 @@ public class TestBooleanStream
     @Override
     protected BooleanOutputStream createValueOutputStream()
     {
-        return new BooleanOutputStream(SNAPPY, Optional.empty(), COMPRESSION_BLOCK_SIZE);
+        CompressionParameters compressionParameters = new CompressionParameters(
+                SNAPPY,
+                OptionalInt.empty(),
+                COMPRESSION_BLOCK_SIZE);
+        return new BooleanOutputStream(compressionParameters, Optional.empty());
     }
 
     @Override

--- a/presto-orc/src/test/java/com/facebook/presto/orc/stream/TestByteArrayStream.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/stream/TestByteArrayStream.java
@@ -17,6 +17,7 @@ import com.facebook.presto.orc.OrcCorruptionException;
 import com.facebook.presto.orc.OrcDecompressor;
 import com.facebook.presto.orc.TestingHiveOrcAggregatedMemoryContext;
 import com.facebook.presto.orc.checkpoint.ByteArrayStreamCheckpoint;
+import com.facebook.presto.orc.metadata.CompressionParameters;
 import io.airlift.slice.Slice;
 import io.airlift.slice.SliceOutput;
 import io.airlift.slice.Slices;
@@ -26,6 +27,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalInt;
 
 import static com.facebook.presto.orc.OrcDecompressor.createOrcDecompressor;
 import static com.facebook.presto.orc.metadata.CompressionKind.SNAPPY;
@@ -55,7 +57,11 @@ public class TestByteArrayStream
     @Override
     protected ByteArrayOutputStream createValueOutputStream()
     {
-        return new ByteArrayOutputStream(SNAPPY, Optional.empty(), COMPRESSION_BLOCK_SIZE);
+        CompressionParameters compressionParameters = new CompressionParameters(
+                SNAPPY,
+                OptionalInt.empty(),
+                COMPRESSION_BLOCK_SIZE);
+        return new ByteArrayOutputStream(compressionParameters, Optional.empty());
     }
 
     @Override

--- a/presto-orc/src/test/java/com/facebook/presto/orc/stream/TestByteStream.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/stream/TestByteStream.java
@@ -17,6 +17,7 @@ import com.facebook.presto.orc.OrcCorruptionException;
 import com.facebook.presto.orc.OrcDecompressor;
 import com.facebook.presto.orc.TestingHiveOrcAggregatedMemoryContext;
 import com.facebook.presto.orc.checkpoint.ByteStreamCheckpoint;
+import com.facebook.presto.orc.metadata.CompressionParameters;
 import io.airlift.slice.Slice;
 import org.testng.annotations.Test;
 
@@ -24,6 +25,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalInt;
 
 import static com.facebook.presto.orc.OrcDecompressor.createOrcDecompressor;
 import static com.facebook.presto.orc.metadata.CompressionKind.SNAPPY;
@@ -79,7 +81,11 @@ public class TestByteStream
     @Override
     protected ByteOutputStream createValueOutputStream()
     {
-        return new ByteOutputStream(SNAPPY, Optional.empty(), COMPRESSION_BLOCK_SIZE);
+        CompressionParameters compressionParameters = new CompressionParameters(
+                SNAPPY,
+                OptionalInt.empty(),
+                COMPRESSION_BLOCK_SIZE);
+        return new ByteOutputStream(compressionParameters, Optional.empty());
     }
 
     @Override

--- a/presto-orc/src/test/java/com/facebook/presto/orc/stream/TestDoubleStream.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/stream/TestDoubleStream.java
@@ -17,6 +17,7 @@ import com.facebook.presto.orc.OrcCorruptionException;
 import com.facebook.presto.orc.OrcDecompressor;
 import com.facebook.presto.orc.TestingHiveOrcAggregatedMemoryContext;
 import com.facebook.presto.orc.checkpoint.DoubleStreamCheckpoint;
+import com.facebook.presto.orc.metadata.CompressionParameters;
 import io.airlift.slice.Slice;
 import org.testng.annotations.Test;
 
@@ -24,6 +25,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalInt;
 
 import static com.facebook.presto.orc.OrcDecompressor.createOrcDecompressor;
 import static com.facebook.presto.orc.metadata.CompressionKind.SNAPPY;
@@ -49,7 +51,11 @@ public class TestDoubleStream
     @Override
     protected DoubleOutputStream createValueOutputStream()
     {
-        return new DoubleOutputStream(SNAPPY, Optional.empty(), COMPRESSION_BLOCK_SIZE);
+        CompressionParameters compressionParameters = new CompressionParameters(
+                SNAPPY,
+                OptionalInt.empty(),
+                COMPRESSION_BLOCK_SIZE);
+        return new DoubleOutputStream(compressionParameters, Optional.empty());
     }
 
     @Override

--- a/presto-orc/src/test/java/com/facebook/presto/orc/stream/TestFloatStream.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/stream/TestFloatStream.java
@@ -17,6 +17,7 @@ import com.facebook.presto.orc.OrcCorruptionException;
 import com.facebook.presto.orc.OrcDecompressor;
 import com.facebook.presto.orc.TestingHiveOrcAggregatedMemoryContext;
 import com.facebook.presto.orc.checkpoint.FloatStreamCheckpoint;
+import com.facebook.presto.orc.metadata.CompressionParameters;
 import io.airlift.slice.Slice;
 import org.testng.annotations.Test;
 
@@ -24,6 +25,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalInt;
 
 import static com.facebook.presto.orc.OrcDecompressor.createOrcDecompressor;
 import static com.facebook.presto.orc.metadata.CompressionKind.SNAPPY;
@@ -49,7 +51,8 @@ public class TestFloatStream
     @Override
     protected FloatOutputStream createValueOutputStream()
     {
-        return new FloatOutputStream(SNAPPY, Optional.empty(), COMPRESSION_BLOCK_SIZE);
+        CompressionParameters compressionParameters = new CompressionParameters(SNAPPY, OptionalInt.empty(), COMPRESSION_BLOCK_SIZE);
+        return new FloatOutputStream(compressionParameters, Optional.empty());
     }
 
     @Override

--- a/presto-orc/src/test/java/com/facebook/presto/orc/stream/TestLongDecimalStream.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/stream/TestLongDecimalStream.java
@@ -17,6 +17,7 @@ import com.facebook.presto.orc.OrcCorruptionException;
 import com.facebook.presto.orc.OrcDecompressor;
 import com.facebook.presto.orc.TestingHiveOrcAggregatedMemoryContext;
 import com.facebook.presto.orc.checkpoint.DecimalStreamCheckpoint;
+import com.facebook.presto.orc.metadata.CompressionParameters;
 import io.airlift.slice.Slice;
 import org.testng.annotations.Test;
 
@@ -25,6 +26,7 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.Random;
 
 import static com.facebook.presto.common.type.UnscaledDecimal128Arithmetic.unscaledDecimal;
@@ -54,7 +56,11 @@ public class TestLongDecimalStream
     @Override
     protected DecimalOutputStream createValueOutputStream()
     {
-        return new DecimalOutputStream(SNAPPY, COMPRESSION_BLOCK_SIZE);
+        CompressionParameters compressionParameters = new CompressionParameters(
+                SNAPPY,
+                OptionalInt.empty(),
+                COMPRESSION_BLOCK_SIZE);
+        return new DecimalOutputStream(compressionParameters);
     }
 
     @Override

--- a/presto-orc/src/test/java/com/facebook/presto/orc/stream/TestLongStreamDwrf.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/stream/TestLongStreamDwrf.java
@@ -17,6 +17,7 @@ import com.facebook.presto.orc.OrcCorruptionException;
 import com.facebook.presto.orc.OrcDecompressor;
 import com.facebook.presto.orc.TestingHiveOrcAggregatedMemoryContext;
 import com.facebook.presto.orc.checkpoint.LongStreamCheckpoint;
+import com.facebook.presto.orc.metadata.CompressionParameters;
 import io.airlift.slice.Slice;
 import org.testng.annotations.Test;
 
@@ -24,6 +25,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalInt;
 
 import static com.facebook.presto.orc.OrcDecompressor.createOrcDecompressor;
 import static com.facebook.presto.orc.metadata.CompressionKind.SNAPPY;
@@ -51,7 +53,11 @@ public class TestLongStreamDwrf
     @Override
     protected LongOutputStreamDwrf createValueOutputStream()
     {
-        return new LongOutputStreamDwrf(SNAPPY, Optional.empty(), COMPRESSION_BLOCK_SIZE, true, DATA);
+        CompressionParameters compressionParameters = new CompressionParameters(
+                SNAPPY,
+                OptionalInt.empty(),
+                COMPRESSION_BLOCK_SIZE);
+        return new LongOutputStreamDwrf(compressionParameters, Optional.empty(), true, DATA);
     }
 
     @Override

--- a/presto-orc/src/test/java/com/facebook/presto/orc/stream/TestLongStreamV1.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/stream/TestLongStreamV1.java
@@ -17,6 +17,7 @@ import com.facebook.presto.orc.OrcCorruptionException;
 import com.facebook.presto.orc.OrcDecompressor;
 import com.facebook.presto.orc.TestingHiveOrcAggregatedMemoryContext;
 import com.facebook.presto.orc.checkpoint.LongStreamCheckpoint;
+import com.facebook.presto.orc.metadata.CompressionParameters;
 import io.airlift.slice.Slice;
 import org.testng.annotations.Test;
 
@@ -24,6 +25,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.Random;
 
 import static com.facebook.presto.orc.OrcDecompressor.createOrcDecompressor;
@@ -71,7 +73,11 @@ public class TestLongStreamV1
     @Override
     protected LongOutputStreamV1 createValueOutputStream()
     {
-        return new LongOutputStreamV1(SNAPPY, Optional.empty(), COMPRESSION_BLOCK_SIZE, true, DATA);
+        CompressionParameters compressionParameters = new CompressionParameters(
+                SNAPPY,
+                OptionalInt.empty(),
+                COMPRESSION_BLOCK_SIZE);
+        return new LongOutputStreamV1(compressionParameters, Optional.empty(), true, DATA);
     }
 
     @Override

--- a/presto-orc/src/test/java/com/facebook/presto/orc/stream/TestLongStreamV2.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/stream/TestLongStreamV2.java
@@ -17,6 +17,7 @@ import com.facebook.presto.orc.OrcCorruptionException;
 import com.facebook.presto.orc.OrcDecompressor;
 import com.facebook.presto.orc.TestingHiveOrcAggregatedMemoryContext;
 import com.facebook.presto.orc.checkpoint.LongStreamCheckpoint;
+import com.facebook.presto.orc.metadata.CompressionParameters;
 import io.airlift.slice.Slice;
 import org.testng.annotations.Test;
 
@@ -24,6 +25,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalInt;
 
 import static com.facebook.presto.orc.OrcDecompressor.createOrcDecompressor;
 import static com.facebook.presto.orc.metadata.CompressionKind.SNAPPY;
@@ -50,7 +52,11 @@ public class TestLongStreamV2
     @Override
     protected LongOutputStreamV2 createValueOutputStream()
     {
-        return new LongOutputStreamV2(SNAPPY, COMPRESSION_BLOCK_SIZE, true, DATA);
+        CompressionParameters compressionParameters = new CompressionParameters(
+                SNAPPY,
+                OptionalInt.empty(),
+                COMPRESSION_BLOCK_SIZE);
+        return new LongOutputStreamV2(compressionParameters, true, DATA);
     }
 
     @Override

--- a/presto-orc/src/test/java/com/facebook/presto/orc/stream/TestShortDecimalStream.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/stream/TestShortDecimalStream.java
@@ -18,6 +18,7 @@ import com.facebook.presto.orc.OrcCorruptionException;
 import com.facebook.presto.orc.OrcDecompressor;
 import com.facebook.presto.orc.TestingHiveOrcAggregatedMemoryContext;
 import com.facebook.presto.orc.checkpoint.DecimalStreamCheckpoint;
+import com.facebook.presto.orc.metadata.CompressionParameters;
 import io.airlift.slice.Slice;
 import org.testng.annotations.Test;
 
@@ -25,6 +26,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.Random;
 
 import static com.facebook.presto.orc.OrcDecompressor.createOrcDecompressor;
@@ -53,7 +55,11 @@ public class TestShortDecimalStream
     @Override
     protected DecimalOutputStream createValueOutputStream()
     {
-        return new DecimalOutputStream(SNAPPY, COMPRESSION_BLOCK_SIZE);
+        CompressionParameters compressionParameters = new CompressionParameters(
+                SNAPPY,
+                OptionalInt.empty(),
+                COMPRESSION_BLOCK_SIZE);
+        return new DecimalOutputStream(compressionParameters);
     }
 
     @Override


### PR DESCRIPTION
OrcWriter uses ZSTD compression level 3 (It uses less CPU, but produces
bigger ORC files). Support configurable ZSTD compression level so
that writer can specify higher levels (more CPU, but smaller ORC files)

Test plan - 
* Added Comrpession Level tests in TestZstdJniCompressor
* Enhanced TestOrcWriter to write DWRF file with ZSTD compression.
* Using Facebook's File format verification tool.

```
== RELEASE NOTES ==

General Changes
* Configurable ZSTD compression Level
```
