### PR TITLE
Use double quotes for all column names in SHOW CREATE TABLE

### DIFF
--- a/presto-elasticsearch/src/test/java/com/facebook/presto/elasticsearch/TestElasticsearchIntegrationSmokeTest.java
+++ b/presto-elasticsearch/src/test/java/com/facebook/presto/elasticsearch/TestElasticsearchIntegrationSmokeTest.java
@@ -146,15 +146,15 @@ public class TestElasticsearchIntegrationSmokeTest
     {
         assertThat(computeActual("SHOW CREATE TABLE orders").getOnlyValue())
                 .isEqualTo("CREATE TABLE elasticsearch.tpch.orders (\n" +
-                        "   clerk varchar,\n" +
-                        "   comment varchar,\n" +
-                        "   custkey bigint,\n" +
-                        "   orderdate timestamp,\n" +
-                        "   orderkey bigint,\n" +
-                        "   orderpriority varchar,\n" +
-                        "   orderstatus varchar,\n" +
-                        "   shippriority bigint,\n" +
-                        "   totalprice real\n" +
+                        "   \"clerk\" varchar,\n" +
+                        "   \"comment\" varchar,\n" +
+                        "   \"custkey\" bigint,\n" +
+                        "   \"orderdate\" timestamp,\n" +
+                        "   \"orderkey\" bigint,\n" +
+                        "   \"orderpriority\" varchar,\n" +
+                        "   \"orderstatus\" varchar,\n" +
+                        "   \"shippriority\" bigint,\n" +
+                        "   \"totalprice\" real\n" +
                         ")");
     }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -2594,45 +2594,60 @@ public class TestHiveIntegrationSmokeTest
     @Test
     public void testShowCreateTable()
     {
-        String createTableSql = format("" +
-                        "CREATE TABLE %s.%s.%s (\n" +
-                        "   c1 bigint,\n" +
-                        "   c2 double,\n" +
-                        "   \"c 3\" varchar,\n" +
-                        "   \"c'4\" array(bigint),\n" +
-                        "   c5 map(bigint, varchar)\n" +
-                        ")\n" +
-                        "WITH (\n" +
-                        "   format = 'RCBINARY'\n" +
-                        ")",
+        String createTableFormat = "CREATE TABLE %s.%s.%s (\n" +
+                "   %s bigint,\n" +
+                "   %s double,\n" +
+                "   \"c 3\" varchar,\n" +
+                "   \"c'4\" array(bigint),\n" +
+                "   %s map(bigint, varchar)\n" +
+                ")\n" +
+                "WITH (\n" +
+                "   format = 'RCBINARY'\n" +
+                ")";
+        String createTableSql = format(
+                createTableFormat,
                 getSession().getCatalog().get(),
                 getSession().getSchema().get(),
-                "test_show_create_table");
-
+                "test_show_create_table",
+                "c1",
+                "c2",
+                "c5");
+        String expectedShowCreateTable = format(
+                createTableFormat,
+                getSession().getCatalog().get(),
+                getSession().getSchema().get(),
+                "test_show_create_table",
+                "\"c1\"",
+                "\"c2\"",
+                "\"c5\"");
         assertUpdate(createTableSql);
         MaterializedResult actualResult = computeActual("SHOW CREATE TABLE test_show_create_table");
-        assertEquals(getOnlyElement(actualResult.getOnlyColumnAsSet()), createTableSql);
+        assertEquals(getOnlyElement(actualResult.getOnlyColumnAsSet()), expectedShowCreateTable);
 
-        createTableSql = format("" +
-                        "CREATE TABLE %s.%s.%s (\n" +
-                        "   c1 bigint,\n" +
-                        "   \"c 2\" varchar,\n" +
-                        "   \"c'3\" array(bigint),\n" +
-                        "   c4 map(bigint, varchar) COMMENT 'comment test4',\n" +
-                        "   c5 double COMMENT 'comment test5'\n)\n" +
-                        "COMMENT 'test'\n" +
-                        "WITH (\n" +
-                        "   bucket_count = 5,\n" +
-                        "   bucketed_by = ARRAY['c1','c 2'],\n" +
-                        "   format = 'ORC',\n" +
-                        "   orc_bloom_filter_columns = ARRAY['c1','c2'],\n" +
-                        "   orc_bloom_filter_fpp = 7E-1,\n" +
-                        "   partitioned_by = ARRAY['c5'],\n" +
-                        "   sorted_by = ARRAY['c1','c 2 DESC']\n" +
-                        ")",
+        createTableFormat = "CREATE TABLE %s.%s.%s (\n" +
+                "   %s bigint,\n" +
+                "   \"c 2\" varchar,\n" +
+                "   \"c'3\" array(bigint),\n" +
+                "   %s map(bigint, varchar) COMMENT 'comment test4',\n" +
+                "   %s double COMMENT 'comment test5'\n)\n" +
+                "COMMENT 'test'\n" +
+                "WITH (\n" +
+                "   bucket_count = 5,\n" +
+                "   bucketed_by = ARRAY['c1','c 2'],\n" +
+                "   format = 'ORC',\n" +
+                "   orc_bloom_filter_columns = ARRAY['c1','c2'],\n" +
+                "   orc_bloom_filter_fpp = 7E-1,\n" +
+                "   partitioned_by = ARRAY['c5'],\n" +
+                "   sorted_by = ARRAY['c1','c 2 DESC']\n" +
+                ")";
+        createTableSql = format(
+                createTableFormat,
                 getSession().getCatalog().get(),
                 getSession().getSchema().get(),
-                "\"test_show_create_table'2\"");
+                "\"test_show_create_table'2\"",
+                "\"c1\"",
+                "\"c2\"",
+                "\"c5\"");
         assertUpdate(createTableSql);
         actualResult = computeActual("SHOW CREATE TABLE \"test_show_create_table'2\"");
         assertEquals(getOnlyElement(actualResult.getOnlyColumnAsSet()), createTableSql);
@@ -2648,7 +2663,7 @@ public class TestHiveIntegrationSmokeTest
 
         @Language("SQL") String createTableSql = format("" +
                         "CREATE TABLE %s.%s.test_create_external (\n" +
-                        "   name varchar\n" +
+                        "   \"name\" varchar\n" +
                         ")\n" +
                         "WITH (\n" +
                         "   external_location = '%s',\n" +
@@ -4744,8 +4759,8 @@ public class TestHiveIntegrationSmokeTest
     private String getAvroCreateTableSql(String tableName, String schemaFile)
     {
         return format("CREATE TABLE %s.%s.%s (\n" +
-                        "   dummy_col varchar,\n" +
-                        "   another_dummy_col varchar\n" +
+                        "   \"dummy_col\" varchar,\n" +
+                        "   \"another_dummy_col\" varchar\n" +
                         ")\n" +
                         "WITH (\n" +
                         "   avro_schema_url = '%s',\n" +

--- a/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowQueriesRewrite.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowQueriesRewrite.java
@@ -36,6 +36,7 @@ import com.facebook.presto.spi.function.SqlInvokedFunction;
 import com.facebook.presto.spi.security.PrestoPrincipal;
 import com.facebook.presto.spi.security.PrincipalType;
 import com.facebook.presto.spi.session.PropertyMetadata;
+import com.facebook.presto.sql.QueryUtil;
 import com.facebook.presto.sql.analyzer.QueryExplainer;
 import com.facebook.presto.sql.analyzer.SemanticException;
 import com.facebook.presto.sql.parser.ParsingException;
@@ -508,12 +509,11 @@ final class ShowQueriesRewrite
                 ConnectorTableMetadata connectorTableMetadata = metadata.getTableMetadata(session, tableHandle.get()).getMetadata();
 
                 Map<String, PropertyMetadata<?>> allColumnProperties = metadata.getColumnPropertyManager().getAllProperties().get(tableHandle.get().getConnectorId());
-
                 List<TableElement> columns = connectorTableMetadata.getColumns().stream()
                         .filter(column -> !column.isHidden())
                         .map(column -> {
                             List<Property> propertyNodes = buildProperties(objectName, Optional.of(column.getName()), INVALID_COLUMN_PROPERTY, column.getProperties(), allColumnProperties);
-                            return new ColumnDefinition(new Identifier(column.getName()), column.getType().getDisplayName(), column.isNullable(), propertyNodes, Optional.ofNullable(column.getComment()));
+                            return new ColumnDefinition(QueryUtil.quotedIdentifier(column.getName()), column.getType().getDisplayName(), column.isNullable(), propertyNodes, Optional.ofNullable(column.getComment()));
                         })
                         .collect(toImmutableList());
 

--- a/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlIntegrationSmokeTest.java
+++ b/presto-mysql/src/test/java/com/facebook/presto/plugin/mysql/TestMySqlIntegrationSmokeTest.java
@@ -202,28 +202,46 @@ public class TestMySqlIntegrationSmokeTest
     @Test
     public void testInsertIntoNotNullColumn()
     {
-        @Language("SQL") String createTableSql = format("" +
-                        "CREATE TABLE %s.tpch.test_insert_not_null (\n" +
-                        "   column_a date,\n" +
-                        "   column_b date NOT NULL\n" +
-                        ")",
-                getSession().getCatalog().get());
+        String createTableFormat = "CREATE TABLE %s.tpch.test_insert_not_null (\n" +
+                "   %s date,\n" +
+                "   %s date NOT NULL\n" +
+                ")";
+        @Language("SQL") String createTableSql = format(
+                createTableFormat,
+                getSession().getCatalog().get(),
+                "column_a",
+                "column_b");
+        @Language("SQL") String expectedCreateTableSql = format(
+                createTableFormat,
+                getSession().getCatalog().get(),
+                "\"column_a\"",
+                "\"column_b\"");
         assertUpdate(createTableSql);
-        assertEquals(computeScalar("SHOW CREATE TABLE test_insert_not_null"), createTableSql);
+        assertEquals(computeScalar("SHOW CREATE TABLE test_insert_not_null"), expectedCreateTableSql);
 
         assertQueryFails("INSERT INTO test_insert_not_null (column_a) VALUES (date '2012-12-31')", "NULL value not allowed for NOT NULL column: column_b");
         assertQueryFails("INSERT INTO test_insert_not_null (column_a, column_b) VALUES (date '2012-12-31', null)", "NULL value not allowed for NOT NULL column: column_b");
 
         assertUpdate("ALTER TABLE test_insert_not_null ADD COLUMN column_c BIGINT NOT NULL");
 
-        createTableSql = format("" +
-                        "CREATE TABLE %s.tpch.test_insert_not_null (\n" +
-                        "   column_a date,\n" +
-                        "   column_b date NOT NULL,\n" +
-                        "   column_c bigint NOT NULL\n" +
-                        ")",
-                getSession().getCatalog().get());
-        assertEquals(computeScalar("SHOW CREATE TABLE test_insert_not_null"), createTableSql);
+        createTableFormat = "CREATE TABLE %s.tpch.test_insert_not_null (\n" +
+                "   %s date,\n" +
+                "   %s date NOT NULL,\n" +
+                "   %s bigint NOT NULL\n" +
+                ")";
+        createTableSql = format(
+                createTableFormat,
+                getSession().getCatalog().get(),
+                "column_a",
+                "column_b",
+                "column_c");
+        expectedCreateTableSql = format(
+                createTableFormat,
+                getSession().getCatalog().get(),
+                "\"column_a\"",
+                "\"column_b\"",
+                "\"column_c\"");
+        assertEquals(computeScalar("SHOW CREATE TABLE test_insert_not_null"), expectedCreateTableSql);
 
         assertQueryFails("INSERT INTO test_insert_not_null (column_b) VALUES (date '2012-12-31')", "NULL value not allowed for NOT NULL column: column_c");
         assertQueryFails("INSERT INTO test_insert_not_null (column_b, column_c) VALUES (date '2012-12-31', null)", "NULL value not allowed for NOT NULL column: column_c");

--- a/presto-oracle/src/test/java/com/facebook/presto/plugin/oracle/BaseOracleIntegrationSmokeTest.java
+++ b/presto-oracle/src/test/java/com/facebook/presto/plugin/oracle/BaseOracleIntegrationSmokeTest.java
@@ -70,15 +70,15 @@ public abstract class BaseOracleIntegrationSmokeTest
         assertThat((String) computeActual("SHOW CREATE TABLE orders").getOnlyValue())
                 // If the connector reports additional column properties, the expected value needs to be adjusted in the test subclass
                 .matches("CREATE TABLE \\w+\\.\\w+\\.orders \\Q(\n" +
-                        "   orderkey decimal(19, 0),\n" +
-                        "   custkey decimal(19, 0),\n" +
-                        "   orderstatus varchar(1),\n" +
-                        "   totalprice double,\n" +
-                        "   orderdate timestamp(3),\n" +
-                        "   orderpriority varchar(15),\n" +
-                        "   clerk varchar(15),\n" +
-                        "   shippriority decimal(10, 0),\n" +
-                        "   comment varchar(79)\n" +
+                        "   \"orderkey\" decimal(19, 0),\n" +
+                        "   \"custkey\" decimal(19, 0),\n" +
+                        "   \"orderstatus\" varchar(1),\n" +
+                        "   \"totalprice\" double,\n" +
+                        "   \"orderdate\" timestamp(3),\n" +
+                        "   \"orderpriority\" varchar(15),\n" +
+                        "   \"clerk\" varchar(15),\n" +
+                        "   \"shippriority\" decimal(10, 0),\n" +
+                        "   \"comment\" varchar(79)\n" +
                         ")");
     }
 }

--- a/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlIntegrationSmokeTest.java
+++ b/presto-postgresql/src/test/java/com/facebook/presto/plugin/postgresql/TestPostgreSqlIntegrationSmokeTest.java
@@ -209,28 +209,40 @@ public class TestPostgreSqlIntegrationSmokeTest
     @Test
     public void testInsertIntoNotNullColumn()
     {
-        @Language("SQL") String createTableSql = format("" +
-                        "CREATE TABLE %s.tpch.test_insert_not_null (\n" +
-                        "   column_a date,\n" +
-                        "   column_b date NOT NULL\n" +
-                        ")",
-                getSession().getCatalog().get());
+        String createTableFormat = "CREATE TABLE %s.tpch.test_insert_not_null (\n" +
+                "   %s date,\n" +
+                "   %s date NOT NULL\n" +
+                ")";
+        @Language("SQL") String createTableSql = format(
+                createTableFormat,
+                getSession().getCatalog().get(),
+                "column_a",
+                "column_b");
+        @Language("SQL") String expectedShowCreateTableSql = format(
+                createTableFormat,
+                getSession().getCatalog().get(),
+                "\"column_a\"",
+                "\"column_b\"");
         assertUpdate(createTableSql);
-        assertEquals(computeScalar("SHOW CREATE TABLE test_insert_not_null"), createTableSql);
+        assertEquals(computeScalar("SHOW CREATE TABLE test_insert_not_null"), expectedShowCreateTableSql);
 
         assertQueryFails("INSERT INTO test_insert_not_null (column_a) VALUES (date '2012-12-31')", "NULL value not allowed for NOT NULL column: column_b");
         assertQueryFails("INSERT INTO test_insert_not_null (column_a, column_b) VALUES (date '2012-12-31', null)", "NULL value not allowed for NOT NULL column: column_b");
 
         assertUpdate("ALTER TABLE test_insert_not_null ADD COLUMN column_c BIGINT NOT NULL");
 
-        createTableSql = format("" +
-                        "CREATE TABLE %s.tpch.test_insert_not_null (\n" +
-                        "   column_a date,\n" +
-                        "   column_b date NOT NULL,\n" +
-                        "   column_c bigint NOT NULL\n" +
-                        ")",
-                getSession().getCatalog().get());
-        assertEquals(computeScalar("SHOW CREATE TABLE test_insert_not_null"), createTableSql);
+        createTableFormat = "CREATE TABLE %s.tpch.test_insert_not_null (\n" +
+                "   %s date,\n" +
+                "   %s date NOT NULL,\n" +
+                "   %s bigint NOT NULL\n" +
+                ")";
+        expectedShowCreateTableSql = format(
+                createTableFormat,
+                getSession().getCatalog().get(),
+                "\"column_a\"",
+                "\"column_b\"",
+                "\"column_c\"");
+        assertEquals(computeScalar("SHOW CREATE TABLE test_insert_not_null"), expectedShowCreateTableSql);
 
         assertQueryFails("INSERT INTO test_insert_not_null (column_b) VALUES (date '2012-12-31')", "NULL value not allowed for NOT NULL column: column_c");
         assertQueryFails("INSERT INTO test_insert_not_null (column_b, column_c) VALUES (date '2012-12-31', null)", "NULL value not allowed for NOT NULL column: column_c");

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/csv_table.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/csv_table.sql
@@ -11,10 +11,10 @@ c_varchar|varchar|||
 --! name: show create csv table
 SHOW CREATE TABLE csv_table
 --!
-CREATE TABLE hive.default.csv_table (\n   c_bigint varchar,\n   c_varchar varchar\n)\nWITH (\n   external_location = 'hdfs://hadoop-master:9000/product-test/datasets/csv_table',\n   format = 'CSV'\n)
+CREATE TABLE hive.default.csv_table (\n   "c_bigint" varchar,\n   "c_varchar" varchar\n)\nWITH (\n   external_location = 'hdfs://hadoop-master:9000/product-test/datasets/csv_table',\n   format = 'CSV'\n)
 --! name: create table like
 DROP TABLE IF EXISTS like_csv_table;
 CREATE TABLE like_csv_table (LIKE csv_table INCLUDING PROPERTIES);
 SHOW CREATE TABLE like_csv_table
 --!
-CREATE TABLE hive.default.like_csv_table (\n   c_bigint varchar,\n   c_varchar varchar\n)\nWITH (\n   external_location = 'hdfs://hadoop-master:9000/product-test/datasets/csv_table',\n   format = 'CSV'\n)
+CREATE TABLE hive.default.like_csv_table (\n   "c_bigint" varchar,\n   "c_varchar" varchar\n)\nWITH (\n   external_location = 'hdfs://hadoop-master:9000/product-test/datasets/csv_table',\n   format = 'CSV'\n)

--- a/presto-product-tests/src/main/resources/sql-tests/testcases/csv_table_with_custom_parameters.sql
+++ b/presto-product-tests/src/main/resources/sql-tests/testcases/csv_table_with_custom_parameters.sql
@@ -11,10 +11,10 @@ c_varchar|varchar|||
 --! name: show create csv table
 SHOW CREATE TABLE csv_table_with_custom_parameters
 --!
-CREATE TABLE hive.default.csv_table_with_custom_parameters (\n   c_bigint varchar,\n   c_varchar varchar\n)\nWITH (\n   csv_escape = 'E',\n   csv_quote = 'Q',\n   csv_separator = 'S',\n   external_location = 'hdfs://hadoop-master:9000/product-test/datasets/csv_table_with_custom_parameters',\n   format = 'CSV'\n)
+CREATE TABLE hive.default.csv_table_with_custom_parameters (\n   "c_bigint" varchar,\n   "c_varchar" varchar\n)\nWITH (\n   csv_escape = 'E',\n   csv_quote = 'Q',\n   csv_separator = 'S',\n   external_location = 'hdfs://hadoop-master:9000/product-test/datasets/csv_table_with_custom_parameters',\n   format = 'CSV'\n)
 --! name: create table like
 DROP TABLE IF EXISTS like_csv_table;
 CREATE TABLE like_csv_table (LIKE csv_table_with_custom_parameters INCLUDING PROPERTIES);
 SHOW CREATE TABLE like_csv_table
 --!
-CREATE TABLE hive.default.like_csv_table (\n   c_bigint varchar,\n   c_varchar varchar\n)\nWITH (\n   csv_escape = 'E',\n   csv_quote = 'Q',\n   csv_separator = 'S',\n   external_location = 'hdfs://hadoop-master:9000/product-test/datasets/csv_table_with_custom_parameters',\n   format = 'CSV'\n)
+CREATE TABLE hive.default.like_csv_table (\n   "c_bigint" varchar,\n   "c_varchar" varchar\n)\nWITH (\n   csv_escape = 'E',\n   csv_quote = 'Q',\n   csv_separator = 'S',\n   external_location = 'hdfs://hadoop-master:9000/product-test/datasets/csv_table_with_custom_parameters',\n   format = 'CSV'\n)

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/integration/TestRaptorIntegrationSmokeTest.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/integration/TestRaptorIntegrationSmokeTest.java
@@ -579,13 +579,13 @@ public class TestRaptorIntegrationSmokeTest
     {
         String createTableSql = format("" +
                         "CREATE TABLE %s.%s.%s (\n" +
-                        "   c1 bigint,\n" +
-                        "   c2 double,\n" +
+                        "   \"c1\" bigint,\n" +
+                        "   \"c2\" double,\n" +
                         "   \"c 3\" varchar,\n" +
                         "   \"c'4\" array(bigint),\n" +
-                        "   c5 map(bigint, varchar),\n" +
-                        "   c6 bigint,\n" +
-                        "   c7 timestamp\n" +
+                        "   \"c5\" map(bigint, varchar),\n" +
+                        "   \"c6\" bigint,\n" +
+                        "   \"c7\" timestamp\n" +
                         ")\n" +
                         "WITH (\n" +
                         "   bucket_count = 32,\n" +
@@ -609,13 +609,13 @@ public class TestRaptorIntegrationSmokeTest
         // With organization enabled
         createTableSql = format("" +
                         "CREATE TABLE %s.%s.%s (\n" +
-                        "   c1 bigint,\n" +
-                        "   c2 double,\n" +
+                        "   \"c1\" bigint,\n" +
+                        "   \"c2\" double,\n" +
                         "   \"c 3\" varchar,\n" +
                         "   \"c'4\" array(bigint),\n" +
-                        "   c5 map(bigint, varchar),\n" +
-                        "   c6 bigint,\n" +
-                        "   c7 timestamp\n" +
+                        "   \"c5\" map(bigint, varchar),\n" +
+                        "   \"c6\" bigint,\n" +
+                        "   \"c7\" timestamp\n" +
                         ")\n" +
                         "WITH (\n" +
                         "   bucket_count = 32,\n" +
@@ -639,10 +639,10 @@ public class TestRaptorIntegrationSmokeTest
         createTableSql = format("" +
                         "CREATE TABLE %s.%s.%s (\n" +
                         "   \"c\"\"1\" bigint,\n" +
-                        "   c2 double,\n" +
+                        "   \"c2\" double,\n" +
                         "   \"c 3\" varchar,\n" +
                         "   \"c'4\" array(bigint),\n" +
-                        "   c5 map(bigint, varchar)\n" +
+                        "   \"c5\" map(bigint, varchar)\n" +
                         ")",
                 getSession().getCatalog().get(), getSession().getSchema().get(), "test_show_create_table_default");
         assertUpdate(createTableSql);

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
@@ -345,8 +345,8 @@ public abstract class AbstractTestDistributedQueries
 
         String catalog = getSession().getCatalog().get();
         String createTableStatement = "CREATE TABLE " + catalog + ".tpch.test_not_null_with_insert (\n" +
-                "   column_a date,\n" +
-                "   column_b date NOT NULL\n" +
+                "   \"column_a\" date,\n" +
+                "   \"column_b\" date NOT NULL\n" +
                 ")";
         assertUpdate("CREATE TABLE test_not_null_with_insert (column_a DATE, column_b DATE NOT NULL)");
         assertQuery(
@@ -360,9 +360,9 @@ public abstract class AbstractTestDistributedQueries
         assertQuery(
                 "SHOW CREATE TABLE test_not_null_with_insert",
                 "VALUES 'CREATE TABLE " + catalog + ".tpch.test_not_null_with_insert (\n" +
-                        "   column_a date,\n" +
-                        "   column_b date NOT NULL,\n" +
-                        "   column_c bigint NOT NULL\n" +
+                        "   \"column_a\" date,\n" +
+                        "   \"column_b\" date NOT NULL,\n" +
+                        "   \"column_c\" bigint NOT NULL\n" +
                         ")'");
 
         assertQueryFails("INSERT INTO test_not_null_with_insert (column_b) VALUES (date '2012-12-31')", "(?s).*column_c.*null.*");


### PR DESCRIPTION
Currently SHOW CREATE TABLE does not use double quotes for column names which are reserved words. Because of this, copying the output from show create table to create the table fails. We are now using double quotes in SHOW CREATE TABLE for all column names if not already double quoted

Test plan - 
1. Tested using unit test
2. Tested by running com.facebook.presto.hive.HiveQueryRunner in local.
```
presto:tpch> CREATE TABLE test (
          ->            a int,
          ->           "order" int,
          ->           limit int,
          ->             ds varchar
          ->            )
          ->            WITH (
          ->               format = 'DWRF',
          ->               partitioned_by = ARRAY['ds']
          ->            );
CREATE TABLE
presto:tpch> show create table test;
          Create Table
---------------------------------
 CREATE TABLE hive.tpch.test (
    "a" integer,
    "order" integer,
    "limit" integer,
    "ds" varchar
 )
 WITH (
    format = 'DWRF',
    partitioned_by = ARRAY['ds']
 )
(1 row)
```


== NO RELEASE NOTE ==

