### PR TITLE
Allow session property rules to override

### DIFF
--- a/presto-docs/src/main/sphinx/admin/session-property-managers.rst
+++ b/presto-docs/src/main/sphinx/admin/session-property-managers.rst
@@ -48,6 +48,10 @@ Match Rules
 
 * ``clientInfo`` (optional): regex to match against the client info text supplied by the client
 
+* ``overrideSessionProperties`` (optional): boolean to indicate whether session properties should override client specified session properties.
+  Note that once a session property has been overridden by ANY rule it remains overridden even if later higher precedence rules change the
+  value, but don't specify override.
+
 * ``sessionProperties``: map with string keys and values. Each entry is a system or catalog property name and
   corresponding value. Values must be specified as strings, no matter the actual data type.
 

--- a/presto-main/src/main/java/com/facebook/presto/Session.java
+++ b/presto-main/src/main/java/com/facebook/presto/Session.java
@@ -27,6 +27,7 @@ import com.facebook.presto.spi.security.AccessControlContext;
 import com.facebook.presto.spi.security.Identity;
 import com.facebook.presto.spi.security.SelectedRole;
 import com.facebook.presto.spi.session.ResourceEstimates;
+import com.facebook.presto.spi.session.SessionPropertyConfigurationManager.SystemSessionPropertyConfiguration;
 import com.facebook.presto.sql.tree.Execute;
 import com.facebook.presto.transaction.TransactionId;
 import com.facebook.presto.transaction.TransactionManager;
@@ -385,9 +386,11 @@ public final class Session
                 sessionFunctions);
     }
 
-    public Session withDefaultProperties(Map<String, String> systemPropertyDefaults, Map<String, Map<String, String>> catalogPropertyDefaults)
+    public Session withDefaultProperties(
+            SystemSessionPropertyConfiguration systemPropertyConfiguration,
+            Map<String, Map<String, String>> catalogPropertyDefaults)
     {
-        requireNonNull(systemPropertyDefaults, "systemPropertyDefaults is null");
+        requireNonNull(systemPropertyConfiguration, "systemPropertyConfiguration is null");
         requireNonNull(catalogPropertyDefaults, "catalogPropertyDefaults is null");
 
         // to remove this check properties must be authenticated and validated as in beginTransactionId
@@ -396,8 +399,9 @@ public final class Session
                 "Session properties cannot be overridden once a transaction is active");
 
         Map<String, String> systemProperties = new HashMap<>();
-        systemProperties.putAll(systemPropertyDefaults);
+        systemProperties.putAll(systemPropertyConfiguration.systemPropertyDefaults);
         systemProperties.putAll(this.systemProperties);
+        systemProperties.putAll(systemPropertyConfiguration.systemPropertyOverrides);
 
         Map<String, Map<String, String>> connectorProperties = catalogPropertyDefaults.entrySet().stream()
                 .map(entry -> Maps.immutableEntry(entry.getKey(), new HashMap<>(entry.getValue())))

--- a/presto-main/src/main/java/com/facebook/presto/server/SessionPropertyDefaults.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/SessionPropertyDefaults.java
@@ -20,6 +20,7 @@ import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
 import com.facebook.presto.spi.resourceGroups.SessionPropertyConfigurationManagerContext;
 import com.facebook.presto.spi.session.SessionConfigurationContext;
 import com.facebook.presto.spi.session.SessionPropertyConfigurationManager;
+import com.facebook.presto.spi.session.SessionPropertyConfigurationManager.SystemSessionPropertyConfiguration;
 import com.facebook.presto.spi.session.SessionPropertyConfigurationManagerFactory;
 import com.google.common.annotations.VisibleForTesting;
 
@@ -119,8 +120,8 @@ public class SessionPropertyDefaults
                 resourceGroupId,
                 session.getClientInfo());
 
-        Map<String, String> systemPropertyOverrides = configurationManager.getSystemSessionProperties(context);
+        SystemSessionPropertyConfiguration systemPropertyConfiguration = configurationManager.getSystemSessionProperties(context);
         Map<String, Map<String, String>> catalogPropertyOverrides = configurationManager.getCatalogSessionProperties(context);
-        return session.withDefaultProperties(systemPropertyOverrides, catalogPropertyOverrides);
+        return session.withDefaultProperties(systemPropertyConfiguration, catalogPropertyOverrides);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/server/TestSessionPropertyDefaults.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestSessionPropertyDefaults.java
@@ -19,6 +19,7 @@ import com.facebook.presto.metadata.SessionPropertyManager;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
 import com.facebook.presto.spi.security.Identity;
+import com.facebook.presto.spi.session.SessionPropertyConfigurationManager.SystemSessionPropertyConfiguration;
 import com.facebook.presto.spi.session.SessionPropertyConfigurationManagerFactory;
 import com.facebook.presto.spi.session.TestingSessionPropertyConfigurationManagerFactory;
 import com.google.common.collect.ImmutableMap;
@@ -41,10 +42,12 @@ public class TestSessionPropertyDefaults
     {
         SessionPropertyDefaults sessionPropertyDefaults = new SessionPropertyDefaults(TEST_NODE_INFO);
         SessionPropertyConfigurationManagerFactory factory = new TestingSessionPropertyConfigurationManagerFactory(
-                ImmutableMap.<String, String>builder()
-                        .put(QUERY_MAX_MEMORY, "override")
-                        .put("system_default", "system_default")
-                        .build(),
+                new SystemSessionPropertyConfiguration(
+                    ImmutableMap.<String, String>builder()
+                            .put(QUERY_MAX_MEMORY, "override")
+                            .put("system_default", "system_default")
+                            .build(),
+                    ImmutableMap.of("override", "overridden")),
                 ImmutableMap.of(
                         "testCatalog",
                         ImmutableMap.<String, String>builder()
@@ -60,6 +63,7 @@ public class TestSessionPropertyDefaults
                 .setSystemProperty(QUERY_MAX_MEMORY, "1GB")
                 .setSystemProperty(JOIN_DISTRIBUTION_TYPE, "partitioned")
                 .setSystemProperty(HASH_PARTITION_COUNT, "43")
+                .setSystemProperty("override", "should be overridden")
                 .setCatalogSessionProperty("testCatalog", "explicit_set", "explicit_set")
                 .build();
 
@@ -67,6 +71,7 @@ public class TestSessionPropertyDefaults
                 .put(QUERY_MAX_MEMORY, "1GB")
                 .put(JOIN_DISTRIBUTION_TYPE, "partitioned")
                 .put(HASH_PARTITION_COUNT, "43")
+                .put("override", "should be overridden")
                 .build());
         assertEquals(
                 session.getUnprocessedCatalogProperties(),
@@ -83,6 +88,7 @@ public class TestSessionPropertyDefaults
                 .put(JOIN_DISTRIBUTION_TYPE, "partitioned")
                 .put(HASH_PARTITION_COUNT, "43")
                 .put("system_default", "system_default")
+                .put("override", "overridden")
                 .build());
         assertEquals(
                 session.getUnprocessedCatalogProperties(),

--- a/presto-session-property-managers/src/main/java/com/facebook/presto/session/SessionMatchSpec.java
+++ b/presto-session-property-managers/src/main/java/com/facebook/presto/session/SessionMatchSpec.java
@@ -37,6 +37,7 @@ public class SessionMatchSpec
     private final Optional<String> queryType;
     private final Optional<Pattern> clientInfoRegex;
     private final Optional<Pattern> resourceGroupRegex;
+    private final Optional<Boolean> overrideSessionProperties;
     private final Map<String, String> sessionProperties;
 
     @JsonCreator
@@ -47,6 +48,7 @@ public class SessionMatchSpec
             @JsonProperty("queryType") Optional<String> queryType,
             @JsonProperty("group") Optional<Pattern> resourceGroupRegex,
             @JsonProperty("clientInfo") Optional<Pattern> clientInfoRegex,
+            @JsonProperty("overrideSessionProperties") Optional<Boolean> overrideSessionProperties,
             @JsonProperty("sessionProperties") Map<String, String> sessionProperties)
     {
         this.userRegex = requireNonNull(userRegex, "userRegex is null");
@@ -56,6 +58,7 @@ public class SessionMatchSpec
         this.queryType = requireNonNull(queryType, "queryType is null");
         this.resourceGroupRegex = requireNonNull(resourceGroupRegex, "resourceGroupRegex is null");
         this.clientInfoRegex = requireNonNull(clientInfoRegex, "clientInfoRegex is null");
+        this.overrideSessionProperties = requireNonNull(overrideSessionProperties, "overrideSessionProperties is null");
         requireNonNull(sessionProperties, "sessionProperties is null");
         this.sessionProperties = ImmutableMap.copyOf(sessionProperties);
     }
@@ -133,6 +136,12 @@ public class SessionMatchSpec
     public Optional<Pattern> getClientInfoRegex()
     {
         return clientInfoRegex;
+    }
+
+    @JsonProperty
+    public Optional<Boolean> getOverrideSessionProperties()
+    {
+        return overrideSessionProperties;
     }
 
     @JsonProperty

--- a/presto-session-property-managers/src/test/java/com/facebook/presto/session/TestFileSessionPropertyManager.java
+++ b/presto-session-property-managers/src/test/java/com/facebook/presto/session/TestFileSessionPropertyManager.java
@@ -19,6 +19,7 @@ import com.facebook.presto.spi.resourceGroups.QueryType;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
 import com.facebook.presto.spi.session.SessionConfigurationContext;
 import com.facebook.presto.spi.session.SessionPropertyConfigurationManager;
+import com.facebook.presto.spi.session.SessionPropertyConfigurationManager.SystemSessionPropertyConfiguration;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -57,6 +58,7 @@ public class TestFileSessionPropertyManager
                 Optional.empty(),
                 Optional.of(Pattern.compile("global.pipeline.user_.*")),
                 Optional.empty(),
+                Optional.empty(),
                 properties);
 
         assertProperties(properties, spec);
@@ -71,6 +73,7 @@ public class TestFileSessionPropertyManager
                 Optional.empty(),
                 Optional.empty(),
                 Optional.of(ImmutableList.of("tag2")),
+                Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
@@ -90,11 +93,13 @@ public class TestFileSessionPropertyManager
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
+                Optional.empty(),
                 ImmutableMap.of("PROPERTY1", "VALUE1"));
         SessionMatchSpec spec2 = new SessionMatchSpec(
                 Optional.empty(),
                 Optional.empty(),
                 Optional.of(ImmutableList.of("tag1", "tag2")),
+                Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
@@ -114,6 +119,7 @@ public class TestFileSessionPropertyManager
                 Optional.empty(),
                 Optional.of(Pattern.compile("global.interactive.user_.*")),
                 Optional.empty(),
+                Optional.empty(),
                 ImmutableMap.of("PROPERTY", "VALUE"));
 
         assertProperties(ImmutableMap.of(), spec);
@@ -131,19 +137,61 @@ public class TestFileSessionPropertyManager
                 Optional.empty(),
                 Optional.empty(),
                 Optional.of(Pattern.compile("bar")),
+                Optional.empty(),
                 properties);
 
         assertProperties(properties, spec);
     }
 
-    private static void assertProperties(Map<String, String> properties, SessionMatchSpec... spec)
+    @Test
+    public void testOverride()
+             throws IOException
+    {
+        ImmutableMap<String, String> overrideProperties = ImmutableMap.of("PROPERTY1", "VALUE1");
+        ImmutableMap<String, String> defaultProperties = ImmutableMap.of("PROPERTY1", "VALUE2", "PROPERTY2", "VALUE");
+
+        SessionMatchSpec specOverride = new SessionMatchSpec(
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.of(Pattern.compile("bar")),
+                Optional.of(true),
+                overrideProperties);
+
+        SessionMatchSpec specDefault = new SessionMatchSpec(
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.of(Pattern.compile("bar")),
+                Optional.empty(),
+                defaultProperties);
+
+        // PROPERTY1 should be an override property with the value from the default (non-override, higher precendence)
+        // spec.
+        // PROPERTY2 should be a default property
+        assertProperties(defaultProperties, ImmutableMap.of("PROPERTY1", "VALUE2"), specOverride, specDefault);
+    }
+
+    private static void assertProperties(Map<String, String> defaultProperties, SessionMatchSpec... spec)
+            throws IOException
+    {
+        assertProperties(defaultProperties, ImmutableMap.of(), spec);
+    }
+
+    private static void assertProperties(Map<String, String> defaultProperties, Map<String, String> overrideProperties, SessionMatchSpec... spec)
             throws IOException
     {
         try (TempFile tempFile = new TempFile()) {
             Path configurationFile = tempFile.path();
             Files.write(configurationFile, CODEC.toJsonBytes(Arrays.asList(spec)));
             SessionPropertyConfigurationManager manager = new FileSessionPropertyManager(new FileSessionPropertyManagerConfig().setConfigFile(configurationFile.toFile()));
-            assertEquals(manager.getSystemSessionProperties(CONTEXT), properties);
+            SystemSessionPropertyConfiguration propertyConfiguration = manager.getSystemSessionProperties(CONTEXT);
+            assertEquals(propertyConfiguration.systemPropertyDefaults, defaultProperties);
+            assertEquals(propertyConfiguration.systemPropertyOverrides, overrideProperties);
         }
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/session/SessionPropertyConfigurationManager.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/session/SessionPropertyConfigurationManager.java
@@ -15,6 +15,8 @@ package com.facebook.presto.spi.session;
 
 import java.util.Map;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * This interface is used to provide default session property overrides for
  * sessions, thus providing a way to dynamically configure default session
@@ -25,7 +27,19 @@ import java.util.Map;
  */
 public interface SessionPropertyConfigurationManager
 {
-    Map<String, String> getSystemSessionProperties(SessionConfigurationContext context);
+    class SystemSessionPropertyConfiguration
+    {
+        public final Map<String, String> systemPropertyDefaults;
+        public final Map<String, String> systemPropertyOverrides;
+
+        public SystemSessionPropertyConfiguration(Map<String, String> sessionPropertyDefaults, Map<String, String> sessionPropertyOverrides)
+        {
+            this.systemPropertyDefaults = requireNonNull(sessionPropertyDefaults, "sessionPropertyDefaults is null");
+            this.systemPropertyOverrides = requireNonNull(sessionPropertyOverrides, "sessionPropertyOverrides is null");
+        }
+    }
+
+    SystemSessionPropertyConfiguration getSystemSessionProperties(SessionConfigurationContext context);
 
     Map<String, Map<String, String>> getCatalogSessionProperties(SessionConfigurationContext context);
 }

--- a/presto-spi/src/test/java/com/facebook/presto/spi/session/TestingSessionPropertyConfigurationManager.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/session/TestingSessionPropertyConfigurationManager.java
@@ -20,17 +20,17 @@ import static java.util.Objects.requireNonNull;
 public class TestingSessionPropertyConfigurationManager
         implements SessionPropertyConfigurationManager
 {
-    private final Map<String, String> systemProperties;
+    private final SystemSessionPropertyConfiguration systemProperties;
     private final Map<String, Map<String, String>> catalogProperties;
 
-    public TestingSessionPropertyConfigurationManager(Map<String, String> systemProperties, Map<String, Map<String, String>> catalogProperties)
+    public TestingSessionPropertyConfigurationManager(SystemSessionPropertyConfiguration systemProperties, Map<String, Map<String, String>> catalogProperties)
     {
         this.systemProperties = requireNonNull(systemProperties, "systemProperties is null");
         this.catalogProperties = requireNonNull(catalogProperties, "catalogProperties is null");
     }
 
     @Override
-    public Map<String, String> getSystemSessionProperties(SessionConfigurationContext context)
+    public SystemSessionPropertyConfiguration getSystemSessionProperties(SessionConfigurationContext context)
     {
         return systemProperties;
     }

--- a/presto-spi/src/test/java/com/facebook/presto/spi/session/TestingSessionPropertyConfigurationManagerFactory.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/session/TestingSessionPropertyConfigurationManagerFactory.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.spi.session;
 
 import com.facebook.presto.spi.resourceGroups.SessionPropertyConfigurationManagerContext;
+import com.facebook.presto.spi.session.SessionPropertyConfigurationManager.SystemSessionPropertyConfiguration;
 
 import java.util.Map;
 
@@ -22,10 +23,10 @@ import static java.util.Objects.requireNonNull;
 public class TestingSessionPropertyConfigurationManagerFactory
         implements SessionPropertyConfigurationManagerFactory
 {
-    private final Map<String, String> systemProperties;
+    private final SystemSessionPropertyConfiguration systemProperties;
     private final Map<String, Map<String, String>> catalogProperties;
 
-    public TestingSessionPropertyConfigurationManagerFactory(Map<String, String> systemProperties, Map<String, Map<String, String>> catalogProperties)
+    public TestingSessionPropertyConfigurationManagerFactory(SystemSessionPropertyConfiguration systemProperties, Map<String, Map<String, String>> catalogProperties)
     {
         this.systemProperties = requireNonNull(systemProperties, "systemProperties is null");
         this.catalogProperties = requireNonNull(catalogProperties, "catalogProperties is null");


### PR DESCRIPTION
This is to allow rules setting resource limits to override values set as session properties. For the sneaky "I want to bypass resource limits case"

Test plan - There are included unit tests

depends on https://github.com/facebookexternal/presto-facebook/pull/1413

```
== RELEASE NOTES ==

General Changes
* Add support for overriding session properties using session property managers :doc:`/admin/session-property-managers`. Setting 'overrideSessionProperties` to true will cause the property to be overridden and remain overridden even if subsequent rules match the property but don't have `overrideSessionProperties` set.
```