### PR TITLE
Feat/enable ctas with unmanaged hive table

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveLocationService.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveLocationService.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.hive;
 
+import com.facebook.airlift.log.Logger;
 import com.facebook.presto.hive.LocationHandle.TableType;
 import com.facebook.presto.hive.LocationHandle.WriteMode;
 import com.facebook.presto.hive.metastore.Partition;
@@ -45,6 +46,8 @@ import static java.util.UUID.randomUUID;
 public class HiveLocationService
         implements LocationService
 {
+    private static final Logger LOGGER = Logger.get(HiveLocationService.class);
+
     private final HdfsEnvironment hdfsEnvironment;
 
     @Inject
@@ -56,7 +59,7 @@ public class HiveLocationService
     @Override
     public LocationHandle forNewTable(SemiTransactionalHiveMetastore metastore, ConnectorSession session, String schemaName, String tableName, boolean tempPathRequired, Optional<Path> externalLocation)
     {
-        Path targetPath = externalLocation.orElse(getTableDefaultLocation(session, metastore, hdfsEnvironment, schemaName, tableName));
+        Path targetPath = externalLocation.orElseGet(() -> getTableDefaultLocation(session, metastore, hdfsEnvironment, schemaName, tableName));
 
         HdfsContext context = new HdfsContext(session, schemaName, tableName, targetPath.toString(), true);
         // verify the target directory for the table

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveLocationService.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveLocationService.java
@@ -37,7 +37,6 @@ import static com.facebook.presto.hive.LocationHandle.TableType.TEMPORARY;
 import static com.facebook.presto.hive.LocationHandle.WriteMode.DIRECT_TO_TARGET_EXISTING_DIRECTORY;
 import static com.facebook.presto.hive.LocationHandle.WriteMode.DIRECT_TO_TARGET_NEW_DIRECTORY;
 import static com.facebook.presto.hive.LocationHandle.WriteMode.STAGE_AND_MOVE_TO_TARGET_DIRECTORY;
-import static com.facebook.presto.hive.metastore.MetastoreUtil.createDirectory;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.pathExists;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -55,16 +54,16 @@ public class HiveLocationService
     }
 
     @Override
-    public LocationHandle forNewTable(SemiTransactionalHiveMetastore metastore, ConnectorSession session, String schemaName, String tableName, boolean tempPathRequired)
+    public LocationHandle forNewTable(SemiTransactionalHiveMetastore metastore, ConnectorSession session, String schemaName, String tableName, boolean tempPathRequired, Optional<Path> externalLocation)
     {
-        Path targetPath = getTableDefaultLocation(session, metastore, hdfsEnvironment, schemaName, tableName);
+        Path targetPath = externalLocation.orElse(getTableDefaultLocation(session, metastore, hdfsEnvironment, schemaName, tableName));
 
         HdfsContext context = new HdfsContext(session, schemaName, tableName, targetPath.toString(), true);
         // verify the target directory for the table
         if (pathExists(context, hdfsEnvironment, targetPath)) {
             throw new PrestoException(HIVE_PATH_ALREADY_EXISTS, format("Target directory for table '%s.%s' already exists: %s", schemaName, tableName, targetPath));
         }
-        return createLocationHandle(context, session, targetPath, NEW, tempPathRequired);
+        return createLocationHandle(context, session, targetPath, NEW, tempPathRequired, externalLocation);
     }
 
     @Override
@@ -73,7 +72,7 @@ public class HiveLocationService
         String tablePath = table.getStorage().getLocation();
         HdfsContext context = new HdfsContext(session, table.getDatabaseName(), table.getTableName(), tablePath, false);
         Path targetPath = new Path(tablePath);
-        return createLocationHandle(context, session, targetPath, EXISTING, tempPathRequired);
+        return createLocationHandle(context, session, targetPath, EXISTING, tempPathRequired, Optional.empty());
     }
 
     @Override
@@ -91,12 +90,12 @@ public class HiveLocationService
                 DIRECT_TO_TARGET_NEW_DIRECTORY);
     }
 
-    private LocationHandle createLocationHandle(HdfsContext context, ConnectorSession session, Path targetPath, TableType tableType, boolean tempPathRequired)
+    private LocationHandle createLocationHandle(HdfsContext context, ConnectorSession session, Path targetPath, TableType tableType, boolean tempPathRequired, Optional<Path> externalLocation)
     {
         Optional<Path> tempPath = tempPathRequired ? Optional.of(createTemporaryPath(session, context, hdfsEnvironment, targetPath)) : Optional.empty();
-        if (shouldUseTemporaryDirectory(session, context, targetPath)) {
+
+        if (shouldUseTemporaryDirectory(session, context, targetPath, externalLocation)) {
             Path writePath = createTemporaryPath(session, context, hdfsEnvironment, targetPath);
-            createDirectory(context, hdfsEnvironment, writePath);
             return new LocationHandle(targetPath, writePath, tempPath, tableType, STAGE_AND_MOVE_TO_TARGET_DIRECTORY);
         }
         if (tableType.equals(EXISTING)) {
@@ -105,11 +104,13 @@ public class HiveLocationService
         return new LocationHandle(targetPath, targetPath, tempPath, tableType, DIRECT_TO_TARGET_NEW_DIRECTORY);
     }
 
-    private boolean shouldUseTemporaryDirectory(ConnectorSession session, HdfsContext context, Path path)
+    private boolean shouldUseTemporaryDirectory(ConnectorSession session, HdfsContext context, Path path, Optional<Path> externalLocation)
     {
         return isTemporaryStagingDirectoryEnabled(session)
                 // skip using temporary directory for S3
-                && !isS3FileSystem(context, hdfsEnvironment, path);
+                && !isS3FileSystem(context, hdfsEnvironment, path)
+                // Skip using temporary directory if destination is external. Target may be on a different file system.
+                && !externalLocation.isPresent();
     }
 
     @Override

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveOutputTableHandle.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveOutputTableHandle.java
@@ -34,6 +34,7 @@ public class HiveOutputTableHandle
     private final List<String> partitionedBy;
     private final String tableOwner;
     private final Map<String, String> additionalTableParameters;
+    private final boolean external;
 
     @JsonCreator
     public HiveOutputTableHandle(
@@ -52,7 +53,8 @@ public class HiveOutputTableHandle
             @JsonProperty("preferredOrderingColumns") List<SortingColumn> preferredOrderingColumns,
             @JsonProperty("tableOwner") String tableOwner,
             @JsonProperty("additionalTableParameters") Map<String, String> additionalTableParameters,
-            @JsonProperty("encryptionInformation") Optional<EncryptionInformation> encryptionInformation)
+            @JsonProperty("encryptionInformation") Optional<EncryptionInformation> encryptionInformation,
+            @JsonProperty("external") boolean external)
     {
         super(
                 schemaName,
@@ -72,6 +74,7 @@ public class HiveOutputTableHandle
         this.partitionedBy = ImmutableList.copyOf(requireNonNull(partitionedBy, "partitionedBy is null"));
         this.tableOwner = requireNonNull(tableOwner, "tableOwner is null");
         this.additionalTableParameters = ImmutableMap.copyOf(requireNonNull(additionalTableParameters, "additionalTableParameters is null"));
+        this.external = external;
     }
 
     @JsonProperty
@@ -90,5 +93,11 @@ public class HiveOutputTableHandle
     public Map<String, String> getAdditionalTableParameters()
     {
         return additionalTableParameters;
+    }
+
+    @JsonProperty
+    public boolean isExternal()
+    {
+        return external;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/LocationService.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/LocationService.java
@@ -25,7 +25,7 @@ import static java.util.Objects.requireNonNull;
 
 public interface LocationService
 {
-    LocationHandle forNewTable(SemiTransactionalHiveMetastore metastore, ConnectorSession session, String schemaName, String tableName, boolean tempPathRequired);
+    LocationHandle forNewTable(SemiTransactionalHiveMetastore metastore, ConnectorSession session, String schemaName, String tableName, boolean tempPathRequired, Optional<Path> externalLocation);
 
     LocationHandle forExistingTable(SemiTransactionalHiveMetastore metastore, ConnectorSession session, Table table, boolean tempPathRequired);
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -2807,7 +2807,7 @@ public abstract class AbstractTestHiveClient
         try {
             try (Transaction transaction = newTransaction()) {
                 LocationService locationService = getLocationService();
-                LocationHandle locationHandle = locationService.forNewTable(transaction.getMetastore(), session, schemaName, tableName, false);
+                LocationHandle locationHandle = locationService.forNewTable(transaction.getMetastore(), session, schemaName, tableName, false, Optional.empty());
                 targetPath = locationService.getQueryWriteInfo(locationHandle).getTargetPath();
                 Table table = createSimpleTable(schemaTableName, columns, session, targetPath, "q1");
                 transaction.getMetastore()
@@ -3502,7 +3502,7 @@ public abstract class AbstractTestHiveClient
             String tableOwner = session.getUser();
             String schemaName = schemaTableName.getSchemaName();
             String tableName = schemaTableName.getTableName();
-            LocationHandle locationHandle = getLocationService().forNewTable(transaction.getMetastore(), session, schemaName, tableName, false);
+            LocationHandle locationHandle = getLocationService().forNewTable(transaction.getMetastore(), session, schemaName, tableName, false, Optional.empty());
             Path targetPath = getLocationService().getQueryWriteInfo(locationHandle).getTargetPath();
             //create table whose storage format is null
             Table.Builder tableBuilder = Table.builder()
@@ -5306,7 +5306,7 @@ public abstract class AbstractTestHiveClient
             String tableName = schemaTableName.getTableName();
 
             LocationService locationService = getLocationService();
-            LocationHandle locationHandle = locationService.forNewTable(transaction.getMetastore(), session, schemaName, tableName, false);
+            LocationHandle locationHandle = locationService.forNewTable(transaction.getMetastore(), session, schemaName, tableName, false, Optional.empty());
             targetPath = locationService.getQueryWriteInfo(locationHandle).getTargetPath();
 
             Table.Builder tableBuilder = Table.builder()

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveCreateExternalTable.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveCreateExternalTable.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.intellij.lang.annotations.Language;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Optional;
+
+import static com.facebook.presto.tests.QueryAssertions.assertEqualsIgnoreOrder;
+import static com.google.common.io.Files.createTempDir;
+import static com.google.common.io.MoreFiles.deleteRecursively;
+import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
+import static io.airlift.tpch.TpchTable.NATION;
+import static java.lang.String.format;
+import static org.testng.Assert.assertTrue;
+
+public class TestHiveCreateExternalTable
+        extends AbstractTestQueryFramework
+{
+    public TestHiveCreateExternalTable()
+    {
+        super(() -> createQueryRunner());
+    }
+
+    private static QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return HiveQueryRunner.createQueryRunner(
+                ImmutableList.of(NATION),
+                ImmutableMap.of(),
+                "sql-standard",
+                ImmutableMap.of(
+                        "hive.non-managed-table-creates-enabled", "true"),
+                Optional.empty());
+    }
+
+    @Test
+    public void testCreateExternalTableWithData()
+            throws IOException
+    {
+        String tableName = "test_create_external";
+        File tempDir = createTempDir();
+        File tableLocation = new File(tempDir, tableName);
+
+        @Language("SQL") String createTableSql = format("" +
+                        "CREATE TABLE test_create_external " +
+                        "WITH (external_location = '%s') AS " +
+                        "SELECT * FROM tpch.tiny.nation",
+                tableLocation.toURI().toASCIIString());
+
+        assertUpdate(createTableSql, 25);
+
+        MaterializedResult expected = computeActual("SELECT * FROM tpch.tiny.nation");
+        MaterializedResult actual = computeActual("SELECT * FROM " + tableName);
+        assertEqualsIgnoreOrder(actual.getMaterializedRows(), expected.getMaterializedRows());
+
+        String tablePath = (String) computeActual("SELECT DISTINCT regexp_replace(\"$path\", '/[^/]*$', '/') FROM " + tableName).getOnlyValue();
+        assertTrue(tablePath.startsWith(tableLocation.toURI().toString()));
+
+        assertUpdate("DROP TABLE test_create_external");
+        deleteRecursively(tempDir.toPath(), ALLOW_INSECURE);
+    }
+
+    @Test
+    public void testCreateExternalTableAsWithExistingDirectory()
+    {
+        File tempDir = createTempDir();
+
+        @Language("SQL") String createTableSql = format("" +
+                        "CREATE TABLE test_create_external " +
+                        "WITH (external_location = '%s') AS " +
+                        "SELECT * FROM tpch.tiny.nation",
+                tempDir.toURI().toASCIIString());
+
+        assertQueryFails(createTableSql, "Target directory for table '.*' already exists:.*");
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSink.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSink.java
@@ -300,7 +300,8 @@ public class TestHivePageSink
                 ImmutableList.of(),
                 "test",
                 ImmutableMap.of(),
-                Optional.empty());
+                Optional.empty(),
+                false);
         JsonCodec<PartitionUpdate> partitionUpdateCodec = JsonCodec.jsonCodec(PartitionUpdate.class);
         HdfsEnvironment hdfsEnvironment = createTestHdfsEnvironment(config, metastoreClientConfig);
         HivePageSinkProvider provider = new HivePageSinkProvider(


### PR DESCRIPTION
Test plan - TU to create an table as a select with an external location with presto-hive plugin and a manual TI to test the creation under EMR, using a Glue catalog and seeing the results in S3 and Athena

This PR allow the creation of an unmanaged table (with external location specified) as a select result (CTAS) with Hive Plugin
Resolve #15946
Based on the trino PR [#2669](https://github.com/trinodb/trino/pull/2669)
Only test `hive.non-managed-table-creates-enabled` and  not `hive.non-managed-table-writes-enabled` as mentioned [here](https://github.com/trinodb/trino/pull/2669#discussion_r373362872) when validating the right to create the table (it's not an insert ... values select ... here)

== RELEASE NOTES ==

Hive Changes
* Allow creation of table with an external location when the catalog configuration `hive.non-managed-table-creates-enabled` set to `true`
