### PR TITLE
Supports pushing down part of the filters when all filters cannot be pushed down

### DIFF
--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/optimization/JdbcComputePushdown.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/optimization/JdbcComputePushdown.java
@@ -28,17 +28,24 @@ import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.spi.plan.PlanVisitor;
 import com.facebook.presto.spi.plan.TableScanNode;
+import com.facebook.presto.spi.relation.ConstantExpression;
 import com.facebook.presto.spi.relation.DeterminismEvaluator;
 import com.facebook.presto.spi.relation.ExpressionOptimizer;
 import com.facebook.presto.spi.relation.RowExpression;
+import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
 import static com.facebook.presto.expressions.translator.FunctionTranslator.buildFunctionTranslator;
 import static com.facebook.presto.expressions.translator.RowExpressionTreeTranslator.translateWith;
+import static com.facebook.presto.plugin.jdbc.optimization.function.JdbcTranslationUtil.mergeSqlBodies;
+import static com.facebook.presto.plugin.jdbc.optimization.function.JdbcTranslationUtil.mergeVariableBindings;
 import static com.facebook.presto.spi.relation.ExpressionOptimizer.Level.OPTIMIZED;
+import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public class JdbcComputePushdown
@@ -123,7 +130,9 @@ public class JdbcComputePushdown
 
             TableScanNode oldTableScanNode = (TableScanNode) node.getSource();
             TableHandle oldTableHandle = oldTableScanNode.getTable();
-            JdbcTableHandle oldConnectorTable = (JdbcTableHandle) oldTableHandle.getConnectorHandle();
+            if (!oldTableHandle.getLayout().isPresent()) {
+                return node;
+            }
 
             RowExpression predicate = expressionOptimizer.optimize(node.getPredicate(), OPTIMIZED, session);
             predicate = logicalRowExpressions.convertToConjunctiveNormalForm(predicate);
@@ -132,16 +141,56 @@ public class JdbcComputePushdown
                     jdbcFilterToSqlTranslator,
                     oldTableScanNode.getAssignments());
 
-            // TODO if jdbcExpression is not present, walk through translated subtree to find out which parts can be pushed down
-            if (!oldTableHandle.getLayout().isPresent() || !jdbcExpression.getTranslated().isPresent()) {
+            Optional<JdbcExpression> translated = jdbcExpression.getTranslated();
+            JdbcTableHandle oldConnectorTable = (JdbcTableHandle) oldTableHandle.getConnectorHandle();
+            // All filter can be pushed down
+            if (translated.isPresent()) {
+                return createNewTableScanNode(oldTableScanNode, oldTableHandle, oldConnectorTable, translated);
+            }
+
+            // Find out which parts can be pushed down
+            List<RowExpression> remainingExpressions = new ArrayList<>();
+            List<JdbcExpression> translatedExpressions = new ArrayList<>();
+
+            List<RowExpression> rowExpressions = LogicalRowExpressions.extractConjuncts(predicate);
+            for (RowExpression expression : rowExpressions) {
+                TranslatedExpression<JdbcExpression> translatedExpression = translateWith(
+                        expression,
+                        jdbcFilterToSqlTranslator,
+                        oldTableScanNode.getAssignments());
+
+                if (!translatedExpression.getTranslated().isPresent()) {
+                    remainingExpressions.add(expression);
+                }
+                else {
+                    translatedExpressions.add(translatedExpression.getTranslated().get());
+                }
+            }
+
+            // no filter can be pushed down
+            if (!remainingExpressions.isEmpty() && translatedExpressions.isEmpty()) {
                 return node;
             }
 
+            List<String> sqlBodies = mergeSqlBodies(translatedExpressions);
+            List<ConstantExpression> variableBindings = mergeVariableBindings(translatedExpressions);
+            translated = Optional.of(new JdbcExpression(format("%s", Joiner.on(" AND ").join(sqlBodies)), variableBindings));
+            TableScanNode newTableScanNode = createNewTableScanNode(oldTableScanNode, oldTableHandle, oldConnectorTable, translated);
+
+            return new FilterNode(idAllocator.getNextId(), newTableScanNode, logicalRowExpressions.combineConjuncts(remainingExpressions));
+        }
+
+        private TableScanNode createNewTableScanNode(
+                TableScanNode oldTableScanNode,
+                TableHandle oldTableHandle,
+                JdbcTableHandle oldConnectorTable,
+                Optional<JdbcExpression> additionalPredicate)
+        {
             JdbcTableLayoutHandle oldTableLayoutHandle = (JdbcTableLayoutHandle) oldTableHandle.getLayout().get();
             JdbcTableLayoutHandle newTableLayoutHandle = new JdbcTableLayoutHandle(
                     oldConnectorTable,
                     oldTableLayoutHandle.getTupleDomain(),
-                    jdbcExpression.getTranslated());
+                    additionalPredicate);
 
             TableHandle tableHandle = new TableHandle(
                     oldTableHandle.getConnectorId(),
@@ -149,15 +198,13 @@ public class JdbcComputePushdown
                     oldTableHandle.getTransaction(),
                     Optional.of(newTableLayoutHandle));
 
-            TableScanNode newTableScanNode = new TableScanNode(
+            return new TableScanNode(
                     idAllocator.getNextId(),
                     tableHandle,
                     oldTableScanNode.getOutputVariables(),
                     oldTableScanNode.getAssignments(),
                     oldTableScanNode.getCurrentConstraint(),
                     oldTableScanNode.getEnforcedConstraint());
-
-            return new FilterNode(idAllocator.getNextId(), newTableScanNode, node.getPredicate());
         }
     }
 }

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/optimization/JdbcFilterToSqlTranslator.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/optimization/JdbcFilterToSqlTranslator.java
@@ -49,6 +49,8 @@ import java.util.Map;
 import java.util.Optional;
 
 import static com.facebook.presto.expressions.translator.TranslatedExpression.untranslated;
+import static com.facebook.presto.plugin.jdbc.optimization.function.JdbcTranslationUtil.mergeSqlBodies;
+import static com.facebook.presto.plugin.jdbc.optimization.function.JdbcTranslationUtil.mergeVariableBindings;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -131,14 +133,8 @@ public class JdbcFilterToSqlTranslator
             return untranslated(specialForm, translatedExpressions);
         }
 
-        List<String> sqlBodies = jdbcExpressions.stream()
-                .map(JdbcExpression::getExpression)
-                .map(sql -> '(' + sql + ')')
-                .collect(toImmutableList());
-        List<ConstantExpression> variableBindings = jdbcExpressions.stream()
-                .map(JdbcExpression::getBoundConstantValues)
-                .flatMap(List::stream)
-                .collect(toImmutableList());
+        List<String> sqlBodies = mergeSqlBodies(jdbcExpressions);
+        List<ConstantExpression> variableBindings = mergeVariableBindings(jdbcExpressions);
 
         switch (specialForm.getForm()) {
             case AND:

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/optimization/function/JdbcTranslationUtil.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/optimization/function/JdbcTranslationUtil.java
@@ -38,4 +38,20 @@ public class JdbcTranslationUtil
                 .flatMap(List::stream)
                 .collect(toImmutableList());
     }
+
+    public static List<String> mergeSqlBodies(List<JdbcExpression> jdbcExpressions)
+    {
+        return jdbcExpressions.stream()
+                .map(JdbcExpression::getExpression)
+                .map(sql -> '(' + sql + ')')
+                .collect(toImmutableList());
+    }
+
+    public static List<ConstantExpression> mergeVariableBindings(List<JdbcExpression> jdbcExpressions)
+    {
+        return jdbcExpressions.stream()
+                .map(JdbcExpression::getBoundConstantValues)
+                .flatMap(List::stream)
+                .collect(toImmutableList());
+    }
 }


### PR DESCRIPTION
The corresponding issue is [#16408](https://github.com/prestodb/presto/issues/16408)
```
== RELEASE NOTES ==

JDBC Changes
* Support partial pushdown of JDBC filters.

