### PR TITLE
Fix retained size after Page deserialization

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/block/VariableWidthBlockEncoding.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/VariableWidthBlockEncoding.java
@@ -68,7 +68,8 @@ public class VariableWidthBlockEncoding
         boolean[] valueIsNull = decodeNullBits(sliceInput, positionCount).orElse(null);
 
         int blockSize = sliceInput.readInt();
-        Slice slice = sliceInput.readSlice(blockSize);
+        Slice slice = Slices.allocate(blockSize);
+        sliceInput.readBytes(slice);
 
         return new VariableWidthBlock(0, positionCount, slice, offsets, valueIsNull);
     }


### PR DESCRIPTION
 Slice in SerializedPage includes all blocks. When VariableWidthBlock
is deserialized using VariableWidthBlockEncoding, VariableWidthBlock
should be backed by a new slice with copied data rather than the
slice for all blocks.

Otherwise, every block holds a slice of the entire page, which leads to 
wrong calculation of Page retained size. Depends on number of affected
blocks in a page, memory could be off by N times (N >= count of VariableWidthBlock).
As a result, spilled query will have incorrect retained size and fail.



Test plan

- Tested in production,   previously OOMed spilled query succeeds after this change.

- Performance regression test
   612 production queries (CPU time >= 1 hour) are run with and without this patch. Total cpu hours  is 24680 for test job and 23956 for control run. 


```
== NO RELEASE NOTE ==
```
