### PR TITLE
Do not propagate streaming preference from remote exchnage node

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddLocalExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddLocalExchanges.java
@@ -613,10 +613,10 @@ public class AddLocalExchanges
                         any().withOrderSensitivity(),
                         any().withOrderSensitivity());
             }
-            if (isEnforceFixedDistributionForOutputOperator(session)) {
-                return planAndEnforceChildren(node, fixedParallelism(), fixedParallelism());
-            }
-            return planAndEnforceChildren(node, any(), defaultParallelism(session));
+            return planAndEnforceChildren(
+                    node,
+                    isEnforceFixedDistributionForOutputOperator(session) ? fixedParallelism() : any(),
+                    defaultParallelism(session));
         }
 
         @Override


### PR DESCRIPTION
Setting streaming preference propagates it down the plan and results
into a local exchange node being introduced right after the TableScan
node. This changes the lifecycle of the partial aggregation (or partial
window function) operator from "per split" to "per task". Unfortunately
some of the "partial" operators, such as partial TopNRowNumber does not
enforce memory limit for the "partial" buffer, resulting into premature
memory exceeding errors. While not enforcing a buffer size is a problem
by itself, this change doesn't try to address that, but instead fixes a
regression introduced by https://github.com/prestodb/presto/pull/15780

Test plan 

Unit test

```
== NO RELEASE NOTE ==
```
