### PR TITLE
Add materialized view query optimization utility

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewInformationExtractor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewInformationExtractor.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.analyzer;
+
+import com.facebook.presto.sql.tree.AllColumns;
+import com.facebook.presto.sql.tree.ComparisonExpression;
+import com.facebook.presto.sql.tree.DefaultTraversalVisitor;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.GroupBy;
+import com.facebook.presto.sql.tree.GroupingElement;
+import com.facebook.presto.sql.tree.Identifier;
+import com.facebook.presto.sql.tree.LogicalBinaryExpression;
+import com.facebook.presto.sql.tree.QuerySpecification;
+import com.facebook.presto.sql.tree.Relation;
+import com.facebook.presto.sql.tree.Select;
+import com.facebook.presto.sql.tree.SingleColumn;
+import com.facebook.presto.sql.tree.Table;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.facebook.presto.sql.analyzer.SemanticErrorCode.NOT_SUPPORTED;
+import static com.google.common.base.Preconditions.checkState;
+
+public class MaterializedViewInformationExtractor
+        extends DefaultTraversalVisitor<Void, Void>
+{
+    private final MaterializedViewInfo materializedViewInfo = new MaterializedViewInfo();
+
+    @Override
+    protected Void visitQuerySpecification(QuerySpecification node, Void context)
+    {
+        if (node.getLimit().isPresent()) {
+            throw new SemanticException(NOT_SUPPORTED, node, "Limit clause is not supported in query optimizer");
+        }
+        if (node.getHaving().isPresent()) {
+            throw new SemanticException(NOT_SUPPORTED, node, "Having clause is not supported in query optimizer");
+        }
+        return super.visitQuerySpecification(node, context);
+    }
+
+    protected Void visitSelect(Select node, Void context)
+    {
+        super.visitSelect(node, context);
+        materializedViewInfo.setDistinct(node.isDistinct());
+        return null;
+    }
+
+    @Override
+    protected Void visitRelation(Relation node, Void context)
+    {
+        if (!(node instanceof Table)) {
+            throw new SemanticException(NOT_SUPPORTED, node, "Relation other than Table is not supported in query optimizer");
+        }
+        if (materializedViewInfo.getBaseTable().isPresent()) {
+            throw new SemanticException(NOT_SUPPORTED, node, "Only support single table rewrite in query optimizer");
+        }
+        materializedViewInfo.setBaseTable(Optional.of(node));
+        return null;
+    }
+
+    @Override
+    protected Void visitSingleColumn(SingleColumn node, Void context)
+    {
+        Expression baseColumnName = node.getExpression();
+        materializedViewInfo.addBaseToViewColumn(baseColumnName, node.getAlias().orElse(new Identifier(baseColumnName.toString())));
+        return null;
+    }
+
+    @Override
+    protected Void visitAllColumns(AllColumns node, Void context)
+    {
+        throw new SemanticException(NOT_SUPPORTED, node, "All columns materialized view is not supported in query optimizer");
+    }
+
+    @Override
+    protected Void visitGroupBy(GroupBy node, Void context)
+    {
+        materializedViewInfo.setGroupBy(Optional.of(ImmutableSet.copyOf(node.getGroupingElements())));
+        return null;
+    }
+
+    @Override
+    protected Void visitLogicalBinaryExpression(LogicalBinaryExpression node, Void context)
+    {
+        materializedViewInfo.setWhereClause(Optional.of(node));
+        return null;
+    }
+
+    @Override
+    protected Void visitComparisonExpression(ComparisonExpression node, Void context)
+    {
+        materializedViewInfo.setWhereClause(Optional.of(node));
+        return null;
+    }
+
+    public MaterializedViewInfo getMaterializedViewInfo()
+    {
+        return materializedViewInfo;
+    }
+
+    public static final class MaterializedViewInfo
+    {
+        private final Map<Expression, Identifier> baseToViewColumnMap = new HashMap<>();
+        private Optional<Relation> baseTable = Optional.empty();
+        private Optional<Expression> whereClause = Optional.empty();
+        private Optional<Set<GroupingElement>> groupBy = Optional.empty();
+        private boolean isDistinct;
+
+        private void addBaseToViewColumn(Expression key, Identifier value)
+        {
+            baseToViewColumnMap.put(key, value);
+        }
+
+        private void setGroupBy(Optional<Set<GroupingElement>> groupBy)
+        {
+            checkState(!this.groupBy.isPresent());
+            this.groupBy = groupBy;
+        }
+
+        private void setBaseTable(Optional<Relation> baseTable)
+        {
+            checkState(!this.baseTable.isPresent());
+            this.baseTable = baseTable;
+        }
+
+        private void setWhereClause(Optional<Expression> whereClause)
+        {
+            checkState(!this.whereClause.isPresent());
+            this.whereClause = whereClause;
+        }
+
+        private void setDistinct(boolean state)
+        {
+            isDistinct = state;
+        }
+
+        public Optional<Relation> getBaseTable()
+        {
+            return baseTable;
+        }
+
+        public Map<Expression, Identifier> getBaseToViewColumnMap()
+        {
+            return ImmutableMap.copyOf(baseToViewColumnMap);
+        }
+
+        public Optional<Set<GroupingElement>> getGroupBy()
+        {
+            return groupBy;
+        }
+
+        public Optional<Expression> getWhereClause()
+        {
+            return whereClause;
+        }
+
+        public boolean isDistinct()
+        {
+            return isDistinct;
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewQueryOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewQueryOptimizer.java
@@ -1,0 +1,259 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.analyzer;
+
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.sql.tree.AllColumns;
+import com.facebook.presto.sql.tree.ArithmeticBinaryExpression;
+import com.facebook.presto.sql.tree.AstVisitor;
+import com.facebook.presto.sql.tree.ComparisonExpression;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.GroupBy;
+import com.facebook.presto.sql.tree.GroupingElement;
+import com.facebook.presto.sql.tree.Identifier;
+import com.facebook.presto.sql.tree.LogicalBinaryExpression;
+import com.facebook.presto.sql.tree.Node;
+import com.facebook.presto.sql.tree.OrderBy;
+import com.facebook.presto.sql.tree.Query;
+import com.facebook.presto.sql.tree.QueryBody;
+import com.facebook.presto.sql.tree.QuerySpecification;
+import com.facebook.presto.sql.tree.Relation;
+import com.facebook.presto.sql.tree.Select;
+import com.facebook.presto.sql.tree.SelectItem;
+import com.facebook.presto.sql.tree.SimpleGroupBy;
+import com.facebook.presto.sql.tree.SingleColumn;
+import com.facebook.presto.sql.tree.SortItem;
+import com.facebook.presto.sql.tree.Table;
+import com.google.common.collect.ImmutableList;
+
+import static com.facebook.presto.sql.analyzer.MaterializedViewInformationExtractor.MaterializedViewInfo;
+import static com.facebook.presto.sql.analyzer.SemanticErrorCode.NOT_SUPPORTED;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class MaterializedViewQueryOptimizer
+        extends AstVisitor<Node, Void>
+{
+    private static final Logger logger = Logger.get(MaterializedViewQueryOptimizer.class);
+
+    private final Table materializedView;
+    private final Query materializedViewQuery;
+
+    private MaterializedViewInfo materializedViewInfo;
+
+    public MaterializedViewQueryOptimizer(Table materializedView, Query materializedViewQuery)
+    {
+        this.materializedView = requireNonNull(materializedView, "materialized view is null");
+        this.materializedViewQuery = requireNonNull(materializedViewQuery, "materialized view query is null");
+    }
+
+    public Node rewrite(Node node)
+    {
+        try {
+            MaterializedViewInformationExtractor materializedViewInformationExtractor = new MaterializedViewInformationExtractor();
+            materializedViewInformationExtractor.process(materializedViewQuery);
+            materializedViewInfo = materializedViewInformationExtractor.getMaterializedViewInfo();
+            return process(node);
+        }
+        catch (Exception ex) {
+            logger.error(ex.getMessage());
+            return node;
+        }
+    }
+
+    @Override
+    protected Node visitNode(Node node, Void context)
+    {
+        return node;
+    }
+
+    @Override
+    protected Node visitQuery(Query node, Void context)
+    {
+        return new Query(
+                node.getWith(),
+                (QueryBody) process(node.getQueryBody(), context),
+                node.getOrderBy(),
+                node.getOffset(),
+                node.getLimit());
+    }
+
+    @Override
+    protected Node visitQuerySpecification(QuerySpecification node, Void context)
+    {
+        if (!node.getFrom().isPresent()) {
+            throw new IllegalStateException("Query with no From clause is not rewritable by materialized view");
+        }
+        // TODO: Handle filter containment problem https://github.com/prestodb/presto/issues/16405
+        if (materializedViewInfo.getWhereClause().isPresent() && !materializedViewInfo.getWhereClause().equals(node.getWhere())) {
+            throw new IllegalStateException("Query with no where clause is not rewritable by materialized view with where clause");
+        }
+        if (materializedViewInfo.getGroupBy().isPresent() && !node.getGroupBy().isPresent()) {
+            throw new IllegalStateException("Query with no groupBy clause is not rewritable by materialized view with groupBy clause");
+        }
+        // TODO: Add HAVING validation to the validator https://github.com/prestodb/presto/issues/16406
+        if (node.getHaving().isPresent()) {
+            throw new SemanticException(NOT_SUPPORTED, node, "Having clause is not supported in query optimizer");
+        }
+
+        return new QuerySpecification(
+                (Select) process(node.getSelect(), context),
+                node.getFrom().map(from -> (Relation) process(from, context)),
+                node.getWhere().map(where -> (Expression) process(where, context)),
+                node.getGroupBy().map(groupBy -> (GroupBy) process(groupBy, context)),
+                node.getHaving().map(having -> (Expression) process(having, context)),
+                node.getOrderBy().map(orderBy -> (OrderBy) process(orderBy, context)),
+                node.getOffset(),
+                node.getLimit());
+    }
+
+    @Override
+    protected Node visitSelect(Select node, Void context)
+    {
+        if (materializedViewInfo.isDistinct() && !node.isDistinct()) {
+            throw new IllegalStateException("Materialized view has distinct and base query does not");
+        }
+        ImmutableList.Builder<SelectItem> rewrittenSelectItems = ImmutableList.builder();
+
+        for (SelectItem selectItem : node.getSelectItems()) {
+            rewrittenSelectItems.add((SelectItem) process(selectItem, context));
+        }
+
+        return new Select(node.isDistinct(), rewrittenSelectItems.build());
+    }
+
+    @Override
+    protected Node visitSingleColumn(SingleColumn node, Void context)
+    {
+        return new SingleColumn((Expression) process(node.getExpression(), context), node.getAlias());
+    }
+
+    @Override
+    protected Node visitAllColumns(AllColumns node, Void context)
+    {
+        throw new SemanticException(NOT_SUPPORTED, node, "All columns rewrite is not supported in query optimizer");
+    }
+
+    @Override
+    protected Node visitArithmeticBinary(ArithmeticBinaryExpression node, Void context)
+    {
+        return new ArithmeticBinaryExpression(
+                node.getOperator(),
+                (Expression) process(node.getLeft(), context),
+                (Expression) process(node.getRight(), context));
+    }
+
+    @Override
+    protected Node visitIdentifier(Identifier node, Void context)
+    {
+        if (!materializedViewInfo.getBaseToViewColumnMap().containsKey(node)) {
+            throw new IllegalStateException("Materialized view definition does not contain mapping for the column: " + node.getValue());
+        }
+        return new Identifier(materializedViewInfo.getBaseToViewColumnMap().get(node).getValue(), node.isDelimited());
+    }
+
+    @Override
+    protected Node visitFunctionCall(FunctionCall node, Void context)
+    {
+        ImmutableList.Builder<Expression> rewrittenArguments = ImmutableList.builder();
+
+        if (materializedViewInfo.getBaseToViewColumnMap().containsKey(node)) {
+            rewrittenArguments.add(materializedViewInfo.getBaseToViewColumnMap().get(node));
+        }
+        else {
+            for (Expression argument : node.getArguments()) {
+                rewrittenArguments.add((Expression) process(argument, context));
+            }
+        }
+
+        return new FunctionCall(
+                node.getName(),
+                node.getWindow(),
+                node.getFilter(),
+                node.getOrderBy(),
+                node.isDistinct(),
+                node.isIgnoreNulls(),
+                rewrittenArguments.build());
+    }
+
+    @Override
+    protected Node visitRelation(Relation node, Void context)
+    {
+        if (materializedViewInfo.getBaseTable().isPresent() && node.equals(materializedViewInfo.getBaseTable().get())) {
+            return materializedView;
+        }
+        throw new IllegalStateException("Mismatching table or non-supporting relation format in base query");
+    }
+
+    @Override
+    protected Node visitLogicalBinaryExpression(LogicalBinaryExpression node, Void context)
+    {
+        return new LogicalBinaryExpression(
+                node.getOperator(),
+                (Expression) process(node.getLeft(), context),
+                (Expression) process(node.getRight(), context));
+    }
+
+    @Override
+    protected Node visitComparisonExpression(ComparisonExpression node, Void context)
+    {
+        return new ComparisonExpression(
+                node.getOperator(),
+                (Expression) process(node.getLeft(), context),
+                (Expression) process(node.getRight(), context));
+    }
+
+    @Override
+    protected Node visitGroupBy(GroupBy node, Void context)
+    {
+        ImmutableList.Builder<GroupingElement> rewrittenGroupBy = ImmutableList.builder();
+        for (GroupingElement element : node.getGroupingElements()) {
+            if (materializedViewInfo.getGroupBy().isPresent() && !materializedViewInfo.getGroupBy().get().contains(element)) {
+                throw new IllegalStateException(format("Grouping element %s is not present in materialized view groupBy field", element));
+            }
+            rewrittenGroupBy.add((GroupingElement) process(element, context));
+        }
+        return new GroupBy(node.isDistinct(), rewrittenGroupBy.build());
+    }
+
+    @Override
+    protected Node visitOrderBy(OrderBy node, Void context)
+    {
+        ImmutableList.Builder<SortItem> rewrittenOrderBy = ImmutableList.builder();
+        for (SortItem sortItem : node.getSortItems()) {
+            if (!materializedViewInfo.getBaseToViewColumnMap().containsKey(sortItem.getSortKey())) {
+                throw new IllegalStateException(format("Sort key %s is not present in materialized view select fields", sortItem.getSortKey()));
+            }
+            rewrittenOrderBy.add((SortItem) process(sortItem, context));
+        }
+        return new OrderBy(rewrittenOrderBy.build());
+    }
+
+    @Override
+    protected Node visitSortItem(SortItem node, Void context)
+    {
+        return new SortItem((Expression) process(node.getSortKey(), context), node.getOrdering(), node.getNullOrdering());
+    }
+
+    @Override
+    protected Node visitSimpleGroupBy(SimpleGroupBy node, Void context)
+    {
+        ImmutableList.Builder<Expression> rewrittenSimpleGroupBy = ImmutableList.builder();
+        for (Expression column : node.getExpressions()) {
+            rewrittenSimpleGroupBy.add((Expression) process(column, context));
+        }
+        return new SimpleGroupBy(rewrittenSimpleGroupBy.build());
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestMaterializedViewQueryOptimizer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestMaterializedViewQueryOptimizer.java
@@ -1,0 +1,283 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.analyzer;
+
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.tree.QualifiedName;
+import com.facebook.presto.sql.tree.Query;
+import com.facebook.presto.sql.tree.Table;
+import org.testng.annotations.Test;
+
+import static java.lang.String.format;
+import static org.testng.Assert.assertEquals;
+
+public class TestMaterializedViewQueryOptimizer
+{
+    private static final SqlParser SQL_PARSER = new SqlParser();
+    private static final String BASE_TABLE_1 = "base_table_1";
+    private static final String BASE_TABLE_2 = "base_table_2";
+    private static final String VIEW = "view";
+
+    @Test
+    public void testWithSimpleQuery()
+    {
+        String originalViewSql = format("SELECT a, b FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT a, b FROM %s", BASE_TABLE_1);
+        String expectedRewrittenSql = format("SELECT a, b FROM %s", VIEW);
+
+        assertOptimizedQuery(originalViewSql, baseQuerySql, expectedRewrittenSql);
+    }
+
+    @Test
+    public void testWithDistinct()
+    {
+        String originalViewSql = format("SELECT DISTINCT a, b FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT DISTINCT a, b FROM %s", BASE_TABLE_1);
+        String expectedRewrittenSql = format("SELECT DISTINCT a, b FROM %s", VIEW);
+
+        assertOptimizedQuery(originalViewSql, baseQuerySql, expectedRewrittenSql);
+
+        originalViewSql = format("SELECT a, b FROM %s", BASE_TABLE_1);
+        baseQuerySql = format("SELECT DISTINCT a, b FROM %s", BASE_TABLE_1);
+        expectedRewrittenSql = format("SELECT DISTINCT a, b FROM %s", VIEW);
+
+        assertOptimizedQuery(originalViewSql, baseQuerySql, expectedRewrittenSql);
+
+        originalViewSql = format("SELECT DISTINCT a, b FROM %s", BASE_TABLE_1);
+        baseQuerySql = format("SELECT a, b FROM %s", BASE_TABLE_1);
+
+        assertOptimizedQuery(originalViewSql, baseQuerySql, baseQuerySql);
+    }
+
+    @Test
+    public void testWithAlias()
+    {
+        String originalViewSql = format("SELECT a as mv_a, b, c as mv_c FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT a, b, c FROM %s", BASE_TABLE_1);
+        String expectedRewrittenSql = format("SELECT mv_a, b, mv_c FROM %s", VIEW);
+
+        assertOptimizedQuery(originalViewSql, baseQuerySql, expectedRewrittenSql);
+
+        originalViewSql = format("SELECT a as mv_a, b, c as mv_c, d FROM %s", BASE_TABLE_1);
+        baseQuerySql = format("SELECT a as result_a, b as result_b, c, d FROM %s", BASE_TABLE_1);
+        expectedRewrittenSql = format("SELECT mv_a as result_a, b as result_b, mv_c, d FROM %s", VIEW);
+
+        assertOptimizedQuery(originalViewSql, baseQuerySql, expectedRewrittenSql);
+    }
+
+    @Test
+    public void testWithAllColumnsSelect()
+    {
+        String originalViewSql = format("SELECT * FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT * FROM %s", BASE_TABLE_1);
+
+        assertOptimizedQuery(originalViewSql, baseQuerySql, baseQuerySql);
+    }
+
+    @Test
+    public void testWithBaseQueryGroupBy()
+    {
+        String originalViewSql = format("SELECT a as mv_a, b, c as mv_c FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT SUM(a * b), MAX(a + b), c FROM %s GROUP BY c", BASE_TABLE_1);
+        String expectedRewrittenSql = format("SELECT SUM(mv_a * b), MAX(mv_a + b), mv_c FROM %s GROUP BY mv_c", VIEW);
+
+        assertOptimizedQuery(originalViewSql, baseQuerySql, expectedRewrittenSql);
+    }
+
+    @Test
+    public void testWithDerivedFields()
+    {
+        String originalViewSql = format("SELECT SUM(a * b + c) as mv_sum, MAX(a * b + c) as mv_max, d, e FROM %s GROUP BY d, e", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT SUM(a * b + c), MAX(a * b + c), d, e FROM %s GROUP BY d, e", BASE_TABLE_1);
+        String expectedRewrittenSql = format("SELECT SUM(mv_sum), MAX(mv_max), d, e FROM %s GROUP BY d, e", VIEW);
+
+        assertOptimizedQuery(originalViewSql, baseQuerySql, expectedRewrittenSql);
+
+        originalViewSql = format("SELECT SUM(a * b + c) as mv_sum, MAX(a * b + c) as mv_max, d as mv_d, e FROM %s GROUP BY d, e", BASE_TABLE_1);
+        baseQuerySql = format("SELECT SUM(a * b + c) as sum_of_abc, MAX(a * b + c) as max_of_abc, d, e FROM %s GROUP BY d, e", BASE_TABLE_1);
+        expectedRewrittenSql = format("SELECT SUM(mv_sum) as sum_of_abc, MAX(mv_max) as max_of_abc, mv_d, e FROM %s GROUP BY mv_d, e", VIEW);
+
+        assertOptimizedQuery(originalViewSql, baseQuerySql, expectedRewrittenSql);
+    }
+
+    @Test
+    public void testWithArithmeticBinary()
+    {
+        String originalViewSql = format("SELECT a, b, c FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT a + b, a * b - c FROM %s", BASE_TABLE_1);
+        String expectedRewrittenSql = format("SELECT a + b, a * b - c FROM %s", VIEW);
+
+        assertOptimizedQuery(originalViewSql, baseQuerySql, expectedRewrittenSql);
+
+        originalViewSql = format("SELECT a as mv_a, b, c as mv_c, d FROM %s", BASE_TABLE_1);
+        baseQuerySql = format("SELECT a + b, c / d, a * c - b * d FROM %s", BASE_TABLE_1);
+        expectedRewrittenSql = format("SELECT mv_a + b, mv_c / d, mv_a * mv_c - b * d FROM %s", VIEW);
+
+        assertOptimizedQuery(originalViewSql, baseQuerySql, expectedRewrittenSql);
+    }
+
+    @Test
+    public void testWithWhereCondition()
+    {
+        String originalViewSql = format("SELECT a, b, c, d FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT a, b FROM %s WHERE a < 10 AND c > 10 or d = '2000-01-01'", BASE_TABLE_1);
+        String expectedRewrittenSql = format("SELECT a, b FROM %s WHERE a < 10 AND c > 10 or d = '2000-01-01'", VIEW);
+
+        assertOptimizedQuery(originalViewSql, baseQuerySql, expectedRewrittenSql);
+
+        originalViewSql = format("SELECT a as mv_a, b, c, d as mv_d FROM %s", BASE_TABLE_1);
+        baseQuerySql = format("SELECT a, b FROM %s WHERE a < 10 AND c > 10 or d = '2000-01-01'", BASE_TABLE_1);
+        expectedRewrittenSql = format("SELECT mv_a, b FROM %s WHERE mv_a < 10 AND c > 10 or mv_d = '2000-01-01'", VIEW);
+
+        assertOptimizedQuery(originalViewSql, baseQuerySql, expectedRewrittenSql);
+    }
+
+    @Test
+    public void testWithOrderBy()
+    {
+        String originalViewSql = format("SELECT a, b, c FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT a, b, c FROM %s ORDER BY c ASC, b DESC, a", BASE_TABLE_1);
+        String expectedRewrittenSql = format("SELECT a, b, c FROM %s ORDER BY c ASC, b DESC, a", VIEW);
+
+        assertOptimizedQuery(originalViewSql, baseQuerySql, expectedRewrittenSql);
+
+        originalViewSql = format("SELECT a as mv_a, b, c as mv_c FROM %s", BASE_TABLE_1);
+        baseQuerySql = format("SELECT a, b, c FROM %s ORDER BY c ASC, b DESC, a", BASE_TABLE_1);
+        expectedRewrittenSql = format("SELECT mv_a, b, mv_c FROM %s ORDER BY mv_c ASC, b DESC, mv_a", VIEW);
+
+        assertOptimizedQuery(originalViewSql, baseQuerySql, expectedRewrittenSql);
+
+        originalViewSql = format("SELECT a as mv_a, b, c as mv_c FROM %s", BASE_TABLE_1);
+        baseQuerySql = format("SELECT a, b, c FROM %s ORDER BY c ASC, b DESC, a", BASE_TABLE_1);
+        expectedRewrittenSql = format("SELECT mv_a, b, mv_c FROM %s ORDER BY mv_c ASC, b DESC, mv_a", VIEW);
+
+        assertOptimizedQuery(originalViewSql, baseQuerySql, expectedRewrittenSql);
+
+        originalViewSql = format("SELECT MAX(a) as mv_max_a, b FROM %s GROUP BY b", BASE_TABLE_1);
+        baseQuerySql = format("SELECT MAX(a), b FROM %s GROUP BY b ORDER BY MAX(a) DESC, b ASC", BASE_TABLE_1);
+        expectedRewrittenSql = format("SELECT MAX(mv_max_a), b FROM %s GROUP BY b ORDER BY MAX(mv_max_a) DESC, b ASC", VIEW);
+
+        assertOptimizedQuery(originalViewSql, baseQuerySql, expectedRewrittenSql);
+    }
+
+    @Test
+    public void testWithNoMatchingBaseTable()
+    {
+        String originalViewSql = format("SELECT a, b FROM %s", BASE_TABLE_2);
+        String baseQuerySql = format("SELECT a, b FROM %s", BASE_TABLE_1);
+
+        assertOptimizedQuery(originalViewSql, baseQuerySql, baseQuerySql);
+    }
+
+    @Test
+    public void testWithNoMatchingColumnNames()
+    {
+        String originalViewSql = format("SELECT a, b, c FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT c, d FROM %s", BASE_TABLE_1);
+
+        assertOptimizedQuery(originalViewSql, baseQuerySql, baseQuerySql);
+
+        originalViewSql = format("SELECT a, b, c FROM %s", BASE_TABLE_1);
+        baseQuerySql = format("SELECT a, c FROM %s WHERE d = 5", BASE_TABLE_1);
+
+        assertOptimizedQuery(originalViewSql, baseQuerySql, baseQuerySql);
+    }
+
+    @Test
+    public void testWithDifferentFilterCondition()
+    {
+        String originalViewSql = format("SELECT a, b, c FROM %s WHERE a = 5 OR b = 3", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT a, c FROM %s WHERE a = 5 OR b = 4", BASE_TABLE_1);
+
+        assertOptimizedQuery(originalViewSql, baseQuerySql, baseQuerySql);
+
+        originalViewSql = format("SELECT a, b, c FROM %s WHERE a = 5", BASE_TABLE_1);
+        baseQuerySql = format("SELECT a, c FROM %s", BASE_TABLE_1);
+
+        assertOptimizedQuery(originalViewSql, baseQuerySql, baseQuerySql);
+    }
+
+    @Test
+    public void testWithNoGroupByInBaseQuery()
+    {
+        String originalViewSql = format("SELECT SUM(a) as sum_a, b FROM %s GROUP BY b", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT b FROM %s", BASE_TABLE_1);
+
+        assertOptimizedQuery(originalViewSql, baseQuerySql, baseQuerySql);
+    }
+
+    @Test
+    public void testWithMissingColumnInOrderBy()
+    {
+        String originalViewSql = format("SELECT a, b, c FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT a, c FROM %s ORDER BY b DESC, d", BASE_TABLE_1);
+
+        assertOptimizedQuery(originalViewSql, baseQuerySql, baseQuerySql);
+    }
+
+    @Test
+    public void testWithLimitClause()
+    {
+        String originalViewSql = format("SELECT a, b, c FROM %s LIMIT 5", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT a, c FROM %s", BASE_TABLE_1);
+
+        assertOptimizedQuery(originalViewSql, baseQuerySql, baseQuerySql);
+    }
+
+    // TODO: Handle table alias rewrite for view definition and base query https://github.com/prestodb/presto/issues/16404#issue-940248564
+    @Test
+    public void testWithTableAliasInView()
+    {
+        String originalViewSql = format("SELECT base1.a, b, c FROM %s base1", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT a, c FROM %s", BASE_TABLE_1);
+
+        assertOptimizedQuery(originalViewSql, baseQuerySql, baseQuerySql);
+    }
+
+    @Test
+    public void testWithTableAliasInBaseQuery()
+    {
+        String originalViewSql = format("SELECT a, b, c FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT base1.a, c FROM %s base1", BASE_TABLE_1);
+
+        assertOptimizedQuery(originalViewSql, baseQuerySql, baseQuerySql);
+    }
+
+    @Test
+    public void testWithJoinTables()
+    {
+        String originalViewSql = format("SELECT %s.a, %s.b FROM %s JOIN %s ON %s.c = %s.c", BASE_TABLE_1, BASE_TABLE_2, BASE_TABLE_1, BASE_TABLE_2, BASE_TABLE_1, BASE_TABLE_2);
+        String baseQuerySql = format("SELECT a, c FROM %s base1", BASE_TABLE_1);
+
+        assertOptimizedQuery(originalViewSql, baseQuerySql, baseQuerySql);
+
+        originalViewSql = format("SELECT a, b, c FROM %s", BASE_TABLE_1);
+        baseQuerySql = format("SELECT %s.a, %s.b FROM %s JOIN %s ON %s.c = %s.c", BASE_TABLE_1, BASE_TABLE_2, BASE_TABLE_1, BASE_TABLE_2, BASE_TABLE_1, BASE_TABLE_2);
+
+        assertOptimizedQuery(originalViewSql, baseQuerySql, baseQuerySql);
+    }
+
+    private void assertOptimizedQuery(String originalViewSql, String baseQuerySql, String expectedViewSql)
+    {
+        Table viewTable = new Table(QualifiedName.of(VIEW));
+
+        Query originalViewQuery = (Query) SQL_PARSER.createStatement(originalViewSql);
+        Query baseQuery = (Query) SQL_PARSER.createStatement(baseQuerySql);
+        Query expectedViewQuery = (Query) SQL_PARSER.createStatement(expectedViewSql);
+
+        Query optimizedBaseToViewQuery = (Query) new MaterializedViewQueryOptimizer(viewTable, originalViewQuery).rewrite(baseQuery);
+
+        assertEquals(optimizedBaseToViewQuery, expectedViewQuery);
+    }
+}


### PR DESCRIPTION
Adding materialized view optimizer utility to optimize eligible queries if supported by a materialized view. The utility is also responsible for validating the original query against the supported formats.

Currently, this utility is very restrictive and supports some simple query formats. It does not support complex queries (Join, Union, subquery, etc.).

```== NO RELEASE NOTE ==```