### PR TITLE
Fix spooling output buffer unit test

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/buffer/SpoolingOutputBufferFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/buffer/SpoolingOutputBufferFactory.java
@@ -46,7 +46,7 @@ public class SpoolingOutputBufferFactory
 
     private final Closer closer = Closer.create();
 
-    private static ExecutorService coreExecutor = newCachedThreadPool(daemonThreadsNamed("spooling-outputbuffer-%s"));
+    private final ExecutorService coreExecutor = newCachedThreadPool(daemonThreadsNamed("spooling-outputbuffer-%s"));
 
     @Inject
     public SpoolingOutputBufferFactory(FeaturesConfig featuresConfig, TempStorageManager tempStorageManager, FinalizerService finalizerService)


### PR DESCRIPTION
The unit tests for `SpoolingOutputBuffer` were disabled due to flakey tests. The executor in the `SpoolingOutputBufferFactory` was static and would get shutdown when the GC from other tests cleans up the factory, causing the tasks in `TestSpoolingOutputBuffer` to get rejected.