### PR TITLE
Fix dupe expression error in orderings

### DIFF
--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestLocalQueries.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestLocalQueries.java
@@ -144,4 +144,10 @@ public class TestLocalQueries
                 jsonCodec(IOPlan.class).fromJson((String) getOnlyElement(result.getOnlyColumnAsSet())),
                 new IOPlan(ImmutableSet.of(input), Optional.empty()));
     }
+
+    @Test
+    public void testMultipleOrderingOnSameCanonicalVariables()
+    {
+        assertQuerySucceeds("SELECT ARRAY_AGG( x ORDER BY x ASC, y ASC ) FROM ( SELECT 0 as x, 0 AS y)");
+    }
 }


### PR DESCRIPTION
Fix dupe expression error in orderings

Fix duplicate expressions in orderings that may be revealed after we unalias references.

Fixes #15320

```
== NO RELEASE NOTE ==
```
