### PR TITLE
Limit the codegen class name length

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/util/CompilerUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/CompilerUtils.java
@@ -46,7 +46,7 @@ public final class CompilerUtils
 
     public static ParameterizedType makeClassName(String baseName, Optional<String> suffix)
     {
-        String className = baseName
+        String className = baseName.length() > 100 ? baseName.substring(0, 100) : baseName
                 + "_" + suffix.orElseGet(() -> Instant.now().atZone(UTC).format(TIMESTAMP_FORMAT))
                 + "_" + CLASS_ID.incrementAndGet();
         return typeFromJavaClassName("com.facebook.presto.$gen." + toJavaIdentifierString(className));


### PR DESCRIPTION
We use the function signature as class name for codegened classes.
When ROW types are used, sometimes the name gets extremely long. Since
we use an AtomicLong as part of the generated class name we should be
able to guarantee uniqueness without using the full name. So truncate
at 100 characters.

Test plan - manually tested


```
== NO RELEASE NOTE ==
```
