### PR TITLE
[TEST] Add release notes for 0.249

### DIFF
--- a/presto-docs/src/main/sphinx/release.rst
+++ b/presto-docs/src/main/sphinx/release.rst
@@ -5,6 +5,7 @@ Release Notes
 .. toctree::
     :maxdepth: 1
 
+    release/release-0.249
     release/release-0.248
     release/release-0.247
     release/release-0.246

--- a/presto-docs/src/main/sphinx/release/release-0.249.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.249.rst
@@ -1,0 +1,25 @@
+=============
+Release 0.249
+=============
+
+**Highlights**
+==============
+
+**Details**
+===========
+
+General Changes
+_______________
+* Fix an error executing index joins when join spilling is enabled.
+* Enforce ``max_total_memory_per_node`` on user memory allocation.
+
+Hive Changes
+____________
+* Fix a bug when S3 access is compromised across s3 enabled hive catalogs (:pr:`15800`).
+* Add Support for Hive Connector to work with Hive 3 metastore for basic tables (ACID Tables and tables using constraints are not supported yet) (:pr:`15805`).
+* Add Support for Hive Connector to work with Hive 3 metastore for basic tables (ACID Tables and tables using constraints are not supported yet) (:pr:`15805`).
+
+**Contributors**
+================
+
+Ajay George, Andrii Rosa, Ariel Weisberg, Arjun Gupta, Arunachalam Thirupathi, Cem Cayiroglu, James Petty, James Sun, John Roll, Ke Wang, Masha Basmanova, Mayank Garg, Neerad Somanchi, Rebecca Schlussel, Rongrong Zhong, Saksham Sachdev, Shixuan Fan, Timothy Meehan, Vic Zhang, Vladimirs Kotovs, Wenlei Xie, agrawalreetika, imjalpreet


### PR DESCRIPTION
# Missing Release Notes
## Andrii Rosa
- [ ] b888504726913f8ac8e521a47f37eb33b6a7e974 Revert "Add PrestoSparkMetadataStorage"
- [ ] 21aec0998137cc9ff2beff935aaec5c679bbefe7 Revert "Add optional sqlLocation to PrestoSparkRunner"
- [ ] 91b907c2d6f9cbd4258bb0c40aba7e6901c0eb1f Revert "Add metadataStorage to PrestoSparkConfiguration"

## Ariel Weisberg
- [ ] https://github.com/prestodb/presto/pull/15787 Update joda to 2.10.8 tzdata 2020d (Merged by: Rebecca Schlussel)
- [ ] https://github.com/prestodb/presto/pull/15778 Add `new_partition_user_supplied_parameter` property (Merged by: Andrii Rosa)

## Arjun Gupta
- [ ] https://github.com/prestodb/presto/pull/15669 Support distribution of broadcast table using disk storage in Presto-on-Spark (Merged by: Andrii Rosa)

## John Roll
- [ ] https://github.com/prestodb/presto/pull/15686 Add Checksum CRC32 to Exchange SerializedPage (Merged by: Andrii Rosa)

## agrawalreetika
- [ ] https://github.com/prestodb/presto/pull/15715 Add readonly for file based system access control (Merged by: Andrii Rosa)

## imjalpreet
- [ ] https://github.com/prestodb/presto/pull/15659 Upgrade to Hive 3.0.0 (Merged by: Rebecca Schlussel)

# Extracted Release Notes
- #15723 (Author: Rebecca Schlussel): Check total memory limit when allocating user memory
  - Enforce ``max_total_memory_per_node`` on user memory allocation.
- #15773 (Author: Rebecca Schlussel): Fix LocalExecutionPlan for IndexJoin when spill enabled
  - Fix an error executing index joins when join spilling is enabled.
- #15800 (Author: imjalpreet): Upgrade hadoop-apache for refreshing S3 FileSystem Cache on Credential Change
  - Fix a bug when S3 access is compromised across s3 enabled hive catalogs (:pr:`15800`).
- #15805 (Author: imjalpreet): Upgrade to Hive 3.0.0
  - Add Support for Hive Connector to work with Hive 3 metastore for basic tables (ACID Tables and tables using constraints are not supported yet) (:pr:`15805`).
- #15805 (Author: imjalpreet): Upgrade to Hive 3.0.0
  - Add Support for Hive Connector to work with Hive 3 metastore for basic tables (ACID Tables and tables using constraints are not supported yet) (:pr:`15805`).

# All Commits
- 51c7888d0a0a54c55f5aa66e4222a8fe4e7e6803 Revert "Avoid planning unnecessary LIMIT/TopN/Sort/DistinctLimit" (Rongrong Zhong)
- a789c3cba0152f5d9640d962bb9de6ad2a8a0f8c Fix reading collection delimiter set by Hive < 3.0 (imjalpreet)
- 3de32e6ba6a3eac18614154a6df914ce4fd74d30 Update to Hive 3.0.0 (imjalpreet)
- 16e6006680edcb9186948a3e9026f8c2388e665c Upgrade hadoop-apache for refreshing S3 FileSystem Cache on Credential Change (imjalpreet)
- 6619eeb68ad25e54b6868df8f7b896aebfc40be5 Revert "Update to Hive 3.0.0" (Neerad Somanchi)
- bf6be9a9bd60abc1b231aa88edb00f2c28fd087c Minor improvement to SpillableFinalOnlyGroupedAccumulator (James Petty)
- 9f44884d2b56293188754d6fcb1f072ef42b06de Bump up alluxio version (Ke Wang)
- 1f1b1d1d0b9f625691617c4d2d5a7ed03011a762 Configure tempstorage for Presto on Spark (Arjun Gupta)
- dfc6aebc268c6fc409ef4ec5977da9a7fa29671b Update hive-apache to 3.0.0-3 (James Petty)
- 06f38c3b9e1e5593129a41b0eec2ea8eb5ade203 Update joda to 2.10.8 tzdata 2020d (Ariel Weisberg)
- fa8874f1ce17dc7d044c71ef109bf68cc5c6c0d8 Fix Input Rows reporting in TableScan operators (Masha Basmanova)
- e4a1d66cdc5b865465232b147bcd8d0ead42f45c Add `new_partition_user_supplied_parameter` property (Ariel Weisberg)
- 0d5ed038e0ae5fef4a6f791efa6491b0456724a4 Improve processing time for Presto on spark events (Arjun Gupta)
- 87e84b2040554cc8981b85b43c9cd941bf2215da Deprecate Joda library in Presto Teradata functions (Vladimirs Kotovs)
- 97ac4974a006ae053298058530afacc8294cfd83 Documentation for Metastore configurations (agrawalreetika)
- dcdedeef0541d74091e046e057845f742ecf18ea Fix overallocation of RowBlockBuilders during aggregation spill (Saksham Sachdev)
- a66d9124d698cdf7bb0c4107a6a89e70f35b1c8a Enforce fixed distribution for output operator (Andrii Rosa)
- b1f85b6a403232858b61d758fdc8defac86d234e Add metadataStorageType to PrestoSparkConfiguration (Vic Zhang)
- ab351bf7d072f97f38e53841a663af79e78c5cac Add optional sqlLocation to PrestoSparkRunner (Vic Zhang)
- e7826a85d47b2995dbf1270c1b83495fec5bc05a Add PrestoSparkMetadataStorage (Vic Zhang)
- 1b72d26500e6a401cf7a765df02afeac08d0e896 Fix LocalExecutionPlan for IndexJoin when spill enabled (Rebecca Schlussel)
- b888504726913f8ac8e521a47f37eb33b6a7e974 Revert "Add PrestoSparkMetadataStorage" (Andrii Rosa)
- 21aec0998137cc9ff2beff935aaec5c679bbefe7 Revert "Add optional sqlLocation to PrestoSparkRunner" (Andrii Rosa)
- 91b907c2d6f9cbd4258bb0c40aba7e6901c0eb1f Revert "Add metadataStorage to PrestoSparkConfiguration" (Andrii Rosa)
- 8471524e3a637ef38009d0433a25d6074aa3291d Add metadataStorage to PrestoSparkConfiguration (Vic Zhang)
- ad1753ebc6e2b57e32eff9bdee3fde22ba9c07c6 Add optional sqlLocation to PrestoSparkRunner (Vic Zhang)
- 474d5844cb0486e2f7b37fee744e70a2da28b66d Add PrestoSparkMetadataStorage (Vic Zhang)
- 4fb658682e5ac6eaf490959a2704d4e1d5fd973d Allow adjusting broadcast memory via session property for PoS (Arjun Gupta)
- c372c58cbb1ed510ec79217fffa37234bfedf577 Register UNKNOWN type same way as other types (Rongrong Zhong)
- bd933262207d87defd838b19a2a7759aa6545ae2 Implement storage based broadcast join in Presto on Spark (Arjun Gupta)
- fd32feac434efd7512df6a5405723816fe1f1fda Update to Hive 3.0.0 (imjalpreet)
- 866578801d36a5fdfb03bf6dc3a882b140f42332 Stop using Travis in favor of GH actions (Ariel Weisberg)
- b043970f4122b5fd242c1916dfea2bdc348ab631 Upgrade fastutil to 8.5.2 (Arunachalam Thirupathi)
- e7a85b3eadc87703a6320d407d9c8e550b614d93 Support enums in SQL functions (Rongrong Zhong)
- 6259ff34917a832f6774cfd3e9ed58d2c6dd7713 CI cache maven repo (Ariel Weisberg)
- b29e78256eb69a37fec5166b8e454e4ec75cbf64 Refactor TempStorage interface (Andrii Rosa)
- a6b1abb31457fc07b18c088349283c6c7f563876 Enable TestBlockBuilder.testNewBlockBuilderLikeForLargeBlockBuilder (Ariel Weisberg)
- e360668b2cc36d0ff1b04e4e53316d6cff3620c9 Add product tests to ci.yml (Ariel Weisberg)
- a1cd3c198fd61d931704ac01956b7ec450395e72 Add Checksum CRC32 to Exchange SerializedPage (John Roll)
- e2ceb67521d327d1f48cf06d0b9d40c984fea143 Skip OOMing testNewBlockBuilderLikeForLargeBlockBuilder (Ariel Weisberg)
- 23f621f451fff60ef3ca09a986cd789987c40b4d Add "America/Nuuk" time zone (Ariel Weisberg)
- 5f5bbe7e8e0e57d698a6fe72701d7d7e5f3c40ea Cherry-pick GH actions scripts from TrinoDB (Ariel Weisberg)
- 06f7801731f52037027101c1763922dc1f7943cd Add readonly for file based system access control (Reetika Agrawal)
- f6b77cad13259bfc8055e056b648c2b7f6c816e5 Support named types in Type and TypeSignature (Rongrong Zhong)
- 0a8158f260cde2eb20cde9041a291fc27d48f9b8 Allow adjusting memory limits with session properties (Arjun Gupta)
- 2358b019ae8428f1615cf449882b48cd7bd49722 Update build badge url from travis-ci.org to travis-ci.com (Ajay George)
- 26a373c269cd68e5497ac670b932c54dad292e6d Add cpu and memory stats to NodeTaskMap (Cem Cayiroglu)
- 201ef82774f523840147fa0d1f0ece97188dd978 Fix task worker host url (Ajay George)
- 6b5268a82095d8a5c6ea5dcca662eaa681ab5b60 Fix adjusted queue size calculation (Mayank Garg)
- d3aea63406489874b17c194f4a41dd8e5ec5d17b Reorder Data Streams in OrcWriter (Arunachalam Thirupathi)
- 4aa0e327bc4ae795152ca1ce23d27be1b6599514 Remove obsolete comment about spill (Rebecca Schlussel)
- d86c679cf641742fa39f3da6c305d9eac4bfbde9 Check total memory limit when allocating user memory (Rebecca Schlussel)
- 29a5e12e084c000aac873148b4b5f1055106695c Supports complex types in reduce_agg (Wenlei Xie)