### PR TITLE
Support parameters in lambda expressions for prepare statement

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/ParameterExtractor.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/ParameterExtractor.java
@@ -14,6 +14,8 @@
 package com.facebook.presto.execution;
 
 import com.facebook.presto.sql.tree.DefaultTraversalVisitor;
+import com.facebook.presto.sql.tree.LambdaArgumentDeclaration;
+import com.facebook.presto.sql.tree.LambdaExpression;
 import com.facebook.presto.sql.tree.Parameter;
 import com.facebook.presto.sql.tree.Statement;
 
@@ -52,6 +54,16 @@ public class ParameterExtractor
         public Void visitParameter(Parameter node, Void context)
         {
             parameters.add(node);
+            return null;
+        }
+
+        @Override
+        protected Void visitLambdaExpression(LambdaExpression node, Void context)
+        {
+            process(node.getBody(), context);
+            for (LambdaArgumentDeclaration argument : node.getArguments()) {
+                process(argument, context);
+            }
             return null;
         }
     }

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkAbstractTestQueries.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkAbstractTestQueries.java
@@ -175,6 +175,12 @@ public class TestPrestoSparkAbstractTestQueries
     }
 
     @Override
+    public void testExecuteWithParametersInLambda()
+    {
+        // prepared statement is not supported by Presto on Spark
+    }
+
+    @Override
     public void testExplainDdl()
     {
         // DDL statements are not supported by Presto on Spark

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -4871,6 +4871,17 @@ public abstract class AbstractTestQueries
     }
 
     @Test
+    public void testExecuteWithParametersInLambda()
+    {
+        String query = "SELECT filter(array[1, 2, 3], x -> x > ?)";
+        Session session = Session.builder(getSession())
+                .addPreparedStatement("my_query", query)
+                .build();
+
+        assertQuery(session, "EXECUTE my_query USING 2", "SELECT array[3]");
+    }
+
+    @Test
     public void testExecuteWithParametersInGroupBy()
     {
         try {
@@ -5725,9 +5736,9 @@ public abstract class AbstractTestQueries
     {
         assertQueryFails(
                 "select y, map_union_sum(x) from (select 1 y, map(array['x', 'z', 'y'], cast(array[null,30,100] as array<tinyint>)) x " +
-                "union all select 1 y, map(array['x', 'y'], cast(array[1,100] as array<tinyint>))x) group by y", ".*Value 200 exceeds MAX_BYTE.*");
+                        "union all select 1 y, map(array['x', 'y'], cast(array[1,100] as array<tinyint>))x) group by y", ".*Value 200 exceeds MAX_BYTE.*");
         assertQueryFails(
                 "select y, map_union_sum(x) from (select 1 y, map(array['x', 'z', 'y'], cast(array[null,30, 32760] as array<smallint>)) x " +
-                "union all select 1 y, map(array['x', 'y'], cast(array[1,100] as array<smallint>))x) group by y", ".*Value 32860 exceeds MAX_SHORT.*");
+                        "union all select 1 y, map(array['x', 'y'], cast(array[1,100] as array<smallint>))x) group by y", ".*Value 32860 exceeds MAX_SHORT.*");
     }
 }


### PR DESCRIPTION
fixes #16005

Override visitLambdaExpression in ParameterExtractingVisitor to support
extracting parameters form lambda expressions. This commit does not add the
override function to DefaultTraversalVisitor because there are other
visitors which do not expect to visit lambdas. For example,
VariablesExtractor doesn't want to extract variables from lambdas and
treat it as dependencies from the source plan.

Test plan
 - Added query tests in presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java.
 - Also started a presto server locally and tested the change manually.

== RELEASE NOTES ==

```
General Changes
* Fix a bug that parameters are not supported in lambda expressions for prepare statements.
```