### PR TITLE
Optimize row constructor code

### DIFF
--- a/presto-bytecode/src/main/java/com/facebook/presto/bytecode/Scope.java
+++ b/presto-bytecode/src/main/java/com/facebook/presto/bytecode/Scope.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableList;
 import org.objectweb.asm.Type;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -32,7 +33,7 @@ public class Scope
 {
     private final Map<String, Variable> variables = new TreeMap<>();
     private final List<Variable> allVariables = new ArrayList<>();
-
+    private final Map<Class<?>, Variable> singletonVariables = new HashMap<>();
     private final Variable thisVariable;
 
     private int nextTempVariableId;
@@ -67,6 +68,18 @@ public class Scope
         nextTempVariableId += Type.getType(type(type).getType()).getSize();
 
         allVariables.add(variable);
+
+        return variable;
+    }
+
+    public Variable getSingletonVariable(BytecodeBlock block, Class<?> clazz)
+    {
+        Variable variable = singletonVariables.get(clazz);
+        if (variable == null) {
+            variable = createTempVariable(clazz);
+            block.initializeVariable(variable);
+            singletonVariables.put(clazz, variable);
+        }
 
         return variable;
     }


### PR DESCRIPTION
Test plan - Added a test in AbstractTestQueries

We now generate a single variable for each distinct primitive type and one Object type variable for all non-primitives. This helps in reducing the bytecode size dramatically. We can now process the 1250 field row that's in the test just added - that was failing before this optimization. 

We also generate a single field add code per field type and a single null handling block. This is the minimal code that we can generate in our current framework.

```
== RELEASE NOTES ==

General Changes
* ROW constructor code is improved that should allow struct/row type with many more fields without bytecode too large error.
```
