### PR TITLE
Support dynamic filter for hash join 

### DIFF
--- a/presto-main/pom.xml
+++ b/presto-main/pom.xml
@@ -358,6 +358,11 @@
             </exclusions>
         </dependency>
 
+        <dependency>
+            <groupId>com.github.luben</groupId>
+            <artifactId>zstd-jni</artifactId>
+        </dependency>
+
         <!-- for testing -->
         <dependency>
             <groupId>org.testng</groupId>

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -172,6 +172,9 @@ public final class SystemSessionProperties
     public static final String CHECK_ACCESS_CONTROL_ON_UTILIZED_COLUMNS_ONLY = "check_access_control_on_utilized_columns_only";
     public static final String SKIP_REDUNDANT_SORT = "skip_redundant_sort";
     public static final String ALLOW_WINDOW_ORDER_BY_LITERALS = "allow_window_order_by_literals";
+    public static final String ENABLE_HASH_JOIN_DYNAMIC_FILTERING = "enable_hash_join_dynamic_filtering";
+    public static final String BLOOM_FILTER_FOR_DYNAMIC_FILTERING_SIZE = "bloom_filter_for_dynamic_filtering_size";
+    public static final String BLOOM_FILTER_FOR_DYNAMIC_FILTERING_FALSE_POSITIVE_PROBABILITY = "bloom_filter_for_dynamic_filtering_false_positive_probability";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -896,6 +899,25 @@ public final class SystemSessionProperties
                         ALLOW_WINDOW_ORDER_BY_LITERALS,
                         "Allow ORDER BY literals in window functions",
                         featuresConfig.isAllowWindowOrderByLiterals(),
+                        false),
+                booleanProperty(
+                        ENABLE_HASH_JOIN_DYNAMIC_FILTERING,
+                        "Enable hash join dynamic filtering",
+                        featuresConfig.isEnableHashJoinDynamicFiltering(),
+                        false),
+                new PropertyMetadata<>(
+                        BLOOM_FILTER_FOR_DYNAMIC_FILTERING_SIZE,
+                        "Hash join dynamic filtering bloom filter size",
+                        VARCHAR,
+                        DataSize.class,
+                        featuresConfig.getBloomFilterForDynamicFilterSize(),
+                        false,
+                        value -> DataSize.valueOf((String) value),
+                        DataSize::toString),
+                doubleProperty(
+                        BLOOM_FILTER_FOR_DYNAMIC_FILTERING_FALSE_POSITIVE_PROBABILITY,
+                        "Hash join dynamic filtering bloom filter false positive probability",
+                        featuresConfig.getBloomFilterForDynamicFilteringFalsePositiveProbability(),
                         false));
     }
 
@@ -1516,5 +1538,20 @@ public final class SystemSessionProperties
     public static boolean isCheckAccessControlOnUtilizedColumnsOnly(Session session)
     {
         return session.getSystemProperty(CHECK_ACCESS_CONTROL_ON_UTILIZED_COLUMNS_ONLY, Boolean.class);
+    }
+
+    public static boolean isEnableHashJoinDynamicFiltering(Session session)
+    {
+        return session.getSystemProperty(ENABLE_HASH_JOIN_DYNAMIC_FILTERING, Boolean.class);
+    }
+
+    public static DataSize getBloomFilterForDynamicFilteringSize(Session session)
+    {
+        return session.getSystemProperty(BLOOM_FILTER_FOR_DYNAMIC_FILTERING_SIZE, DataSize.class);
+    }
+
+    public static Double getBloomFilterForDynamicFilteringFalsePositiveProbability(Session session)
+    {
+        return session.getSystemProperty(BLOOM_FILTER_FOR_DYNAMIC_FILTERING_FALSE_POSITIVE_PROBABILITY, Double.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/bloomfilter/BitArray.java
+++ b/presto-main/src/main/java/com/facebook/presto/bloomfilter/BitArray.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.bloomfilter;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.Arrays;
+
+public final class BitArray
+{
+    private final long[] data;
+    private long bitCount;
+
+    static int numWords(long numBits)
+    {
+        if (numBits <= 0) {
+            throw new IllegalArgumentException("numBits must be positive, but got " + numBits);
+        }
+        long numWords = (long) Math.ceil(numBits / 64.0);
+        if (numWords > Integer.MAX_VALUE) {
+            throw new IllegalArgumentException("Can't allocate enough space for " + numBits + " bits");
+        }
+        return (int) numWords;
+    }
+
+    BitArray(long numBits)
+    {
+        this(new long[numWords(numBits)]);
+    }
+
+    private BitArray(long[] data)
+    {
+        this.data = data;
+        long bitCount = 0;
+        for (long word : data) {
+            bitCount += Long.bitCount(word);
+        }
+        this.bitCount = bitCount;
+    }
+
+    /** Returns true if the bit changed value. */
+    boolean set(long index)
+    {
+        if (!get(index)) {
+            data[(int) (index >>> 6)] |= (1L << index);
+            bitCount++;
+            return true;
+        }
+        return false;
+    }
+
+    boolean get(long index)
+    {
+        return (data[(int) (index >>> 6)] & (1L << index)) != 0;
+    }
+
+    /** Number of bits */
+    long bitSize()
+    {
+        return (long) data.length * Long.SIZE;
+    }
+
+    /** Number of set bits (1s) */
+    long cardinality()
+    {
+        return bitCount;
+    }
+
+    /** Combines the two BitArrays using bitwise OR. */
+    void putAll(BitArray array)
+    {
+        assert data.length == array.data.length : "BitArrays must be of equal length when merging";
+        long bitCount = 0;
+        for (int i = 0; i < data.length; i++) {
+            data[i] |= array.data[i];
+            bitCount += Long.bitCount(data[i]);
+        }
+        this.bitCount = bitCount;
+    }
+
+    void writeTo(DataOutputStream out) throws IOException
+    {
+        out.writeInt(data.length);
+        for (long datum : data) {
+            out.writeLong(datum);
+        }
+    }
+
+    static BitArray readFrom(DataInputStream in) throws IOException
+    {
+        int numWords = in.readInt();
+        long[] data = new long[numWords];
+        for (int i = 0; i < numWords; i++) {
+            data[i] = in.readLong();
+        }
+        return new BitArray(data);
+    }
+
+    public void clear()
+    {
+        Arrays.fill(data, 0);
+        bitCount = 0;
+    }
+
+    @Override
+    public boolean equals(Object other)
+    {
+        if (this == other) {
+            return true;
+        }
+        if (other == null || !(other instanceof BitArray)) {
+            return false;
+        }
+        BitArray that = (BitArray) other;
+        return Arrays.equals(data, that.data);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Arrays.hashCode(data);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/bloomfilter/BloomFilter.java
+++ b/presto-main/src/main/java/com/facebook/presto/bloomfilter/BloomFilter.java
@@ -1,0 +1,273 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.bloomfilter;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+@JsonTypeInfo(
+        use = JsonTypeInfo.Id.NAME,
+        property = "@type")
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = BloomFilterForDynamicFilterImpl.class, name = "spark")})
+public abstract class BloomFilter
+{
+    public enum Version {
+        /**
+         * {@code BloomFilter} binary format version 1. All values written in big-endian order:
+         * <ul>
+         *   <li>Version number, always 1 (32 bit)</li>
+         *   <li>Number of hash functions (32 bit)</li>
+         *   <li>Total number of words of the underlying bit array (32 bit)</li>
+         *   <li>The words/longs (numWords * 64 bit)</li>
+         * </ul>
+         */
+        V1(1);
+
+        private final int versionNumber;
+
+        Version(int versionNumber)
+        {
+            this.versionNumber = versionNumber;
+        }
+
+        int getVersionNumber()
+        {
+            return versionNumber;
+        }
+    }
+
+    /**
+     * Returns the probability that {@linkplain #mightContain(Object)} erroneously return {@code true}
+     * for an object that has not actually been put in the {@code BloomFilter}.
+     *
+     * Ideally, this number should be close to the {@code fpp} parameter passed in
+     * {@linkplain #create(long, double)}, or smaller. If it is significantly higher, it is usually
+     * the case that too many items (more than expected) have been put in the {@code BloomFilter},
+     * degenerating it.
+     */
+    public abstract double expectedFpp();
+
+    /**
+     * Returns the number of bits in the underlying bit array.
+     */
+    public abstract long bitSize();
+
+    /**
+     * Returns the number of set bits (1s) in the underlying bit array.
+     */
+    public abstract long cardinality();
+
+    /**
+     * Clear the content in this {@code BloomFilter}.
+     */
+    public abstract boolean clear();
+
+    /**
+     * Puts an item into this {@code BloomFilter}. Ensures that subsequent invocations of
+     * {@linkplain #mightContain(Object)} with the same item will always return {@code true}.
+     *
+     * @return true if the bloom filter's bits changed as a result of this operation. If the bits
+     *     changed, this is <i>definitely</i> the first time {@code object} has been added to the
+     *     filter. If the bits haven't changed, this <i>might</i> be the first time {@code object}
+     *     has been added to the filter. Note that {@code put(t)} always returns the
+     *     <i>opposite</i> result to what {@code mightContain(t)} would have returned at the time
+     *     it is called.
+     */
+    public abstract boolean put(Object item);
+
+    /**
+     * A specialized variant of {@link #put(Object)} that only supports {@code String} items.
+     */
+    public abstract boolean putString(String item);
+
+    /**
+     * A specialized variant of {@link #put(Object)} that only supports {@code long} items.
+     */
+    public abstract boolean putLong(long item);
+
+    /**
+     * A specialized variant of {@link #put(Object)} that only supports byte array items.
+     */
+    public abstract boolean putBinary(byte[] item);
+
+    /**
+     * Determines whether a given bloom filter is compatible with this bloom filter. For two
+     * bloom filters to be compatible, they must have the same bit size.
+     *
+     * @param other The bloom filter to check for compatibility.
+     */
+    public abstract boolean isCompatible(BloomFilter other);
+
+    /**
+     * Combines this bloom filter with another bloom filter by performing a bitwise OR of the
+     * underlying data. The mutations happen to <b>this</b> instance. Callers must ensure the
+     * bloom filters are appropriately sized to avoid saturating them.
+     *
+     * @param other The bloom filter to combine this bloom filter with. It is not mutated.
+     * @throws IncompatibleMergeException if {@code isCompatible(other) == false}
+     */
+    public abstract BloomFilter mergeInPlace(BloomFilter other) throws IncompatibleMergeException;
+
+    /**
+     * Returns {@code true} if the element <i>might</i> have been put in this Bloom filter,
+     * {@code false} if this is <i>definitely</i> not the case.
+     */
+    public abstract boolean mightContain(Object item);
+
+    /**
+     * A specialized variant of {@link #mightContain(Object)} that only tests {@code String} items.
+     */
+    public abstract boolean mightContainString(String item);
+
+    /**
+     * A specialized variant of {@link #mightContain(Object)} that only tests {@code long} items.
+     */
+    public abstract boolean mightContainLong(long item);
+
+    /**
+     * A specialized variant of {@link #mightContain(Object)} that only tests byte array items.
+     */
+    public abstract boolean mightContainBinary(byte[] item);
+
+    public abstract boolean putNull();
+
+    public abstract boolean containNull();
+
+    /**
+     * Writes out this {@link BloomFilter} to an output stream in binary format. It is the caller's
+     * responsibility to close the stream.
+     */
+    public abstract void writeTo(OutputStream out) throws IOException;
+
+    /**
+     * Reads in a {@link BloomFilter} from an input stream. It is the caller's responsibility to close
+     * the stream.
+     */
+    public static BloomFilterImpl readFrom(InputStream in) throws IOException
+    {
+        return BloomFilterImpl.readFrom(in);
+    }
+
+    /**
+     * Serializes this {@link BloomFilter} and returns the serialized form.
+     */
+    public abstract byte[] toByteArray() throws IOException;
+
+    /**
+     * Reads in a {@link //CountMinSketch} from a byte array.
+     */
+    public static BloomFilterImpl readFrom(byte[] bytes) throws IOException
+    {
+        try (InputStream in = new ByteArrayInputStream(bytes)) {
+            return readFrom(in);
+        }
+    }
+
+    /**
+     * Computes the optimal k (number of hashes per item inserted in Bloom filter), given the
+     * expected insertions and total number of bits in the Bloom filter.
+     *
+     * See http://en.wikipedia.org/wiki/File:Bloom_filter_fp_probability.svg for the formula.
+     *
+     * @param n expected insertions (must be positive)
+     * @param m total number of bits in Bloom filter (must be positive)
+     */
+    public static int optimalNumOfHashFunctions(long n, long m)
+    {
+        // (m / n) * log(2), but avoid truncation due to division!
+        return Math.max(1, (int) Math.round((double) m / n * Math.log(2)));
+    }
+
+    /**
+     * Computes m (total bits of Bloom filter) which is expected to achieve, for the specified
+     * expected insertions, the required false positive probability.
+     *
+     * See http://en.wikipedia.org/wiki/Bloom_filter#Probability_of_false_positives for the formula.
+     *
+     * @param n expected insertions (must be positive)
+     * @param p false positive rate (must be 0 < p < 1)
+     */
+    public static long optimalNumOfBits(long n, double p)
+    {
+        return (long) (-n * Math.log(p) / (Math.log(2) * Math.log(2)));
+    }
+
+    /**
+     * Computes n (expected insertions of Bloom filter) which is expected to achieve, for the
+     * specified expected bloom filter size (bits), the required false positive probability.
+     *
+     * See http://en.wikipedia.org/wiki/Bloom_filter#Probability_of_false_positives for the formula.
+     *
+     * @param m bits for bloom filter (must be positive)
+     * @param p false positive rate (must be 0 < p < 1)
+     */
+    public static long optimalNumOfItems(long m, double p)
+    {
+        return Math.round(m * (Math.log(2) * Math.log(2)) / (-Math.log(p)));
+    }
+
+    static final double DEFAULT_FPP = 0.03;
+
+    /**
+     * Creates a {@link BloomFilter} with the expected number of insertions and a default expected
+     * false positive probability of 3%.
+     *
+     * Note that overflowing a {@code BloomFilter} with significantly more elements than specified,
+     * will result in its saturation, and a sharp deterioration of its false positive probability.
+     */
+    public static BloomFilterImpl create(long expectedNumItems)
+    {
+        return create(expectedNumItems, DEFAULT_FPP);
+    }
+
+    /**
+     * Creates a {@link BloomFilter} with the expected number of insertions and expected false
+     * positive probability.
+     *
+     * Note that overflowing a {@code BloomFilter} with significantly more elements than specified,
+     * will result in its saturation, and a sharp deterioration of its false positive probability.
+     */
+    public static BloomFilterImpl create(long expectedNumItems, double fpp)
+    {
+        if (fpp <= 0D || fpp >= 1D) {
+            throw new IllegalArgumentException(
+                    "False positive probability must be within range (0.0, 1.0)");
+        }
+
+        return create(expectedNumItems, optimalNumOfBits(expectedNumItems, fpp));
+    }
+
+    /**
+     * Creates a {@link BloomFilter} with given {@code expectedNumItems} and {@code numBits}, it will
+     * pick an optimal {@code numHashFunctions} which can minimize {@code fpp} for the bloom filter.
+     */
+    public static BloomFilterImpl create(long expectedNumItems, long numBits)
+    {
+        if (expectedNumItems <= 0) {
+            throw new IllegalArgumentException("Expected insertions must be positive");
+        }
+
+        if (numBits <= 0) {
+            throw new IllegalArgumentException("Number of bits must be positive");
+        }
+
+        return new BloomFilterImpl(optimalNumOfHashFunctions(expectedNumItems, numBits), numBits);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/bloomfilter/BloomFilterForDynamicFilter.java
+++ b/presto-main/src/main/java/com/facebook/presto/bloomfilter/BloomFilterForDynamicFilter.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.bloomfilter;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+
+@JsonTypeInfo(
+        use = JsonTypeInfo.Id.NAME,
+        property = "@type")
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = BloomFilterForDynamicFilterImpl.class, name = "bloomFilter")})
+public abstract class BloomFilterForDynamicFilter
+        implements Serializable
+{
+    public abstract void put(Object value);
+    public abstract boolean contain(Object value);
+    public abstract BloomFilterForDynamicFilter merge(BloomFilterForDynamicFilter bloomFilter);
+    public abstract void writeObject(ObjectOutputStream outputStream) throws IOException;
+    public abstract void readObject(ObjectInputStream inputStream) throws IOException, ClassNotFoundException;
+}

--- a/presto-main/src/main/java/com/facebook/presto/bloomfilter/BloomFilterForDynamicFilterImpl.java
+++ b/presto-main/src/main/java/com/facebook/presto/bloomfilter/BloomFilterForDynamicFilterImpl.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.bloomfilter;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.luben.zstd.Zstd;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+
+public class BloomFilterForDynamicFilterImpl
+        extends BloomFilterForDynamicFilter
+        implements Serializable
+{
+    private BloomFilterImpl bloomFilter;
+    private int sizeBeforeCompressed;
+    private int sizeAfterCompressed;
+    private byte[] compressedBloomFilter;
+
+    @JsonCreator
+    public BloomFilterForDynamicFilterImpl(
+            @JsonProperty("bloomFilter") BloomFilterImpl bloomFilter,
+            @JsonProperty("compressedBloomFilter") byte[] compressedBloomFilter,
+            @JsonProperty("sizeBeforeCompressed") int sizeBeforeCompressed) throws IOException
+    {
+        this.bloomFilter = bloomFilter;
+
+        decompressBloomFilter(compressedBloomFilter, sizeBeforeCompressed);
+    }
+
+    @JsonProperty
+    public BloomFilterImpl getBloomFilter()
+    {
+        return bloomFilter;
+    }
+
+    @JsonProperty
+    public byte[] getCompressedBloomFilter() throws IOException
+    {
+        compressBloomFilter();
+        return compressedBloomFilter;
+    }
+
+    @JsonProperty
+    public int getSizeBeforeCompressed()
+    {
+        return sizeBeforeCompressed;
+    }
+
+    @JsonProperty
+    public int getSizeAfterCompressed()
+    {
+        return sizeAfterCompressed;
+    }
+
+    @JsonProperty
+    public void setSizeAfterCompressed(int sizeAfterCompressed)
+    {
+        this.sizeAfterCompressed = sizeAfterCompressed;
+    }
+
+    @Override
+    public void put(Object object)
+    {
+        this.bloomFilter.put(object);
+    }
+
+    @Override
+    public boolean contain(Object object)
+    {
+        return this.bloomFilter.mightContain(object);
+    }
+
+    @Override
+    public BloomFilterForDynamicFilter merge(BloomFilterForDynamicFilter bloomFilter)
+    {
+        if (bloomFilter.getClass() != BloomFilterForDynamicFilterImpl.class) {
+            return this;
+        }
+
+        BloomFilterForDynamicFilterImpl apacheBloomFilter = (BloomFilterForDynamicFilterImpl) bloomFilter;
+        if (this.bloomFilter == null || apacheBloomFilter.getBloomFilter() == null) {
+            this.bloomFilter = null;
+        }
+        else {
+            try {
+                this.bloomFilter.mergeInPlace(apacheBloomFilter.getBloomFilter());
+            }
+            catch (IncompatibleMergeException e) {
+                e.printStackTrace();
+            }
+        }
+
+        return this;
+    }
+
+    @Override
+    public void readObject(ObjectInputStream inputStream) throws IOException, ClassNotFoundException
+    {
+        inputStream.defaultReadObject();
+        if (compressedBloomFilter != null) {
+            synchronized (this) {
+                byte[] uncompressed = Zstd.decompress(compressedBloomFilter, sizeBeforeCompressed);
+                bloomFilter = BloomFilterImpl.readFrom(uncompressed);
+            }
+            compressedBloomFilter = null;
+        }
+    }
+
+    @Override
+    public void writeObject(ObjectOutputStream outputStream) throws IOException
+    {
+        compressBloomFilter();
+        outputStream.defaultWriteObject();
+    }
+
+    private void compressBloomFilter() throws IOException
+    {
+        synchronized (this) {
+            if (bloomFilter != null) {
+                compressedBloomFilter = Zstd.compress(bloomFilter.toByteArray());
+                sizeBeforeCompressed = bloomFilter.toByteArray().length;
+                sizeAfterCompressed = compressedBloomFilter.length;
+            }
+        }
+    }
+
+    private void decompressBloomFilter(byte[] compressedBloomFilter, int sizeBeforeCompressed) throws IOException
+    {
+        if (compressedBloomFilter != null) {
+            synchronized (this) {
+                byte[] uncompressed = Zstd.decompress(compressedBloomFilter, sizeBeforeCompressed);
+                bloomFilter = BloomFilter.readFrom(uncompressed);
+            }
+            compressedBloomFilter = null;
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/bloomfilter/BloomFilterImpl.java
+++ b/presto-main/src/main/java/com/facebook/presto/bloomfilter/BloomFilterImpl.java
@@ -1,0 +1,327 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.bloomfilter;
+
+import com.google.common.hash.Hashing;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.OutputStream;
+import java.io.Serializable;
+
+public class BloomFilterImpl
+        extends BloomFilter
+        implements Serializable
+{
+    private int numHashFunctions;
+
+    private boolean containsNull;
+
+    private BitArray bits;
+
+    public BloomFilterImpl(int numHashFunctions, long numBits)
+    {
+        this(new BitArray(numBits), numHashFunctions);
+    }
+
+    public BloomFilterImpl(BitArray bits, int numHashFunctions)
+    {
+        this.bits = bits;
+        this.numHashFunctions = numHashFunctions;
+    }
+
+    public BloomFilterImpl() {}
+
+    @Override
+    public boolean equals(Object other)
+    {
+        if (other == this) {
+            return true;
+        }
+
+        if (other == null || !(other instanceof BloomFilterImpl)) {
+            return false;
+        }
+
+        BloomFilterImpl that = (BloomFilterImpl) other;
+
+        return this.numHashFunctions == that.numHashFunctions && this.bits.equals(that.bits);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return bits.hashCode() * 31 + numHashFunctions;
+    }
+
+    @Override
+    public double expectedFpp()
+    {
+        return Math.pow((double) bits.cardinality() / bits.bitSize(), numHashFunctions);
+    }
+
+    @Override
+    public long bitSize()
+    {
+        return bits.bitSize();
+    }
+
+    @Override
+    public long cardinality()
+    {
+        return bits.cardinality();
+    }
+
+    @Override
+    public boolean clear()
+    {
+        bits.clear();
+        return true;
+    }
+
+    @Override
+    public boolean put(Object item)
+    {
+        if (item instanceof String) {
+            return putString((String) item);
+        }
+        else if (item instanceof byte[]) {
+            return putBinary((byte[]) item);
+        }
+        else {
+            return putLong(Utils.integralToLong(item));
+        }
+    }
+
+    @Override
+    public boolean putString(String item)
+    {
+        return putBinary(Utils.getBytesFromUTF8String(item));
+    }
+
+    @Override
+    public boolean putBinary(byte[] item)
+    {
+        int h1 = Hashing.murmur3_32().hashBytes(item, 0, item.length).asInt();
+        int h2 = Hashing.murmur3_32(h1).hashBytes(item, 0, item.length).asInt();
+
+        long bitSize = bits.bitSize();
+        boolean bitsChanged = false;
+        for (int i = 1; i <= numHashFunctions; i++) {
+            int combinedHash = h1 + (i * h2);
+            // Flip all the bits if it's negative (guaranteed positive number)
+            if (combinedHash < 0) {
+                combinedHash = ~combinedHash;
+            }
+            bitsChanged |= bits.set(combinedHash % bitSize);
+        }
+        return bitsChanged;
+    }
+
+    @Override
+    public boolean mightContainString(String item)
+    {
+        return mightContainBinary(Utils.getBytesFromUTF8String(item));
+    }
+
+    @Override
+    public boolean mightContainBinary(byte[] item)
+    {
+        int h1 = Hashing.murmur3_32().hashBytes(item, 0, item.length).asInt();
+        int h2 = Hashing.murmur3_32(h1).hashBytes(item, 0, item.length).asInt();
+
+        long bitSize = bits.bitSize();
+        for (int i = 1; i <= numHashFunctions; i++) {
+            int combinedHash = h1 + (i * h2);
+            // Flip all the bits if it's negative (guaranteed positive number)
+            if (combinedHash < 0) {
+                combinedHash = ~combinedHash;
+            }
+            if (!bits.get(combinedHash % bitSize)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public boolean putNull()
+    {
+        boolean changed = !containsNull;
+        containsNull = true;
+        return changed;
+    }
+
+    @Override
+    public boolean putLong(long item)
+    {
+        // Here we first hash the input long element into 2 int hash values, h1 and h2, then produce n
+        // hash values by `h1 + i * h2` with 1 <= i <= numHashFunctions.
+        // Note that `CountMinSketch` use a different strategy, it hash the input long element with
+        // every i to produce n hash values.
+        // TODO: the strategy of `CountMinSketch` looks more advanced, should we follow it here?
+        int h1 = Hashing.murmur3_32().hashLong(item).asInt();
+        int h2 = Hashing.murmur3_32(h1).hashLong(item).asInt();
+
+        long bitSize = bits.bitSize();
+        boolean bitsChanged = false;
+        for (int i = 1; i <= numHashFunctions; i++) {
+            int combinedHash = h1 + (i * h2);
+            // Flip all the bits if it's negative (guaranteed positive number)
+            if (combinedHash < 0) {
+                combinedHash = ~combinedHash;
+            }
+            bitsChanged |= bits.set(combinedHash % bitSize);
+        }
+        return bitsChanged;
+    }
+
+    @Override
+    public boolean mightContainLong(long item)
+    {
+        int h1 = Hashing.murmur3_32().hashLong(item).asInt();
+        int h2 = Hashing.murmur3_32(h1).hashLong(item).asInt();
+
+        long bitSize = bits.bitSize();
+        for (int i = 1; i <= numHashFunctions; i++) {
+            int combinedHash = h1 + (i * h2);
+            // Flip all the bits if it's negative (guaranteed positive number)
+            if (combinedHash < 0) {
+                combinedHash = ~combinedHash;
+            }
+            if (!bits.get(combinedHash % bitSize)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    @Override
+    public boolean mightContain(Object item)
+    {
+        if (item instanceof String) {
+            return mightContainString((String) item);
+        }
+        else if (item instanceof byte[]) {
+            return mightContainBinary((byte[]) item);
+        }
+        else {
+            return mightContainLong(Utils.integralToLong(item));
+        }
+    }
+
+    @Override
+    public boolean containNull()
+    {
+        return containsNull;
+    }
+
+    @Override
+    public boolean isCompatible(BloomFilter other)
+    {
+        if (other == null) {
+            return false;
+        }
+
+        if (!(other instanceof BloomFilterImpl)) {
+            return false;
+        }
+
+        BloomFilterImpl that = (BloomFilterImpl) other;
+        return this.bitSize() == that.bitSize() && this.numHashFunctions == that.numHashFunctions;
+    }
+
+    @Override
+    public BloomFilter mergeInPlace(BloomFilter other) throws IncompatibleMergeException
+    {
+        // Duplicates the logic of `isCompatible` here to provide better error message.
+        if (other == null) {
+            throw new IncompatibleMergeException("Cannot merge null bloom filter");
+        }
+        if (!(other instanceof BloomFilterImpl)) {
+            throw new IncompatibleMergeException(
+                    "Cannot merge bloom filter of class " + other.getClass().getName());
+        }
+
+        BloomFilterImpl that = (BloomFilterImpl) other;
+        if (this.bitSize() != that.bitSize()) {
+            throw new IncompatibleMergeException("Cannot merge bloom filters with different bit size");
+        }
+
+        if (this.numHashFunctions != that.numHashFunctions) {
+            throw new IncompatibleMergeException(
+                    "Cannot merge bloom filters with different number of hash functions");
+        }
+
+        this.containsNull = this.containsNull || that.containsNull;
+        this.bits.putAll(that.bits);
+        return this;
+    }
+
+    @Override
+    public void writeTo(OutputStream out) throws IOException
+    {
+        DataOutputStream dos = new DataOutputStream(out);
+
+        dos.writeInt(Version.V1.getVersionNumber());
+        dos.writeBoolean(containsNull);
+        dos.writeInt(numHashFunctions);
+        bits.writeTo(dos);
+    }
+
+    private void readFrom0(InputStream in) throws IOException
+    {
+        DataInputStream dis = new DataInputStream(in);
+
+        int version = dis.readInt();
+        if (version != Version.V1.getVersionNumber()) {
+            throw new IOException("Unexpected Bloom filter version number (" + version + ")");
+        }
+
+        this.containsNull = dis.readBoolean();
+        this.numHashFunctions = dis.readInt();
+        this.bits = BitArray.readFrom(dis);
+    }
+
+    public static BloomFilterImpl readFrom(InputStream in) throws IOException
+    {
+        BloomFilterImpl filter = new BloomFilterImpl();
+        filter.readFrom0(in);
+        return filter;
+    }
+
+    private void writeObject(ObjectOutputStream out) throws IOException
+    {
+        writeTo(out);
+    }
+
+    private void readObject(ObjectInputStream in) throws IOException
+    {
+        readFrom0(in);
+    }
+
+    @Override
+    public byte[] toByteArray() throws IOException
+    {
+        try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            writeTo(out);
+            return out.toByteArray();
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/bloomfilter/BloomFilterUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/bloomfilter/BloomFilterUtils.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.bloomfilter;
+
+public class BloomFilterUtils
+{
+    private BloomFilterUtils() {}
+
+    public static long optimalNumOfBits(long n, double p)
+    {
+        return (long) (-n * Math.log(p) / (Math.log(2) * Math.log(2)));
+    }
+
+    public static long optimalNumOfItems(long m, double p)
+    {
+        return Math.round(m * (Math.log(2) * Math.log(2)) / (-Math.log(p)));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/bloomfilter/IncompatibleMergeException.java
+++ b/presto-main/src/main/java/com/facebook/presto/bloomfilter/IncompatibleMergeException.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.bloomfilter;
+
+public class IncompatibleMergeException
+        extends Exception
+{
+    public IncompatibleMergeException(String message)
+    {
+        super(message);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/bloomfilter/Utils.java
+++ b/presto-main/src/main/java/com/facebook/presto/bloomfilter/Utils.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.bloomfilter;
+
+import java.nio.charset.StandardCharsets;
+
+public class Utils
+{
+    private Utils() {}
+
+    public static byte[] getBytesFromUTF8String(String str)
+    {
+        return str.getBytes(StandardCharsets.UTF_8);
+    }
+
+    public static long integralToLong(Object i)
+    {
+        long longValue;
+
+        if (i instanceof Long) {
+            longValue = (Long) i;
+        }
+        else if (i instanceof Integer) {
+            longValue = ((Integer) i).longValue();
+        }
+        else if (i instanceof Short) {
+            longValue = ((Short) i).longValue();
+        }
+        else if (i instanceof Byte) {
+            longValue = ((Byte) i).longValue();
+        }
+        else {
+            throw new IllegalArgumentException("Unsupported data type " + i.getClass().getName());
+        }
+
+        return longValue;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SectionExecutionFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SectionExecutionFactory.java
@@ -30,6 +30,7 @@ import com.facebook.presto.failureDetector.FailureDetector;
 import com.facebook.presto.metadata.InternalNode;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.operator.ForScheduler;
+import com.facebook.presto.server.DynamicFilterService;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.connector.ConnectorPartitionHandle;
 import com.facebook.presto.spi.plan.PlanNode;
@@ -159,7 +160,8 @@ public class SectionExecutionFactory
             boolean summarizeTaskInfo,
             RemoteTaskFactory remoteTaskFactory,
             SplitSourceFactory splitSourceFactory,
-            int attemptId)
+            int attemptId,
+            DynamicFilterService dynamicFilterService)
     {
         // Only fetch a distribution once per section to ensure all stages see the same machine assignments
         Map<PartitioningHandle, NodePartitionMap> partitioningCache = new HashMap<>();
@@ -174,7 +176,8 @@ public class SectionExecutionFactory
                 summarizeTaskInfo,
                 remoteTaskFactory,
                 splitSourceFactory,
-                attemptId);
+                attemptId,
+                dynamicFilterService);
         StageExecutionAndScheduler rootStage = getLast(sectionStages);
         rootStage.getStageExecution().setOutputBuffers(outputBuffers);
         return new SectionExecution(rootStage, sectionStages);
@@ -193,7 +196,8 @@ public class SectionExecutionFactory
             boolean summarizeTaskInfo,
             RemoteTaskFactory remoteTaskFactory,
             SplitSourceFactory splitSourceFactory,
-            int attemptId)
+            int attemptId,
+            DynamicFilterService dynamicFilterService)
     {
         ImmutableList.Builder<StageExecutionAndScheduler> stageExecutionAndSchedulers = ImmutableList.builder();
 
@@ -209,7 +213,8 @@ public class SectionExecutionFactory
                 executor,
                 failureDetector,
                 schedulerStats,
-                tableWriteInfo);
+                tableWriteInfo,
+                dynamicFilterService);
 
         PartitioningHandle partitioningHandle = plan.getFragment().getPartitioning();
         List<RemoteSourceNode> remoteSourceNodes = plan.getFragment().getRemoteSourceNodes();
@@ -228,7 +233,8 @@ public class SectionExecutionFactory
                     summarizeTaskInfo,
                     remoteTaskFactory,
                     splitSourceFactory,
-                    attemptId);
+                    attemptId,
+                    dynamicFilterService);
             stageExecutionAndSchedulers.addAll(subTree);
             childStagesBuilder.add(getLast(subTree).getStageExecution());
         }

--- a/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
@@ -125,6 +125,7 @@ import com.facebook.presto.operator.scalar.EmptyMapConstructor;
 import com.facebook.presto.operator.scalar.FailureFunction;
 import com.facebook.presto.operator.scalar.HmacFunctions;
 import com.facebook.presto.operator.scalar.HyperLogLogFunctions;
+import com.facebook.presto.operator.scalar.InBloomFilterFunction;
 import com.facebook.presto.operator.scalar.IpPrefixFunctions;
 import com.facebook.presto.operator.scalar.JoniRegexpCasts;
 import com.facebook.presto.operator.scalar.JoniRegexpFunctions;
@@ -837,7 +838,8 @@ public class BuiltInTypeAndFunctionNamespaceManager
                 .scalar(DynamicFilterPlaceholderFunction.class)
                 .scalars(EnumCasts.class)
                 .scalars(LongEnumOperators.class)
-                .scalars(VarcharEnumOperators.class);
+                .scalars(VarcharEnumOperators.class)
+                .scalar(InBloomFilterFunction.class);
 
         switch (featuresConfig.getRegexLibrary()) {
             case JONI:

--- a/presto-main/src/main/java/com/facebook/presto/operator/DynamicFilterClient.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/DynamicFilterClient.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.google.common.util.concurrent.ListenableFuture;
+
+public interface DynamicFilterClient
+{
+    ListenableFuture<?> getSummary();
+    ListenableFuture<?> storeSummary(DynamicFilterSummary summary);
+    ListenableFuture<?> getSummary(String queryId, String source);
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/DynamicFilterClientFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/DynamicFilterClientFactory.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.airlift.discovery.client.ForDiscoveryClient;
+import com.facebook.airlift.discovery.client.ServiceDescriptor;
+import com.facebook.airlift.discovery.client.ServiceDescriptorsRepresentation;
+import com.facebook.airlift.http.client.FullJsonResponseHandler;
+import com.facebook.airlift.http.client.HttpClient;
+import com.facebook.airlift.http.client.HttpUriBuilder;
+import com.facebook.airlift.json.JsonCodec;
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.execution.TaskId;
+import com.facebook.presto.spi.PrestoException;
+
+import javax.inject.Inject;
+import javax.ws.rs.core.Response;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import static com.facebook.airlift.http.client.FullJsonResponseHandler.createFullJsonResponseHandler;
+import static com.facebook.airlift.http.client.Request.Builder.prepareGet;
+import static com.facebook.airlift.json.JsonCodec.jsonCodec;
+import static com.facebook.presto.spi.StandardErrorCode.NOT_FOUND;
+import static java.util.stream.Collectors.toSet;
+
+public class DynamicFilterClientFactory
+        implements DynamicFilterClientSupplier
+{
+    private final Supplier<URI> discoveryURISupplier;
+    private URI coordinateUri;
+    private final HttpClient httpClient;
+    private final JsonCodec<DynamicFilterSummary> summaryJsonCodec;
+
+    @Inject
+    public DynamicFilterClientFactory(
+            @ForDiscoveryClient Supplier<URI> discoveryURISupplier,
+            @ForDynamicFilterSummary HttpClient httpClient,
+            JsonCodec<DynamicFilterSummary> summaryJsonCodec)
+    {
+        this.discoveryURISupplier = discoveryURISupplier;
+        this.httpClient = httpClient;
+        this.summaryJsonCodec = summaryJsonCodec;
+    }
+
+    @Override
+    public DynamicFilterClient createClient(TaskId taskId, String source, int driverId, int expectedDriversCount, TypeManager typeManager)
+    {
+        if (coordinateUri == null) {
+            try {
+                coordinateUri = new URI(parseDiscoveryServiceByHttpClient());
+            }
+            catch (URISyntaxException e) {
+                e.printStackTrace();
+            }
+        }
+        return new HttpDynamicFilterClient(summaryJsonCodec, coordinateUri, httpClient, Optional.of(taskId), Optional.of(source), driverId, expectedDriversCount, typeManager);
+    }
+
+    @Override
+    public DynamicFilterClient createClient(TypeManager typeManager)
+    {
+        if (coordinateUri == null) {
+            try {
+                coordinateUri = new URI(parseDiscoveryServiceByHttpClient());
+            }
+            catch (URISyntaxException e) {
+                e.printStackTrace();
+            }
+        }
+        return new HttpDynamicFilterClient(summaryJsonCodec, coordinateUri, httpClient, Optional.empty(), Optional.empty(), -1, -1, typeManager);
+    }
+
+    private String parseDiscoveryServiceByHttpClient()
+    {
+        FullJsonResponseHandler.JsonResponse<ServiceDescriptorsRepresentation> httpResponse = httpClient.execute(
+                prepareGet()
+                        .setUri(HttpUriBuilder.uriBuilderFrom(discoveryURISupplier.get())
+                                .appendPath("/v1/service")
+                                .build())
+                        .build(),
+                createFullJsonResponseHandler(jsonCodec(ServiceDescriptorsRepresentation.class)));
+
+        if (httpResponse.getStatusCode() == Response.Status.OK.getStatusCode()) {
+            ServiceDescriptorsRepresentation serviceDescriptorsRepresentation = httpResponse.getValue();
+
+            Set<ServiceDescriptor> coordinators = serviceDescriptorsRepresentation.getServiceDescriptors().stream()
+                    .filter(serviceDescriptor -> serviceDescriptor.getProperties().getOrDefault("coordinator", "false").equals("true"))
+                    .collect(toSet());
+
+            Optional<ServiceDescriptor> selectedCoordinator = coordinators.stream().findFirst();
+            return selectedCoordinator.get().getProperties().get("http-external");
+        }
+
+        throw new PrestoException(NOT_FOUND, "Coordinator not found");
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/DynamicFilterClientSupplier.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/DynamicFilterClientSupplier.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.execution.TaskId;
+
+public interface DynamicFilterClientSupplier
+{
+    DynamicFilterClient createClient(TaskId taskId, String source, int driverId, int expectedDriversCount, TypeManager typeManager);
+    DynamicFilterClient createClient(TypeManager typeManager);
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/DynamicFilterCollect.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/DynamicFilterCollect.java
@@ -1,0 +1,295 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.airlift.http.client.FullJsonResponseHandler;
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.bloomfilter.BloomFilterForDynamicFilter;
+import com.facebook.presto.bloomfilter.BloomFilterForDynamicFilterImpl;
+import com.facebook.presto.common.function.OperatorType;
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.expressions.DynamicFilters;
+import com.facebook.presto.expressions.LogicalRowExpressions;
+import com.facebook.presto.metadata.CastType;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.spi.function.FunctionHandle;
+import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.ListenableFuture;
+
+import javax.ws.rs.core.Response;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static com.facebook.presto.sql.relational.Expressions.call;
+import static com.facebook.presto.sql.relational.Expressions.constant;
+import static io.airlift.slice.Slices.utf8Slice;
+import static java.util.Objects.requireNonNull;
+
+public class DynamicFilterCollect
+{
+    public static final int MAX_RETRIES = 100;
+    private static final Logger log = Logger.get(DynamicFilterCollect.class);
+    public static final int DYNAMIC_FILTER_RECEIVE_TIMEOUT_MILLIS = 10000;
+    private final Metadata metadata;
+    private final ConcurrentHashMap<DynamicFilters.DynamicFilterPlaceholder, DynamicProcessorState> dynamicFilterState = new ConcurrentHashMap<>();
+    private final AtomicReference<BloomFilterForDynamicFilter> bloomFilterForDynamicFilter = new AtomicReference<>(null);
+    private final long autograph;
+    private final Optional<RowExpression> staticFilter;
+    private final List<DynamicFilters.DynamicFilterPlaceholder> dynamicFilters;
+    private final DynamicFilterClient client;
+    private final QueryId queryId;
+    private List<DynamicFilterCollectorCallback> listeners = new ArrayList();
+
+    enum DynamicProcessorState
+    {
+        NOTFOUND,
+        DONE,
+        FAILED
+    }
+
+    protected DynamicProcessorState globalState = DynamicProcessorState.NOTFOUND;
+    private ExecutorService executorService = Executors.newSingleThreadExecutor(new ThreadFactory() {
+        public Thread newThread(Runnable r)
+        {
+            Thread thread = new Thread(r);
+            return thread;
+        }
+    });
+
+    public DynamicFilterCollect(Metadata metadata,
+            List<DynamicFilters.DynamicFilterPlaceholder> dynamicFilters,
+            Optional<RowExpression> staticFilter,
+            DynamicFilterClient client,
+            QueryId queryId)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.dynamicFilters = requireNonNull(dynamicFilters, "dynamicFilters is null");
+        this.staticFilter = requireNonNull(staticFilter, "staticFilter is null");
+        this.client = requireNonNull(client, "client is null");
+        this.queryId = requireNonNull(queryId, "queryId is null");
+        this.autograph = Long.parseLong(queryId.toString().split("_")[1] + queryId.toString().split("_")[2] + dynamicFilters.get(0).getSource());
+        this.dynamicFilters.stream().forEach(d -> dynamicFilterState.put(d, DynamicProcessorState.NOTFOUND));
+    }
+
+    public interface DynamicFilterCollectorCallback
+    {
+        void onSuccess(RowExpression result);
+    }
+
+    private void fireDynamicFilterCollection(final DynamicFilters.DynamicFilterPlaceholder dynamicFilterPlaceholder)
+    {
+        try {
+            final ListenableFuture result = client.getSummary(queryId.toString(), dynamicFilterPlaceholder.getSource());
+            final Object response = result.get(DYNAMIC_FILTER_RECEIVE_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+            final FullJsonResponseHandler.JsonResponse<DynamicFilterSummary> jsonResponse = (FullJsonResponseHandler.JsonResponse<DynamicFilterSummary>) response;
+            if (jsonResponse.getStatusCode() == Response.Status.OK.getStatusCode()) {
+                final DynamicFilterSummary summary = jsonResponse.getValue();
+                if (bloomFilterForDynamicFilter.get() == null) {
+                    bloomFilterForDynamicFilter.set(summary.getBloomFilterForDynamicFilter());
+                }
+                else {
+                    bloomFilterForDynamicFilter.accumulateAndGet(summary.getBloomFilterForDynamicFilter(),
+                            BloomFilterForDynamicFilter::merge);
+                }
+                dynamicFilterState.put(dynamicFilterPlaceholder, DynamicProcessorState.DONE);
+            }
+            else if (jsonResponse.getStatusCode() == Response.Status.NOT_FOUND.getStatusCode()) {
+                dynamicFilterState.put(dynamicFilterPlaceholder, DynamicProcessorState.NOTFOUND);
+            }
+            else {
+                dynamicFilterState.put(dynamicFilterPlaceholder, DynamicProcessorState.FAILED);
+            }
+        }
+        catch (Exception exp) {
+            exp.printStackTrace();
+            dynamicFilterState.put(dynamicFilterPlaceholder, DynamicProcessorState.FAILED);
+        }
+    }
+
+    public void collectDynamicSummaryAsync()
+    {
+        CompletableFuture.runAsync(this::collectDynamicSummary, executorService).whenComplete((value, exception) ->
+        {
+            this.cleanUp();
+        });
+    }
+
+    private void cleanUp()
+    {
+        //TODO: RejectedExecutionException
+        //es.shutdown();
+    }
+
+    private void collectDynamicSummary()
+    {
+        int retry = 0;
+        while (retry < MAX_RETRIES) {
+            if (globalState == DynamicProcessorState.DONE || globalState == DynamicProcessorState.FAILED) {
+                break;
+            }
+            else {
+                collectDynamicSummaryInternal();
+            }
+            retry++;
+            try {
+                Thread.sleep(1000);
+            }
+            catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        }
+
+        if (retry == MAX_RETRIES) {
+            afterDynamicFilterCollection();
+        }
+    }
+
+    private void collectDynamicSummaryInternal()
+    {
+        boolean inProgress = false;
+        for (ConcurrentHashMap.Entry<DynamicFilters.DynamicFilterPlaceholder, DynamicProcessorState> e : dynamicFilterState.entrySet()) {
+            DynamicProcessorState state = e.getValue();
+            if (state != DynamicProcessorState.DONE && state != DynamicProcessorState.FAILED) {
+                inProgress = true;
+                fireDynamicFilterCollection(e.getKey());
+            }
+        }
+        if (!inProgress) {
+            afterDynamicFilterCollection();
+        }
+    }
+
+    private void afterDynamicFilterCollection()
+    {
+        if (globalState == DynamicProcessorState.DONE || globalState == DynamicProcessorState.FAILED) {
+            return;
+        }
+
+        BloomFilterForDynamicFilter finalBloomFilter = bloomFilterForDynamicFilter.get();
+
+        if (((BloomFilterForDynamicFilterImpl) finalBloomFilter).getBloomFilter() != null && !((BloomFilterForDynamicFilterImpl) finalBloomFilter).getBloomFilter().toString().equals("{}")) {
+            try {
+                ObjectMapper objectMapper = new ObjectMapper();
+                String json = objectMapper.writeValueAsString(finalBloomFilter);
+
+                FunctionAndTypeManager functionManager = metadata.getFunctionAndTypeManager();
+
+                List<RowExpression> arguments = extractDynamicFilterArguments();
+                ImmutableList.Builder<RowExpression> castBuilder = ImmutableList.builder();
+                for (int i = 0; i < arguments.size(); i++) {
+                    Type type = arguments.get(i).getType();
+                    FunctionHandle castFunctionHandle = functionManager.lookupCast(CastType.TRY_CAST, type.getTypeSignature(), VARCHAR.getTypeSignature());
+                    CallExpression callExpression = new CallExpression("cast", castFunctionHandle, VARCHAR, ImmutableList.of(arguments.get(i)));
+                    castBuilder.add(callExpression);
+                }
+                List<RowExpression> castCallExpression = castBuilder.build();
+
+                FunctionHandle arrayFunctionHandle = functionManager.lookupFunction("array_constructor", fromTypes(castCallExpression.stream().map(RowExpression::getType).collect(
+                        Collectors.toList())));
+                CallExpression arrayExpression = new CallExpression("array", arrayFunctionHandle, new ArrayType(VARCHAR), castCallExpression);
+
+                FunctionHandle arrayJoinFunctionHandle = functionManager.lookupFunction("array_join", fromTypes(new ArrayType(VARCHAR), VARCHAR));
+                CallExpression arrayJoinCallExpression = new CallExpression("join", arrayJoinFunctionHandle, VARCHAR, ImmutableList.of(arrayExpression, constant(utf8Slice(""), VARCHAR)));
+
+                FunctionHandle inBloomfilterFunctionHandle = functionManager.lookupFunction("BLOOM_FILTER_CONTAINS", fromTypes(BIGINT, VARCHAR, VARCHAR));
+                CallExpression inBloomfilterCallExpression = new CallExpression(
+                        "bloom_filter_contains",
+                        inBloomfilterFunctionHandle,
+                        BOOLEAN,
+                        ImmutableList.of(
+                                constant(autograph, BIGINT),
+                                constant(utf8Slice(json), VARCHAR),
+                                arrayJoinCallExpression));
+                final Optional<RowExpression> rowExpression = Optional.of(inBloomfilterCallExpression);
+
+                // TODO
+                Optional<RowExpression> andRowExpression;
+                if (staticFilter.isPresent() && rowExpression.isPresent()) {
+                    andRowExpression = Optional.of(
+                            LogicalRowExpressions.and(staticFilter.get(), rowExpression.get()));
+                }
+                else if (staticFilter.isPresent()) {
+                    andRowExpression = staticFilter;
+                }
+                else {
+                    andRowExpression = rowExpression;
+                }
+                final RowExpression combinedExpression = call(metadata.getFunctionAndTypeManager(),
+                        OperatorType.EQUAL.getFunctionName().getObjectName(),
+                        BOOLEAN,
+                        andRowExpression.get(),
+                        LogicalRowExpressions.TRUE_CONSTANT);
+
+                globalState = DynamicProcessorState.DONE;
+                triggerCallback(combinedExpression);
+            }
+            catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+        else {
+            log.debug("RF Processing: Bloom Filter is null");
+            globalState = DynamicProcessorState.FAILED;
+        }
+    }
+
+    private List<RowExpression> extractDynamicFilterArguments()
+    {
+        ImmutableList.Builder<RowExpression> resultBuilder = ImmutableList.builder();
+        for (DynamicFilters.DynamicFilterPlaceholder dynamicFilter : dynamicFilters) {
+            resultBuilder.add(dynamicFilter.getInput());
+        }
+        return resultBuilder.build();
+    }
+
+    public void addListener(DynamicFilterCollectorCallback callback)
+    {
+        listeners.add(callback);
+    }
+
+    private void triggerCallback(RowExpression result)
+    {
+        listeners.forEach(callback -> callback.onSuccess(result));
+    }
+
+    public boolean isFailed()
+    {
+        return globalState == DynamicProcessorState.FAILED;
+    }
+
+    public boolean isDone()
+    {
+        return globalState == DynamicProcessorState.DONE;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/DynamicFilterSummary.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/DynamicFilterSummary.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.bloomfilter.BloomFilterForDynamicFilter;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.annotation.concurrent.Immutable;
+
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+
+@Immutable
+public class DynamicFilterSummary
+        implements Serializable
+{
+    private final BloomFilterForDynamicFilter bloomFilterForDynamicfilter;
+
+    @JsonCreator
+    public DynamicFilterSummary(@JsonProperty("bloomFilterForDynamicFilter") BloomFilterForDynamicFilter bloomFilterForDynamicfilter)
+    {
+        this.bloomFilterForDynamicfilter = bloomFilterForDynamicfilter;
+    }
+
+    @JsonProperty
+    public BloomFilterForDynamicFilter getBloomFilterForDynamicFilter()
+    {
+        return bloomFilterForDynamicfilter;
+    }
+
+    public DynamicFilterSummary mergeWith(DynamicFilterSummary other)
+    {
+        return new DynamicFilterSummary(bloomFilterForDynamicfilter.merge(other.getBloomFilterForDynamicFilter()));
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        DynamicFilterSummary summary = (DynamicFilterSummary) o;
+
+        if (bloomFilterForDynamicfilter != null) {
+            return bloomFilterForDynamicfilter.equals(summary.getBloomFilterForDynamicFilter());
+        }
+        else {
+            return summary.getBloomFilterForDynamicFilter() == null;
+        }
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return bloomFilterForDynamicfilter != null ? bloomFilterForDynamicfilter.hashCode() : 0;
+    }
+
+    public void writeObject(ObjectOutputStream out)
+            throws IOException
+    {
+        bloomFilterForDynamicfilter.writeObject(out);
+    }
+
+    public void readObject(ObjectInputStream in)
+            throws IOException, ClassNotFoundException
+    {
+        bloomFilterForDynamicfilter.readObject(in);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/DynamicPageFilter.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/DynamicPageFilter.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.common.Page;
+import com.facebook.presto.common.function.SqlFunctionProperties;
+import com.facebook.presto.operator.project.DictionaryAwarePageFilter;
+import com.facebook.presto.operator.project.InputChannels;
+import com.facebook.presto.operator.project.PageFilter;
+import com.facebook.presto.operator.project.SelectedPositions;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.sql.gen.PageFunctionCompiler;
+
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+import static java.util.Objects.requireNonNull;
+
+public class DynamicPageFilter
+        implements PageFilter, DynamicFilterCollect.DynamicFilterCollectorCallback
+{
+    private final SqlFunctionProperties sqlFunctionProperties;
+    private final AtomicReference<PageFilter> filter;
+    private final DynamicFilterCollect dynamicFilterCollect;
+    private final Optional<String> classNameSuffix;
+    private final PageFunctionCompiler pageFunctionCompiler;
+
+    public DynamicPageFilter(SqlFunctionProperties sqlFunctionProperties, Optional<PageFilter> filter, DynamicFilterCollect collector, PageFunctionCompiler compiler, Optional<String> className)
+    {
+        this.filter = requireNonNull(filter, "filter is null")
+                .map(pageFilter -> {
+                    if (pageFilter.getInputChannels().size() == 1 && pageFilter.isDeterministic()) {
+                        return new AtomicReference(new DictionaryAwarePageFilter(pageFilter));
+                    }
+                    else {
+                        return new AtomicReference(pageFilter);
+                    }
+                }).get();
+        this.dynamicFilterCollect = collector;
+        this.pageFunctionCompiler = compiler;
+        this.classNameSuffix = className;
+        this.sqlFunctionProperties = sqlFunctionProperties;
+        dynamicFilterCollect.addListener(this);
+        dynamicFilterCollect.collectDynamicSummaryAsync();
+    }
+
+    @Override
+    public boolean isDeterministic()
+    {
+        return filter.get().isDeterministic();
+    }
+
+    @Override
+    public InputChannels getInputChannels()
+    {
+        return filter.get().getInputChannels();
+    }
+
+    public SelectedPositions filter(SqlFunctionProperties properties, Page page)
+    {
+        return filter.get().filter(properties, page);
+    }
+
+    @Override
+    public void onSuccess(RowExpression result)
+    {
+        Supplier<PageFilter> filterFunctionSupplier = pageFunctionCompiler.compileFilter(sqlFunctionProperties, result, false, classNameSuffix);
+        PageFilter pageFilter = filterFunctionSupplier.get();
+        if (pageFilter.getInputChannels().size() == 1 && pageFilter.isDeterministic()) {
+            filter.set(new DictionaryAwarePageFilter(pageFilter));
+        }
+        else {
+            filter.set(pageFilter);
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/ForDynamicFilterSummary.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ForDynamicFilterSummary.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import javax.inject.Qualifier;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target({FIELD, PARAMETER, METHOD})
+@Qualifier
+public @interface ForDynamicFilterSummary
+{
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/HashJoinDynamicFilterSourceOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/HashJoinDynamicFilterSourceOperator.java
@@ -1,0 +1,266 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.bloomfilter.BloomFilter;
+import com.facebook.presto.bloomfilter.BloomFilterForDynamicFilter;
+import com.facebook.presto.bloomfilter.BloomFilterForDynamicFilterImpl;
+import com.facebook.presto.bloomfilter.BloomFilterUtils;
+import com.facebook.presto.common.Page;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.spi.plan.PlanNodeId;
+import com.google.common.collect.ImmutableList;
+import io.airlift.units.DataSize;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.facebook.presto.SystemSessionProperties.getBloomFilterForDynamicFilteringFalsePositiveProbability;
+import static com.facebook.presto.SystemSessionProperties.getBloomFilterForDynamicFilteringSize;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+public class HashJoinDynamicFilterSourceOperator
+        implements Operator
+{
+    public static class Channel
+    {
+        private final Type type;
+        private final int index;
+
+        public Channel(Type type, int index)
+        {
+            this.type = requireNonNull(type, "type is null");
+            this.index = index;
+        }
+
+        public Type getType()
+        {
+            return type;
+        }
+
+        public int getIndex()
+        {
+            return index;
+        }
+    }
+
+    public static class HashJoinDynamicFilterSourceOperatorFactory
+            implements OperatorFactory
+    {
+        private final Session session;
+        private final int operatorId;
+        private final PlanNodeId planNodeId;
+        private final List<Channel> channels;
+        private final DynamicFilterClientSupplier dynamicFilterClientSupplier;
+        private final String sourceId;
+        private final int expectedDrivers;
+
+        private boolean closed;
+        private int driverId;
+
+        public final long defaultBloomFilterSize;
+        public final double defaultFpp;
+        public final long defaultInsertSize;
+
+        public HashJoinDynamicFilterSourceOperatorFactory(
+                Session session,
+                int operatorId,
+                PlanNodeId planNodeId,
+                List<Channel> channels,
+                DynamicFilterClientSupplier dynamicFilterClientSupplier,
+                String sourceId,
+                int expectedDrivers)
+        {
+            this.session = session;
+            this.operatorId = operatorId;
+            this.planNodeId = requireNonNull(planNodeId, "planNodeId is null");
+            this.channels = ImmutableList.copyOf(channels);
+            this.dynamicFilterClientSupplier = requireNonNull(dynamicFilterClientSupplier, "dynamicFilterClientSupplier is null");
+            this.sourceId = requireNonNull(sourceId, "sourceId is null");
+            this.expectedDrivers = requireNonNull(expectedDrivers, "expectedDrivers is null");
+
+            this.defaultBloomFilterSize = (long) getBloomFilterForDynamicFilteringSize(session).getValue(DataSize.Unit.BYTE);
+            this.defaultFpp = getBloomFilterForDynamicFilteringFalsePositiveProbability(session);
+            this.defaultInsertSize = BloomFilterUtils.optimalNumOfItems(defaultBloomFilterSize * 8, defaultFpp);
+        }
+
+        @Override
+        public Operator createOperator(DriverContext driverContext)
+        {
+            checkState(!closed, "Factory is already closed");
+            OperatorContext operatorContext = driverContext.addOperatorContext(operatorId, planNodeId, HashJoinDynamicFilterSourceOperator.class.getSimpleName());
+
+            return new HashJoinDynamicFilterSourceOperator(session,
+                    operatorContext,
+                    channels,
+                    dynamicFilterClientSupplier.createClient(driverContext.getPipelineContext().getTaskId(), sourceId, driverId++, expectedDrivers, null),
+                    defaultInsertSize,
+                    defaultFpp);
+        }
+
+        @Override
+        public void noMoreOperators()
+        {
+            closed = true;
+        }
+
+        @Override
+        public OperatorFactory duplicate()
+        {
+            throw new UnsupportedOperationException("Parallel hash join dynamic filter build can not be duplicated");
+        }
+    }
+
+    private final Session session;
+    private final OperatorContext operatorContext;
+    private final List<Channel> channels;
+    private final DynamicFilterClient client;
+    private final long positionsLimit;
+    private final double fpp;
+
+    private Page current;
+    private boolean finishing;
+    private long positionCount;
+    private List<String> values;
+
+    private ImmutableList.Builder[] builders;
+
+    public HashJoinDynamicFilterSourceOperator(
+            Session session,
+            OperatorContext operatorContext,
+            List<Channel> channels,
+            DynamicFilterClient dynamicFilterClient,
+            long positionsLimit,
+            double fpp)
+    {
+        this.session = session;
+        this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
+        this.channels = ImmutableList.copyOf(channels);
+        this.values = new ArrayList<>();
+        this.client = requireNonNull(dynamicFilterClient, "client is null");
+
+        checkArgument(positionsLimit > 0, "positionsLimit must be greater than zero");
+        this.positionsLimit = positionsLimit;
+        this.fpp = fpp;
+
+        this.builders = new ImmutableList.Builder[channels.size()];
+        for (int i = 0; i < builders.length; i++) {
+            builders[i] = ImmutableList.builder();
+        }
+    }
+
+    // Just for test
+    public List<String> getValues()
+    {
+        return values;
+    }
+
+    @Override
+    public OperatorContext getOperatorContext()
+    {
+        return operatorContext;
+    }
+
+    @Override
+    public boolean needsInput()
+    {
+        return current == null && !finishing;
+    }
+
+    @Override
+    public void addInput(Page page)
+    {
+        current = page;
+
+        processPageWithBloomfilter(page);
+    }
+
+    @Override
+    public Page getOutput()
+    {
+        Page result = current;
+        current = null;
+        return result;
+    }
+
+    @Override
+    public void finish()
+    {
+        if (finishing) {
+            return;
+        }
+        finishing = true;
+
+        try {
+            sendBloomfilter();
+        }
+        catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return current == null && finishing;
+    }
+
+    private void processPageWithBloomfilter(Page page)
+    {
+        if (channels.size() == 0) {
+            return;
+        }
+
+        positionCount += page.getPositionCount();
+        // we don't want to filter if there're too many values
+        if (positionCount > positionsLimit) {
+            return;
+        }
+
+        for (int position = 0; position < page.getPositionCount(); position++) {
+            StringBuilder stringBuilder = new StringBuilder();
+            for (int channelIndex = 0; channelIndex < channels.size(); channelIndex++) {
+                Integer channel = channels.get(channelIndex).getIndex();
+                Object object = channels.get(channelIndex).getType().getObjectValue(session.getSqlFunctionProperties(), page.getBlock(channel), position);
+                if (object == null) {
+                    continue;
+                }
+                else {
+                    stringBuilder.append(object.toString());
+                }
+            }
+            values.add(stringBuilder.toString());
+        }
+    }
+
+    private void sendBloomfilter() throws IOException
+    {
+        // we don't want to filter if there're too many values
+        if (positionCount > positionsLimit) {
+            client.storeSummary(new DynamicFilterSummary(new BloomFilterForDynamicFilterImpl(null, null, 0)));
+            return;
+        }
+
+        BloomFilterForDynamicFilter myBloomFilter = new BloomFilterForDynamicFilterImpl(BloomFilter.create(positionsLimit, fpp), null, 0);
+        for (int i = 0; i < values.size(); i++) {
+            myBloomFilter.put(values.get(i));
+        }
+
+        client.storeSummary(new DynamicFilterSummary(myBloomFilter));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/HttpDynamicFilterClient.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/HttpDynamicFilterClient.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.airlift.http.client.FullJsonResponseHandler.JsonResponse;
+import com.facebook.airlift.http.client.HttpClient;
+import com.facebook.airlift.http.client.HttpUriBuilder;
+import com.facebook.airlift.http.client.StatusResponseHandler.StatusResponse;
+import com.facebook.airlift.json.JsonCodec;
+import com.facebook.airlift.json.JsonCodecFactory;
+import com.facebook.airlift.json.ObjectMapperProvider;
+import com.facebook.presto.block.BlockJsonSerde;
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockEncodingManager;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.execution.TaskId;
+import com.facebook.presto.type.TypeDeserializer;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.ListenableFuture;
+
+import java.net.URI;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+import static com.facebook.airlift.http.client.FullJsonResponseHandler.createFullJsonResponseHandler;
+import static com.facebook.airlift.http.client.JsonBodyGenerator.jsonBodyGenerator;
+import static com.facebook.airlift.http.client.Request.Builder.prepareGet;
+import static com.facebook.airlift.http.client.Request.Builder.preparePut;
+import static com.facebook.airlift.http.client.StatusResponseHandler.createStatusResponseHandler;
+import static com.facebook.airlift.json.JsonCodec.jsonCodec;
+import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
+import static com.google.common.net.MediaType.JSON_UTF_8;
+import static java.util.Objects.requireNonNull;
+
+public class HttpDynamicFilterClient
+        implements DynamicFilterClient
+{
+    private final JsonCodec<DynamicFilterSummary> summaryJsonCodec;
+    private final URI coordinatorUri;
+    private final HttpClient httpClient;
+    private final Optional<TaskId> taskId;
+    private final Optional<String> source;
+    private final int driverId;
+    private final int expectedDriversCount;
+    private final TypeManager typeManager;
+
+    public HttpDynamicFilterClient(JsonCodec<DynamicFilterSummary> summaryJsonCodec, URI coordinatorUri, HttpClient httpClient, Optional<TaskId> taskId, Optional<String> source, int driverId, int expectedDriversCount, TypeManager typeManager)
+    {
+        this.summaryJsonCodec = requireNonNull(summaryJsonCodec, "summaryJsonCodec is null");
+        this.coordinatorUri = requireNonNull(coordinatorUri, "coordinatorURI obtained is null");
+        this.httpClient = requireNonNull(httpClient, "httpClient is null");
+        this.taskId = taskId;
+        this.source = source;
+        this.driverId = driverId;
+        this.expectedDriversCount = expectedDriversCount;
+        this.typeManager = typeManager;
+    }
+
+    @Override
+    public ListenableFuture<JsonResponse<DynamicFilterSummary>> getSummary()
+    {
+        TaskId task = taskId.orElseThrow(() -> new NoSuchElementException("taskId is empty"));
+        String src = source.orElseThrow(() -> new NoSuchElementException("source is empty"));
+        return httpClient.executeAsync(
+                prepareGet()
+                        .setUri(HttpUriBuilder.uriBuilderFrom(coordinatorUri)
+                                .appendPath("/v1/dynamic-filter")
+                                .appendPath("/" + task.getQueryId())
+                                .appendPath("/" + src)
+                                .build())
+                        .build(),
+                createFullJsonResponseHandler(jsonCodec(DynamicFilterSummary.class)));
+    }
+
+    @Override
+    public ListenableFuture<JsonResponse<DynamicFilterSummary>> getSummary(String queryId, String source)
+    {
+        return httpClient.executeAsync(
+                prepareGet()
+                        .setUri(HttpUriBuilder.uriBuilderFrom(coordinatorUri)
+                                .appendPath("/v1/dynamic-filter")
+                                .appendPath("/" + queryId)
+                                .appendPath("/" + source)
+                                .build())
+                        .build(),
+                createFullJsonResponseHandler(new JsonCodecFactory(getObjectMapperProvider(typeManager))
+                        .jsonCodec(DynamicFilterSummary.class)));
+    }
+
+    @Override
+    public ListenableFuture<StatusResponse> storeSummary(DynamicFilterSummary summary)
+    {
+        TaskId task = taskId.orElseThrow(() -> new NoSuchElementException("taskId is empty"));
+        String src = source.orElseThrow(() -> new NoSuchElementException("source is empty"));
+        return httpClient.executeAsync(
+                preparePut()
+                        .setUri(HttpUriBuilder.uriBuilderFrom(coordinatorUri)
+                                .appendPath("/v1/dynamic-filter")
+                                .appendPath("/" + task.getQueryId())
+                                .appendPath("/" + src)
+                                .appendPath("/" + task.getStageExecutionId().getId())
+                                .appendPath("/" + task.getId())
+                                .appendPath("/" + driverId)
+                                .appendPath("/" + expectedDriversCount)
+                                .build())
+                        .addHeader(CONTENT_TYPE, JSON_UTF_8.toString())
+                        .setBodyGenerator(jsonBodyGenerator(summaryJsonCodec, summary))
+                        .build(),
+                createStatusResponseHandler());
+    }
+
+    private ObjectMapperProvider getObjectMapperProvider(TypeManager typeManager)
+    {
+        ObjectMapperProvider provider = new ObjectMapperProvider();
+        if (typeManager != null) {
+            ImmutableMap.Builder deserializers = ImmutableMap.builder();
+            BlockEncodingManager blockEncodingSerde = new BlockEncodingManager();
+            deserializers.put(Block.class, new BlockJsonSerde.Deserializer(blockEncodingSerde));
+            deserializers.put(Type.class, new TypeDeserializer(typeManager));
+            provider.setJsonDeserializers(deserializers.build());
+            provider.setJsonSerializers(ImmutableMap.of(Block.class, new BlockJsonSerde.Serializer(blockEncodingSerde)));
+        }
+        return provider;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/InMemoryDynamicFilterClient.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/InMemoryDynamicFilterClient.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.execution.TaskId;
+import com.facebook.presto.server.DynamicFilterService;
+import com.google.common.util.concurrent.ListenableFuture;
+
+import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static java.util.Objects.requireNonNull;
+
+public class InMemoryDynamicFilterClient
+        implements DynamicFilterClient
+{
+    private final DynamicFilterService service;
+    private final TaskId taskId;
+    private final String source;
+    private final int driverId;
+    private final int expectedDrviersCount;
+
+    public InMemoryDynamicFilterClient(DynamicFilterService service, TaskId taskId, String source, int driverId, int expectedDrviersCount)
+    {
+        this.service = requireNonNull(service, "dynamicFilterService is null");
+        this.taskId = requireNonNull(taskId, "taskId is null");
+        this.source = requireNonNull(source, "source is null");
+        this.driverId = driverId;
+        this.expectedDrviersCount = expectedDrviersCount;
+    }
+
+    @Override
+    public ListenableFuture<DynamicFilterSummary> getSummary()
+    {
+        return service.getSummary(taskId.getQueryId().getId(), source);
+    }
+
+    @Override
+    public ListenableFuture<DynamicFilterSummary> getSummary(String queryId, String source)
+    {
+        return service.getSummary(queryId, source);
+    }
+
+    @Override
+    public ListenableFuture<?> storeSummary(DynamicFilterSummary summary)
+    {
+        service.storeOrMergeSummary(taskId.getQueryId().getId(), source, taskId.getStageExecutionId().getId(), taskId.getId(), driverId, summary, expectedDrviersCount);
+        return immediateFuture(null);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/InMemoryDynamicFilterClientSupplier.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/InMemoryDynamicFilterClientSupplier.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.execution.TaskId;
+import com.facebook.presto.server.DynamicFilterService;
+
+import javax.inject.Inject;
+
+import static java.util.Objects.requireNonNull;
+
+public class InMemoryDynamicFilterClientSupplier
+        implements DynamicFilterClientSupplier
+{
+    private final DynamicFilterService service;
+
+    @Inject
+    public InMemoryDynamicFilterClientSupplier(DynamicFilterService service)
+    {
+        this.service = requireNonNull(service, "dynamicFilterService is null");
+    }
+
+    @Override
+    public DynamicFilterClient createClient(TaskId taskId, String source, int driverId, int expectedDriversCount, TypeManager manager)
+    {
+        return new InMemoryDynamicFilterClient(service, taskId, source, driverId, expectedDriversCount);
+    }
+
+    @Override
+    public DynamicFilterClient createClient(TypeManager manager)
+    {
+        throw new UnsupportedOperationException("Not supported");
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/project/PageProcessor.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/project/PageProcessor.java
@@ -22,6 +22,7 @@ import com.facebook.presto.common.block.LazyBlock;
 import com.facebook.presto.common.function.SqlFunctionProperties;
 import com.facebook.presto.memory.context.LocalMemoryContext;
 import com.facebook.presto.operator.DriverYieldSignal;
+import com.facebook.presto.operator.DynamicPageFilter;
 import com.facebook.presto.operator.Work;
 import com.facebook.presto.operator.WorkProcessor;
 import com.facebook.presto.operator.WorkProcessor.ProcessState;
@@ -85,7 +86,7 @@ public class PageProcessor
 
         this.filter = requireNonNull(filter, "filter is null")
                 .map(pageFilter -> {
-                    if (pageFilter.getInputChannels().size() == 1 && pageFilter.isDeterministic()) {
+                    if (pageFilter.getInputChannels().size() == 1 && pageFilter.isDeterministic() && !(pageFilter instanceof DynamicPageFilter)) {
                         return new DictionaryAwarePageFilter(pageFilter);
                     }
                     return pageFilter;

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/InBloomFilterFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/InBloomFilterFunction.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.bloomfilter.BloomFilterForDynamicFilter;
+import com.facebook.presto.bloomfilter.BloomFilterForDynamicFilterImpl;
+import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.spi.function.Description;
+import com.facebook.presto.spi.function.ScalarFunction;
+import com.facebook.presto.spi.function.SqlNullable;
+import com.facebook.presto.spi.function.SqlType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.airlift.slice.Slice;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+@Description("Determines if this element is in the bloom filter")
+@ScalarFunction(value = "bloom_filter_contains")
+public class InBloomFilterFunction
+{
+    private static BloomFilterForDynamicFilter[] bloomFilterForDynamicFilters = new BloomFilterForDynamicFilter[10007];
+    private static Long[] autoGraphs = new Long[10007];
+
+    private InBloomFilterFunction() {}
+
+    @SqlType(StandardTypes.BOOLEAN)
+    @SqlNullable
+    public static Boolean contains(@SqlType(StandardTypes.BIGINT) long autoGraph, @SqlType(StandardTypes.VARCHAR) Slice bloomFilter, @SqlType(StandardTypes.VARCHAR) Slice value)
+    {
+        try {
+            int index = (int) (autoGraph % 10007);
+            BloomFilterForDynamicFilter myBloomFilter = bloomFilterForDynamicFilters[index];
+            if (myBloomFilter == null) {
+                ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(bloomFilter.getBytes());
+                InputStreamReader inputStreamReader = new InputStreamReader(byteArrayInputStream);
+                BufferedReader bufferedReader = new BufferedReader(inputStreamReader);
+                ObjectMapper objectMapper = new ObjectMapper();
+                myBloomFilter = objectMapper.readValue(bufferedReader.readLine(), BloomFilterForDynamicFilterImpl.class);
+                bloomFilterForDynamicFilters[index] = myBloomFilter;
+                autoGraphs[index] = autoGraph;
+
+                return myBloomFilter.contain(new String(value.getBytes()));
+            }
+
+            return myBloomFilter.contain(new String(value.getBytes()));
+        }
+        catch (IOException e) {
+            return true;
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/DynamicFilterResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/DynamicFilterResource.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server;
+
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.operator.DynamicFilterSummary;
+
+import javax.inject.Inject;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Response;
+
+import java.util.Optional;
+import java.util.concurrent.Future;
+
+import static com.facebook.airlift.concurrent.MoreFutures.tryGetFutureValue;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
+
+@Path("/v1/dynamic-filter/{queryId}/{source}")
+public class DynamicFilterResource
+{
+    private final DynamicFilterService service;
+
+    @Inject
+    public DynamicFilterResource(DynamicFilterService service)
+    {
+        this.service = service;
+    }
+
+    private static final Logger log = Logger.get(DynamicFilterResource.class);
+
+    @PUT
+    @Path("/{stageId}/{taskId}/{driverId}/{expectedCount}")
+    @Consumes(APPLICATION_JSON)
+    @Produces(TEXT_PLAIN)
+    public Response storeOrMergeSummary(
+            @PathParam("queryId") String queryId,
+            @PathParam("source") String source,
+            @PathParam("stageId") int stageId,
+            @PathParam("taskId") int taskId,
+            @PathParam("driverId") int driverId,
+            @PathParam("expectedCount") int expectedCount,
+            DynamicFilterSummary dynamicFilterSummary)
+    {
+        log.debug("Storing Dynamic Summary for queryId: " + queryId + " taskId: " + taskId
+                + " source: " + source + " driverId: " + driverId);
+        service.storeOrMergeSummary(queryId, source, stageId, taskId, driverId, dynamicFilterSummary, expectedCount);
+        return Response.ok().build();
+    }
+
+    @GET
+    @Produces(APPLICATION_JSON)
+    public Response getSummary(
+            @PathParam("queryId") String queryId,
+            @PathParam("source") String source)
+    {
+        log.debug("Getting Dynamic Summary for queryId: " + queryId + " source: " + source);
+        Future<DynamicFilterSummary> summaryFuture = service.getSummary(queryId, source);
+        Optional<DynamicFilterSummary> summary = tryGetFutureValue(summaryFuture);
+        synchronized (this) {
+            if (summary.isPresent() && !service.testAutoGraph(queryId, source)) {
+                service.putAutoGraph(queryId, source);
+                return Response.ok(summary.get()).build();
+            }
+            return Response.status(Response.Status.NOT_FOUND).build();
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/DynamicFilterService.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/DynamicFilterService.java
@@ -1,0 +1,341 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server;
+
+import com.facebook.presto.execution.TaskId;
+import com.facebook.presto.operator.DynamicFilterSummary;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+
+import javax.annotation.concurrent.Immutable;
+import javax.annotation.concurrent.NotThreadSafe;
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static java.util.Objects.requireNonNull;
+
+@ThreadSafe
+public class DynamicFilterService
+{
+    private final Map<SourceDescriptor, DynamicFilterSummaryWithSenders> dynamicFilterSummaries = new HashMap<>();
+    private final Map<SourceDescriptor, SettableFuture<DynamicFilterSummary>> futures = new ConcurrentHashMap<>();
+    private final Map<Integer, SourceDescriptor> autoGraphs = new ConcurrentHashMap<>();
+
+    public void storeOrMergeSummary(String queryId, String source, int stageId, int taskId, int driverId, DynamicFilterSummary dynamicFilterSummary, int expectedSummariesCount)
+    {
+        DynamicFilterSummary mergedSummary;
+        synchronized (this) {
+            DynamicFilterSummaryWithSenders dynamicFilterSummaryWithSenders = dynamicFilterSummaries.get(SourceDescriptor.of(queryId, source));
+            checkState(dynamicFilterSummaryWithSenders != null, "Cannot store summary for not pre-registered task");
+
+            mergedSummary = dynamicFilterSummaryWithSenders.addSummary(DynamicFilterSummaryWithSenders.StageTaskKey.of(stageId, taskId), driverId, dynamicFilterSummary, expectedSummariesCount);
+        }
+
+        if (mergedSummary != null) {
+            DynamicFilterSummaryWithSenders dynamicFilterSummaryWithSenders = dynamicFilterSummaries.get(SourceDescriptor.of(queryId, source));
+            if (dynamicFilterSummaryWithSenders != null) {
+                final Optional<DynamicFilterSummary> summaryIfReady = dynamicFilterSummaryWithSenders.getSummaryIfReady();
+                if (summaryIfReady.isPresent()) {
+                    try {
+                        futures.get(SourceDescriptor.of(queryId, source)).set(summaryIfReady.get());
+                    }
+                    catch (Exception e) {
+                        // TODO
+                    }
+                }
+            }
+        }
+    }
+
+    public synchronized void registerTasks(String source, Set<TaskId> taskIds)
+    {
+        if (taskIds.isEmpty()) {
+            return;
+        }
+
+        String queryId = taskIds.iterator().next().getQueryId().getId();
+        checkArgument(taskIds.stream().allMatch(taskId -> taskId.getQueryId().getId().equals(queryId)), "All tasks have to belong to the same query");
+
+        checkState(!dynamicFilterSummaries.containsKey(SourceDescriptor.of(queryId, source)), "Tasks already registered");
+        dynamicFilterSummaries.put(SourceDescriptor.of(queryId, source), new DynamicFilterSummaryWithSenders(taskIds.stream().map(DynamicFilterSummaryWithSenders.StageTaskKey::of).collect(toImmutableSet())));
+    }
+
+    public synchronized ListenableFuture<DynamicFilterSummary> getSummary(String queryId, String source)
+    {
+        SettableFuture<DynamicFilterSummary> future = futures.get(SourceDescriptor.of(queryId, source));
+        if (future == null) {
+            future = SettableFuture.create();
+            futures.put(SourceDescriptor.of(queryId, source), future);
+        }
+        DynamicFilterSummaryWithSenders dynamicFilterSummaryWithSenders = dynamicFilterSummaries.get(SourceDescriptor.of(queryId, source));
+        if (dynamicFilterSummaryWithSenders != null) {
+            final Optional<DynamicFilterSummary> summaryIfReady
+                    = dynamicFilterSummaryWithSenders.getSummaryIfReady();
+            if (summaryIfReady.isPresent()) {
+                future.set(summaryIfReady.get());
+            }
+        }
+        return future;
+    }
+
+    public synchronized void removeQuery(String queryId)
+    {
+        dynamicFilterSummaries.entrySet().removeIf(entry -> entry.getKey().getQueryId().equals(queryId));
+        futures.entrySet().removeIf(entry -> entry.getKey().getQueryId().equals(queryId));
+        autoGraphs.entrySet().removeIf(entry -> entry.getValue().getQueryId().equals(queryId));
+    }
+
+    public synchronized void putAutoGraph(String queryId, String sourceId)
+    {
+        long autoGraph = Long.parseLong(queryId.split("_")[1] + queryId.split("_")[2] + sourceId);
+        autoGraphs.put((int) (autoGraph % 10007), new SourceDescriptor(queryId, sourceId));
+    }
+
+    public synchronized boolean testAutoGraph(String queryId, String sourceId)
+    {
+        long autoGraph = Long.parseLong(queryId.split("_")[1] + queryId.split("_")[2] + sourceId);
+        if (autoGraphs.containsKey((int) (autoGraph % 10007))) {
+            return !autoGraphs.get((int) (autoGraph % 10007)).equals(new SourceDescriptor(queryId, sourceId));
+        }
+        else {
+            return false;
+        }
+    }
+
+    @Immutable
+    private static class SourceDescriptor
+    {
+        private final String queryId;
+        private final String source;
+
+        public static SourceDescriptor of(String queryId, String source)
+        {
+            return new SourceDescriptor(queryId, source);
+        }
+
+        private SourceDescriptor(String queryId, String source)
+        {
+            this.queryId = requireNonNull(queryId, "queryId is null");
+            this.source = requireNonNull(source, "source is null");
+        }
+
+        public String getQueryId()
+        {
+            return queryId;
+        }
+
+        public String getSource()
+        {
+            return source;
+        }
+
+        @Override
+        public boolean equals(Object other)
+        {
+            if (other == this) {
+                return true;
+            }
+            if (other == null || !(other instanceof SourceDescriptor)) {
+                return false;
+            }
+
+            SourceDescriptor sourceDescriptor = (SourceDescriptor) other;
+
+            return Objects.equals(queryId, sourceDescriptor.queryId) &&
+                    Objects.equals(source, sourceDescriptor.source);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(queryId, source);
+        }
+
+        @Override
+        public String toString()
+        {
+            return toStringHelper(this)
+                    .addValue(queryId)
+                    .addValue(source)
+                    .toString();
+        }
+    }
+
+    @NotThreadSafe
+    static class DynamicFilterSummaryWithSenders
+    {
+        private final Map<StageTaskKey, SenderStats> senderStats = new HashMap<>();
+        private final Set<StageTaskKey> registeredTasks;
+        private DynamicFilterSummary dynamicFilterSummary;
+
+        DynamicFilterSummaryWithSenders(Set<StageTaskKey> tasks)
+        {
+            this.registeredTasks = ImmutableSet.copyOf(tasks);
+            for (StageTaskKey key : tasks) {
+                senderStats.put(key, new SenderStats());
+            }
+        }
+
+        public Optional<DynamicFilterSummary> getSummaryIfReady()
+        {
+            if (!senderStats.keySet().equals(registeredTasks)) {
+                return Optional.empty();
+            }
+
+            for (Map.Entry<StageTaskKey, SenderStats> entry : senderStats.entrySet()) {
+                if (!entry.getValue().isCompleted()) {
+                    return Optional.empty();
+                }
+            }
+
+            return Optional.of(dynamicFilterSummary);
+        }
+
+        public DynamicFilterSummary addSummary(StageTaskKey stageTaskId, int driverId, DynamicFilterSummary summary, int expectedSummariesCount)
+        {
+            SenderStats stats = senderStats.get(stageTaskId);
+            checkArgument(stats != null, "Cannot add summary to not pre-registered task");
+            stats.addSummary(driverId, expectedSummariesCount);
+
+            if (dynamicFilterSummary == null) {
+                dynamicFilterSummary = summary;
+            }
+            else {
+                dynamicFilterSummary = dynamicFilterSummary.mergeWith(summary);
+            }
+
+            if (stats.isCompleted()) {
+                return dynamicFilterSummary;
+            }
+
+            return null;
+        }
+
+        @NotThreadSafe
+        private static class SenderStats
+        {
+            // collection of driverIDs reported
+            private final Set<Integer> driverIds = new HashSet<>();
+            private int expectedSummariesCount = -1;
+
+            public int getExpectedSummariesCount()
+            {
+                return expectedSummariesCount;
+            }
+
+            public boolean isCompleted()
+            {
+                return (expectedSummariesCount == -1) ? false : driverIds.size() == expectedSummariesCount;
+            }
+
+            public boolean isCompleted(int expectedSummariesCount)
+            {
+                return driverIds.size() == expectedSummariesCount;
+            }
+
+            public void addSummary(Integer driverId, int expectedSummariesCount)
+            {
+                if (driverIds.contains(driverId)) {
+                    // skip existing driver IDs in case of HTTP retries
+                    return;
+                }
+
+                checkState(this.getExpectedSummariesCount() == -1 || this.getExpectedSummariesCount() == expectedSummariesCount, "expected summaries count should not change between summaries");
+
+                if (this.expectedSummariesCount == -1) {
+                    this.expectedSummariesCount = expectedSummariesCount;
+                }
+                checkState(driverIds.size() < expectedSummariesCount, "cannot increase number of received summaries beyond the expected count");
+
+                driverIds.add(driverId);
+            }
+        }
+
+        @Immutable
+        private static class StageTaskKey
+        {
+            private final int stageId;
+            private final int taskId;
+
+            static StageTaskKey of(TaskId taskId)
+            {
+                return of(taskId.getStageExecutionId().getId(), taskId.getId());
+            }
+
+            static StageTaskKey of(int stageId, int taskId)
+            {
+                return new StageTaskKey(stageId, taskId);
+            }
+
+            private StageTaskKey(int stageId, int taskId)
+            {
+                this.stageId = stageId;
+                this.taskId = taskId;
+            }
+
+            public int getStageId()
+            {
+                return stageId;
+            }
+
+            public int getTaskId()
+            {
+                return taskId;
+            }
+
+            @Override
+            public boolean equals(Object o)
+            {
+                if (this == o) {
+                    return true;
+                }
+                if (o == null || getClass() != o.getClass()) {
+                    return false;
+                }
+
+                StageTaskKey that = (StageTaskKey) o;
+
+                return Objects.equals(stageId, that.stageId) &&
+                        Objects.equals(taskId, that.taskId);
+            }
+
+            @Override
+            public int hashCode()
+            {
+                return Objects.hash(stageId, taskId);
+            }
+
+            @Override
+            public String toString()
+            {
+                return toStringHelper(this)
+                        .addValue(stageId)
+                        .addValue(taskId)
+                        .toString();
+            }
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
@@ -268,7 +268,7 @@ public class TestingPrestoServer
                 .add(new EventModule())
                 .add(new TraceTokenModule())
                 .add(new ServerSecurityModule())
-                .add(new ServerMainModule(parserOptions))
+                .add(new ServerMainModule(parserOptions, discoveryUri == null))
                 .add(new TestingWarningCollectorModule())
                 .add(binder -> {
                     binder.bind(TestingAccessControlManager.class).in(Scopes.SINGLETON);

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -143,6 +143,9 @@ public class FeaturesConfig
     private boolean enableDynamicFiltering;
     private int dynamicFilteringMaxPerDriverRowCount = 100;
     private DataSize dynamicFilteringMaxPerDriverSize = new DataSize(10, KILOBYTE);
+    private boolean enableHashJoinDynamicFiltering;
+    private DataSize bloomFilterForDynamicFilterSize = new DataSize(4, DataSize.Unit.MEGABYTE);
+    private double bloomFilterForDynamicFilteringFalsePositiveProbability = 0.03;
 
     private boolean fragmentResultCachingEnabled;
 
@@ -1043,6 +1046,42 @@ public class FeaturesConfig
     public FeaturesConfig setDynamicFilteringMaxPerDriverSize(DataSize dynamicFilteringMaxPerDriverSize)
     {
         this.dynamicFilteringMaxPerDriverSize = dynamicFilteringMaxPerDriverSize;
+        return this;
+    }
+
+    public boolean isEnableHashJoinDynamicFiltering()
+    {
+        return enableHashJoinDynamicFiltering;
+    }
+
+    @Config("experimental.enable-hash-join-dynamic-filtering")
+    public FeaturesConfig setEnableHashJoinDynamicFiltering(boolean value)
+    {
+        this.enableHashJoinDynamicFiltering = value;
+        return this;
+    }
+
+    public DataSize getBloomFilterForDynamicFilterSize()
+    {
+        return bloomFilterForDynamicFilterSize;
+    }
+
+    @Config("experimental.bloom-filter-for-dynamic-filtering-size")
+    public FeaturesConfig setBloomFilterForDynamicFilterSize(DataSize value)
+    {
+        this.bloomFilterForDynamicFilterSize = value;
+        return this;
+    }
+
+    public double getBloomFilterForDynamicFilteringFalsePositiveProbability()
+    {
+        return bloomFilterForDynamicFilteringFalsePositiveProbability;
+    }
+
+    @Config("experimental.bloom-filter-for-dynamic-filtering-false-positive-probability")
+    public FeaturesConfig setBloomFilterForDynamicFilteringFalsePositiveProbability(Double value)
+    {
+        this.bloomFilterForDynamicFilteringFalsePositiveProbability = value;
         return this;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -98,6 +98,7 @@ import com.facebook.presto.metadata.ViewDefinition;
 import com.facebook.presto.operator.Driver;
 import com.facebook.presto.operator.DriverContext;
 import com.facebook.presto.operator.DriverFactory;
+import com.facebook.presto.operator.InMemoryDynamicFilterClientSupplier;
 import com.facebook.presto.operator.LookupJoinOperators;
 import com.facebook.presto.operator.NoOpFragmentResultCacheManager;
 import com.facebook.presto.operator.OperatorContext;
@@ -108,6 +109,7 @@ import com.facebook.presto.operator.StageExecutionDescriptor;
 import com.facebook.presto.operator.TableCommitContext;
 import com.facebook.presto.operator.TaskContext;
 import com.facebook.presto.operator.index.IndexJoinLookupStats;
+import com.facebook.presto.server.DynamicFilterService;
 import com.facebook.presto.server.PluginManager;
 import com.facebook.presto.server.PluginManagerConfig;
 import com.facebook.presto.server.SessionPropertyDefaults;
@@ -798,7 +800,8 @@ public class LocalQueryRunner
                 jsonCodec(TableCommitContext.class),
                 new RowExpressionDeterminismEvaluator(metadata),
                 new NoOpFragmentResultCacheManager(),
-                new ObjectMapper());
+                new ObjectMapper(),
+                new InMemoryDynamicFilterClientSupplier(new DynamicFilterService()));
 
         // plan query
         StageExecutionDescriptor stageExecutionDescriptor = subplan.getFragment().getStageExecutionDescriptor();

--- a/presto-main/src/test/java/com/facebook/presto/bloomfilter/TestBloomFilterImpl.java
+++ b/presto-main/src/test/java/com/facebook/presto/bloomfilter/TestBloomFilterImpl.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.bloomfilter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+public class TestBloomFilterImpl
+{
+    @Test
+    public void testBloomFilterContain() throws IOException
+    {
+        BloomFilterForDynamicFilter bloomFilter = new BloomFilterForDynamicFilterImpl(BloomFilter.create(1024, 0.03), null, 0);
+        bloomFilter.put(123);
+        bloomFilter.put(456);
+
+        assertTrue(bloomFilter.contain(123));
+        assertTrue(bloomFilter.contain(456));
+        assertFalse(bloomFilter.contain(234));
+    }
+
+    @Test
+    public void testBloomFilterMerge() throws IOException
+    {
+        BloomFilterForDynamicFilter alice = new BloomFilterForDynamicFilterImpl(BloomFilter.create(1024, 0.03), null, 0);
+        BloomFilterForDynamicFilter bob = new BloomFilterForDynamicFilterImpl(BloomFilter.create(1024, 0.03), null, 0);
+
+        alice.put("123");
+        bob.put("234");
+
+        alice.merge(bob);
+
+        assertTrue(alice.contain("123"));
+        assertFalse(alice.contain("456"));
+        assertTrue(alice.contain("234"));
+
+        BloomFilterForDynamicFilter bloomFilter3 = new BloomFilterForDynamicFilterImpl(null, null, 0);
+        bob.merge(bloomFilter3);
+        assertNull(((BloomFilterForDynamicFilterImpl) bob).getBloomFilter());
+
+        bloomFilter3.merge(alice);
+        assertNull(((BloomFilterForDynamicFilterImpl) bloomFilter3).getBloomFilter());
+    }
+
+    @Test
+    public void testJson() throws IOException
+    {
+        BloomFilterForDynamicFilter alice = new BloomFilterForDynamicFilterImpl(BloomFilter.create(1024, 0.03), null, 0);
+        alice.put(123);
+        alice.put(456);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        String json = objectMapper.writeValueAsString(alice);
+        assertEquals(((BloomFilterForDynamicFilterImpl) alice).getSizeAfterCompressed(), 68);
+
+        BloomFilterForDynamicFilter bob = objectMapper.readValue(json, BloomFilterForDynamicFilterImpl.class);
+        assertTrue(bob.contain(123));
+        assertTrue(bob.contain(456));
+        assertFalse(bob.contain(234));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
@@ -31,6 +31,7 @@ import com.facebook.presto.metadata.ConnectorMetadataUpdaterManager;
 import com.facebook.presto.metadata.InMemoryNodeManager;
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.metadata.Split;
+import com.facebook.presto.operator.InMemoryDynamicFilterClientSupplier;
 import com.facebook.presto.operator.LookupJoinOperators;
 import com.facebook.presto.operator.NoOpFragmentResultCacheManager;
 import com.facebook.presto.operator.PagesIndex;
@@ -38,6 +39,7 @@ import com.facebook.presto.operator.StageExecutionDescriptor;
 import com.facebook.presto.operator.TableCommitContext;
 import com.facebook.presto.operator.index.IndexJoinLookupStats;
 import com.facebook.presto.security.AllowAllAccessControl;
+import com.facebook.presto.server.DynamicFilterService;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.WarningCollector;
@@ -178,7 +180,8 @@ public final class TaskTestUtils
                 jsonCodec(TableCommitContext.class),
                 new RowExpressionDeterminismEvaluator(metadata),
                 new NoOpFragmentResultCacheManager(),
-                new ObjectMapper());
+                new ObjectMapper(),
+                new InMemoryDynamicFilterClientSupplier(new DynamicFilterService()));
     }
 
     public static TaskInfo updateTask(SqlTask sqlTask, List<TaskSource> taskSources, OutputBuffers outputBuffers)

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSqlStageExecution.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSqlStageExecution.java
@@ -20,6 +20,7 @@ import com.facebook.presto.execution.scheduler.TableWriteInfo;
 import com.facebook.presto.failureDetector.NoOpFailureDetector;
 import com.facebook.presto.metadata.InternalNode;
 import com.facebook.presto.operator.StageExecutionDescriptor;
+import com.facebook.presto.server.DynamicFilterService;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeId;
@@ -108,7 +109,8 @@ public class TestSqlStageExecution
                 executor,
                 new NoOpFailureDetector(),
                 new SplitSchedulerStats(),
-                new TableWriteInfo(Optional.empty(), Optional.empty(), Optional.empty()));
+                new TableWriteInfo(Optional.empty(), Optional.empty(), Optional.empty()),
+                new DynamicFilterService());
         stage.setOutputBuffers(createInitialEmptyOutputBuffers(ARBITRARY));
 
         // add listener that fetches stage info when the final status is available

--- a/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestSourcePartitionedScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestSourcePartitionedScheduler.java
@@ -32,6 +32,7 @@ import com.facebook.presto.metadata.InMemoryNodeManager;
 import com.facebook.presto.metadata.InternalNode;
 import com.facebook.presto.metadata.InternalNodeManager;
 import com.facebook.presto.operator.StageExecutionDescriptor;
+import com.facebook.presto.server.DynamicFilterService;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.ConnectorSplitSource;
@@ -522,7 +523,8 @@ public class TestSourcePartitionedScheduler
                 queryExecutor,
                 new NoOpFailureDetector(),
                 new SplitSchedulerStats(),
-                new TableWriteInfo(Optional.empty(), Optional.empty(), Optional.empty()));
+                new TableWriteInfo(Optional.empty(), Optional.empty(), Optional.empty()),
+                new DynamicFilterService());
 
         stage.setOutputBuffers(createInitialEmptyOutputBuffers(PARTITIONED)
                 .withBuffer(OUT, 0)

--- a/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkHashJoinDynamicFilterSourceOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkHashJoinDynamicFilterSourceOperator.java
@@ -1,0 +1,200 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.common.Page;
+import com.facebook.presto.common.PageBuilder;
+import com.facebook.presto.execution.TaskId;
+import com.facebook.presto.server.DynamicFilterService;
+import com.facebook.presto.spi.plan.PlanNodeId;
+import com.facebook.presto.testing.TestingTaskContext;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import io.airlift.tpch.LineItem;
+import io.airlift.tpch.LineItemGenerator;
+import io.airlift.units.DataSize;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+import org.testng.annotations.Test;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import static com.facebook.airlift.concurrent.Threads.daemonThreadsNamed;
+import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static java.util.concurrent.Executors.newCachedThreadPool;
+import static java.util.concurrent.Executors.newScheduledThreadPool;
+import static org.testng.Assert.assertEquals;
+
+@State(Scope.Thread)
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Fork(3)
+@Warmup(iterations = 20, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 20, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+public class BenchmarkHashJoinDynamicFilterSourceOperator
+{
+    private static final int TOTAL_POSITIONS = 1_000_000;
+
+    @State(Scope.Thread)
+    public static class BenchmarkContext
+    {
+        @Param({"32", "256", "1024"})
+        private int positionsPerPage = 32;
+        private ExecutorService executorService;
+        private ScheduledExecutorService scheduledExecutorService;
+        private OperatorFactory operatorFactory;
+        private List<Page> pages;
+        private DynamicFilterService dynamicFilterService;
+
+        @Setup
+        public void setup()
+        {
+            executorService = newCachedThreadPool(daemonThreadsNamed("test-executor-%s"));
+            scheduledExecutorService = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%s"));
+            pages = createPages();
+            dynamicFilterService = new DynamicFilterService();
+            dynamicFilterService.registerTasks("0", ImmutableSet.of(new TaskId("query", 0, 0, 0)));
+
+            operatorFactory = new HashJoinDynamicFilterSourceOperator.HashJoinDynamicFilterSourceOperatorFactory(
+                    TEST_SESSION,
+                    0,
+                    new PlanNodeId("PLAN_NODE_ID"),
+                    ImmutableList.of(new HashJoinDynamicFilterSourceOperator.Channel(BIGINT, 0)),
+                    new InMemoryDynamicFilterClientSupplier(dynamicFilterService),
+                    "0",
+                    128);
+        }
+
+        @TearDown
+        public void cleanup()
+        {
+            executorService.shutdownNow();
+            scheduledExecutorService.shutdownNow();
+        }
+
+        public TaskContext createTaskContext()
+        {
+            return TestingTaskContext.createTaskContext(executorService,
+                    scheduledExecutorService,
+                    TEST_SESSION,
+                    new DataSize(2, DataSize.Unit.GIGABYTE));
+        }
+
+        public OperatorFactory getOperatorFactory()
+        {
+            return operatorFactory;
+        }
+
+        public List<Page> getPages()
+        {
+            return pages;
+        }
+
+        private List<Page> createPages()
+        {
+            ImmutableList.Builder<Page> pages = ImmutableList.builder();
+            PageBuilder pageBuilder = new PageBuilder(ImmutableList.of(BIGINT));
+            LineItemGenerator lineItemGenerator = new LineItemGenerator(1, 1, 1);
+            Iterator<LineItem> iterator = lineItemGenerator.iterator();
+            for (int i = 0; i < TOTAL_POSITIONS; i++) {
+                pageBuilder.declarePosition();
+
+                LineItem lineItem = iterator.next();
+                BIGINT.writeLong(pageBuilder.getBlockBuilder(0), lineItem.getOrderKey());
+
+                if (pageBuilder.getPositionCount() == positionsPerPage) {
+                    pages.add(pageBuilder.build());
+                    pageBuilder.reset();
+                }
+            }
+
+            if (pageBuilder.getPositionCount() > 0) {
+                pages.add(pageBuilder.build());
+            }
+
+            return pages.build();
+        }
+    }
+
+    @Benchmark
+    public List<Page> dynamicFilterCollect(BenchmarkContext context)
+    {
+        DriverContext driverContext = context.createTaskContext().addPipelineContext(0, true, true, false).addDriverContext();
+        Operator operator = context.getOperatorFactory().createOperator(driverContext);
+
+        Iterator<Page> input = context.getPages().iterator();
+        ImmutableList.Builder<Page> outputPages = ImmutableList.builder();
+
+        boolean finishing = false;
+        for (int loop = 0; !operator.isFinished() && loop < TOTAL_POSITIONS; loop++) {
+            if (operator.needsInput()) {
+                if (input.hasNext()) {
+                    Page inputPage = input.next();
+                    operator.addInput(inputPage);
+                }
+                else if (!finishing) {
+                    operator.finish();
+                    finishing = true;
+                }
+            }
+
+            Page outputPage = operator.getOutput();
+            if (outputPage != null) {
+                outputPages.add(outputPage);
+            }
+        }
+
+        return outputPages.build();
+    }
+
+    @Test
+    public void testBenchmark()
+    {
+        BenchmarkContext context = new BenchmarkContext();
+        context.setup();
+
+        List<Page> outputPages = dynamicFilterCollect(context);
+        assertEquals(TOTAL_POSITIONS, outputPages.stream().mapToInt(Page::getPositionCount).sum());
+
+        context.cleanup();
+    }
+
+    public static void main(String[] args)
+            throws RunnerException
+    {
+        Options options = new OptionsBuilder()
+                .verbosity(VerboseMode.NORMAL)
+                .include(".*" + BenchmarkHashJoinDynamicFilterSourceOperator.class.getSimpleName() + ".*")
+                .build();
+
+        new Runner(options).run();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestDynamicFilterSummary.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestDynamicFilterSummary.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.airlift.json.ObjectMapperProvider;
+import com.facebook.presto.block.BlockJsonSerde;
+import com.facebook.presto.bloomfilter.BloomFilter;
+import com.facebook.presto.bloomfilter.BloomFilterForDynamicFilter;
+import com.facebook.presto.bloomfilter.BloomFilterForDynamicFilterImpl;
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockEncodingManager;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.type.TypeDeserializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestDynamicFilterSummary
+{
+    private ObjectMapper mapper = getObjectMapperProvider().get();
+
+    private ObjectMapperProvider getObjectMapperProvider()
+    {
+        ObjectMapperProvider provider = new ObjectMapperProvider();
+        ImmutableMap.Builder deserializers = ImmutableMap.builder();
+        BlockEncodingManager blockEncodingSerde = new BlockEncodingManager();
+        deserializers.put(Block.class, new BlockJsonSerde.Deserializer(blockEncodingSerde));
+        deserializers.put(Type.class, new TypeDeserializer(FunctionAndTypeManager.createTestFunctionAndTypeManager()));
+        provider.setJsonDeserializers(deserializers.build());
+        provider.setJsonSerializers(ImmutableMap.of(Block.class, new BlockJsonSerde.Serializer(blockEncodingSerde)));
+        return provider;
+    }
+
+    @Test
+    public void testDynamicFilterSummarySerialization() throws Exception
+    {
+        BloomFilterForDynamicFilter alice = new BloomFilterForDynamicFilterImpl(BloomFilter.create(1024, 0.03), null, 0);
+        BloomFilterForDynamicFilter bob = new BloomFilterForDynamicFilterImpl(BloomFilter.create(1024, 0.03), null, 0);
+        alice.put("123");
+        alice.put("456");
+        bob.put("234");
+        bob.put("345");
+
+        DynamicFilterSummary aliceSummary = new DynamicFilterSummary(alice);
+        DynamicFilterSummary bobSummary = new DynamicFilterSummary(bob);
+        DynamicFilterSummary summary = aliceSummary.mergeWith(bobSummary);
+
+        String serializedJson = mapper.writeValueAsString(summary);
+        System.out.println(serializedJson);
+        DynamicFilterSummary deserialSummary = mapper.readValue(serializedJson, DynamicFilterSummary.class);
+
+        assertTrue(deserialSummary.getBloomFilterForDynamicFilter().contain("123"));
+        assertTrue(deserialSummary.getBloomFilterForDynamicFilter().contain("234"));
+        assertTrue(deserialSummary.getBloomFilterForDynamicFilter().contain("456"));
+        assertFalse(deserialSummary.getBloomFilterForDynamicFilter().contain("1234"));
+    }
+
+    @Test
+    public void testDynamicFilterSummaryDeserialization() throws Exception
+    {
+        String json = "{\"bloomFilterForDynamicFilter\":{\"@type\":\"bloomFilter\",\"bloomFilter\":{\"@type\":\"BloomFilterImpl\"},\"compressedBloomFilter\":\"KLUv/WC1Au0CACQCAAAAAQAAAAAFAAAAdQBAAAGAABAABAAgAAgABBAIAgIgCBgA4BNwHPDMVBhzKwY2MAUoDzxOXZ4BZHAlACwMMAYGBgzGAArBCRWyUrAABQgDAoEJcn4XKGwASg==\",\"sizeBeforeCompressed\":949,\"sizeAfterCompressed\":103}}";
+        DynamicFilterSummary deserialSummary = mapper.readValue(json, DynamicFilterSummary.class);
+        String serializedJson = mapper.writeValueAsString(deserialSummary);
+        assertEquals(json, serializedJson);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinDynamicFilteringSourceOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinDynamicFilteringSourceOperator.java
@@ -1,0 +1,220 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.common.Page;
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.execution.TaskId;
+import com.facebook.presto.server.DynamicFilterService;
+import com.facebook.presto.spi.plan.PlanNodeId;
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.testing.assertions.Assert;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static com.facebook.airlift.concurrent.Threads.daemonThreadsNamed;
+import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
+import static com.facebook.presto.block.BlockAssertions.createBooleansBlock;
+import static com.facebook.presto.block.BlockAssertions.createDoublesBlock;
+import static com.facebook.presto.block.BlockAssertions.createLongsBlock;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.operator.OperatorAssertion.toMaterializedResult;
+import static com.facebook.presto.operator.OperatorAssertion.toPages;
+import static com.facebook.presto.testing.TestingTaskContext.createTaskContext;
+import static com.facebook.presto.testing.assertions.Assert.assertEquals;
+import static java.util.concurrent.Executors.newCachedThreadPool;
+import static java.util.concurrent.Executors.newScheduledThreadPool;
+import static java.util.stream.Collectors.toList;
+
+public class TestHashJoinDynamicFilteringSourceOperator
+{
+    private ExecutorService executorService;
+    private ScheduledExecutorService scheduledExecutorService;
+    private PipelineContext pipelineContext;
+    private DynamicFilterService dynamicFilterService;
+
+    @BeforeMethod
+    public void setUp()
+    {
+        executorService = newCachedThreadPool(daemonThreadsNamed("test-executor-%s"));
+        scheduledExecutorService = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%s"));
+        pipelineContext = createTaskContext(executorService, scheduledExecutorService, TEST_SESSION)
+                .addPipelineContext(0, true, true, false);
+        dynamicFilterService = new DynamicFilterService();
+        dynamicFilterService.registerTasks("0", ImmutableSet.of(new TaskId("query", 0, 0, 0)));
+    }
+
+    @AfterMethod
+    public void tearDown()
+    {
+        executorService.shutdownNow();
+        scheduledExecutorService.shutdownNow();
+    }
+
+    private void verifyPassThrough(Operator operator, List<Type> types, Page... pages)
+    {
+        List<Page> inputPages = ImmutableList.copyOf(pages);
+        List<Page> outputPages = toPages(operator, inputPages.iterator());
+        MaterializedResult actual = toMaterializedResult(pipelineContext.getSession(), types, outputPages);
+        MaterializedResult expected = toMaterializedResult(pipelineContext.getSession(), types, inputPages);
+        assertEquals(actual, expected);
+    }
+
+    private OperatorFactory createOperatorFactory(HashJoinDynamicFilterSourceOperator.Channel... buildChannels)
+    {
+        return new HashJoinDynamicFilterSourceOperator.HashJoinDynamicFilterSourceOperatorFactory(
+                TEST_SESSION,
+                0,
+                new PlanNodeId("PLAN_NODE_ID"),
+                Arrays.stream(buildChannels).collect(toList()),
+                new InMemoryDynamicFilterClientSupplier(dynamicFilterService),
+                "0",
+                4);
+    }
+
+    private Operator createOperator(OperatorFactory operatorFactory)
+    {
+        return operatorFactory.createOperator(pipelineContext.addDriverContext());
+    }
+
+    private static HashJoinDynamicFilterSourceOperator.Channel channel(int index, Type type)
+    {
+        return new HashJoinDynamicFilterSourceOperator.Channel(type, index);
+    }
+
+    @Test
+    public void testCollectMultipleOperators()
+    {
+        OperatorFactory operatorFactory = createOperatorFactory(channel(0, BIGINT));
+
+        Operator operator1 = createOperator(operatorFactory);
+        verifyPassThrough(operator1,
+                ImmutableList.of(BIGINT),
+                new Page(createLongsBlock(1, 2)),
+                new Page(createLongsBlock(3, 5)));
+
+        Operator operator2 = createOperator(operatorFactory);
+        operatorFactory.noMoreOperators();
+        Assert.assertEquals(((HashJoinDynamicFilterSourceOperator) operator1).getValues(), ImmutableList.of("1", "2", "3", "5"));
+
+        verifyPassThrough(operator2,
+                ImmutableList.of(BIGINT),
+                new Page(createLongsBlock(2, 3)),
+                new Page(createLongsBlock(1, 4)));
+        Assert.assertEquals(((HashJoinDynamicFilterSourceOperator) operator2).getValues(),
+                ImmutableList.of("2", "3", "1", "4"));
+    }
+
+    @Test
+    public void testCollectMultipleColumns()
+    {
+        OperatorFactory operatorFactory = createOperatorFactory(channel(0, BOOLEAN), channel(1, DOUBLE));
+        Operator operator = createOperator(operatorFactory);
+        verifyPassThrough(operator,
+                ImmutableList.of(BOOLEAN, DOUBLE),
+                new Page(createBooleansBlock(true, 2), createDoublesBlock(1.5, 3.0)),
+                new Page(createBooleansBlock(false, 1), createDoublesBlock(4.5)));
+        operatorFactory.noMoreOperators();
+
+        Assert.assertEquals(((HashJoinDynamicFilterSourceOperator) operator).getValues(),
+                ImmutableList.of("true1.5", "true3.0", "false4.5"));
+    }
+
+    @Test
+    public void testCollectOnlyFirstColumn()
+    {
+        OperatorFactory operatorFactory = createOperatorFactory(channel(0, BOOLEAN));
+        Operator operator = createOperator(operatorFactory);
+        verifyPassThrough(operator,
+                ImmutableList.of(BOOLEAN, DOUBLE),
+                new Page(createBooleansBlock(true, 2), createDoublesBlock(1.5, 3.0)),
+                new Page(createBooleansBlock(false, 1), createDoublesBlock(4.5)));
+        operatorFactory.noMoreOperators();
+
+        Assert.assertEquals(((HashJoinDynamicFilterSourceOperator) operator).getValues(),
+                ImmutableList.of("true", "true", "false"));
+    }
+
+    @Test
+    public void testCollectOnlyLastColumn()
+    {
+        OperatorFactory operatorFactory = createOperatorFactory(channel(1, DOUBLE));
+        Operator operator = createOperator(operatorFactory);
+        verifyPassThrough(operator,
+                ImmutableList.of(BOOLEAN, DOUBLE),
+                new Page(createBooleansBlock(true, 2), createDoublesBlock(1.5, 3.0)),
+                new Page(createBooleansBlock(false, 1), createDoublesBlock(4.5)));
+        operatorFactory.noMoreOperators();
+
+        Assert.assertEquals(((HashJoinDynamicFilterSourceOperator) operator).getValues(),
+                ImmutableList.of("1.5", "3.0", "4.5"));
+    }
+
+    @Test
+    public void testCollectWithNulls()
+    {
+        Block blockWithNulls = INTEGER.createFixedSizeBlockBuilder(0)
+                .writeInt(3)
+                .appendNull()
+                .writeInt(4)
+                .build();
+
+        OperatorFactory operatorFactory = createOperatorFactory(channel(0, INTEGER));
+        Operator operator = createOperator(operatorFactory);
+        verifyPassThrough(operator,
+                ImmutableList.of(INTEGER),
+                new Page(createLongsBlock(1, 2, 3)),
+                new Page(blockWithNulls),
+                new Page(createLongsBlock(4, 5)));
+        operatorFactory.noMoreOperators();
+
+        Assert.assertEquals(((HashJoinDynamicFilterSourceOperator) operator).getValues(),
+                ImmutableList.of("1", "2", "3", "3", "", "4", "4", "5"));
+    }
+
+    @Test
+    public void testCollectNoFilters()
+    {
+        OperatorFactory operatorFactory = createOperatorFactory();
+        Operator operator = createOperator(operatorFactory);
+        verifyPassThrough(operator,
+                ImmutableList.of(BIGINT),
+                new Page(createLongsBlock(1, 2, 3)));
+        operatorFactory.noMoreOperators();
+
+        Assert.assertEquals(((HashJoinDynamicFilterSourceOperator) operator).getValues(), ImmutableList.of());
+    }
+
+    @Test
+    public void testCollectEmptyBuildSide()
+    {
+        OperatorFactory operatorFactory = createOperatorFactory(channel(0, BIGINT));
+        Operator operator = createOperator(operatorFactory);
+        verifyPassThrough(createOperator(operatorFactory), ImmutableList.of(BIGINT));
+
+        Assert.assertEquals(((HashJoinDynamicFilterSourceOperator) operator).getValues(), ImmutableList.of());
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestInBloomFilterFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestInBloomFilterFunction.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.bloomfilter.BloomFilter;
+import com.facebook.presto.bloomfilter.BloomFilterForDynamicFilter;
+import com.facebook.presto.bloomfilter.BloomFilterForDynamicFilterImpl;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+
+public class TestInBloomFilterFunction
+        extends AbstractTestFunctions
+{
+    @Test
+    public void bloomFilterContains() throws IOException
+    {
+        BloomFilterForDynamicFilter myBloomFilter = new BloomFilterForDynamicFilterImpl(BloomFilter.create(1024, 0.03), null, 0);
+        myBloomFilter.put("123");
+        myBloomFilter.put("159");
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        String json = objectMapper.writeValueAsString(myBloomFilter);
+        assertFunction("BLOOM_FILTER_CONTAINS(123, '" + json + "', '123')", BOOLEAN, true);
+        assertFunction("BLOOM_FILTER_CONTAINS(123, '" + json + "', '158')", BOOLEAN, false);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -152,7 +152,10 @@ public class TestFeaturesConfig
                 .setWarnOnNoTableLayoutFilter("")
                 .setInlineSqlFunctions(true)
                 .setCheckAccessControlOnUtilizedColumnsOnly(false)
-                .setAllowWindowOrderByLiterals(true));
+                .setAllowWindowOrderByLiterals(true)
+                .setEnableHashJoinDynamicFiltering(false)
+                .setBloomFilterForDynamicFilterSize(new DataSize(4, MEGABYTE))
+                .setBloomFilterForDynamicFilteringFalsePositiveProbability(0.03));
     }
 
     @Test
@@ -258,6 +261,9 @@ public class TestFeaturesConfig
                 .put("check-access-control-on-utilized-columns-only", "true")
                 .put("optimizer.skip-redundant-sort", "false")
                 .put("is-allow-window-order-by-literals", "false")
+                .put("experimental.enable-hash-join-dynamic-filtering", "true")
+                .put("experimental.bloom-filter-for-dynamic-filtering-size", "1MB")
+                .put("experimental.bloom-filter-for-dynamic-filtering-false-positive-probability", "0.01")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -360,7 +366,10 @@ public class TestFeaturesConfig
                 .setInlineSqlFunctions(false)
                 .setCheckAccessControlOnUtilizedColumnsOnly(true)
                 .setSkipRedundantSort(false)
-                .setAllowWindowOrderByLiterals(false);
+                .setAllowWindowOrderByLiterals(false)
+                .setEnableHashJoinDynamicFiltering(true)
+                .setBloomFilterForDynamicFilterSize(new DataSize(1, MEGABYTE))
+                .setBloomFilterForDynamicFilteringFalsePositiveProbability(0.01);
         assertFullMapping(properties, expected);
     }
 

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestDistributedQueriesWithHashJoinDynamicFilter.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestDistributedQueriesWithHashJoinDynamicFilter.java
@@ -16,19 +16,15 @@ package com.facebook.presto.tests;
 import com.facebook.presto.SystemSessionProperties;
 import com.facebook.presto.tests.tpch.TpchQueryRunnerBuilder;
 
-import static com.facebook.presto.SystemSessionProperties.ENABLE_DYNAMIC_FILTERING;
-
-public class TestDistributedQueriesWithDynamicFilter
+public class TestDistributedQueriesWithHashJoinDynamicFilter
         extends AbstractTestQueries
 {
-    public TestDistributedQueriesWithDynamicFilter()
+    public TestDistributedQueriesWithHashJoinDynamicFilter()
     {
         super(() -> TpchQueryRunnerBuilder.builder()
-                .amendSession(builder -> builder.setSystemProperty(ENABLE_DYNAMIC_FILTERING, "false")
-                        .setSystemProperty(SystemSessionProperties.ENABLE_HASH_JOIN_DYNAMIC_FILTERING, "true")
+                .amendSession(builder -> builder.setSystemProperty(SystemSessionProperties.ENABLE_HASH_JOIN_DYNAMIC_FILTERING, "true")
                         .setSystemProperty(SystemSessionProperties.BLOOM_FILTER_FOR_DYNAMIC_FILTERING_SIZE, "100kB")
-                        .setSystemProperty(SystemSessionProperties.BLOOM_FILTER_FOR_DYNAMIC_FILTERING_FALSE_POSITIVE_PROBABILITY, "0.03")
-                        .setSystemProperty(SystemSessionProperties.PARSE_DECIMAL_LITERALS_AS_DOUBLE, "true"))
+                        .setSystemProperty(SystemSessionProperties.BLOOM_FILTER_FOR_DYNAMIC_FILTERING_FALSE_POSITIVE_PROBABILITY, "0.03"))
                 .build());
     }
 }


### PR DESCRIPTION
Support dynamic filter for hash join. Currently, Presto 0.241+ supports local dynamic filtering for broadcast inner-joins, but does not have a dynamic filtering for hash inner-joins. This PR add a new  session property "ENABLE_HASH_JOIN_DYNAMIC_FILTERING" which support dynamic filter for hash join.

```
== RELEASE NOTES ==

General Changes

* Add `HashJoinDynamicFilterSourceOperator` to collect filter data info before hash table build in build side.

* Add `DynamicFilterService` to aggregate filter data info in coordinator and broadcast it to the probe side.

* Add `DynamicPageFilter` to do page filtering in the probe-side by filter data info which receive from the build side.

```