### PR TITLE
Define custom json serializer for DataSize and Duration

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/DataSizeSerializer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/DataSizeSerializer.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import io.airlift.units.DataSize;
+
+import java.io.IOException;
+
+public class DataSizeSerializer
+        extends JsonSerializer<DataSize>
+{
+    @Override
+    public void serialize(DataSize dataSize, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
+            throws IOException
+    {
+        jsonGenerator.writeString(dataSize.convertToMostSuccinctDataSize().toString());
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/DurationSerializer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/DurationSerializer.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import io.airlift.units.Duration;
+
+import java.io.IOException;
+
+public class DurationSerializer
+        extends JsonSerializer<Duration>
+{
+    @Override
+    public void serialize(Duration duration, JsonGenerator jsonGenerator, SerializerProvider serializerProvider)
+            throws IOException
+    {
+        jsonGenerator.writeString(duration.convertToMostSuccinctTimeUnit().toString());
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/ResourceManagerModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ResourceManagerModule.java
@@ -34,6 +34,8 @@ import com.facebook.presto.transaction.TransactionManager;
 import com.google.inject.Binder;
 import com.google.inject.Provides;
 import com.google.inject.Scopes;
+import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
 
 import javax.inject.Singleton;
 
@@ -41,6 +43,7 @@ import static com.facebook.airlift.configuration.ConditionalModule.installModule
 import static com.facebook.airlift.discovery.client.DiscoveryBinder.discoveryBinder;
 import static com.facebook.airlift.http.client.HttpClientBinder.httpClientBinder;
 import static com.facebook.airlift.jaxrs.JaxrsBinder.jaxrsBinder;
+import static com.facebook.airlift.json.JsonBinder.jsonBinder;
 import static com.facebook.airlift.json.JsonCodecBinder.jsonCodecBinder;
 import static com.facebook.airlift.json.smile.SmileCodecBinder.smileCodecBinder;
 import static com.facebook.drift.server.guice.DriftServerBinder.driftServerBinder;
@@ -95,6 +98,8 @@ public class ResourceManagerModule
 
         httpClientBinder(binder).bindHttpClient("resourceManager", ForResourceManager.class);
         binder.bind(ResourceManagerProxy.class).in(Scopes.SINGLETON);
+        jsonBinder(binder).addSerializerBinding(Duration.class).to(DurationSerializer.class);
+        jsonBinder(binder).addSerializerBinding(DataSize.class).to(DataSizeSerializer.class);
     }
 
     @Provides


### PR DESCRIPTION
Currently thrift encoding leverages ThriftCodec implementations that convert DataSize as well as Duration objects to double for optimization. So even though the resource manager thrift client sends both DataSize as well as Duration objects with well formatted unit, the unit information is getting lost on Resource manager server side. This commit is to address this issue by defining custom json serializer so that UI can display well formatted json value for DataSize and Duration.

Test plan -  Verified by running TpchQueryRunner