### PR TITLE
Add release notes for 0.250

### DIFF
--- a/presto-docs/src/main/sphinx/release.rst
+++ b/presto-docs/src/main/sphinx/release.rst
@@ -5,6 +5,7 @@ Release Notes
 .. toctree::
     :maxdepth: 1
 
+    release/release-0.250
     release/release-0.249.1
     release/release-0.249
     release/release-0.248

--- a/presto-docs/src/main/sphinx/release/release-0.250.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.250.rst
@@ -1,0 +1,18 @@
+=============
+Release 0.250
+=============
+
+**Details**
+===========
+
+General Changes
+_______________
+* Fix a memory leak in ``NodeTaskMap`` which could lead to Full GC or OOMs in coordinator.
+* Add support for configuring the maximum number of unacknowledged source splits per task. This can be enabled by setting the ``max_unacknowledged_splits_per_task`` session property or ``node-scheduler.max-unacknowledged-splits-per-task`` configuration property.
+* Add bitwise shift functions :func:`bitwise_left_shift`, :func:`bitwise_right_shift`, :func:`bitwise_right_shift_arithmetic` (:pr:`15730`)
+* Add support for creating, dropping, querying and seeing materialized view definitions. (:pr:`15589`, :pr:`15779`)
+
+**Contributors**
+================
+
+Ahmad Ghazal, Ajay George, Ariel Weisberg, Arunachalam Thirupathi, David Stryker, Ge Gao, James Petty, James Sun, Lisa Yang, Maria Basmanova, Mayank Garg, Rebecca Schlussel, Rongrong Zhong, Rumeshkrishnan Mohan, Shixuan Fan, Timothy Meehan, Yang Yang, Zhenxiao Luo, tanjialiang, v-jizhang


### PR DESCRIPTION
# Missing Release Notes
## David Stryker
- [x] https://github.com/prestodb/presto/pull/15730 Support Trino bitwise shift functions in Presto (Merged by: Maria Basmanova)

## Ge Gao
- [ ] https://github.com/prestodb/presto/pull/15779 Support SHOW CREATE MATERIALIZED VIEW (Merged by: James Sun)
- [ ] https://github.com/prestodb/presto/pull/15589 Support materialized view creation, drop and query (Merged by: James Sun)
- [ ] https://github.com/prestodb/presto/pull/15589 Support materialized view creation, drop and query (Merged by: James Sun)
- [ ] https://github.com/prestodb/presto/pull/15589 Support materialized view creation, drop and query (Merged by: James Sun)

## Yang Yang
- [x] https://github.com/prestodb/presto/pull/15738 Allow to extend Kafka connector (Merged by: Timothy Meehan)

# Extracted Release Notes
- #15761 (Author: James Petty): Support limiting the number of unacknowledged source splits per task
  - Adds support for configuring the maximum number of unacknowledged source splits per task. This can be enabled by setting the ``max_unacknowledged_splits_per_task`` session property or ``node-scheduler.max-unacknowledged-splits-per-task`` configuration property.
- #15761 (Author: James Petty): Support limiting the number of unacknowledged source splits per task
  - Adds support for configuring the maximum number of unacknowledged source splits per task. This can be enabled by setting the ``max_unacknowledged_splits_per_task`` session property or ``node-scheduler.max-unacknowledged-splits-per-task`` configuration property.
- #15761 (Author: James Petty): Support limiting the number of unacknowledged source splits per task
  - Adds support for configuring the maximum number of unacknowledged source splits per task. This can be enabled by setting the ``max_unacknowledged_splits_per_task`` session property or ``node-scheduler.max-unacknowledged-splits-per-task`` configuration property.
- #15767 (Author: Arunachalam Thirupathi): Dictionary Writer refactor and Long writer first draft
  - Refactor ORC/DWRF String Dictionary.
  - Add DWRF Integer Dictionary encoding.
- #15843 (Author: Arunachalam Thirupathi): Improve performance of getRegionLogicalSizeInBytes
  - Improve Dictionary Block getRegionLogicalSizeInBytes performance.
- #15856 (Author: Mayank Garg): Fix memory leak in NodeTaskMap
  - Fix a memory leak in `NodeTaskMap` which could lead to Full GC or OOMs in coordinator.

# All Commits
- 540c3588734f9cc981a174e1cd4d34b2e83591c8 Improving exception handling of remote UDF execution (Rongrong Zhong)
- 2be4ffcff1381d893c30600bec3a6e26c4ff0250 Add additionalCpu to OperatorContext (Rongrong Zhong)
- 3bf7ba2e7d66729cabd28e0a89ed82695f8c9c91 Change ThriftUdfService.invokeUdf API (Rongrong Zhong)
- 333dbb0a6e52268ba0fbb20152d5958e7be5ea26 Support of inner join optimization with empty source. (Ahmad Ghazal)
- 680baf523a22ddb70fcea3cc667fa1df25061c80 Add Hive schemas into InputFormat#getSplits (Rumeshkrishnan Mohan)
- 2352b8d6fa183c7452ecc9c21b7b4874cef80250 Fix memory leak in NodeTaskMap (Mayank Garg)
- 0b681a7a53ee8e0830198630feda46261158d1d2 Allow to extend Kafka connector (Yang Yang)
- 7c7930e7bde16c396e646f743d569af95293c6c4 Improve performance of getRegionLogicalSizeInBytes (Arunachalam Thirupathi)
- 960390692693b8abddba3571c3d5e8df2122c515 Add error categorization for out task scope errors (tanjialiang)
- beadc29b1494effe8c006684ceb8b869a742cbe5 Add dictionary writer benchmark (Arunachalam Thirupathi)
- 7d78886a9c449fa26ad7734229b4beba038795bd Add DWRF Integer Dictionary Encoding Writer (Arunachalam Thirupathi)
- 427a66db94e42b83951de4b5d4fb7cced9ff16b3 Skip OOMing testNewBlockBuilderLikeForLargeBlockBuilder (Ariel Weisberg)
- 4d3ced82b85c0e7c7a19dbad980170a3508ec232 Add test for grouping sets with limit (Ajay George)
- 1126c2cb272569bf6f3346f00299da4b9253ac50 Support Trino bitwise shift functions in Presto (David Stryker)
- 0ef71f60827f6f5f5a88cd38158ed33440efaf4f Correct presto-product-tests READ.me errors (v-jizhang)
- 05b3342f628370282f890ddb8ddc03ac86cc323e Refactor DBResourceGroupConfigurationManager to support different data providers (Lisa Yang)
- 0b1c725441147ef18ea4c48cd9f1ec2d55562e5b Support SHOW CREATE MATERIALIZED VIEW (Ge Gao)
- fc80960407807f3714063b309c13e0bea5389ce2 Support execution of DROP MATERIALIZED VIEW (Ge Gao)
- 4ee0795e8cb15ae01bdd23703d599aa8ef9aa240 Support DROP MATERIALIZED VIEW syntax (Ge Gao)
- 81c80d5f0f6a0f7f13b0ab3dd506dd91c428fd66 Support execution of CREATE MATERIALIZED VIEW (Ge Gao)
- 9a83668f301ef2f60b0325d42fcca50a2f494743 Support limiting the number of unacknowledged splits per task (James Petty)
- 0209ef5123a3d1acf016c0b1a3dfecd76b5832b3 Avoid unnecessary node list sorting in SimpleNodeSelector (James Petty)
- 325b7b2486a611c4e2bd692c9d0eca3718d2c9c5 Refactor NodeAssignmentStats to simplify the tracked representation (James Petty)