### PR TITLE
Compact deserialized page in SingleStreamSpiller

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/Page.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/Page.java
@@ -177,10 +177,10 @@ public final class Page
         return wrapBlocksWithoutCopy(positionCount, newBlocks);
     }
 
-    public void compact()
+    public Page compact()
     {
         if (getRetainedSizeInBytes() <= getSizeInBytes()) {
-            return;
+            return this;
         }
 
         for (int i = 0; i < blocks.length; i++) {
@@ -202,6 +202,7 @@ public final class Page
         }
 
         updateRetainedSize();
+        return this;
     }
 
     private Map<DictionaryId, DictionaryBlockIndexes> getRelatedDictionaryBlocks()


### PR DESCRIPTION
Deserialized pages may contain block that is not
compact (e.g.,VariableWidthBlock might contain
a slice that is a view of all columns), which
results in incorrect retained size and memory
accounting issue.

When a block holds a slice of the entire page,
depends on number of affected blocks in a page,
memory could be off by N times (N >= count of
VariableWidthBlock).



```
== RELEASE NOTES ==

General Changes
* Fix spilled query exceeding local memory limit due to incorrect memory size calculation when spilled data is read by SingleStreamSpiller.

```
