### PR TITLE
Do not add local exchange for WindowNode with OrderingScheme

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/StreamPropertyDerivations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/StreamPropertyDerivations.java
@@ -507,7 +507,11 @@ public final class StreamPropertyDerivations
         @Override
         public StreamProperties visitWindow(WindowNode node, List<StreamProperties> inputProperties)
         {
-            return Iterables.getOnlyElement(inputProperties);
+            StreamProperties properties = Iterables.getOnlyElement(inputProperties);
+            if (properties.isSingleStream() && node.getOrderingScheme().isPresent()) {
+                return StreamProperties.ordered();
+            }
+            return properties;
         }
 
         @Override
@@ -519,6 +523,10 @@ public final class StreamPropertyDerivations
         @Override
         public StreamProperties visitTopNRowNumber(TopNRowNumberNode node, List<StreamProperties> inputProperties)
         {
+            StreamProperties properties = Iterables.getOnlyElement(inputProperties);
+            if (properties.isSingleStream()) {
+                return StreamProperties.ordered();
+            }
             return Iterables.getOnlyElement(inputProperties);
         }
 


### PR DESCRIPTION
Test plan - probably should add more tests.


```
== RELEASE NOTES ==

General Changes
* Fix a bug where ORDER BY might not be respected when queries using window function with ORDER BY, introduced in :pr:`7251`
```
