### PR TITLE
[thrift connector] Add ThriftConnectorConfig param to getHeaders()

### DIFF
--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/DefaultThriftHeaderProvider.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/DefaultThriftHeaderProvider.java
@@ -22,7 +22,7 @@ public class DefaultThriftHeaderProvider
         implements ThriftHeaderProvider
 {
     @Override
-    public Map<String, String> getHeaders(ConnectorSession session)
+    public Map<String, String> getHeaders(ConnectorSession session, ThriftConnectorConfig config)
     {
         return ImmutableMap.of();
     }

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftHeaderProvider.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftHeaderProvider.java
@@ -19,5 +19,11 @@ import java.util.Map;
 
 public interface ThriftHeaderProvider
 {
-    Map<String, String> getHeaders(ConnectorSession session);
+    @Deprecated
+    default Map<String, String> getHeaders(ConnectorSession session)
+    {
+        return getHeaders(session, null);
+    }
+
+    Map<String, String> getHeaders(ConnectorSession session, ThriftConnectorConfig config);
 }

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftIndexProvider.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftIndexProvider.java
@@ -33,9 +33,8 @@ public class ThriftIndexProvider
 {
     private final DriftClient<PrestoThriftService> client;
     private final ThriftHeaderProvider thriftHeaderProvider;
-    private final long maxBytesPerResponse;
-    private final int lookupRequestsConcurrency;
     private final ThriftConnectorStats stats;
+    private final ThriftConnectorConfig config;
 
     @Inject
     public ThriftIndexProvider(DriftClient<PrestoThriftService> client, ThriftHeaderProvider thriftHeaderProvider, ThriftConnectorStats stats, ThriftConnectorConfig config)
@@ -44,8 +43,7 @@ public class ThriftIndexProvider
         this.thriftHeaderProvider = requireNonNull(thriftHeaderProvider, "thriftHeaderProvider is null");
         this.stats = requireNonNull(stats, "stats is null");
         requireNonNull(config, "config is null");
-        this.maxBytesPerResponse = config.getMaxResponseSize().toBytes();
-        this.lookupRequestsConcurrency = config.getLookupRequestsConcurrency();
+        this.config = config;
     }
 
     @Override
@@ -58,12 +56,12 @@ public class ThriftIndexProvider
     {
         return new ThriftConnectorIndex(
                 client,
-                thriftHeaderProvider.getHeaders(session),
+                thriftHeaderProvider.getHeaders(session, config),
                 stats,
                 (ThriftIndexHandle) indexHandle,
                 lookupSchema,
                 outputSchema,
-                maxBytesPerResponse,
-                lookupRequestsConcurrency);
+                config.getMaxResponseSize().toBytes(),
+                config.getLookupRequestsConcurrency());
     }
 }

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftPageSourceProvider.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftPageSourceProvider.java
@@ -34,15 +34,15 @@ public class ThriftPageSourceProvider
 {
     private final DriftClient<PrestoThriftService> client;
     private final ThriftHeaderProvider thriftHeaderProvider;
-    private final long maxBytesPerResponse;
+    private final ThriftConnectorConfig config;
     private final ThriftConnectorStats stats;
 
     @Inject
     public ThriftPageSourceProvider(DriftClient<PrestoThriftService> client, ThriftHeaderProvider thriftHeaderProvider, ThriftConnectorStats stats, ThriftConnectorConfig config)
     {
         this.client = requireNonNull(client, "client is null");
+        this.config = requireNonNull(config, "config is null");
         this.thriftHeaderProvider = requireNonNull(thriftHeaderProvider, "thriftHeaderFactor is null");
-        this.maxBytesPerResponse = requireNonNull(config, "config is null").getMaxResponseSize().toBytes();
         this.stats = requireNonNull(stats, "stats is null");
     }
 
@@ -54,6 +54,6 @@ public class ThriftPageSourceProvider
             List<ColumnHandle> columns,
             SplitContext splitContext)
     {
-        return new ThriftPageSource(client, thriftHeaderProvider.getHeaders(session), (ThriftConnectorSplit) split, columns, stats, maxBytesPerResponse);
+        return new ThriftPageSource(client, thriftHeaderProvider.getHeaders(session), (ThriftConnectorSplit) split, columns, stats, requireNonNull(config, "config is null").getMaxResponseSize().toBytes());
     }
 }

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftSplitManager.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftSplitManager.java
@@ -62,12 +62,14 @@ public class ThriftSplitManager
 {
     private final DriftClient<PrestoThriftService> client;
     private final ThriftHeaderProvider thriftHeaderProvider;
+    private final ThriftConnectorConfig config;
 
     @Inject
-    public ThriftSplitManager(DriftClient<PrestoThriftService> client, ThriftHeaderProvider thriftHeaderProvider)
+    public ThriftSplitManager(DriftClient<PrestoThriftService> client, ThriftHeaderProvider thriftHeaderProvider, ThriftConnectorConfig config)
     {
         this.client = requireNonNull(client, "client is null");
         this.thriftHeaderProvider = requireNonNull(thriftHeaderProvider, "thriftHeaderProvider is null");
+        this.config = requireNonNull(config, "config is null");
     }
 
     @Override
@@ -79,7 +81,7 @@ public class ThriftSplitManager
     {
         ThriftTableLayoutHandle layoutHandle = (ThriftTableLayoutHandle) layout;
         return new ThriftSplitSource(
-                client.get(thriftHeaderProvider.getHeaders(session)),
+                client.get(thriftHeaderProvider.getHeaders(session, config)),
                 new PrestoThriftSchemaTableName(layoutHandle.getSchemaName(), layoutHandle.getTableName()),
                 layoutHandle.getColumns().map(ThriftSplitManager::columnNames),
                 tupleDomainToThriftTupleDomain(layoutHandle.getConstraint()));


### PR DESCRIPTION
Changes:
- This diff passes `ThriftConnectorConfig` into the `getHeaders()` method, so that config options can be read when constructing Thrift headers.

Test plan:
- This diff doesn't introduce any new behavior. It is covered by existing tests.

```
== NO RELEASE NOTE ==
```
