### PR TITLE
Support for query heartbeat from coordinator that is shutting down

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/DiscoveryNodeManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/DiscoveryNodeManager.java
@@ -456,6 +456,12 @@ public final class DiscoveryNodeManager
     }
 
     @Override
+    public Set<InternalNode> getShuttingDownCoordinator()
+    {
+        return getNodes(SHUTTING_DOWN).stream().filter(InternalNode::isCoordinator).collect(toImmutableSet());
+    }
+
+    @Override
     public synchronized Set<InternalNode> getResourceManagers()
     {
         return resourceManagers;

--- a/presto-main/src/main/java/com/facebook/presto/metadata/InMemoryNodeManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/InMemoryNodeManager.java
@@ -32,6 +32,7 @@ import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
+import static com.facebook.presto.spi.NodeState.SHUTTING_DOWN;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Stream.concat;
@@ -40,6 +41,7 @@ public class InMemoryNodeManager
         implements InternalNodeManager
 {
     private final InternalNode localNode;
+    private final ImmutableSet.Builder<InternalNode> shuttingDownNodesBuilder;
     private final SetMultimap<ConnectorId, InternalNode> remoteNodes = Multimaps.synchronizedSetMultimap(HashMultimap.create());
 
     @GuardedBy("this")
@@ -54,6 +56,7 @@ public class InMemoryNodeManager
     public InMemoryNodeManager(URI localUri)
     {
         localNode = new InternalNode("local", localUri, NodeVersion.UNKNOWN, false);
+        shuttingDownNodesBuilder = ImmutableSet.builder();
     }
 
     public void addCurrentNodeConnector(ConnectorId connectorId)
@@ -64,6 +67,11 @@ public class InMemoryNodeManager
     public void addNode(ConnectorId connectorId, InternalNode... nodes)
     {
         addNode(connectorId, ImmutableList.copyOf(nodes));
+    }
+
+    public void addShuttingDownNode(InternalNode node)
+    {
+        shuttingDownNodesBuilder.add(node);
     }
 
     public void addNode(ConnectorId connectorId, Iterable<InternalNode> nodes)
@@ -111,7 +119,7 @@ public class InMemoryNodeManager
         return new AllNodes(
                 ImmutableSet.<InternalNode>builder().add(localNode).addAll(remoteNodes.values()).build(),
                 ImmutableSet.of(),
-                ImmutableSet.of(),
+                shuttingDownNodesBuilder.build(),
                 concat(Stream.of(localNode), remoteNodes.values().stream()).collect(toImmutableSet()).stream().filter(InternalNode::isCoordinator).collect(toImmutableSet()),
                 concat(Stream.of(localNode), remoteNodes.values().stream()).collect(toImmutableSet()).stream().filter(InternalNode::isResourceManager).collect(toImmutableSet()));
     }
@@ -127,6 +135,12 @@ public class InMemoryNodeManager
     {
         // always use localNode as coordinator
         return getAllNodes().getActiveCoordinators();
+    }
+
+    @Override
+    public Set<InternalNode> getShuttingDownCoordinator()
+    {
+        return getNodes(SHUTTING_DOWN).stream().filter(InternalNode::isCoordinator).collect(toImmutableSet());
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/metadata/InternalNodeManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/InternalNodeManager.java
@@ -31,6 +31,8 @@ public interface InternalNodeManager
 
     Set<InternalNode> getCoordinators();
 
+    Set<InternalNode> getShuttingDownCoordinator();
+
     Set<InternalNode> getResourceManagers();
 
     AllNodes getAllNodes();

--- a/presto-main/src/main/java/com/facebook/presto/resourcemanager/ResourceManagerClusterStateProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/resourcemanager/ResourceManagerClusterStateProvider.java
@@ -48,6 +48,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 import static com.facebook.presto.SystemSessionProperties.resourceOvercommit;
 import static com.facebook.presto.execution.QueryState.QUEUED;
@@ -60,6 +61,7 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.stream.Stream.concat;
 
 public class ResourceManagerClusterStateProvider
 {
@@ -141,8 +143,10 @@ public class ResourceManagerClusterStateProvider
     {
         requireNonNull(nodeId, "nodeId is null");
         requireNonNull(basicQueryInfo, "basicQueryInfo is null");
+        Stream<InternalNode> activeOrShuttingDownCoordinators = concat(internalNodeManager.getCoordinators().stream(),
+                internalNodeManager.getShuttingDownCoordinator().stream());
         checkArgument(
-                internalNodeManager.getCoordinators().stream().anyMatch(i -> nodeId.equals(i.getNodeIdentifier())),
+                activeOrShuttingDownCoordinators.anyMatch(i -> nodeId.equals(i.getNodeIdentifier())),
                 "%s is not a coordinator (coordinators: %s)",
                 nodeId,
                 internalNodeManager.getCoordinators().stream().collect(toImmutableSet()));

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/node/PrestoSparkInternalNodeManager.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/node/PrestoSparkInternalNodeManager.java
@@ -76,6 +76,12 @@ public class PrestoSparkInternalNodeManager
     }
 
     @Override
+    public Set<InternalNode> getShuttingDownCoordinator()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public Set<InternalNode> getResourceManagers()
     {
         throw new UnsupportedOperationException();


### PR DESCRIPTION
Currently query heartbeat is failing to register if it comes from a coordinator node which is shutting down. The fix here is to consider query heartbeat from a shutting down coordinator as a valid one.

Test plan - unit test

```
== NO RELEASE NOTE ==
```
