### PR TITLE
Add `new_partition_user_supplied_parameter` property

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
@@ -24,6 +24,7 @@ import io.airlift.units.DataSize;
 import javax.inject.Inject;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static com.facebook.presto.common.type.DoubleType.DOUBLE;
@@ -115,6 +116,7 @@ public final class HiveSessionProperties
     public static final String FILE_RENAMING_ENABLED = "file_renaming_enabled";
     public static final String PREFER_MANIFESTS_TO_LIST_FILES = "prefer_manifests_to_list_files";
     public static final String MANIFEST_VERIFICATION_ENABLED = "manifest_verification_enabled";
+    public static final String NEW_PARTITION_USER_SUPPLIED_PARAMETER = "new_partition_user_supplied_parameter";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -544,7 +546,12 @@ public final class HiveSessionProperties
                         MANIFEST_VERIFICATION_ENABLED,
                         "Enable manifest verification",
                         hiveClientConfig.isManifestVerificationEnabled(),
-                        false));
+                        false),
+                stringProperty(
+                        NEW_PARTITION_USER_SUPPLIED_PARAMETER,
+                        "\"user_supplied\" parameter added to all newly created partitions",
+                        null,
+                        true));
     }
 
     public List<PropertyMetadata<?>> getSessionProperties()
@@ -953,5 +960,10 @@ public final class HiveSessionProperties
     public static boolean isManifestVerificationEnabled(ConnectorSession session)
     {
         return session.getProperty(MANIFEST_VERIFICATION_ENABLED, Boolean.class);
+    }
+
+    public static Optional<String> getNewPartitionUserSuppliedParameter(ConnectorSession session)
+    {
+        return Optional.ofNullable(session.getProperty(NEW_PARTITION_USER_SUPPLIED_PARAMETER, String.class));
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriterFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriterFactory.java
@@ -251,7 +251,10 @@ public class HiveWriterFactory
         requireNonNull(hiveSessionProperties, "hiveSessionProperties is null");
         this.sessionProperties = hiveSessionProperties.getSessionProperties().stream()
                 .collect(toImmutableMap(PropertyMetadata::getName,
-                        entry -> session.getProperty(entry.getName(), entry.getJavaType()).toString()));
+                        entry -> {
+                            Object value = session.getProperty(entry.getName(), entry.getJavaType());
+                            return value == null ? "null" : value.toString();
+                        }));
 
         this.conf = configureCompression(hdfsEnvironment.getConfiguration(
                 new HdfsContext(session, schemaName, tableName, locationHandle.getTargetPath().toString(), isCreateTable),

--- a/presto-main/src/main/java/com/facebook/presto/testing/TestingConnectorSession.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/TestingConnectorSession.java
@@ -62,6 +62,11 @@ public class TestingConnectorSession
         this("user", Optional.of("test"), Optional.empty(), UTC_KEY, ENGLISH, System.currentTimeMillis(), properties, ImmutableMap.of(), new FeaturesConfig().isLegacyTimestamp(), Optional.empty(), Optional.empty(), ImmutableMap.of());
     }
 
+    public TestingConnectorSession(List<PropertyMetadata<?>> properties, Map<String, Object> propertyValues)
+    {
+        this("user", Optional.of("test"), Optional.empty(), UTC_KEY, ENGLISH, System.currentTimeMillis(), properties, propertyValues, new FeaturesConfig().isLegacyTimestamp(), Optional.empty(), Optional.empty(), ImmutableMap.of());
+    }
+
     public TestingConnectorSession(List<PropertyMetadata<?>> properties, Optional<String> schema)
     {
         this("user", Optional.of("test"), Optional.empty(), UTC_KEY, ENGLISH, System.currentTimeMillis(), properties, ImmutableMap.of(), new FeaturesConfig().isLegacyTimestamp(), Optional.empty(), schema, ImmutableMap.of());


### PR DESCRIPTION
Test plan - Includes unit test

This is to support an auditing use case where the client wants to add an extra information to the metastore entry for every partition. To keep things somewhat isolated they can specify a single key ('user_supplied') as a session parameter and then put whatever they want in the string value. JSON would be fine for instance.

I didn't want them to put arbitrary keys in the the metastore extra_params to avoid the potential for collisions on key names.

I had a tough time finding a good place to put this very simple unit test in. There is a large amount of ceremony required to set up the test case and I didn't want to duplicate it all.

```
== RELEASE NOTES ==

Hive Changes
* Add `new_partition_user_supplied_parameter` session property which causes all partitions created by a query to have the `user_supplied` parameter set to the supplied string in Hive metastore.
```

depends on https://github.com/facebookexternal/presto-facebook/pull/1439