### PR TITLE
Create GenericHiveRecordCursor within doAs block to pass the correct credentials to storage

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/GenericHiveRecordCursorProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/GenericHiveRecordCursorProvider.java
@@ -72,16 +72,16 @@ public class GenericHiveRecordCursorProvider
 
         RecordReader<?, ?> recordReader = hdfsEnvironment.doAs(session.getUser(),
                 () -> HiveUtil.createRecordReader(configuration, path, start, length, schema, columns, customSplitInfo));
-
-        return Optional.of(new GenericHiveRecordCursor<>(
-                configuration,
-                path,
-                genericRecordReader(recordReader),
-                length,
-                schema,
-                columns,
-                hiveStorageTimeZone,
-                typeManager));
+        return hdfsEnvironment.doAs(session.getUser(),
+                () -> Optional.of(new GenericHiveRecordCursor<>(
+                        configuration,
+                        path,
+                        genericRecordReader(recordReader),
+                        length,
+                        schema,
+                        columns,
+                        hiveStorageTimeZone,
+                        typeManager)));
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Add authentication when creating Hive page source, this is needed when:
1. table schema is stored as an Avro file schema on some remote path, e.g. avro.schema.url = hdfs://...
2. the remote HDFS path requires authentication

Currently this code path in Presto does not include authentication, so this fetching remote Avro schema would fail. Causing exception something like below:
```
java.lang.RuntimeException: error initializing deserializer: com.facebook.presto.hive.avro.PrestoAvroSerDe
	at com.facebook.presto.hive.HiveUtil.initializeDeserializer(HiveUtil.java:443)
	at com.facebook.presto.hive.HiveUtil.getDeserializer(HiveUtil.java:396)
	at com.facebook.presto.hive.GenericHiveRecordCursor.<init>(GenericHiveRecordCursor.java:141)
	at com.facebook.presto.hive.GenericHiveRecordCursorProvider.createRecordCursor(GenericHiveRecordCursorProvider.java:79)
	at com.facebook.presto.hive.HivePageSourceProvider.createHivePageSource(HivePageSourceProvider.java:357)
	at com.facebook.presto.hive.HivePageSourceProvider.createPageSource(HivePageSourceProvider.java:125)
	at com.facebook.presto.spi.connector.classloader.ClassLoaderSafeConnectorPageSourceProvider.createPageSource(ClassLoaderSafeConnectorPageSourceProvider.java:51)
	at com.facebook.presto.split.PageSourceManager.createPageSource(PageSourceManager.java:58)
....
Caused by: org.ietf.jgss.GSSException: No valid credentials provided (Mechanism level: Failed to find any Kerberos tgt)
	at java.security.jgss/sun.security.jgss.krb5.Krb5InitCredential.getInstance(Krb5InitCredential.java:147)
	at java.security.jgss/sun.security.jgss.krb5.Krb5MechFactory.getCredentialElement(Krb5MechFactory.java:126)
	at java.security.jgss/sun.security.jgss.krb5.Krb5MechFactory.getMechanismContext(Krb5MechFactory.java:191)
	at java.security.jgss/sun.security.jgss.GSSManagerImpl.getMechanismContext(GSSManagerImpl.java:218)
	at java.security.jgss/sun.security.jgss.GSSContextImpl.initSecContext(GSSContextImpl.java:230)
	at java.security.jgss/sun.security.jgss.GSSContextImpl.initSecContext(GSSContextImpl.java:196)
	at jdk.security.jgss/com.sun.security.sasl.gsskerb.GssKrb5Client.evaluateChallenge(GssKrb5Client.java:192)
	... 68 more
```

Test plan - (Please fill in how you tested your changes)

Tested in our internal testing cluster, with this change, the exception no longer shows up.