### PR TITLE
Use long for partitionVersion

### DIFF
--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/CachingHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/CachingHiveMetastore.java
@@ -618,7 +618,7 @@ public class CachingHiveMetastore
         HivePartitionName hivePartitionName = hivePartitionName(databaseName, tableName, partitionNameWithVersion.getPartitionName());
         Optional<Partition> partition = partitionCache.getIfPresent(hivePartitionName);
         if (partition != null && partition.isPresent()) {
-            Optional<Integer> partitionVersion = partition.get().getPartitionVersion();
+            Optional<Long> partitionVersion = partition.get().getPartitionVersion();
             if (!partitionVersion.isPresent() || partitionVersion.get() != partitionNameWithVersion.getPartitionVersion()) {
                 partitionCache.invalidate(hivePartitionName);
                 partitionStatisticsCache.invalidate(hivePartitionName);

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/Partition.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/Partition.java
@@ -38,7 +38,7 @@ public class Partition
     private final Storage storage;
     private final List<Column> columns;
     private final Map<String, String> parameters;
-    private final Optional<Integer> partitionVersion;
+    private final Optional<Long> partitionVersion;
     private final boolean eligibleToIgnore;
     private final boolean sealedPartition;
 
@@ -50,7 +50,7 @@ public class Partition
             @JsonProperty("storage") Storage storage,
             @JsonProperty("columns") List<Column> columns,
             @JsonProperty("parameters") Map<String, String> parameters,
-            @JsonProperty("partitionVersion") Optional<Integer> partitionVersion,
+            @JsonProperty("partitionVersion") Optional<Long> partitionVersion,
             @JsonProperty("eligibleToIgnore") boolean eligibleToIgnore,
             @JsonProperty("sealedPartition") boolean sealedPartition)
     {
@@ -102,7 +102,7 @@ public class Partition
     }
 
     @JsonProperty
-    public Optional<Integer> getPartitionVersion()
+    public Optional<Long> getPartitionVersion()
     {
         return partitionVersion;
     }
@@ -175,7 +175,7 @@ public class Partition
         private List<String> values;
         private List<Column> columns;
         private Map<String, String> parameters = ImmutableMap.of();
-        private Optional<Integer> partitionVersion = Optional.empty();
+        private Optional<Long> partitionVersion = Optional.empty();
         private boolean isEligibleToIgnore;
         private boolean isSealedPartition = true;
 
@@ -237,7 +237,7 @@ public class Partition
             return this;
         }
 
-        public Builder setPartitionVersion(int partitionVersion)
+        public Builder setPartitionVersion(long partitionVersion)
         {
             this.partitionVersion = Optional.of(partitionVersion);
             return this;

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/PartitionNameWithVersion.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/PartitionNameWithVersion.java
@@ -18,9 +18,9 @@ import static java.util.Objects.requireNonNull;
 public class PartitionNameWithVersion
 {
     private final String partitionName;
-    private final int partitionVersion;
+    private final long partitionVersion;
 
-    public PartitionNameWithVersion(String partitionName, int partitionVersion)
+    public PartitionNameWithVersion(String partitionName, long partitionVersion)
     {
         this.partitionName = requireNonNull(partitionName, "partitionName is null");
         this.partitionVersion = partitionVersion;
@@ -31,7 +31,7 @@ public class PartitionNameWithVersion
         return partitionName;
     }
 
-    public int getPartitionVersion()
+    public long getPartitionVersion()
     {
         return partitionVersion;
     }


### PR DESCRIPTION
This PR is to support the use-case where partition version is calculated based on the last modified time of the
partition. For such cases, we need version to be long since it depends on unix time.

```
== NO RELEASE NOTE ==
```

depended by https://github.com/facebookexternal/presto-facebook/pull/1408