### PR TITLE
Fix broadcast table memory accounting bug in PrestoSparkRemoteSourceOperator

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkDiskPageInput.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkDiskPageInput.java
@@ -172,6 +172,6 @@ public class PrestoSparkDiskPageInput
 
     public long getRetainedSizeInBytes()
     {
-        return prestoSparkBroadcastTableCacheManager.getCacheSizeInBytes();
+        return prestoSparkBroadcastTableCacheManager.getBroadcastTableSizeInBytes(stageId, planNodeId);
     }
 }

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkQueryRunner.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkQueryRunner.java
@@ -840,6 +840,45 @@ public class TestPrestoSparkQueryRunner
                 "SELECT o.custkey, l.orderkey " +
                         "FROM (SELECT * FROM lineitem WHERE linenumber = 4) l " +
                         "CROSS JOIN (SELECT * FROM orders WHERE orderkey = 5) o");
+
+        assertQuery(session,
+                "WITH broadcast_table1 AS ( " +
+                        "    SELECT " +
+                        "        * " +
+                        "    FROM lineitem " +
+                        "    WHERE " +
+                        "        linenumber = 1 " +
+                        ")," +
+                        "broadcast_table2 AS ( " +
+                        "    SELECT " +
+                        "        * " +
+                        "    FROM lineitem " +
+                        "    WHERE " +
+                        "        linenumber = 2 " +
+                        ")," +
+                        "broadcast_table3 AS ( " +
+                        "    SELECT " +
+                        "        * " +
+                        "    FROM lineitem " +
+                        "    WHERE " +
+                        "        linenumber = 3 " +
+                        ")," +
+                        "broadcast_table4 AS ( " +
+                        "    SELECT " +
+                        "        * " +
+                        "    FROM lineitem " +
+                        "    WHERE " +
+                        "        linenumber = 4 " +
+                        ")" +
+                        "SELECT " +
+                        "    * " +
+                        "FROM broadcast_table1 a " +
+                        "JOIN broadcast_table2 b " +
+                        "    ON a.orderkey = b.orderkey " +
+                        "JOIN broadcast_table3 c " +
+                        "    ON a.orderkey = c.orderkey " +
+                        "JOIN broadcast_table4 d " +
+                        "    ON a.orderkey = d.orderkey");
     }
 
     @Test


### PR DESCRIPTION
BroadcastTableCacheManager caches HT for a stage so that it can be reused. Memory
used by the cache is accounted for inside PrestoSparkRemoteSourceOperator systemMemoryContext.
The accounting works fine where there is only 1 BHJ in a stage. However, if a stage has N
BHJ, then cache memory is accounted N number of times, which can trigger broadcast OOM.
This PR fixes the accounting bug so that we account for actual memory used by all the
hashtables in the cache properly.

```
== NO RELEASE NOTE ==
```
