### PR TITLE
Support exception stack and error code in remote function execution

### DIFF
--- a/presto-function-namespace-managers/pom.xml
+++ b/presto-function-namespace-managers/pom.xml
@@ -25,11 +25,6 @@
 
         <dependency>
             <groupId>com.facebook.airlift</groupId>
-            <artifactId>concurrent</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.facebook.airlift</groupId>
             <artifactId>configuration</artifactId>
         </dependency>
 

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/execution/ExceptionUtils.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/execution/ExceptionUtils.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.functionNamespace.execution;
+
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.thrift.api.udf.ThriftUdfServiceException;
+import com.facebook.presto.thrift.api.udf.UdfExecutionFailureInfo;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static com.google.common.base.MoreObjects.firstNonNull;
+
+public class ExceptionUtils
+{
+    private static final Pattern STACK_TRACE_PATTERN = Pattern.compile("(.*)\\.(.*)\\(([^:]*)(?::(.*))?\\)");
+
+    private ExceptionUtils()
+    {
+    }
+
+    public static PrestoException toPrestoException(ThriftUdfServiceException thriftException)
+    {
+        UdfExecutionFailure cause = toUdfExecutionException(thriftException.getFailureInfo());
+        PrestoException prestoException = new PrestoException(
+                thriftException::getErrorCode,
+                firstNonNull(cause.getMessage(), "Error executing remote function"),
+                cause);
+        prestoException.addSuppressed(thriftException);
+        return prestoException;
+    }
+
+    private static UdfExecutionFailure toUdfExecutionException(UdfExecutionFailureInfo failureInfo)
+    {
+        UdfExecutionFailure exception = new UdfExecutionFailure(
+                failureInfo.getType(),
+                failureInfo.getMessage(),
+                failureInfo.getCause() == null ? null : toUdfExecutionException(failureInfo.getCause()));
+        for (UdfExecutionFailureInfo suppressed : failureInfo.getSuppressed()) {
+            exception.addSuppressed(toUdfExecutionException(suppressed));
+        }
+        exception.setStackTrace(failureInfo.getStack().stream()
+                .map(ExceptionUtils::toStackTraceElement)
+                .toArray(StackTraceElement[]::new));
+        return exception;
+    }
+
+    private static StackTraceElement toStackTraceElement(String stack)
+    {
+        Matcher matcher = STACK_TRACE_PATTERN.matcher(stack);
+        if (matcher.matches()) {
+            String declaringClass = matcher.group(1);
+            String methodName = matcher.group(2);
+            String fileName = matcher.group(3);
+            int number = -1;
+            if (fileName.equals("Native Method")) {
+                fileName = null;
+                number = -2;
+            }
+            else if (matcher.group(4) != null) {
+                number = Integer.parseInt(matcher.group(4));
+            }
+            return new StackTraceElement(declaringClass, methodName, fileName, number);
+        }
+        return new StackTraceElement("Unknown", stack, null, -1);
+    }
+}

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/execution/UdfExecutionFailure.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/execution/UdfExecutionFailure.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.functionNamespace.execution;
+
+import javax.annotation.Nullable;
+
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class UdfExecutionFailure
+        extends RuntimeException
+{
+    private final String type;
+
+    public UdfExecutionFailure(String type, String message, @Nullable UdfExecutionFailure cause)
+    {
+        super(message, cause);
+        this.type = requireNonNull(type, "type is null");
+    }
+
+    @Override
+    public String getMessage()
+    {
+        return format("%s: %s", type, super.getMessage());
+    }
+}

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/execution/thrift/ThriftSqlFunctionExecutor.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/execution/thrift/ThriftSqlFunctionExecutor.java
@@ -35,15 +35,18 @@ import com.facebook.presto.thrift.api.udf.ThriftUdfResult;
 import com.facebook.presto.thrift.api.udf.ThriftUdfService;
 import com.facebook.presto.thrift.api.udf.ThriftUdfServiceException;
 import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.ListenableFuture;
 import com.google.inject.Inject;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 
-import static com.facebook.airlift.concurrent.MoreFutures.toCompletableFuture;
 import static com.facebook.presto.common.Page.wrapBlocksWithoutCopy;
+import static com.facebook.presto.functionNamespace.execution.ExceptionUtils.toPrestoException;
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.thrift.api.udf.ThriftUdfPage.prestoPage;
 import static com.facebook.presto.thrift.api.udf.ThriftUdfPage.thriftPage;
@@ -51,6 +54,8 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.google.common.util.concurrent.Futures.addCallback;
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -74,26 +79,73 @@ public class ThriftSqlFunctionExecutor
         this.blockEncodingSerde = blockEncodingSerde;
     }
 
-    public CompletableFuture<Block> executeFunction(ThriftScalarFunctionImplementation functionImplementation, Page input, List<Integer> channels, List<Type> argumentTypes, Type returnType)
+    public CompletableFuture<Block> executeFunction(
+            ThriftScalarFunctionImplementation functionImplementation,
+            Page input,
+            List<Integer> channels,
+            List<Type> argumentTypes,
+            Type returnType)
     {
         ThriftUdfPage page = buildThriftPage(functionImplementation, input, channels, argumentTypes);
         SqlFunctionHandle functionHandle = functionImplementation.getFunctionHandle();
         SqlFunctionId functionId = functionHandle.getFunctionId();
+        ThriftFunctionHandle thriftFunctionHandle = new ThriftFunctionHandle(
+                functionId.getFunctionName().toString(),
+                functionId.getArgumentTypes().stream()
+                        .map(TypeSignature::toString)
+                        .collect(toImmutableList()),
+                returnType.toString(),
+                functionHandle.getVersion());
+        ThriftUdfService thriftUdfService = thriftUdfClient.get(Optional.of(functionImplementation.getLanguage().getLanguage()));
+        return invokeUdfAndHandleException(thriftUdfService, thriftFunctionHandle, page)
+                .thenApply(result -> getResultBlock(result, returnType));
+    }
+
+    public static CompletableFuture<ThriftUdfResult> invokeUdfAndHandleException(
+            ThriftUdfService thriftUdfService,
+            ThriftFunctionHandle functionHandle,
+            ThriftUdfPage page)
+    {
+        ListenableFuture<ThriftUdfResult> resultFuture;
         try {
-            return toCompletableFuture(thriftUdfClient.get(Optional.of(functionImplementation.getLanguage().getLanguage())).invokeUdf(
-                    new ThriftFunctionHandle(
-                            functionId.getFunctionName().toString(),
-                            functionId.getArgumentTypes().stream()
-                                    .map(TypeSignature::toString)
-                                    .collect(toImmutableList()),
-                            returnType.toString(),
-                            functionHandle.getVersion()),
-                    page))
-                    .thenApply(result -> getResultBlock(result, returnType));
+            resultFuture = thriftUdfService.invokeUdf(functionHandle, page);
         }
         catch (ThriftUdfServiceException | TException e) {
-            throw new PrestoException(GENERIC_INTERNAL_ERROR, e);
+            // Those exceptions are declared in ThriftUdfService.invokedUdf but
+            // we don't expect them to be thrown here. Instead, the exceptions
+            // are thrown when the resultFuture is consumed.
+            throw new RuntimeException(e);
         }
+
+        // Create a CompletableFuture which sources from resultFuture, while
+        // transforming the exception to a PrestoException if case of failure.
+        CompletableFuture<ThriftUdfResult> future = new CompletableFuture<>();
+        future.exceptionally(throwable -> {
+            if (throwable instanceof CancellationException) {
+                resultFuture.cancel(true);
+            }
+            return null;
+        });
+
+        FutureCallback<ThriftUdfResult> callback = new FutureCallback<ThriftUdfResult>()
+        {
+            @Override
+            public void onSuccess(ThriftUdfResult result)
+            {
+                future.complete(result);
+            }
+
+            @Override
+            public void onFailure(Throwable t)
+            {
+                PrestoException prestoException = t instanceof ThriftUdfServiceException ?
+                        toPrestoException((ThriftUdfServiceException) t) :
+                        new PrestoException(GENERIC_INTERNAL_ERROR, t);
+                future.completeExceptionally(prestoException);
+            }
+        };
+        addCallback(resultFuture, callback, directExecutor());
+        return future;
     }
 
     private ThriftUdfPage buildThriftPage(ThriftScalarFunctionImplementation functionImplementation, Page input, List<Integer> channels, List<Type> argumentTypes)

--- a/presto-main/src/main/java/com/facebook/presto/operator/RemoteProjectOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/RemoteProjectOperator.java
@@ -16,6 +16,7 @@ package com.facebook.presto.operator;
 import com.facebook.presto.common.Page;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.spi.relation.CallExpression;
 import com.facebook.presto.spi.relation.ConstantExpression;
@@ -28,6 +29,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
+import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Throwables.throwIfUnchecked;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -116,9 +118,9 @@ public class RemoteProjectOperator
                 Throwable cause = e.getCause();
                 if (cause != null) {
                     throwIfUnchecked(cause);
-                    throw new RuntimeException(cause);
+                    throw new PrestoException(GENERIC_INTERNAL_ERROR, cause);
                 }
-                throw new RuntimeException(e);
+                throw new PrestoException(GENERIC_INTERNAL_ERROR, e);
             }
         }
         return null;
@@ -174,6 +176,7 @@ public class RemoteProjectOperator
             this.functionAndTypeManager = requireNonNull(functionAndTypeManager, "functionManager is null");
             this.projections = ImmutableList.copyOf(requireNonNull(projections, "projections is null"));
         }
+
         @Override
         public Operator createOperator(DriverContext driverContext)
         {

--- a/presto-thrift-api/src/main/java/com/facebook/presto/thrift/api/udf/ThriftUdfServiceException.java
+++ b/presto-thrift-api/src/main/java/com/facebook/presto/thrift/api/udf/ThriftUdfServiceException.java
@@ -16,18 +16,25 @@ package com.facebook.presto.thrift.api.udf;
 import com.facebook.drift.annotations.ThriftConstructor;
 import com.facebook.drift.annotations.ThriftField;
 import com.facebook.drift.annotations.ThriftStruct;
+import com.facebook.presto.spi.ErrorCode;
+
+import static java.util.Objects.requireNonNull;
 
 @ThriftStruct("UdfServiceException")
 public final class ThriftUdfServiceException
         extends Exception
 {
     private final boolean retryable;
+    private final ErrorCode errorCode;
+    private final UdfExecutionFailureInfo failureInfo;
 
     @ThriftConstructor
-    public ThriftUdfServiceException(String message, boolean retryable)
+    public ThriftUdfServiceException(String message, boolean retryable, ErrorCode errorCode, UdfExecutionFailureInfo failureInfo)
     {
         super(message);
         this.retryable = retryable;
+        this.errorCode = requireNonNull(errorCode, "errorCode is null");
+        this.failureInfo = requireNonNull(failureInfo, "failureInfo is null");
     }
 
     @Override
@@ -41,5 +48,17 @@ public final class ThriftUdfServiceException
     public boolean isRetryable()
     {
         return retryable;
+    }
+
+    @ThriftField(3)
+    public ErrorCode getErrorCode()
+    {
+        return errorCode;
+    }
+
+    @ThriftField(4)
+    public UdfExecutionFailureInfo getFailureInfo()
+    {
+        return failureInfo;
     }
 }

--- a/presto-thrift-api/src/main/java/com/facebook/presto/thrift/api/udf/UdfExecutionFailureInfo.java
+++ b/presto-thrift-api/src/main/java/com/facebook/presto/thrift/api/udf/UdfExecutionFailureInfo.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.thrift.api.udf;
+
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
+import com.google.common.collect.ImmutableList;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+
+import java.util.List;
+
+import static com.facebook.drift.annotations.ThriftField.Recursiveness.TRUE;
+import static com.facebook.drift.annotations.ThriftField.Requiredness.OPTIONAL;
+import static java.util.Objects.requireNonNull;
+
+@Immutable
+@ThriftStruct
+public class UdfExecutionFailureInfo
+{
+    private final String type;
+    private final String message;
+    private final UdfExecutionFailureInfo cause;
+    private final List<UdfExecutionFailureInfo> suppressed;
+    private final List<String> stack;
+
+    @ThriftConstructor
+    public UdfExecutionFailureInfo(
+            String type,
+            String message,
+            @Nullable UdfExecutionFailureInfo cause,
+            List<UdfExecutionFailureInfo> suppressed,
+            List<String> stack)
+    {
+        this.type = requireNonNull(type, "type is null");
+        this.message = requireNonNull(message, "message is null");
+        this.cause = cause;
+        this.suppressed = ImmutableList.copyOf(suppressed);
+        this.stack = ImmutableList.copyOf(stack);
+    }
+
+    @ThriftField(1)
+    public String getType()
+    {
+        return type;
+    }
+
+    @Nullable
+    @ThriftField(2)
+    public String getMessage()
+    {
+        return message;
+    }
+
+    @Nullable
+    @ThriftField(value = 3, isRecursive = TRUE, requiredness = OPTIONAL)
+    public UdfExecutionFailureInfo getCause()
+    {
+        return cause;
+    }
+
+    @ThriftField(4)
+    public List<UdfExecutionFailureInfo> getSuppressed()
+    {
+        return suppressed;
+    }
+
+    @ThriftField(5)
+    public List<String> getStack()
+    {
+        return stack;
+    }
+}


### PR DESCRIPTION
Add additional fields in ThriftUdfServiceException so that we'll be able to receive those information from the remote UDF server:
- Error code
- Nested structure to represent Java exception

The implementation mimics conversion between thrift object class `ExecutionFailureInfo` and Java Exception class `Failure`.
- `UdfExecutionFailureInfo` mimics `com.facebook.presto.execution.ExecutionFailureInfo`
- `UdfExecutionException` mimics `com.facebook.presto.execution.Failure`.


```
== NO RELEASE NOTE ==
```
