### PR TITLE
Interrupt runaway splits

### DIFF
--- a/presto-docs/src/main/sphinx/admin/properties.rst
+++ b/presto-docs/src/main/sphinx/admin/properties.rst
@@ -408,6 +408,16 @@ Task Properties
     to become overloaded due to excessive resource utilization. This can also be specified on
     a per-query basis using the ``task_writer_count`` session property.
 
+``task.interrupt-runaway-splits-timeout``
+^^^^^^^^^^^^^^^^^^^^^
+
+    * **Type:** ``duration``
+    * **Default value:** ``10m``
+
+    Timeout for interrupting split threads blocked without yielding control.
+    Only threads blocked in specific locations are interrupted. Currently this is just threads
+    blocked in the Joni regular expression library.
+
 
 Node Scheduler Properties
 -------------------------

--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskManagerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskManagerConfig.java
@@ -30,6 +30,8 @@ import javax.validation.constraints.NotNull;
 import java.math.BigDecimal;
 import java.util.concurrent.TimeUnit;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 @DefunctConfig({
         "experimental.big-query-max-task-memory",
         "task.max-memory",
@@ -83,6 +85,8 @@ public class TaskManagerConfig
 
     private boolean legacyLifespanCompletionCondition;
     private TaskPriorityTracking taskPriorityTracking = TaskPriorityTracking.TASK_FAIR;
+
+    private Duration interruptRunawaySplitsTimeout = new Duration(600, SECONDS);
 
     @MinDuration("1ms")
     @MaxDuration("10s")
@@ -556,5 +560,19 @@ public class TaskManagerConfig
     {
         TASK_FAIR,
         QUERY_FAIR,
+    }
+
+    @MinDuration("1s")
+    public Duration getInterruptRunawaySplitsTimeout()
+    {
+        return interruptRunawaySplitsTimeout;
+    }
+
+    @Config("task.interrupt-runaway-splits-timeout")
+    @ConfigDescription("Interrupt runaway split threads after this timeout if the task is stuck in certain allow listed places")
+    public TaskManagerConfig setInterruptRunawaySplitsTimeout(Duration interruptRunawaySplitsTimeout)
+    {
+        this.interruptRunawaySplitsTimeout = interruptRunawaySplitsTimeout;
+        return this;
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestTaskManagerConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestTaskManagerConfig.java
@@ -28,6 +28,7 @@ import static com.facebook.airlift.configuration.testing.ConfigAssertions.record
 import static com.facebook.presto.execution.TaskManagerConfig.TaskPriorityTracking.QUERY_FAIR;
 import static com.facebook.presto.execution.TaskManagerConfig.TaskPriorityTracking.TASK_FAIR;
 import static io.airlift.units.DataSize.Unit;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class TestTaskManagerConfig
 {
@@ -37,9 +38,9 @@ public class TestTaskManagerConfig
         assertRecordedDefaults(recordDefaults(TaskManagerConfig.class)
                 .setInitialSplitsPerNode(Runtime.getRuntime().availableProcessors() * 2)
                 .setSplitConcurrencyAdjustmentInterval(new Duration(100, TimeUnit.MILLISECONDS))
-                .setStatusRefreshMaxWait(new Duration(1, TimeUnit.SECONDS))
-                .setInfoUpdateInterval(new Duration(3, TimeUnit.SECONDS))
-                .setInfoRefreshMaxWait(new Duration(0, TimeUnit.SECONDS))
+                .setStatusRefreshMaxWait(new Duration(1, SECONDS))
+                .setInfoUpdateInterval(new Duration(3, SECONDS))
+                .setInfoRefreshMaxWait(new Duration(0, SECONDS))
                 .setPerOperatorCpuTimerEnabled(true)
                 .setTaskCpuTimerEnabled(true)
                 .setPerOperatorAllocationTrackingEnabled(false)
@@ -68,7 +69,8 @@ public class TestTaskManagerConfig
                 .setLevelTimeMultiplier(new BigDecimal("2"))
                 .setStatisticsCpuTimerEnabled(true)
                 .setLegacyLifespanCompletionCondition(false)
-                .setTaskPriorityTracking(TASK_FAIR));
+                .setTaskPriorityTracking(TASK_FAIR)
+                .setInterruptRunawaySplitsTimeout(new Duration(600, SECONDS)));
     }
 
     @Test
@@ -109,14 +111,15 @@ public class TestTaskManagerConfig
                 .put("task.statistics-cpu-timer-enabled", "false")
                 .put("task.legacy-lifespan-completion-condition", "true")
                 .put("task.task-priority-tracking", "QUERY_FAIR")
+                .put("task.interrupt-runaway-splits-timeout", "599s")
                 .build();
 
         TaskManagerConfig expected = new TaskManagerConfig()
                 .setInitialSplitsPerNode(1)
-                .setSplitConcurrencyAdjustmentInterval(new Duration(1, TimeUnit.SECONDS))
-                .setStatusRefreshMaxWait(new Duration(2, TimeUnit.SECONDS))
-                .setInfoUpdateInterval(new Duration(2, TimeUnit.SECONDS))
-                .setInfoRefreshMaxWait(new Duration(3, TimeUnit.SECONDS))
+                .setSplitConcurrencyAdjustmentInterval(new Duration(1, SECONDS))
+                .setStatusRefreshMaxWait(new Duration(2, SECONDS))
+                .setInfoUpdateInterval(new Duration(2, SECONDS))
+                .setInfoRefreshMaxWait(new Duration(3, SECONDS))
                 .setPerOperatorCpuTimerEnabled(false)
                 .setTaskCpuTimerEnabled(false)
                 .setPerOperatorAllocationTrackingEnabled(true)
@@ -131,7 +134,7 @@ public class TestTaskManagerConfig
                 .setMaxDriversPerTask(13)
                 .setMaxTasksPerStage(999)
                 .setInfoMaxAge(new Duration(22, TimeUnit.MINUTES))
-                .setClientTimeout(new Duration(10, TimeUnit.SECONDS))
+                .setClientTimeout(new Duration(10, SECONDS))
                 .setSinkMaxBufferSize(new DataSize(42, Unit.MEGABYTE))
                 .setMaxPagePartitioningBufferSize(new DataSize(40, Unit.MEGABYTE))
                 .setWriterCount(4)
@@ -145,7 +148,8 @@ public class TestTaskManagerConfig
                 .setLevelTimeMultiplier(new BigDecimal("2.1"))
                 .setStatisticsCpuTimerEnabled(false)
                 .setLegacyLifespanCompletionCondition(true)
-                .setTaskPriorityTracking(QUERY_FAIR);
+                .setTaskPriorityTracking(QUERY_FAIR)
+                .setInterruptRunawaySplitsTimeout(new Duration(599, SECONDS));
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
Test plan - Included unit test, deploy to a cluster and test with a known bad query

We do use thread interruption as part of the query cancellation mechanism so it is probably safer then I thought it was in some earlier discussions.

What this is really implementing is eager split termination where we don't honor the user specified query timeout. Because of that I am limiting this to only killing a split that looks like it is blocked in Joni. We can add more if we find other common culprits.

@arhimondr brought up the possibility of edge cases like JDBC where we might have an expensive query that might not yield a page for 10 minutes as it tries to generate a small number of rows from a system that isn't very fast. Even with Hive + HDFS if it is needle in a haystack type stuff this could occur. I think a targeted approach of interrupting allow listed things is a good place to start.

```
== RELEASE NOTES ==

General Changes
* Add interruption for runaway splits blocked in known situations controlled by ``task.interrupt-runaway-splits-timeout`` property which defaults to ``600s``.
```
