### PR TITLE
Fix PlanRemoteProjections

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PlanRemotePojections.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PlanRemotePojections.java
@@ -260,7 +260,7 @@ public class PlanRemotePojections
                     newArguments);
 
             if (local) {
-                if (processedArguments.size() == 1 && !processedArguments.get(0).isRemote()) {
+                if (processedArguments.size() == 0 || (processedArguments.size() == 1 && !processedArguments.get(0).isRemote())) {
                     // This call and all its arguments are local
                     return ImmutableList.of();
                 }
@@ -330,7 +330,7 @@ public class PlanRemotePojections
             ImmutableList.Builder<RowExpression> newArgumentsBuilder = ImmutableList.builder();
             List<ProjectionContext> processedArguments = processArguments(specialForm.getArguments(), newArgumentsBuilder, true);
             List<RowExpression> newArguments = newArgumentsBuilder.build();
-            if (processedArguments.size() == 1 && !processedArguments.get(0).isRemote()) {
+            if (processedArguments.size() == 0 || (processedArguments.size() == 1 && !processedArguments.get(0).isRemote())) {
                 // Arguments do not contain remote projection
                 return ImmutableList.of();
             }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPlanRemoteProjections.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPlanRemoteProjections.java
@@ -181,9 +181,10 @@ public class TestPlanRemoteProjections
                 .put(planBuilder.variable("b"), planBuilder.rowExpression("x IS NULL OR y IS NULL"))
                 .put(planBuilder.variable("c"), planBuilder.rowExpression("IF(abs(unittest.memory.remote_foo()) > 0, x, y)"))
                 .put(planBuilder.variable("d"), planBuilder.rowExpression("unittest.memory.remote_foo(x + y, abs(x))"))
+                .put(planBuilder.variable("e"), planBuilder.rowExpression("TRUE OR FALSE"))
                 .build(), new PlanVariableAllocator(planBuilder.getTypes().allVariables()));
         assertEquals(rewritten.size(), 4);
-        assertEquals(rewritten.get(3).getProjections().size(), 4);
+        assertEquals(rewritten.get(3).getProjections().size(), 5);
     }
 
     @Test
@@ -223,10 +224,10 @@ public class TestPlanRemoteProjections
                     p.variable("y", INTEGER);
                     return p.project(
                             Assignments.builder()
-                                    .put(p.variable("a"), p.rowExpression("unittest.memory.remote_foo(1, y + unittest.memory.remote_foo(x))")) // identity
-                                    .put(p.variable("b"), p.rowExpression("x IS NULL OR y IS NULL")) // complex expression referenced multiple times
-                                    .put(p.variable("c"), p.rowExpression("abs(unittest.memory.remote_foo()) > 0")) // complex expression referenced multiple times
-                                    .put(p.variable("d"), p.rowExpression("unittest.memory.remote_foo(x + y, abs(x))")) // literal referenced multiple times
+                                    .put(p.variable("a"), p.rowExpression("unittest.memory.remote_foo(1, y + unittest.memory.remote_foo(x))"))
+                                    .put(p.variable("b"), p.rowExpression("x IS NULL OR y IS NULL"))
+                                    .put(p.variable("c"), p.rowExpression("abs(unittest.memory.remote_foo()) > 0"))
+                                    .put(p.variable("d"), p.rowExpression("unittest.memory.remote_foo(x + y, abs(1))"))
                                     .build(),
                             p.values(p.variable("x", INTEGER), p.variable("y", INTEGER)));
                 })
@@ -260,7 +261,7 @@ public class TestPlanRemoteProjections
                                                                 .put("expr", PlanMatchPattern.expression("1"))
                                                                 .put("b", PlanMatchPattern.expression("x IS NULL OR y is NULL"))
                                                                 .put("add_10", PlanMatchPattern.expression("x + y"))
-                                                                .put("abs_12", PlanMatchPattern.expression("abs(x)"))
+                                                                .put("abs_12", PlanMatchPattern.expression("abs(1)"))
                                                                 .build(),
                                                         values(ImmutableMap.of("x", 0, "y", 1)))))));
     }


### PR DESCRIPTION
When a function/operator only has constants as input, processedArguments.size() could be 0.
Previous logic can produce index out of bound exception.

Test plan - unit test

```
== RELEASE NOTES ==

General Changes
* Fix a bug where queries that have both remote functions and a local function with only constant arguments could throw an IndexOutOfBoundException during planning. The bug was introduced in release 0.253 by :pr:`16039`.
```
