### PR TITLE
Add OrcFeature class to represent optional flags in OrcReaderOptions

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcFeature.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcFeature.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc;
+
+/**
+ * Defines features that can be enabled in OrcReader or OrcWriter. A feature
+ * can have an optional config value represented by the generic type of the feature.
+ *
+ * @param <T> the type of this feature's config class
+ */
+public final class OrcFeature<T>
+{
+    public static final OrcFeature<Void> ZSTD_JNI_DECOMPRESSION_ENABLED = new OrcFeature<>();
+    public static final OrcFeature<Void> MAP_NULL_KEYS_ENABLED = new OrcFeature<>();
+    public static final OrcFeature<Void> TIMESTAMP_MICRO_PRECISION_ENABLED = new OrcFeature<>();
+
+    private OrcFeature()
+    {
+        // keep this constructor private to emulate enum with generic
+    }
+}

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcFeatures.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcFeatures.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Convenient holder for enabled features and their configs.
+ */
+public class OrcFeatures
+{
+    private final Set<OrcFeature<?>> enabledFeatures;
+    private final Map<OrcFeature<?>, Object> featureConfigs;
+
+    public OrcFeatures()
+    {
+        this.enabledFeatures = ImmutableSet.of();
+        this.featureConfigs = ImmutableMap.of();
+    }
+
+    public OrcFeatures(Set<OrcFeature<?>> enabledFeatures, Map<OrcFeature<?>, Object> featureConfigs)
+    {
+        this.enabledFeatures = ImmutableSet.copyOf(requireNonNull(enabledFeatures, "enabledFeatures is null"));
+        this.featureConfigs = ImmutableMap.copyOf(requireNonNull(featureConfigs, "featureConfigs is null"));
+    }
+
+    public <T> boolean isEnabled(OrcFeature<T> feature)
+    {
+        requireNonNull(feature, "feature is null");
+        return enabledFeatures.contains(feature);
+    }
+
+    public <T> Optional<T> getFeatureConfig(OrcFeature<T> feature)
+    {
+        requireNonNull(feature, "feature is null");
+        return Optional.ofNullable((T) featureConfigs.get(feature));
+    }
+
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    public static class Builder
+    {
+        private final Set<OrcFeature<?>> enabledFeatures = new HashSet<>();
+        private final Map<OrcFeature<?>, Object> featureConfigs = new HashMap<>();
+
+        /**
+         * Enable a feature without adding a config.
+         */
+        public <T> Builder enable(OrcFeature<T> feature)
+        {
+            enabledFeatures.add(feature);
+            return this;
+        }
+
+        /**
+         * Enable a feature without adding a config only if enabled flag is true.
+         */
+        public <T> Builder enable(OrcFeature<T> feature, boolean enabled)
+        {
+            if (enabled) {
+                enable(feature);
+            }
+            return this;
+        }
+
+        /**
+         * Enable feature and add a custom config.
+         */
+        public <T> Builder enable(OrcFeature<T> feature, T config)
+        {
+            enabledFeatures.add(feature);
+            featureConfigs.put(feature, config);
+            return this;
+        }
+
+        /**
+         * Enable feature and add a custom config if enabled flag is true.
+         */
+        public <T> Builder enable(OrcFeature<T> feature, T config, boolean enabled)
+        {
+            if (enabled) {
+                enable(feature, config);
+            }
+            return this;
+        }
+
+        public OrcFeatures build()
+        {
+            return new OrcFeatures(enabledFeatures, featureConfigs);
+        }
+    }
+}

--- a/presto-orc/src/test/java/com/facebook/presto/orc/OrcFeaturesTest.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/OrcFeaturesTest.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc;
+
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Constructor;
+import java.util.Optional;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+
+public class OrcFeaturesTest
+{
+    private OrcFeature<Object> feature1 = createOrcFeature();
+    private OrcFeature<Object> feature2 = createOrcFeature();
+    private OrcFeature<Object> feature3 = createOrcFeature();
+    private Object valueObject1 = new Object();
+    private Object valueObject2 = new Object();
+    private Object valueObject3 = new Object();
+
+    @Test
+    public void testNoArgsConstructor()
+    {
+        OrcFeatures features = new OrcFeatures();
+        assertFalse(features.isEnabled(feature1));
+        Optional<Object> cfg = features.getFeatureConfig(feature1);
+        assertFalse(cfg.isPresent());
+    }
+
+    @Test
+    public void testEnableFeature()
+    {
+        OrcFeatures features = OrcFeatures.builder()
+                .enable(feature1)
+                .enable(feature2, true)
+                .enable(feature3, false)
+                .build();
+        assertTrue(features.isEnabled(feature1));
+        Optional<Object> cfg1 = features.getFeatureConfig(feature1);
+        assertFalse(cfg1.isPresent());
+
+        assertTrue(features.isEnabled(feature2));
+        Optional<Object> cfg2 = features.getFeatureConfig(feature2);
+        assertFalse(cfg2.isPresent());
+
+        Optional<Object> cfg3 = features.getFeatureConfig(feature3);
+        assertFalse(cfg3.isPresent());
+        assertFalse(features.isEnabled(feature3));
+    }
+
+    @Test
+    public void testEnableFeatureWithConfig()
+    {
+        OrcFeatures features = OrcFeatures.builder()
+                .enable(feature1, valueObject1)
+                .enable(feature2, valueObject2, true)
+                .enable(feature3, valueObject3, false)
+                .build();
+
+        assertTrue(features.isEnabled(feature1));
+        Optional<Object> cfg1 = features.getFeatureConfig(feature1);
+        assertTrue(cfg1.isPresent());
+        assertSame(cfg1.get(), valueObject1);
+
+        assertTrue(features.isEnabled(feature2));
+        Optional<Object> cfg2 = features.getFeatureConfig(feature2);
+        assertTrue(cfg2.isPresent());
+        assertSame(cfg2.get(), valueObject2);
+
+        assertFalse(features.isEnabled(feature3));
+        Optional<Object> cfg3 = features.getFeatureConfig(feature3);
+        assertFalse(cfg3.isPresent());
+    }
+
+    private <T> OrcFeature<T> createOrcFeature()
+    {
+        try {
+            Constructor<?> ctor = OrcFeature.class.getDeclaredConstructors()[0];
+            ctor.setAccessible(true);
+            return (OrcFeature<T>) ctor.newInstance();
+        }
+        catch (Exception e) {
+            throw new RuntimeException("Failed to create a new OrcFeature", e);
+        }
+    }
+}


### PR DESCRIPTION
OrcReaderOptions and OrcRecordReaderOptions have constructors with a bunch of boolean fields. Every time we add a new optional features, we need to extend constructors of these classes - which is kind of not the best thing to do, especially when we deprecate old features. This change introduces a new class OrcFeature which represents a feature and the type of optional feature config (in the original Stripe metadata PR I only used a boolean version of this change). An alternative way is to use Hive's Configuration class, but that will make a dependency on Hive a hard dependency, and may also require adding a bunch of default settings.

If this change goes through, I plan to use it to enable stripe metadata cache in OrcReader and OrcWriter. A new flag would signify if the feature is enabled/disabled, and its config value may represent the orc file tail read size + max size for the cache to hold in memory; for the writer it may represent the max size of the stripe metadata cache.

Test plan:
* add unit tests covering new classes

```
== NO RELEASE NOTE ==
```