### PR TITLE
Support multiple search ranges for Z-Order library

### DIFF
--- a/presto-hive-common/src/main/java/com/facebook/presto/hive/zorder/ZValueRange.java
+++ b/presto-hive-common/src/main/java/com/facebook/presto/hive/zorder/ZValueRange.java
@@ -13,35 +13,55 @@
  */
 package com.facebook.presto.hive.zorder;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
- * The ZValueRange class contains Optional Integer minimum and maximum values. If existing, they are both inclusive.
+ * The ZValueRange class contains Optional Integer minimum and maximum value lists. If existing, they are all inclusive.
  * <p/>
  * Examples of converting queries into ZValueRange variables:
- * (1) "column == 5"                    -> <code> new ZValueRange(Optional.of(5), Optional.of(5)); </code>
- * (2) "column >= 0 and column <= 9"    -> <code> new ZValueRange(Optional.of(0), Optional.of(9)); </code>
- * (3) "column >= 1"                    -> <code> new ZValueRange(Optional.of(1), Optional.empty()); </code>
- * (4) no range for the column          -> <code> new ZValueRange(Optional.empty(), Optional.empty()); </code>
+ * (1) "column == 5"                    -> <code> new ZValueRange(ImmutableList.of(Optional.of(5)), ImmutableList.of(Optional.of(5))); </code>
+ * (2) "column >= 0 AND column <= 9"    -> <code> new ZValueRange(ImmutableList.of(Optional.of(0)), ImmutableList.of(Optional.of(9))); </code>
+ * (3) "column >= 1"                    -> <code> new ZValueRange(ImmutableList.of(Optional.of(1)), ImmutableList.of(Optional.empty())); </code>
+ * (4) no range for column              -> <code> new ZValueRange(ImmutableList.of(Optional.empty()), ImmutableList.of(Optional.empty())); </code>
+ * (5) "column <= 5 OR column >= 10"    -> <code> new ZValueRange(ImmutableList.of(Optional.empty(), Optional.of(10)), ImmutableList.of(Optional.of(5), Optional.empty())); </code>
  */
 public class ZValueRange
 {
-    private final Integer minimumValue;
-    private final Integer maximumValue;
+    private final List<Integer> minimumValues;
+    private final List<Integer> maximumValues;
 
-    public ZValueRange(Optional<Integer> minimumValue, Optional<Integer> maximumValue)
+    /**
+     * Class constructor initializing <code>minimumValues</code> and <code>maximumValues</code> from optional minimum/maximum value ranges.
+     * <p/>
+     * A value can be set to <code>Optional.empty()</code>, or <code>null</code>, if the query is unbounded in any dimension.
+     */
+    public ZValueRange(List<Optional<Integer>> minimumValues, List<Optional<Integer>> maximumValues)
     {
-        this.minimumValue = minimumValue.orElse(null);
-        this.maximumValue = maximumValue.orElse(null);
+        this.minimumValues = minimumValues.stream().map(optionalInteger -> optionalInteger.orElse(null)).collect(Collectors.toList());
+        this.maximumValues = maximumValues.stream().map(optionalInteger -> optionalInteger.orElse(null)).collect(Collectors.toList());
     }
 
-    public Integer getMinimumValue()
+    /**
+     * Sets null minimum values to the default minimum value based on <code>maximumBits</code> before returning the list.
+     * The default minimum value will be <code>-(1 << maximumBits)</code>.
+     * @param maximumBits the maximum amount of bits the values can have, not including the sign bit
+     * @return a list of non-null minimum range values
+     */
+    public List<Integer> getMinimumValues(int maximumBits)
     {
-        return minimumValue;
+        return minimumValues.stream().map(x -> (x == null) ? -(1 << maximumBits) : x).collect(Collectors.toList());
     }
 
-    public Integer getMaximumValue()
+    /**
+     * Sets null maximum values to the default maximum value based on <code>maximumBits</code> before returning the list.
+     * The default maximum value will be <code>(1 << maximumBits) - 1</code>.
+     * @param maximumBits the maximum amount of bits the values can have, not including the sign bit
+     * @return a list of non-null maximum range values
+     */
+    public List<Integer> getMaximumValues(int maximumBits)
     {
-        return maximumValue;
+        return maximumValues.stream().map(x -> (x == null) ? (1 << maximumBits) - 1 : x).collect(Collectors.toList());
     }
 }

--- a/presto-hive-common/src/test/java/com/facebook/presto/hive/zorder/TestZOrder.java
+++ b/presto-hive-common/src/test/java/com/facebook/presto/hive/zorder/TestZOrder.java
@@ -40,9 +40,18 @@ public class TestZOrder
             {42, 43, 46, 47, 58, 59, 62, 63}};
 
     private static final ZValueRange[][] SEARCH_CURVE_RANGES = {
-            {new ZValueRange(Optional.of(0), Optional.of(1)), new ZValueRange(Optional.of(-2), Optional.of(-1))},
-            {new ZValueRange(Optional.of(-1), Optional.of(0)), new ZValueRange(Optional.of(-1), Optional.of(0))},
-            {new ZValueRange(Optional.of(0), Optional.of(1)), new ZValueRange(Optional.of(-4), Optional.of(-1))},
+            {
+                    new ZValueRange(ImmutableList.of(Optional.of(0)), ImmutableList.of(Optional.of(1))),
+                    new ZValueRange(ImmutableList.of(Optional.of(-2)), ImmutableList.of(Optional.of(-1)))
+            },
+            {
+                    new ZValueRange(ImmutableList.of(Optional.of(-1)), ImmutableList.of(Optional.of(0))),
+                    new ZValueRange(ImmutableList.of(Optional.of(-1)), ImmutableList.of(Optional.of(0)))
+            },
+            {
+                    new ZValueRange(ImmutableList.of(Optional.of(0)), ImmutableList.of(Optional.of(1))),
+                    new ZValueRange(ImmutableList.of(Optional.of(-4)), ImmutableList.of(Optional.of(-1)))
+            }
     };
 
     private static final ZAddressRange<Long>[][] EXPECTED_Z_ADDRESS_RANGES = new ZAddressRange[][] {
@@ -289,8 +298,8 @@ public class TestZOrder
         ZOrder zOrder = new ZOrder(bitPositions);
 
         List<ZValueRange> ranges = ImmutableList.of(
-                new ZValueRange(Optional.of(-2), Optional.of(0)),
-                new ZValueRange(Optional.of(-1), Optional.of(2)));
+                new ZValueRange(ImmutableList.of(Optional.of(-2)), ImmutableList.of(Optional.of(0))),
+                new ZValueRange(ImmutableList.of(Optional.of(-1)), ImmutableList.of(Optional.of(2))));
 
         List<ZAddressRange<Integer>> addresses = zOrder.zOrderSearchCurveIntegers(ranges);
 
@@ -305,9 +314,9 @@ public class TestZOrder
         ZOrder zOrder = new ZOrder(bitPositions);
 
         List<ZValueRange> ranges = ImmutableList.of(
-                new ZValueRange(Optional.empty(), Optional.of(-1)),
-                new ZValueRange(Optional.of(-1), Optional.empty()),
-                new ZValueRange(Optional.of(-1), Optional.of(1)));
+                new ZValueRange(ImmutableList.of(Optional.empty()), ImmutableList.of(Optional.of(-1))),
+                new ZValueRange(ImmutableList.of(Optional.of(-1)), ImmutableList.of(Optional.empty())),
+                new ZValueRange(ImmutableList.of(Optional.of(-1)), ImmutableList.of(Optional.of(1))));
 
         List<ZAddressRange<Integer>> addresses = zOrder.zOrderSearchCurveIntegers(ranges);
 
@@ -316,18 +325,45 @@ public class TestZOrder
     }
 
     @Test
+    public void testZOrderSearchCurveMultipleRanges()
+    {
+        List<Integer> bitPositions = ImmutableList.of(3);
+        ZOrder zOrder = new ZOrder(bitPositions);
+
+        List<ZValueRange> ranges = ImmutableList.of(new ZValueRange(ImmutableList.of(Optional.empty(), Optional.of(6)), ImmutableList.of(Optional.of(-7), Optional.empty())));
+
+        List<ZAddressRange<Integer>> addresses = zOrder.zOrderSearchCurveIntegers(ranges);
+
+        assertEquals(addresses, ImmutableList.of(new ZAddressRange<>(0L, 1L), new ZAddressRange<>(14L, 15L)));
+
+        bitPositions = ImmutableList.of(3, 1, 2);
+        zOrder = new ZOrder(bitPositions);
+
+        ranges = ImmutableList.of(
+                new ZValueRange(ImmutableList.of(Optional.empty(), Optional.of(6)), ImmutableList.of(Optional.of(-7), Optional.empty())),
+                new ZValueRange(ImmutableList.of(Optional.of(0)), ImmutableList.of(Optional.empty())),
+                new ZValueRange(ImmutableList.of(Optional.of(1)), ImmutableList.of(Optional.of(1))));
+
+        addresses = zOrder.zOrderSearchCurveIntegers(ranges);
+
+        assertEquals(addresses, ImmutableList.of(
+                new ZAddressRange<>(194L, 195L), new ZAddressRange<>(210L, 211L),
+                new ZAddressRange<>(486L, 487L), new ZAddressRange<>(502L, 503L)));
+    }
+
+    @Test
     public void testZOrderSearchCurveOutOfBounds()
     {
         List<Integer> bitPositions = ImmutableList.of(1);
         ZOrder zOrder = new ZOrder(bitPositions);
 
-        List<ZValueRange> ranges = ImmutableList.of(new ZValueRange(Optional.of(-3), Optional.of(-3)));
+        List<ZValueRange> ranges = ImmutableList.of(new ZValueRange(ImmutableList.of(Optional.of(-3)), ImmutableList.of(Optional.of(-3))));
 
         List<ZAddressRange<Integer>> addresses = zOrder.zOrderSearchCurveIntegers(ranges);
 
         assertEquals(addresses, ImmutableList.of());
 
-        ranges = ImmutableList.of(new ZValueRange(Optional.of(3), Optional.of(3)));
+        ranges = ImmutableList.of(new ZValueRange(ImmutableList.of(Optional.of(3)), ImmutableList.of(Optional.of(3))));
 
         addresses = zOrder.zOrderSearchCurveIntegers(ranges);
 


### PR DESCRIPTION
Modify Z-Order library functions to support multi-range queries such as _`"column <= 5 OR column >= 10"`_.

```
== NO RELEASE NOTE ==
```
