### PR TITLE
Add iceberg connector to devel config

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergModule.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergModule.java
@@ -33,12 +33,14 @@ import com.facebook.presto.hive.HiveHdfsConfiguration;
 import com.facebook.presto.hive.HiveNodePartitioningProvider;
 import com.facebook.presto.hive.MetastoreClientConfig;
 import com.facebook.presto.hive.ParquetFileWriterConfig;
+import com.facebook.presto.hive.PartitionMutator;
 import com.facebook.presto.hive.cache.HiveCachingHdfsConfiguration;
 import com.facebook.presto.hive.gcs.GcsConfigurationInitializer;
 import com.facebook.presto.hive.gcs.HiveGcsConfig;
 import com.facebook.presto.hive.gcs.HiveGcsConfigurationInitializer;
 import com.facebook.presto.hive.metastore.CachingHiveMetastore;
 import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
+import com.facebook.presto.hive.metastore.HivePartitionMutator;
 import com.facebook.presto.hive.metastore.MetastoreConfig;
 import com.facebook.presto.spi.connector.ConnectorNodePartitioningProvider;
 import com.facebook.presto.spi.connector.ConnectorPageSinkProvider;
@@ -81,6 +83,7 @@ public class IcebergModule
         binder.bind(GcsConfigurationInitializer.class).to(HiveGcsConfigurationInitializer.class).in(Scopes.SINGLETON);
         binder.bind(HdfsConfiguration.class).annotatedWith(ForMetastoreHdfsEnvironment.class).to(HiveCachingHdfsConfiguration.class).in(Scopes.SINGLETON);
         binder.bind(HdfsConfiguration.class).annotatedWith(ForCachingFileSystem.class).to(HiveHdfsConfiguration.class).in(Scopes.SINGLETON);
+        binder.bind(PartitionMutator.class).to(HivePartitionMutator.class).in(Scopes.SINGLETON);
         binder.bind(ExtendedHiveMetastore.class).to(CachingHiveMetastore.class).in(Scopes.SINGLETON);
         binder.bind(MBeanServer.class).toInstance(new TestingMBeanServer());
 

--- a/presto-main/etc/catalog/iceberg.properties
+++ b/presto-main/etc/catalog/iceberg.properties
@@ -1,0 +1,2 @@
+connector.name=iceberg
+hive.metastore.uri=thrift://localhost:9083


### PR DESCRIPTION
Add iceberg to the devel config in presto-main
Fix load iceberg module failure when connecting hive-metastore

```
== NO RELEASE NOTE ==
```
