### PR TITLE
Fix NPE when predicate column is not contained in domain

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitManager.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitManager.java
@@ -553,8 +553,9 @@ public class HiveSplitManager
                 for (Map.Entry<String, HiveColumnHandle> predicateColumnEntry : predicateColumns.entrySet()) {
                     if (columnStatistics.containsKey(predicateColumnEntry.getKey())) {
                         Optional<ValueSet> columnsStatisticsValueSet = getColumnStatisticsValueSet(columnStatistics.get(predicateColumnEntry.getKey()), predicateColumnEntry.getValue().getHiveType());
-                        if (columnsStatisticsValueSet.isPresent()) {
-                            ValueSet columnPredicateValueSet = domains.get().get(new Subfield(predicateColumnEntry.getKey())).getValues();
+                        Subfield subfield = new Subfield(predicateColumnEntry.getKey());
+                        if (columnsStatisticsValueSet.isPresent() && domains.get().containsKey(subfield)) {
+                            ValueSet columnPredicateValueSet = domains.get().get(subfield).getValues();
                             if (!columnPredicateValueSet.overlaps(columnsStatisticsValueSet.get())) {
                                 pruned = true;
                                 break;


### PR DESCRIPTION
I don't have a test case that can reproduce this, but it seems theoretically possible so might as well patch it.

```
== NO RELEASE NOTE ==
```
