### PR TITLE
fix parquet column stats bug

### DIFF
--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/cache/MetadataReader.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/cache/MetadataReader.java
@@ -219,11 +219,15 @@ public final class MetadataReader
     public static org.apache.parquet.column.statistics.Statistics<?> readStats(Statistics statistics, PrimitiveTypeName type)
     {
         org.apache.parquet.column.statistics.Statistics<?> stats = org.apache.parquet.column.statistics.Statistics.getStatsBasedOnType(type);
+        //manual initial num_nulls
+        stats.setNumNulls(-1);
         if (statistics != null) {
             if (statistics.isSetMax() && statistics.isSetMin()) {
                 stats.setMinMaxFromBytes(statistics.min.array(), statistics.max.array());
             }
-            stats.setNumNulls(statistics.null_count);
+            if (statistics.isSetNull_count()) {
+                stats.setNumNulls(statistics.null_count);
+            }
         }
         return stats;
     }


### PR DESCRIPTION
Test plan - (Please fill in how you tested your changes)
In current version, for parquet files, the null_count statistics info is always initial to 0. this will lead to error, when where condition is '*** = null' and actual parquet file don't have null_count statistics info. 
we should change it to :  0 means the null_count is 0, -1 means we don't have statistics info about null_count.

== RELEASE NOTES ==

== NO RELEASE NOTE ==
