### PR TITLE
Ignore Resource Manager host from scheduling

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/connector/system/SystemSplitManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/system/SystemSplitManager.java
@@ -38,6 +38,7 @@ import static com.facebook.presto.spi.StandardErrorCode.NOT_FOUND;
 import static com.facebook.presto.spi.SystemTable.Distribution.ALL_COORDINATORS;
 import static com.facebook.presto.spi.SystemTable.Distribution.ALL_NODES;
 import static com.facebook.presto.spi.SystemTable.Distribution.SINGLE_COORDINATOR;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -81,7 +82,7 @@ public class SystemSplitManager
             nodes.addAll(nodeManager.getCoordinators());
         }
         else if (tableDistributionMode == ALL_NODES) {
-            nodes.addAll(nodeManager.getNodes(ACTIVE));
+            nodes.addAll(nodeManager.getNodes(ACTIVE).stream().filter(node -> !node.isResourceManager()).collect(toImmutableSet()));
         }
         Set<InternalNode> nodeSet = nodes.build();
         for (InternalNode node : nodeSet) {

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NodeScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NodeScheduler.java
@@ -180,11 +180,11 @@ public class NodeScheduler
             Set<InternalNode> activeNodes;
             Set<InternalNode> allNodes;
             if (connectorId != null) {
-                activeNodes = nodeManager.getActiveConnectorNodes(connectorId);
-                allNodes = nodeManager.getAllConnectorNodes(connectorId);
+                activeNodes = nodeManager.getActiveConnectorNodes(connectorId).stream().filter(node -> !node.isResourceManager()).collect(toImmutableSet());
+                allNodes = nodeManager.getAllConnectorNodes(connectorId).stream().filter(node -> !node.isResourceManager()).collect(toImmutableSet());
             }
             else {
-                activeNodes = nodeManager.getNodes(ACTIVE);
+                activeNodes = nodeManager.getNodes(ACTIVE).stream().filter(node -> !node.isResourceManager()).collect(toImmutableSet());
                 allNodes = activeNodes;
             }
 


### PR DESCRIPTION
Test plan - Verified using test run

With multi coordinator support, we are introducing a new component resource manager. Resource managers are meant to not run any task on it, and this changes are to ignore resource manager from active nodes when scheduling work on nodes.

```
== NO RELEASE NOTE ==
```
