### PR TITLE
add logistic cdf and inverse cdf (#15798)

### DIFF
--- a/presto-docs/src/main/sphinx/functions/math.rst
+++ b/presto-docs/src/main/sphinx/functions/math.rst
@@ -184,6 +184,12 @@ Probability Functions: cdf
     Compute the Chi-square cdf with given df (degrees of freedom) parameter:  P(N < value; df).
     The df parameter must be a positive real number, and value must be a non-negative real value (both of type DOUBLE).
 
+.. function:: logistic_cdf(mu, s, value) -> double
+
+    Compute the logistic cdf with given mu, s parameters:  P(N < v; mu, s).
+    The s parameter must be a positive real number and value v must be a real value.
+    The value v must lie on the interval [0, 1].
+
 .. function:: normal_cdf(mean, sd, value) -> double
 
     Compute the Normal cdf with given mean and standard deviation (sd):  P(N < value; mean, sd).
@@ -226,6 +232,12 @@ Probability Functions: inverse_cdf
 
     Compute the inverse of the Chi-square cdf with given df (degrees of freedom) parameter for the cumulative
     probability (p): P(N < n). The df parameter must be positive real values.
+    The probability p must lie on the interval [0, 1].
+
+.. function:: inverse_logistic_cdf(mu, s, p) -> double
+
+    Compute the inverse of the logistic cdf with given mu, s parameters for the cumulative
+    probability (p): P(N < n). The s parameter must be a positive real value.
     The probability p must lie on the interval [0, 1].
 
 .. function:: inverse_normal_cdf(mean, sd, p) -> double

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
@@ -34,6 +34,7 @@ import org.apache.commons.math3.distribution.BetaDistribution;
 import org.apache.commons.math3.distribution.BinomialDistribution;
 import org.apache.commons.math3.distribution.CauchyDistribution;
 import org.apache.commons.math3.distribution.ChiSquaredDistribution;
+import org.apache.commons.math3.distribution.LogisticDistribution;
 import org.apache.commons.math3.distribution.PoissonDistribution;
 import org.apache.commons.math3.distribution.WeibullDistribution;
 import org.apache.commons.math3.special.Erf;
@@ -788,6 +789,33 @@ public final class MathFunctions
         checkCondition(value >= 0, INVALID_FUNCTION_ARGUMENT, "value must non-negative");
         checkCondition(df > 0, INVALID_FUNCTION_ARGUMENT, "df must be greater than 0");
         ChiSquaredDistribution distribution = new ChiSquaredDistribution(null, df, ChiSquaredDistribution.DEFAULT_INVERSE_ABSOLUTE_ACCURACY);
+        return distribution.cumulativeProbability(value);
+    }
+
+    @Description("Inverse of logistic cdf given mu, s parameters and probability")
+    @ScalarFunction
+    @SqlType(StandardTypes.DOUBLE)
+    public static double inverseLogisticCdf(
+            @SqlType(StandardTypes.DOUBLE) double mu,
+            @SqlType(StandardTypes.DOUBLE) double s,
+            @SqlType(StandardTypes.DOUBLE) double p)
+    {
+        checkCondition(p >= 0 && p <= 1, INVALID_FUNCTION_ARGUMENT, "p must be in the interval [0, 1]");
+        checkCondition(s > 0, INVALID_FUNCTION_ARGUMENT, "s must be greater than 0");
+        LogisticDistribution distribution = new LogisticDistribution(null, mu, s);
+        return distribution.inverseCumulativeProbability(p);
+    }
+
+    @Description("Logistic cdf given the mu, s parameters and value")
+    @ScalarFunction
+    @SqlType(StandardTypes.DOUBLE)
+    public static double logisticCdf(
+            @SqlType(StandardTypes.DOUBLE) double mu,
+            @SqlType(StandardTypes.DOUBLE) double s,
+            @SqlType(StandardTypes.DOUBLE) double value)
+    {
+        checkCondition(s > 0, INVALID_FUNCTION_ARGUMENT, "s must be greater than 0");
+        LogisticDistribution distribution = new LogisticDistribution(null, mu, s);
         return distribution.cumulativeProbability(value);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
@@ -1452,6 +1452,29 @@ public class TestMathFunctions
     }
 
     @Test
+    public void testInverseLogisticCdf()
+    {
+        assertFunction("inverse_logistic_cdf(0, 1, 0.5)", DOUBLE, 0.0);
+        assertFunction("inverse_logistic_cdf(0, 1, 0.0)", DOUBLE, Double.NEGATIVE_INFINITY);
+        assertFunction("inverse_logistic_cdf(0, 1, 1.0)", DOUBLE, Double.POSITIVE_INFINITY);
+
+        assertInvalidFunction("inverse_logistic_cdf(0, -1, 0.5)", "s must be greater than 0");
+        assertInvalidFunction("inverse_logistic_cdf(0, 1, -0.1)", "p must be in the interval [0, 1]");
+        assertInvalidFunction("inverse_logistic_cdf(0, 1, 1.1)", "p must be in the interval [0, 1]");
+    }
+
+    @Test
+    public void testLogisticCdf()
+            throws Exception
+    {
+        assertFunction("logistic_cdf(0, 1, 0.0)", DOUBLE, 0.5);
+        assertFunction("logistic_cdf(1, 1, 1.0)", DOUBLE, 0.5);
+        assertFunction("logistic_cdf(1, 1, infinity())", DOUBLE, 1.0);
+
+        assertInvalidFunction("logistic_cdf(0, -1, 0.5)", "s must be greater than 0");
+    }
+
+    @Test
     public void testInversePoissonCdf()
     {
         assertFunction("inverse_poisson_cdf(3, 0.0)", INTEGER, 0);


### PR DESCRIPTION
Test plan - built locally

Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines. Don't forget to follow our [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution) for any code copied from other projects.

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== RELEASE NOTES ==

General Changes
* Added `logistic_cdf()` and `inverse_logistic_cdf()` functions
```
