### PR TITLE
Include queuing time while computing query completion deadline

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkInjectorFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkInjectorFactory.java
@@ -50,6 +50,7 @@ import java.util.Optional;
 import static com.facebook.presto.server.PrestoSystemRequirements.verifySystemTimeIsReasonable;
 import static com.facebook.presto.spark.classloader_interface.SparkProcessType.DRIVER;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.inject.multibindings.Multibinder.newSetBinder;
 import static java.util.Objects.requireNonNull;
 
 public class PrestoSparkInjectorFactory
@@ -145,6 +146,9 @@ public class PrestoSparkInjectorFactory
 
                 binder.bind(TestingTempStorageManager.class).in(Scopes.SINGLETON);
                 binder.bind(TempStorageManager.class).to(TestingTempStorageManager.class).in(Scopes.SINGLETON);
+
+                newSetBinder(binder, PrestoSparkServiceWaitTimeMetrics.class).addBinding()
+                        .to(PrestoSparkTestingServiceWaitTimeMetrics.class).in(Scopes.SINGLETON);
             });
         }
         else {

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
@@ -443,6 +443,7 @@ public class PrestoSparkModule
         binder.bind(PrestoSparkQueryExecutionFactory.class).in(Scopes.SINGLETON);
         binder.bind(PrestoSparkService.class).in(Scopes.SINGLETON);
         binder.bind(PrestoSparkBroadcastTableCacheManager.class).in(Scopes.SINGLETON);
+        newSetBinder(binder, PrestoSparkServiceWaitTimeMetrics.class);
 
         // extra credentials and authenticator for Presto-on-Spark
         newSetBinder(binder, PrestoSparkCredentialsProvider.class);

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
@@ -236,6 +236,7 @@ public class PrestoSparkQueryExecutionFactory
     private final TempStorageManager tempStorageManager;
     private final String storageBasedBroadcastJoinStorage;
     private final NodeMemoryConfig nodeMemoryConfig;
+    private final Set<PrestoSparkServiceWaitTimeMetrics> waitTimeMetrics;
 
     @Inject
     public PrestoSparkQueryExecutionFactory(
@@ -265,7 +266,8 @@ public class PrestoSparkQueryExecutionFactory
             Set<PrestoSparkAuthenticatorProvider> authenticatorProviders,
             TempStorageManager tempStorageManager,
             PrestoSparkConfig prestoSparkConfig,
-            NodeMemoryConfig nodeMemoryConfig)
+            NodeMemoryConfig nodeMemoryConfig,
+            Set<PrestoSparkServiceWaitTimeMetrics> waitTimeMetrics)
     {
         this.queryIdGenerator = requireNonNull(queryIdGenerator, "queryIdGenerator is null");
         this.sessionSupplier = requireNonNull(sessionSupplier, "sessionSupplier is null");
@@ -294,6 +296,7 @@ public class PrestoSparkQueryExecutionFactory
         this.tempStorageManager = requireNonNull(tempStorageManager, "tempStorageManager is null");
         this.storageBasedBroadcastJoinStorage = requireNonNull(prestoSparkConfig, "prestoSparkConfig is null").getStorageBasedBroadcastJoinStorage();
         this.nodeMemoryConfig = requireNonNull(nodeMemoryConfig, "nodeMemoryConfig is null");
+        this.waitTimeMetrics = ImmutableSet.copyOf(requireNonNull(waitTimeMetrics, "waitTimeMetrics is null"));
     }
 
     @Override
@@ -438,7 +441,8 @@ public class PrestoSparkQueryExecutionFactory
                     queryStatusInfoOutputLocation,
                     queryDataOutputLocation,
                     tempStorage,
-                    nodeMemoryConfig);
+                    nodeMemoryConfig,
+                    waitTimeMetrics);
         }
         catch (Throwable executionFailure) {
             queryStateTimer.beginFinishing();
@@ -839,6 +843,7 @@ public class PrestoSparkQueryExecutionFactory
         private final long queryCompletionDeadline;
         private final TempStorage tempStorage;
         private final NodeMemoryConfig nodeMemoryConfig;
+        private final Set<PrestoSparkServiceWaitTimeMetrics> waitTimeMetrics;
 
         private PrestoSparkQueryExecution(
                 JavaSparkContext sparkContext,
@@ -869,7 +874,8 @@ public class PrestoSparkQueryExecutionFactory
                 Optional<String> queryStatusInfoOutputLocation,
                 Optional<String> queryDataOutputLocation,
                 TempStorage tempStorage,
-                NodeMemoryConfig nodeMemoryConfig)
+                NodeMemoryConfig nodeMemoryConfig,
+                Set<PrestoSparkServiceWaitTimeMetrics> waitTimeMetrics)
         {
             this.sparkContext = requireNonNull(sparkContext, "sparkContext is null");
             this.session = requireNonNull(session, "session is null");
@@ -901,6 +907,7 @@ public class PrestoSparkQueryExecutionFactory
             this.queryDataOutputLocation = requireNonNull(queryDataOutputLocation, "queryDataOutputLocation is null");
             this.tempStorage = requireNonNull(tempStorage, "tempStorage is null");
             this.nodeMemoryConfig = requireNonNull(nodeMemoryConfig, "nodeMemoryConfig is null");
+            this.waitTimeMetrics = requireNonNull(waitTimeMetrics, "waitTimeMetrics is null");
         }
 
         @Override
@@ -1048,7 +1055,7 @@ public class PrestoSparkQueryExecutionFactory
                 Map<String, JavaFutureAction<List<Tuple2<MutablePartitionId, PrestoSparkSerializedPage>>>> inputFutures = inputRdds.entrySet().stream()
                         .collect(toImmutableMap(entry -> entry.getKey().toString(), entry -> entry.getValue().getRdd().collectAsync()));
 
-                waitForActionsCompletionWithTimeout(inputFutures.values(), computeNextTimeout(queryCompletionDeadline), MILLISECONDS);
+                waitForActionsCompletionWithTimeout(inputFutures.values(), computeNextTimeout(queryCompletionDeadline), MILLISECONDS, waitTimeMetrics);
 
                 Map<String, List<PrestoSparkSerializedPage>> inputs = inputFutures.entrySet().stream()
                         .collect(toImmutableMap(
@@ -1068,7 +1075,7 @@ public class PrestoSparkQueryExecutionFactory
             }
 
             RddAndMore<PrestoSparkSerializedPage> rootRdd = createRdd(root, PrestoSparkSerializedPage.class);
-            return rootRdd.collectAndDestroyDependenciesWithTimeout(computeNextTimeout(queryCompletionDeadline), MILLISECONDS);
+            return rootRdd.collectAndDestroyDependenciesWithTimeout(computeNextTimeout(queryCompletionDeadline), MILLISECONDS, waitTimeMetrics);
         }
 
         private <T extends PrestoSparkTaskOutput> RddAndMore<T> createRdd(SubPlan subPlan, Class<T> outputType)
@@ -1100,14 +1107,16 @@ public class PrestoSparkQueryExecutionFactory
                                 maxBroadcastMemory,
                                 queryCompletionDeadline,
                                 tempStorage,
-                                tempDataOperationContext);
+                                tempDataOperationContext,
+                                waitTimeMetrics);
                     }
                     else {
                         RddAndMore<PrestoSparkSerializedPage> childRdd = createRdd(child, PrestoSparkSerializedPage.class);
                         broadcastDependency = new PrestoSparkMemoryBasedBroadcastDependency(
                                 childRdd,
                                 maxBroadcastMemory,
-                                queryCompletionDeadline);
+                                queryCompletionDeadline,
+                                waitTimeMetrics);
                     }
 
                     broadcastInputs.put(childFragment.getId(), broadcastDependency.executeBroadcast(sparkContext));
@@ -1278,7 +1287,7 @@ public class PrestoSparkQueryExecutionFactory
         }
     }
 
-    private static <T> void waitForActionsCompletionWithTimeout(Collection<JavaFutureAction<T>> actions, long timeout, TimeUnit timeUnit)
+    private static <T> void waitForActionsCompletionWithTimeout(Collection<JavaFutureAction<T>> actions, long timeout, TimeUnit timeUnit, Set<PrestoSparkServiceWaitTimeMetrics> waitTimeMetrics)
             throws SparkException, TimeoutException
     {
         long deadline = System.currentTimeMillis() + timeUnit.toMillis(timeout);
@@ -1289,7 +1298,7 @@ public class PrestoSparkQueryExecutionFactory
                 if (nextTimeoutInMillis <= 0) {
                     throw new TimeoutException();
                 }
-                getActionResultWithTimeout(action, nextTimeoutInMillis, MILLISECONDS);
+                getActionResultWithTimeout(action, nextTimeoutInMillis, MILLISECONDS, waitTimeMetrics);
             }
         }
         finally {

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkServiceWaitTimeMetrics.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkServiceWaitTimeMetrics.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark;
+
+import io.airlift.units.Duration;
+
+public interface PrestoSparkServiceWaitTimeMetrics
+{
+    Duration getWaitTime();
+}

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkStorageBasedBroadcastDependency.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkStorageBasedBroadcastDependency.java
@@ -27,6 +27,7 @@ import scala.Tuple2;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeoutException;
 
 import static com.facebook.presto.ExceededMemoryLimitException.exceededLocalBroadcastMemoryLimit;
@@ -48,23 +49,25 @@ public class PrestoSparkStorageBasedBroadcastDependency
     private final long queryCompletionDeadline;
     private final TempStorage tempStorage;
     private final TempDataOperationContext tempDataOperationContext;
+    private final Set<PrestoSparkServiceWaitTimeMetrics> waitTimeMetrics;
 
     private Broadcast<List<PrestoSparkStorageHandle>> broadcastVariable;
 
-    public PrestoSparkStorageBasedBroadcastDependency(RddAndMore<PrestoSparkStorageHandle> broadcastDependency, DataSize maxBroadcastSize, long queryCompletionDeadline, TempStorage tempStorage, TempDataOperationContext tempDataOperationContext)
+    public PrestoSparkStorageBasedBroadcastDependency(RddAndMore<PrestoSparkStorageHandle> broadcastDependency, DataSize maxBroadcastSize, long queryCompletionDeadline, TempStorage tempStorage, TempDataOperationContext tempDataOperationContext, Set<PrestoSparkServiceWaitTimeMetrics> waitTimeMetrics)
     {
         this.broadcastDependency = requireNonNull(broadcastDependency, "broadcastDependency cannot be null");
         this.maxBroadcastSize = requireNonNull(maxBroadcastSize, "maxBroadcastSize cannot be null");
         this.queryCompletionDeadline = queryCompletionDeadline;
         this.tempStorage = requireNonNull(tempStorage, "tempStorage cannot be null");
         this.tempDataOperationContext = requireNonNull(tempDataOperationContext, "tempDataOperationContext cannot be null");
+        this.waitTimeMetrics = requireNonNull(waitTimeMetrics, "waitTimeMetrics cannot be null");
     }
 
     @Override
     public Broadcast<List<PrestoSparkStorageHandle>> executeBroadcast(JavaSparkContext sparkContext)
             throws SparkException, TimeoutException
     {
-        List<PrestoSparkStorageHandle> broadcastValue = broadcastDependency.collectAndDestroyDependenciesWithTimeout(computeNextTimeout(queryCompletionDeadline), MILLISECONDS).stream()
+        List<PrestoSparkStorageHandle> broadcastValue = broadcastDependency.collectAndDestroyDependenciesWithTimeout(computeNextTimeout(queryCompletionDeadline), MILLISECONDS, waitTimeMetrics).stream()
                 .map(Tuple2::_2)
                 .collect(toList());
 

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkTestingServiceWaitTimeMetrics.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkTestingServiceWaitTimeMetrics.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark;
+
+import io.airlift.units.Duration;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+public class PrestoSparkTestingServiceWaitTimeMetrics
+        implements PrestoSparkServiceWaitTimeMetrics
+{
+    private Duration waitTimeDuration = new Duration(0, MILLISECONDS);
+
+    public void setWaitTime(Duration waitTime)
+    {
+        waitTimeDuration = waitTime;
+    }
+
+    @Override
+    public Duration getWaitTime()
+    {
+        return waitTimeDuration;
+    }
+}

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/RddAndMore.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/RddAndMore.java
@@ -21,6 +21,7 @@ import org.apache.spark.api.java.JavaPairRDD;
 import scala.Tuple2;
 
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -43,12 +44,12 @@ public class RddAndMore<T extends PrestoSparkTaskOutput>
         this.broadcastDependencies = ImmutableList.copyOf(requireNonNull(broadcastDependencies, "broadcastDependencies is null"));
     }
 
-    public List<Tuple2<MutablePartitionId, T>> collectAndDestroyDependenciesWithTimeout(long timeout, TimeUnit timeUnit)
+    public List<Tuple2<MutablePartitionId, T>> collectAndDestroyDependenciesWithTimeout(long timeout, TimeUnit timeUnit, Set<PrestoSparkServiceWaitTimeMetrics> waitTimeMetrics)
             throws SparkException, TimeoutException
     {
         checkState(!collected, "already collected");
         collected = true;
-        List<Tuple2<MutablePartitionId, T>> result = getActionResultWithTimeout(rdd.collectAsync(), timeout, timeUnit);
+        List<Tuple2<MutablePartitionId, T>> result = getActionResultWithTimeout(rdd.collectAsync(), timeout, timeUnit, waitTimeMetrics);
         broadcastDependencies.forEach(PrestoSparkBroadcastDependency::destroy);
         return result;
     }

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/PrestoSparkQueryRunner.java
@@ -62,6 +62,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Injector;
+import com.google.inject.Key;
 import io.airlift.tpch.TpchTable;
 import org.apache.spark.SparkConf;
 import org.apache.spark.SparkContext;
@@ -73,6 +74,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -126,6 +128,7 @@ public class PrestoSparkQueryRunner
     private final StatsCalculator statsCalculator;
     private final PluginManager pluginManager;
     private final ConnectorManager connectorManager;
+    private final Set<PrestoSparkServiceWaitTimeMetrics> waitTimeMetrics;
 
     private final LifeCycleManager lifeCycleManager;
 
@@ -236,6 +239,7 @@ public class PrestoSparkQueryRunner
         statsCalculator = injector.getInstance(StatsCalculator.class);
         pluginManager = injector.getInstance(PluginManager.class);
         connectorManager = injector.getInstance(ConnectorManager.class);
+        waitTimeMetrics = injector.getInstance(new Key<Set<PrestoSparkServiceWaitTimeMetrics>>() {});
 
         lifeCycleManager = injector.getInstance(LifeCycleManager.class);
 
@@ -471,6 +475,11 @@ public class PrestoSparkQueryRunner
     public FileHiveMetastore getMetastore()
     {
         return metastore;
+    }
+
+    public Set<PrestoSparkServiceWaitTimeMetrics> getWaitTimeMetrics()
+    {
+        return waitTimeMetrics;
     }
 
     @Override


### PR DESCRIPTION
Currently, Presto on Spark has no way to track queuing time
and this would cause queries to timeout while waiting for resources.
We should add support for tracking service queuing time and use it
for query deadline time calculations.

```
== NO RELEASE NOTE ==
```
