### PR TITLE
Add support for static AWS credentials in GlueHiveMetastore

### DIFF
--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -231,6 +231,16 @@ Property Name                                        Description
 
 ``hive.metastore.glue.default-warehouse-dir``        Hive Glue metastore default warehouse directory
 
+``hive.metastore.glue.aws-access-key``               AWS access key to use to connect to the Glue Catalog. If
+                                                     specified along with ``hive.metastore.glue.aws-secret-key``,
+                                                     this parameter takes precedence over
+                                                     ``hive.metastore.glue.iam-role``.
+
+``hive.metastore.glue.aws-secret-key``               AWS secret key to use to connect to the Glue Catalog. If
+                                                     specified along with ``hive.metastore.glue.aws-access-key``,
+                                                     this parameter takes precedence over
+                                                     ``hive.metastore.glue.iam-role``.
+
 ``hive.metastore.glue.catalogid``                    The ID of the Glue Catalog in which the metadata database
                                                      resides.
 

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/glue/GlueHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/glue/GlueHiveMetastore.java
@@ -16,6 +16,8 @@ package com.facebook.presto.hive.metastore.glue;
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
 import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
 import com.amazonaws.metrics.RequestMetricCollector;
@@ -202,7 +204,12 @@ public class GlueHiveMetastore
             }
         }
 
-        if (config.getIamRole().isPresent()) {
+        if (config.getAwsAccessKey().isPresent() && config.getAwsSecretKey().isPresent()) {
+            AWSCredentialsProvider credentialsProvider = new AWSStaticCredentialsProvider(
+                    new BasicAWSCredentials(config.getAwsAccessKey().get(), config.getAwsSecretKey().get()));
+            asyncGlueClientBuilder.setCredentials(credentialsProvider);
+        }
+        else if (config.getIamRole().isPresent()) {
             AWSCredentialsProvider credentialsProvider = new STSAssumeRoleSessionCredentialsProvider
                     .Builder(config.getIamRole().get(), "roleSessionName")
                     .build();

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/glue/GlueHiveMetastoreConfig.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/glue/GlueHiveMetastoreConfig.java
@@ -15,6 +15,7 @@ package com.facebook.presto.hive.metastore.glue;
 
 import com.facebook.airlift.configuration.Config;
 import com.facebook.airlift.configuration.ConfigDescription;
+import com.facebook.airlift.configuration.ConfigSecuritySensitive;
 
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
@@ -33,6 +34,8 @@ public class GlueHiveMetastoreConfig
     private int partitionSegments = 5;
     private int getPartitionThreads = 20;
     private Optional<String> iamRole = Optional.empty();
+    private Optional<String> awsAccessKey = Optional.empty();
+    private Optional<String> awsSecretKey = Optional.empty();
 
     public Optional<String> getGlueRegion()
     {
@@ -165,6 +168,33 @@ public class GlueHiveMetastoreConfig
     public GlueHiveMetastoreConfig setIamRole(String iamRole)
     {
         this.iamRole = Optional.ofNullable(iamRole);
+        return this;
+    }
+
+    public Optional<String> getAwsAccessKey()
+    {
+        return awsAccessKey;
+    }
+
+    @Config("hive.metastore.glue.aws-access-key")
+    @ConfigDescription("Hive Glue metastore AWS access key")
+    public GlueHiveMetastoreConfig setAwsAccessKey(String awsAccessKey)
+    {
+        this.awsAccessKey = Optional.ofNullable(awsAccessKey);
+        return this;
+    }
+
+    public Optional<String> getAwsSecretKey()
+    {
+        return awsSecretKey;
+    }
+
+    @Config("hive.metastore.glue.aws-secret-key")
+    @ConfigDescription("Hive Glue metastore AWS secret key")
+    @ConfigSecuritySensitive
+    public GlueHiveMetastoreConfig setAwsSecretKey(String awsSecretKey)
+    {
+        this.awsSecretKey = Optional.ofNullable(awsSecretKey);
         return this;
     }
 }

--- a/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/glue/TestGlueHiveMetastoreConfig.java
+++ b/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/glue/TestGlueHiveMetastoreConfig.java
@@ -37,7 +37,9 @@ public class TestGlueHiveMetastoreConfig
                 .setCatalogId(null)
                 .setPartitionSegments(5)
                 .setGetPartitionThreads(20)
-                .setIamRole(null));
+                .setIamRole(null)
+                .setAwsAccessKey(null)
+                .setAwsSecretKey(null));
     }
 
     @Test
@@ -54,6 +56,8 @@ public class TestGlueHiveMetastoreConfig
                 .put("hive.metastore.glue.partitions-segments", "10")
                 .put("hive.metastore.glue.get-partition-threads", "42")
                 .put("hive.metastore.glue.iam-role", "role")
+                .put("hive.metastore.glue.aws-access-key", "ABC")
+                .put("hive.metastore.glue.aws-secret-key", "DEF")
                 .build();
 
         GlueHiveMetastoreConfig expected = new GlueHiveMetastoreConfig()
@@ -66,7 +70,9 @@ public class TestGlueHiveMetastoreConfig
                 .setCatalogId("0123456789")
                 .setPartitionSegments(10)
                 .setGetPartitionThreads(42)
-                .setIamRole("role");
+                .setIamRole("role")
+                .setAwsAccessKey("ABC")
+                .setAwsSecretKey("DEF");
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
Cherry pick of https://github.com/trinodb/trino/pull/748
This PR adds support for specifying static AWS credentials for
GlueHiveMetastore through two new configuration options,
hive.metastore.glue.aws-access-key and
hive.metastore.glue.aws-secret-key.
This is helpful in situations where someone may want to access a glue
catalog through Presto without running the cluster on AWS
infrastructure.

Co-authored-by: Philippe Gagnon <pgagnon@users.noreply.github.com>

```
== RELEASE NOTES ==

Hive Changes
* Add support for static AWS credentials in GlueHiveMetastore
   :doc:`/connector/hive`
```
