### PR TITLE
Fix the partition cache invalidation logic to be more efficient

### DIFF
--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/PartitionNameWithVersion.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/PartitionNameWithVersion.java
@@ -13,17 +13,19 @@
  */
 package com.facebook.presto.hive.metastore;
 
+import java.util.Optional;
+
 import static java.util.Objects.requireNonNull;
 
 public class PartitionNameWithVersion
 {
     private final String partitionName;
-    private final long partitionVersion;
+    private final Optional<Long> partitionVersion;
 
-    public PartitionNameWithVersion(String partitionName, long partitionVersion)
+    public PartitionNameWithVersion(String partitionName, Optional<Long> partitionVersion)
     {
         this.partitionName = requireNonNull(partitionName, "partitionName is null");
-        this.partitionVersion = partitionVersion;
+        this.partitionVersion = requireNonNull(partitionVersion, "partitionVersion is null");
     }
 
     public String getPartitionName()
@@ -31,7 +33,7 @@ public class PartitionNameWithVersion
         return partitionName;
     }
 
-    public long getPartitionVersion()
+    public Optional<Long> getPartitionVersion()
     {
         return partitionVersion;
     }

--- a/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/TestCachingHiveMetastore.java
+++ b/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/TestCachingHiveMetastore.java
@@ -187,10 +187,10 @@ public class TestCachingHiveMetastore
     private static class MockPartitionMutator
             implements PartitionMutator
     {
-        private final Function<Integer, Integer> versionUpdater;
-        private int version = PARTITION_VERSION;
+        private final Function<Long, Long> versionUpdater;
+        private long version = PARTITION_VERSION;
 
-        public MockPartitionMutator(Function<Integer, Integer> versionUpdater)
+        public MockPartitionMutator(Function<Long, Long> versionUpdater)
         {
             this.versionUpdater = versionUpdater;
         }

--- a/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/thrift/MockHiveMetastoreClient.java
+++ b/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/thrift/MockHiveMetastoreClient.java
@@ -60,9 +60,9 @@ public class MockHiveMetastoreClient
     public static final String TEST_PARTITION2 = "key=testpartition2";
     public static final List<String> TEST_PARTITION_VALUES1 = ImmutableList.of("testpartition1");
     public static final List<String> TEST_PARTITION_VALUES2 = ImmutableList.of("testpartition2");
-    public static final int PARTITION_VERSION = 1000;
-    public static final PartitionNameWithVersion TEST_PARTITION_NAME_WITH_VERSION1 = new PartitionNameWithVersion(TEST_PARTITION1, PARTITION_VERSION);
-    public static final PartitionNameWithVersion TEST_PARTITION_NAME_WITH_VERSION2 = new PartitionNameWithVersion(TEST_PARTITION2, PARTITION_VERSION);
+    public static final long PARTITION_VERSION = 1000;
+    public static final PartitionNameWithVersion TEST_PARTITION_NAME_WITH_VERSION1 = new PartitionNameWithVersion(TEST_PARTITION1, Optional.of(PARTITION_VERSION));
+    public static final PartitionNameWithVersion TEST_PARTITION_NAME_WITH_VERSION2 = new PartitionNameWithVersion(TEST_PARTITION2, Optional.of(PARTITION_VERSION));
     public static final List<String> TEST_ROLES = ImmutableList.of("testrole");
     public static final List<RolePrincipalGrant> TEST_ROLE_GRANTS = ImmutableList.of(
             new RolePrincipalGrant("role1", "user", USER, false, 0, "grantor1", USER),


### PR DESCRIPTION
depended by https://github.com/facebookexternal/presto-facebook/pull/1548

```
== NO RELEASE NOTE ==
```
