### PR TITLE
Implement a new mechanism to expose metrics from operators and connectors

### DIFF
--- a/presto-cli/src/main/java/com/facebook/presto/cli/StatusPrinter.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/StatusPrinter.java
@@ -215,6 +215,13 @@ Spilled: 20GB
             if (stats.getSpilledBytes() > 0) {
                 reprintLine("Spilled: " + formatDataSize(bytes(stats.getSpilledBytes()), true));
             }
+
+            // bytesFromCache: sum=2K count=2 min=1K max=1K
+            if (stats.getRuntimeStats() != null) {
+                stats.getRuntimeStats().getMetrics().values().forEach(
+                        metric -> reprintLine(
+                                metric.getName() + ": sum=" + formatCount(metric.getSum()) + " count=" + formatCount(metric.getCount()) + " min=" + formatCount(metric.getMin()) + " max=" + formatCount(metric.getMax())));
+            }
         }
 
         // 0:32 [2.12GB, 15M rows] [67MB/s, 463K rows/s]
@@ -314,6 +321,12 @@ Spilled: 20GB
                 // Spilled Data: 20GB
                 if (stats.getSpilledBytes() > 0) {
                     reprintLine("Spilled: " + formatDataSize(bytes(stats.getSpilledBytes()), true));
+                }
+
+                if (stats.getRuntimeStats() != null) {
+                    stats.getRuntimeStats().getMetrics().values().forEach(
+                            metric -> reprintLine(
+                                    metric.getName() + ": sum=" + metric.getSum() + " count=" + metric.getCount() + " min=" + metric.getMin() + " max=" + metric.getMax()));
                 }
             }
 

--- a/presto-client/src/main/java/com/facebook/presto/client/StatementStats.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/StatementStats.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.client;
 
+import com.facebook.presto.common.RuntimeStats;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -49,6 +50,7 @@ public class StatementStats
     private final long peakTaskTotalMemoryBytes;
     private final long spilledBytes;
     private final StageStats rootStage;
+    private final RuntimeStats runtimeStats;
 
     @JsonCreator
     public StatementStats(
@@ -72,7 +74,8 @@ public class StatementStats
             @JsonProperty("peakTotalMemoryBytes") long peakTotalMemoryBytes,
             @JsonProperty("peakTaskTotalMemoryBytes") long peakTaskTotalMemoryBytes,
             @JsonProperty("spilledBytes") long spilledBytes,
-            @JsonProperty("rootStage") StageStats rootStage)
+            @JsonProperty("rootStage") StageStats rootStage,
+            @JsonProperty("runtimeStats") RuntimeStats runtimeStats)
     {
         this.state = requireNonNull(state, "state is null");
         this.waitingForPrerequisites = waitingForPrerequisites;
@@ -95,6 +98,7 @@ public class StatementStats
         this.peakTaskTotalMemoryBytes = peakTaskTotalMemoryBytes;
         this.spilledBytes = spilledBytes;
         this.rootStage = rootStage;
+        this.runtimeStats = runtimeStats;
     }
 
     @JsonProperty
@@ -218,6 +222,13 @@ public class StatementStats
         return rootStage;
     }
 
+    @Nullable
+    @JsonProperty
+    public RuntimeStats getRuntimeStats()
+    {
+        return runtimeStats;
+    }
+
     @JsonProperty
     public OptionalDouble getProgressPercentage()
     {
@@ -289,6 +300,7 @@ public class StatementStats
         private long peakTaskTotalMemoryBytes;
         private long spilledBytes;
         private StageStats rootStage;
+        private RuntimeStats runtimeStats;
 
         private Builder() {}
 
@@ -418,6 +430,12 @@ public class StatementStats
             return this;
         }
 
+        public Builder setRuntimeStats(RuntimeStats runtimeStats)
+        {
+            this.runtimeStats = runtimeStats;
+            return this;
+        }
+
         public StatementStats build()
         {
             return new StatementStats(
@@ -441,7 +459,8 @@ public class StatementStats
                     peakTotalMemoryBytes,
                     peakTaskTotalMemoryBytes,
                     spilledBytes,
-                    rootStage);
+                    rootStage,
+                    runtimeStats);
         }
     }
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/RuntimeMetric.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/RuntimeMetric.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A metric exposed by a presto operator or connector. It will be aggregated at the query level.
+ */
+public class RuntimeMetric
+{
+    private final String name;
+    private long sum;
+    private long count;
+    private long max = Long.MIN_VALUE;
+    private long min = Long.MAX_VALUE;
+
+    public RuntimeMetric(String name)
+    {
+        this.name = name;
+    }
+
+    public static RuntimeMetric copyOf(RuntimeMetric metric)
+    {
+        requireNonNull(metric, "metric is null");
+        return new RuntimeMetric(metric.getName(), metric.getSum(), metric.getCount(), metric.getMax(), metric.getMin());
+    }
+
+    @JsonCreator
+    public RuntimeMetric(
+            @JsonProperty("name") String name,
+            @JsonProperty("sum") long sum,
+            @JsonProperty("count") long count,
+            @JsonProperty("max") long max,
+            @JsonProperty("min") long min)
+    {
+        this.name = requireNonNull(name, "name is null");
+        this.sum = sum;
+        this.count = count;
+        this.max = max;
+        this.min = min;
+    }
+
+    @JsonProperty
+    public String getName()
+    {
+        return name;
+    }
+
+    public void addValue(long value)
+    {
+        sum += value;
+        count++;
+        max = Math.max(max, value);
+        min = Math.min(min, value);
+    }
+
+    /**
+     * Merges {@code metric1} and {@code metric2} and returns the result. The input parameters are not updated.
+     */
+    public static RuntimeMetric merge(RuntimeMetric metric1, RuntimeMetric metric2)
+    {
+        if (metric1 == null) {
+            return metric2;
+        }
+        if (metric2 == null) {
+            return metric1;
+        }
+        RuntimeMetric mergedMetric = copyOf(metric1);
+        mergedMetric.mergeWith(metric2);
+        return mergedMetric;
+    }
+
+    /**
+     * Merges {@code metric} into this object.
+     */
+    public void mergeWith(RuntimeMetric metric)
+    {
+        if (metric == null) {
+            return;
+        }
+        sum += metric.getSum();
+        count += metric.getCount();
+        max = Math.max(max, metric.getMax());
+        min = Math.min(min, metric.getMin());
+    }
+
+    @JsonProperty
+    public long getSum()
+    {
+        return sum;
+    }
+
+    @JsonProperty
+    public long getCount()
+    {
+        return count;
+    }
+
+    @JsonProperty
+    public long getMax()
+    {
+        return max;
+    }
+
+    @JsonProperty
+    public long getMin()
+    {
+        return min;
+    }
+}

--- a/presto-common/src/main/java/com/facebook/presto/common/RuntimeStats.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/RuntimeStats.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Metrics exposed by presto operators or connectors. These will be aggregated at the query level.
+ */
+public class RuntimeStats
+{
+    private final Map<String, RuntimeMetric> metrics;
+
+    public RuntimeStats()
+    {
+        metrics = new HashMap<>();
+    }
+
+    @JsonCreator
+    public RuntimeStats(Map<String, RuntimeMetric> metrics)
+    {
+        this.metrics = requireNonNull(metrics, "metrics is null");
+    }
+
+    public static RuntimeStats copyOf(RuntimeStats stats)
+    {
+        requireNonNull(stats, "stats is null");
+        RuntimeStats statsCopy = new RuntimeStats();
+        statsCopy.mergeWith(stats);
+        return statsCopy;
+    }
+
+    /**
+     * Merges {@code stats1} and {@code stats2} and returns the result. The input parameters are not updated.
+     */
+    public static RuntimeStats merge(RuntimeStats stats1, RuntimeStats stats2)
+    {
+        if (stats1 == null) {
+            return stats2;
+        }
+        if (stats2 == null) {
+            return stats1;
+        }
+        RuntimeStats mergedStats = copyOf(stats1);
+        mergedStats.mergeWith(stats2);
+        return mergedStats;
+    }
+
+    public void reset()
+    {
+        metrics.clear();
+    }
+
+    public RuntimeMetric getMetric(String name)
+    {
+        return metrics.get(name);
+    }
+
+    @JsonValue
+    public Map<String, RuntimeMetric> getMetrics()
+    {
+        return metrics;
+    }
+
+    public void addMetricValue(String name, long value)
+    {
+        metrics.computeIfAbsent(name, RuntimeMetric::new);
+        metrics.get(name).addValue(value);
+    }
+
+    /**
+     * Merges {@code stats} into this object.
+     */
+    public void mergeWith(RuntimeStats stats)
+    {
+        if (stats == null) {
+            return;
+        }
+        stats.getMetrics().values().forEach(metric -> {
+            metrics.computeIfAbsent(metric.getName(), RuntimeMetric::new);
+            metrics.get(metric.getName()).mergeWith(metric);
+        });
+    }
+
+    /**
+     * Updates the metrics according to their values in {@code stats}.
+     * Metrics not included in {@code stats} will not be changed.
+     */
+    public void update(RuntimeStats stats)
+    {
+        if (stats == null) {
+            return;
+        }
+        stats.getMetrics().values().forEach(metric -> {
+            metrics.put(metric.getName(), RuntimeMetric.copyOf(metric));
+        });
+    }
+}

--- a/presto-common/src/test/java/com/facebook/presto/common/TestRuntimeMetric.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/TestRuntimeMetric.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common;
+
+import com.facebook.airlift.json.JsonCodec;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestRuntimeMetric
+{
+    private static final String TEST_METRIC_NAME = "test_metric";
+
+    private void assertRuntimeMetricEquals(RuntimeMetric m1, RuntimeMetric m2)
+    {
+        assertEquals(m1.getName(), m2.getName());
+        assertEquals(m1.getSum(), m2.getSum());
+        assertEquals(m1.getCount(), m2.getCount());
+        assertEquals(m1.getMax(), m2.getMax());
+        assertEquals(m1.getMin(), m2.getMin());
+    }
+
+    @Test
+    public void testAddValue()
+    {
+        RuntimeMetric metric = new RuntimeMetric(TEST_METRIC_NAME);
+        metric.addValue(101);
+        assertRuntimeMetricEquals(metric, new RuntimeMetric(TEST_METRIC_NAME, 101, 1, 101, 101));
+
+        metric.addValue(99);
+        assertRuntimeMetricEquals(metric, new RuntimeMetric(TEST_METRIC_NAME, 200, 2, 101, 99));
+
+        metric.addValue(201);
+        assertRuntimeMetricEquals(metric, new RuntimeMetric(TEST_METRIC_NAME, 401, 3, 201, 99));
+    }
+
+    @Test
+    public void testCopy()
+    {
+        RuntimeMetric metric = new RuntimeMetric(TEST_METRIC_NAME, 1, 1, 1, 1);
+        RuntimeMetric metricCopy = RuntimeMetric.copyOf(metric);
+
+        // Verify that updating one metric doesn't affect its copy.
+        metric.addValue(2);
+        assertRuntimeMetricEquals(metric, new RuntimeMetric(TEST_METRIC_NAME, 3, 2, 2, 1));
+        assertRuntimeMetricEquals(metricCopy, new RuntimeMetric(TEST_METRIC_NAME, 1, 1, 1, 1));
+        metricCopy.addValue(2);
+        assertRuntimeMetricEquals(metric, new RuntimeMetric(TEST_METRIC_NAME, 3, 2, 2, 1));
+        assertRuntimeMetricEquals(metricCopy, metric);
+    }
+
+    @Test
+    public void testMergeWith()
+    {
+        RuntimeMetric metric1 = new RuntimeMetric(TEST_METRIC_NAME, 5, 2, 4, 1);
+        RuntimeMetric metric2 = new RuntimeMetric(TEST_METRIC_NAME, 20, 2, 11, 9);
+        metric1.mergeWith(metric2);
+        assertRuntimeMetricEquals(metric1, new RuntimeMetric(TEST_METRIC_NAME, 25, 4, 11, 1));
+
+        metric2.mergeWith(metric2);
+        assertRuntimeMetricEquals(metric2, new RuntimeMetric(TEST_METRIC_NAME, 40, 4, 11, 9));
+
+        metric2.mergeWith(null);
+        assertRuntimeMetricEquals(metric2, new RuntimeMetric(TEST_METRIC_NAME, 40, 4, 11, 9));
+    }
+
+    @Test
+    public void testMerge()
+    {
+        RuntimeMetric metric1 = new RuntimeMetric(TEST_METRIC_NAME, 5, 2, 4, 1);
+        RuntimeMetric metric2 = new RuntimeMetric(TEST_METRIC_NAME, 20, 2, 11, 9);
+        assertRuntimeMetricEquals(RuntimeMetric.merge(metric1, metric2), new RuntimeMetric(TEST_METRIC_NAME, 25, 4, 11, 1));
+
+        assertRuntimeMetricEquals(metric1, new RuntimeMetric(TEST_METRIC_NAME, 5, 2, 4, 1));
+        assertRuntimeMetricEquals(metric2, new RuntimeMetric(TEST_METRIC_NAME, 20, 2, 11, 9));
+    }
+
+    @Test
+    public void testJson()
+    {
+        JsonCodec<RuntimeMetric> codec = JsonCodec.jsonCodec(RuntimeMetric.class);
+        RuntimeMetric metric = new RuntimeMetric(TEST_METRIC_NAME);
+        metric.addValue(101);
+        metric.addValue(202);
+
+        String json = codec.toJson(metric);
+        RuntimeMetric actual = codec.fromJson(json);
+
+        assertRuntimeMetricEquals(actual, metric);
+    }
+}

--- a/presto-common/src/test/java/com/facebook/presto/common/TestRuntimeStats.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/TestRuntimeStats.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common;
+
+import com.facebook.airlift.json.JsonCodec;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+public class TestRuntimeStats
+{
+    private static final String TEST_METRIC_NAME_1 = "test1";
+    private static final String TEST_METRIC_NAME_2 = "test2";
+    private static final String TEST_METRIC_NAME_3 = "test3";
+
+    private void assertRuntimeMetricEquals(RuntimeMetric m1, RuntimeMetric m2)
+    {
+        assertEquals(m1.getName(), m2.getName());
+        assertEquals(m1.getSum(), m2.getSum());
+        assertEquals(m1.getCount(), m2.getCount());
+        assertEquals(m1.getMax(), m2.getMax());
+        assertEquals(m1.getMin(), m2.getMin());
+    }
+
+    @Test
+    public void testAddMetricValue()
+    {
+        RuntimeStats stats = new RuntimeStats();
+        stats.addMetricValue(TEST_METRIC_NAME_1, 2);
+        stats.addMetricValue(TEST_METRIC_NAME_1, 3);
+        stats.addMetricValue(TEST_METRIC_NAME_1, 5);
+
+        assertRuntimeMetricEquals(
+                stats.getMetric(TEST_METRIC_NAME_1),
+                new RuntimeMetric(TEST_METRIC_NAME_1, 10, 3, 5, 2));
+
+        stats.reset();
+        assertEquals(stats.getMetrics().size(), 0);
+    }
+
+    @Test
+    public void testMerge()
+    {
+        RuntimeStats stats1 = new RuntimeStats();
+        stats1.addMetricValue(TEST_METRIC_NAME_1, 2);
+        stats1.addMetricValue(TEST_METRIC_NAME_1, 3);
+        stats1.addMetricValue(TEST_METRIC_NAME_2, 1);
+        stats1.addMetricValue(TEST_METRIC_NAME_2, 2);
+
+        RuntimeStats stats2 = new RuntimeStats();
+        stats2.addMetricValue(TEST_METRIC_NAME_2, 0);
+        stats2.addMetricValue(TEST_METRIC_NAME_2, 3);
+        stats2.addMetricValue(TEST_METRIC_NAME_3, 8);
+
+        RuntimeStats mergedStats = RuntimeStats.merge(stats1, stats2);
+        assertRuntimeMetricEquals(
+                mergedStats.getMetric(TEST_METRIC_NAME_1),
+                new RuntimeMetric(TEST_METRIC_NAME_1, 5, 2, 3, 2));
+        assertRuntimeMetricEquals(
+                mergedStats.getMetric(TEST_METRIC_NAME_2),
+                new RuntimeMetric(TEST_METRIC_NAME_2, 6, 4, 3, 0));
+        assertRuntimeMetricEquals(
+                mergedStats.getMetric(TEST_METRIC_NAME_3),
+                new RuntimeMetric(TEST_METRIC_NAME_3, 8, 1, 8, 8));
+
+        stats1.mergeWith(stats2);
+        mergedStats.getMetrics().values().forEach(metric -> assertRuntimeMetricEquals(metric, stats1.getMetric(metric.getName())));
+        assertEquals(mergedStats.getMetrics().size(), stats1.getMetrics().size());
+    }
+
+    @Test
+    public void testMergeWithNull()
+    {
+        RuntimeStats stats = new RuntimeStats();
+        stats.addMetricValue(TEST_METRIC_NAME_1, 2);
+        stats.mergeWith(null);
+        assertRuntimeMetricEquals(
+                stats.getMetric(TEST_METRIC_NAME_1),
+                new RuntimeMetric(TEST_METRIC_NAME_1, 2, 1, 2, 2));
+    }
+
+    @Test
+    public void testUpdate()
+    {
+        RuntimeStats stats1 = new RuntimeStats();
+        stats1.addMetricValue(TEST_METRIC_NAME_1, 2);
+        stats1.update(null);
+        assertRuntimeMetricEquals(
+                stats1.getMetric(TEST_METRIC_NAME_1),
+                new RuntimeMetric(TEST_METRIC_NAME_1, 2, 1, 2, 2));
+
+        RuntimeStats stats2 = new RuntimeStats();
+        stats2.addMetricValue(TEST_METRIC_NAME_2, 2);
+        stats1.update(stats2);
+        assertRuntimeMetricEquals(
+                stats1.getMetric(TEST_METRIC_NAME_1),
+                new RuntimeMetric(TEST_METRIC_NAME_1, 2, 1, 2, 2));
+        assertRuntimeMetricEquals(
+                stats1.getMetric(TEST_METRIC_NAME_2),
+                stats1.getMetric(TEST_METRIC_NAME_2));
+
+        stats2.addMetricValue(TEST_METRIC_NAME_2, 4);
+        stats1.update(stats2);
+        assertRuntimeMetricEquals(
+                stats1.getMetric(TEST_METRIC_NAME_2),
+                stats1.getMetric(TEST_METRIC_NAME_2));
+    }
+
+    @Test
+    public void testJson()
+    {
+        RuntimeStats stats = new RuntimeStats();
+        stats.addMetricValue(TEST_METRIC_NAME_1, 2);
+        stats.addMetricValue(TEST_METRIC_NAME_1, 3);
+        stats.addMetricValue(TEST_METRIC_NAME_2, 8);
+
+        JsonCodec<RuntimeStats> codec = JsonCodec.jsonCodec(RuntimeStats.class);
+        String json = codec.toJson(stats);
+        RuntimeStats actual = codec.fromJson(json);
+
+        assertRuntimeMetricEquals(actual.getMetric(TEST_METRIC_NAME_1), stats.getMetric(TEST_METRIC_NAME_1));
+        assertRuntimeMetricEquals(actual.getMetric(TEST_METRIC_NAME_2), stats.getMetric(TEST_METRIC_NAME_2));
+    }
+
+    @Test
+    public void testNullJson()
+    {
+        JsonCodec<RuntimeStats> codec = JsonCodec.jsonCodec(RuntimeStats.class);
+        String nullJson = codec.toJson(null);
+        RuntimeStats actual = codec.fromJson(nullJson);
+        assertNull(actual);
+    }
+}

--- a/presto-hive-common/pom.xml
+++ b/presto-hive-common/pom.xml
@@ -16,6 +16,11 @@
     <dependencies>
         <dependency>
             <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-common</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
             <artifactId>presto-spi</artifactId>
         </dependency>
 

--- a/presto-hive-common/src/main/java/com/facebook/presto/hive/HiveFileContext.java
+++ b/presto-hive-common/src/main/java/com/facebook/presto/hive/HiveFileContext.java
@@ -13,6 +13,8 @@
  */
 package com.facebook.presto.hive;
 
+import com.facebook.presto.common.RuntimeStats;
+
 import java.util.Optional;
 
 import static com.facebook.presto.hive.CacheQuota.NO_CACHE_CONSTRAINTS;
@@ -26,6 +28,8 @@ public class HiveFileContext
     private final CacheQuota cacheQuota;
     private final Optional<ExtraHiveFileInfo<?>> extraFileInfo;
     private final Optional<Long> fileSize;
+
+    private final RuntimeStats stats = new RuntimeStats();
 
     public HiveFileContext(boolean cacheable, CacheQuota cacheQuota, Optional<ExtraHiveFileInfo<?>> extraFileInfo, Optional<Long> fileSize)
     {
@@ -64,5 +68,15 @@ public class HiveFileContext
     public interface ExtraHiveFileInfo<T>
     {
         T getExtraFileInfo();
+    }
+
+    public void incrementCounter(String name, long value)
+    {
+        stats.addMetricValue(name, value);
+    }
+
+    public RuntimeStats getStats()
+    {
+        return stats;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/FilteringPageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/FilteringPageSource.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.hive;
 
 import com.facebook.presto.common.Page;
+import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.predicate.Domain;
 import com.facebook.presto.common.predicate.TupleDomain;
@@ -199,6 +200,12 @@ public class FilteringPageSource
     public long getSystemMemoryUsage()
     {
         return delegate.getSystemMemoryUsage();
+    }
+
+    @Override
+    public RuntimeStats getRuntimeStats()
+    {
+        return delegate.getRuntimeStats();
     }
 
     @Override

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSource.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.hive;
 
 import com.facebook.presto.common.Page;
+import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.LazyBlock;
 import com.facebook.presto.common.block.LazyBlockLoader;
@@ -184,6 +185,12 @@ public class HivePageSource
         catch (IOException e) {
             throw new UncheckedIOException(e);
         }
+    }
+
+    @Override
+    public RuntimeStats getRuntimeStats()
+    {
+        return delegate.getRuntimeStats();
     }
 
     @Override

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcBatchPageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcBatchPageSource.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.hive.orc;
 
 import com.facebook.presto.common.Page;
+import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.LazyBlock;
 import com.facebook.presto.common.block.LazyBlockLoader;
@@ -63,13 +64,16 @@ public class OrcBatchPageSource
 
     private final FileFormatDataSourceStats stats;
 
+    private final RuntimeStats runtimeStats;
+
     public OrcBatchPageSource(
             OrcBatchRecordReader recordReader,
             OrcDataSource orcDataSource,
             List<HiveColumnHandle> columns,
             TypeManager typeManager,
             OrcAggregatedMemoryContext systemMemoryContext,
-            FileFormatDataSourceStats stats)
+            FileFormatDataSourceStats stats,
+            RuntimeStats runtimeStats)
     {
         this.recordReader = requireNonNull(recordReader, "recordReader is null");
         this.orcDataSource = requireNonNull(orcDataSource, "orcDataSource is null");
@@ -77,6 +81,7 @@ public class OrcBatchPageSource
         int size = requireNonNull(columns, "columns is null").size();
 
         this.stats = requireNonNull(stats, "stats is null");
+        this.runtimeStats = runtimeStats;
 
         this.constantBlocks = new Block[size];
         this.hiveColumnIndexes = new int[size];
@@ -103,6 +108,12 @@ public class OrcBatchPageSource
         columnNames = namesBuilder.build();
 
         this.systemMemoryContext = requireNonNull(systemMemoryContext, "systemMemoryContext is null");
+    }
+
+    @Override
+    public RuntimeStats getRuntimeStats()
+    {
+        return runtimeStats;
     }
 
     @Override

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcBatchPageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcBatchPageSourceFactory.java
@@ -293,7 +293,8 @@ public class OrcBatchPageSourceFactory
                     physicalColumns,
                     typeManager,
                     systemMemoryUsage,
-                    stats);
+                    stats,
+                    hiveFileContext.getStats());
         }
         catch (Exception e) {
             try {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcSelectivePageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcSelectivePageSource.java
@@ -15,6 +15,7 @@ package com.facebook.presto.hive.orc;
 
 import com.facebook.presto.common.InvalidFunctionArgumentException;
 import com.facebook.presto.common.Page;
+import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.hive.FileFormatDataSourceStats;
 import com.facebook.presto.orc.OrcAggregatedMemoryContext;
 import com.facebook.presto.orc.OrcCorruptionException;
@@ -40,6 +41,7 @@ public class OrcSelectivePageSource
     private final OrcDataSource orcDataSource;
     private final OrcAggregatedMemoryContext systemMemoryContext;
     private final FileFormatDataSourceStats stats;
+    private final RuntimeStats runtimeStats;
 
     private boolean closed;
 
@@ -47,12 +49,20 @@ public class OrcSelectivePageSource
             OrcSelectiveRecordReader recordReader,
             OrcDataSource orcDataSource,
             OrcAggregatedMemoryContext systemMemoryContext,
-            FileFormatDataSourceStats stats)
+            FileFormatDataSourceStats stats,
+            RuntimeStats runtimeStats)
     {
         this.recordReader = requireNonNull(recordReader, "recordReader is null");
         this.orcDataSource = requireNonNull(orcDataSource, "orcDataSource is null");
         this.systemMemoryContext = requireNonNull(systemMemoryContext, "systemMemoryContext is null");
         this.stats = requireNonNull(stats, "stats is null");
+        this.runtimeStats = runtimeStats;
+    }
+
+    @Override
+    public RuntimeStats getRuntimeStats()
+    {
+        return runtimeStats;
     }
 
     @Override

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcSelectivePageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcSelectivePageSourceFactory.java
@@ -410,7 +410,8 @@ public class OrcSelectivePageSourceFactory
                     recordReader,
                     reader.getOrcDataSource(),
                     systemMemoryUsage,
-                    stats);
+                    stats,
+                    hiveFileContext.getStats());
         }
         catch (Exception e) {
             try {

--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestProgressMonitor.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestProgressMonitor.java
@@ -90,7 +90,11 @@ public class TestProgressMonitor
                 nextUriId == null ? null : server.url(format("/v1/statement/%s/%s", queryId, nextUriId)).uri(),
                 responseColumns,
                 data,
-                new StatementStats(state, state.equals("WAITING_FOR_PREREQUISITES"), state.equals("QUEUED"), true, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, null),
+                StatementStats.builder()
+                        .setState(state)
+                        .setWaitingForPrerequisites(state.equals("WAITING_FOR_PREREQUISITES"))
+                        .setScheduled(true)
+                        .build(),
                 null,
                 ImmutableList.of(),
                 null,

--- a/presto-main/src/main/java/com/facebook/presto/event/QueryMonitor.java
+++ b/presto-main/src/main/java/com/facebook/presto/event/QueryMonitor.java
@@ -279,7 +279,8 @@ public class QueryMonitor
                         operatorSummary.getPeakSystemMemoryReservation(),
                         operatorSummary.getPeakTotalMemoryReservation(),
                         operatorSummary.getSpilledDataSize(),
-                        Optional.ofNullable(operatorSummary.getInfo()).map(operatorInfoCodec::toJson)))
+                        Optional.ofNullable(operatorSummary.getInfo()).map(operatorInfoCodec::toJson),
+                        operatorSummary.getRuntimeStats()))
                 .collect(toImmutableList());
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryStats.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.execution;
 
+import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.operator.BlockedReason;
 import com.facebook.presto.operator.OperatorStats;
 import com.facebook.presto.operator.TableWriterOperator;
@@ -862,5 +863,13 @@ public class QueryStats
         return succinctBytes(operatorSummaries.stream()
                 .mapToLong(stats -> stats.getSpilledDataSize().toBytes())
                 .sum());
+    }
+
+    @JsonProperty
+    public RuntimeStats getRuntimeStats()
+    {
+        RuntimeStats runtimeStats = new RuntimeStats();
+        operatorSummaries.stream().forEach(stats -> runtimeStats.mergeWith(stats.getRuntimeStats()));
+        return runtimeStats;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/DriverContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/DriverContext.java
@@ -409,7 +409,7 @@ public class DriverContext
                 outputDataSize.convertToMostSuccinctDataSize(),
                 outputPositions,
                 succinctBytes(physicalWrittenDataSize),
-                ImmutableList.copyOf(transform(operatorContexts, OperatorContext::getOperatorStats)));
+                operators);
     }
 
     public <C, R> R accept(QueryContextVisitor<C, R> visitor, C context)

--- a/presto-main/src/main/java/com/facebook/presto/operator/TableScanOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TableScanOperator.java
@@ -275,6 +275,7 @@ public class TableScanOperator
         long positionCount = endCompletedPositions - completedPositions;
         operatorContext.recordProcessedInput(inputBytes, positionCount);
         operatorContext.recordRawInputWithTiming(inputBytes, positionCount, endReadTimeNanos - readTimeNanos);
+        operatorContext.updateStats(source.getRuntimeStats());
         completedBytes = endCompletedBytes;
         completedPositions = endCompletedPositions;
         readTimeNanos = endReadTimeNanos;

--- a/presto-main/src/main/java/com/facebook/presto/server/protocol/QueryResourceUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/protocol/QueryResourceUtil.java
@@ -147,6 +147,7 @@ public final class QueryResourceUtil
                 .setPeakTaskTotalMemoryBytes(queryStats.getPeakTaskTotalMemory().toBytes())
                 .setSpilledBytes(queryStats.getSpilledDataSize().toBytes())
                 .setRootStage(toStageStats(outputStage))
+                .setRuntimeStats(queryStats.getRuntimeStats())
                 .build();
     }
 

--- a/presto-main/src/main/resources/webapp/src/components/QueryDetail.jsx
+++ b/presto-main/src/main/resources/webapp/src/components/QueryDetail.jsx
@@ -1046,6 +1046,39 @@ export class QueryDetail extends React.Component {
         }
     }
 
+    renderRuntimeStats() {
+        const query = this.state.query;
+        if (Object.values(query.queryStats.runtimeStats).length == 0) return null;
+        return (
+            <div className="row">
+                <div className="col-xs-6">
+                    <h3>RuntimeStats</h3>
+                    <hr className="h3-hr"/>
+                     <table className="table" id="runtime-stats-table">
+                         <tbody>
+                         <tr>
+                             <th className="info-text">Metric Name</th>
+                             <th className="info-text">Sum</th>
+                             <th className="info-text">Count</th>
+                             <th className="info-text">Max</th>
+                             <th className="info-text">Min</th>
+                         </tr>
+                         {Object.values(query.queryStats.runtimeStats).map((metric) =>
+                             <tr>
+                                 <td className="info-text">{metric.name}</td>
+                                 <td className="info-text">{formatCount(metric.sum)}</td>
+                                 <td className="info-text">{formatCount(metric.count)}</td>
+                                 <td className="info-text">{formatCount(metric.max)}</td>
+                                 <td className="info-text">{formatCount(metric.min)}</td>
+                             </tr>
+                         )}
+                         </tbody>
+                     </table>
+                </div>
+            </div>
+        );
+    }
+
     renderFailureInfo() {
         const query = this.state.query;
         if (query.failureInfo) {
@@ -1523,6 +1556,7 @@ export class QueryDetail extends React.Component {
                         </div>
                     </div>
                 </div>
+                {this.renderRuntimeStats()}
                 {this.renderWarningInfo()}
                 {this.renderFailureInfo()}
                 <div className="row">

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestQueryStats.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestQueryStats.java
@@ -14,12 +14,15 @@
 package com.facebook.presto.execution;
 
 import com.facebook.airlift.json.JsonCodec;
+import com.facebook.presto.common.RuntimeMetric;
+import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.operator.FilterAndProjectOperator;
 import com.facebook.presto.operator.OperatorStats;
 import com.facebook.presto.operator.TableWriterOperator;
 import com.facebook.presto.spi.eventlistener.StageGcStatistics;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
@@ -37,6 +40,10 @@ import static org.testng.Assert.assertEquals;
 
 public class TestQueryStats
 {
+    private static final String TEST_METRIC_NAME = "test_metric";
+    private static final RuntimeMetric TEST_RUNTIME_METRIC_1 = new RuntimeMetric(TEST_METRIC_NAME, 10, 2, 9, 1);
+    private static final RuntimeMetric TEST_RUNTIME_METRIC_2 = new RuntimeMetric(TEST_METRIC_NAME, 5, 2, 3, 2);
+
     private static final List<OperatorStats> OPERATOR_SUMMARIES = ImmutableList.of(
             new OperatorStats(
                     10,
@@ -76,7 +83,8 @@ public class TestQueryStats
                     succinctBytes(129L),
                     succinctBytes(130L),
                     Optional.empty(),
-                    null),
+                    null,
+                    new RuntimeStats(ImmutableMap.of(TEST_METRIC_NAME, RuntimeMetric.copyOf(TEST_RUNTIME_METRIC_1)))),
             new OperatorStats(
                     20,
                     201,
@@ -115,7 +123,8 @@ public class TestQueryStats
                     succinctBytes(229L),
                     succinctBytes(230L),
                     Optional.empty(),
-                    null),
+                    null,
+                    new RuntimeStats(ImmutableMap.of(TEST_METRIC_NAME, RuntimeMetric.copyOf(TEST_RUNTIME_METRIC_2)))),
             new OperatorStats(
                     30,
                     301,
@@ -154,7 +163,8 @@ public class TestQueryStats
                     succinctBytes(329L),
                     succinctBytes(330L),
                     Optional.empty(),
-                    null));
+                    null,
+                    new RuntimeStats()));
 
     private static final QueryStats EXPECTED = new QueryStats(
             new DateTime(1),
@@ -314,5 +324,16 @@ public class TestQueryStats
         assertEquals(gcStatistics.getMaxFullGcSec(), 105);
         assertEquals(gcStatistics.getTotalFullGcSec(), 106);
         assertEquals(gcStatistics.getAverageFullGcSec(), 107);
+
+        assertRuntimeMetricEquals(actual.getRuntimeStats().getMetric(TEST_METRIC_NAME), RuntimeMetric.merge(TEST_RUNTIME_METRIC_1, TEST_RUNTIME_METRIC_2));
+    }
+
+    private static void assertRuntimeMetricEquals(RuntimeMetric m1, RuntimeMetric m2)
+    {
+        assertEquals(m1.getName(), m2.getName());
+        assertEquals(m1.getSum(), m2.getSum());
+        assertEquals(m1.getCount(), m2.getCount());
+        assertEquals(m1.getMax(), m2.getMax());
+        assertEquals(m1.getMin(), m2.getMin());
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestOperatorStats.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestOperatorStats.java
@@ -14,8 +14,11 @@
 package com.facebook.presto.operator;
 
 import com.facebook.airlift.json.JsonCodec;
+import com.facebook.presto.common.RuntimeMetric;
+import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.operator.repartition.PartitionedOutputInfo;
 import com.facebook.presto.spi.plan.PlanNodeId;
+import com.google.common.collect.ImmutableMap;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import org.testng.annotations.Test;
@@ -31,6 +34,9 @@ public class TestOperatorStats
 {
     private static final SplitOperatorInfo NON_MERGEABLE_INFO = new SplitOperatorInfo("some_info");
     private static final PartitionedOutputInfo MERGEABLE_INFO = new PartitionedOutputInfo(1, 2, 1024);
+    private static final String TEST_METRIC_NAME = "test_metric";
+    private static final RuntimeMetric TEST_RUNTIME_METRIC_1 = new RuntimeMetric(TEST_METRIC_NAME, 10, 2, 9, 1);
+    private static final RuntimeMetric TEST_RUNTIME_METRIC_2 = new RuntimeMetric(TEST_METRIC_NAME, 5, 2, 3, 2);
 
     public static final OperatorStats EXPECTED = new OperatorStats(
             0,
@@ -76,8 +82,10 @@ public class TestOperatorStats
             new DataSize(23, BYTE),
             new DataSize(24, BYTE),
             new DataSize(25, BYTE),
+
             Optional.empty(),
-            NON_MERGEABLE_INFO);
+            NON_MERGEABLE_INFO,
+            new RuntimeStats(ImmutableMap.of(TEST_METRIC_NAME, RuntimeMetric.copyOf(TEST_RUNTIME_METRIC_1))));
 
     public static final OperatorStats MERGEABLE = new OperatorStats(
             0,
@@ -124,7 +132,8 @@ public class TestOperatorStats
             new DataSize(24, BYTE),
             new DataSize(25, BYTE),
             Optional.empty(),
-            MERGEABLE_INFO);
+            MERGEABLE_INFO,
+            new RuntimeStats(ImmutableMap.of(TEST_METRIC_NAME, RuntimeMetric.copyOf(TEST_RUNTIME_METRIC_2))));
 
     @Test
     public void testJson()
@@ -135,6 +144,15 @@ public class TestOperatorStats
         OperatorStats actual = codec.fromJson(json);
 
         assertExpectedOperatorStats(actual);
+    }
+
+    private static void assertRuntimeMetricEquals(RuntimeMetric m1, RuntimeMetric m2)
+    {
+        assertEquals(m1.getName(), m2.getName());
+        assertEquals(m1.getSum(), m2.getSum());
+        assertEquals(m1.getCount(), m2.getCount());
+        assertEquals(m1.getMax(), m2.getMax());
+        assertEquals(m1.getMin(), m2.getMin());
     }
 
     public static void assertExpectedOperatorStats(OperatorStats actual)
@@ -179,6 +197,7 @@ public class TestOperatorStats
         assertEquals(actual.getSpilledDataSize(), new DataSize(25, BYTE));
         assertEquals(actual.getInfo().getClass(), SplitOperatorInfo.class);
         assertEquals(((SplitOperatorInfo) actual.getInfo()).getSplitInfo(), NON_MERGEABLE_INFO.getSplitInfo());
+        assertRuntimeMetricEquals(actual.getRuntimeStats().getMetric(TEST_METRIC_NAME), TEST_RUNTIME_METRIC_1);
     }
 
     @Test
@@ -225,6 +244,9 @@ public class TestOperatorStats
         assertEquals(actual.getPeakTotalMemoryReservation(), new DataSize(24, BYTE));
         assertEquals(actual.getSpilledDataSize(), new DataSize(3 * 25, BYTE));
         assertNull(actual.getInfo());
+        RuntimeMetric expectedMetric = RuntimeMetric.merge(TEST_RUNTIME_METRIC_1, TEST_RUNTIME_METRIC_1);
+        expectedMetric.mergeWith(TEST_RUNTIME_METRIC_1);
+        assertRuntimeMetricEquals(actual.getRuntimeStats().getMetric(TEST_METRIC_NAME), expectedMetric);
     }
 
     @Test
@@ -273,5 +295,8 @@ public class TestOperatorStats
         assertEquals(actual.getSpilledDataSize(), new DataSize(3 * 25, BYTE));
         assertEquals(actual.getInfo().getClass(), PartitionedOutputInfo.class);
         assertEquals(((PartitionedOutputInfo) actual.getInfo()).getPagesAdded(), 3 * MERGEABLE_INFO.getPagesAdded());
+        RuntimeMetric expectedMetric = RuntimeMetric.merge(TEST_RUNTIME_METRIC_2, TEST_RUNTIME_METRIC_2);
+        expectedMetric.mergeWith(TEST_RUNTIME_METRIC_2);
+        assertRuntimeMetricEquals(actual.getRuntimeStats().getMetric(TEST_METRIC_NAME), expectedMetric);
     }
 }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
@@ -760,6 +760,7 @@ public class PrestoSparkQueryExecutionFactory
                 stats.getPeakTotalMemoryBytes(),
                 stats.getPeakTaskTotalMemoryBytes(),
                 stats.getSpilledBytes(),
+                null,
                 null);
 
         return new PrestoSparkQueryStatusInfo(

--- a/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorPageSource.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorPageSource.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.spi;
 
 import com.facebook.presto.common.Page;
+import com.facebook.presto.common.RuntimeStats;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -75,5 +76,13 @@ public interface ConnectorPageSource
     default CompletableFuture<?> isBlocked()
     {
         return NOT_BLOCKED;
+    }
+
+    /**
+     * Returns the stats of this page source accumulated so far.
+     */
+    default RuntimeStats getRuntimeStats()
+    {
+        return null;
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/OperatorStatistics.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/OperatorStatistics.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.spi.eventlistener;
 
+import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
@@ -72,6 +73,8 @@ public class OperatorStatistics
 
     private final Optional<String> info;
 
+    private final RuntimeStats runtimeStats;
+
     public OperatorStatistics(
             int stageId,
             int stageExecutionId,
@@ -117,7 +120,8 @@ public class OperatorStatistics
 
             DataSize spilledDataSize,
 
-            Optional<String> info)
+            Optional<String> info,
+            RuntimeStats runtimeStats)
     {
         this.stageId = stageId;
         this.stageExecutionId = stageExecutionId;
@@ -166,6 +170,7 @@ public class OperatorStatistics
         this.spilledDataSize = requireNonNull(spilledDataSize, "spilledDataSize is null");
 
         this.info = requireNonNull(info, "info is null");
+        this.runtimeStats = runtimeStats;
     }
 
     public int getStageId()
@@ -346,5 +351,10 @@ public class OperatorStatistics
     public Optional<String> getInfo()
     {
         return info;
+    }
+
+    public RuntimeStats getRuntimeStats()
+    {
+        return runtimeStats;
     }
 }


### PR DESCRIPTION
In the previous metric tracking mechanism, adding a new operator metric requires lots of manually work such as adding a specific variable, updating the aggregation logic at different levels, etc.

This new metric tracking mechanism uses a map to track the metrics values and use string to represent arbitrary metric names. So adding a new metric is extremely easy. The aggregation logic doesn't need to change.

Test plan - (Please fill in how you tested your changes)
Added unit test and tested it locally.
Note that the Alliuxo per query cache counter change depends on https://github.com/Alluxio/alluxio/pull/13665. It doesn't work until that change is pushed and integrated into presto.

```
== NO RELEASE NOTE ==
```
