### PR TITLE
Add 0.253.1 release notes

### DIFF
--- a/presto-docs/src/main/sphinx/release.rst
+++ b/presto-docs/src/main/sphinx/release.rst
@@ -6,6 +6,7 @@ Release Notes
     :maxdepth: 1
 
     release/release-0.254
+    release/release-0.253.1
     release/release-0.253
     release/release-0.252
     release/release-0.251.1

--- a/presto-docs/src/main/sphinx/release/release-0.253.1.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.253.1.rst
@@ -1,0 +1,7 @@
+===============
+Release 0.253.1
+===============
+
+General Changes
+_______________
+* Fix a CPU regression for queries using :func:`element_at` for ``MAP``. Introduced by :pr:`16027`

--- a/presto-docs/src/main/sphinx/release/release-0.253.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.253.rst
@@ -2,6 +2,9 @@
 Release 0.253
 =============
 
+.. warning::
+    A CPU regression was introduced by :pr:`16027` for queries using :func:`element_at` with ``MAP``
+
 **Details**
 ===========
 


### PR DESCRIPTION
Test plan - `mvn clean package -DskipTests -am -pl presto-docs` and accessed the generated HTML pages to ensure that the links are correct

```
== NO RELEASE NOTE ==
```
