### PR TITLE
Upgrade zstd-jni to v1.4.9-2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1568,7 +1568,7 @@
             <dependency>
                 <groupId>com.github.luben</groupId>
                 <artifactId>zstd-jni</artifactId>
-                <version>1.3.5-4</version>
+                <version>1.4.9-2</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
New zstd has better performance on compression and decompression. 1%-2% overall improvement was measured on some Presto workloads.
Previously new zstd-jni caused long GC pause because of finalizer in ZstdCompressCtx and ZstdDecompressCtx (introduced by zstd-jni commit https://github.com/luben/zstd-jni/commit/5209351fc8e071084a3e6df13c0f60bd13f916f6). This has been fixed in v1.4.9-2, and we verified that no long GC occurred.

Test plan - (Please fill in how you tested your changes)

Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines. Don't forget to follow our [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution) for any code copied from other projects.

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== RELEASE NOTES ==

General Changes
* ...
* ...

Hive Changes
* ...
* ...
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```
