### PR TITLE
Fix memory leak in NodeTaskMap

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/NodeTaskMap.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/NodeTaskMap.java
@@ -129,9 +129,13 @@ public class NodeTaskMap
 
             // when nodeStatsTracker is garbage collected, run the cleanup method on the tracker
             // Note: tracker can not have a reference to nodeStatsTracker
-            finalizerService.addFinalizer(nodeStatsTracker, splitTracker::cleanup);
-            finalizerService.addFinalizer(memoryUsageTracker, memoryUsageTracker::cleanup);
-            finalizerService.addFinalizer(cpuUtilizationPercentageTracker, cpuUtilizationPercentageTracker::cleanup);
+            // instances of TaskStatsTracker and AccumulatedTaskStatsTracker should not be passed for GC to
+            // help ensure that GC is actually invoked for nodeStatsTracker
+            finalizerService.addFinalizer(nodeStatsTracker, () -> {
+                splitTracker.cleanup();
+                memoryUsageTracker.cleanup();
+                cpuUtilizationPercentageTracker.cleanup();
+            });
 
             return nodeStatsTracker;
         }


### PR DESCRIPTION
This fixes a leak introduced recently in 26a373c. `memoryUsageTracker` and `cpuUtilizationPercentageTracker`
were being passed as both the referrant and as a part of the cleanup function. This caused 2 references to
these objects - one from the `FinalizerService#finalizers` and `FinalizerService#FinalizeReference#cleanup`
and prevented a cleanup.

Fixing this to just pass all 3 cleanups in a single function along with the `NodeStatsTracker` object.

Test plan - Using a heapdump I could now ensure that entries were indeed being cleaned up

```
== RELEASE NOTES ==

General Changes
* Fix a memory leak in `NodeTaskMap` which could lead to Full GC or OOMs in coordinator
```