### PR TITLE
Add release notes for 0.255

### DIFF
--- a/presto-docs/src/main/sphinx/release.rst
+++ b/presto-docs/src/main/sphinx/release.rst
@@ -5,6 +5,7 @@ Release Notes
 .. toctree::
     :maxdepth: 1
 
+    release/release-0.255
     release/release-0.254.1
     release/release-0.254
     release/release-0.253.1

--- a/presto-docs/src/main/sphinx/release/release-0.255.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.255.rst
@@ -1,0 +1,40 @@
+=============
+Release 0.255
+=============
+
+**Highlights**
+==============
+
+**Details**
+===========
+
+General Changes
+_______________
+* Fix an issue where regular expression functions were not interruptible and could  keep running for a long time after the query they were a part of failed.
+* Add interruption for runaway splits blocked in known situations controlled by ``task.interrupt-runaway-splits-timeout`` property which defaults to ``600s``.
+* Add support for querying non-lowercase table names in Druid connector (:pr:`15920`).
+* Added array_normalize function.
+* Added connection param "protocols" that allows a user to specify which HTTP protocols the Presto client is allowed to use.
+* Reject @BeforeMethod in Multi-threaded tests.
+
+Cassandra Connector Changes
+___________________________
+* Add support for Cassandra ``SMALLINT``, ``TINYINT`` and ``DATE`` types and fix tests.
+
+SPI Changes
+___________
+* Add support for custom query prerequisites to be checked and satisfied through ``QueryPrerequisites`` interface. See :pr:`16073`.
+* Add support for custom query prerequisites to be checked and satisfied through ``QueryPrerequisites`` interface. See :pr:`16073`.
+
+Elasticserarch Changes
+______________________
+* Fix to avoid NullPointerException when there is an unsupported data type column in the Object field.
+
+Hive Changes
+____________
+* Add support for static AWS credentials in GlueHiveMetastore :doc:`/connector/hive`.
+
+**Contributors**
+================
+
+Abhisek Gautam Saikia, Amit Adhikari, Andrew Donley, Andrii Rosa, Ariel Weisberg, Arunachalam Thirupathi, Basar Hamdi Onat, Chen, Chunxu Tang, Darren Fu, Jalpreet Singh Nanda (:imjalpreet), James Petty, James Sun, Julian Zhuoran Zhao, Maria Basmanova, Mayank Garg, Rebecca Schlussel, Reetika Agrawal, Rohit Jain, Rongrong Zhong, Sergii Druzkin, Shixuan Fan, Sreeni Viswanadha, Tim Meehan, Venki Korukanti, Zhan Yuan, Zhenxiao Luo, beinan, henneberger, prithvip, v-jizhang


### PR DESCRIPTION
# Missing Release Notes
## Chen
- [ ] https://github.com/prestodb/presto/pull/16152 Fix the import of SMALLINT in ParquetReader (Merged by: Venki Korukanti)

## Darren Fu
- [ ] https://github.com/prestodb/presto/pull/16164 Fix Config Validation (Merged by: Andrii Rosa)

## Julian Zhuoran Zhao
- [ ] https://github.com/prestodb/presto/pull/16129 Implement efficient way to fetch partition name and values (Merged by: James Sun)

## Shixuan Fan
- [ ] https://github.com/prestodb/presto/pull/16204 Revert "Support Dwrf Sequence Ids in Writer" (Merged by: Shixuan Fan)

# Extracted Release Notes
- #15617 (Author: Reetika Agrawal): Skip Unsupported datatype from Object field in ES connector
  - Fix to avoid NullPointerException when there is an unsupported data type column in the Object field.
- #15842 (Author: v-jizhang): Fix and turn on Cassandra product tests
  - Add support for Cassandra ``SMALLINT``, ``TINYINT`` and ``DATE`` types and fix tests.
- #15914 (Author: v-jizhang): Reject @BeforeMethod in Multi-threaded tests
  - Reject @BeforeMethod in Multi-threaded tests.
- #15920 (Author: Jalpreet Singh Nanda (:imjalpreet)): Support non-lowercase table names in Druid connector
  - Add support for querying non-lowercase table names in Druid connector (:pr:`15920`).
- #15950 (Author: v-jizhang): Add support for static AWS credentials in GlueHiveMetastore
  - Add support for static AWS credentials in GlueHiveMetastore :doc:`/connector/hive`.
- #15955 (Author: Andrew Donley): Add Connection Params for JDBC HTTP Protocol
  - Added connection param "protocols" that allows a user to specify which HTTP protocols the Presto client is allowed to use.
- #16073 (Author: Mayank Garg): Add support for custom query prerequisite logic
  - Add support for custom query prerequisites to be checked and satisfied through ``QueryPrerequisites`` interface. See :pr:`16073`.
- #16073 (Author: Mayank Garg): Add support for custom query prerequisite logic
  - Add support for custom query prerequisites to be checked and satisfied through ``QueryPrerequisites`` interface. See :pr:`16073`.
- #16109 (Author: Sreeni Viswanadha): Use searchInterruptible for Joni regexp matching
  - Fix an issue where regular expression functions were not interruptible and could  keep running for a long time after the query they were a part of failed.
- #16111 (Author: Ariel Weisberg): Interrupt runaway splits
  - Add interruption for runaway splits blocked in known situations controlled by ``task.interrupt-runaway-splits-timeout`` property which defaults to ``600s``.
- #16159 (Author: Zhan Yuan): Implement ARRAY_NORMALIZE function
  - Added array_normalize function.

# All Commits
- fe48d865fbf4aab072e8443a251a42dfb5399356 Adding a counter to track TaskUpdateRequest size (Basar Hamdi Onat)
- 42590d86527b2b4428b8fe7706125a4048edb306 Revert "Support Dwrf Sequence Ids in Writer" (Shixuan Fan)
- 6ea61ba39268e43e508cf412957c8646f532d8b1 Reduce memory usage in Analysis getter (prithvip)
- 7f7747321b18656445223eba762c951ca859b3c1 Fix NPE when desc table in iceberg connector (beinan)
- afbfd21aaee90889f5638561f5440d792d3917fa Use double quotes for all field names within struct in SHOW CREATE TABLE. (Abhisek Gautam Saikia)
- 9095346f47c9237ed79ef6eaf0df24a8938c2f6a Implement ARRAY_NORMALIZE function (Zhan Yuan)
- faf0cfec04adb82efcc8128f8d9b8afa46b3edb7 Temporarily disable test (Tim Meehan)
- 4cc76ded774803f6ef7830b166a17076e3bf4ab1 Add resource manager profile to presto-tests and enable in CI (Tim Meehan)
- 96c1a22435a26c5a9a3400449c4d0a2f78af2c9f Fix TestDistributedQueryResource (Tim Meehan)
- 867dd6f73ac9e03b6bebf78abefef0d199b8404f Fix TestDistributedClusterStatsResource (Tim Meehan)
- 5865c76837c1ac71b81f16b7969bdc1961febb77 Add StripeMetadataSource implementation working with DwrfStripeCache (Sergii Druzkin)
- 84907066c57c23cdbabb1bdcea86dabeafb58b24 Avoid shaded guava imports in Presto on Spark codebase (Andrii Rosa)
- 6a0257522531941731a71e2c768e1bcef4fb5780 Add 0.253.1 release notes (Mayank Garg)
- add05d0c16729dfa5bde0b41a13356ff00fc829e Add Connection Params for JDBC HTTP Protocol (Andrew Donley)
- 02bb379ef6e2fda78525566b00c60180ea7feed6 Fix Config Validation issue (Darren Fu)
- 42b9ef81b9b2a2789587ee252d520ce026664d83 Implement case-insensitive name matching for Druid (Jalpreet Singh Nanda (:imjalpreet))
- 269758ca0dea82bf3c77f672ae4862d0e1dce0f4 Avoid accidental H2 databse name collisions when using System.nanoTime() (James Petty)
- 59b469cf2d8a4ea117b239943b4a6e164b27fa3b Add StripeMetadataSourceFactory to consume loaded DWRF stripe cache (Sergii Druzkin)
- 5706c39f5697d7d1a4dacb55e439ec6f863bfc04 Revert "Use segmented Slice in SliceDictionaryWriter" (Andrii Rosa)
- 278e87deeade3a6d2052af07a17dc34dd1e522d4 Revert "Make HashTable computation Lazy in MapBlockBuilder" (Andrii Rosa)
- 91ef9deb64b59a4f303dffa59d0b2bee9823ea90 Revert "Fix Size Calculation in MapBlock" (Andrii Rosa)
- 058be9c06e545781bde5e7874019b953b9e7213d Log warning on Unsupported datatype from Object field in ES connector (Reetika Agrawal)
- aff4a75253ea769993944ea4415c8a50114f115d Refactor OrcWriterOptions to builder pattern (Arunachalam Thirupathi)
- ac6187d74b00b52526140eba7c00971bdca878e0 Remove duplicate UtcEquivalentName check from TimeZoneKey (henneberger)
- 8e8a546fcd4367fadda181e3eb334891215bba93 Interrupt runaway splits in known locations (Ariel Weisberg)
- 399d80955c4475690384f451e65e134509160074 Upgrade airlift dependency to 0.201 (Abhisek Gautam Saikia)
- f93db75eca4cabf89f54da34b6fd41a5bf382af0 Improve type errors messages for structs (Amit Adhikari)
- 127949e5914add4653cc3e7edb1cd6269f61a52c Add iceberg connector doc (Chunxu Tang)
- 1463e683708fd8887eca3d6042f3afec88bbb7ce Fix the import of SMALLINT in ParquetReader (Chen)
- a178e5dcf5fd337bf44ab1211e165a6715e3c3cc Add support for static AWS credentials in GlueHiveMetastore (v-jizhang)
- 27f338e606c17cf06d304d6b6d4b2a42df436dfc Fix PartitionMutator not bound error during server start (beinan)
- edcc4f7ac4aecfeab316e722a90c88f0bedaab54 Add iceberg connector to devel configs (beinan)
- 96a9acafc22a1147cdbcac6ad73d498a12293ed9 Add predicate stitching for more nodes (Rohit Jain)
- 56c5e52a154378d0a9e9214f50940283e56d6468 Reject @BeforeMethod in Multi-threaded tests (v-jizhang)
- f38548b9a60091720e3fb649cc51fbad6a696003 Fix and turn on Cassandra product tests (v-jizhang)
- cc944e2d79768abf7832dbd10c693f3386a06414 Fix MySQL connection failure on startup (Ariel Weisberg)
- bf94d65472945880d6522a662e76d428795cac11 Add support to introduce custom prerequisite waiting logic (Mayank Garg)
- b011a55edf4e9ceb43a9df71069f383fdfcf015c Add new query state `WAITING_FOR_PREREQUISITES` (Mayank Garg)
- e20b4b6dd0af672d6a75e82622ca6ee293d91930 Use searchInterruptible so that we can interrupt runaway regexp matching thread. (Sreeni Viswanadha)
- 0aeca14a21998a4f3a7bcf2e0aebe6b43ca0c1b1 Implement efficient way to fetch partition name and values (Julian Zhuoran Zhao)
- 72d714532ba44e36ac04e05694bb119e95c5d1e7 Make NodeTaskMap inner classes static (James Petty)