### PR TITLE
[thrift connector] Add property to forward user via Thrift Header

### DIFF
--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/DefaultThriftHeaderProvider.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/DefaultThriftHeaderProvider.java
@@ -18,12 +18,19 @@ import com.google.common.collect.ImmutableMap;
 
 import java.util.Map;
 
+import static com.facebook.presto.connector.thrift.ThriftSessionProperties.isUseIdentityThriftHeader;
+
 public class DefaultThriftHeaderProvider
         implements ThriftHeaderProvider
 {
+    private static final String PRESTO_CONNECTOR_IDENTITY_USER = "presto_connector_user";
+
     @Override
     public Map<String, String> getHeaders(ConnectorSession session)
     {
+        if (isUseIdentityThriftHeader(session)) {
+            return ImmutableMap.of(PRESTO_CONNECTOR_IDENTITY_USER, session.getUser());
+        }
         return ImmutableMap.of();
     }
 }

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftConnectorConfig.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftConnectorConfig.java
@@ -28,6 +28,7 @@ public class ThriftConnectorConfig
     private DataSize maxResponseSize = new DataSize(16, MEGABYTE);
     private int metadataRefreshThreads = 1;
     private int lookupRequestsConcurrency = 1;
+    private boolean useIdentityThriftHeaders;
 
     @NotNull
     @MinDataSize("1MB")
@@ -67,6 +68,18 @@ public class ThriftConnectorConfig
     public ThriftConnectorConfig setLookupRequestsConcurrency(int lookupRequestsConcurrency)
     {
         this.lookupRequestsConcurrency = lookupRequestsConcurrency;
+        return this;
+    }
+
+    public boolean getUseIdentityThriftHeader()
+    {
+        return useIdentityThriftHeaders;
+    }
+
+    @Config("presto-thrift.use-identity-thrift-headers")
+    public ThriftConnectorConfig setUseIdentityThriftHeader(boolean setIdentityThriftHeaders)
+    {
+        this.useIdentityThriftHeaders = setIdentityThriftHeaders;
         return this;
     }
 }

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftSessionProperties.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftSessionProperties.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.connector.thrift;
 
+import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.session.PropertyMetadata;
 import com.google.common.collect.ImmutableList;
 
@@ -20,18 +21,30 @@ import javax.inject.Inject;
 
 import java.util.List;
 
+import static com.facebook.presto.spi.session.PropertyMetadata.booleanProperty;
+
 /**
  * Internal session properties are those defined by the connector itself.
  * These properties control certain aspects of connector's work.
  */
 public final class ThriftSessionProperties
 {
+    private static final String SET_THRIFT_IDENTITY_HEADER = "use_thrift_identity_header";
     private final List<PropertyMetadata<?>> sessionProperties;
 
     @Inject
     public ThriftSessionProperties(ThriftConnectorConfig config)
     {
-        sessionProperties = ImmutableList.of();
+        sessionProperties = ImmutableList.of(booleanProperty(
+                SET_THRIFT_IDENTITY_HEADER,
+                "Thrift identity is used when set to true",
+                config.getUseIdentityThriftHeader(),
+                false));
+    }
+
+    public static boolean isUseIdentityThriftHeader(ConnectorSession session)
+    {
+        return session.getProperty(SET_THRIFT_IDENTITY_HEADER, Boolean.class);
     }
 
     public List<PropertyMetadata<?>> getSessionProperties()

--- a/presto-thrift-connector/src/test/java/com/facebook/presto/connector/thrift/TestDefaultThriftHeaderProvider.java
+++ b/presto-thrift-connector/src/test/java/com/facebook/presto/connector/thrift/TestDefaultThriftHeaderProvider.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.connector.thrift;
+
+import com.facebook.presto.testing.TestingConnectorSession;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class TestDefaultThriftHeaderProvider
+{
+    @Test
+    public void testWithoutIdentityHeaders()
+    {
+        ThriftConnectorConfig config = new ThriftConnectorConfig().setUseIdentityThriftHeader(false);
+        ThriftSessionProperties properties = new ThriftSessionProperties(config);
+        TestingConnectorSession session = new TestingConnectorSession(properties.getSessionProperties());
+        DefaultThriftHeaderProvider headerProvider = new DefaultThriftHeaderProvider();
+        Map<String, String> headers = headerProvider.getHeaders(session);
+        assertTrue(headers.isEmpty());
+    }
+
+    @Test
+    public void testWithIdentityHeaders()
+    {
+        ThriftConnectorConfig config = new ThriftConnectorConfig()
+                .setUseIdentityThriftHeader(true);
+        ThriftSessionProperties properties = new ThriftSessionProperties(config);
+        TestingConnectorSession session = new TestingConnectorSession(properties.getSessionProperties());
+        DefaultThriftHeaderProvider headerProvider = new DefaultThriftHeaderProvider();
+        Map<String, String> headers = headerProvider.getHeaders(session);
+        assertEquals(headers.get("presto_connector_user"), session.getUser());
+    }
+}

--- a/presto-thrift-connector/src/test/java/com/facebook/presto/connector/thrift/TestThriftConnectorConfig.java
+++ b/presto-thrift-connector/src/test/java/com/facebook/presto/connector/thrift/TestThriftConnectorConfig.java
@@ -30,7 +30,8 @@ public class TestThriftConnectorConfig
         ConfigAssertions.assertRecordedDefaults(ConfigAssertions.recordDefaults(ThriftConnectorConfig.class)
                 .setMaxResponseSize(new DataSize(16, MEGABYTE))
                 .setMetadataRefreshThreads(1)
-                .setLookupRequestsConcurrency(1));
+                .setLookupRequestsConcurrency(1)
+                .setUseIdentityThriftHeader(false));
     }
 
     @Test
@@ -40,12 +41,14 @@ public class TestThriftConnectorConfig
                 .put("presto-thrift.max-response-size", "2MB")
                 .put("presto-thrift.metadata-refresh-threads", "10")
                 .put("presto-thrift.lookup-requests-concurrency", "8")
+                .put("presto-thrift.use-identity-thrift-headers", "true")
                 .build();
 
         ThriftConnectorConfig expected = new ThriftConnectorConfig()
                 .setMaxResponseSize(new DataSize(2, MEGABYTE))
                 .setMetadataRefreshThreads(10)
-                .setLookupRequestsConcurrency(8);
+                .setLookupRequestsConcurrency(8)
+                .setUseIdentityThriftHeader(true);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
Changes:
- This diff introduces an option to pass the Presto user to Thrift Services using the Thrift Connector.
- This is needed for us to apply admission control to users of the Thrift Connected service.

Test plan
- Added unit tests

```
== NO RELEASE NOTE ==
```
