### PR TITLE
Allow adjusting broadcast memory via session property for PoS

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkConfig.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkConfig.java
@@ -34,6 +34,7 @@ public class PrestoSparkConfig
     private boolean storageBasedBroadcastJoinEnabled;
     private DataSize storageBasedBroadcastJoinWriteBufferSize = new DataSize(24, MEGABYTE);
     private String storageBasedBroadcastJoinStorage = "local";
+    private DataSize sparkBroadcastJoinMaxMemoryOverride;
 
     public boolean isSparkPartitionCountAutoTuneEnabled()
     {
@@ -150,6 +151,18 @@ public class PrestoSparkConfig
     public PrestoSparkConfig setStorageBasedBroadcastJoinStorage(String storageBasedBroadcastJoinStorage)
     {
         this.storageBasedBroadcastJoinStorage = storageBasedBroadcastJoinStorage;
+        return this;
+    }
+
+    public DataSize getSparkBroadcastJoinMaxMemoryOverride()
+    {
+        return sparkBroadcastJoinMaxMemoryOverride;
+    }
+
+    @Config("spark.broadcast-join-max-memory-override")
+    public PrestoSparkConfig setSparkBroadcastJoinMaxMemoryOverride(DataSize sparkBroadcastJoinMaxMemoryOverride)
+    {
+        this.sparkBroadcastJoinMaxMemoryOverride = sparkBroadcastJoinMaxMemoryOverride;
         return this;
     }
 }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkSessionProperties.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkSessionProperties.java
@@ -36,6 +36,7 @@ public class PrestoSparkSessionProperties
     public static final String SHUFFLE_OUTPUT_TARGET_AVERAGE_ROW_SIZE = "shuffle_output_target_average_row_size";
     public static final String STORAGE_BASED_BROADCAST_JOIN_ENABLED = "storage_based_broadcast_join_enabled";
     public static final String STORAGE_BASED_BROADCAST_JOIN_WRITE_BUFFER_SIZE = "storage_based_broadcast_join_write_buffer_size";
+    public static final String SPARK_BROADCAST_JOIN_MAX_MEMORY_OVERRIDE = "spark_broadcast_join_max_memory_override";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -82,6 +83,11 @@ public class PrestoSparkSessionProperties
                         STORAGE_BASED_BROADCAST_JOIN_WRITE_BUFFER_SIZE,
                         "Maximum size in bytes to buffer before flushing pages to disk",
                         prestoSparkConfig.getStorageBasedBroadcastJoinWriteBufferSize(),
+                        false),
+                dataSizeProperty(
+                        SPARK_BROADCAST_JOIN_MAX_MEMORY_OVERRIDE,
+                        "Maximum size of broadcast table in Presto on Spark",
+                        prestoSparkConfig.getSparkBroadcastJoinMaxMemoryOverride(),
                         false));
     }
 
@@ -128,5 +134,10 @@ public class PrestoSparkSessionProperties
     public static DataSize getStorageBasedBroadcastJoinWriteBufferSize(Session session)
     {
         return session.getSystemProperty(STORAGE_BASED_BROADCAST_JOIN_WRITE_BUFFER_SIZE, DataSize.class);
+    }
+
+    public static DataSize getSparkBroadcastJoinMaxMemoryOverride(Session session)
+    {
+        return session.getSystemProperty(SPARK_BROADCAST_JOIN_MAX_MEMORY_OVERRIDE, DataSize.class);
     }
 }

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkConfig.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkConfig.java
@@ -40,7 +40,8 @@ public class TestPrestoSparkConfig
                 .setShuffleOutputTargetAverageRowSize(new DataSize(1, KILOBYTE))
                 .setStorageBasedBroadcastJoinEnabled(false)
                 .setStorageBasedBroadcastJoinStorage("local")
-                .setStorageBasedBroadcastJoinWriteBufferSize(new DataSize(24, MEGABYTE)));
+                .setStorageBasedBroadcastJoinWriteBufferSize(new DataSize(24, MEGABYTE))
+                .setSparkBroadcastJoinMaxMemoryOverride(null));
     }
 
     @Test
@@ -56,6 +57,7 @@ public class TestPrestoSparkConfig
                 .put("spark.storage-based-broadcast-join-enabled", "true")
                 .put("spark.storage-based-broadcast-join-storage", "tempfs")
                 .put("spark.storage-based-broadcast-join-write-buffer-size", "4MB")
+                .put("spark.broadcast-join-max-memory-override", "1GB")
                 .build();
         PrestoSparkConfig expected = new PrestoSparkConfig()
                 .setSparkPartitionCountAutoTuneEnabled(false)
@@ -66,7 +68,8 @@ public class TestPrestoSparkConfig
                 .setShuffleOutputTargetAverageRowSize(new DataSize(10, KILOBYTE))
                 .setStorageBasedBroadcastJoinEnabled(true)
                 .setStorageBasedBroadcastJoinStorage("tempfs")
-                .setStorageBasedBroadcastJoinWriteBufferSize(new DataSize(4, MEGABYTE));
+                .setStorageBasedBroadcastJoinWriteBufferSize(new DataSize(4, MEGABYTE))
+                .setSparkBroadcastJoinMaxMemoryOverride(new DataSize(1, GIGABYTE));
         assertFullMapping(properties, expected);
     }
 }


### PR DESCRIPTION
Broadcast memory limits in PoS could be different than Presto classic based
on container sizes and the user should have the flexibility to change broadcast
memory limits as per their queries requirements. On the other hand, users
should not change container level memory configs since it can result into
cluster wide issues in case of mis-configuration. We should cap the global
limits by config properties but give the flexibility of changing PoS broadcast
limits via a new session property

Test plan - Existing tests

```
== NO RELEASE NOTE ==
```
