### PR TITLE
Enable snapshot timestamp specification for tables in SELECT

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
@@ -36,6 +36,7 @@ import static com.facebook.presto.hive.HiveSessionProperties.InsertExistingParti
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_SESSION_PROPERTY;
 import static com.facebook.presto.spi.session.PropertyMetadata.booleanProperty;
 import static com.facebook.presto.spi.session.PropertyMetadata.integerProperty;
+import static com.facebook.presto.spi.session.PropertyMetadata.longProperty;
 import static com.facebook.presto.spi.session.PropertyMetadata.stringProperty;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.String.format;
@@ -118,6 +119,7 @@ public final class HiveSessionProperties
     public static final String MANIFEST_VERIFICATION_ENABLED = "manifest_verification_enabled";
     public static final String NEW_PARTITION_USER_SUPPLIED_PARAMETER = "new_partition_user_supplied_parameter";
     public static final String OPTIMIZED_PARTITION_UPDATE_SERIALIZATION_ENABLED = "optimized_partition_update_serialization_enabled";
+    public static final String SOURCE_HIVE_TABLE_SNAPSHOTS_TIMESTAMP_MS = "source_hive_table_snapshots_timestamp_ms";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -557,6 +559,11 @@ public final class HiveSessionProperties
                         OPTIMIZED_PARTITION_UPDATE_SERIALIZATION_ENABLED,
                         "Serialize PartitionUpdate objects using binary SMILE encoding and compress with the ZSTD compression",
                         hiveClientConfig.isOptimizedPartitionUpdateSerializationEnabled(),
+                        true),
+                longProperty(
+                        SOURCE_HIVE_TABLE_SNAPSHOTS_TIMESTAMP_MS,
+                        "timestamp_ms for reading specific snapshots of input tables",
+                        0L,
                         true));
     }
 
@@ -894,6 +901,11 @@ public final class HiveSessionProperties
     public static boolean isParquetBatchReaderVerificationEnabled(ConnectorSession session)
     {
         return session.getProperty(PARQUET_BATCH_READER_VERIFICATION_ENABLED, Boolean.class);
+    }
+
+    public static long getSourceHiveTableSnapshotsMS(ConnectorSession session)
+    {
+        return session.getProperty(SOURCE_HIVE_TABLE_SNAPSHOTS_TIMESTAMP_MS, Long.class);
     }
 
     public static PropertyMetadata<DataSize> dataSizeSessionProperty(String name, String description, DataSize defaultValue, boolean hidden)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveTableHandle.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveTableHandle.java
@@ -30,6 +30,7 @@ public class HiveTableHandle
 {
     private final String schemaName;
     private final String tableName;
+    private final Optional<Long> snapshotTimestampMS;
 
     private final Optional<List<List<String>>> analyzePartitionValues;
 
@@ -37,11 +38,21 @@ public class HiveTableHandle
     public HiveTableHandle(
             @JsonProperty("schemaName") String schemaName,
             @JsonProperty("tableName") String tableName,
+            @JsonProperty("snapshotTimestampMS") Optional<Long> snapshotTimestampMS,
             @JsonProperty("analyzePartitionValues") Optional<List<List<String>>> analyzePartitionValues)
     {
         this.schemaName = requireNonNull(schemaName, "schemaName is null");
         this.tableName = requireNonNull(tableName, "tableName is null");
+        this.snapshotTimestampMS = snapshotTimestampMS;
         this.analyzePartitionValues = requireNonNull(analyzePartitionValues, "analyzePartitionValues is null");
+    }
+
+    public HiveTableHandle(
+            String schemaName,
+            String tableName,
+            Optional<List<List<String>>> analyzePartitionValues)
+    {
+        this(schemaName, tableName, null, analyzePartitionValues);
     }
 
     public HiveTableHandle(String schemaName, String tableName)
@@ -106,5 +117,12 @@ public class HiveTableHandle
                 .add("tableName", tableName)
                 .add("analyzePartitionValues", analyzePartitionValues)
                 .toString();
+    }
+
+    @Override
+    @JsonProperty
+    public Optional<Long> getSnapshotTimestampMS()
+    {
+        return snapshotTimestampMS;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -187,6 +187,7 @@ public final class SystemSessionProperties
     public static final String PARTIAL_RESULTS_ENABLED = "partial_results_enabled";
     public static final String PARTIAL_RESULTS_COMPLETION_RATIO_THRESHOLD = "partial_results_completion_ratio_threshold";
     public static final String PARTIAL_RESULTS_MAX_EXECUTION_TIME_MULTIPLIER = "partial_results_max_execution_time_multiplier";
+    public static final String TABLE_SNAPSHOTS_ENABLED = "table_snapshots_enabled";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -1002,6 +1003,11 @@ public final class SystemSessionProperties
                         PARTIAL_RESULTS_MAX_EXECUTION_TIME_MULTIPLIER,
                         "This value is multiplied by the time taken to reach the completion ratio threshold and is set as max task end time",
                         featuresConfig.getPartialResultsMaxExecutionTimeMultiplier(),
+                        false),
+                booleanProperty(
+                        TABLE_SNAPSHOTS_ENABLED,
+                        "Enable snapshotted tables to be used in SELECT, CREATE TABLE AS and INSERT statements",
+                        featuresConfig.isTableSnapshotsEnabled(),
                         false));
     }
 
@@ -1689,5 +1695,10 @@ public final class SystemSessionProperties
     public static double getPartialResultsMaxExecutionTimeMultiplier(Session session)
     {
         return session.getSystemProperty(PARTIAL_RESULTS_MAX_EXECUTION_TIME_MULTIPLIER, Double.class);
+    }
+
+    public static boolean isTableSnapshotsEnabled(Session session)
+    {
+        return session.getSystemProperty(TABLE_SNAPSHOTS_ENABLED, Boolean.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -193,6 +193,7 @@ public class FeaturesConfig
     private boolean partialResultsEnabled;
     private double partialResultsCompletionRatioThreshold = 0.5;
     private double partialResultsMaxExecutionTimeMultiplier = 2.0;
+    private boolean tableSnapshotsEnabled = true;
 
     public enum PartitioningPrecisionStrategy
     {
@@ -1666,5 +1667,17 @@ public class FeaturesConfig
     {
         this.partialResultsMaxExecutionTimeMultiplier = partialResultsMaxExecutionTimeMultiplier;
         return this;
+    }
+
+    @Config("table-snapshots-enabled")
+    public FeaturesConfig setTableSnapshotsEnabled(boolean tableSnapshotsEnabled)
+    {
+        this.tableSnapshotsEnabled = tableSnapshotsEnabled;
+        return this;
+    }
+
+    public boolean isTableSnapshotsEnabled()
+    {
+        return tableSnapshotsEnabled;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -1140,7 +1140,6 @@ class StatementAnalyzer
                     throw new SemanticException(MATERIALIZED_VIEW_IS_RECURSIVE, table, "Materialized view is recursive");
                 }
             }
-
             Optional<TableHandle> tableHandle = metadata.getTableHandle(session, name);
             if (!tableHandle.isPresent()) {
                 if (!metadata.getCatalogHandle(session, name.getCatalogName()).isPresent()) {

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -165,7 +165,8 @@ public class TestFeaturesConfig
                 .setPrestoSparkAssignBucketToPartitionForPartitionedTableWriteEnabled(false)
                 .setPartialResultsEnabled(false)
                 .setPartialResultsCompletionRatioThreshold(0.5)
-                .setPartialResultsMaxExecutionTimeMultiplier(2.0));
+                .setPartialResultsMaxExecutionTimeMultiplier(2.0)
+                .setTableSnapshotsEnabled(true));
     }
 
     @Test
@@ -284,6 +285,7 @@ public class TestFeaturesConfig
                 .put("partial-results-enabled", "true")
                 .put("partial-results-completion-ratio-threshold", "0.9")
                 .put("partial-results-max-execution-time-multiplier", "1.5")
+                .put("table-snapshots-enabled", "false")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -399,7 +401,8 @@ public class TestFeaturesConfig
                 .setPrestoSparkAssignBucketToPartitionForPartitionedTableWriteEnabled(true)
                 .setPartialResultsEnabled(true)
                 .setPartialResultsCompletionRatioThreshold(0.9)
-                .setPartialResultsMaxExecutionTimeMultiplier(1.5);
+                .setPartialResultsMaxExecutionTimeMultiplier(1.5)
+                .setTableSnapshotsEnabled(false);
         assertFullMapping(properties, expected);
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorTableHandle.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorTableHandle.java
@@ -13,6 +13,12 @@
  */
 package com.facebook.presto.spi;
 
+import java.util.Optional;
+
 public interface ConnectorTableHandle
 {
+    default Optional<Long> getSnapshotTimestampMS()
+    {
+        return Optional.empty();
+    }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
@@ -753,4 +753,9 @@ public interface ConnectorMetadata
     {
         return NOT_APPLICABLE;
     }
+
+    default ConnectorTableHandle getTableHandle(ConnectorSession session, SchemaTableName tableName, Optional<Long> snapshotTimestampMS)
+    {
+        throw new PrestoException(NOT_SUPPORTED, "This connector does not support table snapshot timestamp specification");
+    }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -32,6 +32,7 @@ import com.facebook.presto.spi.ConnectorTableMetadata;
 import com.facebook.presto.spi.ConnectorViewDefinition;
 import com.facebook.presto.spi.Constraint;
 import com.facebook.presto.spi.MaterializedViewStatus;
+import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.SchemaTablePrefix;
@@ -59,6 +60,7 @@ import java.util.OptionalLong;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
+import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static java.util.Objects.requireNonNull;
 
 public class ClassLoaderSafeConnectorMetadata
@@ -683,5 +685,11 @@ public class ClassLoaderSafeConnectorMetadata
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             return delegate.getTableLayoutFilterCoverage(tableHandle, relevantPartitionColumns);
         }
+    }
+
+    @Override
+    public ConnectorTableHandle getTableHandle(ConnectorSession session, SchemaTableName tableName, Optional<Long> snapshotTimestampMS)
+    {
+        throw new PrestoException(NOT_SUPPORTED, "This connector does not support table snapshot timestamp specification");
     }
 }


### PR DESCRIPTION
Test plan - N/A

We are extending the metadata SPI to allow for snapshot timestamp for tables. This PR just extends the SPI with the feature with default as unimplemented. We have some specific connectors that will implement it. This is currently controlled by a session property and feature config. We also allow it only for SELECT queries and for tables in the SELECT part of INSERT and CREATE TABLE AS SELECT.

```
== RELEASE NOTES ==

General Changes
* Add a session property to enable table snapshots

Hive Changes
* Extended the HiveMetadata APIs to record the timestamp in the ConnectorTableHandle
```

