### PR TITLE
Add cpu and memory stats to NodeTaskMap

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/NodeTaskMap.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/NodeTaskMap.java
@@ -17,14 +17,16 @@ import com.facebook.airlift.log.Logger;
 import com.facebook.presto.metadata.InternalNode;
 import com.facebook.presto.util.FinalizerService;
 import com.google.common.collect.Sets;
+import com.google.common.util.concurrent.AtomicDouble;
 
 import javax.annotation.concurrent.ThreadSafe;
 import javax.inject.Inject;
 
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.IntConsumer;
+import java.util.function.LongConsumer;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
@@ -52,34 +54,32 @@ public class NodeTaskMap
         return createOrGetNodeTasks(node).getPartitionedSplitCount();
     }
 
-    public PartitionedSplitCountTracker createPartitionedSplitCountTracker(InternalNode node, TaskId taskId)
+    public long getNodeTotalMemoryUsageInBytes(InternalNode node)
     {
-        return createOrGetNodeTasks(node).createPartitionedSplitCountTracker(taskId);
+        return createOrGetNodeTasks(node).getTotalMemoryUsageInBytes();
+    }
+
+    public double getNodeCpuUtilizationPercentage(InternalNode node)
+    {
+        return createOrGetNodeTasks(node).getTotalCpuTimePerMillis();
+    }
+
+    public NodeStatsTracker createTaskStatsTracker(InternalNode node, TaskId taskId)
+    {
+        return createOrGetNodeTasks(node).createTaskStatsTrackers(taskId);
     }
 
     private NodeTasks createOrGetNodeTasks(InternalNode node)
     {
-        NodeTasks nodeTasks = nodeTasksMap.get(node);
-        if (nodeTasks == null) {
-            nodeTasks = addNodeTask(node);
-        }
-        return nodeTasks;
-    }
-
-    private NodeTasks addNodeTask(InternalNode node)
-    {
-        NodeTasks newNodeTasks = new NodeTasks(finalizerService);
-        NodeTasks nodeTasks = nodeTasksMap.putIfAbsent(node, newNodeTasks);
-        if (nodeTasks == null) {
-            return newNodeTasks;
-        }
-        return nodeTasks;
+        return nodeTasksMap.computeIfAbsent(node, key -> new NodeTasks(finalizerService));
     }
 
     private static class NodeTasks
     {
         private final Set<RemoteTask> remoteTasks = Sets.newConcurrentHashSet();
-        private final AtomicInteger nodeTotalPartitionedSplitCount = new AtomicInteger();
+        private final AtomicLong nodeTotalPartitionedSplitCount = new AtomicLong();
+        private final AtomicLong nodeTotalMemoryUsageInBytes = new AtomicLong();
+        private final AtomicDouble nodeTotalCpuTimePerMillis = new AtomicDouble();
         private final FinalizerService finalizerService;
 
         public NodeTasks(FinalizerService finalizerService)
@@ -89,7 +89,17 @@ public class NodeTaskMap
 
         private int getPartitionedSplitCount()
         {
-            return nodeTotalPartitionedSplitCount.get();
+            return nodeTotalPartitionedSplitCount.intValue();
+        }
+
+        private long getTotalMemoryUsageInBytes()
+        {
+            return nodeTotalMemoryUsageInBytes.get();
+        }
+
+        private double getTotalCpuTimePerMillis()
+        {
+            return nodeTotalCpuTimePerMillis.get();
         }
 
         private void addTask(RemoteTask task)
@@ -108,56 +118,65 @@ public class NodeTaskMap
             }
         }
 
-        public PartitionedSplitCountTracker createPartitionedSplitCountTracker(TaskId taskId)
+        public NodeStatsTracker createTaskStatsTrackers(TaskId taskId)
         {
             requireNonNull(taskId, "taskId is null");
 
-            TaskPartitionedSplitCountTracker tracker = new TaskPartitionedSplitCountTracker(taskId);
-            PartitionedSplitCountTracker partitionedSplitCountTracker = new PartitionedSplitCountTracker(tracker::setPartitionedSplitCount);
+            TaskStatsTracker splitTracker = new TaskStatsTracker("SplitTracker", taskId, nodeTotalPartitionedSplitCount);
+            TaskStatsTracker memoryUsageTracker = new TaskStatsTracker("MemoryTracker", taskId, nodeTotalMemoryUsageInBytes);
+            AccumulatedTaskStatsTracker cpuUtilizationPercentageTracker = new AccumulatedTaskStatsTracker("CpuTracker", taskId, nodeTotalCpuTimePerMillis);
+            NodeStatsTracker nodeStatsTracker = new NodeStatsTracker(splitTracker::setValue, memoryUsageTracker::setValue, cpuUtilizationPercentageTracker::setValue);
 
-            // when partitionedSplitCountTracker is garbage collected, run the cleanup method on the tracker
-            // Note: tracker can not have a reference to partitionedSplitCountTracker
-            finalizerService.addFinalizer(partitionedSplitCountTracker, tracker::cleanup);
+            // when nodeStatsTracker is garbage collected, run the cleanup method on the tracker
+            // Note: tracker can not have a reference to nodeStatsTracker
+            finalizerService.addFinalizer(nodeStatsTracker, splitTracker::cleanup);
+            finalizerService.addFinalizer(memoryUsageTracker, memoryUsageTracker::cleanup);
+            finalizerService.addFinalizer(cpuUtilizationPercentageTracker, cpuUtilizationPercentageTracker::cleanup);
 
-            return partitionedSplitCountTracker;
+            return nodeStatsTracker;
         }
 
         @ThreadSafe
-        private class TaskPartitionedSplitCountTracker
+        private class TaskStatsTracker
         {
+            private final String counterName;
             private final TaskId taskId;
-            private final AtomicInteger localPartitionedSplitCount = new AtomicInteger();
+            private final AtomicLong totalValue;
+            private final AtomicLong localValue = new AtomicLong();
 
-            public TaskPartitionedSplitCountTracker(TaskId taskId)
+            public TaskStatsTracker(String counterName, TaskId taskId, AtomicLong totalValue)
             {
+                this.counterName = requireNonNull(counterName, "counterName is null");
                 this.taskId = requireNonNull(taskId, "taskId is null");
+                this.totalValue = requireNonNull(totalValue, "totalValue is null");
             }
 
-            public synchronized void setPartitionedSplitCount(int partitionedSplitCount)
+            public synchronized void setValue(long value)
             {
-                if (partitionedSplitCount < 0) {
-                    int oldValue = localPartitionedSplitCount.getAndSet(0);
-                    nodeTotalPartitionedSplitCount.addAndGet(-oldValue);
-                    throw new IllegalArgumentException("partitionedSplitCount is negative");
+                if (value < 0) {
+                    long oldValue = this.localValue.getAndSet(0L);
+                    totalValue.addAndGet(-oldValue);
+                    throw new IllegalArgumentException(counterName + " is negative");
                 }
 
-                int oldValue = localPartitionedSplitCount.getAndSet(partitionedSplitCount);
-                nodeTotalPartitionedSplitCount.addAndGet(partitionedSplitCount - oldValue);
+                long oldValue = this.localValue.getAndSet(value);
+                totalValue.addAndGet(value - oldValue);
             }
 
             public void cleanup()
             {
-                int leakedSplits = localPartitionedSplitCount.getAndSet(0);
-                if (leakedSplits == 0) {
+                long leakedValues = localValue.getAndSet(0);
+                if (leakedValues == 0) {
                     return;
                 }
 
-                log.error("BUG! %s for %s leaked with %s partitioned splits.  Cleaning up so server can continue to function.",
+                log.error("BUG! %s for %s leaked with %s %s.  Cleaning up so server can continue to function.",
                         getClass().getName(),
                         taskId,
-                        leakedSplits);
+                        leakedValues,
+                        counterName);
 
-                nodeTotalPartitionedSplitCount.addAndGet(-leakedSplits);
+                totalValue.addAndGet(-leakedValues);
             }
 
             @Override
@@ -165,19 +184,94 @@ public class NodeTaskMap
             {
                 return toStringHelper(this)
                         .add("taskId", taskId)
-                        .add("splits", localPartitionedSplitCount)
+                        .add(counterName, localValue)
                         .toString();
+            }
+        }
+
+        // tracks stats which are passed as accumulated (cpu time) by calculating delta / duration.
+        @ThreadSafe
+        private class AccumulatedTaskStatsTracker
+        {
+            private final String counterName;
+            private final TaskId taskId;
+            private final AtomicDouble totalValue;
+            private final AtomicDouble localValue = new AtomicDouble();
+            private long previousTaskAge;
+            private long previousValue;
+
+            AccumulatedTaskStatsTracker(String counterName, TaskId taskId, AtomicDouble totalValue)
+            {
+                this.counterName = requireNonNull(counterName, "counterName is null");
+                this.taskId = requireNonNull(taskId, "taskId is null");
+                this.totalValue = requireNonNull(totalValue, "totalValue is null");
+            }
+
+            private double getDeltaPerSecond(long taskAgeInMillis, long value)
+            {
+                if (previousTaskAge == 0 && value > 0) {
+                    previousTaskAge = taskAgeInMillis;
+                    previousValue = value;
+                    return 0;
+                }
+
+                if (taskAgeInMillis <= previousTaskAge) {
+                    return 0;
+                }
+
+                if (value > 0) {
+                    double deltaValue = (value - previousValue) * 100;
+                    long deltaDuration = taskAgeInMillis - previousTaskAge;
+                    previousTaskAge = taskAgeInMillis;
+                    previousValue = value;
+                    return deltaValue > 0 ? deltaValue / deltaDuration : 0;
+                }
+                return 0;
+            }
+
+            public synchronized void setValue(long taskAgeInMillis, long value)
+            {
+                double delta = getDeltaPerSecond(taskAgeInMillis, value);
+
+                if (delta < 0) {
+                    double oldValue = this.localValue.getAndSet(0D);
+                    totalValue.addAndGet(-oldValue);
+                    throw new IllegalArgumentException(counterName + " is negative");
+                }
+
+                double oldValue = this.localValue.getAndSet(delta);
+                totalValue.addAndGet(delta - oldValue);
+            }
+
+            public void cleanup()
+            {
+                double leakedValues = localValue.getAndSet(0D);
+                if (leakedValues == 0) {
+                    return;
+                }
+
+                log.error("BUG! %s for %s leaked with %s %s.  Cleaning up so server can continue to function.",
+                        getClass().getName(),
+                        taskId,
+                        leakedValues,
+                        counterName);
+
+                totalValue.addAndGet(-leakedValues);
             }
         }
     }
 
-    public static class PartitionedSplitCountTracker
+    public static class NodeStatsTracker
     {
         private final IntConsumer splitSetter;
+        private final LongConsumer memoryUsageSetter;
+        private final CumulativeStatsConsumer cpuUsageSetter;
 
-        public PartitionedSplitCountTracker(IntConsumer splitSetter)
+        public NodeStatsTracker(IntConsumer splitSetter, LongConsumer memoryUsageSetter, CumulativeStatsConsumer cpuUsageSetter)
         {
             this.splitSetter = requireNonNull(splitSetter, "splitSetter is null");
+            this.memoryUsageSetter = requireNonNull(memoryUsageSetter, "memoryUsageSetter is null");
+            this.cpuUsageSetter = requireNonNull(cpuUsageSetter, "cpuUsageSetter is null");
         }
 
         public void setPartitionedSplitCount(int partitionedSplitCount)
@@ -185,10 +279,29 @@ public class NodeTaskMap
             splitSetter.accept(partitionedSplitCount);
         }
 
+        public void setMemoryUsage(long memoryUsage)
+        {
+            memoryUsageSetter.accept(memoryUsage);
+        }
+
+        public void setCpuUsage(long age, long cpuUsage)
+        {
+            cpuUsageSetter.accept(age, cpuUsage);
+        }
+
         @Override
         public String toString()
         {
-            return splitSetter.toString();
+            return toStringHelper(this)
+                    .add("splitSetter", splitSetter.toString())
+                    .add("memoryUsageSetter", memoryUsageSetter.toString())
+                    .add("cpuUsageSetter", cpuUsageSetter.toString())
+                    .toString();
         }
+    }
+
+    public interface CumulativeStatsConsumer
+    {
+        void accept(long age, long value);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/RemoteTaskFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/RemoteTaskFactory.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.execution;
 
 import com.facebook.presto.Session;
-import com.facebook.presto.execution.NodeTaskMap.PartitionedSplitCountTracker;
 import com.facebook.presto.execution.buffer.OutputBuffers;
 import com.facebook.presto.execution.scheduler.TableWriteInfo;
 import com.facebook.presto.metadata.InternalNode;
@@ -22,6 +21,8 @@ import com.facebook.presto.metadata.Split;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.sql.planner.PlanFragment;
 import com.google.common.collect.Multimap;
+
+import static com.facebook.presto.execution.NodeTaskMap.NodeStatsTracker;
 
 public interface RemoteTaskFactory
 {
@@ -31,7 +32,7 @@ public interface RemoteTaskFactory
             PlanFragment fragment,
             Multimap<PlanNodeId, Split> initialSplits,
             OutputBuffers outputBuffers,
-            PartitionedSplitCountTracker partitionedSplitCountTracker,
+            NodeStatsTracker nodeStatsTracker,
             boolean summarizeTaskInfo,
             TableWriteInfo tableWriteInfo);
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlStageExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlStageExecution.java
@@ -518,7 +518,7 @@ public final class SqlStageExecution
                 planFragment,
                 initialSplits.build(),
                 outputBuffers,
-                nodeTaskMap.createPartitionedSplitCountTracker(node, taskId),
+                nodeTaskMap.createTaskStatsTracker(node, taskId),
                 summarizeTaskInfo,
                 tableWriteInfo);
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlTask.java
@@ -86,6 +86,7 @@ public class SqlTask
 
     private final AtomicReference<TaskHolder> taskHolderReference = new AtomicReference<>(new TaskHolder());
     private final AtomicBoolean needsPlan = new AtomicBoolean(true);
+    private final long creationTimeInMillis = System.currentTimeMillis();
 
     public static SqlTask createSqlTask(
             TaskId taskId,
@@ -247,6 +248,7 @@ public class SqlTask
 
     private TaskStatus createTaskStatus(TaskHolder taskHolder)
     {
+        long taskStatusAgeInMilis = System.currentTimeMillis() - creationTimeInMillis;
         // Always return a new TaskInfo with a larger version number;
         // otherwise a client will not accept the update
         long versionNumber = nextTaskInfoVersion.getAndIncrement();
@@ -266,6 +268,7 @@ public class SqlTask
         Set<Lifespan> completedDriverGroups = ImmutableSet.of();
         long fullGcCount = 0;
         long fullGcTimeInMillis = 0L;
+        long totalCpuTimeInNanos = 0L;
         if (taskHolder.getFinalTaskInfo() != null) {
             TaskStats taskStats = taskHolder.getFinalTaskInfo().getStats();
             queuedPartitionedDrivers = taskStats.getQueuedPartitionedDrivers();
@@ -275,6 +278,7 @@ public class SqlTask
             systemMemoryReservationInBytes = taskStats.getSystemMemoryReservationInBytes();
             fullGcCount = taskStats.getFullGcCount();
             fullGcTimeInMillis = taskStats.getFullGcTimeInMillis();
+            totalCpuTimeInNanos = taskStats.getTotalCpuTimeInNanos();
         }
         else if (taskHolder.getTaskExecution() != null) {
             long physicalWrittenBytes = 0;
@@ -284,6 +288,7 @@ public class SqlTask
                 queuedPartitionedDrivers += pipelineStatus.getQueuedPartitionedDrivers();
                 runningPartitionedDrivers += pipelineStatus.getRunningPartitionedDrivers();
                 physicalWrittenBytes += pipelineContext.getPhysicalWrittenDataSize();
+                totalCpuTimeInNanos += pipelineContext.getPipelineStats().getTotalCpuTimeInNanos();
             }
             physicalWrittenDataSizeInBytes = physicalWrittenBytes;
             userMemoryReservationInBytes = taskContext.getMemoryReservation().toBytes();
@@ -310,7 +315,9 @@ public class SqlTask
                 systemMemoryReservationInBytes,
                 queryContext.getPeakNodeTotalMemory(),
                 fullGcCount,
-                fullGcTimeInMillis);
+                fullGcTimeInMillis,
+                totalCpuTimeInNanos,
+                taskStatusAgeInMilis);
     }
 
     private TaskStats getTaskStats(TaskHolder taskHolder)

--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskStatus.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskStatus.java
@@ -74,6 +74,9 @@ public class TaskStatus
 
     private final List<ExecutionFailureInfo> failures;
 
+    private final long totalCpuTimeInNanos;
+    private final long taskAgeInMillis;
+
     @JsonCreator
     @ThriftConstructor
     public TaskStatus(
@@ -93,7 +96,9 @@ public class TaskStatus
             @JsonProperty("systemMemoryReservationInBytes") long systemMemoryReservationInBytes,
             @JsonProperty("peakNodeTotalMemoryReservationInBytes") long peakNodeTotalMemoryReservationInBytes,
             @JsonProperty("fullGcCount") long fullGcCount,
-            @JsonProperty("fullGcTimeInMillis") long fullGcTimeInMillis)
+            @JsonProperty("fullGcTimeInMillis") long fullGcTimeInMillis,
+            @JsonProperty("totalCpuTimeInNanos") long totalCpuTimeInNanos,
+            @JsonProperty("taskAgeInMillis") long taskAgeInMillis)
     {
         this.taskInstanceIdLeastSignificantBits = taskInstanceIdLeastSignificantBits;
         this.taskInstanceIdMostSignificantBits = taskInstanceIdMostSignificantBits;
@@ -122,6 +127,8 @@ public class TaskStatus
         checkArgument(fullGcCount >= 0, "fullGcCount is negative");
         this.fullGcCount = fullGcCount;
         this.fullGcTimeInMillis = fullGcTimeInMillis;
+        this.totalCpuTimeInNanos = totalCpuTimeInNanos;
+        this.taskAgeInMillis = taskAgeInMillis;
     }
 
     @JsonProperty
@@ -243,6 +250,20 @@ public class TaskStatus
         return peakNodeTotalMemoryReservationInBytes;
     }
 
+    @JsonProperty
+    @ThriftField(18)
+    public long getTotalCpuTimeInNanos()
+    {
+        return totalCpuTimeInNanos;
+    }
+
+    @JsonProperty
+    @ThriftField(19)
+    public long getTaskAgeInMillis()
+    {
+        return taskAgeInMillis;
+    }
+
     @Override
     public String toString()
     {
@@ -270,6 +291,8 @@ public class TaskStatus
                 0,
                 0,
                 0,
+                0,
+                0,
                 0);
     }
 
@@ -292,6 +315,8 @@ public class TaskStatus
                 taskStatus.getSystemMemoryReservationInBytes(),
                 taskStatus.getPeakNodeTotalMemoryReservationInBytes(),
                 taskStatus.getFullGcCount(),
-                taskStatus.getFullGcTimeInMillis());
+                taskStatus.getFullGcTimeInMillis(),
+                taskStatus.getTotalCpuTimeInNanos(),
+                taskStatus.getTaskAgeInMillis());
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/TrackingRemoteTaskFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TrackingRemoteTaskFactory.java
@@ -14,7 +14,7 @@
 package com.facebook.presto.execution;
 
 import com.facebook.presto.Session;
-import com.facebook.presto.execution.NodeTaskMap.PartitionedSplitCountTracker;
+import com.facebook.presto.execution.NodeTaskMap.NodeStatsTracker;
 import com.facebook.presto.execution.StateMachine.StateChangeListener;
 import com.facebook.presto.execution.buffer.OutputBuffers;
 import com.facebook.presto.execution.scheduler.TableWriteInfo;
@@ -47,7 +47,7 @@ public class TrackingRemoteTaskFactory
             PlanFragment fragment,
             Multimap<PlanNodeId, Split> initialSplits,
             OutputBuffers outputBuffers,
-            PartitionedSplitCountTracker partitionedSplitCountTracker,
+            NodeStatsTracker nodeStatsTracker,
             boolean summarizeTaskInfo,
             TableWriteInfo tableWriteInfo)
     {
@@ -57,7 +57,7 @@ public class TrackingRemoteTaskFactory
                 fragment,
                 initialSplits,
                 outputBuffers,
-                partitionedSplitCountTracker,
+                nodeStatsTracker,
                 summarizeTaskInfo,
                 tableWriteInfo);
 

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTask.java
@@ -24,7 +24,7 @@ import com.facebook.drift.transport.netty.codec.Protocol;
 import com.facebook.presto.Session;
 import com.facebook.presto.execution.FutureStateChange;
 import com.facebook.presto.execution.Lifespan;
-import com.facebook.presto.execution.NodeTaskMap.PartitionedSplitCountTracker;
+import com.facebook.presto.execution.NodeTaskMap.NodeStatsTracker;
 import com.facebook.presto.execution.QueryManager;
 import com.facebook.presto.execution.RemoteTask;
 import com.facebook.presto.execution.ScheduledSplit;
@@ -188,7 +188,7 @@ public final class HttpRemoteTask
     private final AtomicBoolean needsUpdate = new AtomicBoolean(true);
     private final AtomicBoolean sendPlan = new AtomicBoolean(true);
 
-    private final PartitionedSplitCountTracker partitionedSplitCountTracker;
+    private final NodeStatsTracker nodeStatsTracker;
 
     private final AtomicBoolean aborting = new AtomicBoolean(false);
 
@@ -222,7 +222,7 @@ public final class HttpRemoteTask
             Codec<TaskUpdateRequest> taskUpdateRequestCodec,
             Codec<PlanFragment> planFragmentCodec,
             Codec<MetadataUpdates> metadataUpdatesCodec,
-            PartitionedSplitCountTracker partitionedSplitCountTracker,
+            NodeStatsTracker nodeStatsTracker,
             RemoteTaskStats stats,
             boolean binaryTransportEnabled,
             boolean thriftTransportEnabled,
@@ -245,7 +245,7 @@ public final class HttpRemoteTask
         requireNonNull(taskInfoCodec, "taskInfoCodec is null");
         requireNonNull(taskUpdateRequestCodec, "taskUpdateRequestCodec is null");
         requireNonNull(planFragmentCodec, "planFragmentCodec is null");
-        requireNonNull(partitionedSplitCountTracker, "partitionedSplitCountTracker is null");
+        requireNonNull(nodeStatsTracker, "nodeStatsTracker is null");
         requireNonNull(maxErrorDuration, "maxErrorDuration is null");
         requireNonNull(stats, "stats is null");
         requireNonNull(taskInfoRefreshMaxWait, "taskInfoRefreshMaxWait is null");
@@ -270,7 +270,7 @@ public final class HttpRemoteTask
             this.taskUpdateRequestCodec = taskUpdateRequestCodec;
             this.planFragmentCodec = planFragmentCodec;
             this.updateErrorTracker = taskRequestErrorTracker(taskId, location, maxErrorDuration, errorScheduledExecutor, "updating task");
-            this.partitionedSplitCountTracker = requireNonNull(partitionedSplitCountTracker, "partitionedSplitCountTracker is null");
+            this.nodeStatsTracker = requireNonNull(nodeStatsTracker, "nodeStatsTracker is null");
             this.maxErrorDuration = maxErrorDuration;
             this.stats = stats;
             this.binaryTransportEnabled = binaryTransportEnabled;
@@ -340,12 +340,12 @@ public final class HttpRemoteTask
                     cleanUpTask();
                 }
                 else {
-                    partitionedSplitCountTracker.setPartitionedSplitCount(getPartitionedSplitCount());
+                    updateTaskStats();
                     updateSplitQueueSpace();
                 }
             });
 
-            partitionedSplitCountTracker.setPartitionedSplitCount(getPartitionedSplitCount());
+            updateTaskStats();
             updateSplitQueueSpace();
         }
     }
@@ -416,7 +416,7 @@ public final class HttpRemoteTask
             }
             if (tableScanPlanNodeIds.contains(sourceId)) {
                 pendingSourceSplitCount += added;
-                partitionedSplitCountTracker.setPartitionedSplitCount(getPartitionedSplitCount());
+                updateTaskStats();
             }
             needsUpdate = true;
         }
@@ -602,6 +602,21 @@ public final class HttpRemoteTask
         }
     }
 
+    private void updateTaskStats()
+    {
+        TaskStatus taskStatus = getTaskStatus();
+        if (taskStatus.getState().isDone()) {
+            nodeStatsTracker.setPartitionedSplitCount(0);
+            nodeStatsTracker.setMemoryUsage(0);
+            nodeStatsTracker.setCpuUsage(taskStatus.getTaskAgeInMillis(), 0);
+        }
+        else {
+            nodeStatsTracker.setPartitionedSplitCount(getPartitionedSplitCount());
+            nodeStatsTracker.setMemoryUsage(taskStatus.getMemoryReservationInBytes() + taskStatus.getSystemMemoryReservationInBytes());
+            nodeStatsTracker.setCpuUsage(taskStatus.getTaskAgeInMillis(), taskStatus.getTotalCpuTimeInNanos());
+        }
+    }
+
     private synchronized void processTaskUpdate(TaskInfo newValue, List<TaskSource> sources)
     {
         updateTaskInfo(newValue);
@@ -627,7 +642,7 @@ public final class HttpRemoteTask
         }
         updateSplitQueueSpace();
 
-        partitionedSplitCountTracker.setPartitionedSplitCount(getPartitionedSplitCount());
+        updateTaskStats();
     }
 
     private void updateTaskInfo(TaskInfo taskInfo)
@@ -765,7 +780,7 @@ public final class HttpRemoteTask
         // clear pending splits to free memory
         pendingSplits.clear();
         pendingSourceSplitCount = 0;
-        partitionedSplitCountTracker.setPartitionedSplitCount(getPartitionedSplitCount());
+        updateTaskStats();
         splitQueueHasSpace = true;
         whenSplitQueueHasSpace.complete(null, executor);
 

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTaskFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTaskFactory.java
@@ -21,7 +21,7 @@ import com.facebook.drift.codec.ThriftCodec;
 import com.facebook.drift.transport.netty.codec.Protocol;
 import com.facebook.presto.Session;
 import com.facebook.presto.execution.LocationFactory;
-import com.facebook.presto.execution.NodeTaskMap.PartitionedSplitCountTracker;
+import com.facebook.presto.execution.NodeTaskMap;
 import com.facebook.presto.execution.QueryManager;
 import com.facebook.presto.execution.QueryManagerConfig;
 import com.facebook.presto.execution.RemoteTask;
@@ -181,7 +181,7 @@ public class HttpRemoteTaskFactory
             PlanFragment fragment,
             Multimap<PlanNodeId, Split> initialSplits,
             OutputBuffers outputBuffers,
-            PartitionedSplitCountTracker partitionedSplitCountTracker,
+            NodeTaskMap.NodeStatsTracker nodeStatsTracker,
             boolean summarizeTaskInfo,
             TableWriteInfo tableWriteInfo)
     {
@@ -208,7 +208,7 @@ public class HttpRemoteTaskFactory
                 taskUpdateRequestCodec,
                 planFragmentCodec,
                 metadataUpdatesCodec,
-                partitionedSplitCountTracker,
+                nodeStatsTracker,
                 stats,
                 binaryTransportEnabled,
                 thriftTransportEnabled,

--- a/presto-main/src/test/java/com/facebook/presto/execution/BenchmarkNodeScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/BenchmarkNodeScheduler.java
@@ -162,7 +162,7 @@ public class BenchmarkNodeScheduler
                     initialSplits.add(new Split(CONNECTOR_ID, transactionHandle, new TestSplitRemote(i)));
                 }
                 TaskId taskId = new TaskId("test", 1, 0, i);
-                MockRemoteTaskFactory.MockRemoteTask remoteTask = remoteTaskFactory.createTableScanTask(taskId, node, initialSplits.build(), nodeTaskMap.createPartitionedSplitCountTracker(node, taskId));
+                MockRemoteTaskFactory.MockRemoteTask remoteTask = remoteTaskFactory.createTableScanTask(taskId, node, initialSplits.build(), nodeTaskMap.createTaskStatsTracker(node, taskId));
                 nodeTaskMap.addTask(node, remoteTask);
                 taskMap.put(node, remoteTask);
             }

--- a/presto-main/src/test/java/com/facebook/presto/execution/MockRemoteTaskFactory.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/MockRemoteTaskFactory.java
@@ -17,7 +17,7 @@ import com.facebook.airlift.stats.TestingGcMonitor;
 import com.facebook.presto.Session;
 import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.cost.StatsAndCosts;
-import com.facebook.presto.execution.NodeTaskMap.PartitionedSplitCountTracker;
+import com.facebook.presto.execution.NodeTaskMap.NodeStatsTracker;
 import com.facebook.presto.execution.buffer.LazyOutputBuffer;
 import com.facebook.presto.execution.buffer.OutputBuffer;
 import com.facebook.presto.execution.buffer.OutputBuffers;
@@ -104,7 +104,7 @@ public class MockRemoteTaskFactory
         this.scheduledExecutor = scheduledExecutor;
     }
 
-    public MockRemoteTask createTableScanTask(TaskId taskId, InternalNode newNode, List<Split> splits, PartitionedSplitCountTracker partitionedSplitCountTracker)
+    public MockRemoteTask createTableScanTask(TaskId taskId, InternalNode newNode, List<Split> splits, NodeTaskMap.NodeStatsTracker nodeStatsTracker)
     {
         VariableReferenceExpression variable = new VariableReferenceExpression("column", VARCHAR);
         PlanNodeId sourceId = new PlanNodeId("sourceId");
@@ -137,7 +137,7 @@ public class MockRemoteTaskFactory
                 testFragment,
                 initialSplits.build(),
                 createInitialEmptyOutputBuffers(BROADCAST),
-                partitionedSplitCountTracker,
+                nodeStatsTracker,
                 true,
                 new TableWriteInfo(Optional.empty(), Optional.empty(), Optional.empty()));
     }
@@ -150,17 +150,18 @@ public class MockRemoteTaskFactory
             PlanFragment fragment,
             Multimap<PlanNodeId, Split> initialSplits,
             OutputBuffers outputBuffers,
-            PartitionedSplitCountTracker partitionedSplitCountTracker,
+            NodeTaskMap.NodeStatsTracker nodeStatsTracker,
             boolean summarizeTaskInfo,
             TableWriteInfo tableWriteInfo)
     {
-        return new MockRemoteTask(taskId, fragment, node.getNodeIdentifier(), executor, scheduledExecutor, initialSplits, partitionedSplitCountTracker);
+        return new MockRemoteTask(taskId, fragment, node.getNodeIdentifier(), executor, scheduledExecutor, initialSplits, nodeStatsTracker);
     }
 
     public static final class MockRemoteTask
             implements RemoteTask
     {
         private final AtomicLong nextTaskInfoVersion = new AtomicLong(TaskStatus.STARTING_VERSION);
+        private final AtomicLong nextAgeOffset = new AtomicLong(0);
 
         private final URI location;
         private final TaskStateMachine taskStateMachine;
@@ -182,7 +183,7 @@ public class MockRemoteTaskFactory
         @GuardedBy("this")
         private SettableFuture<?> whenSplitQueueHasSpace = SettableFuture.create();
 
-        private final PartitionedSplitCountTracker partitionedSplitCountTracker;
+        private final NodeStatsTracker nodeStatsTracker;
 
         public MockRemoteTask(TaskId taskId,
                 PlanFragment fragment,
@@ -190,7 +191,7 @@ public class MockRemoteTaskFactory
                 Executor executor,
                 ScheduledExecutorService scheduledExecutor,
                 Multimap<PlanNodeId, Split> initialSplits,
-                PartitionedSplitCountTracker partitionedSplitCountTracker)
+                NodeTaskMap.NodeStatsTracker nodeStatsTracker)
         {
             this.taskStateMachine = new TaskStateMachine(requireNonNull(taskId, "taskId is null"), requireNonNull(executor, "executor is null"));
 
@@ -228,8 +229,8 @@ public class MockRemoteTaskFactory
             this.fragment = requireNonNull(fragment, "fragment is null");
             this.nodeId = requireNonNull(nodeId, "nodeId is null");
             splits.putAll(initialSplits);
-            this.partitionedSplitCountTracker = requireNonNull(partitionedSplitCountTracker, "partitionedSplitCountTracker is null");
-            partitionedSplitCountTracker.setPartitionedSplitCount(getPartitionedSplitCount());
+            this.nodeStatsTracker = requireNonNull(nodeStatsTracker, "nodeStatsTracker is null");
+            updateTaskStats();
             updateSplitQueueSpace();
         }
 
@@ -248,6 +249,7 @@ public class MockRemoteTaskFactory
         @Override
         public TaskInfo getTaskInfo()
         {
+            TaskStats stats = taskContext.getTaskStats();
             TaskState state = taskStateMachine.getState();
             List<ExecutionFailureInfo> failures = ImmutableList.of();
             if (state == TaskState.FAILED) {
@@ -273,7 +275,9 @@ public class MockRemoteTaskFactory
                             0,
                             0,
                             0,
-                            0),
+                            0,
+                            0,
+                            System.currentTimeMillis() + 100 - stats.getCreateTime().getMillis()),
                     DateTime.now(),
                     outputBuffer.getInfo(),
                     ImmutableSet.of(),
@@ -310,7 +314,27 @@ public class MockRemoteTaskFactory
                     stats.getSystemMemoryReservationInBytes(),
                     stats.getPeakNodeTotalMemoryInBytes(),
                     0,
-                    0);
+                    0,
+                    stats.getTotalCpuTimeInNanos(),
+                    // Adding 100 millis to make sure task age > 0 for testing
+                    System.currentTimeMillis() + 100 - stats.getCreateTime().getMillis());
+        }
+
+        private void updateTaskStats()
+        {
+            TaskStatus taskStatus = getTaskStatus();
+            if (taskStatus.getState().isDone()) {
+                nodeStatsTracker.setPartitionedSplitCount(0);
+                nodeStatsTracker.setMemoryUsage(0);
+                nodeStatsTracker.setCpuUsage(taskStatus.getTaskAgeInMillis(), 0);
+            }
+            else {
+                nodeStatsTracker.setPartitionedSplitCount(getPartitionedSplitCount());
+                // setting some values for testing
+                nodeStatsTracker.setMemoryUsage(100);
+                long ageOffset = nextAgeOffset.addAndGet(1);
+                nodeStatsTracker.setCpuUsage(taskStatus.getTaskAgeInMillis() + ageOffset, taskStatus.getTaskAgeInMillis() + ageOffset);
+            }
         }
 
         private synchronized void updateSplitQueueSpace()
@@ -343,7 +367,7 @@ public class MockRemoteTaskFactory
         public synchronized void clearSplits()
         {
             splits.clear();
-            partitionedSplitCountTracker.setPartitionedSplitCount(getPartitionedSplitCount());
+            updateTaskStats();
             runningDrivers = 0;
             updateSplitQueueSpace();
         }
@@ -371,7 +395,7 @@ public class MockRemoteTaskFactory
             synchronized (this) {
                 this.splits.putAll(splits);
             }
-            partitionedSplitCountTracker.setPartitionedSplitCount(getPartitionedSplitCount());
+            updateTaskStats();
             updateSplitQueueSpace();
         }
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestThriftTaskStatus.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestThriftTaskStatus.java
@@ -74,6 +74,8 @@ public class TestThriftTaskStatus
     public static final int PEAK_NODE_TOTAL_MEMORY_RESERVATION_IN_BYTES = 42 * 1024 * 1024;
     public static final int FULL_GC_COUNT = 10;
     public static final int FULL_GC_TIME_IN_MILLIS = 1001;
+    public static final int TOTAL_CPU_TIME_IN_NANOS = 1002;
+    public static final int TASK_AGE = 1003;
     public static final HostAddress REMOTE_HOST = HostAddress.fromParts("www.fake.invalid", 8080);
     private TaskStatus taskStatus;
 
@@ -135,6 +137,8 @@ public class TestThriftTaskStatus
         assertEquals(taskStatus.getPeakNodeTotalMemoryReservationInBytes(), PEAK_NODE_TOTAL_MEMORY_RESERVATION_IN_BYTES);
         assertEquals(taskStatus.getFullGcCount(), FULL_GC_COUNT);
         assertEquals(taskStatus.getFullGcTimeInMillis(), FULL_GC_TIME_IN_MILLIS);
+        assertEquals(taskStatus.getTotalCpuTimeInNanos(), TOTAL_CPU_TIME_IN_NANOS);
+        assertEquals(taskStatus.getTaskAgeInMillis(), TASK_AGE);
 
         List<ExecutionFailureInfo> failures = taskStatus.getFailures();
         assertEquals(failures.size(), 3);
@@ -195,7 +199,9 @@ public class TestThriftTaskStatus
                 SYSTEM_MEMORY_RESERVATION_IN_BYTES,
                 PEAK_NODE_TOTAL_MEMORY_RESERVATION_IN_BYTES,
                 FULL_GC_COUNT,
-                FULL_GC_TIME_IN_MILLIS);
+                FULL_GC_TIME_IN_MILLIS,
+                TOTAL_CPU_TIME_IN_NANOS,
+                TASK_AGE);
     }
 
     private List<ExecutionFailureInfo> getExecutionFailureInfos()

--- a/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestFixedCountScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestFixedCountScheduler.java
@@ -15,7 +15,7 @@ package com.facebook.presto.execution.scheduler;
 
 import com.facebook.presto.client.NodeVersion;
 import com.facebook.presto.execution.MockRemoteTaskFactory;
-import com.facebook.presto.execution.NodeTaskMap.PartitionedSplitCountTracker;
+import com.facebook.presto.execution.NodeTaskMap;
 import com.facebook.presto.execution.RemoteTask;
 import com.facebook.presto.execution.TaskId;
 import com.facebook.presto.metadata.InternalNode;
@@ -63,7 +63,7 @@ public class TestFixedCountScheduler
                 (node, partition) -> Optional.of(taskFactory.createTableScanTask(
                         new TaskId("test", 1, 0, 1),
                         node, ImmutableList.of(),
-                        new PartitionedSplitCountTracker(delta -> {}))),
+                        new NodeTaskMap.NodeStatsTracker(delta -> {}, delta -> {}, (age, delta) -> {}))),
                 generateRandomNodes(1));
 
         ScheduleResult result = nodeScheduler.schedule();
@@ -80,7 +80,7 @@ public class TestFixedCountScheduler
                 (node, partition) -> Optional.of(taskFactory.createTableScanTask(
                         new TaskId("test", 1, 0, 1),
                         node, ImmutableList.of(),
-                        new PartitionedSplitCountTracker(delta -> {}))),
+                        new NodeTaskMap.NodeStatsTracker(delta -> {}, delta -> {}, (age, delta) -> {}))),
                 generateRandomNodes(5));
 
         ScheduleResult result = nodeScheduler.schedule();

--- a/presto-main/src/test/java/com/facebook/presto/server/remotetask/TestHttpRemoteTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/remotetask/TestHttpRemoteTask.java
@@ -238,7 +238,7 @@ public class TestHttpRemoteTask
                 createPlanFragment(),
                 ImmutableMultimap.of(),
                 createInitialEmptyOutputBuffers(OutputBuffers.BufferType.BROADCAST),
-                new NodeTaskMap.PartitionedSplitCountTracker(i -> {}),
+                new NodeTaskMap.NodeStatsTracker(i -> {}, i -> {}, (age, i) -> {}),
                 true,
                 new TableWriteInfo(Optional.empty(), Optional.empty(), Optional.empty()));
     }
@@ -548,7 +548,9 @@ public class TestHttpRemoteTask
                     initialTaskStatus.getSystemMemoryReservationInBytes(),
                     initialTaskStatus.getPeakNodeTotalMemoryReservationInBytes(),
                     initialTaskStatus.getFullGcCount(),
-                    initialTaskStatus.getFullGcTimeInMillis());
+                    initialTaskStatus.getFullGcTimeInMillis(),
+                    initialTaskStatus.getTotalCpuTimeInNanos(),
+                    initialTaskStatus.getTaskAgeInMillis());
         }
     }
 }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkTaskExecutorFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkTaskExecutorFactory.java
@@ -677,7 +677,9 @@ public class PrestoSparkTaskExecutorFactory
                     taskStats.getSystemMemoryReservationInBytes(),
                     taskStats.getPeakNodeTotalMemoryInBytes(),
                     taskStats.getFullGcCount(),
-                    taskStats.getFullGcTimeInMillis());
+                    taskStats.getFullGcTimeInMillis(),
+                    taskStats.getTotalCpuTimeInNanos(),
+                    System.currentTimeMillis() - taskStats.getCreateTime().getMillis());
 
             OutputBufferInfo outputBufferInfo = new OutputBufferInfo(
                     outputBufferType.name(),


### PR DESCRIPTION
Test plan - Only unit tests are added. This PR is about adding CPU and memory stats as the first step to perform resource based task placement. 

```
== NO RELEASE NOTES ==
```



(cherry picked from commit adaa2574364bb08f12e1c070fb779338ead8dbb8)

NodeTaskMap holds the worker level aggregated split stats which is used by NodeSelectors. NodeSelector accesses to NodeTaskMap via NodeAssignmentStats. CPU and Memory stats are added to NodeTaskMap. CPU and Memory stats will used in planed new feature "workload placement".