### PR TITLE
Configure tempstorage for Presto on Spark

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/storage/TempStorageManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/storage/TempStorageManager.java
@@ -51,6 +51,7 @@ public class TempStorageManager
     private static final Logger log = Logger.get(TempStorageManager.class);
     // TODO: Make this configurable
     private static final File TEMP_STORAGE_CONFIGURATION_DIR = new File("etc/temp-storage/");
+    public static final String TEMP_STORAGE_FACTORY_NAME = "temp-storage-factory.name";
 
     private final Map<String, TempStorageFactory> tempStorageFactories = new ConcurrentHashMap<>();
     private final Map<String, TempStorage> loadedTempStorages = new ConcurrentHashMap<>();
@@ -86,24 +87,7 @@ public class TempStorageManager
     public void loadTempStorages()
             throws IOException
     {
-        if (!tempStorageLoading.compareAndSet(false, true)) {
-            return;
-        }
-        // Always load local temp storage
-        loadTempStorage(
-                LocalTempStorage.NAME,
-                // TODO: Local temp storage should be configurable
-                ImmutableMap.of(
-                        TEMP_STORAGE_PATH,
-                        Paths.get(System.getProperty("java.io.tmpdir"), "presto", "temp_storage").toAbsolutePath().toString()));
-
-        for (File file : listFiles(TEMP_STORAGE_CONFIGURATION_DIR)) {
-            if (file.isFile() && file.getName().endsWith(".properties")) {
-                String name = getNameWithoutExtension(file.getName());
-                Map<String, String> properties = new HashMap<>(loadProperties(file));
-                loadTempStorage(name, properties);
-            }
-        }
+        loadTempStorages(ImmutableMap.of());
     }
 
     public TempStorage getTempStorage(String name)
@@ -114,17 +98,59 @@ public class TempStorageManager
         return tempStorage;
     }
 
+    public void loadTempStorages(Map<String, Map<String, String>> storageProperties)
+            throws IOException
+    {
+        if (!tempStorageLoading.compareAndSet(false, true)) {
+            return;
+        }
+
+        // Always load local temp storage
+        loadTempStorage(
+                LocalTempStorage.NAME,
+                // TODO: Local temp storage should be configurable
+                ImmutableMap.of(
+                        TEMP_STORAGE_PATH,
+                        Paths.get(System.getProperty("java.io.tmpdir"), "presto", "temp_storage").toAbsolutePath().toString(),
+                        TEMP_STORAGE_FACTORY_NAME,
+                        "local"));
+
+        for (File file : listFiles(TEMP_STORAGE_CONFIGURATION_DIR)) {
+            if (file.isFile() && file.getName().endsWith(".properties")) {
+                String name = getNameWithoutExtension(file.getName());
+                Map<String, String> properties = new HashMap<>(loadProperties(file));
+                loadTempStorage(name, properties);
+            }
+        }
+
+        storageProperties.entrySet().stream()
+                .forEach(entry -> loadTempStorage(entry.getKey(), entry.getValue()));
+    }
+
     protected void loadTempStorage(String name, Map<String, String> properties)
     {
         requireNonNull(name, "name is null");
         requireNonNull(properties, "properties is null");
 
-        log.info("-- Loading temp storage --");
+        log.info("-- Loading temp storage %s --", name);
 
-        TempStorageFactory factory = tempStorageFactories.get(name);
-        checkState(factory != null, "Temp Storage %s is not registered", name);
+        String tempStorageFactoryName = null;
+        ImmutableMap.Builder<String, String> tempStorageProperties = ImmutableMap.builder();
+        for (Map.Entry<String, String> entry : properties.entrySet()) {
+            if (entry.getKey().equals(TEMP_STORAGE_FACTORY_NAME)) {
+                tempStorageFactoryName = entry.getValue();
+            }
+            else {
+                tempStorageProperties.put(entry.getKey(), entry.getValue());
+            }
+        }
 
-        TempStorage tempStorage = factory.create(properties, new TempStorageContext(nodeManager));
+        checkState(tempStorageFactoryName != null, "Configuration for tempStorage %s does not contain temp-storage-factory.name", name);
+
+        TempStorageFactory factory = tempStorageFactories.get(tempStorageFactoryName);
+        checkState(factory != null, "Temp Storage Factory %s is not registered", tempStorageFactoryName);
+
+        TempStorage tempStorage = factory.create(tempStorageProperties.build(), new TempStorageContext(nodeManager));
         if (loadedTempStorages.putIfAbsent(name, tempStorage) != null) {
             throw new IllegalArgumentException(format("Temp Storage '%s' is already loaded", name));
         }

--- a/presto-main/src/main/java/com/facebook/presto/testing/TestingTempStorageManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/TestingTempStorageManager.java
@@ -42,6 +42,6 @@ public class TestingTempStorageManager
         super(new TestingNodeManager());
         loadTempStorage(
                 LocalTempStorage.NAME,
-                ImmutableMap.of(TEMP_STORAGE_PATH, tempStoragePath));
+                ImmutableMap.of(TEMP_STORAGE_PATH, tempStoragePath, TempStorageManager.TEMP_STORAGE_FACTORY_NAME, "local"));
     }
 }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkServiceFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkServiceFactory.java
@@ -48,6 +48,7 @@ public class PrestoSparkServiceFactory
                 configuration.getAccessControlProperties(),
                 configuration.getSessionPropertyConfigurationProperties(),
                 configuration.getFunctionNamespaceProperties(),
+                configuration.getTempStorageProperties(),
                 getSqlParserOptions(),
                 getAdditionalModules(configuration));
 

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkTaskExecutorFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkTaskExecutorFactory.java
@@ -1016,7 +1016,9 @@ public class PrestoSparkTaskExecutorFactory
                     ioException = e;
                 }
                 try {
-                    tempDataSink.rollback();
+                    if (tempDataSink != null) {
+                        tempDataSink.rollback();
+                    }
                 }
                 catch (IOException exception) {
                     if (ioException != exception) {
@@ -1026,7 +1028,9 @@ public class PrestoSparkTaskExecutorFactory
             }
             finally {
                 try {
-                    tempDataSink.close();
+                    if (tempDataSink != null) {
+                        tempDataSink.close();
+                    }
                 }
                 catch (IOException e) {
                     if (ioException == null) {

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
@@ -204,6 +204,7 @@ public class PrestoSparkQueryRunner
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
+                Optional.empty(),
                 new SqlParserOptions(),
                 ImmutableList.of(new PrestoSparkLocalMetadataStorageModule()),
                 true);

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkConfiguration.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkConfiguration.java
@@ -31,6 +31,7 @@ public class PrestoSparkConfiguration
     private final Optional<Map<String, String>> accessControlProperties;
     private final Optional<Map<String, String>> sessionPropertyConfigurationProperties;
     private final Optional<Map<String, Map<String, String>>> functionNamespaceProperties;
+    private final Optional<Map<String, Map<String, String>>> tempStorageProperties;
 
     public PrestoSparkConfiguration(
             Map<String, String> configProperties,
@@ -40,7 +41,8 @@ public class PrestoSparkConfiguration
             Optional<Map<String, String>> eventListenerProperties,
             Optional<Map<String, String>> accessControlProperties,
             Optional<Map<String, String>> sessionPropertyConfigurationProperties,
-            Optional<Map<String, Map<String, String>>> functionNamespaceProperties)
+            Optional<Map<String, Map<String, String>>> functionNamespaceProperties,
+            Optional<Map<String, Map<String, String>>> tempStorageProperties)
     {
         this.configProperties = unmodifiableMap(new HashMap<>(requireNonNull(configProperties, "configProperties is null")));
         this.pluginsDirectoryPath = requireNonNull(pluginsDirectoryPath, "pluginsDirectoryPath is null");
@@ -54,6 +56,9 @@ public class PrestoSparkConfiguration
         this.sessionPropertyConfigurationProperties = requireNonNull(sessionPropertyConfigurationProperties, "sessionPropertyConfigurationProperties is null")
                 .map(properties -> unmodifiableMap(new HashMap<>(properties)));
         this.functionNamespaceProperties = requireNonNull(functionNamespaceProperties, "functionNamespaceProperties is null")
+                .map(map -> map.entrySet().stream()
+                        .collect(toMap(Map.Entry::getKey, entry -> unmodifiableMap(new HashMap<>(entry.getValue())))));
+        this.tempStorageProperties = requireNonNull(tempStorageProperties, "tempStorageProperties is null")
                 .map(map -> map.entrySet().stream()
                         .collect(toMap(Map.Entry::getKey, entry -> unmodifiableMap(new HashMap<>(entry.getValue())))));
     }
@@ -96,5 +101,10 @@ public class PrestoSparkConfiguration
     public Optional<Map<String, Map<String, String>>> getFunctionNamespaceProperties()
     {
         return functionNamespaceProperties;
+    }
+
+    public Optional<Map<String, Map<String, String>>> getTempStorageProperties()
+    {
+        return tempStorageProperties;
     }
 }

--- a/presto-spark-launcher/src/main/java/com/facebook/presto/spark/launcher/PrestoSparkDistribution.java
+++ b/presto-spark-launcher/src/main/java/com/facebook/presto/spark/launcher/PrestoSparkDistribution.java
@@ -36,6 +36,7 @@ public class PrestoSparkDistribution
     private final Optional<Map<String, String>> accessControlProperties;
     private final Optional<Map<String, String>> sessionPropertyConfigurationProperties;
     private final Optional<Map<String, Map<String, String>>> functionNamespaceProperties;
+    private final Optional<Map<String, Map<String, String>>> tempStorageProperties;
 
     public PrestoSparkDistribution(
             SparkContext sparkContext,
@@ -46,7 +47,8 @@ public class PrestoSparkDistribution
             Optional<Map<String, String>> eventListenerProperties,
             Optional<Map<String, String>> accessControlProperties,
             Optional<Map<String, String>> sessionPropertyConfigurationProperties,
-            Optional<Map<String, Map<String, String>>> functionNamespaceProperties)
+            Optional<Map<String, Map<String, String>>> functionNamespaceProperties,
+            Optional<Map<String, Map<String, String>>> tempStorageProperties)
     {
         this.sparkContext = requireNonNull(sparkContext, "sparkContext is null");
         this.packageSupplier = requireNonNull(packageSupplier, "packageSupplier is null");
@@ -61,6 +63,9 @@ public class PrestoSparkDistribution
         this.sessionPropertyConfigurationProperties = requireNonNull(sessionPropertyConfigurationProperties, "sessionPropertyConfigurationProperties is null")
                 .map(properties -> unmodifiableMap(new HashMap<>(properties)));
         this.functionNamespaceProperties = requireNonNull(functionNamespaceProperties, "functionNamespaceProperties is null")
+                .map(map -> map.entrySet().stream()
+                        .collect(toMap(Map.Entry::getKey, entry -> unmodifiableMap(new HashMap<>(entry.getValue())))));
+        this.tempStorageProperties = requireNonNull(tempStorageProperties, "tempStorageProperties is null")
                 .map(map -> map.entrySet().stream()
                         .collect(toMap(Map.Entry::getKey, entry -> unmodifiableMap(new HashMap<>(entry.getValue())))));
     }
@@ -108,5 +113,10 @@ public class PrestoSparkDistribution
     public Optional<Map<String, Map<String, String>>> getFunctionNamespaceProperties()
     {
         return functionNamespaceProperties;
+    }
+
+    public Optional<Map<String, Map<String, String>>> getTempStorageProperties()
+    {
+        return tempStorageProperties;
     }
 }

--- a/presto-spark-launcher/src/main/java/com/facebook/presto/spark/launcher/PrestoSparkLauncherCommand.java
+++ b/presto-spark-launcher/src/main/java/com/facebook/presto/spark/launcher/PrestoSparkLauncherCommand.java
@@ -61,6 +61,7 @@ public class PrestoSparkLauncherCommand
                 Optional.empty(),
                 Optional.empty(),
                 Optional.empty(),
+                Optional.empty(),
                 Optional.empty());
 
         try (PrestoSparkRunner runner = new PrestoSparkRunner(distribution)) {

--- a/presto-spark-launcher/src/main/java/com/facebook/presto/spark/launcher/PrestoSparkRunner.java
+++ b/presto-spark-launcher/src/main/java/com/facebook/presto/spark/launcher/PrestoSparkRunner.java
@@ -62,7 +62,8 @@ public class PrestoSparkRunner
                 distribution.getEventListenerProperties(),
                 distribution.getAccessControlProperties(),
                 distribution.getSessionPropertyConfigurationProperties(),
-                distribution.getFunctionNamespaceProperties());
+                distribution.getFunctionNamespaceProperties(),
+                distribution.getTempStorageProperties());
     }
 
     public void run(
@@ -157,7 +158,8 @@ public class PrestoSparkRunner
             Optional<Map<String, String>> eventListenerProperties,
             Optional<Map<String, String>> accessControlProperties,
             Optional<Map<String, String>> sessionPropertyConfigurationProperties,
-            Optional<Map<String, Map<String, String>>> functionNamespaceProperties)
+            Optional<Map<String, Map<String, String>>> functionNamespaceProperties,
+            Optional<Map<String, Map<String, String>>> tempStorageProperties)
     {
         String packagePath = getPackagePath(packageSupplier);
         File pluginsDirectory = checkDirectory(new File(packagePath, "plugin"));
@@ -169,7 +171,8 @@ public class PrestoSparkRunner
                 eventListenerProperties,
                 accessControlProperties,
                 sessionPropertyConfigurationProperties,
-                functionNamespaceProperties);
+                functionNamespaceProperties,
+                tempStorageProperties);
         IPrestoSparkServiceFactory serviceFactory = createServiceFactory(checkDirectory(new File(packagePath, "lib")));
         return serviceFactory.createService(sparkProcessType, configuration);
     }
@@ -190,6 +193,7 @@ public class PrestoSparkRunner
         private final Map<String, String> accessControlProperties;
         private final Map<String, String> sessionPropertyConfigurationProperties;
         private final Map<String, Map<String, String>> functionNamespaceProperties;
+        private final Map<String, Map<String, String>> tempStorageProperties;
 
         public DistributionBasedPrestoSparkTaskExecutorFactoryProvider(PrestoSparkDistribution distribution)
         {
@@ -203,6 +207,7 @@ public class PrestoSparkRunner
             this.accessControlProperties = distribution.getAccessControlProperties().orElse(null);
             this.sessionPropertyConfigurationProperties = distribution.getSessionPropertyConfigurationProperties().orElse(null);
             this.functionNamespaceProperties = distribution.getFunctionNamespaceProperties().orElse(null);
+            this.tempStorageProperties = distribution.getTempStorageProperties().orElse(null);
         }
 
         @Override
@@ -222,6 +227,7 @@ public class PrestoSparkRunner
         private static Map<String, String> currentAccessControlProperties;
         private static Map<String, String> currentSessionPropertyConfigurationProperties;
         private static Map<String, Map<String, String>> currentFunctionNamespaceProperties;
+        private static Map<String, Map<String, String>> currentTempStorageProperties;
 
         private IPrestoSparkService getOrCreatePrestoSparkService()
         {
@@ -236,7 +242,8 @@ public class PrestoSparkRunner
                             Optional.ofNullable(eventListenerProperties),
                             Optional.ofNullable(accessControlProperties),
                             Optional.ofNullable(sessionPropertyConfigurationProperties),
-                            Optional.ofNullable(functionNamespaceProperties));
+                            Optional.ofNullable(functionNamespaceProperties),
+                            Optional.ofNullable(tempStorageProperties));
 
                     currentMetadataStorageType = metadataStorageType;
                     currentPackagePath = getPackagePath(packageSupplier);
@@ -246,6 +253,7 @@ public class PrestoSparkRunner
                     currentAccessControlProperties = accessControlProperties;
                     currentSessionPropertyConfigurationProperties = sessionPropertyConfigurationProperties;
                     currentFunctionNamespaceProperties = functionNamespaceProperties;
+                    currentTempStorageProperties = tempStorageProperties;
                 }
                 else {
                     checkEquals("packagePath", currentPackagePath, getPackagePath(packageSupplier));
@@ -258,6 +266,7 @@ public class PrestoSparkRunner
                             currentSessionPropertyConfigurationProperties,
                             sessionPropertyConfigurationProperties);
                     checkEquals("functionNamespaceProperties", currentFunctionNamespaceProperties, functionNamespaceProperties);
+                    checkEquals("tempStorageProperties", currentTempStorageProperties, tempStorageProperties);
                 }
                 return service;
             }


### PR DESCRIPTION
Storage based broadcast join uses tempstorage for distributing
hash tables across workers. tempStorage needs to configured
uniquely for broadcast spills like increasing replica factor etc
to improve reliability and availability of spill files. We should have 
the ability to tune storage configs for a specific usecases like 
broadcast join etc.

```
== NO RELEASE NOTE ==
```
