### PR TITLE
[WIP] Support multi coordinator while serving resource group info

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/resourcemanager/AggregatedResourceGroupInfoBuilder.java
+++ b/presto-main/src/main/java/com/facebook/presto/resourcemanager/AggregatedResourceGroupInfoBuilder.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.resourcemanager;
+
+import com.facebook.presto.server.QueryStateInfo;
+import com.facebook.presto.server.ResourceGroupInfo;
+import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
+import com.facebook.presto.spi.resourceGroups.ResourceGroupState;
+import com.facebook.presto.spi.resourceGroups.SchedulingPolicy;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.units.DataSize;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.facebook.presto.spi.resourceGroups.ResourceGroupState.CAN_QUEUE;
+import static com.facebook.presto.spi.resourceGroups.ResourceGroupState.CAN_RUN;
+import static com.facebook.presto.spi.resourceGroups.ResourceGroupState.FULL;
+import static com.google.common.base.Preconditions.checkState;
+import static java.lang.Math.addExact;
+import static java.util.Objects.requireNonNull;
+
+public class AggregatedResourceGroupInfoBuilder
+{
+    private final ResourceGroupId id;
+    private final SchedulingPolicy schedulingPolicy;
+    private final int schedulingWeight;
+    private final Map<ResourceGroupId, ResourceGroupInfo> subGroupsMap;
+    private final List<QueryStateInfo> runningQueries;
+    private static final Map<ResourceGroupState, Integer> resourceGroupStatePreference
+            = ImmutableMap.of(FULL, 1, CAN_QUEUE, 2, CAN_RUN, 3);
+
+    private ResourceGroupState state;
+    private DataSize softMemoryLimit;
+    private int softConcurrencyLimit;
+    private int hardConcurrencyLimit;
+    private int maxQueuedQueries;
+    private long memoryUsageBytes;
+    private int numQueuedQueries;
+    //TODO check if we need to deprecate this
+    private int numEligibleSubGroups;
+
+    public AggregatedResourceGroupInfoBuilder(ResourceGroupInfo resourceGroupInfo)
+    {
+        this.id = requireNonNull(resourceGroupInfo.getId(), "id is null");
+        this.state = requireNonNull(resourceGroupInfo.getState(), "state is null");
+        this.schedulingPolicy = resourceGroupInfo.getSchedulingPolicy();
+        this.schedulingWeight = resourceGroupInfo.getSchedulingWeight();
+        this.softMemoryLimit = resourceGroupInfo.getSoftMemoryLimit();
+        this.softConcurrencyLimit = resourceGroupInfo.getSoftConcurrencyLimit();
+        this.hardConcurrencyLimit = resourceGroupInfo.getHardConcurrencyLimit();
+        this.maxQueuedQueries = resourceGroupInfo.getMaxQueuedQueries();
+        this.memoryUsageBytes = resourceGroupInfo.getMemoryUsage().toBytes();
+        this.numQueuedQueries = resourceGroupInfo.getNumQueuedQueries();
+        this.numEligibleSubGroups = resourceGroupInfo.getNumEligibleSubGroups();
+        this.subGroupsMap = new HashMap<>();
+        this.runningQueries = new ArrayList<>();
+        addRunningQueries(resourceGroupInfo.getRunningQueries());
+        addSubgroups(resourceGroupInfo.getSubGroups());
+    }
+
+    public AggregatedResourceGroupInfoBuilder add(ResourceGroupInfo resourceGroupInfo)
+    {
+        checkState(resourceGroupInfo != null && this.id.equals(resourceGroupInfo.getId()));
+        this.numQueuedQueries = addExact(this.numQueuedQueries, resourceGroupInfo.getNumQueuedQueries());
+        if (resourceGroupStatePreference.get(resourceGroupInfo.getState()) < resourceGroupStatePreference.get(this.state)) {
+            this.state = resourceGroupInfo.getState();
+        }
+        this.memoryUsageBytes = addExact(this.memoryUsageBytes, resourceGroupInfo.getMemoryUsage().toBytes());
+        List<ResourceGroupInfo> subGroups = resourceGroupInfo.getSubGroups();
+        addSubgroups(subGroups);
+
+        List<QueryStateInfo> runningQueries = resourceGroupInfo.getRunningQueries();
+        addRunningQueries(runningQueries);
+        return this;
+    }
+
+    private void addSubgroups(List<ResourceGroupInfo> subGroups)
+    {
+        if (subGroups != null) {
+            for (ResourceGroupInfo subgroup : subGroups) {
+                subGroupsMap.compute(subgroup.getId(), (k, v) -> v == null ? subgroup : new AggregatedResourceGroupInfoBuilder(v).add(subgroup).build());
+            }
+        }
+    }
+
+    private void addRunningQueries(List<QueryStateInfo> runningQueries)
+    {
+        if (runningQueries != null) {
+            this.runningQueries.addAll(runningQueries);
+        }
+    }
+
+    public ResourceGroupInfo build()
+    {
+        return new ResourceGroupInfo(
+                id,
+                state,
+                schedulingPolicy,
+                schedulingWeight,
+                softMemoryLimit,
+                softConcurrencyLimit,
+                hardConcurrencyLimit,
+                maxQueuedQueries,
+                DataSize.succinctBytes(memoryUsageBytes),
+                numQueuedQueries,
+                runningQueries.size(),
+                numEligibleSubGroups,
+                ImmutableList.copyOf(subGroupsMap.values()),
+                runningQueries);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/resourcemanager/DistributedQueryInfoResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/resourcemanager/DistributedQueryInfoResource.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.resourcemanager;
+
+import com.facebook.airlift.json.JsonCodec;
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.metadata.InternalNode;
+import com.facebook.presto.metadata.InternalNodeManager;
+import com.facebook.presto.server.BasicQueryInfo;
+import com.facebook.presto.server.QueryStateInfo;
+import com.facebook.presto.spi.QueryId;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+
+import javax.annotation.security.RolesAllowed;
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.container.AsyncResponse;
+import javax.ws.rs.container.Suspended;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.Future;
+
+import static com.facebook.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
+import static com.facebook.presto.server.security.RoleType.ADMIN;
+import static com.facebook.presto.server.security.RoleType.USER;
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.google.common.net.HttpHeaders.X_FORWARDED_PROTO;
+import static java.util.Objects.requireNonNull;
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+
+@Path("/v1/queryState")
+@RolesAllowed({USER, ADMIN})
+public class DistributedQueryInfoResource
+{
+    private static final Logger log = Logger.get(DistributedQueryInfoResource.class);
+    private static final JsonCodec<List<QueryStateInfo>> JSON_CODEC = JsonCodec.listJsonCodec(QueryStateInfo.class);
+    private final ResourceManagerClusterStateProvider clusterStateProvider;
+    private final InternalNodeManager internalNodeManager;
+    private ListeningExecutorService executor;
+    private final ResourceManagerProxy proxyHelper;
+
+    @Inject
+    public DistributedQueryInfoResource(ResourceManagerClusterStateProvider clusterStateProvider, InternalNodeManager internalNodeManager,
+            @ForResourceManager ListeningExecutorService executor, ResourceManagerProxy proxyHelper)
+    {
+        this.clusterStateProvider = requireNonNull(clusterStateProvider, "clusterStateProvider is null");
+        this.internalNodeManager = requireNonNull(internalNodeManager, "internalNodeManager is null");
+        this.executor = requireNonNull(executor, "executor is null");
+        this.proxyHelper = requireNonNull(proxyHelper, "proxyHelper is null");
+    }
+
+    @GET
+    public void getAllQueryInfo(@QueryParam("user") String user,
+            @HeaderParam(X_FORWARDED_PROTO) String xForwardedProto,
+            @Context HttpServletRequest servletRequest,
+            @Context UriInfo uriInfo,
+            @Suspended AsyncResponse asyncResponse)
+    {
+        try {
+            Set<InternalNode> coordinators = internalNodeManager.getCoordinators();
+            List<ListenableFuture<List<QueryStateInfo>>> queryStateInfoFutureList = new ArrayList<>();
+            for (InternalNode coordinator : coordinators) {
+                queryStateInfoFutureList.add(getQueryStateFromCoordinator(servletRequest, xForwardedProto, uriInfo, coordinator));
+            }
+            Futures.whenAllComplete(queryStateInfoFutureList).call(() -> {
+                try {
+                    List<QueryStateInfo> queryStateInfoList = new ArrayList<>();
+                    for (Future<List<QueryStateInfo>> queryStateInfoFuture : queryStateInfoFutureList) {
+                        queryStateInfoList.addAll(queryStateInfoFuture.get());
+                    }
+                    return asyncResponse.resume(Response.ok(queryStateInfoList).build());
+                }
+                catch (Exception ex) {
+                    log.error(ex, "Error in getting query info from one of the coordinators");
+                    return asyncResponse.resume(Response.serverError().entity(ex.getMessage()).build());
+                }
+            }, executor);
+        }
+        catch (Exception ex) {
+            log.error(ex, "Error in getting query info");
+            asyncResponse.resume(Response.serverError().entity(ex.getMessage()).build());
+        }
+    }
+
+    @GET
+    @Path("{queryId}")
+    @Produces(MediaType.APPLICATION_JSON)
+    public void getQueryStateInfo(@PathParam("queryId") QueryId queryId,
+            @HeaderParam(X_FORWARDED_PROTO) String xForwardedProto,
+            @Context UriInfo uriInfo,
+            @Context HttpServletRequest servletRequest,
+            @Suspended AsyncResponse asyncResponse)
+            throws WebApplicationException
+    {
+        proxyQueryInfoResponse(servletRequest, asyncResponse, uriInfo, queryId);
+    }
+
+    private ListenableFuture<List<QueryStateInfo>> getQueryStateFromCoordinator(HttpServletRequest servletRequest, String xForwardedProto, UriInfo uriInfo, InternalNode coordinatorNode)
+            throws IOException
+    {
+        String scheme = isNullOrEmpty(xForwardedProto) ? uriInfo.getRequestUri().getScheme() : xForwardedProto;
+        URI uri = uriInfo.getRequestUriBuilder()
+                .queryParam("includeLocalQueryOnly", true)
+                .scheme(scheme)
+                .host(coordinatorNode.getHostAndPort().toInetAddress().getHostName())
+                .port(coordinatorNode.getInternalUri().getPort())
+                .build();
+        return proxyHelper.getResponse(servletRequest, uri, JSON_CODEC);
+    }
+
+    private void proxyQueryInfoResponse(HttpServletRequest servletRequest, AsyncResponse asyncResponse, UriInfo uriInfo, QueryId queryId)
+    {
+        Optional<BasicQueryInfo> queryInfo = clusterStateProvider.getClusterQueries().stream()
+                .filter(query -> query.getQueryId().equals(queryId))
+                .findFirst();
+
+        if (!queryInfo.isPresent()) {
+            asyncResponse.resume(Response.status(NOT_FOUND).type(MediaType.APPLICATION_JSON).build());
+            return;
+        }
+        proxyHelper.performRequest(servletRequest, asyncResponse, uriBuilderFrom(queryInfo.get().getSelf()).replacePath(uriInfo.getPath()).build());
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/resourcemanager/DistributedResourceGroupInfoResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/resourcemanager/DistributedResourceGroupInfoResource.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.resourcemanager;
+
+import com.facebook.airlift.json.JsonCodec;
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.metadata.InternalNode;
+import com.facebook.presto.metadata.InternalNodeManager;
+import com.facebook.presto.server.ResourceGroupInfo;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+
+import javax.annotation.security.RolesAllowed;
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.Encoded;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.container.AsyncResponse;
+import javax.ws.rs.container.Suspended;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URLDecoder;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import static com.facebook.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
+import static com.facebook.presto.server.security.RoleType.ADMIN;
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.google.common.net.HttpHeaders.X_FORWARDED_PROTO;
+import static java.util.Objects.requireNonNull;
+import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+
+@Path("/v1/resourceGroupState")
+@RolesAllowed(ADMIN)
+public class DistributedResourceGroupInfoResource
+{
+    private static final Logger log = Logger.get(DistributedResourceGroupInfoResource.class);
+    private final InternalNodeManager internalNodeManager;
+    private final ResourceManagerProxy proxyHelper;
+    private final ListeningExecutorService executor;
+    private static final JsonCodec<ResourceGroupInfo> JSON_CODEC = JsonCodec.jsonCodec(ResourceGroupInfo.class);
+
+    @Inject
+    public DistributedResourceGroupInfoResource(InternalNodeManager internalNodeManager, @ForResourceManager ListeningExecutorService executor, ResourceManagerProxy proxyHelper)
+    {
+        this.internalNodeManager = requireNonNull(internalNodeManager, "clusterStateProvider is null");
+        this.executor = requireNonNull(executor, "executor is null");
+        this.proxyHelper = requireNonNull(proxyHelper, "proxyHelper is null");
+    }
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Encoded
+    @Path("{resourceGroupId: .+}")
+    public void getResourceGroupInfos(
+            @PathParam("resourceGroupId") String resourceGroupIdString,
+            @QueryParam("includeQueryInfo") @DefaultValue("true") boolean includeQueryInfo,
+            @QueryParam("summarizeSubgroups") @DefaultValue("true") boolean summarizeSubgroups,
+            @QueryParam("includeStaticSubgroupsOnly") @DefaultValue("false") boolean includeStaticSubgroupsOnlytring,
+            @HeaderParam(X_FORWARDED_PROTO) String xForwardedProto,
+            @Context UriInfo uriInfo,
+            @Context HttpServletRequest servletRequest,
+            @Suspended AsyncResponse asyncResponse)
+    {
+        if (isNullOrEmpty(resourceGroupIdString)) {
+            throw new WebApplicationException(NOT_FOUND);
+        }
+        try {
+            List<ListenableFuture<ResourceGroupInfo>> queryStateInfoFutureList = new ArrayList<>();
+            for (InternalNode coordinator : internalNodeManager.getCoordinators()) {
+                queryStateInfoFutureList.add(getResourceGroupInfoFromCoordinator(servletRequest, xForwardedProto, uriInfo, coordinator));
+            }
+            Futures.whenAllComplete(queryStateInfoFutureList).call(() -> {
+                try {
+                    ResourceGroupInfo aggregatedResourceGroupInfo = aggregateResourceGroupInfo(queryStateInfoFutureList);
+                    return asyncResponse.resume(Response.ok(aggregatedResourceGroupInfo).build());
+                }
+                catch (Exception ex) {
+                    log.error(ex, "Error in getting resource group info from one of the coordinators");
+                    return asyncResponse.resume(Response.serverError().entity(ex.getMessage()).build());
+                }
+            }, executor);
+        }
+        catch (NoSuchElementException e) {
+            throw new WebApplicationException(NOT_FOUND);
+        }
+        catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private ResourceGroupInfo aggregateResourceGroupInfo(List<ListenableFuture<ResourceGroupInfo>> queryStateInfoFutureList)
+            throws InterruptedException, java.util.concurrent.ExecutionException
+    {
+        Iterator<ListenableFuture<ResourceGroupInfo>> iterator = queryStateInfoFutureList.iterator();
+        if (iterator.hasNext()) {
+            AggregatedResourceGroupInfoBuilder builder = new AggregatedResourceGroupInfoBuilder(iterator.next().get());
+            while (iterator.hasNext()) {
+                builder.add(iterator.next().get());
+            }
+            return builder.build();
+        }
+        return null;
+    }
+
+    private static String urlDecode(String value)
+    {
+        try {
+            return URLDecoder.decode(value, "UTF-8");
+        }
+        catch (UnsupportedEncodingException e) {
+            throw new WebApplicationException(BAD_REQUEST);
+        }
+    }
+
+    private void proxyQueryInfoResponse(HttpServletRequest servletRequest, AsyncResponse asyncResponse, UriInfo uriInfo, URI remoteURI)
+    {
+        if (remoteURI == null) {
+            asyncResponse.resume(Response.status(NOT_FOUND).type(MediaType.APPLICATION_JSON).build());
+            return;
+        }
+        URI coordinatorURI = uriInfo.getRequestUriBuilder().queryParam("includeLocalQueryOnly", true).build();
+        proxyHelper.performRequest(servletRequest, asyncResponse, uriBuilderFrom(remoteURI).replacePath(coordinatorURI.getPath()).build());
+    }
+
+    private ListenableFuture<ResourceGroupInfo> getResourceGroupInfoFromCoordinator(HttpServletRequest servletRequest, String xForwardedProto, UriInfo uriInfo, InternalNode coordinatorNode)
+            throws IOException
+    {
+        String scheme = isNullOrEmpty(xForwardedProto) ? uriInfo.getRequestUri().getScheme() : xForwardedProto;
+        URI uri = uriInfo.getRequestUriBuilder()
+                .queryParam("includeLocalInfoOnly", true)
+                .scheme(scheme)
+                .host(coordinatorNode.getHostAndPort().toInetAddress().getHostName())
+                .port(coordinatorNode.getInternalUri().getPort())
+                .build();
+        return proxyHelper.getResponse(servletRequest, uri, JSON_CODEC);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/QueryStateInfoResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/QueryStateInfoResource.java
@@ -15,19 +15,32 @@ package com.facebook.presto.server;
 
 import com.facebook.presto.dispatcher.DispatchManager;
 import com.facebook.presto.execution.resourceGroups.ResourceGroupManager;
+import com.facebook.presto.metadata.InternalNode;
+import com.facebook.presto.metadata.InternalNodeManager;
+import com.facebook.presto.resourcemanager.ResourceManagerProxy;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
 
 import javax.annotation.security.RolesAllowed;
 import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.container.AsyncResponse;
+import javax.ws.rs.container.Suspended;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
 
+import java.net.URI;
+import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -38,10 +51,13 @@ import static com.facebook.presto.server.QueryStateInfo.createQueryStateInfo;
 import static com.facebook.presto.server.QueryStateInfo.createQueuedQueryStateInfo;
 import static com.facebook.presto.server.security.RoleType.ADMIN;
 import static com.facebook.presto.server.security.RoleType.USER;
+import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.net.HttpHeaders.X_FORWARDED_PROTO;
 import static java.util.Objects.requireNonNull;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static javax.ws.rs.core.Response.Status.SERVICE_UNAVAILABLE;
 
 @Path("/v1/queryState")
 @RolesAllowed({ADMIN, USER})
@@ -49,32 +65,51 @@ public class QueryStateInfoResource
 {
     private final DispatchManager dispatchManager;
     private final ResourceGroupManager<?> resourceGroupManager;
+    private final boolean resourceManagerEnabled;
+    private final InternalNodeManager internalNodeManager;
+    private final Optional<ResourceManagerProxy> proxyHelper;
 
     @Inject
     public QueryStateInfoResource(
             DispatchManager dispatchManager,
-            ResourceGroupManager<?> resourceGroupManager)
+            ResourceGroupManager<?> resourceGroupManager,
+            InternalNodeManager internalNodeManager,
+            ServerConfig serverConfig,
+            Optional<ResourceManagerProxy> proxyHelper)
     {
         this.dispatchManager = requireNonNull(dispatchManager, "dispatchManager is null");
         this.resourceGroupManager = requireNonNull(resourceGroupManager, "resourceGroupManager is null");
+        this.internalNodeManager = requireNonNull(internalNodeManager, "internalNodeManager is null");
+        this.resourceManagerEnabled = requireNonNull(serverConfig, "serverConfig is null").isResourceManagerEnabled();
+        this.proxyHelper = requireNonNull(proxyHelper, "proxyHelper is null");
     }
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    public List<QueryStateInfo> getQueryStateInfos(@QueryParam("user") String user)
+    public void getQueryStateInfos(@QueryParam("user") String user,
+            @QueryParam("includeLocalQueryOnly") @DefaultValue("false") boolean isIncludeLocalQueryOnly,
+            @HeaderParam(X_FORWARDED_PROTO) String xForwardedProto,
+            @Context UriInfo uriInfo,
+            @Context HttpServletRequest servletRequest,
+            @Suspended AsyncResponse asyncResponse)
     {
-        List<BasicQueryInfo> queryInfos = dispatchManager.getQueries();
-
-        if (!isNullOrEmpty(user)) {
-            queryInfos = queryInfos.stream()
-                    .filter(queryInfo -> Pattern.matches(user, queryInfo.getSession().getUser()))
-                    .collect(toImmutableList());
+        if (resourceManagerEnabled && !isIncludeLocalQueryOnly) {
+            proxyQueryStateInfo(servletRequest, asyncResponse, xForwardedProto, uriInfo);
         }
+        else {
+            List<BasicQueryInfo> queryInfos = dispatchManager.getQueries();
 
-        return queryInfos.stream()
-                .filter(queryInfo -> !queryInfo.getState().isDone())
-                .map(this::getQueryStateInfo)
-                .collect(toImmutableList());
+            if (!isNullOrEmpty(user)) {
+                queryInfos = queryInfos.stream()
+                        .filter(queryInfo -> Pattern.matches(user, queryInfo.getSession().getUser()))
+                        .collect(toImmutableList());
+            }
+
+            asyncResponse.resume(Response.ok(queryInfos.stream()
+                    .filter(queryInfo -> !queryInfo.getState().isDone())
+                    .map(this::getQueryStateInfo)
+                    .collect(toImmutableList())).build());
+        }
     }
 
     private QueryStateInfo getQueryStateInfo(BasicQueryInfo queryInfo)
@@ -92,14 +127,49 @@ public class QueryStateInfoResource
     @GET
     @Path("{queryId}")
     @Produces(MediaType.APPLICATION_JSON)
-    public QueryStateInfo getQueryStateInfo(@PathParam("queryId") String queryId)
+    public void getQueryStateInfo(@PathParam("queryId") String queryId, @HeaderParam(X_FORWARDED_PROTO) String xForwardedProto,
+            @Context UriInfo uriInfo,
+            @Context HttpServletRequest servletRequest,
+            @Suspended AsyncResponse asyncResponse)
             throws WebApplicationException
     {
         try {
-            return getQueryStateInfo(dispatchManager.getQueryInfo(new QueryId(queryId)));
+            QueryId queryID = new QueryId(queryId);
+            if (resourceManagerEnabled && !dispatchManager.isQueryPresent(queryID)) {
+                proxyQueryStateInfo(servletRequest, asyncResponse, xForwardedProto, uriInfo);
+            }
+            else {
+                BasicQueryInfo queryInfo = dispatchManager.getQueryInfo(queryID);
+                asyncResponse.resume(Response.ok(getQueryStateInfo(queryInfo)).build());
+            }
         }
         catch (NoSuchElementException e) {
-            throw new WebApplicationException(NOT_FOUND);
+            asyncResponse.resume(Response.status(NOT_FOUND).build());
+        }
+    }
+
+    //TODO the pattern of this function is similar with ClusterStatsResource and QueryResource, we can move it to a common place and re-use.
+    private void proxyQueryStateInfo(HttpServletRequest servletRequest, AsyncResponse asyncResponse, String xForwardedProto, UriInfo uriInfo)
+    {
+        try {
+            checkState(proxyHelper.isPresent());
+            Iterator<InternalNode> resourceManagers = internalNodeManager.getResourceManagers().iterator();
+            if (!resourceManagers.hasNext()) {
+                asyncResponse.resume(Response.status(SERVICE_UNAVAILABLE).build());
+                return;
+            }
+            InternalNode resourceManagerNode = resourceManagers.next();
+            String scheme = isNullOrEmpty(xForwardedProto) ? uriInfo.getRequestUri().getScheme() : xForwardedProto;
+
+            URI uri = uriInfo.getRequestUriBuilder()
+                    .scheme(scheme)
+                    .host(resourceManagerNode.getHostAndPort().toInetAddress().getHostName())
+                    .port(resourceManagerNode.getInternalUri().getPort())
+                    .build();
+            proxyHelper.get().performRequest(servletRequest, asyncResponse, uri);
+        }
+        catch (Exception e) {
+            asyncResponse.resume(e);
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/ResourceGroupStateInfoResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ResourceGroupStateInfoResource.java
@@ -14,70 +14,105 @@
 package com.facebook.presto.server;
 
 import com.facebook.presto.execution.resourceGroups.ResourceGroupManager;
+import com.facebook.presto.metadata.InternalNode;
+import com.facebook.presto.metadata.InternalNodeManager;
+import com.facebook.presto.resourcemanager.ResourceManagerProxy;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
 
 import javax.annotation.security.RolesAllowed;
 import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.Encoded;
 import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.container.AsyncResponse;
+import javax.ws.rs.container.Suspended;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
 
 import java.io.UnsupportedEncodingException;
+import java.net.URI;
 import java.net.URLDecoder;
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 
 import static com.facebook.presto.server.security.RoleType.ADMIN;
+import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.net.HttpHeaders.X_FORWARDED_PROTO;
 import static java.util.Objects.requireNonNull;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static javax.ws.rs.core.Response.Status.SERVICE_UNAVAILABLE;
 
 @Path("/v1/resourceGroupState")
 @RolesAllowed(ADMIN)
 public class ResourceGroupStateInfoResource
 {
     private final ResourceGroupManager<?> resourceGroupManager;
+    private final boolean resourceManagerEnabled;
+    private final InternalNodeManager internalNodeManager;
+    private final Optional<ResourceManagerProxy> proxyHelper;
 
     @Inject
-    public ResourceGroupStateInfoResource(ResourceGroupManager<?> resourceGroupManager)
+    public ResourceGroupStateInfoResource(
+            ServerConfig serverConfig,
+            ResourceGroupManager<?> resourceGroupManager,
+            InternalNodeManager internalNodeManager,
+            Optional<ResourceManagerProxy> proxyHelper)
     {
+        this.resourceManagerEnabled = requireNonNull(serverConfig, "serverConfig is null").isResourceManagerEnabled();
         this.resourceGroupManager = requireNonNull(resourceGroupManager, "resourceGroupManager is null");
+        this.internalNodeManager = requireNonNull(internalNodeManager, "internalNodeManager is null");
+        this.proxyHelper = requireNonNull(proxyHelper, "proxyHelper is null");
     }
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Encoded
     @Path("{resourceGroupId: .+}")
-    public ResourceGroupInfo getQueryStateInfos(
+    public void getResourceGroupInfos(
             @PathParam("resourceGroupId") String resourceGroupIdString,
             @QueryParam("includeQueryInfo") @DefaultValue("true") boolean includeQueryInfo,
+            @QueryParam("includeLocalInfoOnly") @DefaultValue("false") boolean includeFromLocal,
             @QueryParam("summarizeSubgroups") @DefaultValue("true") boolean summarizeSubgroups,
-            @QueryParam("includeStaticSubgroupsOnly") @DefaultValue("false") boolean includeStaticSubgroupsOnly)
+            @QueryParam("includeStaticSubgroupsOnly") @DefaultValue("false") boolean includeStaticSubgroupsOnly,
+            @HeaderParam(X_FORWARDED_PROTO) String xForwardedProto,
+            @Context UriInfo uriInfo,
+            @Context HttpServletRequest servletRequest,
+            @Suspended AsyncResponse asyncResponse)
     {
+        if (resourceManagerEnabled && !includeFromLocal) {
+            proxyResourceGroupInfoResponse(servletRequest, asyncResponse, xForwardedProto, uriInfo);
+            return;
+        }
         if (!isNullOrEmpty(resourceGroupIdString)) {
             try {
-                return resourceGroupManager.getResourceGroupInfo(
+                asyncResponse.resume(Response.ok().entity(resourceGroupManager.getResourceGroupInfo(
                         new ResourceGroupId(
                                 Arrays.stream(resourceGroupIdString.split("/"))
                                         .map(ResourceGroupStateInfoResource::urlDecode)
                                         .collect(toImmutableList())),
                         includeQueryInfo,
                         summarizeSubgroups,
-                        includeStaticSubgroupsOnly);
+                        includeStaticSubgroupsOnly)).build());
             }
             catch (NoSuchElementException e) {
                 throw new WebApplicationException(NOT_FOUND);
             }
         }
-        throw new WebApplicationException(NOT_FOUND);
+        asyncResponse.resume(Response.status(NOT_FOUND).build());
     }
 
     private static String urlDecode(String value)
@@ -87,6 +122,31 @@ public class ResourceGroupStateInfoResource
         }
         catch (UnsupportedEncodingException e) {
             throw new WebApplicationException(BAD_REQUEST);
+        }
+    }
+
+    //TODO move this to a common place and reuse in all resource
+    private void proxyResourceGroupInfoResponse(HttpServletRequest servletRequest, AsyncResponse asyncResponse, String xForwardedProto, UriInfo uriInfo)
+    {
+        try {
+            checkState(proxyHelper.isPresent());
+            Iterator<InternalNode> resourceManagers = internalNodeManager.getResourceManagers().iterator();
+            if (!resourceManagers.hasNext()) {
+                asyncResponse.resume(Response.status(SERVICE_UNAVAILABLE).build());
+                return;
+            }
+            InternalNode resourceManagerNode = resourceManagers.next();
+            String scheme = isNullOrEmpty(xForwardedProto) ? uriInfo.getRequestUri().getScheme() : xForwardedProto;
+
+            URI uri = uriInfo.getRequestUriBuilder()
+                    .scheme(scheme)
+                    .host(resourceManagerNode.getHostAndPort().toInetAddress().getHostName())
+                    .port(resourceManagerNode.getInternalUri().getPort())
+                    .build();
+            proxyHelper.get().performRequest(servletRequest, asyncResponse, uri);
+        }
+        catch (Exception e) {
+            asyncResponse.resume(e);
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/ResourceManagerModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ResourceManagerModule.java
@@ -24,6 +24,7 @@ import com.facebook.presto.execution.resourceGroups.NoOpResourceGroupManager;
 import com.facebook.presto.execution.resourceGroups.ResourceGroupManager;
 import com.facebook.presto.failureDetector.FailureDetectorModule;
 import com.facebook.presto.resourcemanager.DistributedClusterStatsResource;
+import com.facebook.presto.resourcemanager.DistributedQueryInfoResource;
 import com.facebook.presto.resourcemanager.DistributedQueryResource;
 import com.facebook.presto.resourcemanager.ForResourceManager;
 import com.facebook.presto.resourcemanager.ResourceManagerClusterStateProvider;
@@ -94,6 +95,7 @@ public class ResourceManagerModule
         binder.bind(NodeResourceStatusProvider.class).toInstance(() -> true);
 
         jaxrsBinder(binder).bind(DistributedQueryResource.class);
+        jaxrsBinder(binder).bind(DistributedQueryInfoResource.class);
         jaxrsBinder(binder).bind(DistributedClusterStatsResource.class);
 
         httpClientBinder(binder).bindHttpClient("resourceManager", ForResourceManager.class);

--- a/presto-main/src/main/java/com/facebook/presto/server/ResourceManagerModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ResourceManagerModule.java
@@ -26,6 +26,7 @@ import com.facebook.presto.failureDetector.FailureDetectorModule;
 import com.facebook.presto.resourcemanager.DistributedClusterStatsResource;
 import com.facebook.presto.resourcemanager.DistributedQueryInfoResource;
 import com.facebook.presto.resourcemanager.DistributedQueryResource;
+import com.facebook.presto.resourcemanager.DistributedResourceGroupInfoResource;
 import com.facebook.presto.resourcemanager.ForResourceManager;
 import com.facebook.presto.resourcemanager.ResourceManagerClusterStateProvider;
 import com.facebook.presto.resourcemanager.ResourceManagerProxy;
@@ -75,7 +76,7 @@ public class ResourceManagerModule
 
         // TODO: decouple query-level configuration that is not needed for Resource Manager
         binder.bind(QueryManager.class).to(NoOpQueryManager.class).in(Scopes.SINGLETON);
-        jaxrsBinder(binder).bind(ResourceGroupStateInfoResource.class);
+        jaxrsBinder(binder).bind(DistributedResourceGroupInfoResource.class);
         binder.bind(QueryIdGenerator.class).in(Scopes.SINGLETON);
         binder.bind(QueryPreparer.class).in(Scopes.SINGLETON);
         binder.bind(SessionSupplier.class).to(QuerySessionSupplier.class).in(Scopes.SINGLETON);

--- a/presto-tests/src/test/java/com/facebook/presto/resourcemanager/BaseQueryResourceTest.java
+++ b/presto-tests/src/test/java/com/facebook/presto/resourcemanager/BaseQueryResourceTest.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.resourcemanager;
+
+import com.facebook.airlift.http.client.HttpClient;
+import com.facebook.airlift.http.client.Request;
+import com.facebook.airlift.http.client.jetty.JettyHttpClient;
+import com.facebook.presto.client.QueryResults;
+import com.facebook.presto.resourceGroups.FileResourceGroupConfigurationManagerFactory;
+import com.facebook.presto.server.testing.TestingPrestoServer;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+
+import java.net.URI;
+import java.util.Optional;
+
+import static com.facebook.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
+import static com.facebook.airlift.http.client.JsonResponseHandler.createJsonResponseHandler;
+import static com.facebook.airlift.http.client.Request.Builder.prepareGet;
+import static com.facebook.airlift.http.client.Request.Builder.preparePost;
+import static com.facebook.airlift.http.client.StaticBodyGenerator.createStaticBodyGenerator;
+import static com.facebook.airlift.json.JsonCodec.jsonCodec;
+import static com.facebook.airlift.testing.Closeables.closeQuietly;
+import static com.facebook.presto.client.PrestoHeaders.PRESTO_USER;
+import static com.facebook.presto.tests.tpch.TpchQueryRunner.createQueryRunner;
+import static com.google.common.base.Preconditions.checkState;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public abstract class BaseQueryResourceTest
+{
+    protected HttpClient client;
+    protected TestingPrestoServer coordinator1;
+    protected TestingPrestoServer coordinator2;
+    protected TestingPrestoServer resourceManager;
+
+    @BeforeClass
+    public void setup()
+            throws Exception
+    {
+        client = new JettyHttpClient();
+        DistributedQueryRunner runner = createQueryRunner(ImmutableMap.of("query.client.timeout", "20s"), 2);
+        coordinator1 = runner.getCoordinators().get(0);
+        coordinator2 = runner.getCoordinators().get(1);
+        Optional<TestingPrestoServer> resourceManager = runner.getResourceManager();
+        checkState(resourceManager.isPresent(), "resource manager not present");
+        this.resourceManager = resourceManager.get();
+        coordinator1.getResourceGroupManager().get().addConfigurationManagerFactory(new FileResourceGroupConfigurationManagerFactory());
+        coordinator1.getResourceGroupManager().get()
+                .setConfigurationManager("file", ImmutableMap.of("resource-groups.config-file", getResourceFilePath("resource_groups_config_simple.json")));
+        coordinator2.getResourceGroupManager().get().addConfigurationManagerFactory(new FileResourceGroupConfigurationManagerFactory());
+        coordinator2.getResourceGroupManager().get()
+                .setConfigurationManager("file", ImmutableMap.of("resource-groups.config-file", getResourceFilePath("resource_groups_config_simple.json")));
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void teardown()
+    {
+        closeQuietly(coordinator1);
+        closeQuietly(coordinator2);
+        closeQuietly(resourceManager);
+        closeQuietly(client);
+        coordinator1 = null;
+        coordinator2 = null;
+        resourceManager = null;
+        client = null;
+    }
+
+    private String getResourceFilePath(String fileName)
+    {
+        return this.getClass().getClassLoader().getResource(fileName).getPath();
+    }
+
+    protected QueryResults postQuery(String sql, URI uri)
+    {
+        Request request = preparePost()
+                .setHeader(PRESTO_USER, "user")
+                .setUri(uri)
+                .setBodyGenerator(createStaticBodyGenerator(sql, UTF_8))
+                .build();
+        return client.execute(request, createJsonResponseHandler(jsonCodec(QueryResults.class)));
+    }
+
+    protected void runToCompletion(TestingPrestoServer server, String sql)
+    {
+        URI uri = uriBuilderFrom(server.getBaseUrl().resolve("/v1/statement")).build();
+        QueryResults queryResults = postQuery(sql, uri);
+        while (queryResults.getNextUri() != null) {
+            queryResults = getQueryResults(queryResults);
+        }
+    }
+
+    protected void runToFirstResult(TestingPrestoServer server, String sql)
+    {
+        URI uri = uriBuilderFrom(server.getBaseUrl().resolve("/v1/statement")).build();
+        QueryResults queryResults = postQuery(sql, uri);
+        while (queryResults.getData() == null) {
+            queryResults = getQueryResults(queryResults);
+        }
+    }
+
+    protected void runToQueued(TestingPrestoServer server, String sql)
+    {
+        URI uri = uriBuilderFrom(server.getBaseUrl().resolve("/v1/statement")).build();
+        QueryResults queryResults = postQuery(sql, uri);
+        while (!"QUEUED".equals(queryResults.getStats().getState())) {
+            queryResults = getQueryResults(queryResults);
+        }
+        getQueryResults(queryResults);
+    }
+
+    protected QueryResults getQueryResults(QueryResults queryResults)
+    {
+        Request request = prepareGet()
+                .setHeader(PRESTO_USER, "user")
+                .setUri(queryResults.getNextUri())
+                .build();
+        queryResults = client.execute(request, createJsonResponseHandler(jsonCodec(QueryResults.class)));
+        return queryResults;
+    }
+}

--- a/presto-tests/src/test/java/com/facebook/presto/resourcemanager/ResourceManagerTestHelper.java
+++ b/presto-tests/src/test/java/com/facebook/presto/resourcemanager/ResourceManagerTestHelper.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.resourcemanager;
+
+import com.facebook.airlift.http.client.HttpClient;
+import com.facebook.airlift.http.client.Request;
+import com.facebook.presto.client.QueryResults;
+import com.facebook.presto.server.BasicQueryInfo;
+import com.facebook.presto.server.QueryStateInfo;
+import com.facebook.presto.server.testing.TestingPrestoServer;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+
+import static com.facebook.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
+import static com.facebook.airlift.http.client.JsonResponseHandler.createJsonResponseHandler;
+import static com.facebook.airlift.http.client.Request.Builder.prepareGet;
+import static com.facebook.airlift.http.client.Request.Builder.preparePost;
+import static com.facebook.airlift.http.client.StaticBodyGenerator.createStaticBodyGenerator;
+import static com.facebook.airlift.json.JsonCodec.jsonCodec;
+import static com.facebook.airlift.json.JsonCodec.listJsonCodec;
+import static com.facebook.presto.client.PrestoHeaders.PRESTO_USER;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public class ResourceManagerTestHelper
+        implements Closeable
+{
+    private HttpClient client;
+
+    public ResourceManagerTestHelper(HttpClient client)
+    {
+        this.client = client;
+    }
+
+    public String getResourceFilePath(String fileName)
+    {
+        return this.getClass().getClassLoader().getResource(fileName).getPath();
+    }
+
+    public QueryResults postQuery(String sql, URI uri)
+    {
+        Request request = preparePost()
+                .setHeader(PRESTO_USER, "user")
+                .setUri(uri)
+                .setBodyGenerator(createStaticBodyGenerator(sql, UTF_8))
+                .build();
+        return client.execute(request, createJsonResponseHandler(jsonCodec(QueryResults.class)));
+    }
+
+    public void runToCompletion(TestingPrestoServer server, String sql)
+    {
+        URI uri = uriBuilderFrom(server.getBaseUrl().resolve("/v1/statement")).build();
+        QueryResults queryResults = postQuery(sql, uri);
+        while (queryResults.getNextUri() != null) {
+            queryResults = getQueryResults(queryResults);
+        }
+    }
+
+    public void runToFirstResult(TestingPrestoServer server, String sql)
+    {
+        URI uri = uriBuilderFrom(server.getBaseUrl().resolve("/v1/statement")).build();
+        QueryResults queryResults = postQuery(sql, uri);
+        while (queryResults.getData() == null) {
+            queryResults = getQueryResults(queryResults);
+        }
+    }
+
+    public void runToQueued(TestingPrestoServer server, String sql)
+    {
+        URI uri = uriBuilderFrom(server.getBaseUrl().resolve("/v1/statement")).build();
+        QueryResults queryResults = postQuery(sql, uri);
+        while (!"QUEUED".equals(queryResults.getStats().getState())) {
+            queryResults = getQueryResults(queryResults);
+        }
+        getQueryResults(queryResults);
+    }
+
+    public QueryResults getQueryResults(QueryResults queryResults)
+    {
+        Request request = prepareGet()
+                .setHeader(PRESTO_USER, "user")
+                .setUri(queryResults.getNextUri())
+                .build();
+        queryResults = client.execute(request, createJsonResponseHandler(jsonCodec(QueryResults.class)));
+        return queryResults;
+    }
+
+    public List<BasicQueryInfo> getQueryInfos(TestingPrestoServer server, String path)
+    {
+        Request request = prepareGet().setUri(server.resolve(path)).build();
+        return client.execute(request, createJsonResponseHandler(listJsonCodec(BasicQueryInfo.class)));
+    }
+
+    public List<QueryStateInfo> getQueryStateInfos(TestingPrestoServer server, String path)
+    {
+        Request request = prepareGet().setUri(server.resolve(path)).build();
+        return client.execute(request, createJsonResponseHandler(listJsonCodec(QueryStateInfo.class)));
+    }
+
+    public QueryStateInfo getQueryStateInfo(TestingPrestoServer server, String path)
+    {
+        Request request = prepareGet().setUri(server.resolve(path)).build();
+        return client.execute(request, createJsonResponseHandler(jsonCodec(QueryStateInfo.class)));
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        this.client.close();
+    }
+}

--- a/presto-tests/src/test/java/com/facebook/presto/resourcemanager/ResourceManagerTestHelper.java
+++ b/presto-tests/src/test/java/com/facebook/presto/resourcemanager/ResourceManagerTestHelper.java
@@ -15,6 +15,7 @@ package com.facebook.presto.resourcemanager;
 
 import com.facebook.airlift.http.client.HttpClient;
 import com.facebook.airlift.http.client.Request;
+import com.facebook.airlift.json.JsonCodec;
 import com.facebook.presto.client.QueryResults;
 import com.facebook.presto.server.BasicQueryInfo;
 import com.facebook.presto.server.QueryStateInfo;
@@ -38,6 +39,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 public class ResourceManagerTestHelper
         implements Closeable
 {
+    public static final String DEFAULT_TEST_USER = "user";
     private HttpClient client;
 
     public ResourceManagerTestHelper(HttpClient client)
@@ -50,10 +52,10 @@ public class ResourceManagerTestHelper
         return this.getClass().getClassLoader().getResource(fileName).getPath();
     }
 
-    public QueryResults postQuery(String sql, URI uri)
+    private QueryResults postQuery(String sql, URI uri, String user)
     {
         Request request = preparePost()
-                .setHeader(PRESTO_USER, "user")
+                .setHeader(PRESTO_USER, user)
                 .setUri(uri)
                 .setBodyGenerator(createStaticBodyGenerator(sql, UTF_8))
                 .build();
@@ -62,36 +64,51 @@ public class ResourceManagerTestHelper
 
     public void runToCompletion(TestingPrestoServer server, String sql)
     {
+        runToCompletion(server, sql, DEFAULT_TEST_USER);
+    }
+
+    public void runToCompletion(TestingPrestoServer server, String sql, String user)
+    {
         URI uri = uriBuilderFrom(server.getBaseUrl().resolve("/v1/statement")).build();
-        QueryResults queryResults = postQuery(sql, uri);
+        QueryResults queryResults = postQuery(sql, uri, user);
         while (queryResults.getNextUri() != null) {
-            queryResults = getQueryResults(queryResults);
+            queryResults = getQueryResults(queryResults, user);
         }
     }
 
     public void runToFirstResult(TestingPrestoServer server, String sql)
     {
+        runToFirstResult(server, sql, DEFAULT_TEST_USER);
+    }
+
+    public void runToFirstResult(TestingPrestoServer server, String sql, String user)
+    {
         URI uri = uriBuilderFrom(server.getBaseUrl().resolve("/v1/statement")).build();
-        QueryResults queryResults = postQuery(sql, uri);
+        QueryResults queryResults = postQuery(sql, uri, user);
         while (queryResults.getData() == null) {
-            queryResults = getQueryResults(queryResults);
+            queryResults = getQueryResults(queryResults, user);
         }
     }
 
     public void runToQueued(TestingPrestoServer server, String sql)
     {
-        URI uri = uriBuilderFrom(server.getBaseUrl().resolve("/v1/statement")).build();
-        QueryResults queryResults = postQuery(sql, uri);
-        while (!"QUEUED".equals(queryResults.getStats().getState())) {
-            queryResults = getQueryResults(queryResults);
-        }
-        getQueryResults(queryResults);
+        runToQueued(server, sql, DEFAULT_TEST_USER);
     }
 
-    public QueryResults getQueryResults(QueryResults queryResults)
+    public void runToQueued(TestingPrestoServer server, String sql, String user)
+    {
+        URI uri = uriBuilderFrom(server.getBaseUrl().resolve("/v1/statement")).build();
+        QueryResults queryResults = postQuery(sql, uri, user);
+        while (!"QUEUED".equals(queryResults.getStats().getState())) {
+            queryResults = getQueryResults(queryResults, user);
+        }
+        getQueryResults(queryResults, user);
+    }
+
+    private QueryResults getQueryResults(QueryResults queryResults, String user)
     {
         Request request = prepareGet()
-                .setHeader(PRESTO_USER, "user")
+                .setHeader(PRESTO_USER, user)
                 .setUri(queryResults.getNextUri())
                 .build();
         queryResults = client.execute(request, createJsonResponseHandler(jsonCodec(QueryResults.class)));
@@ -108,6 +125,12 @@ public class ResourceManagerTestHelper
     {
         Request request = prepareGet().setUri(server.resolve(path)).build();
         return client.execute(request, createJsonResponseHandler(listJsonCodec(QueryStateInfo.class)));
+    }
+
+    public <T> T getEntity(TestingPrestoServer server, String path, JsonCodec<T> codec)
+    {
+        Request request = prepareGet().setUri(server.resolve(path)).build();
+        return client.execute(request, createJsonResponseHandler(codec));
     }
 
     public QueryStateInfo getQueryStateInfo(TestingPrestoServer server, String path)

--- a/presto-tests/src/test/java/com/facebook/presto/resourcemanager/TestDistributedResourceGroupInfoResource.java
+++ b/presto-tests/src/test/java/com/facebook/presto/resourcemanager/TestDistributedResourceGroupInfoResource.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.resourcemanager;
+
+import com.facebook.airlift.http.client.jetty.JettyHttpClient;
+import com.facebook.airlift.json.JsonCodec;
+import com.facebook.presto.resourceGroups.FileResourceGroupConfigurationManagerFactory;
+import com.facebook.presto.server.ResourceGroupInfo;
+import com.facebook.presto.server.testing.TestingPrestoServer;
+import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.facebook.airlift.testing.Closeables.closeQuietly;
+import static com.facebook.presto.tests.tpch.TpchQueryRunner.createQueryRunner;
+import static com.google.common.base.Preconditions.checkState;
+import static java.lang.Thread.sleep;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class TestDistributedResourceGroupInfoResource
+{
+    private ResourceManagerTestHelper rmTestHelper;
+    private TestingPrestoServer coordinator1;
+    private TestingPrestoServer coordinator2;
+    private TestingPrestoServer resourceManager;
+
+    @BeforeClass
+    public void setup()
+            throws Exception
+    {
+        rmTestHelper = new ResourceManagerTestHelper(new JettyHttpClient());
+        DistributedQueryRunner runner = createQueryRunner(ImmutableMap.of("query.client.timeout", "20s"), 2);
+        coordinator1 = runner.getCoordinators().get(0);
+        coordinator2 = runner.getCoordinators().get(1);
+        Optional<TestingPrestoServer> resourceManager = runner.getResourceManager();
+        checkState(resourceManager.isPresent(), "resource manager not present");
+        this.resourceManager = resourceManager.get();
+        coordinator1.getResourceGroupManager().get().addConfigurationManagerFactory(new FileResourceGroupConfigurationManagerFactory());
+        coordinator1.getResourceGroupManager().get()
+                .setConfigurationManager("file", ImmutableMap.of("resource-groups.config-file", rmTestHelper.getResourceFilePath("resource_groups_config_simple.json")));
+        coordinator2.getResourceGroupManager().get().addConfigurationManagerFactory(new FileResourceGroupConfigurationManagerFactory());
+        coordinator2.getResourceGroupManager().get()
+                .setConfigurationManager("file", ImmutableMap.of("resource-groups.config-file", rmTestHelper.getResourceFilePath("resource_groups_config_simple.json")));
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void teardown()
+    {
+        closeQuietly(coordinator1);
+        closeQuietly(coordinator2);
+        closeQuietly(resourceManager);
+        closeQuietly(rmTestHelper);
+        coordinator1 = null;
+        coordinator2 = null;
+        resourceManager = null;
+        rmTestHelper = null;
+    }
+
+    @Test(timeOut = 220_000)
+    public void testGetResourceGroupInfo()
+            throws Exception
+    {
+        rmTestHelper.runToCompletion(coordinator1, "SELECT 1", "user1");
+        rmTestHelper.runToCompletion(coordinator2, "SELECT 2", "user2");
+        rmTestHelper.runToFirstResult(coordinator1, "SELECT * from tpch.sf100.orders", " user3");
+        rmTestHelper.runToFirstResult(coordinator1, "SELECT * from tpch.sf101.orders", " user3");
+        rmTestHelper.runToFirstResult(coordinator1, "SELECT * from tpch.sf102.orders", " user3");
+        rmTestHelper.runToFirstResult(coordinator2, "SELECT * from tpch.sf100.orders", "user6");
+        rmTestHelper.runToQueued(coordinator1, "SELECT 3", "user3");
+        sleep(SECONDS.toMillis(5));
+        ResourceGroupInfo resourceGroupInfo = rmTestHelper.getEntity(coordinator1, "/v1/resourceGroupState/global", JsonCodec.jsonCodec(ResourceGroupInfo.class));
+        assertEquals(resourceGroupInfo.getNumRunningQueries(), 4);
+        assertEquals(resourceGroupInfo.getNumQueuedQueries(), 1);
+
+        Set<ResourceGroupId> subGroupResourceIdSet = resourceGroupInfo.getSubGroups().stream().map(a -> a.getId()).collect(Collectors.toSet());
+
+        assertEquals(subGroupResourceIdSet.size(), 2);
+        assertTrue(subGroupResourceIdSet.contains(new ResourceGroupId(resourceGroupInfo.getId(), "user-user3")));
+        assertTrue(subGroupResourceIdSet.contains(new ResourceGroupId(resourceGroupInfo.getId(), "user-user6")));
+    }
+}


### PR DESCRIPTION
Currently v1/resourceGroupState/* endpoint serves resource group info available within a particular coordinator. The change here is to enable these endpoints to retrieve cluster wide resource group info.

This PR depends on https://github.com/prestodb/presto/pull/16163

Test plan - unit tests

```
== NO RELEASE NOTE ==
```
