### PR TITLE
Add release notes for 0.254

### DIFF
--- a/presto-docs/src/main/sphinx/release.rst
+++ b/presto-docs/src/main/sphinx/release.rst
@@ -5,6 +5,7 @@ Release Notes
 .. toctree::
     :maxdepth: 1
 
+    release/release-0.254
     release/release-0.253
     release/release-0.252
     release/release-0.251.1

--- a/presto-docs/src/main/sphinx/release/release-0.254.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.254.rst
@@ -1,0 +1,39 @@
+=============
+Release 0.254
+=============
+
+**Details**
+===========
+
+General Changes
+_______________
+* Fix a bug where queries that have both remote functions and a local function with only constant arguments could throw an ``IndexOutOfBoundException`` during planning. The bug was introduced by :pr:`16039`.
+* Fix a CPU regression for queries using :func:`element_at` for ``MAP``. Introduced by :pr:`16027`.
+* Add fragment result caching support for ``UNNEST`` queries.
+* Add :func:`poisson_cdf` and :func:`inverse_poisson_cdf` functions.
+* Add memory tracking in ``TableFinishOperator`` which can be enabled by setting the ``table-finish-operator-memory-tracking-enabled`` configuration property to ``true``. Enabling this property can help with investigating GC issues on the coordinator by allowing us to debug whether stats collection uses a lot of memory.
+* Remove spilling strategy ``PER_QUERY_MEMORY_LIMIT`` and add configuration property ``experimental.query-limit-spill-enabled`` and session property ``query_limit_spill_enabled``. When ``query_limit_spill_enabled`` is set to ``true`` and the spill strategy is not ``PER_TASK_MEMORY_THRESHOLD``, then we will spill whenever a query uses more than the per-node total memory limit in combined revocable and non-revocable memory.
+
+Hive Changes
+____________
+* Fix a bug where the files would not be sorted when inserting into bucketed sorted tables with Glue.
+* Add support for validating the values returned from the partition cache with the actual value from Metastore. This can be enabled by setting the configuration property ``hive.partition-cache-validation-percentage``.
+* Add support for allowing to match columns between table and partition schemas by names when the configuration property ``hive.parquet.use-column-names`` or the hive catalog session property ``parquet_use_column_names`` is set to ``true``. By default they are mapped by index.
+* Add support for configuring the Glue endpoint URL. :doc:`/connector/hive`.
+* Add support for accessing tables in Glue metastore that do not have a table type.
+* Add support for the S3 Intelligent-Tiering storage class writing data. This can be enabled by setting the configuration property ``hive.s3.storage-class`` to ``INTELLIGENT_TIERING``.
+* Add configuration property ``hive.metastore.glue.max-error-retries`` for the maximum number of retries for glue client connections. The default value is 10.  :doc:`/connector/hive`.
+
+Presto On Spark Changes
+_______________________
+* Optimize Driver commit memory footprint.
+* Add session property ``spark_memory_revoking_threshold`` and configuration property ``spark.memory-revoking-threshold``. Spilling is triggered when total memory is beyond this threshold.
+
+SPI Changes
+_______________________
+* Add support for custom query prerequisites to be checked and satisfied through ``QueryPrerequisites`` interface. See :pr:`16073`.
+
+**Contributors**
+================
+
+Abhisek Gautam Saikia, Akhil Umesh Mehendale, Andrii Rosa, Arjun Gupta, Beinan, Bhavani Hari, Chunxu Tang, Jalpreet Singh Nanda (:imjalpreet), James Petty, James Sun, Ke Wang, Maria Basmanova, Mayank Garg, Nikhil Collooru, Rebecca Schlussel, Rohit Jain, Rongrong Zhong, Sergey Pershin, Sergii Druzkin, Shixuan Fan, Tal Galili, Tim Meehan, Vic Zhang, Zhenxiao Luo, guhanjie, linjunhua, v-jizhang


### PR DESCRIPTION
# Missing Release Notes
## Abhisek Gautam Saikia
- [x] https://github.com/prestodb/presto/pull/16087 Define custom json serializer for DataSize and Duration (Merged by: Timothy Meehan)

## Akhil Umesh Mehendale
- [x] https://github.com/prestodb/presto/pull/16037 Support Dwrf Sequence Ids in Writer (Merged by: Rebecca Schlussel)

## Tal Galili
- [x] https://github.com/prestodb/presto/pull/15814 Adding the Poisson distribution (Merged by: Maria Basmanova)

## Vic Zhang
- [x] https://github.com/prestodb/presto/pull/16133 Support spilling for Presto on Spark (Merged by: Andrii Rosa)
- [x] https://github.com/prestodb/presto/pull/16133 Support spilling for Presto on Spark (Merged by: Andrii Rosa)
- [x] https://github.com/prestodb/presto/pull/16133 Support spilling for Presto on Spark (Merged by: Andrii Rosa)
- [x] https://github.com/prestodb/presto/pull/16133 Support spilling for Presto on Spark (Merged by: Andrii Rosa)
- [x] https://github.com/prestodb/presto/pull/16133 Support spilling for Presto on Spark (Merged by: Andrii Rosa)
- [x] https://github.com/prestodb/presto/pull/16133 Support spilling for Presto on Spark (Merged by: Andrii Rosa)

## guhanjie
- [x] https://github.com/prestodb/presto/pull/15848 Add a flag for HttpRemoteTask to avoid eager but unnecessary sendUpdate (Merged by: Andrii Rosa)

# Extracted Release Notes
- #15836 (Author: Chunxu Tang): Add Presto iceberg connector
  - Add iceberg connector.
- #15836 (Author: Chunxu Tang): Add Presto iceberg connector
  - Add iceberg connector.
- #15836 (Author: Chunxu Tang): Add Presto iceberg connector
  - Add iceberg connector.
- #15836 (Author: Chunxu Tang): Add Presto iceberg connector
  - Add iceberg connector.
- #15836 (Author: Chunxu Tang): Add Presto iceberg connector
  - Add iceberg connector.
- #15836 (Author: Chunxu Tang): Add Presto iceberg connector
  - Add iceberg connector.
- #15836 (Author: Chunxu Tang): Add Presto iceberg connector
  - Add iceberg connector.
- #15836 (Author: Chunxu Tang): Add Presto iceberg connector
  - Add iceberg connector.
- #15836 (Author: Chunxu Tang): Add Presto iceberg connector
  - Add iceberg connector.
- #15836 (Author: Chunxu Tang): Add Presto iceberg connector
  - Add iceberg connector.
- #15836 (Author: Chunxu Tang): Add Presto iceberg connector
  - Add iceberg connector.
- #15836 (Author: Chunxu Tang): Add Presto iceberg connector
  - Add iceberg connector.
- #15836 (Author: Chunxu Tang): Add Presto iceberg connector
  - Add iceberg connector.
- #15836 (Author: Chunxu Tang): Add Presto iceberg connector
  - Add iceberg connector.
- #15937 (Author: v-jizhang): Do not allocate resources within test constructor
  - Do not allocate resources within test constructor for a cleaner code.
- #15993 (Author: v-jizhang): Fix Athena Glue table compatibility issue
  - Allow accessing tables in Glue metastore that do not have a table type.
- #16003 (Author: v-jizhang): Add missing support for bucket sort order in Glue
  - Add support for bucket sort order in Glue when creating or updating a table or partition.
- #16011 (Author: Jalpreet Singh Nanda (:imjalpreet)): Partition schema evolution for Parquet
  - Add support for partition schema evolution for parquet.
- #16011 (Author: Jalpreet Singh Nanda (:imjalpreet)): Partition schema evolution for Parquet
  - Add support for partition schema evolution for parquet.
- #16012 (Author: v-jizhang): Add support for MaxResults on Glue Hive Metastore
  - Add support for MaxResults on Glue Hive Metastore.
- #16014 (Author: v-jizhang): Add support for Glue endpoint URL
  - Add support for Glue endpoint URL :doc:`/connector/hive`.
- #16018 (Author: v-jizhang): Add max error retry config option to glue client
  - Add max error retry config option to glue client. Defaults to 10. :doc:`/connector/hive`.
- #16028 (Author: v-jizhang): Add intelligent tiering storage class
  - Added intelligent tiering storage class. The S3 storage class to use when writing the data. STANDARD and INTELLIGENT_TIERING storage classes are supported. Default storage class is STANDARD :doc:`/connector/hive`.
- #16058 (Author: v-jizhang): Add documentation for Glue Catalog support in Hive
  - Add documentation for Glue Catalog support in Hive. :doc:`/connector/hive`.
- #16069 (Author: Rebecca Schlussel): Combine spill strategies
  - Remove spilling strategy ``PER_QUERY_MEMORY_LIMIT`` and instead add configuration property ``experimental.query-limit-spill-enabled`` and session property ``query_limit_spill_enabled``.  When this property is set to ``true``, and the spill strategy is not ``PER_TASK_MEMORY_THRESHOLD``, then we will spill whenever a query uses more than the per-node total memory limit in combined revocable and non-revocable memory, in addition to whenever the memory pool exceeds the spill threshold.  This fixes an issue where using the ``PER_QUERY_MEMORY_LIMIT`` spilling strategy could prevent the oom killer from running when the memory pool was full.  The issue is still present for the ``PER_TASK_MEMORY_THRESHOLD`` spilling strategy.
- #16069 (Author: Rebecca Schlussel): Combine spill strategies
  - Remove spilling strategy ``PER_QUERY_MEMORY_LIMIT`` and instead add configuration property ``experimental.query-limit-spill-enabled`` and session property ``query_limit_spill_enabled``.  When this property is set to ``true``, and the spill strategy is not ``PER_TASK_MEMORY_THRESHOLD``, then we will spill whenever a query uses more than the per-node total memory limit in combined revocable and non-revocable memory, in addition to whenever the memory pool exceeds the spill threshold.  This fixes an issue where using the ``PER_QUERY_MEMORY_LIMIT`` spilling strategy could prevent the oom killer from running when the memory pool was full.  The issue is still present for the ``PER_TASK_MEMORY_THRESHOLD`` spilling strategy.
- #16069 (Author: Rebecca Schlussel): Combine spill strategies
  - Remove spilling strategy ``PER_QUERY_MEMORY_LIMIT`` and instead add configuration property ``experimental.query-limit-spill-enabled`` and session property ``query_limit_spill_enabled``.  When this property is set to ``true``, and the spill strategy is not ``PER_TASK_MEMORY_THRESHOLD``, then we will spill whenever a query uses more than the per-node total memory limit in combined revocable and non-revocable memory, in addition to whenever the memory pool exceeds the spill threshold.  This fixes an issue where using the ``PER_QUERY_MEMORY_LIMIT`` spilling strategy could prevent the oom killer from running when the memory pool was full.  The issue is still present for the ``PER_TASK_MEMORY_THRESHOLD`` spilling strategy.
- #16069 (Author: Rebecca Schlussel): Combine spill strategies
  - Remove spilling strategy ``PER_QUERY_MEMORY_LIMIT`` and instead add configuration property ``experimental.query-limit-spill-enabled`` and session property ``query_limit_spill_enabled``.  When this property is set to ``true``, and the spill strategy is not ``PER_TASK_MEMORY_THRESHOLD``, then we will spill whenever a query uses more than the per-node total memory limit in combined revocable and non-revocable memory, in addition to whenever the memory pool exceeds the spill threshold.  This fixes an issue where using the ``PER_QUERY_MEMORY_LIMIT`` spilling strategy could prevent the oom killer from running when the memory pool was full.  The issue is still present for the ``PER_TASK_MEMORY_THRESHOLD`` spilling strategy.
- #16071 (Author: Shixuan Fan): Support Unnest in fragment result caching
  - Add support to fragment result caching for unnest.
- #16095 (Author: Vic Zhang): Add properties to update memory in TableFinishOperator
  - Memory tracking in TableFinishOperator can be enabled by setting the `table-finish-operator-memory-tracking-enabled` configuration property to `true`.
- #16113 (Author: Nikhil Collooru): Add support for partition cache verification
  - Add support for partition cache validation. This can be enabled by setting `hive.partition-cache-validation-percentage` configuration parameter.
- #16120 (Author: Andrii Rosa): Reduce memory utilization on the Driver during the commit phase
  - Reduce commit memory footprint on the Driver.
- #16120 (Author: Andrii Rosa): Reduce memory utilization on the Driver during the commit phase
  - Reduce commit memory footprint on the Driver.
- #16120 (Author: Andrii Rosa): Reduce memory utilization on the Driver during the commit phase
  - Reduce commit memory footprint on the Driver.
- #16136 (Author: Rongrong Zhong): Fix PlanRemoteProjections
  - Fix a bug where queries that have both remote functions and a local function with only constant arguments could throw an IndexOutOfBoundException during planning. The bug was introduced in release 0.253 by :pr:`16039`.

# All Commits
- 8aa29612584603a6aab836a54e445790eefc59bc Fix PlanRemoteProjections (Rongrong Zhong)
- e2944c678f79eef09096f961e80c50c497fabfd9 Disable flaky test AbstractTestQueries.testEmptyJoins (Vic Zhang)
- 8d7d0a9470b8768db027b8b2d5c9dc4655b1d0cd Add spilling threshold for Presto on Spark (Vic Zhang)
- 5f11dd2b61316b49cf206c86c28cc97b83731d60 Include revocable memory for peak node total memory (Vic Zhang)
- 5f692c0bd985d3421b3b49e7a1dd7c043d11c30a Include revocable memory for memory limit error (Vic Zhang)
- 4d17bb089170d7fe1415244e6da6d9b86dc8e532 Support spilling for Presto on Spark (Vic Zhang)
- 129aab3bfd6574ff5468e30d68fc8377f81192c4 Rename TestPrestoSparkAbstractTestAggregations (Vic Zhang)
- 4428cf732e8f6b3743d209d2c2327b848cc4c893 Fix the partition cache invalidation logic to be more efficient (Nikhil Collooru)
- a6d52705ee6b80fba898b9e4dff1e132b8b56779 Fix ZeroRowFileCreator to use DataSink instead of OutputStream interface (Arjun Gupta)
- 5eb36ae64a70f22fffa44731a910ec90e083d9c2 Add session property for temp storage buffer size (Vic Zhang)
- 100c120d403e03827001b0f862fdbe64c9d5c4fa Disable flaky TestQueues.testQueuedQueryInteraction (Vic Zhang)
- 4bd5dc5d5f25d92cf0bfed74f455353d529aebfa Log sizes for pages received on the Driver (Andrii Rosa)
- 2692f3004f8919d77f866f7c97af735c9b3319f1 Release inmemory input pages incrementally (Andrii Rosa)
- a31785bed1fdb582b84bfd7192c55bd4373f21c0 Support compression for PartitionUpdate in Hive connector (Andrii Rosa)
- 81e45abfb0893a9b6a276003fd8949f1fde0f79d Fix MetastoreContext creation in presto-iceberg module (Nikhil Collooru)
- baea41bb7dee6384aa5b30d7eb27af4c16635e3d Allow StorageOrcFileTailSource to read DWRF stripe cache data (Sergii Druzkin)
- 9958e198c4c40d36f594f5a1a93c4dc1449383cf Make ORC read tail size configurable (Sergii Druzkin)
- 6681e91b9f3db800c25f8fa118897059b412e0ca Fix Athena Glue table compatibility issue (v-jizhang)
- e87999e56c0d4639b59e26cf144890e9a7768dbd Add missing support for bucket sort order in Glue (v-jizhang)
- b8b0e522e9a287828e76a45aa4b85c24ca74816e Upgrade to 0.254 (Chunxu Tang)
- 97953b1ae0dc705b48bc989d526525b6b6ba3052 Adjust the test change of AbstractTestDistributedQueries (Chunxu Tang)
- 1769297678ebaa73bfd30859a67408d74f501648 Include presto-iceberg in example config (Chunxu Tang)
- 70fd449dca7f4cad53e53b361b7a9c0e1080d733 Remove unnecessary comments (Chunxu Tang)
- cea7117c6b7ee4f34978d7f18376be8f42057d1e Add MetastoreContext in the iceberg HiveTableOperations (Chunxu Tang)
- 656f7afe31174df6e2f5fe5218fdca98dc64198a Adjust the usage of Hive Metastore with MetastoreContext (Chunxu Tang)
- 68003043b31cbadce2fd8bb85a20be3e0da41be2 Fix review comments (Chunxu Tang)
- 8180ce3d5bcee4e4be05fd69eb413ceafb76ac08 Upgrade Presto to 0.252 (Chunxu Tang)
- d749f3f087ae7e42894c9c54f1b5581379f105d7 Refactor HdfsFileIo names (Chunxu Tang)
- b6ba9134f1edfa798586251f0f95aed64c71ef14 Fix parquet version conflict (Chunxu Tang)
- ddb67db8ebc734f186198353b9b3c5afa88db999 Include iceberg connector in the root POM (Chunxu Tang)
- 2d37a11debbbef6ffb66bd738acdc4e490c11342 Set up query tests (Chunxu Tang)
- f738ed3bed0ce290d3bc61e540b0a2cf89b527a1 Add iceberg connector (Chunxu Tang)
- 28f558b2fa55014d8bfb7b0dff5731c21f5819ac upgrade parquet to 1.11.0 (Chunxu Tang)
- a7a98121aee1fce65ede01ba6edac02e838a0936 Use username for comparison only when impersonation is enabled (Nikhil Collooru)
- fca1f2429069b44c04a41d02818e5b38974b596b Add support for partition cache verification (Nikhil Collooru)
- 8f4ef27fc72aa68facb6f0f5049a460d2b649333 Add support for MaxResults on Glue Hive Metastore (v-jizhang)
- 8be15cfd2acf882067bdbb052c09e02769d6e35c Add a flag for HttpRemoteTask to avoid eager but unnecessary sendUpdate (guhanjie)
- e9c4a306f114b9a68f2cc6498d03a79dc44e23cb Decode Parquet dictionary faster (Zhenxiao Luo)
- c9571e1e449a76740c0f3fad46f3679b95bf653d Fix generics in declaration of ValueSet.copyOf (Zhenxiao Luo)
- 6a4f0ab55fc1709f775b642e0b1c42f44a8bd48b Benchmark Parquet dictionary to Domain conversion (Zhenxiao Luo)
- b302af11b64eea922e7c3a523544931a64dc3dd9 Add a test for BenchmarkSortedRangeSet (Zhenxiao Luo)
- ca09cd31fedba77611975d5717cbaae80d2e984b Simplify Range consumption (Zhenxiao Luo)
- d887f690ae79d8de4bb5d1c2e720acbbb6445b8c Add benchmark for SortedRangeSet's getOrderedRanges (Zhenxiao Luo)
- 3faafe1de59d6fcc3f1e8d4fe50d88ffc2e5962b Benchmark SortedRangeSet methods (Zhenxiao Luo)
- 494b7f5dcbbcde8bb658a2d04be2d21da6e01f74 Plumb DWRF stripe cache info from proto to model (Sergii Druzkin)
- 54c3304e0c651d87675501aaaf395eea789b3b48 Add queryId to MetastoreContext (Nikhil Collooru)
- c63a7c7773e62fc8d96e9a9ec00ffb5edef37def Use double quotes for all column names in SHOW CREATE TABLE (Abhisek Gautam Saikia)
- 18f7e1786265c82ca8ba0949d8de69ac7e89b663 Use alias in case of predicate stitching (Rohit Jain)
- 2e180bafba1452a13a61e18ab5c4a9f7dd90bfc0 Add support for partition schema evolution for Parquet (Jalpreet Singh Nanda (:imjalpreet))
- 9e07362f03517320001bb7923a8050a5b113a885 Introduce TableToPartitionMapping (Jalpreet Singh Nanda (:imjalpreet))
- 865753c0b6d3508ab0343eb13b0af447e6ab3200 Allow classes that inherit from AbstractTestQueryFramework to supply expectedQueryRunner. (Sergey Pershin)
- d441316da87c5e814f6b8ba6ed7ab09124946b64 Revert "Revert "Bring retry queries to the beginning of the queue"" (Mayank Garg)
- 779afcc460625f5dc77d5520e0924e1591407533 Add properties to update memory in TableFinishOperator (Vic Zhang)
- 7f9e2426360f87718e634c8c35bd811f4e3096f5 Catch UncheckedIOException while reading broadcast table from storage (Arjun Gupta)
- aa59a8d51fdae1d412e063afc3a6a0d35a4b0c02 Do not allocate resources within test constructor (v-jizhang)
- f434ea10a590ef0f79d3226608632fb2b15f5140 Disable flaky test in TestJdbcClient (Rebecca Schlussel)
- 970e67e3e1486559af3e7757cd878e8aa51436ce Disable flaky test TestPrestoDriver.testQueryCancelByInterrupt (Rebecca Schlussel)
- 44240cce3d84bdd11506f5e0529f0ab17f7e0b24 Combine memory pool and query based spill strategies (Rebecca Schlussel)
- eae526629ed41fa62044019c429859073a4e4158 Remove periodic check from MemoryRevokingScheduler (Rebecca Schlussel)
- dec319521f6a76b9de83afc74387ed4ed0bfa940 Support Unnest in fragment result caching (Shixuan Fan)
- 39c66e30d87cf10345827194469a7a847751f18d Adding the Poisson distribution (Tal Galili)
- 77989bf483be56098af47a662a1b549fea6d2874 Add max error retry config option to glue client (v-jizhang)
- 012e9bd554eb413cd19cd69e188dbe0f7446d7be Add support for Glue endpoint URL (v-jizhang)
- 486f4e214b16e53e776f2a122af1ba6313d83b3c Define custom json serializer for DataSize and Duration (Abhisek Gautam Saikia)
- 54bde4ced47b984b3ca32103e9693feae33e72e3 Fix iterator in IndexedPriorityQueue (Tim Meehan)
- 88a14ba1e4580be885cf990051edd96ff1f1a821 Include queuing time while computing query completion deadline (Arjun Gupta)
- cdc9dca2ae1e82a9484703f368bc75943de5ca0d Release note for 0.251.1 (Ke Wang)
- 150fb77b9300857e696077858d107cf37adf2f34 Revert "Bring retry queries to the beginning of the queue" (Bhavani Hari)
- 408c2a19c95ab55b478c8295e6b09cc3c5e4ca72 Add documentation for Glue Catalog support in Hive (v-jizhang)
- 7e4fe3d909a598d561b7e9b8b37c606a9df7241c Add intelligent tiering storage class (v-jizhang)
- 3d78f134dadc33827ed2074583cb79dc7649495d Add cluster-wide endpoints for query and cluster information (Tim Meehan)
- f6611cbc0ae3dee90e6f5476a2c2aa027999b200 Support Dwrf Sequence Ids in Writer (Akhil Umesh Mehendale)
- 54a7ec79a344a4766e8fcf06e7ff4d10b7f2c380 Fix typo in connectors.rst (linjunhua)
- 299933063dd20a9c39d4d018ce76f4190dba0b1a Short-circuit TupleDomain columnWiseUnion and intersect (Zhenxiao Luo)