### PR TITLE
Fix Input Rows reporting in TableScan operators

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/TableScanOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TableScanOperator.java
@@ -254,8 +254,7 @@ public class TableScanOperator
             page = page.getLoadedPage();
 
             // update operator stats
-            operatorContext.recordProcessedInput(page.getSizeInBytes(), page.getPositionCount());
-            recordSourceRawInputStats();
+            recordInputStats();
         }
 
         // updating system memory usage should happen after page is loaded.
@@ -264,14 +263,17 @@ public class TableScanOperator
         return page;
     }
 
-    private void recordSourceRawInputStats()
+    private void recordInputStats()
     {
         checkState(source != null, "source must not be null");
         // update operator stats
         long endCompletedBytes = source.getCompletedBytes();
         long endCompletedPositions = source.getCompletedPositions();
         long endReadTimeNanos = source.getReadTimeNanos();
-        operatorContext.recordRawInputWithTiming(endCompletedBytes - completedBytes, endCompletedPositions - completedPositions, endReadTimeNanos - readTimeNanos);
+        long inputBytes = endCompletedBytes - completedBytes;
+        long positionCount = endCompletedPositions - completedPositions;
+        operatorContext.recordProcessedInput(inputBytes, positionCount);
+        operatorContext.recordRawInputWithTiming(inputBytes, positionCount, endReadTimeNanos - readTimeNanos);
         completedBytes = endCompletedBytes;
         completedPositions = endCompletedPositions;
         readTimeNanos = endReadTimeNanos;


### PR DESCRIPTION
TableScan and ScanFilterProject operators reported input size and
position count as they were after applying pushed down filters. This
made the overal Input Rows counter for the query incorrect.

For example, select * from nation where nationkey % 2 = 0 reported
Input Rows as 13 instead of 25.

This commit fixes TableScan and ScanFilterProject to report input size
and position count as they are before applying pushed down filter.

presto:tpch> explain analyze select sum(nationkey + 1) from nation where nationkey < 2

         - ScanProject[table = TableHandle {connectorId='hive', connectorHandle='HiveTableHandle{schemaName=tpch, tableName=nation, analyzePartitionValues=Optional.empty}', layout='Optional[tpch.nation{domains={nationkey=[ [(<min>, 2)] ]}}]'}, grouped = false, projectLocality = LOCAL] => [expr:bigint]
                 CPU: 4.00ms (100.00%), Scheduled: 9.00ms (47.37%), Output: 2 rows (18B)
                 Input: 25 rows (1.47kB), Filtered: 92.00%

Query 20210309_010704_00007_wbiq7, FINISHED, 2 nodes
Splits: 11 total, 11 done (100.00%)
0:00 [25 rows, 1.47KB] [78 rows/s, 4.64KB/s]

presto:tpch> explain analyze select count(*) from nation where nationkey < 2;

         - TableScan[TableHandle {connectorId='hive', connectorHandle='HiveTableHandle{schemaName=tpch, tableName=nation, analyzePartitionValues=Optional.empty}', layout='Optional[tpch.nation{domains={nationkey=[ [(<min>, 2)] ]}}]'}, grouped = false] => []
                 CPU: 4.00ms (100.00%), Scheduled: 6.00ms (35.29%), Output: 2 rows (0B)
                 Input: 25 rows (1.47kB), Filtered: 92.00%

Query 20210309_010630_00006_wbiq7, FINISHED, 3 nodes
Splits: 11 total, 11 done (100.00%)
0:00 [25 rows, 1.47KB] [86 rows/s, 5.06KB/s]

```
== NO RELEASE NOTE ==
```
