### PR TITLE
Reenable product tests disabled due to dockerhub issue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,6 @@ jobs:
         run: presto-main/bin/check_webui.sh
 
   product-tests-basic-environment:
-    if: ${{ false }}  # disable for now
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -88,7 +87,6 @@ jobs:
         run: presto-product-tests/bin/run_on_docker.sh multinode -x quarantine,big_query,storage_formats,profile_specific_tests,tpcds,cassandra,mysql_connector,postgresql_connector,mysql,kafka,avro
 
   product-tests-specific-environment1:
-    if: ${{ false }}  # disable for now
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -127,7 +125,6 @@ jobs:
         run: presto-product-tests/bin/run_on_docker.sh multinode-tls-kerberos -g cli,group-by,join,tls
 
   product-tests-specific-environment2:
-    if: ${{ false }}  # disable for now
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -202,7 +199,6 @@ jobs:
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
           ./mvnw install ${MAVEN_FAST_INSTALL} -am -pl :presto-hive-hadoop2
       - name: Run Hive Tests
-        if: ${{ false }}  # disable for now
         run: presto-hive-hadoop2/bin/run_hive_tests.sh
       - name: Run Hive S3 Tests
         env:

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -4770,6 +4770,8 @@ public abstract class AbstractTestHiveClient
             List<? extends ColumnHandle> columnHandles)
             throws IOException
     {
+        // Some page sources may need to read additional bytes (eg: the metadata footer) in addition to the split data
+        long initialPageSourceCompletedBytes = pageSource.getCompletedBytes();
         try {
             MaterializedResult result = materializeSourceDataStream(newSession(), pageSource, getTypes(columnHandles));
 
@@ -4966,11 +4968,11 @@ public abstract class AbstractTestHiveClient
 
                 long newCompletedBytes = pageSource.getCompletedBytes();
                 assertTrue(newCompletedBytes >= completedBytes);
-                assertTrue(newCompletedBytes <= hiveSplit.getLength());
+                assertTrue(newCompletedBytes <= hiveSplit.getLength() + initialPageSourceCompletedBytes);
                 completedBytes = newCompletedBytes;
             }
 
-            assertTrue(completedBytes <= hiveSplit.getLength());
+            assertTrue(completedBytes <= hiveSplit.getLength() + initialPageSourceCompletedBytes);
             assertEquals(rowNumber, 100);
         }
         finally {


### PR DESCRIPTION
Supercedes https://github.com/prestodb/presto/pull/15907 in reenabling product tests previously disabled by 8e761e8 due to a dockerhub issue. 

Also fixes `AbstractTestHiveClient#testParquetTypes` after https://github.com/prestodb/presto/pull/15883 changed the parquet page source behavior to include footer metadata reads towards completed bytes.

```
== NO RELEASE NOTE ==
```
