### PR TITLE
Use node location instead of nodeId to validate nodes

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/DiscoveryNodeManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/DiscoveryNodeManager.java
@@ -234,7 +234,7 @@ public final class DiscoveryNodeManager
         Set<ServiceDescriptor> services = serviceSelector.selectAllServices().stream()
                 .filter(service -> !failureDetector.getFailed().contains(service))
                 // Allowing coordinator node in the list of services, even if it's not allowed by nodeStatusService with currentNode check
-                .filter(service -> !nodeStatusService.isPresent() || nodeStatusService.get().isAllowed(service.getNodeId()) || isCoordinator(service))
+                .filter(service -> !nodeStatusService.isPresent() || nodeStatusService.get().isAllowed(service.getLocation()) || isCoordinator(service))
                 .collect(toImmutableSet());
 
         ImmutableSet.Builder<InternalNode> activeNodesBuilder = ImmutableSet.builder();


### PR DESCRIPTION
This PR has code changes to use `node.location`  instead of `node.id` for worker node validation. Until now we are sending nodeId to NodeStatusService.isAllowed() method to figure out if a node is allowed to register with DiscoveryNodeManager. But with this PR, we will be sending nodeLocation to NodeStatusService to figure out if this node is allowed to register or not.

When SOFT_AFFINITY node selection strategy is used, we sort the nodes based on nodeId and then calculate the split placement. The order of nodes in the sorted list plays an important role for having a good cache affinity. Currently, in Facebook deployment, we are setting nodeId as hostname. We also depend on container service to provide us the nodes for a cluster. But this container service may replace one or many nodes of cluster during kernel update etc. So when a node is replaced with a new host, the nodeId is also changed. The order of nodes in a sorted list changes when a nodeId changes and as a result the cache affinity will go bad. So in order to avoid this, we want to have nodeId as a constant and not change when underlying node changes. So for that we need nodeId to migrate away from hostname and remove any dependencies that assume nodeId to contain hostname. NodeStatusService expects nodeId to contain hostname. Hence this PR makes changes to send nodeLocation to NodeStatusService instead of nodeId. 


Depended by https://github.com/facebookexternal/presto-facebook/pull/1472

```
== RELEASE NOTES ==

General Changes
* NodeStatusService implementation is now expected to validate & check if a node is allowed to register with DiscoveryNodeManager based on node.location instead of node.id configuration parameter.
```
