### PR TITLE
Minor improvement to SpillableFinalOnlyGroupedAccumulator

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/GenericAccumulatorFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/GenericAccumulatorFactory.java
@@ -666,7 +666,7 @@ public class GenericAccumulatorFactory
             for (int i = 0; i < groupIdsBlock.getPositionCount(); i++) {
                 long currentGroupId = groupIdsBlock.getGroupId(i);
                 groupIdCount.ensureCapacity(currentGroupId);
-                groupIdCount.set(currentGroupId, groupIdCount.get(currentGroupId) + 1);
+                groupIdCount.increment(currentGroupId);
             }
         }
 


### PR DESCRIPTION
Uses `IntBigArray#increment(index)` instead of `IntBigArray#set(index, IntBigArray#get(index) + 1)` which avoids traversing the 2D array twice, following up from https://github.com/prestodb/presto/pull/15775
```
== NO RELEASE NOTE ==
```
