### PR TITLE
Add release notes for 0.257

### DIFF
--- a/presto-docs/src/main/sphinx/release.rst
+++ b/presto-docs/src/main/sphinx/release.rst
@@ -5,6 +5,7 @@ Release Notes
 .. toctree::
     :maxdepth: 1
 
+    release/release-0.257
     release/release-0.256
     release/release-0.255
     release/release-0.254.1

--- a/presto-docs/src/main/sphinx/release/release-0.257.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.257.rst
@@ -1,0 +1,27 @@
+=============
+Release 0.257
+=============
+
+**Details**
+===========
+
+General Changes
+_______________
+* Fix queries failing with ``EXCEEDED_LOCAL_MEMORY_LIMIT`` error due to incorrect memory tracking while reading spilled data.
+* Fix deadlock for queries with ``JOIN`` and ``LIMIT`` with spilling enabled.
+* Fix query failures due to expressions with multiple ``is null`` checks on the same variable.
+* Improve memory usage of queries spilling in the join operator.
+* Improve expressions printed in query plans to be closer to valid SQL.
+* Add support to find the n-th instance in :func:`array_position`.
+* Add support for correlated subqueries with complex expressions in the correlation.
+* Add support for the ``OFFSET`` clause in SQL query expressions. This feature can be enabled by setting the session property ``offset_clause_enabled`` or configuration property ``offset-clause-enabled`` to ``true``.
+
+Hive Changes
+____________
+* Fix a bug in reading Avro format table with schema located in a Kerberos enabled HDFS compliant filesystem.
+* Fix dynamic pruning for null keys in hive partition.
+
+**Contributors**
+================
+
+Abhisek Gautam Saikia, Andrii Rosa, Arjun Gupta, Basar Hamdi Onat, Chen, George Wang, Grace Xin, Huameng Jiang, James Petty, James Sun, Masha Basmanova, Mayank Garg, Rebecca Schlussel, Rohit Jain, Roman Zeyde, Rongrong Zhong, Saumitra Shahapure, Seba Villalobos, Sergey Pershin, Sergii Druzkin, Shixuan Fan, Swapnil Tailor, Timothy Meehan, Venki Korukanti, Vic Zhang, Xiang Fu, Zhenxiao Luo, beinan, prithvip, tanjialiang


### PR DESCRIPTION
# Missing Release Notes
## Sergey Pershin
- [x] a56c5441c01a87cc3db21a04904a9aa8fac0c79c Disable flaky test 'testGetQueryInfos'.

# Extracted Release Notes
- #15170 (Author: Saumitra Shahapure): Supporting instance count in ARRAY_POSITION
  - Add support for ``ARRAY_POSITION(array, element, instance)``.
- #15575 (Author: George Wang): Support correlated column mapping type coercion
  - Add support for more kinds of correlated subqueries.
- #16035 (Author: George Wang): Add support for OFFSET clause
  - Add support for the result offset clause in SQL query expressions. This feature can be enabled by setting the session property ``offset_clause_enabled`` or configuration property ``offset-clause-enabled`` to true.
- #16035 (Author: George Wang): Add support for OFFSET clause
  - Add support for the result offset clause in SQL query expressions. This feature can be enabled by setting the session property ``offset_clause_enabled`` or configuration property ``offset-clause-enabled`` to true.
- #16035 (Author: George Wang): Add support for OFFSET clause
  - Add support for the result offset clause in SQL query expressions. This feature can be enabled by setting the session property ``offset_clause_enabled`` or configuration property ``offset-clause-enabled`` to true.
- #16035 (Author: George Wang): Add support for OFFSET clause
  - Add support for the result offset clause in SQL query expressions. This feature can be enabled by setting the session property ``offset_clause_enabled`` or configuration property ``offset-clause-enabled`` to true.
- #16205 (Author: Abhisek Gautam Saikia): Support multi coordinator while serving resource group info
  - Support multi coordinator for v1/resourceGroupState/* endpoint.
- #16254 (Author: Abhisek Gautam Saikia): Display coordinator host name in web ui
  - Display coordinator host name in web ui to support multi coordinator setup.
- #16261 (Author: James Petty): Reintroduce fix for dynamic pruning for with null keys in hive partition
  - Fix dynamic pruning for null keys in hive partition.
- #16261 (Author: James Petty): Reintroduce fix for dynamic pruning for with null keys in hive partition
  - Fix dynamic pruning for null keys in hive partition.
- #16293 (Author: Andrii Rosa): Fix deadlock in join spilling
  - Resolve deadlock problem that results into join + limit getting stuck when spilling is enabled.
- #16293 (Author: Andrii Rosa): Fix deadlock in join spilling
  - Resolve deadlock problem that results into join + limit getting stuck when spilling is enabled.
- #16293 (Author: Andrii Rosa): Fix deadlock in join spilling
  - Resolve deadlock problem that results into join + limit getting stuck when spilling is enabled.
- #16333 (Author: Chen): Create GenericHiveRecordCursor within doAs block to pass the correct credentials to storage
  - Fix a bug in reading Avro format table with schema located in a Kerberos enabled HDFS compliant filesystem.
- #16335 (Author: Seba Villalobos): Change RowExpressionFormatter output to be closer to valid SQL
  - Improved RowExpressionFormatter output to be closer to valid SQL. Constant expressions are now output as ``TYPE 'value'`` (e.g. ``BIGINT'2'``) using TypeConstructor (with single quotes appearing in the string escaped with ``''``), with the exception of ``VARBINARY`` constants, which use the binary literal syntax (e.g. ``X'abc123'``). ``LIKE`` expressions are now output as valid SQL.
- #16336 (Author: Chen): RowExpression duplicate isNull on same variable issue
  - Add support for expressions with multiple ``IS NULL`` on the same variable.
- #16338 (Author: Vic Zhang): Compact deserialized page in SingleStreamSpiller
  - Fix spilled query exceeding local memory limit due to incorrect memory size calculation when spilled data is read by SingleStreamSpiller.
- #16339 (Author: Vic Zhang): Fix unspill scheduling in join spill
  - Fix scheduling issue in join spill to improve memory used by unspilled data.

# All Commits
- a56c5441c01a87cc3db21a04904a9aa8fac0c79c Disable flaky test 'testGetQueryInfos'. (Sergey Pershin)
- 4de2228d8b4c34e1d90a733f874a67d006b16d3a RowExpression duplicate isNull on same variable issue (Chen)
- 307efd4347e0e620022a0ffaa5d05dc3384f11d3 Add WarningCollector to QueryPrerequisites (Basar Hamdi Onat)
- bb4b68e6ffe8a8b57f3847e8b88bc3a3f75f6447 Invalidate cache if partition is not present (Rohit Jain)
- 32face2f0a4cc58d908c84d81123b3ffff70452e Add cross join unnest support for materialized view (Rohit Jain)
- 50d9c07b4656e2ba698995ce910269ec518a10fe Add option to remove from session properties (Basar Hamdi Onat)
- f6e532fb278a4ebee716d1358a85e3f4bf89c4df Disable Flaky test (Arjun Gupta)
- d2295a3ded2c96827ae01f5fc854db9aa8d1ea2d Close LocalMemoryContext inside PrestoSparkRemoteSourceOperator (Arjun Gupta)
- fafbefc149b0b211cf7d9664a8d52b484d804d4a Support user defined types in FunctionNamespaceManager (Rongrong Zhong)
- 014ba1a2c9c124539cf0ad88035f0d656a39cc09 Fix to adjusted queue size for multi coordinator (Swapnil Tailor)
- 98cfd412b55cb46599ab071646d609284b27ef69 Fix broadcast table memory accounting bug in PrestoSparkRemoteSourceOperator (Arjun Gupta)
- 42cf2e92a7693c335a37832b1761d911582d933a Change RowExpressionFormatter output to be closer to valid SQL (Seba Villalobos)
- e4cd8ea8985af50db1a81ad5280e1b821bb08234 Fixing distinct count pushdown when there are multiple count distinct queries (Xiang Fu)
- 3ef9184912ace04c6fc949090baf7a5db7c52ca9 Compact deserialized page in SingleStreamSpiller (Vic Zhang)
- 21d6dd3ec0a9c657f79de1c294c25d45a84f4803 Add authentication when creating Hive page source (Chen)
- f50e888e40ff8b7e3d446241fdbd926a6d52ec4c Support multi coordinator while serving resource group info (Abhisek Gautam Saikia)
- c82233e7c6d8c5845312439a48bbd3fab84d88b9 Allow Resource Manager as an active node when NodeStatusService won't allow it (Swapnil Tailor)
- 5c951a99be0ff5491ffbedd6d1c07d05a36e6ab9 Fix unspill scheduling in join spill (Vic Zhang)
- cd48fd9975f632ed489ffdbf138f3642cefffa83 Add session property for partial agg threshold (prithvip)
- 98e0924095e133cff0479ef230d9086788ddbf6b Selectively enable partial aggregations based on statistics (prithvip)
- 8a875fa3a7995a343d00f1c03c51461f64dac16c Add session property for partial aggregation strategy (prithvip)
- 667e6f60a5eedda6570dbf221876f2cd7179bc38 Add notion of confidence to PlanNodeStatsEstimate (prithvip)
- a921aa5939253fec3069ec0587e2994a472f6629 Fix the missing table from querying the BigQuery tables (#16145, #16178) (George Wang)
- 55126d899f9893d693e180079b281aadc8b9d030 Fix NoClassDefFoundError during presto launch time (#16093) (George Wang)
- 6560c80121aee55c44d19ddbcc9330638429f9e3 Centralize Long Type Dictionary Loading Logic (Huameng Jiang)
- a089c10424f568bcfe6caf3c02fdc1818ee13fee Support type coercion for correlated column mapping (George Wang)
- 85b24179c057ad5364f788e1ae7f1d91f3691ed7 Ignore RM from scheduling (Swapnil Tailor)
- 44b7a7b114e81e788841f387745f6ebe1617719b Add DWRF stripe cache support to OrcWriter (Sergii Druzkin)
- b66da38d8306cfd4b35a4e2dc7d63d93094a00da Create ZOrder library for integers (Grace Xin)
- 87d759c3a78270c5a9348c8e577827f91229c10d Split Presto on Spark tests into multiple jobs on CI (Andrii Rosa)
- f5507830985d3c7264b23999624a01574091ceff Readjust concurrency and thread pool settings for Presto on Spark tests (Andrii Rosa)
- 0cd31fcc9777257679da413ffcea5f9213064ed3 Fix deadlock in join spilling (Andrii Rosa)
- 67646c98aa43932c5789ad7afc17b1cf52cbaa9f Disable testLimitWithJoin for Presto on Spark (Vic Zhang)
- 2947eceaba8d37ff38288f7d6993bb380c59de52 Improve memory for HashBuilderOperator unspill (Vic Zhang)
- 91cf5a0be0ff22ee286b51205dbe154653b1e997 Skip loading StaticCatalogStore and AccessControlManager for RM (Swapnil Tailor)
- e54bd739b880d1fa55a4292762e7cde2f378418f Improve DistinctLimitOperator (James Petty)
- 9dba528462f174e390a8472ac6c6ef930325e2f6 Optimize TupleDomain.columnWiseUnion during dynamic filtering collection (Roman Zeyde)
- 14ad556876ead826069781bd6471855320b05815 Fix iceberg table params dropped after insert (beinan)
- 656d1553f69b158f3efb1172cae6c109be2a891c Add 'limit' parameter to GET:/v1/query (Sergey Pershin)
- 13a241b845c531ba2bb84cb81bf54a320fff102e Update documentation for OFFSET (George Wang)
- 676a0a50a257584d41690070c266bbeb4247ca6e Support configurable switch `offset_clause_enabled` for OFFSET (George Wang)
- cf2011ef6744fbba3325e02b6cc46cd15e644664 Add OFFSET implementation (George Wang)
- 3cde0e4ba66c77cb0e1a12605347a05f553279f5 Add support for OFFSET syntax in grammar and AST (George Wang)
- 3d262b56a77d67f02ed98bc7486b35e774cabdcf Make DWRF reader fail with verbose error when encounter 2GB+ streams (Sergii Druzkin)
- d31ea9f11633e66ca7ee3ca4e2bca009399b7e51 Add additional query time statistics (tanjialiang)
- 837809473de077bc85203b93c371916b5155dbf9 Supporting instance count in ARRAY_POSITION (Saumitra Shahapure)
- a29bf65f94ad322bfa0b08d5c5237436edeb5cdc Document SerializedPage wire format (Masha Basmanova)
- 30114f5b9c0fa1f3e536913a557dbbd784d4d456 Prepare ORC writer API for DWRF stripe cache (Sergii Druzkin)
- a95a2e61deb0cae6b3e1b9922ef57ffd53e66ee3 Avoid ambiguous null value encoding in HivePartitionKey (James Petty)
- 998614e676980602ddd3ba5067157d0edd5f5c58 Revert "Revert "Fix dynamic pruning for null keys in hive partition"" (James Petty)
- 43a656e27c44ad88090ab0d516c223b39b1dbf65 Display coordinator host name in web ui (Abhisek Gautam Saikia)
- 033323a15756ad5ffa1d631e1ef1f2a79c4a1663 Disable TestDistributedClusterStatsResource since it is failing (Mayank Garg)