### PR TITLE
Update airlift to version 102

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.facebook.airlift</groupId>
         <artifactId>airbase</artifactId>
-        <version>101</version>
+        <version>102</version>
     </parent>
 
     <groupId>com.facebook.presto</groupId>


### PR DESCRIPTION
Airlift 102 includes the includeOnlyProperty git.commit.id.abbrev that fixes the presto CLI version

Test plan 
Tested with presto cli executable jar file created, prior to this change:
Presto CLI 0.253-SNAPSHOT-${git.commit.id.abbrev}
After:
Presto CLI 0.253-SNAPSHOT-ead3f71


```
== RELEASE NOTES ==

General Changes
-----------------
* Fix the version name displayed in the UI
```
