### PR TITLE
Adding schema access rules to file based system access control

### DIFF
--- a/presto-docs/src/main/sphinx/security/built-in-system-access-control.rst
+++ b/presto-docs/src/main/sphinx/security/built-in-system-access-control.rst
@@ -64,10 +64,11 @@ contents:
 The config file is specified in JSON format.
 
 * It contains the rules defining which catalog can be accessed by which user (see Catalog Rules below).
+* The schema access rules defining which schema can be accessed by which user (see Schema Rules below).
 * The principal rules specifying what principals can identify as what users (see Principal Rules below).
 
-This plugin currently only supports catalog access control rules and principal
-rules. If you want to limit access on a system level in any other way, you
+This plugin currently supports catalog access control rules, schema access control rules
+and principal rules. If you want to limit access on a system level in any other way, you
 must implement a custom SystemAccessControl plugin
 (see :doc:`/develop/system-access-control`).
 
@@ -132,6 +133,48 @@ and deny all other access, you can use the following rules:
         {
           "catalog": "system",
           "allow": "none"
+        }
+      ]
+    }
+
+Schema Rules
+------------
+
+These rules allow you to grant ownership of a schema. Having ownership of an
+schema allows users to execute ``DROP SCHEMA``, ``ALTER SCHEMA`` and
+``CREATE SCHEMA``. The user is granted ownership of a schema, based on
+the first matching rule read from top to bottom. If no rule matches, ownership
+is not granted. Each rule is composed of the following fields:
+
+* ``user`` (optional): regex to match against user name. Defaults to ``.*``.
+* ``schema`` (optional): regex to match against schema name. Defaults to ``.*``.
+* ``owner`` (required): boolean indicating whether the user is to be considered
+  an owner of the schema. Defaults to ``false``.
+
+For example, to provide ownership of all schemas to user ``admin``, treat all
+users as owners of ``default`` schema and prevent user ``guest`` from ownership
+of any schema, you can use the following rules:
+
+.. code-block:: json
+    {
+      "catalogs": [
+        {
+          "allow": true
+        }
+      ],
+      "schemas": [
+        {
+          "user": "admin",
+          "schema": ".*",
+          "owner": true
+        },
+        {
+          "user": "guest",
+          "owner": false
+        },
+        {
+          "schema": "default",
+          "owner": true
         }
       ]
     }

--- a/presto-main/src/main/java/com/facebook/presto/security/FileBasedSystemAccessControlRules.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/FileBasedSystemAccessControlRules.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.security;
 
+import com.facebook.presto.plugin.base.security.SchemaAccessControlRule;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
@@ -24,14 +25,17 @@ public class FileBasedSystemAccessControlRules
 {
     private final List<CatalogAccessControlRule> catalogRules;
     private final Optional<List<PrincipalUserMatchRule>> principalUserMatchRules;
+    private final Optional<List<SchemaAccessControlRule>> schemaRules;
 
     @JsonCreator
     public FileBasedSystemAccessControlRules(
             @JsonProperty("catalogs") Optional<List<CatalogAccessControlRule>> catalogRules,
-            @JsonProperty("principals") Optional<List<PrincipalUserMatchRule>> principalUserMatchRules)
+            @JsonProperty("principals") Optional<List<PrincipalUserMatchRule>> principalUserMatchRules,
+            @JsonProperty("schemas") Optional<List<SchemaAccessControlRule>> schemaRules)
     {
         this.catalogRules = catalogRules.map(ImmutableList::copyOf).orElse(ImmutableList.of());
         this.principalUserMatchRules = principalUserMatchRules.map(ImmutableList::copyOf);
+        this.schemaRules = schemaRules.map(ImmutableList::copyOf);
     }
 
     public List<CatalogAccessControlRule> getCatalogRules()
@@ -42,5 +46,10 @@ public class FileBasedSystemAccessControlRules
     public Optional<List<PrincipalUserMatchRule>> getPrincipalUserMatchRules()
     {
         return principalUserMatchRules;
+    }
+
+    public Optional<List<SchemaAccessControlRule>> getSchemaRules()
+    {
+        return schemaRules;
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/security/TestFileBasedSystemAccessControl.java
+++ b/presto-main/src/test/java/com/facebook/presto/security/TestFileBasedSystemAccessControl.java
@@ -170,6 +170,125 @@ public class TestFileBasedSystemAccessControl
     }
 
     @Test
+    public void testSchemaRulesForCheckCanCreateSchema()
+    {
+        TransactionManager transactionManager = createTestTransactionManager();
+        AccessControlManager accessControlManager = newAccessControlManager(transactionManager, "file-based-system-access-schema.json");
+
+        transaction(transactionManager, accessControlManager)
+                .execute(transactionId -> {
+                    accessControlManager.checkCanCreateSchema(transactionId, bob, context, new CatalogSchemaName("alice-catalog", "bob"));
+                    accessControlManager.checkCanCreateSchema(transactionId, bob, context, new CatalogSchemaName("bob-catalog", "bob"));
+                    accessControlManager.checkCanCreateSchema(transactionId, admin, context, new CatalogSchemaName("some-catalog", "some-schema"));
+                    accessControlManager.checkCanCreateSchema(transactionId, admin, context, new CatalogSchemaName("some-catalog", "bob"));
+                    accessControlManager.checkCanCreateSchema(transactionId, admin, context, new CatalogSchemaName("some-catalog", "alice"));
+                });
+
+        assertThrows(AccessDeniedException.class, () -> transaction(transactionManager, accessControlManager).execute(transactionId -> {
+            accessControlManager.checkCanCreateSchema(transactionId, bob, context, new CatalogSchemaName("alice-catalog", "alice"));
+        }));
+
+        assertThrows(AccessDeniedException.class, () -> transaction(transactionManager, accessControlManager).execute(transactionId -> {
+            accessControlManager.checkCanCreateSchema(transactionId, bob, context, new CatalogSchemaName("bob-catalog", "alice"));
+        }));
+
+        assertThrows(AccessDeniedException.class, () -> transaction(transactionManager, accessControlManager).execute(transactionId -> {
+            accessControlManager.checkCanCreateSchema(transactionId, bob, context, new CatalogSchemaName("secret-catalog", "secret"));
+        }));
+
+        assertThrows(AccessDeniedException.class, () -> transaction(transactionManager, accessControlManager).execute(transactionId -> {
+            accessControlManager.checkCanCreateSchema(transactionId, alice, context, new CatalogSchemaName("secret-catalog", "secret"));
+        }));
+
+        assertThrows(AccessDeniedException.class, () -> transaction(transactionManager, accessControlManager).execute(transactionId -> {
+            accessControlManager.checkCanCreateSchema(transactionId, admin, context, new CatalogSchemaName("secret-catalog", "secret"));
+        }));
+
+        assertThrows(AccessDeniedException.class, () -> transaction(transactionManager, accessControlManager).execute(transactionId -> {
+            accessControlManager.checkCanCreateSchema(transactionId, alice, context, new CatalogSchemaName("alice-catalog", "alice"));
+        }));
+    }
+
+    @Test
+    public void testSchemaRulesForCheckCanDropSchema()
+    {
+        TransactionManager transactionManager = createTestTransactionManager();
+        AccessControlManager accessControlManager = newAccessControlManager(transactionManager, "file-based-system-access-schema.json");
+
+        transaction(transactionManager, accessControlManager)
+                .execute(transactionId -> {
+                    accessControlManager.checkCanDropSchema(transactionId, bob, context, new CatalogSchemaName("alice-catalog", "bob"));
+                    accessControlManager.checkCanDropSchema(transactionId, bob, context, new CatalogSchemaName("bob-catalog", "bob"));
+                    accessControlManager.checkCanDropSchema(transactionId, admin, context, new CatalogSchemaName("some-catalog", "bob"));
+                    accessControlManager.checkCanDropSchema(transactionId, admin, context, new CatalogSchemaName("some-catalog", "alice"));
+                    accessControlManager.checkCanDropSchema(transactionId, admin, context, new CatalogSchemaName("some-catalog", "some-schema"));
+                });
+
+        assertThrows(AccessDeniedException.class, () -> transaction(transactionManager, accessControlManager).execute(transactionId -> {
+            accessControlManager.checkCanDropSchema(transactionId, bob, context, new CatalogSchemaName("alice-catalog", "alice"));
+        }));
+
+        assertThrows(AccessDeniedException.class, () -> transaction(transactionManager, accessControlManager).execute(transactionId -> {
+            accessControlManager.checkCanDropSchema(transactionId, bob, context, new CatalogSchemaName("bob-catalog", "alice"));
+        }));
+
+        assertThrows(AccessDeniedException.class, () -> transaction(transactionManager, accessControlManager).execute(transactionId -> {
+            accessControlManager.checkCanDropSchema(transactionId, bob, context, new CatalogSchemaName("secret-catalog", "secret"));
+        }));
+
+        assertThrows(AccessDeniedException.class, () -> transaction(transactionManager, accessControlManager).execute(transactionId -> {
+            accessControlManager.checkCanDropSchema(transactionId, alice, context, new CatalogSchemaName("secret-catalog", "secret"));
+        }));
+
+        assertThrows(AccessDeniedException.class, () -> transaction(transactionManager, accessControlManager).execute(transactionId -> {
+            accessControlManager.checkCanDropSchema(transactionId, admin, context, new CatalogSchemaName("secret-catalog", "secret"));
+        }));
+
+        assertThrows(AccessDeniedException.class, () -> transaction(transactionManager, accessControlManager).execute(transactionId -> {
+            accessControlManager.checkCanDropSchema(transactionId, alice, context, new CatalogSchemaName("alice-catalog", "alice"));
+        }));
+    }
+
+    @Test
+    public void testSchemaRulesForCheckCanRenameSchema()
+    {
+        TransactionManager transactionManager = createTestTransactionManager();
+        AccessControlManager accessControlManager = newAccessControlManager(transactionManager, "file-based-system-access-schema.json");
+
+        transaction(transactionManager, accessControlManager)
+                .execute(transactionId -> {
+                    accessControlManager.checkCanRenameSchema(transactionId, bob, context, new CatalogSchemaName("alice-catalog", "bob"), "some-schema");
+                    accessControlManager.checkCanRenameSchema(transactionId, bob, context, new CatalogSchemaName("bob-catalog", "bob"), "some-schema");
+                    accessControlManager.checkCanRenameSchema(transactionId, admin, context, new CatalogSchemaName("some-catalog", "bob"), "new-schema-name");
+                    accessControlManager.checkCanRenameSchema(transactionId, admin, context, new CatalogSchemaName("some-catalog", "alice"), "new-schema-name");
+                });
+
+        assertThrows(AccessDeniedException.class, () -> transaction(transactionManager, accessControlManager).execute(transactionId -> {
+            accessControlManager.checkCanRenameSchema(transactionId, bob, context, new CatalogSchemaName("alice-catalog", "alice"), "new-schema-name");
+        }));
+
+        assertThrows(AccessDeniedException.class, () -> transaction(transactionManager, accessControlManager).execute(transactionId -> {
+            accessControlManager.checkCanRenameSchema(transactionId, bob, context, new CatalogSchemaName("bob-catalog", "alice"), "new-schema-name");
+        }));
+
+        assertThrows(AccessDeniedException.class, () -> transaction(transactionManager, accessControlManager).execute(transactionId -> {
+            accessControlManager.checkCanRenameSchema(transactionId, bob, context, new CatalogSchemaName("secret-catalog", "secret"), "new-schema-name");
+        }));
+
+        assertThrows(AccessDeniedException.class, () -> transaction(transactionManager, accessControlManager).execute(transactionId -> {
+            accessControlManager.checkCanRenameSchema(transactionId, alice, context, new CatalogSchemaName("secret-catalog", "secret"), "new-schema-name");
+        }));
+
+        assertThrows(AccessDeniedException.class, () -> transaction(transactionManager, accessControlManager).execute(transactionId -> {
+            accessControlManager.checkCanRenameSchema(transactionId, admin, context, new CatalogSchemaName("secret-catalog", "secret"), "new-schema-name");
+        }));
+
+        assertThrows(AccessDeniedException.class, () -> transaction(transactionManager, accessControlManager).execute(transactionId -> {
+            accessControlManager.checkCanRenameSchema(transactionId, alice, context, new CatalogSchemaName("alice-catalog", "alice"), "new-schema-name");
+        }));
+    }
+
+    @Test
     public void testSchemaOperationsReadOnly()
     {
         TransactionManager transactionManager = createTestTransactionManager();

--- a/presto-main/src/test/resources/file-based-system-access-schema.json
+++ b/presto-main/src/test/resources/file-based-system-access-schema.json
@@ -1,0 +1,33 @@
+{
+  "catalogs": [
+    {
+      "user": "alice",
+      "catalog": "alice-catalog",
+      "allow": "read-only"
+    },
+    {
+      "allow": true
+    }
+  ],
+  "schemas": [
+    {
+      "schema": "secret",
+      "owner": false
+    },
+    {
+      "user": "admin",
+      "schema": ".*",
+      "owner": true
+    },
+    {
+      "user": "bob",
+      "schema": "bob|some-schema",
+      "owner": true
+    },
+    {
+      "user": "alice",
+      "schema": "alice",
+      "owner": true
+    }
+  ]
+}

--- a/presto-main/src/test/resources/security-config-file-with-unknown-rules.json
+++ b/presto-main/src/test/resources/security-config-file-with-unknown-rules.json
@@ -1,9 +1,9 @@
 {
-  "schemas": [
+  "sessionProperties": [
     {
-      "user": "(alice|bob)",
-      "schema": "(default|pv)",
-      "owner": true
+      "user": "admin",
+      "property": "max_split_size",
+      "allow": true
     }
   ]
 }


### PR DESCRIPTION
Currently, file-based system access control allows defining catalog level rule. As a part of these changes, schema access rules can be included with file-based system access control for the below operations -

- checkCanCreateSchema    : If the user has access to the catalog and is also schema owner, then access is provided. 
- checkCanDropSchema       : If the user has access to the catalog and is also schema owner, then access is provided. 
- checkCanRenameSchema  : If the user has access to the catalog and is also schema owner, then access is provided. 

```
== RELEASE NOTES ==

Security Changes

- Add ability to set schema access rules in file-based system access control

```
