### PR TITLE
Bump Alluxio client version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <dep.nexus-staging-plugin.version>1.6.8</dep.nexus-staging-plugin.version>
         <dep.asm.version>9.0</dep.asm.version>
         <dep.gcs.version>1.9.17</dep.gcs.version>
-        <dep.alluxio.version>2.4.1-3</dep.alluxio.version>
+        <dep.alluxio.version>2.5.0-3</dep.alluxio.version>
         <dep.kafka.version>2.3.1</dep.kafka.version>
         <dep.druid.version>0.19.0</dep.druid.version>
         <dep.jaxb.version>2.3.1</dep.jaxb.version>

--- a/presto-cache/src/main/java/com/facebook/presto/cache/alluxio/EvictionPolicy.java
+++ b/presto-cache/src/main/java/com/facebook/presto/cache/alluxio/EvictionPolicy.java
@@ -15,7 +15,7 @@ package com.facebook.presto.cache.alluxio;
 
 public enum EvictionPolicy
 {
-    FIFO("alluxio.client.file.cache.evictor.FIFOEvictor"),
+    FIFO("alluxio.client.file.cache.evictor.FIFOCacheEvictor"),
     LFU("alluxio.client.file.cache.evictor.LFUCacheEvictor"),
     LRU("alluxio.client.file.cache.evictor.LRUCacheEvictor"),
     UNEVICTABLE("alluxio.client.file.cache.evictor.UnevictableCacheEvictor"),


### PR DESCRIPTION
Upgrade to Alluxio v2.5.0-3 which fixes a regression in cleaning up unused cache dirs.
Also update a class name used in Presto which is renamed in v2.5.0-3

```
== NO RELEASE NOTE ==
```
