### PR TITLE
Support Dwrf Sequence Ids in Writer

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
@@ -76,6 +76,7 @@ import static com.facebook.presto.orc.WriterStats.FlushReason.DICTIONARY_FULL;
 import static com.facebook.presto.orc.WriterStats.FlushReason.MAX_BYTES;
 import static com.facebook.presto.orc.WriterStats.FlushReason.MAX_ROWS;
 import static com.facebook.presto.orc.metadata.ColumnEncoding.ColumnEncodingKind.DIRECT;
+import static com.facebook.presto.orc.metadata.ColumnEncoding.DEFAULT_SEQUENCE_ID;
 import static com.facebook.presto.orc.metadata.DwrfMetadataWriter.toFileStatistics;
 import static com.facebook.presto.orc.metadata.DwrfMetadataWriter.toStripeEncryptionGroup;
 import static com.facebook.presto.orc.metadata.PostScript.MAGIC;
@@ -240,6 +241,7 @@ public class OrcWriter
             Type fieldType = types.get(fieldId);
             ColumnWriter columnWriter = createColumnWriter(
                     fieldColumnIndex,
+                    DEFAULT_SEQUENCE_ID,
                     orcTypes,
                     fieldType,
                     columnWriterOptions,

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfMetadataReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfMetadataReader.java
@@ -299,10 +299,10 @@ public class DwrfMetadataReader
     {
         return new Stream(
                 stream.getColumn(),
+                stream.getSequence(),
                 toStreamKind(stream.getKind()),
                 toIntExact(stream.getLength()),
                 stream.getUseVInts(),
-                stream.getSequence(),
                 stream.hasOffset() ? Optional.of(stream.getOffset()) : Optional.empty());
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfMetadataWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfMetadataWriter.java
@@ -252,6 +252,7 @@ public class DwrfMetadataWriter
     {
         DwrfProto.Stream.Builder streamBuilder = DwrfProto.Stream.newBuilder()
                 .setColumn(stream.getColumn())
+                .setSequence(stream.getSequence())
                 .setKind(toStreamKind(stream.getStreamKind()))
                 .setLength(stream.getLength())
                 .setUseVInts(stream.isUseVInts());

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcMetadataWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcMetadataWriter.java
@@ -35,6 +35,7 @@ import java.io.OutputStream;
 import java.util.List;
 import java.util.Map.Entry;
 
+import static com.facebook.presto.orc.metadata.ColumnEncoding.DEFAULT_SEQUENCE_ID;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.Math.toIntExact;
 import static java.util.stream.Collectors.toList;
@@ -283,6 +284,10 @@ public class OrcMetadataWriter
 
     private static OrcProto.Stream toStream(Stream stream)
     {
+        checkArgument(
+                stream.getSequence() == DEFAULT_SEQUENCE_ID,
+                "Writing streams with non-zero sequence IDs is not supported in ORC : {} ",
+                stream);
         return OrcProto.Stream.newBuilder()
                 .setColumn(stream.getColumn())
                 .setKind(toStreamKind(stream.getStreamKind()))
@@ -315,7 +320,8 @@ public class OrcMetadataWriter
     {
         checkArgument(
                 !columnEncodings.getAdditionalSequenceEncodings().isPresent(),
-                "Writing columns with non-zero sequence IDs is not supported in ORC: " + columnEncodings);
+                "Writing columns with non-zero sequence IDs is not supported in ORC: {}",
+                columnEncodings);
 
         return OrcProto.ColumnEncoding.newBuilder()
                 .setKind(toColumnEncoding(columnEncodings.getColumnEncodingKind()))

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/Stream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/Stream.java
@@ -15,6 +15,7 @@ package com.facebook.presto.orc.metadata;
 
 import java.util.Optional;
 
+import static com.facebook.presto.orc.metadata.ColumnEncoding.DEFAULT_SEQUENCE_ID;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
@@ -47,10 +48,15 @@ public class Stream
 
     public Stream(int column, StreamKind streamKind, int length, boolean useVInts)
     {
-        this(column, streamKind, length, useVInts, ColumnEncoding.DEFAULT_SEQUENCE_ID, Optional.empty());
+        this(column, DEFAULT_SEQUENCE_ID, streamKind, length, useVInts, Optional.empty());
     }
 
-    public Stream(int column, StreamKind streamKind, int length, boolean useVInts, int sequence, Optional<Long> offset)
+    public Stream(int column, int sequence, StreamKind streamKind, int length, boolean useVInts)
+    {
+        this(column, sequence, streamKind, length, useVInts, Optional.empty());
+    }
+
+    public Stream(int column, int sequence, StreamKind streamKind, int length, boolean useVInts, Optional<Long> offset)
     {
         this.column = column;
         this.streamKind = requireNonNull(streamKind, "streamKind is null");
@@ -107,10 +113,10 @@ public class Stream
     {
         return new Stream(
                 this.column,
+                this.sequence,
                 this.streamKind,
                 this.length,
                 this.useVInts,
-                this.sequence,
                 Optional.of(offset));
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/BooleanOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/BooleanOutputStream.java
@@ -157,10 +157,10 @@ public class BooleanOutputStream
     }
 
     @Override
-    public StreamDataOutput getStreamDataOutput(int column)
+    public StreamDataOutput getStreamDataOutput(int column, int dwrfSequence)
     {
         checkState(closed);
-        return byteOutputStream.getStreamDataOutput(column);
+        return byteOutputStream.getStreamDataOutput(column, dwrfSequence);
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/ByteArrayOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/ByteArrayOutputStream.java
@@ -89,9 +89,9 @@ public class ByteArrayOutputStream
     }
 
     @Override
-    public StreamDataOutput getStreamDataOutput(int column)
+    public StreamDataOutput getStreamDataOutput(int column, int dwrfSequence)
     {
-        return new StreamDataOutput(buffer::writeDataTo, new Stream(column, streamKind, toIntExact(buffer.getOutputDataSize()), false));
+        return new StreamDataOutput(buffer::writeDataTo, new Stream(column, dwrfSequence, streamKind, toIntExact(buffer.getOutputDataSize()), false));
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/ByteOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/ByteOutputStream.java
@@ -149,9 +149,9 @@ public class ByteOutputStream
     }
 
     @Override
-    public StreamDataOutput getStreamDataOutput(int column)
+    public StreamDataOutput getStreamDataOutput(int column, int dwrfSequence)
     {
-        return new StreamDataOutput(buffer::writeDataTo, new Stream(column, DATA, toIntExact(buffer.getOutputDataSize()), false));
+        return new StreamDataOutput(buffer::writeDataTo, new Stream(column, dwrfSequence, DATA, toIntExact(buffer.getOutputDataSize()), false));
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/DecimalOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/DecimalOutputStream.java
@@ -110,9 +110,9 @@ public class DecimalOutputStream
     }
 
     @Override
-    public StreamDataOutput getStreamDataOutput(int column)
+    public StreamDataOutput getStreamDataOutput(int column, int dwrfSequence)
     {
-        return new StreamDataOutput(buffer::writeDataTo, new Stream(column, DATA, toIntExact(buffer.getOutputDataSize()), true));
+        return new StreamDataOutput(buffer::writeDataTo, new Stream(column, dwrfSequence, DATA, toIntExact(buffer.getOutputDataSize()), true));
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/DoubleOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/DoubleOutputStream.java
@@ -71,9 +71,9 @@ public class DoubleOutputStream
     }
 
     @Override
-    public StreamDataOutput getStreamDataOutput(int column)
+    public StreamDataOutput getStreamDataOutput(int column, int dwrfSequence)
     {
-        return new StreamDataOutput(buffer::writeDataTo, new Stream(column, DATA, toIntExact(buffer.getOutputDataSize()), false));
+        return new StreamDataOutput(buffer::writeDataTo, new Stream(column, dwrfSequence, DATA, toIntExact(buffer.getOutputDataSize()), false));
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/FloatOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/FloatOutputStream.java
@@ -71,9 +71,9 @@ public class FloatOutputStream
     }
 
     @Override
-    public StreamDataOutput getStreamDataOutput(int column)
+    public StreamDataOutput getStreamDataOutput(int column, int dwrfSequence)
     {
-        return new StreamDataOutput(buffer::writeDataTo, new Stream(column, DATA, toIntExact(buffer.getOutputDataSize()), false));
+        return new StreamDataOutput(buffer::writeDataTo, new Stream(column, dwrfSequence, DATA, toIntExact(buffer.getOutputDataSize()), false));
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamDwrf.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamDwrf.java
@@ -80,9 +80,9 @@ public class LongOutputStreamDwrf
     }
 
     @Override
-    public StreamDataOutput getStreamDataOutput(int column)
+    public StreamDataOutput getStreamDataOutput(int column, int dwrfSequence)
     {
-        return new StreamDataOutput(buffer::writeDataTo, new Stream(column, streamKind, toIntExact(buffer.getOutputDataSize()), true));
+        return new StreamDataOutput(buffer::writeDataTo, new Stream(column, dwrfSequence, streamKind, toIntExact(buffer.getOutputDataSize()), true));
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamV1.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamV1.java
@@ -190,9 +190,9 @@ public class LongOutputStreamV1
     }
 
     @Override
-    public StreamDataOutput getStreamDataOutput(int column)
+    public StreamDataOutput getStreamDataOutput(int column, int dwrfSequence)
     {
-        return new StreamDataOutput(buffer::writeDataTo, new Stream(column, streamKind, toIntExact(buffer.getOutputDataSize()), true));
+        return new StreamDataOutput(buffer::writeDataTo, new Stream(column, dwrfSequence, streamKind, toIntExact(buffer.getOutputDataSize()), true));
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamV2.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamV2.java
@@ -748,9 +748,9 @@ public class LongOutputStreamV2
     }
 
     @Override
-    public StreamDataOutput getStreamDataOutput(int column)
+    public StreamDataOutput getStreamDataOutput(int column, int dwrfSequence)
     {
-        return new StreamDataOutput(buffer::writeDataTo, new Stream(column, streamKind, toIntExact(buffer.getOutputDataSize()), true));
+        return new StreamDataOutput(buffer::writeDataTo, new Stream(column, dwrfSequence, streamKind, toIntExact(buffer.getOutputDataSize()), true));
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/PresentOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/PresentOutputStream.java
@@ -102,15 +102,15 @@ public class PresentOutputStream
         return Optional.of(booleanOutputStream.getCheckpoints());
     }
 
-    public Optional<StreamDataOutput> getStreamDataOutput(int column)
+    public Optional<StreamDataOutput> getStreamDataOutput(int column, int dwrfSequence)
     {
         checkArgument(closed);
         if (booleanOutputStream == null) {
             return Optional.empty();
         }
-        StreamDataOutput streamDataOutput = booleanOutputStream.getStreamDataOutput(column);
+        StreamDataOutput streamDataOutput = booleanOutputStream.getStreamDataOutput(column, dwrfSequence);
         // rewrite the DATA stream created by the boolean output stream to a PRESENT stream
-        Stream stream = new Stream(column, PRESENT, toIntExact(streamDataOutput.size()), streamDataOutput.getStream().isUseVInts());
+        Stream stream = new Stream(column, dwrfSequence, PRESENT, toIntExact(streamDataOutput.size()), streamDataOutput.getStream().isUseVInts());
         return Optional.of(new StreamDataOutput(
                 sliceOutput -> {
                     streamDataOutput.writeData(sliceOutput);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/ValueOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/ValueOutputStream.java
@@ -25,7 +25,7 @@ public interface ValueOutputStream<C extends StreamCheckpoint>
 
     List<C> getCheckpoints();
 
-    StreamDataOutput getStreamDataOutput(int column);
+    StreamDataOutput getStreamDataOutput(int column, int dwrfSequence);
 
     /**
      * This method returns the size of the flushed data plus any unflushed data.

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/BooleanColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/BooleanColumnWriter.java
@@ -53,6 +53,7 @@ public class BooleanColumnWriter
     private static final ColumnEncoding COLUMN_ENCODING = new ColumnEncoding(DIRECT, 0);
 
     private final int column;
+    private final int dwrfSequence;
     private final Type type;
     private final boolean compressed;
     private final BooleanOutputStream dataStream;
@@ -68,16 +69,19 @@ public class BooleanColumnWriter
 
     public BooleanColumnWriter(
             int column,
+            int dwrfSequence,
             Type type,
             ColumnWriterOptions columnWriterOptions,
             Optional<DwrfDataEncryptor> dwrfEncryptor,
             MetadataWriter metadataWriter)
     {
         checkArgument(column >= 0, "column is negative");
+        checkArgument(dwrfSequence >= 0, "sequence is negative");
         requireNonNull(columnWriterOptions, "columnWriterOptions is null");
         requireNonNull(dwrfEncryptor, "dwrfEncryptor is null");
         requireNonNull(metadataWriter, "metadataWriter is null");
         this.column = column;
+        this.dwrfSequence = dwrfSequence;
         this.type = requireNonNull(type, "type is null");
         this.compressed = columnWriterOptions.getCompressionKind() != NONE;
         this.dataStream = new BooleanOutputStream(columnWriterOptions, dwrfEncryptor);
@@ -165,7 +169,7 @@ public class BooleanColumnWriter
         }
 
         Slice slice = metadataWriter.writeRowIndexes(rowGroupIndexes.build());
-        Stream stream = new Stream(column, StreamKind.ROW_INDEX, slice.length(), false);
+        Stream stream = new Stream(column, dwrfSequence, StreamKind.ROW_INDEX, slice.length(), false);
         return ImmutableList.of(new StreamDataOutput(slice, stream));
     }
 
@@ -186,8 +190,8 @@ public class BooleanColumnWriter
         checkState(closed);
 
         ImmutableList.Builder<StreamDataOutput> outputDataStreams = ImmutableList.builder();
-        presentStream.getStreamDataOutput(column).ifPresent(outputDataStreams::add);
-        outputDataStreams.add(dataStream.getStreamDataOutput(column));
+        presentStream.getStreamDataOutput(column, dwrfSequence).ifPresent(outputDataStreams::add);
+        outputDataStreams.add(dataStream.getStreamDataOutput(column, dwrfSequence));
         return outputDataStreams.build();
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/DoubleColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/DoubleColumnWriter.java
@@ -54,6 +54,7 @@ public class DoubleColumnWriter
     private static final ColumnEncoding COLUMN_ENCODING = new ColumnEncoding(DIRECT, 0);
 
     private final int column;
+    private final int dwrfSequence;
     private final Type type;
     private final boolean compressed;
     private final DoubleOutputStream dataStream;
@@ -67,13 +68,15 @@ public class DoubleColumnWriter
 
     private boolean closed;
 
-    public DoubleColumnWriter(int column, Type type, ColumnWriterOptions columnWriterOptions, Optional<DwrfDataEncryptor> dwrfEncryptor, MetadataWriter metadataWriter)
+    public DoubleColumnWriter(int column, int dwrfSequence, Type type, ColumnWriterOptions columnWriterOptions, Optional<DwrfDataEncryptor> dwrfEncryptor, MetadataWriter metadataWriter)
     {
         checkArgument(column >= 0, "column is negative");
+        checkArgument(dwrfSequence >= 0, "sequence is negative");
         requireNonNull(columnWriterOptions, "columnWriterOptions is null");
         requireNonNull(dwrfEncryptor, "dwrfEncryptor is null");
         requireNonNull(metadataWriter, "metadataWriter is null");
         this.column = column;
+        this.dwrfSequence = dwrfSequence;
         this.type = requireNonNull(type, "type is null");
         this.compressed = columnWriterOptions.getCompressionKind() != NONE;
         this.dataStream = new DoubleOutputStream(columnWriterOptions, dwrfEncryptor);
@@ -161,7 +164,7 @@ public class DoubleColumnWriter
         }
 
         Slice slice = metadataWriter.writeRowIndexes(rowGroupIndexes.build());
-        Stream stream = new Stream(column, StreamKind.ROW_INDEX, slice.length(), false);
+        Stream stream = new Stream(column, dwrfSequence, StreamKind.ROW_INDEX, slice.length(), false);
         return ImmutableList.of(new StreamDataOutput(slice, stream));
     }
 
@@ -182,8 +185,8 @@ public class DoubleColumnWriter
         checkState(closed);
 
         ImmutableList.Builder<StreamDataOutput> outputDataStreams = ImmutableList.builder();
-        presentStream.getStreamDataOutput(column).ifPresent(outputDataStreams::add);
-        outputDataStreams.add(dataStream.getStreamDataOutput(column));
+        presentStream.getStreamDataOutput(column, dwrfSequence).ifPresent(outputDataStreams::add);
+        outputDataStreams.add(dataStream.getStreamDataOutput(column, dwrfSequence));
         return outputDataStreams.build();
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/FloatColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/FloatColumnWriter.java
@@ -55,6 +55,7 @@ public class FloatColumnWriter
     private static final ColumnEncoding COLUMN_ENCODING = new ColumnEncoding(DIRECT, 0);
 
     private final int column;
+    private final int dwrfSequence;
     private final Type type;
     private final boolean compressed;
     private final FloatOutputStream dataStream;
@@ -68,13 +69,15 @@ public class FloatColumnWriter
 
     private boolean closed;
 
-    public FloatColumnWriter(int column, Type type, ColumnWriterOptions columnWriterOptions, Optional<DwrfDataEncryptor> dwrfEncryptor, MetadataWriter metadataWriter)
+    public FloatColumnWriter(int column, int dwrfSequence, Type type, ColumnWriterOptions columnWriterOptions, Optional<DwrfDataEncryptor> dwrfEncryptor, MetadataWriter metadataWriter)
     {
         checkArgument(column >= 0, "column is negative");
+        checkArgument(dwrfSequence >= 0, "sequence is negative");
         requireNonNull(columnWriterOptions, "columnWriterOptions is null");
         requireNonNull(dwrfEncryptor, "dwrfEncryptor is null");
         requireNonNull(metadataWriter, "metadataWriter is null");
         this.column = column;
+        this.dwrfSequence = dwrfSequence;
         this.type = requireNonNull(type, "type is null");
         this.compressed = columnWriterOptions.getCompressionKind() != NONE;
         this.dataStream = new FloatOutputStream(columnWriterOptions, dwrfEncryptor);
@@ -163,7 +166,7 @@ public class FloatColumnWriter
         }
 
         Slice slice = metadataWriter.writeRowIndexes(rowGroupIndexes.build());
-        Stream stream = new Stream(column, StreamKind.ROW_INDEX, slice.length(), false);
+        Stream stream = new Stream(column, dwrfSequence, StreamKind.ROW_INDEX, slice.length(), false);
         return ImmutableList.of(new StreamDataOutput(slice, stream));
     }
 
@@ -184,8 +187,8 @@ public class FloatColumnWriter
         checkState(closed);
 
         ImmutableList.Builder<StreamDataOutput> outputDataStreams = ImmutableList.builder();
-        presentStream.getStreamDataOutput(column).ifPresent(outputDataStreams::add);
-        outputDataStreams.add(dataStream.getStreamDataOutput(column));
+        presentStream.getStreamDataOutput(column, dwrfSequence).ifPresent(outputDataStreams::add);
+        outputDataStreams.add(dataStream.getStreamDataOutput(column, dwrfSequence));
         return outputDataStreams.build();
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/LongDictionaryColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/LongDictionaryColumnWriter.java
@@ -62,13 +62,14 @@ public class LongDictionaryColumnWriter
 
     public LongDictionaryColumnWriter(
             int column,
+            int dwrfSequence,
             Type type,
             ColumnWriterOptions columnWriterOptions,
             Optional<DwrfDataEncryptor> dwrfEncryptor,
             OrcEncoding orcEncoding,
             MetadataWriter metadataWriter)
     {
-        super(column, type, columnWriterOptions, dwrfEncryptor, orcEncoding, metadataWriter);
+        super(column, dwrfSequence, type, columnWriterOptions, dwrfEncryptor, orcEncoding, metadataWriter);
         checkArgument(orcEncoding == DWRF, "Long dictionary encoding is only supported in DWRF");
         checkArgument(type instanceof FixedWidthType, "Not a fixed width type");
         this.dictionaryDataStream = new LongOutputStreamDwrf(columnWriterOptions, dwrfEncryptor, true, DICTIONARY_DATA);
@@ -93,7 +94,7 @@ public class LongDictionaryColumnWriter
     protected ColumnWriter createDirectColumnWriter()
     {
         if (directColumnWriter == null) {
-            directColumnWriter = new LongColumnWriter(column, type, columnWriterOptions, dwrfEncryptor, orcEncoding, IntegerStatisticsBuilder::new, metadataWriter);
+            directColumnWriter = new LongColumnWriter(column, dwrfSequence, type, columnWriterOptions, dwrfEncryptor, orcEncoding, IntegerStatisticsBuilder::new, metadataWriter);
         }
         return directColumnWriter;
     }
@@ -203,7 +204,7 @@ public class LongDictionaryColumnWriter
     @Override
     protected List<StreamDataOutput> getDictionaryStreams(int column)
     {
-        return ImmutableList.of(dictionaryDataStream.getStreamDataOutput(column));
+        return ImmutableList.of(dictionaryDataStream.getStreamDataOutput(column, dwrfSequence));
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/SliceDictionaryColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/SliceDictionaryColumnWriter.java
@@ -62,13 +62,14 @@ public class SliceDictionaryColumnWriter
 
     public SliceDictionaryColumnWriter(
             int column,
+            int dwrfSequence,
             Type type,
             ColumnWriterOptions columnWriterOptions,
             Optional<DwrfDataEncryptor> dwrfEncryptor,
             OrcEncoding orcEncoding,
             MetadataWriter metadataWriter)
     {
-        super(column, type, columnWriterOptions, dwrfEncryptor, orcEncoding, metadataWriter);
+        super(column, dwrfSequence, type, columnWriterOptions, dwrfEncryptor, orcEncoding, metadataWriter);
         this.dictionaryDataStream = new ByteArrayOutputStream(columnWriterOptions, dwrfEncryptor, Stream.StreamKind.DICTIONARY_DATA);
         this.dictionaryLengthStream = createLengthOutputStream(columnWriterOptions, dwrfEncryptor, orcEncoding);
         this.stringStatisticsLimitInBytes = toIntExact(columnWriterOptions.getStringStatisticsLimit().toBytes());
@@ -253,7 +254,7 @@ public class SliceDictionaryColumnWriter
     protected ColumnWriter createDirectColumnWriter()
     {
         if (directColumnWriter == null) {
-            directColumnWriter = new SliceDirectColumnWriter(column, type, columnWriterOptions, dwrfEncryptor, orcEncoding, this::newStringStatisticsBuilder, metadataWriter);
+            directColumnWriter = new SliceDirectColumnWriter(column, dwrfSequence, type, columnWriterOptions, dwrfEncryptor, orcEncoding, this::newStringStatisticsBuilder, metadataWriter);
         }
         return directColumnWriter;
     }
@@ -268,6 +269,6 @@ public class SliceDictionaryColumnWriter
     @Override
     protected List<StreamDataOutput> getDictionaryStreams(int column)
     {
-        return ImmutableList.of(dictionaryLengthStream.getStreamDataOutput(column), dictionaryDataStream.getStreamDataOutput(column));
+        return ImmutableList.of(dictionaryLengthStream.getStreamDataOutput(column, dwrfSequence), dictionaryDataStream.getStreamDataOutput(column, dwrfSequence));
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/SliceDirectColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/SliceDirectColumnWriter.java
@@ -59,6 +59,7 @@ public class SliceDirectColumnWriter
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(SliceDirectColumnWriter.class).instanceSize();
     private final int column;
+    private final int dwrfSequence;
     private final Type type;
     private final boolean compressed;
     private final ColumnEncoding columnEncoding;
@@ -77,6 +78,7 @@ public class SliceDirectColumnWriter
 
     public SliceDirectColumnWriter(
             int column,
+            int dwrfSequence,
             Type type,
             ColumnWriterOptions columnWriterOptions,
             Optional<DwrfDataEncryptor> dwrfEncryptor,
@@ -85,10 +87,12 @@ public class SliceDirectColumnWriter
             MetadataWriter metadataWriter)
     {
         checkArgument(column >= 0, "column is negative");
+        checkArgument(dwrfSequence >= 0, "sequence is negative");
         requireNonNull(columnWriterOptions, "columnWriterOptions is null");
         requireNonNull(dwrfEncryptor, "dwrfEncryptor is null");
         requireNonNull(metadataWriter, "metadataWriter is null");
         this.column = column;
+        this.dwrfSequence = dwrfSequence;
         this.type = requireNonNull(type, "type is null");
         this.compressed = columnWriterOptions.getCompressionKind() != NONE;
         this.columnEncoding = new ColumnEncoding(orcEncoding == DWRF ? DIRECT : DIRECT_V2, 0);
@@ -204,7 +208,7 @@ public class SliceDirectColumnWriter
         }
 
         Slice slice = metadataWriter.writeRowIndexes(rowGroupIndexes.build());
-        Stream stream = new Stream(column, StreamKind.ROW_INDEX, slice.length(), false);
+        Stream stream = new Stream(column, dwrfSequence, StreamKind.ROW_INDEX, slice.length(), false);
         return ImmutableList.of(new StreamDataOutput(slice, stream));
     }
 
@@ -227,9 +231,9 @@ public class SliceDirectColumnWriter
         checkState(closed);
 
         ImmutableList.Builder<StreamDataOutput> outputDataStreams = ImmutableList.builder();
-        presentStream.getStreamDataOutput(column).ifPresent(outputDataStreams::add);
-        outputDataStreams.add(lengthStream.getStreamDataOutput(column));
-        outputDataStreams.add(dataStream.getStreamDataOutput(column));
+        presentStream.getStreamDataOutput(column, dwrfSequence).ifPresent(outputDataStreams::add);
+        outputDataStreams.add(lengthStream.getStreamDataOutput(column, dwrfSequence));
+        outputDataStreams.add(dataStream.getStreamDataOutput(column, dwrfSequence));
         return outputDataStreams.build();
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/StructColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/StructColumnWriter.java
@@ -52,6 +52,7 @@ public class StructColumnWriter
     private static final ColumnEncoding COLUMN_ENCODING = new ColumnEncoding(DIRECT, 0);
 
     private final int column;
+    private final int dwrfSequence;
     private final boolean compressed;
     private final PresentOutputStream presentStream;
     private final CompressedMetadataWriter metadataWriter;
@@ -64,11 +65,13 @@ public class StructColumnWriter
 
     private boolean closed;
 
-    public StructColumnWriter(int column, ColumnWriterOptions columnWriterOptions, Optional<DwrfDataEncryptor> dwrfEncryptor, List<ColumnWriter> structFields, MetadataWriter metadataWriter)
+    public StructColumnWriter(int column, int dwrfSequence, ColumnWriterOptions columnWriterOptions, Optional<DwrfDataEncryptor> dwrfEncryptor, List<ColumnWriter> structFields, MetadataWriter metadataWriter)
     {
         checkArgument(column >= 0, "column is negative");
+        checkArgument(dwrfSequence >= 0, "sequence is negative");
         requireNonNull(columnWriterOptions, "columnWriterOptions is null");
         this.column = column;
+        this.dwrfSequence = dwrfSequence;
         this.compressed = columnWriterOptions.getCompressionKind() != NONE;
         this.structFields = ImmutableList.copyOf(requireNonNull(structFields, "structFields is null"));
         this.presentStream = new PresentOutputStream(columnWriterOptions, dwrfEncryptor);
@@ -192,7 +195,7 @@ public class StructColumnWriter
         }
 
         Slice slice = metadataWriter.writeRowIndexes(rowGroupIndexes.build());
-        Stream stream = new Stream(column, StreamKind.ROW_INDEX, slice.length(), false);
+        Stream stream = new Stream(column, dwrfSequence, StreamKind.ROW_INDEX, slice.length(), false);
 
         ImmutableList.Builder<StreamDataOutput> indexStreams = ImmutableList.builder();
         indexStreams.add(new StreamDataOutput(slice, stream));
@@ -217,7 +220,7 @@ public class StructColumnWriter
         checkState(closed);
 
         ImmutableList.Builder<StreamDataOutput> outputDataStreams = ImmutableList.builder();
-        presentStream.getStreamDataOutput(column).ifPresent(outputDataStreams::add);
+        presentStream.getStreamDataOutput(column, dwrfSequence).ifPresent(outputDataStreams::add);
         for (ColumnWriter structField : structFields) {
             outputDataStreams.addAll(structField.getDataStreams());
         }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkDictionaryWriter.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkDictionaryWriter.java
@@ -53,6 +53,7 @@ import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.orc.OrcEncoding.DWRF;
 import static com.facebook.presto.orc.OrcWriterOptions.DEFAULT_MAX_STRING_STATISTICS_LIMIT;
+import static com.facebook.presto.orc.metadata.ColumnEncoding.DEFAULT_SEQUENCE_ID;
 import static com.google.common.base.Preconditions.checkState;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
@@ -96,10 +97,10 @@ public class BenchmarkDictionaryWriter
         ColumnWriter columnWriter;
         Type type = data.getType();
         if (type.equals(VARCHAR)) {
-            columnWriter = new SliceDirectColumnWriter(COLUMN_INDEX, type, columnWriterOptions, Optional.empty(), DWRF, this::newStringStatisticsBuilder, DWRF.createMetadataWriter());
+            columnWriter = new SliceDirectColumnWriter(COLUMN_INDEX, DEFAULT_SEQUENCE_ID, type, columnWriterOptions, Optional.empty(), DWRF, this::newStringStatisticsBuilder, DWRF.createMetadataWriter());
         }
         else {
-            columnWriter = new LongColumnWriter(COLUMN_INDEX, type, columnWriterOptions, Optional.empty(), DWRF, IntegerStatisticsBuilder::new, DWRF.createMetadataWriter());
+            columnWriter = new LongColumnWriter(COLUMN_INDEX, DEFAULT_SEQUENCE_ID, type, columnWriterOptions, Optional.empty(), DWRF, IntegerStatisticsBuilder::new, DWRF.createMetadataWriter());
         }
         for (Block block : data.getBlocks()) {
             columnWriter.beginRowGroup();
@@ -144,10 +145,10 @@ public class BenchmarkDictionaryWriter
         DictionaryColumnWriter columnWriter;
         Type type = data.getType();
         if (type.equals(VARCHAR)) {
-            columnWriter = new SliceDictionaryColumnWriter(COLUMN_INDEX, type, columnWriterOptions, Optional.empty(), DWRF, DWRF.createMetadataWriter());
+            columnWriter = new SliceDictionaryColumnWriter(COLUMN_INDEX, DEFAULT_SEQUENCE_ID, type, columnWriterOptions, Optional.empty(), DWRF, DWRF.createMetadataWriter());
         }
         else {
-            columnWriter = new LongDictionaryColumnWriter(COLUMN_INDEX, type, columnWriterOptions, Optional.empty(), DWRF, DWRF.createMetadataWriter());
+            columnWriter = new LongDictionaryColumnWriter(COLUMN_INDEX, DEFAULT_SEQUENCE_ID, type, columnWriterOptions, Optional.empty(), DWRF, DWRF.createMetadataWriter());
         }
         return columnWriter;
     }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestDecryption.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestDecryption.java
@@ -208,22 +208,22 @@ public class TestDecryption
     public void testGetDiskRanges()
     {
         List<Stream> unencryptedStreams = ImmutableList.of(
-                new Stream(3, ROW_INDEX, 5, true, DEFAULT_SEQUENCE_ID, Optional.of(15L)),
-                new Stream(4, ROW_INDEX, 5, true),
-                new Stream(3, DATA, 5, true, DEFAULT_SEQUENCE_ID, Optional.of(45L)),
-                new Stream(4, DATA, 5, true));
+                new Stream(3, DEFAULT_SEQUENCE_ID, ROW_INDEX, 5, true, Optional.of(15L)),
+                new Stream(4, DEFAULT_SEQUENCE_ID, ROW_INDEX, 5, true),
+                new Stream(3, DEFAULT_SEQUENCE_ID, DATA, 5, true, Optional.of(45L)),
+                new Stream(4, DEFAULT_SEQUENCE_ID, DATA, 5, true));
 
         List<Stream> group1Streams = ImmutableList.of(
-                new Stream(0, ROW_INDEX, 5, true),
-                new Stream(5, ROW_INDEX, 5, true, DEFAULT_SEQUENCE_ID, Optional.of(25L)),
-                new Stream(0, DATA, 5, true, DEFAULT_SEQUENCE_ID, Optional.of(30L)),
-                new Stream(5, DATA, 5, true, DEFAULT_SEQUENCE_ID, Optional.of(55L)));
+                new Stream(0, DEFAULT_SEQUENCE_ID, ROW_INDEX, 5, true),
+                new Stream(5, DEFAULT_SEQUENCE_ID, ROW_INDEX, 5, true, Optional.of(25L)),
+                new Stream(0, DEFAULT_SEQUENCE_ID, DATA, 5, true, Optional.of(30L)),
+                new Stream(5, DEFAULT_SEQUENCE_ID, DATA, 5, true, Optional.of(55L)));
 
         List<Stream> group2Streams = ImmutableList.of(
-                new Stream(1, ROW_INDEX, 5, true, DEFAULT_SEQUENCE_ID, Optional.of(5L)),
-                new Stream(2, ROW_INDEX, 5, true),
-                new Stream(1, DATA, 5, true, DEFAULT_SEQUENCE_ID, Optional.of(35L)),
-                new Stream(2, DATA, 5, true));
+                new Stream(1, DEFAULT_SEQUENCE_ID, ROW_INDEX, 5, true, Optional.of(5L)),
+                new Stream(2, DEFAULT_SEQUENCE_ID, ROW_INDEX, 5, true),
+                new Stream(1, DEFAULT_SEQUENCE_ID, DATA, 5, true, Optional.of(35L)),
+                new Stream(2, DEFAULT_SEQUENCE_ID, DATA, 5, true));
 
         Map<StreamId, DiskRange> actual = getDiskRanges(ImmutableList.of(unencryptedStreams, group1Streams, group2Streams));
 

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestDictionaryColumnWriter.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestDictionaryColumnWriter.java
@@ -52,6 +52,7 @@ import static com.facebook.presto.orc.metadata.ColumnEncoding.ColumnEncodingKind
 import static com.facebook.presto.orc.metadata.ColumnEncoding.ColumnEncodingKind.DIRECT;
 import static com.facebook.presto.orc.metadata.ColumnEncoding.ColumnEncodingKind.DIRECT_V2;
 import static com.facebook.presto.orc.metadata.ColumnEncoding.ColumnEncodingKind.DWRF_DIRECT;
+import static com.facebook.presto.orc.metadata.ColumnEncoding.DEFAULT_SEQUENCE_ID;
 import static com.facebook.presto.orc.metadata.CompressionKind.ZSTD;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.Iterables.cycle;
@@ -90,6 +91,7 @@ public class TestDictionaryColumnWriter
         ColumnWriterOptions columnWriterOptions = ColumnWriterOptions.builder().setCompressionKind(CompressionKind.NONE).build();
         DictionaryColumnWriter writer = new SliceDictionaryColumnWriter(
                 0,
+                DEFAULT_SEQUENCE_ID,
                 VARCHAR,
                 columnWriterOptions,
                 Optional.empty(),

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestStreamLayout.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestStreamLayout.java
@@ -26,6 +26,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
+import static com.facebook.presto.orc.metadata.ColumnEncoding.DEFAULT_SEQUENCE_ID;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 
@@ -33,7 +34,7 @@ public class TestStreamLayout
 {
     private static StreamDataOutput createStream(int column, StreamKind streamKind, int length)
     {
-        Stream stream = new Stream(column, streamKind, length, true);
+        Stream stream = new Stream(column, DEFAULT_SEQUENCE_ID, streamKind, length, true);
         return new StreamDataOutput(Slices.allocate(1024), stream);
     }
 

--- a/presto-orc/src/test/java/com/facebook/presto/orc/stream/AbstractTestValueStream.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/stream/AbstractTestValueStream.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.facebook.presto.orc.OrcDecompressor.createOrcDecompressor;
+import static com.facebook.presto.orc.metadata.ColumnEncoding.DEFAULT_SEQUENCE_ID;
 import static com.facebook.presto.orc.metadata.CompressionKind.SNAPPY;
 import static io.airlift.units.DataSize.Unit.KILOBYTE;
 import static java.lang.Math.toIntExact;
@@ -57,7 +58,7 @@ public abstract class AbstractTestValueStream<T, C extends StreamCheckpoint, W e
             outputStream.close();
 
             DynamicSliceOutput sliceOutput = new DynamicSliceOutput(1000);
-            StreamDataOutput streamDataOutput = outputStream.getStreamDataOutput(33);
+            StreamDataOutput streamDataOutput = outputStream.getStreamDataOutput(33, DEFAULT_SEQUENCE_ID);
             streamDataOutput.writeData(sliceOutput);
             Stream stream = streamDataOutput.getStream();
             assertEquals(stream.getStreamKind(), StreamKind.DATA);

--- a/presto-orc/src/test/java/com/facebook/presto/orc/stream/TestBooleanStream.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/stream/TestBooleanStream.java
@@ -30,6 +30,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import static com.facebook.presto.orc.metadata.ColumnEncoding.DEFAULT_SEQUENCE_ID;
 import static org.testng.Assert.assertEquals;
 
 public class TestBooleanStream
@@ -181,7 +182,7 @@ public class TestBooleanStream
             throws OrcCorruptionException
     {
         DynamicSliceOutput sliceOutput = new DynamicSliceOutput(1000);
-        StreamDataOutput streamDataOutput = outputStream.getStreamDataOutput(33);
+        StreamDataOutput streamDataOutput = outputStream.getStreamDataOutput(33, DEFAULT_SEQUENCE_ID);
         streamDataOutput.writeData(sliceOutput);
         Stream stream = streamDataOutput.getStream();
         assertEquals(stream.getStreamKind(), StreamKind.DATA);


### PR DESCRIPTION
Sequence Ids are used by Dwrf FlatMap implementations. This commit introduces sequence for DWRF writer.
Following PR of flat map implementation will use this sequence id to add multiple streams per column. 