### PR TITLE
Reject @BeforeMethod without singleThreaded=true

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/execution/TestThriftTaskStatus.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestThriftTaskStatus.java
@@ -31,7 +31,7 @@ import com.facebook.presto.sql.tree.NodeLocation;
 import com.facebook.presto.util.Failures;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -77,13 +77,7 @@ public class TestThriftTaskStatus
     public static final int TOTAL_CPU_TIME_IN_NANOS = 1002;
     public static final int TASK_AGE = 1003;
     public static final HostAddress REMOTE_HOST = HostAddress.fromParts("www.fake.invalid", 8080);
-    private TaskStatus taskStatus;
-
-    @BeforeMethod
-    public void setUp()
-    {
-        taskStatus = getTaskStatus();
-    }
+    private static TaskStatus taskStatus;
 
     @DataProvider
     public Object[][] codecCombinations()
@@ -94,6 +88,12 @@ public class TestThriftTaskStatus
                 {REFLECTION_READ_CODEC, COMPILER_WRITE_CODEC},
                 {REFLECTION_READ_CODEC, REFLECTION_WRITE_CODEC}
         };
+    }
+
+    @BeforeTest
+    public void setup()
+    {
+        taskStatus = getTaskStatus();
     }
 
     @Test(dataProvider = "codecCombinations")

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/ParsingExceptionTest.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/ParsingExceptionTest.java
@@ -14,17 +14,17 @@
 package com.facebook.presto.sql.parser;
 
 import com.facebook.presto.sql.tree.NodeLocation;
-import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
 
 public class ParsingExceptionTest
 {
-    private ParsingException parsingException;
+    private static ParsingException parsingException;
 
-    @BeforeMethod
-    public void setUp()
+    @BeforeTest
+    public void setup()
     {
         parsingException = new ParsingException("ParsingException", new NodeLocation(100, 1));
     }

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestQueryConfiguration.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestQueryConfiguration.java
@@ -14,7 +14,7 @@
 package com.facebook.presto.verifier.framework;
 
 import com.google.common.collect.ImmutableMap;
-import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 import java.util.Map;
@@ -50,9 +50,9 @@ public class TestQueryConfiguration
             Optional.of(PASSWORD_OVERRIDE),
             Optional.of(SESSION_PROPERTIES_OVERRIDE));
 
-    private QueryConfigurationOverridesConfig overrides;
+    private static QueryConfigurationOverridesConfig overrides;
 
-    @BeforeMethod
+    @BeforeTest
     public void setup()
     {
         overrides = new QueryConfigurationOverridesConfig()

--- a/src/checkstyle/presto-checks.xml
+++ b/src/checkstyle/presto-checks.xml
@@ -91,6 +91,10 @@
         <property name="format" value="^[ \t]*import static org\.testng\.AssertJUnit\." />
         <property name="message" value="Use org.testng.Assert instead of org.testng.AssertJUnit" />
     </module>
+    <module name="RegexpMultiline">
+        <property name="format" value="(?&lt;!@Test\(singleThreaded[ ]?=[ ]?true\))\npublic class \w+\n\{\n(.*\n){0,200}\s+@BeforeMethod\n" />
+        <property name="message" value="@BeforeMethod cannot be used in a class that is not @Test(singleThreaded=true)" />
+    </module>
 
     <module name="SuppressWarningsFilter" />
 


### PR DESCRIPTION
@BeforeMethod in a class that is not @Test(singleThreaded=true) is
usually (always?) a bug. We should automatically find and reject them.

This change uses Regex negative LookBehind match to find @BeforeMethod
in a class that is not @Test(singleThreaded=true). Only top 200 lines
of a class is scanned to save time and avoid potential stack overflow
if a file is too big. This works because @BeforeMethod should appear at
top a class definition.

Some violations have been caught and are fixed in this change too.

Resolves: #12044

```
== NO RELEASE NOTE ==
```
