### PR TITLE
Reorder Data Streams in OrcWriter

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
@@ -57,7 +57,6 @@ import javax.annotation.Nullable;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -118,6 +117,7 @@ public class OrcWriter
     private final int chunkMaxLogicalBytes;
     private final int stripeMaxRowCount;
     private final int rowGroupMaxRowCount;
+    private final StreamLayout streamLayout;
     private final Map<String, String> userMetadata;
     private final CompressedMetadataWriter metadataWriter;
     private final DateTimeZone hiveStorageTimeZone;
@@ -177,6 +177,7 @@ public class OrcWriter
         this.stripeMaxRowCount = options.getStripeMaxRowCount();
         this.rowGroupMaxRowCount = options.getRowGroupMaxRowCount();
         recordValidation(validation -> validation.setRowGroupMaxRowCount(rowGroupMaxRowCount));
+        this.streamLayout = requireNonNull(options.getStreamLayout(), "streamLayout is null");
 
         this.userMetadata = ImmutableMap.<String, String>builder()
                 .putAll(requireNonNull(userMetadata, "userMetadata is null"))
@@ -491,7 +492,7 @@ public class OrcWriter
                     .mapToLong(StreamDataOutput::size)
                     .sum();
         }
-        Collections.sort(dataStreams);
+        streamLayout.reorder(dataStreams);
 
         // add data streams
         for (StreamDataOutput dataStream : dataStreams) {

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriterOptions.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriterOptions.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.orc;
 
+import com.facebook.presto.orc.StreamLayout.ByStreamSize;
 import com.google.common.annotations.VisibleForTesting;
 import io.airlift.units.DataSize;
 
@@ -47,6 +48,7 @@ public class OrcWriterOptions
     private final DataSize maxStringStatisticsLimit;
     private final DataSize maxCompressionBufferSize;
     private final OptionalInt compressionLevel;
+    private final StreamLayout streamLayout;
 
     public OrcWriterOptions()
     {
@@ -58,7 +60,8 @@ public class OrcWriterOptions
                 DEFAULT_DICTIONARY_MAX_MEMORY,
                 DEFAULT_MAX_STRING_STATISTICS_LIMIT,
                 DEFAULT_MAX_COMPRESSION_BUFFER_SIZE,
-                OptionalInt.empty());
+                OptionalInt.empty(),
+                new ByStreamSize());
     }
 
     private OrcWriterOptions(
@@ -69,7 +72,8 @@ public class OrcWriterOptions
             DataSize dictionaryMaxMemory,
             DataSize maxStringStatisticsLimit,
             DataSize maxCompressionBufferSize,
-            OptionalInt compressionLevel)
+            OptionalInt compressionLevel,
+            StreamLayout streamLayout)
     {
         requireNonNull(stripeMinSize, "stripeMinSize is null");
         requireNonNull(stripeMaxSize, "stripeMaxSize is null");
@@ -78,7 +82,8 @@ public class OrcWriterOptions
         requireNonNull(dictionaryMaxMemory, "dictionaryMaxMemory is null");
         requireNonNull(maxStringStatisticsLimit, "maxStringStatisticsLimit is null");
         requireNonNull(maxCompressionBufferSize, "maxCompressionBufferSize is null");
-        requireNonNull(compressionLevel, "zstdCompressionLevel is null");
+        requireNonNull(compressionLevel, "compressionLevel is null");
+        requireNonNull(streamLayout, "streamLayout is null");
 
         this.stripeMinSize = stripeMinSize;
         this.stripeMaxSize = stripeMaxSize;
@@ -88,6 +93,7 @@ public class OrcWriterOptions
         this.maxStringStatisticsLimit = maxStringStatisticsLimit;
         this.maxCompressionBufferSize = maxCompressionBufferSize;
         this.compressionLevel = compressionLevel;
+        this.streamLayout = streamLayout;
     }
 
     public DataSize getStripeMinSize()
@@ -130,6 +136,11 @@ public class OrcWriterOptions
         return compressionLevel;
     }
 
+    public StreamLayout getStreamLayout()
+    {
+        return streamLayout;
+    }
+
     public OrcWriterOptions withStripeMinSize(DataSize stripeMinSize)
     {
         return new OrcWriterOptions(
@@ -140,7 +151,8 @@ public class OrcWriterOptions
                 dictionaryMaxMemory,
                 maxStringStatisticsLimit,
                 maxCompressionBufferSize,
-                compressionLevel);
+                compressionLevel,
+                streamLayout);
     }
 
     public OrcWriterOptions withStripeMaxSize(DataSize stripeMaxSize)
@@ -153,7 +165,8 @@ public class OrcWriterOptions
                 dictionaryMaxMemory,
                 maxStringStatisticsLimit,
                 maxCompressionBufferSize,
-                compressionLevel);
+                compressionLevel,
+                streamLayout);
     }
 
     public OrcWriterOptions withStripeMaxRowCount(int stripeMaxRowCount)
@@ -166,7 +179,8 @@ public class OrcWriterOptions
                 dictionaryMaxMemory,
                 maxStringStatisticsLimit,
                 maxCompressionBufferSize,
-                compressionLevel);
+                compressionLevel,
+                streamLayout);
     }
 
     public OrcWriterOptions withRowGroupMaxRowCount(int rowGroupMaxRowCount)
@@ -179,7 +193,8 @@ public class OrcWriterOptions
                 dictionaryMaxMemory,
                 maxStringStatisticsLimit,
                 maxCompressionBufferSize,
-                compressionLevel);
+                compressionLevel,
+                streamLayout);
     }
 
     public OrcWriterOptions withDictionaryMaxMemory(DataSize dictionaryMaxMemory)
@@ -192,7 +207,8 @@ public class OrcWriterOptions
                 dictionaryMaxMemory,
                 maxStringStatisticsLimit,
                 maxCompressionBufferSize,
-                compressionLevel);
+                compressionLevel,
+                streamLayout);
     }
 
     public OrcWriterOptions withMaxStringStatisticsLimit(DataSize maxStringStatisticsLimit)
@@ -205,7 +221,8 @@ public class OrcWriterOptions
                 dictionaryMaxMemory,
                 maxStringStatisticsLimit,
                 maxCompressionBufferSize,
-                compressionLevel);
+                compressionLevel,
+                streamLayout);
     }
 
     public OrcWriterOptions withMaxCompressionBufferSize(DataSize maxCompressionBufferSize)
@@ -218,7 +235,8 @@ public class OrcWriterOptions
                 dictionaryMaxMemory,
                 maxStringStatisticsLimit,
                 maxCompressionBufferSize,
-                compressionLevel);
+                compressionLevel,
+                streamLayout);
     }
 
     public OrcWriterOptions withCompressionLevel(OptionalInt compressionLevel)
@@ -231,7 +249,22 @@ public class OrcWriterOptions
                 dictionaryMaxMemory,
                 maxStringStatisticsLimit,
                 maxCompressionBufferSize,
-                compressionLevel);
+                compressionLevel,
+                streamLayout);
+    }
+
+    public OrcWriterOptions withStreamLayout(StreamLayout streamLayout)
+    {
+        return new OrcWriterOptions(
+                stripeMinSize,
+                stripeMaxSize,
+                stripeMaxRowCount,
+                rowGroupMaxRowCount,
+                dictionaryMaxMemory,
+                maxStringStatisticsLimit,
+                maxCompressionBufferSize,
+                compressionLevel,
+                streamLayout);
     }
 
     @Override
@@ -246,6 +279,7 @@ public class OrcWriterOptions
                 .add("maxStringStatisticsLimit", maxStringStatisticsLimit)
                 .add("maxCompressionBufferSize", maxCompressionBufferSize)
                 .add("compressionLevel", compressionLevel)
+                .add("streamLayout", streamLayout)
                 .toString();
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/StreamLayout.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/StreamLayout.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc;
+
+import com.facebook.presto.orc.metadata.Stream;
+import com.facebook.presto.orc.stream.StreamDataOutput;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * StreamLayout is used by the Writer to determine the order of the data streams.
+ * In ORC, a column is stored in multiple streams (for example DATA, PRESENT,
+ * LENGTH, DICTIONARY and so on).
+ */
+public interface StreamLayout
+{
+    void reorder(List<StreamDataOutput> dataStreams);
+
+    /**
+     * Streams are ordered by the Stream Size. There is no ordering between
+     * two streams of the same size. It orders them by ascending order of the
+     * stream size, so that multiple of these small IOs can be combined. Note:
+     * usually columns contain small (e.g. PRESENT) and large streams (e.g. DATA).
+     * This strategy places them far apart and may result in increased IO.
+     */
+    class ByStreamSize
+            implements StreamLayout
+    {
+        @Override
+        public void reorder(List<StreamDataOutput> dataStreams)
+        {
+            Collections.sort(requireNonNull(dataStreams, "dataStreams is null"));
+        }
+
+        @Override
+        public String toString()
+        {
+            return "ByStreamSize{}";
+        }
+    }
+
+    /**
+     * Streams are ordered by Column Size. If two columns have same size then
+     * columnId, stream size and stream kind are used for ordering. It orders them
+     * by ascending order of column size to read multiple small columns in one IO.
+     * All streams for a column are stored together to read one column in one IO.
+     */
+    class ByColumnSize
+            implements StreamLayout
+    {
+        @Override
+        public void reorder(List<StreamDataOutput> dataStreams)
+        {
+            requireNonNull(dataStreams, "dataStreams is null");
+            if (dataStreams.isEmpty()) {
+                return;
+            }
+
+            Map<Integer, Long> columnSizes = dataStreams.stream()
+                    .collect(toImmutableMap(
+                            s -> s.getStream().getColumn(),
+                            s -> (long) s.getStream().getLength(),
+                            Long::sum));
+
+            dataStreams.sort((left, right) -> {
+                Stream leftStream = left.getStream();
+                Stream rightStream = right.getStream();
+
+                long sizeDelta = columnSizes.get(leftStream.getColumn()) - columnSizes.get(rightStream.getColumn());
+                if (sizeDelta != 0) {
+                    return sizeDelta < 0 ? -1 : 1;
+                }
+
+                int columnDelta = leftStream.getColumn() - rightStream.getColumn();
+                if (columnDelta != 0) {
+                    return columnDelta;
+                }
+
+                sizeDelta = leftStream.getLength() - rightStream.getLength();
+                if (sizeDelta != 0) {
+                    return sizeDelta < 0 ? -1 : 1;
+                }
+
+                return leftStream.getStreamKind().compareTo(rightStream.getStreamKind());
+            });
+        }
+
+        @Override
+        public String toString()
+        {
+            return "ByColumnSize{}";
+        }
+    }
+}

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcWriter.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcWriter.java
@@ -124,7 +124,7 @@ public class TestOrcWriter
             writer.close();
 
             // read the footer and verify the streams are ordered by size
-            boolean isZstdJniCompressorEnabled = true;
+            boolean zstdJniDecompressionEnabled = true;
             DataSize dataSize = new DataSize(1, MEGABYTE);
             OrcDataSource orcDataSource = new FileOrcDataSource(tempFile.getFile(), dataSize, dataSize, dataSize, true);
             Footer footer = new OrcReader(
@@ -137,14 +137,14 @@ public class TestOrcWriter
                             dataSize,
                             dataSize,
                             dataSize,
-                            isZstdJniCompressorEnabled),
+                            zstdJniDecompressionEnabled),
                     false,
                     NO_ENCRYPTION,
                     DwrfKeyProvider.EMPTY
             ).getFooter();
 
             int bufferSize = toIntExact(orcWriterOptions.getMaxCompressionBufferSize().toBytes());
-            Optional<OrcDecompressor> decompressor = createOrcDecompressor(orcDataSource.getId(), kind, bufferSize, isZstdJniCompressorEnabled);
+            Optional<OrcDecompressor> decompressor = createOrcDecompressor(orcDataSource.getId(), kind, bufferSize, zstdJniDecompressionEnabled);
 
             for (StripeInformation stripe : footer.getStripes()) {
                 // read the footer

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestStreamLayout.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestStreamLayout.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc;
+
+import com.facebook.presto.orc.StreamLayout.ByColumnSize;
+import com.facebook.presto.orc.StreamLayout.ByStreamSize;
+import com.facebook.presto.orc.metadata.Stream;
+import com.facebook.presto.orc.metadata.Stream.StreamKind;
+import com.facebook.presto.orc.stream.StreamDataOutput;
+import io.airlift.slice.Slices;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+
+public class TestStreamLayout
+{
+    private static StreamDataOutput createStream(int column, StreamKind streamKind, int length)
+    {
+        Stream stream = new Stream(column, streamKind, length, true);
+        return new StreamDataOutput(Slices.allocate(1024), stream);
+    }
+
+    private static void verifyStream(Stream stream, int column, StreamKind streamKind, int length)
+    {
+        assertEquals(stream.getColumn(), column);
+        assertEquals(stream.getLength(), length);
+        assertEquals(stream.getStreamKind(), streamKind);
+    }
+
+    @Test
+    public void testByStreamSize()
+    {
+        List<StreamDataOutput> streams = new ArrayList<>();
+        int length = 10_000;
+        for (int i = 0; i < 10; i++) {
+            streams.add(createStream(i, StreamKind.PRESENT, length - i));
+            streams.add(createStream(i, StreamKind.DATA, length - 100 - i));
+        }
+
+        Collections.shuffle(streams);
+
+        new ByStreamSize().reorder(streams);
+
+        assertEquals(streams.size(), 20);
+        Iterator<StreamDataOutput> iterator = streams.iterator();
+        for (int i = 9; i >= 0; i--) {
+            verifyStream(iterator.next().getStream(), i, StreamKind.DATA, length - 100 - i);
+        }
+
+        for (int i = 9; i >= 0; i--) {
+            verifyStream(iterator.next().getStream(), i, StreamKind.PRESENT, length - i);
+        }
+        assertFalse(iterator.hasNext());
+    }
+
+    @Test
+    public void testByColumnSize()
+    {
+        // Assume the file has 3 streams
+        // 1st Column( 1010), Data(1000), Present(10)
+        // 2nd column (1010), Dictionary (300), Present (10), Data(600), Length(100)
+        // 3rd Column > 2GB
+
+        List<StreamDataOutput> streams = new ArrayList<>();
+        streams.add(createStream(1, StreamKind.DATA, 1_000));
+        streams.add(createStream(1, StreamKind.PRESENT, 10));
+
+        streams.add(createStream(2, StreamKind.DICTIONARY_DATA, 300));
+        streams.add(createStream(2, StreamKind.PRESENT, 10));
+        streams.add(createStream(2, StreamKind.DATA, 600));
+        streams.add(createStream(2, StreamKind.LENGTH, 100));
+
+        streams.add(createStream(3, StreamKind.DATA, Integer.MAX_VALUE));
+        streams.add(createStream(3, StreamKind.PRESENT, Integer.MAX_VALUE));
+
+        Collections.shuffle(streams);
+        new ByColumnSize().reorder(streams);
+
+        Iterator<StreamDataOutput> iterator = streams.iterator();
+        verifyStream(iterator.next().getStream(), 1, StreamKind.PRESENT, 10);
+        verifyStream(iterator.next().getStream(), 1, StreamKind.DATA, 1000);
+
+        verifyStream(iterator.next().getStream(), 2, StreamKind.PRESENT, 10);
+        verifyStream(iterator.next().getStream(), 2, StreamKind.LENGTH, 100);
+        verifyStream(iterator.next().getStream(), 2, StreamKind.DICTIONARY_DATA, 300);
+        verifyStream(iterator.next().getStream(), 2, StreamKind.DATA, 600);
+
+        verifyStream(iterator.next().getStream(), 3, StreamKind.PRESENT, Integer.MAX_VALUE);
+        verifyStream(iterator.next().getStream(), 3, StreamKind.DATA, Integer.MAX_VALUE);
+
+        assertFalse(iterator.hasNext());
+    }
+}


### PR DESCRIPTION
OrcWriter orders stream by size. This will place different streams
of same column separated and thereby requiring more IOs.

Refactored the StreamLayout as an interface and made it configurable.
Added an option for placing the streams by column size, rather than
stream size. This enables one column to be read with one IO.

StreamLayout is pluggable in OrcWriterOptions. If the query pattern is
known, columns read together in popular query can be stored together
by implementing a new StreamLayout functionality.

Test plan - Added new test to verify the different options.


```
== NO RELEASE NOTE ==
```
