### PR TITLE
Simple TTL based scheduling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -172,6 +172,8 @@
         <module>presto-thrift-testing-udf-server</module>
         <module>presto-thrift-spec</module>
         <module>presto-testng-services</module>
+        <module>presto-node-ttl-fetchers</module>
+        <module>presto-cluster-ttl-providers</module>
     </modules>
 
     <dependencyManagement>
@@ -230,6 +232,18 @@
             <dependency>
                 <groupId>com.facebook.presto</groupId>
                 <artifactId>presto-session-property-managers</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-node-ttl-fetchers</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-cluster-ttl-providers</artifactId>
                 <version>${project.version}</version>
             </dependency>
 

--- a/presto-cluster-ttl-providers/pom.xml
+++ b/presto-cluster-ttl-providers/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>presto-root</artifactId>
+        <groupId>com.facebook.presto</groupId>
+        <version>0.262-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>presto-cluster-ttl-providers</artifactId>
+    <description>Presto - Cluster Ttl Providers</description>
+    <packaging>presto-plugin</packaging>
+
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>configuration</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>bootstrap</artifactId>
+        </dependency>
+
+        <!-- Presto SPI -->
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-spi</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>units</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-common</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/presto-cluster-ttl-providers/src/main/java/com/facebook/presto/clusterttlproviders/ClusterTtlProviderPlugin.java
+++ b/presto-cluster-ttl-providers/src/main/java/com/facebook/presto/clusterttlproviders/ClusterTtlProviderPlugin.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.clusterttlproviders;
+
+import com.facebook.presto.clusterttlproviders.infinite.InfiniteClusterTtlProviderFactory;
+import com.facebook.presto.clusterttlproviders.percentile.PercentileClusterTtlProviderFactory;
+import com.facebook.presto.spi.Plugin;
+import com.facebook.presto.spi.ttl.ClusterTtlProviderFactory;
+import com.google.common.collect.ImmutableList;
+
+public class ClusterTtlProviderPlugin
+        implements Plugin
+{
+    @Override
+    public Iterable<ClusterTtlProviderFactory> getClusterTtlProviderFactories()
+    {
+        return ImmutableList.of(new InfiniteClusterTtlProviderFactory(), new PercentileClusterTtlProviderFactory());
+    }
+}

--- a/presto-cluster-ttl-providers/src/main/java/com/facebook/presto/clusterttlproviders/infinite/InfiniteClusterTtlProvider.java
+++ b/presto-cluster-ttl-providers/src/main/java/com/facebook/presto/clusterttlproviders/infinite/InfiniteClusterTtlProvider.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.clusterttlproviders.infinite;
+
+import com.facebook.presto.spi.ttl.ClusterTtlProvider;
+import com.facebook.presto.spi.ttl.ConfidenceBasedTtlInfo;
+import com.facebook.presto.spi.ttl.NodeTtl;
+
+import java.util.List;
+
+import static com.facebook.presto.spi.ttl.ConfidenceBasedTtlInfo.getInfiniteTtl;
+
+public class InfiniteClusterTtlProvider
+        implements ClusterTtlProvider
+{
+    @Override
+    public ConfidenceBasedTtlInfo getClusterTtl(List<NodeTtl> nodeTtls)
+    {
+        return getInfiniteTtl();
+    }
+}

--- a/presto-cluster-ttl-providers/src/main/java/com/facebook/presto/clusterttlproviders/infinite/InfiniteClusterTtlProviderFactory.java
+++ b/presto-cluster-ttl-providers/src/main/java/com/facebook/presto/clusterttlproviders/infinite/InfiniteClusterTtlProviderFactory.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.clusterttlproviders.infinite;
+
+import com.facebook.presto.spi.ttl.ClusterTtlProvider;
+import com.facebook.presto.spi.ttl.ClusterTtlProviderFactory;
+
+import java.util.Map;
+
+public class InfiniteClusterTtlProviderFactory
+        implements ClusterTtlProviderFactory
+{
+    @Override
+    public String getName()
+    {
+        return "infinite";
+    }
+
+    @Override
+    public ClusterTtlProvider create(Map<String, String> config)
+    {
+        return new InfiniteClusterTtlProvider();
+    }
+}

--- a/presto-cluster-ttl-providers/src/main/java/com/facebook/presto/clusterttlproviders/percentile/PercentileBasedClusterTtlProvider.java
+++ b/presto-cluster-ttl-providers/src/main/java/com/facebook/presto/clusterttlproviders/percentile/PercentileBasedClusterTtlProvider.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.clusterttlproviders.percentile;
+
+import com.facebook.presto.spi.ttl.ClusterTtlProvider;
+import com.facebook.presto.spi.ttl.ConfidenceBasedTtlInfo;
+import com.facebook.presto.spi.ttl.NodeTtl;
+import com.google.inject.Inject;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
+
+public class PercentileBasedClusterTtlProvider
+        implements ClusterTtlProvider
+{
+    private final Comparator<ConfidenceBasedTtlInfo> ttlComparator = Comparator.comparing(ConfidenceBasedTtlInfo::getExpiryInstant);
+    private final int percentile;
+
+    @Inject
+    public PercentileBasedClusterTtlProvider(PercentileBasedClusterTtlProviderConfig config)
+    {
+        requireNonNull(config, "config is null");
+        checkArgument(config.getPercentile() > 0, "percentile should be greater than 0");
+        this.percentile = config.getPercentile();
+    }
+
+    @Override
+    public ConfidenceBasedTtlInfo getClusterTtl(List<NodeTtl> nodeTtls)
+    {
+        List<ConfidenceBasedTtlInfo> ttls = nodeTtls.stream()
+                .map(this::getMinTtl)
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .sorted(ttlComparator)
+                .collect(toList());
+
+        if (ttls.size() == 0) {
+            return new ConfidenceBasedTtlInfo(0, 100);
+        }
+
+        return ttls.get((int) Math.ceil(ttls.size() * percentile / 100.0) - 1);
+    }
+
+    private Optional<ConfidenceBasedTtlInfo> getMinTtl(NodeTtl nodeTtl)
+    {
+        return nodeTtl.getTtlInfo().stream().min(ttlComparator);
+    }
+}

--- a/presto-cluster-ttl-providers/src/main/java/com/facebook/presto/clusterttlproviders/percentile/PercentileBasedClusterTtlProviderConfig.java
+++ b/presto-cluster-ttl-providers/src/main/java/com/facebook/presto/clusterttlproviders/percentile/PercentileBasedClusterTtlProviderConfig.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.clusterttlproviders.percentile;
+
+import com.facebook.airlift.configuration.Config;
+
+public class PercentileBasedClusterTtlProviderConfig
+{
+    private int percentile = 1;
+
+    public int getPercentile()
+    {
+        return percentile;
+    }
+
+    @Config("percentile")
+    public PercentileBasedClusterTtlProviderConfig setPercentile(int percentile)
+    {
+        this.percentile = percentile;
+        return this;
+    }
+}

--- a/presto-cluster-ttl-providers/src/main/java/com/facebook/presto/clusterttlproviders/percentile/PercentileBasedClusterTtlProviderModule.java
+++ b/presto-cluster-ttl-providers/src/main/java/com/facebook/presto/clusterttlproviders/percentile/PercentileBasedClusterTtlProviderModule.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.clusterttlproviders.percentile;
+
+import com.facebook.presto.spi.ttl.ClusterTtlProvider;
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+
+import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
+
+public class PercentileBasedClusterTtlProviderModule
+        implements Module
+{
+    @Override
+    public void configure(Binder binder)
+    {
+        configBinder(binder).bindConfig(PercentileBasedClusterTtlProviderConfig.class, "cluster-ttl-provider");
+        binder.bind(ClusterTtlProvider.class).to(PercentileBasedClusterTtlProvider.class).in(Scopes.SINGLETON);
+    }
+}

--- a/presto-cluster-ttl-providers/src/main/java/com/facebook/presto/clusterttlproviders/percentile/PercentileClusterTtlProviderFactory.java
+++ b/presto-cluster-ttl-providers/src/main/java/com/facebook/presto/clusterttlproviders/percentile/PercentileClusterTtlProviderFactory.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.clusterttlproviders.percentile;
+
+import com.facebook.airlift.bootstrap.Bootstrap;
+import com.facebook.presto.spi.ttl.ClusterTtlProvider;
+import com.facebook.presto.spi.ttl.ClusterTtlProviderFactory;
+import com.google.inject.Injector;
+
+import java.util.Map;
+
+public class PercentileClusterTtlProviderFactory
+        implements ClusterTtlProviderFactory
+{
+    @Override
+    public String getName()
+    {
+        return "percentile";
+    }
+
+    @Override
+    public ClusterTtlProvider create(Map<String, String> config)
+    {
+        try {
+            Bootstrap app = new Bootstrap(new PercentileBasedClusterTtlProviderModule());
+            Injector injector = app
+                    .doNotInitializeLogging()
+                    .setRequiredConfigurationProperties(config)
+                    .initialize();
+            return injector.getInstance(ClusterTtlProvider.class);
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/presto-cluster-ttl-providers/src/test/java/com/facebook/presto/clusterttlproviders/TestInfiniteClusterTtlProvider.java
+++ b/presto-cluster-ttl-providers/src/test/java/com/facebook/presto/clusterttlproviders/TestInfiniteClusterTtlProvider.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.clusterttlproviders;
+
+import com.facebook.presto.clusterttlproviders.infinite.InfiniteClusterTtlProvider;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.spi.ttl.ConfidenceBasedTtlInfo.getInfiniteTtl;
+import static org.testng.Assert.assertEquals;
+
+public class TestInfiniteClusterTtlProvider
+{
+    @Test
+    public void testGetClusterTtl()
+    {
+        assertEquals(new InfiniteClusterTtlProvider().getClusterTtl(ImmutableList.of()), getInfiniteTtl());
+    }
+}

--- a/presto-cluster-ttl-providers/src/test/java/com/facebook/presto/clusterttlproviders/TestPercentileBasedClusterTtlProvider.java
+++ b/presto-cluster-ttl-providers/src/test/java/com/facebook/presto/clusterttlproviders/TestPercentileBasedClusterTtlProvider.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.clusterttlproviders;
+
+import com.facebook.presto.clusterttlproviders.percentile.PercentileBasedClusterTtlProvider;
+import com.facebook.presto.clusterttlproviders.percentile.PercentileBasedClusterTtlProviderConfig;
+import com.facebook.presto.spi.ttl.ClusterTtlProvider;
+import com.facebook.presto.spi.ttl.ConfidenceBasedTtlInfo;
+import com.facebook.presto.spi.ttl.NodeTtl;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestPercentileBasedClusterTtlProvider
+{
+    private final ClusterTtlProvider clusterTtlProvider = new PercentileBasedClusterTtlProvider(
+            new PercentileBasedClusterTtlProviderConfig().setPercentile(1));
+
+    @Test
+    public void testWithEmptyTtlList()
+    {
+        assertEquals(clusterTtlProvider.getClusterTtl(ImmutableList.of()), new ConfidenceBasedTtlInfo(0, 100));
+    }
+
+    @Test
+    public void testWithNonEmptyTtlList()
+    {
+        List<NodeTtl> nodeTtls = ImmutableList.of(new NodeTtl(ImmutableSet.of(new ConfidenceBasedTtlInfo(10, 100))),
+                new NodeTtl(ImmutableSet.of(new ConfidenceBasedTtlInfo(30, 100))));
+        assertEquals(clusterTtlProvider.getClusterTtl(nodeTtls), new ConfidenceBasedTtlInfo(10, 100));
+    }
+}

--- a/presto-main/etc/config.properties
+++ b/presto-main/etc/config.properties
@@ -45,7 +45,9 @@ plugin.bundles=\
   ../presto-i18n-functions/pom.xml,\
   ../presto-function-namespace-managers/pom.xml,\
   ../presto-druid/pom.xml,\
-  ../presto-iceberg/pom.xml
+  ../presto-iceberg/pom.xml,\
+  ../presto-cluster-ttl-providers/pom.xml,\
+  ../presto-node-ttl-fetchers/pom.xml
 
 presto.version=testversion
 node-scheduler.include-coordinator=true

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -17,6 +17,7 @@ import com.facebook.presto.execution.QueryManagerConfig;
 import com.facebook.presto.execution.QueryManagerConfig.ExchangeMaterializationStrategy;
 import com.facebook.presto.execution.TaskManagerConfig;
 import com.facebook.presto.execution.scheduler.NodeSchedulerConfig;
+import com.facebook.presto.execution.scheduler.NodeSchedulerConfig.ResourceAwareSchedulingStrategy;
 import com.facebook.presto.execution.warnings.WarningCollectorConfig;
 import com.facebook.presto.execution.warnings.WarningHandlingLevel;
 import com.facebook.presto.memory.MemoryManagerConfig;
@@ -205,6 +206,7 @@ public final class SystemSessionProperties
     public static final String MATERIALIZED_VIEW_DATA_CONSISTENCY_ENABLED = "materialized_view_data_consistency_enabled";
     public static final String QUERY_OPTIMIZATION_WITH_MATERIALIZED_VIEW_ENABLED = "query_optimization_with_materialized_view_enabled";
     public static final String AGGREGATION_IF_TO_FILTER_REWRITE_STRATEGY = "aggregation_if_to_filter_rewrite_strategy";
+    public static final String RESOURCE_AWARE_SCHEDULING_STRATEGY = "resource_aware_scheduling_strategy";
 
     //TODO: Prestissimo related session properties that are temporarily put here. They will be relocated in the future
     public static final String PRESTISSIMO_SIMPLIFIED_EXPRESSION_EVALUATION_ENABLED = "simplified_expression_evaluation_enabled";
@@ -1116,7 +1118,19 @@ public final class SystemSessionProperties
                         PRESTISSIMO_SIMPLIFIED_EXPRESSION_EVALUATION_ENABLED,
                         "Enable simplified path in expression evaluation",
                         false,
-                        false));
+                        false),
+                new PropertyMetadata<>(
+                        RESOURCE_AWARE_SCHEDULING_STRATEGY,
+                        format("Task assignment strategy to use. Options are %s",
+                                Stream.of(ResourceAwareSchedulingStrategy.values())
+                                        .map(ResourceAwareSchedulingStrategy::name)
+                                        .collect(joining(","))),
+                        VARCHAR,
+                        ResourceAwareSchedulingStrategy.class,
+                        nodeSchedulerConfig.getResourceAwareSchedulingStrategy(),
+                        false,
+                        value -> ResourceAwareSchedulingStrategy.valueOf(((String) value).toUpperCase()),
+                        ResourceAwareSchedulingStrategy::name));
     }
 
     public static boolean isEmptyJoinOptimization(Session session)
@@ -1875,5 +1889,10 @@ public final class SystemSessionProperties
     public static AggregationIfToFilterRewriteStrategy getAggregationIfToFilterRewriteStrategy(Session session)
     {
         return session.getSystemProperty(AGGREGATION_IF_TO_FILTER_REWRITE_STRATEGY, AggregationIfToFilterRewriteStrategy.class);
+    }
+
+    public static ResourceAwareSchedulingStrategy getResourceAwareSchedulingStrategy(Session session)
+    {
+        return session.getSystemProperty(RESOURCE_AWARE_SCHEDULING_STRATEGY, ResourceAwareSchedulingStrategy.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NodeScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NodeScheduler.java
@@ -16,10 +16,12 @@ package com.facebook.presto.execution.scheduler;
 import com.facebook.airlift.stats.CounterStat;
 import com.facebook.presto.Session;
 import com.facebook.presto.execution.NodeTaskMap;
+import com.facebook.presto.execution.QueryManager;
 import com.facebook.presto.execution.RemoteTask;
 import com.facebook.presto.execution.scheduler.nodeSelection.NodeSelectionStats;
 import com.facebook.presto.execution.scheduler.nodeSelection.NodeSelector;
 import com.facebook.presto.execution.scheduler.nodeSelection.SimpleNodeSelector;
+import com.facebook.presto.execution.scheduler.nodeSelection.SimpleTtlNodeSelector;
 import com.facebook.presto.execution.scheduler.nodeSelection.TopologyAwareNodeSelector;
 import com.facebook.presto.metadata.InternalNode;
 import com.facebook.presto.metadata.InternalNodeManager;
@@ -27,6 +29,7 @@ import com.facebook.presto.metadata.Split;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.HostAddress;
 import com.facebook.presto.spi.SplitContext;
+import com.facebook.presto.ttl.nodettlfetchermanagers.NodeTtlFetcherManager;
 import com.google.common.base.Supplier;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableList;
@@ -53,7 +56,10 @@ import java.util.Set;
 
 import static com.facebook.airlift.concurrent.MoreFutures.whenAnyCompleteCancelOthers;
 import static com.facebook.presto.SystemSessionProperties.getMaxUnacknowledgedSplitsPerTask;
+import static com.facebook.presto.SystemSessionProperties.getResourceAwareSchedulingStrategy;
 import static com.facebook.presto.execution.scheduler.NodeSchedulerConfig.NetworkTopologyType;
+import static com.facebook.presto.execution.scheduler.NodeSchedulerConfig.ResourceAwareSchedulingStrategy;
+import static com.facebook.presto.execution.scheduler.NodeSchedulerConfig.ResourceAwareSchedulingStrategy.TTL;
 import static com.facebook.presto.metadata.InternalNode.NodeStatus.ALIVE;
 import static com.facebook.presto.spi.NodeState.ACTIVE;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -80,11 +86,28 @@ public class NodeScheduler
     private final NodeTaskMap nodeTaskMap;
     private final boolean useNetworkTopology;
     private final Duration nodeMapRefreshInterval;
+    private final NodeTtlFetcherManager nodeTtlFetcherManager;
+    private final QueryManager queryManager;
 
     @Inject
-    public NodeScheduler(NetworkTopology networkTopology, InternalNodeManager nodeManager, NodeSelectionStats nodeSelectionStats, NodeSchedulerConfig config, NodeTaskMap nodeTaskMap)
+    public NodeScheduler(
+            NetworkTopology networkTopology,
+            InternalNodeManager nodeManager,
+            NodeSelectionStats nodeSelectionStats,
+            NodeSchedulerConfig config,
+            NodeTaskMap nodeTaskMap,
+            NodeTtlFetcherManager nodeTtlFetcherManager,
+            QueryManager queryManager)
     {
-        this(new NetworkLocationCache(networkTopology), networkTopology, nodeManager, nodeSelectionStats, config, nodeTaskMap, new Duration(5, SECONDS));
+        this(new NetworkLocationCache(networkTopology),
+                networkTopology,
+                nodeManager,
+                nodeSelectionStats,
+                config,
+                nodeTaskMap,
+                new Duration(5, SECONDS),
+                nodeTtlFetcherManager,
+                queryManager);
     }
 
     public NodeScheduler(
@@ -94,7 +117,9 @@ public class NodeScheduler
             NodeSelectionStats nodeSelectionStats,
             NodeSchedulerConfig config,
             NodeTaskMap nodeTaskMap,
-            Duration nodeMapRefreshInterval)
+            Duration nodeMapRefreshInterval,
+            NodeTtlFetcherManager nodeTtlFetcherManager,
+            QueryManager queryManager)
     {
         this.networkLocationCache = networkLocationCache;
         this.nodeManager = nodeManager;
@@ -119,6 +144,8 @@ public class NodeScheduler
         }
         topologicalSplitCounters = builder.build();
         this.nodeMapRefreshInterval = requireNonNull(nodeMapRefreshInterval, "nodeMapRefreshInterval is null");
+        this.nodeTtlFetcherManager = requireNonNull(nodeTtlFetcherManager, "nodeTtlFetcherManager is null");
+        this.queryManager = requireNonNull(queryManager, "queryManager is null");
     }
 
     @PreDestroy
@@ -149,6 +176,7 @@ public class NodeScheduler
                 memoizeWithExpiration(createNodeMapSupplier(connectorId), nodeMapRefreshInterval.toMillis(), MILLISECONDS) : createNodeMapSupplier(connectorId);
 
         int maxUnacknowledgedSplitsPerTask = getMaxUnacknowledgedSplitsPerTask(requireNonNull(session, "session is null"));
+        ResourceAwareSchedulingStrategy resourceAwareSchedulingStrategy = getResourceAwareSchedulingStrategy(session);
         if (useNetworkTopology) {
             return new TopologyAwareNodeSelector(
                     nodeManager,
@@ -164,9 +192,35 @@ public class NodeScheduler
                     networkLocationSegmentNames,
                     networkLocationCache);
         }
-        else {
-            return new SimpleNodeSelector(nodeManager, nodeSelectionStats, nodeTaskMap, includeCoordinator, nodeMap, minCandidates, maxSplitsPerNode, maxPendingSplitsPerTask, maxUnacknowledgedSplitsPerTask, maxTasksPerStage);
+
+        SimpleNodeSelector simpleNodeSelector = new SimpleNodeSelector(
+                nodeManager,
+                nodeSelectionStats,
+                nodeTaskMap,
+                includeCoordinator,
+                nodeMap,
+                minCandidates,
+                maxSplitsPerNode,
+                maxPendingSplitsPerTask,
+                maxUnacknowledgedSplitsPerTask,
+                maxTasksPerStage);
+
+        if (resourceAwareSchedulingStrategy == TTL) {
+            return new SimpleTtlNodeSelector(
+                    simpleNodeSelector,
+                    nodeTaskMap,
+                    nodeMap,
+                    minCandidates,
+                    includeCoordinator,
+                    maxSplitsPerNode,
+                    maxPendingSplitsPerTask,
+                    maxTasksPerStage,
+                    nodeTtlFetcherManager,
+                    queryManager,
+                    session);
         }
+
+        return simpleNodeSelector;
     }
 
     private Supplier<NodeMap> createNodeMapSupplier(ConnectorId connectorId)

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NodeSchedulerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NodeSchedulerConfig.java
@@ -37,6 +37,7 @@ public class NodeSchedulerConfig
     private int maxPendingSplitsPerTask = 10;
     private int maxUnacknowledgedSplitsPerTask = 500;
     private String networkTopology = NetworkTopologyType.LEGACY;
+    private ResourceAwareSchedulingStrategy resourceAwareSchedulingStrategy = ResourceAwareSchedulingStrategy.RANDOM;
 
     @NotNull
     public String getNetworkTopology()
@@ -113,5 +114,23 @@ public class NodeSchedulerConfig
     {
         this.maxUnacknowledgedSplitsPerTask = maxUnacknowledgedSplitsPerTask;
         return this;
+    }
+
+    public ResourceAwareSchedulingStrategy getResourceAwareSchedulingStrategy()
+    {
+        return resourceAwareSchedulingStrategy;
+    }
+
+    @Config("experimental.resource-aware-scheduling-strategy")
+    public NodeSchedulerConfig setResourceAwareSchedulingStrategy(ResourceAwareSchedulingStrategy resourceAwareSchedulingStrategy)
+    {
+        this.resourceAwareSchedulingStrategy = resourceAwareSchedulingStrategy;
+        return this;
+    }
+
+    public enum ResourceAwareSchedulingStrategy
+    {
+        RANDOM,
+        TTL
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/nodeSelection/SimpleTtlNodeSelector.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/nodeSelection/SimpleTtlNodeSelector.java
@@ -1,0 +1,286 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.scheduler.nodeSelection;
+
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.Session;
+import com.facebook.presto.execution.NodeTaskMap;
+import com.facebook.presto.execution.QueryManager;
+import com.facebook.presto.execution.RemoteTask;
+import com.facebook.presto.execution.scheduler.BucketNodeMap;
+import com.facebook.presto.execution.scheduler.InternalNodeInfo;
+import com.facebook.presto.execution.scheduler.NodeAssignmentStats;
+import com.facebook.presto.execution.scheduler.NodeMap;
+import com.facebook.presto.execution.scheduler.ResettableRandomizedIterator;
+import com.facebook.presto.execution.scheduler.SplitPlacementResult;
+import com.facebook.presto.metadata.InternalNode;
+import com.facebook.presto.metadata.Split;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.SplitContext;
+import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
+import com.facebook.presto.spi.ttl.ConfidenceBasedTtlInfo;
+import com.facebook.presto.spi.ttl.NodeTtl;
+import com.facebook.presto.ttl.nodettlfetchermanagers.NodeTtlFetcherManager;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.ListenableFuture;
+import io.airlift.units.Duration;
+
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalInt;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.facebook.presto.execution.scheduler.NodeScheduler.calculateLowWatermark;
+import static com.facebook.presto.execution.scheduler.NodeScheduler.selectNodes;
+import static com.facebook.presto.execution.scheduler.NodeScheduler.toWhenHasSplitQueueSpaceFuture;
+import static com.facebook.presto.spi.StandardErrorCode.NODE_SELECTION_NOT_SUPPORTED;
+import static com.facebook.presto.spi.StandardErrorCode.NO_NODES_AVAILABLE;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Verify.verify;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static java.lang.String.format;
+import static java.time.temporal.ChronoUnit.MILLIS;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
+
+public class SimpleTtlNodeSelector
+        implements NodeSelector
+{
+    private static final Logger log = Logger.get(SimpleTtlNodeSelector.class);
+    private final NodeTtlFetcherManager nodeTtlFetcherManager;
+    private final Session session;
+    private final AtomicReference<Supplier<NodeMap>> nodeMap;
+    private final NodeTaskMap nodeTaskMap;
+    private final int minCandidates;
+    private final boolean includeCoordinator;
+    private final int maxSplitsPerNode;
+    private final int maxPendingSplitsPerTask;
+    private final int maxTasksPerStage;
+    private final SimpleNodeSelector simpleNodeSelector;
+    private final QueryManager queryManager;
+    private final Duration estimatedExecutionTime;
+
+    public SimpleTtlNodeSelector(
+            SimpleNodeSelector simpleNodeSelector,
+            NodeTaskMap nodeTaskMap,
+            Supplier<NodeMap> nodeMap,
+            int minCandidates,
+            boolean includeCoordinator,
+            int maxSplitsPerNode,
+            int maxPendingSplitsPerTask,
+            int maxTasksPerStage,
+            NodeTtlFetcherManager ttlFetcherManager,
+            QueryManager queryManager,
+            Session session)
+    {
+        this.simpleNodeSelector = requireNonNull(simpleNodeSelector, "simpleNodeSelector is null");
+        this.nodeTaskMap = requireNonNull(nodeTaskMap, "nodeTaskMap is null");
+        this.nodeMap = new AtomicReference<>(requireNonNull(nodeMap, "nodeMap is null"));
+        this.minCandidates = minCandidates;
+        this.includeCoordinator = includeCoordinator;
+        this.maxSplitsPerNode = maxSplitsPerNode;
+        this.maxPendingSplitsPerTask = maxPendingSplitsPerTask;
+        this.maxTasksPerStage = maxTasksPerStage;
+        this.nodeTtlFetcherManager = requireNonNull(ttlFetcherManager, "ttlFetcherManager is null");
+        this.queryManager = requireNonNull(queryManager, "queryManager is null");
+        this.session = requireNonNull(session, "session is null");
+        checkArgument(session.getResourceEstimates().getExecutionTime().isPresent(), "Estimated execution time is not present");
+        estimatedExecutionTime = session.getResourceEstimates().getExecutionTime().get();
+    }
+
+    @Override
+    public void lockDownNodes()
+    {
+        nodeMap.set(Suppliers.ofInstance(nodeMap.get().get()));
+        simpleNodeSelector.lockDownNodes();
+    }
+
+    @Override
+    public List<InternalNode> getActiveNodes()
+    {
+        return simpleNodeSelector.getActiveNodes();
+    }
+
+    @Override
+    public List<InternalNode> getAllNodes()
+    {
+        return simpleNodeSelector.getAllNodes();
+    }
+
+    @Override
+    public InternalNode selectCurrentNode()
+    {
+        return simpleNodeSelector.selectCurrentNode();
+    }
+
+    @Override
+    public List<InternalNode> selectRandomNodes(int limit, Set<InternalNode> excludedNodes)
+    {
+        Map<InternalNode, NodeTtl> nodeTtlInfo = nodeTtlFetcherManager.getAllTtls();
+
+        Map<InternalNode, Optional<ConfidenceBasedTtlInfo>> ttlInfo = nodeTtlInfo
+                .entrySet()
+                .stream()
+                .collect(toImmutableMap(
+                        Map.Entry::getKey,
+                        e -> e.getValue().getTtlInfo()
+                                .stream()
+                                .min(Comparator.comparing(ConfidenceBasedTtlInfo::getExpiryInstant))));
+
+        NodeMap nodeMap = this.nodeMap.get().get();
+        List<InternalNode> activeNodes = nodeMap.getActiveNodes();
+
+        List<InternalNode> eligibleNodes = filterNodesByTtl(activeNodes, excludedNodes, ttlInfo);
+        return selectNodes(limit, new ResettableRandomizedIterator<>(eligibleNodes));
+    }
+
+    @Override
+    public SplitPlacementResult computeAssignments(Set<Split> splits, List<RemoteTask> existingTasks)
+    {
+        ImmutableMultimap.Builder<InternalNode, Split> assignment = ImmutableMultimap.builder();
+        NodeMap nodeMap = this.nodeMap.get().get();
+        NodeAssignmentStats assignmentStats = new NodeAssignmentStats(nodeTaskMap, nodeMap, existingTasks);
+
+        List<InternalNode> eligibleNodes = getEligibleNodes(maxTasksPerStage, nodeMap, existingTasks);
+        NodeSelection randomNodeSelection = new RandomNodeSelection(eligibleNodes, minCandidates);
+
+        boolean splitWaitingForAnyNode = false;
+
+        OptionalInt preferredNodeCount = OptionalInt.empty();
+        for (Split split : splits) {
+            if (split.getNodeSelectionStrategy() != NodeSelectionStrategy.NO_PREFERENCE) {
+                throw new PrestoException(
+                        NODE_SELECTION_NOT_SUPPORTED,
+                        format("Unsupported node selection strategy for TTL scheduling: %s", split.getNodeSelectionStrategy()));
+            }
+
+            List<InternalNode> candidateNodes = randomNodeSelection.pickNodes(split);
+            if (candidateNodes.isEmpty()) {
+                log.warn("No nodes available to schedule %s. Available nodes %s", split, nodeMap.getActiveNodes());
+                throw new PrestoException(NO_NODES_AVAILABLE, "No nodes available to run query");
+            }
+
+            Optional<InternalNodeInfo> chosenNodeInfo = simpleNodeSelector.chooseLeastBusyNode(
+                    candidateNodes,
+                    assignmentStats::getTotalSplitCount,
+                    preferredNodeCount,
+                    maxSplitsPerNode,
+                    assignmentStats);
+            if (!chosenNodeInfo.isPresent()) {
+                chosenNodeInfo = simpleNodeSelector.chooseLeastBusyNode(
+                        candidateNodes, assignmentStats::getQueuedSplitCountForStage, preferredNodeCount, maxPendingSplitsPerTask, assignmentStats);
+            }
+
+            if (chosenNodeInfo.isPresent()) {
+                split = new Split(
+                        split.getConnectorId(),
+                        split.getTransactionHandle(),
+                        split.getConnectorSplit(),
+                        split.getLifespan(),
+                        new SplitContext(chosenNodeInfo.get().isCacheable()));
+
+                InternalNode chosenNode = chosenNodeInfo.get().getInternalNode();
+                assignment.put(chosenNode, split);
+                assignmentStats.addAssignedSplit(chosenNode);
+            }
+            else {
+                splitWaitingForAnyNode = true;
+            }
+        }
+
+        ListenableFuture<?> blocked = splitWaitingForAnyNode ?
+                toWhenHasSplitQueueSpaceFuture(existingTasks, calculateLowWatermark(maxPendingSplitsPerTask)) : immediateFuture(null);
+
+        return new SplitPlacementResult(blocked, assignment.build());
+    }
+
+    @Override
+    public SplitPlacementResult computeAssignments(Set<Split> splits, List<RemoteTask> existingTasks, BucketNodeMap bucketNodeMap)
+    {
+        return simpleNodeSelector.computeAssignments(splits, existingTasks, bucketNodeMap);
+    }
+
+    private boolean isTtlEnough(ConfidenceBasedTtlInfo ttlInfo, Duration estimatedExecutionTime)
+    {
+        Instant expiryTime = ttlInfo.getExpiryInstant();
+        long timeRemaining = MILLIS.between(Instant.now(), expiryTime);
+        return new Duration(Math.max(timeRemaining, 0), TimeUnit.MILLISECONDS).compareTo(estimatedExecutionTime) >= 0;
+    }
+
+    private Duration getEstimatedExecutionTimeRemaining()
+    {
+        double totalEstimatedExecutionTime = estimatedExecutionTime.getValue(TimeUnit.MILLISECONDS);
+        double elapsedExecutionTime = queryManager.getQueryInfo(session.getQueryId()).getQueryStats().getExecutionTime().getValue(TimeUnit.MILLISECONDS);
+        double estimatedExecutionTimeRemaining = Math.max(totalEstimatedExecutionTime - elapsedExecutionTime, 0);
+        return new Duration(estimatedExecutionTimeRemaining, TimeUnit.MILLISECONDS);
+    }
+
+    private List<InternalNode> getEligibleNodes(int limit, NodeMap nodeMap, List<RemoteTask> existingTasks)
+    {
+        Map<InternalNode, NodeTtl> nodeTtlInfo = nodeTtlFetcherManager.getAllTtls();
+        Map<InternalNode, Optional<ConfidenceBasedTtlInfo>> ttlInfo = nodeTtlInfo
+                .entrySet()
+                .stream()
+                .collect(toImmutableMap(
+                        Map.Entry::getKey,
+                        e -> e.getValue().getTtlInfo()
+                                .stream()
+                                .min(Comparator.comparing(ConfidenceBasedTtlInfo::getExpiryInstant))));
+
+        // Of the nodes on which already have existing tasks, pick only those whose TTL is enough
+        List<InternalNode> existingEligibleNodes = existingTasks.stream()
+                .map(remoteTask -> nodeMap.getActiveNodesByNodeId().get(remoteTask.getNodeId()))
+                // nodes may sporadically disappear from the nodeMap if the announcement is delayed
+                .filter(Objects::nonNull)
+                .filter(node -> ttlInfo.get(node).isPresent())
+                .filter(node -> isTtlEnough(ttlInfo.get(node).get(), estimatedExecutionTime))
+                .collect(toList());
+
+        int alreadySelectedNodeCount = existingEligibleNodes.size();
+        List<InternalNode> activeNodes = nodeMap.getActiveNodes();
+        List<InternalNode> newEligibleNodes = filterNodesByTtl(activeNodes, ImmutableSet.copyOf(existingEligibleNodes), ttlInfo);
+
+        if (alreadySelectedNodeCount < limit && newEligibleNodes.size() > 0) {
+            List<InternalNode> moreNodes = selectNodes(limit - alreadySelectedNodeCount, new ResettableRandomizedIterator<>(newEligibleNodes));
+            existingEligibleNodes.addAll(moreNodes);
+        }
+        verify(existingEligibleNodes.stream().allMatch(Objects::nonNull), "existingNodes list must not contain any nulls");
+        return existingEligibleNodes;
+    }
+
+    private List<InternalNode> filterNodesByTtl(
+            List<InternalNode> nodes,
+            Set<InternalNode> excludedNodes,
+            Map<InternalNode, Optional<ConfidenceBasedTtlInfo>> ttlInfo)
+    {
+        return nodes.stream()
+                .filter(ttlInfo::containsKey)
+                .filter(node -> includeCoordinator || !node.isCoordinator())
+                .filter(node -> !excludedNodes.contains(node))
+                .filter(node -> ttlInfo.get(node).isPresent())
+                .filter(node -> isTtlEnough(ttlInfo.get(node).get(), getEstimatedExecutionTimeRemaining()))
+                .collect(toImmutableList());
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/ClusterStatsResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ClusterStatsResource.java
@@ -22,6 +22,7 @@ import com.facebook.presto.metadata.InternalNode;
 import com.facebook.presto.metadata.InternalNodeManager;
 import com.facebook.presto.resourcemanager.ResourceManagerProxy;
 import com.facebook.presto.spi.NodeState;
+import com.facebook.presto.ttl.clusterttlprovidermanagers.ClusterTtlProviderManager;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -61,9 +62,9 @@ public class ClusterStatsResource
     private final boolean isIncludeCoordinator;
     private final boolean resourceManagerEnabled;
     private final ClusterMemoryManager clusterMemoryManager;
-    private final InternalNodeManager internalNodeManager;
     private final Optional<ResourceManagerProxy> proxyHelper;
     private final InternalResourceGroupManager internalResourceGroupManager;
+    private final ClusterTtlProviderManager clusterTtlProviderManager;
 
     @Inject
     public ClusterStatsResource(
@@ -72,18 +73,18 @@ public class ClusterStatsResource
             InternalNodeManager nodeManager,
             DispatchManager dispatchManager,
             ClusterMemoryManager clusterMemoryManager,
-            InternalNodeManager internalNodeManager,
             Optional<ResourceManagerProxy> proxyHelper,
-            InternalResourceGroupManager internalResourceGroupManager)
+            InternalResourceGroupManager internalResourceGroupManager,
+            ClusterTtlProviderManager clusterTtlProviderManager)
     {
         this.isIncludeCoordinator = requireNonNull(nodeSchedulerConfig, "nodeSchedulerConfig is null").isIncludeCoordinator();
         this.resourceManagerEnabled = requireNonNull(serverConfig, "serverConfig is null").isResourceManagerEnabled();
         this.nodeManager = requireNonNull(nodeManager, "nodeManager is null");
         this.dispatchManager = requireNonNull(dispatchManager, "dispatchManager is null");
         this.clusterMemoryManager = requireNonNull(clusterMemoryManager, "clusterMemoryManager is null");
-        this.internalNodeManager = requireNonNull(internalNodeManager, "internalNodeManager is null");
         this.proxyHelper = requireNonNull(proxyHelper, "internalNodeManager is null");
         this.internalResourceGroupManager = requireNonNull(internalResourceGroupManager, "internalResourceGroupManager is null");
+        this.clusterTtlProviderManager = requireNonNull(clusterTtlProviderManager, "clusterTtlProvider is null");
     }
 
     @GET
@@ -169,11 +170,18 @@ public class ClusterStatsResource
                 .build();
     }
 
+    @GET
+    @Path("ttl")
+    public Response getClusterTtl()
+    {
+        return Response.ok().entity(clusterTtlProviderManager.getClusterTtl()).build();
+    }
+
     private void proxyClusterStats(HttpServletRequest servletRequest, AsyncResponse asyncResponse, String xForwardedProto, UriInfo uriInfo)
     {
         try {
             checkState(proxyHelper.isPresent());
-            Iterator<InternalNode> resourceManagers = internalNodeManager.getResourceManagers().iterator();
+            Iterator<InternalNode> resourceManagers = nodeManager.getResourceManagers().iterator();
             if (!resourceManagers.hasNext()) {
                 asyncResponse.resume(Response.status(SERVICE_UNAVAILABLE).build());
                 return;

--- a/presto-main/src/main/java/com/facebook/presto/server/HttpRequestSessionContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/HttpRequestSessionContext.java
@@ -175,7 +175,7 @@ public final class HttpRequestSessionContext
         this.sessionFunctions = parseSessionFunctionHeader(servletRequest);
     }
 
-    private static List<String> splitSessionHeader(Enumeration<String> headers)
+    public static List<String> splitSessionHeader(Enumeration<String> headers)
     {
         Splitter splitter = Splitter.on(',').trimResults().omitEmptyStrings();
         return Collections.list(headers).stream()
@@ -438,7 +438,7 @@ public final class HttpRequestSessionContext
         return ImmutableSet.copyOf(splitter.split(nullToEmpty(servletRequest.getHeader(PRESTO_CLIENT_TAGS))));
     }
 
-    private ResourceEstimates parseResourceEstimate(HttpServletRequest servletRequest)
+    public static ResourceEstimates parseResourceEstimate(HttpServletRequest servletRequest)
     {
         ResourceEstimateBuilder builder = new ResourceEstimateBuilder();
         for (String header : splitSessionHeader(servletRequest.getHeaders(PRESTO_RESOURCE_ESTIMATE))) {

--- a/presto-main/src/main/java/com/facebook/presto/server/PluginManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PluginManager.java
@@ -37,7 +37,11 @@ import com.facebook.presto.spi.security.PasswordAuthenticatorFactory;
 import com.facebook.presto.spi.security.SystemAccessControlFactory;
 import com.facebook.presto.spi.session.SessionPropertyConfigurationManagerFactory;
 import com.facebook.presto.spi.storage.TempStorageFactory;
+import com.facebook.presto.spi.ttl.ClusterTtlProviderFactory;
+import com.facebook.presto.spi.ttl.NodeTtlFetcherFactory;
 import com.facebook.presto.storage.TempStorageManager;
+import com.facebook.presto.ttl.clusterttlprovidermanagers.ClusterTtlProviderManager;
+import com.facebook.presto.ttl.nodettlfetchermanagers.NodeTtlFetcherManager;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Ordering;
@@ -102,6 +106,8 @@ public class PluginManager
     private final TempStorageManager tempStorageManager;
     private final SessionPropertyDefaults sessionPropertyDefaults;
     private final QueryPrerequisitesManager queryPrerequisitesManager;
+    private final NodeTtlFetcherManager nodeTtlFetcherManager;
+    private final ClusterTtlProviderManager clusterTtlProviderManager;
     private final ArtifactResolver resolver;
     private final File installedPluginsDir;
     private final List<String> plugins;
@@ -122,7 +128,9 @@ public class PluginManager
             BlockEncodingManager blockEncodingManager,
             TempStorageManager tempStorageManager,
             QueryPrerequisitesManager queryPrerequisitesManager,
-            SessionPropertyDefaults sessionPropertyDefaults)
+            SessionPropertyDefaults sessionPropertyDefaults,
+            NodeTtlFetcherManager nodeTtlFetcherManager,
+            ClusterTtlProviderManager clusterTtlProviderManager)
     {
         requireNonNull(nodeInfo, "nodeInfo is null");
         requireNonNull(config, "config is null");
@@ -146,6 +154,8 @@ public class PluginManager
         this.tempStorageManager = requireNonNull(tempStorageManager, "tempStorageManager is null");
         this.queryPrerequisitesManager = requireNonNull(queryPrerequisitesManager, "queryPrerequisitesManager is null");
         this.sessionPropertyDefaults = requireNonNull(sessionPropertyDefaults, "sessionPropertyDefaults is null");
+        this.nodeTtlFetcherManager = requireNonNull(nodeTtlFetcherManager, "nodeTtlFetcherManager is null");
+        this.clusterTtlProviderManager = requireNonNull(clusterTtlProviderManager, "clusterTtlProviderManager is null");
         this.disabledConnectors = requireNonNull(config.getDisabledConnectors(), "disabledConnectors is null");
     }
 
@@ -266,6 +276,16 @@ public class PluginManager
         for (QueryPrerequisitesFactory queryPrerequisitesFactory : plugin.getQueryPrerequisitesFactories()) {
             log.info("Registering query prerequisite factory %s", queryPrerequisitesFactory.getName());
             queryPrerequisitesManager.addQueryPrerequisitesFactory(queryPrerequisitesFactory);
+        }
+
+        for (NodeTtlFetcherFactory nodeTtlFetcherFactory : plugin.getNodeTtlFetcherFactories()) {
+            log.info("Registering Ttl fetcher factory %s", nodeTtlFetcherFactory.getName());
+            nodeTtlFetcherManager.addNodeTtlFetcherFactory(nodeTtlFetcherFactory);
+        }
+
+        for (ClusterTtlProviderFactory clusterTtlProviderFactory : plugin.getClusterTtlProviderFactories()) {
+            log.info("Registering Cluster Ttl provider factory %s", clusterTtlProviderFactory.getName());
+            clusterTtlProviderManager.addClusterTtlProviderFactory(clusterTtlProviderFactory);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/server/PrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/PrestoServer.java
@@ -50,6 +50,10 @@ import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.parser.SqlParserOptions;
 import com.facebook.presto.storage.TempStorageManager;
 import com.facebook.presto.storage.TempStorageModule;
+import com.facebook.presto.ttl.clusterttlprovidermanagers.ClusterTtlProviderManager;
+import com.facebook.presto.ttl.clusterttlprovidermanagers.ClusterTtlProviderManagerModule;
+import com.facebook.presto.ttl.nodettlfetchermanagers.NodeTtlFetcherManager;
+import com.facebook.presto.ttl.nodettlfetchermanagers.NodeTtlFetcherManagerModule;
 import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
@@ -127,7 +131,9 @@ public class PrestoServer
                 new GracefulShutdownModule(),
                 new WarningCollectorModule(),
                 new TempStorageModule(),
-                new QueryPrerequisitesManagerModule());
+                new QueryPrerequisitesManagerModule(),
+                new NodeTtlFetcherManagerModule(),
+                new ClusterTtlProviderManagerModule());
 
         modules.addAll(getAdditionalModules());
 
@@ -166,6 +172,8 @@ public class PrestoServer
             injector.getInstance(EventListenerManager.class).loadConfiguredEventListener();
             injector.getInstance(TempStorageManager.class).loadTempStorages();
             injector.getInstance(QueryPrerequisitesManager.class).loadQueryPrerequisites();
+            injector.getInstance(NodeTtlFetcherManager.class).loadNodeTtlFetcher();
+            injector.getInstance(ClusterTtlProviderManager.class).loadClusterTtlProvider();
 
             injector.getInstance(Announcer.class).start();
 

--- a/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/testing/TestingPrestoServer.java
@@ -80,6 +80,8 @@ import com.facebook.presto.testing.TestingEventListenerManager;
 import com.facebook.presto.testing.TestingTempStorageManager;
 import com.facebook.presto.testing.TestingWarningCollectorModule;
 import com.facebook.presto.transaction.TransactionManager;
+import com.facebook.presto.ttl.clusterttlprovidermanagers.ClusterTtlProviderManagerModule;
+import com.facebook.presto.ttl.nodettlfetchermanagers.NodeTtlFetcherManagerModule;
 import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
@@ -276,6 +278,8 @@ public class TestingPrestoServer
                 .add(new ServerMainModule(parserOptions))
                 .add(new TestingWarningCollectorModule())
                 .add(new QueryPrerequisitesManagerModule())
+                .add(new NodeTtlFetcherManagerModule())
+                .add(new ClusterTtlProviderManagerModule())
                 .add(binder -> {
                     binder.bind(TestingAccessControlManager.class).in(Scopes.SINGLETON);
                     binder.bind(TestingEventListenerManager.class).in(Scopes.SINGLETON);

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -41,6 +41,7 @@ import com.facebook.presto.cost.ScalarStatsCalculator;
 import com.facebook.presto.cost.StatsCalculator;
 import com.facebook.presto.cost.StatsNormalizer;
 import com.facebook.presto.cost.TaskCountEstimator;
+import com.facebook.presto.dispatcher.NoOpQueryManager;
 import com.facebook.presto.dispatcher.QueryPrerequisitesManager;
 import com.facebook.presto.eventlistener.EventListenerManager;
 import com.facebook.presto.execution.AlterFunctionTask;
@@ -191,6 +192,8 @@ import com.facebook.presto.testing.PageConsumerOperator.PageConsumerOutputFactor
 import com.facebook.presto.transaction.InMemoryTransactionManager;
 import com.facebook.presto.transaction.TransactionManager;
 import com.facebook.presto.transaction.TransactionManagerConfig;
+import com.facebook.presto.ttl.clusterttlprovidermanagers.ThrowingClusterTtlProviderManager;
+import com.facebook.presto.ttl.nodettlfetchermanagers.ThrowingNodeTtlFetcherManager;
 import com.facebook.presto.util.FinalizerService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
@@ -335,7 +338,9 @@ public class LocalQueryRunner
                 nodeManager,
                 new NodeSelectionStats(),
                 nodeSchedulerConfig,
-                new NodeTaskMap(finalizerService));
+                new NodeTaskMap(finalizerService),
+                new ThrowingNodeTtlFetcherManager(),
+                new NoOpQueryManager());
         this.pageSinkManager = new PageSinkManager();
         CatalogManager catalogManager = new CatalogManager();
         this.transactionManager = InMemoryTransactionManager.create(
@@ -436,7 +441,9 @@ public class LocalQueryRunner
                 blockEncodingManager,
                 new TestingTempStorageManager(),
                 new QueryPrerequisitesManager(),
-                new SessionPropertyDefaults(nodeInfo));
+                new SessionPropertyDefaults(nodeInfo),
+                new ThrowingNodeTtlFetcherManager(),
+                new ThrowingClusterTtlProviderManager());
 
         connectorManager.addConnectorFactory(globalSystemConnectorFactory);
         connectorManager.createConnection(GlobalSystemConnector.NAME, GlobalSystemConnector.NAME, ImmutableMap.of());

--- a/presto-main/src/main/java/com/facebook/presto/ttl/clusterttlprovidermanagers/ClusterTtlProviderManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/ttl/clusterttlprovidermanagers/ClusterTtlProviderManager.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.ttl.clusterttlprovidermanagers;
+
+import com.facebook.presto.spi.ttl.ClusterTtlProviderFactory;
+import com.facebook.presto.spi.ttl.ConfidenceBasedTtlInfo;
+
+public interface ClusterTtlProviderManager
+{
+    ConfidenceBasedTtlInfo getClusterTtl();
+
+    void addClusterTtlProviderFactory(ClusterTtlProviderFactory clusterTtlProviderFactory);
+
+    void loadClusterTtlProvider()
+            throws Exception;
+}

--- a/presto-main/src/main/java/com/facebook/presto/ttl/clusterttlprovidermanagers/ClusterTtlProviderManagerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/ttl/clusterttlprovidermanagers/ClusterTtlProviderManagerConfig.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.ttl.clusterttlprovidermanagers;
+
+import com.facebook.airlift.configuration.Config;
+
+public class ClusterTtlProviderManagerConfig
+{
+    private ClusterTtlProviderManagerType clusterTtlProviderType = ClusterTtlProviderManagerType.THROWING;
+
+    public enum ClusterTtlProviderManagerType
+    {
+        THROWING,
+        CONFIDENCE
+    }
+
+    @Config("cluster-ttl-provider-manager.type")
+    public ClusterTtlProviderManagerConfig setClusterTtlProviderManagerType(ClusterTtlProviderManagerType clusterTtlProviderType)
+    {
+        this.clusterTtlProviderType = clusterTtlProviderType;
+        return this;
+    }
+
+    public ClusterTtlProviderManagerType getClusterTtlProviderManagerType()
+    {
+        return clusterTtlProviderType;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/ttl/clusterttlprovidermanagers/ClusterTtlProviderManagerModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/ttl/clusterttlprovidermanagers/ClusterTtlProviderManagerModule.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.ttl.clusterttlprovidermanagers;
+
+import com.facebook.airlift.configuration.AbstractConfigurationAwareModule;
+import com.google.inject.Binder;
+import com.google.inject.Scopes;
+
+public class ClusterTtlProviderManagerModule
+        extends AbstractConfigurationAwareModule
+{
+    @Override
+    protected void setup(Binder binder)
+    {
+        ClusterTtlProviderManagerConfig config = buildConfigObject(ClusterTtlProviderManagerConfig.class);
+        switch (config.getClusterTtlProviderManagerType()) {
+            case THROWING:
+                binder.bind(ClusterTtlProviderManager.class).to(ThrowingClusterTtlProviderManager.class).in(Scopes.SINGLETON);
+                break;
+            case CONFIDENCE:
+                binder.bind(ClusterTtlProviderManager.class).to(ConfidenceBasedClusterTtlProviderManager.class).in(Scopes.SINGLETON);
+                break;
+            default:
+                throw new UnsupportedOperationException("Unknown cluster Ttl provider manager " + config.getClusterTtlProviderManagerType());
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/ttl/clusterttlprovidermanagers/ConfidenceBasedClusterTtlProviderManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/ttl/clusterttlprovidermanagers/ConfidenceBasedClusterTtlProviderManager.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.ttl.clusterttlprovidermanagers;
+
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.spi.ttl.ClusterTtlProvider;
+import com.facebook.presto.spi.ttl.ClusterTtlProviderFactory;
+import com.facebook.presto.spi.ttl.ConfidenceBasedTtlInfo;
+import com.facebook.presto.ttl.nodettlfetchermanagers.NodeTtlFetcherManager;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static com.facebook.presto.util.PropertiesUtil.loadProperties;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class ConfidenceBasedClusterTtlProviderManager
+        implements ClusterTtlProviderManager
+{
+    private static final Logger log = Logger.get(ConfidenceBasedClusterTtlProviderManager.class);
+    private static final File CLUSTER_TTL_PROVIDER_CONFIG = new File("etc/cluster-ttl-provider.properties");
+    private static final String CLUSTER_TTL_PROVIDER_PROPERTY_NAME = "cluster-ttl-provider.factory";
+    private final AtomicReference<ClusterTtlProvider> clusterTtlProvider = new AtomicReference<>();
+    private final NodeTtlFetcherManager nodeTtlFetcherManager;
+    private final Map<String, ClusterTtlProviderFactory> clusterTtlProviderFactories = new ConcurrentHashMap<>();
+
+    @Inject
+    public ConfidenceBasedClusterTtlProviderManager(NodeTtlFetcherManager nodeTtlFetcherManager)
+    {
+        this.nodeTtlFetcherManager = requireNonNull(nodeTtlFetcherManager, "nodeTtlFetcherManager is null");
+    }
+
+    @Override
+    public ConfidenceBasedTtlInfo getClusterTtl()
+    {
+        return clusterTtlProvider.get().getClusterTtl(ImmutableList.copyOf(nodeTtlFetcherManager.getAllTtls().values()));
+    }
+
+    @Override
+    public void addClusterTtlProviderFactory(ClusterTtlProviderFactory clusterTtlProviderFactory)
+    {
+        requireNonNull(clusterTtlProviderFactory, "clusterTtlProviderFactory is null");
+        if (clusterTtlProviderFactories.putIfAbsent(clusterTtlProviderFactory.getName(), clusterTtlProviderFactory) != null) {
+            throw new IllegalArgumentException(format("Query Prerequisites '%s' is already registered", clusterTtlProviderFactory.getName()));
+        }
+    }
+
+    @Override
+    public void loadClusterTtlProvider()
+            throws Exception
+    {
+        if (CLUSTER_TTL_PROVIDER_CONFIG.exists()) {
+            Map<String, String> properties = new HashMap<>(loadProperties(CLUSTER_TTL_PROVIDER_CONFIG));
+            String factoryName = properties.remove(CLUSTER_TTL_PROVIDER_PROPERTY_NAME);
+
+            checkArgument(!isNullOrEmpty(factoryName),
+                    "Cluster Ttl Provider configuration %s does not contain %s", CLUSTER_TTL_PROVIDER_CONFIG.getAbsoluteFile(), CLUSTER_TTL_PROVIDER_PROPERTY_NAME);
+            load(factoryName, properties);
+        }
+        else {
+            load("infinite", ImmutableMap.of());
+        }
+    }
+
+    @VisibleForTesting
+    public void load(String factoryName, Map<String, String> properties)
+    {
+        log.info("-- Loading Cluster Ttl Provider factory --");
+
+        ClusterTtlProviderFactory clusterTtlProviderFactory = clusterTtlProviderFactories.get(factoryName);
+        checkState(clusterTtlProviderFactory != null, "Cluster Ttl Provider factory %s is not registered", factoryName);
+
+        ClusterTtlProvider clusterTtlProvider = clusterTtlProviderFactory.create(properties);
+        checkState(this.clusterTtlProvider.compareAndSet(null, clusterTtlProvider), "Cluster Ttl Provider has already been set!");
+
+        log.info("-- Loaded Cluster Ttl Provider %s --", factoryName);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/ttl/clusterttlprovidermanagers/ThrowingClusterTtlProviderManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/ttl/clusterttlprovidermanagers/ThrowingClusterTtlProviderManager.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.ttl.clusterttlprovidermanagers;
+
+import com.facebook.presto.spi.ttl.ClusterTtlProviderFactory;
+import com.facebook.presto.spi.ttl.ConfidenceBasedTtlInfo;
+
+public class ThrowingClusterTtlProviderManager
+        implements ClusterTtlProviderManager
+{
+    @Override
+    public ConfidenceBasedTtlInfo getClusterTtl()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void addClusterTtlProviderFactory(ClusterTtlProviderFactory clusterTtlProviderFactory)
+    {
+    }
+
+    @Override
+    public void loadClusterTtlProvider()
+    {
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/ttl/nodettlfetchermanagers/ConfidenceBasedNodeTtlFetcherManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/ttl/nodettlfetchermanagers/ConfidenceBasedNodeTtlFetcherManager.java
@@ -1,0 +1,238 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.ttl.nodettlfetchermanagers;
+
+import com.facebook.airlift.log.Logger;
+import com.facebook.airlift.stats.CounterStat;
+import com.facebook.presto.execution.scheduler.NodeSchedulerConfig;
+import com.facebook.presto.metadata.AllNodes;
+import com.facebook.presto.metadata.InternalNode;
+import com.facebook.presto.metadata.InternalNodeManager;
+import com.facebook.presto.spi.ttl.NodeInfo;
+import com.facebook.presto.spi.ttl.NodeTtl;
+import com.facebook.presto.spi.ttl.NodeTtlFetcher;
+import com.facebook.presto.spi.ttl.NodeTtlFetcherFactory;
+import com.facebook.presto.util.PeriodicTaskExecutor;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+import io.airlift.units.Duration;
+import org.weakref.jmx.Managed;
+import org.weakref.jmx.Nested;
+
+import javax.annotation.PreDestroy;
+import javax.inject.Inject;
+
+import java.io.File;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import static com.facebook.airlift.concurrent.Threads.threadsNamed;
+import static com.facebook.presto.util.PropertiesUtil.loadProperties;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static com.google.common.collect.Sets.difference;
+import static java.lang.Math.round;
+import static java.lang.String.format;
+import static java.lang.System.currentTimeMillis;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
+
+public class ConfidenceBasedNodeTtlFetcherManager
+        implements NodeTtlFetcherManager
+{
+    private static final Logger log = Logger.get(ConfidenceBasedNodeTtlFetcherManager.class);
+    private static final File TTL_FETCHER_CONFIG = new File("etc/node-ttl-fetcher.properties");
+    private static final String TTL_FETCHER_PROPERTY_NAME = "node-ttl-fetcher.factory";
+    private final AtomicReference<NodeTtlFetcher> ttlFetcher = new AtomicReference<>();
+    private final InternalNodeManager nodeManager;
+    private final ConcurrentHashMap<InternalNode, NodeTtl> nodeTtlMap = new ConcurrentHashMap<>();
+    private final boolean isWorkScheduledOnCoordinator;
+    private final Map<String, NodeTtlFetcherFactory> ttlFetcherFactories = new ConcurrentHashMap<>();
+    private final NodeTtlFetcherManagerConfig nodeTtlFetcherManagerConfig;
+    private final AtomicLong lastRefreshEpochMillis = new AtomicLong(Long.MAX_VALUE);
+    private final CounterStat refreshFailures = new CounterStat();
+    private final Consumer<AllNodes> nodeChangeListener = this::refreshTtlInfo;
+    private PeriodicTaskExecutor periodicTtlRefresher;
+
+    @Inject
+    public ConfidenceBasedNodeTtlFetcherManager(InternalNodeManager nodeManager, NodeSchedulerConfig schedulerConfig, NodeTtlFetcherManagerConfig nodeTtlFetcherManagerConfig)
+    {
+        this.nodeManager = requireNonNull(nodeManager, "nodeManager is null");
+        this.isWorkScheduledOnCoordinator = requireNonNull(schedulerConfig, "nodeSchedulerConfig is null").isIncludeCoordinator();
+        this.nodeTtlFetcherManagerConfig = requireNonNull(nodeTtlFetcherManagerConfig, "nodeTtlFetcherManagerConfig is null");
+    }
+
+    private static long jitterForPeriodicRefresh(long delayMillis)
+    {
+        double maxJitter = delayMillis * 0.1;
+        return round(delayMillis + (maxJitter * (2 * ThreadLocalRandom.current().nextDouble() - 1)));
+    }
+
+    public void scheduleRefresh()
+    {
+        periodicTtlRefresher = new PeriodicTaskExecutor(
+                ttlFetcher.get().getRefreshInterval().toMillis(),
+                nodeTtlFetcherManagerConfig.getInitialDelayBeforeRefresh().toMillis(),
+                newSingleThreadScheduledExecutor(threadsNamed("refresh-node-ttl-executor-%s")),
+                this::refreshTtlInfo,
+                ConfidenceBasedNodeTtlFetcherManager::jitterForPeriodicRefresh);
+        periodicTtlRefresher.start();
+    }
+
+    @PreDestroy
+    public void stop()
+    {
+        nodeManager.removeNodeChangeListener(nodeChangeListener);
+        if (periodicTtlRefresher != null) {
+            periodicTtlRefresher.stop();
+        }
+    }
+
+    @VisibleForTesting
+    public synchronized void refreshTtlInfo()
+    {
+        AllNodes allNodes = nodeManager.getAllNodes();
+        refreshTtlInfo(allNodes);
+    }
+
+    private synchronized void refreshTtlInfo(AllNodes allNodes)
+    {
+        try {
+            Set<InternalNode> activeWorkers = Sets.difference(allNodes.getActiveNodes(), allNodes.getActiveResourceManagers());
+
+            if (!isWorkScheduledOnCoordinator) {
+                activeWorkers = Sets.difference(activeWorkers, allNodes.getActiveCoordinators());
+            }
+
+            Map<NodeInfo, InternalNode> internalNodeMap = activeWorkers
+                    .stream()
+                    .collect(toImmutableMap(node -> new NodeInfo(node.getNodeIdentifier(), node.getHost()), Function.identity()));
+
+            Map<NodeInfo, NodeTtl> ttlInfo = ttlFetcher.get().getTtlInfo(ImmutableSet.copyOf(internalNodeMap.keySet()));
+
+            nodeTtlMap.putAll(ttlInfo.entrySet().stream().collect(toImmutableMap(e -> internalNodeMap.get(e.getKey()), Map.Entry::getValue)));
+
+            Set<InternalNode> deadNodes = difference(nodeTtlMap.keySet(), activeWorkers).immutableCopy();
+            nodeTtlMap.keySet().removeAll(deadNodes);
+
+            log.info("Node ttls refreshed, nodeTtlMap: %s", nodeTtlMap);
+
+            lastRefreshEpochMillis.set(currentTimeMillis());
+        }
+        catch (Throwable e) {
+            refreshFailures.update(1);
+            log.error(e, "Error loading node ttls");
+        }
+    }
+
+    public Optional<NodeTtl> getTtlInfo(InternalNode node)
+    {
+        return nodeTtlMap.containsKey(node) ? Optional.of(nodeTtlMap.get(node)) : Optional.empty();
+    }
+
+    @Override
+    public Map<InternalNode, NodeTtl> getAllTtls()
+    {
+        return ImmutableMap.copyOf(nodeTtlMap);
+    }
+
+    @Override
+    public void addNodeTtlFetcherFactory(NodeTtlFetcherFactory nodeTtlFetcherFactory)
+    {
+        requireNonNull(nodeTtlFetcherFactory, "nodeTtlFetcherFactory is null");
+
+        if (ttlFetcherFactories.putIfAbsent(nodeTtlFetcherFactory.getName(), nodeTtlFetcherFactory) != null) {
+            throw new IllegalArgumentException(format("Node ttl fetcher factory '%s' is already registered", nodeTtlFetcherFactory.getName()));
+        }
+    }
+
+    @Override
+    public void loadNodeTtlFetcher()
+            throws Exception
+    {
+        String factoryName = "infinite";
+        Map<String, String> properties = ImmutableMap.of();
+
+        if (TTL_FETCHER_CONFIG.exists()) {
+            properties = new HashMap<>(loadProperties(TTL_FETCHER_CONFIG));
+            factoryName = properties.remove(TTL_FETCHER_PROPERTY_NAME);
+
+            checkArgument(!isNullOrEmpty(factoryName),
+                    "Node ttl fetcher configuration %s does not contain %s", TTL_FETCHER_CONFIG.getAbsoluteFile(), TTL_FETCHER_PROPERTY_NAME);
+        }
+
+        load(factoryName, properties);
+
+        if (ttlFetcher.get().needsPeriodicRefresh()) {
+            scheduleRefresh();
+        }
+        else {
+            refreshTtlInfo();
+        }
+
+        nodeManager.addNodeChangeListener(nodeChangeListener);
+    }
+
+    @VisibleForTesting
+    public void load(String factoryName, Map<String, String> properties)
+    {
+        log.info("-- Loading node ttl fetcher factory --");
+
+        NodeTtlFetcherFactory nodeTtlFetcherFactory = ttlFetcherFactories.get(factoryName);
+        checkState(nodeTtlFetcherFactory != null, "Node ttl fetcher factory %s is not registered", factoryName);
+
+        NodeTtlFetcher nodeTtlFetcher = nodeTtlFetcherFactory.create(properties);
+        checkState(this.ttlFetcher.compareAndSet(null, nodeTtlFetcher), "Node ttl fetcher has already been set!");
+
+        log.info("-- Loaded node ttl fetcher %s --", factoryName);
+    }
+
+    @Managed
+    public long getTimeInMillisSinceLastTtlRefresh()
+    {
+        if (lastRefreshEpochMillis.get() == Long.MAX_VALUE) {
+            return -1;
+        }
+        return currentTimeMillis() - lastRefreshEpochMillis.get();
+    }
+
+    @Managed
+    public long getStaleTtlWorkerCount()
+    {
+        Duration staleDuration = nodeTtlFetcherManagerConfig.getStaleTtlThreshold();
+        Instant staleInstant = Instant.now().minus(staleDuration.toMillis(), ChronoUnit.MILLIS);
+        return nodeTtlMap.values().stream().filter(nodeTtl -> nodeTtl.getTtlPredictionInstant().isBefore(staleInstant)).count();
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getRefreshFailures()
+    {
+        return refreshFailures;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/ttl/nodettlfetchermanagers/NodeTtlFetcherManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/ttl/nodettlfetchermanagers/NodeTtlFetcherManager.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.ttl.nodettlfetchermanagers;
+
+import com.facebook.presto.metadata.InternalNode;
+import com.facebook.presto.spi.ttl.NodeTtl;
+import com.facebook.presto.spi.ttl.NodeTtlFetcherFactory;
+
+import java.util.Map;
+import java.util.Optional;
+
+public interface NodeTtlFetcherManager
+{
+    Optional<NodeTtl> getTtlInfo(InternalNode node);
+
+    Map<InternalNode, NodeTtl> getAllTtls();
+
+    void addNodeTtlFetcherFactory(NodeTtlFetcherFactory factory);
+
+    void loadNodeTtlFetcher()
+            throws Exception;
+}

--- a/presto-main/src/main/java/com/facebook/presto/ttl/nodettlfetchermanagers/NodeTtlFetcherManagerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/ttl/nodettlfetchermanagers/NodeTtlFetcherManagerConfig.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.ttl.nodettlfetchermanagers;
+
+import com.facebook.airlift.configuration.Config;
+import io.airlift.units.Duration;
+
+public class NodeTtlFetcherManagerConfig
+{
+    private Duration initialDelayBeforeRefresh = Duration.valueOf("1m");
+    private Duration staleTtlThreshold = Duration.valueOf("15m");
+    private NodeTtlFetcherManagerType nodeTtlFetcherManagerType = NodeTtlFetcherManagerType.THROWING;
+
+    public enum NodeTtlFetcherManagerType
+    {
+        THROWING,
+        CONFIDENCE
+    }
+
+    public Duration getInitialDelayBeforeRefresh()
+    {
+        return initialDelayBeforeRefresh;
+    }
+
+    @Config("node-ttl-fetcher-manager.initial-delay-before-refresh")
+    public NodeTtlFetcherManagerConfig setInitialDelayBeforeRefresh(Duration initialDelayBeforeRefresh)
+    {
+        this.initialDelayBeforeRefresh = initialDelayBeforeRefresh;
+        return this;
+    }
+
+    @Config("node-ttl-fetcher-manager.stale-ttl-threshold")
+    public NodeTtlFetcherManagerConfig setStaleTtlThreshold(Duration staleTtlThreshold)
+    {
+        this.staleTtlThreshold = staleTtlThreshold;
+        return this;
+    }
+
+    public Duration getStaleTtlThreshold()
+    {
+        return staleTtlThreshold;
+    }
+
+    @Config("node-ttl-fetcher-manager.type")
+    public NodeTtlFetcherManagerConfig setNodeTtlFetcherManagerType(NodeTtlFetcherManagerType nodeTtlFetcherManagerType)
+    {
+        this.nodeTtlFetcherManagerType = nodeTtlFetcherManagerType;
+        return this;
+    }
+
+    public NodeTtlFetcherManagerType getNodeTtlFetcherManagerType()
+    {
+        return nodeTtlFetcherManagerType;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/ttl/nodettlfetchermanagers/NodeTtlFetcherManagerModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/ttl/nodettlfetchermanagers/NodeTtlFetcherManagerModule.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.ttl.nodettlfetchermanagers;
+
+import com.facebook.airlift.configuration.AbstractConfigurationAwareModule;
+import com.google.inject.Binder;
+import com.google.inject.Scopes;
+
+import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
+import static org.weakref.jmx.guice.ExportBinder.newExporter;
+
+public class NodeTtlFetcherManagerModule
+        extends AbstractConfigurationAwareModule
+{
+    @Override
+    protected void setup(Binder binder)
+    {
+        NodeTtlFetcherManagerConfig config = buildConfigObject(NodeTtlFetcherManagerConfig.class);
+        configBinder(binder).bindConfig(NodeTtlFetcherManagerConfig.class);
+        switch (config.getNodeTtlFetcherManagerType()) {
+            case THROWING:
+                binder.bind(NodeTtlFetcherManager.class).to(ThrowingNodeTtlFetcherManager.class).in(Scopes.SINGLETON);
+                break;
+            case CONFIDENCE:
+                binder.bind(NodeTtlFetcherManager.class).to(ConfidenceBasedNodeTtlFetcherManager.class).in(Scopes.SINGLETON);
+                break;
+            default:
+                throw new UnsupportedOperationException("Unknown Node Ttl Fetcher Manager: " + config.getNodeTtlFetcherManagerType());
+        }
+        newExporter(binder).export(NodeTtlFetcherManager.class).withGeneratedName();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/ttl/nodettlfetchermanagers/ThrowingNodeTtlFetcherManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/ttl/nodettlfetchermanagers/ThrowingNodeTtlFetcherManager.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.ttl.nodettlfetchermanagers;
+
+import com.facebook.presto.metadata.InternalNode;
+import com.facebook.presto.spi.ttl.NodeTtl;
+import com.facebook.presto.spi.ttl.NodeTtlFetcherFactory;
+
+import java.util.Map;
+import java.util.Optional;
+
+public class ThrowingNodeTtlFetcherManager
+        implements NodeTtlFetcherManager
+{
+    @Override
+    public Optional<NodeTtl> getTtlInfo(InternalNode node)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<InternalNode, NodeTtl> getAllTtls()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void addNodeTtlFetcherFactory(NodeTtlFetcherFactory factory)
+    {
+    }
+
+    @Override
+    public void loadNodeTtlFetcher()
+    {
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/util/PeriodicTaskExecutor.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/PeriodicTaskExecutor.java
@@ -39,16 +39,23 @@ public class PeriodicTaskExecutor
 
     public PeriodicTaskExecutor(long delayTargetMillis, ScheduledExecutorService executor, Runnable runnable)
     {
-        this(delayTargetMillis, executor, runnable, PeriodicTaskExecutor::nextDelayWithJitterMillis);
+        this(delayTargetMillis, 0, executor, runnable, PeriodicTaskExecutor::nextDelayWithJitterMillis);
     }
 
-    public PeriodicTaskExecutor(long delayTargetMillis, ScheduledExecutorService executor, Runnable runnable, LongUnaryOperator nextDelayFunction)
+    public PeriodicTaskExecutor(long delayTargetMillis, long initDelayMillis, ScheduledExecutorService executor, Runnable runnable)
+    {
+        this(delayTargetMillis, initDelayMillis, executor, runnable, PeriodicTaskExecutor::nextDelayWithJitterMillis);
+    }
+
+    public PeriodicTaskExecutor(long delayTargetMillis, long initDelayMillis, ScheduledExecutorService executor, Runnable runnable, LongUnaryOperator nextDelayFunction)
     {
         checkArgument(delayTargetMillis > 0, "delayTargetMillis must be > 0");
+        checkArgument(initDelayMillis >= 0, "initDelayMillis must be > 0");
         this.delayTargetMillis = delayTargetMillis;
         this.executor = requireNonNull(executor, "executor is null");
         this.runnable = requireNonNull(runnable, "runnable is null");
         this.nextDelayFunction = requireNonNull(nextDelayFunction, "nextDelayFunction is null");
+        this.delayMillis = initDelayMillis;
     }
 
     public void start()

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestCostCalculator.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestCostCalculator.java
@@ -16,6 +16,7 @@ package com.facebook.presto.cost;
 import com.facebook.presto.Session;
 import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.common.type.Type;
+import com.facebook.presto.dispatcher.NoOpQueryManager;
 import com.facebook.presto.execution.NodeTaskMap;
 import com.facebook.presto.execution.QueryManagerConfig;
 import com.facebook.presto.execution.scheduler.LegacyNetworkTopology;
@@ -60,6 +61,7 @@ import com.facebook.presto.tpch.TpchTableHandle;
 import com.facebook.presto.tpch.TpchTableLayoutHandle;
 import com.facebook.presto.tpch.TpchTransactionHandle;
 import com.facebook.presto.transaction.TransactionManager;
+import com.facebook.presto.ttl.nodettlfetchermanagers.ThrowingNodeTtlFetcherManager;
 import com.facebook.presto.util.FinalizerService;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -134,7 +136,9 @@ public class TestCostCalculator
                 new InMemoryNodeManager(),
                 new NodeSelectionStats(),
                 new NodeSchedulerConfig().setIncludeCoordinator(true),
-                new NodeTaskMap(finalizerService));
+                new NodeTaskMap(finalizerService),
+                new ThrowingNodeTtlFetcherManager(),
+                new NoOpQueryManager());
         PartitioningProviderManager partitioningProviderManager = new PartitioningProviderManager();
         nodePartitioningManager = new NodePartitioningManager(nodeScheduler, partitioningProviderManager, new NodeSelectionStats());
         planFragmenter = new PlanFragmenter(metadata, nodePartitioningManager, new QueryManagerConfig(), new SqlParser(), new FeaturesConfig());

--- a/presto-main/src/test/java/com/facebook/presto/execution/BenchmarkNodeScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/BenchmarkNodeScheduler.java
@@ -15,6 +15,7 @@ package com.facebook.presto.execution;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.client.NodeVersion;
+import com.facebook.presto.dispatcher.NoOpQueryManager;
 import com.facebook.presto.execution.scheduler.FlatNetworkTopology;
 import com.facebook.presto.execution.scheduler.LegacyNetworkTopology;
 import com.facebook.presto.execution.scheduler.NetworkLocation;
@@ -33,6 +34,7 @@ import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.facebook.presto.testing.TestingSession;
 import com.facebook.presto.testing.TestingTransactionHandle;
+import com.facebook.presto.ttl.nodettlfetchermanagers.ThrowingNodeTtlFetcherManager;
 import com.facebook.presto.util.FinalizerService;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
@@ -176,7 +178,7 @@ public class BenchmarkNodeScheduler
 
             InMemoryNodeManager nodeManager = new InMemoryNodeManager();
             nodeManager.addNode(CONNECTOR_ID, nodes);
-            NodeScheduler nodeScheduler = new NodeScheduler(getNetworkTopology(), nodeManager, new NodeSelectionStats(), getNodeSchedulerConfig(), nodeTaskMap);
+            NodeScheduler nodeScheduler = new NodeScheduler(getNetworkTopology(), nodeManager, new NodeSelectionStats(), getNodeSchedulerConfig(), nodeTaskMap, new ThrowingNodeTtlFetcherManager(), new NoOpQueryManager());
             Session session = TestingSession.testSessionBuilder()
                     .setSystemProperty(MAX_UNACKNOWLEDGED_SPLITS_PER_TASK, Integer.toString(Integer.MAX_VALUE))
                     .build();

--- a/presto-main/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
@@ -18,6 +18,7 @@ import com.facebook.presto.Session;
 import com.facebook.presto.common.block.BlockEncodingManager;
 import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.cost.StatsAndCosts;
+import com.facebook.presto.dispatcher.NoOpQueryManager;
 import com.facebook.presto.event.SplitMonitor;
 import com.facebook.presto.eventlistener.EventListenerManager;
 import com.facebook.presto.execution.buffer.OutputBuffers;
@@ -69,6 +70,7 @@ import com.facebook.presto.testing.TestingMetadata.TestingTableHandle;
 import com.facebook.presto.testing.TestingSplit;
 import com.facebook.presto.testing.TestingTransactionHandle;
 import com.facebook.presto.transaction.TransactionManager;
+import com.facebook.presto.ttl.nodettlfetchermanagers.ThrowingNodeTtlFetcherManager;
 import com.facebook.presto.util.FinalizerService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
@@ -137,13 +139,14 @@ public final class TaskTestUtils
 
         // we don't start the finalizer so nothing will be collected, which is ok for a test
         FinalizerService finalizerService = new FinalizerService();
-
         NodeScheduler nodeScheduler = new NodeScheduler(
                 new LegacyNetworkTopology(),
                 new InMemoryNodeManager(),
                 new NodeSelectionStats(),
                 new NodeSchedulerConfig().setIncludeCoordinator(true),
-                new NodeTaskMap(finalizerService));
+                new NodeTaskMap(finalizerService),
+                new ThrowingNodeTtlFetcherManager(),
+                new NoOpQueryManager());
         PartitioningProviderManager partitioningProviderManager = new PartitioningProviderManager();
         NodePartitioningManager nodePartitioningManager = new NodePartitioningManager(nodeScheduler, partitioningProviderManager, new NodeSelectionStats());
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestNodeScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestNodeScheduler.java
@@ -15,6 +15,7 @@ package com.facebook.presto.execution;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.client.NodeVersion;
+import com.facebook.presto.dispatcher.NoOpQueryManager;
 import com.facebook.presto.execution.scheduler.LegacyNetworkTopology;
 import com.facebook.presto.execution.scheduler.NetworkLocation;
 import com.facebook.presto.execution.scheduler.NetworkLocationCache;
@@ -27,41 +28,60 @@ import com.facebook.presto.execution.scheduler.nodeSelection.NodeSelector;
 import com.facebook.presto.metadata.InMemoryNodeManager;
 import com.facebook.presto.metadata.InternalNode;
 import com.facebook.presto.metadata.Split;
+import com.facebook.presto.server.BasicQueryInfo;
+import com.facebook.presto.server.BasicQueryStats;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
+import com.facebook.presto.spi.ttl.ConfidenceBasedTtlInfo;
+import com.facebook.presto.spi.ttl.NodeInfo;
+import com.facebook.presto.spi.ttl.NodeTtl;
+import com.facebook.presto.spi.ttl.NodeTtlFetcherFactory;
+import com.facebook.presto.spi.ttl.TestingNodeTtlFetcherFactory;
 import com.facebook.presto.testing.TestingSession;
 import com.facebook.presto.testing.TestingTransactionHandle;
+import com.facebook.presto.ttl.nodettlfetchermanagers.ConfidenceBasedNodeTtlFetcherManager;
+import com.facebook.presto.ttl.nodettlfetchermanagers.NodeTtlFetcherManagerConfig;
+import com.facebook.presto.ttl.nodettlfetchermanagers.ThrowingNodeTtlFetcherManager;
 import com.facebook.presto.util.FinalizerService;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
+import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.net.URI;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.OptionalDouble;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
 
 import static com.facebook.airlift.concurrent.Threads.daemonThreadsNamed;
 import static com.facebook.presto.SystemSessionProperties.MAX_UNACKNOWLEDGED_SPLITS_PER_TASK;
+import static com.facebook.presto.SystemSessionProperties.RESOURCE_AWARE_SCHEDULING_STRATEGY;
 import static com.facebook.presto.execution.scheduler.NetworkLocation.ROOT_LOCATION;
 import static com.facebook.presto.spi.schedule.NodeSelectionStrategy.HARD_AFFINITY;
 import static com.facebook.presto.spi.schedule.NodeSelectionStrategy.NO_PREFERENCE;
@@ -109,7 +129,14 @@ public class TestNodeScheduler
                 .setIncludeCoordinator(false)
                 .setMaxPendingSplitsPerTask(10);
 
-        nodeScheduler = new NodeScheduler(new LegacyNetworkTopology(), nodeManager, new NodeSelectionStats(), nodeSchedulerConfig, nodeTaskMap);
+        nodeScheduler = new NodeScheduler(
+                new LegacyNetworkTopology(),
+                nodeManager,
+                new NodeSelectionStats(),
+                nodeSchedulerConfig,
+                nodeTaskMap,
+                new ThrowingNodeTtlFetcherManager(),
+                new NoOpQueryManager());
         // contents of taskMap indicate the node-task map for the current stage
         taskMap = new HashMap<>();
         nodeSelector = nodeScheduler.createNodeSelector(session, CONNECTOR_ID);
@@ -128,6 +155,75 @@ public class TestNodeScheduler
         nodeSchedulerConfig = null;
         nodeScheduler = null;
         nodeSelector = null;
+    }
+
+    private class TestingQueryManager
+            extends NoOpQueryManager
+    {
+        private Duration executionTime;
+
+        private BasicQueryStats getBasicQueryStats(Duration executionTime)
+        {
+            Duration defaultDuration = Duration.valueOf("5m");
+            return new BasicQueryStats(
+                    null,
+                    null,
+                    defaultDuration,
+                    defaultDuration,
+                    defaultDuration,
+                    executionTime,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    DataSize.valueOf("1MB"),
+                    0,
+                    0,
+                    0,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    false,
+                    ImmutableSet.of(),
+                    DataSize.valueOf("1MB"),
+                    OptionalDouble.empty());
+        }
+
+        private BasicQueryInfo getBasicQueryInfo(Duration executionTime)
+        {
+            return new BasicQueryInfo(
+                    session.getQueryId(),
+                    session.toSessionRepresentation(),
+                    Optional.empty(),
+                    QueryState.RUNNING,
+                    null,
+                    true,
+                    URI.create("http://127.0.0.1:55"),
+                    "",
+                    getBasicQueryStats(executionTime),
+                    null,
+                    null,
+                    null,
+                    Optional.empty(),
+                    ImmutableList.of());
+        }
+
+        @Override
+        public BasicQueryInfo getQueryInfo(QueryId queryId)
+        {
+            return getBasicQueryInfo(executionTime);
+        }
+
+        public void setExecutionTime(Duration executionTime)
+        {
+            this.executionTime = executionTime;
+        }
     }
 
     @Test
@@ -179,7 +275,7 @@ public class TestNodeScheduler
                 }
             }
         };
-        NodeScheduler nodeScheduler = new NodeScheduler(locationCache, topology, nodeManager, new NodeSelectionStats(), nodeSchedulerConfig, nodeTaskMap, new Duration(5, SECONDS));
+        NodeScheduler nodeScheduler = new NodeScheduler(locationCache, topology, nodeManager, new NodeSelectionStats(), nodeSchedulerConfig, nodeTaskMap, new Duration(5, SECONDS), new ThrowingNodeTtlFetcherManager(), new NoOpQueryManager());
         NodeSelector nodeSelector = nodeScheduler.createNodeSelector(session, CONNECTOR_ID);
 
         // Fill up the nodes with non-local data
@@ -281,6 +377,98 @@ public class TestNodeScheduler
     }
 
     @Test
+    public void testTtlAwareScheduling()
+    {
+        InMemoryNodeManager nodeManager = new InMemoryNodeManager();
+
+        InternalNode node1 = new InternalNode("other1", URI.create("http://127.0.0.1:11"), NodeVersion.UNKNOWN, false);
+        InternalNode node2 = new InternalNode("other2", URI.create("http://127.0.0.1:12"), NodeVersion.UNKNOWN, false);
+        InternalNode node3 = new InternalNode("other3", URI.create("http://127.0.0.1:13"), NodeVersion.UNKNOWN, false);
+        List<InternalNode> nodes = ImmutableList.of(node1, node2, node3);
+        nodeManager.addNode(CONNECTOR_ID, nodes);
+        NodeSchedulerConfig nodeSchedulerConfig = new NodeSchedulerConfig()
+                .setMaxSplitsPerNode(20)
+                .setIncludeCoordinator(false)
+                .setMaxPendingSplitsPerTask(10);
+
+        Instant currentInstant = Instant.now();
+        NodeTtl ttl1 = new NodeTtl(ImmutableSet.of(
+                new ConfidenceBasedTtlInfo(currentInstant.plus(5, ChronoUnit.MINUTES).getEpochSecond(), 100)));
+        NodeTtl ttl2 = new NodeTtl(ImmutableSet.of(
+                new ConfidenceBasedTtlInfo(currentInstant.plus(30, ChronoUnit.MINUTES).getEpochSecond(), 100)));
+        NodeTtl ttl3 = new NodeTtl(ImmutableSet.of(
+                new ConfidenceBasedTtlInfo(currentInstant.plus(2, ChronoUnit.HOURS).getEpochSecond(), 100)));
+        Map<NodeInfo, NodeTtl> nodeToTtl = ImmutableMap.of(
+                new NodeInfo(node1.getNodeIdentifier(), node1.getHost()),
+                ttl1,
+                new NodeInfo(node2.getNodeIdentifier(), node2.getHost()),
+                ttl2,
+                new NodeInfo(node3.getNodeIdentifier(), node3.getHost()),
+                ttl3);
+
+        ConfidenceBasedNodeTtlFetcherManager nodeTtlFetcherManager = new ConfidenceBasedNodeTtlFetcherManager(
+                nodeManager,
+                new NodeSchedulerConfig(),
+                new NodeTtlFetcherManagerConfig());
+        NodeTtlFetcherFactory nodeTtlFetcherFactory = new TestingNodeTtlFetcherFactory(nodeToTtl);
+        nodeTtlFetcherManager.addNodeTtlFetcherFactory(nodeTtlFetcherFactory);
+        nodeTtlFetcherManager.load(nodeTtlFetcherFactory.getName(), ImmutableMap.of());
+        nodeTtlFetcherManager.refreshTtlInfo();
+
+        TestingQueryManager queryManager = new TestingQueryManager();
+        NodeScheduler nodeScheduler = new NodeScheduler(
+                new LegacyNetworkTopology(),
+                nodeManager,
+                new NodeSelectionStats(),
+                nodeSchedulerConfig,
+                nodeTaskMap,
+                nodeTtlFetcherManager,
+                queryManager);
+
+        // Query is estimated to take 20 mins and has been executing for 3 mins, i.e, 17 mins left
+        // So only node2 and node3 have enough TTL to run additional work
+        Session session = sessionWithTtlAwareSchedulingStrategyAndEstimatedExecutionTime(new Duration(20, TimeUnit.MINUTES));
+        NodeSelector nodeSelector = nodeScheduler.createNodeSelector(session, CONNECTOR_ID);
+        queryManager.setExecutionTime(new Duration(3, TimeUnit.MINUTES));
+        assertEquals(ImmutableSet.copyOf(nodeSelector.selectRandomNodes(3)), ImmutableSet.of(node2, node3));
+
+        // Query is estimated to take 1 hour and has been executing for 45 mins, i.e, 15 mins left
+        // So only node2 and node3 have enough TTL to work on new splits
+        session = sessionWithTtlAwareSchedulingStrategyAndEstimatedExecutionTime(new Duration(1, TimeUnit.HOURS));
+        nodeSelector = nodeScheduler.createNodeSelector(session, CONNECTOR_ID);
+        queryManager.setExecutionTime(new Duration(45, TimeUnit.MINUTES));
+        Set<Split> splits = new HashSet<>();
+        for (int i = 0; i < 2; i++) {
+            splits.add(new Split(CONNECTOR_ID, TestingTransactionHandle.create(), new TestSplitRemote()));
+        }
+        Multimap<InternalNode, Split> assignments = nodeSelector.computeAssignments(splits, ImmutableList.copyOf(taskMap.values())).getAssignments();
+        assertEquals(assignments.size(), 2);
+        assertTrue(assignments.keySet().contains(node2));
+        assertTrue(assignments.keySet().contains(node3));
+
+        // Query is estimated to take 1 hour and has been executing for 20 mins, i.e, 40 mins left
+        // So only node3 has enough TTL to work on new splits
+        MockRemoteTaskFactory remoteTaskFactory = new MockRemoteTaskFactory(remoteTaskExecutor, remoteTaskScheduledExecutor);
+        TaskId taskId = new TaskId("test", 1, 0, 1);
+        RemoteTask newRemoteTask = remoteTaskFactory.createTableScanTask(taskId, node2, ImmutableList.of(), nodeTaskMap.createTaskStatsTracker(node2, taskId));
+        taskMap.put(node2, newRemoteTask);
+        nodeTaskMap.addTask(node2, newRemoteTask);
+
+        session = sessionWithTtlAwareSchedulingStrategyAndEstimatedExecutionTime(new Duration(1, TimeUnit.HOURS));
+        nodeSelector = nodeScheduler.createNodeSelector(session, CONNECTOR_ID);
+        queryManager.setExecutionTime(new Duration(20, TimeUnit.MINUTES));
+        splits.clear();
+        for (int i = 0; i < 2; i++) {
+            splits.add(new Split(CONNECTOR_ID, TestingTransactionHandle.create(), new TestSplitRemote()));
+        }
+
+        assignments = nodeSelector.computeAssignments(splits, ImmutableList.copyOf(taskMap.values())).getAssignments();
+        assertEquals(assignments.size(), 2);
+        assertEquals(assignments.keySet().size(), 1);
+        assertTrue(assignments.keySet().contains(node3));
+    }
+
+    @Test
     public void testScheduleRemote()
     {
         Set<Split> splits = new HashSet<>();
@@ -333,7 +521,7 @@ public class TestNodeScheduler
                 .setIncludeCoordinator(false)
                 .setMaxPendingSplitsPerTask(10);
 
-        NodeScheduler nodeScheduler = new NodeScheduler(new LegacyNetworkTopology(), nodeManager, new NodeSelectionStats(), nodeSchedulerConfig, nodeTaskMap);
+        NodeScheduler nodeScheduler = new NodeScheduler(new LegacyNetworkTopology(), nodeManager, new NodeSelectionStats(), nodeSchedulerConfig, nodeTaskMap, new ThrowingNodeTtlFetcherManager(), new NoOpQueryManager());
         NodeSelector nodeSelector = nodeScheduler.createNodeSelector(session, CONNECTOR_ID, 2);
 
         Set<Split> splits = new HashSet<>();
@@ -356,7 +544,7 @@ public class TestNodeScheduler
                 .setIncludeCoordinator(false)
                 .setMaxPendingSplitsPerTask(10);
 
-        NodeScheduler nodeScheduler = new NodeScheduler(new LegacyNetworkTopology(), nodeManager, new NodeSelectionStats(), nodeSchedulerConfig, nodeTaskMap);
+        NodeScheduler nodeScheduler = new NodeScheduler(new LegacyNetworkTopology(), nodeManager, new NodeSelectionStats(), nodeSchedulerConfig, nodeTaskMap, new ThrowingNodeTtlFetcherManager(), new NoOpQueryManager());
         NodeSelector nodeSelector = nodeScheduler.createNodeSelector(session, CONNECTOR_ID, 3);
 
         Set<Split> splits = new HashSet<>();
@@ -394,7 +582,7 @@ public class TestNodeScheduler
                 .setIncludeCoordinator(false)
                 .setMaxPendingSplitsPerTask(10);
 
-        NodeScheduler nodeScheduler = new NodeScheduler(new LegacyNetworkTopology(), nodeManager, new NodeSelectionStats(), nodeSchedulerConfig, nodeTaskMap);
+        NodeScheduler nodeScheduler = new NodeScheduler(new LegacyNetworkTopology(), nodeManager, new NodeSelectionStats(), nodeSchedulerConfig, nodeTaskMap, new ThrowingNodeTtlFetcherManager(), new NoOpQueryManager());
         NodeSelector nodeSelector = nodeScheduler.createNodeSelector(session, CONNECTOR_ID, 3);
 
         Set<Split> splits = new HashSet<>();
@@ -697,7 +885,7 @@ public class TestNodeScheduler
                 .setIncludeCoordinator(false)
                 .setMaxPendingSplitsPerTask(10);
 
-        NodeScheduler nodeScheduler = new NodeScheduler(new LegacyNetworkTopology(), nodeManager, new NodeSelectionStats(), nodeSchedulerConfig, nodeTaskMap);
+        NodeScheduler nodeScheduler = new NodeScheduler(new LegacyNetworkTopology(), nodeManager, new NodeSelectionStats(), nodeSchedulerConfig, nodeTaskMap, new ThrowingNodeTtlFetcherManager(), new NoOpQueryManager());
         NodeSelector nodeSelector = nodeScheduler.createNodeSelector(session, CONNECTOR_ID, 2);
 
         Set<Split> splits = new HashSet<>();
@@ -735,7 +923,7 @@ public class TestNodeScheduler
 
         LegacyNetworkTopology networkTopology = new LegacyNetworkTopology();
         // refresh interval is 1 nanosecond
-        NodeScheduler nodeScheduler = new NodeScheduler(new NetworkLocationCache(networkTopology), networkTopology, nodeManager, new NodeSelectionStats(), nodeSchedulerConfig, nodeTaskMap, Duration.valueOf("0s"));
+        NodeScheduler nodeScheduler = new NodeScheduler(new NetworkLocationCache(networkTopology), networkTopology, nodeManager, new NodeSelectionStats(), nodeSchedulerConfig, nodeTaskMap, Duration.valueOf("0s"), new ThrowingNodeTtlFetcherManager(), new NoOpQueryManager());
         NodeSelector nodeSelector = nodeScheduler.createNodeSelector(session, CONNECTOR_ID, 2);
 
         Set<Split> splits = new HashSet<>();
@@ -782,6 +970,14 @@ public class TestNodeScheduler
     {
         return TestingSession.testSessionBuilder()
                 .setSystemProperty(MAX_UNACKNOWLEDGED_SPLITS_PER_TASK, Integer.toString(maxUnacknowledgedSplitsPerTask))
+                .build();
+    }
+
+    private static Session sessionWithTtlAwareSchedulingStrategyAndEstimatedExecutionTime(Duration estimatedExecutionTime)
+    {
+        return TestingSession.testSessionBuilder()
+                .setSystemProperty(RESOURCE_AWARE_SCHEDULING_STRATEGY, NodeSchedulerConfig.ResourceAwareSchedulingStrategy.TTL.name())
+                .setResourceEstimates(new Session.ResourceEstimateBuilder().setExecutionTime(estimatedExecutionTime).build())
                 .build();
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestNodeSchedulerConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestNodeSchedulerConfig.java
@@ -21,6 +21,8 @@ import org.testng.annotations.Test;
 import java.util.Map;
 
 import static com.facebook.presto.execution.scheduler.NodeSchedulerConfig.NetworkTopologyType.LEGACY;
+import static com.facebook.presto.execution.scheduler.NodeSchedulerConfig.ResourceAwareSchedulingStrategy.RANDOM;
+import static com.facebook.presto.execution.scheduler.NodeSchedulerConfig.ResourceAwareSchedulingStrategy.TTL;
 
 public class TestNodeSchedulerConfig
 {
@@ -33,7 +35,8 @@ public class TestNodeSchedulerConfig
                 .setMaxSplitsPerNode(100)
                 .setMaxPendingSplitsPerTask(10)
                 .setMaxUnacknowledgedSplitsPerTask(500)
-                .setIncludeCoordinator(true));
+                .setIncludeCoordinator(true)
+                .setResourceAwareSchedulingStrategy(RANDOM));
     }
 
     @Test
@@ -46,6 +49,7 @@ public class TestNodeSchedulerConfig
                 .put("node-scheduler.max-pending-splits-per-task", "11")
                 .put("node-scheduler.max-unacknowledged-splits-per-task", "501")
                 .put("node-scheduler.max-splits-per-node", "101")
+                .put("experimental.resource-aware-scheduling-strategy", "TTL")
                 .build();
 
         NodeSchedulerConfig expected = new NodeSchedulerConfig()
@@ -54,7 +58,8 @@ public class TestNodeSchedulerConfig
                 .setMaxSplitsPerNode(101)
                 .setMaxPendingSplitsPerTask(11)
                 .setMaxUnacknowledgedSplitsPerTask(501)
-                .setMinCandidates(11);
+                .setMinCandidates(11)
+                .setResourceAwareSchedulingStrategy(TTL);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-main/src/test/java/com/facebook/presto/ttl/TestConfidenceBasedClusterTtlProviderManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/ttl/TestConfidenceBasedClusterTtlProviderManager.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.ttl;
+
+import com.facebook.presto.client.NodeVersion;
+import com.facebook.presto.execution.scheduler.NodeSchedulerConfig;
+import com.facebook.presto.metadata.InMemoryNodeManager;
+import com.facebook.presto.metadata.InternalNode;
+import com.facebook.presto.spi.ConnectorId;
+import com.facebook.presto.spi.ttl.ClusterTtlProviderFactory;
+import com.facebook.presto.spi.ttl.ConfidenceBasedTtlInfo;
+import com.facebook.presto.spi.ttl.NodeInfo;
+import com.facebook.presto.spi.ttl.NodeTtl;
+import com.facebook.presto.spi.ttl.NodeTtlFetcherFactory;
+import com.facebook.presto.spi.ttl.TestingClusterTtlProviderFactory;
+import com.facebook.presto.spi.ttl.TestingNodeTtlFetcherFactory;
+import com.facebook.presto.ttl.clusterttlprovidermanagers.ConfidenceBasedClusterTtlProviderManager;
+import com.facebook.presto.ttl.nodettlfetchermanagers.ConfidenceBasedNodeTtlFetcherManager;
+import com.facebook.presto.ttl.nodettlfetchermanagers.NodeTtlFetcherManagerConfig;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.net.URI;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestConfidenceBasedClusterTtlProviderManager
+{
+    private final InternalNode node1 = new InternalNode("node_1", URI.create("local://127.0.0.1"), NodeVersion.UNKNOWN, true);
+    private final InternalNode node2 = new InternalNode("node_2", URI.create("local://127.0.0.2"), NodeVersion.UNKNOWN, false);
+    private final InternalNode node3 = new InternalNode("node_3", URI.create("local://127.0.0.3"), NodeVersion.UNKNOWN, false);
+    private final NodeTtl ttl1 = new NodeTtl(ImmutableSet.of(new ConfidenceBasedTtlInfo(10, 90)));
+    private final NodeTtl ttl2 = new NodeTtl(ImmutableSet.of(new ConfidenceBasedTtlInfo(20, 80)));
+    private final NodeTtl ttl3 = new NodeTtl(ImmutableSet.of(new ConfidenceBasedTtlInfo(30, 70)));
+    private final Map<NodeInfo, NodeTtl> nodeToTtl = ImmutableMap.of(
+            new NodeInfo(node1.getNodeIdentifier(), node1.getHost()),
+            ttl1,
+            new NodeInfo(node2.getNodeIdentifier(), node2.getHost()),
+            ttl2,
+            new NodeInfo(node3.getNodeIdentifier(), node3.getHost()),
+            ttl3);
+    private ConfidenceBasedClusterTtlProviderManager clusterTtlProviderManager;
+
+    @BeforeClass
+    public void setup()
+    {
+        InMemoryNodeManager nodeManager = new InMemoryNodeManager();
+        nodeManager.addNode(new ConnectorId("prism"), ImmutableSet.of(node1, node2, node3));
+
+        ConfidenceBasedNodeTtlFetcherManager nodeTtlFetcherManager = new ConfidenceBasedNodeTtlFetcherManager(nodeManager, new NodeSchedulerConfig(), new NodeTtlFetcherManagerConfig());
+        NodeTtlFetcherFactory nodeTtlFetcherFactory = new TestingNodeTtlFetcherFactory(nodeToTtl);
+        nodeTtlFetcherManager.addNodeTtlFetcherFactory(nodeTtlFetcherFactory);
+        nodeTtlFetcherManager.load(nodeTtlFetcherFactory.getName(), ImmutableMap.of());
+        nodeTtlFetcherManager.refreshTtlInfo();
+
+        clusterTtlProviderManager = new ConfidenceBasedClusterTtlProviderManager(nodeTtlFetcherManager);
+        ClusterTtlProviderFactory clusterTtlProviderFactory = new TestingClusterTtlProviderFactory();
+        clusterTtlProviderManager.addClusterTtlProviderFactory(clusterTtlProviderFactory);
+        clusterTtlProviderManager.load(clusterTtlProviderFactory.getName(), ImmutableMap.of());
+    }
+
+    @Test
+    public void testGetClusterTtl()
+    {
+        assertEquals(clusterTtlProviderManager.getClusterTtl(), new ConfidenceBasedTtlInfo(60, 100));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/ttl/TestConfidenceBasedNodeTtlFetcherManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/ttl/TestConfidenceBasedNodeTtlFetcherManager.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.ttl;
+
+import com.facebook.presto.client.NodeVersion;
+import com.facebook.presto.execution.scheduler.NodeSchedulerConfig;
+import com.facebook.presto.metadata.InMemoryNodeManager;
+import com.facebook.presto.metadata.InternalNode;
+import com.facebook.presto.spi.ConnectorId;
+import com.facebook.presto.spi.ttl.ConfidenceBasedTtlInfo;
+import com.facebook.presto.spi.ttl.NodeInfo;
+import com.facebook.presto.spi.ttl.NodeTtl;
+import com.facebook.presto.spi.ttl.NodeTtlFetcherFactory;
+import com.facebook.presto.spi.ttl.TestingNodeTtlFetcherFactory;
+import com.facebook.presto.ttl.nodettlfetchermanagers.ConfidenceBasedNodeTtlFetcherManager;
+import com.facebook.presto.ttl.nodettlfetchermanagers.NodeTtlFetcherManagerConfig;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+
+public class TestConfidenceBasedNodeTtlFetcherManager
+{
+    private final InternalNode node1 = new InternalNode("node_1", URI.create("local://127.0.0.1"), NodeVersion.UNKNOWN, true);
+    private final InternalNode node2 = new InternalNode("node_2", URI.create("local://127.0.0.2"), NodeVersion.UNKNOWN, false);
+    private final InternalNode node3 = new InternalNode("node_3", URI.create("local://127.0.0.3"), NodeVersion.UNKNOWN, false);
+    private final NodeTtl ttl1 = new NodeTtl(ImmutableSet.of(new ConfidenceBasedTtlInfo(10, 90)));
+    private final NodeTtl ttl2 = new NodeTtl(ImmutableSet.of(new ConfidenceBasedTtlInfo(20, 80)));
+    private final NodeTtl ttl3 = new NodeTtl(ImmutableSet.of(new ConfidenceBasedTtlInfo(30, 70)));
+    private final Map<NodeInfo, NodeTtl> nodeToTtl = ImmutableMap.of(
+            new NodeInfo(node1.getNodeIdentifier(), node1.getHost()),
+            ttl1,
+            new NodeInfo(node2.getNodeIdentifier(), node2.getHost()),
+            ttl2,
+            new NodeInfo(node3.getNodeIdentifier(), node3.getHost()),
+            ttl3);
+    private InMemoryNodeManager nodeManager;
+    private ConfidenceBasedNodeTtlFetcherManager nodeTtlFetcherManager;
+
+    @BeforeClass
+    public void setup()
+    {
+        nodeManager = new InMemoryNodeManager();
+        nodeManager.addNode(new ConnectorId("prism"), ImmutableSet.of(node1, node2, node3));
+        nodeTtlFetcherManager = new ConfidenceBasedNodeTtlFetcherManager(nodeManager, new NodeSchedulerConfig(), new NodeTtlFetcherManagerConfig());
+        NodeTtlFetcherFactory factory = new TestingNodeTtlFetcherFactory(nodeToTtl);
+        nodeTtlFetcherManager.addNodeTtlFetcherFactory(factory);
+        nodeTtlFetcherManager.load(factory.getName(), ImmutableMap.of());
+        nodeTtlFetcherManager.refreshTtlInfo();
+    }
+
+    @Test
+    public void testEmptyTtlInfo()
+    {
+        assertFalse(nodeTtlFetcherManager.getTtlInfo(nodeManager.getCurrentNode()).isPresent());
+    }
+
+    @Test
+    public void testNonEmptyTtlInfo()
+    {
+        assertEquals(nodeTtlFetcherManager.getTtlInfo(node2),
+                Optional.of(new NodeTtl(ImmutableSet.of(new ConfidenceBasedTtlInfo(20, 80)))));
+        assertEquals(nodeTtlFetcherManager.getTtlInfo(node3),
+                Optional.of(new NodeTtl(ImmutableSet.of(new ConfidenceBasedTtlInfo(30, 70)))));
+    }
+
+    @Test
+    public void testGetAllTtls()
+    {
+        assertEquals(nodeTtlFetcherManager.getAllTtls(), ImmutableMap.of(node1, ttl1, node2, ttl2, node3, ttl3));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/ttl/TestNodeTtlFetcherManagerConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/ttl/TestNodeTtlFetcherManagerConfig.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.ttl;
+
+import com.facebook.airlift.configuration.testing.ConfigAssertions;
+import com.facebook.presto.ttl.nodettlfetchermanagers.NodeTtlFetcherManagerConfig;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.units.Duration;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static com.facebook.presto.ttl.nodettlfetchermanagers.NodeTtlFetcherManagerConfig.NodeTtlFetcherManagerType.CONFIDENCE;
+import static com.facebook.presto.ttl.nodettlfetchermanagers.NodeTtlFetcherManagerConfig.NodeTtlFetcherManagerType.THROWING;
+
+public class TestNodeTtlFetcherManagerConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        ConfigAssertions.assertRecordedDefaults(ConfigAssertions.recordDefaults(NodeTtlFetcherManagerConfig.class)
+                .setInitialDelayBeforeRefresh(new Duration(1, TimeUnit.MINUTES))
+                .setStaleTtlThreshold(new Duration(15, TimeUnit.MINUTES))
+                .setNodeTtlFetcherManagerType(THROWING));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("node-ttl-fetcher-manager.initial-delay-before-refresh", "5m")
+                .put("node-ttl-fetcher-manager.stale-ttl-threshold", "10m")
+                .put("node-ttl-fetcher-manager.type", "CONFIDENCE")
+                .build();
+
+        NodeTtlFetcherManagerConfig expected = new NodeTtlFetcherManagerConfig()
+                .setInitialDelayBeforeRefresh(new Duration(5, TimeUnit.MINUTES))
+                .setStaleTtlThreshold(new Duration(10, TimeUnit.MINUTES))
+                .setNodeTtlFetcherManagerType(CONFIDENCE);
+
+        ConfigAssertions.assertFullMapping(properties, expected);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/util/TestPeriodicTaskExecutor.java
+++ b/presto-main/src/test/java/com/facebook/presto/util/TestPeriodicTaskExecutor.java
@@ -52,7 +52,7 @@ public class TestPeriodicTaskExecutor
         CountDownLatch latch = new CountDownLatch(3);
         Runnable runnable = latch::countDown;
 
-        try (PeriodicTaskExecutor executor = new PeriodicTaskExecutor(SECONDS.toMillis(durationBetweenTicksInSeconds), executorService, runnable, i -> i)) {
+        try (PeriodicTaskExecutor executor = new PeriodicTaskExecutor(SECONDS.toMillis(durationBetweenTicksInSeconds), 500, executorService, runnable, i -> i)) {
             executor.start();
             Stopwatch stopwatch = Stopwatch.createStarted();
             latch.await(10, SECONDS);

--- a/presto-node-ttl-fetchers/pom.xml
+++ b/presto-node-ttl-fetchers/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>presto-root</artifactId>
+        <groupId>com.facebook.presto</groupId>
+        <version>0.262-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>presto-node-ttl-fetchers</artifactId>
+    <description>Presto - Node Ttl Fetchers</description>
+    <packaging>presto-plugin</packaging>
+
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>bootstrap</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+        </dependency>
+        <!-- Presto SPI -->
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-spi</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>units</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-common</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/presto-node-ttl-fetchers/src/main/java/com/facebook/presto/nodettlfetchers/PrestoNodeTtlFetcherPlugin.java
+++ b/presto-node-ttl-fetchers/src/main/java/com/facebook/presto/nodettlfetchers/PrestoNodeTtlFetcherPlugin.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.nodettlfetchers;
+
+import com.facebook.presto.nodettlfetchers.infinite.InfiniteNodeTtlFetcherFactory;
+import com.facebook.presto.spi.Plugin;
+import com.facebook.presto.spi.ttl.NodeTtlFetcherFactory;
+import com.google.common.collect.ImmutableList;
+
+public class PrestoNodeTtlFetcherPlugin
+        implements Plugin
+{
+    @Override
+    public Iterable<NodeTtlFetcherFactory> getNodeTtlFetcherFactories()
+    {
+        return ImmutableList.of(new InfiniteNodeTtlFetcherFactory());
+    }
+}

--- a/presto-node-ttl-fetchers/src/main/java/com/facebook/presto/nodettlfetchers/infinite/InfiniteNodeTtlFetcher.java
+++ b/presto-node-ttl-fetchers/src/main/java/com/facebook/presto/nodettlfetchers/infinite/InfiniteNodeTtlFetcher.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.nodettlfetchers.infinite;
+
+import com.facebook.presto.spi.ttl.NodeInfo;
+import com.facebook.presto.spi.ttl.NodeTtl;
+import com.facebook.presto.spi.ttl.NodeTtlFetcher;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Map;
+import java.util.Set;
+
+import static com.facebook.presto.spi.ttl.ConfidenceBasedTtlInfo.getInfiniteTtl;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static java.util.Objects.requireNonNull;
+import static java.util.function.Function.identity;
+
+public class InfiniteNodeTtlFetcher
+        implements NodeTtlFetcher
+{
+    @Override
+    public Map<NodeInfo, NodeTtl> getTtlInfo(Set<NodeInfo> nodes)
+    {
+        requireNonNull(nodes, "nodes is null");
+        return nodes.stream().collect(toImmutableMap(identity(), node -> new NodeTtl(ImmutableSet.of(getInfiniteTtl()))));
+    }
+
+    @Override
+    public boolean needsPeriodicRefresh()
+    {
+        return false;
+    }
+}

--- a/presto-node-ttl-fetchers/src/main/java/com/facebook/presto/nodettlfetchers/infinite/InfiniteNodeTtlFetcherFactory.java
+++ b/presto-node-ttl-fetchers/src/main/java/com/facebook/presto/nodettlfetchers/infinite/InfiniteNodeTtlFetcherFactory.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.nodettlfetchers.infinite;
+
+import com.facebook.airlift.bootstrap.Bootstrap;
+import com.facebook.presto.spi.ttl.NodeTtlFetcher;
+import com.facebook.presto.spi.ttl.NodeTtlFetcherFactory;
+import com.google.inject.Injector;
+import com.google.inject.Scopes;
+
+import java.util.Map;
+
+public class InfiniteNodeTtlFetcherFactory
+        implements NodeTtlFetcherFactory
+{
+    @Override
+    public String getName()
+    {
+        return "infinite";
+    }
+
+    @Override
+    public NodeTtlFetcher create(Map<String, String> config)
+    {
+        try {
+            Bootstrap app = new Bootstrap(binder -> binder.bind(NodeTtlFetcher.class).to(InfiniteNodeTtlFetcher.class).in(Scopes.SINGLETON));
+
+            Injector injector = app
+                    .doNotInitializeLogging()
+                    .setRequiredConfigurationProperties(config)
+                    .initialize();
+            return injector.getInstance(NodeTtlFetcher.class);
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/presto-node-ttl-fetchers/src/test/java/com/facebook/presto/nodettlfetchers/TestInfiniteNodeTtlFetcher.java
+++ b/presto-node-ttl-fetchers/src/test/java/com/facebook/presto/nodettlfetchers/TestInfiniteNodeTtlFetcher.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.nodettlfetchers;
+
+import com.facebook.presto.nodettlfetchers.infinite.InfiniteNodeTtlFetcher;
+import com.facebook.presto.spi.ttl.NodeInfo;
+import com.facebook.presto.spi.ttl.NodeTtl;
+import com.facebook.presto.spi.ttl.NodeTtlFetcher;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.spi.ttl.ConfidenceBasedTtlInfo.getInfiniteTtl;
+import static org.testng.Assert.assertEquals;
+
+public class TestInfiniteNodeTtlFetcher
+{
+    private final NodeInfo nodeInfo = new NodeInfo("id", "host");
+    private final NodeTtlFetcher infiniteNodeTtlFetcher = new InfiniteNodeTtlFetcher();
+
+    @Test
+    public void testWithNoNodes()
+    {
+        assertEquals(infiniteNodeTtlFetcher.getTtlInfo(ImmutableSet.of()), ImmutableMap.of());
+    }
+
+    @Test
+    public void testWithOneNode()
+    {
+        assertEquals(infiniteNodeTtlFetcher.getTtlInfo(ImmutableSet.of(nodeInfo)), ImmutableMap.of(nodeInfo, new NodeTtl(ImmutableSet.of(getInfiniteTtl()))));
+    }
+}

--- a/presto-server/pom.xml
+++ b/presto-server/pom.xml
@@ -78,6 +78,22 @@
 
         <dependency>
             <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-node-ttl-fetchers</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-cluster-ttl-providers</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
             <artifactId>presto-jmx</artifactId>
             <version>${project.version}</version>
             <type>zip</type>

--- a/presto-server/src/main/assembly/presto.xml
+++ b/presto-server/src/main/assembly/presto.xml
@@ -65,6 +65,14 @@
             <outputDirectory>plugin/session-property-managers</outputDirectory>
         </fileSet>
         <fileSet>
+            <directory>${project.build.directory}/dependency/presto-node-ttl-fetchers-${project.version}</directory>
+            <outputDirectory>plugin/ttl-fetchers</outputDirectory>
+        </fileSet>
+        <fileSet>
+            <directory>${project.build.directory}/dependency/presto-cluster-ttl-providers-${project.version}</directory>
+            <outputDirectory>plugin/cluster-ttl-providers</outputDirectory>
+        </fileSet>
+        <fileSet>
             <directory>${project.build.directory}/dependency/presto-function-namespace-managers-${project.version}</directory>
             <outputDirectory>plugin/function-namespace-managers</outputDirectory>
         </fileSet>

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
@@ -161,6 +161,10 @@ import com.facebook.presto.sql.tree.Statement;
 import com.facebook.presto.transaction.InMemoryTransactionManager;
 import com.facebook.presto.transaction.TransactionManager;
 import com.facebook.presto.transaction.TransactionManagerConfig;
+import com.facebook.presto.ttl.clusterttlprovidermanagers.ClusterTtlProviderManager;
+import com.facebook.presto.ttl.clusterttlprovidermanagers.ThrowingClusterTtlProviderManager;
+import com.facebook.presto.ttl.nodettlfetchermanagers.NodeTtlFetcherManager;
+import com.facebook.presto.ttl.nodettlfetchermanagers.ThrowingNodeTtlFetcherManager;
 import com.facebook.presto.type.TypeDeserializer;
 import com.facebook.presto.version.EmbedVersion;
 import com.google.inject.Binder;
@@ -428,6 +432,8 @@ public class PrestoSparkModule
         binder.bind(ClusterMemoryPoolManager.class).toInstance(((poolId, listener) -> {}));
         binder.bind(QueryPrerequisitesManager.class).in(Scopes.SINGLETON);
         binder.bind(ResourceGroupService.class).to(NoopResourceGroupService.class).in(Scopes.SINGLETON);
+        binder.bind(NodeTtlFetcherManager.class).to(ThrowingNodeTtlFetcherManager.class).in(Scopes.SINGLETON);
+        binder.bind(ClusterTtlProviderManager.class).to(ThrowingClusterTtlProviderManager.class).in(Scopes.SINGLETON);
 
         // TODO: Decouple and remove: required by SessionPropertyDefaults, PluginManager, InternalResourceGroupManager, ConnectorManager
         configBinder(binder).bindConfig(NodeConfig.class);

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/node/PrestoSparkNodeScheduler.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/node/PrestoSparkNodeScheduler.java
@@ -15,6 +15,7 @@ package com.facebook.presto.spark.node;
 
 import com.facebook.airlift.stats.CounterStat;
 import com.facebook.presto.Session;
+import com.facebook.presto.dispatcher.NoOpQueryManager;
 import com.facebook.presto.execution.NodeTaskMap;
 import com.facebook.presto.execution.scheduler.LegacyNetworkTopology;
 import com.facebook.presto.execution.scheduler.NetworkLocationCache;
@@ -24,6 +25,7 @@ import com.facebook.presto.execution.scheduler.nodeSelection.NodeSelectionStats;
 import com.facebook.presto.execution.scheduler.nodeSelection.NodeSelector;
 import com.facebook.presto.metadata.InMemoryNodeManager;
 import com.facebook.presto.spi.ConnectorId;
+import com.facebook.presto.ttl.nodettlfetchermanagers.ThrowingNodeTtlFetcherManager;
 import com.facebook.presto.util.FinalizerService;
 import io.airlift.units.Duration;
 
@@ -46,7 +48,9 @@ public class PrestoSparkNodeScheduler
                 new NodeSelectionStats(),
                 new NodeSchedulerConfig(),
                 new NodeTaskMap(new FinalizerService()),
-                new Duration(5, SECONDS));
+                new Duration(5, SECONDS),
+                new ThrowingNodeTtlFetcherManager(),
+                new NoOpQueryManager());
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/Plugin.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/Plugin.java
@@ -25,6 +25,8 @@ import com.facebook.presto.spi.security.PasswordAuthenticatorFactory;
 import com.facebook.presto.spi.security.SystemAccessControlFactory;
 import com.facebook.presto.spi.session.SessionPropertyConfigurationManagerFactory;
 import com.facebook.presto.spi.storage.TempStorageFactory;
+import com.facebook.presto.spi.ttl.ClusterTtlProviderFactory;
+import com.facebook.presto.spi.ttl.NodeTtlFetcherFactory;
 
 import java.util.Set;
 
@@ -94,6 +96,16 @@ public interface Plugin
     }
 
     default Iterable<QueryPrerequisitesFactory> getQueryPrerequisitesFactories()
+    {
+        return emptyList();
+    }
+
+    default Iterable<NodeTtlFetcherFactory> getNodeTtlFetcherFactories()
+    {
+        return emptyList();
+    }
+
+    default Iterable<ClusterTtlProviderFactory> getClusterTtlProviderFactories()
     {
         return emptyList();
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/ttl/ClusterTtlProvider.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ttl/ClusterTtlProvider.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.spi.ttl;
+
+import java.util.List;
+
+public interface ClusterTtlProvider
+{
+    ConfidenceBasedTtlInfo getClusterTtl(List<NodeTtl> nodeTtls);
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/ttl/ClusterTtlProviderFactory.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ttl/ClusterTtlProviderFactory.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.ttl;
+
+import java.util.Map;
+
+public interface ClusterTtlProviderFactory
+{
+    String getName();
+
+    ClusterTtlProvider create(Map<String, String> config);
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/ttl/ConfidenceBasedTtlInfo.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ttl/ConfidenceBasedTtlInfo.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.spi.ttl;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.Instant;
+import java.util.Objects;
+
+public class ConfidenceBasedTtlInfo
+{
+    private final Instant expiryInstant;
+    private final Double confidencePercentage;
+
+    @JsonCreator
+    public ConfidenceBasedTtlInfo(
+            @JsonProperty("expiryEpochTime") long expiryEpochTime,
+            @JsonProperty("confidencePercentage") double confidencePercentage)
+    {
+        this.expiryInstant = Instant.ofEpochSecond(expiryEpochTime);
+        this.confidencePercentage = confidencePercentage;
+    }
+
+    public static ConfidenceBasedTtlInfo getInfiniteTtl()
+    {
+        return new ConfidenceBasedTtlInfo(Instant.MAX.getEpochSecond(), 100);
+    }
+
+    @JsonProperty("expiryEpochTime")
+    public long getExpiryEpochSecond()
+    {
+        return expiryInstant.getEpochSecond();
+    }
+
+    public Instant getExpiryInstant()
+    {
+        return expiryInstant;
+    }
+
+    @JsonProperty
+    public Double getConfidencePercentage()
+    {
+        return confidencePercentage;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(expiryInstant, confidencePercentage);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        ConfidenceBasedTtlInfo other = (ConfidenceBasedTtlInfo) obj;
+        return expiryInstant.equals(other.getExpiryInstant()) &&
+                confidencePercentage.equals(other.getConfidencePercentage());
+    }
+
+    public String toString()
+    {
+        return "expiryEpochTimeUTC=" + expiryInstant + ", confidencePercentage=" + confidencePercentage;
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/ttl/NodeInfo.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ttl/NodeInfo.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.ttl;
+
+import java.util.Objects;
+
+public class NodeInfo
+{
+    private final String nodeIdentifier;
+    private final String host;
+
+    public NodeInfo(String nodeIdentifier, String host)
+    {
+        this.nodeIdentifier = nodeIdentifier;
+        this.host = host;
+    }
+
+    public String getHost()
+    {
+        return host;
+    }
+
+    public String getNodeIdentifier()
+    {
+        return nodeIdentifier;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(nodeIdentifier, host);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        NodeInfo other = (NodeInfo) obj;
+        return this.getNodeIdentifier().equals(other.getNodeIdentifier()) && this.getHost().equals(other.getHost());
+    }
+
+    public String toString()
+    {
+        return "nodeIdentifier=" + nodeIdentifier + ", host=" + host;
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/ttl/NodeTtl.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ttl/NodeTtl.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.ttl;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
+
+public class NodeTtl
+{
+    private final Set<ConfidenceBasedTtlInfo> ttls;
+    private final Instant ttlPredictionInstant;
+
+    public NodeTtl(Set<ConfidenceBasedTtlInfo> ttls)
+    {
+        this(ttls, Instant.now());
+    }
+
+    public NodeTtl(Set<ConfidenceBasedTtlInfo> ttls, Instant ttlPredictionEpochTime)
+    {
+        this.ttls = requireNonNull(ttls, "ttls is null");
+        this.ttlPredictionInstant = requireNonNull(ttlPredictionEpochTime, "ttlPredictionEpochTime is null");
+    }
+
+    public Set<ConfidenceBasedTtlInfo> getTtlInfo()
+    {
+        return ttls;
+    }
+
+    public Instant getTtlPredictionInstant()
+    {
+        return ttlPredictionInstant;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(ttls);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        NodeTtl other = (NodeTtl) obj;
+        return this.getTtlInfo().equals(other.getTtlInfo());
+    }
+
+    public String toString()
+    {
+        return ttls.toString();
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/ttl/NodeTtlFetcher.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ttl/NodeTtlFetcher.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.ttl;
+
+import io.airlift.units.Duration;
+
+import java.util.Map;
+import java.util.Set;
+
+public interface NodeTtlFetcher
+{
+    Map<NodeInfo, NodeTtl> getTtlInfo(Set<NodeInfo> nodes);
+
+    default Duration getRefreshInterval()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    boolean needsPeriodicRefresh();
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/ttl/NodeTtlFetcherFactory.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ttl/NodeTtlFetcherFactory.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.ttl;
+
+import java.util.Map;
+
+public interface NodeTtlFetcherFactory
+{
+    String getName();
+
+    NodeTtlFetcher create(Map<String, String> config);
+}

--- a/presto-spi/src/test/java/com/facebook/presto/spi/ttl/TestingClusterTtlProvider.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/ttl/TestingClusterTtlProvider.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.ttl;
+
+import java.util.List;
+
+public class TestingClusterTtlProvider
+        implements ClusterTtlProvider
+{
+    @Override
+    public ConfidenceBasedTtlInfo getClusterTtl(List<NodeTtl> nodeTtls)
+    {
+        long expiryEpochSum = nodeTtls.stream()
+                .map(nodeTtl -> nodeTtl.getTtlInfo()
+                        .stream()
+                        .mapToLong(ConfidenceBasedTtlInfo::getExpiryEpochSecond)
+                        .sum())
+                .mapToLong(Long::longValue)
+                .sum();
+
+        return new ConfidenceBasedTtlInfo(expiryEpochSum, 100);
+    }
+}

--- a/presto-spi/src/test/java/com/facebook/presto/spi/ttl/TestingClusterTtlProviderFactory.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/ttl/TestingClusterTtlProviderFactory.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.ttl;
+
+import java.util.Map;
+
+public class TestingClusterTtlProviderFactory
+        implements ClusterTtlProviderFactory
+{
+    @Override
+    public String getName()
+    {
+        return "testing-cluster-ttl-provider";
+    }
+
+    @Override
+    public ClusterTtlProvider create(Map<String, String> config)
+    {
+        return new TestingClusterTtlProvider();
+    }
+}

--- a/presto-spi/src/test/java/com/facebook/presto/spi/ttl/TestingNodeTtlFetcher.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/ttl/TestingNodeTtlFetcher.java
@@ -35,7 +35,7 @@ public class TestingNodeTtlFetcher
     @Override
     public Map<NodeInfo, NodeTtl> getTtlInfo(Set<NodeInfo> nodes)
     {
-        return nodes.stream().collect(toImmutableMap(Function.identity(), ttlInfo::get));
+        return nodes.stream().filter(ttlInfo::containsKey).collect(toImmutableMap(Function.identity(), ttlInfo::get));
     }
 
     @Override

--- a/presto-spi/src/test/java/com/facebook/presto/spi/ttl/TestingNodeTtlFetcher.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/ttl/TestingNodeTtlFetcher.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.ttl;
+
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
+import static java.util.Objects.requireNonNull;
+
+public class TestingNodeTtlFetcher
+        implements NodeTtlFetcher
+{
+    private final Map<NodeInfo, NodeTtl> ttlInfo;
+
+    public TestingNodeTtlFetcher(Map<NodeInfo, NodeTtl> ttlInfo)
+    {
+        this.ttlInfo = ImmutableMap.copyOf(requireNonNull(ttlInfo, "ttlInfo is null"));
+    }
+
+    @Override
+    public Map<NodeInfo, NodeTtl> getTtlInfo(Set<NodeInfo> nodes)
+    {
+        return nodes.stream().collect(toImmutableMap(Function.identity(), ttlInfo::get));
+    }
+
+    @Override
+    public boolean needsPeriodicRefresh()
+    {
+        return false;
+    }
+}

--- a/presto-spi/src/test/java/com/facebook/presto/spi/ttl/TestingNodeTtlFetcherFactory.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/ttl/TestingNodeTtlFetcherFactory.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.ttl;
+
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+public class TestingNodeTtlFetcherFactory
+        implements NodeTtlFetcherFactory
+{
+    private final Map<NodeInfo, NodeTtl> ttlInfo;
+
+    public TestingNodeTtlFetcherFactory(Map<NodeInfo, NodeTtl> ttlInfo)
+    {
+        this.ttlInfo = requireNonNull(ttlInfo, "ttlInfo is null");
+    }
+
+    @Override
+    public String getName()
+    {
+        return "testing-node-ttl-fetcher";
+    }
+
+    @Override
+    public NodeTtlFetcher create(Map<String, String> config)
+    {
+        return new TestingNodeTtlFetcher(ttlInfo);
+    }
+}


### PR DESCRIPTION
At a high level, this PR aims to introduce some simple intelligence into the node scheduling logic to support elastic workers in a Presto cluster. Elastic workers are those which will be removed from the Presto cluster at a predefined time in the future, i.e, these workers have a time-to-live (TTL). The `SimpleTTLNodeSelector` aims to pick workers for query execution based on their TTL estimates and the query execution time estimates.

In the first commit ("TTL fetchers and Cluster TTL providers"), two new plugins are added:

1. `presto-node-ttl-fetchers`: This plugin has node TTL fetchers, i.e, its responsible for fetching the TTLs of a given set of nodes. To install a custom `NodeTtlFetcher` implementation, a factory instance of `NodeTtlFetcherFactory` should be provided and this is loaded by the coordinator as a `Plugin`. The coordinator loads the appropriate factory by reading the `node-ttl-fetcher.factory` property in the configuration file `etc/node-ttl-fetcher.properties`. By default, the `InfinteNodeTtlFetcher` is loaded which returns the TTL for a worker as "infinite".
2. `presto-cluster-ttl-providers`: This plugin has cluster TTL providers, i.e, its responsible for providing the TTL at a Presto cluster-level at the `v1/cluster/ttl` endpoint. This information can be used by a load balancer sitting in front of the clusters to make routing decisions. To install a custom `ClusterTtlProvider` implementation, a factory instance of `ClusterTtlProviderFactory` should be provided and this is loaded by the coordinator as a `Plugin`. The coordinator loads the appropriate factory by reading the `cluster-ttl-provider.factory` property in the configuration file `etc/cluster-ttl-provider.properties`. By default, the `InfiniteClusterTtlProvider` is loaded which returns the TTL for a cluster as "infinite".

The implementations of these plugins are loaded by the `NodeTtlFetcherManager` and `ClusterTtlProviderManager` interfaces respectively, which expose the node-level and cluster-level TTLs for any prospective consumer. The default implementations of these interfaces are "throwing", i.e, they just throw exceptions when called. **Even if no custom implementations are provided for all these interfaces, existing Presto functionality will be unaffected.**
   
In the second commit ("TTL based scheduling"), the TTL information exposed via the `NodeTtlFetcherManager` implementation, `ConfidenceBasedNodeTtlFetcherManager`, is used to schedule a query on the workers in a Presto cluster. This feature can be enabled by setting either the `resource_aware_scheduling_strategy` session property or the `experimental.resource-aware-scheduling-strategy` configuration property to `TTL`. **Note that to use this feature, the `node-ttl-fetcher-manager.type` configuration must be set to `CONFIDENCE` in the `etc/config.properties` file and custom `NodeTtlFetcherFactory` implementations may also be provided.**


```
== RELEASE NOTES ==

General Changes
* Add support for simple TTL based scheduling where the scheduler picks workers for query execution based on their availability estimates and query execution time estimates. This can be enabled by setting either the ``resource_aware_scheduling_strategy`` session property or the ``experimental.resource-aware-scheduling-strategy`` configuration property to ``TTL``. See :pr:`16409`.

SPI Changes
* Add support for custom Node TTL fetchers and Cluster TTL providers through the ``NodeTtlFetcher`` and ``ClusterTtlProvider`` interfaces respectively. See :pr:`16409`. 
```
