### PR TITLE
Refactor presto-parquet to avoid depending on hadoop

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSourceFactory.java
@@ -220,7 +220,7 @@ public class ParquetPageSourceFactory
         try {
             FSDataInputStream inputStream = hdfsEnvironment.getFileSystem(user, path, configuration).openFile(path, hiveFileContext);
             dataSource = buildHdfsParquetDataSource(inputStream, path, stats);
-            ParquetMetadata parquetMetadata = parquetMetadataSource.getParquetMetadata(inputStream, dataSource.getId(), fileSize, hiveFileContext.isCacheable()).getParquetMetadata();
+            ParquetMetadata parquetMetadata = parquetMetadataSource.getParquetMetadata(dataSource, fileSize, hiveFileContext.isCacheable()).getParquetMetadata();
 
             if (!columns.isEmpty() && columns.stream().allMatch(hiveColumnHandle -> hiveColumnHandle.getColumnType() == AGGREGATED)) {
                 return new AggregatedParquetPageSource(columns, parquetMetadata, typeManager, functionResolution);

--- a/presto-parquet/pom.xml
+++ b/presto-parquet/pom.xml
@@ -26,12 +26,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.facebook.presto.hadoop</groupId>
-            <artifactId>hadoop-apache2</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
             <groupId>com.facebook.presto.hive</groupId>
             <artifactId>hive-apache</artifactId>
         </dependency>
@@ -100,6 +94,12 @@
         <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-main</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto.hadoop</groupId>
+            <artifactId>hadoop-apache2</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/cache/CachingParquetMetadataSource.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/cache/CachingParquetMetadataSource.java
@@ -14,10 +14,10 @@
  */
 package com.facebook.presto.parquet.cache;
 
+import com.facebook.presto.parquet.ParquetDataSource;
 import com.facebook.presto.parquet.ParquetDataSourceId;
 import com.google.common.cache.Cache;
 import com.google.common.util.concurrent.UncheckedExecutionException;
-import org.apache.hadoop.fs.FSDataInputStream;
 
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
@@ -38,14 +38,14 @@ public class CachingParquetMetadataSource
     }
 
     @Override
-    public ParquetFileMetadata getParquetMetadata(FSDataInputStream inputStream, ParquetDataSourceId parquetDataSourceId, long fileSize, boolean cacheable)
+    public ParquetFileMetadata getParquetMetadata(ParquetDataSource parquetDataSource, long fileSize, boolean cacheable)
             throws IOException
     {
         try {
             if (cacheable) {
-                return cache.get(parquetDataSourceId, () -> delegate.getParquetMetadata(inputStream, parquetDataSourceId, fileSize, cacheable));
+                return cache.get(parquetDataSource.getId(), () -> delegate.getParquetMetadata(parquetDataSource, fileSize, cacheable));
             }
-            return delegate.getParquetMetadata(inputStream, parquetDataSourceId, fileSize, cacheable);
+            return delegate.getParquetMetadata(parquetDataSource, fileSize, cacheable);
         }
         catch (ExecutionException | UncheckedExecutionException e) {
             throwIfInstanceOf(e.getCause(), IOException.class);

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/cache/MetadataReader.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/cache/MetadataReader.java
@@ -14,11 +14,8 @@
 package com.facebook.presto.parquet.cache;
 
 import com.facebook.presto.parquet.ParquetCorruptionException;
-import com.facebook.presto.parquet.ParquetDataSourceId;
+import com.facebook.presto.parquet.ParquetDataSource;
 import io.airlift.slice.Slice;
-import org.apache.hadoop.fs.FSDataInputStream;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
 import org.apache.parquet.format.ColumnChunk;
 import org.apache.parquet.format.ColumnMetaData;
 import org.apache.parquet.format.ConvertedType;
@@ -70,17 +67,8 @@ public final class MetadataReader
     private static final int EXPECTED_FOOTER_SIZE = 16 * 1024;
     private static final ParquetMetadataConverter PARQUET_METADATA_CONVERTER = new ParquetMetadataConverter();
 
-    public static ParquetFileMetadata readFooter(FileSystem fileSystem, Path file, long fileSize)
+    public static ParquetFileMetadata readFooter(ParquetDataSource parquetDataSource, long fileSize)
             throws IOException
-    {
-        try (FSDataInputStream inputStream = fileSystem.open(file)) {
-            return readFooter(inputStream, file, fileSize);
-        }
-    }
-
-    public static ParquetFileMetadata readFooter(FSDataInputStream inputStream, Path file, long fileSize)
-            throws IOException
-
     {
         // Parquet File Layout:
         //
@@ -90,27 +78,27 @@ public final class MetadataReader
         // 4 bytes: MetadataLength
         // MAGIC
 
-        validateParquet(fileSize >= MAGIC.length() + POST_SCRIPT_SIZE, "%s is not a valid Parquet File", file);
+        validateParquet(fileSize >= MAGIC.length() + POST_SCRIPT_SIZE, "%s is not a valid Parquet File", parquetDataSource.getId());
 
         //  EXPECTED_FOOTER_SIZE is an int, so this will never fail
         byte[] buffer = new byte[toIntExact(min(fileSize, EXPECTED_FOOTER_SIZE))];
-        inputStream.readFully(fileSize - buffer.length, buffer);
+        parquetDataSource.readFully(fileSize - buffer.length, buffer);
         Slice tailSlice = wrappedBuffer(buffer);
 
         Slice magic = tailSlice.slice(tailSlice.length() - MAGIC.length(), MAGIC.length());
         if (!MAGIC.equals(magic)) {
-            throw new ParquetCorruptionException(format("Not valid Parquet file: %s expected magic number: %s got: %s", file, Arrays.toString(MAGIC.getBytes()), Arrays.toString(magic.getBytes())));
+            throw new ParquetCorruptionException(format("Not valid Parquet file: %s expected magic number: %s got: %s", parquetDataSource.getId(), Arrays.toString(MAGIC.getBytes()), Arrays.toString(magic.getBytes())));
         }
 
         int metadataLength = tailSlice.getInt(tailSlice.length() - POST_SCRIPT_SIZE);
         int completeFooterSize = metadataLength + POST_SCRIPT_SIZE;
 
         long metadataFileOffset = fileSize - completeFooterSize;
-        validateParquet(metadataFileOffset >= MAGIC.length() && metadataFileOffset + POST_SCRIPT_SIZE < fileSize, "Corrupted Parquet file: %s metadata index: %s out of range", file, metadataFileOffset);
+        validateParquet(metadataFileOffset >= MAGIC.length() && metadataFileOffset + POST_SCRIPT_SIZE < fileSize, "Corrupted Parquet file: %s metadata index: %s out of range", parquetDataSource.getId(), metadataFileOffset);
         //  Ensure the slice covers the entire metadata range
         if (tailSlice.length() < completeFooterSize) {
             byte[] footerBuffer = new byte[completeFooterSize];
-            inputStream.readFully(metadataFileOffset, footerBuffer, 0, footerBuffer.length - tailSlice.length());
+            parquetDataSource.readFully(metadataFileOffset, footerBuffer, 0, footerBuffer.length - tailSlice.length());
             // Copy the previous slice contents into the new buffer
             tailSlice.getBytes(0, footerBuffer, footerBuffer.length - tailSlice.length(), tailSlice.length());
             tailSlice = wrappedBuffer(footerBuffer, 0, footerBuffer.length);
@@ -118,7 +106,7 @@ public final class MetadataReader
 
         FileMetaData fileMetaData = readFileMetaData(tailSlice.slice(tailSlice.length() - completeFooterSize, metadataLength).getInput());
         List<SchemaElement> schema = fileMetaData.getSchema();
-        validateParquet(!schema.isEmpty(), "Empty Parquet schema in file: %s", file);
+        validateParquet(!schema.isEmpty(), "Empty Parquet schema in file: %s", parquetDataSource.getId());
 
         MessageType messageType = readParquetSchema(schema);
         List<BlockMetaData> blocks = new ArrayList<>();
@@ -312,9 +300,9 @@ public final class MetadataReader
     }
 
     @Override
-    public ParquetFileMetadata getParquetMetadata(FSDataInputStream inputStream, ParquetDataSourceId parquetDataSourceId, long fileSize, boolean cacheable)
+    public ParquetFileMetadata getParquetMetadata(ParquetDataSource parquetDataSource, long fileSize, boolean cacheable)
             throws IOException
     {
-        return readFooter(inputStream, new Path(parquetDataSourceId.toString()), fileSize);
+        return readFooter(parquetDataSource, fileSize);
     }
 }

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/cache/ParquetMetadataSource.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/cache/ParquetMetadataSource.java
@@ -13,13 +13,12 @@
  */
 package com.facebook.presto.parquet.cache;
 
-import com.facebook.presto.parquet.ParquetDataSourceId;
-import org.apache.hadoop.fs.FSDataInputStream;
+import com.facebook.presto.parquet.ParquetDataSource;
 
 import java.io.IOException;
 
 public interface ParquetMetadataSource
 {
-    ParquetFileMetadata getParquetMetadata(FSDataInputStream inputStream, ParquetDataSourceId parquetDataSourceId, long fileSize, boolean cacheable)
+    ParquetFileMetadata getParquetMetadata(ParquetDataSource parquetDataSource, long fileSize, boolean cacheable)
             throws IOException;
 }

--- a/presto-parquet/src/test/java/com/facebook/presto/parquet/BenchmarkParquetReader.java
+++ b/presto-parquet/src/test/java/com/facebook/presto/parquet/BenchmarkParquetReader.java
@@ -22,9 +22,6 @@ import com.facebook.presto.parquet.cache.MetadataReader;
 import com.facebook.presto.parquet.reader.ParquetReader;
 import com.google.common.base.Strings;
 import io.airlift.units.DataSize;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
 import org.apache.parquet.hadoop.metadata.ParquetMetadata;
 import org.apache.parquet.io.ColumnIOConverter;
 import org.apache.parquet.io.MessageColumnIO;
@@ -275,7 +272,7 @@ public class BenchmarkParquetReader
                 throws IOException
         {
             FileParquetDataSource dataSource = new FileParquetDataSource(file);
-            ParquetMetadata parquetMetadata = MetadataReader.readFooter(FileSystem.getLocal(new Configuration()), new Path(file.getAbsolutePath()), file.length()).getParquetMetadata();
+            ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, file.length()).getParquetMetadata();
             MessageType schema = parquetMetadata.getFileMetaData().getSchema();
             MessageColumnIO messageColumnIO = getColumnIO(schema, schema);
 


### PR DESCRIPTION
Refactors `MetadataReader#readFooter` and usages to avoid depending on `FSDataInputStream` and to use the `ParquetDataSource` methods instead. There are no more usages of `hadoop-apache2` except in tests after this change, so the dependency has been changed to reflect that.

As a side effect of using the `ParquetDataSource` instead of the `FSDataInputStream`, metadata reads will now count towards `ParquetDataSource` read bytes and read nanos, as well as the `FileFormatDataSourceStats` in the case of `HdfsParquetDataSource`.

```
== NO RELEASE NOTE ==
```
