### PR TITLE
Reject @BeforeMethod in Multi-threaded tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,6 +169,7 @@
         <module>presto-common</module>
         <module>presto-thrift-testing-udf-server</module>
         <module>presto-thrift-spec</module>
+        <module>testing/presto-testng-services</module>
     </modules>
 
     <dependencyManagement>
@@ -651,6 +652,12 @@
             <dependency>
                 <groupId>com.facebook.presto</groupId>
                 <artifactId>presto-function-namespace-managers</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-testng-services</artifactId>
                 <version>${project.version}</version>
             </dependency>
 

--- a/presto-accumulo/pom.xml
+++ b/presto-accumulo/pom.xml
@@ -302,6 +302,12 @@
         <!-- for testing -->
         <dependency>
             <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
             <artifactId>presto-main</artifactId>
             <scope>test</scope>
         </dependency>

--- a/presto-array/pom.xml
+++ b/presto-array/pom.xml
@@ -38,6 +38,12 @@
 
         <!-- for testing -->
         <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/presto-atop/pom.xml
+++ b/presto-atop/pom.xml
@@ -125,6 +125,12 @@
         <!-- for testing -->
         <dependency>
             <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
             <artifactId>presto-tests</artifactId>
             <scope>test</scope>
         </dependency>

--- a/presto-base-jdbc/pom.xml
+++ b/presto-base-jdbc/pom.xml
@@ -107,6 +107,12 @@
 
         <!-- for testing -->
         <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/presto-benchmark-driver/pom.xml
+++ b/presto-benchmark-driver/pom.xml
@@ -79,6 +79,12 @@
 
         <!-- for testing -->
         <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/presto-benchmark/pom.xml
+++ b/presto-benchmark/pom.xml
@@ -108,6 +108,12 @@
 
         <!-- for testing -->
         <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.openjdk.jmh</groupId>
             <artifactId>jmh-core</artifactId>
             <scope>test</scope>

--- a/presto-benchto-benchmarks/pom.xml
+++ b/presto-benchto-benchmarks/pom.xml
@@ -30,6 +30,12 @@
 
         <dependency>
             <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
             <artifactId>presto-main</artifactId>
             <type>test-jar</type>
             <scope>test</scope>

--- a/presto-bigquery/pom.xml
+++ b/presto-bigquery/pom.xml
@@ -245,6 +245,12 @@
 
         <!-- for testing -->
         <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/presto-blackhole/pom.xml
+++ b/presto-blackhole/pom.xml
@@ -74,6 +74,12 @@
         <!-- for testing -->
         <dependency>
             <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
             <artifactId>presto-tests</artifactId>
             <scope>test</scope>
         </dependency>

--- a/presto-bytecode/pom.xml
+++ b/presto-bytecode/pom.xml
@@ -51,6 +51,12 @@
 
         <!-- for testing -->
         <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/presto-cache/pom.xml
+++ b/presto-cache/pom.xml
@@ -128,6 +128,12 @@
 
         <!-- for testing -->
         <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/presto-cassandra/pom.xml
+++ b/presto-cassandra/pom.xml
@@ -127,6 +127,12 @@
         <!-- for testing -->
         <dependency>
             <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
             <artifactId>presto-main</artifactId>
             <scope>test</scope>
         </dependency>

--- a/presto-client/pom.xml
+++ b/presto-client/pom.xml
@@ -88,6 +88,12 @@
 
         <!-- for testing -->
         <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/presto-common/pom.xml
+++ b/presto-common/pom.xml
@@ -44,6 +44,12 @@
 
         <!-- for testing -->
         <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/presto-druid/pom.xml
+++ b/presto-druid/pom.xml
@@ -293,6 +293,12 @@
 
         <!-- for testing -->
         <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/presto-example-http/pom.xml
+++ b/presto-example-http/pom.xml
@@ -101,6 +101,12 @@
         <!-- for testing -->
         <dependency>
             <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
             <artifactId>presto-main</artifactId>
             <scope>test</scope>
         </dependency>

--- a/presto-function-namespace-managers/pom.xml
+++ b/presto-function-namespace-managers/pom.xml
@@ -137,6 +137,12 @@
 
         <!-- for testing -->
         <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.facebook.airlift</groupId>
             <artifactId>testing</artifactId>
             <scope>test</scope>

--- a/presto-geospatial-toolkit/pom.xml
+++ b/presto-geospatial-toolkit/pom.xml
@@ -62,6 +62,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.openjdk.jmh</groupId>
             <artifactId>jmh-core</artifactId>
             <scope>test</scope>

--- a/presto-geospatial/pom.xml
+++ b/presto-geospatial/pom.xml
@@ -90,6 +90,12 @@
 
         <!-- for testing -->
         <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.facebook.presto.hadoop</groupId>
             <artifactId>hadoop-apache2</artifactId>
             <scope>test</scope>

--- a/presto-hive-hadoop2/pom.xml
+++ b/presto-hive-hadoop2/pom.xml
@@ -89,6 +89,12 @@
 
         <!-- for testing -->
         <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/presto-hive-metastore/pom.xml
+++ b/presto-hive-metastore/pom.xml
@@ -167,6 +167,12 @@
 
         <!-- for testing -->
         <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.openjdk.jmh</groupId>
             <artifactId>jmh-core</artifactId>
             <scope>test</scope>

--- a/presto-hive/pom.xml
+++ b/presto-hive/pom.xml
@@ -282,6 +282,12 @@
         <!-- for testing -->
         <dependency>
             <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
             <artifactId>presto-spi</artifactId>
             <type>test-jar</type>
             <scope>test</scope>

--- a/presto-i18n-functions/pom.xml
+++ b/presto-i18n-functions/pom.xml
@@ -59,6 +59,12 @@
 
         <!-- for testing -->
         <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/presto-jdbc/pom.xml
+++ b/presto-jdbc/pom.xml
@@ -89,6 +89,12 @@
         <!-- for testing -->
         <dependency>
             <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
             <artifactId>presto-main</artifactId>
             <scope>test</scope>
         </dependency>

--- a/presto-jmx/pom.xml
+++ b/presto-jmx/pom.xml
@@ -111,6 +111,12 @@
 
         <!-- for testing -->
         <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/presto-kafka/pom.xml
+++ b/presto-kafka/pom.xml
@@ -171,6 +171,12 @@
 
         <!-- for testing -->
         <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/presto-kudu/pom.xml
+++ b/presto-kudu/pom.xml
@@ -137,6 +137,12 @@
         <!-- for testing -->
         <dependency>
             <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
             <artifactId>presto-main</artifactId>
             <scope>test</scope>
         </dependency>

--- a/presto-local-file/pom.xml
+++ b/presto-local-file/pom.xml
@@ -97,6 +97,12 @@
         <!-- for testing -->
         <dependency>
             <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
             <artifactId>presto-main</artifactId>
             <scope>test</scope>
         </dependency>

--- a/presto-main/pom.xml
+++ b/presto-main/pom.xml
@@ -445,6 +445,12 @@
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-plugin-toolkit</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestThriftTaskStatus.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestThriftTaskStatus.java
@@ -47,6 +47,7 @@ import static com.facebook.presto.spi.StandardErrorCode.SYNTAX_ERROR;
 import static com.facebook.presto.spi.StandardErrorCode.TOO_MANY_REQUESTS_FAILED;
 import static org.testng.Assert.assertEquals;
 
+@Test(singleThreaded = true)
 public class TestThriftTaskStatus
 {
     private static final ThriftCodecManager COMPILER_READ_CODEC_MANAGER = new ThriftCodecManager(new CompilerThriftCodecFactory(false));

--- a/presto-main/src/test/resources/META-INF/services/org.testng.ITestNGListener
+++ b/presto-main/src/test/resources/META-INF/services/org.testng.ITestNGListener
@@ -1,1 +1,0 @@
-com.facebook.presto.tests.LogTestDurationListener

--- a/presto-matching/pom.xml
+++ b/presto-matching/pom.xml
@@ -36,6 +36,12 @@
 
         <!-- for testing -->
         <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/presto-memory-context/pom.xml
+++ b/presto-memory-context/pom.xml
@@ -30,6 +30,12 @@
 
         <!-- for testing -->
         <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.facebook.airlift</groupId>
             <artifactId>testing</artifactId>
             <scope>test</scope>

--- a/presto-memory/pom.xml
+++ b/presto-memory/pom.xml
@@ -111,6 +111,12 @@
         <!-- for testing -->
         <dependency>
             <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
             <artifactId>presto-tests</artifactId>
             <scope>test</scope>
         </dependency>

--- a/presto-ml/pom.xml
+++ b/presto-ml/pom.xml
@@ -101,6 +101,12 @@
 
         <!-- for testing -->
         <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/presto-mongodb/pom.xml
+++ b/presto-mongodb/pom.xml
@@ -120,6 +120,12 @@
         <!-- for testing -->
         <dependency>
             <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
             <artifactId>presto-tests</artifactId>
             <scope>test</scope>
         </dependency>

--- a/presto-mysql/pom.xml
+++ b/presto-mysql/pom.xml
@@ -91,6 +91,12 @@
 
         <!-- for testing -->
         <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>

--- a/presto-oracle/pom.xml
+++ b/presto-oracle/pom.xml
@@ -111,6 +111,12 @@
 
         <!-- for testing -->
         <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/presto-orc/pom.xml
+++ b/presto-orc/pom.xml
@@ -108,6 +108,12 @@
 
         <dependency>
             <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
             <artifactId>presto-spi</artifactId>
             <scope>test</scope>
         </dependency>
@@ -145,7 +151,6 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>6.9.6</version>
             <scope>test</scope>
         </dependency>
 

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestStorageOrcFileTailSource.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestStorageOrcFileTailSource.java
@@ -41,6 +41,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
+@Test(singleThreaded = true)
 public class TestStorageOrcFileTailSource
 {
     private static final DataSize DEFAULT_SIZE = new DataSize(1, MEGABYTE);

--- a/presto-parquet/pom.xml
+++ b/presto-parquet/pom.xml
@@ -93,6 +93,12 @@
         <!-- for testing -->
         <dependency>
             <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
             <artifactId>presto-main</artifactId>
             <scope>test</scope>
         </dependency>

--- a/presto-parser/pom.xml
+++ b/presto-parser/pom.xml
@@ -49,6 +49,12 @@
 
         <!-- for testing -->
         <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/presto-password-authenticators/pom.xml
+++ b/presto-password-authenticators/pom.xml
@@ -108,6 +108,12 @@
 
         <!-- for testing -->
         <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/presto-pinot-toolkit/pom.xml
+++ b/presto-pinot-toolkit/pom.xml
@@ -150,6 +150,12 @@
         <!-- for testing -->
         <dependency>
             <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
             <artifactId>presto-main</artifactId>
             <scope>test</scope>
         </dependency>

--- a/presto-plugin-toolkit/pom.xml
+++ b/presto-plugin-toolkit/pom.xml
@@ -80,6 +80,12 @@
 
         <!-- for testing -->
         <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/presto-postgresql/pom.xml
+++ b/presto-postgresql/pom.xml
@@ -86,6 +86,12 @@
 
         <!-- for testing -->
         <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/presto-proxy/pom.xml
+++ b/presto-proxy/pom.xml
@@ -156,6 +156,12 @@
 
         <!-- for testing -->
         <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/presto-raptor/pom.xml
+++ b/presto-raptor/pom.xml
@@ -215,6 +215,12 @@
 
         <!-- for testing -->
         <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/presto-rcfile/pom.xml
+++ b/presto-rcfile/pom.xml
@@ -79,6 +79,12 @@
 
         <!-- for testing -->
         <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/presto-record-decoder/pom.xml
+++ b/presto-record-decoder/pom.xml
@@ -87,6 +87,12 @@
 
         <!-- for testing -->
         <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/presto-redis/pom.xml
+++ b/presto-redis/pom.xml
@@ -120,6 +120,12 @@
 
         <!-- for testing -->
         <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/presto-redshift/pom.xml
+++ b/presto-redshift/pom.xml
@@ -88,6 +88,12 @@
 
         <!-- for testing -->
         <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/presto-resource-group-managers/pom.xml
+++ b/presto-resource-group-managers/pom.xml
@@ -147,6 +147,12 @@
 
         <!-- for testing -->
         <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/presto-session-property-managers/pom.xml
+++ b/presto-session-property-managers/pom.xml
@@ -89,6 +89,12 @@
 
         <!-- for testing -->
         <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/presto-spark-base/pom.xml
+++ b/presto-spark-base/pom.xml
@@ -172,6 +172,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/presto-spark-testing/pom.xml
+++ b/presto-spark-testing/pom.xml
@@ -32,6 +32,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/presto-spi/pom.xml
+++ b/presto-spi/pom.xml
@@ -56,6 +56,12 @@
         <!-- for testing -->
         <dependency>
             <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
             <artifactId>presto-common</artifactId>
             <type>test-jar</type>
             <scope>test</scope>

--- a/presto-sqlserver/pom.xml
+++ b/presto-sqlserver/pom.xml
@@ -84,6 +84,12 @@
 
         <!-- for testing -->
         <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/presto-teradata-functions/pom.xml
+++ b/presto-teradata-functions/pom.xml
@@ -69,6 +69,12 @@
 
         <!-- for testing -->
         <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/presto-tests/pom.xml
+++ b/presto-tests/pom.xml
@@ -224,6 +224,12 @@
         <!-- for testing -->
         <dependency>
             <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
             <artifactId>presto-resource-group-managers</artifactId>
             <scope>test</scope>
         </dependency>

--- a/presto-thrift-api/pom.xml
+++ b/presto-thrift-api/pom.xml
@@ -55,6 +55,12 @@
 
         <!-- for testing -->
         <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/presto-thrift-connector/pom.xml
+++ b/presto-thrift-connector/pom.xml
@@ -150,6 +150,12 @@
 
         <!-- for testing -->
         <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/presto-thrift-testing-server/pom.xml
+++ b/presto-thrift-testing-server/pom.xml
@@ -120,5 +120,11 @@
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/presto-tpcds/pom.xml
+++ b/presto-tpcds/pom.xml
@@ -80,6 +80,12 @@
         <!-- for testing -->
         <dependency>
             <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
             <artifactId>presto-tests</artifactId>
             <scope>test</scope>
         </dependency>
@@ -87,13 +93,6 @@
         <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-main</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>com.facebook.presto</groupId>
-            <artifactId>presto-main</artifactId>
-            <type>test-jar</type>
             <scope>test</scope>
         </dependency>
 

--- a/presto-tpch/pom.xml
+++ b/presto-tpch/pom.xml
@@ -69,6 +69,12 @@
 
         <!-- for testing -->
         <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>

--- a/presto-verifier/pom.xml
+++ b/presto-verifier/pom.xml
@@ -259,6 +259,12 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testng-services</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <!-- for assembly -->
         <dependency>
             <groupId>com.facebook.airlift</groupId>

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestQueryConfiguration.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestQueryConfiguration.java
@@ -25,6 +25,7 @@ import static com.facebook.presto.testing.assertions.Assert.assertEquals;
 import static com.facebook.presto.verifier.framework.QueryConfigurationOverrides.SessionPropertiesOverrideStrategy.OVERRIDE;
 import static com.facebook.presto.verifier.framework.QueryConfigurationOverrides.SessionPropertiesOverrideStrategy.SUBSTITUTE;
 
+@Test(singleThreaded = true)
 public class TestQueryConfiguration
 {
     private static final String CATALOG = "catalog";

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestVerificationManager.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestVerificationManager.java
@@ -55,6 +55,7 @@ import static com.facebook.presto.verifier.prestoaction.QueryActionStats.EMPTY_S
 import static com.google.common.base.Preconditions.checkArgument;
 import static org.testng.Assert.assertEquals;
 
+@Test(singleThreaded = true)
 public class TestVerificationManager
 {
     private static class MockPrestoAction

--- a/testing/presto-testng-services/pom.xml
+++ b/testing/presto-testng-services/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.facebook.presto</groupId>
+        <artifactId>presto-root</artifactId>
+        <version>0.255-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>presto-testng-services</artifactId>
+    <name>presto-testng-services</name>
+
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>log</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>units</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>concurrent</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/testing/presto-testng-services/src/main/java/com/facebook/presto/testng/services/Listeners.java
+++ b/testing/presto-testng-services/src/main/java/com/facebook/presto/testng/services/Listeners.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.testng.services;
+
+import org.testng.ITestNGListener;
+
+import static java.lang.String.format;
+
+final class Listeners
+{
+    private Listeners() {}
+
+    /**
+     * Print error to standard error and exit JVM.
+     *
+     * @apiNote A TestNG listener cannot throw an exception, as this are not currently properly handlded by TestNG.
+     */
+    public static void reportListenerFailure(Class<? extends ITestNGListener> listenerClass, String format, Object... args)
+    {
+        System.err.println(format("FATAL: %s: ", listenerClass.getName()) + format(format, args));
+        System.err.println("JVM will be terminated");
+
+        // TestNG may or may not propagate listener's exception as test execution exception.
+        // Therefore, instead of throwing, we terminate the JVM.
+        System.exit(1);
+    }
+}

--- a/testing/presto-testng-services/src/main/java/com/facebook/presto/testng/services/LogTestDurationListener.java
+++ b/testing/presto-testng-services/src/main/java/com/facebook/presto/testng/services/LogTestDurationListener.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.tests;
+package com.facebook.presto.testng.services;
 
 import com.facebook.airlift.log.Logger;
 import com.google.common.collect.ImmutableMap;
@@ -103,7 +103,7 @@ public class LogTestDurationListener
         Map<String, Long> runningTests = ImmutableMap.copyOf(started);
         if (!runningTests.isEmpty()) {
             String testDetails = runningTests.entrySet().stream()
-                    .map(entry -> String.format("%s running for %s", entry.getKey(), nanosSince(entry.getValue())))
+                    .map(entry -> format("%s running for %s", entry.getKey(), nanosSince(entry.getValue())))
                     .collect(joining("\n\t", "\n\t", ""));
             dumpAllThreads(format("No test started or completed in %s. Running tests:%s.", GLOBAL_IDLE_LOGGING_THRESHOLD, testDetails));
         }

--- a/testing/presto-testng-services/src/main/java/com/facebook/presto/testng/services/ReportMultiThreadedBeforeOrAfterMethod.java
+++ b/testing/presto-testng-services/src/main/java/com/facebook/presto/testng/services/ReportMultiThreadedBeforeOrAfterMethod.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.testng.services;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.testng.IClassListener;
+import org.testng.ITestClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.testng.xml.XmlSuite.ParallelMode;
+import org.testng.xml.XmlTest;
+
+import java.lang.reflect.Method;
+
+import static com.facebook.presto.testng.services.Listeners.reportListenerFailure;
+import static com.google.common.base.Throwables.getStackTraceAsString;
+import static java.lang.String.format;
+
+public class ReportMultiThreadedBeforeOrAfterMethod
+        implements IClassListener
+{
+    @Override
+    public void onBeforeClass(ITestClass testClass)
+    {
+        try {
+            if (!isParallel(testClass.getXmlTest())) {
+                return;
+            }
+
+            reportMultiThreadedBeforeOrAfterMethod(testClass.getRealClass());
+        }
+        catch (RuntimeException | Error e) {
+            reportListenerFailure(
+                    ReportMultiThreadedBeforeOrAfterMethod.class,
+                    "Failed to process %s: \n%s",
+                    testClass,
+                    getStackTraceAsString(e));
+        }
+    }
+
+    private boolean isParallel(XmlTest xmlTest)
+    {
+        if (xmlTest.getThreadCount() == 1) {
+            return false;
+        }
+
+        ParallelMode parallel = xmlTest.getParallel();
+        return parallel.isParallel();
+    }
+
+    @VisibleForTesting
+    static void reportMultiThreadedBeforeOrAfterMethod(Class<?> testClass)
+    {
+        Test testAnnotation = testClass.getAnnotation(Test.class);
+        if (testAnnotation != null && testAnnotation.singleThreaded()) {
+            return;
+        }
+
+        Method[] methods = testClass.getMethods();
+        for (Method method : methods) {
+            if (method.getAnnotation(BeforeMethod.class) != null || method.getAnnotation(AfterMethod.class) != null) {
+                throw new RuntimeException(format(
+                        "Test class %s should be annotated as @Test(singleThreaded=true), if it contains mutable state as indicated by %s",
+                        testClass.getName(),
+                        method));
+            }
+        }
+    }
+
+    @Override
+    public void onAfterClass(ITestClass iTestClass) {}
+}

--- a/testing/presto-testng-services/src/main/resources/META-INF/services/org.testng.ITestNGListener
+++ b/testing/presto-testng-services/src/main/resources/META-INF/services/org.testng.ITestNGListener
@@ -1,0 +1,2 @@
+com.facebook.presto.testng.services.LogTestDurationListener
+com.facebook.presto.testng.services.ReportMultiThreadedBeforeOrAfterMethod

--- a/testing/presto-testng-services/src/test/java/com/facebook/presto/testng/services/TestReportMultiThreadedBeforeOrAfterMethod.java
+++ b/testing/presto-testng-services/src/test/java/com/facebook/presto/testng/services/TestReportMultiThreadedBeforeOrAfterMethod.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.testng.services;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.testng.services.ReportMultiThreadedBeforeOrAfterMethod.reportMultiThreadedBeforeOrAfterMethod;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class TestReportMultiThreadedBeforeOrAfterMethod
+{
+    @Test
+    public void test()
+    {
+        // no @BeforeMethod
+        reportMultiThreadedBeforeOrAfterMethod(ClassWithoutBeforeMethod.class);
+
+        // @BeforeMethod but not @Test(singleThreaded)
+        assertThatThrownBy(() -> reportMultiThreadedBeforeOrAfterMethod(ClassWithBeforeMethod.class))
+                .hasMessageMatching("Test class \\S*\\Q.TestReportMultiThreadedBeforeOrAfterMethod$ClassWithBeforeMethod should be annotated as @Test(singleThreaded=true)\\E, " +
+                        "if it contains mutable state as indicated by public void \\S*\\Q.TestReportMultiThreadedBeforeOrAfterMethod$ClassWithBeforeMethod.someBeforeMethod()");
+
+        // @BeforeMethod and @Test(singleThreaded)
+        reportMultiThreadedBeforeOrAfterMethod(SingleThreadedClassWithBeforeMethod.class);
+
+        // inherited @BeforeMethod but not @Test(singleThreaded)
+        assertThatThrownBy(() -> reportMultiThreadedBeforeOrAfterMethod(ClassWithInheritedBeforeMethod.class))
+                .hasMessageMatching("Test class \\S*\\Q.TestReportMultiThreadedBeforeOrAfterMethod$ClassWithInheritedBeforeMethod should be annotated as @Test(singleThreaded=true)\\E, " +
+                        "if it contains mutable state as indicated by public void \\S*\\Q.TestReportMultiThreadedBeforeOrAfterMethod$ClassWithBeforeMethod.someBeforeMethod()");
+
+        // inherited @BeforeMethod and "inherited" @Test(singleThreaded) (this does not get propagated to child class yet, see https://github.com/cbeust/testng/issues/144)
+        assertThatThrownBy(() -> reportMultiThreadedBeforeOrAfterMethod(ClassExtendingSingleThreadedClassWithBeforeMethod.class))
+                .hasMessageMatching("Test class \\S*\\Q.TestReportMultiThreadedBeforeOrAfterMethod$ClassExtendingSingleThreadedClassWithBeforeMethod should be annotated as @Test(singleThreaded=true)\\E, " +
+                        "if it contains mutable state as indicated by public void \\S*\\Q.TestReportMultiThreadedBeforeOrAfterMethod$SingleThreadedClassWithBeforeMethod.someBeforeMethod()");
+    }
+
+    public static class ClassWithoutBeforeMethod {}
+
+    public static class ClassWithBeforeMethod
+    {
+        @BeforeMethod
+        public void someBeforeMethod() {}
+    }
+
+    @Test(singleThreaded = true)
+    public static class SingleThreadedClassWithBeforeMethod
+    {
+        @BeforeMethod
+        public void someBeforeMethod() {}
+    }
+
+    public static class ClassWithInheritedBeforeMethod
+            extends ClassWithBeforeMethod {}
+
+    public static class ClassExtendingSingleThreadedClassWithBeforeMethod
+            extends SingleThreadedClassWithBeforeMethod {}
+}


### PR DESCRIPTION
This replaces #15756.

Existence of @BeforeMethod or @AfterMethod most often indicates a
shared mutable state that needs to be e.g. reset. This means the class
should be marked @Test(singleThreaded=true)
Also allow @BeforeMethod and @AfterMethod on non-single-threaded test
classes when the whole suite is marked as single-threaded.

Depends on https://github.com/facebookexternal/presto-facebook/pull/1543

```
== RELEASE NOTES ==
General Changes
* Reject @BeforeMethod in Multi-threaded tests.
```
