### PR TITLE
Enforce fixed distribution for output operator

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -173,6 +173,7 @@ public final class SystemSessionProperties
     public static final String CHECK_ACCESS_CONTROL_ON_UTILIZED_COLUMNS_ONLY = "check_access_control_on_utilized_columns_only";
     public static final String SKIP_REDUNDANT_SORT = "skip_redundant_sort";
     public static final String ALLOW_WINDOW_ORDER_BY_LITERALS = "allow_window_order_by_literals";
+    public static final String ENFORCE_FIXED_DISTRIBUTION_FOR_OUTPUT_OPERATOR = "enforce_fixed_distribution_for_output_operator";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -902,7 +903,12 @@ public final class SystemSessionProperties
                         ALLOW_WINDOW_ORDER_BY_LITERALS,
                         "Allow ORDER BY literals in window functions",
                         featuresConfig.isAllowWindowOrderByLiterals(),
-                        false));
+                        false),
+                booleanProperty(
+                        ENFORCE_FIXED_DISTRIBUTION_FOR_OUTPUT_OPERATOR,
+                        "Enforce fixed distribution for output operator",
+                        featuresConfig.isEnforceFixedDistributionForOutputOperator(),
+                        true));
     }
 
     public static boolean isSkipRedundantSort(Session session)
@@ -1527,5 +1533,10 @@ public final class SystemSessionProperties
     public static boolean isCheckAccessControlOnUtilizedColumnsOnly(Session session)
     {
         return session.getSystemProperty(CHECK_ACCESS_CONTROL_ON_UTILIZED_COLUMNS_ONLY, Boolean.class);
+    }
+
+    public static boolean isEnforceFixedDistributionForOutputOperator(Session session)
+    {
+        return session.getSystemProperty(ENFORCE_FIXED_DISTRIBUTION_FOR_OUTPUT_OPERATOR, Boolean.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -180,6 +180,8 @@ public class FeaturesConfig
 
     private PartitioningPrecisionStrategy partitioningPrecisionStrategy = PartitioningPrecisionStrategy.AUTOMATIC;
 
+    private boolean enforceFixedDistributionForOutputOperator;
+
     public enum PartitioningPrecisionStrategy
     {
         // Let Presto decide when to repartition
@@ -1514,6 +1516,18 @@ public class FeaturesConfig
     public FeaturesConfig setAllowWindowOrderByLiterals(boolean value)
     {
         this.isAllowWindowOrderByLiterals = value;
+        return this;
+    }
+
+    public boolean isEnforceFixedDistributionForOutputOperator()
+    {
+        return enforceFixedDistributionForOutputOperator;
+    }
+
+    @Config("enforce-fixed-distribution-for-output-operator")
+    public FeaturesConfig setEnforceFixedDistributionForOutputOperator(boolean enforceFixedDistributionForOutputOperator)
+    {
+        this.enforceFixedDistributionForOutputOperator = enforceFixedDistributionForOutputOperator;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddLocalExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddLocalExchanges.java
@@ -68,6 +68,7 @@ import static com.facebook.presto.SystemSessionProperties.getTaskConcurrency;
 import static com.facebook.presto.SystemSessionProperties.getTaskPartitionedWriterCount;
 import static com.facebook.presto.SystemSessionProperties.getTaskWriterCount;
 import static com.facebook.presto.SystemSessionProperties.isDistributedSortEnabled;
+import static com.facebook.presto.SystemSessionProperties.isEnforceFixedDistributionForOutputOperator;
 import static com.facebook.presto.SystemSessionProperties.isJoinSpillingEnabled;
 import static com.facebook.presto.SystemSessionProperties.isSpillEnabled;
 import static com.facebook.presto.SystemSessionProperties.isTableWriterMergeOperatorEnabled;
@@ -611,6 +612,9 @@ public class AddLocalExchanges
                         node,
                         any().withOrderSensitivity(),
                         any().withOrderSensitivity());
+            }
+            if (isEnforceFixedDistributionForOutputOperator(session)) {
+                return planAndEnforceChildren(node, fixedParallelism(), fixedParallelism());
             }
             return planAndEnforceChildren(node, any(), defaultParallelism(session));
         }

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -154,7 +154,8 @@ public class TestFeaturesConfig
                 .setWarnOnNoTableLayoutFilter("")
                 .setInlineSqlFunctions(true)
                 .setCheckAccessControlOnUtilizedColumnsOnly(false)
-                .setAllowWindowOrderByLiterals(true));
+                .setAllowWindowOrderByLiterals(true)
+                .setEnforceFixedDistributionForOutputOperator(false));
     }
 
     @Test
@@ -262,6 +263,7 @@ public class TestFeaturesConfig
                 .put("check-access-control-on-utilized-columns-only", "true")
                 .put("optimizer.skip-redundant-sort", "false")
                 .put("is-allow-window-order-by-literals", "false")
+                .put("enforce-fixed-distribution-for-output-operator", "true")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -366,7 +368,8 @@ public class TestFeaturesConfig
                 .setInlineSqlFunctions(false)
                 .setCheckAccessControlOnUtilizedColumnsOnly(true)
                 .setSkipRedundantSort(false)
-                .setAllowWindowOrderByLiterals(false);
+                .setAllowWindowOrderByLiterals(false)
+                .setEnforceFixedDistributionForOutputOperator(true);
         assertFullMapping(properties, expected);
     }
 

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkSettingsRequirements.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkSettingsRequirements.java
@@ -89,6 +89,7 @@ public class PrestoSparkSettingsRequirements
         config.setPreferDistributedUnion(true);
         config.setForceSingleNodeOutput(false);
         config.setInlineSqlFunctions(true);
+        config.setEnforceFixedDistributionForOutputOperator(true);
     }
 
     public static void setDefaults(QueryManagerConfig config)


### PR DESCRIPTION
Output operator in Spark does rows compaction. It has to accumulate enough
rows to ensure at least 1kb of data per partition is being written to the
shuffle service in a single call. Without a local exchange the output operator
will inherit the table scan driver lifecycle, effectively buffering only the
rows produced by a single split. If splits are small that results into very
tiny batched being flushed to the shuffle service

```
== NO RELEASE NOTE ==
```
