### PR TITLE
Export output table names in QueryInfo

### DIFF
--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/event/QueryInfo.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/event/QueryInfo.java
@@ -48,6 +48,7 @@ public class QueryInfo
     private final List<String> teardownQueries;
     private final String checksumQuery;
     private final String jsonPlan;
+    private final String outputTableName;
 
     private final Double cpuTimeSecs;
     private final Double wallTimeSecs;
@@ -69,7 +70,8 @@ public class QueryInfo
             Optional<List<String>> teardownQueries,
             Optional<String> checksumQuery,
             Optional<String> jsonPlan,
-            Optional<QueryActionStats> queryActionStats)
+            Optional<QueryActionStats> queryActionStats,
+            Optional<String> outputTableName)
     {
         Optional<QueryStats> stats = queryActionStats.flatMap(QueryActionStats::getQueryStats);
         this.catalog = requireNonNull(catalog, "catalog is null");
@@ -90,6 +92,7 @@ public class QueryInfo
         this.peakTotalMemoryBytes = stats.map(QueryStats::getPeakTotalMemoryBytes).orElse(null);
         this.peakTaskTotalMemoryBytes = stats.map(QueryStats::getPeakTaskTotalMemoryBytes).orElse(null);
         this.extraStats = queryActionStats.flatMap(QueryActionStats::getExtraStats).orElse(null);
+        this.outputTableName = outputTableName.orElse(null);
     }
 
     private static double millisToSeconds(long millis)
@@ -176,6 +179,12 @@ public class QueryInfo
     }
 
     @EventField
+    public String getOutputTableName()
+    {
+        return outputTableName;
+    }
+
+    @EventField
     public Double getCpuTimeSecs()
     {
         return cpuTimeSecs;
@@ -229,6 +238,7 @@ public class QueryInfo
         private Optional<String> checksumQuery = Optional.empty();
         private Optional<String> jsonPlan = Optional.empty();
         private Optional<QueryActionStats> queryActionStats = Optional.empty();
+        private Optional<String> outputTableName = Optional.empty();
 
         private Builder(
                 String catalog,
@@ -296,6 +306,12 @@ public class QueryInfo
             return this;
         }
 
+        public Builder setOutputTableName(Optional<String> outputTableName)
+        {
+            this.outputTableName = requireNonNull(outputTableName, "outputTableName is null");
+            return this;
+        }
+
         public QueryInfo build()
         {
             return new QueryInfo(
@@ -311,7 +327,8 @@ public class QueryInfo
                     teardownQueries,
                     checksumQuery,
                     jsonPlan,
-                    queryActionStats);
+                    queryActionStats,
+                    outputTableName);
         }
     }
 }

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/AbstractVerification.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/AbstractVerification.java
@@ -124,6 +124,13 @@ public abstract class AbstractVerification<B extends QueryBundle, R extends Matc
 
     protected void updateQueryInfo(QueryInfo.Builder queryInfo, Optional<QueryResult<V>> queryResult) {}
 
+    protected void updateQueryInfoWithQueryBundle(QueryInfo.Builder queryInfo, Optional<B> queryBundle)
+    {
+        queryInfo.setQuery(queryBundle.map(B::getQuery).map(AbstractVerification::formatSql))
+                .setSetupQueries(queryBundle.map(B::getSetupQueries).map(AbstractVerification::formatSqls))
+                .setTeardownQueries(queryBundle.map(B::getTeardownQueries).map(AbstractVerification::formatSqls));
+    }
+
     protected PrestoAction getHelperAction()
     {
         return queryActions.getHelperAction();
@@ -360,11 +367,9 @@ public abstract class AbstractVerification<B extends QueryBundle, R extends Matc
                 .setSetupQueryIds(queryContext.getSetupQueryIds())
                 .setTeardownQueryIds(queryContext.getTeardownQueryIds())
                 .setChecksumQueryId(checksumQueryContext.getChecksumQueryId())
-                .setQuery(queryBundle.map(B::getQuery).map(AbstractVerification::formatSql))
-                .setSetupQueries(queryBundle.map(B::getSetupQueries).map(AbstractVerification::formatSqls))
-                .setTeardownQueries(queryBundle.map(B::getTeardownQueries).map(AbstractVerification::formatSqls))
                 .setChecksumQuery(checksumQueryContext.getChecksumQuery())
                 .setQueryActionStats(queryContext.getMainQueryStats());
+        updateQueryInfoWithQueryBundle(queryInfo, queryBundle);
         updateQueryInfo(queryInfo, queryResult);
         return queryInfo.build();
     }

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DataVerification.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DataVerification.java
@@ -15,10 +15,12 @@ package com.facebook.presto.verifier.framework;
 
 import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.jdbc.QueryStats;
+import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.Query;
 import com.facebook.presto.verifier.checksum.ChecksumResult;
 import com.facebook.presto.verifier.checksum.ChecksumValidator;
 import com.facebook.presto.verifier.event.DeterminismAnalysisDetails;
+import com.facebook.presto.verifier.event.QueryInfo;
 import com.facebook.presto.verifier.prestoaction.QueryActions;
 import com.facebook.presto.verifier.prestoaction.SqlExceptionClassifier;
 import com.facebook.presto.verifier.resolver.FailureResolverManager;
@@ -69,6 +71,13 @@ public class DataVerification
     protected QueryObjectBundle getQueryRewrite(ClusterType clusterType)
     {
         return queryRewriter.rewriteQuery(getSourceQuery().getQuery(clusterType), clusterType);
+    }
+
+    @Override
+    protected void updateQueryInfoWithQueryBundle(QueryInfo.Builder queryInfo, Optional<QueryObjectBundle> queryBundle)
+    {
+        super.updateQueryInfoWithQueryBundle(queryInfo, queryBundle);
+        queryInfo.setOutputTableName(queryBundle.map(QueryObjectBundle::getObjectName).map(QualifiedName::toString));
     }
 
     @Override

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestDataVerification.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestDataVerification.java
@@ -360,6 +360,8 @@ public class TestDataVerification
             assertEquals(queryInfo.getSetupQueryIds().size(), 1);
         }
 
+        assertNotNull(queryInfo.getOutputTableName());
+
         assertNotNull(queryInfo.getCpuTimeSecs());
         assertNotNull(queryInfo.getWallTimeSecs());
         assertNotNull(queryInfo.getPeakTotalMemoryBytes());


### PR DESCRIPTION
Presto verifier rewrites queries to replace output table names with temporary table names so that presto verifier doesn't affect production tables. However, it is not easy to retrieve the temporary output table names without parsing the rewritten queries. This commit adds a field `outputTableName` to QueryInfo to export temporary output table names to presto verifier's outputs.

Test plan:
  (1) Updated unittest: TestDataVerification.java and ran all the unittests in presto-verifier.
  (2) Ran presto verifier locally and checked the field `outputTableName` was populated correctly.


```
== RELEASE NOTES ==

Verifier Changes
* Add output table names to Presto Verifier's outputs.
```

