### PR TITLE
Supporting bucket names in width_bucket function.

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
@@ -1363,6 +1363,20 @@ public final class MathFunctions
         return lower;
     }
 
+    @Description("The bucket name of a value given an array of bins and corresponding bin names")
+    @ScalarFunction("width_bucket")
+    @SqlType(StandardTypes.VARCHAR)
+    public static Slice widthBucket(@SqlType(StandardTypes.DOUBLE) double operand, @SqlType("array(double)") Block bins, @SqlType("array(varchar)") Block binNames)
+    {
+        int numberOfBins = bins.getPositionCount();
+        int numberOfBinNames = binNames.getPositionCount();
+
+        checkCondition(numberOfBinNames == numberOfBins + 1, INVALID_FUNCTION_ARGUMENT, "For N bins, N + 1 bin names are required.");
+
+        int binIndex = (int) widthBucket(operand, bins);
+        return VARCHAR.getSlice(binNames, binIndex);
+    }
+
     @Description("cosine similarity between the given sparse vectors")
     @ScalarFunction
     @SqlNullable

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
@@ -1290,6 +1290,22 @@ public class TestMathFunctions
     }
 
     @Test
+    public void testWidthBucketNamesArray()
+    {
+        assertFunction("width_bucket(3.14E0, array[0.0E0, 2.0E0, 4.0E0], array['a', 'b', 'c', 'd'])", VarcharType.VARCHAR, "c");
+        assertFunction("width_bucket(infinity(), array[0.0E0, 2.0E0, 4.0E0], array['a', 'b', 'c', 'd'])", VarcharType.VARCHAR, "d");
+        assertFunction("width_bucket(-1, array[0.0E0, 1.2E0, 3.3E0, 4.5E0], array['a', 'b', 'c', 'd', 'e'])", VarcharType.VARCHAR, "a");
+
+        // edge case of only a single bin
+        assertFunction("width_bucket(3.145E0, array[0.0E0], array['a', 'b'])", VarcharType.VARCHAR, "b");
+        assertFunction("width_bucket(-3.145E0, array[0.0E0], array['a', 'b'])", VarcharType.VARCHAR, "a");
+
+        // fail if number of binNames are not equal to number of bins + 1
+        assertInvalidFunction("width_bucket(3.145E0, array[0.0E0], array['a'])", "For N bins, N + 1 bin names are required.");
+        assertInvalidFunction("width_bucket(3.145E0, array[0.0E0], array['a', 'b', 'c'])", "For N bins, N + 1 bin names are required.");
+    }
+
+    @Test
     public void testCosineSimilarity()
     {
         assertFunction("cosine_similarity(map(array ['a', 'b'], array [1.0E0, 2.0E0]), map(array ['c', 'b'], array [1.0E0, 3.0E0]))",


### PR DESCRIPTION
Test plan - Unit tests and Make sure all CI tests pass.

```
== RELEASE NOTES ==

General Changes
* Extending width_bucket function to support bucket names. It returns a bucket name corresponding to the bucket number, where item was found.