### PR TITLE
Fix Athena Glue table compatibility issue

### DIFF
--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/glue/converter/GlueToPrestoConverter.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/glue/converter/GlueToPrestoConverter.java
@@ -40,7 +40,7 @@ import java.util.function.UnaryOperator;
 
 import static com.facebook.presto.hive.BucketFunctionType.HIVE_COMPATIBLE;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_INVALID_METADATA;
-import static com.facebook.presto.hive.metastore.PrestoTableType.OTHER;
+import static com.facebook.presto.hive.metastore.PrestoTableType.EXTERNAL_TABLE;
 import static com.facebook.presto.hive.metastore.util.Memoizers.memoizeLast;
 import static com.google.common.base.Strings.nullToEmpty;
 import static java.lang.String.format;
@@ -73,7 +73,8 @@ public final class GlueToPrestoConverter
                 .setDatabaseName(dbName)
                 .setTableName(glueTable.getName())
                 .setOwner(nullToEmpty(glueTable.getOwner()))
-                .setTableType(PrestoTableType.optionalValueOf(glueTable.getTableType()).orElse(OTHER))
+                // Athena treats missing table type as EXTERNAL_TABLE.
+                .setTableType(PrestoTableType.optionalValueOf(glueTable.getTableType()).orElse(EXTERNAL_TABLE))
                 .setDataColumns(convertColumns(sd.getColumns()))
                 .setParameters(convertParameters(glueTable.getParameters()))
                 .setViewOriginalText(Optional.ofNullable(glueTable.getViewOriginalText()))

--- a/presto-hive/src/test/java/com/facebook/presto/hive/metastore/glue/TestGlueToPrestoConverter.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/metastore/glue/TestGlueToPrestoConverter.java
@@ -32,6 +32,7 @@ import java.util.HashMap;
 import java.util.List;
 
 import static com.amazonaws.util.CollectionUtils.isNullOrEmpty;
+import static com.facebook.presto.hive.metastore.PrestoTableType.EXTERNAL_TABLE;
 import static com.facebook.presto.hive.metastore.glue.TestingMetastoreObjects.getGlueTestColumn;
 import static com.facebook.presto.hive.metastore.glue.TestingMetastoreObjects.getGlueTestDatabase;
 import static com.facebook.presto.hive.metastore.glue.TestingMetastoreObjects.getGlueTestPartition;
@@ -174,6 +175,15 @@ public class TestGlueToPrestoConverter
     {
         testPartition.setParameters(null);
         assertNotNull(new GluePartitionConverter(testDb.getName(), testTbl.getName()).apply(testPartition).getParameters());
+    }
+
+    @Test
+    public void testConvertTableWithoutTableType()
+    {
+        Table table = getGlueTestTable(testDb.getName());
+        table.setTableType(null);
+        com.facebook.presto.hive.metastore.Table prestoTable = GlueToPrestoConverter.convertTable(table, testDb.getName());
+        assertEquals(prestoTable.getTableType(), EXTERNAL_TABLE);
     }
 
     private static void assertColumnList(List<Column> actual, List<com.amazonaws.services.glue.model.Column> expected)


### PR DESCRIPTION
Cherry pick of Trino https://github.com/trinodb/trino/pull/1343,
Athena is fine reading Glue tables that have no table type set.
Currently Presto set to default OTHER but Athena tables are external:
https://docs.aws.amazon.com/athena/latest/ug/drop-table.html so set
the table type to EXTTERNAL if it is unset.

Co-authored-by: Henning Schmiedehausen <henning@schmiedehausen.org>

```
== NO RELEASE NOTE ==
```
