### PR TITLE
Add configs for enabling the metrics of shadow cache 

### DIFF
--- a/presto-cache/src/main/java/com/facebook/presto/cache/alluxio/AlluxioCacheConfig.java
+++ b/presto-cache/src/main/java/com/facebook/presto/cache/alluxio/AlluxioCacheConfig.java
@@ -19,6 +19,7 @@ import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 
 import static io.airlift.units.DataSize.Unit.GIGABYTE;
+import static java.util.concurrent.TimeUnit.DAYS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class AlluxioCacheConfig
@@ -35,6 +36,8 @@ public class AlluxioCacheConfig
     private int timeoutThreads = 64;
     private int evictionRetries = 10;
     private EvictionPolicy evictionPolicy = EvictionPolicy.LRU;
+    private boolean shadowCacheEnabled;
+    private Duration shadowCacheWindow = new Duration(7, DAYS);
 
     public boolean isMetricsCollectionEnabled()
     {
@@ -189,6 +192,32 @@ public class AlluxioCacheConfig
     public AlluxioCacheConfig setCacheQuotaEnabled(boolean cacheQuotaEnabled)
     {
         this.cacheQuotaEnabled = cacheQuotaEnabled;
+        return this;
+    }
+
+    public boolean isShadowCacheEnabled()
+    {
+        return shadowCacheEnabled;
+    }
+
+    @Config("cache.alluxio.shadow-cache-enabled")
+    @ConfigDescription("Whether to enable alluxio shadow cache")
+    public AlluxioCacheConfig setShadowCacheEnabled(boolean shadowCacheEnabled)
+    {
+        this.shadowCacheEnabled = shadowCacheEnabled;
+        return this;
+    }
+
+    public Duration getShadowCacheWindow()
+    {
+        return shadowCacheWindow;
+    }
+
+    @Config("cache.alluxio.shadow-cache-window")
+    @ConfigDescription("The time window of alluxio shadow cache for working set calculation")
+    public AlluxioCacheConfig setShadowCacheWindow(Duration shadowCacheWindow)
+    {
+        this.shadowCacheWindow = shadowCacheWindow;
         return this;
     }
 }

--- a/presto-cache/src/main/java/com/facebook/presto/cache/alluxio/AlluxioCachingConfigurationProvider.java
+++ b/presto-cache/src/main/java/com/facebook/presto/cache/alluxio/AlluxioCachingConfigurationProvider.java
@@ -61,6 +61,8 @@ public class AlluxioCachingConfigurationProvider
             else {
                 configuration.set("alluxio.user.client.cache.timeout.duration", "-1");
             }
+            configuration.set("alluxio.user.client.cache.shadow.enabled", String.valueOf(alluxioCacheConfig.isShadowCacheEnabled()));
+            configuration.set("alluxio.user.client.cache.shadow.window", String.valueOf(alluxioCacheConfig.getShadowCacheWindow().toMillis()));
         }
     }
 }

--- a/presto-cache/src/test/java/com/facebook/presto/cache/alluxio/TestAlluxioCacheConfig.java
+++ b/presto-cache/src/test/java/com/facebook/presto/cache/alluxio/TestAlluxioCacheConfig.java
@@ -25,6 +25,7 @@ import static com.facebook.airlift.configuration.testing.ConfigAssertions.assert
 import static com.facebook.airlift.configuration.testing.ConfigAssertions.recordDefaults;
 import static io.airlift.units.DataSize.Unit.GIGABYTE;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static java.util.concurrent.TimeUnit.DAYS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class TestAlluxioCacheConfig
@@ -44,7 +45,9 @@ public class TestAlluxioCacheConfig
                 .setTimeoutDuration(new Duration(60, SECONDS))
                 .setTimeoutEnabled(true)
                 .setTimeoutThreads(64)
-                .setCacheQuotaEnabled(false));
+                .setCacheQuotaEnabled(false)
+                .setShadowCacheEnabled(false)
+                .setShadowCacheWindow(new Duration(7, DAYS)));
     }
 
     @Test
@@ -63,6 +66,8 @@ public class TestAlluxioCacheConfig
                 .put("cache.alluxio.timeout-enabled", "false")
                 .put("cache.alluxio.timeout-threads", "512")
                 .put("cache.alluxio.quota-enabled", "true")
+                .put("cache.alluxio.shadow-cache-enabled", "true")
+                .put("cache.alluxio.shadow-cache-window", "1d")
                 .build();
 
         AlluxioCacheConfig expected = new AlluxioCacheConfig()
@@ -77,7 +82,9 @@ public class TestAlluxioCacheConfig
                 .setTimeoutDuration(new Duration(120, SECONDS))
                 .setTimeoutEnabled(false)
                 .setTimeoutThreads(512)
-                .setCacheQuotaEnabled(true);
+                .setCacheQuotaEnabled(true)
+                .setShadowCacheEnabled(true)
+                .setShadowCacheWindow(new Duration(1, DAYS));
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
Alluxio's shadow cache is able to measure the working set during runtime, which would be helpful for the cache capacity planning.

To enable the shadow cache metrics, you could add the properties below into hive catalog's config.

```
cache.alluxio.shadow-cache-enabled=true
cache.alluxio.shadow-cache-window=1d
cache.alluxio.metrics-enabled=true
```

You could change alluxio.user.client.cache.shadow.window  to 1w if you wanna watch the tables with longer data retention
But I recommend starting from 1d or 1h for test, because it would take 1/4 time window to report the metrics.

You could collect the metrics from shadow cache via jmx.

```
== NO RELEASE NOTE ==
```
