### PR TITLE
Refactor TempStorage interface

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/spiller/LocalTempStorage.java
+++ b/presto-main/src/main/java/com/facebook/presto/spiller/LocalTempStorage.java
@@ -72,11 +72,10 @@ public class LocalTempStorage
     {
         this.spillPaths = ImmutableList.copyOf(requireNonNull(spillPaths, "spillPaths is null"));
         this.maxUsedSpaceThreshold = maxUsedSpaceThreshold;
+        initialize();
     }
 
-    @Override
-    public void initialize()
-            throws IOException
+    private void initialize()
     {
         // From FileSingleStreamSpillerFactory constructor
         spillPaths.forEach(path -> {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/storage/TempStorage.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/storage/TempStorage.java
@@ -18,9 +18,6 @@ import java.io.InputStream;
 
 public interface TempStorage
 {
-    void initialize()
-            throws IOException;
-
     TempDataSink create(TempDataOperationContext context)
             throws IOException;
 


### PR DESCRIPTION
Remove the "initialize" method from the user visible interface.

Initialization is an internal detail of a TempStorage implementation.
The TempStorageFactory#create method should perform the initialization
internally and return an already initialized instance.
Clients of a TempStorage implementation shouldn't be responsible of
initialization.

```
== NO RELEASE NOTE ==
```
