### PR TITLE
Make DWRF reader fail with verbose error when encounter 2GB+ streams

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/StripeReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/StripeReader.java
@@ -291,7 +291,7 @@ public class StripeReader
                 Optional.of(decryptor),
                 systemMemoryUsage,
                 encryptedGroup.length());
-        return toStripeEncryptionGroup(orcInputStream, types);
+        return toStripeEncryptionGroup(orcDataSource.getId(), orcInputStream, types);
     }
 
     /**
@@ -484,7 +484,7 @@ public class StripeReader
                 Optional.empty(),
                 systemMemoryUsage,
                 footerLength)) {
-            return metadataReader.readStripeFooter(types, inputStream);
+            return metadataReader.readStripeFooter(orcDataSource.getId(), types, inputStream);
         }
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/ExceptionWrappingMetadataReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/ExceptionWrappingMetadataReader.java
@@ -85,11 +85,11 @@ public class ExceptionWrappingMetadataReader
     }
 
     @Override
-    public StripeFooter readStripeFooter(List<OrcType> types, InputStream inputStream)
+    public StripeFooter readStripeFooter(OrcDataSourceId orcDataSourceId, List<OrcType> types, InputStream inputStream)
             throws IOException
     {
         try {
-            return delegate.readStripeFooter(types, inputStream);
+            return delegate.readStripeFooter(orcDataSourceId, types, inputStream);
         }
         catch (IOException e) {
             throw propagate(e, "Invalid stripe footer");

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/MetadataReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/MetadataReader.java
@@ -16,6 +16,7 @@ package com.facebook.presto.orc.metadata;
 import com.facebook.presto.orc.DwrfEncryptionProvider;
 import com.facebook.presto.orc.DwrfKeyProvider;
 import com.facebook.presto.orc.OrcDataSource;
+import com.facebook.presto.orc.OrcDataSourceId;
 import com.facebook.presto.orc.OrcDecompressor;
 import com.facebook.presto.orc.metadata.PostScript.HiveWriterVersion;
 import com.facebook.presto.orc.metadata.statistics.HiveBloomFilter;
@@ -41,7 +42,9 @@ public interface MetadataReader
             Optional<OrcDecompressor> decompressor)
             throws IOException;
 
-    StripeFooter readStripeFooter(List<OrcType> types, InputStream inputStream)
+    StripeFooter readStripeFooter(OrcDataSourceId orcDataSourceId,
+            List<OrcType> types,
+            InputStream inputStream)
             throws IOException;
 
     List<RowGroupIndex> readRowIndexes(HiveWriterVersion hiveWriterVersion, InputStream inputStream)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcMetadataReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcMetadataReader.java
@@ -16,6 +16,7 @@ package com.facebook.presto.orc.metadata;
 import com.facebook.presto.orc.DwrfEncryptionProvider;
 import com.facebook.presto.orc.DwrfKeyProvider;
 import com.facebook.presto.orc.OrcDataSource;
+import com.facebook.presto.orc.OrcDataSourceId;
 import com.facebook.presto.orc.OrcDecompressor;
 import com.facebook.presto.orc.metadata.ColumnEncoding.ColumnEncodingKind;
 import com.facebook.presto.orc.metadata.OrcType.OrcTypeKind;
@@ -171,7 +172,7 @@ public class OrcMetadataReader
     }
 
     @Override
-    public StripeFooter readStripeFooter(List<OrcType> types, InputStream inputStream)
+    public StripeFooter readStripeFooter(OrcDataSourceId orcDataSourceId, List<OrcType> types, InputStream inputStream)
             throws IOException
     {
         CodedInputStream input = CodedInputStream.newInstance(inputStream);

--- a/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
@@ -1574,7 +1574,7 @@ public class OrcTester
                     Optional.empty(),
                     new TestingHiveOrcAggregatedMemoryContext(),
                     tailBuffer.length)) {
-                StripeFooter stripeFooter = encoding.createMetadataReader().readStripeFooter(footer.getTypes(), inputStream);
+                StripeFooter stripeFooter = encoding.createMetadataReader().readStripeFooter(orcDataSource.getId(), footer.getTypes(), inputStream);
                 stripes.add(stripeFooter);
             }
         }


### PR DESCRIPTION
DWRF file reader doesn't support streams larger than Integer.MAX_VALUE (aka 2GB+), and throws ArithmeticException when it encounters large streams. This change makes it fail with a bit more verbose error message instead of cryptic default `integer overflow`:

Before:
```
Caused by: java.lang.ArithmeticException: integer overflow
	at java.lang.Math.toIntExact(Math.java:1011)
	at com.facebook.presto.orc.metadata.DwrfMetadataReader.toStream(DwrfMetadataReader.java:303)
```

After:
```
com.facebook.presto.orc.OrcCorruptionException: java.io.IOException: Malformed ORC file. Stream size 9223372036854775807 of one of the streams for column 0 is larger than supported size 2147483647 [test]

	at com.facebook.presto.orc.metadata.DwrfMetadataReader.toStream(DwrfMetadataReader.java:320)
...
Caused by: java.io.IOException: Malformed ORC file. Stream size 9223372036854775807 of one of the streams for column 0 is larger than supported size 2147483647 [test]
	at com.facebook.presto.orc.OrcCorruptionException.<init>(OrcCorruptionException.java:31)
	... 36 more
```

Test plan:
- new unit test

```
== NO RELEASE NOTE ==
```
