### PR TITLE
Add SQL function array_frequency

### DIFF
--- a/presto-docs/src/main/sphinx/functions/array.rst
+++ b/presto-docs/src/main/sphinx/functions/array.rst
@@ -48,6 +48,16 @@ Array Functions
 
     Returns an array of elements in ``x`` but not in ``y``, without duplicates.
 
+.. function:: array_frequency(array(bigint)) -> map(bigint, int)
+
+    Returns a map: keys are the unique elements in the ``array``, values are how many times the key appears.
+    Ignores null elements. Empty array returns empty map.
+
+.. function:: array_frequency(array(varchar)) -> map(varchar, int)
+
+    Returns a map: keys are the unique elements in the ``array``, values are how many times the key appears.
+    Ignores null elements. Empty array returns empty map.
+
 .. function:: array_intersect(x, y) -> array
 
     Returns an array of the elements in the intersection of ``x`` and ``y``, without duplicates.

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/sql/ArrayArithmeticFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/sql/ArrayArithmeticFunctions.java
@@ -52,4 +52,30 @@ public class ArrayArithmeticFunctions
                 "(s, x) -> IF(x IS NOT NULL, (s[1] + x, s[2] + 1), s), " +
                 "s -> if(s[2] = 0, cast(null as double), s[1] / cast(s[2] as double)))";
     }
+
+    @SqlInvokedScalarFunction(value = "array_frequency", deterministic = true, calledOnNullInput = false)
+    @Description("Returns the frequency of all array elements as a map.")
+    @SqlParameter(name = "input", type = "array(bigint)")
+    @SqlType("map(bigint, int)")
+    public static String arrayFrequencyBigint()
+    {
+        return "RETURN reduce(" +
+                "input," +
+                "MAP()," +
+                "(m, x) -> IF (x IS NOT NULL, MAP_CONCAT(m,MAP_FROM_ENTRIES(ARRAY[ROW(x, COALESCE(ELEMENT_AT(m,x) + 1, 1))])), m)," +
+                "m -> m)";
+    }
+
+    @SqlInvokedScalarFunction(value = "array_frequency", deterministic = true, calledOnNullInput = false)
+    @Description("Returns the frequency of all array elements as a map.")
+    @SqlParameter(name = "input", type = "array(varchar)")
+    @SqlType("map(varchar, int)")
+    public static String arrayFrequencyVarchar()
+    {
+        return "RETURN reduce(" +
+                "input," +
+                "MAP()," +
+                "(m, x) -> IF (x IS NOT NULL, MAP_CONCAT(m,MAP_FROM_ENTRIES(ARRAY[ROW(x, COALESCE(ELEMENT_AT(m,x) + 1, 1))])), m)," +
+                "m -> m)";
+    }
 }


### PR DESCRIPTION
Test plan - Wrote unit tests to check the function works with varchar and bigints. Can deal with duplicates.

Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines. Don't forget to follow our [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution) for any code copied from other projects.

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== RELEASE NOTES ==

General Changes
* Add function :func:`array_frequency'
