### PR TITLE
Allow ExchangeClient to notify blocked callers when a threshold buffe…

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/protocol/Query.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/protocol/Query.java
@@ -290,7 +290,7 @@ class Query
 
         // wait for a results data or query to finish, up to the wait timeout
         ListenableFuture<?> futureStateChange = addTimeout(
-                getFutureStateChange(),
+                getFutureStateChange(targetResultSize),
                 () -> null,
                 wait,
                 timeoutExecutor);
@@ -299,11 +299,11 @@ class Query
         return Futures.transform(futureStateChange, ignored -> getNextResult(token, uriInfo, scheme, targetResultSize), resultsProcessorExecutor);
     }
 
-    private synchronized ListenableFuture<?> getFutureStateChange()
+    private synchronized ListenableFuture<?> getFutureStateChange(DataSize targetResultSize)
     {
         // if the exchange client is open, wait for data
         if (!exchangeClient.isClosed()) {
-            return exchangeClient.isBlocked();
+            return exchangeClient.isBlocked(targetResultSize.toBytes());
         }
 
         // otherwise, wait for the query to finish


### PR DESCRIPTION
…r size is reached

Currently, blocked callers are notified when a single page arrives into the ExchangeClient.
For high QPS queries that have small amounts of data being fetched, this unintentionally
introduces latency by adding an additional hop: the first page received is the last page
to be sent to the client, but the coordinator is not aware of this until some small time later.
By making the exchange client block on a target result size, we can instead be notified
when the query is completed, or, worst case, when the target result size threshold is
reached.

Test plan - (Please fill in how you tested your changes)

Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines. Don't forget to follow our [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution) for any code copied from other projects.

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== RELEASE NOTES ==

General Changes
* ...
* ...

Hive Changes
* ...
* ...
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```
