### PR TITLE
Fix class not found error when running queries on Spark

### DIFF
--- a/presto-spark-launcher/pom.xml
+++ b/presto-spark-launcher/pom.xml
@@ -47,7 +47,7 @@
         <dependency>
             <groupId>com.facebook.presto.spark</groupId>
             <artifactId>spark-core</artifactId>
-            <scope>provided</scope>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
 

--- a/presto-spark-testing/pom.xml
+++ b/presto-spark-testing/pom.xml
@@ -83,6 +83,16 @@
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-hive-hadoop2</artifactId>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.xerial.snappy</groupId>
+                    <artifactId>snappy-java</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.roaringbitmap</groupId>
+                    <artifactId>RoaringBitmap</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Both project presto-spark-launcher and prfesto-spark-classloader-interface
add spark-core as dependecy with scope of 'provided' in pom.xml. That
means spark-core won't be packaged in the jar file and expect the runtime
to provide. The fix is to change 'provided' to 'compile' in
presto-spark-launcher and fix dependencies in tests.


```
== RELEASE NOTES ==

Spark Changes
* Fix class not found error when running queries on Spark
```
