### PR TITLE
Support multi coordinator while serving resource group info

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/resourcemanager/AggregatedResourceGroupInfoBuilder.java
+++ b/presto-main/src/main/java/com/facebook/presto/resourcemanager/AggregatedResourceGroupInfoBuilder.java
@@ -1,0 +1,132 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.resourcemanager;
+
+import com.facebook.presto.server.QueryStateInfo;
+import com.facebook.presto.server.ResourceGroupInfo;
+import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
+import com.facebook.presto.spi.resourceGroups.ResourceGroupState;
+import com.facebook.presto.spi.resourceGroups.SchedulingPolicy;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.units.DataSize;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.facebook.presto.spi.resourceGroups.ResourceGroupState.CAN_QUEUE;
+import static com.facebook.presto.spi.resourceGroups.ResourceGroupState.CAN_RUN;
+import static com.facebook.presto.spi.resourceGroups.ResourceGroupState.FULL;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.lang.Math.addExact;
+import static java.util.Objects.requireNonNull;
+
+public class AggregatedResourceGroupInfoBuilder
+{
+    private ResourceGroupId id;
+    private SchedulingPolicy schedulingPolicy;
+    private int schedulingWeight;
+    private Map<ResourceGroupId, AggregatedResourceGroupInfoBuilder> subGroupsMap;
+    private ImmutableList.Builder<QueryStateInfo> runningQueriesBuilder;
+    private static final Map<ResourceGroupState, Integer> resourceGroupStatePreference
+            = ImmutableMap.of(FULL, 1, CAN_QUEUE, 2, CAN_RUN, 3);
+    private ResourceGroupState state;
+    private DataSize softMemoryLimit;
+    private int softConcurrencyLimit;
+    private int hardConcurrencyLimit;
+    private int maxQueuedQueries;
+    private long memoryUsageBytes;
+    private int numQueuedQueries;
+
+    private void init(ResourceGroupInfo resourceGroupInfo)
+    {
+        this.id = requireNonNull(resourceGroupInfo.getId(), "id is null");
+        this.state = requireNonNull(resourceGroupInfo.getState(), "state is null");
+        this.schedulingPolicy = resourceGroupInfo.getSchedulingPolicy();
+        this.schedulingWeight = resourceGroupInfo.getSchedulingWeight();
+        this.softMemoryLimit = resourceGroupInfo.getSoftMemoryLimit();
+        this.softConcurrencyLimit = resourceGroupInfo.getSoftConcurrencyLimit();
+        this.hardConcurrencyLimit = resourceGroupInfo.getHardConcurrencyLimit();
+        this.maxQueuedQueries = resourceGroupInfo.getMaxQueuedQueries();
+        this.memoryUsageBytes = resourceGroupInfo.getMemoryUsage().toBytes();
+        this.numQueuedQueries = resourceGroupInfo.getNumQueuedQueries();
+        this.subGroupsMap = new HashMap<>();
+        this.runningQueriesBuilder = ImmutableList.builder();
+        addRunningQueries(resourceGroupInfo.getRunningQueries());
+        addSubgroups(resourceGroupInfo.getSubGroups());
+    }
+
+    public AggregatedResourceGroupInfoBuilder add(ResourceGroupInfo resourceGroupInfo)
+    {
+        if (this.id == null) {
+            init(resourceGroupInfo);
+            return this;
+        }
+        checkState(resourceGroupInfo != null && this.id.equals(resourceGroupInfo.getId()));
+        this.numQueuedQueries = addExact(this.numQueuedQueries, resourceGroupInfo.getNumQueuedQueries());
+        if (resourceGroupStatePreference.get(resourceGroupInfo.getState()) < resourceGroupStatePreference.get(this.state)) {
+            this.state = resourceGroupInfo.getState();
+        }
+        this.memoryUsageBytes = addExact(this.memoryUsageBytes, resourceGroupInfo.getMemoryUsage().toBytes());
+        List<ResourceGroupInfo> subGroups = resourceGroupInfo.getSubGroups();
+        addSubgroups(subGroups);
+
+        List<QueryStateInfo> runningQueries = resourceGroupInfo.getRunningQueries();
+        addRunningQueries(runningQueries);
+        return this;
+    }
+
+    private void addSubgroups(List<ResourceGroupInfo> subGroups)
+    {
+        if (subGroups == null) {
+            return;
+        }
+        for (ResourceGroupInfo subgroup : subGroups) {
+            subGroupsMap.computeIfAbsent(subgroup.getId(), k -> new AggregatedResourceGroupInfoBuilder()).add(subgroup);
+        }
+    }
+
+    private void addRunningQueries(List<QueryStateInfo> runningQueries)
+    {
+        if (runningQueries == null) {
+            return;
+        }
+        this.runningQueriesBuilder.addAll(runningQueries);
+    }
+
+    public ResourceGroupInfo build()
+    {
+        if (this.id == null) {
+            return null;
+        }
+        ImmutableList<QueryStateInfo> runningQueries = runningQueriesBuilder.build();
+        return new ResourceGroupInfo(
+                id,
+                state,
+                schedulingPolicy,
+                schedulingWeight,
+                softMemoryLimit,
+                softConcurrencyLimit,
+                hardConcurrencyLimit,
+                maxQueuedQueries,
+                DataSize.succinctBytes(memoryUsageBytes),
+                numQueuedQueries,
+                runningQueries.size(),
+                0,
+                subGroupsMap.values().stream().map(AggregatedResourceGroupInfoBuilder::build).collect(toImmutableList()),
+                runningQueries);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/resourcemanager/DistributedResourceGroupInfoResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/resourcemanager/DistributedResourceGroupInfoResource.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.resourcemanager;
+
+import com.facebook.airlift.http.client.HttpClient;
+import com.facebook.airlift.http.client.Request;
+import com.facebook.airlift.http.client.UnexpectedResponseException;
+import com.facebook.airlift.json.JsonCodec;
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.metadata.InternalNode;
+import com.facebook.presto.metadata.InternalNodeManager;
+import com.facebook.presto.server.ResourceGroupInfo;
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+
+import javax.annotation.security.RolesAllowed;
+import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.Encoded;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.container.AsyncResponse;
+import javax.ws.rs.container.Suspended;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import static com.facebook.airlift.http.client.JsonResponseHandler.createJsonResponseHandler;
+import static com.facebook.airlift.http.client.Request.Builder.prepareGet;
+import static com.facebook.presto.server.security.RoleType.ADMIN;
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.google.common.net.HttpHeaders.X_FORWARDED_PROTO;
+import static java.util.Objects.requireNonNull;
+import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+
+@Path("/v1/resourceGroupState")
+@RolesAllowed(ADMIN)
+public class DistributedResourceGroupInfoResource
+{
+    private static final Logger log = Logger.get(DistributedResourceGroupInfoResource.class);
+    private final InternalNodeManager internalNodeManager;
+    private final ListeningExecutorService executor;
+    private final HttpClient httpClient;
+    private final JsonCodec<ResourceGroupInfo> jsonCodec;
+
+    @Inject
+    public DistributedResourceGroupInfoResource(InternalNodeManager internalNodeManager,
+            @ForResourceManager ListeningExecutorService executor, @ForResourceManager HttpClient httpClient, JsonCodec<ResourceGroupInfo> jsonCodec)
+    {
+        this.internalNodeManager = requireNonNull(internalNodeManager, "internalNodeManager is null");
+        this.executor = requireNonNull(executor, "executor is null");
+        this.httpClient = requireNonNull(httpClient, "httpClient is null");
+        this.jsonCodec = requireNonNull(jsonCodec, "jsonCodec is null");
+    }
+
+    @GET
+    @Produces(MediaType.APPLICATION_JSON)
+    @Encoded
+    @Path("{resourceGroupId: .+}")
+    public void getResourceGroupInfos(
+            @PathParam("resourceGroupId") String resourceGroupIdString,
+            @HeaderParam(X_FORWARDED_PROTO) String xForwardedProto,
+            @Context UriInfo uriInfo,
+            @Context HttpServletRequest servletRequest,
+            @Suspended AsyncResponse asyncResponse)
+    {
+        if (isNullOrEmpty(resourceGroupIdString)) {
+            asyncResponse.resume(Response.status(NOT_FOUND).build());
+        }
+        try {
+            ImmutableList.Builder<ListenableFuture<ResourceGroupInfo>> resourceGroupInfoFutureBuilder = ImmutableList.builder();
+            for (InternalNode coordinator : internalNodeManager.getCoordinators()) {
+                resourceGroupInfoFutureBuilder.add(getResourceGroupInfoFromCoordinator(xForwardedProto, uriInfo, coordinator));
+            }
+            List<ListenableFuture<ResourceGroupInfo>> resourceGroupInfoFutureList = resourceGroupInfoFutureBuilder.build();
+            Futures.whenAllComplete(resourceGroupInfoFutureList).call(() -> {
+                try {
+                    ResourceGroupInfo aggregatedResourceGroupInfo = aggregateResourceGroupInfo(resourceGroupInfoFutureList);
+                    if (aggregatedResourceGroupInfo == null) {
+                        return asyncResponse.resume(Response.status(NOT_FOUND).build());
+                    }
+                    return asyncResponse.resume(Response.ok(aggregatedResourceGroupInfo).build());
+                }
+                catch (Exception ex) {
+                    log.error(ex, "Error in getting resource group info from one of the coordinators");
+                    return asyncResponse.resume(Response.serverError().entity(ex.getMessage()).build());
+                }
+            }, executor);
+        }
+        catch (IOException ex) {
+            log.error(ex, "Error in getting resource group info");
+            asyncResponse.resume(Response.serverError().entity(ex.getMessage()).build());
+        }
+    }
+
+    private ResourceGroupInfo aggregateResourceGroupInfo(List<ListenableFuture<ResourceGroupInfo>> queryStateInfoFutureList)
+            throws InterruptedException, ExecutionException
+
+    {
+        Iterator<ListenableFuture<ResourceGroupInfo>> iterator = queryStateInfoFutureList.iterator();
+        AggregatedResourceGroupInfoBuilder builder = new AggregatedResourceGroupInfoBuilder();
+        while (iterator.hasNext()) {
+            try {
+                builder.add(iterator.next().get());
+            }
+            catch (ExecutionException e) {
+                Throwable exceptionCause = e.getCause();
+                //airlift JsonResponseHandler throws UnexpectedResponseException for cases where http status code != 2xx
+                if (!(exceptionCause instanceof UnexpectedResponseException) ||
+                        ((UnexpectedResponseException) exceptionCause).getStatusCode() != NOT_FOUND.getStatusCode()) {
+                    throw e;
+                }
+            }
+        }
+        return builder.build();
+    }
+
+    private ListenableFuture<ResourceGroupInfo> getResourceGroupInfoFromCoordinator(String xForwardedProto, UriInfo uriInfo,
+            InternalNode coordinatorNode)
+            throws IOException
+    {
+        String scheme = isNullOrEmpty(xForwardedProto) ? uriInfo.getRequestUri().getScheme() : xForwardedProto;
+        URI uri = uriInfo.getRequestUriBuilder()
+                .queryParam("includeLocalInfoOnly", true)
+                .scheme(scheme)
+                .host(coordinatorNode.getHostAndPort().toInetAddress().getHostName())
+                .port(coordinatorNode.getInternalUri().getPort())
+                .build();
+        Request request = prepareGet().setUri(uri).build();
+        return httpClient.executeAsync(request, createJsonResponseHandler(jsonCodec));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/ResourceGroupInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ResourceGroupInfo.java
@@ -171,6 +171,12 @@ public class ResourceGroupInfo
         return numRunningQueries;
     }
 
+    /**
+     * @deprecated This field is not very useful to expose as part of resource endpoint.
+     * In case of multi coordinator set up, it requires adding additional complexity and
+     * overhead to existing system to expose this field  with accurate value.
+     */
+    @Deprecated
     @JsonProperty
     public int getNumEligibleSubGroups()
     {

--- a/presto-main/src/main/java/com/facebook/presto/server/ResourceGroupStateInfoResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ResourceGroupStateInfoResource.java
@@ -14,70 +14,105 @@
 package com.facebook.presto.server;
 
 import com.facebook.presto.execution.resourceGroups.ResourceGroupManager;
+import com.facebook.presto.metadata.InternalNode;
+import com.facebook.presto.metadata.InternalNodeManager;
+import com.facebook.presto.resourcemanager.ResourceManagerProxy;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
 
 import javax.annotation.security.RolesAllowed;
 import javax.inject.Inject;
+import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.Encoded;
 import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.container.AsyncResponse;
+import javax.ws.rs.container.Suspended;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
 
 import java.io.UnsupportedEncodingException;
+import java.net.URI;
 import java.net.URLDecoder;
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 
 import static com.facebook.presto.server.security.RoleType.ADMIN;
+import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.net.HttpHeaders.X_FORWARDED_PROTO;
 import static java.util.Objects.requireNonNull;
 import static javax.ws.rs.core.Response.Status.BAD_REQUEST;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
+import static javax.ws.rs.core.Response.Status.SERVICE_UNAVAILABLE;
 
 @Path("/v1/resourceGroupState")
 @RolesAllowed(ADMIN)
 public class ResourceGroupStateInfoResource
 {
     private final ResourceGroupManager<?> resourceGroupManager;
+    private final boolean resourceManagerEnabled;
+    private final InternalNodeManager internalNodeManager;
+    private final Optional<ResourceManagerProxy> proxyHelper;
 
     @Inject
-    public ResourceGroupStateInfoResource(ResourceGroupManager<?> resourceGroupManager)
+    public ResourceGroupStateInfoResource(
+            ServerConfig serverConfig,
+            ResourceGroupManager<?> resourceGroupManager,
+            InternalNodeManager internalNodeManager,
+            Optional<ResourceManagerProxy> proxyHelper)
     {
+        this.resourceManagerEnabled = requireNonNull(serverConfig, "serverConfig is null").isResourceManagerEnabled();
         this.resourceGroupManager = requireNonNull(resourceGroupManager, "resourceGroupManager is null");
+        this.internalNodeManager = requireNonNull(internalNodeManager, "internalNodeManager is null");
+        this.proxyHelper = requireNonNull(proxyHelper, "proxyHelper is null");
     }
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Encoded
     @Path("{resourceGroupId: .+}")
-    public ResourceGroupInfo getQueryStateInfos(
+    public void getResourceGroupInfos(
             @PathParam("resourceGroupId") String resourceGroupIdString,
             @QueryParam("includeQueryInfo") @DefaultValue("true") boolean includeQueryInfo,
+            @QueryParam("includeLocalInfoOnly") @DefaultValue("false") boolean includeLocalInfoOnly,
             @QueryParam("summarizeSubgroups") @DefaultValue("true") boolean summarizeSubgroups,
-            @QueryParam("includeStaticSubgroupsOnly") @DefaultValue("false") boolean includeStaticSubgroupsOnly)
+            @QueryParam("includeStaticSubgroupsOnly") @DefaultValue("false") boolean includeStaticSubgroupsOnly,
+            @HeaderParam(X_FORWARDED_PROTO) String xForwardedProto,
+            @Context UriInfo uriInfo,
+            @Context HttpServletRequest servletRequest,
+            @Suspended AsyncResponse asyncResponse)
     {
+        if (resourceManagerEnabled && !includeLocalInfoOnly) {
+            proxyResourceGroupInfoResponse(servletRequest, asyncResponse, xForwardedProto, uriInfo);
+            return;
+        }
         if (!isNullOrEmpty(resourceGroupIdString)) {
             try {
-                return resourceGroupManager.getResourceGroupInfo(
+                asyncResponse.resume(Response.ok().entity(resourceGroupManager.getResourceGroupInfo(
                         new ResourceGroupId(
                                 Arrays.stream(resourceGroupIdString.split("/"))
                                         .map(ResourceGroupStateInfoResource::urlDecode)
                                         .collect(toImmutableList())),
                         includeQueryInfo,
                         summarizeSubgroups,
-                        includeStaticSubgroupsOnly);
+                        includeStaticSubgroupsOnly)).build());
             }
-            catch (NoSuchElementException e) {
-                throw new WebApplicationException(NOT_FOUND);
+            catch (NoSuchElementException | IllegalArgumentException e) {
+                asyncResponse.resume(Response.status(NOT_FOUND).build());
             }
         }
-        throw new WebApplicationException(NOT_FOUND);
+        asyncResponse.resume(Response.status(NOT_FOUND).build());
     }
 
     private static String urlDecode(String value)
@@ -87,6 +122,31 @@ public class ResourceGroupStateInfoResource
         }
         catch (UnsupportedEncodingException e) {
             throw new WebApplicationException(BAD_REQUEST);
+        }
+    }
+
+    //TODO move this to a common place and reuse in all resource
+    private void proxyResourceGroupInfoResponse(HttpServletRequest servletRequest, AsyncResponse asyncResponse, String xForwardedProto, UriInfo uriInfo)
+    {
+        try {
+            checkState(proxyHelper.isPresent());
+            Iterator<InternalNode> resourceManagers = internalNodeManager.getResourceManagers().iterator();
+            if (!resourceManagers.hasNext()) {
+                asyncResponse.resume(Response.status(SERVICE_UNAVAILABLE).build());
+                return;
+            }
+            InternalNode resourceManagerNode = resourceManagers.next();
+            String scheme = isNullOrEmpty(xForwardedProto) ? uriInfo.getRequestUri().getScheme() : xForwardedProto;
+
+            URI uri = uriInfo.getRequestUriBuilder()
+                    .scheme(scheme)
+                    .host(resourceManagerNode.getHostAndPort().toInetAddress().getHostName())
+                    .port(resourceManagerNode.getInternalUri().getPort())
+                    .build();
+            proxyHelper.get().performRequest(servletRequest, asyncResponse, uri);
+        }
+        catch (Exception e) {
+            asyncResponse.resume(e);
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/ResourceManagerModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ResourceManagerModule.java
@@ -26,6 +26,7 @@ import com.facebook.presto.failureDetector.FailureDetectorModule;
 import com.facebook.presto.resourcemanager.DistributedClusterStatsResource;
 import com.facebook.presto.resourcemanager.DistributedQueryInfoResource;
 import com.facebook.presto.resourcemanager.DistributedQueryResource;
+import com.facebook.presto.resourcemanager.DistributedResourceGroupInfoResource;
 import com.facebook.presto.resourcemanager.ForResourceManager;
 import com.facebook.presto.resourcemanager.ResourceManagerClusterStateProvider;
 import com.facebook.presto.resourcemanager.ResourceManagerProxy;
@@ -75,7 +76,7 @@ public class ResourceManagerModule
 
         // TODO: decouple query-level configuration that is not needed for Resource Manager
         binder.bind(QueryManager.class).to(NoOpQueryManager.class).in(Scopes.SINGLETON);
-        jaxrsBinder(binder).bind(ResourceGroupStateInfoResource.class);
+        jaxrsBinder(binder).bind(DistributedResourceGroupInfoResource.class);
         binder.bind(QueryIdGenerator.class).in(Scopes.SINGLETON);
         binder.bind(QueryPreparer.class).in(Scopes.SINGLETON);
         binder.bind(SessionSupplier.class).to(QuerySessionSupplier.class).in(Scopes.SINGLETON);
@@ -87,6 +88,7 @@ public class ResourceManagerModule
         jsonCodecBinder(binder).bindJsonCodec(BasicQueryInfo.class);
         smileCodecBinder(binder).bindSmileCodec(BasicQueryInfo.class);
         jsonCodecBinder(binder).bindListJsonCodec(QueryStateInfo.class);
+        jsonCodecBinder(binder).bindJsonCodec(ResourceGroupInfo.class);
 
         binder.bind(TransactionManager.class).to(NoOpTransactionManager.class);
 

--- a/presto-tests/src/test/java/com/facebook/presto/resourcemanager/TestDistributedResourceGroupInfoResource.java
+++ b/presto-tests/src/test/java/com/facebook/presto/resourcemanager/TestDistributedResourceGroupInfoResource.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.resourcemanager;
+
+import com.facebook.airlift.http.client.UnexpectedResponseException;
+import com.facebook.airlift.http.client.jetty.JettyHttpClient;
+import com.facebook.airlift.json.JsonCodec;
+import com.facebook.presto.metadata.AllNodes;
+import com.facebook.presto.resourceGroups.FileResourceGroupConfigurationManagerFactory;
+import com.facebook.presto.server.ResourceGroupInfo;
+import com.facebook.presto.server.testing.TestingPrestoServer;
+import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
+
+import static com.facebook.airlift.testing.Closeables.closeQuietly;
+import static com.facebook.presto.tests.tpch.TpchQueryRunner.createQueryRunner;
+import static com.facebook.presto.utils.QueryExecutionClientUtil.getResponseEntity;
+import static com.facebook.presto.utils.QueryExecutionClientUtil.runToCompletion;
+import static com.facebook.presto.utils.QueryExecutionClientUtil.runToFirstResult;
+import static com.facebook.presto.utils.ResourceUtils.getResourceFilePath;
+import static com.google.common.base.Preconditions.checkState;
+import static java.lang.String.format;
+import static java.lang.Thread.sleep;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class TestDistributedResourceGroupInfoResource
+{
+    private static final int COORDINATOR_COUNT = 2;
+    private JettyHttpClient client;
+    private TestingPrestoServer coordinator1;
+    private TestingPrestoServer coordinator2;
+    private TestingPrestoServer resourceManager;
+
+    @BeforeClass
+    public void setup()
+            throws Exception
+    {
+        client = new JettyHttpClient();
+        DistributedQueryRunner runner = createQueryRunner(ImmutableMap.of("query.client.timeout", "20s"), COORDINATOR_COUNT);
+        coordinator1 = runner.getCoordinators().get(0);
+        coordinator2 = runner.getCoordinators().get(1);
+        Optional<TestingPrestoServer> resourceManager = runner.getResourceManager();
+        checkState(resourceManager.isPresent(), "resource manager not present");
+        this.resourceManager = resourceManager.get();
+        coordinator1.getResourceGroupManager().get().addConfigurationManagerFactory(new FileResourceGroupConfigurationManagerFactory());
+        coordinator1.getResourceGroupManager().get()
+                .setConfigurationManager("file", ImmutableMap.of("resource-groups.config-file", getResourceFilePath("resource_groups_config_simple.json")));
+        coordinator2.getResourceGroupManager().get().addConfigurationManagerFactory(new FileResourceGroupConfigurationManagerFactory());
+        coordinator2.getResourceGroupManager().get()
+                .setConfigurationManager("file", ImmutableMap.of("resource-groups.config-file", getResourceFilePath("resource_groups_config_simple.json")));
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void teardown()
+    {
+        closeQuietly(coordinator1);
+        closeQuietly(coordinator2);
+        closeQuietly(resourceManager);
+        closeQuietly(client);
+        coordinator1 = null;
+        coordinator2 = null;
+        resourceManager = null;
+        client = null;
+    }
+
+    @Test(timeOut = 220_000)
+    public void testGetResourceGroupInfo()
+            throws InterruptedException, TimeoutException
+    {
+        runToCompletion(client, coordinator1, "SELECT 1", "user1");
+        runToFirstResult(client, coordinator2, "SELECT * from tpch.sf100.orders", "user1");
+        runToFirstResult(client, coordinator1, "SELECT * from tpch.sf101.orders", "user2");
+        waitUntilCoordinatorsDiscoveredHealthyInRM(SECONDS.toMillis(15));
+        ResourceGroupInfo resourceGroupInfo = getResponseEntity(client, coordinator1, "/v1/resourceGroupState/global", JsonCodec.jsonCodec(ResourceGroupInfo.class));
+        assertEquals(resourceGroupInfo.getNumRunningQueries(), 2);
+
+        Set<ResourceGroupId> subGroupResourceIdSet = resourceGroupInfo.getSubGroups().stream().map(a -> a.getId()).collect(Collectors.toSet());
+        assertEquals(subGroupResourceIdSet.size(), 2);
+        assertTrue(subGroupResourceIdSet.contains(new ResourceGroupId(resourceGroupInfo.getId(), "user-user1")));
+        assertTrue(subGroupResourceIdSet.contains(new ResourceGroupId(resourceGroupInfo.getId(), "user-user2")));
+    }
+
+    @Test(expectedExceptions = UnexpectedResponseException.class, expectedExceptionsMessageRegExp = ".*404: Not Found")
+    public void testResourceGroup404()
+    {
+        getResponseEntity(client, coordinator1, "/v1/resourceGroupState/global1", JsonCodec.jsonCodec(ResourceGroupInfo.class));
+    }
+
+    private void waitUntilCoordinatorsDiscoveredHealthyInRM(long timeoutInMillis)
+            throws TimeoutException, InterruptedException
+    {
+        long deadline = System.currentTimeMillis() + timeoutInMillis;
+        while (System.currentTimeMillis() < deadline) {
+            AllNodes allNodes = this.resourceManager.refreshNodes();
+            if (allNodes.getActiveCoordinators().size() == COORDINATOR_COUNT) {
+                return;
+            }
+            sleep(100);
+        }
+        throw new TimeoutException(format("one of the nodes is still missing after: %s ms", timeoutInMillis));
+    }
+}


### PR DESCRIPTION
Currently v1/resourceGroupState/* endpoint serves resource group info available within a particular coordinator. The change here is to enable these endpoints to retrieve cluster wide resource group info.

This PR depends on https://github.com/prestodb/presto/pull/16163

Test plan - unit test

```
== RELEASE NOTES ==

General Changes
* Support multi coordinator for v1/resourceGroupState/* endpoint

```
