### PR TITLE
Correct presto-product-tests README errors

### DIFF
--- a/presto-product-tests/README.md
+++ b/presto-product-tests/README.md
@@ -283,9 +283,9 @@ setup outlined below:
 
     ```
     presto-product-tests/conf/docker/singlenode/compose.sh up -d hadoop-master
-    presto-product-tests/conf/docker/singlenode/compose.sh up -d mysql
-    presto-product-tests/conf/docker/singlenode/compose.sh up -d postgres
-    presto-product-tests/conf/docker/singlenode/compose.sh up -d cassandra
+    presto-product-tests/conf/docker/singlenode-mysql/compose.sh up -d mysql
+    presto-product-tests/conf/docker/singlenode-postgresql/compose.sh up -d postgres
+    presto-product-tests/conf/docker/singlenode-cassandra/compose.sh up -d cassandra
     ```
     
     Tip: To display container logs run:


### PR DESCRIPTION
The instructions in "Start Presto dependent services as Docker
containers" has errors. You will get "ERROR: No such service: mysql"
if you copy and run the commands. Correct the command path should
fix it.



Test plan - No test plan

```
== NO RELEASE NOTE ==
```
