### PR TITLE
Ignore Resource manager from scheduling tasks/splits

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/connector/system/SystemSplitManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/system/SystemSplitManager.java
@@ -38,6 +38,7 @@ import static com.facebook.presto.spi.StandardErrorCode.NOT_FOUND;
 import static com.facebook.presto.spi.SystemTable.Distribution.ALL_COORDINATORS;
 import static com.facebook.presto.spi.SystemTable.Distribution.ALL_NODES;
 import static com.facebook.presto.spi.SystemTable.Distribution.SINGLE_COORDINATOR;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -81,7 +82,8 @@ public class SystemSplitManager
             nodes.addAll(nodeManager.getCoordinators());
         }
         else if (tableDistributionMode == ALL_NODES) {
-            nodes.addAll(nodeManager.getNodes(ACTIVE));
+            Set<InternalNode> allNodes = nodeManager.getNodes(ACTIVE).stream().filter(s -> !s.isResourceManager()).collect(toImmutableSet());
+            nodes.addAll(allNodes);
         }
         Set<InternalNode> nodeSet = nodes.build();
         for (InternalNode node : nodeSet) {

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NodeScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NodeScheduler.java
@@ -50,6 +50,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static com.facebook.airlift.concurrent.MoreFutures.whenAnyCompleteCancelOthers;
 import static com.facebook.presto.SystemSessionProperties.getMaxUnacknowledgedSplitsPerTask;
@@ -184,7 +185,7 @@ public class NodeScheduler
                 allNodes = nodeManager.getAllConnectorNodes(connectorId);
             }
             else {
-                activeNodes = nodeManager.getNodes(ACTIVE);
+                activeNodes = nodeManager.getNodes(ACTIVE).stream().filter(s -> !s.isResourceManager()).collect(Collectors.toSet());
                 allNodes = activeNodes;
             }
 

--- a/presto-main/src/main/java/com/facebook/presto/memory/ClusterMemoryManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/ClusterMemoryManager.java
@@ -501,6 +501,7 @@ public class ClusterMemoryManager
                 .build();
 
         ImmutableSet<String> aliveNodeIds = aliveNodes.stream()
+                .filter(s -> !s.isResourceManager())
                 .map(InternalNode::getNodeIdentifier)
                 .collect(toImmutableSet());
 

--- a/presto-main/src/main/java/com/facebook/presto/server/PrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PrestoServer.java
@@ -134,8 +134,10 @@ public class PrestoServer
             Injector injector = app.initialize();
 
             injector.getInstance(PluginManager.class).loadPlugins();
-
-            injector.getInstance(StaticCatalogStore.class).loadCatalogs();
+            ServerConfig serverConfig = injector.getInstance(ServerConfig.class);
+            if (!serverConfig.isResourceManager()) {
+                injector.getInstance(StaticCatalogStore.class).loadCatalogs();
+            }
 
             // TODO: remove this huge hack
             updateConnectorIds(
@@ -152,7 +154,9 @@ public class PrestoServer
             injector.getInstance(StaticFunctionNamespaceStore.class).loadFunctionNamespaceManagers();
             injector.getInstance(SessionPropertyDefaults.class).loadConfigurationManager();
             injector.getInstance(ResourceGroupManager.class).loadConfigurationManager();
-            injector.getInstance(AccessControlManager.class).loadSystemAccessControl();
+            if (!serverConfig.isResourceManager()) {
+                injector.getInstance(AccessControlManager.class).loadSystemAccessControl();
+            }
             injector.getInstance(PasswordAuthenticatorManager.class).loadPasswordAuthenticator();
             injector.getInstance(EventListenerManager.class).loadConfiguredEventListener();
             injector.getInstance(TempStorageManager.class).loadTempStorages();


### PR DESCRIPTION
Test plan - Test run

- Ignoring RM from scheduling task/splits. 
- Ignore loading StaticCatalogStore and AccessControlManager for RM

```
== NO RELEASE NOTE ==
```
