### PR TITLE
Optimize getSingleValueBlock in Map and Array

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/block/AbstractArrayBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/AbstractArrayBlock.java
@@ -209,8 +209,7 @@ public abstract class AbstractArrayBlock
         }
     }
 
-    @Override
-    public Block getSingleValueBlock(int position)
+    protected Block getSingleValueBlockInternal(int position)
     {
         checkReadablePosition(position);
 

--- a/presto-common/src/main/java/com/facebook/presto/common/block/AbstractMapBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/AbstractMapBlock.java
@@ -319,8 +319,7 @@ public abstract class AbstractMapBlock
         }
     }
 
-    @Override
-    public Block getSingleValueBlock(int position)
+    protected Block getSingleValueBlockInternal(int position)
     {
         checkReadablePosition(position);
 

--- a/presto-common/src/main/java/com/facebook/presto/common/block/ArrayBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/ArrayBlock.java
@@ -208,4 +208,19 @@ public class ArrayBlock
                 offsets,
                 loadedValuesBlock);
     }
+
+    private boolean isSinglePositionBlock(int position)
+    {
+        return position == 0 && positionCount == 1 && offsets.length == 2;
+    }
+
+    @Override
+    public Block getSingleValueBlock(int position)
+    {
+        if (isSinglePositionBlock(position)) {
+            return this;
+        }
+
+        return getSingleValueBlockInternal(position);
+    }
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/block/ArrayBlockBuilder.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/ArrayBlockBuilder.java
@@ -38,9 +38,9 @@ public class ArrayBlockBuilder
     private int positionCount;
 
     @Nullable
-    private BlockBuilderStatus blockBuilderStatus;
+    private final BlockBuilderStatus blockBuilderStatus;
+    private final int initialEntryCount;
     private boolean initialized;
-    private int initialEntryCount;
 
     private int[] offsets = new int[1];
     private boolean[] valueIsNull = new boolean[0];
@@ -160,6 +160,12 @@ public class ArrayBlockBuilder
 
         closeEntry();
         return this;
+    }
+
+    @Override
+    public Block getSingleValueBlock(int position)
+    {
+        return getSingleValueBlockInternal(position);
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/block/Block.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/Block.java
@@ -163,8 +163,8 @@ public interface Block
     }
 
     /**
-     * Gets the value at the specified position as a single element block.  The method
-     * must copy the data into a new block.
+     * Gets the value at the specified position as a single element block. The
+     * returned block should retain only the memory required for a single block.
      * <p>
      * This method is useful for operators that hold on to a single value without
      * holding on to the entire block.

--- a/presto-common/src/main/java/com/facebook/presto/common/block/MapBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/MapBlock.java
@@ -50,7 +50,6 @@ public class MapBlock
     /**
      * Create a map block directly from columnar nulls, keys, values, and offsets into the keys and values.
      * A null map must have no entries.
-     *
      */
     public static MapBlock fromKeyValueBlock(
             int positionCount,
@@ -75,7 +74,6 @@ public class MapBlock
      * Create a map block directly without per element validations.
      * <p>
      * Internal use by this package and com.facebook.presto.spi.Type only.
-     *
      */
     public static MapBlock createMapBlockInternal(
             int startOffset,
@@ -219,6 +217,21 @@ public class MapBlock
             calculateSize();
         }
         return sizeInBytes;
+    }
+
+    private boolean isSinglePositionBlock(int position)
+    {
+        return position == 0 && positionCount == 1 && offsets.length == 2;
+    }
+
+    @Override
+    public Block getSingleValueBlock(int position)
+    {
+        if (isSinglePositionBlock(position)) {
+            return this;
+        }
+
+        return getSingleValueBlockInternal(position);
     }
 
     private void calculateSize()

--- a/presto-common/src/main/java/com/facebook/presto/common/block/MapBlockBuilder.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/MapBlockBuilder.java
@@ -174,6 +174,12 @@ public class MapBlockBuilder
     }
 
     @Override
+    public Block getSingleValueBlock(int position)
+    {
+        return getSingleValueBlockInternal(position);
+    }
+
+    @Override
     public SingleMapBlockWriter beginBlockEntry()
     {
         if (currentEntryOpened) {

--- a/presto-main/src/test/java/com/facebook/presto/block/TestMapBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestMapBlock.java
@@ -52,6 +52,8 @@ import static java.util.Objects.requireNonNull;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNotSame;
+import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
 
 public class TestMapBlock
@@ -88,6 +90,40 @@ public class TestMapBlock
     {
         assertLazyHashTableBuildOverBlockRegion(createTestMap(9, 3, 4, 0, 8, 0, 6, 5));
         assertLazyHashTableBuildOverBlockRegion(alternatingNullValues(createTestMap(9, 3, 4, 0, 8, 0, 6, 5)));
+    }
+
+    @Test
+    public void testSingleValueBlock()
+    {
+        // 1 entry map.
+        Map<String, Long>[] values = createTestMap(50);
+        BlockBuilder mapBlockBuilder = createBlockBuilderWithValues(values);
+        Block mapBlock = mapBlockBuilder.build();
+        assertSame(mapBlock, mapBlock.getSingleValueBlock(0));
+        assertNotSame(mapBlockBuilder, mapBlockBuilder.getSingleValueBlock(0));
+
+        // 2 entries map.
+        values = createTestMap(50, 50);
+        mapBlockBuilder = createBlockBuilderWithValues(values);
+        mapBlock = mapBlockBuilder.build();
+        Block firstElement = mapBlock.getRegion(0, 1);
+        assertNotSame(firstElement, firstElement.getSingleValueBlock(0));
+
+        Block secondElementCopy = mapBlock.copyRegion(1, 1);
+        assertSame(secondElementCopy, secondElementCopy.getSingleValueBlock(0));
+
+        // Test with null elements.
+        values = new Map[] {null};
+        mapBlockBuilder = createBlockBuilderWithValues(values);
+        mapBlock = mapBlockBuilder.build();
+        assertSame(mapBlock, mapBlock.getSingleValueBlock(0));
+        assertNotSame(mapBlock, mapBlockBuilder.getSingleValueBlock(0));
+
+        // Test with 2 null elements.
+        values = new Map[] {null, null};
+        mapBlockBuilder = createBlockBuilderWithValues(values);
+        mapBlock = mapBlockBuilder.build();
+        assertNotSame(mapBlock, mapBlock.getSingleValueBlock(0));
     }
 
     @Test
@@ -229,7 +265,7 @@ public class TestMapBlock
         }
     }
 
-    private Map<String, Long>[] createTestMap(int... entryCounts)
+    private static Map<String, Long>[] createTestMap(int... entryCounts)
     {
         Map<String, Long>[] result = new Map[entryCounts.length];
         for (int rowNumber = 0; rowNumber < entryCounts.length; rowNumber++) {
@@ -277,7 +313,7 @@ public class TestMapBlock
         assertBlockFilteredPositions(expectedValuesWithNull, blockWithNull, () -> blockBuilder.newBlockBuilderLike(null), 2, 3, 4, 9, 13, 14);
     }
 
-    private BlockBuilder createBlockBuilderWithValues(Map<String, Long>[] maps)
+    private static BlockBuilder createBlockBuilderWithValues(Map<String, Long>[] maps)
     {
         MapType mapType = mapType(VARCHAR, BIGINT);
         BlockBuilder mapBlockBuilder = mapType.createBlockBuilder(null, 1);
@@ -287,7 +323,7 @@ public class TestMapBlock
         return mapBlockBuilder;
     }
 
-    private MapBlock createBlockWithValuesFromKeyValueBlock(Map<String, Long>[] maps)
+    private static MapBlock createBlockWithValuesFromKeyValueBlock(Map<String, Long>[] maps)
     {
         List<String> keys = new ArrayList<>();
         List<Long> values = new ArrayList<>();
@@ -311,7 +347,7 @@ public class TestMapBlock
         return (MapBlock) mapType(VARCHAR, BIGINT).createBlockFromKeyValue(positionCount, Optional.of(mapIsNull), offsets, createStringsBlock(keys), createLongsBlock(values));
     }
 
-    private void createBlockBuilderWithValues(Map<String, Long> map, BlockBuilder mapBlockBuilder)
+    private static void createBlockBuilderWithValues(Map<String, Long> map, BlockBuilder mapBlockBuilder)
     {
         if (map == null) {
             mapBlockBuilder.appendNull();
@@ -351,7 +387,7 @@ public class TestMapBlock
         super.assertPositionValueUnchecked(block, internalPosition, expectedValue);
     }
 
-    private void assertValue(Block mapBlock, int position, Map<String, Long> map)
+    private static void assertValue(Block mapBlock, int position, Map<String, Long> map)
     {
         MapType mapType = mapType(VARCHAR, BIGINT);
         MethodHandle keyNativeHashCode = getOperatorMethodHandle(OperatorType.HASH_CODE, VARCHAR);
@@ -398,7 +434,7 @@ public class TestMapBlock
         }
     }
 
-    private void assertValueUnchecked(Block mapBlock, int internalPosition, Map<String, Long> map)
+    private static void assertValueUnchecked(Block mapBlock, int internalPosition, Map<String, Long> map)
     {
         MapType mapType = mapType(VARCHAR, BIGINT);
         MethodHandle keyNativeHashCode = getOperatorMethodHandle(OperatorType.HASH_CODE, VARCHAR);


### PR DESCRIPTION
getSingleValueBlock is used by nested loop joins in broadcast queries.
getSingleValueBlock unconditionally clones even when the underlying
block has only one element. Map and Arrays are used in aggregation
and broad casted. This path is always taken or never taken so the cost
of branching should be minimal.

Test plan - 
Added new tests.

```
== NO RELEASE NOTE ==
```
