### PR TITLE
Refactor: Change StandardTypes to be a enum class #16246

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/type/ArrayType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/ArrayType.java
@@ -39,7 +39,7 @@ public class ArrayType
 
     public ArrayType(Type elementType)
     {
-        super(new TypeSignature(ARRAY, TypeSignatureParameter.of(elementType.getTypeSignature())), Block.class);
+        super(new TypeSignature(ARRAY.getEnumValue(), TypeSignatureParameter.of(elementType.getTypeSignature())), Block.class);
         this.elementType = requireNonNull(elementType, "elementType is null");
     }
 
@@ -216,6 +216,6 @@ public class ArrayType
     @Override
     public String getDisplayName()
     {
-        return ARRAY + "(" + elementType.getDisplayName() + ")";
+        return ARRAY.getEnumValue() + "(" + elementType.getDisplayName() + ")";
     }
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/type/BigintEnumParametricType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/BigintEnumParametricType.java
@@ -27,7 +27,7 @@ public final class BigintEnumParametricType
     @Override
     public String getName()
     {
-        return StandardTypes.BIGINT_ENUM;
+        return StandardTypes.BIGINT_ENUM.getEnumValue();
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/type/BigintEnumType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/BigintEnumType.java
@@ -40,7 +40,7 @@ public class BigintEnumType
 
     public BigintEnumType(LongEnumMap enumMap)
     {
-        super(new TypeSignature(StandardTypes.BIGINT_ENUM, TypeSignatureParameter.of(enumMap)));
+        super(new TypeSignature(StandardTypes.BIGINT_ENUM.getEnumValue(), TypeSignatureParameter.of(enumMap)));
         this.enumMap = enumMap;
     }
 

--- a/presto-common/src/main/java/com/facebook/presto/common/type/BigintType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/BigintType.java
@@ -25,7 +25,7 @@ public final class BigintType
 
     private BigintType()
     {
-        super(parseTypeSignature(StandardTypes.BIGINT));
+        super(parseTypeSignature(StandardTypes.BIGINT.getEnumValue()));
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/type/BooleanType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/BooleanType.java
@@ -31,7 +31,7 @@ public final class BooleanType
 
     private BooleanType()
     {
-        super(parseTypeSignature(StandardTypes.BOOLEAN), boolean.class);
+        super(parseTypeSignature(StandardTypes.BOOLEAN.getEnumValue()), boolean.class);
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/type/CharType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/CharType.java
@@ -42,7 +42,7 @@ public final class CharType
     {
         super(
                 new TypeSignature(
-                        StandardTypes.CHAR,
+                        StandardTypes.CHAR.getEnumValue(),
                         singletonList(TypeSignatureParameter.of(length))),
                 Slice.class);
 

--- a/presto-common/src/main/java/com/facebook/presto/common/type/DateType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/DateType.java
@@ -33,7 +33,7 @@ public final class DateType
 
     private DateType()
     {
-        super(parseTypeSignature(StandardTypes.DATE));
+        super(parseTypeSignature(StandardTypes.DATE.getEnumValue()));
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/type/DecimalType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/DecimalType.java
@@ -54,7 +54,7 @@ public abstract class DecimalType
 
     DecimalType(int precision, int scale, Class<?> javaType)
     {
-        super(new TypeSignature(StandardTypes.DECIMAL, buildTypeParameters(precision, scale)), javaType);
+        super(new TypeSignature(StandardTypes.DECIMAL.getEnumValue(), buildTypeParameters(precision, scale)), javaType);
         this.precision = precision;
         this.scale = scale;
     }

--- a/presto-common/src/main/java/com/facebook/presto/common/type/DoubleType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/DoubleType.java
@@ -33,7 +33,7 @@ public final class DoubleType
 
     private DoubleType()
     {
-        super(parseTypeSignature(StandardTypes.DOUBLE), double.class);
+        super(parseTypeSignature(StandardTypes.DOUBLE.getEnumValue()), double.class);
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/type/HyperLogLogType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/HyperLogLogType.java
@@ -32,7 +32,7 @@ public class HyperLogLogType
     @JsonCreator
     public HyperLogLogType()
     {
-        super(parseTypeSignature(StandardTypes.HYPER_LOG_LOG), Slice.class);
+        super(parseTypeSignature(StandardTypes.HYPER_LOG_LOG.getEnumValue()), Slice.class);
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/type/IntegerType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/IntegerType.java
@@ -28,7 +28,7 @@ public final class IntegerType
 
     private IntegerType()
     {
-        super(parseTypeSignature(StandardTypes.INTEGER));
+        super(parseTypeSignature(StandardTypes.INTEGER.getEnumValue()));
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/type/JsonType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/JsonType.java
@@ -29,7 +29,7 @@ public class JsonType
 
     public JsonType()
     {
-        super(new TypeSignature(StandardTypes.JSON), Slice.class);
+        super(new TypeSignature(StandardTypes.JSON.getEnumValue()), Slice.class);
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/type/MapType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/MapType.java
@@ -52,7 +52,7 @@ public class MapType
             MethodHandle keyBlockEquals,
             MethodHandle keyBlockHashCode)
     {
-        super(new TypeSignature(StandardTypes.MAP,
+        super(new TypeSignature(StandardTypes.MAP.getEnumValue(),
                         TypeSignatureParameter.of(keyType.getTypeSignature()),
                         TypeSignatureParameter.of(valueType.getTypeSignature())),
                 Block.class);

--- a/presto-common/src/main/java/com/facebook/presto/common/type/P4HyperLogLogType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/P4HyperLogLogType.java
@@ -30,7 +30,7 @@ public class P4HyperLogLogType
     @JsonCreator
     public P4HyperLogLogType()
     {
-        super(parseTypeSignature(StandardTypes.P4_HYPER_LOG_LOG), Slice.class);
+        super(parseTypeSignature(StandardTypes.P4_HYPER_LOG_LOG.getEnumValue()), Slice.class);
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/type/QuantileDigestParametricType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/QuantileDigestParametricType.java
@@ -22,7 +22,7 @@ public class QuantileDigestParametricType
     @Override
     public String getName()
     {
-        return StandardTypes.QDIGEST;
+        return StandardTypes.QDIGEST.getEnumValue();
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/type/QuantileDigestType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/QuantileDigestType.java
@@ -20,6 +20,6 @@ class QuantileDigestType
 {
     QuantileDigestType(Type type)
     {
-        super(QDIGEST, type);
+        super(QDIGEST.getEnumValue(), type);
     }
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/type/RealType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/RealType.java
@@ -31,7 +31,7 @@ public final class RealType
 
     private RealType()
     {
-        super(parseTypeSignature(StandardTypes.REAL));
+        super(parseTypeSignature(StandardTypes.REAL.getEnumValue()));
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/type/RowType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/RowType.java
@@ -98,7 +98,7 @@ public class RowType
                 .map(field -> TypeSignatureParameter.of(new NamedTypeSignature(field.getName().map(name -> new RowFieldName(name, false)), field.getType().getTypeSignature())))
                 .collect(Collectors.toList());
 
-        return new TypeSignature(ROW, parameters);
+        return new TypeSignature(ROW.getEnumValue(), parameters);
     }
 
     @Override
@@ -118,7 +118,7 @@ public class RowType
     {
         // Convert to standard sql name
         StringBuilder result = new StringBuilder();
-        result.append(ROW).append('(');
+        result.append(ROW.getEnumValue()).append('(');
         for (Field field : fields) {
             String typeDisplayName = field.getType().getDisplayName();
             if (field.getName().isPresent()) {

--- a/presto-common/src/main/java/com/facebook/presto/common/type/SmallintType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/SmallintType.java
@@ -34,7 +34,7 @@ public final class SmallintType
 
     private SmallintType()
     {
-        super(parseTypeSignature(StandardTypes.SMALLINT), long.class);
+        super(parseTypeSignature(StandardTypes.SMALLINT.getEnumValue()), long.class);
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/type/StandardTypes.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/StandardTypes.java
@@ -19,44 +19,52 @@ import java.util.Set;
 import static java.util.Arrays.asList;
 import static java.util.Collections.unmodifiableSet;
 
-public final class StandardTypes
+public enum StandardTypes
 {
-    public static final String BIGINT = "bigint";
-    public static final String INTEGER = "integer";
-    public static final String SMALLINT = "smallint";
-    public static final String TINYINT = "tinyint";
-    public static final String BOOLEAN = "boolean";
-    public static final String DATE = "date";
-    public static final String DECIMAL = "decimal";
-    public static final String REAL = "real";
-    public static final String DOUBLE = "double";
-    public static final String HYPER_LOG_LOG = "HyperLogLog";
-    public static final String QDIGEST = "qdigest";
-    public static final String TDIGEST = "tdigest";
-    public static final String P4_HYPER_LOG_LOG = "P4HyperLogLog";
-    public static final String INTERVAL_DAY_TO_SECOND = "interval day to second";
-    public static final String INTERVAL_YEAR_TO_MONTH = "interval year to month";
-    public static final String TIMESTAMP = "timestamp";
-    public static final String TIMESTAMP_WITH_TIME_ZONE = "timestamp with time zone";
-    public static final String TIME = "time";
-    public static final String TIME_WITH_TIME_ZONE = "time with time zone";
-    public static final String VARBINARY = "varbinary";
-    public static final String VARCHAR = "varchar";
-    public static final String CHAR = "char";
-    public static final String ROW = "row";
-    public static final String ARRAY = "array";
-    public static final String MAP = "map";
-    public static final String JSON = "json";
-    public static final String IPADDRESS = "ipaddress";
-    public static final String IPPREFIX = "ipprefix";
-    public static final String GEOMETRY = "Geometry";
-    public static final String BING_TILE = "BingTile";
-    public static final String BIGINT_ENUM = "BigintEnum";
-    public static final String VARCHAR_ENUM = "VarcharEnum";
+    BIGINT("bigint"),
+    INTEGER("integer"),
+    SMALLINT("smallint"),
+    TINYINT("tinyint"),
+    BOOLEAN("boolean"),
+    DATE("date"),
+    DECIMAL("decimal"),
+    REAL("real"),
+    DOUBLE("double"),
+    HYPER_LOG_LOG("HyperLogLog"),
+    QDIGEST("qdigest"),
+    TDIGEST("tdigest"),
+    P4_HYPER_LOG_LOG("P4HyperLogLog"),
+    INTERVAL_DAY_TO_SECOND("interval day to second"),
+    INTERVAL_YEAR_TO_MONTH("interval year to month"),
+    TIMESTAMP("timestamp"),
+    TIMESTAMP_WITH_TIME_ZONE("timestamp with time zone"),
+    TIME("time"),
+    TIME_WITH_TIME_ZONE("time with time zone"),
+    VARBINARY("varbinary"),
+    VARCHAR("varchar"),
+    CHAR("char"),
+    ROW("row"),
+    ARRAY("array"),
+    MAP("map"),
+    JSON("json"),
+    IPADDRESS("ipaddress"),
+    IPPREFIX("ipprefix"),
+    GEOMETRY("Geometry"),
+    BING_TILE("BingTile"),
+    BIGINT_ENUM("BigintEnum"),
+    VARCHAR_ENUM("VarcharEnum");
 
-    private StandardTypes() {}
+    private final String enumValue;
 
-    public static final Set<String> PARAMETRIC_TYPES = unmodifiableSet(new HashSet<>(asList(
+    StandardTypes(String enumValue) {
+        this.enumValue = enumValue;
+    }
+
+    public String getEnumValue(){
+        return enumValue;
+    }
+
+    public static final Set<StandardTypes> PARAMETRIC_TYPES = unmodifiableSet(new HashSet<>(asList(
             VARCHAR,
             CHAR,
             DECIMAL,

--- a/presto-common/src/main/java/com/facebook/presto/common/type/TDigestParametricType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TDigestParametricType.java
@@ -23,7 +23,7 @@ public class TDigestParametricType
     @Override
     public String getName()
     {
-        return StandardTypes.TDIGEST;
+        return StandardTypes.TDIGEST.getEnumValue();
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/type/TDigestType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TDigestType.java
@@ -20,6 +20,6 @@ class TDigestType
 {
     TDigestType(Type type)
     {
-        super(TDIGEST, type);
+        super(TDIGEST.getEnumValue(), type);
     }
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/type/TimeType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TimeType.java
@@ -29,7 +29,7 @@ public final class TimeType
 
     private TimeType()
     {
-        super(parseTypeSignature(StandardTypes.TIME));
+        super(parseTypeSignature(StandardTypes.TIME.getEnumValue()));
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/type/TimeWithTimeZoneType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TimeWithTimeZoneType.java
@@ -26,7 +26,7 @@ public final class TimeWithTimeZoneType
 
     private TimeWithTimeZoneType()
     {
-        super(parseTypeSignature(StandardTypes.TIME_WITH_TIME_ZONE));
+        super(parseTypeSignature(StandardTypes.TIME_WITH_TIME_ZONE.getEnumValue()));
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/type/TimestampType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TimestampType.java
@@ -29,7 +29,7 @@ public final class TimestampType
 
     private TimestampType()
     {
-        super(parseTypeSignature(StandardTypes.TIMESTAMP));
+        super(parseTypeSignature(StandardTypes.TIMESTAMP.getEnumValue()));
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/type/TimestampWithTimeZoneType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TimestampWithTimeZoneType.java
@@ -26,7 +26,7 @@ public final class TimestampWithTimeZoneType
 
     private TimestampWithTimeZoneType()
     {
-        super(parseTypeSignature(StandardTypes.TIMESTAMP_WITH_TIME_ZONE));
+        super(parseTypeSignature(StandardTypes.TIMESTAMP_WITH_TIME_ZONE.getEnumValue()));
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/type/TinyintType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TinyintType.java
@@ -34,7 +34,7 @@ public final class TinyintType
 
     private TinyintType()
     {
-        super(parseTypeSignature(StandardTypes.TINYINT), long.class);
+        super(parseTypeSignature(StandardTypes.TINYINT.getEnumValue()), long.class);
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/type/TypeSignature.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TypeSignature.java
@@ -55,16 +55,16 @@ public class TypeSignature
     private static final Set<String> SIMPLE_TYPE_WITH_SPACES =
             new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
 
-    private static final String BIGINT_ENUM_PREFIX = BIGINT_ENUM.toLowerCase(ENGLISH);
+    private static final String BIGINT_ENUM_PREFIX = BIGINT_ENUM.getEnumValue().toLowerCase(ENGLISH);
     private static final Pattern ENUM_PREFIX = Pattern.compile("(varchar|bigint)enum\\(");
 
     static {
-        BASE_NAME_ALIAS_TO_CANONICAL.put("int", StandardTypes.INTEGER);
+        BASE_NAME_ALIAS_TO_CANONICAL.put("int", StandardTypes.INTEGER.getEnumValue());
 
-        SIMPLE_TYPE_WITH_SPACES.add(StandardTypes.TIME_WITH_TIME_ZONE);
-        SIMPLE_TYPE_WITH_SPACES.add(StandardTypes.TIMESTAMP_WITH_TIME_ZONE);
-        SIMPLE_TYPE_WITH_SPACES.add(StandardTypes.INTERVAL_DAY_TO_SECOND);
-        SIMPLE_TYPE_WITH_SPACES.add(StandardTypes.INTERVAL_YEAR_TO_MONTH);
+        SIMPLE_TYPE_WITH_SPACES.add(StandardTypes.TIME_WITH_TIME_ZONE.getEnumValue());
+        SIMPLE_TYPE_WITH_SPACES.add(StandardTypes.TIMESTAMP_WITH_TIME_ZONE.getEnumValue());
+        SIMPLE_TYPE_WITH_SPACES.add(StandardTypes.INTERVAL_DAY_TO_SECOND.getEnumValue());
+        SIMPLE_TYPE_WITH_SPACES.add(StandardTypes.INTERVAL_YEAR_TO_MONTH.getEnumValue());
         SIMPLE_TYPE_WITH_SPACES.add("double precision");
     }
 
@@ -163,7 +163,7 @@ public class TypeSignature
         int posOfColon = signature.indexOf(":");
         if (posOfLessThan < 0 && posOfParent < 0 && posOfColon < 0) {
             // non-parametric standard type
-            if (signature.equalsIgnoreCase(StandardTypes.VARCHAR)) {
+            if (signature.equalsIgnoreCase(StandardTypes.VARCHAR.getEnumValue())) {
                 return VarcharType.createUnboundedVarcharType().getTypeSignature();
             }
             checkArgument(!literalCalculationParameters.contains(signature), "Bad type signature: '%s'", signature);
@@ -182,7 +182,7 @@ public class TypeSignature
                 return new TypeSignature(signature.substring(0, startOfParams), parseTypeSignature(signature.substring(posOfColon + 1)).getParameters());
             }
         }
-        if (lowerCaseSignature.startsWith(StandardTypes.ROW + "(")) {
+        if (lowerCaseSignature.startsWith(StandardTypes.ROW.getEnumValue() + "(")) {
             return parseRowTypeSignature(signature, literalCalculationParameters);
         }
 
@@ -394,7 +394,7 @@ public class TypeSignature
 
     private static TypeSignature parseRowTypeSignature(String signature, Set<String> literalParameters)
     {
-        checkArgument(signature.toLowerCase(ENGLISH).startsWith(StandardTypes.ROW + "("), "Not a row type signature: '%s'", signature);
+        checkArgument(signature.toLowerCase(ENGLISH).startsWith(StandardTypes.ROW.getEnumValue() + "("), "Not a row type signature: '%s'", signature);
 
         RowTypeSignatureParsingState state = RowTypeSignatureParsingState.START_OF_FIELD;
         int bracketLevel = 1;
@@ -403,7 +403,7 @@ public class TypeSignature
 
         List<TypeSignatureParameter> fields = new ArrayList<>();
 
-        for (int i = StandardTypes.ROW.length() + 1; i < signature.length(); i++) {
+        for (int i = StandardTypes.ROW.getEnumValue().length() + 1; i < signature.length(); i++) {
             char c = signature.charAt(i);
             switch (state) {
                 case START_OF_FIELD:
@@ -499,7 +499,7 @@ public class TypeSignature
         }
 
         checkArgument(state == RowTypeSignatureParsingState.FINISHED, "Bad type signature: '%s'", signature);
-        return new TypeSignature(signature.substring(0, StandardTypes.ROW.length()), fields);
+        return new TypeSignature(signature.substring(0, StandardTypes.ROW.getEnumValue().length()), fields);
     }
 
     private static TypeSignatureParameter parseTypeOrNamedType(String typeOrNamedType, Set<String> literalParameters)
@@ -569,7 +569,7 @@ public class TypeSignature
             return baseString;
         }
 
-        if (baseString.equalsIgnoreCase(StandardTypes.VARCHAR) &&
+        if (baseString.equalsIgnoreCase(StandardTypes.VARCHAR.getEnumValue()) &&
                 (parameters.size() == 1) &&
                 parameters.get(0).isLongLiteral() &&
                 parameters.get(0).getLongLiteral() == VarcharType.UNBOUNDED_LENGTH) {

--- a/presto-common/src/main/java/com/facebook/presto/common/type/VarbinaryType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/VarbinaryType.java
@@ -27,7 +27,7 @@ public final class VarbinaryType
 
     private VarbinaryType()
     {
-        super(parseTypeSignature(StandardTypes.VARBINARY), Slice.class);
+        super(parseTypeSignature(StandardTypes.VARBINARY.getEnumValue()), Slice.class);
     }
 
     public static boolean isVarbinaryType(Type type)

--- a/presto-common/src/main/java/com/facebook/presto/common/type/VarcharEnumParametricType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/VarcharEnumParametricType.java
@@ -27,7 +27,7 @@ public final class VarcharEnumParametricType
     @Override
     public String getName()
     {
-        return StandardTypes.VARCHAR_ENUM;
+        return StandardTypes.VARCHAR_ENUM.getEnumValue();
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/type/VarcharEnumType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/VarcharEnumType.java
@@ -39,7 +39,7 @@ public class VarcharEnumType
 
     public VarcharEnumType(VarcharEnumMap enumMap)
     {
-        super(VarcharType.UNBOUNDED_LENGTH, new TypeSignature(StandardTypes.VARCHAR_ENUM, TypeSignatureParameter.of(enumMap)));
+        super(VarcharType.UNBOUNDED_LENGTH, new TypeSignature(StandardTypes.VARCHAR_ENUM.getEnumValue(), TypeSignatureParameter.of(enumMap)));
         this.enumMap = enumMap;
     }
 

--- a/presto-common/src/main/java/com/facebook/presto/common/type/VarcharType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/VarcharType.java
@@ -36,7 +36,7 @@ public final class VarcharType
 
     public static TypeSignature getParametrizedVarcharSignature(String param)
     {
-        return new TypeSignature(StandardTypes.VARCHAR, TypeSignatureParameter.of(param));
+        return new TypeSignature(StandardTypes.VARCHAR.getEnumValue(), TypeSignatureParameter.of(param));
     }
 
     private VarcharType(int length)
@@ -44,7 +44,7 @@ public final class VarcharType
         super(
                 length,
                 new TypeSignature(
-                        StandardTypes.VARCHAR,
+                        StandardTypes.VARCHAR.getEnumValue(),
                         singletonList(TypeSignatureParameter.of((long) length))));
     }
 }

--- a/presto-common/src/test/java/com/facebook/presto/common/type/TestTypeSignature.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/type/TestTypeSignature.java
@@ -178,17 +178,17 @@ public class TestTypeSignature
 
     private TypeSignature varchar()
     {
-        return new TypeSignature(StandardTypes.VARCHAR, TypeSignatureParameter.of(VarcharType.UNBOUNDED_LENGTH));
+        return new TypeSignature(StandardTypes.VARCHAR.getEnumValue(), TypeSignatureParameter.of(VarcharType.UNBOUNDED_LENGTH));
     }
 
     private TypeSignature varchar(long length)
     {
-        return new TypeSignature(StandardTypes.VARCHAR, TypeSignatureParameter.of(length));
+        return new TypeSignature(StandardTypes.VARCHAR.getEnumValue(), TypeSignatureParameter.of(length));
     }
 
     private TypeSignature decimal(String precisionVariable, String scaleVariable)
     {
-        return new TypeSignature(StandardTypes.DECIMAL, ImmutableList.of(
+        return new TypeSignature(StandardTypes.DECIMAL.getEnumValue(), ImmutableList.of(
                 TypeSignatureParameter.of(precisionVariable), TypeSignatureParameter.of(scaleVariable)));
     }
 
@@ -209,12 +209,12 @@ public class TestTypeSignature
 
     private static TypeSignature array(TypeSignature type)
     {
-        return new TypeSignature(StandardTypes.ARRAY, TypeSignatureParameter.of(type));
+        return new TypeSignature(StandardTypes.ARRAY.getEnumValue(), TypeSignatureParameter.of(type));
     }
 
     private static TypeSignature map(TypeSignature keyType, TypeSignature valueType)
     {
-        return new TypeSignature(StandardTypes.MAP, TypeSignatureParameter.of(keyType), TypeSignatureParameter.of(valueType));
+        return new TypeSignature(StandardTypes.MAP.getEnumValue(), TypeSignatureParameter.of(keyType), TypeSignatureParameter.of(valueType));
     }
 
     private TypeSignature signature(String name)
@@ -314,7 +314,7 @@ public class TestTypeSignature
         assertEquals(
                 parseTypeSignature("map(VarcharEnum(test.enum.my_enum{\"k\": \"OYUSSKI=\"}), BigintEnum(test.enum.my_enum_2{\"k\": 1}))"),
                 new TypeSignature(
-                        StandardTypes.MAP,
+                        StandardTypes.MAP.getEnumValue(),
                         TypeSignatureParameter.of((new VarcharEnumType(new VarcharEnumMap("test.enum.my_enum", ImmutableMap.of("k", "v)))"))).getTypeSignature())),
                         TypeSignatureParameter.of(new BigintEnumType(new LongEnumMap("test.enum.my_enum_2", ImmutableMap.of("k", 1L))).getTypeSignature())));
 


### PR DESCRIPTION
Fix for [#16246](https://github.com/prestodb/presto/issues/16246)

Changed StandardTypes to be an enum class
To fetch enum value have added getter method