### PR TITLE
Add PER_QUERY_MEMORY_LIMIT spilling strategy

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/MemoryRevokingScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/MemoryRevokingScheduler.java
@@ -130,7 +130,7 @@ public class MemoryRevokingScheduler
             try {
                 requestMemoryRevokingIfNeeded();
             }
-            catch (Throwable e) {
+            catch (Exception e) {
                 log.error(e, "Error requesting system memory revoking");
             }
         }, 1, 1, SECONDS);
@@ -165,7 +165,7 @@ public class MemoryRevokingScheduler
                 scheduleRevoking();
             }
         }
-        catch (Throwable e) {
+        catch (Exception e) {
             log.error(e, "Error when acting on memory pool reservation");
         }
     }
@@ -184,7 +184,7 @@ public class MemoryRevokingScheduler
             try {
                 runMemoryRevoking();
             }
-            catch (Throwable e) {
+            catch (Exception e) {
                 log.error(e, "Error requesting memory revoking");
             }
         });

--- a/presto-main/src/main/java/com/facebook/presto/execution/MemoryRevokingScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/MemoryRevokingScheduler.java
@@ -22,6 +22,7 @@ import com.facebook.presto.memory.VoidTraversingQueryContextVisitor;
 import com.facebook.presto.operator.OperatorContext;
 import com.facebook.presto.operator.PipelineContext;
 import com.facebook.presto.operator.TaskContext;
+import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.memory.MemoryPoolId;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.TaskSpillingStrategy;
@@ -64,7 +65,7 @@ public class MemoryRevokingScheduler
     private final double memoryRevokingTarget;
     private final TaskSpillingStrategy spillingStrategy;
 
-    private final MemoryPoolListener memoryPoolListener = MemoryPoolListener.onMemoryReserved(this::onMemoryReserved);
+    private final MemoryPoolListener memoryPoolListener = this::onMemoryReserved;
 
     @Nullable
     private ScheduledFuture<?> scheduledFuture;
@@ -152,7 +153,7 @@ public class MemoryRevokingScheduler
         memoryPools.forEach(memoryPool -> memoryPool.addListener(memoryPoolListener));
     }
 
-    private void onMemoryReserved(MemoryPool memoryPool)
+    private void onMemoryReserved(MemoryPool memoryPool, QueryId queryId, long queryMemoryReservation)
     {
         try {
             if (!memoryRevokingNeeded(memoryPool)) {

--- a/presto-main/src/main/java/com/facebook/presto/execution/MemoryRevokingSchedulerUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/MemoryRevokingSchedulerUtils.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution;
+
+import com.facebook.presto.memory.TraversingQueryContextVisitor;
+import com.facebook.presto.operator.OperatorContext;
+import com.facebook.presto.operator.TaskContext;
+
+import java.util.Collection;
+import java.util.List;
+
+public class MemoryRevokingSchedulerUtils
+{
+    private MemoryRevokingSchedulerUtils() {}
+
+    public static long getMemoryAlreadyBeingRevoked(Collection<TaskContext> taskContexts, long targetRevokingLimit)
+    {
+        TraversingQueryContextVisitor<Void, Long> visitor = new TraversingQueryContextVisitor<Void, Long>()
+        {
+            @Override
+            public Long visitOperatorContext(OperatorContext operatorContext, Void context)
+            {
+                if (operatorContext.isMemoryRevokingRequested()) {
+                    return operatorContext.getReservedRevocableBytes();
+                }
+                return 0L;
+            }
+
+            @Override
+            public Long mergeResults(List<Long> childrenResults)
+            {
+                return childrenResults.stream()
+                        .mapToLong(i -> i).sum();
+            }
+        };
+        long currentRevoking = 0;
+        for (TaskContext taskContext : taskContexts) {
+            currentRevoking += taskContext.accept(visitor, null);
+            if (currentRevoking > targetRevokingLimit) {
+                // Return early, target value exceeded and revoking will not occur
+                return currentRevoking;
+            }
+        }
+        return currentRevoking;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryLimitMemoryRevokingScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryLimitMemoryRevokingScheduler.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution;
+
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.memory.LocalMemoryManager;
+import com.facebook.presto.memory.MemoryPool;
+import com.facebook.presto.memory.MemoryPoolListener;
+import com.facebook.presto.memory.QueryContext;
+import com.facebook.presto.memory.VoidTraversingQueryContextVisitor;
+import com.facebook.presto.operator.OperatorContext;
+import com.facebook.presto.operator.TaskContext;
+import com.facebook.presto.spi.QueryId;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.inject.Inject;
+
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
+
+import static com.facebook.presto.execution.MemoryRevokingSchedulerUtils.getMemoryAlreadyBeingRevoked;
+import static com.facebook.presto.execution.MemoryRevokingUtils.getMemoryPools;
+import static com.google.common.base.Verify.verify;
+import static java.util.Objects.requireNonNull;
+
+public class QueryLimitMemoryRevokingScheduler
+{
+    private static final Logger log = Logger.get(QueryLimitMemoryRevokingScheduler.class);
+
+    private final ScheduledExecutorService taskManagementExecutor;
+    private final Function<QueryId, QueryContext> queryContextSupplier;
+
+    private final List<MemoryPool> memoryPools;
+    private final MemoryPoolListener memoryPoolListener = this::onMemoryReserved;
+    private final ConcurrentHashMap<QueryId, Boolean> revocationRequestedByQuery = new ConcurrentHashMap<>();
+
+    @Inject
+    public QueryLimitMemoryRevokingScheduler(
+            LocalMemoryManager localMemoryManager,
+            SqlTaskManager sqlTaskManager,
+            TaskManagementExecutor taskManagementExecutor)
+    {
+        this(
+                ImmutableList.copyOf(getMemoryPools(localMemoryManager)),
+                requireNonNull(sqlTaskManager, "sqlTaskManager cannot be null")::getQueryContext,
+                requireNonNull(taskManagementExecutor, "taskManagementExecutor cannot be null").getExecutor());
+        log.debug("Using QueryLimitMemoryRevokingScheduler spilling strategy");
+    }
+
+    @VisibleForTesting
+    QueryLimitMemoryRevokingScheduler(
+            List<MemoryPool> memoryPools,
+            Function<QueryId, QueryContext> queryContextSupplier,
+            ScheduledExecutorService taskManagementExecutor)
+    {
+        this.memoryPools = ImmutableList.copyOf(requireNonNull(memoryPools, "memoryPools is null"));
+        this.queryContextSupplier = requireNonNull(queryContextSupplier, "queryContextSupplier is null");
+        this.taskManagementExecutor = requireNonNull(taskManagementExecutor, "taskManagementExecutor is null");
+    }
+
+    @PostConstruct
+    public void start()
+    {
+        registerPoolListeners();
+    }
+
+    @PreDestroy
+    public void stop()
+    {
+        memoryPools.forEach(memoryPool -> memoryPool.removeListener(memoryPoolListener));
+    }
+
+    @VisibleForTesting
+    void registerPoolListeners()
+    {
+        memoryPools.forEach(memoryPool -> memoryPool.addListener(memoryPoolListener));
+    }
+
+    private void onMemoryReserved(MemoryPool memoryPool, QueryId queryId, long queryTotalMemoryUse)
+    {
+        try {
+            QueryContext queryContext = queryContextSupplier.apply(queryId);
+            verify(queryContext != null, "QueryContext not found for queryId %s", queryId);
+            long maxTotalMemory = queryContext.getMaxTotalMemory();
+            if (queryTotalMemoryUse <= maxTotalMemory) {
+                return;
+            }
+
+            log.debug("Scheduling check for %s", queryId);
+            if (revocationRequestedByQuery.put(queryId, true) == null) {
+                scheduleRevoking(queryContext, maxTotalMemory);
+            }
+        }
+        catch (Exception e) {
+            log.error(e, "Error when acting on memory pool reservation");
+        }
+    }
+
+    private void scheduleRevoking(QueryContext queryContext, long maxTotalMemory)
+    {
+        taskManagementExecutor.execute(() -> {
+            try {
+                revokeMemory(queryContext, maxTotalMemory);
+            }
+            catch (Exception e) {
+                log.error(e, "Error requesting memory revoking");
+            }
+        });
+    }
+
+    private void revokeMemory(QueryContext queryContext, long maxTotalMemory)
+    {
+        QueryId queryId = queryContext.getQueryId();
+        MemoryPool memoryPool = queryContext.getMemoryPool();
+        // (queryId, true) gets put into the revocationRequestByQueryId map in onMemoryReserved() whenever
+        // revocation is needed. scheduleRevoking() is called at that time if the map does not already
+        // have any entry for that queryId. This ensures that only one revokeMemory() invocation will be running
+        // for any queryId at a time. At the start of this loop, we set the value for that queryId to false in the map.
+        // If an additional memory revocation request comes in, the value will be changed to true in onMemoryReserve().
+        // The condition for this while loop says that if the value for that queryId is false
+        // (meaning no further memory revocation requests have come in since our last iteration through the loop),
+        // then remove that queryId from the map and break out of the loop.
+        while (!revocationRequestedByQuery.remove(queryId, false)) {
+            revocationRequestedByQuery.put(queryId, false);
+            // get a fresh value for queryTotalMemory in case it's changed (e.g. by a previous revocation request)
+            long queryTotalMemory = getTotalQueryMemoryReservation(queryId, memoryPool);
+            // order tasks by decreasing revocableMemory so that we don't spill more tasks than needed
+            SortedMap<Long, TaskContext> queryTaskContextsMap = new TreeMap<>(Comparator.reverseOrder());
+            queryContext.getAllTaskContexts()
+                    .forEach(taskContext -> queryTaskContextsMap.put(taskContext.getTaskMemoryContext().getRevocableMemory(), taskContext));
+
+            AtomicLong remainingBytesToRevoke = new AtomicLong(queryTotalMemory - maxTotalMemory);
+            Collection<TaskContext> queryTaskContexts = queryTaskContextsMap.values();
+            remainingBytesToRevoke.addAndGet(-getMemoryAlreadyBeingRevoked(queryTaskContexts, remainingBytesToRevoke.get()));
+            for (TaskContext taskContext : queryTaskContexts) {
+                if (remainingBytesToRevoke.get() <= 0) {
+                    break;
+                }
+                taskContext.accept(new VoidTraversingQueryContextVisitor<AtomicLong>()
+                {
+                    @Override
+                    public Void visitOperatorContext(OperatorContext operatorContext, AtomicLong remainingBytesToRevoke)
+                    {
+                        if (remainingBytesToRevoke.get() > 0) {
+                            long revokedBytes = operatorContext.requestMemoryRevoking();
+                            if (revokedBytes > 0) {
+                                remainingBytesToRevoke.addAndGet(-revokedBytes);
+                                log.debug("taskId=%s: requested revoking %s; remaining %s", taskContext.getTaskId(), revokedBytes, remainingBytesToRevoke);
+                            }
+                        }
+                        return null;
+                    }
+                }, remainingBytesToRevoke);
+            }
+        }
+    }
+
+    private static long getTotalQueryMemoryReservation(QueryId queryId, MemoryPool memoryPool)
+    {
+        return memoryPool.getQueryMemoryReservation(queryId) + memoryPool.getQueryRevocableMemoryReservation(queryId);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskManager.java
@@ -46,7 +46,6 @@ import com.facebook.presto.sql.gen.OrderingCompiler;
 import com.facebook.presto.sql.planner.LocalExecutionPlanner;
 import com.facebook.presto.sql.planner.PlanFragment;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
@@ -545,7 +544,6 @@ public class SqlTaskManager
         tasks.getUnchecked(taskId).addStateChangeListener(stateChangeListener);
     }
 
-    @VisibleForTesting
     public QueryContext getQueryContext(QueryId queryId)
 
     {

--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskThresholdMemoryRevokingScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskThresholdMemoryRevokingScheduler.java
@@ -59,7 +59,7 @@ public class TaskThresholdMemoryRevokingScheduler
 
     private final AtomicBoolean checkPending = new AtomicBoolean();
     private final List<MemoryPool> memoryPools;
-    private final TaskRevocableMemoryListener taskRevocableMemoryListener = TaskRevocableMemoryListener.onMemoryReserved(this::onMemoryReserved);
+    private final TaskRevocableMemoryListener taskRevocableMemoryListener = this::onMemoryReserved;
 
     @Inject
     public TaskThresholdMemoryRevokingScheduler(
@@ -136,7 +136,7 @@ public class TaskThresholdMemoryRevokingScheduler
         }
     }
 
-    private void onMemoryReserved(TaskId taskId, MemoryPool memoryPool)
+    private void onMemoryReserved(TaskId taskId)
     {
         try {
             SqlTask task = taskSupplier.apply(taskId);
@@ -145,7 +145,7 @@ public class TaskThresholdMemoryRevokingScheduler
             }
 
             if (checkPending.compareAndSet(false, true)) {
-                log.debug("Scheduling check for %s", memoryPool);
+                log.debug("Scheduling check for %s", taskId);
                 scheduleRevoking();
             }
         }

--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskThresholdMemoryRevokingScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskThresholdMemoryRevokingScheduler.java
@@ -105,7 +105,7 @@ public class TaskThresholdMemoryRevokingScheduler
             try {
                 revokeHighMemoryTasksIfNeeded();
             }
-            catch (Throwable e) {
+            catch (Exception e) {
                 log.error(e, "Error requesting task memory revoking");
             }
         }, 1, 1, SECONDS);
@@ -149,7 +149,7 @@ public class TaskThresholdMemoryRevokingScheduler
                 scheduleRevoking();
             }
         }
-        catch (Throwable e) {
+        catch (Exception e) {
             log.error(e, "Error when acting on memory pool reservation");
         }
     }
@@ -160,7 +160,7 @@ public class TaskThresholdMemoryRevokingScheduler
             try {
                 revokeHighMemoryTasks();
             }
-            catch (Throwable e) {
+            catch (Exception e) {
                 log.error(e, "Error requesting memory revoking");
             }
         });

--- a/presto-main/src/main/java/com/facebook/presto/memory/MemoryPool.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/MemoryPool.java
@@ -155,9 +155,9 @@ public class MemoryPool
         listeners.forEach(listener -> listener.onMemoryReserved(this, queryId, totalMemoryReservation));
     }
 
-    public void onTaskMemoryReserved(TaskId taskId)
+    public void onTaskRevocableMemoryReserved(TaskId taskId)
     {
-        taskRevocableMemoryListeners.forEach(listener -> listener.onMemoryReserved(taskId, this));
+        taskRevocableMemoryListeners.forEach(listener -> listener.onMemoryReserved(taskId));
     }
 
     public ListenableFuture<?> reserveRevocable(QueryId queryId, long bytes)

--- a/presto-main/src/main/java/com/facebook/presto/memory/MemoryPool.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/MemoryPool.java
@@ -145,13 +145,14 @@ public class MemoryPool
             }
         }
 
-        onMemoryReserved();
+        onMemoryReserved(queryId);
         return result;
     }
 
-    private void onMemoryReserved()
+    private void onMemoryReserved(QueryId queryId)
     {
-        listeners.forEach(listener -> listener.onMemoryReserved(this));
+        long totalMemoryReservation = queryMemoryReservations.getOrDefault(queryId, 0L) + queryMemoryRevocableReservations.getOrDefault(queryId, 0L);
+        listeners.forEach(listener -> listener.onMemoryReserved(this, queryId, totalMemoryReservation));
     }
 
     public void onTaskMemoryReserved(TaskId taskId)
@@ -181,7 +182,7 @@ public class MemoryPool
             }
         }
 
-        onMemoryReserved();
+        onMemoryReserved(queryId);
         return result;
     }
 
@@ -202,7 +203,7 @@ public class MemoryPool
             }
         }
 
-        onMemoryReserved();
+        onMemoryReserved(queryId);
         return true;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/memory/MemoryPool.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/MemoryPool.java
@@ -306,12 +306,12 @@ public class MemoryPool
         return reservedRevocableBytes;
     }
 
-    synchronized long getQueryMemoryReservation(QueryId queryId)
+    public synchronized long getQueryMemoryReservation(QueryId queryId)
     {
         return queryMemoryReservations.getOrDefault(queryId, 0L);
     }
 
-    synchronized long getQueryRevocableMemoryReservation(QueryId queryId)
+    public synchronized long getQueryRevocableMemoryReservation(QueryId queryId)
     {
         return queryMemoryRevocableReservations.getOrDefault(queryId, 0L);
     }

--- a/presto-main/src/main/java/com/facebook/presto/memory/MemoryPoolListener.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/MemoryPoolListener.java
@@ -13,22 +13,17 @@
  */
 package com.facebook.presto.memory;
 
-import java.util.function.Consumer;
+import com.facebook.presto.spi.QueryId;
 
+@FunctionalInterface
 public interface MemoryPoolListener
 {
     /**
      * Invoked when memory reservation completes successfully.
      *
-     * @param memoryPool the {@link MemoryPool} where the reservation took place
+     * @param memoryPool             the {@link MemoryPool} where the reservation took place
+     * @param queryId                the {@link QueryId} of the query that reserved the memory
+     * @param queryMemoryReservation the total amount of memory reserved by the query (revocable and regular)
      */
-    void onMemoryReserved(MemoryPool memoryPool);
-
-    /**
-     * Creates {@link MemoryPoolListener} implementing {@link #onMemoryReserved(MemoryPool)} only.
-     */
-    static MemoryPoolListener onMemoryReserved(Consumer<? super MemoryPool> action)
-    {
-        return action::accept;
-    }
+    void onMemoryReserved(MemoryPool memoryPool, QueryId queryId, long queryMemoryReservation);
 }

--- a/presto-main/src/main/java/com/facebook/presto/memory/QueryContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/QueryContext.java
@@ -23,12 +23,14 @@ import com.facebook.presto.operator.TaskContext;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spiller.SpillSpaceTracker;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.units.DataSize;
 
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -364,6 +366,11 @@ public class QueryContext
         TaskContext taskContext = taskContexts.get(taskId);
         verify(taskContext != null, "task does not exist");
         return taskContext;
+    }
+
+    public Collection<TaskContext> getAllTaskContexts()
+    {
+        return ImmutableList.copyOf(taskContexts.values());
     }
 
     public QueryId getQueryId()

--- a/presto-main/src/main/java/com/facebook/presto/memory/TaskRevocableMemoryListener.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/TaskRevocableMemoryListener.java
@@ -15,8 +15,7 @@ package com.facebook.presto.memory;
 
 import com.facebook.presto.execution.TaskId;
 
-import java.util.function.BiConsumer;
-
+@FunctionalInterface
 public interface TaskRevocableMemoryListener
 {
     /**
@@ -24,12 +23,6 @@ public interface TaskRevocableMemoryListener
      * memory in a given MemoryPool successfully
      *
      * @param taskId the {@link TaskId} of the task that reserved the memory
-     * @param memoryPool the {@link MemoryPool} where the reservation took place
      */
-    void onMemoryReserved(TaskId taskId, MemoryPool memoryPool);
-
-    static TaskRevocableMemoryListener onMemoryReserved(BiConsumer<TaskId, ? super MemoryPool> action)
-    {
-        return action::accept;
-    }
+    void onMemoryReserved(TaskId taskId);
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/OperatorContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/OperatorContext.java
@@ -297,7 +297,7 @@ public class OperatorContext
     // listen to revocable memory allocations and call any listeners waiting on task memory allocation
     private void updateTaskRevocableMemoryReservation()
     {
-        driverContext.getPipelineContext().getTaskContext().getQueryContext().getMemoryPool().onTaskMemoryReserved(driverContext.getTaskId());
+        driverContext.getPipelineContext().getTaskContext().getQueryContext().getMemoryPool().onTaskRevocableMemoryReserved(driverContext.getTaskId());
     }
 
     public long getReservedRevocableBytes()

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -247,7 +247,8 @@ public class FeaturesConfig
     {
         ORDER_BY_CREATE_TIME, // When spilling is triggered, revoke tasks in order of oldest to newest
         ORDER_BY_REVOCABLE_BYTES, // When spilling is triggered, revoke tasks by most allocated revocable memory to least allocated revocable memory
-        PER_TASK_MEMORY_THRESHOLD // Spill any task after it reaches the per task memory threshold defined by experimental.spiller.max-revocable-task-memory
+        PER_TASK_MEMORY_THRESHOLD, // Spill any task after it reaches the per task memory threshold defined by experimental.spiller.max-revocable-task-memory
+        PER_QUERY_MEMORY_LIMIT // Spill whenever a query's combined revocable, system, and user memory exceeds the per-node total memory limit
     }
 
     public enum SingleStreamSpillerChoice

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestMemoryRevokingScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestMemoryRevokingScheduler.java
@@ -76,6 +76,7 @@ import static com.facebook.presto.sql.analyzer.FeaturesConfig.TaskSpillingStrate
 import static com.facebook.presto.sql.analyzer.FeaturesConfig.TaskSpillingStrategy.ORDER_BY_REVOCABLE_BYTES;
 import static io.airlift.units.DataSize.Unit.BYTE;
 import static io.airlift.units.DataSize.Unit.GIGABYTE;
+import static io.airlift.units.DataSize.Unit.KILOBYTE;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;
@@ -459,6 +460,91 @@ public class TestMemoryRevokingScheduler
         assertMemoryRevokingRequestedFor(operatorContext2);
     }
 
+    @Test
+    public void testQueryLimitMemoryRevokingScheduler()
+            throws Exception
+    {
+        // The various tasks created here use a small amount of system memory independent of what's set explicitly
+        // in this test. Triggering spilling based on differences of thousands of bytes rather than hundreds
+        // makes the test resilient to any noise that creates.
+
+        // There can still be a race condition where some of these allocations are made when the total memory is above
+        // the spill threshold, but in revokeMemory() some memory is reduced between when we get the total memory usage
+        // and when we get the task memory usage.  This can cause some extra spilling.
+        // To prevent flakiness in the test, we reset revoke memory requested for all operators, even if only one spilled.
+
+        QueryId queryId = new QueryId("query");
+        SqlTask sqlTask1 = newSqlTask(queryId);
+        TestOperatorContext operatorContext11 = createTestingOperatorContexts(sqlTask1, "operator11");
+        TestOperatorContext operatorContext12 = createTestingOperatorContexts(sqlTask1, "operator12");
+
+        SqlTask sqlTask2 = newSqlTask(queryId);
+        TestOperatorContext operatorContext2 = createTestingOperatorContexts(sqlTask2, "operator2");
+
+        allOperatorContexts = ImmutableSet.of(operatorContext11, operatorContext12, operatorContext2);
+        QueryLimitMemoryRevokingScheduler scheduler = new QueryLimitMemoryRevokingScheduler(singletonList(memoryPool), queryContexts::get, executor);
+        scheduler.registerPoolListeners();
+
+        assertMemoryRevokingNotRequested();
+
+        operatorContext11.localRevocableMemoryContext().setBytes(150_000);
+        operatorContext2.localRevocableMemoryContext().setBytes(100_000);
+        // at this point, Task1 = 150k total bytes, Task2 = 100k total bytes
+
+        // this ensures that we are waiting for the memory revocation listener and not using polling-based revoking
+        awaitAsynchronousCallbacksRun();
+        assertMemoryRevokingNotRequested();
+
+        operatorContext12.localRevocableMemoryContext().setBytes(300_000);
+        // at this point, Task1 =  450k total bytes, Task2 = 100k total bytes
+
+        awaitAsynchronousCallbacksRun();
+        // only operator11 should revoke since we need to revoke only 50k bytes
+        // limit - (task1 + task2) => 500k - (450k + 100k) = 50k byte to revoke
+        assertMemoryRevokingRequestedFor(operatorContext11);
+
+        // revoke all bytes in operator11
+        operatorContext11.localRevocableMemoryContext().setBytes(0);
+        // at this point, Task1 = 300k total bytes, Task2 = 100k total bytes
+        awaitAsynchronousCallbacksRun();
+        operatorContext11.resetMemoryRevokingRequested();
+        operatorContext12.resetMemoryRevokingRequested();
+        operatorContext2.resetMemoryRevokingRequested();
+        assertMemoryRevokingNotRequested();
+
+        operatorContext11.localRevocableMemoryContext().setBytes(20_000);
+        // at this point, Task1 = 320,000 total bytes (oc11 - 20k, oc12 - 300k), Task2 = 100k total bytes
+        awaitAsynchronousCallbacksRun();
+        assertMemoryRevokingNotRequested();
+
+        operatorContext2.localSystemMemoryContext().setBytes(150_000);
+        // at this point, Task1 = 320K total bytes, Task2 = 250K total bytes
+        // both operator11 and operator 12 are revoking since we revoke in order of operator creation within the task until we are below the memory revoking threshold
+        awaitAsynchronousCallbacksRun();
+        assertMemoryRevokingRequestedFor(operatorContext11, operatorContext12);
+
+        operatorContext11.localRevocableMemoryContext().setBytes(0);
+        operatorContext12.localRevocableMemoryContext().setBytes(0);
+        awaitAsynchronousCallbacksRun();
+        operatorContext11.resetMemoryRevokingRequested();
+        operatorContext12.resetMemoryRevokingRequested();
+        operatorContext2.resetMemoryRevokingRequested();
+        assertMemoryRevokingNotRequested();
+
+        operatorContext11.localRevocableMemoryContext().setBytes(50_000);
+        operatorContext12.localRevocableMemoryContext().setBytes(50_000);
+        operatorContext2.localSystemMemoryContext().setBytes(150_000);
+        operatorContext2.localRevocableMemoryContext().setBytes(150_000);
+        awaitAsynchronousCallbacksRun();
+        assertMemoryRevokingNotRequested(); // no need to revoke
+        // at this point, Task1 = 75k total bytes, Task2 = 300k total bytes (150k revocable, 150k system)
+
+        operatorContext12.localUserMemoryContext().setBytes(300_000);
+        // at this point, Task1 = 400K total bytes (100k revocable, 300k user), Task2 = 300k total bytes (150k revocable, 150k system)
+        awaitAsynchronousCallbacksRun();
+        assertMemoryRevokingRequestedFor(operatorContext2, operatorContext11);
+    }
+
     private OperatorContext createContexts(SqlTask sqlTask)
     {
         TaskContext taskContext = getOrCreateTaskContext(sqlTask);
@@ -582,9 +668,9 @@ public class TestMemoryRevokingScheduler
     private QueryContext getOrCreateQueryContext(QueryId queryId)
     {
         return queryContexts.computeIfAbsent(queryId, id -> new QueryContext(id,
-                new DataSize(1, MEGABYTE),
-                new DataSize(2, MEGABYTE),
-                new DataSize(1, MEGABYTE),
+                new DataSize(500, KILOBYTE),
+                new DataSize(500, KILOBYTE),
+                new DataSize(500, KILOBYTE),
                 new DataSize(1, GIGABYTE),
                 memoryPool,
                 new TestingGcMonitor(),

--- a/presto-main/src/test/java/com/facebook/presto/memory/TestMemoryPools.java
+++ b/presto-main/src/test/java/com/facebook/presto/memory/TestMemoryPools.java
@@ -165,10 +165,10 @@ public class TestMemoryPools
         setupConsumeRevocableMemory(ONE_BYTE, 10);
         AtomicReference<MemoryPool> notifiedPool = new AtomicReference<>();
         AtomicLong notifiedBytes = new AtomicLong();
-        userPool.addListener(MemoryPoolListener.onMemoryReserved(pool -> {
+        userPool.addListener((pool, queryId, memoryReservation) -> {
             notifiedPool.set(pool);
             notifiedBytes.set(pool.getReservedBytes());
-        }));
+        });
 
         userPool.reserve(fakeQueryId, "test", 3);
         assertEquals(notifiedPool.get(), userPool);


### PR DESCRIPTION
Test plan - new unit test

```
== RELEASE NOTES ==

General Changes
* Add new spilling strategy to spill when the user + system + revocable memory on a node exceeds max_total_memory_per_node.  This can be enabled by setting ``experimental.spiller.task-spilling-strategy`` to ``PER_QUERY_MEMORY_LIMIT``.
```
