### PR TITLE
Fix NPE bug when retrieving big query table metadata

### DIFF
--- a/presto-bigquery/src/main/java/com/facebook/presto/plugin/bigquery/BigQueryMetadata.java
+++ b/presto-bigquery/src/main/java/com/facebook/presto/plugin/bigquery/BigQueryMetadata.java
@@ -116,7 +116,7 @@ public class BigQueryMetadata
     {
         log.debug("getTableHandle(session=%s, tableName=%s)", session, tableName);
         Optional<TableInfo> tableInfo = getBigQueryTable(tableName);
-        if (tableInfo.isPresent()) {
+        if (!tableInfo.isPresent()) {
             log.debug("Table [%s.%s] was not found", tableName.getSchemaName(), tableName.getTableName());
             return null;
         }
@@ -157,7 +157,7 @@ public class BigQueryMetadata
     private Optional<TableInfo> getBigQueryTable(SchemaTableName tableName)
     {
         TableInfo tableInfo = bigQueryClient.getTable(TableId.of(projectId, tableName.getSchemaName(), tableName.getTableName()));
-        return tableInfo == null ? Optional.of(tableInfo) : Optional.empty();
+        return Optional.ofNullable(tableInfo);
     }
 
     public ConnectorTableMetadata getTableMetadata(ConnectorSession session, SchemaTableName schemaTableName)
@@ -230,7 +230,7 @@ public class BigQueryMetadata
         SchemaTableName tableName = prefix.toSchemaTableName();
         Optional<TableInfo> tableInfo = getBigQueryTable(tableName);
         return tableInfo.isPresent() ?
-                ImmutableList.of() : // table does not exist
-                ImmutableList.of(tableName);
+                ImmutableList.of(tableName) :
+                ImmutableList.of();
     }
 }


### PR DESCRIPTION
Fixes ternary check which returned incorrect side, causing an NPE when obtaining for big query table info. Reference #16178 

Signed-off-by: Daniel Henneberger <git@danielhenneberger.com>

Test plan -
Did not test, visually identified the issue. 

```
== RELEASE NOTES ==

General Changes
* Fix NPE error when obtaining big query table metadata
```
