### PR TITLE
Fix load mysql jdbc driver failure in function namespace module

### DIFF
--- a/presto-function-namespace-managers/pom.xml
+++ b/presto-function-namespace-managers/pom.xml
@@ -120,6 +120,12 @@
         </dependency>
 
         <dependency>
+            <groupId>mysql</groupId>
+            <artifactId>mysql-connector-java</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.jdbi</groupId>
             <artifactId>jdbi3-core</artifactId>
         </dependency>

--- a/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/mysql/MySqlConnectionModule.java
+++ b/presto-function-namespace-managers/src/main/java/com/facebook/presto/functionNamespace/mysql/MySqlConnectionModule.java
@@ -37,6 +37,12 @@ public class MySqlConnectionModule
         configBinder(binder).bindConfig(MySqlConnectionConfig.class);
 
         String databaseUrl = buildConfigObject(MySqlConnectionConfig.class).getDatabaseUrl();
+        try {
+            Class.forName("com.mysql.jdbc.Driver");
+        }
+        catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
         Jdbi jdbi = createJdbi(
                 () -> DriverManager.getConnection(databaseUrl),
                 buildConfigObject(MySqlFunctionNamespaceManagerConfig.class));


### PR DESCRIPTION
Fix load mysql jdbc driver failure in the presto-function-namespace-manager module.

I'm not sure why we need `Class.forName("com.mysql.jdbc.Driver");` ,   looks like we only need it for legacy jdbc drivers.

Note that we need a mysql instance running on localhost:3306  to start presto-main locally.

```
== NO RELEASE NOTE ==
```
