### PR TITLE
Fix iceberg table params dropped after insert

### DIFF
--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/Table.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/Table.java
@@ -289,6 +289,12 @@ public class Table
             return this;
         }
 
+        public Builder setParameter(String key, String value)
+        {
+            this.parameters.put(key, value);
+            return this;
+        }
+
         public Builder setViewOriginalText(Optional<String> viewOriginalText)
         {
             this.viewOriginalText = viewOriginalText;

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/HiveTableOperations.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/HiveTableOperations.java
@@ -29,7 +29,6 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.TableNotFoundException;
 import com.facebook.presto.spi.security.PrestoPrincipal;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe;
 import org.apache.hadoop.mapred.FileInputFormat;
@@ -243,9 +242,8 @@ public class HiveTableOperations
                 table = Table.builder(currentTable)
                         .setDataColumns(toHiveColumns(metadata.schema().columns()))
                         .withStorage(storage -> storage.setLocation(metadata.location()))
-                        .setParameters(ImmutableMap.of(
-                                METADATA_LOCATION, newMetadataLocation,
-                                PREVIOUS_METADATA_LOCATION, currentMetadataLocation))
+                        .setParameter(METADATA_LOCATION, newMetadataLocation)
+                        .setParameter(PREVIOUS_METADATA_LOCATION, currentMetadataLocation)
                         .build();
             }
         }


### PR DESCRIPTION
Some iceberg table params are dropped after insertion because iceberg connector replaced all the existing params during the metadata updating.   We should set each param one by one rather than replacing the entire params map.

This PR would fix the second issue found in https://github.com/prestodb/presto/issues/16242


```
== NO RELEASE NOTE ==
```
