### PR TITLE
Add SQL functions ARRAY_DUPES and ARRAY_HAS_DUPES

### DIFF
--- a/presto-docs/src/main/sphinx/functions/array.rst
+++ b/presto-docs/src/main/sphinx/functions/array.rst
@@ -44,6 +44,14 @@ Array Functions
 
     Remove duplicate values from the array ``x``.
 
+.. function:: array_dupes(array(bigint)) -> array(bigint)
+
+    Returns an array with elements that are duplicated in the ``array``. Each element is repeated only once and may be in any order.
+
+.. function:: array_dupes(array(varchar)) -> array(varchar)
+
+    Returns an array with elements that are duplicated in the ``array``. Each element is repeated only once and may be in any order.
+
 .. function:: array_except(x, y) -> array
 
     Returns an array of elements in ``x`` but not in ``y``, without duplicates.
@@ -57,6 +65,14 @@ Array Functions
 
     Returns a map: keys are the unique elements in the ``array``, values are how many times the key appears.
     Ignores null elements. Empty array returns empty map.
+
+.. function:: array_has_dupes(array(bigint)) -> boolean
+
+    Returns a boolean: whether ``array`` has any duplicate elements.
+
+.. function:: array_has_dupes(array(varchar)) -> boolean
+
+    Returns a boolean: whether ``array`` has any duplicate elements.
 
 .. function:: array_intersect(x, y) -> array
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/sql/ArrayArithmeticFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/sql/ArrayArithmeticFunctions.java
@@ -78,4 +78,52 @@ public class ArrayArithmeticFunctions
                 "(m, x) -> IF (x IS NOT NULL, MAP_CONCAT(m,MAP_FROM_ENTRIES(ARRAY[ROW(x, COALESCE(ELEMENT_AT(m,x) + 1, 1))])), m)," +
                 "m -> m)";
     }
+
+    @SqlInvokedScalarFunction(value = "array_dupes", deterministic = true, calledOnNullInput = false)
+    @Description("Returns set of elements that have duplicates")
+    @SqlParameter(name = "input", type = "array(varchar)")
+    @SqlType("array(varchar)")
+    public static String arrayDupesVarchar()
+    {
+        return "RETURN CONCAT(" +
+                "CAST(IF (cardinality(filter(input, x -> x is NULL)) > 1, ARRAY[NULL], ARRAY[]) AS ARRAY(VARCHAR))," +
+                "reduce(" +
+                "input," +
+                "MAP()," +
+                "(m, x) -> IF (x IS NOT NULL, MAP_CONCAT(m, MAP_FROM_ENTRIES(ARRAY[ROW(x, COALESCE(ELEMENT_AT(m,x) + 1, 1))])), m)," +
+                "m -> map_keys(map_filter(m, (k, v) -> v > 1))))";
+    }
+
+    @SqlInvokedScalarFunction(value = "array_dupes", deterministic = true, calledOnNullInput = false)
+    @Description("Returns set of elements that have duplicates")
+    @SqlParameter(name = "input", type = "array(bigint)")
+    @SqlType("array(bigint)")
+    public static String arrayDupesBigint()
+    {
+        return "RETURN CONCAT(" +
+                "CAST(IF (cardinality(filter(input, x -> x is NULL)) > 1, ARRAY[NULL], ARRAY[]) AS ARRAY(BIGINT))," +
+                "reduce(" +
+                "input," +
+                "MAP()," +
+                "(m, x) -> IF (x IS NOT NULL, MAP_CONCAT(m, MAP_FROM_ENTRIES(ARRAY[ROW(x, COALESCE(ELEMENT_AT(m,x) + 1, 1))])), m)," +
+                "m -> map_keys(map_filter(m, (k, v) -> v > 1))))";
+    }
+
+    @SqlInvokedScalarFunction(value = "array_has_dupes", deterministic = true, calledOnNullInput = false)
+    @Description("Returns whether array has any duplicate element")
+    @SqlParameter(name = "input", type = "array(varchar)")
+    @SqlType("boolean")
+    public static String arrayHasDupesVarchar()
+    {
+        return "RETURN cardinality(array_dupes(input)) > 0";
+    }
+
+    @SqlInvokedScalarFunction(value = "array_has_dupes", deterministic = true, calledOnNullInput = false)
+    @Description("Returns whether array has any duplicate element")
+    @SqlParameter(name = "input", type = "array(bigint)")
+    @SqlType("boolean")
+    public static String arrayHasDupesBigint()
+    {
+        return "RETURN cardinality(array_dupes(input)) > 0";
+    }
 }


### PR DESCRIPTION
Added SQL functions:

ARRAY_DUPES: Returns elements that are duplicated in input
ARRAY_HAS_DUPES: Retruns boolean whether array has any duplicates
null is also considered a valid element and accounted for. This follows what array_distinct does.

Tracking Issue: #15656

== RELEASE NOTES ==

General Changes
* Add SQL functions ARRAY_DUPES and ARRAY_HAS_DUPES