### PR TITLE
Always create HdfsContext with ConnectorSession

### DIFF
--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/EmptyConnectorSession.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/EmptyConnectorSession.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.metastore;
+
+import com.facebook.presto.common.function.SqlFunctionProperties;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.function.SqlFunctionId;
+import com.facebook.presto.spi.function.SqlInvokedFunction;
+import com.facebook.presto.spi.security.ConnectorIdentity;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * This is a basic connector session. Should only be used to create HdfsContext, in the absence of FullConnectorSession.
+ */
+
+public class EmptyConnectorSession
+        implements ConnectorSession
+{
+    private static final String NO_QUERY_ID = "";
+    private final ConnectorIdentity connectorIdentity;
+
+    public EmptyConnectorSession(ConnectorIdentity connectorIdentity)
+    {
+        this.connectorIdentity = connectorIdentity;
+    }
+
+    @Override
+    public String getQueryId()
+    {
+        return NO_QUERY_ID;
+    }
+
+    @Override
+    public Optional<String> getSource()
+    {
+        return Optional.empty();
+    }
+
+    @Override
+    public ConnectorIdentity getIdentity()
+    {
+        return connectorIdentity;
+    }
+
+    @Override
+    public Locale getLocale()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<String> getTraceToken()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<String> getClientInfo()
+    {
+        return Optional.empty();
+    }
+
+    @Override
+    public long getStartTime()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SqlFunctionProperties getSqlFunctionProperties()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<SqlFunctionId, SqlInvokedFunction> getSessionFunctions()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T> T getProperty(String name, Class<T> type)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<String> getSchema()
+    {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/file/FileHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/file/FileHiveMetastore.java
@@ -23,6 +23,7 @@ import com.facebook.presto.hive.HiveType;
 import com.facebook.presto.hive.PartitionNotFoundException;
 import com.facebook.presto.hive.SchemaAlreadyExistsException;
 import com.facebook.presto.hive.TableAlreadyExistsException;
+import com.facebook.presto.hive.metastore.EmptyConnectorSession;
 import com.facebook.presto.hive.metastore.Column;
 import com.facebook.presto.hive.metastore.Database;
 import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
@@ -135,7 +136,7 @@ public class FileHiveMetastore
     {
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
         this.catalogDirectory = new Path(requireNonNull(catalogDirectory, "baseDirectory is null"));
-        this.hdfsContext = new HdfsContext(new ConnectorIdentity(metastoreUser, Optional.empty(), Optional.empty()));
+        this.hdfsContext = new HdfsContext(new EmptyConnectorSession(new ConnectorIdentity(metastoreUser, Optional.empty(), Optional.empty())));
         try {
             metadataFileSystem = hdfsEnvironment.getFileSystem(hdfsContext, this.catalogDirectory);
         }

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/glue/GlueHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/glue/GlueHiveMetastore.java
@@ -64,6 +64,7 @@ import com.facebook.presto.hive.HiveType;
 import com.facebook.presto.hive.PartitionNotFoundException;
 import com.facebook.presto.hive.SchemaAlreadyExistsException;
 import com.facebook.presto.hive.TableAlreadyExistsException;
+import com.facebook.presto.hive.metastore.EmptyConnectorSession;
 import com.facebook.presto.hive.metastore.Column;
 import com.facebook.presto.hive.metastore.Database;
 import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
@@ -165,7 +166,7 @@ public class GlueHiveMetastore
             @ForGlueHiveMetastore Executor executor)
     {
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
-        this.hdfsContext = new HdfsContext(new ConnectorIdentity(DEFAULT_METASTORE_USER, Optional.empty(), Optional.empty()));
+        this.hdfsContext = new HdfsContext(new EmptyConnectorSession(new ConnectorIdentity(DEFAULT_METASTORE_USER, Optional.empty(), Optional.empty())));
         this.glueClient = createAsyncGlueClient(requireNonNull(glueConfig, "glueConfig is null"), stats.newRequestMetricsCollector());
         this.defaultDir = glueConfig.getDefaultWarehouseDir();
         this.catalogId = glueConfig.getCatalogId().orElse(null);

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystem.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystem.java
@@ -22,6 +22,7 @@ import com.facebook.presto.hive.AbstractTestHiveClient.HiveTransaction;
 import com.facebook.presto.hive.AbstractTestHiveClient.Transaction;
 import com.facebook.presto.hive.authentication.NoHdfsAuthentication;
 import com.facebook.presto.hive.datasink.OutputStreamDataSinkFactory;
+import com.facebook.presto.hive.metastore.EmptyConnectorSession;
 import com.facebook.presto.hive.metastore.CachingHiveMetastore;
 import com.facebook.presto.hive.metastore.Database;
 import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
@@ -119,7 +120,7 @@ import static org.testng.Assert.assertTrue;
 
 public abstract class AbstractTestHiveFileSystem
 {
-    private static final HdfsContext TESTING_CONTEXT = new HdfsContext(new ConnectorIdentity("test", Optional.empty(), Optional.empty()));
+    private static final HdfsContext TESTING_CONTEXT = new HdfsContext(new EmptyConnectorSession(new ConnectorIdentity("test", Optional.empty(), Optional.empty())));
     public static final SplitSchedulingContext SPLIT_SCHEDULING_CONTEXT = new SplitSchedulingContext(UNGROUPED_SCHEDULING, false, WarningCollector.NOOP);
 
     protected String database;

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/filesystem/FileSystemUtil.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/filesystem/FileSystemUtil.java
@@ -13,8 +13,12 @@
  */
 package com.facebook.presto.raptor.filesystem;
 
+import com.facebook.presto.common.function.SqlFunctionProperties;
 import com.facebook.presto.hive.HdfsContext;
+import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.function.SqlFunctionId;
+import com.facebook.presto.spi.function.SqlInvokedFunction;
 import com.facebook.presto.spi.security.ConnectorIdentity;
 import io.airlift.slice.XxHash64;
 import org.apache.hadoop.conf.Configuration;
@@ -23,6 +27,7 @@ import org.apache.hadoop.fs.Path;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 
@@ -30,7 +35,7 @@ import static com.facebook.presto.raptor.RaptorErrorCode.RAPTOR_ERROR;
 
 public final class FileSystemUtil
 {
-    public static final HdfsContext DEFAULT_RAPTOR_CONTEXT = new HdfsContext(new ConnectorIdentity("presto-raptor", Optional.empty(), Optional.empty()));
+    public static final HdfsContext DEFAULT_RAPTOR_CONTEXT = new HdfsContext(new DefaultRaptorConnectorSession(new ConnectorIdentity("presto-raptor", Optional.empty(), Optional.empty())));
 
     private static final Configuration INITIAL_CONFIGURATION;
 
@@ -73,6 +78,83 @@ public final class FileSystemUtil
         }
         catch (IOException e) {
             throw new PrestoException(RAPTOR_ERROR, "Failed to read file: " + file, e);
+        }
+    }
+
+    private static class DefaultRaptorConnectorSession
+            implements ConnectorSession
+    {
+        private ConnectorIdentity connectorIdentity;
+
+        public DefaultRaptorConnectorSession(ConnectorIdentity connectorIdentity)
+        {
+            this.connectorIdentity = connectorIdentity;
+        }
+
+        @Override
+        public String getQueryId()
+        {
+            return "";
+        }
+
+        @Override
+        public Optional<String> getSource()
+        {
+            return Optional.empty();
+        }
+
+        @Override
+        public ConnectorIdentity getIdentity()
+        {
+            return connectorIdentity;
+        }
+
+        @Override
+        public Locale getLocale()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Optional<String> getTraceToken()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Optional<String> getClientInfo()
+        {
+            return Optional.empty();
+        }
+
+        @Override
+        public long getStartTime()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public SqlFunctionProperties getSqlFunctionProperties()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Map<SqlFunctionId, SqlInvokedFunction> getSessionFunctions()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <T> T getProperty(String name, Class<T> type)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Optional<String> getSchema()
+        {
+            throw new UnsupportedOperationException();
         }
     }
 }


### PR DESCRIPTION
This PR modifies the HdfsContext construction to always take a ConnectorSession

```
== NO RELEASE NOTE ==
```
