### PR TITLE
Add dictionary writer benchmark

### DIFF
--- a/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkDictionaryWriter.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkDictionaryWriter.java
@@ -1,0 +1,306 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.orc.metadata.CompressionKind;
+import com.facebook.presto.orc.metadata.CompressionParameters;
+import com.facebook.presto.orc.metadata.statistics.IntegerStatisticsBuilder;
+import com.facebook.presto.orc.metadata.statistics.StringStatisticsBuilder;
+import com.facebook.presto.orc.writer.ColumnWriter;
+import com.facebook.presto.orc.writer.DictionaryColumnWriter;
+import com.facebook.presto.orc.writer.LongColumnWriter;
+import com.facebook.presto.orc.writer.LongDictionaryColumnWriter;
+import com.facebook.presto.orc.writer.SliceDictionaryColumnWriter;
+import com.facebook.presto.orc.writer.SliceDirectColumnWriter;
+import io.airlift.units.DataSize;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.Random;
+import java.util.UUID;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.orc.OrcEncoding.DWRF;
+import static com.facebook.presto.orc.OrcWriterOptions.DEFAULT_MAX_COMPRESSION_BUFFER_SIZE;
+import static com.facebook.presto.orc.OrcWriterOptions.DEFAULT_MAX_STRING_STATISTICS_LIMIT;
+import static com.google.common.base.Preconditions.checkState;
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static java.lang.Math.max;
+import static java.lang.Math.toIntExact;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+@SuppressWarnings("MethodMayBeStatic")
+@State(Scope.Thread)
+@OutputTimeUnit(MILLISECONDS)
+@Fork(0)
+@Warmup(iterations = 3, time = 1000, timeUnit = MILLISECONDS)
+@Measurement(iterations = 10, time = 1000, timeUnit = MILLISECONDS)
+@BenchmarkMode(Mode.AverageTime)
+public class BenchmarkDictionaryWriter
+{
+    private static final int COLUMN_INDEX = 0;
+    private static final int STRING_LIMIT_BYTES = toIntExact(DEFAULT_MAX_STRING_STATISTICS_LIMIT.toBytes());
+
+    private final CompressionParameters compressionParameters = new CompressionParameters(
+            CompressionKind.NONE,
+            OptionalInt.empty(),
+            toIntExact(DEFAULT_MAX_COMPRESSION_BUFFER_SIZE.toBytes()));
+
+    public static void main(String[] args)
+            throws Throwable
+    {
+        Options options = new OptionsBuilder()
+                .verbosity(VerboseMode.NORMAL)
+                .include(".*" + BenchmarkDictionaryWriter.class.getSimpleName() + ".*")
+                .build();
+
+        new Runner(options).run();
+    }
+
+    private StringStatisticsBuilder newStringStatisticsBuilder()
+    {
+        return new StringStatisticsBuilder(STRING_LIMIT_BYTES);
+    }
+
+    @Benchmark
+    public void writeDirect(BenchmarkData data)
+    {
+        ColumnWriter columnWriter;
+        Type type = data.getType();
+        if (type.equals(VARCHAR)) {
+            columnWriter = new SliceDirectColumnWriter(COLUMN_INDEX, type, compressionParameters, Optional.empty(), DWRF, this::newStringStatisticsBuilder, DWRF.createMetadataWriter());
+        }
+        else {
+            columnWriter = new LongColumnWriter(COLUMN_INDEX, type, compressionParameters, Optional.empty(), DWRF, IntegerStatisticsBuilder::new, DWRF.createMetadataWriter());
+        }
+        for (Block block : data.getBlocks()) {
+            columnWriter.beginRowGroup();
+            columnWriter.writeBlock(block);
+            columnWriter.finishRowGroup();
+        }
+        columnWriter.close();
+        columnWriter.reset();
+    }
+
+    @Benchmark
+    public void writeDictionary(BenchmarkData data)
+    {
+        ColumnWriter columnWriter;
+        Type type = data.getType();
+        if (type.equals(VARCHAR)) {
+            columnWriter = new SliceDictionaryColumnWriter(COLUMN_INDEX, type, compressionParameters, Optional.empty(), DWRF, DEFAULT_MAX_STRING_STATISTICS_LIMIT, DWRF.createMetadataWriter());
+        }
+        else {
+            columnWriter = new LongDictionaryColumnWriter(COLUMN_INDEX, type, compressionParameters, Optional.empty(), DWRF, DWRF.createMetadataWriter());
+        }
+        for (Block block : data.getBlocks()) {
+            columnWriter.beginRowGroup();
+            columnWriter.writeBlock(block);
+            columnWriter.finishRowGroup();
+        }
+        columnWriter.close();
+        columnWriter.reset();
+    }
+
+    @Benchmark
+    public void writeDictionaryAndConvert(BenchmarkData data)
+    {
+        DictionaryColumnWriter columnWriter;
+        Type type = data.getType();
+        if (type.equals(VARCHAR)) {
+            columnWriter = new SliceDictionaryColumnWriter(COLUMN_INDEX, type, compressionParameters, Optional.empty(), DWRF, DEFAULT_MAX_STRING_STATISTICS_LIMIT, DWRF.createMetadataWriter());
+        }
+        else {
+            columnWriter = new LongDictionaryColumnWriter(COLUMN_INDEX, type, compressionParameters, Optional.empty(), DWRF, DWRF.createMetadataWriter());
+        }
+        for (Block block : data.getBlocks()) {
+            columnWriter.beginRowGroup();
+            columnWriter.writeBlock(block);
+            columnWriter.finishRowGroup();
+        }
+        int maxDirectBytes = toIntExact(new DataSize(128, MEGABYTE).toBytes());
+        columnWriter.tryConvertToDirect(maxDirectBytes);
+        columnWriter.close();
+        columnWriter.reset();
+    }
+
+    @State(Scope.Thread)
+    public static class BenchmarkData
+    {
+        private static final int NUM_BLOCKS = 10_000;
+        private static final int ROWS_PER_BLOCK = 1_000;
+        private static final String INTEGER_TYPE = "integer";
+        private static final String BIGINT_TYPE = "bigint";
+        private static final String VARCHAR_TYPE = "varchar";
+
+        private final Random random = new Random(0);
+        private final List<Block> blocks;
+
+        @Param({
+                INTEGER_TYPE,
+                BIGINT_TYPE,
+                VARCHAR_TYPE
+        })
+        private String typeSignature = INTEGER_TYPE;
+        @Param({
+                "1",
+                "5",
+                "10",
+                "100"
+        })
+        private String uniqueValuesPercentage = "100";
+        private Type type;
+
+        public BenchmarkData()
+        {
+            blocks = new ArrayList<>();
+        }
+
+        public List<Block> getBlocks()
+        {
+            return blocks;
+        }
+
+        public Type getType()
+        {
+            return type;
+        }
+
+        @Setup
+        public void setUp()
+        {
+            type = getType(typeSignature);
+            for (int i = 0; i < NUM_BLOCKS; i++) {
+                blocks.add(getBlock(ROWS_PER_BLOCK));
+            }
+        }
+
+        private Type getType(String typeSignature)
+        {
+            switch (typeSignature) {
+                case VARCHAR_TYPE:
+                    return VARCHAR;
+                case BIGINT_TYPE:
+                    return BIGINT;
+                case INTEGER_TYPE:
+                    return INTEGER;
+                default:
+                    throw new UnsupportedOperationException("Unsupported type " + typeSignature);
+            }
+        }
+
+        private int getUniqueValues(int numRows)
+        {
+            int value = Integer.parseInt(uniqueValuesPercentage);
+            checkState(value <= 100);
+            int uniqueValues = (int) (value * numRows / 100.0);
+            return max(uniqueValues, 1);
+        }
+
+        private List<String> generateStrings(int numRows)
+        {
+            int valuesToGenerate = getUniqueValues(numRows);
+            List<String> strings = new ArrayList<>(numRows);
+            for (int i = 0; i < valuesToGenerate; i++) {
+                strings.add(UUID.randomUUID().toString());
+            }
+
+            for (int i = valuesToGenerate; i < numRows; i++) {
+                int randomIndex = random.nextInt(valuesToGenerate);
+                strings.add(strings.get(randomIndex));
+            }
+            return strings;
+        }
+
+        private List<Integer> generateIntegers(int numRows)
+        {
+            int valuesToGenerate = getUniqueValues(numRows);
+            List<Integer> integers = new ArrayList<>(numRows);
+            for (int i = 0; i < valuesToGenerate; i++) {
+                integers.add(random.nextInt());
+            }
+
+            for (int i = valuesToGenerate; i < numRows; i++) {
+                int randomIndex = random.nextInt(valuesToGenerate);
+                integers.add(integers.get(randomIndex));
+            }
+            return integers;
+        }
+
+        private List<Long> generateLongs(int numRows)
+        {
+            int valuesToGenerate = getUniqueValues(numRows);
+            List<Long> longs = new ArrayList<>(numRows);
+            for (int i = 0; i < valuesToGenerate; i++) {
+                longs.add(random.nextLong());
+            }
+
+            for (int i = valuesToGenerate; i < numRows; i++) {
+                int randomIndex = random.nextInt(valuesToGenerate);
+                longs.add(longs.get(randomIndex));
+            }
+            return longs;
+        }
+
+        private Block getBlock(int numRows)
+        {
+            BlockBuilder blockBuilder;
+            if (type.equals(VARCHAR)) {
+                blockBuilder = VARCHAR.createBlockBuilder(null, numRows);
+                for (String string : generateStrings(numRows)) {
+                    VARCHAR.writeSlice(blockBuilder, utf8Slice(string));
+                }
+            }
+            else if (type.equals(BIGINT)) {
+                blockBuilder = BIGINT.createBlockBuilder(null, numRows);
+                for (Long value : generateLongs(numRows)) {
+                    BIGINT.writeLong(blockBuilder, value);
+                }
+            }
+            else if (type.equals(INTEGER)) {
+                blockBuilder = INTEGER.createBlockBuilder(null, numRows);
+                for (Integer value : generateIntegers(numRows)) {
+                    INTEGER.writeLong(blockBuilder, value.longValue());
+                }
+            }
+            else {
+                throw new UnsupportedOperationException("Unsupported type " + typeSignature);
+            }
+            return blockBuilder.build();
+        }
+    }
+}


### PR DESCRIPTION
Create benchmarks for comparing direct writer (Consume less CPU, but
could producer larger files) with Dictionary writer (Consume more CPU,
but could produce smaller files).

Three methods are bench marked.

writeDirect - write a column using direct encoding writer.
writeDictionary - writer a column using dictionary encoding writer
writeDictionaryAndConvert - write using a dictionary writer, but convert
to direct encoding later. (simulates situation where memory pressure
converts it).

In the benchmark, integer dictionary could consume 4 times the CPU.
String writers could be 150 times worse when abandoning dictionary
and 50 times worse when using dictionary. All the dictionary worse
performing cases happen when the dictionary contains all unique values.

String performance is due to bugs and I will send the PRs to fix them.
https://github.com/prestodb/presto/issues/15506

Test plan - (Please fill in how you tested your changes)
No product code change.

```
== NO RELEASE NOTE ==
```
