### PR TITLE
[WIP] Changes necessary for Accumulo 2.x

### DIFF
--- a/presto-accumulo/pom.xml
+++ b/presto-accumulo/pom.xml
@@ -14,7 +14,7 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <dep.accumulo.version>1.7.4</dep.accumulo.version>
+        <dep.accumulo.version>2.0.1</dep.accumulo.version>
         <dep.curator.version>2.12.0</dep.curator.version>
         <dep.log4j.version>1.2.17</dep.log4j.version>
     </properties>

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/Indexer.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/Indexer.java
@@ -35,6 +35,7 @@ import org.apache.accumulo.core.client.IteratorSetting;
 import org.apache.accumulo.core.client.MutationsRejectedException;
 import org.apache.accumulo.core.client.Scanner;
 import org.apache.accumulo.core.client.TableNotFoundException;
+import org.apache.accumulo.core.client.lexicoder.Encoder;
 import org.apache.accumulo.core.data.ColumnUpdate;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.data.Mutation;
@@ -117,7 +118,7 @@ public class Indexer
 
     private static final byte[] EMPTY_BYTES = new byte[0];
     private static final byte UNDERSCORE = '_';
-    private static final TypedValueCombiner.Encoder<Long> ENCODER = new LongCombiner.StringEncoder();
+    private static final Encoder<Long> ENCODER = new LongCombiner.StringEncoder();
 
     private final AccumuloTable table;
     private final BatchWriter indexWriter;

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/serializers/MapLexicoder.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/serializers/MapLexicoder.java
@@ -19,10 +19,10 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import static org.apache.accumulo.core.client.lexicoder.impl.ByteUtils.concat;
-import static org.apache.accumulo.core.client.lexicoder.impl.ByteUtils.escape;
-import static org.apache.accumulo.core.client.lexicoder.impl.ByteUtils.split;
-import static org.apache.accumulo.core.client.lexicoder.impl.ByteUtils.unescape;
+import static org.apache.accumulo.core.clientImpl.lexicoder.ByteUtils.concat;
+import static org.apache.accumulo.core.clientImpl.lexicoder.ByteUtils.escape;
+import static org.apache.accumulo.core.clientImpl.lexicoder.ByteUtils.split;
+import static org.apache.accumulo.core.clientImpl.lexicoder.ByteUtils.unescape;
 
 /**
  * Accumulo lexicoder for encoding a Java Map

--- a/presto-accumulo/src/test/java/com/facebook/presto/accumulo/MiniAccumuloConfigUtil.java
+++ b/presto-accumulo/src/test/java/com/facebook/presto/accumulo/MiniAccumuloConfigUtil.java
@@ -15,7 +15,7 @@ package com.facebook.presto.accumulo;
 
 import com.google.common.base.Splitter;
 import org.apache.accumulo.minicluster.MiniAccumuloConfig;
-import org.apache.accumulo.minicluster.impl.MiniAccumuloConfigImpl;
+import org.apache.accumulo.miniclusterImpl.MiniAccumuloConfigImpl;
 
 import java.io.File;
 import java.lang.reflect.Field;


### PR DESCRIPTION
Adopt Accumulo 2.0.1 in module dependencies. Adjust to API changes in
Accumulo and fix authorizations testing in TestIndexer.

Fixes #15837

Test plan - (Please fill in how you tested your changes)
I used [Apache Uno](https://accumulo.apache.org/blog/2017/04/21/introducing-uno-and-muchos.html) to create a single-node Accumulo 2.0.1 instance. I followed the documentation for [installing the Accumulo connector](https://prestodb.io/docs/current/connector/accumulo.html#installing-the-iterator-dependency) and installed the necessary jar files from my built version of the Accumulo connector. I then followed the [documentation for creating and scanning an external table using the Accumulo connector](https://prestodb.io/docs/current/connector/accumulo.html#external-tables). Everything worked as expected. I also ran the unit tests and made the necessary changes in TestIndexer, replacing the removed MockInstance with MiniAccumuloCluster.

== RELEASE NOTES ==

Connector Changes
* Replace Accumulo 1.x dependency with Accumulo 2.x dependency
* Fix code in the Accumulo connector broken by API changes in Accumulo
* Fix broken use of Authorizations in TestIndexer
