### PR TITLE
Extend avro reader to support more primitive types

### DIFF
--- a/presto-record-decoder/src/main/java/com/facebook/presto/decoder/avro/AvroColumnDecoder.java
+++ b/presto-record-decoder/src/main/java/com/facebook/presto/decoder/avro/AvroColumnDecoder.java
@@ -18,6 +18,10 @@ import com.facebook.presto.common.block.BlockBuilder;
 import com.facebook.presto.common.type.BigintType;
 import com.facebook.presto.common.type.BooleanType;
 import com.facebook.presto.common.type.DoubleType;
+import com.facebook.presto.common.type.IntegerType;
+import com.facebook.presto.common.type.RealType;
+import com.facebook.presto.common.type.SmallintType;
+import com.facebook.presto.common.type.TinyintType;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.VarbinaryType;
 import com.facebook.presto.common.type.VarcharType;
@@ -25,21 +29,25 @@ import com.facebook.presto.decoder.DecoderColumnHandle;
 import com.facebook.presto.decoder.FieldValueProvider;
 import com.facebook.presto.spi.PrestoException;
 import com.google.common.base.Splitter;
-import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
+import org.apache.avro.generic.GenericEnumSymbol;
+import org.apache.avro.generic.GenericFixed;
 import org.apache.avro.generic.GenericRecord;
-import org.apache.avro.util.Utf8;
 
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static com.facebook.presto.common.type.StandardTypes.ARRAY;
 import static com.facebook.presto.common.type.StandardTypes.BIGINT;
 import static com.facebook.presto.common.type.StandardTypes.BOOLEAN;
 import static com.facebook.presto.common.type.StandardTypes.DOUBLE;
+import static com.facebook.presto.common.type.StandardTypes.INTEGER;
 import static com.facebook.presto.common.type.StandardTypes.MAP;
+import static com.facebook.presto.common.type.StandardTypes.REAL;
 import static com.facebook.presto.common.type.StandardTypes.VARBINARY;
 import static com.facebook.presto.common.type.StandardTypes.VARCHAR;
 import static com.facebook.presto.common.type.Varchars.isVarcharType;
@@ -48,11 +56,22 @@ import static com.facebook.presto.decoder.DecoderErrorCode.DECODER_CONVERSION_NO
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_USER_ERROR;
 import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.slice.Slices.utf8Slice;
+import static java.lang.Float.floatToIntBits;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public class AvroColumnDecoder
 {
+    private static final Set<Type> SUPPORTED_PRIMITIVE_TYPES = ImmutableSet.of(
+            BooleanType.BOOLEAN,
+            TinyintType.TINYINT,
+            SmallintType.SMALLINT,
+            IntegerType.INTEGER,
+            BigintType.BIGINT,
+            RealType.REAL,
+            DoubleType.DOUBLE,
+            VarbinaryType.VARBINARY);
+
     private final Type columnType;
     private final String columnMapping;
     private final String columnName;
@@ -99,12 +118,7 @@ public class AvroColumnDecoder
 
     private boolean isSupportedPrimitive(Type type)
     {
-        return isVarcharType(type) ||
-                ImmutableList.of(
-                        BigintType.BIGINT,
-                        BooleanType.BOOLEAN,
-                        DoubleType.DOUBLE,
-                        VarbinaryType.VARBINARY).contains(type);
+        return isVarcharType(type) || SUPPORTED_PRIMITIVE_TYPES.contains(type);
     }
 
     public FieldValueProvider decodeField(GenericRecord avroRecord)
@@ -189,12 +203,15 @@ public class AvroColumnDecoder
     {
         switch (type.getTypeSignature().getBase()) {
             case VARCHAR:
-                if (value instanceof Utf8) {
+                if (type instanceof VarcharType && (value instanceof CharSequence || value instanceof GenericEnumSymbol)) {
                     return truncateToLength(utf8Slice(value.toString()), type);
                 }
             case VARBINARY:
                 if (value instanceof ByteBuffer) {
                     return Slices.wrappedBuffer((ByteBuffer) value);
+                }
+                else if (value instanceof GenericFixed) {
+                    return Slices.wrappedBuffer(((GenericFixed) value).bytes());
                 }
             default:
                 throw new PrestoException(DECODER_CONVERSION_NOT_SUPPORTED, format("cannot decode object of '%s' as '%s' for column '%s'", value.getClass(), type, columnName));
@@ -209,7 +226,7 @@ public class AvroColumnDecoder
             case MAP:
                 return serializeMap(builder, value, type, columnName);
             default:
-                serializeGeneric(builder, value, type, columnName);
+                serializePrimitive(builder, value, type, columnName);
         }
         return null;
     }
@@ -244,7 +261,7 @@ public class AvroColumnDecoder
         return currentBlockBuilder.build();
     }
 
-    private static void serializeGeneric(BlockBuilder blockBuilder, Object value, Type type, String columnName)
+    private static void serializePrimitive(BlockBuilder blockBuilder, Object value, Type type, String columnName)
     {
         requireNonNull(blockBuilder, "parent blockBuilder is null");
 
@@ -257,11 +274,15 @@ public class AvroColumnDecoder
             case BOOLEAN:
                 type.writeBoolean(blockBuilder, (Boolean) value);
                 break;
+            case INTEGER:
             case BIGINT:
-                type.writeLong(blockBuilder, (Long) value);
+                type.writeLong(blockBuilder, ((Number) value).longValue());
                 break;
             case DOUBLE:
                 type.writeDouble(blockBuilder, (Double) value);
+                break;
+            case REAL:
+                type.writeLong(blockBuilder, floatToIntBits((Float) value));
                 break;
             case VARCHAR:
             case VARBINARY:

--- a/presto-record-decoder/src/test/java/com/facebook/presto/decoder/avro/TestAvroDecoder.java
+++ b/presto-record-decoder/src/test/java/com/facebook/presto/decoder/avro/TestAvroDecoder.java
@@ -19,10 +19,6 @@ import com.facebook.presto.common.type.BigintType;
 import com.facebook.presto.common.type.BooleanType;
 import com.facebook.presto.common.type.DecimalType;
 import com.facebook.presto.common.type.DoubleType;
-import com.facebook.presto.common.type.IntegerType;
-import com.facebook.presto.common.type.RealType;
-import com.facebook.presto.common.type.SmallintType;
-import com.facebook.presto.common.type.TinyintType;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.VarbinaryType;
 import com.facebook.presto.decoder.DecoderColumnHandle;
@@ -33,8 +29,10 @@ import com.facebook.presto.spi.PrestoException;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import io.airlift.slice.Slices;
 import org.apache.avro.AvroTypeException;
 import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
 import org.apache.avro.file.DataFileWriter;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericDatumWriter;
@@ -55,6 +53,10 @@ import java.util.stream.Collectors;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.common.type.RealType.REAL;
+import static com.facebook.presto.common.type.SmallintType.SMALLINT;
+import static com.facebook.presto.common.type.TinyintType.TINYINT;
 import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
@@ -192,6 +194,25 @@ public class TestAvroDecoder
     }
 
     @Test
+    public void testEnumDecodedAsVarchar()
+    {
+        Schema schema = SchemaBuilder.record("record")
+                .fields()
+                .name("enum_field")
+                .type()
+                .enumeration("Weekday")
+                .symbols("Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday")
+                .noDefault()
+                .endRecord();
+        Schema enumType = schema.getField("enum_field").schema();
+        GenericData.EnumSymbol enumValue = new GenericData.EnumSymbol(enumType, "Wednesday");
+        DecoderTestColumnHandle row = new DecoderTestColumnHandle(0, "row", VARCHAR, "enum_field", null, null, false, false, false);
+        Map<DecoderColumnHandle, FieldValueProvider> decodedRow = buildAndDecodeColumn(row, "enum_field", enumType.toString(), enumValue);
+
+        checkValue(decodedRow, row, "Wednesday");
+    }
+
+    @Test
     public void testSchemaEvolutionRenamingColumn()
             throws Exception
     {
@@ -310,10 +331,46 @@ public class TestAvroDecoder
     }
 
     @Test
+    public void testIntDecodedAsInteger()
+    {
+        DecoderTestColumnHandle row = new DecoderTestColumnHandle(0, "row", INTEGER, "id", null, null, false, false, false);
+        Map<DecoderColumnHandle, FieldValueProvider> decodedRow = buildAndDecodeColumn(row, "id", "\"int\"", 100_000);
+
+        checkValue(decodedRow, row, 100_000);
+    }
+
+    @Test
+    public void testIntDecodedAsSmallInt()
+    {
+        DecoderTestColumnHandle row = new DecoderTestColumnHandle(0, "row", SMALLINT, "id", null, null, false, false, false);
+        Map<DecoderColumnHandle, FieldValueProvider> decodedRow = buildAndDecodeColumn(row, "id", "\"int\"", 1000);
+
+        checkValue(decodedRow, row, 1000);
+    }
+
+    @Test
+    public void testIntDecodedAsTinyInt()
+    {
+        DecoderTestColumnHandle row = new DecoderTestColumnHandle(0, "row", TINYINT, "id", null, null, false, false, false);
+        Map<DecoderColumnHandle, FieldValueProvider> decodedRow = buildAndDecodeColumn(row, "id", "\"int\"", 100);
+
+        checkValue(decodedRow, row, 100);
+    }
+
+    @Test
     public void testFloatDecodedAsDouble()
             throws Exception
     {
         DecoderTestColumnHandle row = new DecoderTestColumnHandle(0, "row", DOUBLE, "float_field", null, null, false, false, false);
+        Map<DecoderColumnHandle, FieldValueProvider> decodedRow = buildAndDecodeColumn(row, "float_field", "\"float\"", 10.2f);
+
+        checkValue(decodedRow, row, 10.2);
+    }
+
+    @Test
+    public void testFloatDecodedAsReal()
+    {
+        DecoderTestColumnHandle row = new DecoderTestColumnHandle(0, "row", REAL, "float_field", null, null, false, false, false);
         Map<DecoderColumnHandle, FieldValueProvider> decodedRow = buildAndDecodeColumn(row, "float_field", "\"float\"", 10.2f);
 
         checkValue(decodedRow, row, 10.2);
@@ -327,6 +384,26 @@ public class TestAvroDecoder
         Map<DecoderColumnHandle, FieldValueProvider> decodedRow = buildAndDecodeColumn(row, "encoded", "\"bytes\"", ByteBuffer.wrap("mytext".getBytes(UTF_8)));
 
         checkValue(decodedRow, row, "mytext");
+    }
+
+    @Test
+    public void testFixedDecodedAsVarbinary()
+    {
+        Schema schema = SchemaBuilder.record("record")
+                .fields().name("fixed_field")
+                .type()
+                .fixed("fixed5")
+                .size(5)
+                .noDefault()
+                .endRecord();
+        Schema fixedType = schema.getField("fixed_field").schema();
+        GenericData.Fixed fixedValue = new GenericData.Fixed(schema.getField("fixed_field").schema());
+        byte[] bytes = {5, 4, 3, 2, 1};
+        fixedValue.bytes(bytes);
+        DecoderTestColumnHandle row = new DecoderTestColumnHandle(0, "row", VARBINARY, "fixed_field", null, null, false, false, false);
+        Map<DecoderColumnHandle, FieldValueProvider> decodedRow = buildAndDecodeColumn(row, "fixed_field", fixedType.toString(), fixedValue);
+
+        checkValue(decodedRow, row, Slices.wrappedBuffer(bytes));
     }
 
     @Test
@@ -545,13 +622,7 @@ public class TestAvroDecoder
         singleColumnDecoder(DOUBLE_MAP_TYPE);
 
         // some unsupported types
-        assertUnsupportedColumnTypeException(() -> singleColumnDecoder(RealType.REAL));
-        assertUnsupportedColumnTypeException(() -> singleColumnDecoder(IntegerType.INTEGER));
-        assertUnsupportedColumnTypeException(() -> singleColumnDecoder(SmallintType.SMALLINT));
-        assertUnsupportedColumnTypeException(() -> singleColumnDecoder(TinyintType.TINYINT));
         assertUnsupportedColumnTypeException(() -> singleColumnDecoder(DecimalType.createDecimalType(10, 4)));
-        assertUnsupportedColumnTypeException(() -> singleColumnDecoder(new ArrayType(RealType.REAL)));
-        assertUnsupportedColumnTypeException(() -> singleColumnDecoder(REAL_MAP_TYPE));
     }
 
     private void assertUnsupportedColumnTypeException(ThrowableAssert.ThrowingCallable callable)

--- a/presto-record-decoder/src/test/java/com/facebook/presto/decoder/util/DecoderTestUtil.java
+++ b/presto-record-decoder/src/test/java/com/facebook/presto/decoder/util/DecoderTestUtil.java
@@ -15,6 +15,7 @@ package com.facebook.presto.decoder.util;
 
 import com.facebook.presto.decoder.DecoderColumnHandle;
 import com.facebook.presto.decoder.FieldValueProvider;
+import io.airlift.slice.Slice;
 
 import java.util.Map;
 
@@ -25,6 +26,13 @@ import static org.testng.Assert.assertTrue;
 public final class DecoderTestUtil
 {
     private DecoderTestUtil() {}
+
+    public static void checkValue(Map<DecoderColumnHandle, FieldValueProvider> decodedRow, DecoderColumnHandle handle, Slice value)
+    {
+        FieldValueProvider provider = decodedRow.get(handle);
+        assertNotNull(provider);
+        assertEquals(provider.getSlice(), value);
+    }
 
     public static void checkValue(Map<DecoderColumnHandle, FieldValueProvider> decodedRow, DecoderColumnHandle handle, String value)
     {


### PR DESCRIPTION
cherry-pick of https://github.com/trinodb/trino/commit/bf91d13aeab169a6882931d034b9d6dcab262984

Co-Authored-By: Elon Azoulay <elon.azoulay@gmail.com>

Test plan - (Please fill in how you tested your changes)

Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines. Don't forget to follow our [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution) for any code copied from other projects.

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== RELEASE NOTES ==

Avro Decoder Changes
* Extend avro reader to support more primitive types 
```

