### PR TITLE
Fix scheduling bug that causes queries to be scheduled onto drained workers

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/DiscoveryNodeManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/DiscoveryNodeManager.java
@@ -390,7 +390,7 @@ public final class DiscoveryNodeManager
         Optional<NodeState> remoteNodeState = nodeStates.containsKey(nodeId)
                 ? nodeStates.get(nodeId).getNodeState()
                 : Optional.empty();
-        return remoteNodeState.isPresent() && remoteNodeState.get() == SHUTTING_DOWN;
+        return !remoteNodeState.isPresent() || remoteNodeState.get() == SHUTTING_DOWN;
     }
 
     @Override


### PR DESCRIPTION
Description of bug:

As we are moving to twshared, I have been testing Presto on low memory machines with the interactive workload. I have noticed that queries that are submitted can be scheduled onto workers that are in the SHUTTING_DOWN state. Here is how this bug manifests:

1. This bug occurs on the very last poll before the drained worker dies.
2. When a worker is draining, it is put into the SHUTTING_DOWN state and contained in the `allNodes` member of `DiscoveryNodeManager`.  This member supplies the set of ALIVE nodes to schedule queries onto.
3. DiscoveryNodeManager.refreshNodesInternal is run in 3 main places. 1. on DiscoveryNodeManager creation. 2. On new query creation. 3. Every 5sec in a polling loop `DiscoveryNodeManager.pollWorkers`.
4. If a worker is shutting down, it is determined by the following logic:
```
Optional<NodeState> remoteNodeState = nodeStates.containsKey(nodeId) // 
                ? nodeStates.get(nodeId).getNodeState()
                : Optional.empty();
        return !remoteNodeState.isPresent() || remoteNodeState.get() == SHUTTING_DOWN;
```


Test plan - (Please fill in how you tested your changes)

Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines. Don't forget to follow our [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution) for any code copied from other projects.

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== RELEASE NOTES ==

General Changes
* ...
* ...

Hive Changes
* ...
* ...
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```
