### PR TITLE
Include all tables in the column mapping of materialized views

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/CreateMaterializedViewTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/CreateMaterializedViewTask.java
@@ -43,6 +43,7 @@ import static com.facebook.presto.metadata.MetadataUtil.createQualifiedObjectNam
 import static com.facebook.presto.metadata.MetadataUtil.toSchemaTableName;
 import static com.facebook.presto.spi.StandardErrorCode.ALREADY_EXISTS;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_FOUND;
+import static com.facebook.presto.sql.MaterializedViewUtils.computeMaterializedViewToBaseTableColumnMappings;
 import static com.facebook.presto.sql.NodeUtils.mapFromProperties;
 import static com.facebook.presto.sql.SqlFormatterUtil.getFormattedSql;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.MATERIALIZED_VIEW_ALREADY_EXISTS;
@@ -133,7 +134,7 @@ public class CreateMaterializedViewTask
                 viewName.getObjectName(),
                 baseTables,
                 Optional.of(session.getUser()),
-                analysis.getOriginalColumnMapping(statement.getQuery()),
+                computeMaterializedViewToBaseTableColumnMappings(analysis),
                 Optional.empty());
         try {
             metadata.createMaterializedView(session, viewName.getCatalogName(), viewMetadata, viewDefinition, statement.isNotExists());

--- a/presto-main/src/main/java/com/facebook/presto/sql/MaterializedViewUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/MaterializedViewUtils.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.sql;
+
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.sql.analyzer.Analysis;
+import com.facebook.presto.sql.analyzer.MaterializedViewColumnMappingExtractor;
+import com.facebook.presto.sql.tree.CreateMaterializedView;
+import com.facebook.presto.sql.tree.Node;
+import com.facebook.presto.sql.tree.Query;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.facebook.presto.metadata.MetadataUtil.toSchemaTableName;
+import static com.facebook.presto.spi.ConnectorMaterializedViewDefinition.TableColumn;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+
+public class MaterializedViewUtils
+{
+    private MaterializedViewUtils() {}
+
+    /**
+     * Compute the 1-to-N column mapping from a materialized view to its base tables.
+     * <p>
+     * From {@code analysis}, we could derive only one base table column that one materialized view column maps to.
+     * In case of 1 materialized view defined on N base tables via join, union, etc, this method helps compute
+     * all the N base table columns that one materialized view column maps to.
+     * It calls on {@link MaterializedViewColumnMappingExtractor} to get all base table columns mapped by join, union, etc,
+     * and then uses them to expand the 1-to-1 column mapping derived from {@code analysis} to the 1-to-N column mapping.
+     * <p>
+     * For example, given SELECT column_a AS column_x FROM table_a JOIN table_b ON (table_a.column_a = table_b.column_b),
+     * the 1-to-1 column mapping from {@code analysis} is column_x -> table_a.column_a. Mapped base table columns are
+     * [table_a.column_a, table_b.column_b]. Then it will return a 1-to-N column mapping column_x -> {table_a -> column_a, table_b -> column_b}.
+     */
+    public static Map<String, Map<SchemaTableName, String>> computeMaterializedViewToBaseTableColumnMappings(Analysis analysis)
+    {
+        checkState(
+                analysis.getStatement() instanceof CreateMaterializedView,
+                "Only support the computation of column mappings when analyzing CreateMaterializedView");
+
+        ImmutableMap.Builder<String, Map<SchemaTableName, String>> fullColumnMappings = ImmutableMap.builder();
+
+        Query viewQuery = ((CreateMaterializedView) analysis.getStatement()).getQuery();
+        Map<String, TableColumn> originalColumnMappings = getOriginalColumnsFromAnalysis(viewQuery, analysis);
+
+        List<List<TableColumn>> mappedBaseColumns = MaterializedViewColumnMappingExtractor.extractMappedBaseColumns(analysis);
+
+        for (Map.Entry<String, TableColumn> columnMapping : originalColumnMappings.entrySet()) {
+            String viewColumn = columnMapping.getKey();
+            TableColumn originalBaseColumn = columnMapping.getValue();
+
+            Map<SchemaTableName, String> fullBaseColumns = new HashMap<>();
+
+            mappedBaseColumns.forEach(mappedBaseColumnPair -> {
+                if (originalBaseColumn.equals(mappedBaseColumnPair.get(0))) {
+                    fullBaseColumns.put(mappedBaseColumnPair.get(1).getTableName(), mappedBaseColumnPair.get(1).getColumnName());
+                }
+                else if (originalBaseColumn.equals(mappedBaseColumnPair.get(1))) {
+                    fullBaseColumns.put(mappedBaseColumnPair.get(0).getTableName(), mappedBaseColumnPair.get(0).getColumnName());
+                }
+            });
+
+            fullBaseColumns.put(originalBaseColumn.getTableName(), originalBaseColumn.getColumnName());
+
+            fullColumnMappings.put(viewColumn, ImmutableMap.copyOf(fullBaseColumns));
+        }
+
+        return fullColumnMappings.build();
+    }
+
+    private static Map<String, TableColumn> getOriginalColumnsFromAnalysis(Node viewQuery, Analysis analysis)
+    {
+        return analysis.getOutputDescriptor(viewQuery).getVisibleFields().stream()
+                .filter(field -> field.getOriginTable().isPresent() && field.getOriginColumnName().isPresent())
+                .collect(toImmutableMap(
+                        field -> field.getName().get(),
+                        field -> new TableColumn(toSchemaTableName(field.getOriginTable().get()), field.getOriginColumnName().get())));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
@@ -18,7 +18,6 @@ import com.facebook.presto.common.QualifiedObjectName;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.security.AccessControl;
 import com.facebook.presto.spi.ColumnHandle;
-import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.function.FunctionHandle;
 import com.facebook.presto.spi.security.Identity;
@@ -65,14 +64,12 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.facebook.presto.SystemSessionProperties.isCheckAccessControlOnUtilizedColumnsOnly;
-import static com.facebook.presto.metadata.MetadataUtil.toSchemaTableName;
 import static com.facebook.presto.sql.analyzer.Analysis.MaterializedViewAnalysisState.NOT_VISITED;
 import static com.facebook.presto.sql.analyzer.Analysis.MaterializedViewAnalysisState.VISITED;
 import static com.facebook.presto.sql.analyzer.Analysis.MaterializedViewAnalysisState.VISITING;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.Multimaps.forMap;
 import static com.google.common.collect.Multimaps.unmodifiableMultimap;
 import static java.lang.String.format;
@@ -799,15 +796,6 @@ public class Analysis
     public boolean isOrderByRedundant(OrderBy orderBy)
     {
         return redundantOrderBy.contains(NodeRef.of(orderBy));
-    }
-
-    public Map<String, Map<SchemaTableName, String>> getOriginalColumnMapping(Node node)
-    {
-        return getOutputDescriptor(node).getVisibleFields().stream()
-                .filter(field -> field.getOriginTable().isPresent() && field.getOriginColumnName().isPresent())
-                .collect(toImmutableMap(
-                        field -> field.getName().get(),
-                        field -> ImmutableMap.of(toSchemaTableName(field.getOriginTable().get()), field.getOriginColumnName().get())));
     }
 
     @Immutable

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewColumnMappingExtractor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewColumnMappingExtractor.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.analyzer;
+
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.sql.tree.ComparisonExpression;
+import com.facebook.presto.sql.tree.CreateMaterializedView;
+import com.facebook.presto.sql.tree.Query;
+import com.facebook.presto.sql.tree.SetOperation;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.facebook.presto.metadata.MetadataUtil.toSchemaTableName;
+import static com.facebook.presto.spi.ConnectorMaterializedViewDefinition.TableColumn;
+import static com.facebook.presto.sql.analyzer.SemanticErrorCode.NOT_SUPPORTED;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNull;
+
+public class MaterializedViewColumnMappingExtractor
+        extends MaterializedViewPlanValidator
+{
+    private final Analysis analysis;
+
+    private ImmutableList.Builder<List<TableColumn>> mappedBaseColumns;
+
+    private MaterializedViewColumnMappingExtractor(Analysis analysis)
+    {
+        this.analysis = requireNonNull(analysis, "analysis is null");
+
+        this.mappedBaseColumns = ImmutableList.builder();
+    }
+
+    /**
+     * Call MaterializedViewColumnMappingExtractor to traverse the materialized view query,
+     * and return possible pairs of the base table columns that are mapped by join criteria,
+     * union, intersect, etc.
+     * <p>
+     * For example, given SELECT column_a AS column_x FROM table_a JOIN table_b ON (table_a.column_a = table_b.column_b),
+     * one possible pair of mapped base table columns is (table_a.column_a, table_b.column_b).
+     */
+    public static List<List<TableColumn>> extractMappedBaseColumns(Analysis analysis)
+    {
+        checkState(
+                analysis.getStatement() instanceof CreateMaterializedView,
+                "Only support extracting of mapped columns from create materialized view query");
+
+        MaterializedViewColumnMappingExtractor extractor = new MaterializedViewColumnMappingExtractor(analysis);
+        Query viewQuery = ((CreateMaterializedView) analysis.getStatement()).getQuery();
+        extractor.process(viewQuery, new MaterializedViewPlanValidatorContext());
+
+        return extractor.getMappedBaseColumns();
+    }
+
+    @Override
+    protected Void visitSetOperation(SetOperation node, MaterializedViewPlanValidatorContext context)
+    {
+        super.visitSetOperation(node, context);
+
+        List<RelationType> outputDescriptorList = node.getRelations().stream()
+                .map(relation -> analysis.getOutputDescriptor(relation).withOnlyVisibleFields())
+                .collect(toImmutableList());
+
+        int numRelations = outputDescriptorList.size();
+        int numFields = outputDescriptorList.get(0).getVisibleFieldCount();
+        for (int fieldIndex = 0; fieldIndex < numFields; fieldIndex++) {
+            for (int firstRelationIndex = 0; firstRelationIndex < numRelations; firstRelationIndex++) {
+                Optional<TableColumn> firstBaseColumn = tryGetOriginalTableColumn(outputDescriptorList.get(firstRelationIndex).getFieldByIndex(fieldIndex));
+                for (int secondRelationIndex = firstRelationIndex + 1; secondRelationIndex < numRelations; secondRelationIndex++) {
+                    Optional<TableColumn> secondBaseColumn = tryGetOriginalTableColumn(outputDescriptorList.get(secondRelationIndex).getFieldByIndex(fieldIndex));
+                    if (firstBaseColumn.isPresent() && secondBaseColumn.isPresent() && !firstBaseColumn.get().equals(secondBaseColumn.get())) {
+                        mappedBaseColumns.add(ImmutableList.of(firstBaseColumn.get(), secondBaseColumn.get()));
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    @Override
+    protected Void visitComparisonExpression(ComparisonExpression node, MaterializedViewPlanValidatorContext context)
+    {
+        super.visitComparisonExpression(node, context);
+
+        if (!context.isProcessingJoinNode()) {
+            return null;
+        }
+
+        Field left = analysis.getScope(context.getTopJoinNode()).tryResolveField(node.getLeft())
+                .orElseThrow(() -> new SemanticException(
+                        NOT_SUPPORTED,
+                        node.getLeft(),
+                        "%s in join criteria is not supported for materialized view.", node.getLeft().getClass().getSimpleName()))
+                .getField();
+        Field right = analysis.getScope(context.getTopJoinNode()).tryResolveField(node.getRight())
+                .orElseThrow(() -> new SemanticException(
+                        NOT_SUPPORTED,
+                        node.getRight(),
+                        "%s in join criteria is not supported for materialized view.", node.getRight().getClass().getSimpleName()))
+                .getField();
+
+        Optional<TableColumn> leftBaseColumn = tryGetOriginalTableColumn(left);
+        Optional<TableColumn> rightBaseColumn = tryGetOriginalTableColumn(right);
+        if (leftBaseColumn.isPresent() && rightBaseColumn.isPresent() && !leftBaseColumn.get().equals(rightBaseColumn.get())) {
+            mappedBaseColumns.add(ImmutableList.of(leftBaseColumn.get(), rightBaseColumn.get()));
+        }
+
+        return null;
+    }
+
+    private static Optional<TableColumn> tryGetOriginalTableColumn(Field field)
+    {
+        if (field.getOriginTable().isPresent() && field.getOriginColumnName().isPresent()) {
+            SchemaTableName table = toSchemaTableName(field.getOriginTable().get());
+            String column = field.getOriginColumnName().get();
+            return Optional.of(new TableColumn(table, column));
+        }
+        return Optional.empty();
+    }
+
+    private List<List<TableColumn>> getMappedBaseColumns()
+    {
+        return mappedBaseColumns.build();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -206,7 +206,6 @@ import static com.facebook.presto.sql.analyzer.ExpressionAnalyzer.getExpressionT
 import static com.facebook.presto.sql.analyzer.ExpressionTreeUtils.extractAggregateFunctions;
 import static com.facebook.presto.sql.analyzer.ExpressionTreeUtils.extractExpressions;
 import static com.facebook.presto.sql.analyzer.ExpressionTreeUtils.extractWindowFunctions;
-import static com.facebook.presto.sql.analyzer.MaterializedViewPlanValidator.MaterializedViewPlanValidatorContext;
 import static com.facebook.presto.sql.analyzer.PredicateStitcher.PredicateStitcherContext;
 import static com.facebook.presto.sql.analyzer.RefreshMaterializedViewPredicateAnalyzer.extractTablePredicates;
 import static com.facebook.presto.sql.analyzer.ScopeReferenceExtractor.hasReferencesToScope;
@@ -683,7 +682,6 @@ class StatementAnalyzer
                 }
                 throw new SemanticException(MATERIALIZED_VIEW_ALREADY_EXISTS, node, "Destination materialized view '%s' already exists", viewName);
             }
-            validateMaterialziedViewQueryPlan(node.getQuery());
             validateProperties(node.getProperties(), scope);
 
             analysis.setCreateTableProperties(mapFromProperties(node.getProperties()));
@@ -700,12 +698,6 @@ class StatementAnalyzer
             validateBaseTables(analysis.getTableNodes(), node);
 
             return createAndAssignScope(node, scope);
-        }
-
-        private void validateMaterialziedViewQueryPlan(Statement query)
-        {
-            MaterializedViewPlanValidator validator = new MaterializedViewPlanValidator(query);
-            validator.process(query, new MaterializedViewPlanValidatorContext());
         }
 
         @Override
@@ -1326,7 +1318,7 @@ class StatementAnalyzer
                 ConnectorMaterializedViewDefinition materializedViewDefinition,
                 MaterializedViewStatus materializedViewStatus)
         {
-            validateMaterialziedViewQueryPlan(sqlParser.createStatement(materializedViewDefinition.getOriginalSql(), createParsingOptions(session, warningCollector)));
+            MaterializedViewPlanValidator.validate((Query) sqlParser.createStatement(materializedViewDefinition.getOriginalSql(), createParsingOptions(session, warningCollector)));
 
             String newSql = getMaterializedViewSQL(materializedView, materializedViewDefinition, materializedViewStatus);
 


### PR DESCRIPTION
Support the computation of 1-to-N column mappings from the view to the base table columns for materialized views. Matched base table columns are derived by parsing equi join and set operation.

The computation logic is put into MaterializedViewPlanValidator to avoid logic duplication. The assumption is a valid materialized view plan means we are able to derive the right column mappings for SELECT and REFRESH.

Resolves #16220

```
== NO RELEASE NOTE ==
```


