### PR TITLE
Support shutting down coordinator using /info/state endpoint

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/GracefulShutdownHandler.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/GracefulShutdownHandler.java
@@ -15,6 +15,7 @@ package com.facebook.presto.server;
 
 import com.facebook.airlift.bootstrap.LifeCycleManager;
 import com.facebook.airlift.log.Logger;
+import com.facebook.presto.execution.QueryManager;
 import com.facebook.presto.execution.TaskInfo;
 import com.facebook.presto.execution.TaskManager;
 import io.airlift.units.Duration;
@@ -48,6 +49,7 @@ public class GracefulShutdownHandler
     private final ScheduledExecutorService shutdownHandler = newSingleThreadScheduledExecutor(threadsNamed("shutdown-handler-%s"));
     private final ExecutorService lifeCycleStopper = newSingleThreadExecutor(threadsNamed("lifecycle-stopper-%s"));
     private final LifeCycleManager lifeCycleManager;
+    private final QueryManager queryManager;
     private final TaskManager sqlTaskManager;
     private final boolean isCoordinator;
     private final ShutdownAction shutdownAction;
@@ -61,22 +63,20 @@ public class GracefulShutdownHandler
             TaskManager sqlTaskManager,
             ServerConfig serverConfig,
             ShutdownAction shutdownAction,
-            LifeCycleManager lifeCycleManager)
+            LifeCycleManager lifeCycleManager,
+            QueryManager queryManager)
     {
         this.sqlTaskManager = requireNonNull(sqlTaskManager, "sqlTaskManager is null");
         this.shutdownAction = requireNonNull(shutdownAction, "shutdownAction is null");
         this.lifeCycleManager = requireNonNull(lifeCycleManager, "lifeCycleManager is null");
         this.isCoordinator = requireNonNull(serverConfig, "serverConfig is null").isCoordinator();
         this.gracePeriod = serverConfig.getGracePeriod();
+        this.queryManager = requireNonNull(queryManager, "queryManager is null");
     }
 
     public synchronized void requestShutdown()
     {
         log.info("Shutdown requested");
-
-        if (isCoordinator) {
-            throw new UnsupportedOperationException("Cannot shutdown coordinator");
-        }
 
         if (isShutdownRequested()) {
             return;
@@ -86,33 +86,14 @@ public class GracefulShutdownHandler
 
         //wait for a grace period to start the shutdown sequence
         shutdownHandler.schedule(() -> {
-            List<TaskInfo> activeTasks = getActiveTasks();
-            while (activeTasks.size() > 0) {
-                CountDownLatch countDownLatch = new CountDownLatch(activeTasks.size());
-
-                for (TaskInfo taskInfo : activeTasks) {
-                    sqlTaskManager.addStateChangeListener(taskInfo.getTaskId(), newState -> {
-                        if (newState.isDone()) {
-                            countDownLatch.countDown();
-                        }
-                    });
-                }
-
-                log.info("Waiting for all tasks to finish");
-
-                try {
-                    countDownLatch.await();
-                }
-                catch (InterruptedException e) {
-                    log.warn("Interrupted while waiting for all tasks to finish");
-                    currentThread().interrupt();
-                }
-
-                activeTasks = getActiveTasks();
+            if (isCoordinator) {
+                waitForQueriesToComplete();
             }
-
-            // wait for another grace period for all task states to be observed by the coordinator
-            sleepUninterruptibly(gracePeriod.toMillis(), MILLISECONDS);
+            else {
+                waitForTasksToComplete();
+                // wait for another grace period for all task states to be observed by the coordinator
+                sleepUninterruptibly(gracePeriod.toMillis(), MILLISECONDS);
+            }
 
             Future<?> shutdownFuture = lifeCycleStopper.submit(() -> {
                 lifeCycleManager.stop();
@@ -138,11 +119,71 @@ public class GracefulShutdownHandler
         }, gracePeriod.toMillis(), MILLISECONDS);
     }
 
+    private void waitForTasksToComplete()
+    {
+        List<TaskInfo> activeTasks = getActiveTasks();
+        while (activeTasks.size() > 0) {
+            CountDownLatch countDownLatch = new CountDownLatch(activeTasks.size());
+
+            for (TaskInfo taskInfo : activeTasks) {
+                sqlTaskManager.addStateChangeListener(taskInfo.getTaskId(), newState -> {
+                    if (newState.isDone()) {
+                        countDownLatch.countDown();
+                    }
+                });
+            }
+
+            log.info("Waiting for all tasks to finish");
+
+            try {
+                countDownLatch.await();
+            }
+            catch (InterruptedException e) {
+                log.warn("Interrupted while waiting for all tasks to finish");
+                currentThread().interrupt();
+            }
+
+            activeTasks = getActiveTasks();
+        }
+    }
+
     private List<TaskInfo> getActiveTasks()
     {
         return sqlTaskManager.getAllTaskInfo()
                 .stream()
                 .filter(taskInfo -> !taskInfo.getTaskStatus().getState().isDone())
+                .collect(toImmutableList());
+    }
+
+    private void waitForQueriesToComplete()
+    {
+        List<BasicQueryInfo> activeQueries = getActiveQueryInfo();
+        while (activeQueries.size() > 0) {
+            CountDownLatch countDownLatch = new CountDownLatch(activeQueries.size());
+            for (BasicQueryInfo queryInfo : activeQueries) {
+                queryManager.addStateChangeListener(queryInfo.getQueryId(), newState -> {
+                    if (newState.isDone()) {
+                        countDownLatch.countDown();
+                    }
+                });
+            }
+            log.info("Waiting for all queries to finish");
+            try {
+                countDownLatch.await();
+            }
+            catch (InterruptedException e) {
+                log.warn("Interrupted while waiting for all queries to finish");
+                currentThread().interrupt();
+            }
+            activeQueries = getActiveQueryInfo();
+        }
+    }
+
+    private List<BasicQueryInfo> getActiveQueryInfo()
+    {
+        return queryManager.getQueries()
+                .stream()
+                .filter(queryInfo -> !queryInfo.getState().isDone())
                 .collect(toImmutableList());
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
@@ -169,12 +169,12 @@ public class TestingPrestoServer
         private final CountDownLatch shutdownCalled = new CountDownLatch(1);
 
         @GuardedBy("this")
-        private boolean isWorkerShutdown;
+        private boolean isShutdown;
 
         @Override
         public synchronized void onShutdown()
         {
-            isWorkerShutdown = true;
+            isShutdown = true;
             shutdownCalled.countDown();
         }
 
@@ -184,9 +184,9 @@ public class TestingPrestoServer
             shutdownCalled.await(millis, MILLISECONDS);
         }
 
-        public synchronized boolean isWorkerShutdown()
+        public synchronized boolean isShutdown()
         {
-            return isWorkerShutdown;
+            return isShutdown;
         }
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/server/TestThriftServerInfoIntegration.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestThriftServerInfoIntegration.java
@@ -25,6 +25,8 @@ import com.facebook.drift.transport.netty.client.DriftNettyMethodInvokerFactory;
 import com.facebook.drift.transport.netty.server.DriftNettyServerModule;
 import com.facebook.drift.transport.netty.server.DriftNettyServerTransport;
 import com.facebook.presto.Session;
+import com.facebook.presto.dispatcher.NoOpQueryManager;
+import com.facebook.presto.execution.QueryManager;
 import com.facebook.presto.execution.StateMachine;
 import com.facebook.presto.execution.TaskId;
 import com.facebook.presto.execution.TaskInfo;
@@ -132,7 +134,8 @@ public class TestThriftServerInfoIntegration
         public void configure(Binder binder)
         {
             configBinder(binder).bindConfig(ServerConfig.class);
-
+            //Bind noop QueryManager similar to the binding done for TaskManager here
+            binder.bind(QueryManager.class).to(NoOpQueryManager.class).in(Scopes.SINGLETON);
             binder.bind(GracefulShutdownHandler.class).in(Scopes.SINGLETON);
             binder.bind(ShutdownAction.class).to(TestingPrestoServer.TestShutdownAction.class).in(Scopes.SINGLETON);
 


### PR DESCRIPTION
Support shutting down coordinator using PUT /info/state

Currently we cannot shut down coordinator through /info/state endpoint. With the disagg coordinator setup, we should able to do this so that we can drain individual coordinators gracefully.

Test plan - 
1.  Verified by running unit test
2. Verified by running HiveQueryRunner in local  -
        Use PUT  /v1/info endpoint with payload "SHUTTING_DOWN"
        Before the coordinator is shutdown,  GET /v1/info/state returns  "SHUTTING_DOWN" as the response.
        Once the coordinator is shutdown (after grace period), server refuses connection to port used by coordinator  

== RELEASE NOTES ==

General Changes
* Add support for shutting down coordinator via the /v1/info/state endpoint.
