### PR TITLE
Add Hive session level partition limit enforcement in PlanChecker

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
@@ -118,6 +118,7 @@ public final class HiveSessionProperties
     public static final String MANIFEST_VERIFICATION_ENABLED = "manifest_verification_enabled";
     public static final String NEW_PARTITION_USER_SUPPLIED_PARAMETER = "new_partition_user_supplied_parameter";
     public static final String OPTIMIZED_PARTITION_UPDATE_SERIALIZATION_ENABLED = "optimized_partition_update_serialization_enabled";
+    public static final String MAX_PARTITIONS_PER_SCAN = "max_partitions_per_scan";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -557,7 +558,12 @@ public final class HiveSessionProperties
                         OPTIMIZED_PARTITION_UPDATE_SERIALIZATION_ENABLED,
                         "Serialize PartitionUpdate objects using binary SMILE encoding and compress with the ZSTD compression",
                         hiveClientConfig.isOptimizedPartitionUpdateSerializationEnabled(),
-                        true));
+                        true),
+                integerProperty(
+                        MAX_PARTITIONS_PER_SCAN,
+                        "Maximum allowed partitions for a single table scan",
+                        hiveClientConfig.getMaxPartitionsPerScan(),
+                        false));
     }
 
     public List<PropertyMetadata<?>> getSessionProperties()
@@ -976,5 +982,10 @@ public final class HiveSessionProperties
     public static boolean isOptimizedPartitionUpdateSerializationEnabled(ConnectorSession session)
     {
         return session.getProperty(OPTIMIZED_PARTITION_UPDATE_SERIALIZATION_ENABLED, Boolean.class);
+    }
+
+    public static int getMaxPartitionsPerScan(ConnectorSession session)
+    {
+        return session.getProperty(MAX_PARTITIONS_PER_SCAN, Integer.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
@@ -446,6 +446,8 @@ public interface Metadata
      */
     List<GrantInfo> listTablePrivileges(Session session, QualifiedTablePrefix prefix);
 
+    default void validateScan(Session session, TableHandle table) {}
+
     /**
      * Commits page sink for table creation.
      */

--- a/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
@@ -1346,6 +1346,14 @@ public class MetadataManager
         return metadata.getTableLayoutFilterCoverage(tableHandle.getLayout().get(), relevantPartitionColumns);
     }
 
+    @Override
+    public void validateScan(Session session, TableHandle table)
+    {
+        ConnectorId connectorId = table.getConnectorId();
+        ConnectorMetadata metadata = getMetadata(session, connectorId);
+        metadata.validateScan(session.toConnectorSession(connectorId), table.getConnectorHandle(), table.getLayout());
+    }
+
     private ViewDefinition deserializeView(String data)
     {
         try {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/PlanChecker.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/PlanChecker.java
@@ -74,7 +74,8 @@ public final class PlanChecker
                         new VerifyNoOriginalExpression(),
                         new VerifyProjectionLocality(),
                         new DynamicFiltersChecker(),
-                        new WarnOnScanWithoutPartitionPredicate(featuresConfig))
+                        new WarnOnScanWithoutPartitionPredicate(featuresConfig),
+                        new ValidateTableScan())
                 .build();
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateTableScan.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateTableScan.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.sanity;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.TableScanNode;
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.planner.SimplePlanVisitor;
+import com.facebook.presto.sql.planner.TypeProvider;
+
+public class ValidateTableScan
+        implements PlanChecker.Checker
+{
+    @Override
+    public void validate(PlanNode planNode, Session session, Metadata metadata, SqlParser sqlParser, TypeProvider types, WarningCollector warningCollector)
+    {
+        planNode.accept(new SimplePlanVisitor<Void>()
+        {
+            @Override
+            public Void visitTableScan(TableScanNode node, Void context)
+            {
+                metadata.validateScan(session, node.getTable());
+                return null;
+            }
+        }, null);
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
@@ -753,4 +753,13 @@ public interface ConnectorMetadata
     {
         return NOT_APPLICABLE;
     }
+
+    /**
+     * Allows the connector to reject the table scan produced by the planner.
+     * <p>
+     * Connectors can choose to reject a query based on the table scan potentially being too expensive, for example
+     * if no filtering is done on a partition column.
+     * <p>
+     */
+    default void validateScan(ConnectorSession session, ConnectorTableHandle handle, Optional<ConnectorTableLayoutHandle> layout) {}
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -684,4 +684,12 @@ public class ClassLoaderSafeConnectorMetadata
             return delegate.getTableLayoutFilterCoverage(tableHandle, relevantPartitionColumns);
         }
     }
+
+    @Override
+    public void validateScan(ConnectorSession session, ConnectorTableHandle handle, Optional<ConnectorTableLayoutHandle> layout)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            delegate.validateScan(session, handle, layout);
+        }
+    }
 }


### PR DESCRIPTION
This change is to support the use case of user setting partition limit as a safe guard. Specifically, there is already an existing partition limit hive.max-partitions-per-scan that can be set system wide to enforce max number of partitions a scan can query. 

For this use case, we want to allow skillful users (who knows about Presto internal fundamentals) to further improve their queries by adding another partition limit after filters applied. So in this case, the check of the flow would be:

1. check against hive.max-partitions-per-scan, to see if existing global partition limit exceed
2. if not, apply all the filters, which prune the partitions
3. then check if remaining partitions exceed the new safe guard limit, this can be user/query specific

For reference, the approach we took here is very close to how Trinodb handles a similar problem, as in this PR
https://github.com/trinodb/trino/pull/2334

Test plan - (Please fill in how you tested your changes)

- Added a new unite test to validate the change
- Have deployed and tested on our testing cluster with prod traffic

```
== RELEASE NOTES ==

General Changes
* Allow setting max number of Hive partition a query is allowed to scan at per session level
* This partition limit is added to after all predicates are resolved, so that filters are taken into account

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```
