### PR TITLE
Fix loading config properties for temp storage

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/testing/TestingTempStorageManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/TestingTempStorageManager.java
@@ -40,6 +40,7 @@ public class TestingTempStorageManager
     public TestingTempStorageManager(String tempStoragePath)
     {
         super(new TestingNodeManager());
+        addTempStorageFactory(new LocalTempStorage.Factory());
         loadTempStorage(
                 LocalTempStorage.NAME,
                 ImmutableMap.of(TEMP_STORAGE_PATH, tempStoragePath, TempStorageManager.TEMP_STORAGE_FACTORY_NAME, "local"));


### PR DESCRIPTION
1. Before this change, Presto classic did't load temp storage related configs from local files. This PR fixes `loadTempStorages()`
2. Presto on spark doesn't need to use local temp storage. If it does, code order needs to change.

```
== NO RELEASE NOTE ==
```
