### PR TITLE
Invalidate cache if partition is not present

### DIFF
--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/CachingHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/CachingHiveMetastore.java
@@ -670,7 +670,11 @@ public class CachingHiveMetastore
             HivePartitionName hivePartitionName = hivePartitionName(databaseName, tableName, partitionNameWithVersion.getPartitionName());
             KeyAndContext<HivePartitionName> partitionNameKey = getCachingKey(metastoreContext, hivePartitionName);
             Optional<Partition> partition = partitionCache.getIfPresent(partitionNameKey);
-            if (partition != null && partition.isPresent()) {
+            if (partition == null || !partition.isPresent()) {
+                partitionCache.invalidate(partitionNameKey);
+                partitionStatisticsCache.invalidate(partitionNameKey);
+            }
+            else {
                 Optional<Long> partitionVersion = partition.get().getPartitionVersion();
                 if (!partitionVersion.isPresent() || !partitionVersion.equals(partitionNameWithVersion.getPartitionVersion())) {
                     partitionCache.invalidate(partitionNameKey);


### PR DESCRIPTION
Invalidating the partition cache if partition object is not present.

```
== NO RELEASE NOTE ==
```
