### PR TITLE
Improve processing time for Presto on spark events

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkTaskExecutorFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkTaskExecutorFactory.java
@@ -707,8 +707,6 @@ public class PrestoSparkTaskExecutorFactory
 
             TaskInfo taskInfo = createTaskInfo(taskContext, taskStateMachine, taskInstanceId, outputBufferType, outputBuffer);
             SerializedTaskInfo serializedTaskInfo = new SerializedTaskInfo(
-                    taskInfo.getTaskId().getStageExecutionId().getStageId().getId(),
-                    taskInfo.getTaskId().getId(),
                     compress(taskInfoJsonCodec.toJsonBytes(taskInfo)));
             taskInfoCollector.add(serializedTaskInfo);
 

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkShuffleStats.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkShuffleStats.java
@@ -15,9 +15,7 @@ package com.facebook.presto.spark.classloader_interface;
 
 import java.io.Serializable;
 
-import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
-import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.spark_project.guava.base.Preconditions.checkArgument;
 
 public class PrestoSparkShuffleStats
@@ -97,14 +95,6 @@ public class PrestoSparkShuffleStats
     @Override
     public String toString()
     {
-        // readable summary to be displayed at the Spark web interface
-        return format(
-                "%s.%s:%s:%sM:%sMB:%smin",
-                fragmentId,
-                taskId,
-                operation.toString().charAt(0),
-                processedRows / 1000 / 1000,
-                processedBytes / 1024 / 1024,
-                MILLISECONDS.toMinutes(elapsedWallTimeMills));
+        return "";
     }
 }

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/SerializedTaskInfo.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/SerializedTaskInfo.java
@@ -20,14 +20,10 @@ import static java.util.Objects.requireNonNull;
 public class SerializedTaskInfo
         implements Serializable
 {
-    private final int fragmentId;
-    private final int taskId;
     private final byte[] bytes;
 
-    public SerializedTaskInfo(int fragmentId, int taskId, byte[] bytes)
+    public SerializedTaskInfo(byte[] bytes)
     {
-        this.fragmentId = fragmentId;
-        this.taskId = taskId;
         this.bytes = requireNonNull(bytes, "bytes is null");
     }
 
@@ -40,6 +36,6 @@ public class SerializedTaskInfo
     // Displayed at the Spark web interface
     public String toString()
     {
-        return fragmentId + "." + taskId;
+        return "";
     }
 }


### PR DESCRIPTION
Spark queries with very high parallelism can generate a
large number of events. These events needs to be processed
before spark context can stop. If processing is slower, spark
driver can take long time to exit and events can be dropped
which would result in stale Spark UI. Driver profile shows a
large amount of time being spent in toString() method. This
information is not useful in Spark UI and thus we can just
return an empty string.

```
== NO RELEASE NOTE ==
```
