### PR TITLE
Fix NPE in HiveSpiltManager when there are upper case letters in partition columns

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitManager.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitManager.java
@@ -506,7 +506,7 @@ public class HiveSplitManager
                                 Optional.of(partition),
                                 partitionSchemaDifference.build(),
                                 encryptionInformation,
-                                partitionSplitInfo.get(partitionName).getRedundantColumnDomains()));
+                                partitionSplitInfo.get(hivePartition.getPartitionId()).getRedundantColumnDomains()));
             }
             if (unreadablePartitionsSkipped > 0) {
                 StringBuilder warningMessage = new StringBuilder(format("Table '%s' has %s out of %s partitions unreadable: ", tableName, unreadablePartitionsSkipped, partitionBatch.size()));


### PR DESCRIPTION
We're seeing HIVE_UNKNOWN_ERROR which is caused by a NPE in HiveSplitManager as below.

`com.facebook.presto.spi.PrestoException: HIVE_UNKNOWN_ERROR
	at com.facebook.presto.hive.BackgroundHiveSplitLoader$HiveSplitLoaderTask.process(BackgroundHiveSplitLoader.java:128)
	at com.facebook.presto.hive.util.ResumableTasks.safeProcessTask(ResumableTasks.java:47)
	at com.facebook.presto.hive.util.ResumableTasks.access$000(ResumableTasks.java:20)
	at com.facebook.presto.hive.util.ResumableTasks$1.run(ResumableTasks.java:35)
	at com.facebook.airlift.concurrent.BoundedExecutor.drainQueue(BoundedExecutor.java:78)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
Caused by: java.lang.NullPointerException
	at com.facebook.presto.hive.HiveSplitManager.lambda$getPartitionMetadata$5(HiveSplitManager.java:508)
	at com.google.common.collect.Iterators$6.transform(Iterators.java:785)
	at com.google.common.collect.TransformedIterator.next(TransformedIterator.java:47)
	at com.google.common.collect.TransformedIterator.next(TransformedIterator.java:47)
	at com.google.common.collect.Iterators$ConcatenatedIterator.hasNext(Iterators.java:1332)
	at com.facebook.presto.hive.ConcurrentLazyQueue.poll(ConcurrentLazyQueue.java:37)
	at com.facebook.presto.hive.BackgroundHiveSplitLoader.loadSplits(BackgroundHiveSplitLoader.java:188)
	at com.facebook.presto.hive.BackgroundHiveSplitLoader.access$300(BackgroundHiveSplitLoader.java:40)
	at com.facebook.presto.hive.BackgroundHiveSplitLoader$HiveSplitLoaderTask.process(BackgroundHiveSplitLoader.java:121)`

It's caused by the 'partitionName' is all lower case (makePartName make it to lower case), but the keys in partitionSplitInfo are still the original case.  So I use hivePartition.getPartitionId which is also original case instead of partitionName.

Canary this change in twitter starting from tonight.

```
== NO RELEASE NOTE ==
```
