### PR TITLE
Implement getSystemMemoryUsage in GenericHiveRecordCursor

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/GenericHiveRecordCursor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/GenericHiveRecordCursor.java
@@ -565,6 +565,12 @@ class GenericHiveRecordCursor<K, V extends Writable>
     }
 
     @Override
+    public long getSystemMemoryUsage()
+    {
+        return totalBytes;
+    }
+
+    @Override
     public void close()
     {
         // some hive input formats are broken and bad things can happen if you close them multiple times


### PR DESCRIPTION
In our cluster, most of the input source comes from hadoop. If GenericHiveRecordCursor implements getSystemMemoryUsage, query memory reservation will be more accurate
