### PR TITLE
Fix column in parquet dereference pushdown

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveLogicalPlanner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveLogicalPlanner.java
@@ -1723,7 +1723,7 @@ public class TestHiveLogicalPlanner
                 anyTree(
                         node(JoinNode.class,
                                 anyTree(tableScanParquetDeferencePushDowns("test_pushdown_nestedcolumn_parquet", nestedColumnMap("x.a"))),
-                                anyTree(tableScanParquetDeferencePushDowns("test_pushdown_nestedcolumn_parquet", nestedColumnMap("x_1.a"))))));
+                                anyTree(tableScanParquetDeferencePushDowns("test_pushdown_nestedcolumn_parquet", nestedColumnMap("x.a"))))));
 
         // Aggregation
         assertParquetDereferencePushDown("SELECT id, min(x.a) FROM test_pushdown_nestedcolumn_parquet GROUP BY 1",


### PR DESCRIPTION
This is to fix [this issue](https://github.com/prestodb/presto/issues/16364).

Test plan - (Please fill in how you tested your changes)

Tested in our internal cluster. Updated unit test

== RELEASE NOTES ==

General Changes
* Fixes a bug in Parquet dereference pushdown. The issue causes column name not picked up properly, resulting in inconsistent query result in certain cases.