### PR TITLE
Fix adjusted queue size calculation

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroupManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroupManager.java
@@ -303,7 +303,7 @@ public final class InternalResourceGroupManager<C>
     private static int getQueriesQueuedOnInternal(InternalResourceGroup resourceGroup)
     {
         if (resourceGroup.subGroups().isEmpty()) {
-            return Math.min(resourceGroup.getQueuedQueries(), resourceGroup.getSoftConcurrencyLimit() - resourceGroup.getRunningQueries());
+            return Math.max(Math.min(resourceGroup.getQueuedQueries(), resourceGroup.getSoftConcurrencyLimit() - resourceGroup.getRunningQueries()), 0);
         }
 
         int queriesQueuedInternal = 0;


### PR DESCRIPTION
In situations that number of running queries > soft concurrency limit, the adjusted queue size is negative.
This is incorrect - since if 1 RG gets a good share of resources when the cluster is free and holds onto
it, in that situation we should not have that 1 RG's negative quota impact other users, it just means
that the adjusted queue size for that RG is 0 - no waiting

Test plan - This is a small change - and hence just relying on the test cases to see if something major is wrong

```
== NO RELEASE NOTE ==
```
