### PR TITLE
Add support for returning partial results

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -182,6 +182,9 @@ public final class SystemSessionProperties
     public static final String LOG_FORMATTED_QUERY_ENABLED = "log_formatted_query_enabled";
     public static final String QUERY_RETRY_LIMIT = "query_retry_limit";
     public static final String QUERY_RETRY_MAX_EXECUTION_TIME = "query_retry_max_execution_time";
+    public static final String PARTIAL_RESULTS_ENABLED = "partial_results_enabled";
+    public static final String PARTIAL_RESULTS_COMPLETION_RATIO_THRESHOLD = "partial_results_completion_ratio_threshold";
+    public static final String PARTIAL_RESULTS_MAX_EXECUTION_TIME_MULTIPLIER = "partial_results_max_execution_time_multiplier";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -964,7 +967,22 @@ public final class SystemSessionProperties
                         queryManagerConfig.getPerQueryRetryMaxExecutionTime(),
                         true,
                         value -> Duration.valueOf((String) value),
-                        Duration::toString));
+                        Duration::toString),
+                booleanProperty(
+                        PARTIAL_RESULTS_ENABLED,
+                        "Enable returning partial results. Please note that queries might not read all the data when this is enabled",
+                        featuresConfig.isPartialResultsEnabled(),
+                        false),
+                doubleProperty(
+                        PARTIAL_RESULTS_COMPLETION_RATIO_THRESHOLD,
+                        "Minimum query completion ratio threshold for partial results",
+                        featuresConfig.getPartialResultsCompletionRatioThreshold(),
+                        false),
+                doubleProperty(
+                        PARTIAL_RESULTS_MAX_EXECUTION_TIME_MULTIPLIER,
+                        "This value is multiplied by the time taken to reach the completion ratio threshold and is set as max task end time",
+                        featuresConfig.getPartialResultsMaxExecutionTimeMultiplier(),
+                        false));
     }
 
     public static boolean isEmptyJoinOptimization(Session session)
@@ -1629,5 +1647,20 @@ public final class SystemSessionProperties
     public static Duration getQueryRetryMaxExecutionTime(Session session)
     {
         return session.getSystemProperty(QUERY_RETRY_MAX_EXECUTION_TIME, Duration.class);
+    }
+
+    public static boolean isPartialResultsEnabled(Session session)
+    {
+        return session.getSystemProperty(PARTIAL_RESULTS_ENABLED, Boolean.class);
+    }
+
+    public static double getPartialResultsCompletionRatioThreshold(Session session)
+    {
+        return session.getSystemProperty(PARTIAL_RESULTS_COMPLETION_RATIO_THRESHOLD, Double.class);
+    }
+
+    public static double getPartialResultsMaxExecutionTimeMultiplier(Session session)
+    {
+        return session.getSystemProperty(PARTIAL_RESULTS_MAX_EXECUTION_TIME_MULTIPLIER, Double.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/PartialResultQueryManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/PartialResultQueryManager.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution;
+
+import com.facebook.presto.execution.scheduler.PartialResultQueryTaskTracker;
+import com.google.inject.Inject;
+
+import javax.annotation.PreDestroy;
+
+import java.util.concurrent.PriorityBlockingQueue;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.facebook.airlift.concurrent.Threads.threadsNamed;
+import static java.util.Comparator.comparing;
+import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
+
+public class PartialResultQueryManager
+{
+    private final AtomicReference<ScheduledExecutorService> executor = new AtomicReference<>();
+    private final PriorityBlockingQueue<PartialResultQueryTaskTracker> queue;
+
+    @Inject
+    public PartialResultQueryManager()
+    {
+        this.queue = new PriorityBlockingQueue<>(1, comparing(PartialResultQueryTaskTracker::getMaxEndTime));
+    }
+
+    private void startExecutor()
+    {
+        // Start the executor if not already started
+        if (executor.compareAndSet(null, newSingleThreadScheduledExecutor(threadsNamed("partial-result-query-manager-%s")))) {
+            executor.get().scheduleWithFixedDelay(this::checkAndCancelTasks, 1, 1, TimeUnit.SECONDS);
+        }
+    }
+
+    public void addQueryTaskTracker(PartialResultQueryTaskTracker queryTaskTracker)
+    {
+        startExecutor();
+        queue.add(queryTaskTracker);
+    }
+
+    public void checkAndCancelTasks()
+    {
+        long currentTime = System.nanoTime();
+        while (!queue.isEmpty() && currentTime >= queue.peek().getMaxEndTime()) {
+            PartialResultQueryTaskTracker queryTracker = queue.poll();
+            // Reached max task end time. Cancel pending tasks.
+            queryTracker.cancelUnfinishedTasks();
+        }
+    }
+
+    public int getQueueSize()
+    {
+        return queue.size();
+    }
+
+    @PreDestroy
+    public void stop()
+    {
+        if (executor.get() != null) {
+            executor.get().shutdownNow();
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/LegacySqlQueryScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/LegacySqlQueryScheduler.java
@@ -19,6 +19,7 @@ import com.facebook.airlift.stats.TimeStat;
 import com.facebook.presto.Session;
 import com.facebook.presto.execution.BasicStageExecutionStats;
 import com.facebook.presto.execution.LocationFactory;
+import com.facebook.presto.execution.PartialResultQueryManager;
 import com.facebook.presto.execution.QueryState;
 import com.facebook.presto.execution.QueryStateMachine;
 import com.facebook.presto.execution.RemoteTask;
@@ -72,6 +73,9 @@ import static com.facebook.airlift.concurrent.MoreFutures.tryGetFutureValue;
 import static com.facebook.airlift.concurrent.MoreFutures.whenAnyComplete;
 import static com.facebook.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
 import static com.facebook.presto.SystemSessionProperties.getMaxConcurrentMaterializations;
+import static com.facebook.presto.SystemSessionProperties.getPartialResultsCompletionRatioThreshold;
+import static com.facebook.presto.SystemSessionProperties.getPartialResultsMaxExecutionTimeMultiplier;
+import static com.facebook.presto.SystemSessionProperties.isPartialResultsEnabled;
 import static com.facebook.presto.SystemSessionProperties.isRuntimeOptimizerEnabled;
 import static com.facebook.presto.execution.BasicStageExecutionStats.aggregateBasicStageStats;
 import static com.facebook.presto.execution.StageExecutionState.ABORTED;
@@ -139,6 +143,8 @@ public class LegacySqlQueryScheduler
     private final AtomicBoolean started = new AtomicBoolean();
     private final AtomicBoolean scheduling = new AtomicBoolean();
 
+    private final PartialResultQueryTaskTracker partialResultQueryTaskTracker;
+
     public static LegacySqlQueryScheduler createSqlQueryScheduler(
             LocationFactory locationFactory,
             ExecutionPolicy executionPolicy,
@@ -159,7 +165,8 @@ public class LegacySqlQueryScheduler
             PlanVariableAllocator variableAllocator,
             PlanChecker planChecker,
             Metadata metadata,
-            SqlParser sqlParser)
+            SqlParser sqlParser,
+            PartialResultQueryManager partialResultQueryManager)
     {
         LegacySqlQueryScheduler sqlQueryScheduler = new LegacySqlQueryScheduler(
                 locationFactory,
@@ -181,7 +188,8 @@ public class LegacySqlQueryScheduler
                 variableAllocator,
                 planChecker,
                 metadata,
-                sqlParser);
+                sqlParser,
+                partialResultQueryManager);
         sqlQueryScheduler.initialize();
         return sqlQueryScheduler;
     }
@@ -206,7 +214,8 @@ public class LegacySqlQueryScheduler
             PlanVariableAllocator variableAllocator,
             PlanChecker planChecker,
             Metadata metadata,
-            SqlParser sqlParser)
+            SqlParser sqlParser,
+            PartialResultQueryManager partialResultQueryManager)
     {
         this.locationFactory = requireNonNull(locationFactory, "locationFactory is null");
         this.executionPolicy = requireNonNull(executionPolicy, "schedulerPolicyFactory is null");
@@ -246,6 +255,7 @@ public class LegacySqlQueryScheduler
                 .forEach(execution -> this.stageExecutions.put(execution.getStageExecution().getStageExecutionId().getStageId(), execution));
 
         this.maxConcurrentMaterializations = getMaxConcurrentMaterializations(session);
+        this.partialResultQueryTaskTracker = new PartialResultQueryTaskTracker(partialResultQueryManager, getPartialResultsCompletionRatioThreshold(session), getPartialResultsMaxExecutionTimeMultiplier(session), warningCollector);
     }
 
     // this is a separate method to ensure that the `this` reference is not leaked during construction
@@ -422,6 +432,14 @@ public class LegacySqlQueryScheduler
                         ScheduleResult result = stageExecutionAndScheduler.getStageScheduler()
                                 .schedule();
 
+                        // Track leaf tasks if partial results are enabled
+                        if (isPartialResultsEnabled(session) && stageExecutionAndScheduler.getStageExecution().getFragment().isLeaf()) {
+                            for (RemoteTask task : result.getNewTasks()) {
+                                partialResultQueryTaskTracker.trackTask(task);
+                                task.addFinalTaskInfoListener(partialResultQueryTaskTracker::recordTaskFinish);
+                            }
+                        }
+
                         // modify parent and children based on the results of the scheduling
                         if (result.isFinished()) {
                             stageExecution.schedulingComplete();
@@ -493,6 +511,9 @@ public class LegacySqlQueryScheduler
             }
 
             scheduling.set(false);
+
+            // Inform the tracker that task scheduling has completed
+            partialResultQueryTaskTracker.completeTaskScheduling();
 
             if (!getSectionsReadyForExecution().isEmpty()) {
                 startScheduling();

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/PartialResultQueryTaskTracker.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/PartialResultQueryTaskTracker.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.scheduler;
+
+import com.facebook.presto.execution.PartialResultQueryManager;
+import com.facebook.presto.execution.RemoteTask;
+import com.facebook.presto.execution.TaskId;
+import com.facebook.presto.execution.TaskInfo;
+import com.facebook.presto.spi.PrestoWarning;
+import com.facebook.presto.spi.WarningCollector;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static com.facebook.presto.spi.StandardWarningCode.PARTIAL_RESULT_WARNING;
+import static com.google.common.collect.Sets.SetView;
+import static com.google.common.collect.Sets.difference;
+import static com.google.common.collect.Sets.newConcurrentHashSet;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class PartialResultQueryTaskTracker
+{
+    private final PartialResultQueryManager partialResultQueryManager;
+    private final double minCompletionRatioThreshold;
+    private final double timeMultiplier;
+    private final WarningCollector warningCollector;
+    private final long startTime;
+    private final Map<TaskId, RemoteTask> taskIdMap = new HashMap<>();
+    private final Set<TaskId> completedTaskIds = newConcurrentHashSet();
+    private final AtomicBoolean addedToQueryManager = new AtomicBoolean();
+
+    private long maxEndTime;
+    private boolean taskSchedulingCompleted;
+
+    public PartialResultQueryTaskTracker(
+            PartialResultQueryManager partialResultQueryManager,
+            double minCompletionRatioThreshold,
+            double timeMultiplier,
+            WarningCollector warningCollector)
+    {
+        this.partialResultQueryManager = requireNonNull(partialResultQueryManager, "partialResultQueryManager is null");
+        this.minCompletionRatioThreshold = minCompletionRatioThreshold;
+        this.timeMultiplier = timeMultiplier;
+        this.warningCollector = requireNonNull(warningCollector, "warningCollector is null");
+        this.startTime = System.nanoTime();
+    }
+
+    public double getTaskCompletionRatio()
+    {
+        if (completedTaskIds.isEmpty() || taskIdMap.isEmpty()) {
+            return 0.0;
+        }
+        return (double) completedTaskIds.size() / (double) taskIdMap.size();
+    }
+
+    private void checkAndAddToQueryManager()
+    {
+        // If completion ratio greater than equal to threshold, then query is eligible for partial results
+        if (taskSchedulingCompleted && getTaskCompletionRatio() >= minCompletionRatioThreshold && addedToQueryManager.compareAndSet(false, true)) {
+            // Set max task time = timeMultiplier x time taken to reach minCompletionRatioThreshold
+            long elapsedTime = System.nanoTime() - startTime;
+            maxEndTime = startTime + (long) (timeMultiplier * elapsedTime);
+
+            partialResultQueryManager.addQueryTaskTracker(this);
+        }
+    }
+
+    public void trackTask(RemoteTask task)
+    {
+        taskIdMap.put(task.getTaskId(), task);
+    }
+
+    public void recordTaskFinish(TaskInfo taskInfo)
+    {
+        completedTaskIds.add(taskInfo.getTaskId());
+        checkAndAddToQueryManager();
+    }
+
+    public long getMaxEndTime()
+    {
+        return maxEndTime;
+    }
+
+    public void completeTaskScheduling()
+    {
+        this.taskSchedulingCompleted = true;
+    }
+
+    public void cancelUnfinishedTasks()
+    {
+        SetView<TaskId> pendingTaskIds = difference(taskIdMap.keySet(), completedTaskIds);
+        double partialResultPercentage = getTaskCompletionRatio() * 100;
+        for (TaskId taskId : pendingTaskIds) {
+            RemoteTask pendingTask = taskIdMap.get(taskId);
+            // Cancel pending tasks
+            pendingTask.cancel();
+        }
+        if (!pendingTaskIds.isEmpty()) {
+            String warningMessage = format("Partial results are returned. Only %.2f percent of the data is read.", partialResultPercentage);
+            warningCollector.add(new PrestoWarning(PARTIAL_RESULT_WARNING, warningMessage));
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SqlQueryScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SqlQueryScheduler.java
@@ -20,6 +20,7 @@ import com.facebook.presto.Session;
 import com.facebook.presto.execution.BasicStageExecutionStats;
 import com.facebook.presto.execution.ExecutionFailureInfo;
 import com.facebook.presto.execution.LocationFactory;
+import com.facebook.presto.execution.PartialResultQueryManager;
 import com.facebook.presto.execution.QueryState;
 import com.facebook.presto.execution.QueryStateMachine;
 import com.facebook.presto.execution.RemoteTask;
@@ -81,6 +82,9 @@ import static com.facebook.airlift.concurrent.MoreFutures.whenAnyComplete;
 import static com.facebook.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
 import static com.facebook.presto.SystemSessionProperties.getMaxConcurrentMaterializations;
 import static com.facebook.presto.SystemSessionProperties.getMaxStageRetries;
+import static com.facebook.presto.SystemSessionProperties.getPartialResultsCompletionRatioThreshold;
+import static com.facebook.presto.SystemSessionProperties.getPartialResultsMaxExecutionTimeMultiplier;
+import static com.facebook.presto.SystemSessionProperties.isPartialResultsEnabled;
 import static com.facebook.presto.SystemSessionProperties.isRuntimeOptimizerEnabled;
 import static com.facebook.presto.execution.BasicStageExecutionStats.aggregateBasicStageStats;
 import static com.facebook.presto.execution.SqlStageExecution.RECOVERABLE_ERROR_CODES;
@@ -150,6 +154,8 @@ public class SqlQueryScheduler
     private final AtomicBoolean scheduling = new AtomicBoolean();
     private final AtomicInteger retriedSections = new AtomicInteger();
 
+    private final PartialResultQueryTaskTracker partialResultQueryTaskTracker;
+
     public static SqlQueryScheduler createSqlQueryScheduler(
             LocationFactory locationFactory,
             ExecutionPolicy executionPolicy,
@@ -170,7 +176,8 @@ public class SqlQueryScheduler
             PlanVariableAllocator variableAllocator,
             PlanChecker planChecker,
             Metadata metadata,
-            SqlParser sqlParser)
+            SqlParser sqlParser,
+            PartialResultQueryManager partialResultQueriesHandler)
     {
         SqlQueryScheduler sqlQueryScheduler = new SqlQueryScheduler(
                 locationFactory,
@@ -192,7 +199,8 @@ public class SqlQueryScheduler
                 variableAllocator,
                 planChecker,
                 metadata,
-                sqlParser);
+                sqlParser,
+                partialResultQueriesHandler);
         sqlQueryScheduler.initialize();
         return sqlQueryScheduler;
     }
@@ -217,7 +225,8 @@ public class SqlQueryScheduler
             PlanVariableAllocator variableAllocator,
             PlanChecker planChecker,
             Metadata metadata,
-            SqlParser sqlParser)
+            SqlParser sqlParser,
+            PartialResultQueryManager partialResultQueryManager)
     {
         this.locationFactory = requireNonNull(locationFactory, "locationFactory is null");
         this.executionPolicy = requireNonNull(executionPolicy, "schedulerPolicyFactory is null");
@@ -242,6 +251,7 @@ public class SqlQueryScheduler
         this.summarizeTaskInfo = summarizeTaskInfo;
         this.maxConcurrentMaterializations = getMaxConcurrentMaterializations(session);
         this.maxStageRetries = getMaxStageRetries(session);
+        this.partialResultQueryTaskTracker = new PartialResultQueryTaskTracker(partialResultQueryManager, getPartialResultsCompletionRatioThreshold(session), getPartialResultsMaxExecutionTimeMultiplier(session), warningCollector);
     }
 
     // this is a separate method to ensure that the `this` reference is not leaked during construction
@@ -327,6 +337,14 @@ public class SqlQueryScheduler
                         ScheduleResult result = executionAndScheduler.getStageScheduler()
                                 .schedule();
 
+                        // Track leaf tasks if partial results are enabled
+                        if (isPartialResultsEnabled(session) && executionAndScheduler.getStageExecution().getFragment().isLeaf()) {
+                            for (RemoteTask task : result.getNewTasks()) {
+                                partialResultQueryTaskTracker.trackTask(task);
+                                task.addFinalTaskInfoListener(partialResultQueryTaskTracker::recordTaskFinish);
+                            }
+                        }
+
                         // modify parent and children based on the results of the scheduling
                         if (result.isFinished()) {
                             executionAndScheduler.getStageExecution().schedulingComplete();
@@ -398,6 +416,9 @@ public class SqlQueryScheduler
             }
 
             scheduling.set(false);
+
+            // Inform the tracker that task scheduling has completed
+            partialResultQueryTaskTracker.completeTaskScheduling();
 
             if (!getSectionsReadyForExecution().isEmpty()) {
                 startScheduling();

--- a/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
@@ -56,6 +56,7 @@ import com.facebook.presto.execution.ForQueryExecution;
 import com.facebook.presto.execution.GrantRolesTask;
 import com.facebook.presto.execution.GrantTask;
 import com.facebook.presto.execution.NodeResourceStatusConfig;
+import com.facebook.presto.execution.PartialResultQueryManager;
 import com.facebook.presto.execution.PrepareTask;
 import com.facebook.presto.execution.QueryExecution;
 import com.facebook.presto.execution.QueryExecutionMBean;
@@ -326,6 +327,7 @@ public class CoordinatorModule
         getAllQueryTypes().entrySet().stream()
                 .filter(entry -> entry.getValue() != QueryType.DATA_DEFINITION)
                 .forEach(entry -> executionBinder.addBinding(entry.getKey()).to(SqlQueryExecutionFactory.class).in(Scopes.SINGLETON));
+        binder.bind(PartialResultQueryManager.class).in(Scopes.SINGLETON);
 
         binder.bind(DataDefinitionExecutionFactory.class).in(Scopes.SINGLETON);
         bindDataDefinitionTask(binder, executionBinder, CreateSchema.class, CreateSchemaTask.class);

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -189,6 +189,10 @@ public class FeaturesConfig
     private boolean enforceFixedDistributionForOutputOperator;
     private boolean prestoSparkAssignBucketToPartitionForPartitionedTableWriteEnabled;
 
+    private boolean partialResultsEnabled;
+    private double partialResultsCompletionRatioThreshold = 0.5;
+    private double partialResultsMaxExecutionTimeMultiplier = 2.0;
+
     public enum PartitioningPrecisionStrategy
     {
         // Let Presto decide when to repartition
@@ -1609,6 +1613,45 @@ public class FeaturesConfig
     public FeaturesConfig setPrestoSparkAssignBucketToPartitionForPartitionedTableWriteEnabled(boolean prestoSparkAssignBucketToPartitionForPartitionedTableWriteEnabled)
     {
         this.prestoSparkAssignBucketToPartitionForPartitionedTableWriteEnabled = prestoSparkAssignBucketToPartitionForPartitionedTableWriteEnabled;
+        return this;
+    }
+
+    public boolean isPartialResultsEnabled()
+    {
+        return partialResultsEnabled;
+    }
+
+    @Config("partial-results-enabled")
+    @ConfigDescription("Enable returning partial results. Please note that queries might not read all the data when this is enabled.")
+    public FeaturesConfig setPartialResultsEnabled(boolean partialResultsEnabled)
+    {
+        this.partialResultsEnabled = partialResultsEnabled;
+        return this;
+    }
+
+    public double getPartialResultsCompletionRatioThreshold()
+    {
+        return partialResultsCompletionRatioThreshold;
+    }
+
+    @Config("partial-results-completion-ratio-threshold")
+    @ConfigDescription("Minimum query completion ratio threshold for partial results")
+    public FeaturesConfig setPartialResultsCompletionRatioThreshold(double partialResultsCompletionRatioThreshold)
+    {
+        this.partialResultsCompletionRatioThreshold = partialResultsCompletionRatioThreshold;
+        return this;
+    }
+
+    public double getPartialResultsMaxExecutionTimeMultiplier()
+    {
+        return partialResultsMaxExecutionTimeMultiplier;
+    }
+
+    @Config("partial-results-max-execution-time-multiplier")
+    @ConfigDescription("This value is multiplied by the time taken to reach the completion ratio threshold and is set as max task end time")
+    public FeaturesConfig setPartialResultsMaxExecutionTimeMultiplier(double partialResultsMaxExecutionTimeMultiplier)
+    {
+        this.partialResultsMaxExecutionTimeMultiplier = partialResultsMaxExecutionTimeMultiplier;
         return this;
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestPartialResultQueryManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestPartialResultQueryManager.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution;
+
+import com.facebook.presto.execution.scheduler.PartialResultQueryTaskTracker;
+import com.facebook.presto.execution.warnings.DefaultWarningCollector;
+import com.facebook.presto.execution.warnings.WarningCollectorConfig;
+import com.facebook.presto.spi.WarningCollector;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.execution.warnings.WarningHandlingLevel.NORMAL;
+import static org.testng.Assert.assertEquals;
+
+public class TestPartialResultQueryManager
+{
+    private final WarningCollector warningCollector = new DefaultWarningCollector(new WarningCollectorConfig(), NORMAL);
+
+    @Test
+    public void testPartialResultQueryManager()
+            throws Exception
+    {
+        PartialResultQueryManager partialResultQueryManager = new PartialResultQueryManager();
+        assertEquals(0, partialResultQueryManager.getQueueSize());
+
+        PartialResultQueryTaskTracker tracker1 = new PartialResultQueryTaskTracker(partialResultQueryManager, 0.0, 2.0, warningCollector);
+        PartialResultQueryTaskTracker tracker2 = new PartialResultQueryTaskTracker(partialResultQueryManager, 0.0, 2.0, warningCollector);
+
+        // Assert that the trackers created above will have a default maxEndTime = 0. So current_time is always > tracker's maxEndTime.Meaning tracker is instantly ready for partial results.
+        assertEquals(0, tracker1.getMaxEndTime());
+        assertEquals(0, tracker2.getMaxEndTime());
+
+        partialResultQueryManager.addQueryTaskTracker(tracker1);
+        partialResultQueryManager.addQueryTaskTracker(tracker2);
+
+        // Assert that the trackers are added to the queue
+        assertEquals(2, partialResultQueryManager.getQueueSize());
+
+        // Sleep for 2s so that we give enough time to partialResultQueryManager to wake up and clear the trackers in queue
+        Thread.sleep(2000);
+
+        // Assert the trackers are cleared
+        assertEquals(0, partialResultQueryManager.getQueueSize());
+
+        partialResultQueryManager.stop();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestPartialResultQueryTaskTracker.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestPartialResultQueryTaskTracker.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.scheduler;
+
+import com.facebook.presto.client.NodeVersion;
+import com.facebook.presto.execution.MockRemoteTaskFactory;
+import com.facebook.presto.execution.NodeTaskMap;
+import com.facebook.presto.execution.PartialResultQueryManager;
+import com.facebook.presto.execution.RemoteTask;
+import com.facebook.presto.execution.TaskId;
+import com.facebook.presto.execution.warnings.DefaultWarningCollector;
+import com.facebook.presto.execution.warnings.WarningCollectorConfig;
+import com.facebook.presto.metadata.InternalNode;
+import com.facebook.presto.spi.PrestoWarning;
+import com.facebook.presto.spi.WarningCollector;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+import java.net.URI;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static com.facebook.airlift.concurrent.Threads.daemonThreadsNamed;
+import static com.facebook.presto.execution.warnings.WarningHandlingLevel.NORMAL;
+import static com.facebook.presto.spi.StandardWarningCode.PARTIAL_RESULT_WARNING;
+import static java.util.concurrent.Executors.newCachedThreadPool;
+import static java.util.concurrent.Executors.newScheduledThreadPool;
+import static org.testng.Assert.assertEquals;
+
+public class TestPartialResultQueryTaskTracker
+{
+    private final ExecutorService executor = newCachedThreadPool(daemonThreadsNamed("stageExecutor-%s"));
+    private final ScheduledExecutorService scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("stageScheduledExecutor-%s"));
+    private final PartialResultQueryManager partialResultQueryManager = new PartialResultQueryManager();
+    private final WarningCollector warningCollector = new DefaultWarningCollector(new WarningCollectorConfig(), NORMAL);
+    private final MockRemoteTaskFactory taskFactory;
+
+    public TestPartialResultQueryTaskTracker()
+    {
+        taskFactory = new MockRemoteTaskFactory(executor, scheduledExecutor);
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void destroyExecutor()
+    {
+        executor.shutdownNow();
+        scheduledExecutor.shutdown();
+        partialResultQueryManager.stop();
+    }
+
+    @Test
+    public void testPartialResultQueryTaskTracker()
+            throws Exception
+    {
+        PartialResultQueryTaskTracker tracker = new PartialResultQueryTaskTracker(partialResultQueryManager, 0.50, 2.0, warningCollector);
+        InternalNode node1 = new InternalNode(UUID.randomUUID().toString(), URI.create("https://192.0.2.8"), new NodeVersion("1"), false, false);
+        InternalNode node2 = new InternalNode(UUID.randomUUID().toString(), URI.create("https://192.0.2.9"), new NodeVersion("1"), false, false);
+        TaskId taskId1 = new TaskId("test1", 1, 0, 1);
+        TaskId taskId2 = new TaskId("test2", 2, 0, 1);
+        RemoteTask task1 = taskFactory.createTableScanTask(taskId1, node1, ImmutableList.of(), new NodeTaskMap.NodeStatsTracker(delta -> {}, delta -> {}, (age, delta) -> {}));
+        RemoteTask task2 = taskFactory.createTableScanTask(taskId2, node2, ImmutableList.of(), new NodeTaskMap.NodeStatsTracker(delta -> {}, delta -> {}, (age, delta) -> {}));
+
+        tracker.trackTask(task1);
+        tracker.trackTask(task2);
+
+        // Assert that completion ratio is 0.0 since the tasks did not complete yet
+        assertEquals(0.0, tracker.getTaskCompletionRatio());
+
+        tracker.completeTaskScheduling();
+
+        tracker.recordTaskFinish(task1.getTaskInfo());
+        // Assert that completion ratio is 0.5 since we have set that task1 finished in above line
+        assertEquals(0.5, tracker.getTaskCompletionRatio());
+
+        // Assert that the query is added to query manager, queue size = 1 since the query reached minCompletion ratio of 0.5 and is eligible for partial results
+        assertEquals(1, partialResultQueryManager.getQueueSize());
+
+        // Sleep for 2 seconds so that we give enough time for query manager to cancel tasks and complete the query with partial results
+        Thread.sleep(2000);
+        assertEquals(0, partialResultQueryManager.getQueueSize());
+
+        // Assert that partial result warning is set correctly
+        assertEquals(1, warningCollector.getWarnings().size());
+        PrestoWarning prestoWarning = warningCollector.getWarnings().get(0);
+
+        // Assert that warning code is set to PARTIAL_RESULT_WARNING
+        assertEquals(PARTIAL_RESULT_WARNING.toWarningCode(), prestoWarning.getWarningCode());
+
+        // Assert that completion percent of 50.00 is specified correctly in the warning message
+        assertEquals("Partial results are returned. Only 50.00 percent of the data is read.", prestoWarning.getMessage());
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -161,7 +161,10 @@ public class TestFeaturesConfig
                 .setSpoolingOutputBufferEnabled(false)
                 .setSpoolingOutputBufferThreshold(new DataSize(8, MEGABYTE))
                 .setSpoolingOutputBufferTempStorage("local")
-                .setPrestoSparkAssignBucketToPartitionForPartitionedTableWriteEnabled(false));
+                .setPrestoSparkAssignBucketToPartitionForPartitionedTableWriteEnabled(false)
+                .setPartialResultsEnabled(false)
+                .setPartialResultsCompletionRatioThreshold(0.5)
+                .setPartialResultsMaxExecutionTimeMultiplier(2.0));
     }
 
     @Test
@@ -276,6 +279,9 @@ public class TestFeaturesConfig
                 .put("spooling-output-buffer-threshold", "16MB")
                 .put("spooling-output-buffer-temp-storage", "tempfs")
                 .put("spark.assign-bucket-to-partition-for-partitioned-table-write-enabled", "true")
+                .put("partial-results-enabled", "true")
+                .put("partial-results-completion-ratio-threshold", "0.9")
+                .put("partial-results-max-execution-time-multiplier", "1.5")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -387,7 +393,10 @@ public class TestFeaturesConfig
                 .setSpoolingOutputBufferEnabled(true)
                 .setSpoolingOutputBufferThreshold(new DataSize(16, MEGABYTE))
                 .setSpoolingOutputBufferTempStorage("tempfs")
-                .setPrestoSparkAssignBucketToPartitionForPartitionedTableWriteEnabled(true);
+                .setPrestoSparkAssignBucketToPartitionForPartitionedTableWriteEnabled(true)
+                .setPartialResultsEnabled(true)
+                .setPartialResultsCompletionRatioThreshold(0.9)
+                .setPartialResultsMaxExecutionTimeMultiplier(1.5);
         assertFullMapping(properties, expected);
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/StandardWarningCode.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/StandardWarningCode.java
@@ -20,7 +20,8 @@ public enum StandardWarningCode
     PARSER_WARNING(0x0000_0002),
     PERFORMANCE_WARNING(0x0000_0003),
     SEMANTIC_WARNING(0x0000_0004),
-    REDUNDANT_ORDER_BY(0x0000_0005)
+    REDUNDANT_ORDER_BY(0x0000_0005),
+    PARTIAL_RESULT_WARNING(0x0000_0006)
     /**/;
     private final WarningCode warningCode;
 


### PR DESCRIPTION
Long tail tasks that take a lot of time to finish the assigned splits and affect the query latency a lot. These tail tasks might be slow because of various reasons like bad node, low cache hit rate etc. Some clients might be okay with skipping such slow tasks and finishing the query with partial results. This commit adds support for returning partial results to such clients.

If we set `partial_results_completion_ratio_threshold=0.75`, then it means that we want the query to wait for 75% of the scan tasks to finish before becoming eligible and returning partial results. 

If we set `partial_results_max_execution_time_multiplier=1.5`, then the max scan task end time is set as 1.5 * X, where X is time taken for 75% of the scan tasks to complete. Meaning any pending scan tasks that are still running after 1.5X elapsed time are cancelled and partial results are returned for the query.

When partial results are enabled, the default values are `partial_results_completion_ratio_threshold=0.50` and `partial_results_max_execution_time_multiplier=2.0`

```
== RELEASE NOTES ==

General Changes
* Add support for returning partial results for the queries by setting `partial_results_enabled` session property. Additionally `partial_results_max_execution_time_multiplier`, `partial_results_completion_ratio_threshold`  session properties can be set to configure the max execution time multiplier and minimum completion ratio threshold for the queries.
```
