### PR TITLE
Disable TestDistributedClusterStatsResource since it is failing

### DIFF
--- a/presto-tests/src/test/java/com/facebook/presto/resourcemanager/TestDistributedClusterStatsResource.java
+++ b/presto-tests/src/test/java/com/facebook/presto/resourcemanager/TestDistributedClusterStatsResource.java
@@ -79,7 +79,7 @@ public class TestDistributedClusterStatsResource
         return this.getClass().getClassLoader().getResource(fileName).getPath();
     }
 
-    @Test(timeOut = 60_000)
+    @Test(timeOut = 60_000, enabled = false)
     public void testClusterStatsRedirectToResourceManager()
             throws Exception
     {


### PR DESCRIPTION
Test plan - This PR just disables a test - will let the build on the PR complete before merging

```
== NO RELEASE NOTE ==
```
