### PR TITLE
Fix MetastoreContext creation in presto-iceberg module

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
@@ -64,7 +64,7 @@ final class IcebergUtil
         HdfsContext hdfsContext = new HdfsContext(session, table.getSchemaName(), table.getTableName());
         TableOperations operations = new HiveTableOperations(
                 metastore,
-                new MetastoreContext(session.getIdentity()),
+                new MetastoreContext(session.getIdentity(), session.getQueryId(), session.getClientInfo(), session.getSource()),
                 hdfsEnvironment,
                 hdfsContext,
                 table.getSchemaName(),


### PR DESCRIPTION
Fix MetastoreContext object creation in presto-iceberg module. The MetastoreContext constructor was changed recently and looks like tests were not re-run before merging in PR https://github.com/prestodb/presto/pull/15836. The build is broken and this PR fixes it.

```
== NO RELEASE NOTE ==
```
