### PR TITLE
Allow dynamic filtering with comparison operators

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/function/OperatorType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/function/OperatorType.java
@@ -75,11 +75,6 @@ public enum OperatorType
         return calledOnNullInput;
     }
 
-    public static Optional<OperatorType> tryGetOperatorType(QualifiedObjectName operatorName)
-    {
-        return Optional.ofNullable(OPERATOR_TYPES.get(operatorName));
-    }
-
     public boolean isComparisonOperator()
     {
         return this.equals(EQUAL) ||
@@ -94,5 +89,52 @@ public enum OperatorType
     public boolean isArithmeticOperator()
     {
         return this.equals(ADD) || this.equals(SUBTRACT) || this.equals(MULTIPLY) || this.equals(DIVIDE) || this.equals(MODULUS);
+    }
+
+    public static Optional<OperatorType> tryGetOperatorType(QualifiedObjectName operatorName)
+    {
+        return Optional.ofNullable(OPERATOR_TYPES.get(operatorName));
+    }
+
+    public static OperatorType flip(OperatorType operator)
+    {
+        switch (operator) {
+            case EQUAL:
+                return EQUAL;
+            case NOT_EQUAL:
+                return NOT_EQUAL;
+            case LESS_THAN:
+                return GREATER_THAN;
+            case LESS_THAN_OR_EQUAL:
+                return GREATER_THAN_OR_EQUAL;
+            case GREATER_THAN:
+                return LESS_THAN;
+            case GREATER_THAN_OR_EQUAL:
+                return LESS_THAN_OR_EQUAL;
+            case IS_DISTINCT_FROM:
+                return IS_DISTINCT_FROM;
+            default:
+                throw new IllegalArgumentException("Unsupported flip non-comparison operator: " + operator);
+        }
+    }
+
+    public static OperatorType negate(OperatorType operator)
+    {
+        switch (operator) {
+            case EQUAL:
+                return NOT_EQUAL;
+            case NOT_EQUAL:
+                return EQUAL;
+            case LESS_THAN:
+                return GREATER_THAN_OR_EQUAL;
+            case LESS_THAN_OR_EQUAL:
+                return GREATER_THAN;
+            case GREATER_THAN:
+                return LESS_THAN_OR_EQUAL;
+            case GREATER_THAN_OR_EQUAL:
+                return LESS_THAN;
+            default:
+                throw new IllegalArgumentException("Unsupported negate non-comparison operator: " + operator);
+        }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalDynamicFilter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalDynamicFilter.java
@@ -45,7 +45,7 @@ import static java.util.stream.Collectors.toMap;
 public class LocalDynamicFilter
 {
     // Mapping from dynamic filter ID to its probe variables.
-    private final Multimap<String, VariableReferenceExpression> probeVariables;
+    private final Multimap<String, DynamicFilterPlaceholder> probeVariables;
 
     // Mapping from dynamic filter ID to its build channel indices.
     private final Map<String, Integer> buildChannels;
@@ -58,7 +58,7 @@ public class LocalDynamicFilter
     // The resulting predicates from each build-side partition.
     private final List<TupleDomain<String>> partitions;
 
-    public LocalDynamicFilter(Multimap<String, VariableReferenceExpression> probeVariables, Map<String, Integer> buildChannels, int partitionCount)
+    public LocalDynamicFilter(Multimap<String, DynamicFilterPlaceholder> probeVariables, Map<String, Integer> buildChannels, int partitionCount)
     {
         this.probeVariables = requireNonNull(probeVariables, "probeVariables is null");
         this.buildChannels = requireNonNull(buildChannels, "buildChannels is null");
@@ -95,8 +95,9 @@ public class LocalDynamicFilter
         for (Map.Entry<String, Domain> entry : result.getDomains().get().entrySet()) {
             Domain domain = entry.getValue();
             // Store all matching variables for each build channel index.
-            for (VariableReferenceExpression probeVariable : probeVariables.get(entry.getKey())) {
-                builder.put(probeVariable, domain);
+            for (DynamicFilterPlaceholder placeholder : probeVariables.get(entry.getKey())) {
+                Domain updatedDomain = placeholder.applyComparison(domain);
+                builder.put((VariableReferenceExpression) placeholder.getInput(), updatedDomain);
             }
         }
         return TupleDomain.withColumnDomains(builder.build());
@@ -111,21 +112,20 @@ public class LocalDynamicFilter
                 .findAll();
 
         // Mapping from probe-side dynamic filters' IDs to their matching probe variables.
-        ImmutableMultimap.Builder<String, VariableReferenceExpression> probeVariablesBuilder = ImmutableMultimap.builder();
+        ImmutableMultimap.Builder<String, DynamicFilterPlaceholder> probeVariablesBuilder = ImmutableMultimap.builder();
         for (FilterNode filterNode : filterNodes) {
             DynamicFilterExtractResult extractResult = extractDynamicFilters(filterNode.getPredicate());
             for (DynamicFilterPlaceholder placeholder : extractResult.getDynamicConjuncts()) {
                 if (placeholder.getInput() instanceof VariableReferenceExpression) {
                     // Add descriptors that match the local dynamic filter (from the current join node).
                     if (joinDynamicFilters.contains(placeholder.getId())) {
-                        VariableReferenceExpression probeVariable = (VariableReferenceExpression) placeholder.getInput();
-                        probeVariablesBuilder.put(placeholder.getId(), probeVariable);
+                        probeVariablesBuilder.put(placeholder.getId(), placeholder);
                     }
                 }
             }
         }
 
-        Multimap<String, VariableReferenceExpression> probeVariables = probeVariablesBuilder.build();
+        Multimap<String, DynamicFilterPlaceholder> probeVariables = probeVariablesBuilder.build();
         PlanNode buildNode = planNode.getBuild();
         Map<String, Integer> buildChannels = planNode.getDynamicFilters().entrySet().stream()
                 // Skip build channels that don't match local probe dynamic filters.

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -2008,14 +2008,19 @@ public class LocalExecutionPlanner
                     node.getId(),
                     nestedLoopJoinBridgeManager);
 
-            checkArgument(buildContext.getDriverInstanceCount().orElse(1) == 1, "Expected local execution to not be parallel");
+            int partitionCount = buildContext.getDriverInstanceCount().orElse(1);
+            checkArgument(partitionCount == 1, "Expected local execution to not be parallel");
+
+            ImmutableList.Builder<OperatorFactory> factoriesBuilder = new ImmutableList.Builder<>();
+            factoriesBuilder.addAll(buildSource.getOperatorFactories());
+            createDynamicFilter(buildSource, node, context, partitionCount).ifPresent(
+                    filter -> factoriesBuilder.add(createDynamicFilterSourceOperatorFactory(filter, node.getId(), buildSource, buildContext)));
+            factoriesBuilder.add(nestedLoopBuildOperatorFactory);
+
             context.addDriverFactory(
                     buildContext.isInputDriver(),
                     false,
-                    ImmutableList.<OperatorFactory>builder()
-                            .addAll(buildSource.getOperatorFactories())
-                            .add(nestedLoopBuildOperatorFactory)
-                            .build(),
+                    factoriesBuilder.build(),
                     buildContext.getDriverInstanceCount(),
                     buildSource.getPipelineExecutionStrategy(),
                     Optional.empty());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
@@ -624,15 +624,6 @@ public class PredicatePushDown
             return new DynamicFiltersResult(dynamicFilters, predicates);
         }
 
-        private static RowExpression createDynamicFilterExpression(String id, VariableReferenceExpression input, FunctionAndTypeManager functionAndTypeManager)
-        {
-            return call(
-                    functionAndTypeManager,
-                    DynamicFilters.DynamicFilterPlaceholderFunction.NAME,
-                    BooleanType.BOOLEAN,
-                    ImmutableList.of(new ConstantExpression(Slices.utf8Slice(id), VarcharType.VARCHAR), input));
-        }
-
         private static DynamicFiltersResult createDynamicFilters(
                 VariableReferenceExpression probeVariable,
                 VariableReferenceExpression buildVariable,

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
@@ -60,6 +60,8 @@ import com.facebook.presto.sql.relational.FunctionResolution;
 import com.facebook.presto.sql.relational.RowExpressionDeterminismEvaluator;
 import com.facebook.presto.sql.relational.RowExpressionDomainTranslator;
 import com.facebook.presto.sql.relational.RowExpressionOptimizer;
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -78,7 +80,13 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static com.facebook.presto.SystemSessionProperties.isEnableDynamicFiltering;
+import static com.facebook.presto.common.function.OperatorType.BETWEEN;
 import static com.facebook.presto.common.function.OperatorType.EQUAL;
+import static com.facebook.presto.common.function.OperatorType.GREATER_THAN_OR_EQUAL;
+import static com.facebook.presto.common.function.OperatorType.IS_DISTINCT_FROM;
+import static com.facebook.presto.common.function.OperatorType.LESS_THAN_OR_EQUAL;
+import static com.facebook.presto.common.function.OperatorType.NOT_EQUAL;
+import static com.facebook.presto.common.function.OperatorType.negate;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.expressions.LogicalRowExpressions.FALSE_CONSTANT;
@@ -138,11 +146,23 @@ public class PredicatePushDown
 
     public static RowExpression createDynamicFilterExpression(String id, VariableReferenceExpression input, FunctionAndTypeManager functionAndTypeManager)
     {
+        return createDynamicFilterExpression(id, input, functionAndTypeManager, EQUAL.name());
+    }
+
+    private static RowExpression createDynamicFilterExpression(
+            String id,
+            VariableReferenceExpression input,
+            FunctionAndTypeManager functionAndTypeManager,
+            String operator)
+    {
         return call(
                 functionAndTypeManager,
                 DynamicFilters.DynamicFilterPlaceholderFunction.NAME,
                 BooleanType.BOOLEAN,
-                ImmutableList.of(new ConstantExpression(Slices.utf8Slice(id), VarcharType.VARCHAR), input));
+                ImmutableList.of(
+                        input,
+                        new ConstantExpression(Slices.utf8Slice(operator), VarcharType.VARCHAR),
+                        new ConstantExpression(Slices.utf8Slice(id), VarcharType.VARCHAR)));
     }
 
     private static class Rewriter
@@ -510,10 +530,11 @@ public class PredicatePushDown
             PlanNode leftSource;
             PlanNode rightSource;
 
+            List<RowExpression> joinFilter = joinFilterBuilder.build();
             boolean dynamicFilterEnabled = isEnableDynamicFiltering(session);
             Map<String, VariableReferenceExpression> dynamicFilters = ImmutableMap.of();
             if (dynamicFilterEnabled) {
-                DynamicFiltersResult dynamicFiltersResult = createDynamicFilters(node, equiJoinClauses, idAllocator, metadata.getFunctionAndTypeManager());
+                DynamicFiltersResult dynamicFiltersResult = createDynamicFilters(node, equiJoinClauses, joinFilter, idAllocator, metadata.getFunctionAndTypeManager());
                 dynamicFilters = dynamicFiltersResult.getDynamicFilters();
                 leftPredicate = logicalRowExpressions.combineConjuncts(leftPredicate, logicalRowExpressions.combineConjuncts(dynamicFiltersResult.getPredicates()));
             }
@@ -529,7 +550,7 @@ public class PredicatePushDown
                 rightSource = context.rewrite(node.getRight(), rightPredicate);
             }
 
-            Optional<RowExpression> newJoinFilter = Optional.of(logicalRowExpressions.combineConjuncts(joinFilterBuilder.build()));
+            Optional<RowExpression> newJoinFilter = Optional.of(logicalRowExpressions.combineConjuncts(joinFilter));
             if (newJoinFilter.get() == TRUE_CONSTANT) {
                 newJoinFilter = Optional.empty();
             }
@@ -599,29 +620,149 @@ public class PredicatePushDown
         private static DynamicFiltersResult createDynamicFilters(
                 JoinNode node,
                 List<JoinNode.EquiJoinClause> equiJoinClauses,
+                List<RowExpression> joinFilter,
                 PlanNodeIdAllocator idAllocator,
                 FunctionAndTypeManager functionAndTypeManager)
         {
             Map<String, VariableReferenceExpression> dynamicFilters = ImmutableMap.of();
             List<RowExpression> predicates = ImmutableList.of();
             if (node.getType() == INNER) {
-                // New equiJoinClauses could potentially not contain symbols used in current dynamic filters.
-                // Since we use PredicatePushdown to push dynamic filters themselves,
-                // instead of separate ApplyDynamicFilters rule we derive dynamic filters within PredicatePushdown itself.
-                // Even if equiJoinClauses.equals(node.getCriteria), current dynamic filters may not match equiJoinClauses
-                ImmutableMap.Builder<String, VariableReferenceExpression> dynamicFiltersBuilder = ImmutableMap.builder();
-                ImmutableList.Builder<RowExpression> predicatesBuilder = ImmutableList.builder();
-                for (JoinNode.EquiJoinClause clause : equiJoinClauses) {
-                    VariableReferenceExpression probeSymbol = clause.getLeft();
-                    VariableReferenceExpression buildSymbol = clause.getRight();
-                    String id = idAllocator.getNextId().toString();
-                    predicatesBuilder.add(createDynamicFilterExpression(id, probeSymbol, functionAndTypeManager));
-                    dynamicFiltersBuilder.put(id, buildSymbol);
+                List<CallExpression> clauses = getDynamicFilterClauses(node, equiJoinClauses, joinFilter, functionAndTypeManager);
+                List<VariableReferenceExpression> buildSymbols = clauses.stream()
+                        .map(expression -> (VariableReferenceExpression) expression.getArguments().get(1))
+                        .collect(Collectors.toList());
+
+                BiMap<VariableReferenceExpression, String> buildSymbolToIdMap = HashBiMap.create(node.getDynamicFilters()).inverse();
+                for (VariableReferenceExpression buildSymbol : buildSymbols) {
+                    buildSymbolToIdMap.put(buildSymbol, idAllocator.getNextId().toString());
                 }
-                dynamicFilters = dynamicFiltersBuilder.build();
+
+                ImmutableList.Builder<RowExpression> predicatesBuilder = ImmutableList.builder();
+                for (CallExpression expression : clauses) {
+                    VariableReferenceExpression probeSymbol = (VariableReferenceExpression) expression.getArguments().get(0);
+                    VariableReferenceExpression buildSymbol = (VariableReferenceExpression) expression.getArguments().get(1);
+                    String id = buildSymbolToIdMap.get(buildSymbol);
+                    RowExpression predicate = createDynamicFilterExpression(id, probeSymbol, functionAndTypeManager, expression.getDisplayName());
+                    predicatesBuilder.add(predicate);
+                }
+                dynamicFilters = buildSymbolToIdMap.inverse();
                 predicates = predicatesBuilder.build();
             }
             return new DynamicFiltersResult(dynamicFilters, predicates);
+        }
+
+        private static List<CallExpression> getDynamicFilterClauses(
+                JoinNode node,
+                List<JoinNode.EquiJoinClause> equiJoinClauses,
+                List<RowExpression> joinFilter,
+                FunctionAndTypeManager functionAndTypeManager)
+        {
+            // New equiJoinClauses could potentially not contain symbols used in current dynamic filters.
+            // Since we use PredicatePushdown to push dynamic filters themselves,
+            // instead of separate ApplyDynamicFilters rule we derive dynamic filters within PredicatePushdown itself.
+            // Even if equiJoinClauses.equals(node.getCriteria), current dynamic filters may not match equiJoinClauses
+            ImmutableList.Builder<CallExpression> clausesBuilder = ImmutableList.builder();
+            for (JoinNode.EquiJoinClause clause : equiJoinClauses) {
+                VariableReferenceExpression probeSymbol = clause.getLeft();
+                VariableReferenceExpression buildSymbol = clause.getRight();
+                clausesBuilder.add(call(
+                                    EQUAL.name(),
+                                    functionAndTypeManager.resolveOperator(EQUAL, fromTypes(probeSymbol.getType(), buildSymbol.getType())),
+                                    BOOLEAN,
+                                    probeSymbol,
+                                    buildSymbol));
+            }
+
+            for (RowExpression filter : joinFilter) {
+                if ((filter instanceof CallExpression)) {
+                    CallExpression call = (CallExpression) filter;
+                    List<RowExpression> arguments = call.getArguments();
+
+                    // TODO: support for complex inequalities, e.g. left < right + 10, NOT, LIKE
+                    if (arguments.size() == 1) {
+                        continue;
+                    }
+
+                    if (arguments.size() == 3) {
+                        // try convert BETWEEN into GREATER_THAN_OR_EQUAL and LESS_THAN_OR_EQUAL
+                        String function = call.getDisplayName();
+                        if (function.equals(BETWEEN.name()) && arguments.get(0) instanceof VariableReferenceExpression) {
+                            if (arguments.get(1) instanceof VariableReferenceExpression) {
+                                CallExpression callExpression = call(
+                                                                    GREATER_THAN_OR_EQUAL.name(),
+                                                                    functionAndTypeManager.resolveOperator(GREATER_THAN_OR_EQUAL, fromTypes(arguments.get(0).getType(), arguments.get(1).getType())),
+                                                                    BOOLEAN,
+                                                                    arguments.get(0),
+                                                                    arguments.get(1));
+                                Optional<CallExpression> comparisonExpression = getDynamicFilterComparison(node, callExpression, functionAndTypeManager);
+                                if (comparisonExpression.isPresent()) {
+                                    clausesBuilder.add(comparisonExpression.get());
+                                }
+                            }
+                            if (arguments.get(2) instanceof VariableReferenceExpression) {
+                                CallExpression callExpression = call(
+                                                                    LESS_THAN_OR_EQUAL.name(),
+                                                                    functionAndTypeManager.resolveOperator(LESS_THAN_OR_EQUAL, fromTypes(arguments.get(0).getType(), arguments.get(2).getType())),
+                                                                    BOOLEAN,
+                                                                    arguments.get(0),
+                                                                    arguments.get(2));
+                                Optional<CallExpression> comparisonExpression = getDynamicFilterComparison(node, callExpression, functionAndTypeManager);
+                                if (comparisonExpression.isPresent()) {
+                                    clausesBuilder.add(comparisonExpression.get());
+                                }
+                            }
+                        }
+                        continue;
+                    }
+
+                    checkArgument(arguments.size() == 2, "invalid arguments count: %s", arguments.size());
+                    Optional<CallExpression> comparisonExpression = getDynamicFilterComparison(node, call, functionAndTypeManager);
+                    if (comparisonExpression.isPresent()) {
+                        clausesBuilder.add(comparisonExpression.get());
+                    }
+                }
+            }
+            return clausesBuilder.build();
+        }
+
+        private static Optional<CallExpression> getDynamicFilterComparison(
+                JoinNode node,
+                CallExpression call,
+                FunctionAndTypeManager functionAndTypeManager)
+        {
+            String function = call.getDisplayName();
+            List<RowExpression> arguments = call.getArguments();
+            RowExpression left = arguments.get(0);
+            RowExpression right = arguments.get(1);
+            boolean shouldFlip = false;
+            if (!(left instanceof VariableReferenceExpression && right instanceof VariableReferenceExpression)) {
+                return Optional.empty();
+            }
+
+            OperatorType operator = OperatorType.valueOf(function);
+            if (!operator.isComparisonOperator() || operator == NOT_EQUAL || operator == IS_DISTINCT_FROM) {
+                return Optional.empty();
+            }
+
+            if (node.getRight().getOutputVariables().contains(left)) {
+                shouldFlip = true;
+            }
+            if (node.getLeft().getOutputVariables().contains(right)) {
+                shouldFlip = true;
+            }
+
+            if (shouldFlip) {
+                operator = negate(operator);
+                left = arguments.get(1);
+                right = arguments.get(0);
+            }
+
+            return Optional.of(call(
+                                operator.name(),
+                                functionAndTypeManager.resolveOperator(operator, fromTypes(left.getType(), right.getType())),
+                                BOOLEAN,
+                                left,
+                                right));
         }
 
         private static DynamicFiltersResult createDynamicFilters(

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
@@ -503,6 +503,13 @@ public class PlanPrinter
                             node.getFilteringSourceJoinVariable(),
                             formatHash(node.getSourceHashVariable(), node.getFilteringSourceHashVariable())));
             node.getDistributionType().ifPresent(distributionType -> nodeOutput.appendDetailsLine("Distribution: %s", distributionType));
+            if (!node.getDynamicFilters().isEmpty()) {
+                nodeOutput.appendDetails(
+                        "dynamicFilterAssignments = %s",
+                        node.getDynamicFilters().entrySet().stream()
+                                .map(filter -> filter.getValue() + " -> " + filter.getKey())
+                                .collect(Collectors.joining(", ", "{", "}")));
+            }
             node.getSource().accept(this, context);
             node.getFilteringSource().accept(this, context);
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestDynamicFilter.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestDynamicFilter.java
@@ -74,6 +74,19 @@ public class TestDynamicFilter
     }
 
     @Test
+    public void testCrossJoinInequalityWithCast()
+    {
+        assertPlan("SELECT o.comment, l.comment FROM orders o, lineitem l WHERE o.comment < l.comment",
+                anyTree(filter("O_COMMENT < CAST(L_COMMENT AS varchar(79))",
+                        join(
+                                INNER,
+                                ImmutableList.of(),
+                                tableScan("orders", ImmutableMap.of("O_COMMENT", "comment")),
+                                exchange(
+                                        tableScan("lineitem", ImmutableMap.of("L_COMMENT", "comment")))))));
+    }
+
+    @Test
     public void testJoin()
     {
         assertPlan(

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestLocalDynamicFilter.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestLocalDynamicFilter.java
@@ -17,6 +17,7 @@ package com.facebook.presto.sql.planner;
 import com.facebook.presto.Session;
 import com.facebook.presto.common.predicate.Domain;
 import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.expressions.DynamicFilters.DynamicFilterPlaceholder;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.planner.assertions.BasePlanTest;
 import com.facebook.presto.sql.planner.optimizations.PlanNodeSearcher;
@@ -38,6 +39,7 @@ import java.util.function.Consumer;
 import static com.facebook.presto.SystemSessionProperties.ENABLE_DYNAMIC_FILTERING;
 import static com.facebook.presto.SystemSessionProperties.FORCE_SINGLE_NODE_OUTPUT;
 import static com.facebook.presto.SystemSessionProperties.JOIN_DISTRIBUTION_TYPE;
+import static com.facebook.presto.common.function.OperatorType.EQUAL;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static com.facebook.presto.testing.assertions.Assert.assertEquals;
@@ -60,7 +62,7 @@ public class TestLocalDynamicFilter
             throws ExecutionException, InterruptedException
     {
         LocalDynamicFilter filter = new LocalDynamicFilter(
-                ImmutableMultimap.of("123", new VariableReferenceExpression("a", INTEGER)),
+                ImmutableMultimap.of("123", new DynamicFilterPlaceholder("123", new VariableReferenceExpression("a", INTEGER), EQUAL)),
                 ImmutableMap.of("123", 0),
                 1);
         assertEquals(filter.getBuildChannels(), ImmutableMap.of("123", 0));
@@ -81,7 +83,7 @@ public class TestLocalDynamicFilter
             throws ExecutionException, InterruptedException
     {
         LocalDynamicFilter filter = new LocalDynamicFilter(
-                ImmutableMultimap.of("123", new VariableReferenceExpression("a1", INTEGER), "123", new VariableReferenceExpression("a2", INTEGER)),
+                ImmutableMultimap.of("123", new DynamicFilterPlaceholder("123", new VariableReferenceExpression("a1", INTEGER), EQUAL), "123", new DynamicFilterPlaceholder("123", new VariableReferenceExpression("a2", INTEGER), EQUAL)),
                 ImmutableMap.of("123", 0),
                 1);
         assertEquals(filter.getBuildChannels(), ImmutableMap.of("123", 0));
@@ -101,7 +103,7 @@ public class TestLocalDynamicFilter
             throws ExecutionException, InterruptedException
     {
         LocalDynamicFilter filter = new LocalDynamicFilter(
-                ImmutableMultimap.of("123", new VariableReferenceExpression("a", INTEGER)),
+                ImmutableMultimap.of("123", new DynamicFilterPlaceholder("123", new VariableReferenceExpression("a", INTEGER), EQUAL)),
                 ImmutableMap.of("123", 0),
                 2);
         assertEquals(filter.getBuildChannels(), ImmutableMap.of("123", 0));
@@ -125,7 +127,7 @@ public class TestLocalDynamicFilter
             throws ExecutionException, InterruptedException
     {
         LocalDynamicFilter filter = new LocalDynamicFilter(
-                ImmutableMultimap.of("123", new VariableReferenceExpression("a", INTEGER)),
+                ImmutableMultimap.of("123", new DynamicFilterPlaceholder("123", new VariableReferenceExpression("a", INTEGER), EQUAL)),
                 ImmutableMap.of("123", 0),
                 1);
         assertEquals(filter.getBuildChannels(), ImmutableMap.of("123", 0));
@@ -145,7 +147,7 @@ public class TestLocalDynamicFilter
             throws ExecutionException, InterruptedException
     {
         LocalDynamicFilter filter = new LocalDynamicFilter(
-                ImmutableMultimap.of("123", new VariableReferenceExpression("a", INTEGER), "456", new VariableReferenceExpression("b", INTEGER)),
+                ImmutableMultimap.of("123", new DynamicFilterPlaceholder("123", new VariableReferenceExpression("a", INTEGER), EQUAL), "456", new DynamicFilterPlaceholder("456", new VariableReferenceExpression("b", INTEGER), EQUAL)),
                 ImmutableMap.of("123", 0, "456", 1),
                 1);
         assertEquals(filter.getBuildChannels(), ImmutableMap.of("123", 0, "456", 1));
@@ -166,7 +168,7 @@ public class TestLocalDynamicFilter
             throws ExecutionException, InterruptedException
     {
         LocalDynamicFilter filter = new LocalDynamicFilter(
-                ImmutableMultimap.of("123", new VariableReferenceExpression("a", INTEGER), "456", new VariableReferenceExpression("b", BIGINT)),
+                ImmutableMultimap.of("123", new DynamicFilterPlaceholder("123", new VariableReferenceExpression("a", INTEGER), EQUAL), "456", new DynamicFilterPlaceholder("456", new VariableReferenceExpression("b", BIGINT), EQUAL)),
                 ImmutableMap.of("123", 0, "456", 1),
                 2);
         assertEquals(filter.getBuildChannels(), ImmutableMap.of("123", 0, "456", 1));


### PR DESCRIPTION
Cherry-pick of https://github.com/trinodb/trino/commit/609723a3eed065a8cdad2b4a3e2c92fff5623d0a

Co-authored-by: Roman Zeyde <zeyde@varada.io>


```
== RELEASE NOTES ==

General Changes
* Support dynamic filtering with comparison operators
```
