### PR TITLE
Fix ReorderJoin#getPossibleJoinNodes bug

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ReorderJoins.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ReorderJoins.java
@@ -421,7 +421,7 @@ public class ReorderJoins
                 case AUTOMATIC:
                     ImmutableList.Builder<JoinEnumerationResult> result = ImmutableList.builder();
                     result.addAll(getPossibleJoinNodes(joinNode, PARTITIONED));
-                    if (isBelowMaxBroadcastSize(joinNode, context)) {
+                    if (isBelowMaxBroadcastSize(joinNode, context) || isBelowMaxBroadcastSize(joinNode.flipChildren(), context)) {
                         result.addAll(getPossibleJoinNodes(joinNode, REPLICATED));
                     }
                     return result.build();


### PR DESCRIPTION
Reorderjoins should add possible broadcast join node to result when left table is 'belowMaxBroadcastSize'

TPC-DS Q3: `SELECT
  dt.d_year,
  item.i_brand_id brand_id,
  item.i_brand brand,
  SUM(ss_ext_sales_price) sum_agg
FROM date_dim dt, store_sales, item
WHERE dt.d_date_sk = store_sales.ss_sold_date_sk
  AND store_sales.ss_item_sk = item.i_item_sk
  AND item.i_manufact_id = 128
  AND dt.d_moy = 11
GROUP BY dt.d_year, item.i_brand, item.i_brand_id
ORDER BY dt.d_year, sum_agg DESC, brand_id
LIMIT 100`
store_sales broadcastJoin date_dim is better than date_dim hashJoin store_sales when it comes to date_dim join store_sales

