### PR TITLE
Fix over allocation of RowBlockBuilder during spilling

### DIFF
--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestSpilledAggregations.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestSpilledAggregations.java
@@ -79,4 +79,10 @@ public class TestSpilledAggregations
     {
         assertQuery("SELECT array_agg(orderstatus ORDER BY orderstatus) FROM orders");
     }
+
+    @Test
+    public void TestMultipleDistinctAggregations()
+    {
+        assertQuery("SELECT custkey, count(DISTINCT orderpriority), count(DISTINCT orderstatus), count(DISTINCT totalprice), count(DISTINCT clerk) FROM orders GROUP BY custkey");
+    }
 }


### PR DESCRIPTION
Test plan - Deployed and tested on query that was causing JVM OOM. After this fix, the query succeeded.

Description of bug: RowBlockBuilders were using a lot more memory than their corresponding rawInputs according to the heapdump I found. This showed that we were overallocating the blockBuilders array during SpillableFinalOnlyGroupedAccumulator.evaulateIntermediate.

```
== NO RELEASE NOTE ==
```
