### PR TITLE
Revert "Revert "Bring retry queries to the beginning of the queue""

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/dispatcher/FailedDispatchQuery.java
+++ b/presto-main/src/main/java/com/facebook/presto/dispatcher/FailedDispatchQuery.java
@@ -131,6 +131,12 @@ public class FailedDispatchQuery
     }
 
     @Override
+    public boolean isRetry()
+    {
+        return false;
+    }
+
+    @Override
     public void recordHeartbeat() {}
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/dispatcher/LocalDispatchQueryFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/dispatcher/LocalDispatchQueryFactory.java
@@ -123,6 +123,7 @@ public class LocalDispatchQueryFactory
                 queryExecutionFuture,
                 clusterSizeMonitor,
                 executor,
-                queryManager::createQuery);
+                queryManager::createQuery,
+                retryCount > 0);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/ManagedQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/ManagedQueryExecution.java
@@ -51,4 +51,6 @@ public interface ManagedQueryExecution
      * @return Returns non-empty value iff error has occurred and query failed state is visible.
      */
     Optional<ErrorCode> getErrorCode();
+
+    boolean isRetry();
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/TieredQueue.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/TieredQueue.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.resourceGroups;
+
+import java.util.Iterator;
+import java.util.function.Supplier;
+
+import static com.google.common.collect.Iterators.concat;
+import static java.util.Objects.requireNonNull;
+
+final class TieredQueue<E>
+        implements UpdateablePriorityQueue<E>
+{
+    private final UpdateablePriorityQueue<E> highPriorityQueue;
+    private final UpdateablePriorityQueue<E> lowPriorityQueue;
+
+    public TieredQueue(UpdateablePriorityQueue<E> highPriorityQueue, UpdateablePriorityQueue<E> lowPriorityQueue)
+    {
+        this.highPriorityQueue = requireNonNull(highPriorityQueue, "highPriorityQueue is null");
+        this.lowPriorityQueue = requireNonNull(lowPriorityQueue, "lowPriorityQueue is null");
+    }
+
+    public TieredQueue(Supplier<UpdateablePriorityQueue<E>> supplier)
+    {
+        this(supplier.get(), supplier.get());
+    }
+
+    @Override
+    public boolean addOrUpdate(E element, long priority)
+    {
+        return lowPriorityQueue.addOrUpdate(element, priority);
+    }
+
+    public boolean prioritize(E element, long priority)
+    {
+        return highPriorityQueue.addOrUpdate(element, priority);
+    }
+
+    @Override
+    public boolean contains(E element)
+    {
+        return highPriorityQueue.contains(element) || lowPriorityQueue.contains(element);
+    }
+
+    @Override
+    public boolean remove(E element)
+    {
+        boolean highPriorityRemoved = highPriorityQueue.remove(element);
+        boolean lowPriorityRemoved = lowPriorityQueue.remove(element);
+        return highPriorityRemoved || lowPriorityRemoved;
+    }
+
+    @Override
+    public E poll()
+    {
+        Iterator<E> iterator = iterator();
+        if (!iterator.hasNext()) {
+            return null;
+        }
+        E element = iterator.next();
+        iterator.remove();
+        return element;
+    }
+
+    @Override
+    public E peek()
+    {
+        Iterator<E> iterator = iterator();
+        if (!iterator.hasNext()) {
+            return null;
+        }
+        return iterator.next();
+    }
+
+    @Override
+    public int size()
+    {
+        return highPriorityQueue.size() + lowPriorityQueue.size();
+    }
+
+    @Override
+    public boolean isEmpty()
+    {
+        return highPriorityQueue.isEmpty() && lowPriorityQueue.isEmpty();
+    }
+
+    @Override
+    public Iterator<E> iterator()
+    {
+        return concat(highPriorityQueue.iterator(), lowPriorityQueue.iterator());
+    }
+
+    public UpdateablePriorityQueue<E> getLowPriorityQueue()
+    {
+        return lowPriorityQueue;
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/dispatcher/TestLocalDispatchQuery.java
+++ b/presto-main/src/test/java/com/facebook/presto/dispatcher/TestLocalDispatchQuery.java
@@ -84,7 +84,8 @@ public class TestLocalDispatchQuery
                 immediateFailedFuture(new IllegalStateException("abc")),
                 createClusterSizeMonitor(0),
                 directExecutor(),
-                execution -> {});
+                execution -> {},
+                false);
 
         assertEquals(query.getBasicQueryInfo().getState(), FAILED);
         assertEquals(query.getBasicQueryInfo().getErrorCode(), GENERIC_INTERNAL_ERROR.toErrorCode());
@@ -106,7 +107,8 @@ public class TestLocalDispatchQuery
                 immediateFailedFuture(new IllegalStateException("abc")),
                 createClusterSizeMonitor(0),
                 directExecutor(),
-                execution -> {});
+                execution -> {},
+                false);
 
         assertEquals(query.getBasicQueryInfo().getState(), FAILED);
         assertEquals(query.getBasicQueryInfo().getErrorCode(), QUERY_QUEUE_FULL.toErrorCode());
@@ -127,7 +129,8 @@ public class TestLocalDispatchQuery
                 directExecutor(),
                 execution -> {
                     throw new AccessDeniedException("sdf");
-                });
+                },
+                false);
 
         assertEquals(query.getBasicQueryInfo().getState(), QUEUED);
         assertFalse(eventListener.getQueryCompletedEvent().isPresent());
@@ -154,7 +157,8 @@ public class TestLocalDispatchQuery
                 immediateFuture(null),
                 createClusterSizeMonitor(1),
                 directExecutor(),
-                execution -> {});
+                execution -> {},
+                false);
 
         assertEquals(query.getBasicQueryInfo().getState(), QUEUED);
         assertFalse(eventListener.getQueryCompletedEvent().isPresent());
@@ -182,7 +186,8 @@ public class TestLocalDispatchQuery
                 immediateFuture(null),
                 createClusterSizeMonitor(0),
                 directExecutor(),
-                execution -> {});
+                execution -> {},
+                false);
 
         assertEquals(query.getBasicQueryInfo().getState(), QUEUED);
         assertFalse(eventListener.getQueryCompletedEvent().isPresent());
@@ -208,7 +213,8 @@ public class TestLocalDispatchQuery
                 immediateFuture(null),
                 createClusterSizeMonitor(0),
                 directExecutor(),
-                execution -> {});
+                execution -> {},
+                false);
 
         assertEquals(query.getBasicQueryInfo().getState(), QUEUED);
         assertFalse(eventListener.getQueryCompletedEvent().isPresent());

--- a/presto-main/src/test/java/com/facebook/presto/execution/MockManagedQueryExecution.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/MockManagedQueryExecution.java
@@ -96,6 +96,12 @@ public class MockManagedQueryExecution
     }
 
     @Override
+    public boolean isRetry()
+    {
+        return false;
+    }
+
+    @Override
     public BasicQueryInfo getBasicQueryInfo()
     {
         return new BasicQueryInfo(

--- a/presto-main/src/test/java/com/facebook/presto/execution/resourceGroups/TestUpdateablePriorityQueue.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/resourceGroups/TestUpdateablePriorityQueue.java
@@ -47,6 +47,17 @@ public class TestUpdateablePriorityQueue
         assertTrue(populateAndExtract(new StochasticPriorityQueue<>()).size() == 3);
     }
 
+    @Test
+    public void testTieredQueue()
+    {
+        TieredQueue<Integer> queue = new TieredQueue<>(FifoQueue::new);
+        assertEquals(populateAndExtract(queue), ImmutableList.of(1, 2, 3));
+
+        queue.prioritize(4, 0);
+        queue.prioritize(5, 0);
+        assertEquals(populateAndExtract(queue), ImmutableList.of(4, 5, 1, 2, 3));
+    }
+
     private static List<Integer> populateAndExtract(UpdateablePriorityQueue<Integer> queue)
     {
         queue.addOrUpdate(1, 1);


### PR DESCRIPTION
This reverts commit 150fb77b9300857e696077858d107cf37adf2f34. `IndexedPriorityQueue`'s
iterator has been fixed to not have this leak and hence we can reinstate this commit

Test plan - This PR is a revert of a revert. The actual issue was fixed in https://github.com/prestodb/presto/pull/16084

```
== NO RELEASE NOTE ==
```
