### PR TITLE
Fix incorrect stats.numNulls value in Parquet

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/AbstractTestParquetReader.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/AbstractTestParquetReader.java
@@ -40,9 +40,11 @@ import org.apache.hadoop.hive.common.type.HiveDecimal;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.JavaHiveDecimalObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.DecimalTypeInfo;
+import org.apache.parquet.format.Statistics;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.MessageTypeParser;
+import org.apache.parquet.schema.PrimitiveType;
 import org.joda.time.DateTimeZone;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -119,6 +121,8 @@ import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveO
 import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.javaStringObjectInspector;
 import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.javaTimestampObjectInspector;
 import static org.apache.parquet.schema.MessageTypeParser.parseMessageType;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
+import static org.apache.parquet.schema.Type.Repetition.OPTIONAL;
 import static org.testng.Assert.assertEquals;
 
 public abstract class AbstractTestParquetReader
@@ -1557,6 +1561,16 @@ public abstract class AbstractTestParquetReader
                 structValues,
                 structType,
                 maxReadBlockSize);
+    }
+
+    @Test
+    public void testNullableNullCount()
+    {
+        PrimitiveType primitiveType = new PrimitiveType(OPTIONAL, BINARY, "testColumn");
+        Statistics statistics = new Statistics();
+        assertEquals(MetadataReader.readStats(statistics, primitiveType.getPrimitiveTypeName()).getNumNulls(), -1);
+        statistics.setNull_count(10);
+        assertEquals(MetadataReader.readStats(statistics, primitiveType.getPrimitiveTypeName()).getNumNulls(), 10);
     }
 
     @Test

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/cache/MetadataReader.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/cache/MetadataReader.java
@@ -207,11 +207,14 @@ public final class MetadataReader
     public static org.apache.parquet.column.statistics.Statistics<?> readStats(Statistics statistics, PrimitiveTypeName type)
     {
         org.apache.parquet.column.statistics.Statistics<?> stats = org.apache.parquet.column.statistics.Statistics.getStatsBasedOnType(type);
+        stats.setNumNulls(-1);
         if (statistics != null) {
             if (statistics.isSetMax() && statistics.isSetMin()) {
                 stats.setMinMaxFromBytes(statistics.min.array(), statistics.max.array());
             }
-            stats.setNumNulls(statistics.null_count);
+            if (statistics.isSetNull_count()) {
+                stats.setNumNulls(statistics.null_count);
+            }
         }
         return stats;
     }


### PR DESCRIPTION
There are some incorrect column statistics in parquet format.

e.g.`select * from table where name is null`
It returns nothing, but the name field has null value in fact.

### Describe:
The name field has null value, but we can't get them.
The reason is that some parquet file footer doesn't set the null_count which make stats.numNulls initialize to 0, and Presto will think it is a field without null.
### Solution:
Preset stats.numNulls to -1 and set stats.numNulls when statistics.isSetNull_count().

Test plan - Verified in test cluster
```
== NO RELEASE NOTE ==