### PR TITLE
Add query statistic cumulative total memory

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/event/QueryMonitor.java
+++ b/presto-main/src/main/java/com/facebook/presto/event/QueryMonitor.java
@@ -176,6 +176,7 @@ public class QueryMonitor
                         0,
                         0,
                         0,
+                        0,
                         true),
                 createQueryContext(queryInfo.getSession(), queryInfo.getResourceGroupId()),
                 new QueryIOMetadata(ImmutableList.of(), Optional.empty()),
@@ -310,6 +311,7 @@ public class QueryMonitor
                 queryStats.getWrittenIntermediatePhysicalDataSize().toBytes(),
                 queryStats.getSpilledDataSize().toBytes(),
                 queryStats.getCumulativeUserMemory(),
+                queryStats.getCumulativeTotalMemory(),
                 queryStats.getCompletedDrivers(),
                 queryInfo.isCompleteInfo());
     }

--- a/presto-main/src/main/java/com/facebook/presto/execution/BasicStageExecutionStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/BasicStageExecutionStats.java
@@ -43,6 +43,7 @@ public class BasicStageExecutionStats
             0,
 
             0.0,
+            0.0,
             new DataSize(0, BYTE),
             new DataSize(0, BYTE),
 
@@ -64,6 +65,7 @@ public class BasicStageExecutionStats
     private final DataSize rawInputDataSize;
     private final long rawInputPositions;
     private final double cumulativeUserMemory;
+    private final double cumulativeTotalMemory;
     private final DataSize userMemoryReservation;
     private final DataSize totalMemoryReservation;
     private final Duration totalCpuTime;
@@ -85,6 +87,7 @@ public class BasicStageExecutionStats
             long rawInputPositions,
 
             double cumulativeUserMemory,
+            double cumulativeTotalMemory,
             DataSize userMemoryReservation,
             DataSize totalMemoryReservation,
 
@@ -106,6 +109,7 @@ public class BasicStageExecutionStats
         this.rawInputDataSize = requireNonNull(rawInputDataSize, "rawInputDataSize is null");
         this.rawInputPositions = rawInputPositions;
         this.cumulativeUserMemory = cumulativeUserMemory;
+        this.cumulativeTotalMemory = cumulativeTotalMemory;
         this.userMemoryReservation = requireNonNull(userMemoryReservation, "userMemoryReservation is null");
         this.totalMemoryReservation = requireNonNull(totalMemoryReservation, "totalMemoryReservation is null");
         this.totalCpuTime = requireNonNull(totalCpuTime, "totalCpuTime is null");
@@ -156,6 +160,11 @@ public class BasicStageExecutionStats
         return cumulativeUserMemory;
     }
 
+    public double getCumulativeTotalMemory()
+    {
+        return cumulativeTotalMemory;
+    }
+
     public DataSize getUserMemoryReservation()
     {
         return userMemoryReservation;
@@ -204,6 +213,7 @@ public class BasicStageExecutionStats
         int completedDrivers = 0;
 
         double cumulativeUserMemory = 0;
+        double cumulativeTotalMemory = 0;
         long userMemoryReservation = 0;
         long totalMemoryReservation = 0;
 
@@ -227,6 +237,7 @@ public class BasicStageExecutionStats
             completedDrivers += stageStats.getCompletedDrivers();
 
             cumulativeUserMemory += stageStats.getCumulativeUserMemory();
+            cumulativeTotalMemory += stageStats.getCumulativeTotalMemory();
             userMemoryReservation += stageStats.getUserMemoryReservation().toBytes();
             totalMemoryReservation += stageStats.getTotalMemoryReservation().toBytes();
 
@@ -261,6 +272,7 @@ public class BasicStageExecutionStats
                 rawInputPositions,
 
                 cumulativeUserMemory,
+                cumulativeTotalMemory,
                 succinctBytes(userMemoryReservation),
                 succinctBytes(totalMemoryReservation),
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
@@ -360,6 +360,7 @@ public class QueryStateMachine
                 stageStats.getRawInputPositions(),
 
                 stageStats.getCumulativeUserMemory(),
+                stageStats.getCumulativeTotalMemory(),
                 stageStats.getUserMemoryReservation(),
                 stageStats.getTotalMemoryReservation(),
                 succinctBytes(getPeakUserMemoryInBytes()),
@@ -969,6 +970,7 @@ public class QueryStateMachine
                 queryStats.getBlockedDrivers(),
                 queryStats.getCompletedDrivers(),
                 queryStats.getCumulativeUserMemory(),
+                queryStats.getCumulativeTotalMemory(),
                 queryStats.getUserMemoryReservation(),
                 queryStats.getTotalMemoryReservation(),
                 queryStats.getPeakUserMemoryReservation(),

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryStats.java
@@ -73,6 +73,7 @@ public class QueryStats
     private final int completedDrivers;
 
     private final double cumulativeUserMemory;
+    private final double cumulativeTotalMemory;
     private final DataSize userMemoryReservation;
     private final DataSize totalMemoryReservation;
     private final DataSize peakUserMemoryReservation;
@@ -139,6 +140,7 @@ public class QueryStats
             @JsonProperty("completedDrivers") int completedDrivers,
 
             @JsonProperty("cumulativeUserMemory") double cumulativeUserMemory,
+            @JsonProperty("cumulativeTotalMemory") double cumulativeTotalMemory,
             @JsonProperty("userMemoryReservation") DataSize userMemoryReservation,
             @JsonProperty("totalMemoryReservation") DataSize totalMemoryReservation,
             @JsonProperty("peakUserMemoryReservation") DataSize peakUserMemoryReservation,
@@ -212,6 +214,8 @@ public class QueryStats
         this.completedDrivers = completedDrivers;
         checkArgument(cumulativeUserMemory >= 0, "cumulativeUserMemory is negative");
         this.cumulativeUserMemory = cumulativeUserMemory;
+        checkArgument(cumulativeTotalMemory >= 0, "cumulativeTotalMemory is negative");
+        this.cumulativeTotalMemory = cumulativeTotalMemory;
         this.userMemoryReservation = requireNonNull(userMemoryReservation, "userMemoryReservation is null");
         this.totalMemoryReservation = requireNonNull(totalMemoryReservation, "totalMemoryReservation is null");
         this.peakUserMemoryReservation = requireNonNull(peakUserMemoryReservation, "peakUserMemoryReservation is null");
@@ -273,6 +277,7 @@ public class QueryStats
         int completedDrivers = 0;
 
         double cumulativeUserMemory = 0;
+        double cumulativeTotalMemory = 0;
         long userMemoryReservation = 0;
         long totalMemoryReservation = 0;
 
@@ -318,6 +323,7 @@ public class QueryStats
             completedDrivers += stageExecutionStats.getCompletedDrivers();
 
             cumulativeUserMemory += stageExecutionStats.getCumulativeUserMemory();
+            cumulativeTotalMemory += stageExecutionStats.getCumulativeTotalMemory();
             userMemoryReservation += stageExecutionStats.getUserMemoryReservation().toBytes();
             totalMemoryReservation += stageExecutionStats.getTotalMemoryReservation().toBytes();
             totalScheduledTime += stageExecutionStats.getTotalScheduledTime().roundTo(MILLISECONDS);
@@ -397,6 +403,7 @@ public class QueryStats
                 completedDrivers,
 
                 cumulativeUserMemory,
+                cumulativeTotalMemory,
                 succinctBytes(userMemoryReservation),
                 succinctBytes(totalMemoryReservation),
                 peakUserMemoryReservation,
@@ -471,6 +478,7 @@ public class QueryStats
                 new Duration(0, MILLISECONDS),
                 new Duration(0, MILLISECONDS),
                 new Duration(0, MILLISECONDS),
+                0,
                 0,
                 0,
                 0,
@@ -647,6 +655,12 @@ public class QueryStats
     public double getCumulativeUserMemory()
     {
         return cumulativeUserMemory;
+    }
+
+    @JsonProperty
+    public double getCumulativeTotalMemory()
+    {
+        return cumulativeTotalMemory;
     }
 
     @JsonProperty

--- a/presto-main/src/main/java/com/facebook/presto/execution/StageExecutionInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/StageExecutionInfo.java
@@ -72,6 +72,7 @@ public class StageExecutionInfo
         int completedDrivers = 0;
 
         double cumulativeUserMemory = 0;
+        double cumulativeTotalMemory = 0;
         long userMemoryReservation = 0;
         long totalMemoryReservation = 0;
 
@@ -122,6 +123,7 @@ public class StageExecutionInfo
             completedDrivers += taskStats.getCompletedDrivers();
 
             cumulativeUserMemory += taskStats.getCumulativeUserMemory();
+            cumulativeTotalMemory += taskStats.getCumulativeTotalMemory();
 
             long taskUserMemory = taskStats.getUserMemoryReservationInBytes();
             long taskSystemMemory = taskStats.getSystemMemoryReservationInBytes();
@@ -187,6 +189,7 @@ public class StageExecutionInfo
                 completedDrivers,
 
                 cumulativeUserMemory,
+                cumulativeTotalMemory,
                 succinctBytes(userMemoryReservation),
                 succinctBytes(totalMemoryReservation),
                 peakUserMemoryReservation,

--- a/presto-main/src/main/java/com/facebook/presto/execution/StageExecutionStateMachine.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/StageExecutionStateMachine.java
@@ -238,6 +238,7 @@ public class StageExecutionStateMachine
         int completedDrivers = 0;
 
         double cumulativeUserMemory = 0;
+        double cumulativeTotalMemory = 0;
         long userMemoryReservation = 0;
         long totalMemoryReservation = 0;
 
@@ -300,6 +301,7 @@ public class StageExecutionStateMachine
                 rawInputPositions,
 
                 cumulativeUserMemory,
+                cumulativeTotalMemory,
                 succinctBytes(userMemoryReservation),
                 succinctBytes(totalMemoryReservation),
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/StageExecutionStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/StageExecutionStats.java
@@ -60,6 +60,7 @@ public class StageExecutionStats
     private final int completedDrivers;
 
     private final double cumulativeUserMemory;
+    private final double cumulativeTotalMemory;
     private final DataSize userMemoryReservation;
     private final DataSize totalMemoryReservation;
     private final DataSize peakUserMemoryReservation;
@@ -110,6 +111,7 @@ public class StageExecutionStats
             @JsonProperty("completedDrivers") int completedDrivers,
 
             @JsonProperty("cumulativeUserMemory") double cumulativeUserMemory,
+            @JsonProperty("cumulativeTotalMemory") double cumulativeTotalMemory,
             @JsonProperty("userMemoryReservation") DataSize userMemoryReservation,
             @JsonProperty("totalMemoryReservation") DataSize totalMemoryReservation,
             @JsonProperty("peakUserMemoryReservation") DataSize peakUserMemoryReservation,
@@ -167,6 +169,8 @@ public class StageExecutionStats
         this.completedDrivers = completedDrivers;
         checkArgument(cumulativeUserMemory >= 0, "cumulativeUserMemory is negative");
         this.cumulativeUserMemory = cumulativeUserMemory;
+        checkArgument(cumulativeTotalMemory >= 0, "cumulativeTotalMemory is negative");
+        this.cumulativeTotalMemory = cumulativeTotalMemory;
         this.userMemoryReservation = requireNonNull(userMemoryReservation, "userMemoryReservation is null");
         this.totalMemoryReservation = requireNonNull(totalMemoryReservation, "totalMemoryReservation is null");
         this.peakUserMemoryReservation = requireNonNull(peakUserMemoryReservation, "peakUserMemoryReservation is null");
@@ -277,6 +281,12 @@ public class StageExecutionStats
     public double getCumulativeUserMemory()
     {
         return cumulativeUserMemory;
+    }
+
+    @JsonProperty
+    public double getCumulativeTotalMemory()
+    {
+        return cumulativeTotalMemory;
     }
 
     @JsonProperty
@@ -423,6 +433,7 @@ public class StageExecutionStats
                 rawInputDataSize,
                 rawInputPositions,
                 cumulativeUserMemory,
+                cumulativeTotalMemory,
                 userMemoryReservation,
                 totalMemoryReservation,
                 totalCpuTime,
@@ -438,6 +449,7 @@ public class StageExecutionStats
         return new StageExecutionStats(
                 null,
                 new Distribution().snapshot(),
+                0,
                 0,
                 0,
                 0,

--- a/presto-main/src/main/java/com/facebook/presto/operator/TaskStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TaskStats.java
@@ -48,6 +48,7 @@ public class TaskStats
     private final int completedDrivers;
 
     private final double cumulativeUserMemory;
+    private final double cumulativeTotalMemory;
     private final long userMemoryReservationInBytes;
     private final long revocableMemoryReservationInBytes;
     private final long systemMemoryReservationInBytes;
@@ -98,6 +99,7 @@ public class TaskStats
                 0,
                 0,
                 0.0,
+                0.0,
                 0L,
                 0L,
                 0L,
@@ -141,6 +143,7 @@ public class TaskStats
             @JsonProperty("completedDrivers") int completedDrivers,
 
             @JsonProperty("cumulativeUserMemory") double cumulativeUserMemory,
+            @JsonProperty("cumulativeTotalMemory") double cumulativeTotalMemory,
             @JsonProperty("userMemoryReservation") long userMemoryReservationInBytes,
             @JsonProperty("revocableMemoryReservationInBytes") long revocableMemoryReservationInBytes,
             @JsonProperty("systemMemoryReservationInBytes") long systemMemoryReservationInBytes,
@@ -200,6 +203,7 @@ public class TaskStats
         this.completedDrivers = completedDrivers;
 
         this.cumulativeUserMemory = cumulativeUserMemory;
+        this.cumulativeTotalMemory = cumulativeTotalMemory;
         this.userMemoryReservationInBytes = userMemoryReservationInBytes;
         this.revocableMemoryReservationInBytes = revocableMemoryReservationInBytes;
         this.systemMemoryReservationInBytes = systemMemoryReservationInBytes;
@@ -317,6 +321,12 @@ public class TaskStats
     public double getCumulativeUserMemory()
     {
         return cumulativeUserMemory;
+    }
+
+    @JsonProperty
+    public double getCumulativeTotalMemory()
+    {
+        return cumulativeTotalMemory;
     }
 
     @JsonProperty
@@ -481,6 +491,7 @@ public class TaskStats
                 blockedDrivers,
                 completedDrivers,
                 cumulativeUserMemory,
+                cumulativeTotalMemory,
                 userMemoryReservationInBytes,
                 revocableMemoryReservationInBytes,
                 systemMemoryReservationInBytes,
@@ -523,6 +534,7 @@ public class TaskStats
                 blockedDrivers,
                 completedDrivers,
                 cumulativeUserMemory,
+                cumulativeTotalMemory,
                 userMemoryReservationInBytes,
                 revocableMemoryReservationInBytes,
                 systemMemoryReservationInBytes,

--- a/presto-main/src/main/java/com/facebook/presto/server/BasicQueryStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/BasicQueryStats.java
@@ -62,6 +62,7 @@ public class BasicQueryStats
     private final long rawInputPositions;
 
     private final double cumulativeUserMemory;
+    private final double cumulativeTotalMemory;
     private final DataSize userMemoryReservation;
     private final DataSize totalMemoryReservation;
     private final DataSize peakUserMemoryReservation;
@@ -95,6 +96,7 @@ public class BasicQueryStats
             @JsonProperty("rawInputDataSize") DataSize rawInputDataSize,
             @JsonProperty("rawInputPositions") long rawInputPositions,
             @JsonProperty("cumulativeUserMemory") double cumulativeUserMemory,
+            @JsonProperty("cumulativeTotalMemory") double cumulativeTotalMemory,
             @JsonProperty("userMemoryReservation") DataSize userMemoryReservation,
             @JsonProperty("totalMemoryReservation") DataSize totalMemoryReservation,
             @JsonProperty("peakUserMemoryReservation") DataSize peakUserMemoryReservation,
@@ -131,6 +133,7 @@ public class BasicQueryStats
         this.rawInputPositions = rawInputPositions;
 
         this.cumulativeUserMemory = cumulativeUserMemory;
+        this.cumulativeTotalMemory = cumulativeTotalMemory;
         this.userMemoryReservation = userMemoryReservation;
         this.totalMemoryReservation = totalMemoryReservation;
         this.peakUserMemoryReservation = peakUserMemoryReservation;
@@ -164,6 +167,7 @@ public class BasicQueryStats
                 queryStats.getRawInputDataSize(),
                 queryStats.getRawInputPositions(),
                 queryStats.getCumulativeUserMemory(),
+                queryStats.getCumulativeTotalMemory(),
                 queryStats.getUserMemoryReservation(),
                 queryStats.getTotalMemoryReservation(),
                 queryStats.getPeakUserMemoryReservation(),
@@ -194,6 +198,7 @@ public class BasicQueryStats
                 0,
                 0,
                 new DataSize(0, BYTE),
+                0,
                 0,
                 0,
                 new DataSize(0, BYTE),
@@ -389,5 +394,12 @@ public class BasicQueryStats
     public Duration getWaitingForPrerequisitesTime()
     {
         return waitingForPrerequisitesTime;
+    }
+
+    @ThriftField(27)
+    @JsonProperty
+    public double getCumulativeTotalMemory()
+    {
+        return cumulativeTotalMemory;
     }
 }

--- a/presto-main/src/main/resources/webapp/src/components/QueryDetail.jsx
+++ b/presto-main/src/main/resources/webapp/src/components/QueryDetail.jsx
@@ -488,6 +488,14 @@ class StageSummary extends React.Component {
                                     </tr>
                                     <tr>
                                         <td className="stage-table-stat-title">
+                                            Cumulative Total
+                                        </td>
+                                        <td className="stage-table-stat-text">
+                                            {formatDataSizeBytes(stage.latestAttemptExecutionInfo.stats.cumulativeTotalMemory / 1000)}
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td className="stage-table-stat-title">
                                             Current
                                         </td>
                                         <td className="stage-table-stat-text">
@@ -1358,6 +1366,14 @@ export class QueryDetail extends React.Component {
                                         </td>
                                         <td className="info-text">
                                             {formatDataSizeBytes(query.queryStats.cumulativeUserMemory / 1000.0) + " seconds"}
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td className="info-title">
+                                            Cumulative Total
+                                        </td>
+                                        <td className="info-text">
+                                            {formatDataSizeBytes(query.queryStats.cumulativeTotalMemory / 1000.0) + " seconds"}
                                         </td>
                                     </tr>
                                     <tr>

--- a/presto-main/src/test/java/com/facebook/presto/execution/MockManagedQueryExecution.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/MockManagedQueryExecution.java
@@ -129,6 +129,7 @@ public class MockManagedQueryExecution
                         new DataSize(14, BYTE),
                         15,
                         16.0,
+                        25.0,
                         new DataSize(17, BYTE),
                         new DataSize(18, BYTE),
                         new DataSize(19, BYTE),

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestQueryStats.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestQueryStats.java
@@ -184,6 +184,7 @@ public class TestQueryStats
             16,
 
             17.0,
+            43.0,
             new DataSize(18, BYTE),
             new DataSize(19, BYTE),
             new DataSize(20, BYTE),

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestStageExecutionStats.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestStageExecutionStats.java
@@ -49,6 +49,7 @@ public class TestStageExecutionStats
             11,
 
             12.0,
+            27.0,
             new DataSize(13, BYTE),
             new DataSize(14, BYTE),
             new DataSize(15, BYTE),

--- a/presto-main/src/test/java/com/facebook/presto/memory/TestMemoryTracking.java
+++ b/presto-main/src/test/java/com/facebook/presto/memory/TestMemoryTracking.java
@@ -390,6 +390,25 @@ public class TestMemoryTracking
         assertTrue(cumulativeUserMemory < elapsedTimeInMillis * averageMemoryForLastPeriod);
     }
 
+    @Test
+    public void testCumulativeTotalMemoryEstimation()
+    {
+        LocalMemoryContext userMemory = operatorContext.localUserMemoryContext();
+        LocalMemoryContext systemMemory = operatorContext.localSystemMemoryContext();
+        long userMemoryBytes = 100_000_000;
+        long systemMemoryBytes = 40_000_000;
+        userMemory.setBytes(userMemoryBytes);
+        systemMemory.setBytes(systemMemoryBytes);
+        long startTime = System.nanoTime();
+        double cumulativeTotalMemory = taskContext.getTaskStats().getCumulativeTotalMemory();
+        long endTime = System.nanoTime();
+
+        double elapsedTimeInMillis = (endTime - startTime) / 1_000_000.0;
+        long averageMemoryForLastPeriod = (userMemoryBytes + systemMemoryBytes) / 2;
+
+        assertTrue(cumulativeTotalMemory < elapsedTimeInMillis * averageMemoryForLastPeriod);
+    }
+
     private void assertStats(
             OperatorStats operatorStats,
             DriverStats driverStats,

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestTaskStats.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestTaskStats.java
@@ -43,6 +43,7 @@ public class TestTaskStats
             10,
 
             11.0,
+            43.0,
             12,
             13,
             14,

--- a/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStateProvider.java
+++ b/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStateProvider.java
@@ -392,6 +392,7 @@ public class TestResourceManagerClusterStateProvider
                         DataSize.valueOf("21GB"),
                         22,
                         23,
+                        24,
                         DataSize.valueOf("1MB"),
                         DataSize.valueOf("24GB"),
                         DataSize.valueOf("25GB"),

--- a/presto-main/src/test/java/com/facebook/presto/server/TestBasicQueryInfo.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestBasicQueryInfo.java
@@ -76,6 +76,7 @@ public class TestBasicQueryInfo
                                 34,
                                 19,
                                 20.0,
+                                43.0,
                                 DataSize.valueOf("21GB"),
                                 DataSize.valueOf("22GB"),
                                 DataSize.valueOf("23GB"),

--- a/presto-main/src/test/java/com/facebook/presto/server/TestQueryStateInfo.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestQueryStateInfo.java
@@ -126,6 +126,7 @@ public class TestQueryStateInfo
                         34,
                         19,
                         20.0,
+                        43.0,
                         DataSize.valueOf("21GB"),
                         DataSize.valueOf("22GB"),
                         DataSize.valueOf("23GB"),

--- a/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/QueryStatistics.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/QueryStatistics.java
@@ -48,6 +48,7 @@ public class QueryStatistics
     private final long spilledBytes;
 
     private final double cumulativeMemory;
+    private final double cumulativeTotalMemory;
 
     private final int completedSplits;
     private final boolean complete;
@@ -78,6 +79,7 @@ public class QueryStatistics
             long writtenIntermediateBytes,
             long spilledBytes,
             double cumulativeMemory,
+            double cumulativeTotalMemory,
             int completedSplits,
             boolean complete)
     {
@@ -106,6 +108,7 @@ public class QueryStatistics
         this.writtenIntermediateBytes = writtenIntermediateBytes;
         this.spilledBytes = spilledBytes;
         this.cumulativeMemory = cumulativeMemory;
+        this.cumulativeTotalMemory = cumulativeTotalMemory;
         this.completedSplits = completedSplits;
         this.complete = complete;
     }
@@ -233,6 +236,11 @@ public class QueryStatistics
     public double getCumulativeMemory()
     {
         return cumulativeMemory;
+    }
+
+    public double getCumulativeTotalMemory()
+    {
+        return cumulativeTotalMemory;
     }
 
     public int getCompletedSplits()

--- a/presto-tests/src/test/java/com/facebook/presto/memory/TestClusterMemoryLeakDetector.java
+++ b/presto-tests/src/test/java/com/facebook/presto/memory/TestClusterMemoryLeakDetector.java
@@ -92,6 +92,7 @@ public class TestClusterMemoryLeakDetector
                         DataSize.valueOf("21GB"),
                         22,
                         23,
+                        28,
                         DataSize.valueOf("23GB"),
                         DataSize.valueOf("24GB"),
                         DataSize.valueOf("25GB"),


### PR DESCRIPTION
This statistic counts not just user memory, but also system memory.

Test plan - Ran the unit tests and check_webui.sh

```
== RELEASE NOTES ==

General Changes
* Add a new total cumulative memory statistic

Web UI
* Add cumulative total memory to the Memory and Resource Utilization Summary tables on the QueryDetail page.
```
