### PR TITLE
Fix Config Validation

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskManagerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskManagerConfig.java
@@ -243,6 +243,7 @@ public class TaskManagerConfig
         return this;
     }
 
+    @Min(0)
     public BigDecimal getLevelTimeMultiplier()
     {
         return levelTimeMultiplier;
@@ -250,7 +251,6 @@ public class TaskManagerConfig
 
     @Config("task.level-time-multiplier")
     @ConfigDescription("Factor that determines the target scheduled time for a level relative to the next")
-    @Min(0)
     public TaskManagerConfig setLevelTimeMultiplier(BigDecimal levelTimeMultiplier)
     {
         this.levelTimeMultiplier = levelTimeMultiplier;

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -494,13 +494,13 @@ public class FeaturesConfig
         return this;
     }
 
+    @Min(0)
     public int getConcurrentLifespansPerTask()
     {
         return concurrentLifespansPerTask;
     }
 
     @Config("concurrent-lifespans-per-task")
-    @Min(0)
     @ConfigDescription("Experimental: Default number of lifespans that run in parallel on each task when grouped execution is enabled")
     // When set to zero, a limit is not imposed on the number of lifespans that run in parallel
     public FeaturesConfig setConcurrentLifespansPerTask(int concurrentLifespansPerTask)
@@ -1307,7 +1307,6 @@ public class FeaturesConfig
     }
 
     @Config("max-concurrent-materializations")
-    @Min(1)
     @ConfigDescription("The maximum number of materializing plan sections that can run concurrently")
     public FeaturesConfig setMaxConcurrentMaterializations(int maxConcurrentMaterializations)
     {
@@ -1315,6 +1314,7 @@ public class FeaturesConfig
         return this;
     }
 
+    @Min(1)
     public int getMaxConcurrentMaterializations()
     {
         return maxConcurrentMaterializations;


### PR DESCRIPTION
```
== RELEASE NOTES ==

General Changes
* Fix config validation. Based on JSR 303, validation should be applied on getter methods only. This fix will move all setter-side javax validation annotations to getter methods. This applies to all three Config Bean files.
```

Reference: 
* [JSR 303 official link](https://beanvalidation.org/1.0/spec/#constraintdeclarationvalidationprocess-requirements-object)
* [JSR 303 bean validation - Why on getter and not setter discussion link](https://stackoverflow.com/questions/6283726/jsr-303-bean-validation-why-on-getter-and-not-setter)
* [Errors without this fix](https://docs.google.com/document/d/1anSc1D6lV07zpm1RlSRs67_qQbS4xTeZRhlYPLsnHmw/edit?usp=sharing)

Similar PR as the one applied to 0.228: https://github.com/prestodb/presto/pull/16162