### PR TITLE
Fix the count distinct pushdown for Pinot

### DIFF
--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotPushdownUtils.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotPushdownUtils.java
@@ -165,7 +165,7 @@ public class PinotPushdownUtils
                 if (aggregation.getMask().isPresent()) {
                     // This block handles the case when a distinct aggregation is present in addition to another aggregation function.
                     // E.g. `SELECT count(distinct COL_A), sum(COL_B) FROM myTable` to Pinot as `SELECT distinctCount(COL_A), sum(COL_B) FROM myTable`
-                    if (aggregation.getCall().getDisplayName().equalsIgnoreCase(COUNT_FUNCTION_NAME) && aggregation.getMask().get().getName().equalsIgnoreCase(aggregation.getArguments().get(0) + DISTINCT_MASK)) {
+                    if (aggregation.getCall().getDisplayName().equalsIgnoreCase(COUNT_FUNCTION_NAME) && aggregation.getMask().get().getName().contains(DISTINCT_MASK)) {
                         nodeBuilder.add(new AggregationFunctionColumnNode(outputColumn, new CallExpression(PINOT_DISTINCT_COUNT_FUNCTION_NAME, aggregation.getCall().getFunctionHandle(), aggregation.getCall().getType(), aggregation.getCall().getArguments())));
                         continue;
                     }

--- a/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/query/TestPinotPlanOptimizer.java
+++ b/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/query/TestPinotPlanOptimizer.java
@@ -19,6 +19,7 @@ import com.facebook.presto.cost.StatsAndCosts;
 import com.facebook.presto.cost.StatsProvider;
 import com.facebook.presto.expressions.LogicalRowExpressions;
 import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.pinot.PinotColumnHandle;
 import com.facebook.presto.pinot.PinotConfig;
 import com.facebook.presto.pinot.PinotPlanOptimizer;
 import com.facebook.presto.pinot.PinotTableHandle;
@@ -308,5 +309,41 @@ public class TestPinotPlanOptimizer
         PinotQueryGenerator pinotQueryGenerator = new PinotQueryGenerator(pinotConfig, functionAndTypeManager, functionAndTypeManager, standardFunctionResolution);
         PinotPlanOptimizer optimizer = new PinotPlanOptimizer(pinotQueryGenerator, functionAndTypeManager, functionAndTypeManager, logicalRowExpressions, standardFunctionResolution);
         return optimizer.optimize(originalPlan, defaultSessionHolder.getConnectorSession(), new PlanVariableAllocator(), planBuilder.getIdAllocator());
+    }
+
+    @Test
+    public void testDistinctCountInSubQueryPushdown()
+    {
+        PlanBuilder planBuilder = createPlanBuilder(defaultSessionHolder);
+        Map<VariableReferenceExpression, PinotColumnHandle> leftColumnHandleMap = ImmutableMap.of(new VariableReferenceExpression("regionid", regionId.getDataType()), regionId);
+        PlanNode leftJustScan = tableScan(planBuilder, pinotTable, leftColumnHandleMap);
+        PlanNode leftMarkDistinct = markDistinct(planBuilder, variable("regionid$distinct"), ImmutableList.of(variable("regionid")), leftJustScan);
+        PlanNode leftAggregation = planBuilder.aggregation(aggBuilder -> aggBuilder.source(leftMarkDistinct).addAggregation(planBuilder.variable("count(regionid)"), getRowExpression("count(regionid)", defaultSessionHolder), Optional.empty(), Optional.empty(), false, Optional.of(variable("regionid$distinct"))).globalGrouping());
+        PlanNode optimized = getOptimizedPlan(planBuilder, leftAggregation);
+        assertPlanMatch(
+                optimized,
+                PinotTableScanMatcher.match(
+                        pinotTable,
+                        Optional.of("SELECT DISTINCTCOUNT\\(regionId\\) FROM hybrid"),
+                        Optional.of(false),
+                        leftAggregation.getOutputVariables(),
+                        useSqlSyntax()),
+                typeProvider);
+
+        Map<VariableReferenceExpression, PinotColumnHandle> rightColumnHandleMap = ImmutableMap.of(new VariableReferenceExpression("regionid_33", regionId.getDataType()), regionId);
+        PlanNode rightJustScan = tableScan(planBuilder, pinotTable, rightColumnHandleMap);
+        PlanNode rightMarkDistinct = markDistinct(planBuilder, variable("regionid$distinct_62"), ImmutableList.of(variable("regionid")), rightJustScan);
+        PlanNode rightAggregation = planBuilder.aggregation(aggBuilder -> aggBuilder.source(rightMarkDistinct).addAggregation(planBuilder.variable("count(regionid_33)"), getRowExpression("count(regionid_33)", defaultSessionHolder), Optional.empty(), Optional.empty(), false, Optional.of(variable("regionid$distinct_62"))).globalGrouping());
+
+        optimized = getOptimizedPlan(planBuilder, rightAggregation);
+        assertPlanMatch(
+                optimized,
+                PinotTableScanMatcher.match(
+                        pinotTable,
+                        Optional.of("SELECT DISTINCTCOUNT\\(regionId\\) FROM hybrid"),
+                        Optional.of(false),
+                        rightAggregation.getOutputVariables(),
+                        useSqlSyntax()),
+                typeProvider);
     }
 }


### PR DESCRIPTION
The current implementation of handling distinct count pushdown only assumes it's a single query not as part of sub-queries.

Example query: 
```
SELECT t1.a, t1.b, t2.c, t2.d
FROM 
    (SELECT SUM(numberofgames) as a, COUNT(DISTINCT playerid) as b
        FROM baseballstats WHERE teamid = 'SFN') as t1 
INNER JOIN 
    (SELECT SUM(numberofgames) as c, COUNT(DISTINCT playerid) as d
        FROM baseballstats WHERE teamid = 'CHN') as t2
ON 1=1;
```

Above fails for error:
```
Query 20210617_211339_00000_yz7p3 failed: Invalid node. Aggregation mask symbol (playerid$distinct_62) not in source plan output ([numberofgames_34, playerid_33])
```

By digging into the method `public static List<AggregationColumnNode> computeAggregationNodes(AggregationNode aggregationNode)` in `PinotPushdownUtils.java`.

For the first sub-query, it's ok:
`aggregation.getMask().get().getName()` is `playerid$distinct`
`aggregation.getArguments().get(0)` is `playerid`
![image](https://user-images.githubusercontent.com/1202120/122473431-b3872080-cf76-11eb-87b3-9bb0a47f1c5e.png)

However for the second sub-query:
`aggregation.getMask().get().getName()` is `playerid$distinct_62`
`aggregation.getArguments().get(0)` is `playerid_33`
![image](https://user-images.githubusercontent.com/1202120/122473621-f77a2580-cf76-11eb-89e6-af8b19259d89.png)

This issue is caused by an extra check on the mask name, which we expect to be `playerid_33$distinct`, but the actual mask is `playerid$distinct_62`.

This check prevents us from pushing down the distinct count query. The fix here is to remove the extra check on the mask and always allow the pushdown.

After this change, the example query generate the correct plan:
```
presto:default> explain SELECT t1.a, t1.b, t2.c, t2.d FROM (SELECT SUM(numberofgames) as a, COUNT(DISTINCT playerid) as b FROM baseballstats WHERE teamid = 'SFN') as t1 INNER JOIN ( SELECT SUM(numberofgames) as c, COUNT(DISTINCT playerid) as d FROM baseballstats WHERE teamid = 'CHN') as t2 ON 1=1;

----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 - Output[a, b, c, d] => [sum:bigint, count:bigint, sum_36:bigint, count_37:bigint]
         a := sum
         b := count
         c := sum_36
         d := count_37
     - RemoteStreamingExchange[GATHER] => [count:bigint, sum:bigint, count_37:bigint, sum_36:bigint]
         - CrossJoin => [count:bigint, sum:bigint, count_37:bigint, sum_36:bigint]
                 Distribution: REPLICATED
             - TableScan[TableHandle {connectorId='pinot', connectorHandle='PinotTableHandle{connectorId=pinot, schemaName=default, tableName=baseballStats, isQueryShort=Optional[true], expectedColumnHandles=Optional[[PinotColumnHandle{columnHandle{columnName=count, dataType=bigint, type=DERIVED}, PinotColumnHandle{columnName=sum, dataType=bigint, type=DERIVED}]], pinotQuery=Optional[GeneratedPinotQuery{query=SELECT DISTINCTCOUNT(playerID), sum(numberOfGames) FROM baseballStats WHERE (teamID = 'SFN'), format=SQL, table=baseballStats, expectedColumnIndices=[], groupByClauses=0, haveFilter=true, isQueryShort=true}]}', layout='Optional[PinotTableHandle{connectorId=pinot, schemaName=default, tableName=baseballStats, isQueryShort=Optional[true], expectedColumnHandles=Optional[[PinotColumnHandle{columnName=count, dataType=bigint, type=DERIVED}, PinotColumnHandle{columnName=sum, dataType=bigint, type=DERIVED}]], pinotQuery=Optional[GeneratedPinotQuery{query=SELECT DISTINCTCOUNT(playerID), sum(numberOfGames) FROM baseballStats WHERE (teamID = 'SFN'), format=SQL, table=baseballStats, expectedColumnIndices=[], groupByClauses=0, haveFilter=true, isQueryShort=true}]}]'}] => [count:bigint, sum:bigint]
                     Estimates: {rows: ? (?), cpu: ?, memory: 0.00, network: 0.00}
                     count := PinotColumnHandle{columnName=count, dataType=bigint, type=DERIVED}
                     sum := PinotColumnHandle{columnName=sum, dataType=bigint, type=DERIVED}
             - LocalExchange[SINGLE] () => [count_37:bigint, sum_36:bigint]
                     Estimates: {rows: ? (?), cpu: ?, memory: 0.00, network: ?}
                 - RemoteStreamingExchange[REPLICATE] => [count_37:bigint, sum_36:bigint]
                         Estimates: {rows: ? (?), cpu: ?, memory: 0.00, network: ?}
                     - TableScan[TableHandle {connectorId='pinot', connectorHandle='PinotTableHandle{connectorId=pinot, schemaName=default, tableName=baseballStats, isQueryShort=Optional[true], expectedColumnHandles=Optional[[PinotColumnHandle{columnName=count_37, dataType=bigint, type=DERIVED}, PinotColumnHandle{columnName=sum_36, dataType=bigint, type=DERIVED}]], pinotQuery=Optional[GeneratedPinotQuery{query=SELECT DISTINCTCOUNT(playerID), sum(numberOfGames) FROM baseballStats WHERE (teamID = 'CHN'), format=SQL, table=baseballStats, expectedColumnIndices=[], groupByClauses=0, haveFilter=true, isQueryShort=true}]}', layout='Optional[PinotTableHandle{connectorId=pinot, schemaName=default, tableName=baseballStats, isQueryShort=Optional[true], expectedColumnHandles=Optional[[PinotColumnHandle{columnName=count_37, dataType=bigint, type=DERIVED}, PinotColumnHandle{columnName=sum_36, dataType=bigint, type=DERIVED}]], pinotQuery=Optional[GeneratedPinotQuery{query=SELECT DISTINCTCOUNT(playerID), sum(numberOfGames) FROM baseballStats WHERE (teamID = 'CHN'), format=SQL, table=baseballStats, expectedColumnIndices=[], groupByClauses=0, haveFilter=true, isQueryShort=true}]}]'}] => [count_37:bigint, sum_36:bigint]
                             Estimates: {rows: ? (?), cpu: ?, memory: 0.00, network: 0.00}
                             count_37 := PinotColumnHandle{columnName=count_37, dataType=bigint, type=DERIVED}
                             sum_36 := PinotColumnHandle{columnName=sum_36, dataType=bigint, type=DERIVED}

(1 row)
```

Test plan - (Please fill in how you tested your changes)

Tested locally.
```
== NO RELEASE NOTE ==
```
