### PR TITLE
Support multi coordinator while serving query state info

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/resourcemanager/DistributedQueryInfoResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/resourcemanager/DistributedQueryInfoResource.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.resourcemanager;
+
+import com.facebook.airlift.http.client.HttpClient;
+import com.facebook.airlift.http.client.Request;
+import com.facebook.airlift.json.JsonCodec;
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.metadata.InternalNode;
+import com.facebook.presto.metadata.InternalNodeManager;
+import com.facebook.presto.server.BasicQueryInfo;
+import com.facebook.presto.server.QueryStateInfo;
+import com.facebook.presto.spi.QueryId;
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+
+import javax.annotation.security.RolesAllowed;
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.container.AsyncResponse;
+import javax.ws.rs.container.Suspended;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.Future;
+
+import static com.facebook.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
+import static com.facebook.airlift.http.client.JsonResponseHandler.createJsonResponseHandler;
+import static com.facebook.airlift.http.client.Request.Builder.prepareGet;
+import static com.facebook.presto.server.security.RoleType.ADMIN;
+import static com.facebook.presto.server.security.RoleType.USER;
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.google.common.net.HttpHeaders.X_FORWARDED_PROTO;
+import static java.util.Objects.requireNonNull;
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+
+@Path("/v1/queryState")
+@RolesAllowed({USER, ADMIN})
+public class DistributedQueryInfoResource
+{
+    private static final Logger log = Logger.get(DistributedQueryInfoResource.class);
+    private final ResourceManagerClusterStateProvider clusterStateProvider;
+    private final InternalNodeManager internalNodeManager;
+    private final ListeningExecutorService executor;
+    private final ResourceManagerProxy proxyHelper;
+    private final JsonCodec<List<QueryStateInfo>> jsonCodec;
+    private final HttpClient httpClient;
+
+    @Inject
+    public DistributedQueryInfoResource(ResourceManagerClusterStateProvider clusterStateProvider, InternalNodeManager internalNodeManager,
+            @ForResourceManager ListeningExecutorService executor, ResourceManagerProxy proxyHelper, JsonCodec<List<QueryStateInfo>> jsonCodec,
+            @ForResourceManager HttpClient httpClient)
+    {
+        this.clusterStateProvider = requireNonNull(clusterStateProvider, "clusterStateProvider is null");
+        this.internalNodeManager = requireNonNull(internalNodeManager, "internalNodeManager is null");
+        this.executor = requireNonNull(executor, "executor is null");
+        this.proxyHelper = requireNonNull(proxyHelper, "proxyHelper is null");
+        this.jsonCodec = requireNonNull(jsonCodec, "jsonCodec is null");
+        this.httpClient = requireNonNull(httpClient, "httpClient is null");
+    }
+
+    @GET
+    public void getAllQueryInfo(@QueryParam("user") String user,
+            @HeaderParam(X_FORWARDED_PROTO) String xForwardedProto,
+            @Context HttpServletRequest servletRequest,
+            @Context UriInfo uriInfo,
+            @Suspended AsyncResponse asyncResponse)
+    {
+        try {
+            Set<InternalNode> coordinators = internalNodeManager.getCoordinators();
+            ImmutableList.Builder<ListenableFuture<List<QueryStateInfo>>> queryStateInfoFutureBuilder = ImmutableList.builder();
+            for (InternalNode coordinator : coordinators) {
+                queryStateInfoFutureBuilder.add(getQueryStateFromCoordinator(xForwardedProto, uriInfo, coordinator));
+            }
+            List<ListenableFuture<List<QueryStateInfo>>> queryStateInfoFutureList = queryStateInfoFutureBuilder.build();
+            Futures.whenAllComplete(queryStateInfoFutureList).call(() -> {
+                try {
+                    List<QueryStateInfo> queryStateInfoList = new ArrayList<>();
+                    for (Future<List<QueryStateInfo>> queryStateInfoFuture : queryStateInfoFutureList) {
+                        queryStateInfoList.addAll(queryStateInfoFuture.get());
+                    }
+                    return asyncResponse.resume(Response.ok(queryStateInfoList).build());
+                }
+                catch (Exception ex) {
+                    log.error(ex, "Error in getting query info from one of the coordinators");
+                    return asyncResponse.resume(Response.serverError().entity(ex.getMessage()).build());
+                }
+            }, executor);
+        }
+        catch (Exception ex) {
+            log.error(ex, "Error in getting query info");
+            asyncResponse.resume(Response.serverError().entity(ex.getMessage()).build());
+        }
+    }
+
+    @GET
+    @Path("{queryId}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public void getQueryStateInfo(@PathParam("queryId") QueryId queryId,
+            @HeaderParam(X_FORWARDED_PROTO) String xForwardedProto,
+            @Context UriInfo uriInfo,
+            @Context HttpServletRequest servletRequest,
+            @Suspended AsyncResponse asyncResponse)
+            throws WebApplicationException
+    {
+        proxyQueryInfoResponse(servletRequest, asyncResponse, uriInfo, queryId);
+    }
+
+    private ListenableFuture<List<QueryStateInfo>> getQueryStateFromCoordinator(String xForwardedProto, UriInfo uriInfo, InternalNode coordinatorNode)
+            throws IOException
+    {
+        String scheme = isNullOrEmpty(xForwardedProto) ? uriInfo.getRequestUri().getScheme() : xForwardedProto;
+        URI uri = uriInfo.getRequestUriBuilder()
+                .queryParam("includeLocalQueryOnly", true)
+                .scheme(scheme)
+                .host(coordinatorNode.getHostAndPort().toInetAddress().getHostName())
+                .port(coordinatorNode.getInternalUri().getPort())
+                .build();
+
+        Request request = prepareGet().setUri(uri).build();
+        return httpClient.executeAsync(request, createJsonResponseHandler(jsonCodec));
+    }
+
+    private void proxyQueryInfoResponse(HttpServletRequest servletRequest, AsyncResponse asyncResponse, UriInfo uriInfo, QueryId queryId)
+    {
+        Optional<BasicQueryInfo> queryInfo = clusterStateProvider.getClusterQueries().stream()
+                .filter(query -> query.getQueryId().equals(queryId))
+                .findFirst();
+
+        if (!queryInfo.isPresent()) {
+            asyncResponse.resume(Response.status(NOT_FOUND).type(MediaType.APPLICATION_JSON).build());
+            return;
+        }
+        proxyHelper.performRequest(servletRequest, asyncResponse, uriBuilderFrom(queryInfo.get().getSelf()).replacePath(uriInfo.getPath()).build());
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/QueryStateInfoResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/QueryStateInfoResource.java
@@ -15,19 +15,32 @@ package com.facebook.presto.server;
 
 import com.facebook.presto.dispatcher.DispatchManager;
 import com.facebook.presto.execution.resourceGroups.ResourceGroupManager;
+import com.facebook.presto.metadata.InternalNode;
+import com.facebook.presto.metadata.InternalNodeManager;
+import com.facebook.presto.resourcemanager.ResourceManagerProxy;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
 
 import javax.annotation.security.RolesAllowed;
 import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.container.AsyncResponse;
+import javax.ws.rs.container.Suspended;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
 
+import java.net.URI;
+import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -38,10 +51,13 @@ import static com.facebook.presto.server.QueryStateInfo.createQueryStateInfo;
 import static com.facebook.presto.server.QueryStateInfo.createQueuedQueryStateInfo;
 import static com.facebook.presto.server.security.RoleType.ADMIN;
 import static com.facebook.presto.server.security.RoleType.USER;
+import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.net.HttpHeaders.X_FORWARDED_PROTO;
 import static java.util.Objects.requireNonNull;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static javax.ws.rs.core.Response.Status.SERVICE_UNAVAILABLE;
 
 @Path("/v1/queryState")
 @RolesAllowed({ADMIN, USER})
@@ -49,32 +65,51 @@ public class QueryStateInfoResource
 {
     private final DispatchManager dispatchManager;
     private final ResourceGroupManager<?> resourceGroupManager;
+    private final boolean resourceManagerEnabled;
+    private final InternalNodeManager internalNodeManager;
+    private final Optional<ResourceManagerProxy> proxyHelper;
 
     @Inject
     public QueryStateInfoResource(
             DispatchManager dispatchManager,
-            ResourceGroupManager<?> resourceGroupManager)
+            ResourceGroupManager<?> resourceGroupManager,
+            InternalNodeManager internalNodeManager,
+            ServerConfig serverConfig,
+            Optional<ResourceManagerProxy> proxyHelper)
     {
         this.dispatchManager = requireNonNull(dispatchManager, "dispatchManager is null");
         this.resourceGroupManager = requireNonNull(resourceGroupManager, "resourceGroupManager is null");
+        this.internalNodeManager = requireNonNull(internalNodeManager, "internalNodeManager is null");
+        this.resourceManagerEnabled = requireNonNull(serverConfig, "serverConfig is null").isResourceManagerEnabled();
+        this.proxyHelper = requireNonNull(proxyHelper, "proxyHelper is null");
     }
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    public List<QueryStateInfo> getQueryStateInfos(@QueryParam("user") String user)
+    public void getQueryStateInfos(@QueryParam("user") String user,
+            @QueryParam("includeLocalQueryOnly") @DefaultValue("false") boolean isIncludeLocalQueryOnly,
+            @HeaderParam(X_FORWARDED_PROTO) String xForwardedProto,
+            @Context UriInfo uriInfo,
+            @Context HttpServletRequest servletRequest,
+            @Suspended AsyncResponse asyncResponse)
     {
-        List<BasicQueryInfo> queryInfos = dispatchManager.getQueries();
-
-        if (!isNullOrEmpty(user)) {
-            queryInfos = queryInfos.stream()
-                    .filter(queryInfo -> Pattern.matches(user, queryInfo.getSession().getUser()))
-                    .collect(toImmutableList());
+        if (resourceManagerEnabled && !isIncludeLocalQueryOnly) {
+            proxyQueryStateInfo(servletRequest, asyncResponse, xForwardedProto, uriInfo);
         }
+        else {
+            List<BasicQueryInfo> queryInfos = dispatchManager.getQueries();
 
-        return queryInfos.stream()
-                .filter(queryInfo -> !queryInfo.getState().isDone())
-                .map(this::getQueryStateInfo)
-                .collect(toImmutableList());
+            if (!isNullOrEmpty(user)) {
+                queryInfos = queryInfos.stream()
+                        .filter(queryInfo -> Pattern.matches(user, queryInfo.getSession().getUser()))
+                        .collect(toImmutableList());
+            }
+
+            asyncResponse.resume(Response.ok(queryInfos.stream()
+                    .filter(queryInfo -> !queryInfo.getState().isDone())
+                    .map(this::getQueryStateInfo)
+                    .collect(toImmutableList())).build());
+        }
     }
 
     private QueryStateInfo getQueryStateInfo(BasicQueryInfo queryInfo)
@@ -92,14 +127,49 @@ public class QueryStateInfoResource
     @GET
     @Path("{queryId}")
     @Produces(MediaType.APPLICATION_JSON)
-    public QueryStateInfo getQueryStateInfo(@PathParam("queryId") String queryId)
+    public void getQueryStateInfo(@PathParam("queryId") String queryId, @HeaderParam(X_FORWARDED_PROTO) String xForwardedProto,
+            @Context UriInfo uriInfo,
+            @Context HttpServletRequest servletRequest,
+            @Suspended AsyncResponse asyncResponse)
             throws WebApplicationException
     {
         try {
-            return getQueryStateInfo(dispatchManager.getQueryInfo(new QueryId(queryId)));
+            QueryId queryID = new QueryId(queryId);
+            if (resourceManagerEnabled && !dispatchManager.isQueryPresent(queryID)) {
+                proxyQueryStateInfo(servletRequest, asyncResponse, xForwardedProto, uriInfo);
+            }
+            else {
+                BasicQueryInfo queryInfo = dispatchManager.getQueryInfo(queryID);
+                asyncResponse.resume(Response.ok(getQueryStateInfo(queryInfo)).build());
+            }
         }
         catch (NoSuchElementException e) {
-            throw new WebApplicationException(NOT_FOUND);
+            asyncResponse.resume(Response.status(NOT_FOUND).build());
+        }
+    }
+
+    //TODO the pattern of this function is similar with ClusterStatsResource and QueryResource, we can move it to a common place and re-use.
+    private void proxyQueryStateInfo(HttpServletRequest servletRequest, AsyncResponse asyncResponse, String xForwardedProto, UriInfo uriInfo)
+    {
+        try {
+            checkState(proxyHelper.isPresent());
+            Iterator<InternalNode> resourceManagers = internalNodeManager.getResourceManagers().iterator();
+            if (!resourceManagers.hasNext()) {
+                asyncResponse.resume(Response.status(SERVICE_UNAVAILABLE).build());
+                return;
+            }
+            InternalNode resourceManagerNode = resourceManagers.next();
+            String scheme = isNullOrEmpty(xForwardedProto) ? uriInfo.getRequestUri().getScheme() : xForwardedProto;
+
+            URI uri = uriInfo.getRequestUriBuilder()
+                    .scheme(scheme)
+                    .host(resourceManagerNode.getHostAndPort().toInetAddress().getHostName())
+                    .port(resourceManagerNode.getInternalUri().getPort())
+                    .build();
+            proxyHelper.get().performRequest(servletRequest, asyncResponse, uri);
+        }
+        catch (Exception e) {
+            asyncResponse.resume(e);
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/ResourceManagerModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ResourceManagerModule.java
@@ -24,6 +24,7 @@ import com.facebook.presto.execution.resourceGroups.NoOpResourceGroupManager;
 import com.facebook.presto.execution.resourceGroups.ResourceGroupManager;
 import com.facebook.presto.failureDetector.FailureDetectorModule;
 import com.facebook.presto.resourcemanager.DistributedClusterStatsResource;
+import com.facebook.presto.resourcemanager.DistributedQueryInfoResource;
 import com.facebook.presto.resourcemanager.DistributedQueryResource;
 import com.facebook.presto.resourcemanager.ForResourceManager;
 import com.facebook.presto.resourcemanager.ResourceManagerClusterStateProvider;
@@ -85,6 +86,7 @@ public class ResourceManagerModule
         smileCodecBinder(binder).bindSmileCodec(QueryInfo.class);
         jsonCodecBinder(binder).bindJsonCodec(BasicQueryInfo.class);
         smileCodecBinder(binder).bindSmileCodec(BasicQueryInfo.class);
+        jsonCodecBinder(binder).bindListJsonCodec(QueryStateInfo.class);
 
         binder.bind(TransactionManager.class).to(NoOpTransactionManager.class);
 
@@ -94,6 +96,7 @@ public class ResourceManagerModule
         binder.bind(NodeResourceStatusProvider.class).toInstance(() -> true);
 
         jaxrsBinder(binder).bind(DistributedQueryResource.class);
+        jaxrsBinder(binder).bind(DistributedQueryInfoResource.class);
         jaxrsBinder(binder).bind(DistributedClusterStatsResource.class);
 
         httpClientBinder(binder).bindHttpClient("resourceManager", ForResourceManager.class);

--- a/presto-tests/src/test/java/com/facebook/presto/utils/QueryExecutionClientUtil.java
+++ b/presto-tests/src/test/java/com/facebook/presto/utils/QueryExecutionClientUtil.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.utils;
+
+import com.facebook.airlift.http.client.HttpClient;
+import com.facebook.airlift.http.client.Request;
+import com.facebook.presto.client.QueryResults;
+import com.facebook.presto.server.BasicQueryInfo;
+import com.facebook.presto.server.QueryStateInfo;
+import com.facebook.presto.server.testing.TestingPrestoServer;
+
+import java.net.URI;
+import java.util.List;
+
+import static com.facebook.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
+import static com.facebook.airlift.http.client.JsonResponseHandler.createJsonResponseHandler;
+import static com.facebook.airlift.http.client.Request.Builder.prepareGet;
+import static com.facebook.airlift.http.client.Request.Builder.preparePost;
+import static com.facebook.airlift.http.client.StaticBodyGenerator.createStaticBodyGenerator;
+import static com.facebook.airlift.json.JsonCodec.jsonCodec;
+import static com.facebook.airlift.json.JsonCodec.listJsonCodec;
+import static com.facebook.presto.client.PrestoHeaders.PRESTO_USER;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public class QueryExecutionClientUtil
+{
+    private QueryExecutionClientUtil()
+    {
+    }
+
+    public static QueryResults postQuery(HttpClient client, String sql, URI uri)
+    {
+        Request request = preparePost()
+                .setHeader(PRESTO_USER, "user")
+                .setUri(uri)
+                .setBodyGenerator(createStaticBodyGenerator(sql, UTF_8))
+                .build();
+        return client.execute(request, createJsonResponseHandler(jsonCodec(QueryResults.class)));
+    }
+
+    public static void runToCompletion(HttpClient client, TestingPrestoServer server, String sql)
+    {
+        URI uri = uriBuilderFrom(server.getBaseUrl().resolve("/v1/statement")).build();
+        QueryResults queryResults = postQuery(client, sql, uri);
+        while (queryResults.getNextUri() != null) {
+            queryResults = getQueryResults(client, queryResults);
+        }
+    }
+
+    public static void runToFirstResult(HttpClient client, TestingPrestoServer server, String sql)
+    {
+        URI uri = uriBuilderFrom(server.getBaseUrl().resolve("/v1/statement")).build();
+        QueryResults queryResults = postQuery(client, sql, uri);
+        while (queryResults.getData() == null) {
+            queryResults = getQueryResults(client, queryResults);
+        }
+    }
+
+    public static void runToQueued(HttpClient client, TestingPrestoServer server, String sql)
+    {
+        URI uri = uriBuilderFrom(server.getBaseUrl().resolve("/v1/statement")).build();
+        QueryResults queryResults = postQuery(client, sql, uri);
+        while (!"QUEUED".equals(queryResults.getStats().getState())) {
+            queryResults = getQueryResults(client, queryResults);
+        }
+        getQueryResults(client, queryResults);
+    }
+
+    public static QueryResults getQueryResults(HttpClient client, QueryResults queryResults)
+    {
+        Request request = prepareGet()
+                .setHeader(PRESTO_USER, "user")
+                .setUri(queryResults.getNextUri())
+                .build();
+        queryResults = client.execute(request, createJsonResponseHandler(jsonCodec(QueryResults.class)));
+        return queryResults;
+    }
+
+    public static List<BasicQueryInfo> getQueryInfos(HttpClient client, TestingPrestoServer server, String path)
+    {
+        Request request = prepareGet().setUri(server.resolve(path)).build();
+        return client.execute(request, createJsonResponseHandler(listJsonCodec(BasicQueryInfo.class)));
+    }
+
+    public static List<QueryStateInfo> getQueryStateInfos(HttpClient client, TestingPrestoServer server, String path)
+    {
+        Request request = prepareGet().setUri(server.resolve(path)).build();
+        return client.execute(request, createJsonResponseHandler(listJsonCodec(QueryStateInfo.class)));
+    }
+
+    public static QueryStateInfo getQueryStateInfo(HttpClient client, TestingPrestoServer server, String path)
+    {
+        Request request = prepareGet().setUri(server.resolve(path)).build();
+        return client.execute(request, createJsonResponseHandler(jsonCodec(QueryStateInfo.class)));
+    }
+}

--- a/presto-tests/src/test/java/com/facebook/presto/utils/ResourceUtils.java
+++ b/presto-tests/src/test/java/com/facebook/presto/utils/ResourceUtils.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.utils;
+
+public class ResourceUtils
+{
+    private ResourceUtils()
+    {
+    }
+
+    public static String getResourceFilePath(String fileName)
+    {
+        return ResourceUtils.class.getClassLoader().getResource(fileName).getPath();
+    }
+}


### PR DESCRIPTION
Currently /v1/queryState/* endpoints serve query state info available within a particular coordinator. The change here is to enable these endpoints to retrieve cluster wide query state info.

Test plan - Verified though unit test and TpchQueryRunner

```
== RELEASE NOTES ==

General Changes
* Support multi coordinator for /v1/queryState/ endpoint

```