### PR TITLE
Fix task worker host url

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlTask.java
@@ -374,7 +374,8 @@ public class SqlTask
                 noMoreSplits,
                 taskStats,
                 needsPlan.get(),
-                metadataRequests);
+                metadataRequests,
+                nodeId);
     }
 
     public ListenableFuture<TaskStatus> getTaskStatus(TaskState callersCurrentState)

--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskInfo.java
@@ -47,6 +47,7 @@ public class TaskInfo
 
     private final boolean needsPlan;
     private final MetadataUpdates metadataUpdates;
+    private final String nodeId;
 
     @JsonCreator
     public TaskInfo(
@@ -57,7 +58,8 @@ public class TaskInfo
             @JsonProperty("noMoreSplits") Set<PlanNodeId> noMoreSplits,
             @JsonProperty("stats") TaskStats stats,
             @JsonProperty("needsPlan") boolean needsPlan,
-            @JsonProperty("metadataUpdates") MetadataUpdates metadataUpdates)
+            @JsonProperty("metadataUpdates") MetadataUpdates metadataUpdates,
+            @JsonProperty("nodeId") String nodeId)
     {
         this.taskId = requireNonNull(taskId, "taskId is null");
         this.taskStatus = requireNonNull(taskStatus, "taskStatus is null");
@@ -68,6 +70,7 @@ public class TaskInfo
 
         this.needsPlan = needsPlan;
         this.metadataUpdates = metadataUpdates;
+        this.nodeId = requireNonNull(nodeId, "nodeId is null");
     }
 
     @JsonProperty
@@ -118,12 +121,36 @@ public class TaskInfo
         return metadataUpdates;
     }
 
+    @JsonProperty
+    public String getNodeId()
+    {
+        return nodeId;
+    }
+
     public TaskInfo summarize()
     {
         if (taskStatus.getState().isDone()) {
-            return new TaskInfo(taskId, taskStatus, lastHeartbeat, outputBuffers.summarize(), noMoreSplits, stats.summarizeFinal(), needsPlan, metadataUpdates);
+            return new TaskInfo(
+                    taskId,
+                    taskStatus,
+                    lastHeartbeat,
+                    outputBuffers.summarize(),
+                    noMoreSplits,
+                    stats.summarizeFinal(),
+                    needsPlan,
+                    metadataUpdates,
+                    nodeId);
         }
-        return new TaskInfo(taskId, taskStatus, lastHeartbeat, outputBuffers.summarize(), noMoreSplits, stats.summarize(), needsPlan, metadataUpdates);
+        return new TaskInfo(
+                taskId,
+                taskStatus,
+                lastHeartbeat,
+                outputBuffers.summarize(),
+                noMoreSplits,
+                stats.summarize(),
+                needsPlan,
+                metadataUpdates,
+                nodeId);
     }
 
     @Override
@@ -135,7 +162,7 @@ public class TaskInfo
                 .toString();
     }
 
-    public static TaskInfo createInitialTask(TaskId taskId, URI location, List<BufferInfo> bufferStates, TaskStats taskStats)
+    public static TaskInfo createInitialTask(TaskId taskId, URI location, List<BufferInfo> bufferStates, TaskStats taskStats, String nodeId)
     {
         return new TaskInfo(
                 taskId,
@@ -145,11 +172,12 @@ public class TaskInfo
                 ImmutableSet.of(),
                 taskStats,
                 true,
-                DEFAULT_METADATA_UPDATES);
+                DEFAULT_METADATA_UPDATES,
+                nodeId);
     }
 
     public TaskInfo withTaskStatus(TaskStatus newTaskStatus)
     {
-        return new TaskInfo(taskId, newTaskStatus, lastHeartbeat, outputBuffers, noMoreSplits, stats, needsPlan, metadataUpdates);
+        return new TaskInfo(taskId, newTaskStatus, lastHeartbeat, outputBuffers, noMoreSplits, stats, needsPlan, metadataUpdates, nodeId);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTask.java
@@ -298,7 +298,7 @@ public final class HttpRemoteTask
                     .map(outputId -> new BufferInfo(outputId, false, 0, 0, PageBufferInfo.empty()))
                     .collect(toImmutableList());
 
-            TaskInfo initialTask = createInitialTask(taskId, location, bufferStates, new TaskStats(DateTime.now(), null));
+            TaskInfo initialTask = createInitialTask(taskId, location, bufferStates, new TaskStats(DateTime.now(), null), nodeId);
 
             this.taskStatusFetcher = new ContinuousTaskStatusFetcher(
                     this::failTask,

--- a/presto-main/src/main/resources/webapp/src/components/QueryDetail.jsx
+++ b/presto-main/src/main/resources/webapp/src/components/QueryDetail.jsx
@@ -122,7 +122,7 @@ class TaskList extends React.Component {
                         </a>
                     </Td>
                     <Td column="host" value={getHostname(task.taskStatus.self)}>
-                        <a href={"worker.html?" + task.taskStatus.nodeId} className="font-light" target="_blank">
+                        <a href={"worker.html?" + task.nodeId} className="font-light" target="_blank">
                             {showPortNumbers ? getHostAndPort(task.taskStatus.self) : getHostname(task.taskStatus.self)}
                         </a>
                     </Td>

--- a/presto-main/src/test/java/com/facebook/presto/execution/MockRemoteTaskFactory.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/MockRemoteTaskFactory.java
@@ -279,7 +279,8 @@ public class MockRemoteTaskFactory
                     ImmutableSet.of(),
                     taskContext.getTaskStats(),
                     true,
-                    DEFAULT_METADATA_UPDATES);
+                    DEFAULT_METADATA_UPDATES,
+                    nodeId);
         }
 
         @Override

--- a/presto-main/src/test/java/com/facebook/presto/server/remotetask/TestHttpRemoteTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/remotetask/TestHttpRemoteTask.java
@@ -502,7 +502,8 @@ public class TestHttpRemoteTask
                     initialTaskInfo.getNoMoreSplits(),
                     initialTaskInfo.getStats(),
                     initialTaskInfo.isNeedsPlan(),
-                    initialTaskInfo.getMetadataUpdates());
+                    initialTaskInfo.getMetadataUpdates(),
+                    initialTaskInfo.getNodeId());
         }
 
         private TaskStatus buildTaskStatus()

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkTaskExecutorFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkTaskExecutorFactory.java
@@ -698,7 +698,8 @@ public class PrestoSparkTaskExecutorFactory
                     ImmutableSet.of(),
                     taskStats,
                     false,
-                    DEFAULT_METADATA_UPDATES);
+                    DEFAULT_METADATA_UPDATES,
+                    "");
         }
     }
 


### PR DESCRIPTION
The removal of nodeId from TaskStatus broke the task worker host url
link from the Query Details page. This commit adds the nodeId in TaskInfo
and updates the UI to use that instead.

fixes https://github.com/prestodb/presto/issues/15121

Test plan
**Before the fix** 

![image](https://user-images.githubusercontent.com/236188/108320126-3b028580-7177-11eb-8cb3-268676008e36.png)

**After the fix** 
![image](https://user-images.githubusercontent.com/236188/108320185-4f468280-7177-11eb-9c49-59c2096e330b.png)
![image](https://user-images.githubusercontent.com/236188/108320202-55d4fa00-7177-11eb-8b90-840839abd50e.png)


```
== NO RELEASE NOTE ==
```