### PR TITLE
Move TableDescriptionSupplier to separate guice module

### DIFF
--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaConnectorConfig.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaConnectorConfig.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.kafka;
 
 import com.facebook.airlift.configuration.Config;
+import com.facebook.presto.kafka.schema.file.FileTableDescriptionSupplier;
 import com.facebook.presto.spi.HostAddress;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableSet;
@@ -22,9 +23,7 @@ import io.airlift.units.MinDuration;
 
 import javax.validation.constraints.NotNull;
 
-import java.io.File;
 import java.util.List;
-import java.util.Set;
 
 import static com.google.common.collect.Iterables.transform;
 
@@ -48,16 +47,6 @@ public class KafkaConnectorConfig
     private String defaultSchema = "default";
 
     /**
-     * Set of tables known to this connector. For each table, a description file may be present in the catalog folder which describes columns for the given topic.
-     */
-    private Set<String> tableNames = ImmutableSet.of();
-
-    /**
-     * Folder holding the JSON description files for Kafka topics.
-     */
-    private File tableDescriptionDir = new File("etc/kafka/");
-
-    /**
      * Whether internal columns are shown in table metadata or not. Default is no.
      */
     private boolean hideInternalColumns = true;
@@ -72,31 +61,10 @@ public class KafkaConnectorConfig
      */
     private int maxPartitionFetchBytes = 1024 * 1024;
 
-    @NotNull
-    public File getTableDescriptionDir()
-    {
-        return tableDescriptionDir;
-    }
-
-    @Config("kafka.table-description-dir")
-    public KafkaConnectorConfig setTableDescriptionDir(File tableDescriptionDir)
-    {
-        this.tableDescriptionDir = tableDescriptionDir;
-        return this;
-    }
-
-    @NotNull
-    public Set<String> getTableNames()
-    {
-        return tableNames;
-    }
-
-    @Config("kafka.table-names")
-    public KafkaConnectorConfig setTableNames(String tableNames)
-    {
-        this.tableNames = ImmutableSet.copyOf(Splitter.on(',').omitEmptyStrings().trimResults().split(tableNames));
-        return this;
-    }
+    /**
+     * The table description supplier to use, default is FILE
+     */
+    private String tableDescriptionSupplier = FileTableDescriptionSupplier.NAME;
 
     @NotNull
     public String getDefaultSchema()
@@ -157,6 +125,19 @@ public class KafkaConnectorConfig
     public KafkaConnectorConfig setMaxPartitionFetchBytes(int maxPartitionFetchBytes)
     {
         this.maxPartitionFetchBytes = maxPartitionFetchBytes;
+        return this;
+    }
+
+    @NotNull
+    public String getTableDescriptionSupplier()
+    {
+        return tableDescriptionSupplier;
+    }
+
+    @Config("kafka.table-description-supplier")
+    public KafkaConnectorConfig setTableDescriptionSupplier(String tableDescriptionSupplier)
+    {
+        this.tableDescriptionSupplier = tableDescriptionSupplier;
         return this;
     }
 

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaConnectorModule.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaConnectorModule.java
@@ -18,18 +18,21 @@ import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.decoder.DecoderModule;
 import com.facebook.presto.kafka.encoder.EncoderModule;
+import com.facebook.presto.kafka.schema.file.FileTableDescriptionSupplier;
+import com.facebook.presto.kafka.schema.file.FileTableDescriptionSupplierModule;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.deser.std.FromStringDeserializer;
 import com.google.inject.Binder;
+import com.google.inject.Module;
 import com.google.inject.Scopes;
 
 import javax.inject.Inject;
 
+import static com.facebook.airlift.configuration.ConditionalModule.installModuleIf;
 import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
 import static com.facebook.airlift.json.JsonBinder.jsonBinder;
 import static com.facebook.airlift.json.JsonCodecBinder.jsonCodecBinder;
 import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
-import static com.google.inject.multibindings.Multibinder.newSetBinder;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -51,7 +54,7 @@ public class KafkaConnectorModule
 
         binder.bind(KafkaConsumerManager.class).in(Scopes.SINGLETON);
         configBinder(binder).bindConfig(KafkaConnectorConfig.class);
-        newSetBinder(binder, TableDescriptionSupplier.class).addBinding().toProvider(KafkaTableDescriptionSupplier.class).in(Scopes.SINGLETON);
+        bindTopicSchemaProviderModule(FileTableDescriptionSupplier.NAME, new FileTableDescriptionSupplierModule());
 
         jsonBinder(binder).addDeserializerBinding(Type.class).to(TypeDeserializer.class);
         jsonCodecBinder(binder).bindJsonCodec(KafkaTopicDescription.class);
@@ -80,5 +83,13 @@ public class KafkaConnectorModule
         {
             return typeManager.getType(parseTypeSignature(value));
         }
+    }
+
+    public void bindTopicSchemaProviderModule(String name, Module module)
+    {
+        install(installModuleIf(
+                KafkaConnectorConfig.class,
+                kafkaConfig -> name.equalsIgnoreCase(kafkaConfig.getTableDescriptionSupplier()),
+                module));
     }
 }

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/schema/MapBasedTableDescriptionSupplier.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/schema/MapBasedTableDescriptionSupplier.java
@@ -11,8 +11,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.kafka;
+package com.facebook.presto.kafka.schema;
 
+import com.facebook.presto.kafka.KafkaTopicDescription;
 import com.facebook.presto.spi.SchemaTableName;
 import com.google.common.collect.ImmutableMap;
 

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/schema/TableDescriptionSupplier.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/schema/TableDescriptionSupplier.java
@@ -11,8 +11,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.kafka;
+package com.facebook.presto.kafka.schema;
 
+import com.facebook.presto.kafka.KafkaTopicDescription;
 import com.facebook.presto.spi.SchemaTableName;
 
 import java.util.Optional;

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/schema/file/FileTableDescriptionSupplier.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/schema/file/FileTableDescriptionSupplier.java
@@ -11,11 +11,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.kafka;
+package com.facebook.presto.kafka.schema.file;
 
 import com.facebook.airlift.json.JsonCodec;
 import com.facebook.airlift.log.Logger;
 import com.facebook.presto.decoder.dummy.DummyRowDecoder;
+import com.facebook.presto.kafka.KafkaConnectorConfig;
+import com.facebook.presto.kafka.KafkaTopicDescription;
+import com.facebook.presto.kafka.KafkaTopicFieldGroup;
+import com.facebook.presto.kafka.schema.MapBasedTableDescriptionSupplier;
+import com.facebook.presto.kafka.schema.TableDescriptionSupplier;
 import com.facebook.presto.spi.SchemaTableName;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
@@ -39,10 +44,12 @@ import static java.nio.file.Files.readAllBytes;
 import static java.util.Arrays.asList;
 import static java.util.Objects.requireNonNull;
 
-public class KafkaTableDescriptionSupplier
+public class FileTableDescriptionSupplier
         implements Provider<TableDescriptionSupplier>
 {
-    private static final Logger log = Logger.get(KafkaTableDescriptionSupplier.class);
+    public static final String NAME = "file";
+
+    private static final Logger log = Logger.get(FileTableDescriptionSupplier.class);
 
     private final JsonCodec<KafkaTopicDescription> topicDescriptionCodec;
     private final File tableDescriptionDir;
@@ -50,15 +57,15 @@ public class KafkaTableDescriptionSupplier
     private final Set<String> tableNames;
 
     @Inject
-    KafkaTableDescriptionSupplier(KafkaConnectorConfig kafkaConnectorConfig,
+    FileTableDescriptionSupplier(FileTableDescriptionSupplierConfig config, KafkaConnectorConfig kafkaConnectorConfig,
             JsonCodec<KafkaTopicDescription> topicDescriptionCodec)
     {
         this.topicDescriptionCodec = requireNonNull(topicDescriptionCodec, "topicDescriptionCodec is null");
-
+        requireNonNull(config, "config is null");
         requireNonNull(kafkaConnectorConfig, "kafkaConfig is null");
-        this.tableDescriptionDir = kafkaConnectorConfig.getTableDescriptionDir();
+        this.tableDescriptionDir = config.getTableDescriptionDir();
         this.defaultSchema = kafkaConnectorConfig.getDefaultSchema();
-        this.tableNames = ImmutableSet.copyOf(kafkaConnectorConfig.getTableNames());
+        this.tableNames = ImmutableSet.copyOf(config.getTableNames());
     }
 
     @Override

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/schema/file/FileTableDescriptionSupplierConfig.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/schema/file/FileTableDescriptionSupplierConfig.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kafka.schema.file;
+
+import com.facebook.airlift.configuration.Config;
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableSet;
+
+import javax.validation.constraints.NotNull;
+
+import java.io.File;
+import java.util.Set;
+
+public class FileTableDescriptionSupplierConfig
+{
+    /**
+     * Set of tables known to this connector. For each table, a description file may be present in the catalog folder which describes columns for the given topic.
+     */
+    private Set<String> tableNames = ImmutableSet.of();
+
+    /**
+     * Folder holding the JSON description files for Kafka topics.
+     */
+    private File tableDescriptionDir = new File("etc/kafka/");
+
+    @NotNull
+    public Set<String> getTableNames()
+    {
+        return tableNames;
+    }
+
+    @Config("kafka.table-names")
+    public FileTableDescriptionSupplierConfig setTableNames(String tableNames)
+    {
+        this.tableNames = ImmutableSet.copyOf(Splitter.on(',').omitEmptyStrings().trimResults().split(tableNames));
+        return this;
+    }
+
+    @NotNull
+    public File getTableDescriptionDir()
+    {
+        return tableDescriptionDir;
+    }
+
+    @Config("kafka.table-description-dir")
+    public FileTableDescriptionSupplierConfig setTableDescriptionDir(File tableDescriptionDir)
+    {
+        this.tableDescriptionDir = tableDescriptionDir;
+        return this;
+    }
+}

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/schema/file/FileTableDescriptionSupplierModule.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/schema/file/FileTableDescriptionSupplierModule.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kafka.schema.file;
+
+import com.facebook.airlift.configuration.AbstractConfigurationAwareModule;
+import com.facebook.presto.kafka.schema.TableDescriptionSupplier;
+import com.google.inject.Binder;
+import com.google.inject.Scopes;
+
+import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
+
+public class FileTableDescriptionSupplierModule
+        extends AbstractConfigurationAwareModule
+{
+    @Override
+    protected void setup(Binder binder)
+    {
+        configBinder(binder).bindConfig(FileTableDescriptionSupplierConfig.class);
+        binder.bind(TableDescriptionSupplier.class).toProvider(FileTableDescriptionSupplier.class).in(Scopes.SINGLETON);
+    }
+}

--- a/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaConnectorConfig.java
+++ b/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaConnectorConfig.java
@@ -14,10 +14,10 @@
 package com.facebook.presto.kafka;
 
 import com.facebook.airlift.configuration.testing.ConfigAssertions;
+import com.facebook.presto.kafka.schema.file.FileTableDescriptionSupplier;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
-import java.io.File;
 import java.util.Map;
 
 public class TestKafkaConnectorConfig
@@ -29,8 +29,7 @@ public class TestKafkaConnectorConfig
                 .setNodes(null)
                 .setKafkaConnectTimeout("10s")
                 .setDefaultSchema("default")
-                .setTableNames("")
-                .setTableDescriptionDir(new File("etc/kafka/"))
+                .setTableDescriptionSupplier(FileTableDescriptionSupplier.NAME)
                 .setHideInternalColumns(true)
                 .setMaxPartitionFetchBytes(1048576)
                 .setMaxPollRecords(500));
@@ -40,8 +39,7 @@ public class TestKafkaConnectorConfig
     public void testExplicitPropertyMappings()
     {
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
-                .put("kafka.table-description-dir", "/var/lib/kafka")
-                .put("kafka.table-names", "table1, table2, table3")
+                .put("kafka.table-description-supplier", "test")
                 .put("kafka.default-schema", "kafka")
                 .put("kafka.nodes", "localhost:12345,localhost:23456")
                 .put("kafka.connect-timeout", "1h")
@@ -51,8 +49,7 @@ public class TestKafkaConnectorConfig
                 .build();
 
         KafkaConnectorConfig expected = new KafkaConnectorConfig()
-                .setTableDescriptionDir(new File("/var/lib/kafka"))
-                .setTableNames("table1, table2, table3")
+                .setTableDescriptionSupplier("test")
                 .setDefaultSchema("kafka")
                 .setNodes("localhost:12345, localhost:23456")
                 .setKafkaConnectTimeout("1h")

--- a/presto-kafka/src/test/java/com/facebook/presto/kafka/schema/file/TestFileTableDescriptionSupplierConfig.java
+++ b/presto-kafka/src/test/java/com/facebook/presto/kafka/schema/file/TestFileTableDescriptionSupplierConfig.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kafka.schema.file;
+
+import com.facebook.airlift.configuration.testing.ConfigAssertions;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.util.Map;
+
+public class TestFileTableDescriptionSupplierConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        ConfigAssertions.assertRecordedDefaults(ConfigAssertions.recordDefaults(FileTableDescriptionSupplierConfig.class)
+                .setTableDescriptionDir(new File("etc/kafka"))
+                .setTableNames(""));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("kafka.table-description-dir", "/var/lib/kafka")
+                .put("kafka.table-names", "table1, table2, table3")
+                .build();
+
+        FileTableDescriptionSupplierConfig expected = new FileTableDescriptionSupplierConfig()
+                .setTableDescriptionDir(new File("/var/lib/kafka"))
+                .setTableNames("table1, table2, table3");
+        ConfigAssertions.assertFullMapping(properties, expected);
+    }
+}

--- a/presto-kafka/src/test/java/com/facebook/presto/kafka/util/TestUtils.java
+++ b/presto-kafka/src/test/java/com/facebook/presto/kafka/util/TestUtils.java
@@ -15,14 +15,14 @@ package com.facebook.presto.kafka.util;
 
 import com.facebook.airlift.json.JsonCodec;
 import com.facebook.presto.common.QualifiedObjectName;
+import com.facebook.presto.kafka.KafkaConnectorConfig;
 import com.facebook.presto.kafka.KafkaPlugin;
 import com.facebook.presto.kafka.KafkaTopicDescription;
-import com.facebook.presto.kafka.MapBasedTableDescriptionSupplier;
-import com.facebook.presto.kafka.TableDescriptionSupplier;
+import com.facebook.presto.kafka.schema.MapBasedTableDescriptionSupplier;
+import com.facebook.presto.kafka.schema.TableDescriptionSupplier;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.TestingPrestoClient;
-import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.ByteStreams;
 import org.apache.kafka.clients.producer.KafkaProducer;
@@ -34,12 +34,14 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 
+import static com.facebook.airlift.configuration.ConditionalModule.installModuleIf;
 import static com.facebook.presto.kafka.ConfigurationAwareModules.combine;
-import static com.google.inject.multibindings.Multibinder.newSetBinder;
 import static java.lang.String.format;
 
 public final class TestUtils
 {
+    private static final String TEST = "test";
+
     private TestUtils() {}
 
     public static int findUnusedPort()
@@ -62,17 +64,19 @@ public final class TestUtils
     public static void installKafkaPlugin(EmbeddedKafka embeddedKafka, QueryRunner queryRunner, Map<SchemaTableName, KafkaTopicDescription> topicDescriptions)
     {
         KafkaPlugin kafkaPlugin = new KafkaPlugin(combine(
-                binder -> newSetBinder(binder, TableDescriptionSupplier.class)
-                        .addBinding()
-                        .toInstance(new MapBasedTableDescriptionSupplier(topicDescriptions))));
+                installModuleIf(
+                        KafkaConnectorConfig.class,
+                        kafkaConfig -> kafkaConfig.getTableDescriptionSupplier().equalsIgnoreCase(TEST),
+                        binder -> binder.bind(TableDescriptionSupplier.class)
+                                .toInstance(new MapBasedTableDescriptionSupplier(topicDescriptions)))));
+
         queryRunner.installPlugin(kafkaPlugin);
 
         Map<String, String> kafkaConfig = ImmutableMap.of(
                 "kafka.nodes", embeddedKafka.getConnectString(),
-                "kafka.table-names", Joiner.on(",").join(topicDescriptions.keySet()),
+                "kafka.table-description-supplier", TEST,
                 "kafka.connect-timeout", "120s",
-                "kafka.default-schema", "default",
-                "kafka.table-description-dir", "write-test");
+                "kafka.default-schema", "default");
         queryRunner.createCatalog("kafka", "kafka", kafkaConfig);
     }
 


### PR DESCRIPTION
Cherry-pick https://github.com/trinodb/trino/commit/696e10ba9e2cd292554b74f24e824719cf5a2449

Co-Authored-By: Elon Azoulay <elon.azoulay@gmail.com>

Test plan - (Please fill in how you tested your changes)

Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines. Don't forget to follow our [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution) for any code copied from other projects.

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== RELEASE NOTES ==

General Changes
* ...
* ...

Hive Changes
* ...
* ...
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```
