### PR TITLE
Fix typo in aggregate.rst

### DIFF
--- a/presto-docs/src/main/sphinx/functions/aggregate.rst
+++ b/presto-docs/src/main/sphinx/functions/aggregate.rst
@@ -107,7 +107,7 @@ General Aggregate Functions
 
 .. function:: reduce_agg(inputValue T, initialState S, inputFunction(S,T,S), combineFunction(S,S,S)) -> S
 
-    Reduces all input values into a single value. ```inputFunction`` will be invoked
+    Reduces all input values into a single value. ``inputFunction`` will be invoked
     for each input value. In addition to taking the input value, ``inputFunction``
     takes the current state, initially ``initialState``, and returns the new state.
     ``combineFunction`` will be invoked to combine two states into a new state.


### PR DESCRIPTION
Resolves https://github.com/prestodb/presto/issues/16382

Test plan -
```
$ open target/html/functions/aggregate.html
```
![image](https://user-images.githubusercontent.com/17170991/124454026-90ec6880-ddba-11eb-851f-5c7bd6a724a5.png)


Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines. Don't forget to follow our [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution) for any code copied from other projects.

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== NO RELEASE NOTE ==
```
