### PR TITLE
Add PrestoConnection getProperties method to presto-jdbc

### DIFF
--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoConnection.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoConnection.java
@@ -89,6 +89,7 @@ public class PrestoConnection
     private final boolean compressionDisabled;
     private final Map<String, String> extraCredentials;
     private final Map<String, String> sessionProperties;
+    private final Properties connectionProperties;
     private final Optional<String> applicationNamePrefix;
     private final Map<String, String> clientInfo = new ConcurrentHashMap<>();
     private final Map<String, String> preparedStatements = new ConcurrentHashMap<>();
@@ -112,6 +113,7 @@ public class PrestoConnection
 
         this.extraCredentials = uri.getExtraCredentials();
         this.sessionProperties = new ConcurrentHashMap<>(uri.getSessionProperties());
+        this.connectionProperties = uri.getProperties();
         this.queryExecutor = requireNonNull(queryExecutor, "queryExecutor is null");
 
         timeZoneId.set(TimeZone.getDefault().getID());
@@ -545,6 +547,16 @@ public class PrestoConnection
     {
         checkOpen();
         return schema.get();
+    }
+
+    public Properties getConnectionProperties()
+    {
+        Properties properties = new Properties();
+        for (Map.Entry<Object, Object> entry : connectionProperties.entrySet()) {
+            properties.setProperty((String) entry.getKey(), (String) entry.getValue());
+        }
+
+        return properties;
     }
 
     public String getTimeZoneId()

--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestJdbcConnection.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestJdbcConnection.java
@@ -42,6 +42,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 
 import static com.facebook.presto.common.type.VarcharType.createUnboundedVarcharType;
@@ -53,6 +54,7 @@ import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
 public class TestJdbcConnection
@@ -254,6 +256,18 @@ public class TestJdbcConnection
             List<QueryInterceptor> queryInterceptorInstances = connection.getQueryInterceptorInstances();
             assertEquals(queryInterceptorInstances.size(), 1);
             assertEquals(queryInterceptorInstances.get(0).getClass().getName(), TestNoopQueryInterceptor.class.getName());
+        }
+    }
+
+    @Test
+    public void testConnectionProperties()
+            throws SQLException
+    {
+        String extra = "extraCredentials=test.token.foo:bar;test.token.abc:xyz";
+        try (PrestoConnection connection = createConnection(extra).unwrap(PrestoConnection.class)) {
+            Properties connectionProperties = connection.getConnectionProperties();
+            assertTrue(connectionProperties.size() > 0);
+            assertNotNull(connectionProperties.getProperty("extraCredentials"));
         }
     }
 


### PR DESCRIPTION
Introduce a method to access PrestoConnection properties at runtime.
The usecase behind this request is described in issue #16320  

Addresses issue #16320 

Test plan 
- Run new test  in TestJdbcConnection
- mvn clean install  -rf :presto-jdbc
- Integration test used by loading the new driver and checking that method returns the properties used to open a presto connection
```
== RELEASE NOTES ==

PrestoConnection getProperties method inclusion
* Adds a method to get the properties used to open a presto conenction in runtime to allwo property reused during queryInterceptor implementations
```
