### PR TITLE
Upgrade fastutil version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -635,7 +635,7 @@
             <dependency>
                 <groupId>com.facebook.hive</groupId>
                 <artifactId>hive-dwrf</artifactId>
-                <version>0.8.3</version>
+                <version>0.8.5</version>
             </dependency>
 
             <dependency>
@@ -923,7 +923,7 @@
             <dependency>
                 <groupId>it.unimi.dsi</groupId>
                 <artifactId>fastutil</artifactId>
-                <version>6.5.9</version>
+                <version>8.5.2</version>
             </dependency>
 
             <dependency>

--- a/presto-array/src/main/java/com/facebook/presto/array/ReferenceCountMap.java
+++ b/presto-array/src/main/java/com/facebook/presto/array/ReferenceCountMap.java
@@ -64,7 +64,7 @@ public final class ReferenceCountMap
      */
     public long sizeOf()
     {
-        return INSTANCE_SIZE + SizeOf.sizeOf(key) + SizeOf.sizeOf(value) + SizeOf.sizeOf(used);
+        return INSTANCE_SIZE + SizeOf.sizeOf(key) + SizeOf.sizeOf(value);
     }
 
     /**

--- a/presto-main/src/main/java/com/facebook/presto/operator/PagesRTreeIndex.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PagesRTreeIndex.java
@@ -177,7 +177,7 @@ public class PagesRTreeIndex
             }
         });
 
-        return matchingPositions.toIntArray(null);
+        return matchingPositions.toIntArray();
     }
 
     private boolean testReferencePoint(Rectangle probeEnvelope, Rectangle buildEnvelope, int partition)

--- a/presto-main/src/main/java/com/facebook/presto/util/FastutilSetHelper.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/FastutilSetHelper.java
@@ -202,6 +202,10 @@ public final class FastutilSetHelper
         @Override
         public boolean equals(Object a, Object b)
         {
+            if (a == null || b == null) {
+                return a == b;
+            }
+
             try {
                 Boolean result = (Boolean) equalsHandle.invokeExact(a, b);
                 return TRUE.equals(result);


### PR DESCRIPTION
Integer dictionary encoding for DWRF format is planned.
For efficient implementation, fastutil putIfAbsent is preferred
available in newer versions.  Upgrading hive-dwrf
as the current version is not compatible with fastutil 8.5.2

Depended by https://github.com/facebookexternal/presto-facebook/pull/1434

Test plan - 
Existing tests should cover the change.

```
== NO RELEASE NOTE ==
```
