### PR TITLE
Fix to adjusted queue size for disagg coordinator

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroupManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroupManager.java
@@ -395,10 +395,19 @@ public final class InternalResourceGroupManager<C>
         return currentTimeMillis() - lastSchedulingCycleRunTimeMs.get();
     }
 
-    private static int getQueriesQueuedOnInternal(InternalResourceGroup resourceGroup)
+    private int getQueriesQueuedOnInternal(InternalResourceGroup resourceGroup)
     {
         if (resourceGroup.subGroups().isEmpty()) {
-            return Math.max(Math.min(resourceGroup.getQueuedQueries(), resourceGroup.getSoftConcurrencyLimit() - resourceGroup.getRunningQueries()), 0);
+            int queuedQueries = resourceGroup.getQueuedQueries();
+            int runningQueries = resourceGroup.getRunningQueries();
+            if (isResourceManagerEnabled) {
+                ResourceGroupRuntimeInfo resourceGroupRuntimeInfo = resourceGroupRuntimeInfos.get().get(resourceGroup.getId());
+                if (resourceGroupRuntimeInfo != null) {
+                    queuedQueries += resourceGroupRuntimeInfo.getQueuedQueries();
+                    runningQueries += resourceGroupRuntimeInfo.getRunningQueries();
+                }
+            }
+            return Math.max(Math.min(queuedQueries, resourceGroup.getSoftConcurrencyLimit() - runningQueries), 0);
         }
 
         int queriesQueuedInternal = 0;


### PR DESCRIPTION
Fixing adjusted queue size metric to support disagg coordinator where queries can be running on multiple coordinator and we consider them when calculating the value.

Test plan - Verified in test cluster

```
== NO RELEASE NOTE ==
```
