### PR TITLE
Update build badge url from travis-ci.org to travis-ci.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Presto [![Build Status](https://travis-ci.org/prestodb/presto.svg?branch=master)](https://travis-ci.org/prestodb/presto)
+# Presto [![Build Status](https://travis-ci.com/prestodb/presto.svg?branch=master)](https://travis-ci.com/prestodb/presto)
 
 Presto is a distributed SQL query engine for big data.
 


### PR DESCRIPTION
Update build badge url from travis-ci.org to travis-ci.com

Test plan 
Navigated to the build badge from my feature branch 
https://github.com/ajaygeorge/presto/tree/feature/update_travis_build_badge

![image](https://user-images.githubusercontent.com/236188/108556096-4f479f00-72ab-11eb-91f7-0d8c2af5b2a3.png)


```
== NO RELEASE NOTE ==
```