### PR TITLE
Fix LocalExecutionPlan for IndexJoin when spill enabled

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -1754,7 +1754,7 @@ public class LocalExecutionPlanner
             }
 
             OperatorFactory lookupJoinOperatorFactory;
-            OptionalInt totalOperatorsCount = getJoinOperatorsCountForSpill(context, session);
+            OptionalInt totalOperatorsCount = OptionalInt.empty(); // spill not supported for index joins
             switch (node.getType()) {
                 case INNER:
                     lookupJoinOperatorFactory = lookupJoinOperators.innerJoin(context.getNextOperatorId(), node.getId(), lookupSourceFactoryManager, probeSource.getTypes(), probeChannels, probeHashChannel, Optional.empty(), totalOperatorsCount, partitioningSpillerFactory);

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestIndexedQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestIndexedQueries.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.tests;
 
+import com.facebook.presto.Session;
 import com.facebook.presto.testing.MaterializedResult;
 import com.facebook.presto.tests.tpch.TpchIndexSpec;
 import com.facebook.presto.tests.tpch.TpchIndexSpec.Builder;
@@ -68,6 +69,26 @@ public abstract class AbstractTestIndexedQueries
     public void testBasicIndexJoin()
     {
         assertQuery("" +
+                "SELECT *\n" +
+                "FROM (\n" +
+                "  SELECT *\n" +
+                "  FROM lineitem\n" +
+                "  WHERE partkey % 8 = 0) l\n" +
+                "JOIN orders o\n" +
+                "  ON l.orderkey = o.orderkey");
+    }
+
+    @Test
+    public void testBasicIndexJoinWithSpillEnabled()
+    {
+        // spill is not supported for index join, but it shares the lookup join operator
+        // with non-index join.  Make sure no errors are thrown when running index joins
+        // when spill is enabled.
+        assertQuery(Session.builder(getSession())
+                        .setSystemProperty("spill_enabled", "true")
+                        .setSystemProperty("join_spill_enabled", "true")
+                        .build(),
+                "" +
                 "SELECT *\n" +
                 "FROM (\n" +
                 "  SELECT *\n" +

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestDistributedQueriesIndexed.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestDistributedQueriesIndexed.java
@@ -15,6 +15,9 @@ package com.facebook.presto.tests;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.tests.tpch.IndexedTpchPlugin;
+import com.google.common.collect.ImmutableMap;
+
+import java.nio.file.Paths;
 
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static com.facebook.presto.tpch.TpchMetadata.TINY_SCHEMA_NAME;
@@ -35,7 +38,14 @@ public class TestDistributedQueriesIndexed
                 .setSchema(TINY_SCHEMA_NAME)
                 .build();
 
-        DistributedQueryRunner queryRunner = new DistributedQueryRunner(session, 3);
+        // set spill path so we can enable spill by session property
+        ImmutableMap<String, String> extraProperties = ImmutableMap.of(
+                "experimental.spiller-spill-path",
+                Paths.get(System.getProperty("java.io.tmpdir"), "presto", "spills").toString());
+        DistributedQueryRunner queryRunner = new DistributedQueryRunner.Builder(session)
+                .setNodeCount(3)
+                .setExtraProperties(extraProperties)
+                .build();
 
         queryRunner.installPlugin(new IndexedTpchPlugin(INDEX_SPEC));
         queryRunner.createCatalog("tpch_indexed", "tpch_indexed");

--- a/presto-thrift-connector/src/test/java/com/facebook/presto/connector/thrift/integration/TestThriftDistributedQueriesIndexed.java
+++ b/presto-thrift-connector/src/test/java/com/facebook/presto/connector/thrift/integration/TestThriftDistributedQueriesIndexed.java
@@ -16,6 +16,8 @@ package com.facebook.presto.connector.thrift.integration;
 import com.facebook.presto.tests.AbstractTestIndexedQueries;
 import com.google.common.collect.ImmutableMap;
 
+import java.nio.file.Paths;
+
 import static com.facebook.presto.connector.thrift.integration.ThriftQueryRunner.createThriftQueryRunner;
 
 public class TestThriftDistributedQueriesIndexed
@@ -23,7 +25,12 @@ public class TestThriftDistributedQueriesIndexed
 {
     public TestThriftDistributedQueriesIndexed()
     {
-        super(() -> createThriftQueryRunner(2, 2, true, ImmutableMap.of()));
+        super(() -> createThriftQueryRunner(
+                2,
+                2,
+                true,
+                // set spill path so we can enable spill by session property
+                ImmutableMap.of("experimental.spiller-spill-path", Paths.get(System.getProperty("java.io.tmpdir"), "presto", "spills").toString())));
     }
 
     @Override


### PR DESCRIPTION
Index join does not support spill, so we don't ensure that we add
exchanges with fixed distribution before an index join.  However, we
were still checking for fixed distribution in the LocalExecutionPlanner.
This removes the check for the number of operators since that is only
needed for spill

Test plan - Added unit test 

```
== RELEASE NOTES ==

General Changes
* Fix an error executing index joins when join spilling is enabled
```
