### PR TITLE
Upgrade presto-hive-apache to 3.0.0-5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -602,7 +602,7 @@
             <dependency>
                 <groupId>com.facebook.presto.hive</groupId>
                 <artifactId>hive-apache</artifactId>
-                <version>3.0.0-3</version>
+                <version>3.0.0-5</version>
             </dependency>
 
             <dependency>

--- a/presto-iceberg/pom.xml
+++ b/presto-iceberg/pom.xml
@@ -58,6 +58,10 @@
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-api</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.yetus</groupId>
+                    <artifactId>audience-annotations</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 

--- a/presto-raptor/pom.xml
+++ b/presto-raptor/pom.xml
@@ -253,7 +253,6 @@
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
-            <scope>test</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Upgrade presto-hive-apache to 3.0.0-5 which upgrades parquet to 1.11.1 and avro to 1.9.2

This pr would fix the dependency conflict issue in https://github.com/prestodb/presto/issues/16242

We've tested the change on twitter's production, parquet part is good, but we're not querying avro in twitter


```
== NO RELEASE NOTE ==
```
