### PR TITLE
Add release notes for 0.256

### DIFF
--- a/presto-docs/src/main/sphinx/release.rst
+++ b/presto-docs/src/main/sphinx/release.rst
@@ -5,6 +5,7 @@ Release Notes
 .. toctree::
     :maxdepth: 1
 
+    release/release-0.256
     release/release-0.255
     release/release-0.254.1
     release/release-0.254

--- a/presto-docs/src/main/sphinx/release/release-0.256.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.256.rst
@@ -1,0 +1,28 @@
+=============
+Release 0.256
+=============
+
+**Details**
+===========
+
+General Changes
+_______________
+* Add support for lambda expressions in ``PREPARE`` statements.
+* Add configuration property ``experimental.distinct-aggregation-spill-enabled`` and session property ``distinct_aggregation_spill_enabled`` to disable spilling for distinct aggregations.
+* Add configuration property ``experimental.order-by-aggregation-spill-enabled`` and session property ``order_by_aggregation_spill_enabled`` to disable spilling for order by aggregations.
+* Add double quotes around the column domain values in the text query plan. Literal double quotes in values will be escaped with a backslash (``ab"c`` -> ``ab\"c``).
+* Add function :func:`array_frequency`.
+* Add support for :func:`zip` to take up to 7 arguments.
+
+Web UI Changes
+______________
+* Add ``Cumulative Total Memory`` to the ``Resource Utilization Summary`` table on the ``Query Details`` page.
+
+SPI Changes
+___________
+* Add ``cumulativeTotalMemory`` to ``QueryStatistics``.
+
+**Contributors**
+================
+
+Abhisek Gautam Saikia, Amit Dutta, Andrii Rosa, Ariel Weisberg, Arunachalam Thirupathi, Beinan, Chunxu Tang, Dong Shi, Ge Gao, Grace Xin, Huameng Jiang, James Petty, James Sun, Jennifer Zhou, Jim Apple, Julian Zhuoran Zhao, Kyle B Campbell, Maria Basmanova, Marilyn Beck, Rebecca Schlussel, Rongrong Zhong, Ryan Guo, Seba Villalobos, Shixuan Fan, Tim Meehan, Vic Zhang, Xiang Fu, Zhan Yuan, tanjialiang


### PR DESCRIPTION
# Missing Release Notes
## Ge Gao
- [x] https://github.com/prestodb/presto/pull/15996 Support REFRESH MATERIALIZED VIEW (Merged by: James Sun)
- [x] https://github.com/prestodb/presto/pull/15996 Support REFRESH MATERIALIZED VIEW (Merged by: James Sun)

# Extracted Release Notes
- #16163 (Author: Abhisek Gautam Saikia): Support multi coordinator while serving query state info
  - Support multi coordinator for /v1/queryState/ endpoint.
- #16184 (Author: Zhan Yuan): Support parameters in lambda expressions for prepare statement
  - Fix a bug that parameters are not supported in lambda expressions for prepare statements.
- #16198 (Author: Jennifer Zhou): Add SQL function array_frequency
  - Add function :func:`array_frequency'.
- #16208 (Author: Seba Villalobos): Add quotes around printed domain values
  - Add double quotes around the column domain values in the text query plan. Literal double quotes in values will be escaped with a backslash (ab"c -> ab\"c).
- #16215 (Author: Jim Apple): Add query statistic cumulative total memory
  - Add a new total cumulative memory statistic.
  - Add cumulative total memory to the Memory and Resource Utilization Summary tables on the QueryDetail page.
- #16238 (Author: Marilyn Beck): Add presto-docs/README.md with instructions to build Presto docs
  - Add presto-docs/README.md with instructions to build Presto docs.
- #16250 (Author: Rebecca Schlussel): Add flags to disable spill for distinct and order by aggregations
  - Add configuration property ``experimental.distinct-aggregation-spill-enabled`` and session property ``distinct_aggregation_spill_enabled`` to disable spilling for distinct aggregations.
  - Add configuration property ``experimental.order-by-aggregation-spill-enabled`` and session property ``order_by_aggregation_spill_enabled`` to disable spilling for order by aggregations.
- #16250 (Author: Rebecca Schlussel): Add flags to disable spill for distinct and order by aggregations
  - Add configuration property ``experimental.distinct-aggregation-spill-enabled`` and session property ``distinct_aggregation_spill_enabled`` to disable spilling for distinct aggregations.
  - Add configuration property ``experimental.order-by-aggregation-spill-enabled`` and session property ``order_by_aggregation_spill_enabled`` to disable spilling for order by aggregations.
- #16290 (Author: Dong Shi): Increase MAX_ARITY of zip function to 7
  - Add support for :func:`zip` with max arity of 7.

# All Commits
- 3761cb4dd21022b78af0683d53223051f7219938 Clean up TestDistributedClusterStatsResource (Tim Meehan)
- 2538c36491acc52d48e44d44f8395aa6975ae37d Queue when resource manager state is inconsistent with discovery (Tim Meehan)
- 1cb4dd727b91d6a30c732c5264b2ca82b9e40992 Add distributed resource group queueing (Tim Meehan)
- 05baed42287a68ccee79e4ebec8828e04ed0eda8 Make PeriodicTaskExecutor start lazily (Tim Meehan)
- d3031aa62d233892dd4c9fb552b938c4a444e747 Add instructions to README.md for building Presto docs (Marilyn Beck)
- 9f27b96d749483e363fbbccf5359ff51fa4d439a Increase MAX_ARITY of zip function to 7 (Dong Shi)
- 985f407b6f8e3ffd84ed4497489d44c2aeadee8e Move presto-testng-services to top level (Ariel Weisberg)
- 83fa968824c1654cb2d2e1e3aad82f82fcedcf8e Support multi coordinator while serving query state info (Abhisek Gautam Saikia)
- 20633f68d79e9c6e07788781c4ab1b9fa6cc6093 Determine reserved pool eligibility in resource manager (Tim Meehan)
- e24c23fa549558e629035359dac9932d2bca6013 Add distributed memory management (Tim Meehan)
- 045a11ef46dda78b5742c225cface7a0cd82827c Support equi joins in materialized view plan validator (Grace Xin)
- c21b5a821b9dc194038e3f2cdfeb28eeb58f4339 Add materialized view candidate extractor (Julian Zhuoran Zhao)
- 5ae86ffc749bd475476179fe2af2be543fe159e1 Add SQL function array_frequency (Jennifer Zhou)
- 692ca3de145c5664237315bc18e45b6fd7e7d7d0 Quarantine TestQueues#testExceedSoftLimits (Andrii Rosa)
- a2e48128950c739299b79399931bc3891815e287 Release memory retained by RDD early (Andrii Rosa)
- 8222ebb7dfd9e66ead4a5125db0eb917ab65fc2b Update log messages ReloadingResourceGroupConfigurationManager (Kyle B Campbell)
- b490fd024d40e908c6cb7107ebc03db8929a2720 Fix crc computation to properly support integers. (Amit Dutta)
- 20354ba94ea1091d2f48916f6534da1ce952ddd6 Fixing apache pinot branding words in docs (Xiang Fu)
- f8f26908666c80925ffc679bbb7386d1b4c9a265 Support REFRESH MATERIALIZED VIEW execution (Ge Gao)
- 6edb08b54495fa8542966b3bc0f3c30a14f97fd8 Support syntax and analyze for REFRESH MATERIALIZED VIEW (Ge Gao)
- 804f14fba9e35c1879722b8cdb1b952fd82a8551 Refactor StreamReader::startStripe to take the Stripe directly (Huameng Jiang)
- b0e1b0b24e219cbf7076f0dc952ee9d16b5b2848 Add flags to disable spill for distinct/order by aggregations (Rebecca Schlussel)
- c53ca6d6ba95dd519d11481c3a9618de65406b44 Fix naming for spilled aggregation tests (Rebecca Schlussel)
- 5a4c413a7d3b8eec72ea279ccc05447ca94ffc80 Remove typeBound from TypeVariableConstraint (Rongrong Zhong)
- dd3e52282d221854b0a4627ae5ec1925d1d7b9d5 Add query statistic cumulative total memory (Jim Apple)
- a2efda5abb43520fce4eb10a3e8d4b740f41bf50 Add quotes around printed domain values (Seba Villalobos)
- 12811f07634934408cd217428e12d7026433820b Use instance supplier for scan operator info (James Petty)
- 8111449efb0ce1fe155ee0c38934199cde15e0eb Reduce retained references in TableWriterMergeOperator info supplier (James Petty)
- f5ad82b3a73e4f8d31acd3588485333c1e2684aa Reduce retained references in TableFinishOperator info supplier (James Petty)
- bde34fb815afdc464c524e9652bca1ecbc2f3d06 Reduce retained references in TableWriterOperator info supplier (James Petty)
- 3ad42ed845639615895676fcef730591c98d124c Reduce retained references in partitioned output operators info (James Petty)
- 4f46535dc967b503ad26031b7b0a22b534bfc5c5 Avoid referencing WindowOperator directly from its info supplier (James Petty)
- 01ba1dc71585f4aa9504fbaaff06ef7632a54cb2 Clear live references to info suppliers in OperatorContext#destroy() (James Petty)
- 303d52ba45dcb795611bc78f1e77b49235f55172 Declare OperatorContext#infoSupplier to be a covariant Supplier (James Petty)
- e1bd702401301b47d495dd526f49b0068871cb49 Test iceberg connector configs (Chunxu Tang)
- d9e74e7ba3d2d180a2a1d8fbcdbdbf742ab36ef0 Add additional query time statistics (tanjialiang)
- 3afbd277d07776ba56ccdac3b9e8bafd26dadbf1 Fix missing QueryCompleteEvent for Presto on Spark (Vic Zhang)
- 1a91fe8f1d4a3373132ba58b4e227f84a1688325 Sort view and base tables (Grace Xin)
- ff5afa5ab8d83c334aa6511afd671eaec56e2f99 Verify materialized view tables instead of rowcount (Grace Xin)
- 9f238ee219e0360818090d0ef263ecb39179ad09 Support parameters in lambda expressions for prepare statement (Zhan Yuan)
- e273f7c4420defe7f0d59d5e2a31e101786adc97 Option to disable DWRF String Dictionary Sorting (Arunachalam Thirupathi)
- 12755635b8a5fbc1cc27cb4a522ef8021bd3df14 Add unit tests of iceberg connector (Chunxu Tang)
- 75c9ecf84c5d446f1316d4abadc5ac8cd26ec10e Fix invalid output from GraphvizPrinter (Ryan Guo)
- 1ba26570f679a1c91c0c889ce7c2a0f11a97ed07 Bind shared scheduled executor in verifier (Andrii Rosa)