### PR TITLE
Add a flag for HttpRemoteTask to avoid eager but unnecessary sendUpdate

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTask.java
@@ -190,6 +190,7 @@ public final class HttpRemoteTask
 
     private final NodeStatsTracker nodeStatsTracker;
 
+    private final AtomicBoolean started = new AtomicBoolean(false);
     private final AtomicBoolean aborting = new AtomicBoolean(false);
 
     private final boolean binaryTransportEnabled;
@@ -385,6 +386,7 @@ public final class HttpRemoteTask
     {
         try (SetThreadName ignored = new SetThreadName("HttpRemoteTask-%s", taskId)) {
             // to start we just need to trigger an update
+            started.set(true);
             scheduleUpdate();
 
             taskStatusFetcher.start();
@@ -660,7 +662,7 @@ public final class HttpRemoteTask
     {
         TaskStatus taskStatus = getTaskStatus();
         // don't update if the task hasn't been started yet or if it is already finished
-        if (!needsUpdate.get() || taskStatus.getState().isDone()) {
+        if (!started.get() || !needsUpdate.get() || taskStatus.getState().isDone()) {
             return;
         }
 


### PR DESCRIPTION
It should not sendUpdate before task been started,
as the needsUpdate flag in RemoteHttpTask is not enough to ensure this,
which will happen on all non-leaf stage, as scheduleTask(525-535 lines)  in SqlStageExecution.java
Although task will start soon after noMoreSplits, but we should avoid
this, which is unnecessary and not strictly accurate in principle.

I have requested the issues before as [this](https://github.com/prestodb/presto/issues/15797)

I have tested it, and found the not started tasks(which is on non-leaf Stage) would sendUpdate requests on Worker node eagerly.
The code lead to above case is as below,
![image](https://user-images.githubusercontent.com/5463066/111728688-5bbe1800-88a8-11eb-93a4-7e95881d1103.png)

