### PR TITLE
Add client tags info to ConnectorSession

### DIFF
--- a/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraConnector.java
+++ b/presto-cassandra/src/test/java/com/facebook/presto/cassandra/TestCassandraConnector.java
@@ -40,6 +40,7 @@ import com.facebook.presto.testing.TestingConnectorContext;
 import com.facebook.presto.testing.TestingConnectorSession;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -88,6 +89,7 @@ public class TestCassandraConnector
             ImmutableMap.of(),
             true,
             Optional.empty(),
+            ImmutableSet.of(),
             Optional.empty(),
             ImmutableMap.of());
     protected String database;

--- a/presto-hive-common/src/main/java/com/facebook/presto/hive/HdfsContext.java
+++ b/presto-hive-common/src/main/java/com/facebook/presto/hive/HdfsContext.java
@@ -17,6 +17,7 @@ import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.security.ConnectorIdentity;
 
 import java.util.Optional;
+import java.util.Set;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
@@ -32,6 +33,7 @@ public class HdfsContext
     // true if the table already exist in the metastore, false if the table is about to be created in the current transaction
     private final Optional<Boolean> isNewTable;
     private final Optional<String> clientInfo;
+    private final Optional<Set<String>> clientTags;
     private final Optional<ConnectorSession> session;
 
     /**
@@ -47,6 +49,7 @@ public class HdfsContext
         this.schemaName = Optional.empty();
         this.tableName = Optional.empty();
         this.clientInfo = Optional.empty();
+        this.clientTags = Optional.empty();
         this.tablePath = Optional.empty();
         this.isNewTable = Optional.empty();
         this.session = Optional.empty();
@@ -118,6 +121,7 @@ public class HdfsContext
         this.schemaName = requireNonNull(schemaName, "schemaName is null");
         this.tableName = requireNonNull(tableName, "tableName is null");
         this.clientInfo = session.getClientInfo();
+        this.clientTags = Optional.of(session.getClientTags());
         this.tablePath = requireNonNull(tablePath, "tablePath is null");
         this.isNewTable = requireNonNull(isNewTable, "isNewTable is null");
     }
@@ -162,6 +166,11 @@ public class HdfsContext
         return clientInfo;
     }
 
+    public Optional<Set<String>> getClientTags()
+    {
+        return clientTags;
+    }
+
     public Optional<ConnectorSession> getSession()
     {
         return session;
@@ -180,6 +189,7 @@ public class HdfsContext
                 .add("tablePath", tablePath.orElse(null))
                 .add("isNewTable", isNewTable.orElse(null))
                 .add("clientInfo", clientInfo.orElse(null))
+                .add("clientTags", clientTags.orElse(null))
                 .add("session", session.orElse(null))
                 .toString();
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -1089,6 +1089,12 @@ public abstract class AbstractTestHiveClient
             }
 
             @Override
+            public Set<String> getClientTags()
+            {
+                return session.getClientTags();
+            }
+
+            @Override
             public long getStartTime()
             {
                 return session.getStartTime();

--- a/presto-main/src/main/java/com/facebook/presto/FullConnectorSession.java
+++ b/presto-main/src/main/java/com/facebook/presto/FullConnectorSession.java
@@ -26,6 +26,7 @@ import com.google.common.collect.ImmutableMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_SESSION_PROPERTY;
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -119,6 +120,12 @@ public class FullConnectorSession
     public Optional<String> getClientInfo()
     {
         return session.getClientInfo();
+    }
+
+    @Override
+    public Set<String> getClientTags()
+    {
+        return session.getClientTags();
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/execution/buffer/SpoolingOutputBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/buffer/SpoolingOutputBuffer.java
@@ -138,7 +138,7 @@ public class SpoolingOutputBuffer
         this.finalizerService = requireNonNull(finalizerService, "finalizerService is null");
         this.finalizerService.addFinalizer(this, this::close);
 
-        tempDataOperationContext = new TempDataOperationContext(Optional.empty(), taskId.getQueryId().toString(), Optional.empty(), new Identity("spooling-buffer", Optional.empty()));
+        tempDataOperationContext = new TempDataOperationContext(Optional.empty(), taskId.getQueryId().toString(), Optional.empty(), Optional.empty(), new Identity("spooling-buffer", Optional.empty()));
 
         state.compareAndSet(OPEN, NO_MORE_BUFFERS);
     }

--- a/presto-main/src/main/java/com/facebook/presto/spiller/TempStorageSingleStreamSpiller.java
+++ b/presto-main/src/main/java/com/facebook/presto/spiller/TempStorageSingleStreamSpiller.java
@@ -103,6 +103,7 @@ public class TempStorageSingleStreamSpiller
                 session.getSource(),
                 session.getQueryId().getId(),
                 session.getClientInfo(),
+                Optional.of(session.getClientTags()),
                 session.getIdentity());
 
         this.maxBufferSizeInBytes = toIntExact(getTempStorageSpillerBufferSize(session).toBytes());

--- a/presto-main/src/main/java/com/facebook/presto/testing/TestingConnectorSession.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/TestingConnectorSession.java
@@ -25,12 +25,14 @@ import com.facebook.presto.spi.session.PropertyMetadata;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import static com.facebook.presto.common.type.TimeZoneKey.UTC_KEY;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_SESSION_PROPERTY;
@@ -53,23 +55,24 @@ public class TestingConnectorSession
     private final Map<String, PropertyMetadata<?>> properties;
     private final Map<String, Object> propertyValues;
     private final Optional<String> clientInfo;
+    private final Set<String> clientTags;
     private final SqlFunctionProperties sqlFunctionProperties;
     private final Optional<String> schema;
     private final Map<SqlFunctionId, SqlInvokedFunction> sessionFunctions;
 
     public TestingConnectorSession(List<PropertyMetadata<?>> properties)
     {
-        this("user", Optional.of("test"), Optional.empty(), UTC_KEY, ENGLISH, System.currentTimeMillis(), properties, ImmutableMap.of(), new FeaturesConfig().isLegacyTimestamp(), Optional.empty(), Optional.empty(), ImmutableMap.of());
+        this("user", Optional.of("test"), Optional.empty(), UTC_KEY, ENGLISH, System.currentTimeMillis(), properties, ImmutableMap.of(), new FeaturesConfig().isLegacyTimestamp(), Optional.empty(), ImmutableSet.of(), Optional.empty(), ImmutableMap.of());
     }
 
     public TestingConnectorSession(List<PropertyMetadata<?>> properties, Map<String, Object> propertyValues)
     {
-        this("user", Optional.of("test"), Optional.empty(), UTC_KEY, ENGLISH, System.currentTimeMillis(), properties, propertyValues, new FeaturesConfig().isLegacyTimestamp(), Optional.empty(), Optional.empty(), ImmutableMap.of());
+        this("user", Optional.of("test"), Optional.empty(), UTC_KEY, ENGLISH, System.currentTimeMillis(), properties, propertyValues, new FeaturesConfig().isLegacyTimestamp(), Optional.empty(), ImmutableSet.of(), Optional.empty(), ImmutableMap.of());
     }
 
     public TestingConnectorSession(List<PropertyMetadata<?>> properties, Optional<String> schema)
     {
-        this("user", Optional.of("test"), Optional.empty(), UTC_KEY, ENGLISH, System.currentTimeMillis(), properties, ImmutableMap.of(), new FeaturesConfig().isLegacyTimestamp(), Optional.empty(), schema, ImmutableMap.of());
+        this("user", Optional.of("test"), Optional.empty(), UTC_KEY, ENGLISH, System.currentTimeMillis(), properties, ImmutableMap.of(), new FeaturesConfig().isLegacyTimestamp(), Optional.empty(), ImmutableSet.of(), schema, ImmutableMap.of());
     }
 
     public TestingConnectorSession(
@@ -83,6 +86,7 @@ public class TestingConnectorSession
             Map<String, Object> propertyValues,
             boolean isLegacyTimestamp,
             Optional<String> clientInfo,
+            Set<String> clientTags,
             Optional<String> schema,
             Map<SqlFunctionId, SqlInvokedFunction> sessionFunctions)
     {
@@ -95,6 +99,7 @@ public class TestingConnectorSession
         this.properties = Maps.uniqueIndex(propertyMetadatas, PropertyMetadata::getName);
         this.propertyValues = ImmutableMap.copyOf(propertyValues);
         this.clientInfo = clientInfo;
+        this.clientTags = clientTags;
         this.sqlFunctionProperties = SqlFunctionProperties.builder()
                 .setTimeZoneKey(requireNonNull(timeZoneKey, "timeZoneKey is null"))
                 .setLegacyTimestamp(isLegacyTimestamp)
@@ -146,6 +151,12 @@ public class TestingConnectorSession
     public Optional<String> getClientInfo()
     {
         return clientInfo;
+    }
+
+    @Override
+    public Set<String> getClientTags()
+    {
+        return clientTags;
     }
 
     @Override

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestDateTimeFunctionsBase.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestDateTimeFunctionsBase.java
@@ -30,6 +30,7 @@ import com.facebook.presto.testing.TestingSession;
 import com.facebook.presto.type.SqlIntervalDayTime;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Hours;
@@ -171,6 +172,7 @@ public abstract class TestDateTimeFunctionsBase
                         ImmutableMap.of(),
                         isLegacyTimestamp(session),
                         Optional.empty(),
+                        ImmutableSet.of(),
                         Optional.empty(),
                         session.getSessionFunctions()).getSqlFunctionProperties());
         assertEquals(dateTimeCalculation, expectedDays);

--- a/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotSplitManager.java
+++ b/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotSplitManager.java
@@ -23,6 +23,7 @@ import com.facebook.presto.testing.TestingConnectorSession;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.testng.annotations.Test;
 
 import java.util.ArrayList;
@@ -181,6 +182,7 @@ public class TestPinotSplitManager
                         forbidSegmentQueries),
                 new FeaturesConfig().isLegacyTimestamp(),
                 Optional.empty(),
+                ImmutableSet.of(),
                 Optional.empty(),
                 ImmutableMap.of());
     }
@@ -200,6 +202,7 @@ public class TestPinotSplitManager
                         limitLarge),
                 new FeaturesConfig().isLegacyTimestamp(),
                 Optional.empty(),
+                ImmutableSet.of(),
                 Optional.empty(),
                 ImmutableMap.of());
     }

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/TestRaptorConnector.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/TestRaptorConnector.java
@@ -230,6 +230,7 @@ public class TestRaptorConnector
                 ImmutableMap.of(),
                 true,
                 Optional.empty(),
+                ImmutableSet.of(),
                 Optional.empty(),
                 ImmutableMap.of());
 

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
@@ -1136,6 +1136,7 @@ public class PrestoSparkQueryExecutionFactory
                                 session.getSource(),
                                 session.getQueryId().getId(),
                                 session.getClientInfo(),
+                                Optional.of(session.getClientTags()),
                                 session.getIdentity());
 
                         broadcastDependency = new PrestoSparkStorageBasedBroadcastDependency(

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkTaskExecutorFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkTaskExecutorFactory.java
@@ -502,6 +502,7 @@ public class PrestoSparkTaskExecutorFactory
                 session.getSource(),
                 session.getQueryId().getId(),
                 session.getClientInfo(),
+                Optional.of(session.getClientTags()),
                 session.getIdentity());
         TempStorage tempStorage = tempStorageManager.getTempStorage(storageBasedBroadcastJoinStorage);
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorSession.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorSession.java
@@ -21,6 +21,7 @@ import com.facebook.presto.spi.security.ConnectorIdentity;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 public interface ConnectorSession
 {
@@ -40,6 +41,8 @@ public interface ConnectorSession
     Optional<String> getTraceToken();
 
     Optional<String> getClientInfo();
+
+    Set<String> getClientTags();
 
     long getStartTime();
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/storage/TempDataOperationContext.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/storage/TempDataOperationContext.java
@@ -16,6 +16,7 @@ package com.facebook.presto.spi.storage;
 import com.facebook.presto.spi.security.Identity;
 
 import java.util.Optional;
+import java.util.Set;
 
 import static java.util.Objects.requireNonNull;
 
@@ -24,13 +25,15 @@ public class TempDataOperationContext
     private final Optional<String> source;
     private final String queryId;
     private final Optional<String> clientInfo;
+    private final Optional<Set<String>> clientTags;
     private final Identity identity;
 
-    public TempDataOperationContext(Optional<String> source, String queryId, Optional<String> clientInfo, Identity identity)
+    public TempDataOperationContext(Optional<String> source, String queryId, Optional<String> clientInfo, Optional<Set<String>> clientTags, Identity identity)
     {
         this.source = requireNonNull(source, "source is null");
         this.queryId = requireNonNull(queryId, "queryId is null");
         this.clientInfo = requireNonNull(clientInfo, "clientInfo is null");
+        this.clientTags = requireNonNull(clientTags, "clientTags is null");
         this.identity = requireNonNull(identity, "identity is null");
     }
 
@@ -47,6 +50,11 @@ public class TempDataOperationContext
     public Optional<String> getClientInfo()
     {
         return clientInfo;
+    }
+
+    public Optional<Set<String>> getClientTags()
+    {
+        return clientTags;
     }
 
     public Identity getIdentity()

--- a/presto-spi/src/test/java/com/facebook/presto/spi/TestingSession.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/TestingSession.java
@@ -18,10 +18,12 @@ import com.facebook.presto.spi.function.SqlFunctionId;
 import com.facebook.presto.spi.function.SqlInvokedFunction;
 import com.facebook.presto.spi.security.ConnectorIdentity;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import static com.facebook.presto.common.type.TimeZoneKey.UTC_KEY;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_SESSION_PROPERTY;
@@ -53,6 +55,12 @@ public final class TestingSession
         public Optional<String> getClientInfo()
         {
             return Optional.of("TestClientInfo");
+        }
+
+        @Override
+        public Set<String> getClientTags()
+        {
+            return ImmutableSet.of();
         }
 
         @Override


### PR DESCRIPTION
Send session client tags as part of the HdfsContext. This will help the underlying system to get more info from the requesting client. This is an optional field in HdfsContext. Also expose getClientTags() method in ConnectorSession SPI to help retrieve this client info. 

Test plan - This is a simple change that provides the client tags information to the connector. Existing tests should succeed.

https://github.com/facebookexternal/presto-facebook/pull/1586 depends on this PR.

See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== RELEASE NOTES ==

SPI Changes
* Add ``getClientTags`` to ``ConnectorSession``
```
