### PR TITLE
Fix and turn on Cassandra product tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,9 +165,8 @@ jobs:
         run: presto-product-tests/bin/run_on_docker.sh singlenode-mysql -g mysql_connector,mysql
       - name: Product Tests Specific 2.4
         run: presto-product-tests/bin/run_on_docker.sh singlenode-postgresql -g postgresql_connector
-# Fails currently https://github.com/prestodb/presto/issues/15749
-#      - name: Product Tests Specific 2.5
-#        run: presto-product-tests/bin/run_on_docker.sh singlenode-cassandra -g cassandra
+      - name: Product Tests Specific 2.5
+        run: presto-product-tests/bin/run_on_docker.sh singlenode-cassandra -g cassandra
       - name: Product Tests Specific 2.6
         run: presto-product-tests/bin/run_on_docker.sh singlenode-kerberos-hdfs-impersonation-with-wire-encryption -g storage_formats,cli,hdfs_impersonation,authorization
       - name: Product Tests Specific 2.7

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraType.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraType.java
@@ -193,6 +193,10 @@ public enum CassandraType
                     return NullableValue.of(nativeType, utf8Slice(row.getString(position)));
                 case INT:
                     return NullableValue.of(nativeType, (long) row.getInt(position));
+                case SMALLINT:
+                    return NullableValue.of(nativeType, (long) row.getShort(position));
+                case TINYINT:
+                    return NullableValue.of(nativeType, (long) row.getByte(position));
                 case BIGINT:
                 case COUNTER:
                     return NullableValue.of(nativeType, row.getLong(position));
@@ -209,6 +213,8 @@ public enum CassandraType
                     return NullableValue.of(nativeType, utf8Slice(row.getUUID(position).toString()));
                 case TIMESTAMP:
                     return NullableValue.of(nativeType, row.getTimestamp(position).getTime());
+                case DATE:
+                    return NullableValue.of(nativeType, (long) row.getDate(position).getDaysSinceEpoch());
                 case INET:
                     return NullableValue.of(nativeType, utf8Slice(toAddrString(row.getInet(position))));
                 case VARINT:
@@ -313,6 +319,10 @@ public enum CassandraType
                     return CassandraCqlUtils.quoteStringLiteral(row.getString(position));
                 case INT:
                     return Integer.toString(row.getInt(position));
+                case SMALLINT:
+                    return Short.toString(row.getShort(position));
+                case TINYINT:
+                    return Byte.toString(row.getByte(position));
                 case BIGINT:
                 case COUNTER:
                     return Long.toString(row.getLong(position));
@@ -329,6 +339,8 @@ public enum CassandraType
                     return row.getUUID(position).toString();
                 case TIMESTAMP:
                     return Long.toString(row.getTimestamp(position).getTime());
+                case DATE:
+                    return row.getDate(position).toString();
                 case INET:
                     return CassandraCqlUtils.quoteStringLiteral(toAddrString(row.getInet(position)));
                 case VARINT:

--- a/presto-product-tests/conf/presto/etc/catalog/cassandra.properties
+++ b/presto-product-tests/conf/presto/etc/catalog/cassandra.properties
@@ -1,3 +1,4 @@
 connector.name=cassandra
 cassandra.contact-points=cassandra
 cassandra.allow-drop-table=true
+cassandra.protocol-version=V4

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/cassandra/DataTypesTableDefinition.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/cassandra/DataTypesTableDefinition.java
@@ -53,7 +53,7 @@ public class DataTypesTableDefinition
             try {
                 return ImmutableList.<List<Object>>of(
                         ImmutableList.of("\0", Long.MIN_VALUE, Bytes.fromHexString("0x00"), false,
-                                BigDecimal.ZERO, Double.MIN_VALUE, Float.MIN_VALUE, LocalDate.fromYearMonthDay(1970, 1, 2), ImmutableSet.of(0),
+                                BigDecimal.ZERO, Double.MIN_VALUE, LocalDate.fromYearMonthDay(1970, 1, 2), Float.MIN_VALUE, ImmutableSet.of(0),
                                 Inet4Address.getByName("0.0.0.0"), Integer.MIN_VALUE, ImmutableList.of(0),
                                 ImmutableMap.of("a", 0, "\0", Integer.MIN_VALUE), ImmutableSet.of(0), Short.MIN_VALUE,
                                 "\0", Byte.MIN_VALUE, Timestamp.valueOf(LocalDateTime.of(1970, 1, 1, 0, 0)),

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/cassandra/TestInsertIntoCassandraTable.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/cassandra/TestInsertIntoCassandraTable.java
@@ -73,7 +73,7 @@ public class TestInsertIntoCassandraTable
         // TODO Following types are not supported now. We need to change null into the value after fixing it
         // blob, frozen<set<type>>, inet, list<type>, map<type,type>, set<type>, timeuuid, decimal, uuid, varint
         query("INSERT INTO " + tableNameInDatabase +
-                "(a, b, bl, bo, d, do, dt, f, fr, i, ti, si, integer, l, m, s, t, ti, tu, u, v, vari) VALUES (" +
+                "(a, b, bl, bo, d, do, dt, f, fr, i, ti, si, integer, l, m, s, t, ts, tu, u, v, vari) VALUES (" +
                 "'ascii value', " +
                 "BIGINT '99999', " +
                 "null, " +
@@ -124,7 +124,7 @@ public class TestInsertIntoCassandraTable
 
         // insert null for all datatypes
         query("INSERT INTO " + tableNameInDatabase +
-                "(a, b, bl, bo, d, do, dt, f, fr, i, ti, si, integer, l, m, s, t, ts, ti, tu, u, v, vari) VALUES (" +
+                "(a, b, bl, bo, d, do, dt, f, fr, i, ti, si, integer, l, m, s, t, ts, tu, u, v, vari) VALUES (" +
                 "'key 1', null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null) ");
         assertThat(query(format("SELECT * FROM %s WHERE a = 'key 1'", tableNameInDatabase))).containsOnly(
                 row("key 1", null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null));

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/cassandra/TestSelect.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/cassandra/TestSelect.java
@@ -23,6 +23,7 @@ import io.prestodb.tempto.internal.query.CassandraQueryExecutor;
 import io.prestodb.tempto.query.QueryResult;
 import org.testng.annotations.Test;
 
+import java.sql.Date;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 
@@ -43,10 +44,13 @@ import static io.prestodb.tempto.query.QueryExecutor.query;
 import static java.lang.String.format;
 import static java.sql.JDBCType.BIGINT;
 import static java.sql.JDBCType.BOOLEAN;
+import static java.sql.JDBCType.DATE;
 import static java.sql.JDBCType.DOUBLE;
 import static java.sql.JDBCType.INTEGER;
 import static java.sql.JDBCType.REAL;
+import static java.sql.JDBCType.SMALLINT;
 import static java.sql.JDBCType.TIMESTAMP;
+import static java.sql.JDBCType.TINYINT;
 import static java.sql.JDBCType.VARBINARY;
 import static java.sql.JDBCType.VARCHAR;
 import static java.util.concurrent.TimeUnit.MINUTES;
@@ -170,27 +174,27 @@ public class TestSelect
     {
         // NOTE: DECIMAL is treated like DOUBLE
         QueryResult query = query(format(
-                "SELECT a, b, bl, bo, d, do, f, fr, i, integer, l, m, s, t, ti, tu, u, v, vari FROM %s.%s.%s",
+                "SELECT a, b, bl, bo, d, do, dt, f, fr, i, integer, l, m, s, si, t, ti, ts, tu, u, v, vari FROM %s.%s.%s",
                 CONNECTOR_NAME, KEY_SPACE, CASSANDRA_ALL_TYPES.getName()));
 
         assertThat(query)
-                .hasColumns(VARCHAR, BIGINT, VARBINARY, BOOLEAN, DOUBLE, DOUBLE, REAL, VARCHAR, VARCHAR,
-                        INTEGER, VARCHAR, VARCHAR, VARCHAR, VARCHAR, TIMESTAMP, VARCHAR, VARCHAR,
+                .hasColumns(VARCHAR, BIGINT, VARBINARY, BOOLEAN, DOUBLE, DOUBLE, DATE, REAL, VARCHAR, VARCHAR,
+                        INTEGER, VARCHAR, VARCHAR, VARCHAR, SMALLINT, VARCHAR, TINYINT, TIMESTAMP, VARCHAR, VARCHAR,
                         VARCHAR, VARCHAR)
                 .containsOnly(
-                        row("\0", Long.MIN_VALUE, Bytes.fromHexString("0x00").array(), false, 0f, Double.MIN_VALUE,
+                        row("\0", Long.MIN_VALUE, Bytes.fromHexString("0x00").array(), false, 0f, Double.MIN_VALUE, Date.valueOf("1970-01-02"),
                                 Float.MIN_VALUE, "[0]", "0.0.0.0", Integer.MIN_VALUE, "[0]", "{\"\\u0000\":-2147483648,\"a\":0}",
-                                "[0]", "\0", Timestamp.valueOf(LocalDateTime.of(1970, 1, 1, 0, 0)),
+                                "[0]", Short.MIN_VALUE, "\0", Byte.MIN_VALUE, Timestamp.valueOf(LocalDateTime.of(1970, 1, 1, 0, 0)),
                                 "d2177dd0-eaa2-11de-a572-001b779c76e3", "01234567-0123-0123-0123-0123456789ab",
                                 "\0", String.valueOf(Long.MIN_VALUE)),
                         row("the quick brown fox jumped over the lazy dog", 9223372036854775807L, "01234".getBytes(),
-                                true, new Double("99999999999999999999999999999999999999"), Double.MAX_VALUE,
+                                true, new Double("99999999999999999999999999999999999999"), Double.MAX_VALUE, Date.valueOf("9999-12-31"),
                                 Float.MAX_VALUE, "[4,5,6,7]", "255.255.255.255", Integer.MAX_VALUE, "[4,5,6]",
-                                "{\"a\":1,\"b\":2}", "[4,5,6]", "this is a text value", Timestamp.valueOf(LocalDateTime.of(9999, 12, 31, 23, 59, 59)),
+                                "{\"a\":1,\"b\":2}", "[4,5,6]", Short.MAX_VALUE, "this is a text value", Byte.MAX_VALUE, Timestamp.valueOf(LocalDateTime.of(9999, 12, 31, 23, 59, 59)),
                                 "d2177dd0-eaa2-11de-a572-001b779c76e3", "01234567-0123-0123-0123-0123456789ab",
                                 "abc", String.valueOf(Long.MAX_VALUE)),
                         row("def", null, null, null, null, null, null, null, null, null, null, null,
-                                null, null, null, null, null, null, null));
+                                null, null, null, null, null, null, null, null, null, null));
     }
 
     @Test(groups = CASSANDRA)
@@ -251,17 +255,17 @@ public class TestSelect
                 new Duration(1, MINUTES));
 
         QueryResult query = query(format(
-                "SELECT a, b, bl, bo, d, do, f, fr, i, integer, l, m, s, t, ti, tu, u, v, vari FROM %s.%s.%s WHERE a = '\0'",
+                "SELECT a, b, bl, bo, d, do, dt, f, fr, i, integer, l, m, s, si, t, ti, ts, tu, u, v, vari FROM %s.%s.%s WHERE a = '\0'",
                 CONNECTOR_NAME, KEY_SPACE, materializedViewName));
 
         assertThat(query)
-                .hasColumns(VARCHAR, BIGINT, VARBINARY, BOOLEAN, DOUBLE, DOUBLE, REAL, VARCHAR, VARCHAR,
-                        INTEGER, VARCHAR, VARCHAR, VARCHAR, VARCHAR, TIMESTAMP, VARCHAR, VARCHAR,
+                .hasColumns(VARCHAR, BIGINT, VARBINARY, BOOLEAN, DOUBLE, DOUBLE, DATE, REAL, VARCHAR, VARCHAR,
+                        INTEGER, VARCHAR, VARCHAR, VARCHAR, SMALLINT, VARCHAR, TINYINT, TIMESTAMP, VARCHAR, VARCHAR,
                         VARCHAR, VARCHAR)
                 .containsOnly(
-                        row("\0", Long.MIN_VALUE, Bytes.fromHexString("0x00").array(), false, 0f, Double.MIN_VALUE,
+                        row("\0", Long.MIN_VALUE, Bytes.fromHexString("0x00").array(), false, 0f, Double.MIN_VALUE, Date.valueOf("1970-01-02"),
                                 Float.MIN_VALUE, "[0]", "0.0.0.0", Integer.MIN_VALUE, "[0]", "{\"\\u0000\":-2147483648,\"a\":0}",
-                                "[0]", "\0", Timestamp.valueOf(LocalDateTime.of(1970, 1, 1, 0, 0)),
+                                "[0]", Short.MIN_VALUE, "\0", Byte.MIN_VALUE, Timestamp.valueOf(LocalDateTime.of(1970, 1, 1, 0, 0)),
                                 "d2177dd0-eaa2-11de-a572-001b779c76e3", "01234567-0123-0123-0123-0123456789ab",
                                 "\0", String.valueOf(Long.MIN_VALUE)));
 


### PR DESCRIPTION
Cherry-pick of trinodb/trino#141. This is
also a fix for #15147 which
tried to backport Trino #141 but that backporting was incomplete
and caused the Cassandra tests to fail.

Co-authored-by: Yuya Ebihara <ebyhry@gmail.com>

Resolves: #15749

Test plan - Run `presto-product-tests/bin/run_on_docker.sh singlenode-cassandra -g cassandra`

```
== RELEASE NOTES ==
Cassandra Connector Changes
* Add support for Cassandra ``SMALLINT``, ``TINYINT`` and ``DATE`` types and fix tests.
```
