### PR TITLE
Add release notes for 0.254.1

### DIFF
--- a/presto-docs/src/main/sphinx/release.rst
+++ b/presto-docs/src/main/sphinx/release.rst
@@ -5,6 +5,7 @@ Release Notes
 .. toctree::
     :maxdepth: 1
 
+    release/release-0.254.1
     release/release-0.254
     release/release-0.253.1
     release/release-0.253

--- a/presto-docs/src/main/sphinx/release/release-0.254.1.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.254.1.rst
@@ -1,0 +1,7 @@
+===============
+Release 0.254.1
+===============
+
+Hive Changes
+_______________
+* Revert non-backward-compatible DWRF writer updates (:pr:`15028`)

--- a/presto-docs/src/main/sphinx/release/release-0.254.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.254.rst
@@ -2,6 +2,10 @@
 Release 0.254
 =============
 
+.. warning::
+
+  There is a backward compatibility issue in the DWRF writer that might cause other engines to be unable to read files written by this release.
+
 **Details**
 ===========
 


### PR DESCRIPTION
Test plan - generated presto-docs artifacts and checked in the browser that the generated pages work fine

Original PR - https://github.com/prestodb/presto/pull/16211

```
== NO RELEASE NOTE ==
```
