### PR TITLE
Add task-level RuntimeStats

### DIFF
--- a/presto-cli/src/main/java/com/facebook/presto/cli/FormatUtils.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/FormatUtils.java
@@ -26,6 +26,7 @@ import static io.airlift.units.DataSize.Unit.BYTE;
 import static java.lang.Math.max;
 import static java.lang.Math.min;
 import static java.lang.String.format;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 public final class FormatUtils
@@ -160,6 +161,9 @@ public final class FormatUtils
     public static String formatTime(Duration duration)
     {
         int totalSeconds = Ints.saturatedCast(duration.roundTo(SECONDS));
+        if (totalSeconds == 0) {
+            return format("%sms", Ints.saturatedCast(duration.roundTo(MILLISECONDS)));
+        }
         int minutes = totalSeconds / 60;
         int seconds = totalSeconds % 60;
 

--- a/presto-cli/src/main/java/com/facebook/presto/cli/StatusPrinter.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/StatusPrinter.java
@@ -18,12 +18,14 @@ import com.facebook.presto.client.QueryStatusInfo;
 import com.facebook.presto.client.StageStats;
 import com.facebook.presto.client.StatementClient;
 import com.facebook.presto.client.StatementStats;
+import com.facebook.presto.common.RuntimeMetric;
 import com.google.common.base.Strings;
 import com.google.common.primitives.Ints;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
 
 import java.io.PrintStream;
+import java.util.Comparator;
 import java.util.List;
 import java.util.OptionalInt;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -148,6 +150,16 @@ Spilled: 20GB
         printQueryInfo(client.currentStatusInfo(), warningsPrinter);
     }
 
+    private String autoFormatMetricValue(String name, long value)
+    {
+        // TODO: The current implementation of detecting metric type is hacky. An better solution is to add an enum to RuntimeMetric to track its type. But since there are no
+        // other use cases, it is too heavy to implement. We can revisit this when there are new use cases.
+        if (name.contains("Nanos")) {
+            return formatTime(Duration.succinctNanos(value));
+        }
+        return formatCount(value);
+    }
+
     public void printFinalInfo()
     {
         Duration wallTime = nanosSince(start);
@@ -218,9 +230,13 @@ Spilled: 20GB
 
             // bytesFromCache: sum=2K count=2 min=1K max=1K
             if (stats.getRuntimeStats() != null) {
-                stats.getRuntimeStats().getMetrics().values().forEach(
-                        metric -> reprintLine(
-                                metric.getName() + ": sum=" + formatCount(metric.getSum()) + " count=" + formatCount(metric.getCount()) + " min=" + formatCount(metric.getMin()) + " max=" + formatCount(metric.getMax())));
+                stats.getRuntimeStats().getMetrics().values().stream().sorted(Comparator.comparing(RuntimeMetric::getName)).forEach(
+                        metric -> reprintLine(format("%s: sum=%s count=%s min=%s max=%s",
+                                metric.getName(),
+                                autoFormatMetricValue(metric.getName(), metric.getSum()),
+                                formatCount(metric.getCount()),
+                                autoFormatMetricValue(metric.getName(), metric.getMin()),
+                                autoFormatMetricValue(metric.getName(), metric.getMax()))));
             }
         }
 
@@ -324,9 +340,13 @@ Spilled: 20GB
                 }
 
                 if (stats.getRuntimeStats() != null) {
-                    stats.getRuntimeStats().getMetrics().values().forEach(
-                            metric -> reprintLine(
-                                    metric.getName() + ": sum=" + metric.getSum() + " count=" + metric.getCount() + " min=" + metric.getMin() + " max=" + metric.getMax()));
+                    stats.getRuntimeStats().getMetrics().values().stream().sorted(Comparator.comparing(RuntimeMetric::getName)).forEach(
+                            metric -> reprintLine(format("%s: sum=%s count=%s min=%s max=%s",
+                                    metric.getName(),
+                                    autoFormatMetricValue(metric.getName(), metric.getSum()),
+                                    formatCount(metric.getCount()),
+                                    autoFormatMetricValue(metric.getName(), metric.getMin()),
+                                    autoFormatMetricValue(metric.getName(), metric.getMax()))));
                 }
             }
 

--- a/presto-cli/src/test/java/com/facebook/presto/cli/TestFormatUtils.java
+++ b/presto-cli/src/test/java/com/facebook/presto/cli/TestFormatUtils.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.cli;
+
+import io.airlift.units.Duration;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestFormatUtils
+{
+    @Test
+    public void testFormatTime()
+    {
+        assertEquals(FormatUtils.formatTime(Duration.succinctNanos(100L)), "0ms");
+        assertEquals(FormatUtils.formatTime(Duration.succinctDuration(1.1, TimeUnit.MILLISECONDS)), "1ms");
+        assertEquals(FormatUtils.formatTime(Duration.succinctDuration(1.1, TimeUnit.SECONDS)), "0:01");
+        assertEquals(FormatUtils.formatTime(Duration.succinctDuration(1.5, TimeUnit.MINUTES)), "1:30");
+        assertEquals(FormatUtils.formatTime(Duration.succinctDuration(1.5, TimeUnit.HOURS)), "90:00");
+    }
+}

--- a/presto-common/src/main/java/com/facebook/presto/common/RuntimeMetric.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/RuntimeMetric.java
@@ -29,6 +29,11 @@ public class RuntimeMetric
     private long max = Long.MIN_VALUE;
     private long min = Long.MAX_VALUE;
 
+    /**
+     * Creates a new empty RuntimeMetric.
+     *
+     * @param name Name of this metric. If used in the presto core code base, this should be a value defined in {@link RuntimeMetricName}. But connectors could use arbitrary names.
+     */
     public RuntimeMetric(String name)
     {
         this.name = name;

--- a/presto-common/src/main/java/com/facebook/presto/common/RuntimeMetricName.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/RuntimeMetricName.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.common;
+
+/**
+ * Names for RuntimeMetrics used in the core presto code base.
+ * Connectors could use arbitrary metric names not included in this class.
+ */
+public class RuntimeMetricName
+{
+    private RuntimeMetricName()
+    {
+    }
+
+    public static final String DRIVER_COUNT_PER_TASK = "driverCountPerTask";
+    public static final String TASK_ELAPSED_TIME_NANOS = "taskElapsedTimeNanos";
+}

--- a/presto-main/src/main/java/com/facebook/presto/event/QueryMonitor.java
+++ b/presto-main/src/main/java/com/facebook/presto/event/QueryMonitor.java
@@ -20,6 +20,7 @@ import com.facebook.airlift.stats.Distribution;
 import com.facebook.airlift.stats.Distribution.DistributionSnapshot;
 import com.facebook.presto.SessionRepresentation;
 import com.facebook.presto.client.NodeVersion;
+import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.eventlistener.EventListenerManager;
 import com.facebook.presto.execution.Column;
 import com.facebook.presto.execution.ExecutionFailureInfo;
@@ -179,7 +180,8 @@ public class QueryMonitor
                         0,
                         0,
                         0,
-                        true),
+                        true,
+                        new RuntimeStats()),
                 createQueryContext(queryInfo.getSession(), queryInfo.getResourceGroupId()),
                 new QueryIOMetadata(ImmutableList.of(), Optional.empty()),
                 createQueryFailureInfo(failure, Optional.empty()),
@@ -318,7 +320,8 @@ public class QueryMonitor
                 queryStats.getCumulativeUserMemory(),
                 queryStats.getCumulativeTotalMemory(),
                 queryStats.getCompletedDrivers(),
-                queryInfo.isCompleteInfo());
+                queryInfo.isCompleteInfo(),
+                queryStats.getRuntimeStats());
     }
 
     private QueryContext createQueryContext(SessionRepresentation session, Optional<ResourceGroupId> resourceGroup)

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
@@ -1014,7 +1014,8 @@ public class QueryStateMachine
                 queryStats.getWrittenOutputPhysicalDataSize(),
                 queryStats.getWrittenIntermediatePhysicalDataSize(),
                 queryStats.getStageGcStatistics(),
-                ImmutableList.of()); // Remove the operator summaries as OperatorInfo (especially ExchangeClientStatus) can hold onto a large amount of memory
+                ImmutableList.of(), // Remove the operator summaries as OperatorInfo (especially ExchangeClientStatus) can hold onto a large amount of memory
+                queryStats.getRuntimeStats());
     }
 
     public static class QueryOutputManager

--- a/presto-main/src/main/java/com/facebook/presto/operator/TaskStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TaskStats.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.operator;
 
+import com.facebook.presto.common.RuntimeStats;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
@@ -81,6 +82,9 @@ public class TaskStats
 
     private final List<PipelineStats> pipelines;
 
+    // RuntimeStats aggregated at the task level including the metrics exposed in this task and each operator of this task.
+    private final RuntimeStats runtimeStats;
+
     public TaskStats(DateTime createTime, DateTime endTime)
     {
         this(
@@ -121,7 +125,8 @@ public class TaskStats
                 0L,
                 0,
                 0L,
-                ImmutableList.of());
+                ImmutableList.of(),
+                new RuntimeStats());
     }
 
     @JsonCreator
@@ -174,7 +179,8 @@ public class TaskStats
             @JsonProperty("fullGcCount") int fullGcCount,
             @JsonProperty("fullGcTimeInMillis") long fullGcTimeInMillis,
 
-            @JsonProperty("pipelines") List<PipelineStats> pipelines)
+            @JsonProperty("pipelines") List<PipelineStats> pipelines,
+            @JsonProperty("runtimeStats") RuntimeStats runtimeStats)
     {
         this.createTime = requireNonNull(createTime, "createTime is null");
         this.firstStartTime = firstStartTime;
@@ -239,6 +245,7 @@ public class TaskStats
         this.fullGcTimeInMillis = fullGcTimeInMillis;
 
         this.pipelines = ImmutableList.copyOf(requireNonNull(pipelines, "pipelines is null"));
+        this.runtimeStats = requireNonNull(runtimeStats, "runtimeStats is null");
     }
 
     @JsonProperty
@@ -473,6 +480,12 @@ public class TaskStats
         return fullGcTimeInMillis;
     }
 
+    @JsonProperty
+    public RuntimeStats getRuntimeStats()
+    {
+        return runtimeStats;
+    }
+
     public TaskStats summarize()
     {
         return new TaskStats(
@@ -513,7 +526,8 @@ public class TaskStats
                 physicalWrittenDataSizeInBytes,
                 fullGcCount,
                 fullGcTimeInMillis,
-                ImmutableList.of());
+                ImmutableList.of(),
+                runtimeStats);
     }
 
     public TaskStats summarizeFinal()
@@ -558,6 +572,7 @@ public class TaskStats
                 fullGcTimeInMillis,
                 pipelines.stream()
                         .map(PipelineStats::summarize)
-                        .collect(Collectors.toList()));
+                        .collect(Collectors.toList()),
+                runtimeStats);
     }
 }

--- a/presto-main/src/main/resources/webapp/src/components/QueryDetail.jsx
+++ b/presto-main/src/main/resources/webapp/src/components/QueryDetail.jsx
@@ -1046,6 +1046,11 @@ export class QueryDetail extends React.Component {
         }
     }
 
+    renderMetricValue(name, value) {
+      if (name.includes("Nanos")) return formatDuration(parseDuration(value+ "ns"));
+      return formatCount(value);
+    }
+
     renderRuntimeStats() {
         const query = this.state.query;
         if (Object.values(query.queryStats.runtimeStats).length == 0) return null;
@@ -1060,18 +1065,23 @@ export class QueryDetail extends React.Component {
                              <th className="info-text">Metric Name</th>
                              <th className="info-text">Sum</th>
                              <th className="info-text">Count</th>
-                             <th className="info-text">Max</th>
                              <th className="info-text">Min</th>
+                             <th className="info-text">Max</th>
                          </tr>
-                         {Object.values(query.queryStats.runtimeStats).map((metric) =>
-                             <tr>
-                                 <td className="info-text">{metric.name}</td>
-                                 <td className="info-text">{formatCount(metric.sum)}</td>
-                                 <td className="info-text">{formatCount(metric.count)}</td>
-                                 <td className="info-text">{formatCount(metric.max)}</td>
-                                 <td className="info-text">{formatCount(metric.min)}</td>
-                             </tr>
-                         )}
+                         {
+                           Object
+                             .values(query.queryStats.runtimeStats)
+                             .sort((m1, m2) => (m1.name.localeCompare(m2.name)))
+                             .map((metric) =>
+                                 <tr>
+                                     <td className="info-text">{metric.name}</td>
+                                     <td className="info-text">{this.renderMetricValue(metric.name, metric.sum)}</td>
+                                     <td className="info-text">{formatCount(metric.count)}</td>
+                                     <td className="info-text">{this.renderMetricValue(metric.name, metric.min)}</td>
+                                     <td className="info-text">{this.renderMetricValue(metric.name, metric.max)}</td>
+                                 </tr>
+                             )
+                         }
                          </tbody>
                      </table>
                 </div>

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestQueryStats.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestQueryStats.java
@@ -240,7 +240,8 @@ public class TestQueryStats
                     106,
                     107)),
 
-            OPERATOR_SUMMARIES);
+            OPERATOR_SUMMARIES,
+            new RuntimeStats(ImmutableMap.of(TEST_METRIC_NAME, RuntimeMetric.merge(TEST_RUNTIME_METRIC_1, TEST_RUNTIME_METRIC_2))));
 
     @Test
     public void testJson()

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestStageExecutionStats.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestStageExecutionStats.java
@@ -16,6 +16,7 @@ package com.facebook.presto.execution;
 import com.facebook.airlift.json.JsonCodec;
 import com.facebook.airlift.stats.Distribution;
 import com.facebook.airlift.stats.Distribution.DistributionSnapshot;
+import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.spi.eventlistener.StageGcStatistics;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -86,7 +87,8 @@ public class TestStageExecutionStats
                     106,
                     107),
 
-            ImmutableList.of());
+            ImmutableList.of(),
+            new RuntimeStats());
 
     @Test
     public void testJson()

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestTaskStats.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestTaskStats.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.operator;
 
 import com.facebook.airlift.json.JsonCodec;
+import com.facebook.presto.common.RuntimeStats;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import org.joda.time.DateTime;
@@ -72,7 +73,8 @@ public class TestTaskStats
             26,
             27,
 
-            ImmutableList.of(TestPipelineStats.EXPECTED));
+            ImmutableList.of(TestPipelineStats.EXPECTED),
+            new RuntimeStats());
 
     @Test
     public void testJson()

--- a/presto-main/src/test/java/com/facebook/presto/server/TestBasicQueryInfo.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestBasicQueryInfo.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.server;
 
+import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.execution.QueryInfo;
 import com.facebook.presto.execution.QueryStats;
 import com.facebook.presto.operator.BlockedReason;
@@ -113,7 +114,8 @@ public class TestBasicQueryInfo
                                         105,
                                         106,
                                         107)),
-                                ImmutableList.of()),
+                                ImmutableList.of(),
+                                new RuntimeStats()),
                         Optional.empty(),
                         Optional.empty(),
                         ImmutableMap.of(),

--- a/presto-main/src/test/java/com/facebook/presto/server/TestQueryStateInfo.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestQueryStateInfo.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.server;
 
+import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.execution.QueryInfo;
 import com.facebook.presto.execution.QueryState;
 import com.facebook.presto.execution.QueryStats;
@@ -155,7 +156,8 @@ public class TestQueryStateInfo
                         DataSize.valueOf("35GB"),
                         DataSize.valueOf("36GB"),
                         ImmutableList.of(),
-                        ImmutableList.of()),
+                        ImmutableList.of(),
+                        new RuntimeStats()),
                 Optional.empty(),
                 Optional.empty(),
                 ImmutableMap.of(),

--- a/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/QueryStatistics.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/QueryStatistics.java
@@ -13,6 +13,8 @@
  */
 package com.facebook.presto.spi.eventlistener;
 
+import com.facebook.presto.common.RuntimeStats;
+
 import java.time.Duration;
 import java.util.Optional;
 
@@ -54,6 +56,7 @@ public class QueryStatistics
 
     private final int completedSplits;
     private final boolean complete;
+    private final RuntimeStats runtimeStats;
 
     public QueryStatistics(
             Duration cpuTime,
@@ -85,7 +88,8 @@ public class QueryStatistics
             double cumulativeMemory,
             double cumulativeTotalMemory,
             int completedSplits,
-            boolean complete)
+            boolean complete,
+            RuntimeStats runtimeStats)
     {
         this.cpuTime = requireNonNull(cpuTime, "cpuTime is null");
         this.retriedCpuTime = requireNonNull(retriedCpuTime, "retriedCpuTime is null");
@@ -117,6 +121,7 @@ public class QueryStatistics
         this.cumulativeTotalMemory = cumulativeTotalMemory;
         this.completedSplits = completedSplits;
         this.complete = complete;
+        this.runtimeStats = requireNonNull(runtimeStats, "runtimeStats is null");
     }
 
     public Duration getCpuTime()
@@ -267,5 +272,10 @@ public class QueryStatistics
     public boolean isComplete()
     {
         return complete;
+    }
+
+    public RuntimeStats getRuntimeStats()
+    {
+        return runtimeStats;
     }
 }


### PR DESCRIPTION
Add task-level RuntimeStats to track the metrics which are exposed in
Operators.

Add two task-level metrics splitCountPerTask and taskElapsedTimeNanos.

Change the metric aggregation to not aggregate metrics across stages as
it doesn't make sense to aggregate metrics of different plan fragments.

Test plan - (Please fill in how you tested your changes)

Tested it by starting a locally presto server. See the attached screenshot.
<img width="614" alt="Screen Shot 2021-07-09 at 11 45 10 AM" src="https://user-images.githubusercontent.com/67174152/125133467-c5ae3780-e0ba-11eb-94df-ce9a1df0e8a9.png">
<img width="510" alt="Screen Shot 2021-07-09 at 11 44 24 AM" src="https://user-images.githubusercontent.com/67174152/125133479-c9da5500-e0ba-11eb-8b5b-aad73def5b4f.png">


```
== NO RELEASE NOTE ==
```
