### PR TITLE
Add Option to disable DWRF string dictionary sorting

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/ColumnWriterOptions.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/ColumnWriterOptions.java
@@ -30,13 +30,15 @@ public class ColumnWriterOptions
     private final int compressionMaxBufferSize;
     private final DataSize stringStatisticsLimit;
     private final boolean integerDictionaryEncodingEnabled;
+    private final boolean stringDictionarySortingEnabled;
 
     public ColumnWriterOptions(
             CompressionKind compressionKind,
             OptionalInt compressionLevel,
             DataSize compressionMaxBufferSize,
             DataSize stringStatisticsLimit,
-            boolean integerDictionaryEncodingEnabled)
+            boolean integerDictionaryEncodingEnabled,
+            boolean stringDictionarySortingEnabled)
     {
         this.compressionKind = requireNonNull(compressionKind, "compressionKind is null");
         this.compressionLevel = requireNonNull(compressionLevel, "compressionLevel is null");
@@ -44,6 +46,7 @@ public class ColumnWriterOptions
         this.compressionMaxBufferSize = toIntExact(compressionMaxBufferSize.toBytes());
         this.stringStatisticsLimit = requireNonNull(stringStatisticsLimit, "stringStatisticsLimit is null");
         this.integerDictionaryEncodingEnabled = integerDictionaryEncodingEnabled;
+        this.stringDictionarySortingEnabled = stringDictionarySortingEnabled;
     }
 
     public CompressionKind getCompressionKind()
@@ -71,6 +74,11 @@ public class ColumnWriterOptions
         return integerDictionaryEncodingEnabled;
     }
 
+    public boolean isStringDictionarySortingEnabled()
+    {
+        return stringDictionarySortingEnabled;
+    }
+
     public static Builder builder()
     {
         return new Builder();
@@ -83,6 +91,7 @@ public class ColumnWriterOptions
         private DataSize compressionMaxBufferSize = DEFAULT_MAX_COMPRESSION_BUFFER_SIZE;
         private DataSize stringStatisticsLimit = DEFAULT_MAX_STRING_STATISTICS_LIMIT;
         private boolean integerDictionaryEncodingEnabled;
+        private boolean stringDictionarySortingEnabled = true;
 
         private Builder() {}
 
@@ -116,9 +125,21 @@ public class ColumnWriterOptions
             return this;
         }
 
+        public Builder setStringDictionarySortingEnabled(boolean stringDictionarySortingEnabled)
+        {
+            this.stringDictionarySortingEnabled = stringDictionarySortingEnabled;
+            return this;
+        }
+
         public ColumnWriterOptions build()
         {
-            return new ColumnWriterOptions(compressionKind, compressionLevel, compressionMaxBufferSize, stringStatisticsLimit, integerDictionaryEncodingEnabled);
+            return new ColumnWriterOptions(
+                    compressionKind,
+                    compressionLevel,
+                    compressionMaxBufferSize,
+                    stringStatisticsLimit,
+                    integerDictionaryEncodingEnabled,
+                    stringDictionarySortingEnabled);
         }
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
@@ -171,6 +171,7 @@ public class OrcWriter
                 .setCompressionMaxBufferSize(options.getMaxCompressionBufferSize())
                 .setStringStatisticsLimit(options.getMaxStringStatisticsLimit())
                 .setIntegerDictionaryEncodingEnabled(options.isIntegerDictionaryEncodingEnabled())
+                .setStringDictionarySortingEnabled(options.isStringDictionarySortingEnabled())
                 .build();
         recordValidation(validation -> validation.setCompression(compressionKind));
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriterOptions.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriterOptions.java
@@ -45,6 +45,7 @@ public class OrcWriterOptions
     private final OptionalInt compressionLevel;
     private final StreamLayout streamLayout;
     private final boolean integerDictionaryEncodingEnabled;
+    private final boolean stringDictionarySortingEnabled;
 
     private OrcWriterOptions(
             DataSize stripeMinSize,
@@ -56,7 +57,8 @@ public class OrcWriterOptions
             DataSize maxCompressionBufferSize,
             OptionalInt compressionLevel,
             StreamLayout streamLayout,
-            boolean integerDictionaryEncodingEnabled)
+            boolean integerDictionaryEncodingEnabled,
+            boolean stringDictionarySortingEnabled)
     {
         requireNonNull(stripeMinSize, "stripeMinSize is null");
         requireNonNull(stripeMaxSize, "stripeMaxSize is null");
@@ -78,6 +80,7 @@ public class OrcWriterOptions
         this.compressionLevel = compressionLevel;
         this.streamLayout = streamLayout;
         this.integerDictionaryEncodingEnabled = integerDictionaryEncodingEnabled;
+        this.stringDictionarySortingEnabled = stringDictionarySortingEnabled;
     }
 
     public DataSize getStripeMinSize()
@@ -130,6 +133,11 @@ public class OrcWriterOptions
         return integerDictionaryEncodingEnabled;
     }
 
+    public boolean isStringDictionarySortingEnabled()
+    {
+        return stringDictionarySortingEnabled;
+    }
+
     @Override
     public String toString()
     {
@@ -144,6 +152,7 @@ public class OrcWriterOptions
                 .add("compressionLevel", compressionLevel)
                 .add("streamLayout", streamLayout)
                 .add("integerDictionaryEncodingEnabled", integerDictionaryEncodingEnabled)
+                .add("stringDictionarySortingEnabled", stringDictionarySortingEnabled)
                 .toString();
     }
 
@@ -164,6 +173,7 @@ public class OrcWriterOptions
         private OptionalInt compressionLevel = OptionalInt.empty();
         private StreamLayout streamLayout = new ByStreamSize();
         private boolean integerDictionaryEncodingEnabled;
+        private boolean stringDictionarySortingEnabled = true;
 
         public Builder withStripeMinSize(DataSize stripeMinSize)
         {
@@ -227,6 +237,12 @@ public class OrcWriterOptions
             return this;
         }
 
+        public Builder withStringDictionarySortingEnabled(boolean stringDictionarySortingEnabled)
+        {
+            this.stringDictionarySortingEnabled = stringDictionarySortingEnabled;
+            return this;
+        }
+
         public OrcWriterOptions build()
         {
             return new OrcWriterOptions(
@@ -239,7 +255,8 @@ public class OrcWriterOptions
                     maxCompressionBufferSize,
                     compressionLevel,
                     streamLayout,
-                    integerDictionaryEncodingEnabled);
+                    integerDictionaryEncodingEnabled,
+                    stringDictionarySortingEnabled);
         }
     }
 }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestDictionaryColumnWriter.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestDictionaryColumnWriter.java
@@ -16,16 +16,12 @@ package com.facebook.presto.orc;
 import com.facebook.presto.common.Page;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockBuilder;
-import com.facebook.presto.common.block.RunLengthEncodedBlock;
 import com.facebook.presto.common.type.ArrayType;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.orc.metadata.ColumnEncoding;
-import com.facebook.presto.orc.metadata.CompressionKind;
 import com.facebook.presto.orc.metadata.StripeFooter;
 import com.facebook.presto.orc.writer.DictionaryColumnWriter;
-import com.facebook.presto.orc.writer.SliceDictionaryColumnWriter;
 import com.google.common.collect.ImmutableList;
-import io.airlift.slice.Slices;
 import io.airlift.units.DataSize;
 import org.testng.annotations.Test;
 
@@ -36,7 +32,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Random;
 import java.util.UUID;
-import java.util.concurrent.ThreadLocalRandom;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
@@ -85,35 +80,13 @@ public class TestDictionaryColumnWriter
     }
 
     @Test
-    public void testStringDirectConversion()
-    {
-        ColumnWriterOptions columnWriterOptions = ColumnWriterOptions.builder().setCompressionKind(CompressionKind.NONE).build();
-        DictionaryColumnWriter writer = new SliceDictionaryColumnWriter(
-                0,
-                VARCHAR,
-                columnWriterOptions,
-                Optional.empty(),
-                ORC,
-                ORC.createMetadataWriter());
-
-        // a single row group exceeds 2G after direct conversion
-        byte[] value = new byte[megabytes(1)];
-        ThreadLocalRandom.current().nextBytes(value);
-        Block data = RunLengthEncodedBlock.create(VARCHAR, Slices.wrappedBuffer(value), 3000);
-        writer.beginRowGroup();
-        writer.writeBlock(data);
-        writer.finishRowGroup();
-        assertFalse(writer.tryConvertToDirect(megabytes(64)).isPresent());
-    }
-
-    @Test
     public void testStringNoRows()
             throws Exception
     {
         List<String> values = ImmutableList.of();
-        for (OrcEncoding encoding : OrcEncoding.values()) {
+        for (StringDictionaryInput input : StringDictionaryInput.values()) {
             DirectConversionTester directConversionTester = new DirectConversionTester();
-            List<StripeFooter> stripeFooters = testStringDictionary(directConversionTester, encoding, values);
+            List<StripeFooter> stripeFooters = testStringDictionary(directConversionTester, input, values);
             assertEquals(stripeFooters.size(), getStripeSize(values.size()));
         }
     }
@@ -123,13 +96,13 @@ public class TestDictionaryColumnWriter
             throws Exception
     {
         List<String> values = newArrayList(limit(cycle(new String[] {null}), 90_000));
-        for (OrcEncoding encoding : OrcEncoding.values()) {
+        for (StringDictionaryInput input : StringDictionaryInput.values()) {
             DirectConversionTester directConversionTester = new DirectConversionTester();
             directConversionTester.add(7, megabytes(1), true);
             directConversionTester.add(14, megabytes(1), true);
             directConversionTester.add(32, megabytes(1), true);
-            List<StripeFooter> stripeFooters = testStringDictionary(directConversionTester, encoding, values);
-            verifyDirectEncoding(getStripeSize(values.size()), encoding, stripeFooters);
+            List<StripeFooter> stripeFooters = testStringDictionary(directConversionTester, input, values);
+            verifyDirectEncoding(getStripeSize(values.size()), input.getEncoding(), stripeFooters);
         }
     }
 
@@ -141,10 +114,10 @@ public class TestDictionaryColumnWriter
         for (int i = 0; i < 60_000; i++) {
             values.add(RANDOM.nextBoolean() ? null : UUID.randomUUID().toString());
         }
-        for (OrcEncoding encoding : OrcEncoding.values()) {
+        for (StringDictionaryInput input : StringDictionaryInput.values()) {
             DirectConversionTester directConversionTester = new DirectConversionTester();
-            List<StripeFooter> stripeFooters = testStringDictionary(directConversionTester, encoding, values);
-            verifyDirectEncoding(getStripeSize(values.size()), encoding, stripeFooters);
+            List<StripeFooter> stripeFooters = testStringDictionary(directConversionTester, input, values);
+            verifyDirectEncoding(getStripeSize(values.size()), input.getEncoding(), stripeFooters);
         }
     }
 
@@ -171,10 +144,10 @@ public class TestDictionaryColumnWriter
         Collections.shuffle(stripeValues);
         values.addAll(stripeValues);
 
-        for (OrcEncoding encoding : OrcEncoding.values()) {
+        for (StringDictionaryInput input : StringDictionaryInput.values()) {
             DirectConversionTester directConversionTester = new DirectConversionTester();
-            List<StripeFooter> stripeFooters = testStringDictionary(directConversionTester, encoding, values);
-            verifyDictionaryEncoding(getStripeSize(values.size()), encoding, stripeFooters, ImmutableList.of(dictionarySize, dictionarySize, dictionarySize));
+            List<StripeFooter> stripeFooters = testStringDictionary(directConversionTester, input, values);
+            verifyDictionaryEncoding(getStripeSize(values.size()), input.getEncoding(), stripeFooters, ImmutableList.of(dictionarySize, dictionarySize, dictionarySize));
         }
     }
 
@@ -187,10 +160,10 @@ public class TestDictionaryColumnWriter
             builder.add(Integer.toString(i));
         }
         List<String> values = builder.build();
-        for (OrcEncoding encoding : OrcEncoding.values()) {
+        for (StringDictionaryInput input : StringDictionaryInput.values()) {
             DirectConversionTester directConversionTester = new DirectConversionTester();
-            List<StripeFooter> stripeFooters = testStringDictionary(directConversionTester, encoding, values);
-            verifyDirectEncoding(getStripeSize(values.size()), encoding, stripeFooters);
+            List<StripeFooter> stripeFooters = testStringDictionary(directConversionTester, input, values);
+            verifyDirectEncoding(getStripeSize(values.size()), input.getEncoding(), stripeFooters);
         }
     }
 
@@ -203,13 +176,13 @@ public class TestDictionaryColumnWriter
             builder.add(Integer.toString(i));
         }
         List<String> values = builder.build();
-        for (OrcEncoding encoding : OrcEncoding.values()) {
+        for (StringDictionaryInput input : StringDictionaryInput.values()) {
             DirectConversionTester directConversionTester = new DirectConversionTester();
             OrcWriterOptions writerOptions = OrcWriterOptions.builder()
                     .withRowGroupMaxRowCount(14_876)
                     .withStripeMaxRowCount(STRIPE_MAX_ROWS)
                     .build();
-            testDictionary(VARCHAR, encoding, writerOptions, directConversionTester, values);
+            testDictionary(VARCHAR, input.getEncoding(), writerOptions, directConversionTester, values);
         }
     }
 
@@ -222,11 +195,11 @@ public class TestDictionaryColumnWriter
             // Make a 7 letter String, by using million as base to force dictionary encoding.
             builder.add(Integer.toString((i % 1000) + 1_000_000));
         }
-        for (OrcEncoding encoding : OrcEncoding.values()) {
+        for (StringDictionaryInput input : StringDictionaryInput.values()) {
             DirectConversionTester directConversionTester = new DirectConversionTester();
             List<String> values = builder.build();
-            List<StripeFooter> stripeFooters = testStringDictionary(directConversionTester, encoding, values);
-            verifyDictionaryEncoding(getStripeSize(values.size()), encoding, stripeFooters, ImmutableList.of(1000, 1000, 1000, 1000));
+            List<StripeFooter> stripeFooters = testStringDictionary(directConversionTester, input, values);
+            verifyDictionaryEncoding(getStripeSize(values.size()), input.getEncoding(), stripeFooters, ImmutableList.of(1000, 1000, 1000, 1000));
         }
     }
 
@@ -240,18 +213,18 @@ public class TestDictionaryColumnWriter
         }
         List<String> values = builder.build();
 
-        for (OrcEncoding encoding : OrcEncoding.values()) {
+        for (StringDictionaryInput input : StringDictionaryInput.values()) {
             DirectConversionTester directConversionTester = new DirectConversionTester();
             directConversionTester.add(0, megabytes(1), true);
             directConversionTester.add(16, 5_000, false);
             directConversionTester.add(16, megabytes(1), true);
 
-            List<StripeFooter> stripeFooters = testStringDictionary(directConversionTester, encoding, values);
+            List<StripeFooter> stripeFooters = testStringDictionary(directConversionTester, input, values);
             assertEquals(getStripeSize(values.size()), stripeFooters.size());
-            verifyDirectEncoding(stripeFooters, encoding, 0);
-            verifyDirectEncoding(stripeFooters, encoding, 1);
-            verifyDictionaryEncoding(stripeFooters, encoding, 2, 2000);
-            verifyDictionaryEncoding(stripeFooters, encoding, 3, 2000);
+            verifyDirectEncoding(stripeFooters, input.getEncoding(), 0);
+            verifyDirectEncoding(stripeFooters, input.getEncoding(), 1);
+            verifyDictionaryEncoding(stripeFooters, input.getEncoding(), 2, 2000);
+            verifyDictionaryEncoding(stripeFooters, input.getEncoding(), 3, 2000);
         }
     }
 
@@ -372,7 +345,7 @@ public class TestDictionaryColumnWriter
         verifyDictionaryEncoding(getStripeSize(values.size()), DWRF, stripeFooters, ImmutableList.of(repeatInterval + baseList.size(), repeatInterval, repeatInterval));
 
         // Now disable Integer dictionary encoding and verify that integer dictionary encoding is disabled
-        stripeFooters = testDictionary(INTEGER, DWRF, false, new DirectConversionTester(), values);
+        stripeFooters = testDictionary(INTEGER, DWRF, false, true, new DirectConversionTester(), values);
         verifyDwrfDirectEncoding(getStripeSize(values.size()), stripeFooters);
     }
 
@@ -479,7 +452,7 @@ public class TestDictionaryColumnWriter
         }
         DirectConversionTester directConversionTester = new DirectConversionTester();
         Type listType = new ArrayType(INTEGER);
-        testDictionary(listType, DWRF, true, directConversionTester, values);
+        testDictionary(listType, DWRF, true, true, directConversionTester, values);
     }
 
     @Test
@@ -494,7 +467,7 @@ public class TestDictionaryColumnWriter
         }
         DirectConversionTester directConversionTester = new DirectConversionTester();
         Type listType = new ArrayType(INTEGER);
-        testDictionary(listType, DWRF, true, directConversionTester, values);
+        testDictionary(listType, DWRF, true, true, directConversionTester, values);
     }
 
     @Test
@@ -517,7 +490,7 @@ public class TestDictionaryColumnWriter
         }
         DirectConversionTester directConversionTester = new DirectConversionTester();
         Type listType = new ArrayType(VARCHAR);
-        testDictionary(listType, DWRF, true, directConversionTester, values);
+        testDictionary(listType, DWRF, true, true, directConversionTester, values);
     }
 
     @Test
@@ -532,7 +505,7 @@ public class TestDictionaryColumnWriter
         }
         DirectConversionTester directConversionTester = new DirectConversionTester();
         Type listType = new ArrayType(VARCHAR);
-        testDictionary(listType, DWRF, true, directConversionTester, values);
+        testDictionary(listType, DWRF, true, true, directConversionTester, values);
     }
 
     private ColumnEncoding getColumnEncoding(List<StripeFooter> stripeFooters, int stripeId)
@@ -599,27 +572,28 @@ public class TestDictionaryColumnWriter
     private List<StripeFooter> testLongDictionary(DirectConversionTester directConversionTester, List<?> values)
             throws IOException
     {
-        return testDictionary(BIGINT, DWRF, true, directConversionTester, values);
+        return testDictionary(BIGINT, DWRF, true, true, directConversionTester, values);
     }
 
     private List<StripeFooter> testIntegerDictionary(DirectConversionTester directConversionTester, List<?> values)
             throws IOException
     {
-        return testDictionary(INTEGER, DWRF, true, directConversionTester, values);
+        return testDictionary(INTEGER, DWRF, true, true, directConversionTester, values);
     }
 
-    private List<StripeFooter> testStringDictionary(DirectConversionTester directConversionTester, OrcEncoding encoding, List<String> values)
+    private List<StripeFooter> testStringDictionary(DirectConversionTester directConversionTester, StringDictionaryInput dictionaryInput, List<String> values)
             throws IOException
     {
-        return testDictionary(VARCHAR, encoding, false, directConversionTester, values);
+        return testDictionary(VARCHAR, dictionaryInput.getEncoding(), false, dictionaryInput.isSortStringDictionaryKeys(), directConversionTester, values);
     }
 
-    private List<StripeFooter> testDictionary(Type type, OrcEncoding encoding, boolean enableIntDictionary, DirectConversionTester directConversionTester, List<?> values)
+    private List<StripeFooter> testDictionary(Type type, OrcEncoding encoding, boolean enableIntDictionary, boolean sortStringDictionaryKeys, DirectConversionTester directConversionTester, List<?> values)
             throws IOException
     {
         OrcWriterOptions orcWriterOptions = OrcWriterOptions.builder()
                 .withStripeMaxRowCount(STRIPE_MAX_ROWS)
                 .withIntegerDictionaryEncodingEnabled(enableIntDictionary)
+                .withStringDictionarySortingEnabled(sortStringDictionaryKeys)
                 .build();
         return testDictionary(type, encoding, orcWriterOptions, directConversionTester, values);
     }
@@ -730,7 +704,37 @@ public class TestDictionaryColumnWriter
         return index;
     }
 
-    static class DirectConversionTester
+    private static class StringDictionaryInput
+    {
+        private final OrcEncoding encoding;
+        private final boolean sortStringDictionaryKeys;
+
+        StringDictionaryInput(OrcEncoding encoding, boolean sortStringDictionaryKeys)
+        {
+            this.encoding = encoding;
+            this.sortStringDictionaryKeys = sortStringDictionaryKeys;
+        }
+
+        public OrcEncoding getEncoding()
+        {
+            return encoding;
+        }
+
+        public boolean isSortStringDictionaryKeys()
+        {
+            return sortStringDictionaryKeys;
+        }
+
+        static List<StringDictionaryInput> values()
+        {
+            return ImmutableList.of(
+                    new StringDictionaryInput(ORC, true),
+                    new StringDictionaryInput(DWRF, true),
+                    new StringDictionaryInput(DWRF, false));
+        }
+    }
+
+    private static class DirectConversionTester
     {
         private final List<Integer> batchIds = new ArrayList<>();
         private final List<Integer> maxDirectBytes = new ArrayList<>();

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcWriterOptions.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcWriterOptions.java
@@ -38,6 +38,7 @@ public class TestOrcWriterOptions
         OptionalInt compressionLevel = OptionalInt.of(5);
         StreamLayout streamLayout = new StreamLayout.ByColumnSize();
         boolean integerDictionaryEncodingEnabled = true;
+        boolean stringDictionarySortingEnabled = false;
 
         OrcWriterOptions.Builder builder = OrcWriterOptions.builder()
                 .withStripeMinSize(stripeMinSize)
@@ -49,7 +50,8 @@ public class TestOrcWriterOptions
                 .withMaxCompressionBufferSize(maxCompressionBufferSize)
                 .withCompressionLevel(compressionLevel)
                 .withStreamLayout(streamLayout)
-                .withIntegerDictionaryEncodingEnabled(integerDictionaryEncodingEnabled);
+                .withIntegerDictionaryEncodingEnabled(integerDictionaryEncodingEnabled)
+                .withStringDictionarySortingEnabled(stringDictionarySortingEnabled);
 
         OrcWriterOptions options = builder.build();
 
@@ -63,6 +65,7 @@ public class TestOrcWriterOptions
         assertEquals(compressionLevel, options.getCompressionLevel());
         assertEquals(streamLayout, options.getStreamLayout());
         assertEquals(integerDictionaryEncodingEnabled, options.isIntegerDictionaryEncodingEnabled());
+        assertEquals(stringDictionarySortingEnabled, options.isStringDictionarySortingEnabled());
     }
 
     @Test
@@ -78,6 +81,7 @@ public class TestOrcWriterOptions
         OptionalInt compressionLevel = OptionalInt.of(5);
         StreamLayout streamLayout = new StreamLayout.ByColumnSize();
         boolean integerDictionaryEncodingEnabled = false;
+        boolean stringDictionarySortingEnabled = true;
 
         OrcWriterOptions writerOptions = OrcWriterOptions.builder()
                 .withStripeMinSize(stripeMinSize)
@@ -90,12 +94,13 @@ public class TestOrcWriterOptions
                 .withCompressionLevel(compressionLevel)
                 .withStreamLayout(streamLayout)
                 .withIntegerDictionaryEncodingEnabled(integerDictionaryEncodingEnabled)
+                .withStringDictionarySortingEnabled(stringDictionarySortingEnabled)
                 .build();
 
         String expectedString = "OrcWriterOptions{stripeMinSize=13MB, stripeMaxSize=27MB, stripeMaxRowCount=1100000, "
                 + "rowGroupMaxRowCount=15000, dictionaryMaxMemory=13000kB, maxStringStatisticsLimit=128B, "
                 + "maxCompressionBufferSize=512kB, compressionLevel=OptionalInt[5], streamLayout=ByColumnSize{}, "
-                + "integerDictionaryEncodingEnabled=false}";
+                + "integerDictionaryEncodingEnabled=false, stringDictionarySortingEnabled=true}";
         assertEquals(expectedString, writerOptions.toString());
     }
 }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/writer/TestSliceDictionaryColumnWriter.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/writer/TestSliceDictionaryColumnWriter.java
@@ -1,0 +1,217 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.writer;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.block.RunLengthEncodedBlock;
+import com.facebook.presto.orc.ColumnWriterOptions;
+import com.facebook.presto.orc.OrcCorruptionException;
+import com.facebook.presto.orc.OrcDataSourceId;
+import com.facebook.presto.orc.OrcDecompressor;
+import com.facebook.presto.orc.OrcEncoding;
+import com.facebook.presto.orc.TestingHiveOrcAggregatedMemoryContext;
+import com.facebook.presto.orc.metadata.Stream.StreamKind;
+import com.facebook.presto.orc.stream.ByteArrayInputStream;
+import com.facebook.presto.orc.stream.LongInputStream;
+import com.facebook.presto.orc.stream.LongInputStreamV1;
+import com.facebook.presto.orc.stream.LongInputStreamV2;
+import com.facebook.presto.orc.stream.OrcInputStream;
+import com.facebook.presto.orc.stream.SharedBuffer;
+import com.facebook.presto.orc.stream.StreamDataOutput;
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.DynamicSliceOutput;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import io.airlift.units.DataSize;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.orc.OrcDecompressor.createOrcDecompressor;
+import static com.facebook.presto.orc.OrcEncoding.DWRF;
+import static com.facebook.presto.orc.OrcEncoding.ORC;
+import static com.facebook.presto.orc.metadata.CompressionKind.SNAPPY;
+import static com.facebook.presto.orc.metadata.Stream.StreamKind.DICTIONARY_DATA;
+import static com.facebook.presto.orc.metadata.Stream.StreamKind.LENGTH;
+import static com.google.common.collect.MoreCollectors.onlyElement;
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.airlift.units.DataSize.Unit.KILOBYTE;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static java.lang.Math.toIntExact;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+
+public class TestSliceDictionaryColumnWriter
+{
+    private static final int COLUMN_ID = 1;
+    private static final OrcDataSourceId ORC_DATA_SOURCE_ID = new OrcDataSourceId("test");
+
+    private StreamDataOutput getStreamKind(List<StreamDataOutput> streams, StreamKind streamKind)
+    {
+        return streams.stream()
+                .filter(e -> e.getStream().getStreamKind() == streamKind)
+                .collect(onlyElement());
+    }
+
+    private Optional<OrcDecompressor> getOrcDecompressor()
+    {
+        int compressionBlockSize = toIntExact(new DataSize(256, KILOBYTE).toBytes());
+        return createOrcDecompressor(ORC_DATA_SOURCE_ID, SNAPPY, compressionBlockSize);
+    }
+
+    private OrcInputStream convertSliceToInputStream(Slice slice)
+    {
+        TestingHiveOrcAggregatedMemoryContext aggregatedMemoryContext = new TestingHiveOrcAggregatedMemoryContext();
+        return new OrcInputStream(
+                ORC_DATA_SOURCE_ID,
+                new SharedBuffer(aggregatedMemoryContext.newOrcLocalMemoryContext("sharedDecompressionBuffer")),
+                slice.getInput(),
+                getOrcDecompressor(),
+                Optional.empty(),
+                aggregatedMemoryContext,
+                slice.getRetainedSize());
+    }
+
+    private Slice convertStreamToSlice(StreamDataOutput streamDataOutput)
+            throws OrcCorruptionException
+    {
+        DynamicSliceOutput sliceOutput = new DynamicSliceOutput(toIntExact(streamDataOutput.size()));
+        streamDataOutput.writeData(sliceOutput);
+        return sliceOutput.slice();
+    }
+
+    private OrcInputStream getOrcInputStream(List<StreamDataOutput> streams, StreamKind streamKind)
+            throws OrcCorruptionException
+    {
+        StreamDataOutput stream = getStreamKind(streams, streamKind);
+        Slice slice = convertStreamToSlice(stream);
+        return convertSliceToInputStream(slice);
+    }
+
+    private LongInputStream getDictionaryLengthStream(List<StreamDataOutput> streams, OrcEncoding orcEncoding)
+    {
+        if (orcEncoding == DWRF) {
+            return new LongInputStreamV1(getOrcInputStream(streams, LENGTH), false);
+        }
+        return new LongInputStreamV2(getOrcInputStream(streams, LENGTH), false, false);
+    }
+
+    private List<String> getDictionaryKeys(List<String> values, OrcEncoding orcEncoding, boolean sortDictionaryKeys)
+            throws IOException
+    {
+        DictionaryColumnWriter writer = getDictionaryColumnWriter(orcEncoding, sortDictionaryKeys);
+
+        for (int index = 0; index < values.size(); ) {
+            int endIndex = Math.min(index + 10_000, values.size());
+
+            BlockBuilder blockBuilder = VARCHAR.createBlockBuilder(null, 10_000);
+            while (index < endIndex) {
+                VARCHAR.writeSlice(blockBuilder, utf8Slice(values.get(index++)));
+            }
+
+            writer.beginRowGroup();
+            writer.writeBlock(blockBuilder);
+            writer.finishRowGroup();
+        }
+
+        writer.close();
+        List<StreamDataOutput> streams = writer.getDataStreams();
+        int dictionarySize = writer.getColumnEncodings().get(COLUMN_ID).getDictionarySize();
+        ByteArrayInputStream dictionaryDataStream = new ByteArrayInputStream(getOrcInputStream(streams, DICTIONARY_DATA));
+        LongInputStream dictionaryLengthStream = getDictionaryLengthStream(streams, orcEncoding);
+        List<String> dictionaryKeys = new ArrayList<>(dictionarySize);
+        for (int i = 0; i < dictionarySize; i++) {
+            int length = toIntExact(dictionaryLengthStream.next());
+            String dictionaryKey = new String(dictionaryDataStream.next(length), UTF_8);
+            dictionaryKeys.add(dictionaryKey);
+        }
+        return dictionaryKeys;
+    }
+
+    private DictionaryColumnWriter getDictionaryColumnWriter(OrcEncoding orcEncoding, boolean sortDictionaryKeys)
+    {
+        ColumnWriterOptions columnWriterOptions = ColumnWriterOptions.builder()
+                .setCompressionKind(SNAPPY)
+                .setStringDictionarySortingEnabled(sortDictionaryKeys)
+                .build();
+        DictionaryColumnWriter writer = new SliceDictionaryColumnWriter(
+                COLUMN_ID,
+                VARCHAR,
+                columnWriterOptions,
+                Optional.empty(),
+                orcEncoding,
+                orcEncoding.createMetadataWriter());
+        return writer;
+    }
+
+    @Test
+    public void testSortedDictionaryKeys()
+            throws IOException
+    {
+        for (OrcEncoding orcEncoding : OrcEncoding.values()) {
+            List<String> sortedKeys = getDictionaryKeys(ImmutableList.of("b", "a", "c"), orcEncoding, true);
+            assertEquals(sortedKeys, ImmutableList.of("a", "b", "c"));
+
+            sortedKeys = getDictionaryKeys(ImmutableList.of("b", "b", "a"), orcEncoding, true);
+            assertEquals(sortedKeys, ImmutableList.of("a", "b"));
+        }
+    }
+
+    @Test
+    public void testUnsortedDictionaryKeys()
+            throws IOException
+    {
+        List<String> sortedKeys = getDictionaryKeys(ImmutableList.of("b", "a", "c"), DWRF, false);
+        assertEquals(sortedKeys, ImmutableList.of("b", "a", "c"));
+
+        sortedKeys = getDictionaryKeys(ImmutableList.of("b", "b", "a"), DWRF, false);
+        assertEquals(sortedKeys, ImmutableList.of("b", "a"));
+    }
+
+    @Test(expectedExceptions = IllegalStateException.class)
+    public void testOrcStringSortingDisabledThrows()
+    {
+        getDictionaryColumnWriter(ORC, false);
+    }
+
+    @Test
+    public void testStringDirectConversion()
+    {
+        // a single row group exceeds 2G after direct conversion
+        byte[] value = new byte[megabytes(1)];
+        ThreadLocalRandom.current().nextBytes(value);
+        Block data = RunLengthEncodedBlock.create(VARCHAR, Slices.wrappedBuffer(value), 3000);
+
+        for (OrcEncoding orcEncoding : OrcEncoding.values()) {
+            DictionaryColumnWriter writer = getDictionaryColumnWriter(orcEncoding, true);
+
+            writer.beginRowGroup();
+            writer.writeBlock(data);
+            writer.finishRowGroup();
+            assertFalse(writer.tryConvertToDirect(megabytes(64)).isPresent());
+        }
+    }
+
+    private static int megabytes(int size)
+    {
+        return toIntExact(new DataSize(size, MEGABYTE).toBytes());
+    }
+}


### PR DESCRIPTION
DWRF format does not require the string dictionary to
be sorted. Sorting DWRF string dictionary keys takes
large amount of time. A new option is added to disable
string dictionary sorting in DWRF dictionary encoding.

Test plan 
Enhanced existing tests and added new tests.
Ran the validation service for this change.

```
== NO RELEASE NOTE ==
```
