### PR TITLE
Remove typeBound from TypeVariableConstraint

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/type/StandardTypes.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/StandardTypes.java
@@ -13,6 +13,12 @@
  */
 package com.facebook.presto.common.type;
 
+import java.util.HashSet;
+import java.util.Set;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.unmodifiableSet;
+
 public final class StandardTypes
 {
     public static final String BIGINT = "bigint";
@@ -49,4 +55,16 @@ public final class StandardTypes
     public static final String VARCHAR_ENUM = "VarcharEnum";
 
     private StandardTypes() {}
+
+    public static final Set<String> PARAMETRIC_TYPES = unmodifiableSet(new HashSet<>(asList(
+            VARCHAR,
+            CHAR,
+            DECIMAL,
+            ROW,
+            ARRAY,
+            MAP,
+            QDIGEST,
+            TDIGEST,
+            BIGINT_ENUM,
+            VARCHAR_ENUM)));
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/annotations/FunctionsParserHelper.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/annotations/FunctionsParserHelper.java
@@ -56,6 +56,7 @@ import static com.facebook.presto.common.function.OperatorType.HASH_CODE;
 import static com.facebook.presto.common.function.OperatorType.LESS_THAN;
 import static com.facebook.presto.common.function.OperatorType.LESS_THAN_OR_EQUAL;
 import static com.facebook.presto.common.function.OperatorType.NOT_EQUAL;
+import static com.facebook.presto.common.type.StandardTypes.PARAMETRIC_TYPES;
 import static com.facebook.presto.operator.annotations.ImplementationDependency.isImplementationDependencyAnnotation;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -108,14 +109,16 @@ public class FunctionsParserHelper
         ImmutableList.Builder<TypeVariableConstraint> typeVariableConstraints = ImmutableList.builder();
         for (TypeParameter typeParameter : typeParameters) {
             String name = typeParameter.value();
+            String variadicBound = typeParameter.boundedBy().isEmpty() ? null : typeParameter.boundedBy();
+            checkArgument(variadicBound == null || PARAMETRIC_TYPES.contains(variadicBound), "boundedBy must be a parametric type, got %s", variadicBound);
             if (orderableRequired.contains(name)) {
-                typeVariableConstraints.add(new TypeVariableConstraint(name, false, true, null, false, typeParameter.boundedBy()));
+                typeVariableConstraints.add(new TypeVariableConstraint(name, false, true, variadicBound, false));
             }
             else if (comparableRequired.contains(name)) {
-                typeVariableConstraints.add(new TypeVariableConstraint(name, true, false, null, false, typeParameter.boundedBy()));
+                typeVariableConstraints.add(new TypeVariableConstraint(name, true, false, variadicBound, false));
             }
             else {
-                typeVariableConstraints.add(new TypeVariableConstraint(name, false, false, null, false, typeParameter.boundedBy()));
+                typeVariableConstraints.add(new TypeVariableConstraint(name, false, false, variadicBound, false));
             }
         }
         return typeVariableConstraints.build();

--- a/presto-main/src/main/java/com/facebook/presto/type/EnumCasts.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/EnumCasts.java
@@ -26,6 +26,8 @@ import io.airlift.slice.Slice;
 
 import static com.facebook.presto.common.function.OperatorType.CAST;
 import static com.facebook.presto.common.type.StandardTypes.BIGINT;
+import static com.facebook.presto.common.type.StandardTypes.BIGINT_ENUM;
+import static com.facebook.presto.common.type.StandardTypes.VARCHAR_ENUM;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
 
 public final class EnumCasts
@@ -35,7 +37,7 @@ public final class EnumCasts
     }
 
     @ScalarOperator(CAST)
-    @TypeParameter(value = "T", boundedBy = VarcharEnumType.class)
+    @TypeParameter(value = "T", boundedBy = VARCHAR_ENUM)
     @SqlType("T")
     public static Slice castVarcharToEnum(@TypeParameter("T") Type enumType, @SqlType(StandardTypes.VARCHAR) Slice value)
     {
@@ -50,7 +52,7 @@ public final class EnumCasts
     }
 
     @ScalarOperator(CAST)
-    @TypeParameter(value = "T", boundedBy = VarcharEnumType.class)
+    @TypeParameter(value = "T", boundedBy = VARCHAR_ENUM)
     @SqlType(StandardTypes.VARCHAR)
     public static Slice castEnumToVarchar(@SqlType("T") Slice value)
     {
@@ -58,7 +60,7 @@ public final class EnumCasts
     }
 
     @ScalarOperator(CAST)
-    @TypeParameter(value = "T", boundedBy = BigintEnumType.class)
+    @TypeParameter(value = "T", boundedBy = BIGINT_ENUM)
     @SqlType("T")
     public static long castBigintToEnum(@TypeParameter("T") Type enumType, @SqlType(BIGINT) long value)
     {
@@ -66,7 +68,7 @@ public final class EnumCasts
     }
 
     @ScalarOperator(CAST)
-    @TypeParameter(value = "T", boundedBy = BigintEnumType.class)
+    @TypeParameter(value = "T", boundedBy = BIGINT_ENUM)
     @SqlType("T")
     public static long castIntegerToEnum(@TypeParameter("T") Type enumType, @SqlType(StandardTypes.INTEGER) long value)
     {
@@ -74,7 +76,7 @@ public final class EnumCasts
     }
 
     @ScalarOperator(CAST)
-    @TypeParameter(value = "T", boundedBy = BigintEnumType.class)
+    @TypeParameter(value = "T", boundedBy = BIGINT_ENUM)
     @SqlType("T")
     public static long castSmallintToEnum(@TypeParameter("T") Type enumType, @SqlType(StandardTypes.SMALLINT) long value)
     {
@@ -82,7 +84,7 @@ public final class EnumCasts
     }
 
     @ScalarOperator(CAST)
-    @TypeParameter(value = "T", boundedBy = BigintEnumType.class)
+    @TypeParameter(value = "T", boundedBy = BIGINT_ENUM)
     @SqlType("T")
     public static long castTinyintToEnum(@TypeParameter("T") Type enumType, @SqlType(StandardTypes.TINYINT) long value)
     {
@@ -102,7 +104,7 @@ public final class EnumCasts
     }
 
     @ScalarOperator(CAST)
-    @TypeParameter(value = "T", boundedBy = BigintEnumType.class)
+    @TypeParameter(value = "T", boundedBy = BIGINT_ENUM)
     @SqlType(BIGINT)
     public static long castEnumToBigint(@SqlType("T") long value)
     {

--- a/presto-main/src/main/java/com/facebook/presto/type/LongEnumOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/LongEnumOperators.java
@@ -41,6 +41,7 @@ import static com.facebook.presto.common.function.OperatorType.LESS_THAN_OR_EQUA
 import static com.facebook.presto.common.function.OperatorType.NOT_EQUAL;
 import static com.facebook.presto.common.function.OperatorType.XX_HASH_64;
 import static com.facebook.presto.common.type.StandardTypes.BIGINT;
+import static com.facebook.presto.common.type.StandardTypes.BIGINT_ENUM;
 import static com.facebook.presto.common.type.StandardTypes.BOOLEAN;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static io.airlift.slice.Slices.utf8Slice;
@@ -51,7 +52,7 @@ public final class LongEnumOperators
     private LongEnumOperators() {}
 
     @ScalarOperator(EQUAL)
-    @TypeParameter(value = "T", boundedBy = BigintEnumType.class)
+    @TypeParameter(value = "T", boundedBy = BIGINT_ENUM)
     @SqlType(BOOLEAN)
     @SqlNullable
     public static Boolean equal(@SqlType("T") long left, @SqlType("T") long right)
@@ -60,7 +61,7 @@ public final class LongEnumOperators
     }
 
     @ScalarOperator(NOT_EQUAL)
-    @TypeParameter(value = "T", boundedBy = BigintEnumType.class)
+    @TypeParameter(value = "T", boundedBy = BIGINT_ENUM)
     @SqlType(BOOLEAN)
     @SqlNullable
     public static Boolean notEqual(@SqlType("T") long left, @SqlType("T") long right)
@@ -69,7 +70,7 @@ public final class LongEnumOperators
     }
 
     @ScalarOperator(IS_DISTINCT_FROM)
-    @TypeParameter(value = "T", boundedBy = BigintEnumType.class)
+    @TypeParameter(value = "T", boundedBy = BIGINT_ENUM)
     @SqlType(BOOLEAN)
     public static boolean isDistinctFrom(
             @SqlType("T") long left,
@@ -87,7 +88,7 @@ public final class LongEnumOperators
     }
 
     @ScalarOperator(HASH_CODE)
-    @TypeParameter(value = "T", boundedBy = BigintEnumType.class)
+    @TypeParameter(value = "T", boundedBy = BIGINT_ENUM)
     @SqlType(BIGINT)
     public static long hashCode(@SqlType("T") long value)
     {
@@ -95,7 +96,7 @@ public final class LongEnumOperators
     }
 
     @ScalarOperator(XX_HASH_64)
-    @TypeParameter(value = "T", boundedBy = BigintEnumType.class)
+    @TypeParameter(value = "T", boundedBy = BIGINT_ENUM)
     @SqlType(BIGINT)
     public static long xxHash64(@SqlType("T") long value)
     {
@@ -103,7 +104,7 @@ public final class LongEnumOperators
     }
 
     @ScalarOperator(INDETERMINATE)
-    @TypeParameter(value = "T", boundedBy = BigintEnumType.class)
+    @TypeParameter(value = "T", boundedBy = BIGINT_ENUM)
     @SqlType(BOOLEAN)
     public static boolean indeterminate(@SqlType("T") long value, @IsNull boolean isNull)
     {
@@ -111,7 +112,7 @@ public final class LongEnumOperators
     }
 
     @ScalarOperator(LESS_THAN)
-    @TypeParameter(value = "T", boundedBy = BigintEnumType.class)
+    @TypeParameter(value = "T", boundedBy = BIGINT_ENUM)
     @SqlType(StandardTypes.BOOLEAN)
     public static boolean lessThan(@SqlType("T") long left, @SqlType("T") long right)
     {
@@ -119,7 +120,7 @@ public final class LongEnumOperators
     }
 
     @ScalarOperator(LESS_THAN_OR_EQUAL)
-    @TypeParameter(value = "T", boundedBy = BigintEnumType.class)
+    @TypeParameter(value = "T", boundedBy = BIGINT_ENUM)
     @SqlType(StandardTypes.BOOLEAN)
     public static boolean lessThanOrEqual(@SqlType("T") long left, @SqlType("T") long right)
     {
@@ -127,7 +128,7 @@ public final class LongEnumOperators
     }
 
     @ScalarOperator(GREATER_THAN)
-    @TypeParameter(value = "T", boundedBy = BigintEnumType.class)
+    @TypeParameter(value = "T", boundedBy = BIGINT_ENUM)
     @SqlType(StandardTypes.BOOLEAN)
     public static boolean greaterThan(@SqlType("T") long left, @SqlType("T") long right)
     {
@@ -135,7 +136,7 @@ public final class LongEnumOperators
     }
 
     @ScalarOperator(GREATER_THAN_OR_EQUAL)
-    @TypeParameter(value = "T", boundedBy = BigintEnumType.class)
+    @TypeParameter(value = "T", boundedBy = BIGINT_ENUM)
     @SqlType(StandardTypes.BOOLEAN)
     public static boolean greaterThanOrEqual(@SqlType("T") long left, @SqlType("T") long right)
     {
@@ -143,7 +144,7 @@ public final class LongEnumOperators
     }
 
     @ScalarOperator(BETWEEN)
-    @TypeParameter(value = "T", boundedBy = BigintEnumType.class)
+    @TypeParameter(value = "T", boundedBy = BIGINT_ENUM)
     @SqlType(StandardTypes.BOOLEAN)
     public static boolean between(@SqlType("T") long value, @SqlType("T") long min, @SqlType("T") long max)
     {
@@ -152,7 +153,7 @@ public final class LongEnumOperators
 
     @Description("Get the key corresponding to an enum value")
     @ScalarFunction("enum_key")
-    @TypeParameter(value = "T", boundedBy = BigintEnumType.class)
+    @TypeParameter(value = "T", boundedBy = BIGINT_ENUM)
     @SqlType(StandardTypes.VARCHAR)
     public static Slice enumKey(@TypeParameter("T") BigintEnumType enumType, @SqlType("T") long value)
     {

--- a/presto-main/src/main/java/com/facebook/presto/type/VarcharEnumOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/VarcharEnumOperators.java
@@ -41,6 +41,7 @@ import static com.facebook.presto.common.function.OperatorType.NOT_EQUAL;
 import static com.facebook.presto.common.function.OperatorType.XX_HASH_64;
 import static com.facebook.presto.common.type.StandardTypes.BIGINT;
 import static com.facebook.presto.common.type.StandardTypes.BOOLEAN;
+import static com.facebook.presto.common.type.StandardTypes.VARCHAR_ENUM;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
 import static io.airlift.slice.Slices.utf8Slice;
 import static java.lang.String.format;
@@ -50,7 +51,7 @@ public final class VarcharEnumOperators
     private VarcharEnumOperators() {}
 
     @ScalarOperator(EQUAL)
-    @TypeParameter(value = "T", boundedBy = VarcharEnumType.class)
+    @TypeParameter(value = "T", boundedBy = VARCHAR_ENUM)
     @SqlType(BOOLEAN)
     @SqlNullable
     public static Boolean equal(@SqlType("T") Slice left, @SqlType("T") Slice right)
@@ -59,7 +60,7 @@ public final class VarcharEnumOperators
     }
 
     @ScalarOperator(NOT_EQUAL)
-    @TypeParameter(value = "T", boundedBy = VarcharEnumType.class)
+    @TypeParameter(value = "T", boundedBy = VARCHAR_ENUM)
     @SqlType(BOOLEAN)
     @SqlNullable
     public static Boolean notEqual(@SqlType("T") Slice left, @SqlType("T") Slice right)
@@ -68,7 +69,7 @@ public final class VarcharEnumOperators
     }
 
     @ScalarOperator(IS_DISTINCT_FROM)
-    @TypeParameter(value = "T", boundedBy = VarcharEnumType.class)
+    @TypeParameter(value = "T", boundedBy = VARCHAR_ENUM)
     @SqlType(BOOLEAN)
     public static boolean isDistinctFrom(
             @SqlType("T") Slice left,
@@ -86,7 +87,7 @@ public final class VarcharEnumOperators
     }
 
     @ScalarOperator(HASH_CODE)
-    @TypeParameter(value = "T", boundedBy = VarcharEnumType.class)
+    @TypeParameter(value = "T", boundedBy = VARCHAR_ENUM)
     @SqlType(BIGINT)
     public static long hashCode(@SqlType("T") Slice value)
     {
@@ -94,7 +95,7 @@ public final class VarcharEnumOperators
     }
 
     @ScalarOperator(XX_HASH_64)
-    @TypeParameter(value = "T", boundedBy = VarcharEnumType.class)
+    @TypeParameter(value = "T", boundedBy = VARCHAR_ENUM)
     @SqlType(BIGINT)
     public static long xxHash64(@SqlType("T") Slice value)
     {
@@ -102,7 +103,7 @@ public final class VarcharEnumOperators
     }
 
     @ScalarOperator(INDETERMINATE)
-    @TypeParameter(value = "T", boundedBy = VarcharEnumType.class)
+    @TypeParameter(value = "T", boundedBy = VARCHAR_ENUM)
     @SqlType(BOOLEAN)
     public static boolean indeterminate(@SqlType("T") Slice value, @IsNull boolean isNull)
     {
@@ -110,7 +111,7 @@ public final class VarcharEnumOperators
     }
 
     @ScalarOperator(LESS_THAN)
-    @TypeParameter(value = "T", boundedBy = VarcharEnumType.class)
+    @TypeParameter(value = "T", boundedBy = VARCHAR_ENUM)
     @SqlType(StandardTypes.BOOLEAN)
     public static boolean lessThan(@SqlType("T") Slice left, @SqlType("T") Slice right)
     {
@@ -118,7 +119,7 @@ public final class VarcharEnumOperators
     }
 
     @ScalarOperator(LESS_THAN_OR_EQUAL)
-    @TypeParameter(value = "T", boundedBy = VarcharEnumType.class)
+    @TypeParameter(value = "T", boundedBy = VARCHAR_ENUM)
     @SqlType(StandardTypes.BOOLEAN)
     public static boolean lessThanOrEqual(@SqlType("T") Slice left, @SqlType("T") Slice right)
     {
@@ -126,7 +127,7 @@ public final class VarcharEnumOperators
     }
 
     @ScalarOperator(GREATER_THAN)
-    @TypeParameter(value = "T", boundedBy = VarcharEnumType.class)
+    @TypeParameter(value = "T", boundedBy = VARCHAR_ENUM)
     @SqlType(StandardTypes.BOOLEAN)
     public static boolean greaterThan(@SqlType("T") Slice left, @SqlType("T") Slice right)
     {
@@ -134,7 +135,7 @@ public final class VarcharEnumOperators
     }
 
     @ScalarOperator(GREATER_THAN_OR_EQUAL)
-    @TypeParameter(value = "T", boundedBy = VarcharEnumType.class)
+    @TypeParameter(value = "T", boundedBy = VARCHAR_ENUM)
     @SqlType(StandardTypes.BOOLEAN)
     public static boolean greaterThanOrEqual(@SqlType("T") Slice left, @SqlType("T") Slice right)
     {
@@ -142,7 +143,7 @@ public final class VarcharEnumOperators
     }
 
     @ScalarOperator(BETWEEN)
-    @TypeParameter(value = "T", boundedBy = VarcharEnumType.class)
+    @TypeParameter(value = "T", boundedBy = VARCHAR_ENUM)
     @SqlType(StandardTypes.BOOLEAN)
     public static boolean between(@SqlType("T") Slice value, @SqlType("T") Slice min, @SqlType("T") Slice max)
     {
@@ -151,7 +152,7 @@ public final class VarcharEnumOperators
 
     @Description("Get the key corresponding to an enum value")
     @ScalarFunction("enum_key")
-    @TypeParameter(value = "T", boundedBy = VarcharEnumType.class)
+    @TypeParameter(value = "T", boundedBy = VARCHAR_ENUM)
     @SqlType(StandardTypes.VARCHAR)
     public static Slice enumKey(@TypeParameter("T") VarcharEnumType enumType, @SqlType("T") Slice value)
     {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/TypeParameter.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/TypeParameter.java
@@ -13,8 +13,6 @@
  */
 package com.facebook.presto.spi.function;
 
-import com.facebook.presto.common.type.Type;
-
 import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
@@ -31,5 +29,5 @@ public @interface TypeParameter
 {
     String value();
 
-    Class<? extends Type> boundedBy() default Type.class;
+    String boundedBy() default "";
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/TypeVariableConstraint.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/TypeVariableConstraint.java
@@ -15,7 +15,6 @@ package com.facebook.presto.spi.function;
 
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeUtils;
-import com.facebook.presto.common.type.TypeWithName;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -32,7 +31,6 @@ public class TypeVariableConstraint
     private final boolean orderableRequired;
     private final String variadicBound;
     private final boolean nonDecimalNumericRequired;
-    private final Class<? extends Type> typeBound;
 
     @JsonCreator
     public TypeVariableConstraint(
@@ -40,25 +38,13 @@ public class TypeVariableConstraint
             @JsonProperty("comparableRequired") boolean comparableRequired,
             @JsonProperty("orderableRequired") boolean orderableRequired,
             @JsonProperty("variadicBound") @Nullable String variadicBound,
-            @JsonProperty("nonDecimalNumericRequired") boolean nonDecimalNumericRequired,
-            @JsonProperty("boundedBy") Class<? extends Type> typeBound)
+            @JsonProperty("nonDecimalNumericRequired") boolean nonDecimalNumericRequired)
     {
         this.name = name;
         this.comparableRequired = comparableRequired;
         this.orderableRequired = orderableRequired;
         this.variadicBound = variadicBound;
         this.nonDecimalNumericRequired = nonDecimalNumericRequired;
-        this.typeBound = typeBound;
-    }
-
-    public TypeVariableConstraint(
-            @JsonProperty("name") String name,
-            @JsonProperty("comparableRequired") boolean comparableRequired,
-            @JsonProperty("orderableRequired") boolean orderableRequired,
-            @JsonProperty("variadicBound") @Nullable String variadicBound,
-            @JsonProperty("nonDecimalNumericRequired") boolean nonDecimalNumericRequired)
-    {
-        this(name, comparableRequired, orderableRequired, variadicBound, nonDecimalNumericRequired, Type.class);
     }
 
     @JsonProperty
@@ -91,12 +77,6 @@ public class TypeVariableConstraint
         return nonDecimalNumericRequired;
     }
 
-    @JsonProperty
-    public Class<? extends Type> getTypeBound()
-    {
-        return typeBound;
-    }
-
     public boolean canBind(Type type)
     {
         if (comparableRequired && !type.isComparable()) {
@@ -105,10 +85,7 @@ public class TypeVariableConstraint
         if (orderableRequired && !type.isOrderable()) {
             return false;
         }
-        if (!typeBound.isInstance(type) && !(type instanceof TypeWithName && typeBound.isInstance(((TypeWithName) type).getType()))) {
-            return false;
-        }
-        if (variadicBound != null && !UNKNOWN.equals(type) && !variadicBound.equals(type.getTypeSignature().getBase())) {
+        if (variadicBound != null && !UNKNOWN.equals(type) && !variadicBound.equals(type.getTypeSignature().getStandardTypeSignature().getBase())) {
             return false;
         }
         if (nonDecimalNumericRequired && !TypeUtils.isNonDecimalNumericType(type)) {
@@ -130,9 +107,6 @@ public class TypeVariableConstraint
         if (variadicBound != null) {
             value += ":" + variadicBound + "<*>";
         }
-        if (!typeBound.equals(Type.class)) {
-            value += " extends " + typeBound.getSimpleName();
-        }
         if (nonDecimalNumericRequired) {
             value += ":nonDecimalNumeric";
         }
@@ -153,13 +127,12 @@ public class TypeVariableConstraint
                 orderableRequired == that.orderableRequired &&
                 nonDecimalNumericRequired == that.nonDecimalNumericRequired &&
                 Objects.equals(name, that.name) &&
-                Objects.equals(variadicBound, that.variadicBound) &&
-                Objects.equals(typeBound, that.typeBound);
+                Objects.equals(variadicBound, that.variadicBound);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(name, comparableRequired, orderableRequired, variadicBound, nonDecimalNumericRequired, typeBound);
+        return Objects.hash(name, comparableRequired, orderableRequired, variadicBound, nonDecimalNumericRequired);
     }
 }


### PR DESCRIPTION
EnumType now is implemented as a standard paremetric type so using
the existing variadicBound as type constraint will work.

```
== NO RELEASE NOTE ==
```
