### PR TITLE
Allow for CTAS table creation to external tables when write and creates are enabled for unmanaged tables

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveLocationService.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveLocationService.java
@@ -55,16 +55,17 @@ public class HiveLocationService
     }
 
     @Override
-    public LocationHandle forNewTable(SemiTransactionalHiveMetastore metastore, ConnectorSession session, String schemaName, String tableName, boolean tempPathRequired)
+    public LocationHandle forNewTable(SemiTransactionalHiveMetastore metastore, ConnectorSession session, String schemaName, String tableName, boolean tempPathRequired,
+            Optional<Path> externalLocation)
     {
-        Path targetPath = getTableDefaultLocation(session, metastore, hdfsEnvironment, schemaName, tableName);
+        Path targetPath = externalLocation.orElse(getTableDefaultLocation(session, metastore, hdfsEnvironment, schemaName, tableName));
 
         HdfsContext context = new HdfsContext(session, schemaName, tableName, targetPath.toString(), true);
         // verify the target directory for the table
         if (pathExists(context, hdfsEnvironment, targetPath)) {
             throw new PrestoException(HIVE_PATH_ALREADY_EXISTS, format("Target directory for table '%s.%s' already exists: %s", schemaName, tableName, targetPath));
         }
-        return createLocationHandle(context, session, targetPath, NEW, tempPathRequired);
+        return createLocationHandle(context, session, targetPath, NEW, tempPathRequired, externalLocation);
     }
 
     @Override
@@ -73,7 +74,7 @@ public class HiveLocationService
         String tablePath = table.getStorage().getLocation();
         HdfsContext context = new HdfsContext(session, table.getDatabaseName(), table.getTableName(), tablePath, false);
         Path targetPath = new Path(tablePath);
-        return createLocationHandle(context, session, targetPath, EXISTING, tempPathRequired);
+        return createLocationHandle(context, session, targetPath, EXISTING, tempPathRequired, Optional.empty());
     }
 
     @Override
@@ -91,10 +92,12 @@ public class HiveLocationService
                 DIRECT_TO_TARGET_NEW_DIRECTORY);
     }
 
-    private LocationHandle createLocationHandle(HdfsContext context, ConnectorSession session, Path targetPath, TableType tableType, boolean tempPathRequired)
+    private LocationHandle createLocationHandle(HdfsContext context, ConnectorSession session, Path targetPath, TableType tableType, boolean tempPathRequired,
+            Optional<Path> externalLocation)
     {
         Optional<Path> tempPath = tempPathRequired ? Optional.of(createTemporaryPath(session, context, hdfsEnvironment, targetPath)) : Optional.empty();
-        if (shouldUseTemporaryDirectory(session, context, targetPath)) {
+        // TODO detect when existing table's location is a on a different file system than the temporary directory
+        if (shouldUseTemporaryDirectory(session, context, targetPath, externalLocation)) {
             Path writePath = createTemporaryPath(session, context, hdfsEnvironment, targetPath);
             createDirectory(context, hdfsEnvironment, writePath);
             return new LocationHandle(targetPath, writePath, tempPath, tableType, STAGE_AND_MOVE_TO_TARGET_DIRECTORY);
@@ -105,11 +108,13 @@ public class HiveLocationService
         return new LocationHandle(targetPath, targetPath, tempPath, tableType, DIRECT_TO_TARGET_NEW_DIRECTORY);
     }
 
-    private boolean shouldUseTemporaryDirectory(ConnectorSession session, HdfsContext context, Path path)
+    private boolean shouldUseTemporaryDirectory(ConnectorSession session, HdfsContext context, Path path, Optional<Path> externalLocation)
     {
         return isTemporaryStagingDirectoryEnabled(session)
                 // skip using temporary directory for S3
-                && !isS3FileSystem(context, hdfsEnvironment, path);
+                && !isS3FileSystem(context, hdfsEnvironment, path)
+                // Skip using temporary directory if destination is external. Target may be on a different file system.
+                && !externalLocation.isPresent();
     }
 
     @Override

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -274,6 +274,7 @@ import static com.facebook.presto.hive.HiveUtil.translateHiveUnsupportedTypeForT
 import static com.facebook.presto.hive.HiveUtil.translateHiveUnsupportedTypesForTemporaryTable;
 import static com.facebook.presto.hive.HiveUtil.verifyPartitionTypeSupported;
 import static com.facebook.presto.hive.HiveWriteUtils.checkTableIsWritable;
+import static com.facebook.presto.hive.HiveWriteUtils.isS3FileSystem;
 import static com.facebook.presto.hive.HiveWriteUtils.isWritableType;
 import static com.facebook.presto.hive.HiveWriterFactory.getFileExtension;
 import static com.facebook.presto.hive.PartitionUpdate.UpdateMode.APPEND;
@@ -978,11 +979,12 @@ public class HiveMetadata
             if (!createsOfNonManagedTablesEnabled) {
                 throw new PrestoException(NOT_SUPPORTED, "Cannot create non-managed Hive table");
             }
-            String externalLocation = getExternalLocation(tableMetadata.getProperties());
-            targetPath = getExternalPath(new HdfsContext(session, schemaName, tableName, externalLocation, true), externalLocation);
+            targetPath = getExternalLocationAsPath(getExternalLocation(tableMetadata.getProperties()));
+            checkExternalPath(new HdfsContext(session, schemaName, tableName, targetPath.toString(), true), targetPath);
         }
         else if (tableType.equals(MANAGED_TABLE) || tableType.equals(MATERIALIZED_VIEW)) {
-            LocationHandle locationHandle = locationService.forNewTable(metastore, session, schemaName, tableName, isTempPathRequired(session, bucketProperty, preferredOrderingColumns));
+            LocationHandle locationHandle = locationService.forNewTable(metastore, session, schemaName, tableName, isTempPathRequired(session, bucketProperty,
+                    preferredOrderingColumns), Optional.empty());
             targetPath = locationService.getQueryWriteInfo(locationHandle).getTargetPath();
         }
         else {
@@ -1282,6 +1284,30 @@ public class HiveMetadata
         }
     }
 
+    private static Path getExternalLocationAsPath(String location)
+    {
+        try {
+            return new Path(location);
+        }
+        catch (IllegalArgumentException e) {
+            throw new PrestoException(INVALID_TABLE_PROPERTY, "External location is not a valid file system URI: " + location, e);
+        }
+    }
+
+    private void checkExternalPath(HdfsContext context, Path path)
+    {
+        try {
+            if (!isS3FileSystem(context, hdfsEnvironment, path)) {
+                if (!hdfsEnvironment.getFileSystem(context, path).isDirectory(path)) {
+                    throw new PrestoException(INVALID_TABLE_PROPERTY, "External location must be a directory: " + path);
+                }
+            }
+        }
+        catch (IOException e) {
+            throw new PrestoException(INVALID_TABLE_PROPERTY, "External location is not a valid file system URI: " + path, e);
+        }
+    }
+
     private void checkPartitionTypesSupported(List<Column> partitionColumns)
     {
         for (Column partitionColumn : partitionColumns) {
@@ -1517,8 +1543,14 @@ public class HiveMetadata
     {
         verifyJvmTimeZone();
 
-        if (getExternalLocation(tableMetadata.getProperties()) != null) {
-            throw new PrestoException(NOT_SUPPORTED, "External tables cannot be created using CREATE TABLE AS");
+        Optional<Path> externalLocation = Optional.ofNullable(getExternalLocation(tableMetadata.getProperties()))
+                .map(HiveMetadata::getExternalLocationAsPath);
+        if (!createsOfNonManagedTablesEnabled && externalLocation.isPresent()) {
+            throw new PrestoException(NOT_SUPPORTED, "Creating non-managed Hive tables is disabled");
+        }
+
+        if (!writesToNonManagedTablesEnabled && externalLocation.isPresent()) {
+            throw new PrestoException(NOT_SUPPORTED, "Writes to non-managed Hive tables is disabled");
         }
 
         if (getAvroSchemaUrl(tableMetadata.getProperties()) != null) {
@@ -1561,7 +1593,8 @@ public class HiveMetadata
                 .collect(toList());
         checkPartitionTypesSupported(partitionColumns);
 
-        LocationHandle locationHandle = locationService.forNewTable(metastore, session, schemaName, tableName, isTempPathRequired(session, bucketProperty, preferredOrderingColumns));
+        LocationHandle locationHandle = locationService.forNewTable(metastore, session, schemaName, tableName, isTempPathRequired(session, bucketProperty, preferredOrderingColumns),
+                externalLocation);
 
         HdfsContext context = new HdfsContext(session, schemaName, tableName, locationHandle.getTargetPath().toString(), true);
         MetastoreContext metastoreContext = new MetastoreContext(session.getIdentity(), session.getQueryId(), session.getClientInfo(), session.getSource());
@@ -1586,7 +1619,8 @@ public class HiveMetadata
                 preferredOrderingColumns,
                 session.getUser(),
                 tableProperties,
-                encryptionInformationProvider.getWriteEncryptionInformation(session, tableEncryptionProperties, schemaName, tableName));
+                encryptionInformationProvider.getWriteEncryptionInformation(session, tableEncryptionProperties, schemaName, tableName),
+                externalLocation.isPresent());
 
         WriteInfo writeInfo = locationService.getQueryWriteInfo(locationHandle);
         metastore.declareIntentionToWrite(
@@ -1639,7 +1673,7 @@ public class HiveMetadata
                         .putAll(tableEncryptionParameters)
                         .build(),
                 writeInfo.getTargetPath(),
-                MANAGED_TABLE,
+                handle.isExternal() ? EXTERNAL_TABLE : MANAGED_TABLE,
                 prestoVersion);
         PrincipalPrivileges principalPrivileges = buildInitialPrivilegeSet(handle.getTableOwner());
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveOutputTableHandle.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveOutputTableHandle.java
@@ -34,6 +34,7 @@ public class HiveOutputTableHandle
     private final List<String> partitionedBy;
     private final String tableOwner;
     private final Map<String, String> additionalTableParameters;
+    private final boolean external;
 
     @JsonCreator
     public HiveOutputTableHandle(
@@ -52,7 +53,8 @@ public class HiveOutputTableHandle
             @JsonProperty("preferredOrderingColumns") List<SortingColumn> preferredOrderingColumns,
             @JsonProperty("tableOwner") String tableOwner,
             @JsonProperty("additionalTableParameters") Map<String, String> additionalTableParameters,
-            @JsonProperty("encryptionInformation") Optional<EncryptionInformation> encryptionInformation)
+            @JsonProperty("encryptionInformation") Optional<EncryptionInformation> encryptionInformation,
+            @JsonProperty("external") boolean external)
     {
         super(
                 schemaName,
@@ -72,6 +74,7 @@ public class HiveOutputTableHandle
         this.partitionedBy = ImmutableList.copyOf(requireNonNull(partitionedBy, "partitionedBy is null"));
         this.tableOwner = requireNonNull(tableOwner, "tableOwner is null");
         this.additionalTableParameters = ImmutableMap.copyOf(requireNonNull(additionalTableParameters, "additionalTableParameters is null"));
+        this.external = external;
     }
 
     @JsonProperty
@@ -90,5 +93,11 @@ public class HiveOutputTableHandle
     public Map<String, String> getAdditionalTableParameters()
     {
         return additionalTableParameters;
+    }
+
+    @JsonProperty
+    public boolean isExternal()
+    {
+        return external;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/LocationService.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/LocationService.java
@@ -25,7 +25,8 @@ import static java.util.Objects.requireNonNull;
 
 public interface LocationService
 {
-    LocationHandle forNewTable(SemiTransactionalHiveMetastore metastore, ConnectorSession session, String schemaName, String tableName, boolean tempPathRequired);
+    LocationHandle forNewTable(SemiTransactionalHiveMetastore metastore, ConnectorSession session, String schemaName, String tableName, boolean tempPathRequired,
+            Optional<Path> externalLocation);
 
     LocationHandle forExistingTable(SemiTransactionalHiveMetastore metastore, ConnectorSession session, Table table, boolean tempPathRequired);
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -2814,7 +2814,8 @@ public abstract class AbstractTestHiveClient
         try {
             try (Transaction transaction = newTransaction()) {
                 LocationService locationService = getLocationService();
-                LocationHandle locationHandle = locationService.forNewTable(transaction.getMetastore(), session, schemaName, tableName, false);
+                LocationHandle locationHandle = locationService.forNewTable(transaction.getMetastore(), session, schemaName, tableName, false,
+                        Optional.empty());
                 targetPath = locationService.getQueryWriteInfo(locationHandle).getTargetPath();
                 Table table = createSimpleTable(schemaTableName, columns, session, targetPath, "q1");
                 transaction.getMetastore()
@@ -3510,7 +3511,7 @@ public abstract class AbstractTestHiveClient
             String tableOwner = session.getUser();
             String schemaName = schemaTableName.getSchemaName();
             String tableName = schemaTableName.getTableName();
-            LocationHandle locationHandle = getLocationService().forNewTable(transaction.getMetastore(), session, schemaName, tableName, false);
+            LocationHandle locationHandle = getLocationService().forNewTable(transaction.getMetastore(), session, schemaName, tableName, false, Optional.empty());
             Path targetPath = getLocationService().getQueryWriteInfo(locationHandle).getTargetPath();
             //create table whose storage format is null
             Table.Builder tableBuilder = Table.builder()
@@ -5334,7 +5335,7 @@ public abstract class AbstractTestHiveClient
             String tableName = schemaTableName.getTableName();
 
             LocationService locationService = getLocationService();
-            LocationHandle locationHandle = locationService.forNewTable(transaction.getMetastore(), session, schemaName, tableName, false);
+            LocationHandle locationHandle = locationService.forNewTable(transaction.getMetastore(), session, schemaName, tableName, false, Optional.empty());
             targetPath = locationService.getQueryWriteInfo(locationHandle).getTargetPath();
 
             Table.Builder tableBuilder = Table.builder()

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveCreateExternalTable.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveCreateExternalTable.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.intellij.lang.annotations.Language;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Optional;
+
+import static com.facebook.presto.tests.QueryAssertions.assertEqualsIgnoreOrder;
+import static com.google.common.io.Files.createTempDir;
+import static com.google.common.io.MoreFiles.deleteRecursively;
+import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
+import static io.airlift.tpch.TpchTable.CUSTOMER;
+import static io.airlift.tpch.TpchTable.ORDERS;
+import static java.lang.String.format;
+import static org.testng.Assert.assertTrue;
+
+public class TestHiveCreateExternalTable
+        extends AbstractTestQueryFramework
+{
+    private QueryRunner queryRunner;
+
+    @BeforeClass
+    public void setUp()
+            throws Exception
+    {
+        queryRunner = createQueryRunner();
+    }
+
+    public QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return HiveQueryRunner.createQueryRunner(
+                ImmutableList.of(ORDERS, CUSTOMER),
+                ImmutableMap.of(),
+                "sql-standard",
+                ImmutableMap.of("hive.non-managed-table-writes-enabled", "true"),
+                Optional.empty());
+    }
+
+    @Test
+    public void testCreateExternalTableWithData()
+            throws IOException
+    {
+        String tableName = "test_create_external";
+        File tempDir = createTempDir();
+        File tableLocation = new File(tempDir, tableName);
+
+        @Language("SQL") String createTableSql = format("" +
+                        "CREATE TABLE test_create_external " +
+                        "WITH (external_location = '%s') AS " +
+                        "SELECT * FROM tpch.tiny.nation",
+                tableLocation.toURI().toASCIIString());
+
+        assertUpdate(createTableSql, 25);
+
+        MaterializedResult expected = computeActual("SELECT * FROM tpch.tiny.nation");
+        MaterializedResult actual = computeActual("SELECT * FROM " + tableName);
+        assertEqualsIgnoreOrder(actual.getMaterializedRows(), expected.getMaterializedRows());
+
+        String tablePath = (String) computeActual("SELECT DISTINCT regexp_replace(\"$path\", '/[^/]*$', '/') FROM " + tableName).getOnlyValue();
+        assertTrue(tablePath.startsWith(tableLocation.toURI().toString()));
+
+        assertUpdate("DROP TABLE test_create_external");
+        deleteRecursively(tempDir.toPath(), ALLOW_INSECURE);
+    }
+
+    @Test
+    public void testCreateExternalTableAsWithExistingDirectory()
+    {
+        File tempDir = createTempDir();
+
+        @Language("SQL") String createTableSql = format("" +
+                        "CREATE TABLE test_create_external " +
+                        "WITH (external_location = '%s') AS " +
+                        "SELECT * FROM tpch.tiny.nation",
+                tempDir.toURI().toASCIIString());
+
+        assertQueryFails(createTableSql, "Target directory for table '.*' already exists:.*");
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveCreateExternalTableDisabled.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveCreateExternalTableDisabled.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.intellij.lang.annotations.Language;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.util.Optional;
+
+import static com.google.common.io.Files.createTempDir;
+import static com.google.common.io.MoreFiles.deleteRecursively;
+import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
+import static io.airlift.tpch.TpchTable.CUSTOMER;
+import static io.airlift.tpch.TpchTable.ORDERS;
+import static java.lang.String.format;
+
+public class TestHiveCreateExternalTableDisabled
+        extends AbstractTestQueryFramework
+{
+    private QueryRunner queryRunner;
+
+    @BeforeClass
+    public void setUp()
+            throws Exception
+    {
+        queryRunner = createQueryRunner();
+    }
+
+    public QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return HiveQueryRunner.createQueryRunner(
+                ImmutableList.of(ORDERS, CUSTOMER),
+                ImmutableMap.of(),
+                "sql-standard",
+                ImmutableMap.of("hive.non-managed-table-writes-enabled", "true", "hive.non-managed-table-creates-enabled", "false"),
+                Optional.empty());
+    }
+
+    @Test
+    public void testCreateExternalTableWithData()
+            throws Exception
+    {
+        File tempDir = createTempDir();
+
+        @Language("SQL") String createTableSql = format("" +
+                        "CREATE TABLE test_create_external " +
+                        "WITH (external_location = '%s') AS " +
+                        "SELECT * FROM tpch.tiny.nation",
+                tempDir.toURI().toASCIIString());
+        assertQueryFails(createTableSql, "Creating non-managed Hive tables is disabled");
+
+        deleteRecursively(tempDir.toPath(), ALLOW_INSECURE);
+    }
+
+    @Test
+    public void testCreateExternalTable()
+            throws Exception
+    {
+        File tempDir = createTempDir();
+
+        @Language("SQL") String createTableSql = format("" +
+                        "CREATE TABLE test_create_external (n TINYINT) " +
+                        "WITH (external_location = '%s')",
+                tempDir.toURI().toASCIIString());
+        assertQueryFails(createTableSql, "Cannot create non-managed Hive table");
+
+        deleteRecursively(tempDir.toPath(), ALLOW_INSECURE);
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -59,6 +59,7 @@ import org.intellij.lang.annotations.Language;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.io.IOException;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -2958,6 +2959,22 @@ public class TestHiveIntegrationSmokeTest
 
         MaterializedResult actualAfterTransaction = computeActual(session, "SELECT * FROM tmp_create_query");
         assertEqualsIgnoreOrder(actualAfterTransaction, expected);
+    }
+
+    @Test
+    public void testCreateExternalTableWithDataNotAllowed()
+            throws IOException
+    {
+        File tempDir = createTempDir();
+
+        @Language("SQL") String createTableSql = format("" +
+                        "CREATE TABLE test_create_external " +
+                        "WITH (external_location = '%s') AS " +
+                        "SELECT * FROM tpch.tiny.nation",
+                tempDir.toURI().toASCIIString());
+
+        assertQueryFails(createTableSql, "Cannot create a non-managed Hive table using CREATE TABLE AS");
+        deleteRecursively(tempDir.toPath(), ALLOW_INSECURE);
     }
 
     @Test

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSink.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSink.java
@@ -300,7 +300,8 @@ public class TestHivePageSink
                 ImmutableList.of(),
                 "test",
                 ImmutableMap.of(),
-                Optional.empty());
+                Optional.empty(),
+                false);
         HdfsEnvironment hdfsEnvironment = createTestHdfsEnvironment(config, metastoreClientConfig);
         HivePageSinkProvider provider = new HivePageSinkProvider(
                 getDefaultHiveFileWriterFactories(config, metastoreClientConfig),


### PR DESCRIPTION
…-creates-enabled

are both set to true, external tables can be created and inserted into. This change
allows for that to be done in one step using the CREATE TABLE AS syntax.

Referred Trino #2669 and follow up fix #2669 & #3755

Co-authored-by: alexjo2144 <jo.alex2144@gmail.com>

Test plan - (Please fill in how you tested your changes)

Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines. Don't forget to follow our [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution) for any code copied from other projects.

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== RELEASE NOTES ==

General Changes
* ...
* ...

Hive Changes
* ...
* ...
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```
