### PR TITLE
Bump MAX ARITY up to the next prime number

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ZipFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ZipFunction.java
@@ -48,7 +48,7 @@ public final class ZipFunction
         extends SqlScalarFunction
 {
     public static final int MIN_ARITY = 2;
-    public static final int MAX_ARITY = 5;
+    public static final int MAX_ARITY = 7;
     public static final ZipFunction[] ZIP_FUNCTIONS;
 
     private static final MethodHandle METHOD_HANDLE = methodHandle(ZipFunction.class, "zip", List.class, Block[].class);


### PR DESCRIPTION
We need to zip more than 5 things, so bumping the arity.

Test plan - Unit tests

```
== RELEASE NOTES ==

Add support for :func:`zip` with max arity of 7
