### PR TITLE
Fix SetOperation(UNION/INTERSECT/EXCEPT) for Pinot Connector

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -30,6 +30,7 @@ import com.facebook.presto.spi.plan.AggregationNode;
 import com.facebook.presto.spi.plan.AggregationNode.Aggregation;
 import com.facebook.presto.spi.plan.AggregationNode.Step;
 import com.facebook.presto.spi.plan.Assignments;
+import com.facebook.presto.spi.plan.ExceptNode;
 import com.facebook.presto.spi.plan.FilterNode;
 import com.facebook.presto.spi.plan.IntersectNode;
 import com.facebook.presto.spi.plan.LimitNode;
@@ -800,6 +801,12 @@ public class PlanBuilder
     {
         Map<VariableReferenceExpression, List<VariableReferenceExpression>> mapping = fromListMultimap(outputsToInputs);
         return new IntersectNode(idAllocator.getNextId(), sources, ImmutableList.copyOf(mapping.keySet()), mapping);
+    }
+
+    public ExceptNode except(ListMultimap<VariableReferenceExpression, VariableReferenceExpression> outputsToInputs, List<PlanNode> sources)
+    {
+        Map<VariableReferenceExpression, List<VariableReferenceExpression>> mapping = fromListMultimap(outputsToInputs);
+        return new ExceptNode(idAllocator.getNextId(), sources, ImmutableList.copyOf(mapping.keySet()), mapping);
     }
 
     public TableWriterNode tableWriter(List<VariableReferenceExpression> columns, List<String> columnNames, PlanNode source)

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotPlanOptimizer.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotPlanOptimizer.java
@@ -81,11 +81,7 @@ public class PinotPlanOptimizer
             VariableAllocator variableAllocator,
             PlanNodeIdAllocator idAllocator)
     {
-        Map<TableScanNode, Void> scanNodes = maxSubplan.accept(new TableFindingVisitor(), null);
-        TableScanNode pinotTableScanNode = getOnlyPinotTable(scanNodes)
-                .orElseThrow(() -> new PrestoException(GENERIC_INTERNAL_ERROR,
-                        "Expected to find the pinot table handle for the scan node"));
-        return maxSubplan.accept(new Visitor(pinotTableScanNode, session, idAllocator), null);
+        return maxSubplan.accept(new Visitor(session, idAllocator), null);
     }
 
     private static Optional<PinotTableHandle> getPinotTableHandle(TableScanNode tableScanNode)
@@ -143,24 +139,23 @@ public class PinotPlanOptimizer
 
     // Single use visitor that needs the pinot table handle
     private class Visitor
-            extends PlanVisitor<PlanNode, Void>
+            extends PlanVisitor<PlanNode, TableScanNode>
     {
         private final PlanNodeIdAllocator idAllocator;
         private final ConnectorSession session;
-        private final TableScanNode tableScanNode;
         private final IdentityHashMap<FilterNode, Void> filtersSplitUp = new IdentityHashMap<>();
 
-        public Visitor(TableScanNode tableScanNode, ConnectorSession session, PlanNodeIdAllocator idAllocator)
+        public Visitor(ConnectorSession session, PlanNodeIdAllocator idAllocator)
         {
             this.session = session;
             this.idAllocator = idAllocator;
-            this.tableScanNode = tableScanNode;
-            // Just making sure that the table exists
-            getPinotTableHandle(this.tableScanNode).get().getTableName();
         }
 
-        private Optional<PlanNode> tryCreatingNewScanNode(PlanNode plan)
+        private Optional<PlanNode> tryCreatingNewScanNode(PlanNode plan, TableScanNode tableScanNode)
         {
+            if (tableScanNode == null) {
+                return Optional.empty();
+            }
             Optional<PinotQueryGenerator.PinotQueryGeneratorResult> pinotQuery = pinotQueryGenerator.generate(plan, session);
             if (!pinotQuery.isPresent()) {
                 return Optional.empty();
@@ -192,16 +187,20 @@ public class PinotPlanOptimizer
         }
 
         @Override
-        public PlanNode visitPlan(PlanNode node, Void context)
+        public PlanNode visitPlan(PlanNode node, TableScanNode context)
         {
-            Optional<PlanNode> pushedDownPlan = tryCreatingNewScanNode(node);
+            Map<TableScanNode, Void> scanNodes = node.accept(new TableFindingVisitor(), null);
+            final TableScanNode tableScanNode = (scanNodes.size() == 1) ? getOnlyPinotTable(scanNodes)
+                    .orElseThrow(() -> new PrestoException(GENERIC_INTERNAL_ERROR,
+                        "Expected to find the pinot table handle for the scan node")) : null;
+            Optional<PlanNode> pushedDownPlan = tryCreatingNewScanNode(node, tableScanNode);
             return pushedDownPlan.orElseGet(() -> replaceChildren(
                     node,
-                    node.getSources().stream().map(source -> source.accept(this, null)).collect(toImmutableList())));
+                    node.getSources().stream().map(source -> source.accept(this, tableScanNode)).collect(toImmutableList())));
         }
 
         @Override
-        public PlanNode visitFilter(FilterNode node, Void context)
+        public PlanNode visitFilter(FilterNode node, TableScanNode context)
         {
             if (filtersSplitUp.containsKey(node)) {
                 return this.visitPlan(node, context);


### PR DESCRIPTION
Pinot connector fails all SetOperation(UNION/INTERSECT/EXCEPT) queries.
The reason is that PinotPlanOptimizer doesn't accept a PlanNode with multiple TableScanNodes, which directly fails the query.

E.g. 
Query:
```
SELECT teamid, sum(numberofgames) as sum_numberofgames
FROM pinot.default.baseballstats
WHERE teamid = 'SFN'
GROUP BY teamid
UNION ALL
SELECT teamid, sum(numberofgames) as sum_numberofgames
FROM pinot.default.baseballstats
WHERE teamid = 'CHN'
GROUP BY teamid;
```
Error:
```
presto:default> select teamid, sum(numberofgames) as sum_numberofgames from pinot.default.baseballstats where teamid = 'SFN' group by teamid union all select teamid, sum(numberofgames) as sum_numberofgames from pinot.default.baseballstats where teamid = 'CHN' group by teamid;
Query 20210629_082908_00000_zcfmw failed: Expected to find the pinot table handle for the scan node
```


This fix makes pinot able to pushdown the sub-query to pinot.
Sample plan:
```
presto:default> explain select teamid, sum(numberofgames) as sum_numberofgames from pinot.default.baseballstats where teamid = 'SFN' group by teamid union all select teamid, sum(numberofgames) as sum_numberofgames from pinot.default.baseballstats where teamid = 'CHN' group by teamid;

----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 - Output[teamid, sum_numberofgames] => [teamid_39:varchar, sum_40:bigint]
         Estimates: {rows: ? (?), cpu: ?, memory: 0.00, network: ?}
         teamid := teamid_39
         sum_numberofgames := sum_40
     - RemoteStreamingExchange[GATHER] => [teamid_39:varchar, sum_40:bigint]
             Estimates: {rows: ? (?), cpu: ?, memory: 0.00, network: ?}
         - TableScan[TableHandle {connectorId='pinot', connectorHandle='PinotTableHandle{connectorId=pinot, schemaName=default, tableName=baseballStats, isQueryShort=Optional[true], expectedColumnHandles=Optional[[PinotColumnHandle{columnName=teamID, dataType=varchar, type=REGULAR}, PinotColumnHandle{columnName=sum, dataType=bigint, type=DERIVED}]], pinotQuery=Optional[GeneratedPinotQuery{query=SELECT teamID, sum(numberOfGames) FROM baseballStats WHERE (teamID = 'SFN') GROUP BY teamID LIMIT 10000, format=SQL, table=baseballStats, expectedColumnIndices=[], groupByClauses=1, haveFilter=true, isQueryShort=true}]}', layout='Optional[PinotTableHandle{connectorId=pinot, schemaName=default, tableName=baseballStats, isQueryShort=Optional[true], expectedColumnHandles=Optional[[PinotColumnHandle{columnName=teamID,dataType=varchar, type=REGULAR}, PinotColumnHandle{columnName=sum, dataType=bigint, type=DERIVED}]], pinotQuery=Optional[GeneratedPinotQuery{query=SELECT teamID, sum(numberOfGames) FROM baseballStats WHERE (teamID = 'SFN') GROUP BY teamID LIMIT 10000, format=SQL, table=baseballStats, expectedColumnIndices=[], groupByClauses=1, haveFilter=true, isQueryShort=true}]}]'}] => [teamid:varchar, sum:bigint]
                 Estimates: {rows: ? (?), cpu: ?, memory: 0.00, network: 0.00}
                 sum := PinotColumnHandle{columnName=sum, dataType=bigint, type=DERIVED}
                 teamid := PinotColumnHandle{columnName=teamID, dataType=varchar, type=REGULAR}
         - TableScan[TableHandle {connectorId='pinot', connectorHandle='PinotTableHandle{connectorId=pinot, schemaName=default, tableName=baseballStats, isQueryShort=Optional[true], expectedColumnHandles=Optional[[PinotColumnHandle{columnName=teamID, dataType=varchar, type=REGULAR}, PinotColumnHandle{columnName=sum_34, dataType=bigint, type=DERIVED}]], pinotQuery=Optional[GeneratedPinotQuery{query=SELECT teamID, sum(numberOfGames) FROM baseballStats WHERE (teamID = 'CHN') GROUP BY teamID LIMIT 10000, format=SQL, table=baseballStats, expectedColumnIndices=[], groupByClauses=1, haveFilter=true, isQueryShort=true}]}', layout='Optional[PinotTableHandle{connectorId=pinot, schemaName=default, tableName=baseballStats, isQueryShort=Optional[true], expectedColumnHandles=Optional[[PinotColumnHandle{columnName=teamID, dataType=varchar, type=REGULAR}, PinotColumnHandle{columnName=sum_34, dataType=bigint, type=DERIVED}]], pinotQuery=Optional[GeneratedPinotQuery{query=SELECT teamID, sum(numberOfGames) FROM baseballStats WHERE (teamID = 'CHN') GROUP BY teamID LIMIT 10000, format=SQL, table=baseballStats, expectedColumnIndices=[], groupByClauses=1, haveFilter=true, isQueryShort=true}]}]'}] => [teamid_14:varchar, sum_34:bigint]
                 Estimates: {rows: ? (?), cpu: ?, memory: 0.00, network: 0.00}
                 sum_34 := PinotColumnHandle{columnName=sum_34, dataType=bigint, type=DERIVED}
                 teamid_14 := PinotColumnHandle{columnName=teamID, dataType=varchar, type=REGULAR}

(1 row)
```
Sample output:
```
presto:default>  select teamid, sum(numberofgames) as sum_numberofgames from pinot.default.baseballstats where teamid = 'SFN' group by teamid union all select teamid, sum(numberofgames) as sum_numberofgames from pinot.default.baseballstats where teamid = 'CHN' group by teamid;
 teamid | sum_numberofgames
--------+-------------------
 CHN    |            245920
 SFN    |            121897
(2 rows)

Query 20210629_080332_00001_i3vh2, FINISHED, 1 node
Splits: 18 total, 18 done (100.00%)
0:06 [0 rows, 22B] [0 rows/s, 3B/s]
```

Test plan - (Please fill in how you tested your changes)

Tested locally.

```
== NO RELEASE NOTE ==
```
