### PR TITLE
Add DeltaLakeFileSplitConverter for delta lake support

### DIFF
--- a/presto-hive/pom.xml
+++ b/presto-hive/pom.xml
@@ -54,6 +54,12 @@
         </dependency>
 
         <dependency>
+            <groupId>io.delta</groupId>
+            <artifactId>delta-presto_2.12</artifactId>
+            <version>0.2.1-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-memory-context</artifactId>
         </dependency>

--- a/presto-hive/src/main/java/com/facebook/presto/hive/util/CustomSplitConversionUtils.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/util/CustomSplitConversionUtils.java
@@ -30,7 +30,10 @@ import static com.facebook.presto.hive.HiveErrorCode.HIVE_UNSUPPORTED_FORMAT;
  */
 public class CustomSplitConversionUtils
 {
-    private static final List<CustomSplitConverter> converters = ImmutableList.of(new HudiRealtimeSplitConverter());
+    private static final List<CustomSplitConverter> converters =
+            ImmutableList.of(
+                new HudiRealtimeSplitConverter(),
+                new DeltaLakeFileSplitConverter());
 
     private CustomSplitConversionUtils()
     {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/util/DeltaLakeFileSplitConverter.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/util/DeltaLakeFileSplitConverter.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.util;
+
+import io.delta.hive.DeltaInputSplit;
+import io.delta.hive.PartitionColumnInfo;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapred.FileSplit;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static java.util.Objects.requireNonNull;
+
+public final class DeltaLakeFileSplitConverter
+        implements CustomSplitConverter
+{
+    public static final String CUSTOM_SPLIT_CLASS_KEY = "custom_split_class";
+    public static final String FILE_SPLIT_PATH_KEY = "file_split_path";
+    public static final String FILE_SPLIT_START_KEY = "split_start";
+    public static final String FILE_SPLIT_LEN_KEY = "split_len";
+    public static final String FILE_PARTITION_COLUMNS = "part_cols";
+
+    @Override
+    public Optional<Map<String, String>> extractCustomSplitInfo(FileSplit split)
+    {
+        if (split instanceof DeltaInputSplit) {
+            Map<String, String> customSplitInfo = new HashMap<>();
+            DeltaInputSplit deltaInputSplit = (DeltaInputSplit) split;
+
+            customSplitInfo.put(CUSTOM_SPLIT_CLASS_KEY, DeltaInputSplit.class.getName());
+            customSplitInfo.put(FILE_SPLIT_PATH_KEY, deltaInputSplit.getPath().toString());
+            customSplitInfo.put(FILE_SPLIT_START_KEY, String.valueOf(deltaInputSplit.getStart()));
+            customSplitInfo.put(FILE_SPLIT_LEN_KEY, String.valueOf(deltaInputSplit.getLength()));
+            String partCols = Arrays.stream(deltaInputSplit.getPartitionColumns())
+                    .map(partitionColumnInfo ->
+                            String.join(":",
+                                    String.valueOf(partitionColumnInfo.index()),
+                                    partitionColumnInfo.tpe(),
+                                    partitionColumnInfo.value()))
+                    .collect(Collectors.joining(","));
+            customSplitInfo.put(FILE_PARTITION_COLUMNS, partCols);
+            return Optional.of(customSplitInfo);
+        }
+
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<FileSplit> recreateFileSplitWithCustomInfo(FileSplit split, Map<String, String> customSplitInfo) throws IOException
+    {
+        requireNonNull(customSplitInfo);
+
+        if (customSplitInfo.containsKey(CUSTOM_SPLIT_CLASS_KEY)
+                && customSplitInfo.get(CUSTOM_SPLIT_CLASS_KEY).equals(DeltaInputSplit.class.getName())) {
+            String partCols = customSplitInfo.get(FILE_PARTITION_COLUMNS);
+            if (partCols == null || partCols.equals("")) {
+                split = new DeltaInputSplit(
+                        new Path(customSplitInfo.get(FILE_SPLIT_PATH_KEY)),
+                        Long.parseLong(customSplitInfo.get(FILE_SPLIT_START_KEY)),
+                        Long.parseLong(customSplitInfo.get(FILE_SPLIT_LEN_KEY)),
+                        null, new PartitionColumnInfo[0]);
+            }
+            else {
+                split = new DeltaInputSplit(
+                        new Path(customSplitInfo.get(FILE_SPLIT_PATH_KEY)),
+                        Long.parseLong(customSplitInfo.get(FILE_SPLIT_START_KEY)),
+                        Long.parseLong(customSplitInfo.get(FILE_SPLIT_LEN_KEY)),
+                        null,
+                        Arrays.stream(customSplitInfo.get(FILE_PARTITION_COLUMNS)
+                                .split(","))
+                                .map(s -> {
+                                    String[] ss = s.split(":");
+                                    return new PartitionColumnInfo(
+                                            Integer.parseInt(ss[0]),
+                                            ss[1], ss[2]);
+                                }).toArray(PartitionColumnInfo[]::new));
+            }
+            return Optional.of(split);
+        }
+        return Optional.empty();
+    }
+}


### PR DESCRIPTION
## Changes

PrestoDB missing DeltaLakeSplitConvertor for converting delta hive split into presto custom split with partition column information in customSplitInfo. Will be added once delta-presto artifact released.
Note:- For more details about [CustomSplitConverter](https://github.com/prestodb/presto/blob/master/presto-hive/src/main/java/com/facebook/presto/hive/util/CustomSplitConverter.java) and [CustomSplitConversionUtils](https://github.com/prestodb/presto/blob/master/presto-hive/src/main/java/com/facebook/presto/hive/util/CustomSplitConversionUtils.java).

```
== RELEASE NOTES ==

General Changes
* ...
* ...

Hive Changes
* Add deltalake support using deltalake hive connector. Fore more details about connector https://github.com/delta-io/connectors.
* ...
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```
