### PR TITLE
Make HashTable computation lazy in MapBlockBuilder (Redo)

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/block/AbstractArrayBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/AbstractArrayBlock.java
@@ -209,8 +209,7 @@ public abstract class AbstractArrayBlock
         }
     }
 
-    @Override
-    public Block getSingleValueBlock(int position)
+    protected Block getSingleValueBlockInternal(int position)
     {
         checkReadablePosition(position);
 

--- a/presto-common/src/main/java/com/facebook/presto/common/block/AbstractMapBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/AbstractMapBlock.java
@@ -320,8 +320,7 @@ public abstract class AbstractMapBlock
         }
     }
 
-    @Override
-    public Block getSingleValueBlock(int position)
+    protected Block getSingleValueBlockInternal(int position)
     {
         checkReadablePosition(position);
 

--- a/presto-common/src/main/java/com/facebook/presto/common/block/AbstractMapBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/AbstractMapBlock.java
@@ -34,7 +34,7 @@ import static com.facebook.presto.common.block.BlockUtil.internalPositionInRange
 import static com.facebook.presto.common.block.MapBlock.createMapBlockInternal;
 import static com.facebook.presto.common.block.MapBlockBuilder.buildHashTable;
 import static com.facebook.presto.common.block.MapBlockBuilder.verify;
-import static io.airlift.slice.SizeOf.sizeOfIntArray;
+import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -136,7 +136,7 @@ public abstract class AbstractMapBlock
                 newOffsets,
                 newKeys,
                 newValues,
-                new HashTables(Optional.ofNullable(newRawHashTables), length, newHashTableEntries));
+                new HashTables(Optional.ofNullable(newRawHashTables), length));
     }
 
     @Override
@@ -168,8 +168,7 @@ public abstract class AbstractMapBlock
         return getRawKeyBlock().getRegionSizeInBytes(entriesStart, entryCount) +
                 getRawValueBlock().getRegionSizeInBytes(entriesStart, entryCount) +
                 (Integer.BYTES + Byte.BYTES) * (long) length +
-                Integer.BYTES * HASH_MULTIPLIER * (long) entryCount +
-                getHashTables().getInstanceSizeInBytes();
+                Integer.BYTES * HASH_MULTIPLIER * (long) entryCount;
     }
 
     @Override
@@ -193,8 +192,8 @@ public abstract class AbstractMapBlock
 
         return getRawKeyBlock().getRegionLogicalSizeInBytes(entriesStart, entryCount) +
                 getRawValueBlock().getRegionLogicalSizeInBytes(entriesStart, entryCount) +
-                (Integer.BYTES + Byte.BYTES) * length +
-                Integer.BYTES * HASH_MULTIPLIER * entryCount;
+                (Integer.BYTES + Byte.BYTES) * (long) length +
+                Integer.BYTES * HASH_MULTIPLIER * (long) entryCount;
     }
 
     @Override
@@ -209,8 +208,8 @@ public abstract class AbstractMapBlock
 
         return getRawKeyBlock().getApproximateRegionLogicalSizeInBytes(entriesStart, entryCount) +
                 getRawValueBlock().getApproximateRegionLogicalSizeInBytes(entriesStart, entryCount) +
-                (Integer.BYTES + Byte.BYTES) * length +         // offsets and mapIsNull
-                Integer.BYTES * HASH_MULTIPLIER * entryCount;   // hashtables
+                (Integer.BYTES + Byte.BYTES) * (long) length +         // offsets and mapIsNull
+                Integer.BYTES * HASH_MULTIPLIER * (long) entryCount;   // hash tables
     }
 
     @Override
@@ -240,8 +239,7 @@ public abstract class AbstractMapBlock
         return getRawKeyBlock().getPositionsSizeInBytes(entryPositions) +
                 getRawValueBlock().getPositionsSizeInBytes(entryPositions) +
                 (Integer.BYTES + Byte.BYTES) * (long) usedPositionCount +
-                Integer.BYTES * HASH_MULTIPLIER * (long) usedEntryCount +
-                getHashTables().getInstanceSizeInBytes();
+                Integer.BYTES * HASH_MULTIPLIER * (long) usedEntryCount;
     }
 
     @Override
@@ -276,7 +274,7 @@ public abstract class AbstractMapBlock
                 newOffsets,
                 newKeys,
                 newValues,
-                new HashTables(Optional.ofNullable(newRawHashTables), length, expectedNewHashTableEntries));
+                new HashTables(Optional.ofNullable(newRawHashTables), length));
     }
 
     @Override
@@ -347,7 +345,7 @@ public abstract class AbstractMapBlock
                 new int[] {0, valueLength},
                 newKeys,
                 newValues,
-                new HashTables(Optional.ofNullable(newRawHashTables), 1, expectedNewHashTableEntries));
+                new HashTables(Optional.ofNullable(newRawHashTables), 1));
     }
 
     @Override
@@ -411,17 +409,9 @@ public abstract class AbstractMapBlock
         // The number of hash tables. Each map row corresponds to one hash table if it's built.
         private int expectedHashTableCount;
 
-        // The total number of entries of all hashTables as if they are always built. It's used to calculate the retained size.
-        private int expectedEntryCount;
-
-        HashTables(Optional<int[]> hashTables, int expectedHashTableCount, int expectedEntryCount)
+        HashTables(Optional<int[]> hashTables, int expectedHashTableCount)
         {
-            if (hashTables.isPresent() && hashTables.get().length != expectedEntryCount) {
-                throw new IllegalArgumentException("hashTables size does not match expectedEntryCount");
-            }
-
             this.hashTables = hashTables.orElse(null);
-            this.expectedEntryCount = expectedEntryCount;
             this.expectedHashTableCount = expectedHashTableCount;
         }
 
@@ -435,9 +425,6 @@ public abstract class AbstractMapBlock
         {
             requireNonNull(hashTables, "hashTables is null");
             this.hashTables = hashTables;
-
-            // The passed in hashTables are always sized as if they are fully built.
-            this.expectedEntryCount = hashTables.length;
         }
 
         void setExpectedHashTableCount(int count)
@@ -450,14 +437,9 @@ public abstract class AbstractMapBlock
             return expectedHashTableCount;
         }
 
-        public long getInstanceSizeInBytes()
-        {
-            return INSTANCE_SIZE;
-        }
-
         public long getRetainedSizeInBytes()
         {
-            return INSTANCE_SIZE + sizeOfIntArray(expectedEntryCount);
+            return INSTANCE_SIZE + sizeOf(hashTables);
         }
 
         public void loadHashTables(int positionCount, int[] offsets, boolean[] mapIsNull, Block keyBlock, MethodHandle keyBlockHashCode)

--- a/presto-common/src/main/java/com/facebook/presto/common/block/ArrayBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/ArrayBlock.java
@@ -208,4 +208,19 @@ public class ArrayBlock
                 offsets,
                 loadedValuesBlock);
     }
+
+    private boolean isSinglePositionBlock(int position)
+    {
+        return position == 0 && positionCount == 1 && offsets.length == 2;
+    }
+
+    @Override
+    public Block getSingleValueBlock(int position)
+    {
+        if (isSinglePositionBlock(position)) {
+            return this;
+        }
+
+        return getSingleValueBlockInternal(position);
+    }
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/block/ArrayBlockBuilder.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/ArrayBlockBuilder.java
@@ -38,9 +38,9 @@ public class ArrayBlockBuilder
     private int positionCount;
 
     @Nullable
-    private BlockBuilderStatus blockBuilderStatus;
+    private final BlockBuilderStatus blockBuilderStatus;
+    private final int initialEntryCount;
     private boolean initialized;
-    private int initialEntryCount;
 
     private int[] offsets = new int[1];
     private boolean[] valueIsNull = new boolean[0];
@@ -160,6 +160,12 @@ public class ArrayBlockBuilder
 
         closeEntry();
         return this;
+    }
+
+    @Override
+    public Block getSingleValueBlock(int position)
+    {
+        return getSingleValueBlockInternal(position);
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/block/Block.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/Block.java
@@ -163,8 +163,8 @@ public interface Block
     }
 
     /**
-     * Gets the value at the specified position as a single element block.  The method
-     * must copy the data into a new block.
+     * Gets the value at the specified position as a single element block. The
+     * returned block should retain only the memory required for a single block.
      * <p>
      * This method is useful for operators that hold on to a single value without
      * holding on to the entire block.

--- a/presto-common/src/main/java/com/facebook/presto/common/block/MapBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/MapBlock.java
@@ -47,7 +47,6 @@ public class MapBlock
     /**
      * Create a map block directly from columnar nulls, keys, values, and offsets into the keys and values.
      * A null map must have no entries.
-     *
      */
     public static MapBlock fromKeyValueBlock(
             int positionCount,
@@ -72,7 +71,6 @@ public class MapBlock
      * Create a map block directly without per element validations.
      * <p>
      * Internal use by this package and com.facebook.presto.spi.Type only.
-     *
      */
     public static MapBlock createMapBlockInternal(
             int startOffset,
@@ -215,6 +213,21 @@ public class MapBlock
             calculateSize();
         }
         return sizeInBytes;
+    }
+
+    private boolean isSinglePositionBlock(int position)
+    {
+        return position == 0 && positionCount == 1 && offsets.length == 2;
+    }
+
+    @Override
+    public Block getSingleValueBlock(int position)
+    {
+        if (isSinglePositionBlock(position)) {
+            return this;
+        }
+
+        return getSingleValueBlockInternal(position);
     }
 
     private void calculateSize()

--- a/presto-common/src/main/java/com/facebook/presto/common/block/MapBlockBuilder.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/MapBlockBuilder.java
@@ -90,7 +90,7 @@ public class MapBlockBuilder
         this.mapIsNull = new boolean[expectedEntries];
         this.keyBlockBuilder = requireNonNull(keyBlockBuilder, "keyBlockBuilder is null");
         this.valueBlockBuilder = requireNonNull(valueBlockBuilder, "valueBlockBuilder is null");
-        this.hashTables = new HashTables(Optional.ofNullable(rawHashTables), 0, expectedEntries * HASH_MULTIPLIER);
+        this.hashTables = new HashTables(Optional.ofNullable(rawHashTables), 0);
         this.logicalSizeInBytes = -1;
     }
 
@@ -141,8 +141,7 @@ public class MapBlockBuilder
     {
         return keyBlockBuilder.getSizeInBytes() + valueBlockBuilder.getSizeInBytes() +
                 (Integer.BYTES + Byte.BYTES) * (long) positionCount +
-                Integer.BYTES * HASH_MULTIPLIER * (long) keyBlockBuilder.getPositionCount() +
-                hashTables.getInstanceSizeInBytes();
+                Integer.BYTES * HASH_MULTIPLIER * (long) keyBlockBuilder.getPositionCount();
     }
 
     @Override
@@ -366,7 +365,7 @@ public class MapBlockBuilder
                 offsets,
                 keyBlockBuilder.build(),
                 valueBlockBuilder.build(),
-                new HashTables(Optional.ofNullable(mapBlockHashTables), positionCount, hashTablesEntries));
+                new HashTables(Optional.ofNullable(mapBlockHashTables), positionCount));
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/block/MapBlockBuilder.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/MapBlockBuilder.java
@@ -50,7 +50,7 @@ public class MapBlockBuilder
     private boolean[] mapIsNull;
     private final BlockBuilder keyBlockBuilder;
     private final BlockBuilder valueBlockBuilder;
-    private HashTables hashTables;
+    private final HashTables hashTables;
 
     private boolean currentEntryOpened;
 
@@ -68,9 +68,8 @@ public class MapBlockBuilder
                 blockBuilderStatus,
                 keyType.createBlockBuilder(blockBuilderStatus, expectedEntries),
                 valueType.createBlockBuilder(blockBuilderStatus, expectedEntries),
-                new int[expectedEntries + 1],
-                new boolean[expectedEntries],
-                newNegativeOneFilledArray(expectedEntries * HASH_MULTIPLIER));
+                expectedEntries,
+                null);
     }
 
     private MapBlockBuilder(
@@ -79,20 +78,19 @@ public class MapBlockBuilder
             @Nullable BlockBuilderStatus blockBuilderStatus,
             BlockBuilder keyBlockBuilder,
             BlockBuilder valueBlockBuilder,
-            int[] offsets,
-            boolean[] mapIsNull,
-            int[] rawHashTables)
+            int expectedEntries,
+            @Nullable int[] rawHashTables)
     {
         this.keyBlockEquals = requireNonNull(keyBlockEquals, "keyBlockEquals is null");
         this.keyBlockHashCode = requireNonNull(keyBlockHashCode, "keyBlockHashCode is null");
         this.blockBuilderStatus = blockBuilderStatus;
 
         this.positionCount = 0;
-        this.offsets = requireNonNull(offsets, "offsets is null");
-        this.mapIsNull = requireNonNull(mapIsNull, "mapIsNull is null");
+        this.offsets = new int[expectedEntries + 1];
+        this.mapIsNull = new boolean[expectedEntries];
         this.keyBlockBuilder = requireNonNull(keyBlockBuilder, "keyBlockBuilder is null");
         this.valueBlockBuilder = requireNonNull(valueBlockBuilder, "valueBlockBuilder is null");
-        this.hashTables = new HashTables(Optional.of(requireNonNull(rawHashTables, "hashTables is null")), 0, rawHashTables.length);
+        this.hashTables = new HashTables(Optional.ofNullable(rawHashTables), 0, expectedEntries * HASH_MULTIPLIER);
         this.logicalSizeInBytes = -1;
     }
 
@@ -193,20 +191,21 @@ public class MapBlockBuilder
         entryAdded(false);
         currentEntryOpened = false;
 
-        ensureHashTableSize();
-        int previousAggregatedEntryCount = offsets[positionCount - 1];
-        int aggregatedEntryCount = offsets[positionCount];
-        int entryCount = aggregatedEntryCount - previousAggregatedEntryCount;
-        int[] rawHashTables = hashTables.get();
-        verify(rawHashTables != null, "rawHashTables is null");
-        buildHashTable(
-                keyBlockBuilder,
-                previousAggregatedEntryCount,
-                entryCount,
-                keyBlockHashCode,
-                rawHashTables,
-                previousAggregatedEntryCount * HASH_MULTIPLIER,
-                entryCount * HASH_MULTIPLIER);
+        if (isHashTablesPresent()) {
+            int[] rawHashTables = ensureHashTableSize();
+            int previousAggregatedEntryCount = offsets[positionCount - 1];
+            int aggregatedEntryCount = offsets[positionCount];
+            int entryCount = aggregatedEntryCount - previousAggregatedEntryCount;
+            verify(rawHashTables != null, "rawHashTables is null");
+            buildHashTable(
+                    keyBlockBuilder,
+                    previousAggregatedEntryCount,
+                    entryCount,
+                    keyBlockHashCode,
+                    rawHashTables,
+                    previousAggregatedEntryCount * HASH_MULTIPLIER,
+                    entryCount * HASH_MULTIPLIER);
+        }
         return this;
     }
 
@@ -224,14 +223,14 @@ public class MapBlockBuilder
             throw new IllegalStateException("Expected entry to be opened but was closed");
         }
 
+        ensureHashTableLoaded(keyBlockHashCode);
         entryAdded(false);
         currentEntryOpened = false;
 
-        ensureHashTableSize();
+        int[] rawHashTables = ensureHashTableSize();
         int previousAggregatedEntryCount = offsets[positionCount - 1];
         int aggregatedEntryCount = offsets[positionCount];
         int entryCount = aggregatedEntryCount - previousAggregatedEntryCount;
-        int[] rawHashTables = hashTables.get();
         verify(rawHashTables != null, "rawHashTables is null");
         buildHashTableStrict(
                 keyBlockBuilder,
@@ -245,42 +244,43 @@ public class MapBlockBuilder
         return this;
     }
 
-    private BlockBuilder closeEntry(@Nullable int[] providedHashTable, int providedHashTableOffset)
+    private void closeEntry(@Nullable int[] providedHashTable, int providedHashTableOffset)
     {
         if (!currentEntryOpened) {
             throw new IllegalStateException("Expected entry to be opened but was closed");
         }
 
+        if (providedHashTable != null) {
+            ensureHashTableLoaded(keyBlockHashCode);
+        }
+
         entryAdded(false);
         currentEntryOpened = false;
 
-        ensureHashTableSize();
-        int previousAggregatedEntryCount = offsets[positionCount - 1];
-        int aggregatedEntryCount = offsets[positionCount];
+        if (isHashTablesPresent()) {
+            int[] rawHashTables = ensureHashTableSize();
+            int previousAggregatedEntryCount = offsets[positionCount - 1];
+            int aggregatedEntryCount = offsets[positionCount];
 
-        int[] rawHashTables = hashTables.get();
-        verify(rawHashTables != null, "rawHashTables is null");
-        if (providedHashTable != null) {
-            // Directly copy instead of building hashtable if providedHashTable is not null
-            int hashTableOffset = previousAggregatedEntryCount * HASH_MULTIPLIER;
-            int hashTableSize = (aggregatedEntryCount - previousAggregatedEntryCount) * HASH_MULTIPLIER;
-            for (int i = 0; i < hashTableSize; i++) {
-                rawHashTables[hashTableOffset + i] = providedHashTable[providedHashTableOffset + i];
+            if (providedHashTable != null) {
+                // Directly copy instead of building hashtable if providedHashTable is not null
+                int hashTableOffset = previousAggregatedEntryCount * HASH_MULTIPLIER;
+                int hashTableSize = (aggregatedEntryCount - previousAggregatedEntryCount) * HASH_MULTIPLIER;
+                System.arraycopy(providedHashTable, providedHashTableOffset, rawHashTables, hashTableOffset, hashTableSize);
+            }
+            else {
+                // Build hash table for this map entry.
+                int entryCount = aggregatedEntryCount - previousAggregatedEntryCount;
+                buildHashTable(
+                        keyBlockBuilder,
+                        previousAggregatedEntryCount,
+                        entryCount,
+                        keyBlockHashCode,
+                        rawHashTables,
+                        previousAggregatedEntryCount * HASH_MULTIPLIER,
+                        entryCount * HASH_MULTIPLIER);
             }
         }
-        else {
-            // Build hash table for this map entry.
-            int entryCount = aggregatedEntryCount - previousAggregatedEntryCount;
-            buildHashTable(
-                    keyBlockBuilder,
-                    previousAggregatedEntryCount,
-                    entryCount,
-                    keyBlockHashCode,
-                    rawHashTables,
-                    previousAggregatedEntryCount * HASH_MULTIPLIER,
-                    entryCount * HASH_MULTIPLIER);
-        }
-        return this;
     }
 
     @Override
@@ -307,6 +307,7 @@ public class MapBlockBuilder
         offsets[positionCount + 1] = keyBlockBuilder.getPositionCount();
         mapIsNull[positionCount] = isNull;
         positionCount++;
+        hashTables.setExpectedHashTableCount(positionCount);
 
         if (blockBuilderStatus != null) {
             blockBuilderStatus.addBytes(Integer.BYTES + Byte.BYTES);
@@ -314,7 +315,7 @@ public class MapBlockBuilder
         }
     }
 
-    private void ensureHashTableSize()
+    private int[] ensureHashTableSize()
     {
         int[] rawHashTables = hashTables.get();
         verify(rawHashTables != null, "rawHashTables is null");
@@ -323,7 +324,9 @@ public class MapBlockBuilder
             int[] newRawHashTables = Arrays.copyOf(rawHashTables, newSize);
             Arrays.fill(newRawHashTables, rawHashTables.length, newSize, -1);
             hashTables.set(newRawHashTables);
+            return newRawHashTables;
         }
+        return rawHashTables;
     }
 
     @Override
@@ -353,8 +356,9 @@ public class MapBlockBuilder
         }
 
         int[] rawHashTables = hashTables.get();
-        verify(rawHashTables != null, "rawHashTables is null");
         int hashTablesEntries = offsets[positionCount] * HASH_MULTIPLIER;
+        int[] mapBlockHashTables = (rawHashTables == null) ? null : Arrays.copyOf(rawHashTables, hashTablesEntries);
+
         return createMapBlockInternal(
                 0,
                 positionCount,
@@ -362,7 +366,7 @@ public class MapBlockBuilder
                 offsets,
                 keyBlockBuilder.build(),
                 valueBlockBuilder.build(),
-                new HashTables(Optional.of(Arrays.copyOf(rawHashTables, hashTablesEntries)), positionCount, hashTablesEntries));
+                new HashTables(Optional.ofNullable(mapBlockHashTables), positionCount, hashTablesEntries));
     }
 
     @Override
@@ -439,6 +443,14 @@ public class MapBlockBuilder
         return this;
     }
 
+    private int[] getNewHashTables(int newSize)
+    {
+        if (hashTables.get() != null) {
+            return newNegativeOneFilledArray(newSize * HASH_MULTIPLIER);
+        }
+        return null;
+    }
+
     @Override
     public BlockBuilder newBlockBuilderLike(BlockBuilderStatus blockBuilderStatus)
     {
@@ -449,9 +461,8 @@ public class MapBlockBuilder
                 blockBuilderStatus,
                 keyBlockBuilder.newBlockBuilderLike(blockBuilderStatus),
                 valueBlockBuilder.newBlockBuilderLike(blockBuilderStatus),
-                new int[newSize + 1],
-                new boolean[newSize],
-                newNegativeOneFilledArray(newSize * HASH_MULTIPLIER));
+                newSize,
+                getNewHashTables(newSize));
     }
 
     @Override
@@ -465,9 +476,8 @@ public class MapBlockBuilder
                 blockBuilderStatus,
                 keyBlockBuilder.newBlockBuilderLike(blockBuilderStatus, nestedExpectedEntries),
                 valueBlockBuilder.newBlockBuilderLike(blockBuilderStatus, nestedExpectedEntries),
-                new int[newSize + 1],
-                new boolean[newSize],
-                newNegativeOneFilledArray(newSize * HASH_MULTIPLIER));
+                newSize,
+                getNewHashTables(newSize));
     }
 
     public void loadHashTables()
@@ -476,7 +486,13 @@ public class MapBlockBuilder
     }
 
     @Override
-    protected void ensureHashTableLoaded(MethodHandle keyBlockHashCode) {}
+    protected void ensureHashTableLoaded(MethodHandle keyBlockHashCode)
+    {
+        // MapBlockBuilder does not support concurrent threads, so synchronization is not required.
+        if (!isHashTablesPresent()) {
+            hashTables.loadHashTables(positionCount, offsets, mapIsNull, keyBlockBuilder, keyBlockHashCode);
+        }
+    }
 
     private static int[] newNegativeOneFilledArray(int size)
     {

--- a/presto-common/src/main/java/com/facebook/presto/common/block/MapBlockBuilder.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/MapBlockBuilder.java
@@ -470,6 +470,11 @@ public class MapBlockBuilder
                 newNegativeOneFilledArray(newSize * HASH_MULTIPLIER));
     }
 
+    public void loadHashTables()
+    {
+        ensureHashTableLoaded(keyBlockHashCode);
+    }
+
     @Override
     protected void ensureHashTableLoaded(MethodHandle keyBlockHashCode) {}
 

--- a/presto-common/src/main/java/com/facebook/presto/common/block/MapBlockBuilder.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/MapBlockBuilder.java
@@ -171,6 +171,12 @@ public class MapBlockBuilder
     }
 
     @Override
+    public Block getSingleValueBlock(int position)
+    {
+        return getSingleValueBlockInternal(position);
+    }
+
+    @Override
     public SingleMapBlockWriter beginBlockEntry()
     {
         if (currentEntryOpened) {

--- a/presto-common/src/main/java/com/facebook/presto/common/block/MapBlockEncoding.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/MapBlockEncoding.java
@@ -97,6 +97,6 @@ public class MapBlockEncoding
         int[] offsets = new int[positionCount + 1];
         sliceInput.readBytes(wrappedIntArray(offsets));
         Optional<boolean[]> mapIsNull = EncoderUtil.decodeNullBits(sliceInput, positionCount);
-        return MapType.createMapBlockInternal(0, positionCount, mapIsNull, offsets, keyBlock, valueBlock, new HashTables(Optional.ofNullable(hashTable), positionCount, hashTableLength));
+        return MapType.createMapBlockInternal(0, positionCount, mapIsNull, offsets, keyBlock, valueBlock, new HashTables(Optional.ofNullable(hashTable), positionCount));
     }
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/block/SingleMapBlockEncoding.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/SingleMapBlockEncoding.java
@@ -87,7 +87,7 @@ public class SingleMapBlockEncoding
                 new int[] {0, keyBlock.getPositionCount()},
                 keyBlock,
                 valueBlock,
-                new HashTables(Optional.ofNullable(hashTable), 1, hashTableLength));
+                new HashTables(Optional.ofNullable(hashTable), 1));
 
         return new SingleMapBlock(0, 0, keyBlock.getPositionCount() * 2, mapBlock);
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/MapAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/MapAggregationFunction.java
@@ -16,6 +16,7 @@ package com.facebook.presto.operator.aggregation;
 import com.facebook.presto.bytecode.DynamicClassLoader;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.block.MapBlockBuilder;
 import com.facebook.presto.common.type.MapType;
 import com.facebook.presto.common.type.StandardTypes;
 import com.facebook.presto.common.type.Type;
@@ -148,6 +149,13 @@ public class MapAggregationFunction
         }
         else {
             pairs.serialize(out);
+        }
+        if (out instanceof MapBlockBuilder) {
+            // MapAggregation is used to ensure broadcast joins in Presto.
+            // Compute hash table once before broad casting. Some large queries
+            // where blocks are copied without hashtables performs upto
+            // 5X worse without this fix.
+            ((MapBlockBuilder) out).loadHashTables();
         }
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/block/TestMapBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestMapBlock.java
@@ -14,10 +14,12 @@
 
 package com.facebook.presto.block;
 
+import com.facebook.presto.common.block.AbstractMapBlock;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockBuilder;
 import com.facebook.presto.common.block.ByteArrayBlock;
 import com.facebook.presto.common.block.MapBlock;
+import com.facebook.presto.common.block.MapBlockBuilder;
 import com.facebook.presto.common.block.SingleMapBlock;
 import com.facebook.presto.common.function.OperatorType;
 import com.facebook.presto.common.type.MapType;
@@ -160,23 +162,14 @@ public class TestMapBlock
             MapBlock block = createBlockWithValuesFromKeyValueBlock(testValues);
             BlockBuilder blockBuilder = createBlockBuilderWithValues(testValues);
 
-            MapBlock prefix = (MapBlock) block.getRegion(0, 4);
-
             assertFalse(block.isHashTablesPresent());
-            assertFalse(prefix.isHashTablesPresent());
 
-            assertBlock(prefix, () -> blockBuilder.newBlockBuilderLike(null), Arrays.copyOfRange(testValues, 0, 4));
-
+            verifyBlockAndBuilderRegion(testValues, block, blockBuilder, 0, 4);
             assertTrue(block.isHashTablesPresent());
-            assertTrue(prefix.isHashTablesPresent());
 
-            MapBlock midSection = (MapBlock) block.getRegion(2, 4);
-            assertTrue(midSection.isHashTablesPresent());
-            assertBlock(midSection, () -> blockBuilder.newBlockBuilderLike(null), Arrays.copyOfRange(testValues, 2, 6));
+            verifyBlockAndBuilderRegion(testValues, block, blockBuilder, 2, 4);
 
-            MapBlock suffix = (MapBlock) block.getRegion(4, 4);
-            assertTrue(suffix.isHashTablesPresent());
-            assertBlock(suffix, () -> blockBuilder.newBlockBuilderLike(null), Arrays.copyOfRange(testValues, 4, 8));
+            verifyBlockAndBuilderRegion(testValues, block, blockBuilder, 4, 4);
         }
 
         // use mid-section block to build the hash table
@@ -184,23 +177,14 @@ public class TestMapBlock
             MapBlock block = createBlockWithValuesFromKeyValueBlock(testValues);
             BlockBuilder blockBuilder = createBlockBuilderWithValues(testValues);
 
-            MapBlock midSection = (MapBlock) block.getRegion(2, 4);
-
             assertFalse(block.isHashTablesPresent());
-            assertFalse(midSection.isHashTablesPresent());
 
-            assertBlock(midSection, () -> blockBuilder.newBlockBuilderLike(null), Arrays.copyOfRange(testValues, 2, 6));
-
+            verifyBlockAndBuilderRegion(testValues, block, blockBuilder, 2, 4);
             assertTrue(block.isHashTablesPresent());
-            assertTrue(midSection.isHashTablesPresent());
 
-            MapBlock prefix = (MapBlock) block.getRegion(0, 4);
-            assertTrue(prefix.isHashTablesPresent());
-            assertBlock(prefix, () -> blockBuilder.newBlockBuilderLike(null), Arrays.copyOfRange(testValues, 0, 4));
+            verifyBlockAndBuilderRegion(testValues, block, blockBuilder, 0, 4);
 
-            MapBlock suffix = (MapBlock) block.getRegion(4, 4);
-            assertTrue(suffix.isHashTablesPresent());
-            assertBlock(suffix, () -> blockBuilder.newBlockBuilderLike(null), Arrays.copyOfRange(testValues, 4, 8));
+            verifyBlockAndBuilderRegion(testValues, block, blockBuilder, 4, 4);
         }
 
         // use suffix block to build the hash table
@@ -208,24 +192,32 @@ public class TestMapBlock
             MapBlock block = createBlockWithValuesFromKeyValueBlock(testValues);
             BlockBuilder blockBuilder = createBlockBuilderWithValues(testValues);
 
-            MapBlock suffix = (MapBlock) block.getRegion(4, 4);
-
             assertFalse(block.isHashTablesPresent());
-            assertFalse(suffix.isHashTablesPresent());
 
-            assertBlock(suffix, () -> blockBuilder.newBlockBuilderLike(null), Arrays.copyOfRange(testValues, 4, 8));
-
+            verifyBlockAndBuilderRegion(testValues, block, blockBuilder, 4, 4);
             assertTrue(block.isHashTablesPresent());
-            assertTrue(suffix.isHashTablesPresent());
 
-            MapBlock prefix = (MapBlock) block.getRegion(0, 4);
-            assertTrue(prefix.isHashTablesPresent());
-            assertBlock(prefix, () -> blockBuilder.newBlockBuilderLike(null), Arrays.copyOfRange(testValues, 0, 4));
+            verifyBlockAndBuilderRegion(testValues, block, blockBuilder, 2, 4);
 
-            MapBlock midSection = (MapBlock) block.getRegion(2, 4);
-            assertTrue(midSection.isHashTablesPresent());
-            assertBlock(midSection, () -> blockBuilder.newBlockBuilderLike(null), Arrays.copyOfRange(testValues, 2, 6));
+            verifyBlockAndBuilderRegion(testValues, block, blockBuilder, 0, 4);
         }
+    }
+
+    private void verifyBlockAndBuilderRegion(Map<String, Long>[] testValues, MapBlock block, BlockBuilder blockBuilder, int offset, int length)
+    {
+        verifyMapRegion(testValues, block, blockBuilder, offset, length);
+        // MapBlockBuilder also implements AbstractMapBlock interface, verify it.
+        MapBlockBuilder mapBlockBuilder = (MapBlockBuilder) blockBuilder;
+        verifyMapRegion(testValues, mapBlockBuilder, blockBuilder, offset, length);
+    }
+
+    private void verifyMapRegion(Map<String, Long>[] testValues, AbstractMapBlock block, BlockBuilder blockBuilder, int offset, int length)
+    {
+        boolean isHashTablePresent = block.isHashTablesPresent();
+        MapBlock region = (MapBlock) block.getRegion(offset, length);
+        assertEquals(region.isHashTablesPresent(), isHashTablePresent);
+        assertBlock(region, () -> blockBuilder.newBlockBuilderLike(null), Arrays.copyOfRange(testValues, offset, offset + length));
+        assertTrue(region.isHashTablesPresent());
     }
 
     private Map<String, Long>[] createTestMap(int... entryCounts)

--- a/presto-main/src/test/java/com/facebook/presto/block/TestMapBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestMapBlock.java
@@ -18,7 +18,6 @@ import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockBuilder;
 import com.facebook.presto.common.block.ByteArrayBlock;
 import com.facebook.presto.common.block.MapBlock;
-import com.facebook.presto.common.block.MapBlockBuilder;
 import com.facebook.presto.common.block.SingleMapBlock;
 import com.facebook.presto.common.function.OperatorType;
 import com.facebook.presto.common.type.MapType;
@@ -443,36 +442,6 @@ public class TestMapBlock
             assertTrue(map.containsKey(actualKey));
             assertEquals(actualValue, map.get(actualKey));
         }
-    }
-
-    @Test
-    public void testCloseEntryStrict()
-            throws Exception
-    {
-        MapType mapType = mapType(BIGINT, BIGINT);
-        MapBlockBuilder mapBlockBuilder = (MapBlockBuilder) mapType.createBlockBuilder(null, 1);
-        MethodHandle keyNativeEquals = getOperatorMethodHandle(OperatorType.EQUAL, BIGINT, BIGINT);
-        MethodHandle keyBlockEquals = compose(keyNativeEquals, nativeValueGetter(BIGINT), nativeValueGetter(BIGINT));
-        MethodHandle keyNativeHashCode = getOperatorMethodHandle(OperatorType.HASH_CODE, BIGINT);
-        MethodHandle keyBlockHashCode = compose(keyNativeHashCode, nativeValueGetter(BIGINT));
-
-        // Add 100 maps with only one entry but the same key
-        for (int i = 0; i < 100; i++) {
-            BlockBuilder entryBuilder = mapBlockBuilder.beginBlockEntry();
-            BIGINT.writeLong(entryBuilder, 1);
-            BIGINT.writeLong(entryBuilder, -1);
-            mapBlockBuilder.closeEntry();
-        }
-
-        BlockBuilder entryBuilder = mapBlockBuilder.beginBlockEntry();
-        // Add 50 keys so we get some chance to get hash conflict
-        // The purpose of this test is to make sure offset is calculated correctly in MapBlockBuilder.closeEntryStrict()
-        for (int i = 0; i < 50; i++) {
-            BIGINT.writeLong(entryBuilder, i);
-            BIGINT.writeLong(entryBuilder, -1);
-        }
-
-        mapBlockBuilder.closeEntryStrict(keyBlockEquals, keyBlockHashCode);
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/block/TestMapBlockBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestMapBlockBuilder.java
@@ -1,0 +1,277 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.block;
+
+import com.facebook.presto.common.block.AbstractMapBlock;
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.block.ColumnarMap;
+import com.facebook.presto.common.block.MapBlock;
+import com.facebook.presto.common.block.MapBlockBuilder;
+import com.facebook.presto.common.block.SingleMapBlock;
+import com.facebook.presto.common.function.OperatorType;
+import com.facebook.presto.common.type.MapType;
+import org.testng.annotations.Test;
+
+import java.lang.invoke.MethodHandle;
+
+import static com.facebook.presto.common.block.MethodHandleUtil.compose;
+import static com.facebook.presto.common.block.MethodHandleUtil.nativeValueGetter;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.testing.TestingEnvironment.getOperatorMethodHandle;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestMapBlockBuilder
+{
+    private static final MethodHandle KEY_NATIVE_EQUALS = getOperatorMethodHandle(OperatorType.EQUAL, BIGINT, BIGINT);
+    private static final MethodHandle KEY_BLOCK_EQUALS = compose(KEY_NATIVE_EQUALS, nativeValueGetter(BIGINT), nativeValueGetter(BIGINT));
+    private static final MethodHandle KEY_NATIVE_HASH_CODE = getOperatorMethodHandle(OperatorType.HASH_CODE, BIGINT);
+    private static final MethodHandle KEY_BLOCK_HASH_CODE = compose(KEY_NATIVE_HASH_CODE, nativeValueGetter(BIGINT));
+    private static final MethodHandle KEY_BLOCK_NATIVE_EQUALS = compose(KEY_NATIVE_EQUALS, nativeValueGetter(BIGINT));
+    private static final int MAP_POSITIONS = 100;
+
+    @Test
+    public void testMapBlockBuilderWithNullKeys()
+    {
+        MapBlockBuilder blockBuilder = createMapBlockBuilder();
+        for (int i = 0; i < MAP_POSITIONS; i++) {
+            if (i % 10 == 0) {
+                blockBuilder.appendNull(); // Map is null
+            }
+            else {
+                BlockBuilder entryBuilder = blockBuilder.beginBlockEntry(); // Map is valid.
+                for (int j = 0; j < i; j++) {
+                    if (j == 5) {
+                        entryBuilder.appendNull(); // Null Keys
+                    }
+                    else {
+                        BIGINT.writeLong(entryBuilder, j);
+                    }
+                    BIGINT.writeLong(entryBuilder, i);
+                }
+                blockBuilder.closeEntry();
+            }
+            assertFalse(blockBuilder.isHashTablesPresent());
+        }
+
+        // Verify the contents of the map.
+        MapBlock mapBlock = (MapBlock) blockBuilder.build();
+        assertFalse(mapBlock.isHashTablesPresent());
+        ColumnarMap columnarMap = ColumnarMap.toColumnarMap(mapBlock);
+
+        for (int i = 0; i < MAP_POSITIONS; i++) {
+            assertEquals(columnarMap.isNull(i), i % 10 == 0);
+            Block keysBlock = columnarMap.getKeysBlock();
+            Block valuesBlock = columnarMap.getValuesBlock();
+            if (!columnarMap.isNull(i)) {
+                int offset = columnarMap.getOffset(i);
+                for (int j = 0; j < i; j++) {
+                    assertEquals(keysBlock.isNull(offset + j), j == 5);
+                    if (!keysBlock.isNull(offset + j)) {
+                        assertEquals(BIGINT.getLong(keysBlock, offset + j), j);
+                    }
+                    assertEquals(BIGINT.getLong(valuesBlock, offset + j), i);
+                }
+            }
+        }
+        // Verify block and newBlockBuilder does not have the hashTables present.
+        assertFalse(mapBlock.isHashTablesPresent());
+
+        MapBlockBuilder anotherBuilder = (MapBlockBuilder) blockBuilder.newBlockBuilderLike(null);
+        assertFalse(anotherBuilder.isHashTablesPresent());
+    }
+
+    @Test
+    public void testMapBlockSeek()
+    {
+        MapBlockBuilder blockBuilder = createMapBlockBuilder();
+        for (int i = 0; i < MAP_POSITIONS; i++) {
+            BlockBuilder entryBuilder = blockBuilder.beginBlockEntry();
+            for (int j = 0; j < i; j++) {
+                BIGINT.writeLong(entryBuilder, j); // key
+                BIGINT.writeLong(entryBuilder, i); // value
+            }
+            blockBuilder.closeEntry();
+        }
+        assertFalse(blockBuilder.isHashTablesPresent());
+
+        MapBlock mapBlock = (MapBlock) blockBuilder.build();
+        assertFalse(mapBlock.isHashTablesPresent());
+
+        for (int i = 0; i < MAP_POSITIONS; i++) {
+            SingleMapBlock singleMapBlock = (SingleMapBlock) mapBlock.getBlock(i);
+            for (int j = 0; j < i; j++) {
+                assertEquals(singleMapBlock.seekKeyExact(j, KEY_NATIVE_HASH_CODE, KEY_BLOCK_NATIVE_EQUALS, KEY_BLOCK_HASH_CODE), j * 2 + 1);
+            }
+            assertEquals(mapBlock.isHashTablesPresent(), i > 0);
+        }
+        // Block copies the HashMap, so block builder's hash table is still not present.
+        assertFalse(blockBuilder.isHashTablesPresent());
+    }
+
+    @Test
+    public void testCloseEntryStrict()
+            throws Exception
+    {
+        MapBlockBuilder mapBlockBuilder = createMapBlockBuilder();
+
+        // Add MAP_POSITIONS maps with only one entry but the same key
+        for (int i = 0; i < MAP_POSITIONS; i++) {
+            appendSingleEntryMap(mapBlockBuilder, 1);
+        }
+        assertFalse(mapBlockBuilder.isHashTablesPresent());
+
+        BlockBuilder entryBuilder = mapBlockBuilder.beginBlockEntry();
+        // Add 50 keys so we get some chance to get hash conflict
+        // The purpose of this test is to make sure offset is calculated correctly in MapBlockBuilder.closeEntryStrict()
+        for (int i = 0; i < 50; i++) {
+            BIGINT.writeLong(entryBuilder, i);
+            BIGINT.writeLong(entryBuilder, -1);
+        }
+        mapBlockBuilder.closeEntryStrict(KEY_BLOCK_EQUALS, KEY_BLOCK_HASH_CODE);
+        assertTrue(mapBlockBuilder.isHashTablesPresent());
+
+        // Verify Keys
+        for (int i = 0; i < MAP_POSITIONS; i++) {
+            SingleMapBlock block = (SingleMapBlock) mapBlockBuilder.getBlock(i);
+            assertEquals(block.seekKeyExact(1, KEY_NATIVE_HASH_CODE, KEY_BLOCK_NATIVE_EQUALS, KEY_BLOCK_HASH_CODE), 1);
+        }
+
+        SingleMapBlock singleMapBlock = (SingleMapBlock) mapBlockBuilder.getBlock(MAP_POSITIONS);
+        for (int i = 0; i < 50; i++) {
+            assertEquals(singleMapBlock.seekKeyExact(i, KEY_NATIVE_HASH_CODE, KEY_BLOCK_NATIVE_EQUALS, KEY_BLOCK_HASH_CODE), i * 2 + 1);
+        }
+
+        // Verify that Block also has the hash tables loaded.
+        MapBlock mapBlock = (MapBlock) mapBlockBuilder.build();
+        assertTrue(mapBlock.isHashTablesPresent());
+    }
+
+    @Test
+    public void testMapBuilderSeekLoadsHashMap()
+    {
+        MapBlockBuilder mapBlockBuilder = createMapBlockBuilder();
+
+        for (int i = 0; i < MAP_POSITIONS; i++) {
+            appendSingleEntryMap(mapBlockBuilder, i);
+        }
+        assertFalse(mapBlockBuilder.isHashTablesPresent());
+
+        // Verify Keys
+        for (int i = 0; i < MAP_POSITIONS; i++) {
+            SingleMapBlock block = (SingleMapBlock) mapBlockBuilder.getBlock(i);
+            assertEquals(block.seekKeyExact(i, KEY_NATIVE_HASH_CODE, KEY_BLOCK_NATIVE_EQUALS, KEY_BLOCK_HASH_CODE), 1);
+            assertTrue(mapBlockBuilder.isHashTablesPresent());
+        }
+
+        for (int i = 0; i < MAP_POSITIONS; i++) {
+            //Add more entries and verify the keys.
+            appendSingleEntryMap(mapBlockBuilder, i);
+            verifyOnlyKeyInMap(mapBlockBuilder, MAP_POSITIONS + i, i);
+        }
+
+        // Verify that Block and Block Builder also has hash tables present when created.
+        MapBlock mapBlock = (MapBlock) mapBlockBuilder.build();
+        assertTrue(mapBlock.isHashTablesPresent());
+
+        MapBlockBuilder anotherBuilder = (MapBlockBuilder) mapBlockBuilder.newBlockBuilderLike(null);
+        assertTrue(anotherBuilder.isHashTablesPresent());
+    }
+
+    @Test
+    public void testAppendStructureWithMissingHash()
+    {
+        MapBlockBuilder mapBlockBuilder = createMapBlockBuilder();
+
+        for (int i = 0; i < MAP_POSITIONS; i++) {
+            appendSingleEntryMap(mapBlockBuilder, i);
+        }
+        assertFalse(mapBlockBuilder.isHashTablesPresent());
+
+        MapBlockBuilder anotherBuilder = createMapBlockBuilder();
+        for (int i = 0; i < MAP_POSITIONS; i++) {
+            SingleMapBlock block = (SingleMapBlock) mapBlockBuilder.getBlock(i);
+            anotherBuilder.appendStructure(block);
+        }
+        assertFalse(anotherBuilder.isHashTablesPresent());
+
+        for (int i = 0; i < MAP_POSITIONS; i++) {
+            verifyOnlyKeyInMap(anotherBuilder, i, i);
+            assertTrue(anotherBuilder.isHashTablesPresent());
+        }
+    }
+
+    @Test
+    public void testAppendStructureWithHashPresent()
+    {
+        MapBlockBuilder mapBlockBuilder = createMapBlockBuilder();
+
+        for (int i = 0; i < MAP_POSITIONS; i++) {
+            appendSingleEntryMap(mapBlockBuilder, i);
+        }
+        assertFalse(mapBlockBuilder.isHashTablesPresent());
+
+        MapBlockBuilder anotherBuilder = (MapBlockBuilder) mapBlockBuilder.newBlockBuilderLike(null);
+        MapBlock mapBlock = (MapBlock) mapBlockBuilder.build();
+        for (int i = 0; i < MAP_POSITIONS; i++) {
+            anotherBuilder.appendStructureInternal(mapBlock, i);
+        }
+
+        SingleMapBlock singleMapBlock = (SingleMapBlock) mapBlock.getBlock(1);
+        singleMapBlock.seekKeyExact(1, KEY_NATIVE_HASH_CODE, KEY_BLOCK_NATIVE_EQUALS, KEY_BLOCK_HASH_CODE);
+
+        assertFalse(anotherBuilder.isHashTablesPresent());
+        for (int i = 0; i < MAP_POSITIONS; i++) {
+            //Adding mapBlock with hash table present, forces the builder to build its hash table.
+            anotherBuilder.appendStructureInternal(mapBlock, i);
+            assertTrue(anotherBuilder.isHashTablesPresent());
+
+            // Verify the keys for them automatically.
+            verifyOnlyKeyInMap(anotherBuilder, MAP_POSITIONS + i, i);
+        }
+
+        for (int i = 0; i < MAP_POSITIONS; i++) {
+            verifyOnlyKeyInMap(anotherBuilder, i, i);
+        }
+    }
+
+    private void appendSingleEntryMap(MapBlockBuilder mapBlockBuilder, int i)
+    {
+        BlockBuilder entryBuilder = mapBlockBuilder.beginBlockEntry();
+        BIGINT.writeLong(entryBuilder, i);
+        BIGINT.writeLong(entryBuilder, -1);
+        mapBlockBuilder.closeEntry();
+    }
+
+    private void verifyOnlyKeyInMap(AbstractMapBlock block, int position, int key)
+    {
+        SingleMapBlock singleMapBlock = (SingleMapBlock) block.getBlock(position);
+        assertEquals(singleMapBlock.seekKeyExact(key, KEY_NATIVE_HASH_CODE, KEY_BLOCK_NATIVE_EQUALS, KEY_BLOCK_HASH_CODE), 1);
+        int nonExistentKey = key + 1; // Any int other than key will do.
+        assertEquals(singleMapBlock.seekKeyExact(nonExistentKey, KEY_NATIVE_HASH_CODE, KEY_BLOCK_NATIVE_EQUALS, KEY_BLOCK_HASH_CODE), -1);
+    }
+
+    private MapBlockBuilder createMapBlockBuilder()
+    {
+        MapType mapType = new MapType(
+                BIGINT,
+                BIGINT,
+                KEY_BLOCK_EQUALS,
+                KEY_BLOCK_HASH_CODE);
+        return (MapBlockBuilder) mapType.createBlockBuilder(null, MAP_POSITIONS);
+    }
+}

--- a/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/TestQueuesDb.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/TestQueuesDb.java
@@ -106,7 +106,8 @@ public class TestQueuesDb
         }
     }
 
-    @Test(timeOut = 60_000)
+    // Disabled, please look at https://github.com/prestodb/presto/issues/16461
+    @Test(timeOut = 60_000, enabled = false)
     public void testResourceGroupConcurrencyThreshold()
             throws Exception
     {
@@ -202,7 +203,8 @@ public class TestQueuesDb
         waitForCompleteQueryCount(queryRunner, 1);
     }
 
-    @Test(timeOut = 60_000)
+    // Test is flaky and disabled.
+    @Test(timeOut = 60_000, enabled = false)
     public void testTwoQueriesAtSameTime()
             throws Exception
     {


### PR DESCRIPTION
This change was originally done in https://github.com/prestodb/presto/pull/16027
but reverted as it regressed the Broadcast joins. 
The analysis of the regression is here. 
https://github.com/prestodb/presto/pull/16172#issuecomment-850780629

The regression is addressed by computing the hashtable
before the mapblock is encoded. 

Original commit message:
#12198 made hash computation
lazy in the MapBlock, but MapBlockBuilder computed the hash tables
always.

Always computing the hash table had 2 issues
MapBlockBuilder always computed the hash and it is not used in some
cases (OrcWriter). Hash computation took around 5-10% of the CPU.
Null keys in map, failed the hash computation part.
Note: Presto query engine does not support null keys in map. But we
are using Presto orc writer as a stand alone library and this requires null
keys support in map.

Making the Hash table lazy solves both the issues.

Test plan - (Please fill in how you tested your changes)

Added more unit tests
Ran Presto verifier few times and verifier passed.
Ran Presto shadow tests on multiple regions for query with map_agg, element_at and map. Verified that no regression in performance was identified.
```
== NO RELEASE NOTE ==
```
