### PR TITLE
Add release notes for 0.249.2

### DIFF
--- a/presto-docs/src/main/sphinx/release.rst
+++ b/presto-docs/src/main/sphinx/release.rst
@@ -6,6 +6,7 @@ Release Notes
     :maxdepth: 1
 
     release/release-0.250
+    release/release-0.249.2
     release/release-0.249.1
     release/release-0.249
     release/release-0.248

--- a/presto-docs/src/main/sphinx/release/release-0.249.1.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.249.1.rst
@@ -3,5 +3,5 @@ Release 0.249.1
 ===============
 
 General Changes
-------------
+---------------
 * Fix a memory leak in ``NodeTaskMap`` which could lead to Full GC or OOMs in coordinator.

--- a/presto-docs/src/main/sphinx/release/release-0.249.2.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.249.2.rst
@@ -1,0 +1,7 @@
+===============
+Release 0.249.2
+===============
+
+Hive Changes
+------------
+* Add configuration property ``hive.undo-metastore-operations-enabled`` to set whether to undo metastore operations after encountering an error. This flag is true by default, which maintains the previous behavior.


### PR DESCRIPTION
Test plan - Checked the html pages locally and they look fine.

<img width="1644" alt="Screen Shot 2021-04-16 at 10 42 41 AM" src="https://user-images.githubusercontent.com/22344667/115064126-6b2d8280-9ea1-11eb-8700-77d9c39b8e93.png">

```
== NO RELEASE NOTE ==
```
