### PR TITLE
Move audience-annotations depencency to provided scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1962,6 +1962,14 @@
                         <nexusUrl>https://oss.sonatype.org/</nexusUrl>
                     </configuration>
                 </plugin>
+
+                <plugin>
+                    <groupId>com.facebook.presto</groupId>
+                    <artifactId>presto-maven-plugin</artifactId>
+                    <version>0.4</version>
+                    <extensions>true</extensions>
+                </plugin>
+
             </plugins>
         </pluginManagement>
 
@@ -1969,8 +1977,6 @@
             <plugin>
                 <groupId>com.facebook.presto</groupId>
                 <artifactId>presto-maven-plugin</artifactId>
-                <version>0.3</version>
-                <extensions>true</extensions>
             </plugin>
 
             <plugin>

--- a/presto-kudu/pom.xml
+++ b/presto-kudu/pom.xml
@@ -126,6 +126,14 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- optional dependency of kudu-client needed only for javadoc build -->
+        <dependency>
+            <groupId>org.apache.yetus</groupId>
+            <artifactId>audience-annotations</artifactId>
+            <version>0.8.0</version>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- for testing -->
         <dependency>
             <groupId>com.facebook.presto</groupId>
@@ -216,5 +224,16 @@
                 </plugin>
             </plugins>
         </pluginManagement>
+
+        <plugins>
+            <plugin>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-maven-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <allowedProvidedDependencies>org.apache.yetus:audience-annotations</allowedProvidedDependencies>
+                </configuration>
+            </plugin>
+        </plugins>
     </build>
 </project>


### PR DESCRIPTION
Test plan - run the build

Additional dependencies specified in the javadoc plugin don't seem to hit the local Maven cache.  This makes it more susceptible to issues with Maven central being flaky or down.  By marking this as a provided dependency, it will be available for the Javadoc plugin and not included in the final build artifact, but it will also leverage Maven caching.

```
== NO RELEASE NOTE ==
```
