### PR TITLE
Display coordinator host name in web ui

### DIFF
--- a/presto-main/src/main/resources/webapp/src/components/QueryDetail.jsx
+++ b/presto-main/src/main/resources/webapp/src/components/QueryDetail.jsx
@@ -1268,6 +1268,14 @@ export class QueryDetail extends React.Component {
                                     {query.queryStats.executionTime}
                                 </td>
                             </tr>
+                            <tr>
+                                <td className="info-title">
+                                    Coordinator
+                                </td>
+                                <td className="info-text">
+                                    {getHostname(query.self)}
+                                </td>
+                            </tr>
                             </tbody>
                         </table>
                     </div>


### PR DESCRIPTION
Now that all queries are collectively displayed in the coordinator web UI, regardless of which coordinator we choose to look at, we should also add the coordinator the query is running on, as a diagnostic for troubleshooting.

Test plan -
   Tested by running in local
![image](https://user-images.githubusercontent.com/26416722/121755981-7f6eb400-cacd-11eb-815d-7be7e7b4a928.png)

```
== RELEASE NOTES ==

General Changes
*  Display coordinator host name in web ui to support multi coordinator setup.
```
