### PR TITLE
Update /v1/info/state API

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/NodeResourceStatusConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/NodeResourceStatusConfig.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution;
+
+import com.facebook.airlift.configuration.Config;
+import com.facebook.airlift.configuration.ConfigDescription;
+
+import javax.validation.constraints.Min;
+
+public class NodeResourceStatusConfig
+{
+    private int requiredWorkersActive;
+
+    @Min(0)
+    public int getRequiredWorkersActive()
+    {
+        return requiredWorkersActive;
+    }
+
+    @Config("cluster.required-workers-active")
+    @ConfigDescription("Minimum number of active workers that must be available before activating the cluster")
+    public NodeResourceStatusConfig setRequiredWorkersActive(int requiredWorkersActive)
+    {
+        this.requiredWorkersActive = requiredWorkersActive;
+        return this;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
@@ -55,6 +55,7 @@ import com.facebook.presto.execution.ExplainAnalyzeContext;
 import com.facebook.presto.execution.ForQueryExecution;
 import com.facebook.presto.execution.GrantRolesTask;
 import com.facebook.presto.execution.GrantTask;
+import com.facebook.presto.execution.NodeResourceStatusConfig;
 import com.facebook.presto.execution.PrepareTask;
 import com.facebook.presto.execution.QueryExecution;
 import com.facebook.presto.execution.QueryExecutionMBean;
@@ -360,6 +361,9 @@ public class CoordinatorModule
         MapBinder<String, ExecutionPolicy> executionPolicyBinder = newMapBinder(binder, String.class, ExecutionPolicy.class);
         executionPolicyBinder.addBinding("all-at-once").to(AllAtOnceExecutionPolicy.class);
         executionPolicyBinder.addBinding("phased").to(PhasedExecutionPolicy.class);
+
+        configBinder(binder).bindConfig(NodeResourceStatusConfig.class);
+        binder.bind(NodeResourceStatusProvider.class).to(NodeResourceStatus.class).in(Scopes.SINGLETON);
 
         // cleanup
         binder.bind(ExecutorCleanup.class).in(Scopes.SINGLETON);

--- a/presto-main/src/main/java/com/facebook/presto/server/NodeResourceStatus.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/NodeResourceStatus.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server;
+
+import com.facebook.presto.execution.ClusterSizeMonitor;
+
+import javax.inject.Inject;
+
+public class NodeResourceStatus
+        implements NodeResourceStatusProvider
+{
+    private final ClusterSizeMonitor clusterSizeMonitor;
+
+    @Inject
+    public NodeResourceStatus(ClusterSizeMonitor clusterSizeMonitor)
+    {
+        this.clusterSizeMonitor = clusterSizeMonitor;
+    }
+
+    @Override
+    public boolean hasResources()
+    {
+        return clusterSizeMonitor.hasRequiredWorkers();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/NodeResourceStatusProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/NodeResourceStatusProvider.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server;
+
+public interface NodeResourceStatusProvider
+{
+    boolean hasResources();
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/WorkerModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/WorkerModule.java
@@ -51,6 +51,10 @@ public class WorkerModule
         binder.bind(QueryManager.class).toInstance(newProxy(QueryManager.class, (proxy, method, args) -> {
             throw new UnsupportedOperationException();
         }));
+
+        binder.bind(NodeResourceStatusProvider.class).toInstance(newProxy(NodeResourceStatusProvider.class, (proxy, method, args) -> {
+            return true;
+        }));
     }
 
     @Provides

--- a/presto-main/src/test/java/com/facebook/presto/dispatcher/TestLocalDispatchQuery.java
+++ b/presto-main/src/test/java/com/facebook/presto/dispatcher/TestLocalDispatchQuery.java
@@ -222,7 +222,7 @@ public class TestLocalDispatchQuery
 
     private ClusterSizeMonitor createClusterSizeMonitor(int minimumNodes)
     {
-        return new ClusterSizeMonitor(new InMemoryNodeManager(), true, minimumNodes, new Duration(10, MILLISECONDS), 1, new Duration(1, SECONDS));
+        return new ClusterSizeMonitor(new InMemoryNodeManager(), true, minimumNodes, minimumNodes, new Duration(10, MILLISECONDS), 1, new Duration(1, SECONDS));
     }
 
     private QueryMonitor createQueryMonitor(CountingEventListener eventListener)

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestClusterSizeMonitor.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestClusterSizeMonitor.java
@@ -41,6 +41,7 @@ public class TestClusterSizeMonitor
     public static final ConnectorId CONNECTOR_ID = new ConnectorId("dummy");
     public static final int DESIRED_WORKER_COUNT = 10;
     public static final int DESIRED_COORDINATOR_COUNT = 3;
+    public static final int DESIRED_WORKER_COUNT_ACTIVE = 10;
 
     private InMemoryNodeManager nodeManager;
     private ClusterSizeMonitor monitor;
@@ -64,6 +65,7 @@ public class TestClusterSizeMonitor
                 nodeManager,
                 false,
                 DESIRED_WORKER_COUNT,
+                DESIRED_WORKER_COUNT_ACTIVE,
                 new Duration(4, SECONDS),
                 DESIRED_COORDINATOR_COUNT,
                 new Duration(4, SECONDS));
@@ -91,6 +93,7 @@ public class TestClusterSizeMonitor
             assertFalse(workersTimeout.get());
             addWorker(nodeManager);
         }
+        assertFalse(monitor.hasRequiredWorkers());
         assertFalse(workersTimeout.get());
         assertEquals(minWorkersLatch.getCount(), 1);
         addWorker(nodeManager);
@@ -108,6 +111,7 @@ public class TestClusterSizeMonitor
         minCoordinatorsLatch.await(2, SECONDS);
         assertTrue(coordinatorsFuture.isDone());
         assertFalse(coordinatorsTimeout.get());
+        assertTrue(monitor.hasRequiredWorkers());
     }
 
     @Test(timeOut = 10_000)


### PR DESCRIPTION
Test plan

Tested with:
1) No cluster.required-workers-active set in config.properties
2) cluster.required-workers-active set to 0
3) cluster.required-workers-active set to a positive number

In all three cases, the cluster was coming up and running properly

Also tested the use case when the active workers drop below the threshold and confirmed that the state returns properly.

Checked the API on the worker node confirmed it returns ACTIVE.

```
== RELEASE NOTES ==

General Changes
* Update /v1/info/state API to mark coordinator active when 1) state is not shutting down, 2) active workers >= minimum required workers

```