### PR TITLE
Fix NPE thrown while deleting hashtable spill file

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkTaskExecutorFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkTaskExecutorFactory.java
@@ -717,7 +717,7 @@ public class PrestoSparkTaskExecutorFactory
 
             Throwable failure = getFirst(failures, null);
             // Delete the storage file, if task is not successful
-            if (outputSupplier instanceof DiskPageOutputSupplier) {
+            if (outputSupplier instanceof DiskPageOutputSupplier && output != null) {
                 PrestoSparkStorageHandle sparkStorageHandle = (PrestoSparkStorageHandle) output._2;
                 TempStorageHandle tempStorageHandle = tempStorage.deserialize(sparkStorageHandle.getSerializedStorageHandle());
                 try {


### PR DESCRIPTION
If broadcast stage fails due to any reason, it will return back
null output. If storage based broadcast join in enabled, then we
attempt to drop the spill file. The logic does not perform null
checks and thrown NPE in this case.

```
== NO RELEASE NOTE ==
```
