### PR TITLE
Extract pluggable interface for kafka cluster supplier

### DIFF
--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaConnectorConfig.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaConnectorConfig.java
@@ -15,27 +15,14 @@ package com.facebook.presto.kafka;
 
 import com.facebook.airlift.configuration.Config;
 import com.facebook.presto.kafka.schema.file.FileTableDescriptionSupplier;
-import com.facebook.presto.spi.HostAddress;
-import com.google.common.base.Splitter;
-import com.google.common.collect.ImmutableSet;
+import com.facebook.presto.kafka.server.file.FileKafkaClusterMetadataSupplier;
 import io.airlift.units.Duration;
 import io.airlift.units.MinDuration;
 
 import javax.validation.constraints.NotNull;
 
-import java.util.List;
-
-import static com.google.common.collect.Iterables.transform;
-
 public class KafkaConnectorConfig
 {
-    private static final int KAFKA_DEFAULT_PORT = 9092;
-
-    /**
-     * Seed nodes for Kafka cluster. At least one must exist.
-     */
-    private List<HostAddress> nodes;
-
     /**
      * Timeout to connect to Kafka.
      */
@@ -66,6 +53,11 @@ public class KafkaConnectorConfig
      */
     private String tableDescriptionSupplier = FileTableDescriptionSupplier.NAME;
 
+    /**
+     * The kafka cluster metadata supplier to use, default is FILE
+     */
+    private String clusterMetadataSupplier = FileKafkaClusterMetadataSupplier.NAME;
+
     @NotNull
     public String getDefaultSchema()
     {
@@ -76,18 +68,6 @@ public class KafkaConnectorConfig
     public KafkaConnectorConfig setDefaultSchema(String defaultSchema)
     {
         this.defaultSchema = defaultSchema;
-        return this;
-    }
-
-    public List<HostAddress> getNodes()
-    {
-        return nodes;
-    }
-
-    @Config("kafka.nodes")
-    public KafkaConnectorConfig setNodes(String nodes)
-    {
-        this.nodes = (nodes == null) ? null : parseNodes(nodes).asList();
         return this;
     }
 
@@ -141,6 +121,19 @@ public class KafkaConnectorConfig
         return this;
     }
 
+    @NotNull
+    public String getClusterMetadataSupplier()
+    {
+        return clusterMetadataSupplier;
+    }
+
+    @Config("kafka.cluster-metadata-supplier")
+    public KafkaConnectorConfig setClusterMetadataSupplier(String clusterMetadataSupplier)
+    {
+        this.clusterMetadataSupplier = clusterMetadataSupplier;
+        return this;
+    }
+
     public boolean isHideInternalColumns()
     {
         return hideInternalColumns;
@@ -151,16 +144,5 @@ public class KafkaConnectorConfig
     {
         this.hideInternalColumns = hideInternalColumns;
         return this;
-    }
-
-    public static ImmutableSet<HostAddress> parseNodes(String nodes)
-    {
-        Splitter splitter = Splitter.on(',').omitEmptyStrings().trimResults();
-        return ImmutableSet.copyOf(transform(splitter.split(nodes), KafkaConnectorConfig::toHostAddress));
-    }
-
-    private static HostAddress toHostAddress(String value)
-    {
-        return HostAddress.fromString(value).withDefaultPort(KAFKA_DEFAULT_PORT);
     }
 }

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaConnectorModule.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaConnectorModule.java
@@ -20,6 +20,8 @@ import com.facebook.presto.decoder.DecoderModule;
 import com.facebook.presto.kafka.encoder.EncoderModule;
 import com.facebook.presto.kafka.schema.file.FileTableDescriptionSupplier;
 import com.facebook.presto.kafka.schema.file.FileTableDescriptionSupplierModule;
+import com.facebook.presto.kafka.server.file.FileKafkaClusterMetadataSupplier;
+import com.facebook.presto.kafka.server.file.FileKafkaClusterMetadataSupplierModule;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.deser.std.FromStringDeserializer;
 import com.google.inject.Binder;
@@ -27,6 +29,8 @@ import com.google.inject.Module;
 import com.google.inject.Scopes;
 
 import javax.inject.Inject;
+
+import java.util.function.Function;
 
 import static com.facebook.airlift.configuration.ConditionalModule.installModuleIf;
 import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
@@ -46,7 +50,6 @@ public class KafkaConnectorModule
     {
         binder.bind(KafkaConnector.class).in(Scopes.SINGLETON);
 
-        binder.bind(KafkaStaticServerset.class).in(Scopes.SINGLETON);
         binder.bind(KafkaMetadata.class).in(Scopes.SINGLETON);
         binder.bind(KafkaSplitManager.class).in(Scopes.SINGLETON);
         binder.bind(KafkaRecordSetProvider.class).in(Scopes.SINGLETON);
@@ -54,7 +57,8 @@ public class KafkaConnectorModule
 
         binder.bind(KafkaConsumerManager.class).in(Scopes.SINGLETON);
         configBinder(binder).bindConfig(KafkaConnectorConfig.class);
-        bindTopicSchemaProviderModule(FileTableDescriptionSupplier.NAME, new FileTableDescriptionSupplierModule());
+        bindTopicSchemaProviderModule(FileTableDescriptionSupplier.NAME, new FileTableDescriptionSupplierModule(), KafkaConnectorConfig::getTableDescriptionSupplier);
+        bindTopicSchemaProviderModule(FileKafkaClusterMetadataSupplier.NAME, new FileKafkaClusterMetadataSupplierModule(), KafkaConnectorConfig::getClusterMetadataSupplier);
 
         jsonBinder(binder).addDeserializerBinding(Type.class).to(TypeDeserializer.class);
         jsonCodecBinder(binder).bindJsonCodec(KafkaTopicDescription.class);
@@ -85,11 +89,11 @@ public class KafkaConnectorModule
         }
     }
 
-    public void bindTopicSchemaProviderModule(String name, Module module)
+    public void bindTopicSchemaProviderModule(String name, Module module, Function<KafkaConnectorConfig, String> configSupplier)
     {
         install(installModuleIf(
                 KafkaConnectorConfig.class,
-                kafkaConfig -> name.equalsIgnoreCase(kafkaConfig.getTableDescriptionSupplier()),
+                kafkaConfig -> name.equalsIgnoreCase(configSupplier.apply(kafkaConfig)),
                 module));
     }
 }

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaPageSinkProvider.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaPageSinkProvider.java
@@ -16,6 +16,7 @@ package com.facebook.presto.kafka;
 import com.facebook.presto.kafka.encoder.DispatchingRowEncoderFactory;
 import com.facebook.presto.kafka.encoder.EncoderColumnHandle;
 import com.facebook.presto.kafka.encoder.RowEncoder;
+import com.facebook.presto.kafka.server.KafkaClusterMetadataSupplier;
 import com.facebook.presto.spi.ConnectorInsertTableHandle;
 import com.facebook.presto.spi.ConnectorOutputTableHandle;
 import com.facebook.presto.spi.ConnectorPageSink;
@@ -42,12 +43,14 @@ public class KafkaPageSinkProvider
 {
     private final DispatchingRowEncoderFactory encoderFactory;
     private final PlainTextKafkaProducerFactory producerFactory;
+    private final KafkaClusterMetadataSupplier kafkaClusterMetadataSupplier;
 
     @Inject
-    public KafkaPageSinkProvider(DispatchingRowEncoderFactory encoderFactory, PlainTextKafkaProducerFactory producerFactory)
+    public KafkaPageSinkProvider(DispatchingRowEncoderFactory encoderFactory, PlainTextKafkaProducerFactory producerFactory, KafkaClusterMetadataSupplier kafkaClusterMetadataSupplier)
     {
         this.encoderFactory = requireNonNull(encoderFactory, "encoderFactory is null");
         this.producerFactory = requireNonNull(producerFactory, "producerFactory is null");
+        this.kafkaClusterMetadataSupplier = requireNonNull(kafkaClusterMetadataSupplier, "kafkaClusterMetadataSupplier is null");
     }
 
     @Override
@@ -89,11 +92,13 @@ public class KafkaPageSinkProvider
                 messageColumns.build());
 
         return new KafkaPageSink(
+                handle.getSchemaName(),
                 handle.getTopicName(),
                 handle.getColumns(),
                 keyEncoder,
                 messageEncoder,
-                producerFactory);
+                producerFactory,
+                kafkaClusterMetadataSupplier);
     }
 
     private Optional<String> getDataSchema(Optional<String> dataSchemaLocation)

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/server/KafkaClusterMetadataHelper.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/server/KafkaClusterMetadataHelper.java
@@ -11,37 +11,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.kafka;
+package com.facebook.presto.kafka.server;
 
-import com.facebook.presto.spi.HostAddress;
 import com.google.common.collect.ImmutableList;
-
-import javax.inject.Inject;
 
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static java.util.Objects.requireNonNull;
-
-public class KafkaStaticServerset
+public class KafkaClusterMetadataHelper
 {
-    private final List<HostAddress> nodes;
-
-    @Inject
-    public KafkaStaticServerset(KafkaConnectorConfig config)
+    private KafkaClusterMetadataHelper()
     {
-        requireNonNull(config.getNodes(), "nodes is null");
-        checkArgument(!config.getNodes().isEmpty(), "nodes must specify at least one URI");
-        this.nodes = config.getNodes();
     }
 
-    public HostAddress selectRandomServer()
-    {
-        return selectRandom(this.nodes);
-    }
-
-    private static <T> T selectRandom(Iterable<T> iterable)
+    public static <T> T selectRandom(Iterable<T> iterable)
     {
         List<T> list = ImmutableList.copyOf(iterable);
         return list.get(ThreadLocalRandom.current().nextInt(list.size()));

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/server/KafkaClusterMetadataSupplier.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/server/KafkaClusterMetadataSupplier.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kafka.server;
+
+import com.facebook.presto.spi.HostAddress;
+
+import java.util.List;
+
+/**
+ * This is mainly used to get Kafka cluster metadata such as broker list so that Kafka Connector can communicate with Kafka cluster
+ */
+public interface KafkaClusterMetadataSupplier
+{
+    /**
+     * Gets kafka broker list for specified kafka cluster name
+     * @param clusterName the kafka cluster name
+     * @return kafka broker list
+     */
+    List<HostAddress> getNodes(String clusterName);
+}

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/server/file/FileKafkaClusterMetadataSupplier.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/server/file/FileKafkaClusterMetadataSupplier.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kafka.server.file;
+
+import com.facebook.presto.kafka.server.KafkaClusterMetadataSupplier;
+import com.facebook.presto.spi.HostAddress;
+
+import javax.inject.Inject;
+
+import java.util.List;
+
+/**
+ * Gets cluster metadata data from static configuration file
+ */
+public class FileKafkaClusterMetadataSupplier
+        implements KafkaClusterMetadataSupplier
+{
+    public static final String NAME = "file";
+    private final FileKafkaClusterMetadataSupplierConfig config;
+
+    @Inject
+    public FileKafkaClusterMetadataSupplier(FileKafkaClusterMetadataSupplierConfig config)
+    {
+        this.config = config;
+    }
+
+    @Override
+    public List<HostAddress> getNodes(String clusterName)
+    {
+        return config.getNodes();
+    }
+}

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/server/file/FileKafkaClusterMetadataSupplierConfig.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/server/file/FileKafkaClusterMetadataSupplierConfig.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kafka.server.file;
+
+import com.facebook.airlift.configuration.Config;
+import com.facebook.presto.spi.HostAddress;
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.List;
+
+import static com.google.common.collect.Iterables.transform;
+
+public class FileKafkaClusterMetadataSupplierConfig
+{
+    private static final int KAFKA_DEFAULT_PORT = 9092;
+
+    /**
+     * Seed nodes for Kafka cluster. At least one must exist.
+     */
+    private List<HostAddress> nodes;
+
+    public List<HostAddress> getNodes()
+    {
+        return nodes;
+    }
+
+    @Config("kafka.nodes")
+    public FileKafkaClusterMetadataSupplierConfig setNodes(String nodes)
+    {
+        this.nodes = (nodes == null) ? null : parseNodes(nodes).asList();
+        return this;
+    }
+
+    public static ImmutableSet<HostAddress> parseNodes(String nodes)
+    {
+        Splitter splitter = Splitter.on(',').omitEmptyStrings().trimResults();
+        return ImmutableSet.copyOf(transform(splitter.split(nodes), FileKafkaClusterMetadataSupplierConfig::toHostAddress));
+    }
+
+    private static HostAddress toHostAddress(String value)
+    {
+        return HostAddress.fromString(value).withDefaultPort(KAFKA_DEFAULT_PORT);
+    }
+}

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/server/file/FileKafkaClusterMetadataSupplierModule.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/server/file/FileKafkaClusterMetadataSupplierModule.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kafka.server.file;
+
+import com.facebook.airlift.configuration.AbstractConfigurationAwareModule;
+import com.facebook.presto.kafka.server.KafkaClusterMetadataSupplier;
+import com.google.inject.Binder;
+import com.google.inject.Scopes;
+
+import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
+
+public class FileKafkaClusterMetadataSupplierModule
+        extends AbstractConfigurationAwareModule
+{
+    @Override
+    protected void setup(Binder binder)
+    {
+        configBinder(binder).bindConfig(FileKafkaClusterMetadataSupplierConfig.class);
+        binder.bind(KafkaClusterMetadataSupplier.class).to(FileKafkaClusterMetadataSupplier.class).in(Scopes.SINGLETON);
+    }
+}

--- a/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaConnectorConfig.java
+++ b/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaConnectorConfig.java
@@ -26,9 +26,9 @@ public class TestKafkaConnectorConfig
     public void testDefaults()
     {
         ConfigAssertions.assertRecordedDefaults(ConfigAssertions.recordDefaults(KafkaConnectorConfig.class)
-                .setNodes(null)
                 .setKafkaConnectTimeout("10s")
                 .setDefaultSchema("default")
+                .setClusterMetadataSupplier(FileTableDescriptionSupplier.NAME)
                 .setTableDescriptionSupplier(FileTableDescriptionSupplier.NAME)
                 .setHideInternalColumns(true)
                 .setMaxPartitionFetchBytes(1048576)
@@ -40,8 +40,8 @@ public class TestKafkaConnectorConfig
     {
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("kafka.table-description-supplier", "test")
+                .put("kafka.cluster-metadata-supplier", "test")
                 .put("kafka.default-schema", "kafka")
-                .put("kafka.nodes", "localhost:12345,localhost:23456")
                 .put("kafka.connect-timeout", "1h")
                 .put("kafka.hide-internal-columns", "false")
                 .put("kafka.max-partition-fetch-bytes", "1024")
@@ -50,8 +50,8 @@ public class TestKafkaConnectorConfig
 
         KafkaConnectorConfig expected = new KafkaConnectorConfig()
                 .setTableDescriptionSupplier("test")
+                .setClusterMetadataSupplier("test")
                 .setDefaultSchema("kafka")
-                .setNodes("localhost:12345, localhost:23456")
                 .setKafkaConnectTimeout("1h")
                 .setHideInternalColumns(false)
                 .setMaxPartitionFetchBytes(1024)

--- a/presto-kafka/src/test/java/com/facebook/presto/kafka/server/file/TestFileKafkaClusterMetadataSupplierConfig.java
+++ b/presto-kafka/src/test/java/com/facebook/presto/kafka/server/file/TestFileKafkaClusterMetadataSupplierConfig.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kafka.server.file;
+
+import com.facebook.airlift.configuration.testing.ConfigAssertions;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+public class TestFileKafkaClusterMetadataSupplierConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        ConfigAssertions.assertRecordedDefaults(ConfigAssertions.recordDefaults(FileKafkaClusterMetadataSupplierConfig.class)
+                .setNodes(null));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("kafka.nodes", "localhost:12345,localhost:23456")
+                .build();
+
+        FileKafkaClusterMetadataSupplierConfig expected = new FileKafkaClusterMetadataSupplierConfig()
+                .setNodes("localhost:12345,localhost:23456");
+        ConfigAssertions.assertFullMapping(properties, expected);
+    }
+}


### PR DESCRIPTION
The intention of this PR is to build the ground layer for Kafka multiple clusters support proposed in https://github.com/prestodb/presto/issues/15845
This PR built a pluggable Kafka cluster metadata supplier interface and moved the existing implementation into FileKafkaClusterMetadataSupplier.  
Tested and verified at local.