### PR TITLE
Fix NPE when desc table in iceberg connector

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/HiveTableOperations.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/HiveTableOperations.java
@@ -347,6 +347,10 @@ public class HiveTableOperations
                 .run(metadataLocation -> newMetadata.set(
                         TableMetadataParser.read(this, io().newInputFile(metadataLocation))));
 
+        if (newMetadata.get() == null) {
+            throw new TableNotFoundException(getSchemaTableName(), "Table metadata is missing.");
+        }
+
         String newUUID = newMetadata.get().uuid();
         if (currentMetadata != null) {
             checkState(newUUID == null || newUUID.equals(currentMetadata.uuid()),


### PR DESCRIPTION
Fix NPE when desc table in iceberg connector.   
As far as I know, the json file (metadata) of some iceberg table might be missing during listing tables, so we could throw a TableNotFoundException here (The exception thrown would be handled in listing table functions).

```
== NO RELEASE NOTE ==
```
