### PR TITLE
MODULE_DIR is now renamed to MODULE_WORKING_DIR in IntelliJ

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Presto comes with sample configuration that should work out-of-the-box for devel
 
 * Main Class: `com.facebook.presto.server.PrestoServer`
 * VM Options: `-ea -XX:+UseG1GC -XX:G1HeapRegionSize=32M -XX:+UseGCOverheadLimit -XX:+ExplicitGCInvokesConcurrent -Xmx2G -Dconfig=etc/config.properties -Dlog.levels-file=etc/log.properties`
-* Working directory: `$MODULE_DIR$`
+* Working directory: `$MODULE_WORKING_DIR$` or `$MODULE_DIR$`(Depends on the version of your IntelliJ)
 * Use classpath of module: `presto-main`
 
 The working directory should be the `presto-main` subdirectory. In IntelliJ, using `$MODULE_DIR$` accomplishes this automatically.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Presto comes with sample configuration that should work out-of-the-box for devel
 
 * Main Class: `com.facebook.presto.server.PrestoServer`
 * VM Options: `-ea -XX:+UseG1GC -XX:G1HeapRegionSize=32M -XX:+UseGCOverheadLimit -XX:+ExplicitGCInvokesConcurrent -Xmx2G -Dconfig=etc/config.properties -Dlog.levels-file=etc/log.properties`
-* Working directory: `$MODULE_WORKING_DIR$` or `$MODULE_DIR$`(Depends on the version of your IntelliJ)
+* Working directory: `$MODULE_WORKING_DIR$` or `$MODULE_DIR$`(Depends your version of IntelliJ)
 * Use classpath of module: `presto-main`
 
 The working directory should be the `presto-main` subdirectory. In IntelliJ, using `$MODULE_DIR$` accomplishes this automatically.


### PR DESCRIPTION
MODULE_DIR is now renamed to MODULE_WORKING_DIR in IntelliJ

![image](https://user-images.githubusercontent.com/379733/117928143-b8c8ce00-b32d-11eb-9e83-ec3827b3d9fc.png)

```
== NO RELEASE NOTE ==
```
