### PR TITLE
Revert "Support Dwrf Sequence Ids in Writer"

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
@@ -76,7 +76,6 @@ import static com.facebook.presto.orc.WriterStats.FlushReason.DICTIONARY_FULL;
 import static com.facebook.presto.orc.WriterStats.FlushReason.MAX_BYTES;
 import static com.facebook.presto.orc.WriterStats.FlushReason.MAX_ROWS;
 import static com.facebook.presto.orc.metadata.ColumnEncoding.ColumnEncodingKind.DIRECT;
-import static com.facebook.presto.orc.metadata.ColumnEncoding.DEFAULT_SEQUENCE_ID;
 import static com.facebook.presto.orc.metadata.DwrfMetadataWriter.toFileStatistics;
 import static com.facebook.presto.orc.metadata.DwrfMetadataWriter.toStripeEncryptionGroup;
 import static com.facebook.presto.orc.metadata.PostScript.MAGIC;
@@ -241,7 +240,6 @@ public class OrcWriter
             Type fieldType = types.get(fieldId);
             ColumnWriter columnWriter = createColumnWriter(
                     fieldColumnIndex,
-                    DEFAULT_SEQUENCE_ID,
                     orcTypes,
                     fieldType,
                     columnWriterOptions,

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfMetadataReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfMetadataReader.java
@@ -311,10 +311,10 @@ public class DwrfMetadataReader
     {
         return new Stream(
                 stream.getColumn(),
-                stream.getSequence(),
                 toStreamKind(stream.getKind()),
                 toIntExact(stream.getLength()),
                 stream.getUseVInts(),
+                stream.getSequence(),
                 stream.hasOffset() ? Optional.of(stream.getOffset()) : Optional.empty());
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfMetadataWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfMetadataWriter.java
@@ -252,7 +252,6 @@ public class DwrfMetadataWriter
     {
         DwrfProto.Stream.Builder streamBuilder = DwrfProto.Stream.newBuilder()
                 .setColumn(stream.getColumn())
-                .setSequence(stream.getSequence())
                 .setKind(toStreamKind(stream.getStreamKind()))
                 .setLength(stream.getLength())
                 .setUseVInts(stream.isUseVInts());

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcMetadataWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcMetadataWriter.java
@@ -35,7 +35,6 @@ import java.io.OutputStream;
 import java.util.List;
 import java.util.Map.Entry;
 
-import static com.facebook.presto.orc.metadata.ColumnEncoding.DEFAULT_SEQUENCE_ID;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.Math.toIntExact;
 import static java.util.stream.Collectors.toList;
@@ -284,10 +283,6 @@ public class OrcMetadataWriter
 
     private static OrcProto.Stream toStream(Stream stream)
     {
-        checkArgument(
-                stream.getSequence() == DEFAULT_SEQUENCE_ID,
-                "Writing streams with non-zero sequence IDs is not supported in ORC : {} ",
-                stream);
         return OrcProto.Stream.newBuilder()
                 .setColumn(stream.getColumn())
                 .setKind(toStreamKind(stream.getStreamKind()))
@@ -320,8 +315,7 @@ public class OrcMetadataWriter
     {
         checkArgument(
                 !columnEncodings.getAdditionalSequenceEncodings().isPresent(),
-                "Writing columns with non-zero sequence IDs is not supported in ORC: {}",
-                columnEncodings);
+                "Writing columns with non-zero sequence IDs is not supported in ORC: " + columnEncodings);
 
         return OrcProto.ColumnEncoding.newBuilder()
                 .setKind(toColumnEncoding(columnEncodings.getColumnEncodingKind()))

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/Stream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/Stream.java
@@ -15,7 +15,6 @@ package com.facebook.presto.orc.metadata;
 
 import java.util.Optional;
 
-import static com.facebook.presto.orc.metadata.ColumnEncoding.DEFAULT_SEQUENCE_ID;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
@@ -65,15 +64,10 @@ public class Stream
 
     public Stream(int column, StreamKind streamKind, int length, boolean useVInts)
     {
-        this(column, DEFAULT_SEQUENCE_ID, streamKind, length, useVInts, Optional.empty());
+        this(column, streamKind, length, useVInts, ColumnEncoding.DEFAULT_SEQUENCE_ID, Optional.empty());
     }
 
-    public Stream(int column, int sequence, StreamKind streamKind, int length, boolean useVInts)
-    {
-        this(column, sequence, streamKind, length, useVInts, Optional.empty());
-    }
-
-    public Stream(int column, int sequence, StreamKind streamKind, int length, boolean useVInts, Optional<Long> offset)
+    public Stream(int column, StreamKind streamKind, int length, boolean useVInts, int sequence, Optional<Long> offset)
     {
         this.column = column;
         this.streamKind = requireNonNull(streamKind, "streamKind is null");
@@ -130,10 +124,10 @@ public class Stream
     {
         return new Stream(
                 this.column,
-                this.sequence,
                 this.streamKind,
                 this.length,
                 this.useVInts,
+                this.sequence,
                 Optional.of(offset));
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/BooleanOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/BooleanOutputStream.java
@@ -157,10 +157,10 @@ public class BooleanOutputStream
     }
 
     @Override
-    public StreamDataOutput getStreamDataOutput(int column, int dwrfSequence)
+    public StreamDataOutput getStreamDataOutput(int column)
     {
         checkState(closed);
-        return byteOutputStream.getStreamDataOutput(column, dwrfSequence);
+        return byteOutputStream.getStreamDataOutput(column);
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/ByteArrayOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/ByteArrayOutputStream.java
@@ -89,9 +89,9 @@ public class ByteArrayOutputStream
     }
 
     @Override
-    public StreamDataOutput getStreamDataOutput(int column, int dwrfSequence)
+    public StreamDataOutput getStreamDataOutput(int column)
     {
-        return new StreamDataOutput(buffer::writeDataTo, new Stream(column, dwrfSequence, streamKind, toIntExact(buffer.getOutputDataSize()), false));
+        return new StreamDataOutput(buffer::writeDataTo, new Stream(column, streamKind, toIntExact(buffer.getOutputDataSize()), false));
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/ByteOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/ByteOutputStream.java
@@ -149,9 +149,9 @@ public class ByteOutputStream
     }
 
     @Override
-    public StreamDataOutput getStreamDataOutput(int column, int dwrfSequence)
+    public StreamDataOutput getStreamDataOutput(int column)
     {
-        return new StreamDataOutput(buffer::writeDataTo, new Stream(column, dwrfSequence, DATA, toIntExact(buffer.getOutputDataSize()), false));
+        return new StreamDataOutput(buffer::writeDataTo, new Stream(column, DATA, toIntExact(buffer.getOutputDataSize()), false));
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/DecimalOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/DecimalOutputStream.java
@@ -110,9 +110,9 @@ public class DecimalOutputStream
     }
 
     @Override
-    public StreamDataOutput getStreamDataOutput(int column, int dwrfSequence)
+    public StreamDataOutput getStreamDataOutput(int column)
     {
-        return new StreamDataOutput(buffer::writeDataTo, new Stream(column, dwrfSequence, DATA, toIntExact(buffer.getOutputDataSize()), true));
+        return new StreamDataOutput(buffer::writeDataTo, new Stream(column, DATA, toIntExact(buffer.getOutputDataSize()), true));
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/DoubleOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/DoubleOutputStream.java
@@ -71,9 +71,9 @@ public class DoubleOutputStream
     }
 
     @Override
-    public StreamDataOutput getStreamDataOutput(int column, int dwrfSequence)
+    public StreamDataOutput getStreamDataOutput(int column)
     {
-        return new StreamDataOutput(buffer::writeDataTo, new Stream(column, dwrfSequence, DATA, toIntExact(buffer.getOutputDataSize()), false));
+        return new StreamDataOutput(buffer::writeDataTo, new Stream(column, DATA, toIntExact(buffer.getOutputDataSize()), false));
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/FloatOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/FloatOutputStream.java
@@ -71,9 +71,9 @@ public class FloatOutputStream
     }
 
     @Override
-    public StreamDataOutput getStreamDataOutput(int column, int dwrfSequence)
+    public StreamDataOutput getStreamDataOutput(int column)
     {
-        return new StreamDataOutput(buffer::writeDataTo, new Stream(column, dwrfSequence, DATA, toIntExact(buffer.getOutputDataSize()), false));
+        return new StreamDataOutput(buffer::writeDataTo, new Stream(column, DATA, toIntExact(buffer.getOutputDataSize()), false));
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamDwrf.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamDwrf.java
@@ -80,9 +80,9 @@ public class LongOutputStreamDwrf
     }
 
     @Override
-    public StreamDataOutput getStreamDataOutput(int column, int dwrfSequence)
+    public StreamDataOutput getStreamDataOutput(int column)
     {
-        return new StreamDataOutput(buffer::writeDataTo, new Stream(column, dwrfSequence, streamKind, toIntExact(buffer.getOutputDataSize()), true));
+        return new StreamDataOutput(buffer::writeDataTo, new Stream(column, streamKind, toIntExact(buffer.getOutputDataSize()), true));
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamV1.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamV1.java
@@ -190,9 +190,9 @@ public class LongOutputStreamV1
     }
 
     @Override
-    public StreamDataOutput getStreamDataOutput(int column, int dwrfSequence)
+    public StreamDataOutput getStreamDataOutput(int column)
     {
-        return new StreamDataOutput(buffer::writeDataTo, new Stream(column, dwrfSequence, streamKind, toIntExact(buffer.getOutputDataSize()), true));
+        return new StreamDataOutput(buffer::writeDataTo, new Stream(column, streamKind, toIntExact(buffer.getOutputDataSize()), true));
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamV2.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamV2.java
@@ -748,9 +748,9 @@ public class LongOutputStreamV2
     }
 
     @Override
-    public StreamDataOutput getStreamDataOutput(int column, int dwrfSequence)
+    public StreamDataOutput getStreamDataOutput(int column)
     {
-        return new StreamDataOutput(buffer::writeDataTo, new Stream(column, dwrfSequence, streamKind, toIntExact(buffer.getOutputDataSize()), true));
+        return new StreamDataOutput(buffer::writeDataTo, new Stream(column, streamKind, toIntExact(buffer.getOutputDataSize()), true));
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/PresentOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/PresentOutputStream.java
@@ -102,15 +102,15 @@ public class PresentOutputStream
         return Optional.of(booleanOutputStream.getCheckpoints());
     }
 
-    public Optional<StreamDataOutput> getStreamDataOutput(int column, int dwrfSequence)
+    public Optional<StreamDataOutput> getStreamDataOutput(int column)
     {
         checkArgument(closed);
         if (booleanOutputStream == null) {
             return Optional.empty();
         }
-        StreamDataOutput streamDataOutput = booleanOutputStream.getStreamDataOutput(column, dwrfSequence);
+        StreamDataOutput streamDataOutput = booleanOutputStream.getStreamDataOutput(column);
         // rewrite the DATA stream created by the boolean output stream to a PRESENT stream
-        Stream stream = new Stream(column, dwrfSequence, PRESENT, toIntExact(streamDataOutput.size()), streamDataOutput.getStream().isUseVInts());
+        Stream stream = new Stream(column, PRESENT, toIntExact(streamDataOutput.size()), streamDataOutput.getStream().isUseVInts());
         return Optional.of(new StreamDataOutput(
                 sliceOutput -> {
                     streamDataOutput.writeData(sliceOutput);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/ValueOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/ValueOutputStream.java
@@ -25,7 +25,7 @@ public interface ValueOutputStream<C extends StreamCheckpoint>
 
     List<C> getCheckpoints();
 
-    StreamDataOutput getStreamDataOutput(int column, int dwrfSequence);
+    StreamDataOutput getStreamDataOutput(int column);
 
     /**
      * This method returns the size of the flushed data plus any unflushed data.

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/BooleanColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/BooleanColumnWriter.java
@@ -53,7 +53,6 @@ public class BooleanColumnWriter
     private static final ColumnEncoding COLUMN_ENCODING = new ColumnEncoding(DIRECT, 0);
 
     private final int column;
-    private final int dwrfSequence;
     private final Type type;
     private final boolean compressed;
     private final BooleanOutputStream dataStream;
@@ -69,19 +68,16 @@ public class BooleanColumnWriter
 
     public BooleanColumnWriter(
             int column,
-            int dwrfSequence,
             Type type,
             ColumnWriterOptions columnWriterOptions,
             Optional<DwrfDataEncryptor> dwrfEncryptor,
             MetadataWriter metadataWriter)
     {
         checkArgument(column >= 0, "column is negative");
-        checkArgument(dwrfSequence >= 0, "sequence is negative");
         requireNonNull(columnWriterOptions, "columnWriterOptions is null");
         requireNonNull(dwrfEncryptor, "dwrfEncryptor is null");
         requireNonNull(metadataWriter, "metadataWriter is null");
         this.column = column;
-        this.dwrfSequence = dwrfSequence;
         this.type = requireNonNull(type, "type is null");
         this.compressed = columnWriterOptions.getCompressionKind() != NONE;
         this.dataStream = new BooleanOutputStream(columnWriterOptions, dwrfEncryptor);
@@ -169,7 +165,7 @@ public class BooleanColumnWriter
         }
 
         Slice slice = metadataWriter.writeRowIndexes(rowGroupIndexes.build());
-        Stream stream = new Stream(column, dwrfSequence, StreamKind.ROW_INDEX, slice.length(), false);
+        Stream stream = new Stream(column, StreamKind.ROW_INDEX, slice.length(), false);
         return ImmutableList.of(new StreamDataOutput(slice, stream));
     }
 
@@ -190,8 +186,8 @@ public class BooleanColumnWriter
         checkState(closed);
 
         ImmutableList.Builder<StreamDataOutput> outputDataStreams = ImmutableList.builder();
-        presentStream.getStreamDataOutput(column, dwrfSequence).ifPresent(outputDataStreams::add);
-        outputDataStreams.add(dataStream.getStreamDataOutput(column, dwrfSequence));
+        presentStream.getStreamDataOutput(column).ifPresent(outputDataStreams::add);
+        outputDataStreams.add(dataStream.getStreamDataOutput(column));
         return outputDataStreams.build();
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/ByteColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/ByteColumnWriter.java
@@ -53,7 +53,6 @@ public class ByteColumnWriter
     private static final ColumnEncoding COLUMN_ENCODING = new ColumnEncoding(DIRECT, 0);
 
     private final int column;
-    private final int dwrfSequence;
     private final Type type;
     private final boolean compressed;
     private final ByteOutputStream dataStream;
@@ -67,15 +66,13 @@ public class ByteColumnWriter
 
     private boolean closed;
 
-    public ByteColumnWriter(int column, int dwrfSequence, Type type, ColumnWriterOptions columnWriterOptions, Optional<DwrfDataEncryptor> dwrfEncryptor, MetadataWriter metadataWriter)
+    public ByteColumnWriter(int column, Type type, ColumnWriterOptions columnWriterOptions, Optional<DwrfDataEncryptor> dwrfEncryptor, MetadataWriter metadataWriter)
     {
         checkArgument(column >= 0, "column is negative");
-        checkArgument(dwrfSequence >= 0, "sequence is negative");
         requireNonNull(columnWriterOptions, "columnWriterOptions is null");
         requireNonNull(dwrfEncryptor, "dwrfEncryptor is null");
         requireNonNull(metadataWriter, "metadataWriter is null");
         this.column = column;
-        this.dwrfSequence = dwrfSequence;
         this.type = requireNonNull(type, "type is null");
         this.compressed = columnWriterOptions.getCompressionKind() != NONE;
         this.dataStream = new ByteOutputStream(columnWriterOptions, dwrfEncryptor);
@@ -162,7 +159,7 @@ public class ByteColumnWriter
         }
 
         Slice slice = metadataWriter.writeRowIndexes(rowGroupIndexes.build());
-        Stream stream = new Stream(column, dwrfSequence, StreamKind.ROW_INDEX, slice.length(), false);
+        Stream stream = new Stream(column, StreamKind.ROW_INDEX, slice.length(), false);
         return ImmutableList.of(new StreamDataOutput(slice, stream));
     }
 
@@ -183,8 +180,8 @@ public class ByteColumnWriter
         checkState(closed);
 
         ImmutableList.Builder<StreamDataOutput> outputDataStreams = ImmutableList.builder();
-        presentStream.getStreamDataOutput(column, dwrfSequence).ifPresent(outputDataStreams::add);
-        outputDataStreams.add(dataStream.getStreamDataOutput(column, dwrfSequence));
+        presentStream.getStreamDataOutput(column).ifPresent(outputDataStreams::add);
+        outputDataStreams.add(dataStream.getStreamDataOutput(column));
         return outputDataStreams.build();
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/ColumnWriters.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/ColumnWriters.java
@@ -39,7 +39,6 @@ public final class ColumnWriters
 
     public static ColumnWriter createColumnWriter(
             int columnIndex,
-            int dwrfSequence,
             List<OrcType> orcTypes,
             Type type,
             ColumnWriterOptions columnWriterOptions,
@@ -53,54 +52,53 @@ public final class ColumnWriters
         Optional<DwrfDataEncryptor> dwrfEncryptor = dwrfEncryptors.getEncryptorByNodeId(columnIndex);
         switch (orcType.getOrcTypeKind()) {
             case BOOLEAN:
-                return new BooleanColumnWriter(columnIndex, dwrfSequence, type, columnWriterOptions, dwrfEncryptor, metadataWriter);
+                return new BooleanColumnWriter(columnIndex, type, columnWriterOptions, dwrfEncryptor, metadataWriter);
 
             case FLOAT:
-                return new FloatColumnWriter(columnIndex, dwrfSequence, type, columnWriterOptions, dwrfEncryptor, metadataWriter);
+                return new FloatColumnWriter(columnIndex, type, columnWriterOptions, dwrfEncryptor, metadataWriter);
 
             case DOUBLE:
-                return new DoubleColumnWriter(columnIndex, dwrfSequence, type, columnWriterOptions, dwrfEncryptor, metadataWriter);
+                return new DoubleColumnWriter(columnIndex, type, columnWriterOptions, dwrfEncryptor, metadataWriter);
 
             case BYTE:
-                return new ByteColumnWriter(columnIndex, dwrfSequence, type, columnWriterOptions, dwrfEncryptor, metadataWriter);
+                return new ByteColumnWriter(columnIndex, type, columnWriterOptions, dwrfEncryptor, metadataWriter);
 
             case DATE:
                 checkArgument(orcEncoding != DWRF, "DWRF does not support %s type", type);
-                return new LongColumnWriter(columnIndex, dwrfSequence, type, columnWriterOptions, dwrfEncryptor, orcEncoding, DateStatisticsBuilder::new, metadataWriter);
+                return new LongColumnWriter(columnIndex, type, columnWriterOptions, dwrfEncryptor, orcEncoding, DateStatisticsBuilder::new, metadataWriter);
 
             case SHORT:
-                return new LongColumnWriter(columnIndex, dwrfSequence, type, columnWriterOptions, dwrfEncryptor, orcEncoding, IntegerStatisticsBuilder::new, metadataWriter);
+                return new LongColumnWriter(columnIndex, type, columnWriterOptions, dwrfEncryptor, orcEncoding, IntegerStatisticsBuilder::new, metadataWriter);
             case INT:
             case LONG:
                 if (columnWriterOptions.isIntegerDictionaryEncodingEnabled() && orcEncoding == DWRF) {
                     // ORC V1 does not support Integer Dictionary encoding. DWRF supports Integer dictionary encoding.
-                    return new LongDictionaryColumnWriter(columnIndex, dwrfSequence, type, columnWriterOptions, dwrfEncryptor, orcEncoding, metadataWriter);
+                    return new LongDictionaryColumnWriter(columnIndex, type, columnWriterOptions, dwrfEncryptor, orcEncoding, metadataWriter);
                 }
-                return new LongColumnWriter(columnIndex, dwrfSequence, type, columnWriterOptions, dwrfEncryptor, orcEncoding, IntegerStatisticsBuilder::new, metadataWriter);
+                return new LongColumnWriter(columnIndex, type, columnWriterOptions, dwrfEncryptor, orcEncoding, IntegerStatisticsBuilder::new, metadataWriter);
 
             case DECIMAL:
                 checkArgument(orcEncoding != DWRF, "DWRF does not support %s type", type);
-                return new DecimalColumnWriter(columnIndex, dwrfSequence, type, columnWriterOptions, orcEncoding, metadataWriter);
+                return new DecimalColumnWriter(columnIndex, type, columnWriterOptions, orcEncoding, metadataWriter);
 
             case TIMESTAMP:
-                return new TimestampColumnWriter(columnIndex, dwrfSequence, type, columnWriterOptions, dwrfEncryptor, orcEncoding, hiveStorageTimeZone, metadataWriter);
+                return new TimestampColumnWriter(columnIndex, type, columnWriterOptions, dwrfEncryptor, orcEncoding, hiveStorageTimeZone, metadataWriter);
 
             case BINARY:
-                return new SliceDirectColumnWriter(columnIndex, dwrfSequence, type, columnWriterOptions, dwrfEncryptor, orcEncoding, BinaryStatisticsBuilder::new, metadataWriter);
+                return new SliceDirectColumnWriter(columnIndex, type, columnWriterOptions, dwrfEncryptor, orcEncoding, BinaryStatisticsBuilder::new, metadataWriter);
 
             case CHAR:
                 checkArgument(orcEncoding != DWRF, "DWRF does not support %s type", type);
                 // fall through
             case VARCHAR:
             case STRING:
-                return new SliceDictionaryColumnWriter(columnIndex, dwrfSequence, type, columnWriterOptions, dwrfEncryptor, orcEncoding, metadataWriter);
+                return new SliceDictionaryColumnWriter(columnIndex, type, columnWriterOptions, dwrfEncryptor, orcEncoding, metadataWriter);
 
             case LIST: {
                 int fieldColumnIndex = orcType.getFieldTypeIndex(0);
                 Type fieldType = type.getTypeParameters().get(0);
                 ColumnWriter elementWriter = createColumnWriter(
                         fieldColumnIndex,
-                        dwrfSequence,
                         orcTypes,
                         fieldType,
                         columnWriterOptions,
@@ -108,12 +106,12 @@ public final class ColumnWriters
                         hiveStorageTimeZone,
                         dwrfEncryptors,
                         metadataWriter);
-                return new ListColumnWriter(columnIndex, dwrfSequence, columnWriterOptions, dwrfEncryptor, orcEncoding, elementWriter, metadataWriter);
+                return new ListColumnWriter(columnIndex, columnWriterOptions, dwrfEncryptor, orcEncoding, elementWriter, metadataWriter);
             }
+
             case MAP: {
                 ColumnWriter keyWriter = createColumnWriter(
                         orcType.getFieldTypeIndex(0),
-                        dwrfSequence,
                         orcTypes,
                         type.getTypeParameters().get(0),
                         columnWriterOptions,
@@ -123,7 +121,6 @@ public final class ColumnWriters
                         metadataWriter);
                 ColumnWriter valueWriter = createColumnWriter(
                         orcType.getFieldTypeIndex(1),
-                        dwrfSequence,
                         orcTypes,
                         type.getTypeParameters().get(1),
                         columnWriterOptions,
@@ -131,8 +128,9 @@ public final class ColumnWriters
                         hiveStorageTimeZone,
                         dwrfEncryptors,
                         metadataWriter);
-                return new MapColumnWriter(columnIndex, dwrfSequence, columnWriterOptions, dwrfEncryptor, orcEncoding, keyWriter, valueWriter, metadataWriter);
+                return new MapColumnWriter(columnIndex, columnWriterOptions, dwrfEncryptor, orcEncoding, keyWriter, valueWriter, metadataWriter);
             }
+
             case STRUCT: {
                 ImmutableList.Builder<ColumnWriter> fieldWriters = ImmutableList.builder();
                 for (int fieldId = 0; fieldId < orcType.getFieldCount(); fieldId++) {
@@ -140,7 +138,6 @@ public final class ColumnWriters
                     Type fieldType = type.getTypeParameters().get(fieldId);
                     fieldWriters.add(createColumnWriter(
                             fieldColumnIndex,
-                            dwrfSequence,
                             orcTypes,
                             fieldType,
                             columnWriterOptions,
@@ -149,7 +146,7 @@ public final class ColumnWriters
                             dwrfEncryptors,
                             metadataWriter));
                 }
-                return new StructColumnWriter(columnIndex, dwrfSequence, columnWriterOptions, dwrfEncryptor, fieldWriters.build(), metadataWriter);
+                return new StructColumnWriter(columnIndex, columnWriterOptions, dwrfEncryptor, fieldWriters.build(), metadataWriter);
             }
         }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/DecimalColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/DecimalColumnWriter.java
@@ -61,7 +61,6 @@ public class DecimalColumnWriter
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(DecimalColumnWriter.class).instanceSize();
     private final int column;
-    private final int dwrfSequence;
     private final DecimalType type;
     private final ColumnEncoding columnEncoding;
     private final boolean compressed;
@@ -78,15 +77,13 @@ public class DecimalColumnWriter
 
     private boolean closed;
 
-    public DecimalColumnWriter(int column, int dwrfSequence, Type type, ColumnWriterOptions columnWriterOptions, OrcEncoding orcEncoding, MetadataWriter metadataWriter)
+    public DecimalColumnWriter(int column, Type type, ColumnWriterOptions columnWriterOptions, OrcEncoding orcEncoding, MetadataWriter metadataWriter)
     {
         checkArgument(column >= 0, "column is negative");
-        checkArgument(dwrfSequence >= 0, "sequence is negative");
         requireNonNull(columnWriterOptions, "columnWriterOptions is null");
         checkArgument(orcEncoding != DWRF, "DWRF does not support %s type", type);
         requireNonNull(metadataWriter, "metadataWriter is null");
         this.column = column;
-        this.dwrfSequence = dwrfSequence;
         this.type = (DecimalType) requireNonNull(type, "type is null");
         this.compressed = columnWriterOptions.getCompressionKind() != NONE;
         this.columnEncoding = new ColumnEncoding(DIRECT_V2, 0);
@@ -211,7 +208,7 @@ public class DecimalColumnWriter
         }
 
         Slice slice = metadataWriter.writeRowIndexes(rowGroupIndexes.build());
-        Stream stream = new Stream(column, dwrfSequence, StreamKind.ROW_INDEX, slice.length(), false);
+        Stream stream = new Stream(column, StreamKind.ROW_INDEX, slice.length(), false);
         return ImmutableList.of(new StreamDataOutput(slice, stream));
     }
 
@@ -234,9 +231,9 @@ public class DecimalColumnWriter
         checkState(closed);
 
         ImmutableList.Builder<StreamDataOutput> outputDataStreams = ImmutableList.builder();
-        presentStream.getStreamDataOutput(column, dwrfSequence).ifPresent(outputDataStreams::add);
-        outputDataStreams.add(dataStream.getStreamDataOutput(column, dwrfSequence));
-        outputDataStreams.add(scaleStream.getStreamDataOutput(column, dwrfSequence));
+        presentStream.getStreamDataOutput(column).ifPresent(outputDataStreams::add);
+        outputDataStreams.add(dataStream.getStreamDataOutput(column));
+        outputDataStreams.add(scaleStream.getStreamDataOutput(column));
         return outputDataStreams.build();
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/DictionaryColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/DictionaryColumnWriter.java
@@ -63,7 +63,6 @@ public abstract class DictionaryColumnWriter
         implements ColumnWriter, DictionaryColumn
 {
     protected final int column;
-    protected final int dwrfSequence;
     protected final Type type;
     protected final ColumnWriterOptions columnWriterOptions;
     protected final Optional<DwrfDataEncryptor> dwrfEncryptor;
@@ -87,7 +86,6 @@ public abstract class DictionaryColumnWriter
 
     public DictionaryColumnWriter(
             int column,
-            int dwrfSequence,
             Type type,
             ColumnWriterOptions columnWriterOptions,
             Optional<DwrfDataEncryptor> dwrfEncryptor,
@@ -95,9 +93,7 @@ public abstract class DictionaryColumnWriter
             MetadataWriter metadataWriter)
     {
         checkArgument(column >= 0, "column is negative");
-        checkArgument(dwrfSequence >= 0, "sequence is negative");
         this.column = column;
-        this.dwrfSequence = dwrfSequence;
         this.type = requireNonNull(type, "type is null");
         this.columnWriterOptions = requireNonNull(columnWriterOptions, "columnWriterOptions is null");
         this.dwrfEncryptor = requireNonNull(dwrfEncryptor, "dwrfEncryptor is null");
@@ -369,7 +365,7 @@ public abstract class DictionaryColumnWriter
         }
 
         Slice slice = compressedMetadataWriter.writeRowIndexes(rowGroupIndexes.build());
-        Stream stream = new Stream(column, dwrfSequence, StreamKind.ROW_INDEX, slice.length(), false);
+        Stream stream = new Stream(column, StreamKind.ROW_INDEX, slice.length(), false);
         return ImmutableList.of(new StreamDataOutput(slice, stream));
     }
 
@@ -394,8 +390,8 @@ public abstract class DictionaryColumnWriter
 
         // actually write data
         ImmutableList.Builder<StreamDataOutput> outputDataStreams = ImmutableList.builder();
-        presentStream.getStreamDataOutput(column, dwrfSequence).ifPresent(outputDataStreams::add);
-        outputDataStreams.add(dataStream.getStreamDataOutput(column, dwrfSequence));
+        presentStream.getStreamDataOutput(column).ifPresent(outputDataStreams::add);
+        outputDataStreams.add(dataStream.getStreamDataOutput(column));
         outputDataStreams.addAll(getDictionaryStreams(column));
         return outputDataStreams.build();
     }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/DoubleColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/DoubleColumnWriter.java
@@ -54,7 +54,6 @@ public class DoubleColumnWriter
     private static final ColumnEncoding COLUMN_ENCODING = new ColumnEncoding(DIRECT, 0);
 
     private final int column;
-    private final int dwrfSequence;
     private final Type type;
     private final boolean compressed;
     private final DoubleOutputStream dataStream;
@@ -68,15 +67,13 @@ public class DoubleColumnWriter
 
     private boolean closed;
 
-    public DoubleColumnWriter(int column, int dwrfSequence, Type type, ColumnWriterOptions columnWriterOptions, Optional<DwrfDataEncryptor> dwrfEncryptor, MetadataWriter metadataWriter)
+    public DoubleColumnWriter(int column, Type type, ColumnWriterOptions columnWriterOptions, Optional<DwrfDataEncryptor> dwrfEncryptor, MetadataWriter metadataWriter)
     {
         checkArgument(column >= 0, "column is negative");
-        checkArgument(dwrfSequence >= 0, "sequence is negative");
         requireNonNull(columnWriterOptions, "columnWriterOptions is null");
         requireNonNull(dwrfEncryptor, "dwrfEncryptor is null");
         requireNonNull(metadataWriter, "metadataWriter is null");
         this.column = column;
-        this.dwrfSequence = dwrfSequence;
         this.type = requireNonNull(type, "type is null");
         this.compressed = columnWriterOptions.getCompressionKind() != NONE;
         this.dataStream = new DoubleOutputStream(columnWriterOptions, dwrfEncryptor);
@@ -164,7 +161,7 @@ public class DoubleColumnWriter
         }
 
         Slice slice = metadataWriter.writeRowIndexes(rowGroupIndexes.build());
-        Stream stream = new Stream(column, dwrfSequence, StreamKind.ROW_INDEX, slice.length(), false);
+        Stream stream = new Stream(column, StreamKind.ROW_INDEX, slice.length(), false);
         return ImmutableList.of(new StreamDataOutput(slice, stream));
     }
 
@@ -185,8 +182,8 @@ public class DoubleColumnWriter
         checkState(closed);
 
         ImmutableList.Builder<StreamDataOutput> outputDataStreams = ImmutableList.builder();
-        presentStream.getStreamDataOutput(column, dwrfSequence).ifPresent(outputDataStreams::add);
-        outputDataStreams.add(dataStream.getStreamDataOutput(column, dwrfSequence));
+        presentStream.getStreamDataOutput(column).ifPresent(outputDataStreams::add);
+        outputDataStreams.add(dataStream.getStreamDataOutput(column));
         return outputDataStreams.build();
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/FloatColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/FloatColumnWriter.java
@@ -55,7 +55,6 @@ public class FloatColumnWriter
     private static final ColumnEncoding COLUMN_ENCODING = new ColumnEncoding(DIRECT, 0);
 
     private final int column;
-    private final int dwrfSequence;
     private final Type type;
     private final boolean compressed;
     private final FloatOutputStream dataStream;
@@ -69,15 +68,13 @@ public class FloatColumnWriter
 
     private boolean closed;
 
-    public FloatColumnWriter(int column, int dwrfSequence, Type type, ColumnWriterOptions columnWriterOptions, Optional<DwrfDataEncryptor> dwrfEncryptor, MetadataWriter metadataWriter)
+    public FloatColumnWriter(int column, Type type, ColumnWriterOptions columnWriterOptions, Optional<DwrfDataEncryptor> dwrfEncryptor, MetadataWriter metadataWriter)
     {
         checkArgument(column >= 0, "column is negative");
-        checkArgument(dwrfSequence >= 0, "sequence is negative");
         requireNonNull(columnWriterOptions, "columnWriterOptions is null");
         requireNonNull(dwrfEncryptor, "dwrfEncryptor is null");
         requireNonNull(metadataWriter, "metadataWriter is null");
         this.column = column;
-        this.dwrfSequence = dwrfSequence;
         this.type = requireNonNull(type, "type is null");
         this.compressed = columnWriterOptions.getCompressionKind() != NONE;
         this.dataStream = new FloatOutputStream(columnWriterOptions, dwrfEncryptor);
@@ -166,7 +163,7 @@ public class FloatColumnWriter
         }
 
         Slice slice = metadataWriter.writeRowIndexes(rowGroupIndexes.build());
-        Stream stream = new Stream(column, dwrfSequence, StreamKind.ROW_INDEX, slice.length(), false);
+        Stream stream = new Stream(column, StreamKind.ROW_INDEX, slice.length(), false);
         return ImmutableList.of(new StreamDataOutput(slice, stream));
     }
 
@@ -187,8 +184,8 @@ public class FloatColumnWriter
         checkState(closed);
 
         ImmutableList.Builder<StreamDataOutput> outputDataStreams = ImmutableList.builder();
-        presentStream.getStreamDataOutput(column, dwrfSequence).ifPresent(outputDataStreams::add);
-        outputDataStreams.add(dataStream.getStreamDataOutput(column, dwrfSequence));
+        presentStream.getStreamDataOutput(column).ifPresent(outputDataStreams::add);
+        outputDataStreams.add(dataStream.getStreamDataOutput(column));
         return outputDataStreams.build();
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/ListColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/ListColumnWriter.java
@@ -56,7 +56,6 @@ public class ListColumnWriter
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(ListColumnWriter.class).instanceSize();
     private final int column;
-    private final int dwrfSequence;
     private final boolean compressed;
     private final ColumnEncoding columnEncoding;
     private final LongOutputStream lengthStream;
@@ -71,13 +70,11 @@ public class ListColumnWriter
 
     private boolean closed;
 
-    public ListColumnWriter(int column, int dwrfSequence, ColumnWriterOptions columnWriterOptions, Optional<DwrfDataEncryptor> dwrfEncryptor, OrcEncoding orcEncoding, ColumnWriter elementWriter, MetadataWriter metadataWriter)
+    public ListColumnWriter(int column, ColumnWriterOptions columnWriterOptions, Optional<DwrfDataEncryptor> dwrfEncryptor, OrcEncoding orcEncoding, ColumnWriter elementWriter, MetadataWriter metadataWriter)
     {
         checkArgument(column >= 0, "column is negative");
-        checkArgument(dwrfSequence >= 0, "sequence is negative");
         requireNonNull(columnWriterOptions, "columnWriterOptions is null");
         this.column = column;
-        this.dwrfSequence = dwrfSequence;
         this.compressed = columnWriterOptions.getCompressionKind() != NONE;
         this.columnEncoding = new ColumnEncoding(orcEncoding == DWRF ? DIRECT : DIRECT_V2, 0);
         this.elementWriter = requireNonNull(elementWriter, "elementWriter is null");
@@ -197,7 +194,7 @@ public class ListColumnWriter
         }
 
         Slice slice = metadataWriter.writeRowIndexes(rowGroupIndexes.build());
-        Stream stream = new Stream(column, dwrfSequence, StreamKind.ROW_INDEX, slice.length(), false);
+        Stream stream = new Stream(column, StreamKind.ROW_INDEX, slice.length(), false);
 
         ImmutableList.Builder<StreamDataOutput> indexStreams = ImmutableList.builder();
         indexStreams.add(new StreamDataOutput(slice, stream));
@@ -222,8 +219,8 @@ public class ListColumnWriter
         checkState(closed);
 
         ImmutableList.Builder<StreamDataOutput> outputDataStreams = ImmutableList.builder();
-        presentStream.getStreamDataOutput(column, dwrfSequence).ifPresent(outputDataStreams::add);
-        outputDataStreams.add(lengthStream.getStreamDataOutput(column, dwrfSequence));
+        presentStream.getStreamDataOutput(column).ifPresent(outputDataStreams::add);
+        outputDataStreams.add(lengthStream.getStreamDataOutput(column));
         outputDataStreams.addAll(elementWriter.getDataStreams());
         return outputDataStreams.build();
     }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/LongColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/LongColumnWriter.java
@@ -59,7 +59,6 @@ public class LongColumnWriter
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(LongColumnWriter.class).instanceSize();
     private final int column;
-    private final int dwrfSequence;
     private final Type type;
     private final boolean compressed;
     private final ColumnEncoding columnEncoding;
@@ -77,7 +76,6 @@ public class LongColumnWriter
 
     public LongColumnWriter(
             int column,
-            int dwrfSequence,
             Type type,
             ColumnWriterOptions columnWriterOptions,
             Optional<DwrfDataEncryptor> dwrfEncryptor,
@@ -86,12 +84,10 @@ public class LongColumnWriter
             MetadataWriter metadataWriter)
     {
         checkArgument(column >= 0, "column is negative");
-        checkArgument(dwrfSequence >= 0, "sequence is negative");
         requireNonNull(columnWriterOptions, "columnWriterOptions is null");
         requireNonNull(dwrfEncryptor, "dwrfEncryptor is null");
         requireNonNull(metadataWriter, "metadataWriter is null");
         this.column = column;
-        this.dwrfSequence = dwrfSequence;
         this.type = requireNonNull(type, "type is null");
         this.compressed = columnWriterOptions.getCompressionKind() != NONE;
         if (orcEncoding == DWRF) {
@@ -188,7 +184,7 @@ public class LongColumnWriter
         }
 
         Slice slice = metadataWriter.writeRowIndexes(rowGroupIndexes.build());
-        Stream stream = new Stream(column, dwrfSequence, StreamKind.ROW_INDEX, slice.length(), false);
+        Stream stream = new Stream(column, StreamKind.ROW_INDEX, slice.length(), false);
         return ImmutableList.of(new StreamDataOutput(slice, stream));
     }
 
@@ -209,8 +205,8 @@ public class LongColumnWriter
         checkState(closed);
 
         ImmutableList.Builder<StreamDataOutput> outputDataStreams = ImmutableList.builder();
-        presentStream.getStreamDataOutput(column, dwrfSequence).ifPresent(outputDataStreams::add);
-        outputDataStreams.add(dataStream.getStreamDataOutput(column, dwrfSequence));
+        presentStream.getStreamDataOutput(column).ifPresent(outputDataStreams::add);
+        outputDataStreams.add(dataStream.getStreamDataOutput(column));
         return outputDataStreams.build();
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/LongDictionaryColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/LongDictionaryColumnWriter.java
@@ -62,14 +62,13 @@ public class LongDictionaryColumnWriter
 
     public LongDictionaryColumnWriter(
             int column,
-            int dwrfSequence,
             Type type,
             ColumnWriterOptions columnWriterOptions,
             Optional<DwrfDataEncryptor> dwrfEncryptor,
             OrcEncoding orcEncoding,
             MetadataWriter metadataWriter)
     {
-        super(column, dwrfSequence, type, columnWriterOptions, dwrfEncryptor, orcEncoding, metadataWriter);
+        super(column, type, columnWriterOptions, dwrfEncryptor, orcEncoding, metadataWriter);
         checkArgument(orcEncoding == DWRF, "Long dictionary encoding is only supported in DWRF");
         checkArgument(type instanceof FixedWidthType, "Not a fixed width type");
         this.dictionaryDataStream = new LongOutputStreamDwrf(columnWriterOptions, dwrfEncryptor, true, DICTIONARY_DATA);
@@ -94,7 +93,7 @@ public class LongDictionaryColumnWriter
     protected ColumnWriter createDirectColumnWriter()
     {
         if (directColumnWriter == null) {
-            directColumnWriter = new LongColumnWriter(column, dwrfSequence, type, columnWriterOptions, dwrfEncryptor, orcEncoding, IntegerStatisticsBuilder::new, metadataWriter);
+            directColumnWriter = new LongColumnWriter(column, type, columnWriterOptions, dwrfEncryptor, orcEncoding, IntegerStatisticsBuilder::new, metadataWriter);
         }
         return directColumnWriter;
     }
@@ -204,7 +203,7 @@ public class LongDictionaryColumnWriter
     @Override
     protected List<StreamDataOutput> getDictionaryStreams(int column)
     {
-        return ImmutableList.of(dictionaryDataStream.getStreamDataOutput(column, dwrfSequence));
+        return ImmutableList.of(dictionaryDataStream.getStreamDataOutput(column));
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/MapColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/MapColumnWriter.java
@@ -56,7 +56,6 @@ public class MapColumnWriter
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(MapColumnWriter.class).instanceSize();
     private final int column;
-    private final int dwrfSequence;
     private final boolean compressed;
     private final ColumnEncoding columnEncoding;
     private final LongOutputStream lengthStream;
@@ -72,13 +71,11 @@ public class MapColumnWriter
 
     private boolean closed;
 
-    public MapColumnWriter(int column, int dwrfSequence, ColumnWriterOptions columnWriterOptions, Optional<DwrfDataEncryptor> dwrfEncryptor, OrcEncoding orcEncoding, ColumnWriter keyWriter, ColumnWriter valueWriter, MetadataWriter metadataWriter)
+    public MapColumnWriter(int column, ColumnWriterOptions columnWriterOptions, Optional<DwrfDataEncryptor> dwrfEncryptor, OrcEncoding orcEncoding, ColumnWriter keyWriter, ColumnWriter valueWriter, MetadataWriter metadataWriter)
     {
         checkArgument(column >= 0, "column is negative");
-        checkArgument(dwrfSequence >= 0, "sequence is negative");
         requireNonNull(columnWriterOptions, "columnWriterOptions is null");
         this.column = column;
-        this.dwrfSequence = dwrfSequence;
         this.compressed = columnWriterOptions.getCompressionKind() != NONE;
         this.columnEncoding = new ColumnEncoding(orcEncoding == DWRF ? DIRECT : DIRECT_V2, 0);
         this.keyWriter = requireNonNull(keyWriter, "keyWriter is null");
@@ -207,7 +204,7 @@ public class MapColumnWriter
         }
 
         Slice slice = metadataWriter.writeRowIndexes(rowGroupIndexes.build());
-        Stream stream = new Stream(column, dwrfSequence, StreamKind.ROW_INDEX, slice.length(), false);
+        Stream stream = new Stream(column, StreamKind.ROW_INDEX, slice.length(), false);
 
         ImmutableList.Builder<StreamDataOutput> indexStreams = ImmutableList.builder();
         indexStreams.add(new StreamDataOutput(slice, stream));
@@ -233,8 +230,8 @@ public class MapColumnWriter
         checkState(closed);
 
         ImmutableList.Builder<StreamDataOutput> outputDataStreams = ImmutableList.builder();
-        presentStream.getStreamDataOutput(column, dwrfSequence).ifPresent(outputDataStreams::add);
-        outputDataStreams.add(lengthStream.getStreamDataOutput(column, dwrfSequence));
+        presentStream.getStreamDataOutput(column).ifPresent(outputDataStreams::add);
+        outputDataStreams.add(lengthStream.getStreamDataOutput(column));
         outputDataStreams.addAll(keyWriter.getDataStreams());
         outputDataStreams.addAll(valueWriter.getDataStreams());
         return outputDataStreams.build();

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/SliceDictionaryColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/SliceDictionaryColumnWriter.java
@@ -62,14 +62,13 @@ public class SliceDictionaryColumnWriter
 
     public SliceDictionaryColumnWriter(
             int column,
-            int dwrfSequence,
             Type type,
             ColumnWriterOptions columnWriterOptions,
             Optional<DwrfDataEncryptor> dwrfEncryptor,
             OrcEncoding orcEncoding,
             MetadataWriter metadataWriter)
     {
-        super(column, dwrfSequence, type, columnWriterOptions, dwrfEncryptor, orcEncoding, metadataWriter);
+        super(column, type, columnWriterOptions, dwrfEncryptor, orcEncoding, metadataWriter);
         this.dictionaryDataStream = new ByteArrayOutputStream(columnWriterOptions, dwrfEncryptor, Stream.StreamKind.DICTIONARY_DATA);
         this.dictionaryLengthStream = createLengthOutputStream(columnWriterOptions, dwrfEncryptor, orcEncoding);
         this.stringStatisticsLimitInBytes = toIntExact(columnWriterOptions.getStringStatisticsLimit().toBytes());
@@ -254,7 +253,7 @@ public class SliceDictionaryColumnWriter
     protected ColumnWriter createDirectColumnWriter()
     {
         if (directColumnWriter == null) {
-            directColumnWriter = new SliceDirectColumnWriter(column, dwrfSequence, type, columnWriterOptions, dwrfEncryptor, orcEncoding, this::newStringStatisticsBuilder, metadataWriter);
+            directColumnWriter = new SliceDirectColumnWriter(column, type, columnWriterOptions, dwrfEncryptor, orcEncoding, this::newStringStatisticsBuilder, metadataWriter);
         }
         return directColumnWriter;
     }
@@ -269,6 +268,6 @@ public class SliceDictionaryColumnWriter
     @Override
     protected List<StreamDataOutput> getDictionaryStreams(int column)
     {
-        return ImmutableList.of(dictionaryLengthStream.getStreamDataOutput(column, dwrfSequence), dictionaryDataStream.getStreamDataOutput(column, dwrfSequence));
+        return ImmutableList.of(dictionaryLengthStream.getStreamDataOutput(column), dictionaryDataStream.getStreamDataOutput(column));
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/SliceDirectColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/SliceDirectColumnWriter.java
@@ -59,7 +59,6 @@ public class SliceDirectColumnWriter
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(SliceDirectColumnWriter.class).instanceSize();
     private final int column;
-    private final int dwrfSequence;
     private final Type type;
     private final boolean compressed;
     private final ColumnEncoding columnEncoding;
@@ -78,7 +77,6 @@ public class SliceDirectColumnWriter
 
     public SliceDirectColumnWriter(
             int column,
-            int dwrfSequence,
             Type type,
             ColumnWriterOptions columnWriterOptions,
             Optional<DwrfDataEncryptor> dwrfEncryptor,
@@ -87,12 +85,10 @@ public class SliceDirectColumnWriter
             MetadataWriter metadataWriter)
     {
         checkArgument(column >= 0, "column is negative");
-        checkArgument(dwrfSequence >= 0, "sequence is negative");
         requireNonNull(columnWriterOptions, "columnWriterOptions is null");
         requireNonNull(dwrfEncryptor, "dwrfEncryptor is null");
         requireNonNull(metadataWriter, "metadataWriter is null");
         this.column = column;
-        this.dwrfSequence = dwrfSequence;
         this.type = requireNonNull(type, "type is null");
         this.compressed = columnWriterOptions.getCompressionKind() != NONE;
         this.columnEncoding = new ColumnEncoding(orcEncoding == DWRF ? DIRECT : DIRECT_V2, 0);
@@ -208,7 +204,7 @@ public class SliceDirectColumnWriter
         }
 
         Slice slice = metadataWriter.writeRowIndexes(rowGroupIndexes.build());
-        Stream stream = new Stream(column, dwrfSequence, StreamKind.ROW_INDEX, slice.length(), false);
+        Stream stream = new Stream(column, StreamKind.ROW_INDEX, slice.length(), false);
         return ImmutableList.of(new StreamDataOutput(slice, stream));
     }
 
@@ -231,9 +227,9 @@ public class SliceDirectColumnWriter
         checkState(closed);
 
         ImmutableList.Builder<StreamDataOutput> outputDataStreams = ImmutableList.builder();
-        presentStream.getStreamDataOutput(column, dwrfSequence).ifPresent(outputDataStreams::add);
-        outputDataStreams.add(lengthStream.getStreamDataOutput(column, dwrfSequence));
-        outputDataStreams.add(dataStream.getStreamDataOutput(column, dwrfSequence));
+        presentStream.getStreamDataOutput(column).ifPresent(outputDataStreams::add);
+        outputDataStreams.add(lengthStream.getStreamDataOutput(column));
+        outputDataStreams.add(dataStream.getStreamDataOutput(column));
         return outputDataStreams.build();
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/StructColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/StructColumnWriter.java
@@ -52,7 +52,6 @@ public class StructColumnWriter
     private static final ColumnEncoding COLUMN_ENCODING = new ColumnEncoding(DIRECT, 0);
 
     private final int column;
-    private final int dwrfSequence;
     private final boolean compressed;
     private final PresentOutputStream presentStream;
     private final CompressedMetadataWriter metadataWriter;
@@ -65,13 +64,11 @@ public class StructColumnWriter
 
     private boolean closed;
 
-    public StructColumnWriter(int column, int dwrfSequence, ColumnWriterOptions columnWriterOptions, Optional<DwrfDataEncryptor> dwrfEncryptor, List<ColumnWriter> structFields, MetadataWriter metadataWriter)
+    public StructColumnWriter(int column, ColumnWriterOptions columnWriterOptions, Optional<DwrfDataEncryptor> dwrfEncryptor, List<ColumnWriter> structFields, MetadataWriter metadataWriter)
     {
         checkArgument(column >= 0, "column is negative");
-        checkArgument(dwrfSequence >= 0, "sequence is negative");
         requireNonNull(columnWriterOptions, "columnWriterOptions is null");
         this.column = column;
-        this.dwrfSequence = dwrfSequence;
         this.compressed = columnWriterOptions.getCompressionKind() != NONE;
         this.structFields = ImmutableList.copyOf(requireNonNull(structFields, "structFields is null"));
         this.presentStream = new PresentOutputStream(columnWriterOptions, dwrfEncryptor);
@@ -195,7 +192,7 @@ public class StructColumnWriter
         }
 
         Slice slice = metadataWriter.writeRowIndexes(rowGroupIndexes.build());
-        Stream stream = new Stream(column, dwrfSequence, StreamKind.ROW_INDEX, slice.length(), false);
+        Stream stream = new Stream(column, StreamKind.ROW_INDEX, slice.length(), false);
 
         ImmutableList.Builder<StreamDataOutput> indexStreams = ImmutableList.builder();
         indexStreams.add(new StreamDataOutput(slice, stream));
@@ -220,7 +217,7 @@ public class StructColumnWriter
         checkState(closed);
 
         ImmutableList.Builder<StreamDataOutput> outputDataStreams = ImmutableList.builder();
-        presentStream.getStreamDataOutput(column, dwrfSequence).ifPresent(outputDataStreams::add);
+        presentStream.getStreamDataOutput(column).ifPresent(outputDataStreams::add);
         for (ColumnWriter structField : structFields) {
             outputDataStreams.addAll(structField.getDataStreams());
         }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/TimestampColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/TimestampColumnWriter.java
@@ -63,7 +63,6 @@ public class TimestampColumnWriter
     private static final int MILLIS_TO_NANOS_TRAILING_ZEROS = 5;
 
     private final int column;
-    private final int dwrfSequence;
     private final Type type;
     private final boolean compressed;
     private final ColumnEncoding columnEncoding;
@@ -81,15 +80,13 @@ public class TimestampColumnWriter
 
     private boolean closed;
 
-    public TimestampColumnWriter(int column, int dwrfSequence, Type type, ColumnWriterOptions columnWriterOptions, Optional<DwrfDataEncryptor> dwrfEncryptor, OrcEncoding orcEncoding, DateTimeZone hiveStorageTimeZone, MetadataWriter metadataWriter)
+    public TimestampColumnWriter(int column, Type type, ColumnWriterOptions columnWriterOptions, Optional<DwrfDataEncryptor> dwrfEncryptor, OrcEncoding orcEncoding, DateTimeZone hiveStorageTimeZone, MetadataWriter metadataWriter)
     {
         checkArgument(column >= 0, "column is negative");
-        checkArgument(dwrfSequence >= 0, "sequence is negative");
         requireNonNull(columnWriterOptions, "compression is null");
         requireNonNull(dwrfEncryptor, "dwrfEncryptor is null");
         requireNonNull(metadataWriter, "metadataWriter is null");
         this.column = column;
-        this.dwrfSequence = dwrfSequence;
         this.type = requireNonNull(type, "type is null");
         this.compressed = columnWriterOptions.getCompressionKind() != NONE;
         if (orcEncoding == DWRF) {
@@ -218,7 +215,7 @@ public class TimestampColumnWriter
         }
 
         Slice slice = metadataWriter.writeRowIndexes(rowGroupIndexes.build());
-        Stream stream = new Stream(column, dwrfSequence, StreamKind.ROW_INDEX, slice.length(), false);
+        Stream stream = new Stream(column, StreamKind.ROW_INDEX, slice.length(), false);
         return ImmutableList.of(new StreamDataOutput(slice, stream));
     }
 
@@ -241,10 +238,9 @@ public class TimestampColumnWriter
         checkState(closed);
 
         ImmutableList.Builder<StreamDataOutput> outputDataStreams = ImmutableList.builder();
-        presentStream.getStreamDataOutput(column, dwrfSequence).ifPresent(outputDataStreams::add);
-        outputDataStreams.add(secondsStream.getStreamDataOutput(column, dwrfSequence));
-        outputDataStreams.add(nanosStream.getStreamDataOutput(column, dwrfSequence));
-
+        presentStream.getStreamDataOutput(column).ifPresent(outputDataStreams::add);
+        outputDataStreams.add(secondsStream.getStreamDataOutput(column));
+        outputDataStreams.add(nanosStream.getStreamDataOutput(column));
         return outputDataStreams.build();
     }
 

--- a/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkDictionaryWriter.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkDictionaryWriter.java
@@ -54,7 +54,6 @@ import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.orc.OrcEncoding.DWRF;
 import static com.facebook.presto.orc.OrcWriterOptions.DEFAULT_MAX_STRING_STATISTICS_LIMIT;
-import static com.facebook.presto.orc.metadata.ColumnEncoding.DEFAULT_SEQUENCE_ID;
 import static com.google.common.base.Preconditions.checkState;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
@@ -98,10 +97,10 @@ public class BenchmarkDictionaryWriter
         ColumnWriter columnWriter;
         Type type = data.getType();
         if (type.equals(VARCHAR)) {
-            columnWriter = new SliceDirectColumnWriter(COLUMN_INDEX, DEFAULT_SEQUENCE_ID, type, columnWriterOptions, Optional.empty(), DWRF, this::newStringStatisticsBuilder, DWRF.createMetadataWriter());
+            columnWriter = new SliceDirectColumnWriter(COLUMN_INDEX, type, columnWriterOptions, Optional.empty(), DWRF, this::newStringStatisticsBuilder, DWRF.createMetadataWriter());
         }
         else {
-            columnWriter = new LongColumnWriter(COLUMN_INDEX, DEFAULT_SEQUENCE_ID, type, columnWriterOptions, Optional.empty(), DWRF, IntegerStatisticsBuilder::new, DWRF.createMetadataWriter());
+            columnWriter = new LongColumnWriter(COLUMN_INDEX, type, columnWriterOptions, Optional.empty(), DWRF, IntegerStatisticsBuilder::new, DWRF.createMetadataWriter());
         }
         for (Block block : data.getBlocks()) {
             columnWriter.beginRowGroup();
@@ -146,10 +145,10 @@ public class BenchmarkDictionaryWriter
         DictionaryColumnWriter columnWriter;
         Type type = data.getType();
         if (type.equals(VARCHAR)) {
-            columnWriter = new SliceDictionaryColumnWriter(COLUMN_INDEX, DEFAULT_SEQUENCE_ID, type, columnWriterOptions, Optional.empty(), DWRF, DWRF.createMetadataWriter());
+            columnWriter = new SliceDictionaryColumnWriter(COLUMN_INDEX, type, columnWriterOptions, Optional.empty(), DWRF, DWRF.createMetadataWriter());
         }
         else {
-            columnWriter = new LongDictionaryColumnWriter(COLUMN_INDEX, DEFAULT_SEQUENCE_ID, type, columnWriterOptions, Optional.empty(), DWRF, DWRF.createMetadataWriter());
+            columnWriter = new LongDictionaryColumnWriter(COLUMN_INDEX, type, columnWriterOptions, Optional.empty(), DWRF, DWRF.createMetadataWriter());
         }
         return columnWriter;
     }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestDecryption.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestDecryption.java
@@ -209,22 +209,22 @@ public class TestDecryption
     public void testGetDiskRanges()
     {
         List<Stream> unencryptedStreams = ImmutableList.of(
-                new Stream(3, DEFAULT_SEQUENCE_ID, ROW_INDEX, 5, true, Optional.of(15L)),
-                new Stream(4, DEFAULT_SEQUENCE_ID, ROW_INDEX, 5, true),
-                new Stream(3, DEFAULT_SEQUENCE_ID, DATA, 5, true, Optional.of(45L)),
-                new Stream(4, DEFAULT_SEQUENCE_ID, DATA, 5, true));
+                new Stream(3, ROW_INDEX, 5, true, DEFAULT_SEQUENCE_ID, Optional.of(15L)),
+                new Stream(4, ROW_INDEX, 5, true),
+                new Stream(3, DATA, 5, true, DEFAULT_SEQUENCE_ID, Optional.of(45L)),
+                new Stream(4, DATA, 5, true));
 
         List<Stream> group1Streams = ImmutableList.of(
-                new Stream(0, DEFAULT_SEQUENCE_ID, ROW_INDEX, 5, true),
-                new Stream(5, DEFAULT_SEQUENCE_ID, ROW_INDEX, 5, true, Optional.of(25L)),
-                new Stream(0, DEFAULT_SEQUENCE_ID, DATA, 5, true, Optional.of(30L)),
-                new Stream(5, DEFAULT_SEQUENCE_ID, DATA, 5, true, Optional.of(55L)));
+                new Stream(0, ROW_INDEX, 5, true),
+                new Stream(5, ROW_INDEX, 5, true, DEFAULT_SEQUENCE_ID, Optional.of(25L)),
+                new Stream(0, DATA, 5, true, DEFAULT_SEQUENCE_ID, Optional.of(30L)),
+                new Stream(5, DATA, 5, true, DEFAULT_SEQUENCE_ID, Optional.of(55L)));
 
         List<Stream> group2Streams = ImmutableList.of(
-                new Stream(1, DEFAULT_SEQUENCE_ID, ROW_INDEX, 5, true, Optional.of(5L)),
-                new Stream(2, DEFAULT_SEQUENCE_ID, ROW_INDEX, 5, true),
-                new Stream(1, DEFAULT_SEQUENCE_ID, DATA, 5, true, Optional.of(35L)),
-                new Stream(2, DEFAULT_SEQUENCE_ID, DATA, 5, true));
+                new Stream(1, ROW_INDEX, 5, true, DEFAULT_SEQUENCE_ID, Optional.of(5L)),
+                new Stream(2, ROW_INDEX, 5, true),
+                new Stream(1, DATA, 5, true, DEFAULT_SEQUENCE_ID, Optional.of(35L)),
+                new Stream(2, DATA, 5, true));
 
         Map<StreamId, DiskRange> actual = getDiskRanges(ImmutableList.of(unencryptedStreams, group1Streams, group2Streams));
 

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestDictionaryColumnWriter.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestDictionaryColumnWriter.java
@@ -52,7 +52,6 @@ import static com.facebook.presto.orc.metadata.ColumnEncoding.ColumnEncodingKind
 import static com.facebook.presto.orc.metadata.ColumnEncoding.ColumnEncodingKind.DIRECT;
 import static com.facebook.presto.orc.metadata.ColumnEncoding.ColumnEncodingKind.DIRECT_V2;
 import static com.facebook.presto.orc.metadata.ColumnEncoding.ColumnEncodingKind.DWRF_DIRECT;
-import static com.facebook.presto.orc.metadata.ColumnEncoding.DEFAULT_SEQUENCE_ID;
 import static com.facebook.presto.orc.metadata.CompressionKind.ZSTD;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.Iterables.cycle;
@@ -91,7 +90,6 @@ public class TestDictionaryColumnWriter
         ColumnWriterOptions columnWriterOptions = ColumnWriterOptions.builder().setCompressionKind(CompressionKind.NONE).build();
         DictionaryColumnWriter writer = new SliceDictionaryColumnWriter(
                 0,
-                DEFAULT_SEQUENCE_ID,
                 VARCHAR,
                 columnWriterOptions,
                 Optional.empty(),

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestStreamLayout.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestStreamLayout.java
@@ -26,7 +26,6 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
-import static com.facebook.presto.orc.metadata.ColumnEncoding.DEFAULT_SEQUENCE_ID;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 
@@ -34,7 +33,7 @@ public class TestStreamLayout
 {
     private static StreamDataOutput createStream(int column, StreamKind streamKind, int length)
     {
-        Stream stream = new Stream(column, DEFAULT_SEQUENCE_ID, streamKind, length, true);
+        Stream stream = new Stream(column, streamKind, length, true);
         return new StreamDataOutput(Slices.allocate(1024), stream);
     }
 

--- a/presto-orc/src/test/java/com/facebook/presto/orc/stream/AbstractTestValueStream.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/stream/AbstractTestValueStream.java
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.facebook.presto.orc.OrcDecompressor.createOrcDecompressor;
-import static com.facebook.presto.orc.metadata.ColumnEncoding.DEFAULT_SEQUENCE_ID;
 import static com.facebook.presto.orc.metadata.CompressionKind.SNAPPY;
 import static io.airlift.units.DataSize.Unit.KILOBYTE;
 import static java.lang.Math.toIntExact;
@@ -58,7 +57,7 @@ public abstract class AbstractTestValueStream<T, C extends StreamCheckpoint, W e
             outputStream.close();
 
             DynamicSliceOutput sliceOutput = new DynamicSliceOutput(1000);
-            StreamDataOutput streamDataOutput = outputStream.getStreamDataOutput(33, DEFAULT_SEQUENCE_ID);
+            StreamDataOutput streamDataOutput = outputStream.getStreamDataOutput(33);
             streamDataOutput.writeData(sliceOutput);
             Stream stream = streamDataOutput.getStream();
             assertEquals(stream.getStreamKind(), StreamKind.DATA);

--- a/presto-orc/src/test/java/com/facebook/presto/orc/stream/TestBooleanStream.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/stream/TestBooleanStream.java
@@ -30,7 +30,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import static com.facebook.presto.orc.metadata.ColumnEncoding.DEFAULT_SEQUENCE_ID;
 import static org.testng.Assert.assertEquals;
 
 public class TestBooleanStream
@@ -182,7 +181,7 @@ public class TestBooleanStream
             throws OrcCorruptionException
     {
         DynamicSliceOutput sliceOutput = new DynamicSliceOutput(1000);
-        StreamDataOutput streamDataOutput = outputStream.getStreamDataOutput(33, DEFAULT_SEQUENCE_ID);
+        StreamDataOutput streamDataOutput = outputStream.getStreamDataOutput(33);
         streamDataOutput.writeData(sliceOutput);
         Stream stream = streamDataOutput.getStream();
         assertEquals(stream.getStreamKind(), StreamKind.DATA);


### PR DESCRIPTION
This reverts commit f6611cbc0ae3dee90e6f5476a2c2aa027999b200.

Test plan - (Please fill in how you tested your changes)

Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines. Don't forget to follow our [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution) for any code copied from other projects.

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== RELEASE NOTES ==

General Changes
* ...
* ...

Hive Changes
* ...
* ...
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```
