### PR TITLE
Fix cumulativeUserMemory initial calculation & use double for cumulativeUserMemory consistently

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/BasicStageExecutionStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/BasicStageExecutionStats.java
@@ -42,7 +42,7 @@ public class BasicStageExecutionStats
             new DataSize(0, BYTE),
             0,
 
-            0,
+            0.0,
             new DataSize(0, BYTE),
             new DataSize(0, BYTE),
 
@@ -63,7 +63,7 @@ public class BasicStageExecutionStats
     private final int completedDrivers;
     private final DataSize rawInputDataSize;
     private final long rawInputPositions;
-    private final long cumulativeUserMemory;
+    private final double cumulativeUserMemory;
     private final DataSize userMemoryReservation;
     private final DataSize totalMemoryReservation;
     private final Duration totalCpuTime;
@@ -84,7 +84,7 @@ public class BasicStageExecutionStats
             DataSize rawInputDataSize,
             long rawInputPositions,
 
-            long cumulativeUserMemory,
+            double cumulativeUserMemory,
             DataSize userMemoryReservation,
             DataSize totalMemoryReservation,
 
@@ -151,7 +151,7 @@ public class BasicStageExecutionStats
         return rawInputPositions;
     }
 
-    public long getCumulativeUserMemory()
+    public double getCumulativeUserMemory()
     {
         return cumulativeUserMemory;
     }
@@ -203,7 +203,7 @@ public class BasicStageExecutionStats
         int runningDrivers = 0;
         int completedDrivers = 0;
 
-        long cumulativeUserMemory = 0;
+        double cumulativeUserMemory = 0;
         long userMemoryReservation = 0;
         long totalMemoryReservation = 0;
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryStats.java
@@ -269,7 +269,7 @@ public class QueryStats
         int blockedDrivers = 0;
         int completedDrivers = 0;
 
-        long cumulativeUserMemory = 0;
+        double cumulativeUserMemory = 0;
         long userMemoryReservation = 0;
         long totalMemoryReservation = 0;
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/StageExecutionInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/StageExecutionInfo.java
@@ -71,7 +71,7 @@ public class StageExecutionInfo
         int blockedDrivers = 0;
         int completedDrivers = 0;
 
-        long cumulativeUserMemory = 0;
+        double cumulativeUserMemory = 0;
         long userMemoryReservation = 0;
         long totalMemoryReservation = 0;
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/StageExecutionStateMachine.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/StageExecutionStateMachine.java
@@ -237,7 +237,7 @@ public class StageExecutionStateMachine
         int runningDrivers = 0;
         int completedDrivers = 0;
 
-        long cumulativeUserMemory = 0;
+        double cumulativeUserMemory = 0;
         long userMemoryReservation = 0;
         long totalMemoryReservation = 0;
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/StageExecutionStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/StageExecutionStats.java
@@ -422,7 +422,7 @@ public class StageExecutionStats
                 completedDrivers,
                 rawInputDataSize,
                 rawInputPositions,
-                (long) cumulativeUserMemory,
+                cumulativeUserMemory,
                 userMemoryReservation,
                 totalMemoryReservation,
                 totalCpuTime,

--- a/presto-main/src/main/java/com/facebook/presto/operator/TaskContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TaskContext.java
@@ -503,6 +503,9 @@ public class TaskContext
         updatePeakMemory();
 
         synchronized (cumulativeMemoryLock) {
+            if (lastTaskStatCallNanos == 0) {
+                lastTaskStatCallNanos = startNanos;
+            }
             double sinceLastPeriodMillis = (System.nanoTime() - lastTaskStatCallNanos) / 1_000_000.0;
             long averageMemoryForLastPeriod = (userMemory + lastUserMemoryReservation) / 2;
             cumulativeUserMemory.addAndGet(averageMemoryForLastPeriod * sinceLastPeriodMillis);

--- a/presto-main/src/test/java/com/facebook/presto/memory/TestMemoryTracking.java
+++ b/presto-main/src/test/java/com/facebook/presto/memory/TestMemoryTracking.java
@@ -374,6 +374,22 @@ public class TestMemoryTracking
         assertOperatorMemoryAllocations(operatorContext.getOperatorMemoryContext(), 0, 0, 0);
     }
 
+    @Test
+    public void testCumulativeUserMemoryEstimation()
+    {
+        LocalMemoryContext userMemory = operatorContext.localUserMemoryContext();
+        long userMemoryBytes = 100_000_000;
+        userMemory.setBytes(userMemoryBytes);
+        long startTime = System.nanoTime();
+        double cumulativeUserMemory = taskContext.getTaskStats().getCumulativeUserMemory();
+        long endTime = System.nanoTime();
+
+        double elapsedTimeInMillis = (endTime - startTime) / 1_000_000.0;
+        long averageMemoryForLastPeriod = userMemoryBytes / 2;
+
+        assertTrue(cumulativeUserMemory < elapsedTimeInMillis * averageMemoryForLastPeriod);
+    }
+
     private void assertStats(
             OperatorStats operatorStats,
             DriverStats driverStats,


### PR DESCRIPTION
Currently there is a chance that `Cumulative User Memory` is much larger than `Peak User Memory` * `Execution Time`, refer to the following screenshot of one sample query:

![image](https://user-images.githubusercontent.com/2467199/116615728-8f9d4c00-a8f0-11eb-849d-5475b28bd96a.png)

Extra debug logging in `TaskContext.java` shows, 

```
2021-04-29T18:37:01.352Z    INFO    Task-20210429_183659_00001_stagingva.9.0.16-288 com.facebook.presto.operator.TaskContext    Cumulate user memory: sinceLastPeriodMillis = (34262137327073190 - 0) / 
1_000_000 = 34262137327.073193 ,averageMemoryForLastPeriod= (3184992 + 0) / 2 = 1592496
```

The bug is that `sinceLastPeriodMillis` can equal to current system nano time if the `lastTaskStatCallNanos` is not initialized and defaults to 0.

The fix is basically initialize the `lastTaskStatCallNanos` to task start time.


Signed-off-by: frankobe <mua08p@gmail.com>

Test plan - (Please fill in how you tested your changes)

Unit Test

```
== RELEASE NOTES ==

General Changes
* Fix amplified `Cumulative User Memory` metrics calculation
