### PR TITLE
Fix crc computation to properly support integers.

### DIFF
--- a/presto-spi/src/main/java/com/facebook/presto/spi/page/PagesSerdeUtil.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/page/PagesSerdeUtil.java
@@ -99,6 +99,13 @@ public class PagesSerdeUtil
         return size;
     }
 
+    private static void updateCrc(CRC32 crc32, int value)
+    {
+        for (int i = 0; i < 32; i += 8) {
+            crc32.update(value >> i);
+        }
+    }
+
     public static long computeSerializedPageChecksum(Slice pageData, byte markers, int positionCount, int uncompressedSize)
     {
         CRC32 crc32 = new CRC32();
@@ -107,9 +114,8 @@ public class PagesSerdeUtil
         }
         crc32.update(pageData.byteArray(), pageData.byteArrayOffset(), pageData.length());
         crc32.update(markers);
-        crc32.update(positionCount);
-        crc32.update(uncompressedSize);
-
+        updateCrc(crc32, positionCount);
+        updateCrc(crc32, uncompressedSize);
         return crc32.getValue();
     }
 

--- a/presto-spi/src/test/java/com/facebook/presto/spi/page/TestPageCodecMarker.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/page/TestPageCodecMarker.java
@@ -13,10 +13,13 @@
  */
 package com.facebook.presto.spi.page;
 
+import io.airlift.slice.Slice;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.spi.page.PageCodecMarker.COMPRESSED;
 import static com.facebook.presto.spi.page.PageCodecMarker.ENCRYPTED;
+import static com.facebook.presto.spi.page.PagesSerdeUtil.computeSerializedPageChecksum;
+import static io.airlift.slice.Slices.utf8Slice;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
@@ -83,5 +86,16 @@ public class TestPageCodecMarker
         for (PageCodecMarker marker : PageCodecMarker.values()) {
             assertTrue(allMarkersSummary.contains(marker.name()));
         }
+    }
+
+    @Test
+    public void testComputeCRC()
+    {
+        Slice data = utf8Slice("This is a random text");
+        long crc = computeSerializedPageChecksum(data, (byte) 4, 12444567, 4000000);
+        assertEquals(2052054343, crc);
+
+        crc = computeSerializedPageChecksum(data, (byte) 7, 255698989, 1);
+        assertEquals(60661043, crc);
     }
 }


### PR DESCRIPTION
Fixes #16256

Make sure to use all bytes of an integer (positionCount and uncompressedSize) when calculating checksum for the SerializedPage.