### PR TITLE
RowExpression duplicate isNull on same variable issue

### DIFF
--- a/presto-expressions/src/main/java/com/facebook/presto/expressions/LogicalRowExpressions.java
+++ b/presto-expressions/src/main/java/com/facebook/presto/expressions/LogicalRowExpressions.java
@@ -49,6 +49,7 @@ import static com.facebook.presto.common.function.OperatorType.LESS_THAN_OR_EQUA
 import static com.facebook.presto.common.function.OperatorType.NOT_EQUAL;
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.AND;
+import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.IS_NULL;
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.OR;
 import static java.lang.Math.min;
 import static java.util.Arrays.asList;
@@ -101,14 +102,16 @@ public final class LogicalRowExpressions
     {
         if (expression instanceof SpecialFormExpression && ((SpecialFormExpression) expression).getForm() == form) {
             SpecialFormExpression specialFormExpression = (SpecialFormExpression) expression;
-            if (specialFormExpression.getArguments().size() != 2) {
-                throw new IllegalStateException("logical binary expression requires exactly 2 operands");
+            if (specialFormExpression.getArguments().size() == 2) {
+                List<RowExpression> predicates = new ArrayList<>();
+                predicates.addAll(extractPredicates(form, specialFormExpression.getArguments().get(0)));
+                predicates.addAll(extractPredicates(form, specialFormExpression.getArguments().get(1)));
+                return unmodifiableList(predicates);
             }
-
-            List<RowExpression> predicates = new ArrayList<>();
-            predicates.addAll(extractPredicates(form, specialFormExpression.getArguments().get(0)));
-            predicates.addAll(extractPredicates(form, specialFormExpression.getArguments().get(1)));
-            return unmodifiableList(predicates);
+            if (specialFormExpression.getArguments().size() == 1 && form == IS_NULL) {
+                return singletonList(expression);
+            }
+            throw new IllegalStateException("Unexpected operands:" + expression + " " + form);
         }
 
         return singletonList(expression);

--- a/presto-main/src/test/java/com/facebook/presto/sql/relational/TestLogicalRowExpressions.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/relational/TestLogicalRowExpressions.java
@@ -24,6 +24,8 @@ import com.google.common.collect.ImmutableList;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -42,6 +44,7 @@ import static com.facebook.presto.expressions.LogicalRowExpressions.TRUE_CONSTAN
 import static com.facebook.presto.expressions.LogicalRowExpressions.extractPredicates;
 import static com.facebook.presto.metadata.FunctionAndTypeManager.createTestFunctionAndTypeManager;
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.AND;
+import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.IS_NULL;
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.OR;
 import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
 import static com.facebook.presto.sql.relational.Expressions.call;
@@ -166,6 +169,15 @@ public class TestLogicalRowExpressions
         assertEquals(
                 logicalRowExpressions.convertToConjunctiveNormalForm(and(a, and(b, or(c, and(e, or(f, and(FALSE_CONSTANT, d))))))),
                 and(and(a, b), or(c, and(e, f))));
+    }
+
+    @Test
+    public void testDuplicateIsNullExpressions()
+    {
+        SpecialFormExpression isNullExpression = new SpecialFormExpression(IS_NULL, BOOLEAN, a);
+        List<RowExpression> arguments = Arrays.asList(new SpecialFormExpression[]{isNullExpression, isNullExpression});
+        SpecialFormExpression duplicateIsNullExpression = new SpecialFormExpression(OR, BOOLEAN, arguments);
+        logicalRowExpressions.minimalNormalForm(duplicateIsNullExpression);
     }
 
     @Test


### PR DESCRIPTION
Part of simplifyRowExpressionOptimizer execution is eliminates duplicates. Part of execution is the the code below
```
    public RowExpression minimalNormalForm(RowExpression expression)
    {
        RowExpression conjunctiveNormalForm = convertToConjunctiveNormalForm(expression);
        RowExpression disjunctiveNormalForm = convertToDisjunctiveNormalForm(expression);
        return numOfClauses(conjunctiveNormalForm) > numOfClauses(disjunctiveNormalForm) ? disjunctiveNormalForm : conjunctiveNormalForm;
    }
```

One scenario is that there can be OR(IS_NULL(a), IS_NULL(a)), i.e. two duplicate IS_NULL on same variable. In this case, the two convertTo*NormalForm call will both simplify it to just one IS_NULL(a) instance, and with form set to IS_NULL (replacing original form = OR). However, this causes trouble for the numOfClauses call later, because current code assumes specialFormExpression must have 2 arguments, while here it is just IS_NULL(a) with only one argument. 

It is quite tricky to get to this corner case scenario though, just having a = null or a = null is not enough. I only got one query hitting this, and have been trying to hand craft a query that can cause this. Still have little clue so far, but the query that hit this issue has the core part below hitting the issue:
```
with x as (
  select a from xx
), z as (
  select case when (x.a is null or y.a is null) then 'AAA' else 'BBB' as col
  from y left join x on x.a = y.a
)
select * from z
where col != 'AAA'
```
Interestingly, even slightly tweaking the conditions (e.g. change to col = 'AAA' instead) this issue would not happen.

Test plan - (Please fill in how you tested your changes)

Added unit test.