### PR TITLE
Bind shared scheduled executor in verifier

### DIFF
--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerifierModule.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerifierModule.java
@@ -169,6 +169,13 @@ public class VerifierModule
 
     @Provides
     @Singleton
+    public static ScheduledExecutorService createScheduledExecutorService()
+    {
+        return newSingleThreadScheduledExecutor(daemonThreadsNamed("verifier-scheduled-executor-service"));
+    }
+
+    @Provides
+    @Singleton
     @ForTransactionManager
     public static ScheduledExecutorService createTransactionIdleCheckExecutor()
     {


### PR DESCRIPTION
This executor can be used by the verifier submodules to run scheduled tasks


```
== NO RELEASE NOTE ==
```
