### PR TITLE
Prepare ORC writer API for DWRF stripe cache

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/DwrfWriterOptions.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/DwrfWriterOptions.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc;
+
+import com.facebook.presto.orc.metadata.DwrfStripeCacheMode;
+import io.airlift.units.DataSize;
+
+import static com.facebook.presto.orc.metadata.DwrfStripeCacheMode.INDEX_AND_FOOTER;
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static java.util.Objects.requireNonNull;
+
+public class DwrfWriterOptions
+{
+    public static final DataSize DEFAULT_STRIPE_CACHE_MAX_SIZE = new DataSize(8, MEGABYTE);
+    public static final DwrfStripeCacheMode DEFAULT_STRIPE_CACHE_MODE = INDEX_AND_FOOTER;
+    private final boolean stripeCacheEnabled;
+    private final DwrfStripeCacheMode stripeCacheMode;
+    private final DataSize stripeCacheMaxSize;
+
+    private DwrfWriterOptions(
+            boolean stripeCacheEnabled,
+            DwrfStripeCacheMode stripeCacheMode,
+            DataSize stripeCacheMaxSize)
+    {
+        this.stripeCacheEnabled = stripeCacheEnabled;
+        this.stripeCacheMode = requireNonNull(stripeCacheMode, "stripeCacheMode is null");
+        this.stripeCacheMaxSize = requireNonNull(stripeCacheMaxSize, "stripeCacheMaxSize is null");
+    }
+
+    public boolean isStripeCacheEnabled()
+    {
+        return stripeCacheEnabled;
+    }
+
+    public DwrfStripeCacheMode getStripeCacheMode()
+    {
+        return stripeCacheMode;
+    }
+
+    public DataSize getStripeCacheMaxSize()
+    {
+        return stripeCacheMaxSize;
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("stripeCacheEnabled", stripeCacheEnabled)
+                .add("stripeCacheMode", stripeCacheMode)
+                .add("stripeCacheMaxSize", stripeCacheMaxSize)
+                .toString();
+    }
+
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    public static class Builder
+    {
+        private boolean stripeCacheEnabled;
+        private DwrfStripeCacheMode stripeCacheMode = DEFAULT_STRIPE_CACHE_MODE;
+        private DataSize stripeCacheMaxSize = DEFAULT_STRIPE_CACHE_MAX_SIZE;
+
+        public Builder withStripeCacheEnabled(boolean stripeCacheEnabled)
+        {
+            this.stripeCacheEnabled = stripeCacheEnabled;
+            return this;
+        }
+
+        public Builder withStripeCacheMode(DwrfStripeCacheMode stripeCacheMode)
+        {
+            this.stripeCacheMode = requireNonNull(stripeCacheMode, "stripeCacheMode is null");
+            return this;
+        }
+
+        public Builder withStripeCacheMaxSize(DataSize stripeCacheMaxSize)
+        {
+            this.stripeCacheMaxSize = requireNonNull(stripeCacheMaxSize, "stripeCacheMaxSize is null");
+            return this;
+        }
+
+        public DwrfWriterOptions build()
+        {
+            return new DwrfWriterOptions(
+                    stripeCacheEnabled,
+                    stripeCacheMode,
+                    stripeCacheMaxSize);
+        }
+    }
+}

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/CompressedMetadataWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/CompressedMetadataWriter.java
@@ -47,7 +47,7 @@ public class CompressedMetadataWriter
     {
         // postscript is not compressed
         DynamicSliceOutput output = new DynamicSliceOutput(64);
-        metadataWriter.writePostscript(output, footerLength, metadataLength, compression, compressionBlockSize);
+        metadataWriter.writePostscript(output, footerLength, metadataLength, compression, compressionBlockSize, Optional.empty());
         return output.slice();
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfMetadataWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfMetadataWriter.java
@@ -35,6 +35,7 @@ import java.io.OutputStream;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -60,17 +61,39 @@ public class DwrfMetadataWriter
     }
 
     @Override
-    public int writePostscript(SliceOutput output, int footerLength, int metadataLength, CompressionKind compression, int compressionBlockSize)
+    public int writePostscript(SliceOutput output,
+            int footerLength,
+            int metadataLength,
+            CompressionKind compression,
+            int compressionBlockSize,
+            Optional<DwrfStripeCacheData> dwrfStripeCacheData)
             throws IOException
     {
-        DwrfProto.PostScript postScriptProtobuf = DwrfProto.PostScript.newBuilder()
+        DwrfProto.PostScript.Builder postScriptBuilder = DwrfProto.PostScript.newBuilder()
                 .setFooterLength(footerLength)
                 .setWriterVersion(DWRF_WRITER_VERSION)
                 .setCompression(toCompression(compression))
-                .setCompressionBlockSize(compressionBlockSize)
-                .build();
+                .setCompressionBlockSize(compressionBlockSize);
 
+        dwrfStripeCacheData.ifPresent(cache -> {
+            postScriptBuilder.setCacheMode(toStripeCacheMode(cache.getDwrfStripeCacheMode()));
+            postScriptBuilder.setCacheSize(cache.getDwrfStripeCacheSize());
+        });
+
+        DwrfProto.PostScript postScriptProtobuf = postScriptBuilder.build();
         return writeProtobufObject(output, postScriptProtobuf);
+    }
+
+    @Override
+    public int writeDwrfStripeCache(SliceOutput output, Optional<DwrfStripeCacheData> dwrfStripeCacheData)
+    {
+        int size = 0;
+        if (dwrfStripeCacheData.isPresent()) {
+            DwrfStripeCacheData cache = dwrfStripeCacheData.get();
+            size = cache.getDwrfStripeCacheSize();
+            output.writeBytes(cache.getDwrfStripeCacheSlice(), 0, size);
+        }
+        return size;
     }
 
     @Override
@@ -104,6 +127,10 @@ public class DwrfMetadataWriter
 
         if (footer.getEncryption().isPresent()) {
             footerProtobuf.setEncryption(toEncryption(footer.getEncryption().get()));
+        }
+
+        if (footer.getDwrfStripeCacheOffsets().isPresent()) {
+            footerProtobuf.addAllStripeCacheOffsets(footer.getDwrfStripeCacheOffsets().get());
         }
 
         return writeProtobufObject(output, footerProtobuf.build());
@@ -398,6 +425,21 @@ public class DwrfMetadataWriter
         return DwrfProto.FileStatistics.newBuilder()
                 .addAllStatistics(dwrfColumnStatistics)
                 .build();
+    }
+
+    private static DwrfProto.StripeCacheMode toStripeCacheMode(DwrfStripeCacheMode dwrfStripeCacheMode)
+    {
+        switch (dwrfStripeCacheMode) {
+            case NONE:
+                return DwrfProto.StripeCacheMode.NA;
+            case INDEX:
+                return DwrfProto.StripeCacheMode.INDEX;
+            case FOOTER:
+                return DwrfProto.StripeCacheMode.FOOTER;
+            case INDEX_AND_FOOTER:
+                return DwrfProto.StripeCacheMode.BOTH;
+        }
+        throw new IllegalArgumentException("Unsupported mode: " + dwrfStripeCacheMode);
     }
 
     private static int writeProtobufObject(OutputStream output, MessageLite object)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/MetadataWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/MetadataWriter.java
@@ -17,12 +17,21 @@ import io.airlift.slice.SliceOutput;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 
 public interface MetadataWriter
 {
     List<Integer> getOrcMetadataVersion();
 
-    int writePostscript(SliceOutput output, int footerLength, int metadataLength, CompressionKind compression, int compressionBlockSize)
+    int writePostscript(SliceOutput output,
+            int footerLength,
+            int metadataLength,
+            CompressionKind compression,
+            int compressionBlockSize,
+            Optional<DwrfStripeCacheData> dwrfStripeCacheData)
+            throws IOException;
+
+    int writeDwrfStripeCache(SliceOutput output, Optional<DwrfStripeCacheData> dwrfStripeCacheData)
             throws IOException;
 
     int writeMetadata(SliceOutput output, Metadata metadata)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcMetadataWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcMetadataWriter.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.List;
 import java.util.Map.Entry;
+import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.Math.toIntExact;
@@ -55,7 +56,12 @@ public class OrcMetadataWriter
     }
 
     @Override
-    public int writePostscript(SliceOutput output, int footerLength, int metadataLength, CompressionKind compression, int compressionBlockSize)
+    public int writePostscript(SliceOutput output,
+            int footerLength,
+            int metadataLength,
+            CompressionKind compression,
+            int compressionBlockSize,
+            Optional<DwrfStripeCacheData> dwrfStripeCacheData)
             throws IOException
     {
         OrcProto.PostScript postScriptProtobuf = OrcProto.PostScript.newBuilder()
@@ -68,6 +74,12 @@ public class OrcMetadataWriter
                 .build();
 
         return writeProtobufObject(output, postScriptProtobuf);
+    }
+
+    @Override
+    public int writeDwrfStripeCache(SliceOutput output, Optional<DwrfStripeCacheData> dwrfStripeCacheData)
+    {
+        return 0;
     }
 
     @Override

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestDwrfWriterOptions.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestDwrfWriterOptions.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc;
+
+import com.facebook.presto.orc.metadata.DwrfStripeCacheMode;
+import io.airlift.units.DataSize;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.orc.metadata.DwrfStripeCacheMode.INDEX_AND_FOOTER;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class TestDwrfWriterOptions
+{
+    private static final DwrfStripeCacheMode STRIPE_CACHE_MODE = INDEX_AND_FOOTER;
+    private static final DataSize STRIPE_CACHE_MAX_SIZE = new DataSize(27, MEGABYTE);
+
+    @Test
+    public void testProperties()
+    {
+        DwrfWriterOptions options = DwrfWriterOptions.builder()
+                .withStripeCacheEnabled(true)
+                .withStripeCacheMode(STRIPE_CACHE_MODE)
+                .withStripeCacheMaxSize(STRIPE_CACHE_MAX_SIZE)
+                .build();
+
+        assertTrue(options.isStripeCacheEnabled());
+        assertEquals(options.getStripeCacheMode(), STRIPE_CACHE_MODE);
+        assertEquals(options.getStripeCacheMaxSize(), STRIPE_CACHE_MAX_SIZE);
+    }
+
+    @Test
+    public void testToString()
+    {
+        DwrfWriterOptions options = DwrfWriterOptions.builder()
+                .withStripeCacheEnabled(true)
+                .withStripeCacheMode(STRIPE_CACHE_MODE)
+                .withStripeCacheMaxSize(STRIPE_CACHE_MAX_SIZE)
+                .build();
+
+        String expectedString = "DwrfWriterOptions{stripeCacheEnabled=true, " +
+                "stripeCacheMode=INDEX_AND_FOOTER, stripeCacheMaxSize=27MB}";
+        assertEquals(options.toString(), expectedString);
+    }
+}


### PR DESCRIPTION
Update metadata writer API to support writing of DWRF stripe cache
fields and objects. Add DwrfWriterOptions to hold DWRF specific options.

This is a first commit out of two needed to add support for writing the
DWRF stripe cache. The full change can be found here
https://github.com/prestodb/presto/pull/16279

Test plan:
* added new unit tests
* the second PR will add end-to-end tests for various cache modes
  and changes from this PR

```
== NO RELEASE NOTE ==
```
