### PR TITLE
Improve type errors messages for structs

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/AbstractAnalyzerTest.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/AbstractAnalyzerTest.java
@@ -18,6 +18,7 @@ import com.facebook.presto.Session;
 import com.facebook.presto.common.QualifiedObjectName;
 import com.facebook.presto.common.type.ArrayType;
 import com.facebook.presto.common.type.RealType;
+import com.facebook.presto.common.type.RowType;
 import com.facebook.presto.common.type.StandardTypes;
 import com.facebook.presto.connector.informationSchema.InformationSchemaConnector;
 import com.facebook.presto.connector.system.SystemConnector;
@@ -227,6 +228,21 @@ public class AbstractAnalyzerTest
                         new ColumnMetadata("b", new ArrayType(BIGINT)),
                         new ColumnMetadata("c", RealType.REAL),
                         new ColumnMetadata("d", BIGINT))),
+                false));
+
+        // table with nested struct
+        SchemaTableName table10 = new SchemaTableName("s1", "t10");
+        inSetupTransaction(session -> metadata.createTable(session, TPCH_CATALOG,
+                new ConnectorTableMetadata(table10, ImmutableList.of(
+                        new ColumnMetadata("a", BIGINT),
+                        new ColumnMetadata("b", RowType.from(ImmutableList.of(
+                                new RowType.Field(Optional.of("w"), BIGINT),
+                                new RowType.Field(Optional.of("x"),
+                                        RowType.from(ImmutableList.of(
+                                                new RowType.Field(Optional.of("y"), BIGINT),
+                                                new RowType.Field(Optional.of("z"), DOUBLE))))))),
+                        new ColumnMetadata("c", RowType.from(ImmutableList.of(
+                                new RowType.Field(Optional.of("d"), BIGINT)))))),
                 false));
 
         // valid view referencing table in same schema

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
@@ -134,7 +134,8 @@ public class TestAnalyzer
                 PERFORMANCE_WARNING, "line 1:59: JOIN conditions with an OR can cause performance issues as it may lead to a cross join with filter");
     }
 
-    @Test void testNoORWarning()
+    @Test
+    void testNoORWarning()
     {
         assertNoWarning(analyzeWithWarnings("SELECT * FROM t1 JOIN t2 ON t1.a = t2.a"));
         assertNoWarning(analyzeWithWarnings("SELECT * FROM t1 JOIN t2 ON t1.a = t2.a AND t1.b = t2.b"));
@@ -169,7 +170,7 @@ public class TestAnalyzer
                         "FROM (values (1,10), (2, 10)) AS T(x, y)");
 
         analyze(session, "SELECT SUM(x) OVER (PARTITION BY y ORDER BY y) AS s\n" +
-                        "FROM (values (1,10), (2, 10)) AS T(x, y)");
+                "FROM (values (1,10), (2, 10)) AS T(x, y)");
     }
 
     @Test
@@ -834,6 +835,26 @@ public class TestAnalyzer
         assertFails(MISMATCHED_SET_COLUMN_TYPES,
                 "line 1:40: Insert query has 3 expression.s. but expected 4 target column.s.. Mismatch at column 2: 'b' is of type varchar but expression is of type integer",
                 "INSERT INTO t6 (a, b, c, d) VALUES (1, 1, 1)");
+    }
+
+    @Test
+    public void testInvalidInsertNested()
+    {
+        assertFails(MISMATCHED_SET_COLUMN_TYPES,
+                "line 1:29: Mismatch at column 2: 'b.x.z' is of type double but expression is of type varchar.3.",
+                "INSERT INTO t10 VALUES (10, ROW(20, ROW(30, 'abc')), ROW(40))");
+
+        assertFails(MISMATCHED_SET_COLUMN_TYPES,
+                "line 1:29: Mismatch at column 2: 'b.x' has 2 field.s. but expression has 3 field.s.",
+                "INSERT INTO t10 VALUES (10, ROW(20, ROW(30, 3, 10)), ROW(40))");
+
+        assertFails(MISMATCHED_SET_COLUMN_TYPES,
+                "line 1:29: Mismatch at column 2: 'b.w' is of type bigint but expression is of type varchar.3.",
+                "INSERT INTO t10 VALUES (10, ROW('abc', ROW(30, 40)), ROW(40))");
+
+        assertFails(MISMATCHED_SET_COLUMN_TYPES,
+                "line 1:51: Mismatch at column 3: 'c.d' is of type bigint but expression is of type varchar.3.",
+                "INSERT INTO t10 VALUES (10, ROW(20, ROW(30, 40)), ROW('abc'))");
     }
 
     @Test


### PR DESCRIPTION
Struct fields in query should behave like regular columns with a clear
error message. This fix gives better support for error messages with
struct fields. Error with nested struct fields will come as
dot-separated in the error message for more human readable message.

Test plan
Ran all tests for presto-main. Wrote additional tests to check for type errors in nested structs

Example:
```
> CREATE TABLE test(a BIGINT, b ROW(w BIGINT, x ROW(y BIGINT, z DOUBLE)));
> INSERT INTO test VALUES(10, ROW(20, ROW(30, ROW(50))));
Query 20210525_011822_00022_jdrc5 failed: line 1:42: Mismatch at column 2: 'b.x.z' is of type double but expression is of type row(integer)
```

```
== NO RELEASE NOTE ==
```

