### PR TITLE
Implement writeObject and getObject for RealType and DoubleType

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/type/DoubleType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/DoubleType.java
@@ -57,10 +57,22 @@ public final class DoubleType
     @Override
     public Object getObjectValue(SqlFunctionProperties properties, Block block, int position)
     {
+        return getObject(block, position);
+    }
+
+    @Override
+    public Object getObject(Block block, int position)
+    {
         if (block.isNull(position)) {
             return null;
         }
         return longBitsToDouble(block.getLong(position));
+    }
+
+    @Override
+    public void writeObject(BlockBuilder blockBuilder, Object value)
+    {
+        writeDouble(blockBuilder, ((Number) value).doubleValue());
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/type/RealType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/RealType.java
@@ -37,10 +37,22 @@ public final class RealType
     @Override
     public Object getObjectValue(SqlFunctionProperties properties, Block block, int position)
     {
+        return getObject(block, position);
+    }
+
+    @Override
+    public Object getObject(Block block, int position)
+    {
         if (block.isNull(position)) {
             return null;
         }
         return intBitsToFloat(block.getInt(position));
+    }
+
+    @Override
+    public void writeObject(BlockBuilder blockBuilder, Object value)
+    {
+        writeLong(blockBuilder, Float.floatToIntBits(((Number) value).floatValue()));
     }
 
     @Override

--- a/presto-main/src/test/java/com/facebook/presto/type/TestDoubleType.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestDoubleType.java
@@ -68,4 +68,27 @@ public class TestDoubleType
         assertEquals(DOUBLE.hash(blockBuilder, 0), DOUBLE.hash(blockBuilder, 2));
         assertEquals(DOUBLE.hash(blockBuilder, 0), DOUBLE.hash(blockBuilder, 3));
     }
+
+    @Test
+    public void testGetAndWrite()
+    {
+        BlockBuilder blockBuilder = DOUBLE.createFixedSizeBlockBuilder(5);
+        DOUBLE.writeDouble(blockBuilder, 1.1);
+        DOUBLE.writeObject(blockBuilder, 1.1);
+        DOUBLE.writeDouble(blockBuilder, Double.NaN);
+        DOUBLE.writeObject(blockBuilder, Double.NaN);
+        // Test passing an integer.
+        DOUBLE.writeObject(blockBuilder, 4);
+
+        Block block = blockBuilder.build();
+        assertEquals(DOUBLE.getDouble(block, 0), 1.1);
+        assertEquals(DOUBLE.getObject(block, 0), 1.1);
+        assertEquals(DOUBLE.getDouble(block, 1), 1.1);
+        assertEquals(DOUBLE.getObject(block, 1), 1.1);
+        assertEquals(DOUBLE.getDouble(block, 2), Double.NaN);
+        assertEquals(DOUBLE.getObject(block, 2), Double.NaN);
+        assertEquals(DOUBLE.getDouble(block, 3), Double.NaN);
+        assertEquals(DOUBLE.getObject(block, 3), Double.NaN);
+        assertEquals(DOUBLE.getObject(block, 4), 4.0);
+    }
 }

--- a/presto-main/src/test/java/com/facebook/presto/type/TestRealType.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestRealType.java
@@ -71,4 +71,27 @@ public class TestRealType
         assertEquals(REAL.hash(blockBuilder, 0), REAL.hash(blockBuilder, 2));
         assertEquals(REAL.hash(blockBuilder, 0), REAL.hash(blockBuilder, 3));
     }
+
+    @Test
+    public void testGetAndWrite()
+    {
+        BlockBuilder blockBuilder = REAL.createFixedSizeBlockBuilder(5);
+        REAL.writeLong(blockBuilder, floatToIntBits(1.1f));
+        REAL.writeObject(blockBuilder, 1.1f);
+        REAL.writeLong(blockBuilder, floatToIntBits(Float.NaN));
+        REAL.writeObject(blockBuilder, Float.NaN);
+        // Test passing an integer.
+        REAL.writeObject(blockBuilder, 4);
+        Block block = blockBuilder.build();
+
+        assertEquals(intBitsToFloat((int) REAL.getLong(block, 0)), 1.1f);
+        assertEquals(REAL.getObject(block, 0), 1.1f);
+        assertEquals(intBitsToFloat((int) REAL.getLong(block, 1)), 1.1f);
+        assertEquals(REAL.getObject(block, 1), 1.1f);
+        assertEquals(intBitsToFloat((int) REAL.getLong(block, 2)), Float.NaN);
+        assertEquals(REAL.getObject(block, 2), Float.NaN);
+        assertEquals(intBitsToFloat((int) REAL.getLong(block, 3)), Float.NaN);
+        assertEquals(REAL.getObject(block, 3), Float.NaN);
+        assertEquals(REAL.getObject(block, 4), 4.0f);
+    }
 }


### PR DESCRIPTION
With these util functions, we could remove some per function/operator
specific implementations. This commit removes the ValueAccessor
interfaces in ArrayNormalizeFunction.

Test plan
Added unit tests in TestRealType and TestDoubleType. There are existing unit tests for ArrayNormalizeFunction.

```
== NO RELEASE NOTE ==
```
