### PR TITLE
Improve bucketed table write parallelism for Presto on Spark

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -178,6 +178,7 @@ public final class SystemSessionProperties
     public static final String MAX_UNACKNOWLEDGED_SPLITS_PER_TASK = "max_unacknowledged_splits_per_task";
     public static final String OPTIMIZE_JOINS_WITH_EMPTY_SOURCES = "optimize_joins_with_empty_sources";
     public static final String SPOOLING_OUTPUT_BUFFER_ENABLED = "spooling_output_buffer_enabled";
+    public static final String SPARK_ASSIGN_BUCKET_TO_PARTITION_FOR_PARTITIONED_TABLE_WRITE_ENABLED = "spark_assign_bucket_to_partition_for_partitioned_table_write_enabled";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -932,7 +933,12 @@ public final class SystemSessionProperties
                         SPOOLING_OUTPUT_BUFFER_ENABLED,
                         "Enable spooling output buffer for terminal task",
                         featuresConfig.isSpoolingOutputBufferEnabled(),
-                        false));
+                        false),
+                booleanProperty(
+                        SPARK_ASSIGN_BUCKET_TO_PARTITION_FOR_PARTITIONED_TABLE_WRITE_ENABLED,
+                        "Assign bucket to partition map for partitioned table write when adding an exchange",
+                        featuresConfig.isPrestoSparkAssignBucketToPartitionForPartitionedTableWriteEnabled(),
+                        true));
     }
 
     public static boolean isEmptyJoinOptimization(Session session)
@@ -1577,5 +1583,10 @@ public final class SystemSessionProperties
     public static int getMaxUnacknowledgedSplitsPerTask(Session session)
     {
         return session.getSystemProperty(MAX_UNACKNOWLEDGED_SPLITS_PER_TASK, Integer.class);
+    }
+
+    public static boolean isPrestoSparkAssignBucketToPartitionForPartitionedTableWriteEnabled(Session session)
+    {
+        return session.getSystemProperty(SPARK_ASSIGN_BUCKET_TO_PARTITION_FOR_PARTITIONED_TABLE_WRITE_ENABLED, Boolean.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -186,6 +186,7 @@ public class FeaturesConfig
     private PartitioningPrecisionStrategy partitioningPrecisionStrategy = PartitioningPrecisionStrategy.AUTOMATIC;
 
     private boolean enforceFixedDistributionForOutputOperator;
+    private boolean prestoSparkAssignBucketToPartitionForPartitionedTableWriteEnabled;
 
     public enum PartitioningPrecisionStrategy
     {
@@ -1581,6 +1582,18 @@ public class FeaturesConfig
     public FeaturesConfig setSpoolingOutputBufferTempStorage(String spoolingOutputBufferTempStorage)
     {
         this.spoolingOutputBufferTempStorage = spoolingOutputBufferTempStorage;
+        return this;
+    }
+
+    public boolean isPrestoSparkAssignBucketToPartitionForPartitionedTableWriteEnabled()
+    {
+        return prestoSparkAssignBucketToPartitionForPartitionedTableWriteEnabled;
+    }
+
+    @Config("spark.assign-bucket-to-partition-for-partitioned-table-write-enabled")
+    public FeaturesConfig setPrestoSparkAssignBucketToPartitionForPartitionedTableWriteEnabled(boolean prestoSparkAssignBucketToPartitionForPartitionedTableWriteEnabled)
+    {
+        this.prestoSparkAssignBucketToPartitionForPartitionedTableWriteEnabled = prestoSparkAssignBucketToPartitionForPartitionedTableWriteEnabled;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -165,7 +165,8 @@ public class PlanOptimizers
             CostCalculator costCalculator,
             @EstimatedExchanges CostCalculator estimatedExchangesCostCalculator,
             CostComparator costComparator,
-            TaskCountEstimator taskCountEstimator)
+            TaskCountEstimator taskCountEstimator,
+            PartitioningProviderManager partitioningProviderManager)
     {
         this(metadata,
                 sqlParser,
@@ -178,7 +179,8 @@ public class PlanOptimizers
                 costCalculator,
                 estimatedExchangesCostCalculator,
                 costComparator,
-                taskCountEstimator);
+                taskCountEstimator,
+                partitioningProviderManager);
     }
 
     @PostConstruct
@@ -207,7 +209,8 @@ public class PlanOptimizers
             CostCalculator costCalculator,
             CostCalculator estimatedExchangesCostCalculator,
             CostComparator costComparator,
-            TaskCountEstimator taskCountEstimator)
+            TaskCountEstimator taskCountEstimator,
+            PartitioningProviderManager partitioningProviderManager)
     {
         this.exporter = exporter;
         ImmutableList.Builder<PlanOptimizer> builder = ImmutableList.builder();
@@ -448,7 +451,7 @@ public class PlanOptimizers
                         ImmutableSet.<Rule<?>>builder()
                                 .addAll(new PushDownDereferences(metadata).rules())
                                 .build()),
-                    new PruneUnreferencedOutputs());
+                new PruneUnreferencedOutputs());
 
         builder.add(new IterativeOptimizer(
                 ruleStats,
@@ -540,7 +543,7 @@ public class PlanOptimizers
                             statsCalculator,
                             estimatedExchangesCostCalculator,
                             ImmutableSet.of(new PushTableWriteThroughUnion()))); // Must run before AddExchanges
-            builder.add(new StatsRecordingPlanOptimizer(optimizerStats, new AddExchanges(metadata, sqlParser)));
+            builder.add(new StatsRecordingPlanOptimizer(optimizerStats, new AddExchanges(metadata, sqlParser, partitioningProviderManager)));
         }
 
         //noinspection UnusedAssignment

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddExchanges.java
@@ -18,11 +18,13 @@ import com.facebook.presto.common.type.Type;
 import com.facebook.presto.connector.system.GlobalSystemConnector;
 import com.facebook.presto.execution.QueryManagerConfig.ExchangeMaterializationStrategy;
 import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.GroupingProperty;
 import com.facebook.presto.spi.LocalProperty;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SortingProperty;
 import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.connector.ConnectorNodePartitioningProvider;
 import com.facebook.presto.spi.plan.AggregationNode;
 import com.facebook.presto.spi.plan.Assignments;
 import com.facebook.presto.spi.plan.DistinctLimitNode;
@@ -43,6 +45,7 @@ import com.facebook.presto.sql.analyzer.FeaturesConfig.PartialMergePushdownStrat
 import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.Partitioning;
 import com.facebook.presto.sql.planner.PartitioningHandle;
+import com.facebook.presto.sql.planner.PartitioningProviderManager;
 import com.facebook.presto.sql.planner.PartitioningScheme;
 import com.facebook.presto.sql.planner.PlanVariableAllocator;
 import com.facebook.presto.sql.planner.TypeProvider;
@@ -98,12 +101,14 @@ import static com.facebook.presto.SystemSessionProperties.getExchangeMaterializa
 import static com.facebook.presto.SystemSessionProperties.getHashPartitionCount;
 import static com.facebook.presto.SystemSessionProperties.getPartialMergePushdownStrategy;
 import static com.facebook.presto.SystemSessionProperties.getPartitioningProviderCatalog;
+import static com.facebook.presto.SystemSessionProperties.getTaskPartitionedWriterCount;
 import static com.facebook.presto.SystemSessionProperties.isColocatedJoinEnabled;
 import static com.facebook.presto.SystemSessionProperties.isDistributedIndexJoinEnabled;
 import static com.facebook.presto.SystemSessionProperties.isDistributedSortEnabled;
 import static com.facebook.presto.SystemSessionProperties.isExactPartitioningPreferred;
 import static com.facebook.presto.SystemSessionProperties.isForceSingleNodeOutput;
 import static com.facebook.presto.SystemSessionProperties.isPreferDistributedUnion;
+import static com.facebook.presto.SystemSessionProperties.isPrestoSparkAssignBucketToPartitionForPartitionedTableWriteEnabled;
 import static com.facebook.presto.SystemSessionProperties.isRedistributeWrites;
 import static com.facebook.presto.SystemSessionProperties.isScaleWriters;
 import static com.facebook.presto.SystemSessionProperties.isUseStreamingExchangeForMarkDistinctEnabled;
@@ -140,6 +145,7 @@ import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 
 public class AddExchanges
@@ -147,17 +153,19 @@ public class AddExchanges
 {
     private final SqlParser parser;
     private final Metadata metadata;
+    private final PartitioningProviderManager partitioningProviderManager;
 
-    public AddExchanges(Metadata metadata, SqlParser parser)
+    public AddExchanges(Metadata metadata, SqlParser parser, PartitioningProviderManager partitioningProviderManager)
     {
-        this.metadata = metadata;
-        this.parser = parser;
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.parser = requireNonNull(parser, "parser is null");
+        this.partitioningProviderManager = requireNonNull(partitioningProviderManager, "partitioningProviderManager is null");
     }
 
     @Override
     public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, PlanVariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
     {
-        PlanWithProperties result = plan.accept(new Rewriter(idAllocator, variableAllocator, session), PreferredProperties.any());
+        PlanWithProperties result = plan.accept(new Rewriter(idAllocator, variableAllocator, session, partitioningProviderManager), PreferredProperties.any());
         return result.getNode();
     }
 
@@ -177,8 +185,13 @@ public class AddExchanges
         private final String partitioningProviderCatalog;
         private final int hashPartitionCount;
         private final ExchangeMaterializationStrategy exchangeMaterializationStrategy;
+        private final PartitioningProviderManager partitioningProviderManager;
 
-        public Rewriter(PlanNodeIdAllocator idAllocator, PlanVariableAllocator variableAllocator, Session session)
+        public Rewriter(
+                PlanNodeIdAllocator idAllocator,
+                PlanVariableAllocator variableAllocator,
+                Session session,
+                PartitioningProviderManager partitioningProviderManager)
         {
             this.idAllocator = idAllocator;
             this.variableAllocator = variableAllocator;
@@ -193,6 +206,7 @@ public class AddExchanges
             this.partitioningProviderCatalog = getPartitioningProviderCatalog(session);
             this.hashPartitionCount = getHashPartitionCount(session);
             this.exchangeMaterializationStrategy = getExchangeMaterializationStrategy(session);
+            this.partitioningProviderManager = requireNonNull(partitioningProviderManager, "partitioningProviderManager is null");
         }
 
         @Override
@@ -598,15 +612,42 @@ public class AddExchanges
                     !source.getProperties().isCompatibleTablePartitioningWith(shufflePartitioningScheme.get().getPartitioning(), false, metadata, session) &&
                     !(source.getProperties().isRefinedPartitioningOver(shufflePartitioningScheme.get().getPartitioning(), false, metadata, session) &&
                             canPushdownPartialMerge(source.getNode(), partialMergePushdownStrategy))) {
+                PartitioningScheme exchangePartitioningScheme = shufflePartitioningScheme.get();
+                if (node.getTablePartitioningScheme().isPresent() && isPrestoSparkAssignBucketToPartitionForPartitionedTableWriteEnabled(session)) {
+                    int writerThreadsPerNode = getTaskPartitionedWriterCount(session);
+                    int bucketCount = getBucketCount(node.getTablePartitioningScheme().get().getPartitioning().getHandle());
+                    int[] bucketToPartition = new int[bucketCount];
+                    for (int i = 0; i < bucketCount; i++) {
+                        bucketToPartition[i] = i / writerThreadsPerNode;
+                    }
+                    exchangePartitioningScheme = exchangePartitioningScheme.withBucketToPartition(Optional.of(bucketToPartition));
+                }
+
                 source = withDerivedProperties(
                         partitionedExchange(
                                 idAllocator.getNextId(),
                                 REMOTE_STREAMING,
                                 source.getNode(),
-                                shufflePartitioningScheme.get()),
+                                exchangePartitioningScheme),
                         source.getProperties());
             }
             return rebaseAndDeriveProperties(node, source);
+        }
+
+        private int getBucketCount(PartitioningHandle partitioning)
+        {
+            ConnectorNodePartitioningProvider partitioningProvider = getPartitioningProvider(partitioning);
+            return partitioningProvider.getBucketCount(
+                    partitioning.getTransactionHandle().orElse(null),
+                    session.toConnectorSession(),
+                    partitioning.getConnectorHandle());
+        }
+
+        private ConnectorNodePartitioningProvider getPartitioningProvider(PartitioningHandle partitioning)
+        {
+            ConnectorId connectorId = partitioning.getConnectorId()
+                    .orElseThrow(() -> new IllegalArgumentException("Unexpected partitioning: " + partitioning));
+            return partitioningProviderManager.getPartitioningProvider(connectorId);
         }
 
         private PlanWithProperties planTableScan(TableScanNode node, RowExpression predicate)

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -946,7 +946,8 @@ public class LocalQueryRunner
                 costCalculator,
                 estimatedExchangesCostCalculator,
                 new CostComparator(featuresConfig),
-                taskCountEstimator).getPlanningTimeOptimizers();
+                taskCountEstimator,
+                partitioningProviderManager).getPlanningTimeOptimizers();
     }
 
     public Plan createPlan(Session session, @Language("SQL") String sql, List<PlanOptimizer> optimizers, WarningCollector warningCollector)

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -159,7 +159,8 @@ public class TestFeaturesConfig
                 .setEmptyJoinOptimization(false)
                 .setSpoolingOutputBufferEnabled(false)
                 .setSpoolingOutputBufferThreshold(new DataSize(8, MEGABYTE))
-                .setSpoolingOutputBufferTempStorage("local"));
+                .setSpoolingOutputBufferTempStorage("local")
+                .setPrestoSparkAssignBucketToPartitionForPartitionedTableWriteEnabled(false));
     }
 
     @Test
@@ -272,6 +273,7 @@ public class TestFeaturesConfig
                 .put("spooling-output-buffer-enabled", "true")
                 .put("spooling-output-buffer-threshold", "16MB")
                 .put("spooling-output-buffer-temp-storage", "tempfs")
+                .put("spark.assign-bucket-to-partition-for-partitioned-table-write-enabled", "true")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -381,7 +383,8 @@ public class TestFeaturesConfig
                 .setEmptyJoinOptimization(true)
                 .setSpoolingOutputBufferEnabled(true)
                 .setSpoolingOutputBufferThreshold(new DataSize(16, MEGABYTE))
-                .setSpoolingOutputBufferTempStorage("tempfs");
+                .setSpoolingOutputBufferTempStorage("tempfs")
+                .setPrestoSparkAssignBucketToPartitionForPartitionedTableWriteEnabled(true);
         assertFullMapping(properties, expected);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestEliminateSorts.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestEliminateSorts.java
@@ -15,6 +15,7 @@ package com.facebook.presto.sql.planner.optimizations;
 
 import com.facebook.presto.common.block.SortOrder;
 import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.planner.PartitioningProviderManager;
 import com.facebook.presto.sql.planner.RuleStatsRecorder;
 import com.facebook.presto.sql.planner.assertions.BasePlanTest;
 import com.facebook.presto.sql.planner.assertions.ExpectedValueProvider;
@@ -94,7 +95,7 @@ public class TestEliminateSorts
                         getQueryRunner().getStatsCalculator(),
                         getQueryRunner().getCostCalculator(),
                         new TranslateExpressions(getMetadata(), new SqlParser()).rules()),
-                new AddExchanges(getQueryRunner().getMetadata(), new SqlParser()),
+                new AddExchanges(getQueryRunner().getMetadata(), new SqlParser(), new PartitioningProviderManager()),
                 new UnaliasSymbolReferences(getMetadata().getFunctionAndTypeManager()),
                 new PruneUnreferencedOutputs(),
                 new IterativeOptimizer(

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
@@ -58,8 +58,10 @@ import com.facebook.presto.spark.classloader_interface.MutablePartitionId;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkConfInitializer;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkExecutionException;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkMutableRow;
+import com.facebook.presto.spark.classloader_interface.PrestoSparkPartitioner;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkSerializedPage;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkSession;
+import com.facebook.presto.spark.classloader_interface.PrestoSparkShuffleSerializer;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkShuffleStats;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkShuffleStats.Operation;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkStorageHandle;
@@ -81,6 +83,7 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.connector.ConnectorCapabilities;
+import com.facebook.presto.spi.connector.ConnectorNodePartitioningProvider;
 import com.facebook.presto.spi.memory.MemoryPoolId;
 import com.facebook.presto.spi.page.PagesSerde;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
@@ -88,6 +91,9 @@ import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
 import com.facebook.presto.spi.storage.StorageCapabilities;
 import com.facebook.presto.spi.storage.TempDataOperationContext;
 import com.facebook.presto.spi.storage.TempStorage;
+import com.facebook.presto.sql.planner.PartitioningHandle;
+import com.facebook.presto.sql.planner.PartitioningProviderManager;
+import com.facebook.presto.sql.planner.PartitioningScheme;
 import com.facebook.presto.sql.planner.PlanFragment;
 import com.facebook.presto.sql.planner.SubPlan;
 import com.facebook.presto.sql.planner.plan.PlanFragmentId;
@@ -104,12 +110,14 @@ import com.google.common.collect.ListMultimap;
 import com.google.common.io.BaseEncoding;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
+import org.apache.spark.Partitioner;
 import org.apache.spark.SparkContext;
 import org.apache.spark.SparkException;
 import org.apache.spark.api.java.JavaFutureAction;
 import org.apache.spark.api.java.JavaPairRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.broadcast.Broadcast;
+import org.apache.spark.rdd.ShuffledRDD;
 import org.apache.spark.util.CollectionAccumulator;
 import org.joda.time.DateTime;
 import scala.Option;
@@ -132,8 +140,10 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.stream.IntStream;
 
 import static com.facebook.airlift.concurrent.MoreFutures.getFutureValue;
+import static com.facebook.presto.SystemSessionProperties.getHashPartitionCount;
 import static com.facebook.presto.SystemSessionProperties.getQueryMaxBroadcastMemory;
 import static com.facebook.presto.SystemSessionProperties.getQueryMaxExecutionTime;
 import static com.facebook.presto.SystemSessionProperties.getQueryMaxRunTime;
@@ -156,6 +166,7 @@ import static com.facebook.presto.spark.SparkErrorCode.SPARK_EXECUTOR_OOM;
 import static com.facebook.presto.spark.SparkErrorCode.UNSUPPORTED_STORAGE_TYPE;
 import static com.facebook.presto.spark.classloader_interface.ScalaUtils.collectScalaIterator;
 import static com.facebook.presto.spark.classloader_interface.ScalaUtils.emptyScalaIterator;
+import static com.facebook.presto.spark.util.PrestoSparkUtils.classTag;
 import static com.facebook.presto.spark.util.PrestoSparkUtils.computeNextTimeout;
 import static com.facebook.presto.spark.util.PrestoSparkUtils.createPagesSerde;
 import static com.facebook.presto.spark.util.PrestoSparkUtils.deserializeZstdCompressed;
@@ -167,7 +178,10 @@ import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.spi.connector.ConnectorCapabilities.SUPPORTS_PAGE_SINK_COMMIT;
 import static com.facebook.presto.spi.storage.StorageCapabilities.REMOTELY_ACCESSIBLE;
 import static com.facebook.presto.sql.planner.SystemPartitioningHandle.COORDINATOR_DISTRIBUTION;
+import static com.facebook.presto.sql.planner.SystemPartitioningHandle.FIXED_ARBITRARY_DISTRIBUTION;
 import static com.facebook.presto.sql.planner.SystemPartitioningHandle.FIXED_BROADCAST_DISTRIBUTION;
+import static com.facebook.presto.sql.planner.SystemPartitioningHandle.FIXED_HASH_DISTRIBUTION;
+import static com.facebook.presto.sql.planner.SystemPartitioningHandle.SINGLE_DISTRIBUTION;
 import static com.facebook.presto.sql.planner.planPrinter.PlanPrinter.textDistributedPlan;
 import static com.facebook.presto.util.Failures.toFailure;
 import static com.google.common.base.MoreObjects.firstNonNull;
@@ -215,6 +229,7 @@ public class PrestoSparkQueryExecutionFactory
     private final PrestoSparkTaskExecutorFactory prestoSparkTaskExecutorFactory;
     private final SessionPropertyDefaults sessionPropertyDefaults;
     private final WarningCollectorFactory warningCollectorFactory;
+    private final PartitioningProviderManager partitioningProviderManager;
 
     private final Set<PrestoSparkCredentialsProvider> credentialsProviders;
     private final Set<PrestoSparkAuthenticatorProvider> authenticatorProviders;
@@ -245,6 +260,7 @@ public class PrestoSparkQueryExecutionFactory
             PrestoSparkTaskExecutorFactory prestoSparkTaskExecutorFactory,
             SessionPropertyDefaults sessionPropertyDefaults,
             WarningCollectorFactory warningCollectorFactory,
+            PartitioningProviderManager partitioningProviderManager,
             Set<PrestoSparkCredentialsProvider> credentialsProviders,
             Set<PrestoSparkAuthenticatorProvider> authenticatorProviders,
             TempStorageManager tempStorageManager,
@@ -272,6 +288,7 @@ public class PrestoSparkQueryExecutionFactory
         this.prestoSparkTaskExecutorFactory = requireNonNull(prestoSparkTaskExecutorFactory, "prestoSparkTaskExecutorFactory is null");
         this.sessionPropertyDefaults = requireNonNull(sessionPropertyDefaults, "sessionPropertyDefaults is null");
         this.warningCollectorFactory = requireNonNull(warningCollectorFactory, "warningCollectorFactory is null");
+        this.partitioningProviderManager = requireNonNull(partitioningProviderManager, "partitioningProviderManager is null");
         this.credentialsProviders = ImmutableSet.copyOf(requireNonNull(credentialsProviders, "credentialsProviders is null"));
         this.authenticatorProviders = ImmutableSet.copyOf(requireNonNull(authenticatorProviders, "authenticatorProviders is null"));
         this.tempStorageManager = requireNonNull(tempStorageManager, "tempStorageManager is null");
@@ -381,6 +398,7 @@ public class PrestoSparkQueryExecutionFactory
             planAndMore = queryPlanner.createQueryPlan(session, preparedQuery, warningCollector);
             SubPlan fragmentedPlan = planFragmenter.fragmentQueryPlan(session, planAndMore.getPlan(), warningCollector);
             log.info(textDistributedPlan(fragmentedPlan, metadata.getFunctionAndTypeManager(), session, true));
+            fragmentedPlan = configureOutputPartitioning(session, fragmentedPlan);
             TableWriteInfo tableWriteInfo = getTableWriteInfo(session, fragmentedPlan);
 
             JavaSparkContext javaSparkContext = new JavaSparkContext(sparkContext);
@@ -470,6 +488,61 @@ public class PrestoSparkQueryExecutionFactory
 
             throw failureInfo.get().toFailure();
         }
+    }
+
+    private SubPlan configureOutputPartitioning(Session session, SubPlan subPlan)
+    {
+        PlanFragment fragment = subPlan.getFragment();
+        if (!fragment.getPartitioningScheme().getBucketToPartition().isPresent()) {
+            PartitioningHandle partitioningHandle = fragment.getPartitioningScheme().getPartitioning().getHandle();
+            Optional<int[]> bucketToPartition = getBucketToPartition(session, partitioningHandle);
+            if (bucketToPartition.isPresent()) {
+                fragment = fragment.withBucketToPartition(bucketToPartition);
+            }
+        }
+        return new SubPlan(
+                fragment,
+                subPlan.getChildren().stream()
+                        .map(child -> configureOutputPartitioning(session, child))
+                        .collect(toImmutableList()));
+    }
+
+    private Optional<int[]> getBucketToPartition(Session session, PartitioningHandle partitioningHandle)
+    {
+        if (partitioningHandle.equals(FIXED_HASH_DISTRIBUTION)) {
+            int hashPartitionCount = getHashPartitionCount(session);
+            return Optional.of(IntStream.range(0, hashPartitionCount).toArray());
+        }
+        //  FIXED_ARBITRARY_DISTRIBUTION is used for UNION ALL
+        //  UNION ALL inputs could be source inputs or shuffle inputs
+        if (partitioningHandle.equals(FIXED_ARBITRARY_DISTRIBUTION)) {
+            // given modular hash function, partition count could be arbitrary size
+            // simply reuse hash_partition_count for convenience
+            // it can also be set by a separate session property if needed
+            int partitionCount = getHashPartitionCount(session);
+            return Optional.of(IntStream.range(0, partitionCount).toArray());
+        }
+        if (partitioningHandle.getConnectorId().isPresent()) {
+            int connectorPartitionCount = getPartitionCount(session, partitioningHandle);
+            return Optional.of(IntStream.range(0, connectorPartitionCount).toArray());
+        }
+        return Optional.empty();
+    }
+
+    private int getPartitionCount(Session session, PartitioningHandle partitioning)
+    {
+        ConnectorNodePartitioningProvider partitioningProvider = getPartitioningProvider(partitioning);
+        return partitioningProvider.getBucketCount(
+                partitioning.getTransactionHandle().orElse(null),
+                session.toConnectorSession(),
+                partitioning.getConnectorHandle());
+    }
+
+    private ConnectorNodePartitioningProvider getPartitioningProvider(PartitioningHandle partitioning)
+    {
+        ConnectorId connectorId = partitioning.getConnectorId()
+                .orElseThrow(() -> new IllegalArgumentException("Unexpected partitioning: " + partitioning));
+        return partitioningProviderManager.getPartitioningProvider(connectorId);
     }
 
     private TableWriteInfo getTableWriteInfo(Session session, SubPlan plan)
@@ -1041,7 +1114,7 @@ public class PrestoSparkQueryExecutionFactory
                 }
                 else {
                     RddAndMore<PrestoSparkMutableRow> childRdd = createRdd(child, PrestoSparkMutableRow.class);
-                    rddInputs.put(childFragment.getId(), childRdd.getRdd());
+                    rddInputs.put(childFragment.getId(), partitionBy(childRdd.getRdd(), child.getFragment().getPartitioningScheme()));
                     broadcastDependencies.addAll(childRdd.getBroadcastDependencies());
                 }
             }
@@ -1057,6 +1130,40 @@ public class PrestoSparkQueryExecutionFactory
                     tableWriteInfo,
                     outputType);
             return new RddAndMore<>(rdd, broadcastDependencies.build());
+        }
+
+        private static JavaPairRDD<MutablePartitionId, PrestoSparkMutableRow> partitionBy(
+                JavaPairRDD<MutablePartitionId, PrestoSparkMutableRow> rdd,
+                PartitioningScheme partitioningScheme)
+        {
+            Partitioner partitioner = createPartitioner(partitioningScheme);
+            JavaPairRDD<MutablePartitionId, PrestoSparkMutableRow> javaPairRdd = rdd.partitionBy(partitioner);
+            ShuffledRDD<MutablePartitionId, PrestoSparkMutableRow, PrestoSparkMutableRow> shuffledRdd = (ShuffledRDD<MutablePartitionId, PrestoSparkMutableRow, PrestoSparkMutableRow>) javaPairRdd.rdd();
+            shuffledRdd.setSerializer(new PrestoSparkShuffleSerializer());
+            return JavaPairRDD.fromRDD(
+                    shuffledRdd,
+                    classTag(MutablePartitionId.class),
+                    classTag(PrestoSparkMutableRow.class));
+        }
+
+        private static Partitioner createPartitioner(PartitioningScheme partitioningScheme)
+        {
+            PartitioningHandle partitioning = partitioningScheme.getPartitioning().getHandle();
+            if (partitioning.equals(SINGLE_DISTRIBUTION)) {
+                return new PrestoSparkPartitioner(1);
+            }
+            if (partitioning.equals(FIXED_HASH_DISTRIBUTION)
+                    || partitioning.equals(FIXED_ARBITRARY_DISTRIBUTION)
+                    || partitioning.getConnectorId().isPresent()) {
+                int[] bucketToPartition = partitioningScheme.getBucketToPartition().orElseThrow(
+                        () -> new IllegalArgumentException("bucketToPartition is expected to be assigned at this point"));
+                checkArgument(bucketToPartition.length > 0, "bucketToPartition is expected to be non empty");
+                int numberOfPartitions = IntStream.of(bucketToPartition)
+                        .max()
+                        .getAsInt() + 1;
+                return new PrestoSparkPartitioner(numberOfPartitions);
+            }
+            throw new IllegalArgumentException("Unexpected partitioning: " + partitioning);
         }
 
         private void validateStorageCapabilities(TempStorage tempStorage)

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkSettingsRequirements.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkSettingsRequirements.java
@@ -90,6 +90,7 @@ public class PrestoSparkSettingsRequirements
         config.setForceSingleNodeOutput(false);
         config.setInlineSqlFunctions(true);
         config.setEnforceFixedDistributionForOutputOperator(true);
+        config.setPrestoSparkAssignBucketToPartitionForPartitionedTableWriteEnabled(true);
     }
 
     public static void setDefaults(QueryManagerConfig config)

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/util/PrestoSparkUtils.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/util/PrestoSparkUtils.java
@@ -28,6 +28,7 @@ import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import org.apache.spark.SparkException;
 import org.apache.spark.api.java.JavaFutureAction;
+import scala.reflect.ClassTag;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -247,5 +248,10 @@ public class PrestoSparkUtils
                 action.cancel(true);
             }
         }
+    }
+
+    public static <T> ClassTag<T> classTag(Class<T> clazz)
+    {
+        return scala.reflect.ClassTag$.MODULE$.apply(clazz);
     }
 }

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
@@ -286,7 +286,6 @@ public class PrestoSparkQueryRunner
         logging.setLevel("org.apache.spark", WARN);
         logging.setLevel("org.spark_project", WARN);
         logging.setLevel("com.facebook.presto.spark", WARN);
-        logging.setLevel("com.facebook.presto.spark", WARN);
         logging.setLevel("org.apache.spark.util.ClosureCleaner", ERROR);
         logging.setLevel("com.facebook.presto.security.AccessControlManager", WARN);
         logging.setLevel("com.facebook.presto.server.PluginManager", WARN);

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
@@ -202,6 +202,8 @@ public class PrestoSparkQueryRunner
         ImmutableMap.Builder<String, String> configProperties = ImmutableMap.builder();
         configProperties.put("presto.version", "testversion");
         configProperties.put("query.hash-partition-count", Integer.toString(NODE_COUNT * 2));
+        configProperties.put("task.writer-count", Integer.toString(2));
+        configProperties.put("task.partitioned-writer-count", Integer.toString(4));
         configProperties.putAll(additionalConfigProperties);
 
         PrestoSparkInjectorFactory injectorFactory = new PrestoSparkInjectorFactory(

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkAbstractTestJoinQueries.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkAbstractTestJoinQueries.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark;
+
+import com.facebook.presto.tests.AbstractTestJoinQueries;
+
+public class TestPrestoSparkAbstractTestJoinQueries
+        extends AbstractTestJoinQueries
+{
+    protected TestPrestoSparkAbstractTestJoinQueries()
+    {
+        super(PrestoSparkQueryRunner::createHivePrestoSparkQueryRunner);
+    }
+
+    @Override
+    public void testExecuteUsingComplexJoinCriteria()
+    {
+        // prepared statement is not supported by Presto on Spark
+    }
+
+    @Override
+    public void testExecuteUsingWithSubqueryInJoin()
+    {
+        // prepared statement is not supported by Presto on Spark
+    }
+}

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkAbstractTestOrderByQueries.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkAbstractTestOrderByQueries.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark;
+
+import com.facebook.presto.tests.AbstractTestOrderByQueries;
+
+public class TestPrestoSparkAbstractTestOrderByQueries
+        extends AbstractTestOrderByQueries
+{
+    protected TestPrestoSparkAbstractTestOrderByQueries()
+    {
+        super(PrestoSparkQueryRunner::createHivePrestoSparkQueryRunner);
+    }
+}

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkAbstractTestWindowQueries.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkAbstractTestWindowQueries.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark;
+
+import com.facebook.presto.tests.AbstractTestWindowQueries;
+
+public class TestPrestoSparkAbstractTestWindowQueries
+        extends AbstractTestWindowQueries
+{
+    protected TestPrestoSparkAbstractTestWindowQueries()
+    {
+        super(PrestoSparkQueryRunner::createHivePrestoSparkQueryRunner);
+    }
+}

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkQueryRunner.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkQueryRunner.java
@@ -43,8 +43,8 @@ public class TestPrestoSparkQueryRunner
         // some basic tests
         assertUpdate(
                 "CREATE TABLE hive.hive_test.hive_orders AS " +
-                "SELECT orderkey, custkey, orderstatus, totalprice, orderdate, orderpriority, clerk, shippriority, comment " +
-                "FROM orders",
+                        "SELECT orderkey, custkey, orderstatus, totalprice, orderdate, orderpriority, clerk, shippriority, comment " +
+                        "FROM orders",
                 15000);
 
         assertUpdate(
@@ -311,19 +311,19 @@ public class TestPrestoSparkQueryRunner
 
         // 22 buckets UNION ALL 11 buckets
         assertQuery("SELECT o.regionkey, l.orderkey " +
-                "FROM (SELECT * FROM lineitem  WHERE linenumber = 4) l " +
-                "CROSS JOIN (" +
-                "   SELECT * FROM hive.hive_test.partitioned_nation_22 " +
-                "   UNION ALL " +
-                "   SELECT * FROM hive.hive_test.partitioned_nation_11 " +
-                ") o",
+                        "FROM (SELECT * FROM lineitem  WHERE linenumber = 4) l " +
+                        "CROSS JOIN (" +
+                        "   SELECT * FROM hive.hive_test.partitioned_nation_22 " +
+                        "   UNION ALL " +
+                        "   SELECT * FROM hive.hive_test.partitioned_nation_11 " +
+                        ") o",
                 "SELECT o.regionkey, l.orderkey " +
-                "FROM (SELECT * FROM lineitem  WHERE linenumber = 4) l " +
-                "CROSS JOIN (" +
-                "   SELECT * FROM nation " +
-                "   UNION ALL " +
-                "   SELECT * FROM nation" +
-                ") o");
+                        "FROM (SELECT * FROM lineitem  WHERE linenumber = 4) l " +
+                        "CROSS JOIN (" +
+                        "   SELECT * FROM nation " +
+                        "   UNION ALL " +
+                        "   SELECT * FROM nation" +
+                        ") o");
 
         // 11 buckets UNION ALL 22 buckets
         assertQuery("SELECT o.regionkey, l.orderkey " +

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
@@ -27,6 +27,7 @@ import com.facebook.presto.spi.security.AccessDeniedException;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.analyzer.QueryExplainer;
 import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.planner.PartitioningProviderManager;
 import com.facebook.presto.sql.planner.Plan;
 import com.facebook.presto.sql.planner.PlanFragmenter;
 import com.facebook.presto.sql.planner.PlanOptimizers;
@@ -426,7 +427,8 @@ public abstract class AbstractTestQueryFramework
                 costCalculator,
                 new CostCalculatorWithEstimatedExchanges(costCalculator, taskCountEstimator),
                 new CostComparator(featuresConfig),
-                taskCountEstimator).getPlanningTimeOptimizers();
+                taskCountEstimator,
+                new PartitioningProviderManager()).getPlanningTimeOptimizers();
         return new QueryExplainer(
                 optimizers,
                 new PlanFragmenter(metadata, queryRunner.getNodePartitioningManager(), new QueryManagerConfig(), sqlParser, new FeaturesConfig()),


### PR DESCRIPTION
Make sure each partitioned (bucketed) table writer task has assigned `task_partitioned_writer_count` number of buckets to keep all available writer threads busy. Currently there's only 1 bucket per task being assigned what results in threads starvation.

```
== RELEASE NOTES ==

Presto on Spark Changes
* Improve bucketed table write parallelism
```
