### PR TITLE
Avoid over-retaining objects via operator info supplier

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/OperatorContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/OperatorContext.java
@@ -83,7 +83,7 @@ public class OperatorContext
     private final OperationTiming finishTiming = new OperationTiming();
 
     private final OperatorSpillContext spillContext;
-    private final AtomicReference<Supplier<OperatorInfo>> infoSupplier = new AtomicReference<>();
+    private final AtomicReference<Supplier<? extends OperatorInfo>> infoSupplier = new AtomicReference<>();
 
     private final AtomicLong peakUserMemoryReservation = new AtomicLong();
     private final AtomicLong peakSystemMemoryReservation = new AtomicLong();
@@ -415,7 +415,7 @@ public class OperatorContext
         }
     }
 
-    public void setInfoSupplier(Supplier<OperatorInfo> infoSupplier)
+    public void setInfoSupplier(Supplier<? extends OperatorInfo> infoSupplier)
     {
         requireNonNull(infoSupplier, "infoProvider is null");
         this.infoSupplier.set(infoSupplier);
@@ -454,7 +454,7 @@ public class OperatorContext
 
     public OperatorStats getOperatorStats()
     {
-        Supplier<OperatorInfo> infoSupplier = this.infoSupplier.get();
+        Supplier<? extends OperatorInfo> infoSupplier = this.infoSupplier.get();
         OperatorInfo info = Optional.ofNullable(infoSupplier).map(Supplier::get).orElse(null);
 
         long inputPositionsCount = inputPositions.getTotalCount();

--- a/presto-main/src/main/java/com/facebook/presto/operator/ScanFilterAndProjectOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ScanFilterAndProjectOperator.java
@@ -36,6 +36,7 @@ import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.split.EmptySplit;
 import com.facebook.presto.split.EmptySplitPageSource;
 import com.facebook.presto.split.PageSourceProvider;
+import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
@@ -138,7 +139,7 @@ public class ScanFilterAndProjectOperator
 
         Object splitInfo = split.getInfo();
         if (splitInfo != null) {
-            operatorContext.setInfoSupplier(() -> new SplitOperatorInfo(splitInfo));
+            operatorContext.setInfoSupplier(Suppliers.ofInstance(new SplitOperatorInfo(splitInfo)));
         }
         blocked.set(null);
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/TableScanOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TableScanOperator.java
@@ -24,6 +24,7 @@ import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.split.EmptySplit;
 import com.facebook.presto.split.EmptySplitPageSource;
 import com.facebook.presto.split.PageSourceProvider;
+import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
@@ -151,7 +152,7 @@ public class TableScanOperator
 
         Object splitInfo = split.getInfo();
         if (splitInfo != null) {
-            operatorContext.setInfoSupplier(() -> new SplitOperatorInfo(splitInfo));
+            operatorContext.setInfoSupplier(Suppliers.ofInstance(new SplitOperatorInfo(splitInfo)));
         }
 
         blocked.set(null);

--- a/presto-main/src/main/java/com/facebook/presto/operator/TableWriterMergeOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TableWriterMergeOperator.java
@@ -31,6 +31,7 @@ import io.airlift.slice.Slice;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
+import java.util.function.Supplier;
 
 import static com.facebook.presto.SystemSessionProperties.isStatisticsCpuTimerEnabled;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
@@ -132,7 +133,7 @@ public class TableWriterMergeOperator
         this.tableCommitContextCodec = requireNonNull(tableCommitContextCodec, "tableCommitContextCodec is null");
         this.statisticsCpuTimerEnabled = statisticsCpuTimerEnabled;
         this.types = ImmutableList.copyOf(requireNonNull(types, "types is null"));
-        this.context.setInfoSupplier(this::getInfo);
+        this.context.setInfoSupplier(createTableWriterMergeInfoSupplier(statisticsTiming));
     }
 
     @Override
@@ -347,9 +348,10 @@ public class TableWriterMergeOperator
         systemMemoryContext.setBytes(0);
     }
 
-    public TableWriterMergeInfo getInfo()
+    private static Supplier<TableWriterMergeInfo> createTableWriterMergeInfoSupplier(OperationTiming statisticsTiming)
     {
-        return new TableWriterMergeInfo(
+        requireNonNull(statisticsTiming, "statisticsTiming is null");
+        return () -> new TableWriterMergeInfo(
                 succinctNanos(statisticsTiming.getWallNanos()),
                 succinctNanos(statisticsTiming.getCpuNanos()));
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/WindowInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/WindowInfo.java
@@ -25,11 +25,17 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkState;
-import static com.google.common.collect.Iterables.concat;
 
 public class WindowInfo
         implements Mergeable<WindowInfo>, OperatorInfo
 {
+    private static final WindowInfo EMPTY_INFO = new WindowInfo(ImmutableList.of());
+
+    public static WindowInfo emptyInfo()
+    {
+        return EMPTY_INFO;
+    }
+
     private final List<DriverWindowInfo> windowInfos;
 
     @JsonCreator
@@ -47,7 +53,18 @@ public class WindowInfo
     @Override
     public WindowInfo mergeWith(WindowInfo other)
     {
-        return new WindowInfo(ImmutableList.copyOf(concat(this.windowInfos, other.windowInfos)));
+        int otherSize = other.windowInfos.size();
+        if (otherSize == 0) {
+            return this;
+        }
+        int thisSize = windowInfos.size();
+        if (thisSize == 0) {
+            return other;
+        }
+        return new WindowInfo(ImmutableList.<DriverWindowInfo>builderWithExpectedSize(thisSize + otherSize)
+                .addAll(windowInfos)
+                .addAll(other.windowInfos)
+                .build());
     }
 
     static class DriverWindowInfoBuilder

--- a/presto-main/src/main/java/com/facebook/presto/operator/WindowOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/WindowOperator.java
@@ -188,7 +188,7 @@ public class WindowOperator
     private final int[] outputChannels;
     private final List<FramedWindowFunction> windowFunctions;
     private final WindowInfo.DriverWindowInfoBuilder windowInfo;
-    private final AtomicReference<Optional<WindowInfo.DriverWindowInfo>> driverWindowInfo = new AtomicReference<>(Optional.empty());
+    private final AtomicReference<WindowInfo> driverWindowInfo = new AtomicReference<>(WindowInfo.emptyInfo());
 
     private final Optional<SpillablePagesToPagesIndexes> spillablePagesToPagesIndexes;
 
@@ -307,12 +307,7 @@ public class WindowOperator
         }
 
         windowInfo = new WindowInfo.DriverWindowInfoBuilder();
-        operatorContext.setInfoSupplier(this::getWindowInfo);
-    }
-
-    private OperatorInfo getWindowInfo()
-    {
-        return new WindowInfo(driverWindowInfo.get().map(ImmutableList::of).orElse(ImmutableList.of()));
+        operatorContext.setInfoSupplier(driverWindowInfo::get);
     }
 
     @Override
@@ -854,7 +849,7 @@ public class WindowOperator
     @Override
     public void close()
     {
-        driverWindowInfo.set(Optional.of(windowInfo.build()));
+        driverWindowInfo.set(new WindowInfo(ImmutableList.of(windowInfo.build())));
         spillablePagesToPagesIndexes.ifPresent(SpillablePagesToPagesIndexes::closeSpiller);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/index/IndexSourceOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/index/IndexSourceOperator.java
@@ -28,6 +28,7 @@ import com.facebook.presto.spi.ConnectorPageSource;
 import com.facebook.presto.spi.RecordSet;
 import com.facebook.presto.spi.UpdatablePageSource;
 import com.facebook.presto.spi.plan.PlanNodeId;
+import com.google.common.base.Suppliers;
 
 import java.util.Optional;
 import java.util.function.Function;
@@ -131,7 +132,7 @@ public class IndexSourceOperator
 
         Object splitInfo = split.getInfo();
         if (splitInfo != null) {
-            operatorContext.setInfoSupplier(() -> new SplitOperatorInfo(splitInfo));
+            operatorContext.setInfoSupplier(Suppliers.ofInstance(new SplitOperatorInfo(splitInfo)));
         }
 
         return Optional::empty;

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/PartitionedOutputInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/PartitionedOutputInfo.java
@@ -13,12 +13,17 @@
  */
 package com.facebook.presto.operator.repartition;
 
+import com.facebook.presto.execution.buffer.OutputBuffer;
 import com.facebook.presto.operator.OperatorInfo;
 import com.facebook.presto.util.Mergeable;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
+
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
 
 public class PartitionedOutputInfo
         implements Mergeable<PartitionedOutputInfo>, OperatorInfo
@@ -79,5 +84,13 @@ public class PartitionedOutputInfo
                 .add("pagesAdded", pagesAdded)
                 .add("outputBufferPeakMemoryUsage", outputBufferPeakMemoryUsage)
                 .toString();
+    }
+
+    public static Supplier<PartitionedOutputInfo> createPartitionedOutputInfoSupplier(AtomicLong rowsAdded, AtomicLong pagesAdded, OutputBuffer outputBuffer)
+    {
+        requireNonNull(rowsAdded, "rowsAdded is null");
+        requireNonNull(pagesAdded, "pagesAdded is null");
+        requireNonNull(outputBuffer, "outputBuffer is null");
+        return () -> new PartitionedOutputInfo(rowsAdded.get(), pagesAdded.get(), outputBuffer.getPeakMemoryUsage());
     }
 }


### PR DESCRIPTION
Port of applicable (and some additional) changes from https://github.com/trinodb/trino/pull/8086 which follows up on a fix made in https://github.com/trinodb/trino/pull/7947 (that didn't occur in presto). At a high level, these changes are intended to avoid the pattern of making operator info suppliers from an operator instance method since that can retain the operator and associated memory for longer than necessary. In particular, before this change tasks that failed with some drivers still running could retain references to those driver's active operators for the remaining lifespan of the failed task's `TaskContext` via embedded references in `OperatorContext#infoSupplier`.

The commits in this PR:
- Makes `OperatorContext#infoSupplier` covariant so that suppliers of OperatorInfo subtypes can be passed directly to `OperatorContext#setInfoSupplier`, ie: it changes `OperatorContext#infoSupplier` from `Supplier<OperatorInfo>` (invariant) to `Supplier<? extends OperatorInfo>` (covariant).
- Memoizes the result of and then clears any reference to the original `OperatorContext#infoSupplier` inside of `OperatorContext#destroy()`
- Refactor various operators to create `Supplier<OperatorInfo>` instances using a static method that takes only the required fields instead of using a method reference in the form of `Operator.this#getInfo()` which retains the whole operator
- Adds a minor the allocation rate improvement to the `WindowOperator` info supplier as well as to `WindowInfo#mergeWith`
- Adds a minor allocation rate improvement to scan operator info suppliers by reusing the same instance between calls to `Supplier#get`

```
== NO RELEASE NOTE ==
```
