### PR TITLE
Add cross join unnest support for materialized view 

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveLogicalPlanner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveLogicalPlanner.java
@@ -1570,6 +1570,38 @@ public class TestHiveLogicalPlanner
         }
     }
 
+    @Test
+    public void testMaterializedViewForCrossJoinUnnest()
+    {
+        QueryRunner queryRunner = getQueryRunner();
+        String base = "orders_key_cross_join_unnest";
+        String view = "orders_view_cross_join_unnest";
+        try {
+            queryRunner.execute(format("CREATE TABLE %s WITH (partitioned_by = ARRAY['ds']) AS " +
+                    "SELECT orderkey, ARRAY['MEDIUM', 'LOW'] as volume, '2020-01-01' as ds FROM orders WHERE orderkey < 1000 " +
+                    "UNION ALL " +
+                    "SELECT orderkey, ARRAY['HIGH'] as volume, '2019-01-02' as ds FROM orders WHERE orderkey > 1000 and orderkey < 2000", base));
+
+            assertUpdate(format("CREATE MATERIALIZED VIEW %s WITH (partitioned_by = ARRAY['ds']) " +
+                    "AS SELECT orderkey AS view_orderkey, unnested.view_volume, ds " +
+                    "FROM %s CROSS JOIN UNNEST (volume) AS unnested(view_volume)", view, base));
+
+            assertTrue(queryRunner.tableExists(getSession(), view));
+
+            assertUpdate(format("REFRESH MATERIALIZED VIEW %s WHERE ds='2020-01-01'", view), 510);
+
+            String viewQuery = format("SELECT view_orderkey, view_volume, ds from %s where view_orderkey <  10000 ORDER BY view_orderkey, view_volume", view);
+            String baseQuery = format("SELECT orderkey AS view_orderkey, unnested.view_volume, ds " +
+                    "FROM %s CROSS JOIN UNNEST (volume) AS unnested(view_volume) " +
+                    "WHERE orderkey < 10000 ORDER BY orderkey, view_volume", base);
+            assertEquals(computeActual(viewQuery), computeActual(baseQuery));
+        }
+        finally {
+            queryRunner.execute("DROP TABLE IF EXISTS " + view);
+            queryRunner.execute("DROP TABLE IF EXISTS " + base);
+        }
+    }
+
     // Make sure subfield pruning doesn't interfere with cost-based optimizer
     @Test
     public void testPushdownSubfieldsAndJoinReordering()

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/PredicateStitcher.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/PredicateStitcher.java
@@ -28,6 +28,7 @@ import com.facebook.presto.sql.tree.Relation;
 import com.facebook.presto.sql.tree.Table;
 import com.facebook.presto.sql.tree.TableSubquery;
 import com.facebook.presto.sql.tree.Union;
+import com.facebook.presto.sql.tree.Unnest;
 import com.facebook.presto.sql.tree.With;
 import com.facebook.presto.sql.tree.WithQuery;
 
@@ -97,6 +98,12 @@ public class PredicateStitcher
                     node.getOffset(),
                     node.getLimit());
         }
+        return node;
+    }
+
+    @Override
+    protected Node visitUnnest(Unnest node, PredicateStitcherContext context)
+    {
         return node;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -1215,7 +1215,7 @@ class StatementAnalyzer
                 if (materializedViewAnalysisState.isNotVisited()) {
                     MaterializedViewStatus materializedViewStatus = metadata.getMaterializedViewStatus(session, materializedViewName);
                     if (!materializedViewStatus.isFullyMaterialized()) {
-                        return processMaterializedView(table, materializedViewName, scope, name, optionalMaterializedView.get(), statement, materializedViewStatus);
+                        return processMaterializedView(table, materializedViewName, scope, name, optionalMaterializedView.get(), materializedViewStatus);
                     }
                 }
                 if (materializedViewAnalysisState.isVisited()) {
@@ -1323,11 +1323,11 @@ class StatementAnalyzer
                 Optional<Scope> scope,
                 QualifiedObjectName materializedViewQualifiedObjectName,
                 ConnectorMaterializedViewDefinition materializedViewDefinition,
-                Statement statement,
                 MaterializedViewStatus materializedViewStatus)
         {
-            validateMaterialziedViewQueryPlan(statement);
-            String newSql = getMaterializedViewSQL((Query) statement, materializedViewDefinition, materializedViewStatus);
+            validateMaterialziedViewQueryPlan(sqlParser.createStatement(materializedViewDefinition.getOriginalSql(), createParsingOptions(session, warningCollector)));
+
+            String newSql = getMaterializedViewSQL(materializedView, materializedViewDefinition, materializedViewStatus);
 
             Query query = (Query) sqlParser.createStatement(newSql, createParsingOptions(session, warningCollector));
             analysis.registerNamedQuery(materializedView, query);
@@ -1345,7 +1345,7 @@ class StatementAnalyzer
         }
 
         private String getMaterializedViewSQL(
-                Query statement,
+                Table materializedView,
                 ConnectorMaterializedViewDefinition connectorMaterializedViewDefinition,
                 MaterializedViewStatus materializedViewStatus)
         {
@@ -1364,7 +1364,7 @@ class StatementAnalyzer
             Query predicateStitchedQuery = (Query) new PredicateStitcher(session, partitionPredicates).process(createSqlStatement, new PredicateStitcherContext());
             QuerySpecification materializedViewQuerySpecification = new QuerySpecification(
                     selectList(new AllColumns()),
-                    ((QuerySpecification) statement.getQueryBody()).getFrom(),
+                    Optional.of(materializedView),
                     Optional.empty(),
                     Optional.empty(),
                     Optional.empty(),


### PR DESCRIPTION
Adding cross join unnest support for materialized view. Also fixing a bug by leveraging materialized view instead of from relation while processing materialized view.

```
== NO RELEASE NOTE ==
```
