### PR TITLE
[presto-orc] Add support for DWRF stripe metadata cache in the reader

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcBatchRecordReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcBatchRecordReader.java
@@ -101,7 +101,8 @@ public class OrcBatchRecordReader
                 writeValidation,
                 initialBatchSize,
                 stripeMetadataSource,
-                cacheable);
+                cacheable,
+                Optional.empty());
     }
 
     public int nextBatch()

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcReaderFeature.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcReaderFeature.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc;
+
+public enum OrcReaderFeature
+{
+    /**
+     * Enable stripe metadata cache in the reader.
+     */
+    STRIPE_META_CACHE,
+
+    /**
+     * Enable native ZSTD decompression.
+     */
+    ZSTD_JNI_DECOMPRESSION,
+
+    /**
+     * Allow null keys in maps.
+     */
+    MAP_NULL_KEYS,
+
+    /**
+     * Enable microsecond precision for timestamps.
+     */
+    TIMESTAMP_MICRO_PRECISION
+}

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcReaderOptions.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcReaderOptions.java
@@ -13,7 +13,10 @@
  */
 package com.facebook.presto.orc;
 
+import com.google.common.collect.ImmutableMap;
 import io.airlift.units.DataSize;
+
+import java.util.Map;
 
 import static java.util.Objects.requireNonNull;
 
@@ -22,29 +25,23 @@ public class OrcReaderOptions
     private final DataSize maxMergeDistance;
     private final DataSize tinyStripeThreshold;
     private final DataSize maxBlockSize;
-    private final boolean zstdJniDecompressionEnabled;
-    private final boolean mapNullKeysEnabled;
-    private final boolean enableTimestampMicroPrecision;
+    private final Map<OrcReaderFeature, Boolean> featureFlags;
 
     public OrcReaderOptions(DataSize maxMergeDistance, DataSize tinyStripeThreshold, DataSize maxBlockSize, boolean zstdJniDecompressionEnabled)
     {
-        this(maxMergeDistance, tinyStripeThreshold, maxBlockSize, zstdJniDecompressionEnabled, false, false);
+        this(maxMergeDistance, tinyStripeThreshold, maxBlockSize, ImmutableMap.of(OrcReaderFeature.ZSTD_JNI_DECOMPRESSION, zstdJniDecompressionEnabled));
     }
 
     public OrcReaderOptions(
             DataSize maxMergeDistance,
             DataSize tinyStripeThreshold,
             DataSize maxBlockSize,
-            boolean zstdJniDecompressionEnabled,
-            boolean mapNullKeysEnabled,
-            boolean enableTimestampMicroPrecision)
+            Map<OrcReaderFeature, Boolean> featureFlags)
     {
         this.maxMergeDistance = requireNonNull(maxMergeDistance, "maxMergeDistance is null");
         this.maxBlockSize = requireNonNull(maxBlockSize, "maxBlockSize is null");
         this.tinyStripeThreshold = requireNonNull(tinyStripeThreshold, "tinyStripeThreshold is null");
-        this.zstdJniDecompressionEnabled = zstdJniDecompressionEnabled;
-        this.mapNullKeysEnabled = mapNullKeysEnabled;
-        this.enableTimestampMicroPrecision = enableTimestampMicroPrecision;
+        this.featureFlags = ImmutableMap.copyOf(requireNonNull(featureFlags, "featureFlags is null"));
     }
 
     public DataSize getMaxMergeDistance()
@@ -59,7 +56,7 @@ public class OrcReaderOptions
 
     public boolean isOrcZstdJniDecompressionEnabled()
     {
-        return zstdJniDecompressionEnabled;
+        return isFeatureEnabled(OrcReaderFeature.ZSTD_JNI_DECOMPRESSION);
     }
 
     public DataSize getTinyStripeThreshold()
@@ -69,11 +66,21 @@ public class OrcReaderOptions
 
     public boolean mapNullKeysEnabled()
     {
-        return mapNullKeysEnabled;
+        return isFeatureEnabled(OrcReaderFeature.MAP_NULL_KEYS);
     }
 
     public boolean enableTimestampMicroPrecision()
     {
-        return enableTimestampMicroPrecision;
+        return isFeatureEnabled(OrcReaderFeature.TIMESTAMP_MICRO_PRECISION);
+    }
+
+    public boolean isStripeMetaCacheEnabled()
+    {
+        return isFeatureEnabled(OrcReaderFeature.STRIPE_META_CACHE);
+    }
+
+    private boolean isFeatureEnabled(OrcReaderFeature feature)
+    {
+        return featureFlags.getOrDefault(feature, false);
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcSelectiveRecordReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcSelectiveRecordReader.java
@@ -31,6 +31,7 @@ import com.facebook.presto.orc.metadata.MetadataReader;
 import com.facebook.presto.orc.metadata.OrcType;
 import com.facebook.presto.orc.metadata.PostScript;
 import com.facebook.presto.orc.metadata.StripeInformation;
+import com.facebook.presto.orc.metadata.StripeMetaCache;
 import com.facebook.presto.orc.metadata.statistics.ColumnStatistics;
 import com.facebook.presto.orc.metadata.statistics.StripeStatistics;
 import com.facebook.presto.orc.reader.SelectiveStreamReader;
@@ -178,7 +179,8 @@ public class OrcSelectiveRecordReader
             Optional<OrcWriteValidation> writeValidation,
             int initialBatchSize,
             StripeMetadataSource stripeMetadataSource,
-            boolean cacheable)
+            boolean cacheable,
+            Optional<StripeMetaCache> stripeMetaCache)
     {
         super(includedColumns,
                 requiredSubfields,
@@ -220,7 +222,8 @@ public class OrcSelectiveRecordReader
                 writeValidation,
                 initialBatchSize,
                 stripeMetadataSource,
-                cacheable);
+                cacheable,
+                stripeMetaCache);
 
         // Hive column indices can't be used to index into arrays because they are negative
         // for partition and hidden columns. Hence, we create synthetic zero-based indices.

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
@@ -671,7 +671,8 @@ public class OrcWriter
                 orcTypes,
                 ImmutableList.copyOf(unencryptedStats),
                 userMetadata,
-                dwrfEncryption);
+                dwrfEncryption,
+                ImmutableList.of());
 
         closedStripes.clear();
         closedStripesRetainedBytes = 0;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/StripeInfo.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/StripeInfo.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc;
+
+import com.facebook.presto.orc.metadata.StripeInformation;
+import io.airlift.slice.Slice;
+
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+class StripeInfo
+{
+    private final StripeInformation stripe;
+    private final Optional<Slice> indexCache;
+    private final Optional<Slice> footerCache;
+
+    public StripeInfo(StripeInformation stripe)
+    {
+        this(stripe, Optional.empty(), Optional.empty());
+    }
+
+    public StripeInfo(StripeInformation stripe, Optional<Slice> indexCache, Optional<Slice> footerCache)
+    {
+        this.stripe = requireNonNull(stripe, "stripe is null");
+        this.indexCache = requireNonNull(indexCache, "indexCache is null");
+        this.footerCache = requireNonNull(footerCache, "footerCache is null");
+    }
+
+    public StripeInformation getStripe()
+    {
+        return stripe;
+    }
+
+    public Optional<Slice> getIndexCache()
+    {
+        return indexCache;
+    }
+
+    public Optional<Slice> getFooterCache()
+    {
+        return footerCache;
+    }
+}

--- a/presto-orc/src/main/java/com/facebook/presto/orc/cache/StorageOrcFileTailSource.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/cache/StorageOrcFileTailSource.java
@@ -40,7 +40,8 @@ public class StorageOrcFileTailSource
 {
     private static final Logger log = Logger.get(StorageOrcFileTailSource.class);
 
-    private static final int EXPECTED_FOOTER_SIZE = 16 * 1024;
+    // try to catch both footer and metadata cache with a large enough first read
+    private static final int EXPECTED_FOOTER_SIZE = 1024 * 1024;
 
     private static final int CURRENT_MAJOR_VERSION = 0;
     private static final int CURRENT_MINOR_VERSION = 12;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/cache/StorageOrcFileTailSource.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/cache/StorageOrcFileTailSource.java
@@ -114,7 +114,7 @@ public class StorageOrcFileTailSource
         Slice metadataSlice = completeFooterSlice.slice(0, metadataSize);
         Slice footerSlice = completeFooterSlice.slice(metadataSize, footerSize);
 
-        return new OrcFileTail(hiveWriterVersion, bufferSize, compressionKind, footerSlice, footerSize, metadataSlice, metadataSize);
+        return new OrcFileTail(hiveWriterVersion, bufferSize, compressionKind, footerSlice, footerSize, metadataSlice, metadataSize, postScript.getCacheMode());
     }
 
     /**

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfMetadataReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfMetadataReader.java
@@ -91,7 +91,8 @@ public class DwrfMetadataReader
         return new PostScript(
                 ImmutableList.of(),
                 postScript.getFooterLength(),
-                0,
+                postScript.getCacheSize(),
+                toCacheMode(postScript.getCacheMode()),
                 toCompression(postScript.getCompression()),
                 postScript.getCompressionBlockSize(),
                 writerVersion);
@@ -132,7 +133,8 @@ public class DwrfMetadataReader
                 types,
                 fileStats,
                 toUserMetadata(footer.getMetadataList()),
-                encryption);
+                encryption,
+                footer.getStripeCacheOffsetsList());
     }
 
     private List<ColumnStatistics> decryptAndCombineFileStatistics(HiveWriterVersion hiveWriterVersion,
@@ -589,6 +591,8 @@ public class DwrfMetadataReader
                 return StreamKind.ROW_GROUP_DICTIONARY;
             case STRIDE_DICTIONARY_LENGTH:
                 return StreamKind.ROW_GROUP_DICTIONARY_LENGTH;
+            case BLOOM_FILTER_UTF8:
+                return StreamKind.BLOOM_FILTER_UTF8;
             case IN_MAP:
                 return StreamKind.IN_MAP;
             default:
@@ -642,5 +646,19 @@ public class DwrfMetadataReader
         return new StripeEncryptionGroup(
                 encryptedStreams,
                 toColumnEncoding(types, stripeEncryptionGroup.getEncodingList()));
+    }
+
+    private static StripeMetaCacheMode toCacheMode(DwrfProto.StripeCacheMode mode)
+    {
+        switch (mode) {
+            case INDEX:
+                return StripeMetaCacheMode.INDEX;
+            case FOOTER:
+                return StripeMetaCacheMode.FOOTER;
+            case BOTH:
+                return StripeMetaCacheMode.INDEX_AND_FOOTER;
+            default:
+                return StripeMetaCacheMode.NONE;
+        }
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfMetadataReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfMetadataReader.java
@@ -17,8 +17,10 @@ import com.facebook.presto.orc.DwrfDataEncryptor;
 import com.facebook.presto.orc.DwrfEncryptionProvider;
 import com.facebook.presto.orc.DwrfKeyProvider;
 import com.facebook.presto.orc.EncryptionLibrary;
+import com.facebook.presto.orc.OrcAggregatedMemoryContext;
 import com.facebook.presto.orc.OrcCorruptionException;
 import com.facebook.presto.orc.OrcDataSource;
+import com.facebook.presto.orc.OrcDataSourceId;
 import com.facebook.presto.orc.OrcDecompressor;
 import com.facebook.presto.orc.metadata.ColumnEncoding.ColumnEncodingKind;
 import com.facebook.presto.orc.metadata.OrcType.OrcTypeKind;
@@ -99,9 +101,14 @@ public class DwrfMetadataReader
     }
 
     @Override
-    public Metadata readMetadata(HiveWriterVersion hiveWriterVersion, InputStream inputStream)
+    public Metadata readMetadata(HiveWriterVersion hiveWriterVersion,
+            OrcDataSourceId dataSourceId,
+            Slice metadataSlice,
+            Optional<OrcDecompressor> decompressor,
+            OrcAggregatedMemoryContext memoryContext,
+            Optional<StripeMetaCache> stripeMetaCache)
     {
-        return new Metadata(ImmutableList.of());
+        return new Metadata(ImmutableList.of(), stripeMetaCache);
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/ExceptionWrappingMetadataReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/ExceptionWrappingMetadataReader.java
@@ -15,12 +15,14 @@ package com.facebook.presto.orc.metadata;
 
 import com.facebook.presto.orc.DwrfEncryptionProvider;
 import com.facebook.presto.orc.DwrfKeyProvider;
+import com.facebook.presto.orc.OrcAggregatedMemoryContext;
 import com.facebook.presto.orc.OrcCorruptionException;
 import com.facebook.presto.orc.OrcDataSource;
 import com.facebook.presto.orc.OrcDataSourceId;
 import com.facebook.presto.orc.OrcDecompressor;
 import com.facebook.presto.orc.metadata.PostScript.HiveWriterVersion;
 import com.facebook.presto.orc.metadata.statistics.HiveBloomFilter;
+import io.airlift.slice.Slice;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -55,12 +57,16 @@ public class ExceptionWrappingMetadataReader
         }
     }
 
-    @Override
-    public Metadata readMetadata(HiveWriterVersion hiveWriterVersion, InputStream inputStream)
+    public Metadata readMetadata(HiveWriterVersion hiveWriterVersion,
+            OrcDataSourceId dataSourceId,
+            Slice metadataSlice,
+            Optional<OrcDecompressor> decompressor,
+            OrcAggregatedMemoryContext memoryContext,
+            Optional<StripeMetaCache> stripeMetaCache)
             throws OrcCorruptionException
     {
         try {
-            return delegate.readMetadata(hiveWriterVersion, inputStream);
+            return delegate.readMetadata(hiveWriterVersion, dataSourceId, metadataSlice, decompressor, memoryContext, stripeMetaCache);
         }
         catch (IOException | RuntimeException e) {
             throw propagate(e, "Invalid file metadata");

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/Footer.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/Footer.java
@@ -36,8 +36,16 @@ public class Footer
     private final List<ColumnStatistics> fileStats;
     private final Map<String, Slice> userMetadata;
     private final Optional<DwrfEncryption> encryption;
+    private final List<Integer> stripeCacheOffsets;
 
-    public Footer(long numberOfRows, int rowsInRowGroup, List<StripeInformation> stripes, List<OrcType> types, List<ColumnStatistics> fileStats, Map<String, Slice> userMetadata, Optional<DwrfEncryption> encryption)
+    public Footer(long numberOfRows,
+            int rowsInRowGroup,
+            List<StripeInformation> stripes,
+            List<OrcType> types,
+            List<ColumnStatistics> fileStats,
+            Map<String, Slice> userMetadata,
+            Optional<DwrfEncryption> encryption,
+            List<Integer> stripeCacheOffsets)
     {
         this.numberOfRows = numberOfRows;
         this.rowsInRowGroup = rowsInRowGroup;
@@ -47,6 +55,7 @@ public class Footer
         requireNonNull(userMetadata, "userMetadata is null");
         this.userMetadata = ImmutableMap.copyOf(transformValues(userMetadata, Slices::copyOf));
         this.encryption = requireNonNull(encryption, "encryption is null");
+        this.stripeCacheOffsets = ImmutableList.copyOf(requireNonNull(stripeCacheOffsets, "stripeCacheOffsets is null"));
     }
 
     public long getNumberOfRows()
@@ -79,6 +88,11 @@ public class Footer
         return ImmutableMap.copyOf(transformValues(userMetadata, Slices::copyOf));
     }
 
+    public List<Integer> getStripeCacheOffsets()
+    {
+        return stripeCacheOffsets;
+    }
+
     @Override
     public String toString()
     {
@@ -89,6 +103,7 @@ public class Footer
                 .add("types", types)
                 .add("columnStatistics", fileStats)
                 .add("userMetadata", userMetadata.keySet())
+                .add("stripeCacheOffsets", stripeCacheOffsets)
                 .toString();
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/Metadata.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/Metadata.java
@@ -16,18 +16,31 @@ package com.facebook.presto.orc.metadata;
 import com.facebook.presto.orc.metadata.statistics.StripeStatistics;
 
 import java.util.List;
+import java.util.Optional;
 
 public class Metadata
 {
     private final List<StripeStatistics> stripeStatistics;
+    private final Optional<StripeMetaCache> stripeMetaCache;
 
     public Metadata(List<StripeStatistics> stripeStatistics)
     {
+        this(stripeStatistics, Optional.empty());
+    }
+
+    public Metadata(List<StripeStatistics> stripeStatistics, Optional<StripeMetaCache> stripeMetaCache)
+    {
         this.stripeStatistics = stripeStatistics;
+        this.stripeMetaCache = stripeMetaCache;
     }
 
     public List<StripeStatistics> getStripeStatsList()
     {
         return stripeStatistics;
+    }
+
+    public Optional<StripeMetaCache> getStripeMetaCache()
+    {
+        return stripeMetaCache;
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/MetadataReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/MetadataReader.java
@@ -15,10 +15,13 @@ package com.facebook.presto.orc.metadata;
 
 import com.facebook.presto.orc.DwrfEncryptionProvider;
 import com.facebook.presto.orc.DwrfKeyProvider;
+import com.facebook.presto.orc.OrcAggregatedMemoryContext;
 import com.facebook.presto.orc.OrcDataSource;
+import com.facebook.presto.orc.OrcDataSourceId;
 import com.facebook.presto.orc.OrcDecompressor;
 import com.facebook.presto.orc.metadata.PostScript.HiveWriterVersion;
 import com.facebook.presto.orc.metadata.statistics.HiveBloomFilter;
+import io.airlift.slice.Slice;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -30,7 +33,12 @@ public interface MetadataReader
     PostScript readPostScript(byte[] data, int offset, int length)
             throws IOException;
 
-    Metadata readMetadata(HiveWriterVersion hiveWriterVersion, InputStream inputStream)
+    Metadata readMetadata(HiveWriterVersion hiveWriterVersion,
+            OrcDataSourceId dataSourceId,
+            Slice metadataSlice,
+            Optional<OrcDecompressor> decompressor,
+            OrcAggregatedMemoryContext memoryContext,
+            Optional<StripeMetaCache> stripeMetaCache)
             throws IOException;
 
     Footer readFooter(HiveWriterVersion hiveWriterVersion,

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcFileTail.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcFileTail.java
@@ -27,6 +27,7 @@ public class OrcFileTail
     private final int footerSize;
     private final Slice metadataSlice;
     private final int metadataSize;
+    private final StripeMetaCacheMode cacheMode;
 
     public OrcFileTail(
             HiveWriterVersion hiveWriterVersion,
@@ -35,7 +36,8 @@ public class OrcFileTail
             Slice footerSlice,
             int footerSize,
             Slice metadataSlice,
-            int metadataSize)
+            int metadataSize,
+            StripeMetaCacheMode cacheMode)
     {
         this.hiveWriterVersion = requireNonNull(hiveWriterVersion, "hiveWriterVersion is null");
         this.bufferSize = bufferSize;
@@ -44,6 +46,7 @@ public class OrcFileTail
         this.footerSize = footerSize;
         this.metadataSlice = requireNonNull(metadataSlice, "metadataSlice is null");
         this.metadataSize = metadataSize;
+        this.cacheMode = requireNonNull(cacheMode, "cacheMode is null");
     }
 
     public HiveWriterVersion getHiveWriterVersion()
@@ -79,5 +82,10 @@ public class OrcFileTail
     public int getMetadataSize()
     {
         return metadataSize;
+    }
+
+    public StripeMetaCacheMode getCacheMode()
+    {
+        return cacheMode;
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcMetadataReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcMetadataReader.java
@@ -91,6 +91,7 @@ public class OrcMetadataReader
                 postScript.getVersionList(),
                 postScript.getFooterLength(),
                 postScript.getMetadataLength(),
+                StripeMetaCacheMode.NONE,
                 toCompression(postScript.getCompression()),
                 postScript.getCompressionBlockSize(),
                 toHiveWriterVersion(postScript.getWriterVersion()));
@@ -145,7 +146,8 @@ public class OrcMetadataReader
                 toType(footer.getTypesList()),
                 toColumnStatistics(hiveWriterVersion, footer.getStatisticsList(), false),
                 toUserMetadata(footer.getMetadataList()),
-                Optional.empty());
+                Optional.empty(),
+                ImmutableList.of());
     }
 
     private static List<StripeInformation> toStripeInformation(List<OrcProto.StripeInformation> types)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/PostScript.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/PostScript.java
@@ -46,15 +46,17 @@ public class PostScript
     private final List<Integer> version;
     private final long footerLength;
     private final long metadataLength;
+    private final StripeMetaCacheMode cacheMode;
     private final CompressionKind compression;
     private final long compressionBlockSize;
     private final HiveWriterVersion hiveWriterVersion;
 
-    public PostScript(List<Integer> version, long footerLength, long metadataLength, CompressionKind compression, long compressionBlockSize, HiveWriterVersion hiveWriterVersion)
+    public PostScript(List<Integer> version, long footerLength, long metadataLength, StripeMetaCacheMode cacheMode, CompressionKind compression, long compressionBlockSize, HiveWriterVersion hiveWriterVersion)
     {
         this.version = ImmutableList.copyOf(requireNonNull(version, "version is null"));
         this.footerLength = footerLength;
         this.metadataLength = metadataLength;
+        this.cacheMode = requireNonNull(cacheMode, "cacheMode is null");
         this.compression = requireNonNull(compression, "compressionKind is null");
         this.compressionBlockSize = compressionBlockSize;
         this.hiveWriterVersion = requireNonNull(hiveWriterVersion, "hiveWriterVersion is null");
@@ -73,6 +75,11 @@ public class PostScript
     public long getMetadataLength()
     {
         return metadataLength;
+    }
+
+    public StripeMetaCacheMode getCacheMode()
+    {
+        return cacheMode;
     }
 
     public CompressionKind getCompression()
@@ -97,6 +104,7 @@ public class PostScript
                 .add("version", version)
                 .add("footerLength", footerLength)
                 .add("metadataLength", metadataLength)
+                .add("cacheMode", cacheMode)
                 .add("compressionKind", compression)
                 .add("compressionBlockSize", compressionBlockSize)
                 .add("hiveWriterVersion", hiveWriterVersion)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/StripeMetaCache.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/StripeMetaCache.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.metadata;
+
+import com.facebook.airlift.log.Logger;
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.facebook.presto.orc.metadata.StripeMetaCacheMode.FOOTER;
+import static com.facebook.presto.orc.metadata.StripeMetaCacheMode.INDEX;
+import static com.facebook.presto.orc.metadata.StripeMetaCacheMode.INDEX_AND_FOOTER;
+import static com.facebook.presto.orc.metadata.StripeMetaCacheMode.NONE;
+import static java.util.Objects.requireNonNull;
+
+public class StripeMetaCache
+{
+    private static final Logger log = Logger.get(StripeMetaCache.class);
+    private final List<Integer> cacheOffsets;
+    private final StripeMetaCacheMode cacheMode;
+    private final Slice data;
+
+    public StripeMetaCache(List<Integer> offsets, StripeMetaCacheMode mode, Slice data)
+    {
+        this.cacheOffsets = ImmutableList.copyOf(requireNonNull(offsets, "offsets is null"));
+        this.data = requireNonNull(data, "data is null");
+        this.cacheMode = filterMode(requireNonNull(mode, "mode is null"));
+    }
+
+    // work only with supported modes
+    private StripeMetaCacheMode filterMode(StripeMetaCacheMode mode)
+    {
+        if (mode == INDEX || mode == FOOTER || mode == INDEX_AND_FOOTER) {
+            return mode;
+        }
+        return NONE;
+    }
+
+    public Optional<Slice> getStripeFooterSlice(int stripeOrdinal, long sliceLength)
+    {
+        return getSlice(stripeOrdinal, FOOTER, sliceLength);
+    }
+
+    public Optional<Slice> getStripeIndexSlice(int stripeOrdinal, long expectedSliceLength)
+    {
+        return getSlice(stripeOrdinal, INDEX, expectedSliceLength);
+    }
+
+    private Optional<Slice> getSlice(int stripeOrdinal, StripeMetaCacheMode kind, long expectedSliceLength)
+    {
+        if (!cacheMode.has(kind)) {
+            return Optional.empty();
+        }
+
+        int index = -1;
+        if (cacheMode == kind) {
+            index = stripeOrdinal;
+        }
+        else if (cacheMode == INDEX_AND_FOOTER) {
+            index = stripeOrdinal * 2 + (kind == INDEX ? 0 : 1);
+        }
+
+        // cache might contain data only for first N stripes
+        if (index >= 0 && index < cacheOffsets.size() - 1) {
+            int sliceOffsetStart = cacheOffsets.get(index);
+            int sliceOffsetEnd = cacheOffsets.get(index + 1);
+            int dataLength = sliceOffsetEnd - sliceOffsetStart;
+            if (dataLength != expectedSliceLength) {
+                log.warn("Size mismatch between expected %s and cached data %s for stripe %s", expectedSliceLength, dataLength, stripeOrdinal);
+                return Optional.empty();
+            }
+
+            if (data.length() < sliceOffsetEnd || data.length() < sliceOffsetStart) {
+                log.warn("Cached data size is smaller than to what offsets point to");
+                return Optional.empty();
+            }
+
+            return Optional.of(data.slice(sliceOffsetStart, dataLength));
+        }
+
+        return Optional.empty();
+    }
+}

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/StripeMetaCacheMode.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/StripeMetaCacheMode.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.metadata;
+
+/**
+ * Describes content of the metadata cache stored in DWRF files.
+ */
+public enum StripeMetaCacheMode
+{
+    // no cache
+    NONE(0b00),
+
+    // cache contains stripe indexes
+    INDEX(0b1),
+
+    // cache contains stripe footers
+    FOOTER(0b10),
+
+    // cache contains stripe indexes and footers
+    INDEX_AND_FOOTER(0b11);
+
+    private final int value;
+
+    StripeMetaCacheMode(int value)
+    {
+        this.value = value;
+    }
+
+    public boolean has(StripeMetaCacheMode test)
+    {
+        return (value & test.value) == test.value;
+    }
+}

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/StripeMetaCacheMode.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/StripeMetaCacheMode.java
@@ -18,27 +18,30 @@ package com.facebook.presto.orc.metadata;
  */
 public enum StripeMetaCacheMode
 {
-    // no cache
-    NONE(0b00),
-
-    // cache contains stripe indexes
-    INDEX(0b1),
-
-    // cache contains stripe footers
-    FOOTER(0b10),
-
-    // cache contains stripe indexes and footers
-    INDEX_AND_FOOTER(0b11);
+    NONE(0b00, "no cache"),
+    INDEX(0b01, "stripe indexes"),
+    FOOTER(0b10, "stripe footers"),
+    INDEX_AND_FOOTER(0b11, "stripe indexes and footers");
 
     private final int value;
+    private final String description;
 
-    StripeMetaCacheMode(int value)
+    StripeMetaCacheMode(int value, String description)
     {
         this.value = value;
+        this.description = description;
     }
 
     public boolean has(StripeMetaCacheMode test)
     {
         return (value & test.value) == test.value;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "StripeMetaCacheMode{" +
+                "description='" + description + '\'' +
+                '}';
     }
 }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
@@ -1464,9 +1464,7 @@ public class OrcTester
                         new DataSize(1, MEGABYTE),
                         new DataSize(1, MEGABYTE),
                         MAX_BLOCK_SIZE,
-                        false,
-                        mapNullKeysEnabled,
-                        false),
+                        ImmutableMap.of(OrcReaderFeature.MAP_NULL_KEYS, mapNullKeysEnabled)),
                 cacheable,
                 new DwrfEncryptionProvider(new UnsupportedEncryptionLibrary(), new TestingEncryptionLibrary()),
                 DwrfKeyProvider.of(intermediateEncryptionKeys));
@@ -1498,9 +1496,7 @@ public class OrcTester
                         new DataSize(1, MEGABYTE),
                         new DataSize(1, MEGABYTE),
                         MAX_BLOCK_SIZE,
-                        false,
-                        mapNullKeysEnabled,
-                        false),
+                        ImmutableMap.of(OrcReaderFeature.MAP_NULL_KEYS, mapNullKeysEnabled)),
                 false,
                 new DwrfEncryptionProvider(new UnsupportedEncryptionLibrary(), new TestingEncryptionLibrary()),
                 DwrfKeyProvider.of(intermediateEncryptionKeys));
@@ -1672,9 +1668,7 @@ public class OrcTester
                         new DataSize(1, MEGABYTE),
                         new DataSize(1, MEGABYTE),
                         MAX_BLOCK_SIZE,
-                        false,
-                        mapNullKeysEnabled,
-                        false),
+                        ImmutableMap.of(OrcReaderFeature.MAP_NULL_KEYS, mapNullKeysEnabled)),
                 false,
                 new DwrfEncryptionProvider(new UnsupportedEncryptionLibrary(), new TestingEncryptionLibrary()),
                 DwrfKeyProvider.of(intermediateEncryptionKeys));

--- a/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
@@ -1512,7 +1512,13 @@ public class OrcTester
     public static void writeOrcColumnsPresto(File outputFile, Format format, CompressionKind compression, Optional<DwrfWriterEncryption> dwrfWriterEncryption, List<Type> types, List<List<?>> values, WriterStats stats)
             throws Exception
     {
-        OrcWriter writer = createOrcWriter(outputFile, format.orcEncoding, compression, dwrfWriterEncryption, types, new OrcWriterOptions(), stats);
+        writeOrcColumnsPresto(outputFile, format, compression, new OrcWriterOptions(), dwrfWriterEncryption, types, values, stats);
+    }
+
+    public static void writeOrcColumnsPresto(File outputFile, Format format, CompressionKind compression, OrcWriterOptions writerOptions, Optional<DwrfWriterEncryption> dwrfWriterEncryption, List<Type> types, List<List<?>> values, WriterStats stats)
+            throws Exception
+    {
+        OrcWriter writer = createOrcWriter(outputFile, format.orcEncoding, compression, dwrfWriterEncryption, types, writerOptions, stats);
 
         Block[] blocks = new Block[types.size()];
         for (int i = 0; i < types.size(); i++) {

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestDecryption.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestDecryption.java
@@ -20,7 +20,6 @@ import com.facebook.presto.orc.metadata.DwrfEncryption;
 import com.facebook.presto.orc.metadata.EncryptionGroup;
 import com.facebook.presto.orc.metadata.Footer;
 import com.facebook.presto.orc.metadata.OrcType;
-import com.facebook.presto.orc.metadata.Stream;
 import com.facebook.presto.orc.metadata.StripeInformation;
 import com.facebook.presto.orc.metadata.statistics.ColumnStatistics;
 import com.google.common.collect.ImmutableList;
@@ -56,16 +55,12 @@ import static com.facebook.presto.orc.OrcTester.MAX_BLOCK_SIZE;
 import static com.facebook.presto.orc.OrcTester.assertFileContentsPresto;
 import static com.facebook.presto.orc.OrcTester.rowType;
 import static com.facebook.presto.orc.OrcTester.writeOrcColumnsPresto;
-import static com.facebook.presto.orc.StripeReader.getDiskRanges;
-import static com.facebook.presto.orc.metadata.ColumnEncoding.DEFAULT_SEQUENCE_ID;
 import static com.facebook.presto.orc.metadata.CompressionKind.ZSTD;
 import static com.facebook.presto.orc.metadata.KeyProvider.UNKNOWN;
 import static com.facebook.presto.orc.metadata.OrcType.OrcTypeKind.INT;
 import static com.facebook.presto.orc.metadata.OrcType.OrcTypeKind.LIST;
 import static com.facebook.presto.orc.metadata.OrcType.OrcTypeKind.MAP;
 import static com.facebook.presto.orc.metadata.OrcType.OrcTypeKind.STRUCT;
-import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
-import static com.facebook.presto.orc.metadata.Stream.StreamKind.ROW_INDEX;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.io.Resources.getResource;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
@@ -203,46 +198,6 @@ public class TestDecryption
         List<StripeInformation> unencryptedStripes = ImmutableList.of(NO_KEYS_STRIPE, NO_KEYS_STRIPE);
         assertEquals(getDecryptionKeyMetadata(0, unencryptedStripes), ImmutableList.of());
         assertEquals(getDecryptionKeyMetadata(1, unencryptedStripes), ImmutableList.of());
-    }
-
-    @Test
-    public void testGetDiskRanges()
-    {
-        List<Stream> unencryptedStreams = ImmutableList.of(
-                new Stream(3, ROW_INDEX, 5, true, DEFAULT_SEQUENCE_ID, Optional.of(15L)),
-                new Stream(4, ROW_INDEX, 5, true),
-                new Stream(3, DATA, 5, true, DEFAULT_SEQUENCE_ID, Optional.of(45L)),
-                new Stream(4, DATA, 5, true));
-
-        List<Stream> group1Streams = ImmutableList.of(
-                new Stream(0, ROW_INDEX, 5, true),
-                new Stream(5, ROW_INDEX, 5, true, DEFAULT_SEQUENCE_ID, Optional.of(25L)),
-                new Stream(0, DATA, 5, true, DEFAULT_SEQUENCE_ID, Optional.of(30L)),
-                new Stream(5, DATA, 5, true, DEFAULT_SEQUENCE_ID, Optional.of(55L)));
-
-        List<Stream> group2Streams = ImmutableList.of(
-                new Stream(1, ROW_INDEX, 5, true, DEFAULT_SEQUENCE_ID, Optional.of(5L)),
-                new Stream(2, ROW_INDEX, 5, true),
-                new Stream(1, DATA, 5, true, DEFAULT_SEQUENCE_ID, Optional.of(35L)),
-                new Stream(2, DATA, 5, true));
-
-        Map<StreamId, DiskRange> actual = getDiskRanges(ImmutableList.of(unencryptedStreams, group1Streams, group2Streams));
-
-        Map<StreamId, DiskRange> expected = ImmutableMap.<StreamId, DiskRange>builder()
-                .put(new StreamId(0, DEFAULT_SEQUENCE_ID, ROW_INDEX), new DiskRange(0, 5))
-                .put(new StreamId(1, DEFAULT_SEQUENCE_ID, ROW_INDEX), new DiskRange(5, 5))
-                .put(new StreamId(2, DEFAULT_SEQUENCE_ID, ROW_INDEX), new DiskRange(10, 5))
-                .put(new StreamId(3, DEFAULT_SEQUENCE_ID, ROW_INDEX), new DiskRange(15, 5))
-                .put(new StreamId(4, DEFAULT_SEQUENCE_ID, ROW_INDEX), new DiskRange(20, 5))
-                .put(new StreamId(5, DEFAULT_SEQUENCE_ID, ROW_INDEX), new DiskRange(25, 5))
-                .put(new StreamId(0, DEFAULT_SEQUENCE_ID, DATA), new DiskRange(30, 5))
-                .put(new StreamId(1, DEFAULT_SEQUENCE_ID, DATA), new DiskRange(35, 5))
-                .put(new StreamId(2, DEFAULT_SEQUENCE_ID, DATA), new DiskRange(40, 5))
-                .put(new StreamId(3, DEFAULT_SEQUENCE_ID, DATA), new DiskRange(45, 5))
-                .put(new StreamId(4, DEFAULT_SEQUENCE_ID, DATA), new DiskRange(50, 5))
-                .put(new StreamId(5, DEFAULT_SEQUENCE_ID, DATA), new DiskRange(55, 5))
-                .build();
-        assertEquals(actual, expected);
     }
 
     @Test

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestDecryption.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestDecryption.java
@@ -488,9 +488,7 @@ public class TestDecryption
                         new DataSize(1, MEGABYTE),
                         new DataSize(1, MEGABYTE),
                         MAX_BLOCK_SIZE,
-                        false,
-                        false,
-                        false),
+                        ImmutableMap.of()),
                 false,
                 new DwrfEncryptionProvider(new UnsupportedEncryptionLibrary(), new TestingPlainKeyEncryptionLibrary()),
                 DwrfKeyProvider.of(ImmutableMap.of(0, Slices.utf8Slice("key"))));

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestDecryption.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestDecryption.java
@@ -186,18 +186,18 @@ public class TestDecryption
     public void testGetStripeDecryptionKeys()
     {
         List<StripeInformation> encryptedStripes = ImmutableList.of(A_STRIPE, NO_KEYS_STRIPE, B_STRIPE, NO_KEYS_STRIPE);
-        assertEquals(getDecryptionKeyMetadata(0, encryptedStripes), A_KEYS);
-        assertEquals(getDecryptionKeyMetadata(1, encryptedStripes), A_KEYS);
-        assertEquals(getDecryptionKeyMetadata(2, encryptedStripes), B_KEYS);
-        assertEquals(getDecryptionKeyMetadata(3, encryptedStripes), B_KEYS);
+        assertEquals(getDecryptionKeyMetadata(0, asStripeInfos(encryptedStripes)), A_KEYS);
+        assertEquals(getDecryptionKeyMetadata(1, asStripeInfos(encryptedStripes)), A_KEYS);
+        assertEquals(getDecryptionKeyMetadata(2, asStripeInfos(encryptedStripes)), B_KEYS);
+        assertEquals(getDecryptionKeyMetadata(3, asStripeInfos(encryptedStripes)), B_KEYS);
     }
 
     @Test
     public void testGetStripeDecryptionKeysUnencrypted()
     {
         List<StripeInformation> unencryptedStripes = ImmutableList.of(NO_KEYS_STRIPE, NO_KEYS_STRIPE);
-        assertEquals(getDecryptionKeyMetadata(0, unencryptedStripes), ImmutableList.of());
-        assertEquals(getDecryptionKeyMetadata(1, unencryptedStripes), ImmutableList.of());
+        assertEquals(getDecryptionKeyMetadata(0, asStripeInfos(unencryptedStripes)), ImmutableList.of());
+        assertEquals(getDecryptionKeyMetadata(1, asStripeInfos(unencryptedStripes)), ImmutableList.of());
     }
 
     @Test
@@ -715,5 +715,10 @@ public class TestDecryption
                 new TestingHiveOrcAggregatedMemoryContext(),
                 Optional.empty(),
                 MAX_BATCH_SIZE);
+    }
+
+    private static List<StripeInfo> asStripeInfos(List<StripeInformation> infos)
+    {
+        return infos.stream().map(StripeInfo::new).collect(toImmutableList());
     }
 }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestDecryption.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestDecryption.java
@@ -159,7 +159,8 @@ public class TestDecryption
                 types,
                 ImmutableList.of(),
                 ImmutableMap.of(),
-                encryption);
+                encryption,
+                ImmutableList.of());
     }
 
     @Test

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcWriter.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcWriter.java
@@ -117,7 +117,7 @@ public class TestOrcWriter
                 int size = 0;
                 boolean dataStreamStarted = false;
                 for (Stream stream : stripeFooter.getStreams()) {
-                    if (isIndexStream(stream)) {
+                    if (isIndexStream(stream.getStreamKind())) {
                         assertFalse(dataStreamStarted);
                         continue;
                     }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestStripeMetaCaching.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestStripeMetaCaching.java
@@ -1,0 +1,465 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc;
+
+import com.facebook.presto.common.Page;
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.orc.array.Arrays;
+import com.facebook.presto.orc.cache.StorageOrcFileTailSource;
+import com.facebook.presto.orc.metadata.CompressionKind;
+import com.facebook.presto.orc.metadata.CompressionParameters;
+import com.facebook.presto.orc.proto.DwrfProto;
+import com.facebook.presto.orc.protobuf.CodedInputStream;
+import com.facebook.presto.orc.protobuf.MessageLite;
+import com.facebook.presto.orc.stream.OrcInputStream;
+import com.facebook.presto.orc.stream.SharedBuffer;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.CountingOutputStream;
+import io.airlift.slice.OutputStreamSliceOutput;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import io.airlift.units.DataSize;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.RandomAccessFile;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.Random;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import static com.facebook.airlift.testing.Assertions.assertGreaterThanOrEqual;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.orc.DwrfEncryptionProvider.NO_ENCRYPTION;
+import static com.facebook.presto.orc.NoopOrcAggregatedMemoryContext.NOOP_ORC_AGGREGATED_MEMORY_CONTEXT;
+import static com.facebook.presto.orc.NoopOrcLocalMemoryContext.NOOP_ORC_LOCAL_MEMORY_CONTEXT;
+import static com.facebook.presto.orc.OrcReader.INITIAL_BATCH_SIZE;
+import static com.facebook.presto.orc.OrcTester.Format.DWRF;
+import static com.facebook.presto.orc.OrcTester.writeOrcColumnsPresto;
+import static com.facebook.presto.orc.metadata.CompressionKind.ZLIB;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static java.lang.Math.toIntExact;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.joda.time.DateTimeZone.UTC;
+import static org.testng.Assert.assertEquals;
+
+public class TestStripeMetaCaching
+{
+    private static final int READ_TAIL_SIZE = 1024 * 1024; // comes from StorageOrcFileTailSource
+    private static final int ROW_COUNT = 100_000;
+    private static final DataSize ONE_MB = new DataSize(1, MEGABYTE);
+    private final CompressionKind compressionKind = ZLIB;
+    private final TempFile tempFile = new TempFile();
+    private final TempFile fileWithFooter = new TempFile();
+    private final TempFile fileWithIndex = new TempFile();
+    private final TempFile fileWithBoth = new TempFile();
+    private final OrcDataSourceId dataSourceId = new OrcDataSourceId(tempFile.toString());
+    private List<DwrfProto.StripeInformation> stripes;
+    private int splitStartRow;
+    private long splitOffset;
+    private List<String> values1;
+    private List<String> values2;
+
+    @BeforeClass
+    public void setUp()
+            throws Exception
+    {
+        Random rnd = new Random();
+        values1 = Stream.generate(() -> randomString(rnd)).limit(ROW_COUNT).collect(toImmutableList());
+        values2 = Stream.generate(() -> randomString(rnd)).limit(ROW_COUNT).collect(toImmutableList());
+
+        writeOrcColumnsPresto(tempFile.getFile(),
+                DWRF,
+                compressionKind,
+                new OrcWriterOptions().withStripeMaxRowCount(25_000),
+                Optional.empty(),
+                ImmutableList.of(VARCHAR, VARCHAR),
+                ImmutableList.of(values1, values2),
+                new OrcWriterStats());
+
+        rewriteFile();
+        setSplitInfo();
+    }
+
+    private void setSplitInfo()
+    {
+        int splitPoint = stripes.size() / 2;
+        for (int i = 0; i < splitPoint; i++) {
+            splitStartRow += stripes.get(i).getNumberOfRows();
+        }
+        splitOffset = stripes.get(splitPoint).getOffset();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+            throws Exception
+    {
+        tempFile.close();
+        fileWithFooter.close();
+        fileWithIndex.close();
+        fileWithBoth.close();
+    }
+
+    @Test
+    public void testStripeFooterCache()
+            throws IOException
+    {
+        TestingOrcDataSource dataSource = new TestingOrcDataSource(
+                new FileOrcDataSource(fileWithFooter.getFile(), ONE_MB, ONE_MB, ONE_MB, true));
+
+        assertFileContent(dataSource, 0, 0, dataSource.getSize());
+
+        long fileTailOffset = fileWithFooter.getFile().length() - READ_TAIL_SIZE;
+        validateNoCachedDataRead(dataSource.getReadRanges(), fileTailOffset, this::getStripeFooterRanges);
+    }
+
+    @Test
+    public void testStripeFooterCacheWithSplit()
+            throws IOException
+    {
+        TestingOrcDataSource dataSource = new TestingOrcDataSource(
+                new FileOrcDataSource(fileWithFooter.getFile(), ONE_MB, ONE_MB, ONE_MB, true));
+
+        assertFileContent(dataSource, splitStartRow, splitOffset, dataSource.getSize() - splitOffset);
+
+        long fileTailOffset = fileWithFooter.getFile().length() - READ_TAIL_SIZE;
+        validateNoCachedDataRead(dataSource.getReadRanges(), fileTailOffset, this::getStripeFooterRanges);
+    }
+
+    @Test
+    public void testStripeIndexCache()
+            throws IOException
+    {
+        TestingOrcDataSource dataSource = new TestingOrcDataSource(
+                new FileOrcDataSource(fileWithIndex.getFile(), ONE_MB, ONE_MB, ONE_MB, true));
+
+        assertFileContent(dataSource, 0, 0, dataSource.getSize());
+
+        long fileTailOffset = fileWithIndex.getFile().length() - READ_TAIL_SIZE;
+        validateNoCachedDataRead(dataSource.getReadRanges(), fileTailOffset, this::getStripeIndexRanges);
+    }
+
+    @Test
+    public void testStripeIndexCacheWithSplit()
+            throws IOException
+    {
+        TestingOrcDataSource dataSource = new TestingOrcDataSource(
+                new FileOrcDataSource(fileWithIndex.getFile(), ONE_MB, ONE_MB, ONE_MB, true));
+
+        assertFileContent(dataSource, splitStartRow, splitOffset, dataSource.getSize() - splitOffset);
+
+        long fileTailOffset = fileWithIndex.getFile().length() - READ_TAIL_SIZE;
+        validateNoCachedDataRead(dataSource.getReadRanges(), fileTailOffset, this::getStripeIndexRanges);
+    }
+
+    @Test
+    public void testStripeIndexAndFooterCache()
+            throws IOException
+    {
+        TestingOrcDataSource dataSource = new TestingOrcDataSource(
+                new FileOrcDataSource(fileWithBoth.getFile(), ONE_MB, ONE_MB, ONE_MB, true));
+
+        assertFileContent(dataSource, 0, 0, dataSource.getSize());
+
+        long fileTailOffset = fileWithBoth.getFile().length() - READ_TAIL_SIZE;
+        validateNoCachedDataRead(dataSource.getReadRanges(), fileTailOffset, this::getStripeIndexAndFooterRanges);
+    }
+
+    @Test
+    public void testStripeIndexAndFooterCacheWithSplit()
+            throws IOException
+    {
+        TestingOrcDataSource dataSource = new TestingOrcDataSource(
+                new FileOrcDataSource(fileWithBoth.getFile(), ONE_MB, ONE_MB, ONE_MB, true));
+
+        assertFileContent(dataSource, splitStartRow, splitOffset, dataSource.getSize() - splitOffset);
+
+        long fileTailOffset = fileWithBoth.getFile().length() - READ_TAIL_SIZE;
+        validateNoCachedDataRead(dataSource.getReadRanges(), fileTailOffset, this::getStripeIndexAndFooterRanges);
+    }
+
+    private void validateNoCachedDataRead(List<DiskRange> readRanges, long fileTailOffset, Function<DwrfProto.StripeInformation, List<DiskRange>> stripeRangeProducer)
+    {
+        DiskRange range1;
+        DiskRange range2;
+
+        // go over all pairs of read+stripe ranges,
+        for (DwrfProto.StripeInformation stripe : stripes) {
+            for (DiskRange stripeRange : stripeRangeProducer.apply(stripe)) {
+                for (DiskRange readRange : readRanges) {
+                    // skip read ranges that fall under the file tail read by the StorageOrcFileTailSource
+                    if (readRange.getEnd() >= fileTailOffset) {
+                        continue;
+                    }
+
+                    // sort range pairs so that range1 comes first
+                    if (readRange.getOffset() <= stripeRange.getOffset()) {
+                        range1 = readRange;
+                        range2 = stripeRange;
+                    }
+                    else {
+                        range1 = stripeRange;
+                        range2 = readRange;
+                    }
+
+                    // check that start of the range2 doesn't fall under the range1
+                    assertGreaterThanOrEqual(range2.getOffset(), range1.getEnd());
+                }
+            }
+        }
+    }
+
+    private void assertFileContent(OrcDataSource dataSource, int startRow, long splitOffset, long splitLength)
+            throws IOException
+    {
+        OrcReaderOptions readerOptions = new OrcReaderOptions(ONE_MB, ONE_MB, ONE_MB, ImmutableMap.of(OrcReaderFeature.STRIPE_META_CACHE, true));
+        OrcReader orcReader = new OrcReader(
+                dataSource,
+                OrcEncoding.DWRF,
+                new StorageOrcFileTailSource(),
+                new StorageStripeMetadataSource(),
+                NOOP_ORC_AGGREGATED_MEMORY_CONTEXT,
+                readerOptions,
+                false,
+                NO_ENCRYPTION,
+                DwrfKeyProvider.EMPTY);
+
+        OrcSelectiveRecordReader recordReader = orcReader.createSelectiveRecordReader(
+                ImmutableMap.of(0, VARCHAR, 1, VARCHAR),
+                ImmutableList.of(0, 1),
+                ImmutableMap.of(),
+                ImmutableList.of(),
+                ImmutableMap.of(),
+                ImmutableMap.of(),
+                ImmutableMap.of(),
+                ImmutableMap.of(),
+                OrcPredicate.TRUE,
+                splitOffset,
+                splitLength,
+                UTC, // arbitrary
+                true,
+                NOOP_ORC_AGGREGATED_MEMORY_CONTEXT,
+                Optional.empty(),
+                INITIAL_BATCH_SIZE);
+
+        Page page;
+        int recordCnt = startRow;
+        while ((page = recordReader.getNextPage()) != null) {
+            Block block1 = page.getBlock(0);
+            Block block2 = page.getBlock(1);
+            for (int i = 0; i < page.getPositionCount(); i++) {
+                Slice slice1 = block1.getSlice(i, 0, block1.getSliceLength(i));
+                Slice slice2 = block2.getSlice(i, 0, block2.getSliceLength(i));
+                assertEquals(slice1.toString(UTF_8), values1.get(recordCnt));
+                assertEquals(slice2.toString(UTF_8), values2.get(recordCnt));
+                recordCnt++;
+            }
+        }
+        assertEquals(recordCnt, ROW_COUNT);
+    }
+
+    // Rewrites the file and appends stripe meta caches according to the mode.
+    // Remove this method when OrcWriter gets support for the stripe metadata cache.
+    private void rewriteFile()
+            throws IOException
+    {
+        byte[] buf = new byte[1024];
+        ByteArrayOutputStream footerCache = new ByteArrayOutputStream();
+        ByteArrayOutputStream indexCache = new ByteArrayOutputStream();
+        ByteArrayOutputStream bothCache = new ByteArrayOutputStream();
+
+        try (RandomAccessFile file = new RandomAccessFile(tempFile.getFile(), "r")) {
+            // read postscript size
+            file.seek(file.length() - 1);
+            int postScriptSize = file.read() & 0xff;
+
+            // read postscript
+            long postScriptPos = file.length() - postScriptSize - 1;
+            file.seek(postScriptPos);
+            readBytes(file, buf, postScriptSize);
+
+            CodedInputStream postScriptInput = CodedInputStream.newInstance(buf, 0, postScriptSize);
+            DwrfProto.PostScript postScript = DwrfProto.PostScript.parseFrom(postScriptInput);
+
+            // assume that caching in not supported yet
+            assertEquals(postScript.getCacheSize(), 0);
+
+            // read footer
+            long footerPos = postScriptPos - postScript.getFooterLength();
+            file.seek(footerPos);
+
+            int footerLen = toIntExact(postScript.getFooterLength());
+            buf = readBytes(file, buf, footerLen);
+
+            int compressionBufferSize = toIntExact(postScript.getCompressionBlockSize());
+            Optional<OrcDecompressor> decompressor = OrcDecompressor.createOrcDecompressor(dataSourceId, compressionKind, compressionBufferSize);
+            InputStream footerInputStream = new OrcInputStream(
+                    dataSourceId,
+                    new SharedBuffer(NOOP_ORC_LOCAL_MEMORY_CONTEXT),
+                    Slices.wrappedBuffer(buf).slice(0, footerLen).getInput(),
+                    decompressor,
+                    Optional.empty(),
+                    NOOP_ORC_AGGREGATED_MEMORY_CONTEXT,
+                    footerLen);
+
+            DwrfProto.Footer footer = DwrfProto.Footer.parseFrom(footerInputStream);
+
+            // check that the file has at least two stripes
+            assertGreaterThanOrEqual(footer.getStripesCount(), 2);
+
+            // collect binary versions of stripe indexes and stripe footers for
+            // different versions of the metadata cache
+            List<Integer> footerOffsets = new ArrayList<>();
+            List<Integer> indexOffsets = new ArrayList<>();
+            List<Integer> bothOffsets = new ArrayList<>();
+
+            this.stripes = footer.getStripesList();
+            for (DwrfProto.StripeInformation stripe : stripes) {
+                // read & cache stripe index
+                file.seek(stripe.getOffset());
+                int stripeIndexLen = toIntExact(stripe.getIndexLength());
+                buf = readBytes(file, buf, stripeIndexLen);
+
+                bothOffsets.add(bothCache.size());
+                bothCache.write(buf, 0, stripeIndexLen);
+
+                indexOffsets.add(indexCache.size());
+                indexCache.write(buf, 0, stripeIndexLen);
+
+                // read & cache stripe footer
+                file.seek(stripe.getOffset() + stripe.getIndexLength() + stripe.getDataLength());
+                int stripeFooterLen = toIntExact(stripe.getFooterLength());
+                buf = readBytes(file, buf, stripeFooterLen);
+
+                footerOffsets.add(footerCache.size());
+                footerCache.write(buf, 0, stripeFooterLen);
+
+                bothOffsets.add(bothCache.size());
+                bothCache.write(buf, 0, stripeFooterLen);
+            }
+
+            // collect the final size of the data to be able to calculate the size
+            // of the last cached piece using offsets
+            indexOffsets.add(indexCache.size());
+            footerOffsets.add(footerCache.size());
+            bothOffsets.add(bothCache.size());
+
+            // create new files with the caches
+            try (OutputStream fileWithFooterOut = new FileOutputStream(fileWithFooter.getFile());
+                    OutputStream fileWithIndexOut = new FileOutputStream(fileWithIndex.getFile());
+                    OutputStream fileWithBothOut = new FileOutputStream(fileWithBoth.getFile())) {
+                // copy everything from the beginning all the way to the file tail
+                file.seek(0);
+                buf = readBytes(file, buf, toIntExact(footerPos));
+                fileWithFooterOut.write(buf, 0, toIntExact(footerPos));
+                fileWithIndexOut.write(buf, 0, toIntExact(footerPos));
+                fileWithBothOut.write(buf, 0, toIntExact(footerPos));
+
+                // add cached data and new footer+tail
+                appendOrcFileTailWithCache(fileWithFooterOut, footer, postScript, compressionBufferSize, DwrfProto.StripeCacheMode.FOOTER, footerCache.toByteArray(), footerOffsets);
+                appendOrcFileTailWithCache(fileWithIndexOut, footer, postScript, compressionBufferSize, DwrfProto.StripeCacheMode.INDEX, indexCache.toByteArray(), indexOffsets);
+                appendOrcFileTailWithCache(fileWithBothOut, footer, postScript, compressionBufferSize, DwrfProto.StripeCacheMode.BOTH, bothCache.toByteArray(), bothOffsets);
+            }
+        }
+    }
+
+    private void appendOrcFileTailWithCache(OutputStream outputStream,
+            DwrfProto.Footer footer,
+            DwrfProto.PostScript postScript,
+            int compressionBufferSize,
+            DwrfProto.StripeCacheMode cacheMode,
+            byte[] cache,
+            List<Integer> offsets)
+            throws IOException
+    {
+        // write metadata cache
+        outputStream.write(cache);
+
+        // write compressed file footer
+        CompressionParameters compressionParameters = new CompressionParameters(compressionKind, OptionalInt.empty(), compressionBufferSize);
+        OrcOutputBuffer compressedOut = new OrcOutputBuffer(compressionParameters, Optional.empty());
+
+        DwrfProto.Footer newFooter = footer.toBuilder().addAllStripeCacheOffsets(offsets).build();
+        newFooter.writeTo(compressedOut);
+        compressedOut.flush();
+        OutputStreamSliceOutput sliceOutput = new OutputStreamSliceOutput(outputStream);
+        int footerLen = compressedOut.writeDataTo(sliceOutput);
+        sliceOutput.flush();
+
+        // write uncompressed postscript
+        DwrfProto.PostScript newPostScript = postScript.toBuilder().setCacheSize(cache.length).setCacheMode(cacheMode).setFooterLength(footerLen).build();
+        int postScriptLen = writeProtobufObject(outputStream, newPostScript);
+
+        // write postscript size
+        outputStream.write(postScriptLen & 0xff);
+    }
+
+    private static int writeProtobufObject(OutputStream output, MessageLite object)
+            throws IOException
+    {
+        CountingOutputStream countingOutput = new CountingOutputStream(output);
+        object.writeTo(countingOutput);
+        return toIntExact(countingOutput.getCount());
+    }
+
+    // read bytes into a reusable buffer which can be grown when needed
+    private static byte[] readBytes(RandomAccessFile file, byte[] buf, int length)
+            throws IOException
+    {
+        buf = Arrays.ensureCapacity(buf, length);
+        assertEquals(file.read(buf, 0, length), length);
+        return buf;
+    }
+
+    private String randomString(Random rnd)
+    {
+        byte[] bytes = new byte[Math.max(64, rnd.nextInt(128))];
+        rnd.nextBytes(bytes);
+        return new String(bytes, UTF_8);
+    }
+
+    private List<DiskRange> getStripeFooterRanges(DwrfProto.StripeInformation stripe)
+    {
+        long offset = stripe.getOffset() + stripe.getIndexLength() + stripe.getDataLength();
+        DiskRange diskRange = new DiskRange(offset, toIntExact(stripe.getFooterLength()));
+        return ImmutableList.of(diskRange);
+    }
+
+    private List<DiskRange> getStripeIndexRanges(DwrfProto.StripeInformation stripe)
+    {
+        long offset = stripe.getOffset();
+        DiskRange diskRange = new DiskRange(offset, toIntExact(stripe.getIndexLength()));
+        return ImmutableList.of(diskRange);
+    }
+
+    private List<DiskRange> getStripeIndexAndFooterRanges(DwrfProto.StripeInformation stripe)
+    {
+        long indexOffset = stripe.getOffset();
+        long footerOffset = stripe.getOffset() + stripe.getIndexLength() + stripe.getDataLength();
+        DiskRange stripeIndexRange = new DiskRange(indexOffset, toIntExact(stripe.getIndexLength()));
+        DiskRange stripeFooterRange = new DiskRange(footerOffset, toIntExact(stripe.getFooterLength()));
+        return ImmutableList.of(stripeIndexRange, stripeFooterRange);
+    }
+}

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestStripeReader.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestStripeReader.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc;
+
+import com.facebook.presto.orc.metadata.Stream;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.presto.orc.StripeReader.getDiskRanges;
+import static com.facebook.presto.orc.metadata.ColumnEncoding.DEFAULT_SEQUENCE_ID;
+import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
+import static com.facebook.presto.orc.metadata.Stream.StreamKind.ROW_INDEX;
+import static org.testng.Assert.assertEquals;
+
+public class TestStripeReader
+{
+    @Test
+    public void testGetDiskRanges()
+    {
+        List<Stream> streams1 = ImmutableList.of(
+                new Stream(3, ROW_INDEX, 5, true, DEFAULT_SEQUENCE_ID, Optional.of(15L)),
+                new Stream(4, ROW_INDEX, 5, true),
+                new Stream(3, DATA, 5, true, DEFAULT_SEQUENCE_ID, Optional.of(45L)),
+                new Stream(4, DATA, 5, true));
+
+        List<Stream> streams2 = ImmutableList.of(
+                new Stream(0, ROW_INDEX, 5, true),
+                new Stream(5, ROW_INDEX, 5, true, DEFAULT_SEQUENCE_ID, Optional.of(25L)),
+                new Stream(0, DATA, 5, true, DEFAULT_SEQUENCE_ID, Optional.of(30L)),
+                new Stream(5, DATA, 5, true, DEFAULT_SEQUENCE_ID, Optional.of(55L)));
+
+        List<Stream> streams3 = ImmutableList.of(
+                new Stream(1, ROW_INDEX, 5, true, DEFAULT_SEQUENCE_ID, Optional.of(5L)),
+                new Stream(2, ROW_INDEX, 5, true),
+                new Stream(1, DATA, 5, true, DEFAULT_SEQUENCE_ID, Optional.of(35L)),
+                new Stream(2, DATA, 5, true));
+
+        List<List<Stream>> streams = ImmutableList.of(streams1, streams2, streams3);
+        Map<StreamId, DiskRange> actual = getDiskRanges(streams, (streamId) -> streamId.getColumn() != 1);
+
+        Map<StreamId, DiskRange> expected = ImmutableMap.<StreamId, DiskRange>builder()
+                .put(new StreamId(0, DEFAULT_SEQUENCE_ID, ROW_INDEX), new DiskRange(0, 5))
+                .put(new StreamId(2, DEFAULT_SEQUENCE_ID, ROW_INDEX), new DiskRange(10, 5))
+                .put(new StreamId(3, DEFAULT_SEQUENCE_ID, ROW_INDEX), new DiskRange(15, 5))
+                .put(new StreamId(4, DEFAULT_SEQUENCE_ID, ROW_INDEX), new DiskRange(20, 5))
+                .put(new StreamId(5, DEFAULT_SEQUENCE_ID, ROW_INDEX), new DiskRange(25, 5))
+                .put(new StreamId(0, DEFAULT_SEQUENCE_ID, DATA), new DiskRange(30, 5))
+                .put(new StreamId(2, DEFAULT_SEQUENCE_ID, DATA), new DiskRange(40, 5))
+                .put(new StreamId(3, DEFAULT_SEQUENCE_ID, DATA), new DiskRange(45, 5))
+                .put(new StreamId(4, DEFAULT_SEQUENCE_ID, DATA), new DiskRange(50, 5))
+                .put(new StreamId(5, DEFAULT_SEQUENCE_ID, DATA), new DiskRange(55, 5))
+                .build();
+        assertEquals(actual, expected);
+    }
+}

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestingOrcDataSource.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestingOrcDataSource.java
@@ -16,6 +16,7 @@ package com.facebook.presto.orc;
 import com.google.common.collect.ImmutableList;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -28,6 +29,7 @@ class TestingOrcDataSource
 
     private int readCount;
     private List<DiskRange> lastReadRanges;
+    private List<DiskRange> readRanges = new ArrayList<>();
 
     public TestingOrcDataSource(OrcDataSource delegate)
     {
@@ -48,6 +50,11 @@ class TestingOrcDataSource
     public List<DiskRange> getLastReadRanges()
     {
         return lastReadRanges;
+    }
+
+    public List<DiskRange> getReadRanges()
+    {
+        return ImmutableList.copyOf(readRanges);
     }
 
     @Override
@@ -74,6 +81,7 @@ class TestingOrcDataSource
     {
         readCount++;
         lastReadRanges = ImmutableList.of(new DiskRange(position, buffer.length));
+        readRanges.addAll(lastReadRanges);
         delegate.readFully(position, buffer);
     }
 
@@ -83,6 +91,7 @@ class TestingOrcDataSource
     {
         readCount++;
         lastReadRanges = ImmutableList.of(new DiskRange(position, bufferLength));
+        readRanges.addAll(lastReadRanges);
         delegate.readFully(position, buffer, bufferOffset, bufferLength);
     }
 
@@ -92,6 +101,7 @@ class TestingOrcDataSource
     {
         readCount += diskRanges.size();
         lastReadRanges = ImmutableList.copyOf(diskRanges.values());
+        readRanges.addAll(lastReadRanges);
         return delegate.readFully(diskRanges);
     }
 }


### PR DESCRIPTION
# Description
This change enables support for the stripe metadata cache in the OrcReader and OrcSelectiveRecordReader for DWRF files. Enabling stripe metadata cache can reduce IOs performed to read stripes. 

Most of the changes in this PR are needed to plumb the stripe metadata cache all the way from OrcReader down to the StripeReader. I enabled this feature only for the selective record reader. I replaced a bunch of boolean xyzEnabled fields in the OrcReaderOptions with a map containing feature flags, this would eliminate a need to update the OrcReaderOptions constructor when a new feature is added.

# Stripe Metadata Cache content
Stripe metadata cache consist of three pieces:
1. Cache type: Stripe Index, Stripe Footer, or both Stripe Index and Footer.
2. Concatenated indexes and/or footers as a single binary blob (metadata slice) stored after stripes and before the file footer. 
3. Offsets are used to extract a stripe footer or index from the metadata slice.

Cache type and the metadata slice size are stored in the PostScript, offsets are stored in the file Footer, metadata slice stored before the file footer. It's not guarantied that the cache would contain data for all stripes, it may have data for first N stripes only. We don't need to update dwrf proto spec because it already contains all the required fields.

Ideal place for the stripe cached data would be the StripeInformation class. But it's hard to plumb caches slices into the StripeInformation because it's created during the `readFooter` call and the cached metadata is not loaded yet at this point.

# IO impact
When a DWRF file contains a stripe metadata cache the reader can reduce the number of IO operations needed to read stripe footers and indexes because these objects would already be preloaded, thus the load on the storage subsystem would be reduced.

Test plan:
* Added new unit test for the stripe metadata cache.
* Run tests in presto-orc.
* Run updated presto-orc module against files with the metadata cache written by bbio/dwio in the validation service.

```
== RELEASE NOTES ==

General Changes
* Add support for DWRF stripe metadata cache to the orc reader to optimize IO behavior.
* Add a flag to the OrcReaderOptions to enable this feature. Stripe metadata cache is disabled by default.
```
