### PR TITLE
Centralize Long Type Dictionary Loading Logic

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/Stripe.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/Stripe.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.orc;
 
 import com.facebook.presto.orc.metadata.ColumnEncoding;
+import com.facebook.presto.orc.reader.LongDictionaryProvider;
 import com.facebook.presto.orc.stream.InputStreamSources;
 import com.google.common.collect.ImmutableList;
 
@@ -29,6 +30,7 @@ public class Stripe
     private final Map<Integer, ColumnEncoding> columnEncodings;
     private final List<RowGroup> rowGroups;
     private final InputStreamSources dictionaryStreamSources;
+    private final LongDictionaryProvider longDictionaryProvider;
 
     public Stripe(long rowCount, Map<Integer, ColumnEncoding> columnEncodings, List<RowGroup> rowGroups, InputStreamSources dictionaryStreamSources)
     {
@@ -36,6 +38,7 @@ public class Stripe
         this.columnEncodings = requireNonNull(columnEncodings, "columnEncodings is null");
         this.rowGroups = ImmutableList.copyOf(requireNonNull(rowGroups, "rowGroups is null"));
         this.dictionaryStreamSources = requireNonNull(dictionaryStreamSources, "dictionaryStreamSources is null");
+        this.longDictionaryProvider = new LongDictionaryProvider(this.dictionaryStreamSources);
     }
 
     public long getRowCount()
@@ -58,6 +61,11 @@ public class Stripe
         return dictionaryStreamSources;
     }
 
+    public LongDictionaryProvider getLongDictionaryProvider()
+    {
+        return longDictionaryProvider;
+    }
+
     @Override
     public String toString()
     {
@@ -66,6 +74,7 @@ public class Stripe
                 .add("columnEncodings", columnEncodings)
                 .add("rowGroups", rowGroups)
                 .add("dictionaryStreams", dictionaryStreamSources)
+                .add("longDictionaryProvider", longDictionaryProvider)
                 .toString();
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDictionaryProvider.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDictionaryProvider.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.reader;
+
+import com.facebook.presto.orc.OrcCorruptionException;
+import com.facebook.presto.orc.StreamDescriptor;
+import com.facebook.presto.orc.stream.InputStreamSource;
+import com.facebook.presto.orc.stream.InputStreamSources;
+import com.facebook.presto.orc.stream.LongInputStream;
+
+import java.io.IOException;
+
+import static com.facebook.presto.orc.metadata.Stream.StreamKind.DICTIONARY_DATA;
+import static java.util.Objects.requireNonNull;
+
+public class LongDictionaryProvider
+{
+    private final InputStreamSources dictionaryStreamSources;
+
+    public static class DictionaryResult
+    {
+        private final long[] dictionaryBuffer;
+        // Can be false if not the first to load shared dictionary.
+        private final boolean isBufferOwner;
+
+        DictionaryResult(long[] dictionaryBuffer, boolean isBufferOwner)
+        {
+            this.dictionaryBuffer = requireNonNull(dictionaryBuffer);
+            this.isBufferOwner = isBufferOwner;
+        }
+
+        public long[] dictionaryBuffer()
+        {
+            return dictionaryBuffer;
+        }
+
+        public boolean isBufferOwner()
+        {
+            return isBufferOwner;
+        }
+    }
+
+    public LongDictionaryProvider(InputStreamSources dictionaryStreamSources)
+    {
+        this.dictionaryStreamSources = requireNonNull(dictionaryStreamSources, "dictionaryStreamSources is null");
+    }
+
+    /**
+     * Loads a dictionary from a stream and attempts to reuse the dictionary buffer passed in.
+     *
+     * @param streamDescriptor descriptor indicating node and sequence of the stream reader
+     * the dictionary is associated with.
+     * @param dictionary dictionary buffer the method attempts to fill.
+     * @param items number of items expected in the dictionary.
+     * @return The DictionaryResult contains two parts:
+     * 1) the final dictionary buffer object. Different from the input dictionary buffer if the input
+     *    dictionary buffer is expanded or that the method returns a shared dictionary.
+     * 2) whether the caller will be the owner of the dictionary, for the purpose of memory accounting.
+     *    Callers own all non-shared dictionaries, and only the first caller of the shared dictionary
+     *    is the owner.
+     * @throws IOException
+     */
+    public DictionaryResult getDictionary(StreamDescriptor streamDescriptor, long[] dictionary, int items)
+            throws IOException
+    {
+        InputStreamSource<LongInputStream> dictionaryDataStream = dictionaryStreamSources.getInputStreamSource(streamDescriptor, DICTIONARY_DATA, LongInputStream.class);
+        return loadDictionary(streamDescriptor, requireNonNull(dictionaryDataStream), dictionary, items);
+    }
+
+    private DictionaryResult loadDictionary(StreamDescriptor streamDescriptor, InputStreamSource<LongInputStream> dictionaryDataStream, long[] dictionaryBuffer, int items)
+            throws IOException
+    {
+        // We construct and use the input stream exactly once per stream descriptor per stripe, so we don't
+        // really need to cache it.
+        LongInputStream inputStream = dictionaryDataStream.openStream();
+        if (inputStream == null) {
+            throw new OrcCorruptionException(streamDescriptor.getOrcDataSourceId(), "Dictionary is not empty but data stream is not present for %s", streamDescriptor);
+        }
+
+        if (dictionaryBuffer == null || dictionaryBuffer.length < items) {
+            dictionaryBuffer = new long[items];
+        }
+
+        inputStream.next(dictionaryBuffer, items);
+        return new DictionaryResult(dictionaryBuffer, true);
+    }
+}

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDictionarySelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/LongDictionarySelectiveStreamReader.java
@@ -16,11 +16,11 @@ package com.facebook.presto.orc.reader;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockLease;
 import com.facebook.presto.common.type.Type;
-import com.facebook.presto.orc.OrcCorruptionException;
 import com.facebook.presto.orc.OrcLocalMemoryContext;
 import com.facebook.presto.orc.StreamDescriptor;
 import com.facebook.presto.orc.Stripe;
 import com.facebook.presto.orc.TupleDomainFilter;
+import com.facebook.presto.orc.reader.LongDictionaryProvider.DictionaryResult;
 import com.facebook.presto.orc.stream.BooleanInputStream;
 import com.facebook.presto.orc.stream.InputStreamSource;
 import com.facebook.presto.orc.stream.InputStreamSources;
@@ -35,7 +35,6 @@ import java.util.Optional;
 
 import static com.facebook.presto.orc.array.Arrays.ensureCapacity;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
-import static com.facebook.presto.orc.metadata.Stream.StreamKind.DICTIONARY_DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.IN_DICTIONARY;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
 import static com.facebook.presto.orc.reader.SelectiveStreamReaders.initializeOutputPositions;
@@ -61,14 +60,16 @@ public class LongDictionarySelectiveStreamReader
     private final TupleDomainFilter filter;
     private final boolean nonDeterministicFilter;
     private final boolean nullsAllowed;
+    private final OrcLocalMemoryContext systemMemoryContext;
 
     private InputStreamSource<BooleanInputStream> presentStreamSource = missingStreamSource(BooleanInputStream.class);
     @Nullable
     private BooleanInputStream presentStream;
 
-    private InputStreamSource<LongInputStream> dictionaryDataStreamSource = missingStreamSource(LongInputStream.class);
+    private LongDictionaryProvider dictionaryProvider;
     private int dictionarySize;
-    private long[] dictionary = new long[0];
+    private boolean isDictionaryOwner;
+    private long[] dictionary;
     private byte[] dictionaryFilterStatus;
 
     private InputStreamSource<BooleanInputStream> inDictionaryStreamSource = missingStreamSource(BooleanInputStream.class);
@@ -83,8 +84,6 @@ public class LongDictionarySelectiveStreamReader
     private boolean rowGroupOpen;
     private int readOffset;
 
-    private OrcLocalMemoryContext systemMemoryContext;
-
     public LongDictionarySelectiveStreamReader(
             StreamDescriptor streamDescriptor,
             Optional<TupleDomainFilter> filter,
@@ -97,6 +96,7 @@ public class LongDictionarySelectiveStreamReader
         this.streamDescriptor = requireNonNull(streamDescriptor, "streamDescriptor is null");
         this.filter = filter.orElse(null);
         this.systemMemoryContext = requireNonNull(systemMemoryContext, "systemMemoryContext is null");
+        this.isDictionaryOwner = true;
 
         nonDeterministicFilter = this.filter != null && !this.filter.isDeterministic();
         nullsAllowed = this.filter == null || nonDeterministicFilter || this.filter.testNull();
@@ -275,15 +275,9 @@ public class LongDictionarySelectiveStreamReader
     {
         // read the dictionary
         if (!dictionaryOpen && dictionarySize > 0) {
-            if (dictionary.length < dictionarySize) {
-                dictionary = new long[dictionarySize];
-            }
-
-            LongInputStream dictionaryStream = dictionaryDataStreamSource.openStream();
-            if (dictionaryStream == null) {
-                throw new OrcCorruptionException(streamDescriptor.getOrcDataSourceId(), "Dictionary is not empty but data stream is not present");
-            }
-            dictionaryStream.nextLongVector(dictionarySize, dictionary);
+            DictionaryResult dictionaryResult = dictionaryProvider.getDictionary(streamDescriptor, dictionary, dictionarySize);
+            dictionary = dictionaryResult.dictionaryBuffer();
+            isDictionaryOwner = dictionaryResult.isBufferOwner();
             if (filter != null && !nonDeterministicFilter) {
                 dictionaryFilterStatus = ensureCapacity(dictionaryFilterStatus, dictionarySize);
                 Arrays.fill(dictionaryFilterStatus, 0, dictionarySize, FILTER_NOT_EVALUATED);
@@ -321,7 +315,7 @@ public class LongDictionarySelectiveStreamReader
     @Override
     public void startStripe(Stripe stripe)
     {
-        dictionaryDataStreamSource = stripe.getDictionaryStreamSources().getInputStreamSource(streamDescriptor, DICTIONARY_DATA, LongInputStream.class);
+        dictionaryProvider = stripe.getLongDictionaryProvider();
         dictionarySize = stripe.getColumnEncodings().get(streamDescriptor.getStreamId())
                 .getColumnEncoding(streamDescriptor.getSequence())
                 .getDictionarySize();
@@ -374,16 +368,19 @@ public class LongDictionarySelectiveStreamReader
 
         dataStreamSource = null;
         dataStream = null;
-        dictionaryDataStreamSource = null;
 
         systemMemoryContext.close();
     }
 
+    // The current memory accounting for shared dictionaries is correct because dictionaries
+    // are shared only for flatmap stream readers. Flatmap stream readers are destroyed and recreated
+    // every stripe, and so are the dictionary providers. Hence, it's impossible to have a reference
+    // to shared dictionaries across different stripes at the same time.
     @Override
     public long getRetainedSizeInBytes()
     {
         return INSTANCE_SIZE +
-                sizeOf(dictionary) +
+                (isDictionaryOwner ? sizeOf(dictionary) : 0) +
                 sizeOf(dictionaryFilterStatus) +
                 super.getRetainedSizeInBytes();
     }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/NoopOrcDataSource.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/NoopOrcDataSource.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc;
+
+import java.util.Map;
+
+public class NoopOrcDataSource
+        implements OrcDataSource
+{
+    public static final NoopOrcDataSource INSTANCE = new NoopOrcDataSource();
+
+    @Override
+    public OrcDataSourceId getId()
+    {
+        return new OrcDataSourceId("fake");
+    }
+
+    @Override
+    public long getReadBytes()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long getReadTimeNanos()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long getSize()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void readFully(long position, byte[] buffer)
+    {
+        // do nothing
+    }
+
+    @Override
+    public void readFully(long position, byte[] buffer, int bufferOffset, int bufferLength)
+    {
+        // do nothing
+    }
+
+    @Override
+    public <K> Map<K, OrcDataSourceInput> readFully(Map<K, DiskRange> diskRanges)
+    {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestCachingOrcDataSource.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestCachingOrcDataSource.java
@@ -37,7 +37,6 @@ import org.testng.annotations.Test;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
 import java.util.Properties;
 import java.util.Random;
 import java.util.stream.Stream;
@@ -99,7 +98,7 @@ public class TestCachingOrcDataSource
         OrcAggregatedMemoryContext systemMemoryContext = new TestingHiveOrcAggregatedMemoryContext();
 
         OrcDataSource actual = wrapWithCacheIfTinyStripes(
-                FakeOrcDataSource.INSTANCE,
+                NoopOrcDataSource.INSTANCE,
                 ImmutableList.of(),
                 maxMergeDistance,
                 tinyStripeThreshold,
@@ -107,7 +106,7 @@ public class TestCachingOrcDataSource
         assertInstanceOf(actual, CachingOrcDataSource.class);
 
         actual = wrapWithCacheIfTinyStripes(
-                FakeOrcDataSource.INSTANCE,
+                NoopOrcDataSource.INSTANCE,
                 ImmutableList.of(new StripeInformation(123, 3, 10, 10, 10, ImmutableList.of())),
                 maxMergeDistance,
                 tinyStripeThreshold,
@@ -115,7 +114,7 @@ public class TestCachingOrcDataSource
         assertInstanceOf(actual, CachingOrcDataSource.class);
 
         actual = wrapWithCacheIfTinyStripes(
-                FakeOrcDataSource.INSTANCE,
+                NoopOrcDataSource.INSTANCE,
                 ImmutableList.of(
                         new StripeInformation(123, 3, 10, 10, 10, ImmutableList.of()),
                         new StripeInformation(123, 33, 10, 10, 10, ImmutableList.of()),
@@ -126,7 +125,7 @@ public class TestCachingOrcDataSource
         assertInstanceOf(actual, CachingOrcDataSource.class);
 
         actual = wrapWithCacheIfTinyStripes(
-                FakeOrcDataSource.INSTANCE,
+                NoopOrcDataSource.INSTANCE,
                 ImmutableList.of(
                         new StripeInformation(123, 3, 10, 10, 10, ImmutableList.of()),
                         new StripeInformation(123, 33, 10, 10, 10, ImmutableList.of()),
@@ -137,7 +136,7 @@ public class TestCachingOrcDataSource
         assertInstanceOf(actual, CachingOrcDataSource.class);
 
         actual = wrapWithCacheIfTinyStripes(
-                FakeOrcDataSource.INSTANCE,
+                NoopOrcDataSource.INSTANCE,
                 ImmutableList.of(
                         new StripeInformation(123, 3, 10, 10, 10, ImmutableList.of()),
                         new StripeInformation(123, 33, 10, 10, 10, ImmutableList.of()),
@@ -157,7 +156,7 @@ public class TestCachingOrcDataSource
 
         OrcAggregatedMemoryContext systemMemoryContext = new TestingHiveOrcAggregatedMemoryContext();
 
-        TestingOrcDataSource testingOrcDataSource = new TestingOrcDataSource(FakeOrcDataSource.INSTANCE);
+        TestingOrcDataSource testingOrcDataSource = new TestingOrcDataSource(NoopOrcDataSource.INSTANCE);
         CachingOrcDataSource cachingOrcDataSource = new CachingOrcDataSource(
                 testingOrcDataSource,
                 createTinyStripesRangeFinder(
@@ -175,7 +174,7 @@ public class TestCachingOrcDataSource
         assertEquals(systemMemoryContext.getBytes(), 8 * 1048576);
         assertEquals(testingOrcDataSource.getLastReadRanges(), ImmutableList.of(new DiskRange(63, 8 * 1048576)));
 
-        testingOrcDataSource = new TestingOrcDataSource(FakeOrcDataSource.INSTANCE);
+        testingOrcDataSource = new TestingOrcDataSource(NoopOrcDataSource.INSTANCE);
         cachingOrcDataSource = new CachingOrcDataSource(
                 testingOrcDataSource,
                 createTinyStripesRangeFinder(
@@ -193,7 +192,7 @@ public class TestCachingOrcDataSource
         assertEquals(systemMemoryContext.getBytes(), 8 * 1048576 * 2);
         assertEquals(testingOrcDataSource.getLastReadRanges(), ImmutableList.of(new DiskRange(63, 8 * 1048576)));
 
-        testingOrcDataSource = new TestingOrcDataSource(FakeOrcDataSource.INSTANCE);
+        testingOrcDataSource = new TestingOrcDataSource(NoopOrcDataSource.INSTANCE);
         cachingOrcDataSource = new CachingOrcDataSource(
                 testingOrcDataSource,
                 createTinyStripesRangeFinder(
@@ -298,53 +297,5 @@ public class TestCachingOrcDataSource
                 compression != NONE,
                 tableProperties,
                 () -> {});
-    }
-
-    private static class FakeOrcDataSource
-            implements OrcDataSource
-    {
-        public static final FakeOrcDataSource INSTANCE = new FakeOrcDataSource();
-
-        @Override
-        public OrcDataSourceId getId()
-        {
-            return new OrcDataSourceId("fake");
-        }
-
-        @Override
-        public long getReadBytes()
-        {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public long getReadTimeNanos()
-        {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public long getSize()
-        {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public void readFully(long position, byte[] buffer)
-        {
-            // do nothing
-        }
-
-        @Override
-        public void readFully(long position, byte[] buffer, int bufferOffset, int bufferLength)
-        {
-            // do nothing
-        }
-
-        @Override
-        public <K> Map<K, OrcDataSourceInput> readFully(Map<K, DiskRange> diskRanges)
-        {
-            throw new UnsupportedOperationException();
-        }
     }
 }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestListFilter.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestListFilter.java
@@ -195,7 +195,7 @@ public class TestListFilter
 
     private static StreamDescriptor makeStreamDescriptor(int levels)
     {
-        DummyOrcDataSource orcDataSource = new DummyOrcDataSource();
+        NoopOrcDataSource orcDataSource = NoopOrcDataSource.INSTANCE;
 
         OrcType intType = new OrcType(INT, ImmutableList.of(), ImmutableList.of(), Optional.empty(), Optional.empty(), Optional.empty());
         OrcType listType = new OrcType(LIST, ImmutableList.of(1), ImmutableList.of("item"), Optional.empty(), Optional.empty(), Optional.empty());
@@ -221,50 +221,6 @@ public class TestListFilter
     private interface TestFilter2
     {
         boolean test(int i, int j, Integer value);
-    }
-
-    private static class DummyOrcDataSource
-            implements OrcDataSource
-    {
-        @Override
-        public OrcDataSourceId getId()
-        {
-            return null;
-        }
-
-        @Override
-        public long getReadBytes()
-        {
-            return 0;
-        }
-
-        @Override
-        public long getReadTimeNanos()
-        {
-            return 0;
-        }
-
-        @Override
-        public long getSize()
-        {
-            return 0;
-        }
-
-        @Override
-        public void readFully(long position, byte[] buffer)
-        {
-        }
-
-        @Override
-        public void readFully(long position, byte[] buffer, int bufferOffset, int bufferLength)
-        {
-        }
-
-        @Override
-        public <K> Map<K, OrcDataSourceInput> readFully(Map<K, DiskRange> diskRanges)
-        {
-            return null;
-        }
     }
 
     private static final class RowAndColumn

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestLongDictionaryProvider.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestLongDictionaryProvider.java
@@ -1,0 +1,245 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc;
+
+import com.facebook.presto.orc.checkpoint.StreamCheckpoint;
+import com.facebook.presto.orc.metadata.ColumnEncoding;
+import com.facebook.presto.orc.metadata.OrcType;
+import com.facebook.presto.orc.reader.LongDictionaryProvider;
+import com.facebook.presto.orc.reader.LongDictionaryProvider.DictionaryResult;
+import com.facebook.presto.orc.stream.InputStreamSource;
+import com.facebook.presto.orc.stream.InputStreamSources;
+import com.facebook.presto.orc.stream.LongInputStreamDwrf;
+import com.facebook.presto.orc.stream.LongOutputStreamDwrf;
+import com.facebook.presto.orc.stream.OrcInputStream;
+import com.facebook.presto.orc.stream.SharedBuffer;
+import com.facebook.presto.orc.stream.StreamDataOutput;
+import com.facebook.presto.orc.stream.ValueInputStream;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.slice.DynamicSliceOutput;
+import io.airlift.slice.Slice;
+import io.airlift.units.DataSize;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.presto.orc.OrcDecompressor.createOrcDecompressor;
+import static com.facebook.presto.orc.checkpoint.Checkpoints.getDictionaryStreamCheckpoint;
+import static com.facebook.presto.orc.metadata.CompressionKind.SNAPPY;
+import static com.facebook.presto.orc.metadata.OrcType.OrcTypeKind.LONG;
+import static com.facebook.presto.orc.metadata.Stream.StreamKind.DICTIONARY_DATA;
+import static com.facebook.presto.orc.stream.CheckpointInputStreamSource.createCheckpointStreamSource;
+import static io.airlift.units.DataSize.Unit.KILOBYTE;
+import static java.lang.Math.toIntExact;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+
+public class TestLongDictionaryProvider
+{
+    private static final OrcDataSourceId ORC_DATA_SOURCE_ID = new OrcDataSourceId("dict_provider_test");
+    private static final DataSize COMPRESSION_BLOCK_SIZE = new DataSize(256, KILOBYTE);
+    private static final OrcType LONG_TYPE = new OrcType(LONG, ImmutableList.of(), ImmutableList.of(), Optional.empty(), Optional.empty(), Optional.empty());
+    private static final OrcDataSource DUMMY_ORC_DATA_SOURCE = new NoopOrcDataSource();
+
+    @DataProvider(name = "dataForDictionaryLoadingTest")
+    public Object[][] dataForDictionaryLoadingTest()
+    {
+        return new Object[][] {
+                {
+                        ImmutableMap.of(
+                                new NodeId(1, 0), new long[] {1, 2, 3, 4}),
+                        ImmutableList.of(new NodeId(0, 0),
+                                new NodeId(2, 0),
+                                new NodeId(1, 1),
+                                new NodeId(42, 0))
+                },
+                {
+                        ImmutableMap.of(
+                                new NodeId(1, 0), new long[] {1, 2, 3, 4},
+                                new NodeId(3, 0), new long[] {1, 3, 5, 7}),
+                        ImmutableList.of(new NodeId(0, 0),
+                                new NodeId(2, 0),
+                                new NodeId(1, 1),
+                                new NodeId(3, 1),
+                                new NodeId(42, 0))
+                },
+                {
+                        ImmutableMap.of(
+                                new NodeId(1, 0), new long[] {1, 2, 3, 4},
+                                new NodeId(3, 0), new long[] {1, 3, 5, 7},
+                                new NodeId(4, 1), new long[] {1, 1, 2, 3},
+                                new NodeId(4, 2), new long[] {2, 4, 6, 8},
+                                new NodeId(4, 4), new long[] {1, 4, 9, 16}),
+                        ImmutableList.of(new NodeId(2, 0),
+                                new NodeId(4, 3),
+                                new NodeId(4, 42),
+                                new NodeId(42, 0))
+                },
+        };
+    }
+
+    @DataProvider(name = "dataForBufferReuseTest")
+    public Object[][] dataForBufferReuseTest()
+    {
+        return new Object[][] {
+                {new long[0], 4, false},
+                {new long[4], 0, true},
+                {new long[4], 4, true},
+                {new long[4], 8, false},
+                {new long[8], 4, true},
+                {new long[16], 12, true},
+                {new long[16], 16, true},
+        };
+    }
+
+    @Test(dataProvider = "dataForDictionaryLoadingTest")
+    public void testLongDictionaryLoading(Map<NodeId, long[]> dictionaryStreams, List<NodeId> missingNodes)
+            throws Exception
+    {
+        TestingHiveOrcAggregatedMemoryContext aggregatedMemoryContext = new TestingHiveOrcAggregatedMemoryContext();
+        LongDictionaryProvider dictionaryProvider = new LongDictionaryProvider(createLongDictionaryStreamSources(dictionaryStreams, aggregatedMemoryContext));
+        for (Map.Entry<NodeId, long[]> entry : dictionaryStreams.entrySet()) {
+            StreamId streamId = entry.getKey().toDictionaryDataStreamId();
+            long[] data = entry.getValue();
+            long[] dictionary = new long[0];
+            DictionaryResult dictionaryResult = dictionaryProvider.getDictionary(createFlatStreamDescriptor(streamId), dictionary, data.length);
+            long[] newDictionary = dictionaryResult.dictionaryBuffer();
+            assertTrue(dictionaryResult.isBufferOwner());
+            assertEquals(newDictionary, data);
+        }
+        for (NodeId missingNode : missingNodes) {
+            long[] dictionary = new long[0];
+            expectThrows(
+                    OrcCorruptionException.class,
+                    () -> dictionaryProvider.getDictionary(createFlatStreamDescriptor(missingNode.toDictionaryDataStreamId()), dictionary, 0));
+        }
+    }
+
+    @Test(expectedExceptions = OrcCorruptionException.class, expectedExceptionsMessageRegExp = ".* Dictionary is not empty but data stream is not present.*")
+    public void testDataCorruptionExceptionMessage()
+            throws Exception
+    {
+        Map<NodeId, long[]> dictionaryStreams = ImmutableMap.of(new NodeId(1, 0), new long[] {1, 2, 3, 4});
+        TestingHiveOrcAggregatedMemoryContext aggregatedMemoryContext = new TestingHiveOrcAggregatedMemoryContext();
+        LongDictionaryProvider dictionaryProvider = new LongDictionaryProvider(createLongDictionaryStreamSources(dictionaryStreams, aggregatedMemoryContext));
+
+        StreamId streamId = new NodeId(2, 0).toDictionaryDataStreamId();
+        long[] dictionary = new long[0];
+        dictionaryProvider.getDictionary(createFlatStreamDescriptor(streamId), dictionary, 0);
+    }
+
+    @Test(dataProvider = "dataForBufferReuseTest")
+    public void testBufferReuse(long[] buffer, int items, boolean reused)
+            throws IOException
+    {
+        NodeId nodeId = new NodeId(1, 0);
+        long[] data = new long[] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+        TestingHiveOrcAggregatedMemoryContext aggregatedMemoryContext = new TestingHiveOrcAggregatedMemoryContext();
+        LongDictionaryProvider dictionaryProvider = new LongDictionaryProvider(createLongDictionaryStreamSources(ImmutableMap.of(nodeId, data), aggregatedMemoryContext));
+        StreamId streamId = nodeId.toDictionaryDataStreamId();
+        DictionaryResult dictionaryResult = dictionaryProvider.getDictionary(createFlatStreamDescriptor(streamId), buffer, items);
+        long[] newDictionary = dictionaryResult.dictionaryBuffer();
+        assertTrue(dictionaryResult.isBufferOwner());
+        assertEquals(newDictionary == buffer, reused);
+        assertTrue(newDictionary.length >= items);
+    }
+
+    private StreamDescriptor createFlatStreamDescriptor(StreamId streamId)
+    {
+        return new StreamDescriptor("test_dictionary_stream", streamId.getColumn(),
+                String.format("field_%d", streamId.getColumn()), LONG_TYPE, DUMMY_ORC_DATA_SOURCE, ImmutableList.of(), streamId.getSequence());
+    }
+
+    private InputStreamSources createLongDictionaryStreamSources(Map<NodeId, long[]> streams, OrcAggregatedMemoryContext aggregatedMemoryContext)
+    {
+        SharedBuffer decompressionBuffer = new SharedBuffer(aggregatedMemoryContext.newOrcLocalMemoryContext("sharedDecompressionBuffer"));
+        ImmutableMap.Builder<StreamId, InputStreamSource<?>> dictionaryStreamsBuilder = ImmutableMap.builder();
+        for (Map.Entry<NodeId, long[]> entry : streams.entrySet()) {
+            StreamId streamId = entry.getKey().toDictionaryDataStreamId();
+
+            DynamicSliceOutput sliceOutput = createSliceOutput(streamId, entry.getValue());
+
+            ValueInputStream<?> valueStream = createValueStream(sliceOutput.slice(), aggregatedMemoryContext, decompressionBuffer);
+            StreamCheckpoint streamCheckpoint = getDictionaryStreamCheckpoint(streamId, LONG, ColumnEncoding.ColumnEncodingKind.DICTIONARY);
+            InputStreamSource<?> streamSource = createCheckpointStreamSource(valueStream, streamCheckpoint);
+
+            dictionaryStreamsBuilder.put(streamId, streamSource);
+        }
+        return new InputStreamSources(dictionaryStreamsBuilder.build());
+    }
+
+    private DynamicSliceOutput createSliceOutput(StreamId streamId, long[] data)
+    {
+        LongOutputStreamDwrf outputStream = new LongOutputStreamDwrf(getColumnWriterOptions(), Optional.empty(), true, DICTIONARY_DATA);
+        for (long val : data) {
+            outputStream.writeLong(val);
+        }
+        outputStream.close();
+
+        DynamicSliceOutput sliceOutput = new DynamicSliceOutput(1000);
+        StreamDataOutput streamDataOutput = outputStream.getStreamDataOutput(streamId.getColumn());
+        streamDataOutput.writeData(sliceOutput);
+        return sliceOutput;
+    }
+
+    private ColumnWriterOptions getColumnWriterOptions()
+    {
+        return ColumnWriterOptions.builder()
+                .setCompressionKind(SNAPPY)
+                .setCompressionMaxBufferSize(COMPRESSION_BLOCK_SIZE)
+                .build();
+    }
+
+    private LongInputStreamDwrf createValueStream(Slice slice, OrcAggregatedMemoryContext aggregatedMemoryContext, SharedBuffer decompressionBuffer)
+            throws OrcCorruptionException
+    {
+        OrcInputStream input = new OrcInputStream(
+                ORC_DATA_SOURCE_ID,
+                decompressionBuffer,
+                slice.getInput(),
+                getOrcDecompressor(),
+                Optional.empty(),
+                aggregatedMemoryContext,
+                slice.getRetainedSize());
+        return new LongInputStreamDwrf(input, LONG, true, true);
+    }
+
+    private Optional<OrcDecompressor> getOrcDecompressor()
+    {
+        return createOrcDecompressor(ORC_DATA_SOURCE_ID, SNAPPY, toIntExact(COMPRESSION_BLOCK_SIZE.toBytes()));
+    }
+
+    private static class NodeId
+    {
+        private final int node;
+        private final int sequence;
+
+        public NodeId(int node, int sequence)
+        {
+            this.node = node;
+            this.sequence = sequence;
+        }
+
+        public StreamId toDictionaryDataStreamId()
+        {
+            return new StreamId(node, sequence, DICTIONARY_DATA);
+        }
+    }
+}


### PR DESCRIPTION
This commit is a prerequisite set of changes to enable sharing 
dictionary for DWRF flat map layout, which allows flat map per value
 stream readers to share the same dictionary data stream. 
The main change list as follows:
* Introduce the LongDictionaryProvider class to load long dictionary
  buffers for the specific Stripe. 
* Make long column reader load long dictionary buffers from
  the LongDictionaryProvider in the Stripe.