### PR TITLE
Skip loading StaticCatalogStore and AccessControlManager for RM

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/GracefulShutdownHandler.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/GracefulShutdownHandler.java
@@ -52,6 +52,7 @@ public class GracefulShutdownHandler
     private final QueryManager queryManager;
     private final TaskManager sqlTaskManager;
     private final boolean isCoordinator;
+    private final boolean isResourceManager;
     private final ShutdownAction shutdownAction;
     private final Duration gracePeriod;
 
@@ -70,6 +71,7 @@ public class GracefulShutdownHandler
         this.shutdownAction = requireNonNull(shutdownAction, "shutdownAction is null");
         this.lifeCycleManager = requireNonNull(lifeCycleManager, "lifeCycleManager is null");
         this.isCoordinator = requireNonNull(serverConfig, "serverConfig is null").isCoordinator();
+        this.isResourceManager = serverConfig.isResourceManager();
         this.gracePeriod = serverConfig.getGracePeriod();
         this.queryManager = requireNonNull(queryManager, "queryManager is null");
     }
@@ -77,6 +79,10 @@ public class GracefulShutdownHandler
     public synchronized void requestShutdown()
     {
         log.info("Shutdown requested");
+
+        if (isResourceManager) {
+            throw new UnsupportedOperationException("Cannot shutdown resource manager");
+        }
 
         if (isShutdownRequested()) {
             return;

--- a/presto-main/src/main/java/com/facebook/presto/server/PrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PrestoServer.java
@@ -138,7 +138,11 @@ public class PrestoServer
 
             injector.getInstance(PluginManager.class).loadPlugins();
 
-            injector.getInstance(StaticCatalogStore.class).loadCatalogs();
+            ServerConfig serverConfig = injector.getInstance(ServerConfig.class);
+
+            if (!serverConfig.isResourceManager()) {
+                injector.getInstance(StaticCatalogStore.class).loadCatalogs();
+            }
 
             // TODO: remove this huge hack
             updateConnectorIds(
@@ -155,7 +159,9 @@ public class PrestoServer
             injector.getInstance(StaticFunctionNamespaceStore.class).loadFunctionNamespaceManagers();
             injector.getInstance(SessionPropertyDefaults.class).loadConfigurationManager();
             injector.getInstance(ResourceGroupManager.class).loadConfigurationManager();
-            injector.getInstance(AccessControlManager.class).loadSystemAccessControl();
+            if (!serverConfig.isResourceManager()) {
+                injector.getInstance(AccessControlManager.class).loadSystemAccessControl();
+            }
             injector.getInstance(PasswordAuthenticatorManager.class).loadPasswordAuthenticator();
             injector.getInstance(EventListenerManager.class).loadConfiguredEventListener();
             injector.getInstance(TempStorageManager.class).loadTempStorages();

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerInfoResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerInfoResource.java
@@ -49,6 +49,7 @@ public class ServerInfoResource
     private final NodeVersion version;
     private final String environment;
     private final boolean coordinator;
+    private final boolean resourceManager;
     private final StaticCatalogStore catalogStore;
     private final GracefulShutdownHandler shutdownHandler;
     private final long startTime = System.nanoTime();
@@ -60,6 +61,7 @@ public class ServerInfoResource
         this.version = requireNonNull(nodeVersion, "nodeVersion is null");
         this.environment = requireNonNull(nodeInfo, "nodeInfo is null").getEnvironment();
         this.coordinator = requireNonNull(serverConfig, "serverConfig is null").isCoordinator();
+        this.resourceManager = serverConfig.isResourceManager();
         this.catalogStore = requireNonNull(catalogStore, "catalogStore is null");
         this.shutdownHandler = requireNonNull(shutdownHandler, "shutdownHandler is null");
         this.nodeResourceStatusProvider = requireNonNull(nodeResourceStatusProvider, "nodeResourceStatusProvider is null");
@@ -69,7 +71,7 @@ public class ServerInfoResource
     @Produces(APPLICATION_JSON)
     public ServerInfo getInfo()
     {
-        boolean starting = !catalogStore.areCatalogsLoaded();
+        boolean starting = resourceManager ? true : !catalogStore.areCatalogsLoaded();
         return new ServerInfo(version, environment, coordinator, starting, Optional.of(nanosSince(startTime)));
     }
 


### PR DESCRIPTION
- Skip loading StatigCatalogStore and AccessControlManager for resource manager
- Adding resource manager support in /v1/info endpoint

Test plan - On Test Cluster

```
== NO RELEASE NOTE ==
```
