### PR TITLE
Simplify PartitionedOutputOperator

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/block/DictionaryBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/DictionaryBlock.java
@@ -383,6 +383,12 @@ public class DictionaryBlock
     }
 
     @Override
+    public boolean mayHaveNull()
+    {
+        return positionCount > 0 && dictionary.mayHaveNull();
+    }
+
+    @Override
     public Block getPositions(int[] positions, int offset, int length)
     {
         checkArrayRange(positions, offset, length);

--- a/presto-common/src/main/java/com/facebook/presto/common/block/RunLengthEncodedBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/RunLengthEncodedBlock.java
@@ -299,6 +299,12 @@ public class RunLengthEncodedBlock
     }
 
     @Override
+    public boolean mayHaveNull()
+    {
+        return positionCount > 0 && value.isNull(0);
+    }
+
+    @Override
     public String toString()
     {
         return format("RunLengthEncodedBlock(%d){positionCount=%d,value=%s}", hashCode(), getPositionCount(), value);

--- a/presto-main/src/main/java/com/facebook/presto/operator/GroupByIdBlock.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/GroupByIdBlock.java
@@ -183,6 +183,12 @@ public class GroupByIdBlock
     }
 
     @Override
+    public boolean mayHaveNull()
+    {
+        return block.mayHaveNull();
+    }
+
+    @Override
     public int getPositionCount()
     {
         return block.getPositionCount();

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/OptimizedPartitionedOutputOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/OptimizedPartitionedOutputOperator.java
@@ -185,6 +185,12 @@ public class OptimizedPartitionedOutputOperator
         return null;
     }
 
+    @Override
+    public void close()
+    {
+        systemMemoryContext.close();
+    }
+
     /**
      * Flatten the block and convert the nested-typed block into ColumnarArray/Map/Row.
      * For performance considerations we decode the block only once for each block instead of for each batch.

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/OptimizedPartitionedOutputOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/OptimizedPartitionedOutputOperator.java
@@ -391,7 +391,7 @@ public class OptimizedPartitionedOutputOperator
         private final Block[] partitionConstantBlocks; // when null, no constants are present. Only non-null elements are constants
         private final PagesSerde serde;
         private final boolean replicatesAnyRow;
-        private final OptionalInt nullChannel; // when present, send the position to every partition if this channel is null.
+        private final int nullChannel; // when >= 0, send the position to every partition if this channel is null
         private final AtomicLong rowsAdded = new AtomicLong();
         private final AtomicLong pagesAdded = new AtomicLong();
 
@@ -444,7 +444,7 @@ public class OptimizedPartitionedOutputOperator
             }
 
             this.replicatesAnyRow = replicatesAnyRow;
-            this.nullChannel = requireNonNull(nullChannel, "nullChannel is null");
+            this.nullChannel = requireNonNull(nullChannel, "nullChannel is null").orElse(-1);
             this.outputBuffer = requireNonNull(outputBuffer, "outputBuffer is null");
             this.serde = requireNonNull(serdeFactory, "serdeFactory is null").createPagesSerde();
 
@@ -489,6 +489,9 @@ public class OptimizedPartitionedOutputOperator
         {
             // Populate positions to copy for each destination partition.
             int positionCount = page.getPositionCount();
+            if (positionCount == 0) {
+                return;
+            }
 
             // We initialize the size of the positions array in each partitionBuffers to be at most the incoming page's positionCount, or roughly two times of positionCount
             // divided by the number of partitions. This is because the latter could be greater than the positionCount when the number of partitions is 1 or positionCount is 1.
@@ -497,20 +500,37 @@ public class OptimizedPartitionedOutputOperator
                 partitionBuffers[i].resetPositions(initialPositionCountForEachBuffer);
             }
 
-            Block nullBlock = nullChannel.isPresent() ? page.getBlock(nullChannel.getAsInt()) : null;
-            Page partitionFunctionArgs = getPartitionFunctionArguments(page);
-
-            for (int position = 0; position < positionCount; position++) {
-                boolean shouldReplicate = (replicatesAnyRow && !hasAnyRowBeenReplicated) ||
-                        nullBlock != null && nullBlock.isNull(position);
-
-                if (shouldReplicate) {
-                    for (int i = 0; i < partitionBuffers.length; i++) {
-                        partitionBuffers[i].addPosition(position);
-                    }
-                    hasAnyRowBeenReplicated = true;
+            int position;
+            // Handle "any row" replication outside of the inner loop processing
+            if (replicatesAnyRow && !hasAnyRowBeenReplicated) {
+                for (int i = 0; i < partitionBuffers.length; i++) {
+                    partitionBuffers[i].addPosition(0);
                 }
-                else {
+                hasAnyRowBeenReplicated = true;
+                position = 1;
+            }
+            else {
+                position = 0;
+            }
+
+            Page partitionFunctionArgs = getPartitionFunctionArguments(page);
+            // Skip null block checks if mayHaveNull reports that no positions will be null
+            if (nullChannel >= 0 && page.getBlock(nullChannel).mayHaveNull()) {
+                Block nullBlock = page.getBlock(nullChannel);
+                for (; position < positionCount; position++) {
+                    if (nullBlock.isNull(position)) {
+                        for (int i = 0; i < partitionBuffers.length; i++) {
+                            partitionBuffers[i].addPosition(position);
+                        }
+                    }
+                    else {
+                        int partition = partitionFunction.getPartition(partitionFunctionArgs, position);
+                        partitionBuffers[partition].addPosition(position);
+                    }
+                }
+            }
+            else {
+                for (; position < positionCount; position++) {
                     int partition = partitionFunction.getPartition(partitionFunctionArgs, position);
                     partitionBuffers[partition].addPosition(position);
                 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/PartitionedOutputOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/PartitionedOutputOperator.java
@@ -275,6 +275,12 @@ public class PartitionedOutputOperator
         return null;
     }
 
+    @Override
+    public void close()
+    {
+        partitionFunction.closeMemoryContext();
+    }
+
     private static class PagePartitioner
     {
         private final OutputBuffer outputBuffer;
@@ -341,6 +347,11 @@ public class PartitionedOutputOperator
             for (int i = 0; i < partitionCount; i++) {
                 pageBuilders[i] = PageBuilder.withMaxPageSize(pageSize, sourceTypes);
             }
+        }
+
+        public void closeMemoryContext()
+        {
+            systemMemoryContext.close();
         }
 
         public ListenableFuture<?> isFull()

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/PartitionedOutputOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/PartitionedOutputOperator.java
@@ -284,7 +284,7 @@ public class PartitionedOutputOperator
     private static class PagePartitioner
     {
         private final OutputBuffer outputBuffer;
-        private final List<Type> sourceTypes;
+        private final Type[] sourceTypes;
         private final PartitionFunction partitionFunction;
         private final int[] partitionChannels;
         @Nullable
@@ -292,7 +292,7 @@ public class PartitionedOutputOperator
         private final PagesSerde serde;
         private final PageBuilder[] pageBuilders;
         private final boolean replicatesAnyRow;
-        private final OptionalInt nullChannel; // when present, send the position to every partition if this channel is null.
+        private final int nullChannel; // when >= 0, send the position to every partition if this channel is null
         private final AtomicLong rowsAdded = new AtomicLong();
         private final AtomicLong pagesAdded = new AtomicLong();
         private boolean hasAnyRowBeenReplicated;
@@ -323,9 +323,9 @@ public class PartitionedOutputOperator
                 this.partitionConstantBlocks = null;
             }
             this.replicatesAnyRow = replicatesAnyRow;
-            this.nullChannel = requireNonNull(nullChannel, "nullChannel is null");
+            this.nullChannel = requireNonNull(nullChannel, "nullChannel is null").orElse(-1);
             this.outputBuffer = requireNonNull(outputBuffer, "outputBuffer is null");
-            this.sourceTypes = requireNonNull(sourceTypes, "sourceTypes is null");
+            this.sourceTypes = requireNonNull(sourceTypes, "sourceTypes is null").toArray(new Type[0]);
             this.serde = requireNonNull(serdeFactory, "serdeFactory is null").createPagesSerde();
             this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
             this.systemMemoryContext = operatorContext.newLocalSystemMemoryContext(PartitionedOutputOperator.class.getSimpleName());
@@ -395,18 +395,41 @@ public class PartitionedOutputOperator
         public void partitionPage(Page page)
         {
             requireNonNull(page, "page is null");
+            if (page.getPositionCount() == 0) {
+                return;
+            }
+
+            int position;
+            // Handle "any row" replication outside of the inner loop processing
+            if (replicatesAnyRow && !hasAnyRowBeenReplicated) {
+                for (PageBuilder pageBuilder : pageBuilders) {
+                    appendRow(pageBuilder, page, 0);
+                }
+                hasAnyRowBeenReplicated = true;
+                position = 1;
+            }
+            else {
+                position = 0;
+            }
 
             Page partitionFunctionArgs = getPartitionFunctionArguments(page);
-            for (int position = 0; position < page.getPositionCount(); position++) {
-                boolean shouldReplicate = (replicatesAnyRow && !hasAnyRowBeenReplicated) ||
-                        nullChannel.isPresent() && page.getBlock(nullChannel.getAsInt()).isNull(position);
-                if (shouldReplicate) {
-                    for (PageBuilder pageBuilder : pageBuilders) {
-                        appendRow(pageBuilder, page, position);
+            // Skip null block checks if mayHaveNull reports that no positions will be null
+            if (nullChannel >= 0 && page.getBlock(nullChannel).mayHaveNull()) {
+                Block nullsBlock = page.getBlock(nullChannel);
+                for (; position < page.getPositionCount(); position++) {
+                    if (nullsBlock.isNull(position)) {
+                        for (PageBuilder pageBuilder : pageBuilders) {
+                            appendRow(pageBuilder, page, position);
+                        }
                     }
-                    hasAnyRowBeenReplicated = true;
+                    else {
+                        int partition = partitionFunction.getPartition(partitionFunctionArgs, position);
+                        appendRow(pageBuilders[partition], page, position);
+                    }
                 }
-                else {
+            }
+            else {
+                for (; position < page.getPositionCount(); position++) {
                     int partition = partitionFunction.getPartition(partitionFunctionArgs, position);
                     appendRow(pageBuilders[partition], page, position);
                 }
@@ -442,8 +465,8 @@ public class PartitionedOutputOperator
         {
             pageBuilder.declarePosition();
 
-            for (int channel = 0; channel < sourceTypes.size(); channel++) {
-                Type type = sourceTypes.get(channel);
+            for (int channel = 0; channel < sourceTypes.length; channel++) {
+                Type type = sourceTypes[channel];
                 type.appendTo(page.getBlock(channel), position, pageBuilder.getBlockBuilder(channel));
             }
         }


### PR DESCRIPTION
Cross-port of similar changes as in https://github.com/trinodb/trino/pull/8437 which simplifies `PartitionedOutputOperator` logic in the inner loop by hoisting "any row" replication outside of it and checking `Block#mayHaveNull()` before querying the null channel on each iteration. Similar changes are made to `OptimizedPartitionedOutputOperator` in this PR.

Also adds `mayHaveNull()` implementations to `DictionaryBlock`, `RunLengthEncodedBlock`, and `GroupByIdBlock` without which that hoisted checking would be less effective.

This change also includes a fix for both partitioned output operators failing to call `systemMemoryContext#close()` (memory was still being released by `OperatorContext#destroy()` but would use the "force free" allocation tag, resulting in incorrect query OOM top consumer reporting).

```
== NO RELEASE NOTE ==
```
