### PR TITLE
Refactor HiveTestUtils#SESSION to class Session

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -361,7 +361,7 @@ public abstract class AbstractTestHiveClient
             .build();
 
     private static final MaterializedResult CREATE_TABLE_DATA =
-            MaterializedResult.resultBuilder(SESSION, BIGINT, createUnboundedVarcharType(), TINYINT, SMALLINT, INTEGER, BIGINT, REAL, DOUBLE, BOOLEAN, ARRAY_TYPE, MAP_TYPE, ROW_TYPE)
+            MaterializedResult.resultBuilder(SESSION.toConnectorSession(), BIGINT, createUnboundedVarcharType(), TINYINT, SMALLINT, INTEGER, BIGINT, REAL, DOUBLE, BOOLEAN, ARRAY_TYPE, MAP_TYPE, ROW_TYPE)
                     .row(1L, "hello", (byte) 45, (short) 345, 234, 123L, -754.1985f, 43.5, true, ImmutableList.of("apple", "banana"), ImmutableMap.of("one", 1L, "two", 2L), ImmutableList.of("true", 1L, true))
                     .row(2L, null, null, null, null, null, null, null, null, null, null, null)
                     .row(3L, "bye", (byte) 46, (short) 346, 345, 456L, 754.2008f, 98.1, false, ImmutableList.of("ape", "bear"), ImmutableMap.of("three", 3L, "four", 4L), ImmutableList.of("false", 0L, false))
@@ -384,7 +384,7 @@ public abstract class AbstractTestHiveClient
     private static final String CREATE_TABLE_PARTITIONED_DATA_2ND_PARTITION_VALUE = "2015-07-04";
 
     private static final MaterializedResult CREATE_TABLE_PARTITIONED_DATA_2ND =
-            MaterializedResult.resultBuilder(SESSION, BIGINT, createUnboundedVarcharType(), TINYINT, SMALLINT, INTEGER, BIGINT, REAL, DOUBLE, BOOLEAN, ARRAY_TYPE, MAP_TYPE, ROW_TYPE, createUnboundedVarcharType())
+            MaterializedResult.resultBuilder(SESSION.toConnectorSession(), BIGINT, createUnboundedVarcharType(), TINYINT, SMALLINT, INTEGER, BIGINT, REAL, DOUBLE, BOOLEAN, ARRAY_TYPE, MAP_TYPE, ROW_TYPE, createUnboundedVarcharType())
                     .row(4L, "hello", (byte) 45, (short) 345, 234, 123L, 754.1985f, 43.5, true, ImmutableList.of("apple", "banana"), ImmutableMap.of("one", 1L, "two", 2L), ImmutableList.of("true", 1L, true), CREATE_TABLE_PARTITIONED_DATA_2ND_PARTITION_VALUE)
                     .row(5L, null, null, null, null, null, null, null, null, null, null, null, CREATE_TABLE_PARTITIONED_DATA_2ND_PARTITION_VALUE)
                     .row(6L, "bye", (byte) 46, (short) 346, 345, 456L, -754.2008f, 98.1, false, ImmutableList.of("ape", "bear"), ImmutableMap.of("three", 3L, "four", 4L), ImmutableList.of("false", 0L, false), CREATE_TABLE_PARTITIONED_DATA_2ND_PARTITION_VALUE)
@@ -422,7 +422,7 @@ public abstract class AbstractTestHiveClient
     }
 
     private static final MaterializedResult MISMATCH_SCHEMA_PRIMITIVE_FIELDS_DATA_BEFORE =
-            MaterializedResult.resultBuilder(SESSION, TINYINT, TINYINT, TINYINT, SMALLINT, SMALLINT, INTEGER, INTEGER, createUnboundedVarcharType(), REAL, createUnboundedVarcharType())
+            MaterializedResult.resultBuilder(SESSION.toConnectorSession(), TINYINT, TINYINT, TINYINT, SMALLINT, SMALLINT, INTEGER, INTEGER, createUnboundedVarcharType(), REAL, createUnboundedVarcharType())
                     .row((byte) -11, (byte) 12, (byte) -13, (short) 14, (short) 15, -16, 17, "2147483647", 18.0f, "2016-08-01")
                     .row((byte) 21, (byte) -22, (byte) 23, (short) -24, (short) 25, 26, -27, "asdf", -28.0f, "2016-08-02")
                     .row((byte) -31, (byte) -32, (byte) 33, (short) 34, (short) -35, 36, 37, "-923", 39.5f, "2016-08-03")
@@ -430,7 +430,7 @@ public abstract class AbstractTestHiveClient
                     .build();
 
     private static final MaterializedResult MISMATCH_SCHEMA_TABLE_DATA_BEFORE =
-            MaterializedResult.resultBuilder(SESSION, MISMATCH_SCHEMA_TABLE_BEFORE.stream().map(ColumnMetadata::getType).collect(toList()))
+            MaterializedResult.resultBuilder(SESSION.toConnectorSession(), MISMATCH_SCHEMA_TABLE_BEFORE.stream().map(ColumnMetadata::getType).collect(toList()))
                     .rows(MISMATCH_SCHEMA_PRIMITIVE_FIELDS_DATA_BEFORE.getMaterializedRows()
                             .stream()
                             .map(materializedRow -> {
@@ -473,7 +473,7 @@ public abstract class AbstractTestHiveClient
             .build();
 
     private static final MaterializedResult MISMATCH_SCHEMA_PRIMITIVE_FIELDS_DATA_AFTER =
-            MaterializedResult.resultBuilder(SESSION, SMALLINT, INTEGER, BIGINT, INTEGER, BIGINT, BIGINT, createUnboundedVarcharType(), INTEGER, DOUBLE, createUnboundedVarcharType())
+            MaterializedResult.resultBuilder(SESSION.toConnectorSession(), SMALLINT, INTEGER, BIGINT, INTEGER, BIGINT, BIGINT, createUnboundedVarcharType(), INTEGER, DOUBLE, createUnboundedVarcharType())
                     .row((short) -11, 12, -13L, 14, 15L, -16L, "17", 2147483647, 18.0, "2016-08-01")
                     .row((short) 21, -22, 23L, -24, 25L, 26L, "-27", null, -28.0, "2016-08-02")
                     .row((short) -31, -32, 33L, 34, -35L, 36L, "37", -923, 39.5, "2016-08-03")
@@ -481,7 +481,7 @@ public abstract class AbstractTestHiveClient
                     .build();
 
     private static final MaterializedResult MISMATCH_SCHEMA_TABLE_DATA_AFTER =
-            MaterializedResult.resultBuilder(SESSION, MISMATCH_SCHEMA_TABLE_AFTER.stream().map(ColumnMetadata::getType).collect(toList()))
+            MaterializedResult.resultBuilder(SESSION.toConnectorSession(), MISMATCH_SCHEMA_TABLE_AFTER.stream().map(ColumnMetadata::getType).collect(toList()))
                     .rows(MISMATCH_SCHEMA_PRIMITIVE_FIELDS_DATA_AFTER.getMaterializedRows()
                             .stream()
                             .map(materializedRow -> {
@@ -498,7 +498,7 @@ public abstract class AbstractTestHiveClient
                             }).collect(toList()))
                     .build();
 
-    private static final SubfieldExtractor SUBFIELD_EXTRACTOR = new SubfieldExtractor(FUNCTION_RESOLUTION, ROW_EXPRESSION_SERVICE.getExpressionOptimizer(), SESSION);
+    private static final SubfieldExtractor SUBFIELD_EXTRACTOR = new SubfieldExtractor(FUNCTION_RESOLUTION, ROW_EXPRESSION_SERVICE.getExpressionOptimizer(), SESSION.toConnectorSession());
 
     private static final TypeProvider TYPE_PROVIDER_AFTER = TypeProvider.copyOf(MISMATCH_SCHEMA_TABLE_AFTER.stream()
             .collect(toImmutableMap(ColumnMetadata::getName, ColumnMetadata::getType)));
@@ -682,7 +682,7 @@ public abstract class AbstractTestHiveClient
             .build();
     private static final int TEMPORARY_TABLE_BUCKET_COUNT = 4;
     private static final List<String> TEMPORARY_TABLE_BUCKET_COLUMNS = ImmutableList.of("id");
-    public static final MaterializedResult TEMPORARY_TABLE_DATA = MaterializedResult.resultBuilder(SESSION, VARCHAR, VARCHAR)
+    public static final MaterializedResult TEMPORARY_TABLE_DATA = MaterializedResult.resultBuilder(SESSION.toConnectorSession(), VARCHAR, VARCHAR)
             .row("1", "value1")
             .row("2", "value2")
             .row("3", "value3")
@@ -2045,7 +2045,7 @@ public abstract class AbstractTestHiveClient
                 ImmutableList.of(new Column("pk", HIVE_STRING, Optional.empty())),
                 Optional.of(new HiveBucketProperty(ImmutableList.of("id"), 4, ImmutableList.of(), HIVE_COMPATIBLE, Optional.empty())));
         // write a 4-bucket partition
-        MaterializedResult.Builder bucket8Builder = MaterializedResult.resultBuilder(SESSION, BIGINT, VARCHAR, VARCHAR);
+        MaterializedResult.Builder bucket8Builder = MaterializedResult.resultBuilder(SESSION.toConnectorSession(), BIGINT, VARCHAR, VARCHAR);
         IntStream.range(0, rowCount).forEach(i -> bucket8Builder.row((long) i, String.valueOf(i), "four"));
         insertData(tableName, bucket8Builder.build());
 
@@ -2145,17 +2145,17 @@ public abstract class AbstractTestHiveClient
                 ImmutableList.of(new Column("pk", HIVE_STRING, Optional.empty())),
                 Optional.of(new HiveBucketProperty(ImmutableList.of("id"), 4, ImmutableList.of(), HIVE_COMPATIBLE, Optional.empty())));
         // write a 4-bucket partition
-        MaterializedResult.Builder bucket4Builder = MaterializedResult.resultBuilder(SESSION, BIGINT, VARCHAR, VARCHAR);
+        MaterializedResult.Builder bucket4Builder = MaterializedResult.resultBuilder(SESSION.toConnectorSession(), BIGINT, VARCHAR, VARCHAR);
         IntStream.range(0, rowCount).forEach(i -> bucket4Builder.row((long) i, String.valueOf(i), "four"));
         insertData(tableName, bucket4Builder.build());
         // write a 16-bucket partition
         alterBucketProperty(tableName, Optional.of(new HiveBucketProperty(ImmutableList.of("id"), 16, ImmutableList.of(), HIVE_COMPATIBLE, Optional.empty())));
-        MaterializedResult.Builder bucket16Builder = MaterializedResult.resultBuilder(SESSION, BIGINT, VARCHAR, VARCHAR);
+        MaterializedResult.Builder bucket16Builder = MaterializedResult.resultBuilder(SESSION.toConnectorSession(), BIGINT, VARCHAR, VARCHAR);
         IntStream.range(0, rowCount).forEach(i -> bucket16Builder.row((long) i, String.valueOf(i), "sixteen"));
         insertData(tableName, bucket16Builder.build());
         // write an 8-bucket partition
         alterBucketProperty(tableName, Optional.of(new HiveBucketProperty(ImmutableList.of("id"), 8, ImmutableList.of(), HIVE_COMPATIBLE, Optional.empty())));
-        MaterializedResult.Builder bucket8Builder = MaterializedResult.resultBuilder(SESSION, BIGINT, VARCHAR, VARCHAR);
+        MaterializedResult.Builder bucket8Builder = MaterializedResult.resultBuilder(SESSION.toConnectorSession(), BIGINT, VARCHAR, VARCHAR);
         IntStream.range(0, rowCount).forEach(i -> bucket8Builder.row((long) i, String.valueOf(i), "eight"));
         insertData(tableName, bucket8Builder.build());
 
@@ -3196,7 +3196,7 @@ public abstract class AbstractTestHiveClient
         List<ColumnMetadata> columns = TEMPORARY_TABLE_COLUMNS;
         List<String> bucketingColumns = TEMPORARY_TABLE_BUCKET_COLUMNS;
         int bucketCount = TEMPORARY_TABLE_BUCKET_COUNT;
-        MaterializedResult singleRow = MaterializedResult.resultBuilder(SESSION, VARCHAR, VARCHAR)
+        MaterializedResult singleRow = MaterializedResult.resultBuilder(SESSION.toConnectorSession(), VARCHAR, VARCHAR)
                 .row("1", "value1")
                 .build();
         ConnectorSession session = newSession();
@@ -3263,7 +3263,7 @@ public abstract class AbstractTestHiveClient
                 TEMPORARY_TABLE_COLUMNS,
                 TEMPORARY_TABLE_BUCKET_COUNT,
                 TEMPORARY_TABLE_BUCKET_COLUMNS,
-                MaterializedResult.resultBuilder(SESSION, VARCHAR, VARCHAR).build(),
+                MaterializedResult.resultBuilder(SESSION.toConnectorSession(), VARCHAR, VARCHAR).build(),
                 session,
                 commit);
 
@@ -4054,7 +4054,7 @@ public abstract class AbstractTestHiveClient
         // creating the table
         doCreateEmptyTable(tableName, storageFormat, CREATE_TABLE_COLUMNS);
 
-        MaterializedResult.Builder resultBuilder = MaterializedResult.resultBuilder(SESSION, CREATE_TABLE_DATA.getTypes());
+        MaterializedResult.Builder resultBuilder = MaterializedResult.resultBuilder(SESSION.toConnectorSession(), CREATE_TABLE_DATA.getTypes());
         for (int i = 0; i < 3; i++) {
             insertData(tableName, CREATE_TABLE_DATA);
 
@@ -4410,7 +4410,7 @@ public abstract class AbstractTestHiveClient
         // creating the table
         doCreateEmptyTable(tableName, storageFormat, CREATE_TABLE_COLUMNS_PARTITIONED);
 
-        MaterializedResult.Builder resultBuilder = MaterializedResult.resultBuilder(SESSION, CREATE_TABLE_PARTITIONED_DATA.getTypes());
+        MaterializedResult.Builder resultBuilder = MaterializedResult.resultBuilder(SESSION.toConnectorSession(), CREATE_TABLE_PARTITIONED_DATA.getTypes());
         for (int i = 0; i < 3; i++) {
             // insert the data
             insertData(tableName, CREATE_TABLE_PARTITIONED_DATA);
@@ -4660,7 +4660,7 @@ public abstract class AbstractTestHiveClient
 
         insertData(tableName, CREATE_TABLE_PARTITIONED_DATA);
 
-        MaterializedResult.Builder expectedResultBuilder = MaterializedResult.resultBuilder(SESSION, CREATE_TABLE_PARTITIONED_DATA.getTypes());
+        MaterializedResult.Builder expectedResultBuilder = MaterializedResult.resultBuilder(SESSION.toConnectorSession(), CREATE_TABLE_PARTITIONED_DATA.getTypes());
         expectedResultBuilder.rows(CREATE_TABLE_PARTITIONED_DATA.getMaterializedRows());
 
         try (Transaction transaction = newTransaction()) {
@@ -4866,7 +4866,7 @@ public abstract class AbstractTestHiveClient
                         assertNull(row.getField(index));
                     }
                     else {
-                        SqlTimestamp expected = sqlTimestampOf(2011, 5, 6, 7, 8, 9, 123, timeZone, UTC_KEY, SESSION);
+                        SqlTimestamp expected = sqlTimestampOf(2011, 5, 6, 7, 8, 9, 123, timeZone, UTC_KEY, SESSION.toConnectorSession());
                         assertEquals(row.getField(index), expected);
                     }
                 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -233,13 +233,13 @@ import static com.facebook.presto.hive.HiveTableProperties.BUCKET_COUNT_PROPERTY
 import static com.facebook.presto.hive.HiveTableProperties.PARTITIONED_BY_PROPERTY;
 import static com.facebook.presto.hive.HiveTableProperties.SORTED_BY_PROPERTY;
 import static com.facebook.presto.hive.HiveTableProperties.STORAGE_FORMAT_PROPERTY;
+import static com.facebook.presto.hive.HiveTestUtils.CONNECTOR_SESSION;
 import static com.facebook.presto.hive.HiveTestUtils.FILTER_STATS_CALCULATOR_SERVICE;
 import static com.facebook.presto.hive.HiveTestUtils.FUNCTION_AND_TYPE_MANAGER;
 import static com.facebook.presto.hive.HiveTestUtils.FUNCTION_RESOLUTION;
 import static com.facebook.presto.hive.HiveTestUtils.METADATA;
 import static com.facebook.presto.hive.HiveTestUtils.PAGE_SORTER;
 import static com.facebook.presto.hive.HiveTestUtils.ROW_EXPRESSION_SERVICE;
-import static com.facebook.presto.hive.HiveTestUtils.SESSION;
 import static com.facebook.presto.hive.HiveTestUtils.arrayType;
 import static com.facebook.presto.hive.HiveTestUtils.getDefaultHiveBatchPageSourceFactories;
 import static com.facebook.presto.hive.HiveTestUtils.getDefaultHiveFileWriterFactories;
@@ -361,7 +361,7 @@ public abstract class AbstractTestHiveClient
             .build();
 
     private static final MaterializedResult CREATE_TABLE_DATA =
-            MaterializedResult.resultBuilder(SESSION.toConnectorSession(), BIGINT, createUnboundedVarcharType(), TINYINT, SMALLINT, INTEGER, BIGINT, REAL, DOUBLE, BOOLEAN, ARRAY_TYPE, MAP_TYPE, ROW_TYPE)
+            MaterializedResult.resultBuilder(CONNECTOR_SESSION, BIGINT, createUnboundedVarcharType(), TINYINT, SMALLINT, INTEGER, BIGINT, REAL, DOUBLE, BOOLEAN, ARRAY_TYPE, MAP_TYPE, ROW_TYPE)
                     .row(1L, "hello", (byte) 45, (short) 345, 234, 123L, -754.1985f, 43.5, true, ImmutableList.of("apple", "banana"), ImmutableMap.of("one", 1L, "two", 2L), ImmutableList.of("true", 1L, true))
                     .row(2L, null, null, null, null, null, null, null, null, null, null, null)
                     .row(3L, "bye", (byte) 46, (short) 346, 345, 456L, 754.2008f, 98.1, false, ImmutableList.of("ape", "bear"), ImmutableMap.of("three", 3L, "four", 4L), ImmutableList.of("false", 0L, false))
@@ -384,7 +384,7 @@ public abstract class AbstractTestHiveClient
     private static final String CREATE_TABLE_PARTITIONED_DATA_2ND_PARTITION_VALUE = "2015-07-04";
 
     private static final MaterializedResult CREATE_TABLE_PARTITIONED_DATA_2ND =
-            MaterializedResult.resultBuilder(SESSION.toConnectorSession(), BIGINT, createUnboundedVarcharType(), TINYINT, SMALLINT, INTEGER, BIGINT, REAL, DOUBLE, BOOLEAN, ARRAY_TYPE, MAP_TYPE, ROW_TYPE, createUnboundedVarcharType())
+            MaterializedResult.resultBuilder(CONNECTOR_SESSION, BIGINT, createUnboundedVarcharType(), TINYINT, SMALLINT, INTEGER, BIGINT, REAL, DOUBLE, BOOLEAN, ARRAY_TYPE, MAP_TYPE, ROW_TYPE, createUnboundedVarcharType())
                     .row(4L, "hello", (byte) 45, (short) 345, 234, 123L, 754.1985f, 43.5, true, ImmutableList.of("apple", "banana"), ImmutableMap.of("one", 1L, "two", 2L), ImmutableList.of("true", 1L, true), CREATE_TABLE_PARTITIONED_DATA_2ND_PARTITION_VALUE)
                     .row(5L, null, null, null, null, null, null, null, null, null, null, null, CREATE_TABLE_PARTITIONED_DATA_2ND_PARTITION_VALUE)
                     .row(6L, "bye", (byte) 46, (short) 346, 345, 456L, -754.2008f, 98.1, false, ImmutableList.of("ape", "bear"), ImmutableMap.of("three", 3L, "four", 4L), ImmutableList.of("false", 0L, false), CREATE_TABLE_PARTITIONED_DATA_2ND_PARTITION_VALUE)
@@ -422,7 +422,7 @@ public abstract class AbstractTestHiveClient
     }
 
     private static final MaterializedResult MISMATCH_SCHEMA_PRIMITIVE_FIELDS_DATA_BEFORE =
-            MaterializedResult.resultBuilder(SESSION.toConnectorSession(), TINYINT, TINYINT, TINYINT, SMALLINT, SMALLINT, INTEGER, INTEGER, createUnboundedVarcharType(), REAL, createUnboundedVarcharType())
+            MaterializedResult.resultBuilder(CONNECTOR_SESSION, TINYINT, TINYINT, TINYINT, SMALLINT, SMALLINT, INTEGER, INTEGER, createUnboundedVarcharType(), REAL, createUnboundedVarcharType())
                     .row((byte) -11, (byte) 12, (byte) -13, (short) 14, (short) 15, -16, 17, "2147483647", 18.0f, "2016-08-01")
                     .row((byte) 21, (byte) -22, (byte) 23, (short) -24, (short) 25, 26, -27, "asdf", -28.0f, "2016-08-02")
                     .row((byte) -31, (byte) -32, (byte) 33, (short) 34, (short) -35, 36, 37, "-923", 39.5f, "2016-08-03")
@@ -430,7 +430,7 @@ public abstract class AbstractTestHiveClient
                     .build();
 
     private static final MaterializedResult MISMATCH_SCHEMA_TABLE_DATA_BEFORE =
-            MaterializedResult.resultBuilder(SESSION.toConnectorSession(), MISMATCH_SCHEMA_TABLE_BEFORE.stream().map(ColumnMetadata::getType).collect(toList()))
+            MaterializedResult.resultBuilder(CONNECTOR_SESSION, MISMATCH_SCHEMA_TABLE_BEFORE.stream().map(ColumnMetadata::getType).collect(toList()))
                     .rows(MISMATCH_SCHEMA_PRIMITIVE_FIELDS_DATA_BEFORE.getMaterializedRows()
                             .stream()
                             .map(materializedRow -> {
@@ -473,7 +473,7 @@ public abstract class AbstractTestHiveClient
             .build();
 
     private static final MaterializedResult MISMATCH_SCHEMA_PRIMITIVE_FIELDS_DATA_AFTER =
-            MaterializedResult.resultBuilder(SESSION.toConnectorSession(), SMALLINT, INTEGER, BIGINT, INTEGER, BIGINT, BIGINT, createUnboundedVarcharType(), INTEGER, DOUBLE, createUnboundedVarcharType())
+            MaterializedResult.resultBuilder(CONNECTOR_SESSION, SMALLINT, INTEGER, BIGINT, INTEGER, BIGINT, BIGINT, createUnboundedVarcharType(), INTEGER, DOUBLE, createUnboundedVarcharType())
                     .row((short) -11, 12, -13L, 14, 15L, -16L, "17", 2147483647, 18.0, "2016-08-01")
                     .row((short) 21, -22, 23L, -24, 25L, 26L, "-27", null, -28.0, "2016-08-02")
                     .row((short) -31, -32, 33L, 34, -35L, 36L, "37", -923, 39.5, "2016-08-03")
@@ -481,7 +481,7 @@ public abstract class AbstractTestHiveClient
                     .build();
 
     private static final MaterializedResult MISMATCH_SCHEMA_TABLE_DATA_AFTER =
-            MaterializedResult.resultBuilder(SESSION.toConnectorSession(), MISMATCH_SCHEMA_TABLE_AFTER.stream().map(ColumnMetadata::getType).collect(toList()))
+            MaterializedResult.resultBuilder(CONNECTOR_SESSION, MISMATCH_SCHEMA_TABLE_AFTER.stream().map(ColumnMetadata::getType).collect(toList()))
                     .rows(MISMATCH_SCHEMA_PRIMITIVE_FIELDS_DATA_AFTER.getMaterializedRows()
                             .stream()
                             .map(materializedRow -> {
@@ -498,7 +498,7 @@ public abstract class AbstractTestHiveClient
                             }).collect(toList()))
                     .build();
 
-    private static final SubfieldExtractor SUBFIELD_EXTRACTOR = new SubfieldExtractor(FUNCTION_RESOLUTION, ROW_EXPRESSION_SERVICE.getExpressionOptimizer(), SESSION.toConnectorSession());
+    private static final SubfieldExtractor SUBFIELD_EXTRACTOR = new SubfieldExtractor(FUNCTION_RESOLUTION, ROW_EXPRESSION_SERVICE.getExpressionOptimizer(), CONNECTOR_SESSION);
 
     private static final TypeProvider TYPE_PROVIDER_AFTER = TypeProvider.copyOf(MISMATCH_SCHEMA_TABLE_AFTER.stream()
             .collect(toImmutableMap(ColumnMetadata::getName, ColumnMetadata::getType)));
@@ -682,7 +682,7 @@ public abstract class AbstractTestHiveClient
             .build();
     private static final int TEMPORARY_TABLE_BUCKET_COUNT = 4;
     private static final List<String> TEMPORARY_TABLE_BUCKET_COLUMNS = ImmutableList.of("id");
-    public static final MaterializedResult TEMPORARY_TABLE_DATA = MaterializedResult.resultBuilder(SESSION.toConnectorSession(), VARCHAR, VARCHAR)
+    public static final MaterializedResult TEMPORARY_TABLE_DATA = MaterializedResult.resultBuilder(CONNECTOR_SESSION, VARCHAR, VARCHAR)
             .row("1", "value1")
             .row("2", "value2")
             .row("3", "value3")
@@ -2045,7 +2045,7 @@ public abstract class AbstractTestHiveClient
                 ImmutableList.of(new Column("pk", HIVE_STRING, Optional.empty())),
                 Optional.of(new HiveBucketProperty(ImmutableList.of("id"), 4, ImmutableList.of(), HIVE_COMPATIBLE, Optional.empty())));
         // write a 4-bucket partition
-        MaterializedResult.Builder bucket8Builder = MaterializedResult.resultBuilder(SESSION.toConnectorSession(), BIGINT, VARCHAR, VARCHAR);
+        MaterializedResult.Builder bucket8Builder = MaterializedResult.resultBuilder(CONNECTOR_SESSION, BIGINT, VARCHAR, VARCHAR);
         IntStream.range(0, rowCount).forEach(i -> bucket8Builder.row((long) i, String.valueOf(i), "four"));
         insertData(tableName, bucket8Builder.build());
 
@@ -2145,17 +2145,17 @@ public abstract class AbstractTestHiveClient
                 ImmutableList.of(new Column("pk", HIVE_STRING, Optional.empty())),
                 Optional.of(new HiveBucketProperty(ImmutableList.of("id"), 4, ImmutableList.of(), HIVE_COMPATIBLE, Optional.empty())));
         // write a 4-bucket partition
-        MaterializedResult.Builder bucket4Builder = MaterializedResult.resultBuilder(SESSION.toConnectorSession(), BIGINT, VARCHAR, VARCHAR);
+        MaterializedResult.Builder bucket4Builder = MaterializedResult.resultBuilder(CONNECTOR_SESSION, BIGINT, VARCHAR, VARCHAR);
         IntStream.range(0, rowCount).forEach(i -> bucket4Builder.row((long) i, String.valueOf(i), "four"));
         insertData(tableName, bucket4Builder.build());
         // write a 16-bucket partition
         alterBucketProperty(tableName, Optional.of(new HiveBucketProperty(ImmutableList.of("id"), 16, ImmutableList.of(), HIVE_COMPATIBLE, Optional.empty())));
-        MaterializedResult.Builder bucket16Builder = MaterializedResult.resultBuilder(SESSION.toConnectorSession(), BIGINT, VARCHAR, VARCHAR);
+        MaterializedResult.Builder bucket16Builder = MaterializedResult.resultBuilder(CONNECTOR_SESSION, BIGINT, VARCHAR, VARCHAR);
         IntStream.range(0, rowCount).forEach(i -> bucket16Builder.row((long) i, String.valueOf(i), "sixteen"));
         insertData(tableName, bucket16Builder.build());
         // write an 8-bucket partition
         alterBucketProperty(tableName, Optional.of(new HiveBucketProperty(ImmutableList.of("id"), 8, ImmutableList.of(), HIVE_COMPATIBLE, Optional.empty())));
-        MaterializedResult.Builder bucket8Builder = MaterializedResult.resultBuilder(SESSION.toConnectorSession(), BIGINT, VARCHAR, VARCHAR);
+        MaterializedResult.Builder bucket8Builder = MaterializedResult.resultBuilder(CONNECTOR_SESSION, BIGINT, VARCHAR, VARCHAR);
         IntStream.range(0, rowCount).forEach(i -> bucket8Builder.row((long) i, String.valueOf(i), "eight"));
         insertData(tableName, bucket8Builder.build());
 
@@ -3196,7 +3196,7 @@ public abstract class AbstractTestHiveClient
         List<ColumnMetadata> columns = TEMPORARY_TABLE_COLUMNS;
         List<String> bucketingColumns = TEMPORARY_TABLE_BUCKET_COLUMNS;
         int bucketCount = TEMPORARY_TABLE_BUCKET_COUNT;
-        MaterializedResult singleRow = MaterializedResult.resultBuilder(SESSION.toConnectorSession(), VARCHAR, VARCHAR)
+        MaterializedResult singleRow = MaterializedResult.resultBuilder(CONNECTOR_SESSION, VARCHAR, VARCHAR)
                 .row("1", "value1")
                 .build();
         ConnectorSession session = newSession();
@@ -3263,7 +3263,7 @@ public abstract class AbstractTestHiveClient
                 TEMPORARY_TABLE_COLUMNS,
                 TEMPORARY_TABLE_BUCKET_COUNT,
                 TEMPORARY_TABLE_BUCKET_COLUMNS,
-                MaterializedResult.resultBuilder(SESSION.toConnectorSession(), VARCHAR, VARCHAR).build(),
+                MaterializedResult.resultBuilder(CONNECTOR_SESSION, VARCHAR, VARCHAR).build(),
                 session,
                 commit);
 
@@ -4054,7 +4054,7 @@ public abstract class AbstractTestHiveClient
         // creating the table
         doCreateEmptyTable(tableName, storageFormat, CREATE_TABLE_COLUMNS);
 
-        MaterializedResult.Builder resultBuilder = MaterializedResult.resultBuilder(SESSION.toConnectorSession(), CREATE_TABLE_DATA.getTypes());
+        MaterializedResult.Builder resultBuilder = MaterializedResult.resultBuilder(CONNECTOR_SESSION, CREATE_TABLE_DATA.getTypes());
         for (int i = 0; i < 3; i++) {
             insertData(tableName, CREATE_TABLE_DATA);
 
@@ -4410,7 +4410,7 @@ public abstract class AbstractTestHiveClient
         // creating the table
         doCreateEmptyTable(tableName, storageFormat, CREATE_TABLE_COLUMNS_PARTITIONED);
 
-        MaterializedResult.Builder resultBuilder = MaterializedResult.resultBuilder(SESSION.toConnectorSession(), CREATE_TABLE_PARTITIONED_DATA.getTypes());
+        MaterializedResult.Builder resultBuilder = MaterializedResult.resultBuilder(CONNECTOR_SESSION, CREATE_TABLE_PARTITIONED_DATA.getTypes());
         for (int i = 0; i < 3; i++) {
             // insert the data
             insertData(tableName, CREATE_TABLE_PARTITIONED_DATA);
@@ -4660,7 +4660,7 @@ public abstract class AbstractTestHiveClient
 
         insertData(tableName, CREATE_TABLE_PARTITIONED_DATA);
 
-        MaterializedResult.Builder expectedResultBuilder = MaterializedResult.resultBuilder(SESSION.toConnectorSession(), CREATE_TABLE_PARTITIONED_DATA.getTypes());
+        MaterializedResult.Builder expectedResultBuilder = MaterializedResult.resultBuilder(CONNECTOR_SESSION, CREATE_TABLE_PARTITIONED_DATA.getTypes());
         expectedResultBuilder.rows(CREATE_TABLE_PARTITIONED_DATA.getMaterializedRows());
 
         try (Transaction transaction = newTransaction()) {
@@ -4866,7 +4866,7 @@ public abstract class AbstractTestHiveClient
                         assertNull(row.getField(index));
                     }
                     else {
-                        SqlTimestamp expected = sqlTimestampOf(2011, 5, 6, 7, 8, 9, 123, timeZone, UTC_KEY, SESSION.toConnectorSession());
+                        SqlTimestamp expected = sqlTimestampOf(2011, 5, 6, 7, 8, 9, 123, timeZone, UTC_KEY, CONNECTOR_SESSION);
                         assertEquals(row.getField(index), expected);
                     }
                 }
@@ -5450,7 +5450,7 @@ public abstract class AbstractTestHiveClient
         // There are 12 partitions in this test, 3 for each type.
         // 3 is chosen to verify that cleanups, commit aborts, rollbacks are always as complete as possible regardless of failure.
         MaterializedResult beforeData =
-                MaterializedResult.resultBuilder(SESSION, BIGINT, createUnboundedVarcharType(), createUnboundedVarcharType())
+                MaterializedResult.resultBuilder(CONNECTOR_SESSION, BIGINT, createUnboundedVarcharType(), createUnboundedVarcharType())
                         .row(110L, "a", "alter1")
                         .row(120L, "a", "insert1")
                         .row(140L, "a", "drop1")
@@ -5467,7 +5467,7 @@ public abstract class AbstractTestHiveClient
                 false);
         List<MaterializedRow> extraRowsForInsertExisting = ImmutableList.of();
         if (allowInsertExisting) {
-            extraRowsForInsertExisting = MaterializedResult.resultBuilder(SESSION, BIGINT, createUnboundedVarcharType(), createUnboundedVarcharType())
+            extraRowsForInsertExisting = MaterializedResult.resultBuilder(CONNECTOR_SESSION, BIGINT, createUnboundedVarcharType(), createUnboundedVarcharType())
                     .row(121L, "a", "insert1")
                     .row(611L, "f", "insert2")
                     .row(621L, "f", "insert3")
@@ -5475,7 +5475,7 @@ public abstract class AbstractTestHiveClient
                     .getMaterializedRows();
         }
         MaterializedResult insertData =
-                MaterializedResult.resultBuilder(SESSION, BIGINT, createUnboundedVarcharType(), createUnboundedVarcharType())
+                MaterializedResult.resultBuilder(CONNECTOR_SESSION, BIGINT, createUnboundedVarcharType(), createUnboundedVarcharType())
                         .row(111L, "a", "alter1")
                         .row(131L, "a", "add1")
                         .row(221L, "b", "add2")
@@ -5485,7 +5485,7 @@ public abstract class AbstractTestHiveClient
                         .rows(extraRowsForInsertExisting)
                         .build();
         MaterializedResult afterData =
-                MaterializedResult.resultBuilder(SESSION, BIGINT, createUnboundedVarcharType(), createUnboundedVarcharType())
+                MaterializedResult.resultBuilder(CONNECTOR_SESSION, BIGINT, createUnboundedVarcharType(), createUnboundedVarcharType())
                         .row(120L, "a", "insert1")
                         .row(610L, "f", "insert2")
                         .row(620L, "f", "insert3")

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileFormats.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileFormats.java
@@ -103,8 +103,8 @@ import static com.facebook.presto.hive.HiveColumnHandle.ColumnType.REGULAR;
 import static com.facebook.presto.hive.HiveManifestUtils.getFileSize;
 import static com.facebook.presto.hive.HiveStorageFormat.DWRF;
 import static com.facebook.presto.hive.HiveStorageFormat.ORC;
+import static com.facebook.presto.hive.HiveTestUtils.CONNECTOR_SESSION;
 import static com.facebook.presto.hive.HiveTestUtils.FUNCTION_AND_TYPE_MANAGER;
-import static com.facebook.presto.hive.HiveTestUtils.SESSION;
 import static com.facebook.presto.hive.HiveTestUtils.mapType;
 import static com.facebook.presto.hive.HiveUtil.isStructuralType;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.HIVE_DEFAULT_DYNAMIC_PARTITION;
@@ -732,7 +732,7 @@ public abstract class AbstractTestHiveFileFormats
             throws IOException
     {
         try {
-            MaterializedResult result = materializeSourceDataStream(SESSION.toConnectorSession(), pageSource, types);
+            MaterializedResult result = materializeSourceDataStream(CONNECTOR_SESSION, pageSource, types);
             assertEquals(result.getMaterializedRows().size(), rowCount);
             for (MaterializedRow row : result) {
                 for (int i = 0, testColumnsSize = testColumns.size(); i < testColumnsSize; i++) {
@@ -765,7 +765,7 @@ public abstract class AbstractTestHiveFileFormats
                         assertEquals(actualValue, expectedValue);
                     }
                     else if (testColumn.getObjectInspector().getTypeName().equals("timestamp")) {
-                        SqlTimestamp expectedTimestamp = sqlTimestampOf((Long) expectedValue, SESSION.toConnectorSession());
+                        SqlTimestamp expectedTimestamp = sqlTimestampOf((Long) expectedValue, CONNECTOR_SESSION);
                         assertEquals(actualValue, expectedTimestamp, "Wrong value for column " + testColumn.getName());
                     }
                     else if (testColumn.getObjectInspector().getTypeName().startsWith("char")) {
@@ -791,7 +791,7 @@ public abstract class AbstractTestHiveFileFormats
                     else {
                         BlockBuilder builder = type.createBlockBuilder(null, 1);
                         type.writeObject(builder, expectedValue);
-                        expectedValue = type.getObjectValue(SESSION.toConnectorSession().getSqlFunctionProperties(), builder.build(), 0);
+                        expectedValue = type.getObjectValue(CONNECTOR_SESSION.getSqlFunctionProperties(), builder.build(), 0);
                         assertEquals(actualValue, expectedValue, "Wrong value for column " + testColumn.getName());
                     }
                 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileFormats.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileFormats.java
@@ -732,7 +732,7 @@ public abstract class AbstractTestHiveFileFormats
             throws IOException
     {
         try {
-            MaterializedResult result = materializeSourceDataStream(SESSION, pageSource, types);
+            MaterializedResult result = materializeSourceDataStream(SESSION.toConnectorSession(), pageSource, types);
             assertEquals(result.getMaterializedRows().size(), rowCount);
             for (MaterializedRow row : result) {
                 for (int i = 0, testColumnsSize = testColumns.size(); i < testColumnsSize; i++) {
@@ -765,7 +765,7 @@ public abstract class AbstractTestHiveFileFormats
                         assertEquals(actualValue, expectedValue);
                     }
                     else if (testColumn.getObjectInspector().getTypeName().equals("timestamp")) {
-                        SqlTimestamp expectedTimestamp = sqlTimestampOf((Long) expectedValue, SESSION);
+                        SqlTimestamp expectedTimestamp = sqlTimestampOf((Long) expectedValue, SESSION.toConnectorSession());
                         assertEquals(actualValue, expectedTimestamp, "Wrong value for column " + testColumn.getName());
                     }
                     else if (testColumn.getObjectInspector().getTypeName().startsWith("char")) {
@@ -791,7 +791,7 @@ public abstract class AbstractTestHiveFileFormats
                     else {
                         BlockBuilder builder = type.createBlockBuilder(null, 1);
                         type.writeObject(builder, expectedValue);
-                        expectedValue = type.getObjectValue(SESSION.getSqlFunctionProperties(), builder.build(), 0);
+                        expectedValue = type.getObjectValue(SESSION.toConnectorSession().getSqlFunctionProperties(), builder.build(), 0);
                         assertEquals(actualValue, expectedValue, "Wrong value for column " + testColumn.getName());
                     }
                 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/HiveTestUtils.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/HiveTestUtils.java
@@ -16,6 +16,7 @@ package com.facebook.presto.hive;
 import com.facebook.airlift.json.JsonCodec;
 import com.facebook.airlift.json.smile.SmileCodec;
 import com.facebook.presto.PagesIndexPageSorter;
+import com.facebook.presto.Session;
 import com.facebook.presto.common.block.BlockEncodingManager;
 import com.facebook.presto.common.type.ArrayType;
 import com.facebook.presto.common.type.MapType;
@@ -45,6 +46,7 @@ import com.facebook.presto.hive.s3.HiveS3Config;
 import com.facebook.presto.hive.s3.PrestoS3ConfigurationUpdater;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
 import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.metadata.SessionPropertyManager;
 import com.facebook.presto.operator.PagesIndex;
 import com.facebook.presto.orc.StorageStripeMetadataSource;
 import com.facebook.presto.orc.cache.StorageOrcFileTailSource;
@@ -66,7 +68,7 @@ import com.facebook.presto.sql.relational.FunctionResolution;
 import com.facebook.presto.sql.relational.RowExpressionDeterminismEvaluator;
 import com.facebook.presto.sql.relational.RowExpressionDomainTranslator;
 import com.facebook.presto.sql.relational.RowExpressionOptimizer;
-import com.facebook.presto.testing.TestingConnectorSession;
+import com.facebook.presto.testing.TestingSession;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.slice.Slice;
@@ -90,8 +92,10 @@ public final class HiveTestUtils
     public static final JsonCodec<PartitionUpdate> PARTITION_UPDATE_CODEC = jsonCodec(PartitionUpdate.class);
     public static final SmileCodec<PartitionUpdate> PARTITION_UPDATE_SMILE_CODEC = smileCodec(PartitionUpdate.class);
 
-    public static final ConnectorSession SESSION = new TestingConnectorSession(
-            new HiveSessionProperties(new HiveClientConfig(), new OrcFileWriterConfig(), new ParquetFileWriterConfig()).getSessionProperties());
+    public static final Session SESSION = TestingSession.testSessionBuilder(
+            new SessionPropertyManager(
+                    new HiveSessionProperties(new HiveClientConfig(), new OrcFileWriterConfig(), new ParquetFileWriterConfig()).getSessionProperties()
+            )).build();
 
     public static final MetadataManager METADATA = MetadataManager.createTestMetadataManager();
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/HiveTestUtils.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/HiveTestUtils.java
@@ -52,6 +52,7 @@ import com.facebook.presto.orc.StorageStripeMetadataSource;
 import com.facebook.presto.orc.cache.StorageOrcFileTailSource;
 import com.facebook.presto.parquet.cache.MetadataReader;
 import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.PageSorter;
 import com.facebook.presto.spi.function.StandardFunctionResolution;
@@ -68,7 +69,6 @@ import com.facebook.presto.sql.relational.FunctionResolution;
 import com.facebook.presto.sql.relational.RowExpressionDeterminismEvaluator;
 import com.facebook.presto.sql.relational.RowExpressionDomainTranslator;
 import com.facebook.presto.sql.relational.RowExpressionOptimizer;
-import com.facebook.presto.testing.TestingSession;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.slice.Slice;
@@ -92,10 +92,12 @@ public final class HiveTestUtils
     public static final JsonCodec<PartitionUpdate> PARTITION_UPDATE_CODEC = jsonCodec(PartitionUpdate.class);
     public static final SmileCodec<PartitionUpdate> PARTITION_UPDATE_SMILE_CODEC = smileCodec(PartitionUpdate.class);
 
-    public static final Session SESSION = TestingSession.testSessionBuilder(
+    public static final Session SESSION = Session.builder(
             new SessionPropertyManager(
                     new HiveSessionProperties(new HiveClientConfig(), new OrcFileWriterConfig(), new ParquetFileWriterConfig()).getSessionProperties()
             )).build();
+
+    public static final ConnectorSession CONNECTOR_SESSION = SESSION.toConnectorSession(new ConnectorId(SESSION.getCatalog().get()));
 
     public static final MetadataManager METADATA = MetadataManager.createTestMetadataManager();
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestAbstractDwrfEncryptionInformationSource.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestAbstractDwrfEncryptionInformationSource.java
@@ -32,7 +32,7 @@ import static com.facebook.presto.hive.DwrfTableEncryptionProperties.forTable;
 import static com.facebook.presto.hive.HiveColumnHandle.ColumnType.REGULAR;
 import static com.facebook.presto.hive.HiveStorageFormat.DWRF;
 import static com.facebook.presto.hive.HiveStorageFormat.ORC;
-import static com.facebook.presto.hive.HiveTestUtils.SESSION;
+import static com.facebook.presto.hive.HiveTestUtils.CONNECTOR_SESSION;
 import static com.facebook.presto.hive.HiveType.HIVE_LONG;
 import static com.facebook.presto.hive.HiveType.HIVE_STRING;
 import static com.facebook.presto.hive.TestDwrfEncryptionInformationSource.TEST_EXTRA_METADATA;
@@ -76,17 +76,17 @@ public class TestAbstractDwrfEncryptionInformationSource
     public void testNotDwrfTable()
     {
         Table table = createTable(ORC, Optional.of(forTable("foo", "AES_GCM_256", "TEST")), true);
-        assertFalse(encryptionInformationSource.getReadEncryptionInformation(SESSION.toConnectorSession(), table, Optional.of(ImmutableSet.of()), ImmutableMap.of()).isPresent());
-        assertFalse(encryptionInformationSource.getReadEncryptionInformation(SESSION.toConnectorSession(), table, Optional.of(ImmutableSet.of())).isPresent());
-        assertFalse(encryptionInformationSource.getWriteEncryptionInformation(SESSION.toConnectorSession(), new NonDwrfTableEncryptionProperties(), "db", "table").isPresent());
+        assertFalse(encryptionInformationSource.getReadEncryptionInformation(CONNECTOR_SESSION, table, Optional.of(ImmutableSet.of()), ImmutableMap.of()).isPresent());
+        assertFalse(encryptionInformationSource.getReadEncryptionInformation(CONNECTOR_SESSION, table, Optional.of(ImmutableSet.of())).isPresent());
+        assertFalse(encryptionInformationSource.getWriteEncryptionInformation(CONNECTOR_SESSION, new NonDwrfTableEncryptionProperties(), "db", "table").isPresent());
     }
 
     @Test
     public void testNotEncryptedTable()
     {
         Table table = createTable(DWRF, Optional.empty(), true);
-        assertFalse(encryptionInformationSource.getReadEncryptionInformation(SESSION.toConnectorSession(), table, Optional.of(ImmutableSet.of()), ImmutableMap.of()).isPresent());
-        assertFalse(encryptionInformationSource.getReadEncryptionInformation(SESSION.toConnectorSession(), table, Optional.of(ImmutableSet.of())).isPresent());
+        assertFalse(encryptionInformationSource.getReadEncryptionInformation(CONNECTOR_SESSION, table, Optional.of(ImmutableSet.of()), ImmutableMap.of()).isPresent());
+        assertFalse(encryptionInformationSource.getReadEncryptionInformation(CONNECTOR_SESSION, table, Optional.of(ImmutableSet.of())).isPresent());
     }
 
     @Test
@@ -94,7 +94,7 @@ public class TestAbstractDwrfEncryptionInformationSource
     {
         Table table = createTable(DWRF, Optional.of(forTable("table_level_key", "algo", "provider")), true);
         Optional<Map<String, EncryptionInformation>> encryptionInformation = encryptionInformationSource.getReadEncryptionInformation(
-                SESSION.toConnectorSession(),
+                CONNECTOR_SESSION,
                 table,
                 Optional.of(ImmutableSet.of(
                         // hiveColumnIndex value does not matter in this test
@@ -125,7 +125,7 @@ public class TestAbstractDwrfEncryptionInformationSource
     {
         Table table = createTable(DWRF, Optional.of(forTable("key1", "algo", "provider")), true);
         Optional<Map<String, EncryptionInformation>> encryptionInformation = encryptionInformationSource.getReadEncryptionInformation(
-                SESSION.toConnectorSession(),
+                CONNECTOR_SESSION,
                 table,
                 Optional.of(ImmutableSet.of()),
                 ImmutableMap.of(
@@ -145,7 +145,7 @@ public class TestAbstractDwrfEncryptionInformationSource
     {
         Table table = createTable(DWRF, Optional.of(forPerColumn(fromHiveProperty("key1:col_string,col_struct.b.b2;key2:col_bigint,col_struct.a"), "algo", "provider")), true);
         Optional<Map<String, EncryptionInformation>> encryptionInformation = encryptionInformationSource.getReadEncryptionInformation(
-                SESSION.toConnectorSession(),
+                CONNECTOR_SESSION,
                 table,
                 Optional.of(ImmutableSet.of(
                         // hiveColumnIndex value does not matter in this test
@@ -178,7 +178,7 @@ public class TestAbstractDwrfEncryptionInformationSource
     {
         Table table = createTable(DWRF, Optional.of(forPerColumn(fromHiveProperty("key1:col_string,col_struct.b.b2;key2:col_bigint,col_struct.a"), "algo", "provider")), false);
         Optional<EncryptionInformation> encryptionInformation = encryptionInformationSource.getReadEncryptionInformation(
-                SESSION.toConnectorSession(),
+                CONNECTOR_SESSION,
                 table,
                 Optional.of(ImmutableSet.of(
                         // hiveColumnIndex value does not matter in this test
@@ -204,7 +204,7 @@ public class TestAbstractDwrfEncryptionInformationSource
     @Test
     public void testGetWriteEncryptionInformation()
     {
-        Optional<EncryptionInformation> encryptionInformation = encryptionInformationSource.getWriteEncryptionInformation(SESSION.toConnectorSession(), forTable("table_level", "algo", "provider"), "dbName", "tableName");
+        Optional<EncryptionInformation> encryptionInformation = encryptionInformationSource.getWriteEncryptionInformation(CONNECTOR_SESSION, forTable("table_level", "algo", "provider"), "dbName", "tableName");
         assertTrue(encryptionInformation.isPresent());
         assertEquals(
                 encryptionInformation.get(),

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestAbstractDwrfEncryptionInformationSource.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestAbstractDwrfEncryptionInformationSource.java
@@ -76,17 +76,17 @@ public class TestAbstractDwrfEncryptionInformationSource
     public void testNotDwrfTable()
     {
         Table table = createTable(ORC, Optional.of(forTable("foo", "AES_GCM_256", "TEST")), true);
-        assertFalse(encryptionInformationSource.getReadEncryptionInformation(SESSION, table, Optional.of(ImmutableSet.of()), ImmutableMap.of()).isPresent());
-        assertFalse(encryptionInformationSource.getReadEncryptionInformation(SESSION, table, Optional.of(ImmutableSet.of())).isPresent());
-        assertFalse(encryptionInformationSource.getWriteEncryptionInformation(SESSION, new NonDwrfTableEncryptionProperties(), "db", "table").isPresent());
+        assertFalse(encryptionInformationSource.getReadEncryptionInformation(SESSION.toConnectorSession(), table, Optional.of(ImmutableSet.of()), ImmutableMap.of()).isPresent());
+        assertFalse(encryptionInformationSource.getReadEncryptionInformation(SESSION.toConnectorSession(), table, Optional.of(ImmutableSet.of())).isPresent());
+        assertFalse(encryptionInformationSource.getWriteEncryptionInformation(SESSION.toConnectorSession(), new NonDwrfTableEncryptionProperties(), "db", "table").isPresent());
     }
 
     @Test
     public void testNotEncryptedTable()
     {
         Table table = createTable(DWRF, Optional.empty(), true);
-        assertFalse(encryptionInformationSource.getReadEncryptionInformation(SESSION, table, Optional.of(ImmutableSet.of()), ImmutableMap.of()).isPresent());
-        assertFalse(encryptionInformationSource.getReadEncryptionInformation(SESSION, table, Optional.of(ImmutableSet.of())).isPresent());
+        assertFalse(encryptionInformationSource.getReadEncryptionInformation(SESSION.toConnectorSession(), table, Optional.of(ImmutableSet.of()), ImmutableMap.of()).isPresent());
+        assertFalse(encryptionInformationSource.getReadEncryptionInformation(SESSION.toConnectorSession(), table, Optional.of(ImmutableSet.of())).isPresent());
     }
 
     @Test
@@ -94,7 +94,7 @@ public class TestAbstractDwrfEncryptionInformationSource
     {
         Table table = createTable(DWRF, Optional.of(forTable("table_level_key", "algo", "provider")), true);
         Optional<Map<String, EncryptionInformation>> encryptionInformation = encryptionInformationSource.getReadEncryptionInformation(
-                SESSION,
+                SESSION.toConnectorSession(),
                 table,
                 Optional.of(ImmutableSet.of(
                         // hiveColumnIndex value does not matter in this test
@@ -125,7 +125,7 @@ public class TestAbstractDwrfEncryptionInformationSource
     {
         Table table = createTable(DWRF, Optional.of(forTable("key1", "algo", "provider")), true);
         Optional<Map<String, EncryptionInformation>> encryptionInformation = encryptionInformationSource.getReadEncryptionInformation(
-                SESSION,
+                SESSION.toConnectorSession(),
                 table,
                 Optional.of(ImmutableSet.of()),
                 ImmutableMap.of(
@@ -145,7 +145,7 @@ public class TestAbstractDwrfEncryptionInformationSource
     {
         Table table = createTable(DWRF, Optional.of(forPerColumn(fromHiveProperty("key1:col_string,col_struct.b.b2;key2:col_bigint,col_struct.a"), "algo", "provider")), true);
         Optional<Map<String, EncryptionInformation>> encryptionInformation = encryptionInformationSource.getReadEncryptionInformation(
-                SESSION,
+                SESSION.toConnectorSession(),
                 table,
                 Optional.of(ImmutableSet.of(
                         // hiveColumnIndex value does not matter in this test
@@ -178,7 +178,7 @@ public class TestAbstractDwrfEncryptionInformationSource
     {
         Table table = createTable(DWRF, Optional.of(forPerColumn(fromHiveProperty("key1:col_string,col_struct.b.b2;key2:col_bigint,col_struct.a"), "algo", "provider")), false);
         Optional<EncryptionInformation> encryptionInformation = encryptionInformationSource.getReadEncryptionInformation(
-                SESSION,
+                SESSION.toConnectorSession(),
                 table,
                 Optional.of(ImmutableSet.of(
                         // hiveColumnIndex value does not matter in this test
@@ -204,7 +204,7 @@ public class TestAbstractDwrfEncryptionInformationSource
     @Test
     public void testGetWriteEncryptionInformation()
     {
-        Optional<EncryptionInformation> encryptionInformation = encryptionInformationSource.getWriteEncryptionInformation(SESSION, forTable("table_level", "algo", "provider"), "dbName", "tableName");
+        Optional<EncryptionInformation> encryptionInformation = encryptionInformationSource.getWriteEncryptionInformation(SESSION.toConnectorSession(), forTable("table_level", "algo", "provider"), "dbName", "tableName");
         assertTrue(encryptionInformation.isPresent());
         assertEquals(
                 encryptionInformation.get(),

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestBackgroundHiveSplitLoader.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestBackgroundHiveSplitLoader.java
@@ -70,7 +70,7 @@ import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.hive.BucketFunctionType.HIVE_COMPATIBLE;
 import static com.facebook.presto.hive.CacheQuotaScope.GLOBAL;
 import static com.facebook.presto.hive.HiveSessionProperties.getMaxInitialSplitSize;
-import static com.facebook.presto.hive.HiveTestUtils.SESSION;
+import static com.facebook.presto.hive.HiveTestUtils.CONNECTOR_SESSION;
 import static com.facebook.presto.hive.HiveType.HIVE_INT;
 import static com.facebook.presto.hive.HiveType.HIVE_STRING;
 import static com.facebook.presto.hive.HiveUtil.getRegularColumnHandles;
@@ -254,7 +254,7 @@ public class TestBackgroundHiveSplitLoader
     public void testSplittableNotCheckedOnSmallFiles()
             throws Exception
     {
-        DataSize initialSplitSize = getMaxInitialSplitSize(SESSION.toConnectorSession());
+        DataSize initialSplitSize = getMaxInitialSplitSize(CONNECTOR_SESSION);
 
         Table.Builder builder = Table.builder(table(ImmutableList.of(), Optional.empty()));
         builder.getStorageBuilder().setStorageFormat(
@@ -263,7 +263,7 @@ public class TestBackgroundHiveSplitLoader
 
         //  Exactly minimum split size, no isSplittable check
         BackgroundHiveSplitLoader backgroundHiveSplitLoader = backgroundHiveSplitLoader(
-                SESSION.toConnectorSession(),
+                CONNECTOR_SESSION,
                 ImmutableList.of(locatedFileStatus(new Path(SAMPLE_PATH), initialSplitSize.toBytes())),
                 Optional.empty(),
                 Optional.empty(),
@@ -277,7 +277,7 @@ public class TestBackgroundHiveSplitLoader
 
         //  Large enough for isSplittable to be called
         backgroundHiveSplitLoader = backgroundHiveSplitLoader(
-                SESSION.toConnectorSession(),
+                CONNECTOR_SESSION,
                 ImmutableList.of(locatedFileStatus(new Path(SAMPLE_PATH), initialSplitSize.toBytes() + 1)),
                 Optional.empty(),
                 Optional.empty(),
@@ -570,7 +570,7 @@ public class TestBackgroundHiveSplitLoader
     private static HiveSplitSource hiveSplitSource(BackgroundHiveSplitLoader backgroundHiveSplitLoader)
     {
         return HiveSplitSource.allAtOnce(
-                SESSION.toConnectorSession(),
+                CONNECTOR_SESSION,
                 SIMPLE_TABLE.getDatabaseName(),
                 SIMPLE_TABLE.getTableName(),
                 new CacheQuotaRequirement(GLOBAL, Optional.empty()),

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestBackgroundHiveSplitLoader.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestBackgroundHiveSplitLoader.java
@@ -254,7 +254,7 @@ public class TestBackgroundHiveSplitLoader
     public void testSplittableNotCheckedOnSmallFiles()
             throws Exception
     {
-        DataSize initialSplitSize = getMaxInitialSplitSize(SESSION);
+        DataSize initialSplitSize = getMaxInitialSplitSize(SESSION.toConnectorSession());
 
         Table.Builder builder = Table.builder(table(ImmutableList.of(), Optional.empty()));
         builder.getStorageBuilder().setStorageFormat(
@@ -263,7 +263,7 @@ public class TestBackgroundHiveSplitLoader
 
         //  Exactly minimum split size, no isSplittable check
         BackgroundHiveSplitLoader backgroundHiveSplitLoader = backgroundHiveSplitLoader(
-                SESSION,
+                SESSION.toConnectorSession(),
                 ImmutableList.of(locatedFileStatus(new Path(SAMPLE_PATH), initialSplitSize.toBytes())),
                 Optional.empty(),
                 Optional.empty(),
@@ -277,7 +277,7 @@ public class TestBackgroundHiveSplitLoader
 
         //  Large enough for isSplittable to be called
         backgroundHiveSplitLoader = backgroundHiveSplitLoader(
-                SESSION,
+                SESSION.toConnectorSession(),
                 ImmutableList.of(locatedFileStatus(new Path(SAMPLE_PATH), initialSplitSize.toBytes() + 1)),
                 Optional.empty(),
                 Optional.empty(),
@@ -570,7 +570,7 @@ public class TestBackgroundHiveSplitLoader
     private static HiveSplitSource hiveSplitSource(BackgroundHiveSplitLoader backgroundHiveSplitLoader)
     {
         return HiveSplitSource.allAtOnce(
-                SESSION,
+                SESSION.toConnectorSession(),
                 SIMPLE_TABLE.getDatabaseName(),
                 SIMPLE_TABLE.getTableName(),
                 new CacheQuotaRequirement(GLOBAL, Optional.empty()),

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveEncryptionInformationProvider.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveEncryptionInformationProvider.java
@@ -61,7 +61,7 @@ public class TestHiveEncryptionInformationProvider
                 new TestEncryptionInformationSource(Optional.empty()),
                 new TestEncryptionInformationSource(Optional.empty())));
 
-        assertFalse(provider.getReadEncryptionInformation(SESSION, TEST_TABLE, Optional.empty()).isPresent());
+        assertFalse(provider.getReadEncryptionInformation(SESSION.toConnectorSession(), TEST_TABLE, Optional.empty()).isPresent());
     }
 
     @Test
@@ -76,7 +76,7 @@ public class TestHiveEncryptionInformationProvider
                 new TestEncryptionInformationSource(Optional.of(encryptionInformation1)),
                 new TestEncryptionInformationSource(Optional.of(encryptionInformation2))));
 
-        assertEquals(provider.getReadEncryptionInformation(SESSION, TEST_TABLE, Optional.empty()).get(), encryptionInformation1);
+        assertEquals(provider.getReadEncryptionInformation(SESSION.toConnectorSession(), TEST_TABLE, Optional.empty()).get(), encryptionInformation1);
     }
 
     private static final class TestEncryptionInformationSource

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveEncryptionInformationProvider.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveEncryptionInformationProvider.java
@@ -25,7 +25,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import static com.facebook.presto.hive.HiveTestUtils.SESSION;
+import static com.facebook.presto.hive.HiveTestUtils.CONNECTOR_SESSION;
 import static com.facebook.presto.hive.metastore.PrestoTableType.MANAGED_TABLE;
 import static com.facebook.presto.hive.metastore.StorageFormat.VIEW_STORAGE_FORMAT;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
@@ -61,7 +61,7 @@ public class TestHiveEncryptionInformationProvider
                 new TestEncryptionInformationSource(Optional.empty()),
                 new TestEncryptionInformationSource(Optional.empty())));
 
-        assertFalse(provider.getReadEncryptionInformation(SESSION.toConnectorSession(), TEST_TABLE, Optional.empty()).isPresent());
+        assertFalse(provider.getReadEncryptionInformation(CONNECTOR_SESSION, TEST_TABLE, Optional.empty()).isPresent());
     }
 
     @Test
@@ -76,7 +76,7 @@ public class TestHiveEncryptionInformationProvider
                 new TestEncryptionInformationSource(Optional.of(encryptionInformation1)),
                 new TestEncryptionInformationSource(Optional.of(encryptionInformation2))));
 
-        assertEquals(provider.getReadEncryptionInformation(SESSION.toConnectorSession(), TEST_TABLE, Optional.empty()).get(), encryptionInformation1);
+        assertEquals(provider.getReadEncryptionInformation(CONNECTOR_SESSION, TEST_TABLE, Optional.empty()).get(), encryptionInformation1);
     }
 
     private static final class TestEncryptionInformationSource

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveFileFormats.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveFileFormats.java
@@ -1070,7 +1070,7 @@ public class TestHiveFileFormats
         private HiveCompressionCodec compressionCodec = HiveCompressionCodec.NONE;
         private List<TestColumn> writeColumns;
         private List<TestColumn> readColumns;
-        private ConnectorSession session = SESSION;
+        private ConnectorSession session = SESSION.toConnectorSession();
         private int rowsCount = 1000;
         private HiveFileWriterFactory fileWriterFactory;
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveFileFormats.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveFileFormats.java
@@ -88,12 +88,12 @@ import static com.facebook.presto.hive.HiveStorageFormat.RCBINARY;
 import static com.facebook.presto.hive.HiveStorageFormat.RCTEXT;
 import static com.facebook.presto.hive.HiveStorageFormat.SEQUENCEFILE;
 import static com.facebook.presto.hive.HiveStorageFormat.TEXTFILE;
+import static com.facebook.presto.hive.HiveTestUtils.CONNECTOR_SESSION;
 import static com.facebook.presto.hive.HiveTestUtils.FUNCTION_AND_TYPE_MANAGER;
 import static com.facebook.presto.hive.HiveTestUtils.FUNCTION_RESOLUTION;
 import static com.facebook.presto.hive.HiveTestUtils.HDFS_ENVIRONMENT;
 import static com.facebook.presto.hive.HiveTestUtils.HIVE_CLIENT_CONFIG;
 import static com.facebook.presto.hive.HiveTestUtils.ROW_EXPRESSION_SERVICE;
-import static com.facebook.presto.hive.HiveTestUtils.SESSION;
 import static com.facebook.presto.hive.HiveTestUtils.getTypes;
 import static com.facebook.presto.tests.StructuralTestUtil.arrayBlockOf;
 import static com.facebook.presto.tests.StructuralTestUtil.mapBlockOf;
@@ -1070,7 +1070,7 @@ public class TestHiveFileFormats
         private HiveCompressionCodec compressionCodec = HiveCompressionCodec.NONE;
         private List<TestColumn> writeColumns;
         private List<TestColumn> readColumns;
-        private ConnectorSession session = SESSION.toConnectorSession();
+        private ConnectorSession session = CONNECTOR_SESSION;
         private int rowsCount = 1000;
         private HiveFileWriterFactory fileWriterFactory;
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitSource.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitSource.java
@@ -40,7 +40,7 @@ import static com.facebook.presto.hive.CacheQuotaScope.GLOBAL;
 import static com.facebook.presto.hive.CacheQuotaScope.PARTITION;
 import static com.facebook.presto.hive.CacheQuotaScope.TABLE;
 import static com.facebook.presto.hive.HiveSessionProperties.getMaxInitialSplitSize;
-import static com.facebook.presto.hive.HiveTestUtils.SESSION;
+import static com.facebook.presto.hive.HiveTestUtils.CONNECTOR_SESSION;
 import static com.facebook.presto.spi.connector.NotPartitionedPartitionHandle.NOT_PARTITIONED;
 import static com.facebook.presto.spi.schedule.NodeSelectionStrategy.NO_PREFERENCE;
 import static io.airlift.units.DataSize.Unit.BYTE;
@@ -63,7 +63,7 @@ public class TestHiveSplitSource
     public void testOutstandingSplitCount()
     {
         HiveSplitSource hiveSplitSource = HiveSplitSource.allAtOnce(
-                SESSION.toConnectorSession(),
+                CONNECTOR_SESSION,
                 "database",
                 "table",
                 new CacheQuotaRequirement(TABLE, DEFAULT_QUOTA_SIZE),
@@ -96,9 +96,9 @@ public class TestHiveSplitSource
     @Test
     public void testEvenlySizedSplitRemainder()
     {
-        DataSize initialSplitSize = getMaxInitialSplitSize(SESSION.toConnectorSession());
+        DataSize initialSplitSize = getMaxInitialSplitSize(CONNECTOR_SESSION);
         HiveSplitSource hiveSplitSource = HiveSplitSource.allAtOnce(
-                SESSION.toConnectorSession(),
+                CONNECTOR_SESSION,
                 "database",
                 "table",
                 new CacheQuotaRequirement(TABLE, DEFAULT_QUOTA_SIZE),
@@ -126,7 +126,7 @@ public class TestHiveSplitSource
     {
         // CacheQuota: TABLE 1G for unbucked splits
         HiveSplitSource hiveSplitSource = HiveSplitSource.allAtOnce(
-                SESSION.toConnectorSession(),
+                CONNECTOR_SESSION,
                 "database",
                 "table",
                 new CacheQuotaRequirement(TABLE, DEFAULT_QUOTA_SIZE),
@@ -150,7 +150,7 @@ public class TestHiveSplitSource
 
         // CacheQuota: PARTITION Optional.empty() for bucketed splits
         hiveSplitSource = HiveSplitSource.bucketed(
-                SESSION.toConnectorSession(),
+                CONNECTOR_SESSION,
                 "database",
                 "table",
                 new CacheQuotaRequirement(PARTITION, Optional.empty()),
@@ -177,7 +177,7 @@ public class TestHiveSplitSource
     public void testFail()
     {
         HiveSplitSource hiveSplitSource = HiveSplitSource.allAtOnce(
-                SESSION.toConnectorSession(),
+                CONNECTOR_SESSION,
                 "database",
                 "table",
                 new CacheQuotaRequirement(GLOBAL, Optional.empty()),
@@ -235,7 +235,7 @@ public class TestHiveSplitSource
             throws Exception
     {
         HiveSplitSource hiveSplitSource = HiveSplitSource.allAtOnce(
-                SESSION.toConnectorSession(),
+                CONNECTOR_SESSION,
                 "database",
                 "table",
                 new CacheQuotaRequirement(GLOBAL, Optional.empty()),
@@ -289,7 +289,7 @@ public class TestHiveSplitSource
     {
         DataSize maxOutstandingSplitsSize = new DataSize(1, MEGABYTE);
         HiveSplitSource hiveSplitSource = HiveSplitSource.allAtOnce(
-                SESSION.toConnectorSession(),
+                CONNECTOR_SESSION,
                 "database",
                 "table",
                 new CacheQuotaRequirement(GLOBAL, Optional.empty()),
@@ -328,7 +328,7 @@ public class TestHiveSplitSource
     public void testEmptyBucket()
     {
         final HiveSplitSource hiveSplitSource = HiveSplitSource.bucketed(
-                SESSION.toConnectorSession(),
+                CONNECTOR_SESSION,
                 "database",
                 "table",
                 new CacheQuotaRequirement(GLOBAL, Optional.empty()),
@@ -351,7 +351,7 @@ public class TestHiveSplitSource
             throws Exception
     {
         HiveSplitSource hiveSplitSource = HiveSplitSource.bucketedRewindable(
-                SESSION.toConnectorSession(),
+                CONNECTOR_SESSION,
                 "database",
                 "table",
                 new CacheQuotaRequirement(GLOBAL, Optional.empty()),
@@ -410,7 +410,7 @@ public class TestHiveSplitSource
     public void testRewindOneBucket()
     {
         HiveSplitSource hiveSplitSource = HiveSplitSource.bucketedRewindable(
-                SESSION.toConnectorSession(),
+                CONNECTOR_SESSION,
                 "database",
                 "table",
                 new CacheQuotaRequirement(GLOBAL, Optional.empty()),
@@ -446,7 +446,7 @@ public class TestHiveSplitSource
     public void testRewindMultipleBuckets()
     {
         HiveSplitSource hiveSplitSource = HiveSplitSource.bucketedRewindable(
-                SESSION.toConnectorSession(),
+                CONNECTOR_SESSION,
                 "database",
                 "table",
                 new CacheQuotaRequirement(GLOBAL, Optional.empty()),

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitSource.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitSource.java
@@ -63,7 +63,7 @@ public class TestHiveSplitSource
     public void testOutstandingSplitCount()
     {
         HiveSplitSource hiveSplitSource = HiveSplitSource.allAtOnce(
-                SESSION,
+                SESSION.toConnectorSession(),
                 "database",
                 "table",
                 new CacheQuotaRequirement(TABLE, DEFAULT_QUOTA_SIZE),
@@ -96,9 +96,9 @@ public class TestHiveSplitSource
     @Test
     public void testEvenlySizedSplitRemainder()
     {
-        DataSize initialSplitSize = getMaxInitialSplitSize(SESSION);
+        DataSize initialSplitSize = getMaxInitialSplitSize(SESSION.toConnectorSession());
         HiveSplitSource hiveSplitSource = HiveSplitSource.allAtOnce(
-                SESSION,
+                SESSION.toConnectorSession(),
                 "database",
                 "table",
                 new CacheQuotaRequirement(TABLE, DEFAULT_QUOTA_SIZE),
@@ -126,7 +126,7 @@ public class TestHiveSplitSource
     {
         // CacheQuota: TABLE 1G for unbucked splits
         HiveSplitSource hiveSplitSource = HiveSplitSource.allAtOnce(
-                SESSION,
+                SESSION.toConnectorSession(),
                 "database",
                 "table",
                 new CacheQuotaRequirement(TABLE, DEFAULT_QUOTA_SIZE),
@@ -150,7 +150,7 @@ public class TestHiveSplitSource
 
         // CacheQuota: PARTITION Optional.empty() for bucketed splits
         hiveSplitSource = HiveSplitSource.bucketed(
-                SESSION,
+                SESSION.toConnectorSession(),
                 "database",
                 "table",
                 new CacheQuotaRequirement(PARTITION, Optional.empty()),
@@ -177,7 +177,7 @@ public class TestHiveSplitSource
     public void testFail()
     {
         HiveSplitSource hiveSplitSource = HiveSplitSource.allAtOnce(
-                SESSION,
+                SESSION.toConnectorSession(),
                 "database",
                 "table",
                 new CacheQuotaRequirement(GLOBAL, Optional.empty()),
@@ -235,7 +235,7 @@ public class TestHiveSplitSource
             throws Exception
     {
         HiveSplitSource hiveSplitSource = HiveSplitSource.allAtOnce(
-                SESSION,
+                SESSION.toConnectorSession(),
                 "database",
                 "table",
                 new CacheQuotaRequirement(GLOBAL, Optional.empty()),
@@ -289,7 +289,7 @@ public class TestHiveSplitSource
     {
         DataSize maxOutstandingSplitsSize = new DataSize(1, MEGABYTE);
         HiveSplitSource hiveSplitSource = HiveSplitSource.allAtOnce(
-                SESSION,
+                SESSION.toConnectorSession(),
                 "database",
                 "table",
                 new CacheQuotaRequirement(GLOBAL, Optional.empty()),
@@ -328,7 +328,7 @@ public class TestHiveSplitSource
     public void testEmptyBucket()
     {
         final HiveSplitSource hiveSplitSource = HiveSplitSource.bucketed(
-                SESSION,
+                SESSION.toConnectorSession(),
                 "database",
                 "table",
                 new CacheQuotaRequirement(GLOBAL, Optional.empty()),
@@ -351,7 +351,7 @@ public class TestHiveSplitSource
             throws Exception
     {
         HiveSplitSource hiveSplitSource = HiveSplitSource.bucketedRewindable(
-                SESSION,
+                SESSION.toConnectorSession(),
                 "database",
                 "table",
                 new CacheQuotaRequirement(GLOBAL, Optional.empty()),
@@ -410,7 +410,7 @@ public class TestHiveSplitSource
     public void testRewindOneBucket()
     {
         HiveSplitSource hiveSplitSource = HiveSplitSource.bucketedRewindable(
-                SESSION,
+                SESSION.toConnectorSession(),
                 "database",
                 "table",
                 new CacheQuotaRequirement(GLOBAL, Optional.empty()),
@@ -446,7 +446,7 @@ public class TestHiveSplitSource
     public void testRewindMultipleBuckets()
     {
         HiveSplitSource hiveSplitSource = HiveSplitSource.bucketedRewindable(
-                SESSION,
+                SESSION.toConnectorSession(),
                 "database",
                 "table",
                 new CacheQuotaRequirement(GLOBAL, Optional.empty()),

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveWriteUtils.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveWriteUtils.java
@@ -32,7 +32,7 @@ import static org.testng.Assert.fail;
 
 public class TestHiveWriteUtils
 {
-    private static final HdfsContext CONTEXT = new HdfsContext(SESSION, "test_schema");
+    private static final HdfsContext CONTEXT = new HdfsContext(SESSION.toConnectorSession(), "test_schema");
 
     @Test
     public void testIsS3FileSystem()
@@ -66,7 +66,7 @@ public class TestHiveWriteUtils
         hdfsEnvironment.getConfiguration(CONTEXT, viewfsPath).set("fs.viewfs.mounttable.ns-default.link./test-dir", "file://" + storageDir);
 
         //Make temporary folder under an existing data folder without staging folder ".hive-staging"
-        Path temporaryPath = createTemporaryPath(SESSION, CONTEXT, hdfsEnvironment, viewfsPath);
+        Path temporaryPath = createTemporaryPath(SESSION.toConnectorSession(), CONTEXT, hdfsEnvironment, viewfsPath);
 
         assertEquals(temporaryPath.getParent().toString(), "viewfs://ns-default/test-dir/.hive-staging");
         try {
@@ -77,7 +77,7 @@ public class TestHiveWriteUtils
         }
 
         //Make temporary folder under an existing data folder with an existing staging folder ".hive-staging"
-        temporaryPath = createTemporaryPath(SESSION, CONTEXT, hdfsEnvironment, viewfsPath);
+        temporaryPath = createTemporaryPath(SESSION.toConnectorSession(), CONTEXT, hdfsEnvironment, viewfsPath);
 
         assertEquals(temporaryPath.getParent().toString(), "viewfs://ns-default/test-dir/.hive-staging");
         try {
@@ -88,7 +88,7 @@ public class TestHiveWriteUtils
         }
 
         //Make temporary folder under a non-existing data folder (for new tables), it would use the temporary folder of the parent
-        temporaryPath = createTemporaryPath(SESSION, CONTEXT, hdfsEnvironment, new Path(viewfsPath, "non-existing"));
+        temporaryPath = createTemporaryPath(SESSION.toConnectorSession(), CONTEXT, hdfsEnvironment, new Path(viewfsPath, "non-existing"));
         assertEquals(temporaryPath.getParent().toString(), "viewfs://ns-default/test-dir/.hive-staging");
         try {
             UUID.fromString(temporaryPath.getName());
@@ -103,7 +103,7 @@ public class TestHiveWriteUtils
         HdfsEnvironment hdfsEnvironment = createTestHdfsEnvironment(new HiveClientConfig(), new MetastoreClientConfig());
         Path nonViewfsPath = new Path("file://" + Files.createTempDir());
 
-        Path temporaryPath = createTemporaryPath(SESSION, CONTEXT, hdfsEnvironment, nonViewfsPath);
+        Path temporaryPath = createTemporaryPath(SESSION.toConnectorSession(), CONTEXT, hdfsEnvironment, nonViewfsPath);
 
         assertEquals(temporaryPath.getParent().toString(), "file:/tmp/presto-user");
         try {

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveWriteUtils.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveWriteUtils.java
@@ -20,7 +20,7 @@ import org.testng.annotations.Test;
 import java.io.File;
 import java.util.UUID;
 
-import static com.facebook.presto.hive.HiveTestUtils.SESSION;
+import static com.facebook.presto.hive.HiveTestUtils.CONNECTOR_SESSION;
 import static com.facebook.presto.hive.HiveTestUtils.createTestHdfsEnvironment;
 import static com.facebook.presto.hive.HiveWriteUtils.createTemporaryPath;
 import static com.facebook.presto.hive.HiveWriteUtils.isS3FileSystem;
@@ -32,7 +32,7 @@ import static org.testng.Assert.fail;
 
 public class TestHiveWriteUtils
 {
-    private static final HdfsContext CONTEXT = new HdfsContext(SESSION.toConnectorSession(), "test_schema");
+    private static final HdfsContext CONTEXT = new HdfsContext(CONNECTOR_SESSION, "test_schema");
 
     @Test
     public void testIsS3FileSystem()
@@ -66,7 +66,7 @@ public class TestHiveWriteUtils
         hdfsEnvironment.getConfiguration(CONTEXT, viewfsPath).set("fs.viewfs.mounttable.ns-default.link./test-dir", "file://" + storageDir);
 
         //Make temporary folder under an existing data folder without staging folder ".hive-staging"
-        Path temporaryPath = createTemporaryPath(SESSION.toConnectorSession(), CONTEXT, hdfsEnvironment, viewfsPath);
+        Path temporaryPath = createTemporaryPath(CONNECTOR_SESSION, CONTEXT, hdfsEnvironment, viewfsPath);
 
         assertEquals(temporaryPath.getParent().toString(), "viewfs://ns-default/test-dir/.hive-staging");
         try {
@@ -77,7 +77,7 @@ public class TestHiveWriteUtils
         }
 
         //Make temporary folder under an existing data folder with an existing staging folder ".hive-staging"
-        temporaryPath = createTemporaryPath(SESSION.toConnectorSession(), CONTEXT, hdfsEnvironment, viewfsPath);
+        temporaryPath = createTemporaryPath(CONNECTOR_SESSION, CONTEXT, hdfsEnvironment, viewfsPath);
 
         assertEquals(temporaryPath.getParent().toString(), "viewfs://ns-default/test-dir/.hive-staging");
         try {
@@ -88,7 +88,7 @@ public class TestHiveWriteUtils
         }
 
         //Make temporary folder under a non-existing data folder (for new tables), it would use the temporary folder of the parent
-        temporaryPath = createTemporaryPath(SESSION.toConnectorSession(), CONTEXT, hdfsEnvironment, new Path(viewfsPath, "non-existing"));
+        temporaryPath = createTemporaryPath(CONNECTOR_SESSION, CONTEXT, hdfsEnvironment, new Path(viewfsPath, "non-existing"));
         assertEquals(temporaryPath.getParent().toString(), "viewfs://ns-default/test-dir/.hive-staging");
         try {
             UUID.fromString(temporaryPath.getName());
@@ -103,7 +103,7 @@ public class TestHiveWriteUtils
         HdfsEnvironment hdfsEnvironment = createTestHdfsEnvironment(new HiveClientConfig(), new MetastoreClientConfig());
         Path nonViewfsPath = new Path("file://" + Files.createTempDir());
 
-        Path temporaryPath = createTemporaryPath(SESSION.toConnectorSession(), CONTEXT, hdfsEnvironment, nonViewfsPath);
+        Path temporaryPath = createTemporaryPath(CONNECTOR_SESSION, CONTEXT, hdfsEnvironment, nonViewfsPath);
 
         assertEquals(temporaryPath.getParent().toString(), "file:/tmp/presto-user");
         try {

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestOrcBatchPageSourceMemoryTracking.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestOrcBatchPageSourceMemoryTracking.java
@@ -103,11 +103,11 @@ import static com.facebook.presto.common.type.VarcharType.createUnboundedVarchar
 import static com.facebook.presto.hive.HiveColumnHandle.ColumnType.PARTITION_KEY;
 import static com.facebook.presto.hive.HiveColumnHandle.ColumnType.REGULAR;
 import static com.facebook.presto.hive.HiveFileContext.DEFAULT_HIVE_FILE_CONTEXT;
+import static com.facebook.presto.hive.HiveTestUtils.CONNECTOR_SESSION;
 import static com.facebook.presto.hive.HiveTestUtils.FUNCTION_AND_TYPE_MANAGER;
 import static com.facebook.presto.hive.HiveTestUtils.FUNCTION_RESOLUTION;
 import static com.facebook.presto.hive.HiveTestUtils.HDFS_ENVIRONMENT;
 import static com.facebook.presto.hive.HiveTestUtils.ROW_EXPRESSION_SERVICE;
-import static com.facebook.presto.hive.HiveTestUtils.SESSION;
 import static com.facebook.presto.metadata.MetadataManager.createTestMetadataManager;
 import static com.facebook.presto.orc.OrcReader.MAX_BATCH_SIZE;
 import static com.facebook.presto.sql.relational.Expressions.field;
@@ -431,12 +431,12 @@ public class TestOrcBatchPageSourceMemoryTracking
 
         public ConnectorPageSource newPageSource()
         {
-            return newPageSource(new FileFormatDataSourceStats(), SESSION.toConnectorSession());
+            return newPageSource(new FileFormatDataSourceStats(), CONNECTOR_SESSION);
         }
 
         public ConnectorPageSource newPageSource(FileFormatDataSourceStats stats)
         {
-            return newPageSource(stats, SESSION.toConnectorSession());
+            return newPageSource(stats, CONNECTOR_SESSION);
         }
 
         public ConnectorPageSource newPageSource(FileFormatDataSourceStats stats, ConnectorSession session)
@@ -505,8 +505,8 @@ public class TestOrcBatchPageSourceMemoryTracking
             for (int i = 0; i < types.size(); i++) {
                 projectionsBuilder.add(field(i, types.get(i)));
             }
-            Supplier<CursorProcessor> cursorProcessor = EXPRESSION_COMPILER.compileCursorProcessor(SESSION.toConnectorSession().getSqlFunctionProperties(), Optional.empty(), projectionsBuilder.build(), "key");
-            Supplier<PageProcessor> pageProcessor = EXPRESSION_COMPILER.compilePageProcessor(SESSION.toConnectorSession().getSqlFunctionProperties(), Optional.empty(), projectionsBuilder.build());
+            Supplier<CursorProcessor> cursorProcessor = EXPRESSION_COMPILER.compileCursorProcessor(CONNECTOR_SESSION.getSqlFunctionProperties(), Optional.empty(), projectionsBuilder.build(), "key");
+            Supplier<PageProcessor> pageProcessor = EXPRESSION_COMPILER.compilePageProcessor(CONNECTOR_SESSION.getSqlFunctionProperties(), Optional.empty(), projectionsBuilder.build());
             SourceOperatorFactory sourceOperatorFactory = new ScanFilterAndProjectOperatorFactory(
                     0,
                     new PlanNodeId("test"),

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestOrcBatchPageSourceMemoryTracking.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestOrcBatchPageSourceMemoryTracking.java
@@ -431,12 +431,12 @@ public class TestOrcBatchPageSourceMemoryTracking
 
         public ConnectorPageSource newPageSource()
         {
-            return newPageSource(new FileFormatDataSourceStats(), SESSION);
+            return newPageSource(new FileFormatDataSourceStats(), SESSION.toConnectorSession());
         }
 
         public ConnectorPageSource newPageSource(FileFormatDataSourceStats stats)
         {
-            return newPageSource(stats, SESSION);
+            return newPageSource(stats, SESSION.toConnectorSession());
         }
 
         public ConnectorPageSource newPageSource(FileFormatDataSourceStats stats, ConnectorSession session)
@@ -505,8 +505,8 @@ public class TestOrcBatchPageSourceMemoryTracking
             for (int i = 0; i < types.size(); i++) {
                 projectionsBuilder.add(field(i, types.get(i)));
             }
-            Supplier<CursorProcessor> cursorProcessor = EXPRESSION_COMPILER.compileCursorProcessor(SESSION.getSqlFunctionProperties(), Optional.empty(), projectionsBuilder.build(), "key");
-            Supplier<PageProcessor> pageProcessor = EXPRESSION_COMPILER.compilePageProcessor(SESSION.getSqlFunctionProperties(), Optional.empty(), projectionsBuilder.build());
+            Supplier<CursorProcessor> cursorProcessor = EXPRESSION_COMPILER.compileCursorProcessor(SESSION.toConnectorSession().getSqlFunctionProperties(), Optional.empty(), projectionsBuilder.build(), "key");
+            Supplier<PageProcessor> pageProcessor = EXPRESSION_COMPILER.compilePageProcessor(SESSION.toConnectorSession().getSqlFunctionProperties(), Optional.empty(), projectionsBuilder.build());
             SourceOperatorFactory sourceOperatorFactory = new ScanFilterAndProjectOperatorFactory(
                     0,
                     new PlanNodeId("test"),


### PR DESCRIPTION
As suggested by @shixuan-fan on issue #12367, I refactored the constant SESSION to be a Session class instead of a ConnectorSession.
I initialized it with the same options as the previously used ConnectorSession using the testingSessionBuilder from the TestingSession class and changed all its use cases to SESSION.toConnectorSession().

Test plan
- To be honest, as a beginner, I didn't know exactly how to test it, I was hoping I could get some help from de CI/CD. I'm open to suggestions as well.

```
== NO RELEASE NOTE ==
```
