### PR TITLE
Fix hanging join test

### DIFF
--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -153,7 +153,7 @@ public abstract class AbstractTestQueries
     }
 
     @Test
-    public void selectLargeInterval()
+    public void testSelectLargeInterval()
     {
         MaterializedResult result = computeActual("SELECT INTERVAL '30' DAY");
         assertEquals(result.getRowCount(), 1);
@@ -165,7 +165,7 @@ public abstract class AbstractTestQueries
     }
 
     @Test
-    public void emptyJoins()
+    public void testEmptyJoins()
     {
         // Empty predicate
         assertQuery("select 1 from (select * from orders where 1 = 0) DT join customer on DT.custkey=customer.custkey",
@@ -186,7 +186,7 @@ public abstract class AbstractTestQueries
     }
 
     @Test
-    public void selectNull()
+    public void testSelectNull()
     {
         assertQuery("SELECT NULL");
     }

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestDistributedSpilledQueries.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestDistributedSpilledQueries.java
@@ -78,11 +78,4 @@ public class TestDistributedSpilledQueries
         // TODO: disabled until https://github.com/prestodb/presto/issues/8926 is resolved
         //       due to long running query test created many spill files on disk.
     }
-
-    @Test(enabled = false)
-    @Override
-    public void testCorrelatedNonAggregationScalarSubqueries()
-    {
-        // TODO: disable until https://github.com/prestodb/presto/issues/15542 is resolved
-    }
 }


### PR DESCRIPTION
Test plan - unit test, ci

Cherry-pick of https://github.com/trinodb/trino/pull/7455/commits/42b8e33f7958f4c208a8c6f9b918d6f65ecd0456 plus some required refactoring. 

SpilledLookupSourceHandle needs to be disposed immediately when join operators finished processing probe data. Otherwise SpilledLookupSourceHandle is never disposed as it's not registered in PartitionedConsumption. This prevents HashBuilderOperator from finishing.

This was causing some tests to hang in TestDistributedSpilledQueries. 

Fixes https://github.com/prestodb/presto/issues/15542 and https://github.com/prestodb/presto/issues/15921
```
== RELEASE NOTES ==

General Changes
* Fix hanging join operator when spill is enabled and the probe side finishes before the hash builder starts

```
