### PR TITLE
Upgrade airlift dependency to 0.201

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <air.maven.version>3.3.9</air.maven.version>
 
         <dep.antlr.version>4.7.1</dep.antlr.version>
-        <dep.airlift.version>0.200</dep.airlift.version>
+        <dep.airlift.version>0.201</dep.airlift.version>
         <dep.packaging.version>${dep.airlift.version}</dep.packaging.version>
         <dep.slice.version>0.38</dep.slice.version>
         <dep.testing-mysql-server-5.version>0.6</dep.testing-mysql-server-5.version>


### PR DESCRIPTION
As part of this PR, we are updating the version for airlift dependency to 0.201 version.
Refer to https://github.com/prestodb/airlift/pull/41 for bugfix.

Test plan - Ran build and tests to make sure upgrade does not break anything

```
== NO RELEASE NOTE ==
```
