### PR TITLE
Support named types in Type and TypeSignature

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/type/TypeSignatureBase.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TypeSignatureBase.java
@@ -24,10 +24,14 @@ import static java.util.Locale.ENGLISH;
 public class TypeSignatureBase
 {
     private final Optional<String> standardTypeBase;
-    private final Optional<QualifiedObjectName> typeBase;
+    private final Optional<QualifiedObjectName> typeName;
 
     public static TypeSignatureBase of(String name)
     {
+        int pos = name.indexOf(":");
+        if (pos >= 0) {
+            return new TypeSignatureBase(QualifiedObjectName.valueOf(name.substring(0, pos)), name.substring(pos + 1));
+        }
         if (name.chars().noneMatch(c -> c == '.')) {
             return new TypeSignatureBase(name);
         }
@@ -39,6 +43,11 @@ public class TypeSignatureBase
         return new TypeSignatureBase(name);
     }
 
+    public static TypeSignatureBase of(UserDefinedType userDefinedType)
+    {
+        return new TypeSignatureBase(userDefinedType.getUserDefinedTypeName(), userDefinedType.getPhysicalTypeSignature().getTypeSignatureBase().getStandardTypeBase());
+    }
+
     private TypeSignatureBase(String standardTypeBase)
     {
         checkArgument(standardTypeBase != null, "standardTypeBase is null");
@@ -46,26 +55,46 @@ public class TypeSignatureBase
         checkArgument(standardTypeBase.chars().noneMatch(c -> c == '.'), "Standard type %s should not have '.' in it", standardTypeBase);
         checkArgument(validateName(standardTypeBase), "Bad characters in base type: %s", standardTypeBase);
         this.standardTypeBase = Optional.of(standardTypeBase);
-        this.typeBase = Optional.empty();
+        this.typeName = Optional.empty();
     }
 
-    private TypeSignatureBase(QualifiedObjectName typeBase)
+    private TypeSignatureBase(QualifiedObjectName typeName)
     {
-        checkArgument(typeBase != null, "typeBase is null");
-        checkArgument(validateName(typeBase.getObjectName()), "Bad characters in base type: %s", typeBase);
+        checkArgument(typeName != null, "typeName is null");
+        checkArgument(validateName(typeName.getObjectName()), "Bad characters in typeName: %s", typeName);
         this.standardTypeBase = Optional.empty();
-        this.typeBase = Optional.of(typeBase);
+        this.typeName = Optional.of(typeName);
     }
 
-    public boolean isStandardType()
+    private TypeSignatureBase(QualifiedObjectName typeName, String standardTypeBase)
+    {
+        checkArgument(typeName != null && standardTypeBase != null, "typeName or standardTypeBase is null");
+        checkArgument(validateName(typeName.getObjectName()), "Bad characters in type name: %s", typeName.getObjectName());
+        checkArgument(validateName(standardTypeBase), "Bad characters in base type: %s", standardTypeBase);
+        this.standardTypeBase = Optional.of(standardTypeBase);
+        this.typeName = Optional.of(typeName);
+    }
+
+    public boolean hasStandardType()
     {
         return standardTypeBase.isPresent();
     }
 
-    public QualifiedObjectName getQualifiedObjectName()
+    public boolean hasTypeName()
     {
-        checkArgument(typeBase.isPresent(), "TypeSignatureBase %s is not a QualifiedObjectName", toString());
-        return typeBase.get();
+        return typeName.isPresent();
+    }
+
+    public QualifiedObjectName getTypeName()
+    {
+        checkArgument(typeName.isPresent(), "TypeSignatureBase %s does not have type name", toString());
+        return typeName.get();
+    }
+
+    public String getStandardTypeBase()
+    {
+        checkArgument(standardTypeBase.isPresent(), "TypeSignatureBase %s does not have standard type base", toString());
+        return standardTypeBase.get();
     }
 
     private static boolean validateName(String name)
@@ -93,18 +122,22 @@ public class TypeSignatureBase
         TypeSignatureBase other = (TypeSignatureBase) obj;
 
         return Objects.equals(standardTypeBase.map(s -> s.toLowerCase(ENGLISH)), other.standardTypeBase.map(s -> s.toLowerCase(ENGLISH))) &&
-                Objects.equals(typeBase, other.typeBase);
+                Objects.equals(typeName, other.typeName);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(standardTypeBase.map(s -> s.toLowerCase(ENGLISH)), typeBase);
+        return Objects.hash(standardTypeBase.map(s -> s.toLowerCase(ENGLISH)), typeName);
     }
 
     @Override
     public String toString()
     {
-        return standardTypeBase.orElseGet(() -> typeBase.get().toString());
+        if (standardTypeBase.isPresent() && typeName.isPresent()) {
+            // user defined type
+            return format("%s:%s", typeName.get(), standardTypeBase.get());
+        }
+        return standardTypeBase.orElseGet(() -> typeName.get().toString());
     }
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/type/TypeWithName.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TypeWithName.java
@@ -1,0 +1,250 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.type;
+
+import com.facebook.presto.common.QualifiedObjectName;
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.block.BlockBuilderStatus;
+import com.facebook.presto.common.block.UncheckedBlock;
+import com.facebook.presto.common.function.SqlFunctionProperties;
+import io.airlift.slice.Slice;
+
+import java.util.List;
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+
+public class TypeWithName
+        implements Type
+{
+    private final QualifiedObjectName name;
+    private final Type type;
+    private final TypeSignature typeSignature;
+
+    public TypeWithName(QualifiedObjectName name, Type type)
+    {
+        this.name = requireNonNull(name, "name is null");
+        this.type = requireNonNull(type, "type is null");
+        this.typeSignature = new TypeSignature(new UserDefinedType(name, type.getTypeSignature()));
+    }
+
+    @Override
+    public TypeSignature getTypeSignature()
+    {
+        return typeSignature;
+    }
+
+    @Override
+    public String getDisplayName()
+    {
+        return name.toString();
+    }
+
+    public Type getType()
+    {
+        return type;
+    }
+
+    @Override
+    public String toString()
+    {
+        return typeSignature.toString();
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+
+        TypeWithName other = (TypeWithName) obj;
+
+        return Objects.equals(this.name, other.name) &&
+                Objects.equals(this.type, other.type);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(name, type);
+    }
+
+    // All aspect related to execution are delegated to type
+    @Override
+    public boolean isComparable()
+    {
+        return type.isComparable();
+    }
+
+    @Override
+    public boolean isOrderable()
+    {
+        return type.isOrderable();
+    }
+
+    @Override
+    public Class<?> getJavaType()
+    {
+        return type.getJavaType();
+    }
+
+    @Override
+    public List<Type> getTypeParameters()
+    {
+        return type.getTypeParameters();
+    }
+
+    @Override
+    public BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries, int expectedBytesPerEntry)
+    {
+        return type.createBlockBuilder(blockBuilderStatus, expectedEntries, expectedBytesPerEntry);
+    }
+
+    @Override
+    public BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries)
+    {
+        return type.createBlockBuilder(blockBuilderStatus, expectedEntries);
+    }
+
+    @Override
+    public Object getObjectValue(SqlFunctionProperties properties, Block block, int position)
+    {
+        return type.getObjectValue(properties, block, position);
+    }
+
+    @Override
+    public boolean getBoolean(Block block, int position)
+    {
+        return type.getBoolean(block, position);
+    }
+
+    @Override
+    public boolean getBooleanUnchecked(UncheckedBlock block, int internalPosition)
+    {
+        return type.getBooleanUnchecked(block, internalPosition);
+    }
+
+    @Override
+    public long getLong(Block block, int position)
+    {
+        return type.getLong(block, position);
+    }
+
+    @Override
+    public long getLongUnchecked(UncheckedBlock block, int internalPosition)
+    {
+        return type.getLongUnchecked(block, internalPosition);
+    }
+
+    @Override
+    public double getDouble(Block block, int position)
+    {
+        return type.getDouble(block, position);
+    }
+
+    @Override
+    public double getDoubleUnchecked(UncheckedBlock block, int internalPosition)
+    {
+        return type.getDoubleUnchecked(block, internalPosition);
+    }
+
+    @Override
+    public Slice getSlice(Block block, int position)
+    {
+        return type.getSlice(block, position);
+    }
+
+    @Override
+    public Slice getSliceUnchecked(Block block, int internalPosition)
+    {
+        return type.getSliceUnchecked(block, internalPosition);
+    }
+
+    @Override
+    public Object getObject(Block block, int position)
+    {
+        return type.getObject(block, position);
+    }
+
+    @Override
+    public Block getBlockUnchecked(Block block, int internalPosition)
+    {
+        return type.getBlockUnchecked(block, internalPosition);
+    }
+
+    @Override
+    public void writeBoolean(BlockBuilder blockBuilder, boolean value)
+    {
+        type.writeBoolean(blockBuilder, value);
+    }
+
+    @Override
+    public void writeLong(BlockBuilder blockBuilder, long value)
+    {
+        type.writeLong(blockBuilder, value);
+    }
+
+    @Override
+    public void writeDouble(BlockBuilder blockBuilder, double value)
+    {
+        type.writeDouble(blockBuilder, value);
+    }
+
+    @Override
+    public void writeSlice(BlockBuilder blockBuilder, Slice value)
+    {
+        type.writeSlice(blockBuilder, value);
+    }
+
+    @Override
+    public void writeSlice(BlockBuilder blockBuilder, Slice value, int offset, int length)
+    {
+        type.writeSlice(blockBuilder, value, offset, length);
+    }
+
+    @Override
+    public void writeObject(BlockBuilder blockBuilder, Object value)
+    {
+        type.writeObject(blockBuilder, value);
+    }
+
+    @Override
+    public void appendTo(Block block, int position, BlockBuilder blockBuilder)
+    {
+        type.appendTo(block, position, blockBuilder);
+    }
+
+    @Override
+    public boolean equalTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
+    {
+        return type.equalTo(leftBlock, leftPosition, rightBlock, rightPosition);
+    }
+
+    @Override
+    public long hash(Block block, int position)
+    {
+        return type.hash(block, position);
+    }
+
+    @Override
+    public int compareTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
+    {
+        return type.compareTo(leftBlock, leftPosition, rightBlock, rightPosition);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/metadata/SignatureBinder.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/SignatureBinder.java
@@ -20,6 +20,7 @@ import com.facebook.presto.common.type.StandardTypes;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeSignature;
 import com.facebook.presto.common.type.TypeSignatureParameter;
+import com.facebook.presto.common.type.TypeWithName;
 import com.facebook.presto.spi.function.LongVariableConstraint;
 import com.facebook.presto.spi.function.Signature;
 import com.facebook.presto.spi.function.TypeVariableConstraint;
@@ -190,7 +191,11 @@ public class SignatureBinder
         String baseType = typeSignature.getBase();
         if (boundVariables.containsTypeVariable(baseType)) {
             checkState(typeSignature.getParameters().isEmpty(), "Type parameters cannot have parameters");
-            return boundVariables.getTypeVariable(baseType);
+            Type type = boundVariables.getTypeVariable(baseType);
+            if (type instanceof TypeWithName) {
+                return ((TypeWithName) type).getType();
+            }
+            return type;
         }
 
         List<TypeSignatureParameter> parameters = typeSignature.getParameters().stream()

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
@@ -20,12 +20,12 @@ import com.facebook.presto.common.function.SqlFunctionProperties;
 import com.facebook.presto.common.type.CharType;
 import com.facebook.presto.common.type.DecimalParseResult;
 import com.facebook.presto.common.type.Decimals;
-import com.facebook.presto.common.type.EnumType;
 import com.facebook.presto.common.type.FunctionType;
 import com.facebook.presto.common.type.RowType;
 import com.facebook.presto.common.type.StandardTypes;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeSignatureParameter;
+import com.facebook.presto.common.type.TypeWithName;
 import com.facebook.presto.common.type.VarcharType;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
 import com.facebook.presto.metadata.Metadata;
@@ -446,7 +446,7 @@ public class ExpressionAnalyzer
                 }
                 // otherwise, try to match it to an enum literal (eg Mood.HAPPY)
                 if (!scope.isColumnReference(qualifiedName)) {
-                    Optional<EnumType> enumType = tryResolveEnumLiteralType(qualifiedName, functionAndTypeManager);
+                    Optional<TypeWithName> enumType = tryResolveEnumLiteralType(qualifiedName, functionAndTypeManager);
                     if (enumType.isPresent()) {
                         setExpressionType(node.getBase(), enumType.get());
                         return setExpressionType(node, enumType.get());
@@ -1380,7 +1380,7 @@ public class ExpressionAnalyzer
             for (Expression expression : expressions) {
                 Optional<Type> newSuperType = functionAndTypeManager.getCommonSuperType(superType, process(expression, context));
                 if (!newSuperType.isPresent()) {
-                    throw new SemanticException(TYPE_MISMATCH, expression, message, superType);
+                    throw new SemanticException(TYPE_MISMATCH, expression, message, superType.getDisplayName());
                 }
                 superType = newSuperType.get();
             }
@@ -1390,7 +1390,7 @@ public class ExpressionAnalyzer
                 Type type = process(expression, context);
                 if (!type.equals(superType)) {
                     if (!functionAndTypeManager.canCoerce(type, superType)) {
-                        throw new SemanticException(TYPE_MISMATCH, expression, message, superType);
+                        throw new SemanticException(TYPE_MISMATCH, expression, message, superType.getDisplayName());
                     }
                     addOrReplaceExpressionCoercion(expression, type, superType);
                 }

--- a/presto-main/src/main/java/com/facebook/presto/type/TypeCoercer.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/TypeCoercer.java
@@ -22,6 +22,7 @@ import com.facebook.presto.common.type.StandardTypes;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeSignature;
 import com.facebook.presto.common.type.TypeSignatureParameter;
+import com.facebook.presto.common.type.TypeWithName;
 import com.facebook.presto.common.type.UnknownType;
 import com.facebook.presto.common.type.VarcharType;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
@@ -77,7 +78,7 @@ public class TypeCoercer
 
     public boolean canCoerce(Type fromType, Type toType)
     {
-        TypeCompatibility typeCompatibility = compatibility(fromType, toType);
+        TypeCompatibility typeCompatibility = compatibility(toStandardType(fromType), toStandardType(toType));
         return typeCompatibility.isCoercible();
     }
 
@@ -486,6 +487,14 @@ public class TypeCoercer
         }
         String typeBase = fromType.getTypeSignature().getBase();
         return TypeCompatibility.compatible(functionAndTypeManager.getType(new TypeSignature(typeBase, commonParameterTypes.build())), coercible);
+    }
+
+    private Type toStandardType(Type type)
+    {
+        if (type instanceof TypeWithName) {
+            return ((TypeWithName) type).getType();
+        }
+        return type;
     }
 
     private static class TypeCompatibility

--- a/presto-main/src/main/java/com/facebook/presto/util/JsonUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/JsonUtil.java
@@ -20,7 +20,6 @@ import com.facebook.presto.common.function.SqlFunctionProperties;
 import com.facebook.presto.common.type.ArrayType;
 import com.facebook.presto.common.type.DecimalType;
 import com.facebook.presto.common.type.Decimals;
-import com.facebook.presto.common.type.EnumType;
 import com.facebook.presto.common.type.MapType;
 import com.facebook.presto.common.type.RowType;
 import com.facebook.presto.common.type.RowType.Field;
@@ -134,7 +133,7 @@ public final class JsonUtil
 
     public static boolean canCastToJson(Type type)
     {
-        String baseType = type.getTypeSignature().getBase();
+        String baseType = type.getTypeSignature().getStandardTypeSignature().getBase();
         if (baseType.equals(UnknownType.NAME) ||
                 baseType.equals(StandardTypes.BOOLEAN) ||
                 baseType.equals(StandardTypes.TINYINT) ||
@@ -147,10 +146,9 @@ public final class JsonUtil
                 baseType.equals(StandardTypes.VARCHAR) ||
                 baseType.equals(StandardTypes.JSON) ||
                 baseType.equals(StandardTypes.TIMESTAMP) ||
-                baseType.equals(StandardTypes.DATE)) {
-            return true;
-        }
-        if (type instanceof EnumType) {
+                baseType.equals(StandardTypes.DATE) ||
+                baseType.equals(StandardTypes.VARCHAR_ENUM) ||
+                baseType.equals(StandardTypes.BIGINT_ENUM)) {
             return true;
         }
         if (type instanceof ArrayType) {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/TypeVariableConstraint.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/TypeVariableConstraint.java
@@ -15,6 +15,7 @@ package com.facebook.presto.spi.function;
 
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeUtils;
+import com.facebook.presto.common.type.TypeWithName;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -104,7 +105,7 @@ public class TypeVariableConstraint
         if (orderableRequired && !type.isOrderable()) {
             return false;
         }
-        if (!typeBound.isInstance(type)) {
+        if (!typeBound.isInstance(type) && !(type instanceof TypeWithName && typeBound.isInstance(((TypeWithName) type).getType()))) {
             return false;
         }
         if (variadicBound != null && !UNKNOWN.equals(type) && !variadicBound.equals(type.getTypeSignature().getBase())) {

--- a/presto-tests/src/main/java/com/facebook/presto/tests/TestingPrestoClient.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/TestingPrestoClient.java
@@ -27,6 +27,7 @@ import com.facebook.presto.common.type.RowType;
 import com.facebook.presto.common.type.SqlTimestamp;
 import com.facebook.presto.common.type.SqlTimestampWithTimeZone;
 import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.TypeWithName;
 import com.facebook.presto.common.type.VarcharEnumType;
 import com.facebook.presto.common.type.VarcharType;
 import com.facebook.presto.server.testing.TestingPrestoServer;
@@ -265,6 +266,9 @@ public class TestingPrestoClient
         }
         else if (type instanceof BigintEnumType) {
             return ((Number) value).longValue();
+        }
+        else if (type instanceof TypeWithName) {
+            return convertToRowValue(((TypeWithName) type).getType(), value);
         }
         else if (type.getTypeSignature().getBase().equals("ObjectId")) {
             return value;

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestEnums.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestEnums.java
@@ -185,10 +185,10 @@ public class TestEnums
         assertSingleValue("test.enum.country.\"भारत\" between test.enum.country.FRANCE and test.enum.country.BAHAMAS", true);
         assertSingleValue("test.enum.country.US between test.enum.country.FRANCE and test.enum.country.\"भारत\"", false);
 
-        assertQueryFails("select test.enum.country.US = test.enum.mood.HAPPY", ".* '=' cannot be applied to VarcharEnum\\(test.enum.country.*\\), BigintEnum\\(test.enum.mood.*\\)");
+        assertQueryFails("select test.enum.country.US = test.enum.mood.HAPPY", ".* '=' cannot be applied to test.enum.country:VarcharEnum\\(test.enum.country.*\\), test.enum.mood:BigintEnum\\(test.enum.mood.*\\)");
         assertQueryFails("select test.enum.country.US IN (test.enum.country.CHINA, test.enum.mood.SAD)", ".* All IN list values must be the same type.*");
         assertQueryFails("select test.enum.country.US IN (test.enum.mood.HAPPY, test.enum.mood.SAD)", ".* IN value and list items must be the same type: test.enum.country");
-        assertQueryFails("select test.enum.country.US > 2", ".* '>' cannot be applied to VarcharEnum\\(test.enum.country.*\\), integer");
+        assertQueryFails("select test.enum.country.US > 2", ".* '>' cannot be applied to test.enum.country:VarcharEnum\\(test.enum.country.*\\), integer");
     }
 
     @Test
@@ -196,6 +196,7 @@ public class TestEnums
     {
         assertSingleValue("test.enum.mood.HAPPY = CAST(0 AS test.enum.mood)", true);
         assertSingleValue("test.enum.mood.HAPPY = test.enum.mood.SAD", false);
+        assertSingleValue("array[test.enum.mood.HAPPY, test.enum.mood.SAD] = array[test.enum.mood.HAPPY, test.enum.mood.SAD]", true);
 
         assertSingleValue("test.enum.mood.SAD != test.enum.mood.MELLOW", true);
         assertSingleValue("array[test.enum.mood.HAPPY, test.enum.mood.SAD] != array[test.enum.mood.SAD, test.enum.mood.HAPPY]", true);
@@ -218,7 +219,7 @@ public class TestEnums
         assertSingleValue("test.enum.mood.HAPPY between test.enum.mood.CURIOUS and test.enum.mood.SAD ", true);
         assertSingleValue("test.enum.mood.MELLOW between test.enum.mood.SAD and test.enum.mood.HAPPY", false);
 
-        assertQueryFails("select test.enum.mood.HAPPY = 3", ".* '=' cannot be applied to BigintEnum\\(test.enum.mood.*, integer");
+        assertQueryFails("select test.enum.mood.HAPPY = 3", ".* '=' cannot be applied to test.enum.mood:BigintEnum\\(test.enum.mood.*, integer");
     }
 
     @Test


### PR DESCRIPTION
* Named type's type signature will be formatted as
  qualified_type_name:base_type_signature.
* Introduces TypeWithName, which delegate all execution aspects of the
  type to its base type.
* Make SingatureBinder, type coercion, type constraint, etc to work with
  TypeWithName.

Test plan - (Please fill in how you tested your changes)

```
== NO RELEASE NOTE ==
```
