### PR TITLE
Fix config validation (apply to 0.228)

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -385,13 +385,13 @@ public class HiveClientConfig
         return this;
     }
 
+    @MinDuration("0ms")
     @NotNull
     public Duration getMetastoreCacheTtl()
     {
         return metastoreCacheTtl;
     }
 
-    @MinDuration("0ms")
     @Config("hive.metastore-cache-ttl")
     public HiveClientConfig setMetastoreCacheTtl(Duration metastoreCacheTtl)
     {
@@ -399,13 +399,13 @@ public class HiveClientConfig
         return this;
     }
 
+    @MinDuration("1ms")
     @NotNull
     public Duration getMetastoreRefreshInterval()
     {
         return metastoreRefreshInterval;
     }
 
-    @MinDuration("1ms")
     @Config("hive.metastore-refresh-interval")
     public HiveClientConfig setMetastoreRefreshInterval(Duration metastoreRefreshInterval)
     {
@@ -413,12 +413,12 @@ public class HiveClientConfig
         return this;
     }
 
+    @Min(1)
     public long getMetastoreCacheMaximumSize()
     {
         return metastoreCacheMaximumSize;
     }
 
-    @Min(1)
     @Config("hive.metastore-cache-maximum-size")
     public HiveClientConfig setMetastoreCacheMaximumSize(long metastoreCacheMaximumSize)
     {
@@ -426,12 +426,12 @@ public class HiveClientConfig
         return this;
     }
 
+    @Min(1)
     public long getPerTransactionMetastoreCacheMaximumSize()
     {
         return perTransactionMetastoreCacheMaximumSize;
     }
 
-    @Min(1)
     @Config("hive.per-transaction-metastore-cache-maximum-size")
     public HiveClientConfig setPerTransactionMetastoreCacheMaximumSize(long perTransactionMetastoreCacheMaximumSize)
     {

--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskManagerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskManagerConfig.java
@@ -215,6 +215,7 @@ public class TaskManagerConfig
         return this;
     }
 
+    @Min(0)
     public BigDecimal getLevelTimeMultiplier()
     {
         return levelTimeMultiplier;
@@ -222,7 +223,6 @@ public class TaskManagerConfig
 
     @Config("task.level-time-multiplier")
     @ConfigDescription("Factor that determines the target scheduled time for a level relative to the next")
-    @Min(0)
     public TaskManagerConfig setLevelTimeMultiplier(BigDecimal levelTimeMultiplier)
     {
         this.levelTimeMultiplier = levelTimeMultiplier;

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -394,13 +394,13 @@ public class FeaturesConfig
         return this;
     }
 
+    @Min(0)
     public int getConcurrentLifespansPerTask()
     {
         return concurrentLifespansPerTask;
     }
 
     @Config("concurrent-lifespans-per-task")
-    @Min(0)
     @ConfigDescription("Experimental: Default number of lifespans that run in parallel on each task when grouped execution is enabled")
     // When set to zero, a limit is not imposed on the number of lifespans that run in parallel
     public FeaturesConfig setConcurrentLifespansPerTask(int concurrentLifespansPerTask)
@@ -1026,7 +1026,6 @@ public class FeaturesConfig
     }
 
     @Config("max-concurrent-materializations")
-    @Min(1)
     @ConfigDescription("The maximum number of materializing plan sections that can run concurrently")
     public FeaturesConfig setMaxConcurrentMaterializations(int maxConcurrentMaterializations)
     {
@@ -1034,6 +1033,7 @@ public class FeaturesConfig
         return this;
     }
 
+    @Min(1)
     public int getMaxConcurrentMaterializations()
     {
         return maxConcurrentMaterializations;


### PR DESCRIPTION
```
== RELEASE NOTES ==

General Changes
* Fix config validation in v0.228. Based on JSR 303, validation should be applied on getter methods only. This fix will move all setter-side javax validation annotations to getter methods. This applies to all three Config Bean files.
```

Reference: 
* [JSR 303 official link](https://beanvalidation.org/1.0/spec/#constraintdeclarationvalidationprocess-requirements-object)
* [JSR 303 bean validation - Why on getter and not setter discussion link](https://stackoverflow.com/questions/6283726/jsr-303-bean-validation-why-on-getter-and-not-setter)
* [Errors without this fix](https://docs.google.com/document/d/1anSc1D6lV07zpm1RlSRs67_qQbS4xTeZRhlYPLsnHmw/edit?usp=sharing)