### PR TITLE
Fix documentation of getOutputVariables method in PlanNode

### DIFF
--- a/presto-spi/src/main/java/com/facebook/presto/spi/plan/PlanNode.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/plan/PlanNode.java
@@ -48,8 +48,8 @@ public abstract class PlanNode
     public abstract List<PlanNode> getSources();
 
     /**
-     * The output from the upstream PlanNodes.
-     * It should serve as the input for the current PlanNode.
+     * The output from the current PlanNode.
+     * It should serve as a part of the input for the downstream PlanNode.
      */
     public abstract List<VariableReferenceExpression> getOutputVariables();
 


### PR DESCRIPTION
`getOutputVariables` should return output variables of current node, rather
than upstream nodes.

```
== NO RELEASE NOTE ==
```
