### PR TITLE
Extend memory exceeded errors with more details

### DIFF
--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/AbstractOperatorBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/AbstractOperatorBenchmark.java
@@ -34,6 +34,7 @@ import com.facebook.presto.operator.OperatorContext;
 import com.facebook.presto.operator.OperatorFactory;
 import com.facebook.presto.operator.PageSourceOperator;
 import com.facebook.presto.operator.TaskContext;
+import com.facebook.presto.operator.TaskMemoryReservationSummary;
 import com.facebook.presto.operator.TaskStats;
 import com.facebook.presto.operator.project.InputPageProjection;
 import com.facebook.presto.operator.project.PageProcessor;
@@ -66,6 +67,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import static com.facebook.airlift.concurrent.MoreFutures.getFutureValue;
+import static com.facebook.airlift.json.JsonCodec.listJsonCodec;
 import static com.facebook.airlift.stats.CpuTimer.CpuDuration;
 import static com.facebook.presto.SystemSessionProperties.getFilterAndProjectMinOutputPageRowCount;
 import static com.facebook.presto.SystemSessionProperties.getFilterAndProjectMinOutputPageSize;
@@ -282,9 +284,12 @@ public abstract class AbstractOperatorBenchmark
                 localQueryRunner.getExecutor(),
                 localQueryRunner.getScheduler(),
                 new DataSize(256, MEGABYTE),
-                spillSpaceTracker)
-                .addTaskContext(new TaskStateMachine(new TaskId("query", 0, 0, 0), localQueryRunner.getExecutor()),
+                spillSpaceTracker,
+                listJsonCodec(TaskMemoryReservationSummary.class))
+                .addTaskContext(
+                        new TaskStateMachine(new TaskId("query", 0, 0, 0), localQueryRunner.getExecutor()),
                         session,
+                        Optional.empty(),
                         false,
                         false,
                         false,

--- a/presto-benchmark/src/test/java/com/facebook/presto/benchmark/MemoryLocalQueryRunner.java
+++ b/presto-benchmark/src/test/java/com/facebook/presto/benchmark/MemoryLocalQueryRunner.java
@@ -24,6 +24,7 @@ import com.facebook.presto.memory.QueryContext;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.operator.Driver;
 import com.facebook.presto.operator.TaskContext;
+import com.facebook.presto.operator.TaskMemoryReservationSummary;
 import com.facebook.presto.plugin.memory.MemoryConnectorFactory;
 import com.facebook.presto.spi.Plugin;
 import com.facebook.presto.spi.QueryId;
@@ -42,6 +43,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static com.facebook.airlift.json.JsonCodec.listJsonCodec;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static io.airlift.units.DataSize.Unit.GIGABYTE;
 import static org.testng.Assert.assertTrue;
@@ -86,11 +88,14 @@ public class MemoryLocalQueryRunner
                 localQueryRunner.getExecutor(),
                 localQueryRunner.getScheduler(),
                 new DataSize(4, GIGABYTE),
-                spillSpaceTracker);
+                spillSpaceTracker,
+                listJsonCodec(TaskMemoryReservationSummary.class));
 
         TaskContext taskContext = queryContext
-                .addTaskContext(new TaskStateMachine(new TaskId("query", 0, 0, 0), localQueryRunner.getExecutor()),
+                .addTaskContext(
+                        new TaskStateMachine(new TaskId("query", 0, 0, 0), localQueryRunner.getExecutor()),
                         localQueryRunner.getDefaultSession(),
+                        Optional.empty(),
                         false,
                         false,
                         false,

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -196,6 +196,7 @@ public final class SystemSessionProperties
     public static final String PARTIAL_RESULTS_COMPLETION_RATIO_THRESHOLD = "partial_results_completion_ratio_threshold";
     public static final String PARTIAL_RESULTS_MAX_EXECUTION_TIME_MULTIPLIER = "partial_results_max_execution_time_multiplier";
     public static final String OFFSET_CLAUSE_ENABLED = "offset_clause_enabled";
+    public static final String VERBOSE_EXCEEDED_MEMORY_LIMIT_ERRORS_ENABLED = "verbose_exceeded_memory_limit_errors_enabled";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -1048,6 +1049,11 @@ public final class SystemSessionProperties
                         PARTIAL_RESULTS_MAX_EXECUTION_TIME_MULTIPLIER,
                         "This value is multiplied by the time taken to reach the completion ratio threshold and is set as max task end time",
                         featuresConfig.getPartialResultsMaxExecutionTimeMultiplier(),
+                        false),
+                booleanProperty(
+                        VERBOSE_EXCEEDED_MEMORY_LIMIT_ERRORS_ENABLED,
+                        "When enabled the error message for exceeded memory limit errors will contain additional operator memory allocation details",
+                        nodeMemoryConfig.isVerboseExceededMemoryLimitErrorsEnabled(),
                         false));
     }
 
@@ -1767,5 +1773,10 @@ public final class SystemSessionProperties
     public static boolean isOffsetClauseEnabled(Session session)
     {
         return session.getSystemProperty(OFFSET_CLAUSE_ENABLED, Boolean.class);
+    }
+
+    public static boolean isVerboseExceededMemoryLimitErrorsEnabled(Session session)
+    {
+        return session.getSystemProperty(VERBOSE_EXCEEDED_MEMORY_LIMIT_ERRORS_ENABLED, Boolean.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskExecutionFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskExecutionFactory.java
@@ -30,8 +30,10 @@ import com.facebook.presto.sql.planner.LocalExecutionPlanner.LocalExecutionPlan;
 import com.facebook.presto.sql.planner.PlanFragment;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.Executor;
 
+import static com.facebook.presto.SystemSessionProperties.isVerboseExceededMemoryLimitErrorsEnabled;
 import static com.facebook.presto.execution.SqlTaskExecution.createSqlTaskExecution;
 import static com.google.common.base.Throwables.throwIfUnchecked;
 import static java.util.Objects.requireNonNull;
@@ -88,6 +90,8 @@ public class SqlTaskExecutionFactory
         TaskContext taskContext = queryContext.addTaskContext(
                 taskStateMachine,
                 session,
+                // Plan has to be retained only if verbose memory exceeded errors are requested
+                isVerboseExceededMemoryLimitErrorsEnabled(session) ? Optional.of(fragment.getRoot()) : Optional.empty(),
                 perOperatorCpuTimerEnabled,
                 cpuTimerEnabled,
                 perOperatorAllocationTrackingEnabled,

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskManager.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.execution;
 
 import com.facebook.airlift.concurrent.ThreadPoolExecutorMBean;
+import com.facebook.airlift.json.JsonCodec;
 import com.facebook.airlift.log.Logger;
 import com.facebook.airlift.node.NodeInfo;
 import com.facebook.airlift.stats.CounterStat;
@@ -37,6 +38,7 @@ import com.facebook.presto.memory.QueryContext;
 import com.facebook.presto.metadata.MetadataUpdates;
 import com.facebook.presto.operator.ExchangeClientSupplier;
 import com.facebook.presto.operator.FragmentResultCacheManager;
+import com.facebook.presto.operator.TaskMemoryReservationSummary;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.connector.ConnectorMetadataUpdater;
@@ -77,6 +79,7 @@ import static com.facebook.airlift.concurrent.Threads.threadsNamed;
 import static com.facebook.presto.SystemSessionProperties.getQueryMaxBroadcastMemory;
 import static com.facebook.presto.SystemSessionProperties.getQueryMaxMemoryPerNode;
 import static com.facebook.presto.SystemSessionProperties.getQueryMaxTotalMemoryPerNode;
+import static com.facebook.presto.SystemSessionProperties.isVerboseExceededMemoryLimitErrorsEnabled;
 import static com.facebook.presto.SystemSessionProperties.resourceOvercommit;
 import static com.facebook.presto.execution.SqlTask.createSqlTask;
 import static com.facebook.presto.memory.LocalMemoryManager.GENERAL_POOL;
@@ -107,6 +110,7 @@ public class SqlTaskManager
     private final Duration clientTimeout;
 
     private final LocalMemoryManager localMemoryManager;
+    private final JsonCodec<List<TaskMemoryReservationSummary>> memoryReservationSummaryJsonCodec;
     private final LoadingCache<QueryId, QueryContext> queryContexts;
     private final LoadingCache<TaskId, SqlTask> tasks;
 
@@ -126,6 +130,7 @@ public class SqlTaskManager
             SplitMonitor splitMonitor,
             NodeInfo nodeInfo,
             LocalMemoryManager localMemoryManager,
+            JsonCodec<List<TaskMemoryReservationSummary>> memoryReservationSummaryJsonCodec,
             TaskManagementExecutor taskManagementExecutor,
             TaskManagerConfig config,
             NodeMemoryConfig nodeMemoryConfig,
@@ -162,6 +167,7 @@ public class SqlTaskManager
                 config);
 
         this.localMemoryManager = requireNonNull(localMemoryManager, "localMemoryManager is null");
+        this.memoryReservationSummaryJsonCodec = requireNonNull(memoryReservationSummaryJsonCodec, "memoryReservationSummaryJsonCodec is null");
         DataSize maxQueryUserMemoryPerNode = nodeMemoryConfig.getMaxQueryMemoryPerNode();
         DataSize maxQueryTotalMemoryPerNode = nodeMemoryConfig.getMaxQueryTotalMemoryPerNode();
         DataSize maxQuerySpillPerNode = nodeSpillConfig.getQueryMaxSpillPerNode();
@@ -213,7 +219,8 @@ public class SqlTaskManager
                 taskNotificationExecutor,
                 driverYieldExecutor,
                 maxQuerySpillPerNode,
-                localSpillManager.getSpillSpaceTracker());
+                localSpillManager.getSpillSpaceTracker(),
+                memoryReservationSummaryJsonCodec);
     }
 
     @Override
@@ -408,6 +415,8 @@ public class SqlTaskManager
                         getQueryMaxBroadcastMemory(session));
             }
         }
+
+        queryContext.setVerboseExceededMemoryLimitErrorsEnabled(isVerboseExceededMemoryLimitErrorsEnabled(session));
 
         sqlTask.recordHeartbeat();
         return sqlTask.updateTask(session, fragment, sources, outputBuffers, tableWriteInfo);

--- a/presto-main/src/main/java/com/facebook/presto/memory/NodeMemoryConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/NodeMemoryConfig.java
@@ -42,6 +42,8 @@ public class NodeMemoryConfig
     private DataSize softMaxQueryTotalMemoryPerNode;
     private DataSize heapHeadroom = new DataSize(AVAILABLE_HEAP_MEMORY * 0.3, BYTE);
 
+    private boolean verboseExceededMemoryLimitErrorsEnabled;
+
     @NotNull
     public DataSize getMaxQueryBroadcastMemory()
     {
@@ -141,6 +143,19 @@ public class NodeMemoryConfig
     public NodeMemoryConfig setHeapHeadroom(DataSize heapHeadroom)
     {
         this.heapHeadroom = heapHeadroom;
+        return this;
+    }
+
+    public boolean isVerboseExceededMemoryLimitErrorsEnabled()
+    {
+        return verboseExceededMemoryLimitErrorsEnabled;
+    }
+
+    @Config("memory.verbose-exceeded-memory-limit-errors-enabled")
+    @ConfigDescription("When enabled the error message for exceeded memory limit errors will contain additional operator memory allocation details")
+    public NodeMemoryConfig setVerboseExceededMemoryLimitErrorsEnabled(boolean verboseExceededMemoryLimitErrorsEnabled)
+    {
+        this.verboseExceededMemoryLimitErrorsEnabled = verboseExceededMemoryLimitErrorsEnabled;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/OperatorContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/OperatorContext.java
@@ -92,6 +92,8 @@ public class OperatorContext
     private final AtomicLong peakTotalMemoryReservation = new AtomicLong();
     private final RuntimeStats runtimeStats = new RuntimeStats();
 
+    private final AtomicLong currentTotalMemoryReservationInBytes = new AtomicLong();
+
     @GuardedBy("this")
     private boolean memoryRevokingRequested;
 
@@ -127,6 +129,11 @@ public class OperatorContext
     public int getOperatorId()
     {
         return operatorId;
+    }
+
+    public PlanNodeId getPlanNodeId()
+    {
+        return planNodeId;
     }
 
     public String getOperatorType()
@@ -305,6 +312,12 @@ public class OperatorContext
         peakUserMemoryReservation.accumulateAndGet(userMemory, Math::max);
         peakSystemMemoryReservation.accumulateAndGet(systemMemory, Math::max);
         peakTotalMemoryReservation.accumulateAndGet(totalMemory, Math::max);
+        currentTotalMemoryReservationInBytes.set(totalMemory);
+    }
+
+    public long getCurrentTotalMemoryReservationInBytes()
+    {
+        return currentTotalMemoryReservationInBytes.get();
     }
 
     // listen to revocable memory allocations and call any listeners waiting on task memory allocation

--- a/presto-main/src/main/java/com/facebook/presto/operator/OperatorMemoryReservationSummary.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/OperatorMemoryReservationSummary.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.spi.plan.PlanNodeId;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+import io.airlift.units.DataSize;
+
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class OperatorMemoryReservationSummary
+{
+    private final String type;
+    private final PlanNodeId planNodeId;
+    private final List<DataSize> reservations;
+    private final DataSize total;
+    private final Optional<String> info;
+
+    @JsonCreator
+    public OperatorMemoryReservationSummary(
+            @JsonProperty("type") String type,
+            @JsonProperty("planNodeId") PlanNodeId planNodeId,
+            @JsonProperty("reservations") List<DataSize> reservations,
+            @JsonProperty("total") DataSize total,
+            @JsonProperty("info") Optional<String> info)
+    {
+        this.type = requireNonNull(type, "type is null");
+        this.planNodeId = requireNonNull(planNodeId, "planNodeId is null");
+        this.reservations = ImmutableList.copyOf(requireNonNull(reservations, "reservations is null"));
+        this.total = requireNonNull(total, "total is null");
+        this.info = requireNonNull(info, "info is null");
+    }
+
+    @JsonProperty
+    public String getType()
+    {
+        return type;
+    }
+
+    @JsonProperty
+    public PlanNodeId getPlanNodeId()
+    {
+        return planNodeId;
+    }
+
+    @JsonProperty
+    public List<DataSize> getReservations()
+    {
+        return reservations;
+    }
+
+    @JsonProperty
+    public DataSize getTotal()
+    {
+        return total;
+    }
+
+    @JsonProperty
+    public Optional<String> getInfo()
+    {
+        return info;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/TaskMemoryReservationSummary.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TaskMemoryReservationSummary.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+import io.airlift.units.DataSize;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+public class TaskMemoryReservationSummary
+{
+    private final String taskId;
+    private final DataSize reservation;
+    private final List<OperatorMemoryReservationSummary> topConsumers;
+
+    @JsonCreator
+    public TaskMemoryReservationSummary(
+            @JsonProperty("taskId") String taskId,
+            @JsonProperty("reservation") DataSize reservation,
+            @JsonProperty("topConsumers") List<OperatorMemoryReservationSummary> topConsumers)
+    {
+        this.taskId = requireNonNull(taskId, "taskId is null");
+        this.reservation = requireNonNull(reservation, "reservation is null");
+        this.topConsumers = ImmutableList.copyOf(requireNonNull(topConsumers, "topConsumers is null"));
+    }
+
+    @JsonProperty
+    public String getTaskId()
+    {
+        return taskId;
+    }
+
+    @JsonProperty
+    public DataSize getReservation()
+    {
+        return reservation;
+    }
+
+    @JsonProperty
+    public List<OperatorMemoryReservationSummary> getTopConsumers()
+    {
+        return topConsumers;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -109,6 +109,7 @@ import com.facebook.presto.operator.NoOpFragmentResultCacheManager;
 import com.facebook.presto.operator.OperatorStats;
 import com.facebook.presto.operator.PagesIndex;
 import com.facebook.presto.operator.TableCommitContext;
+import com.facebook.presto.operator.TaskMemoryReservationSummary;
 import com.facebook.presto.operator.index.IndexJoinLookupStats;
 import com.facebook.presto.resourcemanager.ClusterMemoryManagerService;
 import com.facebook.presto.resourcemanager.ClusterStatusSender;
@@ -350,6 +351,7 @@ public class ServerMainModule
         thriftCodecBinder(binder).bindCustomThriftCodec(SqlInvokedFunctionCodec.class);
         thriftCodecBinder(binder).bindCustomThriftCodec(SqlFunctionIdCodec.class);
 
+        jsonCodecBinder(binder).bindListJsonCodec(TaskMemoryReservationSummary.class);
         binder.bind(SqlTaskManager.class).in(Scopes.SINGLETON);
         binder.bind(TaskManager.class).to(Key.get(SqlTaskManager.class));
         binder.bind(SpoolingOutputBufferFactory.class).in(Scopes.SINGLETON);

--- a/presto-main/src/test/java/com/facebook/presto/execution/MockRemoteTaskFactory.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/MockRemoteTaskFactory.java
@@ -30,6 +30,7 @@ import com.facebook.presto.metadata.InternalNode;
 import com.facebook.presto.metadata.Split;
 import com.facebook.presto.operator.StageExecutionDescriptor;
 import com.facebook.presto.operator.TaskContext;
+import com.facebook.presto.operator.TaskMemoryReservationSummary;
 import com.facebook.presto.operator.TaskStats;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.TableHandle;
@@ -77,6 +78,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
 
+import static com.facebook.airlift.json.JsonCodec.listJsonCodec;
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.execution.StateMachine.StateChangeListener;
@@ -215,10 +217,12 @@ public class MockRemoteTaskFactory
                     executor,
                     scheduledExecutor,
                     new DataSize(1, MEGABYTE),
-                    spillSpaceTracker);
+                    spillSpaceTracker,
+                    listJsonCodec(TaskMemoryReservationSummary.class));
             this.taskContext = queryContext.addTaskContext(
                     taskStateMachine,
                     TEST_SESSION,
+                    Optional.of(fragment.getRoot()),
                     true,
                     true,
                     true,

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestMemoryRevokingScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestMemoryRevokingScheduler.java
@@ -30,6 +30,7 @@ import com.facebook.presto.operator.DriverContext;
 import com.facebook.presto.operator.OperatorContext;
 import com.facebook.presto.operator.PipelineContext;
 import com.facebook.presto.operator.TaskContext;
+import com.facebook.presto.operator.TaskMemoryReservationSummary;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.memory.MemoryPoolId;
 import com.facebook.presto.spi.plan.PlanNodeId;
@@ -61,6 +62,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.facebook.airlift.concurrent.Threads.threadsNamed;
+import static com.facebook.airlift.json.JsonCodec.listJsonCodec;
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
 import static com.facebook.presto.execution.SqlTask.createSqlTask;
 import static com.facebook.presto.execution.TaskManagerConfig.TaskPriorityTracking.TASK_FAIR;
@@ -811,7 +813,8 @@ public class TestMemoryRevokingScheduler
                 singleThreadedExecutor,
                 scheduledExecutor,
                 new DataSize(1, GIGABYTE),
-                spillSpaceTracker));
+                spillSpaceTracker,
+                listJsonCodec(TaskMemoryReservationSummary.class)));
     }
 
     private TaskContext getOrCreateTaskContext(SqlTask sqlTask)

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskManager.java
@@ -32,6 +32,7 @@ import com.facebook.presto.metadata.InternalNode;
 import com.facebook.presto.operator.ExchangeClient;
 import com.facebook.presto.operator.ExchangeClientSupplier;
 import com.facebook.presto.operator.NoOpFragmentResultCacheManager;
+import com.facebook.presto.operator.TaskMemoryReservationSummary;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spiller.LocalSpillManager;
 import com.facebook.presto.spiller.NodeSpillConfig;
@@ -51,6 +52,7 @@ import java.net.URI;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
+import static com.facebook.airlift.json.JsonCodec.listJsonCodec;
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
 import static com.facebook.presto.execution.TaskManagerConfig.TaskPriorityTracking.TASK_FAIR;
 import static com.facebook.presto.execution.TaskTestUtils.PLAN_FRAGMENT;
@@ -288,6 +290,7 @@ public class TestSqlTaskManager
                 createTestSplitMonitor(),
                 new NodeInfo("test"),
                 localMemoryManager,
+                listJsonCodec(TaskMemoryReservationSummary.class),
                 taskManagementExecutor,
                 config,
                 new NodeMemoryConfig(),
@@ -318,6 +321,7 @@ public class TestSqlTaskManager
                 .addTaskContext(
                         new TaskStateMachine(taskId, directExecutor()),
                         testSessionBuilder().build(),
+                        Optional.of(PLAN_FRAGMENT.getRoot()),
                         false,
                         false,
                         false,

--- a/presto-main/src/test/java/com/facebook/presto/memory/TestMemoryPools.java
+++ b/presto-main/src/test/java/com/facebook/presto/memory/TestMemoryPools.java
@@ -25,6 +25,7 @@ import com.facebook.presto.operator.OperatorContext;
 import com.facebook.presto.operator.OutputFactory;
 import com.facebook.presto.operator.TableScanOperator;
 import com.facebook.presto.operator.TaskContext;
+import com.facebook.presto.operator.TaskMemoryReservationSummary;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.memory.MemoryPoolId;
 import com.facebook.presto.spi.plan.PlanNodeId;
@@ -49,6 +50,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
+import static com.facebook.airlift.json.JsonCodec.listJsonCodec;
 import static com.facebook.presto.testing.LocalQueryRunner.queryRunnerWithInitialTransaction;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static com.facebook.presto.testing.TestingTaskContext.createTaskContext;
@@ -103,7 +105,8 @@ public class TestMemoryPools
                 localQueryRunner.getExecutor(),
                 localQueryRunner.getScheduler(),
                 TEN_MEGABYTES,
-                spillSpaceTracker);
+                spillSpaceTracker,
+                listJsonCodec(TaskMemoryReservationSummary.class));
         taskContext = createTaskContext(queryContext, localQueryRunner.getExecutor(), session);
         drivers = driversSupplier.get();
     }

--- a/presto-main/src/test/java/com/facebook/presto/memory/TestMemoryTracking.java
+++ b/presto-main/src/test/java/com/facebook/presto/memory/TestMemoryTracking.java
@@ -26,6 +26,7 @@ import com.facebook.presto.operator.OperatorStats;
 import com.facebook.presto.operator.PipelineContext;
 import com.facebook.presto.operator.PipelineStats;
 import com.facebook.presto.operator.TaskContext;
+import com.facebook.presto.operator.TaskMemoryReservationSummary;
 import com.facebook.presto.operator.TaskStats;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.memory.MemoryPoolId;
@@ -37,12 +38,15 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
 
 import static com.facebook.airlift.concurrent.Threads.daemonThreadsNamed;
+import static com.facebook.airlift.json.JsonCodec.listJsonCodec;
+import static com.facebook.presto.execution.TaskTestUtils.PLAN_FRAGMENT;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static io.airlift.units.DataSize.Unit.GIGABYTE;
 import static java.lang.String.format;
@@ -108,10 +112,12 @@ public class TestMemoryTracking
                 notificationExecutor,
                 yieldExecutor,
                 queryMaxSpillSize,
-                spillSpaceTracker);
+                spillSpaceTracker,
+                listJsonCodec(TaskMemoryReservationSummary.class));
         taskContext = queryContext.addTaskContext(
                 new TaskStateMachine(new TaskId("query", 0, 0, 0), notificationExecutor),
                 testSessionBuilder().build(),
+                Optional.of(PLAN_FRAGMENT.getRoot()),
                 true,
                 true,
                 true,

--- a/presto-main/src/test/java/com/facebook/presto/memory/TestNodeMemoryConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/memory/TestNodeMemoryConfig.java
@@ -39,7 +39,8 @@ public class TestNodeMemoryConfig
                 .setMaxQueryTotalMemoryPerNode(new DataSize(AVAILABLE_HEAP_MEMORY * 0.3, BYTE))
                 .setSoftMaxQueryTotalMemoryPerNode(new DataSize(AVAILABLE_HEAP_MEMORY * 0.3, BYTE))
                 .setHeapHeadroom(new DataSize(AVAILABLE_HEAP_MEMORY * 0.3, BYTE))
-                .setReservedPoolEnabled(true));
+                .setReservedPoolEnabled(true)
+                .setVerboseExceededMemoryLimitErrorsEnabled(false));
     }
 
     @Test
@@ -53,6 +54,7 @@ public class TestNodeMemoryConfig
                 .put("query.soft-max-total-memory-per-node", "2GB")
                 .put("memory.heap-headroom-per-node", "1GB")
                 .put("experimental.reserved-pool-enabled", "false")
+                .put("memory.verbose-exceeded-memory-limit-errors-enabled", "true")
                 .build();
 
         NodeMemoryConfig expected = new NodeMemoryConfig()
@@ -62,7 +64,8 @@ public class TestNodeMemoryConfig
                 .setMaxQueryTotalMemoryPerNode(new DataSize(3, GIGABYTE))
                 .setSoftMaxQueryTotalMemoryPerNode(new DataSize(2, GIGABYTE))
                 .setHeapHeadroom(new DataSize(1, GIGABYTE))
-                .setReservedPoolEnabled(false);
+                .setReservedPoolEnabled(false)
+                .setVerboseExceededMemoryLimitErrorsEnabled(true);
 
         assertFullMapping(properties, expected);
     }
@@ -78,6 +81,7 @@ public class TestNodeMemoryConfig
                 .put("query.soft-max-total-memory-per-node", "2GB")
                 .put("memory.heap-headroom-per-node", "1GB")
                 .put("experimental.reserved-pool-enabled", "false")
+                .put("memory.verbose-exceeded-memory-limit-errors-enabled", "true")
                 .build();
 
         NodeMemoryConfig expected = new NodeMemoryConfig()
@@ -87,7 +91,8 @@ public class TestNodeMemoryConfig
                 .setMaxQueryTotalMemoryPerNode(new DataSize(3, GIGABYTE))
                 .setSoftMaxQueryTotalMemoryPerNode(new DataSize(2, GIGABYTE))
                 .setHeapHeadroom(new DataSize(1, GIGABYTE))
-                .setReservedPoolEnabled(false);
+                .setReservedPoolEnabled(false)
+                .setVerboseExceededMemoryLimitErrorsEnabled(true);
 
         assertFullMapping(properties, expected);
     }

--- a/presto-main/src/test/java/com/facebook/presto/operator/GroupByHashYieldAssertion.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/GroupByHashYieldAssertion.java
@@ -32,6 +32,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Function;
 
 import static com.facebook.airlift.concurrent.Threads.daemonThreadsNamed;
+import static com.facebook.airlift.json.JsonCodec.listJsonCodec;
 import static com.facebook.airlift.testing.Assertions.assertBetweenInclusive;
 import static com.facebook.airlift.testing.Assertions.assertGreaterThan;
 import static com.facebook.airlift.testing.Assertions.assertLessThan;
@@ -91,7 +92,8 @@ public final class GroupByHashYieldAssertion
                 EXECUTOR,
                 SCHEDULED_EXECUTOR,
                 new DataSize(512, MEGABYTE),
-                new SpillSpaceTracker(new DataSize(512, MEGABYTE)));
+                new SpillSpaceTracker(new DataSize(512, MEGABYTE)),
+                listJsonCodec(TaskMemoryReservationSummary.class));
 
         DriverContext driverContext = createTaskContext(queryContext, EXECUTOR, TEST_SESSION)
                 .addPipelineContext(0, true, true, false)

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
@@ -92,6 +92,7 @@ import com.facebook.presto.operator.OperatorInfo;
 import com.facebook.presto.operator.OperatorStats;
 import com.facebook.presto.operator.PagesIndex;
 import com.facebook.presto.operator.TableCommitContext;
+import com.facebook.presto.operator.TaskMemoryReservationSummary;
 import com.facebook.presto.operator.index.IndexJoinLookupStats;
 import com.facebook.presto.resourcemanager.NoopResourceGroupService;
 import com.facebook.presto.resourcemanager.ResourceGroupService;
@@ -238,6 +239,7 @@ public class PrestoSparkModule
         jsonCodecBinder(binder).bindJsonCodec(QueryInfo.class);
         jsonCodecBinder(binder).bindJsonCodec(PrestoSparkQueryStatusInfo.class);
         jsonCodecBinder(binder).bindJsonCodec(PrestoSparkQueryData.class);
+        jsonCodecBinder(binder).bindListJsonCodec(TaskMemoryReservationSummary.class);
 
         // smile codecs
         smileCodecBinder(binder).bindSmileCodec(TaskSource.class);

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkVerboseMemoryExceededErrors.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkVerboseMemoryExceededErrors.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spark;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestVerboseMemoryExceededErrors;
+import com.google.common.collect.ImmutableList;
+
+import static com.facebook.presto.SystemSessionProperties.QUERY_MAX_TOTAL_MEMORY_PER_NODE;
+import static com.facebook.presto.spark.PrestoSparkQueryRunner.createHivePrestoSparkQueryRunner;
+
+public class TestPrestoSparkVerboseMemoryExceededErrors
+        extends AbstractTestVerboseMemoryExceededErrors
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+    {
+        return createHivePrestoSparkQueryRunner(ImmutableList.of());
+    }
+
+    @Override
+    protected Session getSession()
+    {
+        return Session.builder(super.getSession())
+                .setCatalog("tpch")
+                .setSchema("sf0.5")
+                .setSystemProperty(QUERY_MAX_TOTAL_MEMORY_PER_NODE, "100MB")
+                .build();
+    }
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestVerboseMemoryExceededErrors.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestVerboseMemoryExceededErrors.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.operator.HashAggregationOperator;
+import com.facebook.presto.operator.HashBuilderOperator;
+import com.facebook.presto.operator.TaskMemoryReservationSummary;
+import com.facebook.presto.operator.WindowOperator;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static com.facebook.airlift.json.JsonCodec.listJsonCodec;
+import static com.facebook.presto.SystemSessionProperties.USE_MARK_DISTINCT;
+import static com.facebook.presto.SystemSessionProperties.VERBOSE_EXCEEDED_MEMORY_LIMIT_ERRORS_ENABLED;
+import static java.util.regex.Pattern.DOTALL;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+@Test(singleThreaded = true)
+public abstract class AbstractTestVerboseMemoryExceededErrors
+        extends AbstractTestQueryFramework
+{
+    private static final int INVOCATION_COUNT = 1;
+
+    @Override
+    protected Session getSession()
+    {
+        return Session.builder(super.getSession())
+                .setSystemProperty(VERBOSE_EXCEEDED_MEMORY_LIMIT_ERRORS_ENABLED, "true")
+                .setSystemProperty(USE_MARK_DISTINCT, "false")
+                .build();
+    }
+
+    @Test(invocationCount = INVOCATION_COUNT)
+    public void testAggregation()
+    {
+        assertMemoryExceededDetails("" +
+                        "SELECT " +
+                        "   linenumber, " +
+                        "   ARRAY_AGG(comment)," +
+                        "   MAP_AGG(comment, comment) " +
+                        "FROM lineitem " +
+                        "GROUP BY linenumber",
+                HashAggregationOperator.class.getSimpleName(),
+                Optional.empty());
+        assertMemoryExceededDetails("" +
+                        "SELECT " +
+                        "   linenumber, " +
+                        "   ARRAY_AGG(DISTINCT comment)," +
+                        "   MAP_AGG(comment, comment) " +
+                        "FROM lineitem " +
+                        "GROUP BY linenumber",
+                HashAggregationOperator.class.getSimpleName(),
+                Optional.of("DISTINCT;"));
+        assertMemoryExceededDetails("" +
+                        "SELECT " +
+                        "   linenumber, " +
+                        "   ARRAY_AGG(comment ORDER BY comment)," +
+                        "   MAP_AGG(comment, comment) " +
+                        "FROM lineitem " +
+                        "GROUP BY linenumber",
+                HashAggregationOperator.class.getSimpleName(),
+                Optional.of("ORDER_BY;"));
+    }
+
+    @Test(invocationCount = INVOCATION_COUNT)
+    public void testJoin()
+    {
+        assertMemoryExceededDetails("" +
+                        "SELECT " +
+                        "   * " +
+                        "FROM lineitem l1 " +
+                        "INNER JOIN lineitem l2 " +
+                        "ON l1.linenumber = l2.linenumber " +
+                        "WHERE l1.quantity = 1.0",
+                HashBuilderOperator.class.getSimpleName(),
+                Optional.of("INNER;"));
+        assertMemoryExceededDetails("" +
+                        "SELECT " +
+                        "   * " +
+                        "FROM (" +
+                        " SELECT * " +
+                        " FROM lineitem " +
+                        " WHERE quantity = 1.0 " +
+                        ") l1 " +
+                        "RIGHT OUTER JOIN lineitem l2 " +
+                        "ON l1.linenumber = l2.linenumber ",
+                HashBuilderOperator.class.getSimpleName(),
+                Optional.of("RIGHT;"));
+    }
+
+    @Test(invocationCount = INVOCATION_COUNT)
+    public void testWindow()
+    {
+        assertMemoryExceededDetails("" +
+                        "SELECT " +
+                        "   rank() OVER (ORDER BY comment DESC) AS rnk " +
+                        "FROM lineitem",
+                WindowOperator.class.getSimpleName(),
+                Optional.empty());
+    }
+
+    private void assertMemoryExceededDetails(String sql, String expectedTopConsumerOperatorName, Optional<String> expectedTopConsumerOperatorInfo)
+    {
+        try {
+            getQueryRunner().execute(getSession(), sql);
+            fail("query expected to fail");
+        }
+        catch (RuntimeException e) {
+            Pattern p = Pattern.compile(".*Query exceeded per-node total memory limit of.*, Details: (.*)", DOTALL);
+            String message = e.getMessage();
+            Matcher matcher = p.matcher(message);
+            if (!matcher.matches()) {
+                fail("Unexpected error message: " + message);
+            }
+            String detailsJson = matcher.group(1);
+            List<TaskMemoryReservationSummary> summaries = listJsonCodec(TaskMemoryReservationSummary.class).fromJson(detailsJson);
+            assertEquals(summaries.get(0).getTopConsumers().get(0).getType(), expectedTopConsumerOperatorName);
+            if (expectedTopConsumerOperatorInfo.isPresent()) {
+                assertTrue(summaries.get(0).getTopConsumers().get(0).getInfo().isPresent());
+                assertThat(summaries.get(0).getTopConsumers().get(0).getInfo().get()).contains(expectedTopConsumerOperatorInfo.get());
+            }
+        }
+    }
+}

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestDistributedVerboseMemoryExceededErrors.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestDistributedVerboseMemoryExceededErrors.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.tpch.TpchQueryRunnerBuilder;
+
+import static com.facebook.presto.SystemSessionProperties.QUERY_MAX_TOTAL_MEMORY_PER_NODE;
+
+public class TestDistributedVerboseMemoryExceededErrors
+        extends AbstractTestVerboseMemoryExceededErrors
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return TpchQueryRunnerBuilder
+                .builder()
+                .setNodeCount(0)
+                .build();
+    }
+
+    @Override
+    protected Session getSession()
+    {
+        return Session.builder(super.getSession())
+                .setSchema("sf10")
+                .setSystemProperty(QUERY_MAX_TOTAL_MEMORY_PER_NODE, "250MB")
+                .build();
+    }
+}

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestLocalVerboseMemoryExceededErrors.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestLocalVerboseMemoryExceededErrors.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.testing.QueryRunner;
+
+import static com.facebook.presto.SystemSessionProperties.QUERY_MAX_TOTAL_MEMORY_PER_NODE;
+import static com.facebook.presto.tests.TestLocalQueries.createLocalQueryRunner;
+
+public class TestLocalVerboseMemoryExceededErrors
+        extends AbstractTestVerboseMemoryExceededErrors
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return createLocalQueryRunner();
+    }
+
+    @Override
+    protected Session getSession()
+    {
+        return Session.builder(super.getSession())
+                .setSchema("sf1")
+                .setSystemProperty(QUERY_MAX_TOTAL_MEMORY_PER_NODE, "50MB")
+                .build();
+    }
+}


### PR DESCRIPTION
This is neeeded to simplify out of memory errors debugging. The verbose
details are completely optional and disabled by default to avoid issues
related to displaying and storing a verbose error message.

The details contain memory reservation for each operator. Having these
details would allow us to more easily identify the root cause of a
memory related failure as it contains the following details:

- Task id
- Memory allocation breakdown by operator instances
- Plan Node Id
- Additional details, such as type of join or whether the distinct
  accumulator is used in hash aggregation

Here is an example of an error message with details:

```
Query exceeded per-node total memory limit of 50MB [Allocated: 49.41MB, Delta: 4.12MB, Top Consumers: {HashAggregationOperator=30.85MB, InMemoryHashAggregationBuilder=18.56MB, ScanFilterAndProjectOperator=468B}, Details: [ {
  "taskId" : "0.0.0",
  "reservation" : "49.41MB",
  "topConsumers" : [ {
    "type" : "HashAggregationOperator",
    "planNodeId" : "3",
    "reservations" : [ "9.78MB", "7.79MB", "7.47MB", "2.93MB", "1.81MB", "1.08MB", "0B", "0B", "0B", "0B", "0B", "0B", "0B", "0B", "0B", "0B" ],
    "total" : "30.85MB"
  }, {
    "type" : "HashAggregationOperator",
    "planNodeId" : "138",
    "reservations" : [ "18.56MB" ],
    "total" : "18.56MB"
  }, {
    "type" : "ScanFilterAndProjectOperator",
    "planNodeId" : "153",
    "reservations" : [ "468B" ],
    "total" : "468B"
  } ]
} ]]
```

```
== RELEASE NOTES ==

General Changes
* Add additional details to memory exceeded error messages to simplify debugging. Disabled by default. Can be enabled by setting the "verbose_exceeded_memory_limit_errors_enabled" session property to "true"

```
