### PR TITLE
Allow user and password passthrough in jdbc connector

### DIFF
--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/BaseJdbcConfig.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/BaseJdbcConfig.java
@@ -46,6 +46,7 @@ public class BaseJdbcConfig
         return this;
     }
 
+    @Nullable
     public String getConnectionUser()
     {
         return connectionUser;
@@ -58,6 +59,7 @@ public class BaseJdbcConfig
         return this;
     }
 
+    @Nullable
     public String getConnectionPassword()
     {
         return connectionPassword;

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/BaseJdbcConfig.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/BaseJdbcConfig.java
@@ -18,6 +18,7 @@ import com.facebook.airlift.configuration.ConfigSecuritySensitive;
 import io.airlift.units.Duration;
 import io.airlift.units.MinDuration;
 
+import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
@@ -27,6 +28,8 @@ public class BaseJdbcConfig
     private String connectionUrl;
     private String connectionUser;
     private String connectionPassword;
+    private String userCredentialName;
+    private String passwordCredentialName;
     private boolean caseInsensitiveNameMatching;
     private Duration caseInsensitiveNameMatchingCacheTtl = new Duration(1, MINUTES);
 
@@ -65,6 +68,32 @@ public class BaseJdbcConfig
     public BaseJdbcConfig setConnectionPassword(String connectionPassword)
     {
         this.connectionPassword = connectionPassword;
+        return this;
+    }
+
+    @Nullable
+    public String getUserCredentialName()
+    {
+        return userCredentialName;
+    }
+
+    @Config("user-credential-name")
+    public BaseJdbcConfig setUserCredentialName(String userCredentialName)
+    {
+        this.userCredentialName = userCredentialName;
+        return this;
+    }
+
+    @Nullable
+    public String getPasswordCredentialName()
+    {
+        return passwordCredentialName;
+    }
+
+    @Config("password-credential-name")
+    public BaseJdbcConfig setPasswordCredentialName(String passwordCredentialName)
+    {
+        this.passwordCredentialName = passwordCredentialName;
         return this;
     }
 

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestBaseJdbcConfig.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestBaseJdbcConfig.java
@@ -32,6 +32,8 @@ public class TestBaseJdbcConfig
                 .setConnectionUrl(null)
                 .setConnectionUser(null)
                 .setConnectionPassword(null)
+                .setUserCredentialName(null)
+                .setPasswordCredentialName(null)
                 .setCaseInsensitiveNameMatching(false)
                 .setCaseInsensitiveNameMatchingCacheTtl(new Duration(1, MINUTES)));
     }
@@ -43,6 +45,8 @@ public class TestBaseJdbcConfig
                 .put("connection-url", "jdbc:h2:mem:config")
                 .put("connection-user", "user")
                 .put("connection-password", "password")
+                .put("user-credential-name", "foo")
+                .put("password-credential-name", "bar")
                 .put("case-insensitive-name-matching", "true")
                 .put("case-insensitive-name-matching.cache-ttl", "1s")
                 .build();
@@ -51,6 +55,8 @@ public class TestBaseJdbcConfig
                 .setConnectionUrl("jdbc:h2:mem:config")
                 .setConnectionUser("user")
                 .setConnectionPassword("password")
+                .setUserCredentialName("foo")
+                .setPasswordCredentialName("bar")
                 .setCaseInsensitiveNameMatching(true)
                 .setCaseInsensitiveNameMatchingCacheTtl(new Duration(1, SECONDS));
 

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestingDatabase.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestingDatabase.java
@@ -51,7 +51,7 @@ final class TestingDatabase
                 new JdbcConnectorId(CONNECTOR_ID),
                 new BaseJdbcConfig(),
                 "\"",
-                new DriverConnectionFactory(new Driver(), connectionUrl, new Properties()));
+                new DriverConnectionFactory(new Driver(), connectionUrl, Optional.empty(), Optional.empty(), new Properties()));
 
         connection = DriverManager.getConnection(connectionUrl);
         connection.createStatement().execute("CREATE SCHEMA example");

--- a/presto-mysql/src/main/java/com/facebook/presto/plugin/mysql/MySqlClient.java
+++ b/presto-mysql/src/main/java/com/facebook/presto/plugin/mysql/MySqlClient.java
@@ -85,7 +85,12 @@ public class MySqlClient
             connectionProperties.setProperty("connectTimeout", String.valueOf(mySqlConfig.getConnectionTimeout().toMillis()));
         }
 
-        return new DriverConnectionFactory(new Driver(), config.getConnectionUrl(), connectionProperties);
+        return new DriverConnectionFactory(
+                new Driver(),
+                config.getConnectionUrl(),
+                Optional.ofNullable(config.getUserCredentialName()),
+                Optional.ofNullable(config.getPasswordCredentialName()),
+                connectionProperties);
     }
 
     @Override

--- a/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestCredentialPassthrough.java
+++ b/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestCredentialPassthrough.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.mysql;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.spi.security.Identity;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.testing.mysql.TestingMySqlServer;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.airlift.testing.Closeables.closeAllSuppress;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static java.lang.String.format;
+
+public class TestCredentialPassthrough
+{
+    private static final String TEST_SCHEMA = "test_database";
+    private final TestingMySqlServer mysqlServer;
+    private final QueryRunner mySqlQueryRunner;
+
+    public TestCredentialPassthrough()
+            throws Exception
+    {
+        mysqlServer = new TestingMySqlServer("testuser", "testpass", TEST_SCHEMA);
+        mySqlQueryRunner = createQueryRunner(mysqlServer);
+    }
+
+    @Test
+    public void testCredentialPassthrough()
+            throws Exception
+    {
+        mySqlQueryRunner.execute(getSession(mysqlServer), "CREATE TABLE test_create (a bigint, b double, c varchar)");
+    }
+
+    public static QueryRunner createQueryRunner(TestingMySqlServer mySqlServer)
+            throws Exception
+    {
+        DistributedQueryRunner queryRunner = null;
+        try {
+            queryRunner = DistributedQueryRunner.builder(testSessionBuilder().build()).build();
+            queryRunner.installPlugin(new MySqlPlugin());
+            Map<String, String> properties = ImmutableMap.<String, String>builder()
+                    .put("connection-url", getConnectionUrl(mySqlServer))
+                    .put("user-credential-name", "mysql.user")
+                    .put("password-credential-name", "mysql.password")
+                    .build();
+            queryRunner.createCatalog("mysql", "mysql", properties);
+
+            return queryRunner;
+        }
+        catch (Exception e) {
+            closeAllSuppress(e, queryRunner, mySqlServer);
+            throw e;
+        }
+    }
+
+    private static Session getSession(TestingMySqlServer mySqlServer)
+    {
+        Map<String, String> extraCredentials = ImmutableMap.of("mysql.user", mySqlServer.getUser(), "mysql.password", mySqlServer.getPassword());
+        return testSessionBuilder()
+                .setCatalog("mysql")
+                .setSchema(TEST_SCHEMA)
+                .setIdentity(new Identity(mySqlServer.getUser(), Optional.empty(), ImmutableMap.of(), extraCredentials, ImmutableMap.of()))
+                .build();
+    }
+
+    private static String getConnectionUrl(TestingMySqlServer mySqlServer)
+    {
+        return format("jdbc:mysql://localhost:%s?useSSL=false&allowPublicKeyRetrieval=true", mySqlServer.getPort());
+    }
+}

--- a/presto-oracle/src/main/java/com/facebook/presto/plugin/oracle/OracleClientModule.java
+++ b/presto-oracle/src/main/java/com/facebook/presto/plugin/oracle/OracleClientModule.java
@@ -26,6 +26,7 @@ import oracle.jdbc.OracleConnection;
 import oracle.jdbc.OracleDriver;
 
 import java.sql.SQLException;
+import java.util.Optional;
 import java.util.Properties;
 
 import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
@@ -53,6 +54,8 @@ public class OracleClientModule
         return new DriverConnectionFactory(
                 new OracleDriver(),
                 config.getConnectionUrl(),
+                Optional.empty(),
+                Optional.empty(),
                 connectionProperties);
     }
 }


### PR DESCRIPTION
Cherry-pick of https://github.com/trinodb/trino/pull/482/

```
== RELEASE NOTES ==
JDBC Connector Changes
* JDBC connector allows user to pass username and password from CLI and other clients through use of extra credentials feature.

```
