### PR TITLE
add t_statistic(), paired_t_statistic() agg functions (#15798)

### DIFF
--- a/presto-docs/src/main/sphinx/functions/aggregate.rst
+++ b/presto-docs/src/main/sphinx/functions/aggregate.rst
@@ -411,6 +411,15 @@ Statistical Aggregate Functions
 
     Returns the sample variance of all input values.
 
+.. function:: t_statistic(x) -> double
+
+    Returns the one-sample Student's t-statistic for all
+    input values.
+
+.. function:: paired_t_statistic(x, y) -> double
+
+    Returns the paired Student's t-statistic for the
+    difference ``y - x`` for all input values.
 
 Classification Metrics Aggregate Functions
 ------------------------------------------

--- a/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
@@ -67,6 +67,7 @@ import com.facebook.presto.operator.aggregation.MaxDataSizeForStats;
 import com.facebook.presto.operator.aggregation.MergeHyperLogLogAggregation;
 import com.facebook.presto.operator.aggregation.MergeQuantileDigestFunction;
 import com.facebook.presto.operator.aggregation.MergeTDigestFunction;
+import com.facebook.presto.operator.aggregation.PairedTStatisticAggregation;
 import com.facebook.presto.operator.aggregation.RealCorrelationAggregation;
 import com.facebook.presto.operator.aggregation.RealCovarianceAggregation;
 import com.facebook.presto.operator.aggregation.RealGeometricMeanAggregations;
@@ -75,6 +76,7 @@ import com.facebook.presto.operator.aggregation.RealRegressionAggregation;
 import com.facebook.presto.operator.aggregation.RealSumAggregation;
 import com.facebook.presto.operator.aggregation.ReduceAggregationFunction;
 import com.facebook.presto.operator.aggregation.SumDataSizeForStats;
+import com.facebook.presto.operator.aggregation.TStatisticAggregation;
 import com.facebook.presto.operator.aggregation.VarianceAggregation;
 import com.facebook.presto.operator.aggregation.approxmostfrequent.BigintApproximateMostFrequent;
 import com.facebook.presto.operator.aggregation.approxmostfrequent.VarcharApproximateMostFrequent;
@@ -591,6 +593,8 @@ public class BuiltInTypeAndFunctionNamespaceManager
                 .aggregates(CentralMomentsAggregation.class)
                 .aggregates(ApproximateLongPercentileAggregations.class)
                 .aggregates(ApproximateLongPercentileArrayAggregations.class)
+                .aggregates(TStatisticAggregation.class)
+                .aggregates(PairedTStatisticAggregation.class)
                 .aggregates(ApproximateDoublePercentileAggregations.class)
                 .aggregates(ApproximateDoublePercentileArrayAggregations.class)
                 .aggregates(ApproximateRealPercentileAggregations.class)

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/PairedTStatisticAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/PairedTStatisticAggregation.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.operator.aggregation.state.CentralMomentsState;
+import com.facebook.presto.spi.function.AggregationFunction;
+import com.facebook.presto.spi.function.AggregationState;
+import com.facebook.presto.spi.function.CombineFunction;
+import com.facebook.presto.spi.function.Description;
+import com.facebook.presto.spi.function.InputFunction;
+import com.facebook.presto.spi.function.OutputFunction;
+import com.facebook.presto.spi.function.SqlType;
+
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.operator.aggregation.AggregationUtils.mergeCentralMomentsState;
+import static com.facebook.presto.operator.aggregation.AggregationUtils.updateCentralMomentsState;
+
+@AggregationFunction
+@Description("Returns the paired t-statistic")
+public final class PairedTStatisticAggregation
+{
+    private PairedTStatisticAggregation() {}
+
+    @InputFunction
+    public static void doubleInput(@AggregationState CentralMomentsState state, @SqlType(StandardTypes.DOUBLE) double x, @SqlType(StandardTypes.DOUBLE) double y)
+    {
+        double value = y - x;
+        updateCentralMomentsState(state, value);
+    }
+
+    @InputFunction
+    public static void intInput(@AggregationState CentralMomentsState state, @SqlType(StandardTypes.INTEGER) long x, @SqlType(StandardTypes.INTEGER) long y)
+    {
+        double value = y - x;
+        updateCentralMomentsState(state, (double) value);
+    }
+
+    @CombineFunction
+    public static void combine(@AggregationState CentralMomentsState state, @AggregationState CentralMomentsState otherState)
+    {
+        mergeCentralMomentsState(state, otherState);
+    }
+
+    @AggregationFunction(value = "paired_t_statistic")
+    @Description("Returns the Student's t-statistic for the paired t-test")
+    @OutputFunction(StandardTypes.DOUBLE)
+    public static void paired_t_statistic(@AggregationState CentralMomentsState state, BlockBuilder out)
+    {
+        long n = state.getCount();
+
+        if (n < 2) {
+            out.appendNull();
+        }
+        else {
+            double sampStdDev = Math.sqrt(state.getM2() / (state.getCount() - 1));
+            double result = state.getM1() / (sampStdDev / Math.sqrt(state.getCount()));
+            DOUBLE.writeDouble(out, result);
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/TStatisticAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/TStatisticAggregation.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.operator.aggregation.state.CentralMomentsState;
+import com.facebook.presto.spi.function.AggregationFunction;
+import com.facebook.presto.spi.function.AggregationState;
+import com.facebook.presto.spi.function.CombineFunction;
+import com.facebook.presto.spi.function.Description;
+import com.facebook.presto.spi.function.InputFunction;
+import com.facebook.presto.spi.function.OutputFunction;
+import com.facebook.presto.spi.function.SqlType;
+
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.operator.aggregation.AggregationUtils.mergeCentralMomentsState;
+import static com.facebook.presto.operator.aggregation.AggregationUtils.updateCentralMomentsState;
+
+@AggregationFunction
+@Description("Returns the Student's t-statistic")
+public final class TStatisticAggregation
+{
+    private TStatisticAggregation() {}
+
+    @InputFunction
+    public static void input(@AggregationState CentralMomentsState state, @SqlType(StandardTypes.DOUBLE) double value)
+    {
+        updateCentralMomentsState(state, value);
+    }
+
+    @InputFunction
+    public static void input(@AggregationState CentralMomentsState state, @SqlType(StandardTypes.BIGINT) long value)
+    {
+        updateCentralMomentsState(state, (double) value);
+    }
+
+    @CombineFunction
+    public static void combine(@AggregationState CentralMomentsState state, @AggregationState CentralMomentsState otherState)
+    {
+        mergeCentralMomentsState(state, otherState);
+    }
+
+    @AggregationFunction(value = "t_statistic")
+    @Description("Returns the Student's t-statistic for the one-sample t-test")
+    @OutputFunction(StandardTypes.DOUBLE)
+    public static void t_statistic(@AggregationState CentralMomentsState state, BlockBuilder out)
+    {
+        long n = state.getCount();
+
+        if (n < 2) {
+            out.appendNull();
+        }
+        else {
+            double sampStdDev = Math.sqrt(state.getM2() / (state.getCount() - 1));
+            double result = state.getM1() / (sampStdDev / Math.sqrt(state.getCount()));
+            DOUBLE.writeDouble(out, result);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Added new t-statistic aggregation functions.
- Student's t distribution statistics provided by scalar functions in #15809

## Test plan

Tested interactively and compared results to R:

```
$ java -jar presto-cli/target/presto-cli-*-executable.jar --catalog tpch --schema sf10

SELECT
  t_statistic(a) AS t_a,
  t_statistic(b) AS t_b,
  paired_t_statistic(a, b) as t_paired_diff
FROM (
VALUES
  (30.02, 29.89),
  (29.99, 29.93), 
  (30.11, 29.72),
  (39.97, 29.98),
  (30.01, 30.02),
  (29.99, 29.98)
) AS t (a, b);

        t_a        |       t_b        |   t_paired_diff    
-------------------+------------------+--------------------
 19.11105607133625 | 679.298607343007 | -1.069793672096585 
(1 row)

Query 20210311_162206_00001_i4ig7, FINISHED, 1 node
Splits: 6 total, 6 done (100.00%)
0:02 [0 rows, 0B] [0 rows/s, 0B/s]


$ R 
a <- c(30.02, 29.99, 30.11, 39.97, 30.01, 29.99)
b <- c(29.89, 29.93, 29.72, 29.98, 30.02, 29.98)

# paired
t.test(b, a, paired = TRUE)$statistic
##        t 
## -1.069794

# unpaired one-sample (b) 
t.test(a)$statistic
##        t 
## 19.11106

# unpaired one-sample (b)
t.test(b)$statistic
##        t 
## 679.2986 
```

Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines. Don't forget to follow our [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution) for any code copied from other projects.

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== RELEASE NOTES ==

General Changes
* Added one-sample Student's t-test `t_statistic()` aggregation function
* Added paired two-sample Student's t-test `paired_t_statistic()` aggregation function
```
