### PR TITLE
Initial commit for adding MBean counter to TaskUpdateRequest

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTask.java
@@ -23,6 +23,7 @@ import com.facebook.airlift.json.Codec;
 import com.facebook.airlift.json.JsonCodec;
 import com.facebook.airlift.json.smile.SmileCodec;
 import com.facebook.airlift.log.Logger;
+import com.facebook.airlift.stats.DecayCounter;
 import com.facebook.drift.transport.netty.codec.Protocol;
 import com.facebook.presto.Session;
 import com.facebook.presto.execution.FutureStateChange;
@@ -202,6 +203,8 @@ public final class HttpRemoteTask
 
     private final TableWriteInfo tableWriteInfo;
 
+    private final DecayCounter taskUpdateRequestSize;
+
     public HttpRemoteTask(
             Session session,
             TaskId taskId,
@@ -233,7 +236,8 @@ public final class HttpRemoteTask
             TableWriteInfo tableWriteInfo,
             int maxTaskUpdateSizeInBytes,
             MetadataManager metadataManager,
-            QueryManager queryManager)
+            QueryManager queryManager,
+            DecayCounter taskUpdateRequestSize)
     {
         requireNonNull(session, "session is null");
         requireNonNull(taskId, "taskId is null");
@@ -256,6 +260,7 @@ public final class HttpRemoteTask
         requireNonNull(metadataManager, "metadataManager is null");
         requireNonNull(queryManager, "queryManager is null");
         requireNonNull(thriftProtocol, "thriftProtocol is null");
+        requireNonNull(taskUpdateRequestSize, "taskUpdateRequestSize cannot be null");
 
         try (SetThreadName ignored = new SetThreadName("HttpRemoteTask-%s", taskId)) {
             this.taskId = taskId;
@@ -288,6 +293,7 @@ public final class HttpRemoteTask
             this.remoteSourcePlanNodeIds = planFragment.getRemoteSourceNodes().stream()
                     .map(PlanNode::getId)
                     .collect(toImmutableSet());
+            this.taskUpdateRequestSize = taskUpdateRequestSize;
 
             for (Entry<PlanNodeId, Split> entry : requireNonNull(initialSplits, "initialSplits is null").entries()) {
                 ScheduledSplit scheduledSplit = new ScheduledSplit(nextSplitId.getAndIncrement(), entry.getKey(), entry.getValue());
@@ -700,6 +706,7 @@ public final class HttpRemoteTask
                 outputBuffers.get(),
                 writeInfo);
         byte[] taskUpdateRequestJson = taskUpdateRequestCodec.toBytes(updateRequest);
+        taskUpdateRequestSize.add(taskUpdateRequestJson.length);
 
         if (taskUpdateRequestJson.length > maxTaskUpdateSizeInBytes) {
             failTask(new PrestoException(EXCEEDED_TASK_UPDATE_SIZE_LIMIT, format("TaskUpdate size of %d Bytes has exceeded the limit of %d Bytes", taskUpdateRequestJson.length, maxTaskUpdateSizeInBytes)));

--- a/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTaskFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/remotetask/HttpRemoteTaskFactory.java
@@ -19,6 +19,8 @@ import com.facebook.airlift.http.client.HttpClient;
 import com.facebook.airlift.json.Codec;
 import com.facebook.airlift.json.JsonCodec;
 import com.facebook.airlift.json.smile.SmileCodec;
+import com.facebook.airlift.stats.DecayCounter;
+import com.facebook.airlift.stats.ExponentialDecay;
 import com.facebook.drift.codec.ThriftCodec;
 import com.facebook.drift.transport.netty.codec.Protocol;
 import com.facebook.presto.Session;
@@ -89,6 +91,7 @@ public class HttpRemoteTaskFactory
     private final int maxTaskUpdateSizeInBytes;
     private final MetadataManager metadataManager;
     private final QueryManager queryManager;
+    private final DecayCounter taskUpdateRequestSize;
 
     @Inject
     public HttpRemoteTaskFactory(
@@ -155,6 +158,7 @@ public class HttpRemoteTaskFactory
 
         this.updateScheduledExecutor = newSingleThreadScheduledExecutor(daemonThreadsNamed("task-info-update-scheduler-%s"));
         this.errorScheduledExecutor = newSingleThreadScheduledExecutor(daemonThreadsNamed("remote-task-error-delay-%s"));
+        this.taskUpdateRequestSize = new DecayCounter(ExponentialDecay.oneMinute());
     }
 
     @Managed
@@ -162,6 +166,12 @@ public class HttpRemoteTaskFactory
     public ThreadPoolExecutorMBean getExecutor()
     {
         return executorMBean;
+    }
+
+    @Managed
+    public double getTaskUpdateRequestSize()
+    {
+        return taskUpdateRequestSize.getCount();
     }
 
     @PreDestroy
@@ -215,6 +225,7 @@ public class HttpRemoteTaskFactory
                 tableWriteInfo,
                 maxTaskUpdateSizeInBytes,
                 metadataManager,
-                queryManager);
+                queryManager,
+                taskUpdateRequestSize);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/server/remotetask/TestHttpRemoteTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/remotetask/TestHttpRemoteTask.java
@@ -196,6 +196,26 @@ public class TestHttpRemoteTask
         httpRemoteTaskFactory.stop();
     }
 
+    @Test(timeOut = 30000)
+    public void testHTTPRemoteTaskSize()
+            throws Exception
+    {
+        AtomicLong lastActivityNanos = new AtomicLong(System.nanoTime());
+        TestingTaskResource testingTaskResource = new TestingTaskResource(lastActivityNanos, FailureScenario.NO_FAILURE);
+
+        HttpRemoteTaskFactory httpRemoteTaskFactory = createHttpRemoteTaskFactory(testingTaskResource, false);
+
+        RemoteTask remoteTask = createRemoteTask(httpRemoteTaskFactory);
+
+        testingTaskResource.setInitialTaskInfo(remoteTask.getTaskInfo());
+        remoteTask.start();
+        // just need to run a TaskUpdateRequest to increment the decay counter
+        remoteTask.cancel();
+        httpRemoteTaskFactory.stop();
+
+        assertTrue(httpRemoteTaskFactory.getTaskUpdateRequestSize() > 0);
+    }
+
     private void runTest(FailureScenario failureScenario, boolean useThriftEncoding)
             throws Exception
     {


### PR DESCRIPTION
Due to large sized TaskUpdateRequest created, coordinator has to invoke a full GC. 
To identify and understand this, we are introducing MBean that tracks the memory size of the serialized TaskUpdateRequests.

Test plan - (Please fill in how you tested your changes)

1. Having a unit test for the code that is written 
2. Running a query and having jconsole that shows that jmx beans are created
![Screen Shot 2021-05-24 at 6 14 51 PM](https://user-images.githubusercontent.com/76267197/119426238-afd8e480-bcbd-11eb-8533-d481cd71d5f8.png)
![Screen Shot 2021-05-24 at 6 15 00 PM](https://user-images.githubusercontent.com/76267197/119426243-b0717b00-bcbd-11eb-9e59-b2451b179448.png)


Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines. Don't forget to follow our [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution) for any code copied from other projects.

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.


== NO RELEASE NOTE ==

