### PR TITLE
Avoid shaded guava imports in Presto on Spark codebase

### DIFF
--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkMutableRow.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkMutableRow.java
@@ -23,8 +23,6 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.nio.ByteBuffer;
 
-import static org.spark_project.guava.base.Preconditions.checkState;
-
 public class PrestoSparkMutableRow
         implements Externalizable, KryoSerializable, PrestoSparkTaskOutput
 {
@@ -128,7 +126,9 @@ public class PrestoSparkMutableRow
     @Override
     public long getSize()
     {
-        checkState(buffer != null, "buffer is expected to be not null");
+        if (buffer == null) {
+            throw new IllegalStateException("buffer is expected to be not null");
+        }
         return buffer.remaining();
     }
 }

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkShuffleStats.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkShuffleStats.java
@@ -15,8 +15,8 @@ package com.facebook.presto.spark.classloader_interface;
 
 import java.io.Serializable;
 
+import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
-import static org.spark_project.guava.base.Preconditions.checkArgument;
 
 public class PrestoSparkShuffleStats
         implements Serializable
@@ -96,5 +96,12 @@ public class PrestoSparkShuffleStats
     public String toString()
     {
         return "";
+    }
+
+    private static void checkArgument(boolean condition, String message, Object... args)
+    {
+        if (!condition) {
+            throw new IllegalArgumentException(format(message, args));
+        }
     }
 }

--- a/src/checkstyle/presto-checks.xml
+++ b/src/checkstyle/presto-checks.xml
@@ -209,6 +209,9 @@
             <property name="illegalPkgs" value="jersey.repackaged" />
             <property name="illegalPkgs" value="jdk.nashorn.internal" />
             <property name="illegalPkgs" value="jdk.internal" />
+            <!-- Added to avoid accidental imports of the Spark shaded guava library that lives under the org.spark_project.guava package -->
+            <!-- It seems unlikely that anything would need to be imported from the org.spark_project package, as it contains private or semi private API -->
+            <property name="illegalPkgs" value="org.spark_project" />
         </module>
 
         <module name="IllegalImport">


### PR DESCRIPTION
Should resolve the issue mentioned here: https://github.com/prestodb/presto/pull/16154#issuecomment-852342015

```
== NO RELEASE NOTE ==
```
