### PR TITLE
Update hive-apache to 3.0.0-3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -581,7 +581,7 @@
             <dependency>
                 <groupId>com.facebook.presto.hive</groupId>
                 <artifactId>hive-apache</artifactId>
-                <version>3.0.0-2</version>
+                <version>3.0.0-3</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Includes a performance improvement for the Hive JsonSerDe from https://github.com/prestodb/presto-hive-apache/pull/44

```
== NO RELEASE NOTE ==
```

depends on https://github.com/facebookexternal/presto-facebook/pull/1444