### PR TITLE
Allow StorageOrcFileTailSource to read DWRF stripe cache data

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/cache/StorageOrcFileTailSource.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/cache/StorageOrcFileTailSource.java
@@ -45,6 +45,18 @@ public class StorageOrcFileTailSource
     private static final int CURRENT_MAJOR_VERSION = 0;
     private static final int CURRENT_MINOR_VERSION = 12;
 
+    private final int expectedFooterSize;
+
+    public StorageOrcFileTailSource()
+    {
+        this(EXPECTED_FOOTER_SIZE);
+    }
+
+    public StorageOrcFileTailSource(int expectedFooterSize)
+    {
+        this.expectedFooterSize = expectedFooterSize;
+    }
+
     @Override
     public OrcFileTail getOrcFileTail(OrcDataSource orcDataSource, MetadataReader metadataReader, Optional<OrcWriteValidation> writeValidation, boolean cacheable)
             throws IOException
@@ -55,7 +67,7 @@ public class StorageOrcFileTailSource
         }
 
         // Read the tail of the file
-        byte[] buffer = new byte[toIntExact(min(size, EXPECTED_FOOTER_SIZE))];
+        byte[] buffer = new byte[toIntExact(min(size, expectedFooterSize))];
         orcDataSource.readFully(size - buffer.length, buffer);
 
         // get length of PostScript - last byte of the file

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfStripeCacheData.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfStripeCacheData.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.metadata;
+
+import io.airlift.slice.Slice;
+
+import static java.util.Objects.requireNonNull;
+
+public class DwrfStripeCacheData
+{
+    private final Slice stripeCacheSlice;
+    private final int stripeCacheSize;
+    private final DwrfStripeCacheMode stripeCacheMode;
+
+    public DwrfStripeCacheData(Slice stripeCacheSlice, int stripeCacheSize, DwrfStripeCacheMode stripeCacheMode)
+    {
+        this.stripeCacheSlice = requireNonNull(stripeCacheSlice, "stripeCacheSlice is null");
+        this.stripeCacheSize = stripeCacheSize;
+        this.stripeCacheMode = requireNonNull(stripeCacheMode, "stripeCacheMode is null");
+    }
+
+    public Slice getDwrfStripeCacheSlice()
+    {
+        return stripeCacheSlice;
+    }
+
+    public int getDwrfStripeCacheSize()
+    {
+        return stripeCacheSize;
+    }
+
+    public DwrfStripeCacheMode getDwrfStripeCacheMode()
+    {
+        return stripeCacheMode;
+    }
+}

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcFileTail.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcFileTail.java
@@ -16,6 +16,8 @@ package com.facebook.presto.orc.metadata;
 import com.facebook.presto.orc.metadata.PostScript.HiveWriterVersion;
 import io.airlift.slice.Slice;
 
+import java.util.Optional;
+
 import static java.util.Objects.requireNonNull;
 
 public class OrcFileTail
@@ -27,6 +29,7 @@ public class OrcFileTail
     private final int footerSize;
     private final Slice metadataSlice;
     private final int metadataSize;
+    private final Optional<DwrfStripeCacheData> dwrfStripeCacheData;
 
     public OrcFileTail(
             HiveWriterVersion hiveWriterVersion,
@@ -35,7 +38,8 @@ public class OrcFileTail
             Slice footerSlice,
             int footerSize,
             Slice metadataSlice,
-            int metadataSize)
+            int metadataSize,
+            Optional<DwrfStripeCacheData> dwrfStripeCacheData)
     {
         this.hiveWriterVersion = requireNonNull(hiveWriterVersion, "hiveWriterVersion is null");
         this.bufferSize = bufferSize;
@@ -44,6 +48,7 @@ public class OrcFileTail
         this.footerSize = footerSize;
         this.metadataSlice = requireNonNull(metadataSlice, "metadataSlice is null");
         this.metadataSize = metadataSize;
+        this.dwrfStripeCacheData = requireNonNull(dwrfStripeCacheData, "dwrfStripeCacheData is null");
     }
 
     public HiveWriterVersion getHiveWriterVersion()
@@ -79,5 +84,24 @@ public class OrcFileTail
     public int getMetadataSize()
     {
         return metadataSize;
+    }
+
+    public Optional<DwrfStripeCacheData> getDwrfStripeCacheData()
+    {
+        return dwrfStripeCacheData;
+    }
+
+    private int getDwrfStripeCacheSize()
+    {
+        int dwrfStripeCacheSize = 0;
+        if (dwrfStripeCacheData.isPresent()) {
+            dwrfStripeCacheSize = dwrfStripeCacheData.get().getDwrfStripeCacheSize();
+        }
+        return dwrfStripeCacheSize;
+    }
+
+    public int getTotalSize()
+    {
+        return getFooterSize() + getMetadataSize() + getDwrfStripeCacheSize();
     }
 }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestStorageOrcFileTailSource.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestStorageOrcFileTailSource.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc;
+
+import com.facebook.presto.orc.cache.StorageOrcFileTailSource;
+import com.facebook.presto.orc.metadata.DwrfMetadataReader;
+import com.facebook.presto.orc.metadata.MetadataReader;
+import com.facebook.presto.orc.proto.DwrfProto;
+import com.facebook.presto.orc.protobuf.AbstractMessageLite;
+import io.airlift.units.DataSize;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Optional;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestStorageOrcFileTailSource
+{
+    private static final DataSize DEFAULT_SIZE = new DataSize(1, DataSize.Unit.MEGABYTE);
+
+    private TempFile file;
+    private MetadataReader metadataReader;
+
+    @BeforeMethod
+    public void setUp()
+            throws Exception
+    {
+        this.file = new TempFile();
+        this.metadataReader = new DwrfMetadataReader();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void tearDown()
+            throws Exception
+    {
+        file.close();
+    }
+
+    @Test
+    public void testReadExpectedFooterSize()
+            throws IOException
+    {
+        // beef up the file size to make sure it's larger than the expectedFooterSize = 567 we will use below
+        FileOutputStream out = new FileOutputStream(file.getFile());
+        out.write(new byte[100 * 1000]);
+
+        // write the post script
+        DwrfProto.PostScript.Builder postScript = DwrfProto.PostScript.newBuilder()
+                .setFooterLength(0)
+                .setCompression(DwrfProto.CompressionKind.NONE);
+        writeTail(postScript, out);
+        out.close();
+
+        // read the OrcFileTail
+        int expectedFooterSize = 567;
+        StorageOrcFileTailSource src = new StorageOrcFileTailSource(expectedFooterSize);
+        TestingOrcDataSource orcDataSource = new TestingOrcDataSource(createFileOrcDataSource());
+        src.getOrcFileTail(orcDataSource, metadataReader, Optional.empty(), false);
+
+        // make sure only the configured expectedFooterSize bytes have been read
+        assertEquals(orcDataSource.getReadCount(), 1);
+        DiskRange lastReadRange = orcDataSource.getLastReadRanges().get(0);
+        assertEquals(lastReadRange.getLength(), expectedFooterSize);
+    }
+
+    private OrcDataSource createFileOrcDataSource()
+            throws FileNotFoundException
+    {
+        return new FileOrcDataSource(file.getFile(), DEFAULT_SIZE, DEFAULT_SIZE, DEFAULT_SIZE, false);
+    }
+
+    /**
+     * Write the post script, and return the number of bytes written.
+     */
+    private int writeTail(DwrfProto.PostScript.Builder postScript, OutputStream out)
+            throws IOException
+    {
+        int postScriptSize = writeObject(postScript.build(), out);
+        out.write(postScriptSize & 0xff);
+        return postScriptSize + 1;
+    }
+
+    private int writeObject(AbstractMessageLite msg, OutputStream out)
+            throws IOException
+    {
+        byte[] bytes = msg.toByteArray();
+        out.write(bytes);
+        return bytes.length;
+    }
+}

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/StorageModule.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/StorageModule.java
@@ -121,7 +121,7 @@ public class StorageModule
         if (orcCacheConfig.isFileTailCacheEnabled()) {
             Cache<OrcDataSourceId, OrcFileTail> cache = CacheBuilder.newBuilder()
                     .maximumWeight(orcCacheConfig.getFileTailCacheSize().toBytes())
-                    .weigher((id, tail) -> ((OrcFileTail) tail).getFooterSize() + ((OrcFileTail) tail).getMetadataSize())
+                    .weigher((id, tail) -> ((OrcFileTail) tail).getTotalSize())
                     .expireAfterAccess(orcCacheConfig.getFileTailCacheTtlSinceLastAccess().toMillis(), TimeUnit.MILLISECONDS)
                     .recordStats()
                     .build();


### PR DESCRIPTION
This change allows StorageOrcFileTailSource to load the DWRF stripe cache data from the source/file into OrcFileTail. This feature is disabled by default. 

To be able to reduce number of IOs while reading the file tail I made the value of the tail read size (the size of the first read operation) configurable.

This is a continuation of https://github.com/prestodb/presto/pull/16102

Test plan:
- added new unit tests for StorageOrcFileTailSource

```
== NO RELEASE NOTE ==
```
