### PR TITLE
Add Connection Params for JDBC HTTP Protocol

### DIFF
--- a/presto-docs/src/main/sphinx/installation/jdbc.rst
+++ b/presto-docs/src/main/sphinx/installation/jdbc.rst
@@ -76,6 +76,8 @@ Name                              Description
 ``password``                      Password to use for LDAP authentication.
 ``socksProxy``                    SOCKS proxy host and port. Example: ``localhost:1080``
 ``httpProxy``                     HTTP proxy host and port. Example: ``localhost:8888``
+``protocols``                     Comma delineated list of HTTP protocols to use. Example: ``protocols=http11``.
+                                  Acceptable values: ``http11,http10,http2``
 ``applicationNamePrefix``         Prefix to append to any specified ``ApplicationName`` client info
                                   property, which is used to set the source name for the Presto query.
                                   If neither this property nor ``ApplicationName`` are set, the source

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/ConnectionProperties.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/ConnectionProperties.java
@@ -16,6 +16,7 @@ package com.facebook.presto.jdbc;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.net.HostAndPort;
+import okhttp3.Protocol;
 
 import java.io.File;
 import java.util.List;
@@ -26,6 +27,7 @@ import java.util.Set;
 import java.util.function.Predicate;
 
 import static com.facebook.presto.jdbc.AbstractConnectionProperty.ClassListConverter.CLASS_LIST_CONVERTER;
+import static com.facebook.presto.jdbc.AbstractConnectionProperty.HttpProtocolConverter.HTTP_PROTOCOL_CONVERTER;
 import static com.facebook.presto.jdbc.AbstractConnectionProperty.StringMapConverter.STRING_MAP_CONVERTER;
 import static com.facebook.presto.jdbc.AbstractConnectionProperty.checkedPredicate;
 import static java.util.Collections.unmodifiableMap;
@@ -54,6 +56,7 @@ final class ConnectionProperties
     public static final ConnectionProperty<String> ACCESS_TOKEN = new AccessToken();
     public static final ConnectionProperty<Map<String, String>> EXTRA_CREDENTIALS = new ExtraCredentials();
     public static final ConnectionProperty<Map<String, String>> SESSION_PROPERTIES = new SessionProperties();
+    public static final ConnectionProperty<List<Protocol>> HTTP_PROTOCOLS = new HttpProtocols();
     public static final ConnectionProperty<List<QueryInterceptor>> QUERY_INTERCEPTORS = new QueryInterceptors();
 
     private static final Set<ConnectionProperty<?>> ALL_PROPERTIES = ImmutableSet.<ConnectionProperty<?>>builder()
@@ -77,6 +80,7 @@ final class ConnectionProperties
             .add(ACCESS_TOKEN)
             .add(EXTRA_CREDENTIALS)
             .add(SESSION_PROPERTIES)
+            .add(HTTP_PROTOCOLS)
             .add(QUERY_INTERCEPTORS)
             .build();
 
@@ -310,6 +314,15 @@ final class ConnectionProperties
         public SessionProperties()
         {
             super("sessionProperties", NOT_REQUIRED, ALLOWED, STRING_MAP_CONVERTER);
+        }
+    }
+
+    private static class HttpProtocols
+            extends AbstractConnectionProperty<List<Protocol>>
+    {
+        public HttpProtocols()
+        {
+            super("protocols", NOT_REQUIRED, ALLOWED, HTTP_PROTOCOL_CONVERTER);
         }
     }
 

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoDriverUri.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoDriverUri.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.net.HostAndPort;
 import okhttp3.OkHttpClient;
+import okhttp3.Protocol;
 
 import java.io.File;
 import java.net.URI;
@@ -47,6 +48,7 @@ import static com.facebook.presto.jdbc.ConnectionProperties.ACCESS_TOKEN;
 import static com.facebook.presto.jdbc.ConnectionProperties.APPLICATION_NAME_PREFIX;
 import static com.facebook.presto.jdbc.ConnectionProperties.DISABLE_COMPRESSION;
 import static com.facebook.presto.jdbc.ConnectionProperties.EXTRA_CREDENTIALS;
+import static com.facebook.presto.jdbc.ConnectionProperties.HTTP_PROTOCOLS;
 import static com.facebook.presto.jdbc.ConnectionProperties.HTTP_PROXY;
 import static com.facebook.presto.jdbc.ConnectionProperties.KERBEROS_CONFIG_PATH;
 import static com.facebook.presto.jdbc.ConnectionProperties.KERBEROS_CREDENTIAL_CACHE_PATH;
@@ -170,6 +172,12 @@ final class PrestoDriverUri
         return DISABLE_COMPRESSION.getValue(properties).orElse(false);
     }
 
+    public Optional<List<Protocol>> getProtocols()
+            throws SQLException
+    {
+        return HTTP_PROTOCOLS.getValue(properties);
+    }
+
     public void setupClient(OkHttpClient.Builder builder)
             throws SQLException
     {
@@ -177,6 +185,9 @@ final class PrestoDriverUri
             setupCookieJar(builder);
             setupSocksProxy(builder, SOCKS_PROXY.getValue(properties));
             setupHttpProxy(builder, HTTP_PROXY.getValue(properties));
+
+            // add user specified protocols to okhttp3 client if specified
+            getProtocols().ifPresent(builder::protocols);
 
             // TODO: fix Tempto to allow empty passwords
             String password = PASSWORD.getValue(properties).orElse("");

--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestJdbcConnection.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestJdbcConnection.java
@@ -217,6 +217,22 @@ public class TestJdbcConnection
     }
 
     @Test
+    public void testHttpProtocols()
+            throws SQLException
+    {
+        String extra = "protocols=http11";
+        try (Connection connection = createConnection(extra)) {
+            assertThat(connection.getCatalog()).isEqualTo("hive");
+        }
+
+        // deduplication
+        extra = "protocols=http11,http11";
+        try (Connection connection = createConnection(extra)) {
+            assertThat(connection.getCatalog()).isEqualTo("hive");
+        }
+    }
+
+    @Test
     public void testExtraCredentials()
             throws SQLException
     {

--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestPrestoDriverUri.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestPrestoDriverUri.java
@@ -24,6 +24,7 @@ import java.util.Properties;
 
 import static com.facebook.presto.jdbc.ConnectionProperties.DISABLE_COMPRESSION;
 import static com.facebook.presto.jdbc.ConnectionProperties.EXTRA_CREDENTIALS;
+import static com.facebook.presto.jdbc.ConnectionProperties.HTTP_PROTOCOLS;
 import static com.facebook.presto.jdbc.ConnectionProperties.HTTP_PROXY;
 import static com.facebook.presto.jdbc.ConnectionProperties.QUERY_INTERCEPTORS;
 import static com.facebook.presto.jdbc.ConnectionProperties.SESSION_PROPERTIES;
@@ -263,6 +264,16 @@ public class TestPrestoDriverUri
         PrestoDriverUri parameters = createDriverUri("presto://localhost:8080?sessionProperties=" + sessionProperties);
         Properties properties = parameters.getProperties();
         assertEquals(properties.getProperty(SESSION_PROPERTIES.getKey()), sessionProperties);
+    }
+
+    @Test
+    public void testUriWithHttpProtocols()
+            throws SQLException
+    {
+        String protocols = "h2,http/1.1";
+        PrestoDriverUri parameters = createDriverUri("presto://localhost:8080?protocols=" + protocols);
+        Properties properties = parameters.getProperties();
+        assertEquals(properties.getProperty(HTTP_PROTOCOLS.getKey()), protocols);
     }
 
     @Test


### PR DESCRIPTION
Fixes an issue for Java > 8_242 where the default is HTTP/2 for users with a loadbalancer infront that accepts the protocol.

```
== RELEASE NOTES ==

General Changes
* Added connection param "protocols" that allows a user to specify which HTTP protocols the Presto client is allowed to use.
```