### PR TITLE
Use double quotes for all field names within struct in SHOW CREATE TABLE

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/type/RowType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/RowType.java
@@ -122,7 +122,7 @@ public class RowType
         for (Field field : fields) {
             String typeDisplayName = field.getType().getDisplayName();
             if (field.getName().isPresent()) {
-                result.append(field.getName().get()).append(' ').append(typeDisplayName);
+                result.append("\"").append(field.getName().get()).append("\"").append(' ').append(typeDisplayName);
             }
             else {
                 result.append(typeDisplayName);

--- a/presto-common/src/test/java/com/facebook/presto/common/type/TestRowType.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/type/TestRowType.java
@@ -42,7 +42,7 @@ public class TestRowType
         RowType row = RowType.from(fields);
         assertEquals(
                 row.getDisplayName(),
-                "row(bool_col boolean, double_col double, array_col array(varchar), map_col map(boolean, double))");
+                "row(\"bool_col\" boolean, \"double_col\" double, \"array_col\" array(varchar), \"map_col\" map(boolean, double))");
     }
 
     @Test
@@ -79,7 +79,7 @@ public class TestRowType
         RowType row = RowType.from(fields);
         assertEquals(
                 row.getDisplayName(),
-                "row(boolean, double_col double, array(varchar), map_col map(boolean, double))");
+                "row(boolean, \"double_col\" double, array(varchar), \"map_col\" map(boolean, double))");
     }
 
     public static void throwUnsupportedOperation()

--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestJdbcPreparedStatement.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestJdbcPreparedStatement.java
@@ -201,7 +201,7 @@ public class TestJdbcPreparedStatement
                 assertEquals(metadata.getColumnTypeName(19), "timestamp with time zone");
 
                 assertEquals(metadata.getColumnName(20), "c_row");
-                assertEquals(metadata.getColumnTypeName(20), "row(x integer,y array(integer))");
+                assertEquals(metadata.getColumnTypeName(20), "row(\"x\" integer,\"y\" array(integer))");
 
                 assertEquals(metadata.getColumnName(21), "c_array");
                 assertEquals(metadata.getColumnTypeName(21), "array(integer)");

--- a/presto-main/src/test/java/com/facebook/presto/type/TestFunctionType.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestFunctionType.java
@@ -29,6 +29,6 @@ public class TestFunctionType
         FunctionAndTypeManager functionAndTypeManager = createTestFunctionAndTypeManager();
 
         Type function = functionAndTypeManager.getType(TypeSignature.parseTypeSignature("function<row(field double),bigint>"));
-        assertEquals(function.getDisplayName(), "function<row(field double),bigint>");
+        assertEquals(function.getDisplayName(), "function<row(\"field\" double),bigint>");
     }
 }

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveCoercion.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestHiveCoercion.java
@@ -368,9 +368,9 @@ public class TestHiveCoercion
                 row("int_to_bigint", "bigint"),
                 row("bigint_to_varchar", "varchar"),
                 row("float_to_double", "double"),
-                row("row_to_row", "row(keep varchar, ti2si smallint, si2int integer, int2bi bigint, bi2vc varchar)"),
-                row("list_to_list", "array(row(ti2int integer, si2bi bigint, bi2vc varchar))"),
-                row("map_to_map", "map(integer, row(ti2bi bigint, int2bi bigint, float2double double, add tinyint))"),
+                row("row_to_row", "row(\"keep\" varchar, \"ti2si\" smallint, \"si2int\" integer, \"int2bi\" bigint, \"bi2vc\" varchar)"),
+                row("list_to_list", "array(row(\"ti2int\" integer, \"si2bi\" bigint, \"bi2vc\" varchar))"),
+                row("map_to_map", "map(integer, row(\"ti2bi\" bigint, \"int2bi\" bigint, \"float2double\" double, \"add\" tinyint))"),
                 row("id", "bigint"));
     }
 


### PR DESCRIPTION
As part of https://github.com/prestodb/presto/pull/16038, we made changes to use double quotes for all column names in SHOW CREATE TABLE to handle usage of reserved words. We need to do the same for field names within struct

Test plan- unit test and local testing using cli
 
```
== NO RELEASE NOTE ==
```
