### PR TITLE
Enable instance and custom credential provider for glue

### DIFF
--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -231,6 +231,10 @@ Property Name                                        Description
 
 ``hive.metastore.glue.default-warehouse-dir``        Hive Glue metastore default warehouse directory
 
+``hive.metastore.glue.aws-credentials-provider``     Fully qualified name of the Java class to use for obtaining
+                                                     AWS credentials. Can be used to supply a custom credentials
+                                                     provider.
+
 ``hive.metastore.glue.aws-access-key``               AWS access key to use to connect to the Glue Catalog. If
                                                      specified along with ``hive.metastore.glue.aws-secret-key``,
                                                      this parameter takes precedence over

--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -231,10 +231,6 @@ Property Name                                        Description
 
 ``hive.metastore.glue.default-warehouse-dir``        Hive Glue metastore default warehouse directory
 
-``hive.metastore.glue.aws-credentials-provider``     Fully qualified name of the Java class to use for obtaining
-                                                     AWS credentials. Can be used to supply a custom credentials
-                                                     provider.
-
 ``hive.metastore.glue.aws-access-key``               AWS access key to use to connect to the Glue Catalog. If
                                                      specified along with ``hive.metastore.glue.aws-secret-key``,
                                                      this parameter takes precedence over

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/glue/GlueHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/glue/GlueHiveMetastore.java
@@ -138,7 +138,6 @@ import static com.facebook.presto.spi.security.PrincipalType.USER;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.collect.Comparators.lexicographical;
-import static java.lang.String.format;
 import static java.util.Comparator.comparing;
 import static java.util.Objects.requireNonNull;
 import static java.util.function.UnaryOperator.identity;
@@ -217,30 +216,13 @@ public class GlueHiveMetastore
             return new AWSStaticCredentialsProvider(
                     new BasicAWSCredentials(config.getAwsAccessKey().get(), config.getAwsSecretKey().get()));
         }
-        if (config.getIamRole().isPresent()) {
+        else if (config.getIamRole().isPresent()) {
             return new STSAssumeRoleSessionCredentialsProvider
                     .Builder(config.getIamRole().get(), "roleSessionName")
                     .build();
         }
-        if (config.getAwsCredentialsProvider().isPresent()) {
-            return getCustomAWSCredentialsProvider(config.getAwsCredentialsProvider().get());
-        }
 
         return DefaultAWSCredentialsProviderChain.getInstance();
-    }
-
-    private static AWSCredentialsProvider getCustomAWSCredentialsProvider(String providerClass)
-    {
-        try {
-            Object instance = Class.forName(providerClass).getConstructor().newInstance();
-            if (!(instance instanceof AWSCredentialsProvider)) {
-                throw new RuntimeException("Invalid credentials provider class: " + instance.getClass().getName());
-            }
-            return (AWSCredentialsProvider) instance;
-        }
-        catch (ReflectiveOperationException e) {
-            throw new RuntimeException(format("Error creating an instance of %s", providerClass), e);
-        }
     }
 
     @Managed

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/glue/GlueHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/glue/GlueHiveMetastore.java
@@ -19,7 +19,6 @@ import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
-import com.amazonaws.auth.InstanceProfileCredentialsProvider;
 import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
 import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
 import com.amazonaws.metrics.RequestMetricCollector;
@@ -217,9 +216,6 @@ public class GlueHiveMetastore
         if (config.getAwsAccessKey().isPresent() && config.getAwsSecretKey().isPresent()) {
             return new AWSStaticCredentialsProvider(
                     new BasicAWSCredentials(config.getAwsAccessKey().get(), config.getAwsSecretKey().get()));
-        }
-        if (config.isUseInstanceCredentials()) {
-            return InstanceProfileCredentialsProvider.getInstance();
         }
         if (config.getIamRole().isPresent()) {
             return new STSAssumeRoleSessionCredentialsProvider

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/glue/GlueHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/glue/GlueHiveMetastore.java
@@ -19,6 +19,7 @@ import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.auth.InstanceProfileCredentialsProvider;
 import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
 import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
 import com.amazonaws.metrics.RequestMetricCollector;
@@ -138,6 +139,7 @@ import static com.facebook.presto.spi.security.PrincipalType.USER;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.collect.Comparators.lexicographical;
+import static java.lang.String.format;
 import static java.util.Comparator.comparing;
 import static java.util.Objects.requireNonNull;
 import static java.util.function.UnaryOperator.identity;
@@ -216,13 +218,33 @@ public class GlueHiveMetastore
             return new AWSStaticCredentialsProvider(
                     new BasicAWSCredentials(config.getAwsAccessKey().get(), config.getAwsSecretKey().get()));
         }
-        else if (config.getIamRole().isPresent()) {
+        if (config.isUseInstanceCredentials()) {
+            return InstanceProfileCredentialsProvider.getInstance();
+        }
+        if (config.getIamRole().isPresent()) {
             return new STSAssumeRoleSessionCredentialsProvider
                     .Builder(config.getIamRole().get(), "roleSessionName")
                     .build();
         }
+        if (config.getAwsCredentialsProvider().isPresent()) {
+            return getCustomAWSCredentialsProvider(config.getAwsCredentialsProvider().get());
+        }
 
         return DefaultAWSCredentialsProviderChain.getInstance();
+    }
+
+    private static AWSCredentialsProvider getCustomAWSCredentialsProvider(String providerClass)
+    {
+        try {
+            Object instance = Class.forName(providerClass).getConstructor().newInstance();
+            if (!(instance instanceof AWSCredentialsProvider)) {
+                throw new RuntimeException("Invalid credentials provider class: " + instance.getClass().getName());
+            }
+            return (AWSCredentialsProvider) instance;
+        }
+        catch (ReflectiveOperationException e) {
+            throw new RuntimeException(format("Error creating an instance of %s", providerClass), e);
+        }
     }
 
     @Managed

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/glue/GlueHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/glue/GlueHiveMetastore.java
@@ -18,6 +18,7 @@ import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
 import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
 import com.amazonaws.metrics.RequestMetricCollector;
@@ -137,6 +138,7 @@ import static com.facebook.presto.spi.security.PrincipalType.USER;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.collect.Comparators.lexicographical;
+import static java.lang.String.format;
 import static java.util.Comparator.comparing;
 import static java.util.Objects.requireNonNull;
 import static java.util.function.UnaryOperator.identity;
@@ -204,19 +206,41 @@ public class GlueHiveMetastore
             }
         }
 
-        if (config.getAwsAccessKey().isPresent() && config.getAwsSecretKey().isPresent()) {
-            AWSCredentialsProvider credentialsProvider = new AWSStaticCredentialsProvider(
-                    new BasicAWSCredentials(config.getAwsAccessKey().get(), config.getAwsSecretKey().get()));
-            asyncGlueClientBuilder.setCredentials(credentialsProvider);
-        }
-        else if (config.getIamRole().isPresent()) {
-            AWSCredentialsProvider credentialsProvider = new STSAssumeRoleSessionCredentialsProvider
-                    .Builder(config.getIamRole().get(), "roleSessionName")
-                    .build();
-            asyncGlueClientBuilder.setCredentials(credentialsProvider);
-        }
+        asyncGlueClientBuilder.setCredentials(getAwsCredentialsProvider(config));
 
         return asyncGlueClientBuilder.build();
+    }
+
+    private static AWSCredentialsProvider getAwsCredentialsProvider(GlueHiveMetastoreConfig config)
+    {
+        if (config.getAwsAccessKey().isPresent() && config.getAwsSecretKey().isPresent()) {
+            return new AWSStaticCredentialsProvider(
+                    new BasicAWSCredentials(config.getAwsAccessKey().get(), config.getAwsSecretKey().get()));
+        }
+        if (config.getIamRole().isPresent()) {
+            return new STSAssumeRoleSessionCredentialsProvider
+                    .Builder(config.getIamRole().get(), "roleSessionName")
+                    .build();
+        }
+        if (config.getAwsCredentialsProvider().isPresent()) {
+            return getCustomAWSCredentialsProvider(config.getAwsCredentialsProvider().get());
+        }
+
+        return DefaultAWSCredentialsProviderChain.getInstance();
+    }
+
+    private static AWSCredentialsProvider getCustomAWSCredentialsProvider(String providerClass)
+    {
+        try {
+            Object instance = Class.forName(providerClass).getConstructor().newInstance();
+            if (!(instance instanceof AWSCredentialsProvider)) {
+                throw new RuntimeException("Invalid credentials provider class: " + instance.getClass().getName());
+            }
+            return (AWSCredentialsProvider) instance;
+        }
+        catch (ReflectiveOperationException e) {
+            throw new RuntimeException(format("Error creating an instance of %s", providerClass), e);
+        }
     }
 
     @Managed

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/glue/GlueHiveMetastoreConfig.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/glue/GlueHiveMetastoreConfig.java
@@ -36,6 +36,8 @@ public class GlueHiveMetastoreConfig
     private Optional<String> iamRole = Optional.empty();
     private Optional<String> awsAccessKey = Optional.empty();
     private Optional<String> awsSecretKey = Optional.empty();
+    private Optional<String> awsCredentialsProvider = Optional.empty();
+    private boolean useInstanceCredentials;
 
     public Optional<String> getGlueRegion()
     {
@@ -195,6 +197,30 @@ public class GlueHiveMetastoreConfig
     public GlueHiveMetastoreConfig setAwsSecretKey(String awsSecretKey)
     {
         this.awsSecretKey = Optional.ofNullable(awsSecretKey);
+        return this;
+    }
+
+    public boolean isUseInstanceCredentials()
+    {
+        return useInstanceCredentials;
+    }
+
+    @Config("hive.metastore.glue.use-instance-credentials")
+    public GlueHiveMetastoreConfig setUseInstanceCredentials(boolean useInstanceCredentials)
+    {
+        this.useInstanceCredentials = useInstanceCredentials;
+        return this;
+    }
+
+    public Optional<String> getAwsCredentialsProvider()
+    {
+        return awsCredentialsProvider;
+    }
+
+    @Config("hive.metastore.glue.aws-credentials-provider")
+    public GlueHiveMetastoreConfig setAwsCredentialsProvider(String awsCredentialsProvider)
+    {
+        this.awsCredentialsProvider = Optional.ofNullable(awsCredentialsProvider);
         return this;
     }
 }

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/glue/GlueHiveMetastoreConfig.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/glue/GlueHiveMetastoreConfig.java
@@ -37,7 +37,6 @@ public class GlueHiveMetastoreConfig
     private Optional<String> awsAccessKey = Optional.empty();
     private Optional<String> awsSecretKey = Optional.empty();
     private Optional<String> awsCredentialsProvider = Optional.empty();
-    private boolean useInstanceCredentials;
 
     public Optional<String> getGlueRegion()
     {
@@ -197,18 +196,6 @@ public class GlueHiveMetastoreConfig
     public GlueHiveMetastoreConfig setAwsSecretKey(String awsSecretKey)
     {
         this.awsSecretKey = Optional.ofNullable(awsSecretKey);
-        return this;
-    }
-
-    public boolean isUseInstanceCredentials()
-    {
-        return useInstanceCredentials;
-    }
-
-    @Config("hive.metastore.glue.use-instance-credentials")
-    public GlueHiveMetastoreConfig setUseInstanceCredentials(boolean useInstanceCredentials)
-    {
-        this.useInstanceCredentials = useInstanceCredentials;
         return this;
     }
 

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/glue/GlueHiveMetastoreConfig.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/glue/GlueHiveMetastoreConfig.java
@@ -36,7 +36,6 @@ public class GlueHiveMetastoreConfig
     private Optional<String> iamRole = Optional.empty();
     private Optional<String> awsAccessKey = Optional.empty();
     private Optional<String> awsSecretKey = Optional.empty();
-    private Optional<String> awsCredentialsProvider = Optional.empty();
 
     public Optional<String> getGlueRegion()
     {
@@ -196,18 +195,6 @@ public class GlueHiveMetastoreConfig
     public GlueHiveMetastoreConfig setAwsSecretKey(String awsSecretKey)
     {
         this.awsSecretKey = Optional.ofNullable(awsSecretKey);
-        return this;
-    }
-
-    public Optional<String> getAwsCredentialsProvider()
-    {
-        return awsCredentialsProvider;
-    }
-
-    @Config("hive.metastore.glue.aws-credentials-provider")
-    public GlueHiveMetastoreConfig setAwsCredentialsProvider(String awsCredentialsProvider)
-    {
-        this.awsCredentialsProvider = Optional.ofNullable(awsCredentialsProvider);
         return this;
     }
 }

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/glue/GlueHiveMetastoreConfig.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/glue/GlueHiveMetastoreConfig.java
@@ -36,6 +36,7 @@ public class GlueHiveMetastoreConfig
     private Optional<String> iamRole = Optional.empty();
     private Optional<String> awsAccessKey = Optional.empty();
     private Optional<String> awsSecretKey = Optional.empty();
+    private Optional<String> awsCredentialsProvider = Optional.empty();
 
     public Optional<String> getGlueRegion()
     {
@@ -195,6 +196,18 @@ public class GlueHiveMetastoreConfig
     public GlueHiveMetastoreConfig setAwsSecretKey(String awsSecretKey)
     {
         this.awsSecretKey = Optional.ofNullable(awsSecretKey);
+        return this;
+    }
+
+    public Optional<String> getAwsCredentialsProvider()
+    {
+        return awsCredentialsProvider;
+    }
+
+    @Config("hive.metastore.glue.aws-credentials-provider")
+    public GlueHiveMetastoreConfig setAwsCredentialsProvider(String awsCredentialsProvider)
+    {
+        this.awsCredentialsProvider = Optional.ofNullable(awsCredentialsProvider);
         return this;
     }
 }

--- a/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/glue/TestGlueHiveMetastoreConfig.java
+++ b/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/glue/TestGlueHiveMetastoreConfig.java
@@ -40,8 +40,7 @@ public class TestGlueHiveMetastoreConfig
                 .setIamRole(null)
                 .setAwsAccessKey(null)
                 .setAwsSecretKey(null)
-                .setAwsCredentialsProvider(null)
-                .setUseInstanceCredentials(false));
+                .setAwsCredentialsProvider(null));
     }
 
     @Test
@@ -77,8 +76,7 @@ public class TestGlueHiveMetastoreConfig
                 .setIamRole("role")
                 .setAwsAccessKey("ABC")
                 .setAwsSecretKey("DEF")
-                .setAwsCredentialsProvider("custom")
-                .setUseInstanceCredentials(true);
+                .setAwsCredentialsProvider("custom");
 
         assertFullMapping(properties, expected);
     }

--- a/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/glue/TestGlueHiveMetastoreConfig.java
+++ b/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/glue/TestGlueHiveMetastoreConfig.java
@@ -39,7 +39,9 @@ public class TestGlueHiveMetastoreConfig
                 .setGetPartitionThreads(20)
                 .setIamRole(null)
                 .setAwsAccessKey(null)
-                .setAwsSecretKey(null));
+                .setAwsSecretKey(null)
+                .setAwsCredentialsProvider(null)
+                .setUseInstanceCredentials(false));
     }
 
     @Test
@@ -58,6 +60,8 @@ public class TestGlueHiveMetastoreConfig
                 .put("hive.metastore.glue.iam-role", "role")
                 .put("hive.metastore.glue.aws-access-key", "ABC")
                 .put("hive.metastore.glue.aws-secret-key", "DEF")
+                .put("hive.metastore.glue.aws-credentials-provider", "custom")
+                .put("hive.metastore.glue.use-instance-credentials", "true")
                 .build();
 
         GlueHiveMetastoreConfig expected = new GlueHiveMetastoreConfig()
@@ -72,7 +76,9 @@ public class TestGlueHiveMetastoreConfig
                 .setGetPartitionThreads(42)
                 .setIamRole("role")
                 .setAwsAccessKey("ABC")
-                .setAwsSecretKey("DEF");
+                .setAwsSecretKey("DEF")
+                .setAwsCredentialsProvider("custom")
+                .setUseInstanceCredentials(true);
 
         assertFullMapping(properties, expected);
     }

--- a/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/glue/TestGlueHiveMetastoreConfig.java
+++ b/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/glue/TestGlueHiveMetastoreConfig.java
@@ -39,7 +39,8 @@ public class TestGlueHiveMetastoreConfig
                 .setGetPartitionThreads(20)
                 .setIamRole(null)
                 .setAwsAccessKey(null)
-                .setAwsSecretKey(null));
+                .setAwsSecretKey(null)
+                .setAwsCredentialsProvider(null));
     }
 
     @Test
@@ -58,6 +59,7 @@ public class TestGlueHiveMetastoreConfig
                 .put("hive.metastore.glue.iam-role", "role")
                 .put("hive.metastore.glue.aws-access-key", "ABC")
                 .put("hive.metastore.glue.aws-secret-key", "DEF")
+                .put("hive.metastore.glue.aws-credentials-provider", "custom")
                 .build();
 
         GlueHiveMetastoreConfig expected = new GlueHiveMetastoreConfig()
@@ -72,7 +74,8 @@ public class TestGlueHiveMetastoreConfig
                 .setGetPartitionThreads(42)
                 .setIamRole("role")
                 .setAwsAccessKey("ABC")
-                .setAwsSecretKey("DEF");
+                .setAwsSecretKey("DEF")
+                .setAwsCredentialsProvider("custom");
 
         assertFullMapping(properties, expected);
     }

--- a/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/glue/TestGlueHiveMetastoreConfig.java
+++ b/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/glue/TestGlueHiveMetastoreConfig.java
@@ -39,8 +39,7 @@ public class TestGlueHiveMetastoreConfig
                 .setGetPartitionThreads(20)
                 .setIamRole(null)
                 .setAwsAccessKey(null)
-                .setAwsSecretKey(null)
-                .setAwsCredentialsProvider(null));
+                .setAwsSecretKey(null));
     }
 
     @Test
@@ -59,7 +58,6 @@ public class TestGlueHiveMetastoreConfig
                 .put("hive.metastore.glue.iam-role", "role")
                 .put("hive.metastore.glue.aws-access-key", "ABC")
                 .put("hive.metastore.glue.aws-secret-key", "DEF")
-                .put("hive.metastore.glue.aws-credentials-provider", "custom")
                 .build();
 
         GlueHiveMetastoreConfig expected = new GlueHiveMetastoreConfig()
@@ -74,8 +72,7 @@ public class TestGlueHiveMetastoreConfig
                 .setGetPartitionThreads(42)
                 .setIamRole("role")
                 .setAwsAccessKey("ABC")
-                .setAwsSecretKey("DEF")
-                .setAwsCredentialsProvider("custom");
+                .setAwsSecretKey("DEF");
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
Add config hive.metastore.glue.aws-credentials-provider for glue
Cherry-pick of trinodb/trino#1363,
trinodb/trino#741 and
trinodb/trino#3689

Add config hive.metastore.glue.aws-credentials-provider for glue
credential provider. where value is fully qualified class name of
custom AWS credential provider implementation.

Co-authored-by: Li Yu <li.yu.sh0211@gmail.com>
Co-authored-by: Anoop Johnson <anoopj@amazon.com>
Co-authored-by: Ashhar Hasan <hashhar_dev@outlook.com>
```
== RELEASE NOTES ==

AWS Changes
* Enable instance and custom credential provider for glue
  Add configuration property
  ``hive.metastore.glue.aws-credentials-provider`` to supply a 
  custom credential provider.

```
