### PR TITLE
Fix HttpRemoteTask task stats and queue space update order

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTask.java
@@ -650,9 +650,9 @@ public final class HttpRemoteTask
                 pendingSourceSplitCount -= removed;
             }
         }
-        updateSplitQueueSpace();
-
+        // Update stats before split queue space to ensure node stats are up to date before waking up the scheduler
         updateTaskStats();
+        updateSplitQueueSpace();
     }
 
     private void updateTaskInfo(TaskInfo taskInfo)


### PR DESCRIPTION
Reorders task stats (and therefore `NodeTaskMap`) update and split queue space update in `HttpRemoteTask#processTaskUpdate`. Before this change, the scheduler could be started before the update to `NodeTaskMap` occurred and would then use stale values to assign splits.

```
== NO RELEASE NOTE ==
```
