### PR TITLE
Add option to remove from session properties

### DIFF
--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/QueryConfiguration.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/QueryConfiguration.java
@@ -63,7 +63,7 @@ public class QueryConfiguration
                 sessionProperties.put(entry.getKey(), entry.getValue());
             }
         }
-
+        overrides.getSessionPropertiesToRemove().forEach(sessionProperties::remove);
         return new QueryConfiguration(
                 overrides.getCatalogOverride().orElse(catalog),
                 overrides.getSchemaOverride().orElse(schema),

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/QueryConfigurationOverrides.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/QueryConfigurationOverrides.java
@@ -15,6 +15,7 @@ package com.facebook.presto.verifier.framework;
 
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 public interface QueryConfigurationOverrides
 {
@@ -36,4 +37,6 @@ public interface QueryConfigurationOverrides
     SessionPropertiesOverrideStrategy getSessionPropertiesOverrideStrategy();
 
     Map<String, String> getSessionPropertiesOverride();
+
+    Set<String> getSessionPropertiesToRemove();
 }

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/QueryConfigurationOverridesConfig.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/QueryConfigurationOverridesConfig.java
@@ -17,13 +17,16 @@ import com.facebook.airlift.configuration.Config;
 import com.facebook.airlift.configuration.ConfigDescription;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 
 import javax.validation.constraints.NotNull;
 
 import java.io.IOException;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 import static com.facebook.presto.verifier.framework.QueryConfigurationOverrides.SessionPropertiesOverrideStrategy.NO_ACTION;
 
@@ -36,6 +39,7 @@ public class QueryConfigurationOverridesConfig
     private Optional<String> passwordOverride = Optional.empty();
     private SessionPropertiesOverrideStrategy sessionPropertiesOverrideStrategy = NO_ACTION;
     private Map<String, String> sessionPropertiesOverride = ImmutableMap.of();
+    private Set<String> sessionPropertiesToRemove = ImmutableSet.of();
 
     @Override
     public Optional<String> getCatalogOverride()
@@ -104,6 +108,23 @@ public class QueryConfigurationOverridesConfig
     public QueryConfigurationOverridesConfig setSessionPropertiesOverrideStrategy(SessionPropertiesOverrideStrategy sessionPropertiesOverrideStrategy)
     {
         this.sessionPropertiesOverrideStrategy = sessionPropertiesOverrideStrategy;
+        return this;
+    }
+
+    @Override
+    public Set<String> getSessionPropertiesToRemove()
+    {
+        return sessionPropertiesToRemove;
+    }
+
+    @Config("session-properties-removal")
+    public QueryConfigurationOverridesConfig setSessionPropertiesToRemove(String sessionPropertiesToRemove)
+    {
+        if (sessionPropertiesToRemove == null) {
+            return this;
+        }
+
+        this.sessionPropertiesToRemove = ImmutableSet.copyOf(Splitter.on(',').trimResults().omitEmptyStrings().split(sessionPropertiesToRemove));
         return this;
     }
 

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestQueryConfiguration.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestQueryConfiguration.java
@@ -113,4 +113,35 @@ public class TestQueryConfiguration
         assertEquals(CONFIGURATION_1.applyOverrides(overrides), substituted);
         assertEquals(CONFIGURATION_2.applyOverrides(overrides), CONFIGURATION_FULL_OVERRIDE);
     }
+
+    @Test
+    public void testSessionPropertyRemoval()
+    {
+        overrides.setSessionPropertiesToRemove("property_1, property_2");
+        overrides.setSessionPropertiesOverrideStrategy(OVERRIDE);
+
+        QueryConfiguration removed = new QueryConfiguration(
+                CATALOG_OVERRIDE,
+                SCHEMA_OVERRIDE,
+                Optional.of(USERNAME_OVERRIDE),
+                Optional.of(PASSWORD_OVERRIDE),
+                Optional.of(ImmutableMap.of("property_3", "value_3")));
+
+        assertEquals(CONFIGURATION_1.applyOverrides(overrides), removed);
+    }
+
+    @Test
+    public void testSessionPropertySubstituteAndRemove()
+    {
+        overrides.setSessionPropertiesToRemove("property_2");
+        overrides.setSessionPropertiesOverrideStrategy(SUBSTITUTE);
+        QueryConfiguration removed = new QueryConfiguration(
+                CATALOG_OVERRIDE,
+                SCHEMA_OVERRIDE,
+                Optional.of(USERNAME_OVERRIDE),
+                Optional.of(PASSWORD_OVERRIDE),
+                Optional.of(SESSION_PROPERTIES_OVERRIDE));
+
+        assertEquals(CONFIGURATION_1.applyOverrides(overrides), removed);
+    }
 }

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestQueryConfigurationOverridesConfig.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestQueryConfigurationOverridesConfig.java
@@ -35,7 +35,8 @@ public class TestQueryConfigurationOverridesConfig
                 .setUsernameOverride(null)
                 .setPasswordOverride(null)
                 .setSessionPropertiesOverrideStrategy(NO_ACTION)
-                .setSessionPropertiesOverride(null));
+                .setSessionPropertiesOverride(null)
+                .setSessionPropertiesToRemove(null));
     }
 
     @Test
@@ -48,6 +49,7 @@ public class TestQueryConfigurationOverridesConfig
                 .put("password-override", "_password")
                 .put("session-properties-override-strategy", "SUBSTITUTE")
                 .put("session-properties-override", "{\"key\": \"value\"}")
+                .put("session-properties-removal", "key2,key3")
                 .build();
         QueryConfigurationOverridesConfig expected = new QueryConfigurationOverridesConfig()
                 .setCatalogOverride("_catalog")
@@ -55,7 +57,8 @@ public class TestQueryConfigurationOverridesConfig
                 .setUsernameOverride("_username")
                 .setPasswordOverride("_password")
                 .setSessionPropertiesOverrideStrategy(SUBSTITUTE)
-                .setSessionPropertiesOverride("{\"key\": \"value\"}");
+                .setSessionPropertiesOverride("{\"key\": \"value\"}")
+                .setSessionPropertiesToRemove("key2,key3");
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
Added a new strategy to enable an option to remove certain fields from session properties when running verifier test

Test plan - (Please fill in how you tested your changes)
Added & ran unit test
== NO RELEASE NOTE ==
