### PR TITLE
Add WarningCollector to QueryPrerequisites

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/dispatcher/DefaultQueryPrerequisites.java
+++ b/presto-main/src/main/java/com/facebook/presto/dispatcher/DefaultQueryPrerequisites.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.dispatcher;
 
 import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.prerequisites.QueryPrerequisites;
 import com.facebook.presto.spi.prerequisites.QueryPrerequisitesContext;
 
@@ -27,7 +28,7 @@ public class DefaultQueryPrerequisites
     private static final CompletableFuture<?> COMPLETED_FUTURE = completedFuture(null);
 
     @Override
-    public CompletableFuture<?> waitForPrerequisites(QueryId queryId, QueryPrerequisitesContext context)
+    public CompletableFuture<?> waitForPrerequisites(QueryId queryId, QueryPrerequisitesContext context, WarningCollector warningCollector)
     {
         return COMPLETED_FUTURE;
     }

--- a/presto-main/src/main/java/com/facebook/presto/dispatcher/QueryPrerequisitesManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/dispatcher/QueryPrerequisitesManager.java
@@ -15,6 +15,7 @@ package com.facebook.presto.dispatcher;
 
 import com.facebook.airlift.log.Logger;
 import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.prerequisites.QueryPrerequisites;
 import com.facebook.presto.spi.prerequisites.QueryPrerequisitesContext;
 import com.facebook.presto.spi.prerequisites.QueryPrerequisitesFactory;
@@ -76,10 +77,10 @@ public class QueryPrerequisitesManager
     }
 
     @Override
-    public CompletableFuture<?> waitForPrerequisites(QueryId queryId, QueryPrerequisitesContext context)
+    public CompletableFuture<?> waitForPrerequisites(QueryId queryId, QueryPrerequisitesContext context, WarningCollector warningCollector)
     {
         checkState(queryPrerequisites.get() != null, "Query prerequisites not initiated");
-        return queryPrerequisites.get().waitForPrerequisites(queryId, context);
+        return queryPrerequisites.get().waitForPrerequisites(queryId, context, warningCollector);
     }
 
     @Override

--- a/presto-main/src/test/java/com/facebook/presto/dispatcher/TestLocalDispatchQuery.java
+++ b/presto-main/src/test/java/com/facebook/presto/dispatcher/TestLocalDispatchQuery.java
@@ -30,6 +30,7 @@ import com.facebook.presto.metadata.SessionPropertyManager;
 import com.facebook.presto.operator.OperatorInfo;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.eventlistener.EventListener;
 import com.facebook.presto.spi.eventlistener.EventListenerFactory;
 import com.facebook.presto.spi.eventlistener.QueryCompletedEvent;
@@ -156,7 +157,7 @@ public class TestLocalDispatchQuery
                     throw new AccessDeniedException("sdf");
                 },
                 false,
-                (queryId, context) -> {
+                (queryId, context, warningCollector) -> {
                     CompletableFuture<?> future = new CompletableFuture<>();
                     future.completeExceptionally(new PrestoException(ABANDONED_TASK, "something went wrong"));
                     return future;
@@ -190,7 +191,7 @@ public class TestLocalDispatchQuery
                     throw new AccessDeniedException("sdf");
                 },
                 false,
-                (queryId, context) -> {
+                (queryId, context, warningCollector) -> {
                     throw new PrestoException(ABANDONED_QUERY, "something went wrong");
                 });
 
@@ -229,7 +230,7 @@ public class TestLocalDispatchQuery
                 false,
                 new QueryPrerequisites() {
                     @Override
-                    public CompletableFuture<?> waitForPrerequisites(QueryId queryId, QueryPrerequisitesContext context)
+                    public CompletableFuture<?> waitForPrerequisites(QueryId queryId, QueryPrerequisitesContext context, WarningCollector warningCollector)
                     {
                         return prequisitesFuture;
                     }
@@ -267,7 +268,7 @@ public class TestLocalDispatchQuery
                 dispatchQuery -> {},
                 execution -> {},
                 false,
-                (queryId, context) -> prequisitesFuture);
+                (queryId, context, warningCollector) -> prequisitesFuture);
 
         assertEquals(query.getBasicQueryInfo().getState(), WAITING_FOR_PREREQUISITES);
         assertFalse(eventListener.getQueryCompletedEvent().isPresent());
@@ -297,7 +298,7 @@ public class TestLocalDispatchQuery
                 },
                 execution -> {},
                 false,
-                (queryId, context) -> prerequisitesFuture);
+                (queryId, context, warningCollector) -> prerequisitesFuture);
 
         assertEquals(stateMachine.getBasicQueryInfo(Optional.empty()).getState(), WAITING_FOR_PREREQUISITES);
         query.startWaitingForPrerequisites();

--- a/presto-spi/src/main/java/com/facebook/presto/spi/prerequisites/QueryPrerequisites.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/prerequisites/QueryPrerequisites.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.spi.prerequisites;
 
 import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.spi.WarningCollector;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -28,7 +29,7 @@ public interface QueryPrerequisites
      * when the query is ready to be queued for execution. If the returned future finishes successfully,
      * it will trigger the query to be queued and its failure will fail the query.
      */
-    CompletableFuture<?> waitForPrerequisites(QueryId queryId, QueryPrerequisitesContext context);
+    CompletableFuture<?> waitForPrerequisites(QueryId queryId, QueryPrerequisitesContext context, WarningCollector warningCollector);
 
     /**
      * Optional method for the implementations to implement if they want to be informed about the finishing


### PR DESCRIPTION
To potentially catch PrestoWarnings, inject WarningCollector to the QueryPrerequisites

Test plan - (Please fill in how you tested your changes)
Unit Tests & mvn build 
As the logic currently not using the WarningCollector just injecting it. 

Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines. Don't forget to follow our [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution) for any code copied from other projects.

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== NO RELEASE NOTE ==
```
