### PR TITLE
Avoid unnecessary variable for ConstantExpression in PlanRemoteProjections

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PlanRemotePojections.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PlanRemotePojections.java
@@ -250,16 +250,14 @@ public class PlanRemotePojections
             boolean local = !functionMetadata.getImplementationType().isExternal();
 
             // Break function arguments into local and remote projections first
-            ImmutableList.Builder<VariableReferenceExpression> newArgumentsBuilder = ImmutableList.builder();
-            List<ProjectionContext> processedArguments = processArguments(call.getArguments(), newArgumentsBuilder);
-            List<VariableReferenceExpression> newArguments = newArgumentsBuilder.build();
+            ImmutableList.Builder<RowExpression> newArgumentsBuilder = ImmutableList.builder();
+            List<ProjectionContext> processedArguments = processArguments(call.getArguments(), newArgumentsBuilder, local);
+            List<RowExpression> newArguments = newArgumentsBuilder.build();
             CallExpression newCall = new CallExpression(
                     call.getDisplayName(),
                     call.getFunctionHandle(),
                     call.getType(),
-                    newArguments.stream()
-                            .map(RowExpression.class::cast)
-                            .collect(toImmutableList()));
+                    newArguments);
 
             if (local) {
                 if (processedArguments.size() == 1 && !processedArguments.get(0).isRemote()) {
@@ -279,7 +277,7 @@ public class PlanRemotePojections
                                             call.getFunctionHandle(),
                                             call.getType(),
                                             newArguments.stream()
-                                                    .map(last.getProjections()::get)
+                                                    .map(argument -> argument instanceof VariableReferenceExpression ? last.getProjections().get(argument) : argument)
                                                     .collect(toImmutableList()))),
                             false));
                     return projectionContextBuilder.build();
@@ -305,7 +303,7 @@ public class PlanRemotePojections
         @Override
         public List<ProjectionContext> visitInputReference(InputReferenceExpression reference, Void context)
         {
-            return ImmutableList.of();
+            throw new IllegalStateException("Optimizers should not see InputReferenceExpression");
         }
 
         @Override
@@ -329,9 +327,9 @@ public class PlanRemotePojections
         @Override
         public List<ProjectionContext> visitSpecialForm(SpecialFormExpression specialForm, Void context)
         {
-            ImmutableList.Builder<VariableReferenceExpression> newArgumentsBuilder = ImmutableList.builder();
-            List<ProjectionContext> processedArguments = processArguments(specialForm.getArguments(), newArgumentsBuilder);
-            List<VariableReferenceExpression> newArguments = newArgumentsBuilder.build();
+            ImmutableList.Builder<RowExpression> newArgumentsBuilder = ImmutableList.builder();
+            List<ProjectionContext> processedArguments = processArguments(specialForm.getArguments(), newArgumentsBuilder, true);
+            List<RowExpression> newArguments = newArgumentsBuilder.build();
             if (processedArguments.size() == 1 && !processedArguments.get(0).isRemote()) {
                 // Arguments do not contain remote projection
                 return ImmutableList.of();
@@ -348,7 +346,7 @@ public class PlanRemotePojections
                                         specialForm.getForm(),
                                         specialForm.getType(),
                                         newArguments.stream()
-                                                .map(last.getProjections()::get)
+                                                .map(argument -> argument instanceof VariableReferenceExpression ? last.getProjections().get(argument) : argument)
                                                 .collect(toImmutableList()))),
                         false));
                 return projectionContextBuilder.build();
@@ -363,27 +361,30 @@ public class PlanRemotePojections
                                 new SpecialFormExpression(
                                         specialForm.getForm(),
                                         specialForm.getType(),
-                                        newArguments.stream()
-                                            .map(RowExpression.class::cast)
-                                            .collect(toImmutableList()))),
+                                        newArguments)),
                         false));
                 return projectionContextBuilder.build();
             }
         }
 
-        private List<ProjectionContext> processArguments(List<RowExpression> arguments, ImmutableList.Builder<VariableReferenceExpression> newArguments)
+        private List<ProjectionContext> processArguments(List<RowExpression> arguments, ImmutableList.Builder<RowExpression> newArguments, boolean local)
         {
             // Break function arguments into local and remote projections first
             ImmutableList.Builder<List<ProjectionContext>> argumentProjections = ImmutableList.builder();
 
             for (RowExpression argument : arguments) {
-                List<ProjectionContext> argumentProjection = argument.accept(this, null);
-                if (argumentProjection.isEmpty()) {
-                    VariableReferenceExpression variable = variableAllocator.newVariable(argument);
-                    argumentProjection = ImmutableList.of(new ProjectionContext(ImmutableMap.of(variable, argument), false));
+                if (local && argument instanceof ConstantExpression) {
+                    newArguments.add(argument);
                 }
-                argumentProjections.add(argumentProjection);
-                newArguments.add(getAssignedArgument(argumentProjection));
+                else {
+                    List<ProjectionContext> argumentProjection = argument.accept(this, null);
+                    if (argumentProjection.isEmpty()) {
+                        VariableReferenceExpression variable = variableAllocator.newVariable(argument);
+                        argumentProjection = ImmutableList.of(new ProjectionContext(ImmutableMap.of(variable, argument), false));
+                    }
+                    argumentProjections.add(argumentProjection);
+                    newArguments.add(getAssignedArgument(argumentProjection));
+                }
             }
             return mergeProjectionContexts(argumentProjections.build());
         }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPlanRemoteProjections.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPlanRemoteProjections.java
@@ -223,7 +223,7 @@ public class TestPlanRemoteProjections
                     p.variable("y", INTEGER);
                     return p.project(
                             Assignments.builder()
-                                    .put(p.variable("a"), p.rowExpression("unittest.memory.remote_foo(x, y + unittest.memory.remote_foo(x))")) // identity
+                                    .put(p.variable("a"), p.rowExpression("unittest.memory.remote_foo(1, y + unittest.memory.remote_foo(x))")) // identity
                                     .put(p.variable("b"), p.rowExpression("x IS NULL OR y IS NULL")) // complex expression referenced multiple times
                                     .put(p.variable("c"), p.rowExpression("abs(unittest.memory.remote_foo()) > 0")) // complex expression referenced multiple times
                                     .put(p.variable("d"), p.rowExpression("unittest.memory.remote_foo(x + y, abs(x))")) // literal referenced multiple times
@@ -233,35 +233,34 @@ public class TestPlanRemoteProjections
                 .matches(
                         project(
                                 ImmutableMap.of(
-                                        "a", PlanMatchPattern.expression("unittest.memory.remote_foo(x, add)"),
+                                        "a", PlanMatchPattern.expression("unittest.memory.remote_foo(expr, add)"),
                                         "b", PlanMatchPattern.expression("b"),
                                         "c", PlanMatchPattern.expression("c"),
                                         "d", PlanMatchPattern.expression("d")),
                                 project(
                                         ImmutableMap.of(
-                                                "x", PlanMatchPattern.expression("x"),
                                                 "add", PlanMatchPattern.expression("y + unittest_memory_remote_foo"),
+                                                "expr", PlanMatchPattern.expression("expr"),
                                                 "b", PlanMatchPattern.expression("b"),
-                                                "c", PlanMatchPattern.expression("abs(unittest_memory_remote_foo_7) > expr_8"),
+                                                "c", PlanMatchPattern.expression("abs(unittest_memory_remote_foo_7) > 0"),
                                                 "d", PlanMatchPattern.expression("d")),
                                         project(
                                                 ImmutableMap.<String, ExpressionMatcher>builder()
-                                                        .put("x", PlanMatchPattern.expression("x"))
                                                         .put("y", PlanMatchPattern.expression("y"))
+                                                        .put("expr", PlanMatchPattern.expression("expr"))
                                                         .put("unittest_memory_remote_foo", PlanMatchPattern.expression("unittest.memory.remote_foo(x)"))
                                                         .put("b", PlanMatchPattern.expression("b"))
                                                         .put("unittest_memory_remote_foo_7", PlanMatchPattern.expression("unittest.memory.remote_foo()"))
-                                                        .put("expr_8", PlanMatchPattern.expression("expr_8"))
-                                                        .put("d", PlanMatchPattern.expression("unittest.memory.remote_foo(add_14, abs_16)"))
+                                                        .put("d", PlanMatchPattern.expression("unittest.memory.remote_foo(add_10, abs_12)"))
                                                         .build(),
                                                 project(
                                                         ImmutableMap.<String, ExpressionMatcher>builder()
                                                                 .put("x", PlanMatchPattern.expression("x"))
                                                                 .put("y", PlanMatchPattern.expression("y"))
+                                                                .put("expr", PlanMatchPattern.expression("1"))
                                                                 .put("b", PlanMatchPattern.expression("x IS NULL OR y is NULL"))
-                                                                .put("expr_8", PlanMatchPattern.expression("0"))
-                                                                .put("add_14", PlanMatchPattern.expression("x + y"))
-                                                                .put("abs_16", PlanMatchPattern.expression("abs(x)"))
+                                                                .put("add_10", PlanMatchPattern.expression("x + y"))
+                                                                .put("abs_12", PlanMatchPattern.expression("abs(x)"))
                                                                 .build(),
                                                         values(ImmutableMap.of("x", 0, "y", 1)))))));
     }


### PR DESCRIPTION
Ran explain verifier test on build 0.253-20210504.000517-49

Reintroducing https://github.com/prestodb/presto/pull/15944/commits/e306f218f737b423f76670b6a4d81e700ced3a9f.

```
== NO RELEASE NOTE ==
```
