### PR TITLE
Introduce query limits at the resource group level

### DIFF
--- a/presto-docs/src/main/sphinx/admin/resource-groups.rst
+++ b/presto-docs/src/main/sphinx/admin/resource-groups.rst
@@ -66,6 +66,19 @@ Resource Group Properties
 * ``jmxExport`` (optional): If true, group statistics are exported to JMX for monitoring.
   Defaults to ``false``.
 
+* ``perQueryLimits`` (optional): specifies max resources each query in a
+  resource group may consume before being killed. These limits are not inherited from parent groups.
+  May set three types of limits:
+
+    * ``executionTimeLimit`` (optional): Specify an absolute value (i.e. ``1h``)
+       for the maximum time a query may take to execute.
+
+    * ``totalMemoryLimit`` (optional): Specify an absolute value (i.e. ``1GB``)
+       for the maximum distributed memory a query may consume.
+
+    * ``cpuTimeLimit`` (optional): Specify Specify an absolute value (i.e. ``1h``)
+       for the maximum CPU time a query may use.
+
 * ``subGroups`` (optional): list of sub-groups.
 
 Selector Rules

--- a/presto-main/src/main/java/com/facebook/presto/ExceededCpuLimitException.java
+++ b/presto-main/src/main/java/com/facebook/presto/ExceededCpuLimitException.java
@@ -17,12 +17,13 @@ import com.facebook.presto.spi.PrestoException;
 import io.airlift.units.Duration;
 
 import static com.facebook.presto.spi.StandardErrorCode.EXCEEDED_CPU_LIMIT;
+import static java.lang.String.format;
 
 public class ExceededCpuLimitException
         extends PrestoException
 {
-    public ExceededCpuLimitException(Duration duration)
+    public ExceededCpuLimitException(Duration limit, String limitSource)
     {
-        super(EXCEEDED_CPU_LIMIT, "Exceeded CPU limit of " + duration.toString());
+        super(EXCEEDED_CPU_LIMIT, format("Exceeded CPU limit of %s defined at the %s level", limit, limitSource));
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/ExceededMemoryLimitException.java
+++ b/presto-main/src/main/java/com/facebook/presto/ExceededMemoryLimitException.java
@@ -30,9 +30,9 @@ public class ExceededMemoryLimitException
         return new ExceededMemoryLimitException(EXCEEDED_GLOBAL_MEMORY_LIMIT, format("Query exceeded distributed user memory limit of %s", maxMemory));
     }
 
-    public static ExceededMemoryLimitException exceededGlobalTotalLimit(DataSize maxMemory)
+    public static ExceededMemoryLimitException exceededGlobalTotalLimit(DataSize maxMemory, String limitSource)
     {
-        return new ExceededMemoryLimitException(EXCEEDED_GLOBAL_MEMORY_LIMIT, format("Query exceeded distributed total memory limit of %s", maxMemory));
+        return new ExceededMemoryLimitException(EXCEEDED_GLOBAL_MEMORY_LIMIT, format("Query exceeded distributed total memory limit of %s defined at the %s", maxMemory, limitSource));
     }
 
     public static ExceededMemoryLimitException exceededLocalUserMemoryLimit(DataSize maxMemory, String additionalFailureInfo)

--- a/presto-main/src/main/java/com/facebook/presto/dispatcher/FailedDispatchQuery.java
+++ b/presto-main/src/main/java/com/facebook/presto/dispatcher/FailedDispatchQuery.java
@@ -21,6 +21,7 @@ import com.facebook.presto.server.BasicQueryInfo;
 import com.facebook.presto.spi.ErrorCode;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
+import com.facebook.presto.spi.resourceGroups.ResourceGroupQueryLimits;
 import com.google.common.util.concurrent.ListenableFuture;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
@@ -184,4 +185,14 @@ public class FailedDispatchQuery
     {
         return new DataSize(0, BYTE);
     }
+
+    @Override
+    public Optional<ResourceGroupQueryLimits> getResourceGroupQueryLimits()
+    {
+        return Optional.empty();
+    }
+
+    @Override
+    public void setResourceGroupQueryLimits(ResourceGroupQueryLimits resourceGroupQueryLimits)
+    { }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/ManagedQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/ManagedQueryExecution.java
@@ -17,6 +17,7 @@ import com.facebook.presto.Session;
 import com.facebook.presto.execution.StateMachine.StateChangeListener;
 import com.facebook.presto.server.BasicQueryInfo;
 import com.facebook.presto.spi.ErrorCode;
+import com.facebook.presto.spi.resourceGroups.ResourceGroupQueryLimits;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 
@@ -46,6 +47,8 @@ public interface ManagedQueryExecution
     Duration getTotalCpuTime();
 
     BasicQueryInfo getBasicQueryInfo();
+
+    void setResourceGroupQueryLimits(ResourceGroupQueryLimits resourceGroupQueryLimits);
 
     boolean isDone();
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryExecution.java
@@ -21,6 +21,7 @@ import com.facebook.presto.memory.VersionedMemoryPoolId;
 import com.facebook.presto.server.BasicQueryInfo;
 import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.resourceGroups.QueryType;
+import com.facebook.presto.spi.resourceGroups.ResourceGroupQueryLimits;
 import com.facebook.presto.sql.planner.Plan;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -70,6 +71,10 @@ public interface QueryExecution
     DataSize getTotalMemoryReservation();
 
     VersionedMemoryPoolId getMemoryPool();
+
+    Optional<ResourceGroupQueryLimits> getResourceGroupQueryLimits();
+
+    void setResourceGroupQueryLimits(ResourceGroupQueryLimits resourceGroupQueryLimits);
 
     void setMemoryPool(VersionedMemoryPoolId poolId);
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryLimit.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryLimit.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution;
+
+import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
+
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static java.util.Objects.requireNonNull;
+
+public class QueryLimit<T extends Comparable<T>>
+{
+    private final T limit;
+    private final Source source;
+
+    private QueryLimit(
+            T limit,
+            Source source)
+    {
+        this.limit = requireNonNull(limit, "limit is null");
+        this.source = requireNonNull(source, "source is null");
+    }
+
+    public static QueryLimit<Duration> createDurationLimit(Duration limit, Source source)
+    {
+        return new QueryLimit<>(limit, source);
+    }
+
+    public static QueryLimit<DataSize> createDataSizeLimit(DataSize limit, Source source)
+    {
+        return new QueryLimit<>(limit, source);
+    }
+
+    public T getLimit()
+    {
+        return limit;
+    }
+
+    public Source getLimitSource()
+    {
+        return source;
+    }
+
+    public enum Source
+    {
+        QUERY,
+        SYSTEM,
+        RESOURCE_GROUP,
+        /**/;
+    }
+
+    @SafeVarargs
+    public static <S extends Comparable<S>> QueryLimit<S> getMinimum(QueryLimit<S> limit, QueryLimit<S>... limits)
+    {
+        Optional<QueryLimit<S>> queryLimit = Stream.concat(
+                limits != null ? Arrays.stream(limits) : Stream.empty(),
+                limit != null ? Stream.of(limit) : Stream.empty())
+                .filter(Objects::nonNull)
+                .min(Comparator.comparing(QueryLimit::getLimit));
+        return queryLimit.orElseThrow(() -> new IllegalArgumentException("At least one nonnull argument is required."));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroup.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroup.java
@@ -688,6 +688,7 @@ public class InternalResourceGroup
                 query.fail(new QueryQueueFullException(id));
                 return;
             }
+            query.setResourceGroupQueryLimits(perQueryLimits);
             if (canRun && queuedQueries.isEmpty()) {
                 startInBackground(query);
             }

--- a/presto-main/src/test/java/com/facebook/presto/dispatcher/TestLocalDispatchQuery.java
+++ b/presto-main/src/test/java/com/facebook/presto/dispatcher/TestLocalDispatchQuery.java
@@ -20,6 +20,7 @@ import com.facebook.presto.event.QueryMonitorConfig;
 import com.facebook.presto.eventlistener.EventListenerManager;
 import com.facebook.presto.execution.ClusterSizeMonitor;
 import com.facebook.presto.execution.ExecutionFailureInfo;
+import com.facebook.presto.execution.MockQueryExecution;
 import com.facebook.presto.execution.QueryExecution;
 import com.facebook.presto.execution.QueryStateMachine;
 import com.facebook.presto.execution.StageInfo;
@@ -321,7 +322,7 @@ public class TestLocalDispatchQuery
         LocalDispatchQuery query = new LocalDispatchQuery(
                 stateMachine,
                 createQueryMonitor(eventListener),
-                immediateFuture(null),
+                immediateFuture(new MockQueryExecution()),
                 createClusterSizeMonitor(0),
                 directExecutor(),
                 dispatchQuery -> {},
@@ -413,7 +414,7 @@ public class TestLocalDispatchQuery
         LocalDispatchQuery query = new LocalDispatchQuery(
                 stateMachine,
                 createQueryMonitor(eventListener),
-                immediateFuture(null),
+                immediateFuture(new MockQueryExecution()),
                 createClusterSizeMonitor(0),
                 directExecutor(),
                 dispatchQuery -> {},

--- a/presto-main/src/test/java/com/facebook/presto/execution/MockManagedQueryExecution.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/MockManagedQueryExecution.java
@@ -20,6 +20,7 @@ import com.facebook.presto.server.BasicQueryStats;
 import com.facebook.presto.spi.ErrorCode;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.memory.MemoryPoolId;
+import com.facebook.presto.spi.resourceGroups.ResourceGroupQueryLimits;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.units.DataSize;
@@ -53,6 +54,7 @@ public class MockManagedQueryExecution
     private final Session session;
     private QueryState state = WAITING_FOR_PREREQUISITES;
     private Throwable failureCause;
+    private Optional<ResourceGroupQueryLimits> resourceGroupQueryLimits = Optional.empty();
 
     public MockManagedQueryExecution(long memoryUsage)
     {
@@ -202,6 +204,12 @@ public class MockManagedQueryExecution
     public void addStateChangeListener(StateChangeListener<QueryState> stateChangeListener)
     {
         listeners.add(stateChangeListener);
+    }
+
+    @Override
+    public void setResourceGroupQueryLimits(ResourceGroupQueryLimits resourceGroupQueryLimits)
+    {
+        this.resourceGroupQueryLimits = Optional.of(resourceGroupQueryLimits);
     }
 
     private void fireStateChange()

--- a/presto-main/src/test/java/com/facebook/presto/execution/MockQueryExecution.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/MockQueryExecution.java
@@ -1,0 +1,208 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.memory.VersionedMemoryPoolId;
+import com.facebook.presto.server.BasicQueryInfo;
+import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.spi.resourceGroups.ResourceGroupQueryLimits;
+import com.facebook.presto.sql.planner.Plan;
+import com.google.common.util.concurrent.ListenableFuture;
+import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
+import org.joda.time.DateTime;
+
+import java.util.Optional;
+import java.util.function.Consumer;
+
+public class MockQueryExecution
+        implements QueryExecution
+{
+    @Override
+    public QueryState getState()
+    {
+        return null;
+    }
+
+    @Override
+    public ListenableFuture<QueryState> getStateChange(QueryState currentState)
+    {
+        return null;
+    }
+
+    @Override
+    public void addStateChangeListener(StateMachine.StateChangeListener<QueryState> stateChangeListener)
+    { }
+
+    @Override
+    public void addOutputInfoListener(Consumer<QueryOutputInfo> listener)
+    { }
+
+    @Override
+    public Plan getQueryPlan()
+    {
+        return null;
+    }
+
+    @Override
+    public BasicQueryInfo getBasicQueryInfo()
+    {
+        return null;
+    }
+
+    @Override
+    public QueryInfo getQueryInfo()
+    {
+        return null;
+    }
+
+    @Override
+    public String getSlug()
+    {
+        return null;
+    }
+
+    @Override
+    public int getRetryCount()
+    {
+        return 0;
+    }
+
+    @Override
+    public Duration getTotalCpuTime()
+    {
+        return null;
+    }
+
+    @Override
+    public DataSize getRawInputDataSize()
+    {
+        return null;
+    }
+
+    @Override
+    public DataSize getOutputDataSize()
+    {
+        return null;
+    }
+
+    @Override
+    public int getRunningTaskCount()
+    {
+        return 0;
+    }
+
+    @Override
+    public DataSize getUserMemoryReservation()
+    {
+        return null;
+    }
+
+    @Override
+    public DataSize getTotalMemoryReservation()
+    {
+        return null;
+    }
+
+    @Override
+    public VersionedMemoryPoolId getMemoryPool()
+    {
+        return null;
+    }
+
+    @Override
+    public QueryId getQueryId()
+    {
+        return null;
+    }
+
+    @Override
+    public boolean isDone()
+    {
+        return false;
+    }
+
+    @Override
+    public Session getSession()
+    {
+        return null;
+    }
+
+    @Override
+    public DateTime getCreateTime()
+    {
+        return null;
+    }
+
+    @Override
+    public Optional<DateTime> getExecutionStartTime()
+    {
+        return Optional.empty();
+    }
+
+    @Override
+    public DateTime getLastHeartbeat()
+    {
+        return null;
+    }
+
+    @Override
+    public Optional<DateTime> getEndTime()
+    {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<ResourceGroupQueryLimits> getResourceGroupQueryLimits()
+    {
+        return Optional.empty();
+    }
+
+    @Override
+    public void fail(Throwable cause)
+    { }
+
+    @Override
+    public void pruneInfo()
+    { }
+
+    @Override
+    public void setResourceGroupQueryLimits(ResourceGroupQueryLimits resourceGroupQueryLimits)
+    { }
+
+    @Override
+    public void setMemoryPool(VersionedMemoryPoolId poolId)
+    { }
+
+    @Override
+    public void start()
+    { }
+
+    @Override
+    public void cancelQuery()
+    { }
+
+    @Override
+    public void cancelStage(StageId stageId)
+    { }
+
+    @Override
+    public void recordHeartbeat()
+    { }
+
+    @Override
+    public void addFinalQueryInfoListener(StateMachine.StateChangeListener<QueryInfo> stateChangeListener)
+    { }
+}

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestQueryLimit.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestQueryLimit.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution;
+
+import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.execution.QueryLimit.Source.QUERY;
+import static com.facebook.presto.execution.QueryLimit.Source.RESOURCE_GROUP;
+import static com.facebook.presto.execution.QueryLimit.Source.SYSTEM;
+import static com.facebook.presto.execution.QueryLimit.createDataSizeLimit;
+import static com.facebook.presto.execution.QueryLimit.createDurationLimit;
+import static com.facebook.presto.execution.QueryLimit.getMinimum;
+import static com.facebook.presto.testing.assertions.Assert.assertEquals;
+import static io.airlift.units.DataSize.Unit.BYTE;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static java.util.concurrent.TimeUnit.HOURS;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static org.testng.Assert.assertThrows;
+
+public class TestQueryLimit
+{
+    private static final QueryLimit<Duration> QUERY_LIMIT_DURATION = createDurationLimit(new Duration(1, HOURS), SYSTEM);
+    private static final QueryLimit<DataSize> QUERY_LIMIT_DATA_SIZE = createDataSizeLimit(new DataSize(1, MEGABYTE), RESOURCE_GROUP);
+
+    @Test
+    public void testGetLimit()
+    {
+        assertEquals(QUERY_LIMIT_DURATION.getLimit(), new Duration(1, HOURS));
+        assertEquals(QUERY_LIMIT_DATA_SIZE.getLimit(), new DataSize(1, MEGABYTE));
+    }
+
+    @Test
+    public void testGetSource()
+    {
+        assertEquals(QUERY_LIMIT_DATA_SIZE.getLimitSource(), RESOURCE_GROUP);
+        assertEquals(QUERY_LIMIT_DURATION.getLimitSource(), SYSTEM);
+        assertEquals(createDurationLimit(new Duration(1, HOURS), QUERY).getLimitSource(), QUERY);
+    }
+
+    @Test
+    public void testGetMinimum()
+    {
+        QueryLimit<Duration> longLimit = createDurationLimit(new Duration(2, HOURS), SYSTEM);
+        QueryLimit<Duration> shortLimit = createDurationLimit(new Duration(1, MINUTES), RESOURCE_GROUP);
+        assertEquals(getMinimum(QUERY_LIMIT_DURATION, longLimit, shortLimit), shortLimit);
+
+        QueryLimit<DataSize> largeLimit = createDataSizeLimit(new DataSize(2, MEGABYTE), QUERY);
+        QueryLimit<DataSize> smallLimit = createDataSizeLimit(new DataSize(1, BYTE), RESOURCE_GROUP);
+        assertEquals(getMinimum(smallLimit, QUERY_LIMIT_DATA_SIZE, largeLimit), smallLimit);
+        assertEquals(getMinimum(null, QUERY_LIMIT_DATA_SIZE, largeLimit), QUERY_LIMIT_DATA_SIZE);
+        assertEquals(getMinimum(null, largeLimit, null, null, QUERY_LIMIT_DATA_SIZE), QUERY_LIMIT_DATA_SIZE);
+        assertEquals(getMinimum(smallLimit, null, null, null), smallLimit);
+        assertThrows(IllegalArgumentException.class, () -> getMinimum(null));
+        assertThrows(IllegalArgumentException.class, () -> getMinimum(null, null, null));
+    }
+}

--- a/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/AbstractResourceConfigurationManager.java
+++ b/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/AbstractResourceConfigurationManager.java
@@ -205,6 +205,7 @@ public abstract class AbstractResourceConfigurationManager
         group.setMaxQueuedQueries(match.getMaxQueued());
         group.setSoftConcurrencyLimit(match.getSoftConcurrencyLimit().orElse(match.getHardConcurrencyLimit()));
         group.setHardConcurrencyLimit(match.getHardConcurrencyLimit());
+        group.setPerQueryLimits(match.getPerQueryLimits());
         match.getSchedulingPolicy().ifPresent(group::setSchedulingPolicy);
         match.getSchedulingWeight().ifPresent(group::setSchedulingWeight);
         match.getJmxExport().filter(isEqual(group.getJmxExport()).negate()).ifPresent(group::setJmxExport);

--- a/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/db/ResourceGroupSpecBuilder.java
+++ b/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/db/ResourceGroupSpecBuilder.java
@@ -15,7 +15,9 @@ package com.facebook.presto.resourceGroups.db;
 
 import com.facebook.presto.resourceGroups.ResourceGroupNameTemplate;
 import com.facebook.presto.resourceGroups.ResourceGroupSpec;
+import com.facebook.presto.spi.resourceGroups.ResourceGroupQueryLimits;
 import com.google.common.collect.ImmutableList;
+import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import org.jdbi.v3.core.mapper.RowMapper;
 import org.jdbi.v3.core.statement.StatementContext;
@@ -39,6 +41,7 @@ public class ResourceGroupSpecBuilder
     private final Optional<Boolean> jmxExport;
     private final Optional<Duration> softCpuLimit;
     private final Optional<Duration> hardCpuLimit;
+    private final Optional<ResourceGroupQueryLimits> perQueryLimits;
     private final Optional<Long> parentId;
     private final ImmutableList.Builder<ResourceGroupSpec> subGroups = ImmutableList.builder();
 
@@ -54,6 +57,9 @@ public class ResourceGroupSpecBuilder
             Optional<Boolean> jmxExport,
             Optional<String> softCpuLimit,
             Optional<String> hardCpuLimit,
+            Optional<String> perQueryExecutionTimeLimit,
+            Optional<String> perQueryTotalMemoryLimit,
+            Optional<String> perQueryCpuTimeLimit,
             Optional<Long> parentId)
     {
         this.id = id;
@@ -67,6 +73,10 @@ public class ResourceGroupSpecBuilder
         this.jmxExport = requireNonNull(jmxExport, "jmxExport is null");
         this.softCpuLimit = requireNonNull(softCpuLimit, "softCpuLimit is null").map(Duration::valueOf);
         this.hardCpuLimit = requireNonNull(hardCpuLimit, "hardCpuLimit is null").map(Duration::valueOf);
+        Optional<Duration> executionTimeLimit = requireNonNull(perQueryExecutionTimeLimit, "perQueryExecutionTimeLimit is null").map(Duration::valueOf);
+        Optional<DataSize> totalMemoryLimit = requireNonNull(perQueryTotalMemoryLimit, "perQueryTotalMemoryLimit is null").map(DataSize::valueOf);
+        Optional<Duration> cpuTimeLimit = requireNonNull(perQueryCpuTimeLimit, "perQueryCpuTimeLimit is null").map(Duration::valueOf);
+        this.perQueryLimits = Optional.of(new ResourceGroupQueryLimits(executionTimeLimit, totalMemoryLimit, cpuTimeLimit));
         this.parentId = parentId;
     }
 
@@ -114,7 +124,8 @@ public class ResourceGroupSpecBuilder
                 Optional.of(subGroups.build()),
                 jmxExport,
                 softCpuLimit,
-                hardCpuLimit);
+                hardCpuLimit,
+                perQueryLimits);
     }
 
     public static class Mapper
@@ -144,6 +155,9 @@ public class ResourceGroupSpecBuilder
             }
             Optional<String> softCpuLimit = Optional.ofNullable(resultSet.getString("soft_cpu_limit"));
             Optional<String> hardCpuLimit = Optional.ofNullable(resultSet.getString("hard_cpu_limit"));
+            Optional<String> perQueryExecutionTimeLimit = Optional.ofNullable(resultSet.getString("per_query_execution_time_limit"));
+            Optional<String> perQueryTotalMemoryLimit = Optional.ofNullable(resultSet.getString("per_query_total_memory_limit"));
+            Optional<String> perQueryCpuTimeLimit = Optional.ofNullable(resultSet.getString("per_query_cpu_time_limit"));
             Optional<Long> parentId = Optional.of(resultSet.getLong("parent"));
             if (resultSet.wasNull()) {
                 parentId = Optional.empty();
@@ -160,6 +174,9 @@ public class ResourceGroupSpecBuilder
                     jmxExport,
                     softCpuLimit,
                     hardCpuLimit,
+                    perQueryExecutionTimeLimit,
+                    perQueryTotalMemoryLimit,
+                    perQueryCpuTimeLimit,
                     parentId);
         }
     }

--- a/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/db/ResourceGroupsDao.java
+++ b/presto-resource-group-managers/src/main/java/com/facebook/presto/resourceGroups/db/ResourceGroupsDao.java
@@ -45,6 +45,9 @@ public interface ResourceGroupsDao
             "  jmx_export BOOLEAN NULL,\n" +
             "  soft_cpu_limit VARCHAR(128) NULL,\n" +
             "  hard_cpu_limit VARCHAR(128) NULL,\n" +
+            "  per_query_execution_time_limit VARCHAR(128) NULL,\n" +
+            "  per_query_total_memory_limit VARCHAR(128) NULL,\n" +
+            "  per_query_cpu_time_limit VARCHAR(128) NULL,\n" +
             "  parent BIGINT NULL,\n" +
             "  environment VARCHAR(128) NULL,\n" +
             "  PRIMARY KEY (resource_group_id),\n" +
@@ -54,7 +57,7 @@ public interface ResourceGroupsDao
 
     @SqlQuery("SELECT resource_group_id, name, soft_memory_limit, max_queued, soft_concurrency_limit, " +
             "  hard_concurrency_limit, scheduling_policy, scheduling_weight, jmx_export, soft_cpu_limit, " +
-            "  hard_cpu_limit, parent\n" +
+            "  hard_cpu_limit, per_query_execution_time_limit, per_query_total_memory_limit, per_query_cpu_time_limit, parent\n" +
             "FROM resource_groups\n" +
             "WHERE environment = :environment\n")
     @UseRowMapper(ResourceGroupSpecBuilder.Mapper.class)

--- a/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/TestFileResourceGroupConfigurationManager.java
+++ b/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/TestFileResourceGroupConfigurationManager.java
@@ -32,7 +32,6 @@ import static com.facebook.presto.spi.resourceGroups.SchedulingPolicy.WEIGHTED;
 import static com.google.common.io.Resources.getResource;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static java.lang.String.format;
-import static java.util.concurrent.TimeUnit.DAYS;
 import static java.util.concurrent.TimeUnit.HOURS;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.testng.Assert.assertEquals;
@@ -101,9 +100,9 @@ public class TestFileResourceGroupConfigurationManager
         ResourceGroupId globalId = new ResourceGroupId("global");
         ResourceGroup global = new TestingResourceGroup(globalId);
         manager.configure(global, new SelectionContext<>(globalId, new VariableMap(ImmutableMap.of("USER", "user"))));
-        assertEquals(global.getSoftMemoryLimit(), new DataSize(1, MEGABYTE));
-        assertEquals(global.getSoftCpuLimit(), new Duration(1, HOURS));
-        assertEquals(global.getHardCpuLimit(), new Duration(1, DAYS));
+        assertEquals(global.getPerQueryLimits().getExecutionTimeLimit(), Optional.of(new Duration(1, HOURS)));
+        assertEquals(global.getPerQueryLimits().getTotalMemoryLimit(), Optional.of(new DataSize(1, MEGABYTE)));
+        assertEquals(global.getPerQueryLimits().getCpuTimeLimit(), Optional.of(new Duration(1, HOURS)));
         assertEquals(global.getCpuQuotaGenerationMillisPerSecond(), 1000 * 24);
         assertEquals(global.getMaxQueuedQueries(), 1000);
         assertEquals(global.getHardConcurrencyLimit(), 100);
@@ -120,6 +119,9 @@ public class TestFileResourceGroupConfigurationManager
         assertEquals(sub.getSchedulingPolicy(), null);
         assertEquals(sub.getSchedulingWeight(), 5);
         assertEquals(sub.getJmxExport(), false);
+        assertEquals(sub.getPerQueryLimits().getExecutionTimeLimit(), Optional.empty());
+        assertEquals(sub.getPerQueryLimits().getTotalMemoryLimit(), Optional.empty());
+        assertEquals(sub.getPerQueryLimits().getCpuTimeLimit(), Optional.empty());
     }
 
     @Test

--- a/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/TestStaticSelector.java
+++ b/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/TestStaticSelector.java
@@ -61,6 +61,7 @@ public class TestStaticSelector
                 Optional.empty(),
                 Optional.empty(),
                 new ResourceGroupIdTemplate("global.foo"));
+
         assertEquals(selector.match(newSelectionCriteria("userA", null, ImmutableSet.of("tag1"), EMPTY_RESOURCE_ESTIMATES)), Optional.empty());
         assertEquals(selector.match(newSelectionCriteria("userB", "source", ImmutableSet.of(), EMPTY_RESOURCE_ESTIMATES)).map(SelectionContext::getResourceGroupId), Optional.of(resourceGroupId));
         assertEquals(selector.match(newSelectionCriteria("A.user", "a source b", ImmutableSet.of("tag1"), EMPTY_RESOURCE_ESTIMATES)).map(SelectionContext::getResourceGroupId), Optional.of(resourceGroupId));

--- a/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/TestingResourceGroup.java
+++ b/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/TestingResourceGroup.java
@@ -15,6 +15,7 @@ package com.facebook.presto.resourceGroups;
 
 import com.facebook.presto.spi.resourceGroups.ResourceGroup;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
+import com.facebook.presto.spi.resourceGroups.ResourceGroupQueryLimits;
 import com.facebook.presto.spi.resourceGroups.SchedulingPolicy;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
@@ -35,6 +36,7 @@ public class TestingResourceGroup
     private int schedulingWeight;
     private SchedulingPolicy policy;
     private boolean jmxExport;
+    private ResourceGroupQueryLimits resourceGroupQueryLimits;
 
     public TestingResourceGroup(ResourceGroupId id)
     {
@@ -165,5 +167,17 @@ public class TestingResourceGroup
     public void setJmxExport(boolean export)
     {
         jmxExport = export;
+    }
+
+    @Override
+    public ResourceGroupQueryLimits getPerQueryLimits()
+    {
+        return resourceGroupQueryLimits;
+    }
+
+    @Override
+    public void setPerQueryLimits(ResourceGroupQueryLimits perQueryLimits)
+    {
+        this.resourceGroupQueryLimits = perQueryLimits;
     }
 }

--- a/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/db/H2ResourceGroupsDao.java
+++ b/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/db/H2ResourceGroupsDao.java
@@ -29,8 +29,8 @@ public interface H2ResourceGroupsDao
     void updateResourceGroupsGlobalProperties(@Bind("name") String name);
 
     @SqlUpdate("INSERT INTO resource_groups\n" +
-            "(resource_group_id, name, soft_memory_limit, max_queued, soft_concurrency_limit, hard_concurrency_limit, scheduling_policy, scheduling_weight, jmx_export, soft_cpu_limit, hard_cpu_limit, parent, environment)\n" +
-            "VALUES (:resource_group_id, :name, :soft_memory_limit, :max_queued, :soft_concurrency_limit, :hard_concurrency_limit, :scheduling_policy, :scheduling_weight, :jmx_export, :soft_cpu_limit, :hard_cpu_limit, :parent, :environment)")
+            "(resource_group_id, name, soft_memory_limit, max_queued, soft_concurrency_limit, hard_concurrency_limit, scheduling_policy, scheduling_weight, jmx_export, soft_cpu_limit, hard_cpu_limit, per_query_execution_time_limit, per_query_total_memory_limit, per_query_cpu_time_limit, parent, environment)\n" +
+            "VALUES (:resource_group_id, :name, :soft_memory_limit, :max_queued, :soft_concurrency_limit, :hard_concurrency_limit, :scheduling_policy, :scheduling_weight, :jmx_export, :soft_cpu_limit, :hard_cpu_limit, :per_query_execution_time_limit, :per_query_total_memory_limit, :per_query_cpu_time_limit, :parent, :environment)")
     void insertResourceGroup(
             @Bind("resource_group_id") long resourceGroupId,
             @Bind("name") String name,
@@ -43,6 +43,9 @@ public interface H2ResourceGroupsDao
             @Bind("jmx_export") Boolean jmxExport,
             @Bind("soft_cpu_limit") String softCpuLimit,
             @Bind("hard_cpu_limit") String hardCpuLimit,
+            @Bind("per_query_execution_time_limit") String perQueryExecutionTimeLimit,
+            @Bind("per_query_total_memory_limit") String perQueryTotalMemoryLimit,
+            @Bind("per_query_cpu_time_limit") String perQueryCpuTimeLimit,
             @Bind("parent") Long parent,
             @Bind("environment") String environment);
 
@@ -58,6 +61,9 @@ public interface H2ResourceGroupsDao
             ", jmx_export = :jmx_export\n" +
             ", soft_cpu_limit = :soft_cpu_limit\n" +
             ", hard_cpu_limit = :hard_cpu_limit\n" +
+            ", per_query_execution_time_limit = :per_query_execution_time_limit\n" +
+            ", per_query_total_memory_limit = :per_query_total_memory_limit\n" +
+            ", per_query_cpu_time_limit = :per_query_cpu_time_limit\n" +
             ", parent = :parent\n" +
             ", environment = :environment\n" +
             "WHERE resource_group_id = :resource_group_id")
@@ -73,6 +79,9 @@ public interface H2ResourceGroupsDao
             @Bind("jmx_export") Boolean jmxExport,
             @Bind("soft_cpu_limit") String softCpuLimit,
             @Bind("hard_cpu_limit") String hardCpuLimit,
+            @Bind("per_query_execution_time_limit") String perQueryExecutionTimeLimit,
+            @Bind("per_query_total_memory_limit") String perQueryTotalMemoryLimit,
+            @Bind("per_query_cpu_time_limit") String perQueryCpuTimeLimit,
             @Bind("parent") Long parent,
             @Bind("environment") String environment);
 

--- a/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/db/TestDbManagerSpecProvider.java
+++ b/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/db/TestDbManagerSpecProvider.java
@@ -53,8 +53,8 @@ public class TestDbManagerSpecProvider
         String devEnvironment = "dev";
         dao.insertResourceGroupsGlobalProperties("cpu_quota_period", "1h");
         // two resource groups are the same except the group for the prod environment has a larger softMemoryLimit
-        dao.insertResourceGroup(1, "prod_global", "10MB", 1000, 100, 100, "weighted", null, true, "1h", "1d", null, prodEnvironment);
-        dao.insertResourceGroup(2, "dev_global", "1MB", 1000, 100, 100, "weighted", null, true, "1h", "1d", null, devEnvironment);
+        dao.insertResourceGroup(1, "prod_global", "10MB", 1000, 100, 100, "weighted", null, true, "1h", "1d", "1h", "1MB", "1h", null, prodEnvironment);
+        dao.insertResourceGroup(2, "dev_global", "1MB", 1000, 100, 100, "weighted", null, true, "1h", "1d", "1h", "1MB", "1h", null, devEnvironment);
         dao.insertSelector(1, 1, ".*prod_user.*", null, null, null, null);
         dao.insertSelector(2, 2, ".*dev_user.*", null, null, null, null);
 
@@ -82,7 +82,7 @@ public class TestDbManagerSpecProvider
         H2ResourceGroupsDao dao = daoProvider.get();
         dao.createResourceGroupsTable();
         dao.createSelectorsTable();
-        dao.insertResourceGroup(1, "global", "100%", 100, 100, 100, null, null, null, null, null, null, ENVIRONMENT);
+        dao.insertResourceGroup(1, "global", "100%", 100, 100, 100, null, null, null, null, null, null, null, null, null, ENVIRONMENT);
 
         final int numberOfUsers = 100;
         List<String> expectedUsers = new ArrayList<>();
@@ -123,9 +123,9 @@ public class TestDbManagerSpecProvider
         dao.createResourceGroupsGlobalPropertiesTable();
         dao.createResourceGroupsTable();
         dao.createSelectorsTable();
-        dao.insertResourceGroup(1, "global", "1MB", 1000, 100, 100, null, null, null, null, null, null, ENVIRONMENT);
+        dao.insertResourceGroup(1, "global", "1MB", 1000, 100, 100, null, null, null, null, null, null, null, null, null, ENVIRONMENT);
         try {
-            dao.insertResourceGroup(1, "global", "1MB", 1000, 100, 100, null, null, null, null, null, null, ENVIRONMENT);
+            dao.insertResourceGroup(1, "global", "1MB", 1000, 100, 100, null, null, null, null, null, null, null, null, null, ENVIRONMENT);
             fail("Expected to fail");
         }
         catch (RuntimeException ex) {
@@ -139,10 +139,10 @@ public class TestDbManagerSpecProvider
         dao.createResourceGroupsGlobalPropertiesTable();
         dao.createResourceGroupsTable();
         dao.createSelectorsTable();
-        dao.insertResourceGroup(1, "global", "1MB", 1000, 100, 100, null, null, null, null, null, null, ENVIRONMENT);
-        dao.insertResourceGroup(2, "sub", "1MB", 1000, 100, 100, null, null, null, null, null, 1L, ENVIRONMENT);
+        dao.insertResourceGroup(1, "global", "1MB", 1000, 100, 100, null, null, null, null, null, null, null, null, null, ENVIRONMENT);
+        dao.insertResourceGroup(2, "sub", "1MB", 1000, 100, 100, null, null, null, null, null, null, null, null, 1L, ENVIRONMENT);
         try {
-            dao.insertResourceGroup(2, "sub", "1MB", 1000, 100, 100, null, null, null, null, null, 1L, ENVIRONMENT);
+            dao.insertResourceGroup(2, "sub", "1MB", 1000, 100, 100, null, null, null, null, null, null, null, null, 1L, ENVIRONMENT);
         }
         catch (RuntimeException ex) {
             assertTrue(ex instanceof UnableToExecuteStatementException);
@@ -161,12 +161,12 @@ public class TestDbManagerSpecProvider
         dao.createResourceGroupsGlobalPropertiesTable();
         dao.createResourceGroupsTable();
         dao.createSelectorsTable();
-        dao.insertResourceGroup(1, "global", "1MB", 1000, 100, 100, null, null, null, null, null, null, ENVIRONMENT);
-        dao.insertResourceGroup(2, "subTo1-1", "1MB", 1000, 100, 100, null, null, null, null, null, 1L, ENVIRONMENT);
-        dao.insertResourceGroup(3, "subTo1-2", "1MB", 1000, 100, 100, null, null, null, null, null, 1L, ENVIRONMENT);
-        dao.insertResourceGroup(4, "subTo2-1", "1MB", 1000, 100, 100, null, null, null, null, null, 2L, ENVIRONMENT);
-        dao.insertResourceGroup(5, "subTo2-2", "1MB", 1000, 100, 100, null, null, null, null, null, 2L, ENVIRONMENT);
-        dao.insertResourceGroup(6, "subTo3", "1MB", 1000, 100, 100, null, null, null, null, null, 3L, ENVIRONMENT);
+        dao.insertResourceGroup(1, "global", "1MB", 1000, 100, 100, null, null, null, null, null, null, null, null, null, ENVIRONMENT);
+        dao.insertResourceGroup(2, "subTo1-1", "1MB", 1000, 100, 100, null, null, null, null, null, null, null, null, 1L, ENVIRONMENT);
+        dao.insertResourceGroup(3, "subTo1-2", "1MB", 1000, 100, 100, null, null, null, null, null, null, null, null, 1L, ENVIRONMENT);
+        dao.insertResourceGroup(4, "subTo2-1", "1MB", 1000, 100, 100, null, null, null, null, null, null, null, null, 2L, ENVIRONMENT);
+        dao.insertResourceGroup(5, "subTo2-2", "1MB", 1000, 100, 100, null, null, null, null, null, null, null, null, 2L, ENVIRONMENT);
+        dao.insertResourceGroup(6, "subTo3", "1MB", 1000, 100, 100, null, null, null, null, null, null, null, null, 3L, ENVIRONMENT);
         DbManagerSpecProvider dbManagerSpecProvider = new DbManagerSpecProvider(daoProvider.get(), ENVIRONMENT, new ReloadingResourceGroupConfig());
         ManagerSpec managerSpec = dbManagerSpecProvider.getManagerSpec();
         assertEquals(managerSpec.getRootGroups().size(), 1);

--- a/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/db/TestDbSourceExactMatchSelector.java
+++ b/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/db/TestDbSourceExactMatchSelector.java
@@ -58,12 +58,14 @@ public class TestDbSourceExactMatchSelector
         assertEquals(
                 selector.match(new SelectionCriteria(true, "testuser", Optional.of("@test@test_pipeline"), ImmutableSet.of("tag"), EMPTY_RESOURCE_ESTIMATES, Optional.empty())),
                 Optional.empty());
+
         assertEquals(
                 selector.match(new SelectionCriteria(true, "testuser", Optional.of("@test@test_pipeline"), ImmutableSet.of("tag"), EMPTY_RESOURCE_ESTIMATES, Optional.of(INSERT.name()))).map(SelectionContext::getResourceGroupId),
                 Optional.of(resourceGroupId1));
         assertEquals(
                 selector.match(new SelectionCriteria(true, "testuser", Optional.of("@test@test_pipeline"), ImmutableSet.of("tag"), EMPTY_RESOURCE_ESTIMATES, Optional.of(SELECT.name()))).map(SelectionContext::getResourceGroupId),
                 Optional.of(resourceGroupId2));
+
         assertEquals(
                 selector.match(new SelectionCriteria(true, "testuser", Optional.of("@test@test_pipeline"), ImmutableSet.of("tag"), EMPTY_RESOURCE_ESTIMATES, Optional.of(DELETE.name()))),
                 Optional.empty());

--- a/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/db/TestResourceGroupsDao.java
+++ b/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/db/TestResourceGroupsDao.java
@@ -78,19 +78,19 @@ public class TestResourceGroupsDao
 
     private static void testResourceGroupInsert(H2ResourceGroupsDao dao, Map<Long, ResourceGroupSpecBuilder> map)
     {
-        dao.insertResourceGroup(1, "global", "100%", 100, 100, 100, null, null, null, null, null, null, ENVIRONMENT);
-        dao.insertResourceGroup(2, "bi", "50%", 50, 50, 50, null, null, null, null, null, 1L, ENVIRONMENT);
+        dao.insertResourceGroup(1, "global", "100%", 100, 100, 100, null, null, null, null, null, null, null, null, null, ENVIRONMENT);
+        dao.insertResourceGroup(2, "bi", "50%", 50, 50, 50, null, null, null, null, null, null, null, null, 1L, ENVIRONMENT);
         List<ResourceGroupSpecBuilder> records = dao.getResourceGroups(ENVIRONMENT);
         assertEquals(records.size(), 2);
-        map.put(1L, new ResourceGroupSpecBuilder(1, new ResourceGroupNameTemplate("global"), "100%", 100, Optional.of(100), 100, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), null));
-        map.put(2L, new ResourceGroupSpecBuilder(2, new ResourceGroupNameTemplate("bi"), "50%", 50, Optional.of(50), 50, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.of(1L)));
+        map.put(1L, new ResourceGroupSpecBuilder(1, new ResourceGroupNameTemplate("global"), "100%", 100, Optional.of(100), 100, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), null));
+        map.put(2L, new ResourceGroupSpecBuilder(2, new ResourceGroupNameTemplate("bi"), "50%", 50, Optional.of(50), 50, Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.of(1L)));
         compareResourceGroups(map, records);
     }
 
     private static void testResourceGroupUpdate(H2ResourceGroupsDao dao, Map<Long, ResourceGroupSpecBuilder> map)
     {
-        dao.updateResourceGroup(2, "bi", "40%", 40, 30, 30, null, null, true, null, null, 1L, ENVIRONMENT);
-        ResourceGroupSpecBuilder updated = new ResourceGroupSpecBuilder(2, new ResourceGroupNameTemplate("bi"), "40%", 40, Optional.of(30), 30, Optional.empty(), Optional.empty(), Optional.of(true), Optional.empty(), Optional.empty(), Optional.of(1L));
+        dao.updateResourceGroup(2, "bi", "40%", 40, 30, 30, null, null, true, null, null, null, null, null, 1L, ENVIRONMENT);
+        ResourceGroupSpecBuilder updated = new ResourceGroupSpecBuilder(2, new ResourceGroupNameTemplate("bi"), "40%", 40, Optional.of(30), 30, Optional.empty(), Optional.empty(), Optional.of(true), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.of(1L));
         map.put(2L, updated);
         compareResourceGroups(map, dao.getResourceGroups(ENVIRONMENT));
     }
@@ -147,10 +147,10 @@ public class TestResourceGroupsDao
                         Optional.empty(),
                         Optional.of(SELECTOR_RESOURCE_ESTIMATE)));
 
-        dao.insertResourceGroup(1, "admin", "100%", 100, 100, 100, null, null, null, null, null, null, ENVIRONMENT);
-        dao.insertResourceGroup(2, "ping_query", "50%", 50, 50, 50, null, null, null, null, null, 1L, ENVIRONMENT);
-        dao.insertResourceGroup(3, "config", "50%", 50, 50, 50, null, null, null, null, null, 1L, ENVIRONMENT);
-        dao.insertResourceGroup(4, "config", "50%", 50, 50, 50, null, null, null, null, null, 1L, ENVIRONMENT);
+        dao.insertResourceGroup(1, "admin", "100%", 100, 100, 100, null, null, null, null, null, null, null, null, 1L, ENVIRONMENT);
+        dao.insertResourceGroup(2, "ping_query", "50%", 50, 50, 50, null, null, null, null, null, null, null, null, 1L, ENVIRONMENT);
+        dao.insertResourceGroup(3, "config", "50%", 50, 50, 50, null, null, null, null, null, null, null, null, 1L, ENVIRONMENT);
+        dao.insertResourceGroup(4, "config", "50%", 50, 50, 50, null, null, null, null, null, null, null, null, 1L, ENVIRONMENT);
 
         dao.insertSelector(2, 1, "ping_user", ".*", null, null, null);
         dao.insertSelector(3, 2, "admin_user", ".*", EXPLAIN.name(), LIST_STRING_CODEC.toJson(ImmutableList.of("tag1", "tag2")), null);

--- a/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/reloading/TestReloadingResourceGroupConfigurationManager.java
+++ b/presto-resource-group-managers/src/test/java/com/facebook/presto/resourceGroups/reloading/TestReloadingResourceGroupConfigurationManager.java
@@ -21,6 +21,7 @@ import com.facebook.presto.resourceGroups.db.DbSourceExactMatchSelector;
 import com.facebook.presto.resourceGroups.db.H2DaoProvider;
 import com.facebook.presto.resourceGroups.db.H2ResourceGroupsDao;
 import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.resourceGroups.ResourceGroupQueryLimits;
 import com.facebook.presto.spi.resourceGroups.SchedulingPolicy;
 import com.facebook.presto.spi.resourceGroups.SelectionContext;
 import com.facebook.presto.spi.session.ResourceEstimates;
@@ -34,12 +35,15 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.facebook.presto.execution.resourceGroups.InternalResourceGroup.DEFAULT_WEIGHT;
+import static com.facebook.presto.spi.resourceGroups.ResourceGroupQueryLimits.NO_LIMITS;
 import static com.facebook.presto.spi.resourceGroups.SchedulingPolicy.FAIR;
 import static com.facebook.presto.spi.resourceGroups.SchedulingPolicy.WEIGHTED;
 import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static java.util.concurrent.TimeUnit.DAYS;
 import static java.util.concurrent.TimeUnit.HOURS;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
@@ -65,19 +69,19 @@ public class TestReloadingResourceGroupConfigurationManager
         dao.createResourceGroupsTable();
         dao.createSelectorsTable();
         dao.insertResourceGroupsGlobalProperties("cpu_quota_period", "1h");
-        dao.insertResourceGroup(1, "global", "1MB", 1000, 100, 100, "weighted", null, true, "1h", "1d", null, ENVIRONMENT);
-        dao.insertResourceGroup(2, "sub", "2MB", 4, 3, 3, null, 5, null, null, null, 1L, ENVIRONMENT);
+        dao.insertResourceGroup(1, "global", "1MB", 1000, 100, 100, "weighted", null, true, "1h", "1d", "1h", "1MB", "1h", null, ENVIRONMENT);
+        dao.insertResourceGroup(2, "sub", "2MB", 4, 3, 3, null, 5, null, null, null, null, null, null, 1L, ENVIRONMENT);
         dao.insertSelector(2, 1, null, null, null, null, null);
         DbManagerSpecProvider dbManagerSpecProvider = new DbManagerSpecProvider(daoProvider.get(), ENVIRONMENT, new ReloadingResourceGroupConfig());
         ReloadingResourceGroupConfigurationManager manager = new ReloadingResourceGroupConfigurationManager((poolId, listener) -> {}, new ReloadingResourceGroupConfig(), dbManagerSpecProvider);
         AtomicBoolean exported = new AtomicBoolean();
         InternalResourceGroup global = new InternalResourceGroup.RootInternalResourceGroup("global", (group, export) -> exported.set(export), directExecutor(), ignored -> Optional.empty(), rg -> false);
         manager.configure(global, new SelectionContext<>(global.getId(), new VariableMap(ImmutableMap.of("USER", "user"))));
-        assertEqualsResourceGroup(global, "1MB", 1000, 100, 100, WEIGHTED, DEFAULT_WEIGHT, true, new Duration(1, HOURS), new Duration(1, DAYS));
+        assertEqualsResourceGroup(global, "1MB", 1000, 100, 100, WEIGHTED, DEFAULT_WEIGHT, true, new Duration(1, HOURS), new Duration(1, DAYS), new ResourceGroupQueryLimits(Optional.of(new Duration(1, HOURS)), Optional.of(new DataSize(1, MEGABYTE)), Optional.of(new Duration(1, HOURS))));
         exported.set(false);
         InternalResourceGroup sub = global.getOrCreateSubGroup("sub", true);
         manager.configure(sub, new SelectionContext<>(sub.getId(), new VariableMap(ImmutableMap.of("USER", "user"))));
-        assertEqualsResourceGroup(sub, "2MB", 4, 3, 3, FAIR, 5, false, new Duration(Long.MAX_VALUE, MILLISECONDS), new Duration(Long.MAX_VALUE, MILLISECONDS));
+        assertEqualsResourceGroup(sub, "2MB", 4, 3, 3, FAIR, 5, false, new Duration(Long.MAX_VALUE, MILLISECONDS), new Duration(Long.MAX_VALUE, MILLISECONDS), NO_LIMITS);
     }
 
     @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = "No matching configuration found for: missing")
@@ -88,8 +92,8 @@ public class TestReloadingResourceGroupConfigurationManager
         dao.createResourceGroupsGlobalPropertiesTable();
         dao.createResourceGroupsTable();
         dao.createSelectorsTable();
-        dao.insertResourceGroup(1, "global", "1MB", 1000, 100, 100, "weighted", null, true, "1h", "1d", null, ENVIRONMENT);
-        dao.insertResourceGroup(2, "sub", "2MB", 4, 3, 3, null, 5, null, null, null, 1L, ENVIRONMENT);
+        dao.insertResourceGroup(1, "global", "1MB", 1000, 100, 100, "weighted", null, true, "1h", "1d", "1h", "1MB", "1h", null, ENVIRONMENT);
+        dao.insertResourceGroup(2, "sub", "2MB", 4, 3, 3, null, 5, null, null, null, null, null, null, 1L, ENVIRONMENT);
         dao.insertResourceGroupsGlobalProperties("cpu_quota_period", "1h");
         dao.insertSelector(2, 1, null, null, null, null, null);
         DbManagerSpecProvider dbManagerSpecProvider = new DbManagerSpecProvider(daoProvider.get(), ENVIRONMENT, new ReloadingResourceGroupConfig());
@@ -107,8 +111,8 @@ public class TestReloadingResourceGroupConfigurationManager
         dao.createResourceGroupsGlobalPropertiesTable();
         dao.createResourceGroupsTable();
         dao.createSelectorsTable();
-        dao.insertResourceGroup(1, "global", "1MB", 1000, 100, 100, "weighted", null, true, "1h", "1d", null, ENVIRONMENT);
-        dao.insertResourceGroup(2, "sub", "2MB", 4, 3, 3, null, 5, null, null, null, 1L, ENVIRONMENT);
+        dao.insertResourceGroup(1, "global", "1MB", 1000, 100, 100, "weighted", null, true, "1h", "1d", "1h", "1MB", "1h", null, ENVIRONMENT);
+        dao.insertResourceGroup(2, "sub", "2MB", 4, 3, 3, null, 5, null, null, null, null, null, null, 1L, ENVIRONMENT);
         dao.insertSelector(2, 1, null, null, null, null, null);
         dao.insertResourceGroupsGlobalProperties("cpu_quota_period", "1h");
         DbManagerSpecProvider dbManagerSpecProvider = new DbManagerSpecProvider(daoProvider.get(), ENVIRONMENT, new ReloadingResourceGroupConfig());
@@ -120,14 +124,14 @@ public class TestReloadingResourceGroupConfigurationManager
         InternalResourceGroup globalSub = global.getOrCreateSubGroup("sub", true);
         manager.configure(globalSub, new SelectionContext<>(globalSub.getId(), new VariableMap(ImmutableMap.of("USER", "user"))));
         // Verify record exists
-        assertEqualsResourceGroup(globalSub, "2MB", 4, 3, 3, FAIR, 5, false, new Duration(Long.MAX_VALUE, MILLISECONDS), new Duration(Long.MAX_VALUE, MILLISECONDS));
-        dao.updateResourceGroup(2, "sub", "3MB", 2, 1, 1, "weighted", 6, true, "1h", "1d", 1L, ENVIRONMENT);
+        assertEqualsResourceGroup(globalSub, "2MB", 4, 3, 3, FAIR, 5, false, new Duration(Long.MAX_VALUE, MILLISECONDS), new Duration(Long.MAX_VALUE, MILLISECONDS), NO_LIMITS);
+        dao.updateResourceGroup(2, "sub", "3MB", 2, 1, 1, "weighted", 6, true, "1h", "1d", "1h", "1MB", "30m", 1L, ENVIRONMENT);
         do {
             MILLISECONDS.sleep(500);
         }
         while (globalSub.getJmxExport() == false);
         // Verify update
-        assertEqualsResourceGroup(globalSub, "3MB", 2, 1, 1, WEIGHTED, 6, true, new Duration(1, HOURS), new Duration(1, DAYS));
+        assertEqualsResourceGroup(globalSub, "3MB", 2, 1, 1, WEIGHTED, 6, true, new Duration(1, HOURS), new Duration(1, DAYS), new ResourceGroupQueryLimits(Optional.of(new Duration(1, HOURS)), Optional.of(new DataSize(1, MEGABYTE)), Optional.of(new Duration(30, MINUTES))));
         // Verify delete
         dao.deleteSelectors(2);
         dao.deleteResourceGroup(2);
@@ -146,8 +150,8 @@ public class TestReloadingResourceGroupConfigurationManager
         dao.createResourceGroupsTable();
         dao.createSelectorsTable();
         dao.createExactMatchSelectorsTable();
-        dao.insertResourceGroup(1, "global", "1MB", 1000, 100, 100, "weighted", null, true, "1h", "1d", null, ENVIRONMENT);
-        dao.insertResourceGroup(2, "sub", "2MB", 4, 3, 3, null, 5, null, null, null, 1L, ENVIRONMENT);
+        dao.insertResourceGroup(1, "global", "1MB", 1000, 100, 100, "weighted", null, true, "1h", "1d", null, null, null, null, ENVIRONMENT);
+        dao.insertResourceGroup(2, "sub", "2MB", 4, 3, 3, null, 5, null, null, null, null, null, null, 1L, ENVIRONMENT);
         dao.insertSelector(2, 1, null, null, null, null, null);
         dao.insertResourceGroupsGlobalProperties("cpu_quota_period", "1h");
         ReloadingResourceGroupConfig config = new ReloadingResourceGroupConfig();
@@ -172,7 +176,7 @@ public class TestReloadingResourceGroupConfigurationManager
         H2ResourceGroupsDao dao = daoProvider.get();
         dao.createResourceGroupsTable();
         dao.createSelectorsTable();
-        dao.insertResourceGroup(1, "global", "100%", 100, 100, 100, null, null, null, null, null, null, ENVIRONMENT);
+        dao.insertResourceGroup(1, "global", "100%", 100, 100, 100, null, null, null, null, null, null, null, null, null, ENVIRONMENT);
 
         DbManagerSpecProvider dbManagerSpecProvider = new DbManagerSpecProvider(daoProvider.get(), ENVIRONMENT, new ReloadingResourceGroupConfig());
         ReloadingResourceGroupConfigurationManager manager = new ReloadingResourceGroupConfigurationManager(
@@ -190,7 +194,7 @@ public class TestReloadingResourceGroupConfigurationManager
         H2ResourceGroupsDao dao = daoProvider.get();
         dao.createResourceGroupsTable();
         dao.createSelectorsTable();
-        dao.insertResourceGroup(1, "global", "100%", 100, 100, 100, null, null, null, null, null, null, ENVIRONMENT);
+        dao.insertResourceGroup(1, "global", "100%", 100, 100, 100, null, null, null, null, null, null, null, null, null, ENVIRONMENT);
 
         DbManagerSpecProvider dbManagerSpecProvider = new DbManagerSpecProvider(daoProvider.get(), ENVIRONMENT, new ReloadingResourceGroupConfig());
         ReloadingResourceGroupConfigurationManager manager = new ReloadingResourceGroupConfigurationManager(
@@ -230,7 +234,8 @@ public class TestReloadingResourceGroupConfigurationManager
             int schedulingWeight,
             boolean jmxExport,
             Duration softCpuLimit,
-            Duration hardCpuLimit)
+            Duration hardCpuLimit,
+            ResourceGroupQueryLimits perQueryLimits)
     {
         assertEquals(group.getSoftMemoryLimit(), DataSize.valueOf(softMemoryLimit));
         assertEquals(group.getMaxQueuedQueries(), maxQueued);
@@ -241,5 +246,6 @@ public class TestReloadingResourceGroupConfigurationManager
         assertEquals(group.getJmxExport(), jmxExport);
         assertEquals(group.getSoftCpuLimit(), softCpuLimit);
         assertEquals(group.getHardCpuLimit(), hardCpuLimit);
+        assertEquals(group.getPerQueryLimits(), perQueryLimits);
     }
 }

--- a/presto-resource-group-managers/src/test/resources/resource_groups_config.json
+++ b/presto-resource-group-managers/src/test/resources/resource_groups_config.json
@@ -9,6 +9,12 @@
       "hardCpuLimit": "1d",
       "schedulingPolicy": "weighted",
       "jmxExport": true,
+      "perQueryLimits":
+      {
+        "executionTimeLimit": "1h",
+        "totalMemoryLimit": "1MB",
+        "cpuTimeLimit": "1h"
+      },
       "subGroups": [
         {
           "name": "sub",

--- a/presto-spi/src/main/java/com/facebook/presto/spi/resourceGroups/ResourceGroup.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/resourceGroups/ResourceGroup.java
@@ -95,4 +95,11 @@ public interface ResourceGroup
      * Whether to export statistics about this group and allow configuration via JMX.
      */
     void setJmxExport(boolean export);
+
+    ResourceGroupQueryLimits getPerQueryLimits();
+
+    /**
+     * The maximum resources a query can consume before being killed.
+     */
+    void setPerQueryLimits(ResourceGroupQueryLimits perQueryLimits);
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/resourceGroups/ResourceGroupQueryLimits.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/resourceGroups/ResourceGroupQueryLimits.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.resourceGroups;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public final class ResourceGroupQueryLimits
+{
+    private final Optional<Duration> executionTimeLimit;
+    private final Optional<DataSize> totalMemoryLimit;
+    private final Optional<Duration> cpuTimeLimit;
+
+    public static final ResourceGroupQueryLimits NO_LIMITS = new ResourceGroupQueryLimits(Optional.empty(), Optional.empty(), Optional.empty());
+
+    @JsonCreator
+    public ResourceGroupQueryLimits(
+            @JsonProperty("executionTimeLimit") Optional<Duration> executionTimeLimit,
+            @JsonProperty("totalMemoryLimit") Optional<DataSize> totalMemoryLimit,
+            @JsonProperty("cpuTimeLimit") Optional<Duration> cpuTimeLimit)
+    {
+        this.executionTimeLimit = requireNonNull(executionTimeLimit, "executionTimeLimit is null");
+        this.totalMemoryLimit = requireNonNull(totalMemoryLimit, "totalMemoryLimit is null");
+        this.cpuTimeLimit = requireNonNull(cpuTimeLimit, "perQueryCpuTime limit is null");
+    }
+
+    public Optional<Duration> getExecutionTimeLimit()
+    {
+        return executionTimeLimit;
+    }
+
+    public Optional<DataSize> getTotalMemoryLimit()
+    {
+        return totalMemoryLimit;
+    }
+
+    public Optional<Duration> getCpuTimeLimit()
+    {
+        return cpuTimeLimit;
+    }
+
+    @Override
+    public boolean equals(Object other)
+    {
+        if (other == this) {
+            return true;
+        }
+        if (!(other instanceof ResourceGroupQueryLimits)) {
+            return false;
+        }
+        ResourceGroupQueryLimits that = (ResourceGroupQueryLimits) other;
+        return (executionTimeLimit.equals(that.executionTimeLimit) &&
+                totalMemoryLimit.equals(that.totalMemoryLimit) &&
+                cpuTimeLimit.equals(that.cpuTimeLimit));
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(executionTimeLimit, totalMemoryLimit, cpuTimeLimit);
+    }
+
+    @Override
+    public String toString()
+    {
+        return format("[executionTimeLimit: %s, totalMemoryLimit: %s], cpuTimeLimit: %s]", executionTimeLimit, totalMemoryLimit, cpuTimeLimit);
+    }
+}

--- a/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/H2TestUtil.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/H2TestUtil.java
@@ -167,13 +167,13 @@ class H2TestUtil
             throws InterruptedException
     {
         dao.insertResourceGroupsGlobalProperties("cpu_quota_period", "1h");
-        dao.insertResourceGroup(1, "global", "1MB", 100, 1000, 1000, null, null, null, null, null, null, TEST_ENVIRONMENT);
-        dao.insertResourceGroup(2, "bi-${USER}", "1MB", 3, 2, 2, null, null, null, null, null, 1L, TEST_ENVIRONMENT);
-        dao.insertResourceGroup(3, "user-${USER}", "1MB", 3, 3, 3, null, null, null, null, null, 1L, TEST_ENVIRONMENT);
-        dao.insertResourceGroup(4, "adhoc-${USER}", "1MB", 3, 3, 3, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
-        dao.insertResourceGroup(5, "dashboard-${USER}", "1MB", 1, 1, 1, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
-        dao.insertResourceGroup(6, "no-queueing", "1MB", 0, 1, 1, null, null, null, null, null, null, TEST_ENVIRONMENT_2);
-        dao.insertResourceGroup(7, "explain", "1MB", 0, 1, 1, null, null, null, null, null, null, TEST_ENVIRONMENT);
+        dao.insertResourceGroup(1, "global", "1MB", 100, 1000, 1000, null, null, null, null, null, null, null, null, null, TEST_ENVIRONMENT);
+        dao.insertResourceGroup(2, "bi-${USER}", "1MB", 3, 2, 2, null, null, null, null, null, null, null, null, 1L, TEST_ENVIRONMENT);
+        dao.insertResourceGroup(3, "user-${USER}", "1MB", 3, 3, 3, null, null, null, null, null, null, null, null, 1L, TEST_ENVIRONMENT);
+        dao.insertResourceGroup(4, "adhoc-${USER}", "1MB", 3, 3, 3, null, null, null, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
+        dao.insertResourceGroup(5, "dashboard-${USER}", "1MB", 1, 1, 1, null, null, null, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
+        dao.insertResourceGroup(6, "no-queueing", "1MB", 0, 1, 1, null, null, null, null, null, null, null, null, null, TEST_ENVIRONMENT_2);
+        dao.insertResourceGroup(7, "explain", "1MB", 0, 1, 1, null, null, null, null, null, null, null, null, null, TEST_ENVIRONMENT);
         dao.insertSelector(2, 10_000, "user.*", "test", null, null, null);
         dao.insertSelector(4, 1_000, "user.*", "(?i).*adhoc.*", null, null, null);
         dao.insertSelector(5, 100, "user.*", "(?i).*dashboard.*", null, null, null);

--- a/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/TestQueuesDb.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/TestQueuesDb.java
@@ -178,8 +178,8 @@ public class TestQueuesDb
         waitForQueryState(queryRunner, secondDashboardQuery, QUEUED);
         waitForRunningQueryCount(queryRunner, 1);
         // Update db to allow for 1 more running query in dashboard resource group
-        dao.updateResourceGroup(3, "user-${USER}", "1MB", 3, 4, 4, null, null, null, null, null, 1L, TEST_ENVIRONMENT);
-        dao.updateResourceGroup(5, "dashboard-${USER}", "1MB", 1, 2, 2, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
+        dao.updateResourceGroup(3, "user-${USER}", "1MB", 3, 4, 4, null, null, null, null, null, null, null, null, 1L, TEST_ENVIRONMENT);
+        dao.updateResourceGroup(5, "dashboard-${USER}", "1MB", 1, 2, 2, null, null, null, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
         waitForQueryState(queryRunner, secondDashboardQuery, RUNNING);
         QueryId thirdDashboardQuery = createQuery(queryRunner, dashboardSession(), LONG_LASTING_QUERY);
         waitForQueryState(queryRunner, thirdDashboardQuery, QUEUED);
@@ -226,8 +226,8 @@ public class TestQueuesDb
         waitForQueryState(queryRunner, thirdDashboardQuery, FAILED);
 
         // Allow one more query to run and resubmit third query
-        dao.updateResourceGroup(3, "user-${USER}", "1MB", 3, 4, 4, null, null, null, null, null, 1L, TEST_ENVIRONMENT);
-        dao.updateResourceGroup(5, "dashboard-${USER}", "1MB", 1, 2, 2, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
+        dao.updateResourceGroup(3, "user-${USER}", "1MB", 3, 4, 4, null, null, null, null, null, null, null, null, 1L, TEST_ENVIRONMENT);
+        dao.updateResourceGroup(5, "dashboard-${USER}", "1MB", 1, 2, 2, null, null, null, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
 
         InternalResourceGroupManager manager = queryRunner.getCoordinator().getResourceGroupManager().get();
         ReloadingResourceGroupConfigurationManager reloadingConfigurationManager = (ReloadingResourceGroupConfigurationManager) manager.getConfigurationManager();
@@ -239,7 +239,7 @@ public class TestQueuesDb
         waitForQueryState(queryRunner, thirdDashboardQuery, QUEUED);
 
         // Lower running queries in dashboard resource groups and reload the config
-        dao.updateResourceGroup(5, "dashboard-${USER}", "1MB", 1, 1, 1, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
+        dao.updateResourceGroup(5, "dashboard-${USER}", "1MB", 1, 1, 1, null, null, null, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
         reloadingConfigurationManager.load();
 
         // Cancel query and verify that third query is still queued
@@ -300,7 +300,7 @@ public class TestQueuesDb
         assertEquals(resourceGroup.get().toString(), "global.user-user.dashboard-user");
 
         // create a new resource group that rejects all queries submitted to it
-        dao.insertResourceGroup(8, "reject-all-queries", "1MB", 0, 0, 0, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
+        dao.insertResourceGroup(8, "reject-all-queries", "1MB", 0, 0, 0, null, null, null, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
 
         // add a new selector that has a higher priority than the existing dashboard selector and that routes queries to the "reject-all-queries" resource group
         dao.insertSelector(8, 200, "user.*", "(?i).*dashboard.*", null, null, null);
@@ -336,7 +336,7 @@ public class TestQueuesDb
         assertEquals(queryManager.getFullQueryInfo(firstQuery).getErrorCode(), EXCEEDED_TIME_LIMIT.toErrorCode());
         assertContains(queryManager.getFullQueryInfo(firstQuery).getFailureInfo().getMessage(), "Query exceeded the maximum execution time limit of 1.00ms");
         // set max running queries to 0 for the dashboard resource group so that new queries get queued immediately
-        dao.updateResourceGroup(5, "dashboard-${USER}", "1MB", 1, null, 0, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
+        dao.updateResourceGroup(5, "dashboard-${USER}", "1MB", 1, null, 0, null, null, null, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
         reloadingConfigurationManager.load();
         QueryId secondQuery = createQuery(
                 queryRunner,
@@ -354,7 +354,7 @@ public class TestQueuesDb
         DispatchManager dispatchManager = queryRunner.getCoordinator().getDispatchManager();
         assertEquals(dispatchManager.getQueryInfo(secondQuery).getState(), QUEUED);
         // reconfigure the resource group to run the second query
-        dao.updateResourceGroup(5, "dashboard-${USER}", "1MB", 1, null, 1, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
+        dao.updateResourceGroup(5, "dashboard-${USER}", "1MB", 1, null, 1, null, null, null, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
         reloadingConfigurationManager.load();
         // cancel the first one and let the second one start
         dispatchManager.cancelQuery(firstQuery);

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestResourceGroupPerQueryLimitEnforcement.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestResourceGroupPerQueryLimitEnforcement.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests;
+
+import com.facebook.presto.dispatcher.DispatchManager;
+import com.facebook.presto.execution.QueryManager;
+import com.facebook.presto.resourceGroups.FileResourceGroupConfigurationManagerFactory;
+import com.facebook.presto.server.BasicQueryInfo;
+import com.facebook.presto.server.testing.TestingPrestoServer;
+import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.tests.tpch.TpchQueryRunnerBuilder;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.execution.QueryLimit.Source.RESOURCE_GROUP;
+import static com.facebook.presto.execution.QueryState.FAILED;
+import static com.facebook.presto.execution.TestQueryRunnerUtil.createQuery;
+import static com.facebook.presto.execution.TestQueryRunnerUtil.waitForQueryState;
+import static com.facebook.presto.spi.StandardErrorCode.EXCEEDED_CPU_LIMIT;
+import static com.facebook.presto.spi.StandardErrorCode.EXCEEDED_GLOBAL_MEMORY_LIMIT;
+import static com.facebook.presto.spi.StandardErrorCode.EXCEEDED_TIME_LIMIT;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static com.facebook.presto.tpch.TpchMetadata.TINY_SCHEMA_NAME;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+@Test(singleThreaded = true)
+public class TestResourceGroupPerQueryLimitEnforcement
+{
+    private DistributedQueryRunner queryRunner;
+
+    @BeforeClass
+    public void setUp()
+            throws Exception
+    {
+        queryRunner = TpchQueryRunnerBuilder.builder().build();
+        TestingPrestoServer server = queryRunner.getCoordinator();
+        server.getResourceGroupManager().get().addConfigurationManagerFactory(new FileResourceGroupConfigurationManagerFactory());
+        server.getResourceGroupManager().get()
+                .setConfigurationManager("file", ImmutableMap.of("resource-groups.config-file", getResourceFilePath("resource_groups_config_simple.json")));
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        queryRunner.close();
+        queryRunner = null;
+    }
+
+    @AfterMethod
+    public void cancelAllQueriesAfterTest()
+    {
+        DispatchManager dispatchManager = queryRunner.getCoordinator().getDispatchManager();
+        ImmutableList.copyOf(dispatchManager.getQueries()).forEach(queryInfo -> dispatchManager.cancelQuery(queryInfo.getQueryId()));
+    }
+
+    @Test(timeOut = 60_000L)
+    public void testQueryCpuLimit()
+            throws Exception
+    {
+        QueryId queryId = createQuery(
+                queryRunner,
+                testSessionBuilder()
+                        .setCatalog("tpch")
+                        .setSchema(TINY_SCHEMA_NAME)
+                        .setSource("per_query_cpu_limit_test")
+                        .build(),
+                "SELECT COUNT(*) FROM lineitem");
+        waitForQueryState(queryRunner, queryId, FAILED);
+        QueryManager queryManager = queryRunner.getCoordinator().getQueryManager();
+        BasicQueryInfo queryInfo = queryManager.getQueryInfo(queryId);
+        assertEquals(queryInfo.getState(), FAILED);
+        assertEquals(queryInfo.getErrorCode(), EXCEEDED_CPU_LIMIT.toErrorCode());
+        assertTrue(queryInfo.getFailureInfo().getMessage().contains(RESOURCE_GROUP.name()));
+    }
+
+    @Test(timeOut = 60_000L)
+    public void testQueryMemoryLimit()
+            throws Exception
+    {
+        QueryId queryId = createQuery(
+                queryRunner,
+                testSessionBuilder()
+                        .setCatalog("tpch")
+                        .setSchema(TINY_SCHEMA_NAME)
+                        .setSource("per_query_memory_limit_test")
+                        .build(),
+                "SELECT COUNT(*) FROM lineitem");
+        waitForQueryState(queryRunner, queryId, FAILED);
+        QueryManager queryManager = queryRunner.getCoordinator().getQueryManager();
+        BasicQueryInfo queryInfo = queryManager.getQueryInfo(queryId);
+        assertEquals(queryInfo.getState(), FAILED);
+        assertEquals(queryInfo.getErrorCode(), EXCEEDED_GLOBAL_MEMORY_LIMIT.toErrorCode());
+        assertTrue(queryInfo.getFailureInfo().getMessage().contains(RESOURCE_GROUP.name()));
+    }
+
+    @Test(timeOut = 60_000L)
+    public void testQueryExecutionTimeLimit()
+            throws Exception
+    {
+        QueryId queryId = createQuery(
+                queryRunner,
+                testSessionBuilder()
+                        .setCatalog("tpch")
+                        .setSchema(TINY_SCHEMA_NAME)
+                        .setSource("per_query_execution_time_limit_test")
+                        .build(),
+                "SELECT COUNT(*) FROM lineitem");
+        waitForQueryState(queryRunner, queryId, FAILED);
+        QueryManager queryManager = queryRunner.getCoordinator().getQueryManager();
+        BasicQueryInfo queryInfo = queryManager.getQueryInfo(queryId);
+        assertEquals(queryInfo.getState(), FAILED);
+        assertEquals(queryInfo.getErrorCode(), EXCEEDED_TIME_LIMIT.toErrorCode());
+        assertTrue(queryInfo.getFailureInfo().getMessage().contains(RESOURCE_GROUP.name()));
+    }
+
+    private String getResourceFilePath(String fileName)
+    {
+        return this.getClass().getClassLoader().getResource(fileName).getPath();
+    }
+}

--- a/presto-tests/src/test/resources/resource_groups_config_simple.json
+++ b/presto-tests/src/test/resources/resource_groups_config_simple.json
@@ -17,7 +17,7 @@
           "softMemoryLimit": "1MB",
           "hardConcurrencyLimit": 3,
           "maxQueued": 3,
-          "resourceGroupQueryLimits":
+          "perQueryLimits":
           {
             "cpuTimeLimit": "1ms"
           }
@@ -27,7 +27,7 @@
           "softMemoryLimit": "1MB",
           "hardConcurrencyLimit": 3,
           "maxQueued": 3,
-          "resourceGroupQueryLimits":
+          "perQueryLimits":
           {
             "executionTimeLimit": "1ms"
           }
@@ -37,7 +37,7 @@
           "softMemoryLimit": "1MB",
           "hardConcurrencyLimit": 3,
           "maxQueued": 3,
-          "resourceGroupQueryLimits":
+          "perQueryLimits":
           {
             "totalMemoryLimit": "1B"
           }
@@ -46,6 +46,18 @@
     }
   ],
   "selectors": [
+    {
+      "source": "per_query_cpu_limit_test",
+      "group": "global.rg_with_cpu_limit"
+    },
+    {
+      "source": "per_query_memory_limit_test",
+      "group": "global.rg_with_memory_limit"
+    },
+    {
+      "source": "per_query_execution_time_limit_test",
+      "group": "global.rg_with_execution_time_limit"
+    },
     {
       "group": "global.user-${USER}"
     }

--- a/presto-tests/src/test/resources/resource_groups_config_simple.json
+++ b/presto-tests/src/test/resources/resource_groups_config_simple.json
@@ -11,6 +11,36 @@
           "softMemoryLimit": "1MB",
           "hardConcurrencyLimit": 3,
           "maxQueued": 3
+        },
+        {
+          "name": "rg_with_cpu_limit",
+          "softMemoryLimit": "1MB",
+          "hardConcurrencyLimit": 3,
+          "maxQueued": 3,
+          "resourceGroupQueryLimits":
+          {
+            "cpuTimeLimit": "1ms"
+          }
+        },
+        {
+          "name": "rg_with_execution_time_limit",
+          "softMemoryLimit": "1MB",
+          "hardConcurrencyLimit": 3,
+          "maxQueued": 3,
+          "resourceGroupQueryLimits":
+          {
+            "executionTimeLimit": "1ms"
+          }
+        },
+        {
+          "name": "rg_with_memory_limit",
+          "softMemoryLimit": "1MB",
+          "hardConcurrencyLimit": 3,
+          "maxQueued": 3,
+          "resourceGroupQueryLimits":
+          {
+            "totalMemoryLimit": "1B"
+          }
         }
       ]
     }


### PR DESCRIPTION
Introduce the ability to add query limits (cpu time, execution time, and memory limit) at the resource group level. These limits can complement the `SelectorResourceEstimate` passed to `SelectorSpec` to ensure that if the query exceeds the indented query limits, we can fail the query and protect the resource group.

This is enabled by adding to the `ResourceGroupSpec` the field `perQueryLimits`, a JSON object of the optional fields `executionTimeLimit`, `totalMemoryLimit`, `cpuTimeLimit` which is then passed to the coordinator to implement the appropriate limits.

Test plan - Unit tests added and build success are sufficient for first commit. Second commit will have e2e by deploying fbpkg to test cluster to ensure resource group limits can be enforced by `SqlQueryManager`. Unit testing also on second commit.

```
== RELEASE NOTES ==

Resource Groups Changes
* Add support to specify query limits (Cpu time, total memory and execution time) at the resource group level. See :doc:`/admin/resource-groups`.

SPI Changes
* Add `ResourceGroupQueryLimits` to the SPI and the corresponding getter and setter functions in `ResourceGroups`.
```
Depends on https://github.com/facebookexternal/presto-facebook/pull/1599
