### PR TITLE
Plumb DWRF stripe cache info from proto to model

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
@@ -675,7 +675,8 @@ public class OrcWriter
                 orcTypes,
                 ImmutableList.copyOf(unencryptedStats),
                 userMetadata,
-                dwrfEncryption);
+                dwrfEncryption,
+                Optional.empty());
 
         closedStripes.clear();
         closedStripesRetainedBytes = 0;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfMetadataReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfMetadataReader.java
@@ -51,6 +51,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.SortedMap;
 
 import static com.facebook.presto.orc.NoopOrcAggregatedMemoryContext.NOOP_ORC_AGGREGATED_MEMORY_CONTEXT;
@@ -88,13 +89,22 @@ public class DwrfMetadataReader
 
         HiveWriterVersion writerVersion = postScript.hasWriterVersion() && postScript.getWriterVersion() > 0 ? ORC_HIVE_8732 : ORIGINAL;
 
+        OptionalInt stripeCacheLength = OptionalInt.empty();
+        Optional<DwrfStripeCacheMode> stripeCacheMode = Optional.empty();
+        if (postScript.hasCacheSize() && postScript.hasCacheMode()) {
+            stripeCacheLength = OptionalInt.of(postScript.getCacheSize());
+            stripeCacheMode = Optional.of(toStripeCacheMode(postScript.getCacheMode()));
+        }
+
         return new PostScript(
                 ImmutableList.of(),
                 postScript.getFooterLength(),
                 0,
                 toCompression(postScript.getCompression()),
                 postScript.getCompressionBlockSize(),
-                writerVersion);
+                writerVersion,
+                stripeCacheLength,
+                stripeCacheMode);
     }
 
     @Override
@@ -118,6 +128,7 @@ public class DwrfMetadataReader
         List<StripeInformation> fileStripes = toStripeInformation(footer.getStripesList());
         List<OrcType> types = toType(footer.getTypesList());
         Optional<DwrfEncryption> encryption = footer.hasEncryption() ? Optional.of(toEncryption(footer.getEncryption())) : Optional.empty();
+        Optional<List<Integer>> stripeCacheOffsets = Optional.of(footer.getStripeCacheOffsetsList());
 
         if (encryption.isPresent()) {
             Map<Integer, Slice> keys = dwrfKeyProvider.getIntermediateKeys(types);
@@ -132,7 +143,8 @@ public class DwrfMetadataReader
                 types,
                 fileStats,
                 toUserMetadata(footer.getMetadataList()),
-                encryption);
+                encryption,
+                stripeCacheOffsets);
     }
 
     private List<ColumnStatistics> decryptAndCombineFileStatistics(HiveWriterVersion hiveWriterVersion,
@@ -630,6 +642,20 @@ public class DwrfMetadataReader
                 return ZSTD;
             default:
                 throw new IllegalArgumentException(compression + " compression not implemented yet");
+        }
+    }
+
+    static DwrfStripeCacheMode toStripeCacheMode(DwrfProto.StripeCacheMode mode)
+    {
+        switch (mode) {
+            case INDEX:
+                return DwrfStripeCacheMode.INDEX;
+            case FOOTER:
+                return DwrfStripeCacheMode.FOOTER;
+            case BOTH:
+                return DwrfStripeCacheMode.INDEX_AND_FOOTER;
+            default:
+                return DwrfStripeCacheMode.NONE;
         }
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfStripeCacheMode.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfStripeCacheMode.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.metadata;
+
+/**
+ * Describes content of the DWRF stripe metadata cache.
+ */
+public enum DwrfStripeCacheMode
+{
+    // no cache
+    NONE,
+
+    // cache contains stripe indexes
+    INDEX,
+
+    // cache contains stripe footers
+    FOOTER,
+
+    // cache contains stripe indexes and footers
+    INDEX_AND_FOOTER;
+}

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/Footer.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/Footer.java
@@ -36,8 +36,17 @@ public class Footer
     private final List<ColumnStatistics> fileStats;
     private final Map<String, Slice> userMetadata;
     private final Optional<DwrfEncryption> encryption;
+    private final Optional<List<Integer>> dwrfStripeCacheOffsets;
 
-    public Footer(long numberOfRows, int rowsInRowGroup, List<StripeInformation> stripes, List<OrcType> types, List<ColumnStatistics> fileStats, Map<String, Slice> userMetadata, Optional<DwrfEncryption> encryption)
+    public Footer(
+            long numberOfRows,
+            int rowsInRowGroup,
+            List<StripeInformation> stripes,
+            List<OrcType> types,
+            List<ColumnStatistics> fileStats,
+            Map<String, Slice> userMetadata,
+            Optional<DwrfEncryption> encryption,
+            Optional<List<Integer>> dwrfStripeCacheOffsets)
     {
         this.numberOfRows = numberOfRows;
         this.rowsInRowGroup = rowsInRowGroup;
@@ -47,6 +56,7 @@ public class Footer
         requireNonNull(userMetadata, "userMetadata is null");
         this.userMetadata = ImmutableMap.copyOf(transformValues(userMetadata, Slices::copyOf));
         this.encryption = requireNonNull(encryption, "encryption is null");
+        this.dwrfStripeCacheOffsets = requireNonNull(dwrfStripeCacheOffsets, "dwrfStripeCacheOffsets is null").map(ImmutableList::copyOf);
     }
 
     public long getNumberOfRows()
@@ -79,6 +89,16 @@ public class Footer
         return ImmutableMap.copyOf(transformValues(userMetadata, Slices::copyOf));
     }
 
+    public Optional<DwrfEncryption> getEncryption()
+    {
+        return encryption;
+    }
+
+    public Optional<List<Integer>> getDwrfStripeCacheOffsets()
+    {
+        return dwrfStripeCacheOffsets;
+    }
+
     @Override
     public String toString()
     {
@@ -89,11 +109,7 @@ public class Footer
                 .add("types", types)
                 .add("columnStatistics", fileStats)
                 .add("userMetadata", userMetadata.keySet())
+                .add("dwrfStripeCacheOffsets", dwrfStripeCacheOffsets)
                 .toString();
-    }
-
-    public Optional<DwrfEncryption> getEncryption()
-    {
-        return encryption;
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcMetadataReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcMetadataReader.java
@@ -48,6 +48,7 @@ import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.stream.IntStream;
 
 import static com.facebook.presto.orc.metadata.CompressionKind.LZ4;
@@ -93,7 +94,9 @@ public class OrcMetadataReader
                 postScript.getMetadataLength(),
                 toCompression(postScript.getCompression()),
                 postScript.getCompressionBlockSize(),
-                toHiveWriterVersion(postScript.getWriterVersion()));
+                toHiveWriterVersion(postScript.getWriterVersion()),
+                OptionalInt.empty(),
+                Optional.empty());
     }
 
     private static HiveWriterVersion toHiveWriterVersion(int writerVersion)
@@ -145,6 +148,7 @@ public class OrcMetadataReader
                 toType(footer.getTypesList()),
                 toColumnStatistics(hiveWriterVersion, footer.getStatisticsList(), false),
                 toUserMetadata(footer.getMetadataList()),
+                Optional.empty(),
                 Optional.empty());
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/PostScript.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/PostScript.java
@@ -18,6 +18,8 @@ import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
@@ -49,8 +51,18 @@ public class PostScript
     private final CompressionKind compression;
     private final long compressionBlockSize;
     private final HiveWriterVersion hiveWriterVersion;
+    private final OptionalInt dwrfStripeCacheLength;
+    private final Optional<DwrfStripeCacheMode> dwrfStripeCacheMode;
 
-    public PostScript(List<Integer> version, long footerLength, long metadataLength, CompressionKind compression, long compressionBlockSize, HiveWriterVersion hiveWriterVersion)
+    public PostScript(
+            List<Integer> version,
+            long footerLength,
+            long metadataLength,
+            CompressionKind compression,
+            long compressionBlockSize,
+            HiveWriterVersion hiveWriterVersion,
+            OptionalInt dwrfStripeCacheLength,
+            Optional<DwrfStripeCacheMode> dwrfStripeCacheMode)
     {
         this.version = ImmutableList.copyOf(requireNonNull(version, "version is null"));
         this.footerLength = footerLength;
@@ -58,6 +70,8 @@ public class PostScript
         this.compression = requireNonNull(compression, "compressionKind is null");
         this.compressionBlockSize = compressionBlockSize;
         this.hiveWriterVersion = requireNonNull(hiveWriterVersion, "hiveWriterVersion is null");
+        this.dwrfStripeCacheLength = requireNonNull(dwrfStripeCacheLength, "dwrfStripeCacheLength is null");
+        this.dwrfStripeCacheMode = requireNonNull(dwrfStripeCacheMode, "dwrfStripeCacheMode is null");
     }
 
     public List<Integer> getVersion()
@@ -90,6 +104,16 @@ public class PostScript
         return hiveWriterVersion;
     }
 
+    public OptionalInt getDwrfStripeCacheLength()
+    {
+        return dwrfStripeCacheLength;
+    }
+
+    public Optional<DwrfStripeCacheMode> getDwrfStripeCacheMode()
+    {
+        return dwrfStripeCacheMode;
+    }
+
     @Override
     public String toString()
     {
@@ -100,6 +124,8 @@ public class PostScript
                 .add("compressionKind", compression)
                 .add("compressionBlockSize", compressionBlockSize)
                 .add("hiveWriterVersion", hiveWriterVersion)
+                .add("dwrfStripeCacheLength", dwrfStripeCacheLength)
+                .add("dwrfStripeCacheMode", dwrfStripeCacheMode)
                 .toString();
     }
 }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestDecryption.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestDecryption.java
@@ -159,7 +159,8 @@ public class TestDecryption
                 types,
                 ImmutableList.of(),
                 ImmutableMap.of(),
-                encryption);
+                encryption,
+                Optional.empty());
     }
 
     @Test


### PR DESCRIPTION
Propagate DWRF stripe cache size, mode, and offsets from the DWRF proto objects to the metadata model.

This change is a part of effort to enable DWRF stripe cache in the reader. The changes are mostly the same as in the original large PR https://github.com/prestodb/presto/pull/15893/commits/8b42d1dc118338db8f668eed4f6ddccd3991bb2b, all notes from the original PR are addressed.

Test plan:
- added new unit tests for DwrfMetadataReader

```
== NO RELEASE NOTE ==
```
