### PR TITLE
Fix typo in CostCalculatorWithEstimatedExchanges

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/cost/CostCalculatorWithEstimatedExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/CostCalculatorWithEstimatedExchanges.java
@@ -158,7 +158,7 @@ public class CostCalculatorWithEstimatedExchanges
         public LocalCostEstimate visitUnion(UnionNode node, Void context)
         {
             // this assumes that all union inputs will be gathered over the network
-            // that is not aways true
+            // that is not always true
             // but this estimate is better that returning UNKNOWN, as it sets
             // cumulative cost to unknown
             double inputSizeInBytes = getStats(node).getOutputSizeInBytes(node.getOutputVariables());


### PR DESCRIPTION
Fix typo in CostCalculatorWithEstimatedExchanges

```
== NO RELEASE NOTE ==
```
