### PR TITLE
Add properties to update memory in TableFinishOperator

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/memory/MemoryManagerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/MemoryManagerConfig.java
@@ -39,6 +39,7 @@ public class MemoryManagerConfig
     private DataSize softMaxQueryTotalMemory;
     private String lowMemoryKillerPolicy = LowMemoryKillerPolicy.NONE;
     private Duration killOnOutOfMemoryDelay = new Duration(5, MINUTES);
+    private boolean tableFinishOperatorMemoryTrackingEnabled;
 
     public String getLowMemoryKillerPolicy()
     {
@@ -128,6 +129,18 @@ public class MemoryManagerConfig
     public MemoryManagerConfig setSoftMaxQueryTotalMemory(DataSize softMaxQueryTotalMemory)
     {
         this.softMaxQueryTotalMemory = softMaxQueryTotalMemory;
+        return this;
+    }
+
+    public boolean isTableFinishOperatorMemoryTrackingEnabled()
+    {
+        return tableFinishOperatorMemoryTrackingEnabled;
+    }
+
+    @Config("table-finish-operator-memory-tracking-enabled")
+    public MemoryManagerConfig setTableFinishOperatorMemoryTrackingEnabled(boolean tableFinishOperatorMemoryTrackingEnabled)
+    {
+        this.tableFinishOperatorMemoryTrackingEnabled = tableFinishOperatorMemoryTrackingEnabled;
         return this;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -44,6 +44,7 @@ import com.facebook.presto.expressions.DynamicFilters.DynamicFilterExtractResult
 import com.facebook.presto.expressions.DynamicFilters.DynamicFilterPlaceholder;
 import com.facebook.presto.expressions.LogicalRowExpressions;
 import com.facebook.presto.index.IndexManager;
+import com.facebook.presto.memory.MemoryManagerConfig;
 import com.facebook.presto.metadata.AnalyzeTableHandle;
 import com.facebook.presto.metadata.ConnectorMetadataUpdaterManager;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
@@ -357,6 +358,7 @@ public class LocalExecutionPlanner
     private final LogicalRowExpressions logicalRowExpressions;
     private final FragmentResultCacheManager fragmentResultCacheManager;
     private final ObjectMapper objectMapper;
+    private final boolean tableFinishOperatorMemoryTrackingEnabled;
 
     private static final TypeSignature SPHERICAL_GEOGRAPHY_TYPE_SIGNATURE = parseTypeSignature("SphericalGeography");
 
@@ -375,6 +377,7 @@ public class LocalExecutionPlanner
             JoinFilterFunctionCompiler joinFilterFunctionCompiler,
             IndexJoinLookupStats indexJoinLookupStats,
             TaskManagerConfig taskManagerConfig,
+            MemoryManagerConfig memoryManagerConfig,
             SpillerFactory spillerFactory,
             SingleStreamSpillerFactory singleStreamSpillerFactory,
             PartitioningSpillerFactory partitioningSpillerFactory,
@@ -419,6 +422,7 @@ public class LocalExecutionPlanner
                 metadata.getFunctionAndTypeManager());
         this.fragmentResultCacheManager = requireNonNull(fragmentResultCacheManager, "fragmentResultCacheManager is null");
         this.objectMapper = requireNonNull(objectMapper, "objectMapper is null");
+        this.tableFinishOperatorMemoryTrackingEnabled = requireNonNull(memoryManagerConfig, "memoryManagerConfig is null").isTableFinishOperatorMemoryTrackingEnabled();
     }
 
     public LocalExecutionPlan plan(
@@ -2688,7 +2692,8 @@ public class LocalExecutionPlanner
                     statisticsAggregation,
                     descriptor,
                     session,
-                    tableCommitContextCodec);
+                    tableCommitContextCodec,
+                    tableFinishOperatorMemoryTrackingEnabled);
             Map<VariableReferenceExpression, Integer> layout = ImmutableMap.of(node.getOutputVariables().get(0), 0);
 
             return new PhysicalOperation(operatorFactory, layout, context, source);

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -794,6 +794,7 @@ public class LocalQueryRunner
                 joinFilterFunctionCompiler,
                 new IndexJoinLookupStats(),
                 new TaskManagerConfig().setTaskConcurrency(4),
+                new MemoryManagerConfig(),
                 spillerFactory,
                 singleStreamSpillerFactory,
                 partitioningSpillerFactory,

--- a/presto-main/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
@@ -27,6 +27,7 @@ import com.facebook.presto.execution.scheduler.NodeSchedulerConfig;
 import com.facebook.presto.execution.scheduler.TableWriteInfo;
 import com.facebook.presto.execution.scheduler.nodeSelection.NodeSelectionStats;
 import com.facebook.presto.index.IndexManager;
+import com.facebook.presto.memory.MemoryManagerConfig;
 import com.facebook.presto.metadata.ConnectorMetadataUpdaterManager;
 import com.facebook.presto.metadata.InMemoryNodeManager;
 import com.facebook.presto.metadata.MetadataManager;
@@ -161,6 +162,7 @@ public final class TaskTestUtils
                 new JoinFilterFunctionCompiler(metadata),
                 new IndexJoinLookupStats(),
                 new TaskManagerConfig(),
+                new MemoryManagerConfig(),
                 new GenericSpillerFactory((types, spillContext, memoryContext) -> {
                     throw new UnsupportedOperationException();
                 }),

--- a/presto-main/src/test/java/com/facebook/presto/memory/TestMemoryManagerConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/memory/TestMemoryManagerConfig.java
@@ -40,7 +40,8 @@ public class TestMemoryManagerConfig
                 .setMaxQueryMemory(new DataSize(20, GIGABYTE))
                 .setSoftMaxQueryMemory(new DataSize(20, GIGABYTE))
                 .setMaxQueryTotalMemory(new DataSize(40, GIGABYTE))
-                .setSoftMaxQueryTotalMemory(new DataSize(40, GIGABYTE)));
+                .setSoftMaxQueryTotalMemory(new DataSize(40, GIGABYTE))
+                .setTableFinishOperatorMemoryTrackingEnabled(false));
     }
 
     @Test
@@ -53,6 +54,7 @@ public class TestMemoryManagerConfig
                 .put("query.soft-max-memory", "1GB")
                 .put("query.max-total-memory", "3GB")
                 .put("query.soft-max-total-memory", "2GB")
+                .put("table-finish-operator-memory-tracking-enabled", "true")
                 .build();
 
         MemoryManagerConfig expected = new MemoryManagerConfig()
@@ -61,7 +63,8 @@ public class TestMemoryManagerConfig
                 .setMaxQueryMemory(new DataSize(2, GIGABYTE))
                 .setSoftMaxQueryMemory(new DataSize(1, GIGABYTE))
                 .setMaxQueryTotalMemory(new DataSize(3, GIGABYTE))
-                .setSoftMaxQueryTotalMemory(new DataSize(2, GIGABYTE));
+                .setSoftMaxQueryTotalMemory(new DataSize(2, GIGABYTE))
+                .setTableFinishOperatorMemoryTrackingEnabled(true);
 
         assertFullMapping(properties, expected);
     }

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestTableFinishOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestTableFinishOperator.java
@@ -121,7 +121,8 @@ public class TestTableFinishOperator
                         true),
                 descriptor,
                 session,
-                TABLE_COMMIT_CONTEXT_CODEC);
+                TABLE_COMMIT_CONTEXT_CODEC,
+                false);
         DriverContext driverContext = createTaskContext(scheduledExecutor, scheduledExecutor, session)
                 .addPipelineContext(0, true, true, false)
                 .addDriverContext();
@@ -201,7 +202,8 @@ public class TestTableFinishOperator
                         true),
                 descriptor,
                 session,
-                TABLE_COMMIT_CONTEXT_CODEC);
+                TABLE_COMMIT_CONTEXT_CODEC,
+                false);
         DriverContext driverContext = createTaskContext(scheduledExecutor, scheduledExecutor, session)
                 .addPipelineContext(0, true, true, false)
                 .addDriverContext();


### PR DESCRIPTION
When system memory used by TableFinishOperator is tracked
and included in query total memory, query may hit memory
limit and fail.

```
== RELEASE NOTES ==

General Changes
* Memory tracking in TableFinishOperator can be enabled by setting the `table-finish-operator-memory-tracking-enabled` configuration property to `true`.

