### PR TITLE
Update joda to 2.10.8 tzdata 2020d

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,9 @@
         <dep.jdbi3.version>3.4.0</dep.jdbi3.version>
         <dep.oracle.version>19.3.0.0</dep.oracle.version>
         <dep.drift.version>1.32</dep.drift.version>
-        <dep.joda.version>2.10.6</dep.joda.version>
+        <!-- Changing joda version changes tzdata which must match deployed JVM tzdata
+             Do not change this without also making sure it matches -->
+        <dep.joda.version>2.10.8</dep.joda.version>
         <dep.tempto.version>1.51</dep.tempto.version>
         <dep.testng.version>6.10</dep.testng.version>
         <dep.assertj-core.version>3.8.0</dep.assertj-core.version>

--- a/presto-common/src/main/resources/com/facebook/presto/common/type/zone-index.properties
+++ b/presto-common/src/main/resources/com/facebook/presto/common/type/zone-index.properties
@@ -2180,7 +2180,7 @@
 2171 US/Michigan
 2172 US/Mountain
 2173 US/Pacific
-2174 US/Pacific-New
+# 2174 US/Pacific-New removed http://mm.icann.org/pipermail/tz-announce/2020-October/000059.html
 2175 US/Samoa
 2176 CET
 2177 CST6CDT

--- a/presto-common/src/test/java/com/facebook/presto/common/type/TestTimeZoneKey.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/type/TestTimeZoneKey.java
@@ -188,6 +188,9 @@ public class TestTimeZoneKey
         // previous spot for MST
         assertFalse(hasValue[2196]);
         hasValue[2196] = true;
+        // US/Pacific-New removed http://mm.icann.org/pipermail/tz-announce/2020-October/000059.html
+        assertFalse(hasValue[2174]);
+        hasValue[2174] = true;
 
         for (int i = 0; i < hasValue.length; i++) {
             assertTrue(hasValue[i], "There is no time zone with key " + i);
@@ -213,7 +216,7 @@ public class TestTimeZoneKey
             hasher.putString(timeZoneKey.getId(), StandardCharsets.UTF_8);
         }
         // Zone file should not (normally) be changed, so let's make this more difficult
-        assertEquals(hasher.hash().asLong(), -3809591333307967388L, "zone-index.properties file contents changed!");
+        assertEquals(hasher.hash().asLong(), 6334606028834602490L, "zone-index.properties file contents changed!");
     }
 
     public void assertTimeZoneNotSupported(String zoneId)

--- a/presto-main/src/test/java/com/facebook/presto/util/TestTimeZoneUtils.java
+++ b/presto-main/src/test/java/com/facebook/presto/util/TestTimeZoneUtils.java
@@ -60,6 +60,13 @@ public class TestTimeZoneUtils
                 continue;
             }
 
+            if (zoneId.equals("US/Pacific-New")) {
+                // TODO: Remove once minimum Java version is increased 11.0.10
+                // https://www.oracle.com/java/technologies/tzdata-versions.html
+                // http://mm.icann.org/pipermail/tz-announce/2020-October/000059.html
+                continue;
+            }
+
             DateTimeZone dateTimeZone = DateTimeZone.forID(zoneId);
             DateTimeZone indexedZone = getDateTimeZone(TimeZoneKey.getTimeZoneKey(zoneId));
 


### PR DESCRIPTION
Test plan - Unit tests

```
== RELEASE NOTES ==

General Changes
* Update joda to 2.10.8 tzdata 2020d. Make sure you deploy with a JVM that is using matching tzdata.
```

depends on https://github.com/facebookexternal/presto-facebook/pull/1442