### PR TITLE
cleaning up array overlap func to avoid temp arrays

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/TypedSet.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/TypedSet.java
@@ -59,7 +59,7 @@ public class TypedSet
     private int hashMask;
     private static final int EMPTY_SLOT = -1;
 
-    private boolean containsNullElement;
+    private boolean containNullElements;
 
     public TypedSet(Type elementType, int expectedSize, String functionName)
     {
@@ -93,7 +93,7 @@ public class TypedSet
             blockPositionByHash.set(i, EMPTY_SLOT);
         }
 
-        this.containsNullElement = false;
+        this.containNullElements = false;
     }
 
     public long getRetainedSizeInBytes()
@@ -107,7 +107,7 @@ public class TypedSet
         checkArgument(position >= 0, "position must be >= 0");
 
         if (block.isNull(position)) {
-            return containsNullElement;
+            return containNullElements;
         }
         else {
             return blockPositionByHash.get(getHashPositionOfElement(block, position)) != EMPTY_SLOT;
@@ -121,7 +121,7 @@ public class TypedSet
 
         // containsNullElement flag is maintained so contains() method can have shortcut for null value
         if (block.isNull(position)) {
-            containsNullElement = true;
+            containNullElements = true;
         }
 
         int hashPosition = getHashPositionOfElement(block, position);
@@ -145,6 +145,11 @@ public class TypedSet
         }
 
         return false;
+    }
+
+    public boolean isContainNullElements()
+    {
+        return containNullElements;
     }
 
     public int size()

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestTypedSet.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestTypedSet.java
@@ -200,6 +200,23 @@ public class TestTypedSet
     }
 
     @Test
+    public void testIsContainNullElements()
+    {
+        int elementCount = 100;
+        TypedSet typedSet = new TypedSet(BIGINT, elementCount, FUNCTION_NAME);
+        BlockBuilder blockBuilder = BIGINT.createFixedSizeBlockBuilder(elementCount);
+        assertEquals(typedSet.isContainNullElements(), false);
+        for (int i = 0; i < elementCount; i++) {
+            BIGINT.writeLong(blockBuilder, i);
+            typedSet.add(blockBuilder, i);
+        }
+        assertEquals(typedSet.isContainNullElements(), false);
+        blockBuilder.appendNull();
+        typedSet.add(blockBuilder, blockBuilder.getPositionCount() - 1);
+        assertEquals(typedSet.isContainNullElements(), true);
+    }
+
+    @Test
     public void testBigintSimpleTypedSet()
     {
         List<Integer> expectedSetSizes = ImmutableList.of(1, 10, 100, 1000);

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArraysOverlap.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkArraysOverlap.java
@@ -1,0 +1,249 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.block.BlockAssertions;
+import com.facebook.presto.common.Page;
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.BooleanType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.operator.DriverYieldSignal;
+import com.facebook.presto.operator.project.PageProcessor;
+import com.facebook.presto.spi.function.FunctionHandle;
+import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.sql.gen.ExpressionCompiler;
+import com.facebook.presto.sql.gen.PageFunctionCompiler;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OperationsPerInvocation;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.VerboseMode;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
+import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static com.facebook.presto.sql.relational.Expressions.field;
+import static com.facebook.presto.testing.TestingConnectorSession.SESSION;
+
+@SuppressWarnings("MethodMayBeStatic")
+@State(Scope.Thread)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(3)
+@BenchmarkMode(Mode.AverageTime)
+public class BenchmarkArraysOverlap
+{
+    private static final int POSITIONS = 10_000;
+    private static final int SMALL_ARRAY_SIZE = 10;
+    private static final int LARGE_ARRAY_SIZE = 1500;
+
+    public static void main(String[] args)
+            throws Throwable
+    {
+        // assure the benchmarks are valid before running
+        BenchmarkData data = new BenchmarkData();
+        data.setup();
+        new BenchmarkArraysOverlap().smallBenchmark(data);
+        new BenchmarkArraysOverlap().largeBenchmark(data);
+
+        Options options = new OptionsBuilder()
+                .verbosity(VerboseMode.NORMAL)
+                .include(".*" + BenchmarkArraysOverlap.class.getSimpleName() + ".*")
+                .build();
+        new Runner(options).run();
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(POSITIONS * SMALL_ARRAY_SIZE)
+    public List<Optional<Page>> smallBenchmark(BenchmarkData data)
+    {
+        return ImmutableList.copyOf(
+                data.getPageProcessor().process(
+                        SESSION.getSqlFunctionProperties(),
+                        new DriverYieldSignal(),
+                        newSimpleAggregatedMemoryContext().newLocalMemoryContext(PageProcessor.class.getSimpleName()),
+                        data.getSmallPage()));
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(POSITIONS * LARGE_ARRAY_SIZE)
+    public List<Optional<Page>> largeBenchmark(BenchmarkData data)
+    {
+        return ImmutableList.copyOf(
+                data.getPageProcessor().process(
+                        SESSION.getSqlFunctionProperties(),
+                        new DriverYieldSignal(),
+                        newSimpleAggregatedMemoryContext().newLocalMemoryContext(PageProcessor.class.getSimpleName()),
+                        data.getLargePage()));
+    }
+
+    @Test
+    public void verify()
+    {
+        BenchmarkData data = new BenchmarkData();
+        data.setup();
+        new BenchmarkArraysOverlap().smallBenchmark(data);
+        new BenchmarkArraysOverlap().largeBenchmark(data);
+    }
+
+    @SuppressWarnings("FieldMayBeFinal")
+    @State(Scope.Thread)
+    public static class BenchmarkData
+    {
+        private static final Map<String, Type> TYPE_MAP
+                = ImmutableMap.of("BIGINT", BIGINT, "BOOLEAN", BOOLEAN,
+                "VARCHAR", VARCHAR, "DOUBLE", DOUBLE);
+        private String name = "arrays_overlap";
+        private Page smallPage;
+        private Page largePage;
+        private PageProcessor pageProcessor;
+
+        @Param({"BIGINT", "DOUBLE", "VARCHAR", "BOOLEAN"})
+        private String elementType = "BIGINT";
+
+        @Param({"ELEMENT", "ARRAY"})
+        private String typeClass = "ELEMENT";
+
+        private static Block createChannel(int positionCount, int arraySize, ArrayType arrayType, TypeClass typeClass)
+        {
+            BlockBuilder blockBuilder = arrayType.createBlockBuilder(null, positionCount);
+            Type basicElementType = (typeClass.equals(TypeClass.ELEMENT)) ? arrayType.getElementType() : ((ArrayType) arrayType.getElementType()).getElementType();
+            for (int position = 0; position < positionCount; position++) {
+                BlockBuilder entryBuilder = blockBuilder.beginBlockEntry();
+                for (int i = 0; i < arraySize; i++) {
+                    if (basicElementType.getJavaType() == long.class) {
+                        if (typeClass.equals(TypeClass.ELEMENT)) {
+                            basicElementType.writeLong(entryBuilder, ThreadLocalRandom.current().nextLong());
+                        }
+                        else {
+                            arrayType.getElementType().writeObject(entryBuilder,
+                                    BlockAssertions.createLongSequenceBlock(0, (ThreadLocalRandom.current().nextInt()) % 10));
+                        }
+                    }
+                    else if (basicElementType.equals(VARCHAR)) {
+                        if (typeClass.equals(TypeClass.ELEMENT)) {
+                            basicElementType.writeSlice(entryBuilder,
+                                    Slices.utf8Slice("test_string " + (ThreadLocalRandom.current().nextInt() % 5)));
+                        }
+                        else {
+                            List<Slice> slices = IntStream.range(0, (ThreadLocalRandom.current().nextInt()) % 10)
+                                    .mapToObj(val -> Slices.utf8Slice("test_string " + (ThreadLocalRandom.current().nextInt() % 5)))
+                                    .collect(Collectors.toList());
+                            arrayType.getElementType().writeObject(entryBuilder, BlockAssertions.createSlicesBlock(slices));
+                        }
+                    }
+                    else if (basicElementType.equals(BOOLEAN)) {
+                        if (typeClass.equals(TypeClass.ELEMENT)) {
+                            basicElementType.writeBoolean(entryBuilder, ThreadLocalRandom.current().nextBoolean());
+                        }
+                        else {
+                            arrayType.getElementType().writeObject(entryBuilder,
+                                    BlockAssertions.createBooleanSequenceBlock(0, (ThreadLocalRandom.current().nextInt()) % 10));
+                        }
+                    }
+                    else if (basicElementType.equals(DOUBLE)) {
+                        if (typeClass.equals(TypeClass.ELEMENT)) {
+                            basicElementType.writeDouble(entryBuilder, ThreadLocalRandom.current().nextDouble());
+                        }
+                        else {
+                            arrayType.getElementType().writeObject(entryBuilder,
+                                    BlockAssertions.createDoubleSequenceBlock(0, (ThreadLocalRandom.current().nextInt()) % 10));
+                        }
+                    }
+                    else {
+                        throw new UnsupportedOperationException();
+                    }
+                }
+                blockBuilder.closeEntry();
+            }
+            return blockBuilder.build();
+        }
+
+        @Setup
+        public void setup()
+        {
+            MetadataManager metadata = MetadataManager.createTestMetadataManager();
+            FunctionAndTypeManager functionAndTypeManager = metadata.getFunctionAndTypeManager();
+            ExpressionCompiler compiler = new ExpressionCompiler(metadata, new PageFunctionCompiler(metadata, 0));
+            ImmutableList.Builder<RowExpression> projectionsBuilder = ImmutableList.builder();
+
+            ArrayType arrayType = new ArrayType(TYPE_MAP.get(elementType));
+            TypeClass typeClassVal = TypeClass.valueOf(typeClass);
+            if (typeClassVal.equals(TypeClass.ARRAY)) {
+                arrayType = new ArrayType(arrayType);
+            }
+            FunctionHandle functionHandle = functionAndTypeManager.lookupFunction(name, fromTypes(arrayType, arrayType));
+
+            projectionsBuilder.add(
+                    new CallExpression(name, functionHandle, BooleanType.BOOLEAN, ImmutableList.of(
+                            field(0, arrayType),
+                            field(1, arrayType))));
+
+            ImmutableList<RowExpression> projections = projectionsBuilder.build();
+            pageProcessor = compiler.compilePageProcessor(SESSION.getSqlFunctionProperties(), Optional.empty(), projections).get();
+
+            largePage = new Page(createChannel(POSITIONS, LARGE_ARRAY_SIZE, arrayType, typeClassVal),
+                    createChannel(POSITIONS, LARGE_ARRAY_SIZE, arrayType, typeClassVal));
+            smallPage = new Page(createChannel(POSITIONS, SMALL_ARRAY_SIZE, arrayType, typeClassVal),
+                    createChannel(POSITIONS, SMALL_ARRAY_SIZE, arrayType, typeClassVal));
+        }
+
+        public PageProcessor getPageProcessor()
+        {
+            return pageProcessor;
+        }
+
+        public Page getSmallPage()
+        {
+            return smallPage;
+        }
+
+        public Page getLargePage()
+        {
+            return largePage;
+        }
+
+        enum TypeClass
+        {ELEMENT, ARRAY}
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestArrayOperators.java
@@ -1161,6 +1161,7 @@ public class TestArrayOperators
         assertFunction("ARRAYS_OVERLAP(ARRAY [2, NULL], ARRAY [1, 2])", BooleanType.BOOLEAN, true);
         assertFunction("ARRAYS_OVERLAP(ARRAY [NULL, 3], ARRAY [2, 1])", BooleanType.BOOLEAN, null);
         assertFunction("ARRAYS_OVERLAP(ARRAY [3, NULL], ARRAY [2, 1])", BooleanType.BOOLEAN, null);
+        assertFunction("ARRAYS_OVERLAP(ARRAY [3, NULL], ARRAY [2, 1, NULL])", BooleanType.BOOLEAN, null);
 
         assertFunction("ARRAYS_OVERLAP(ARRAY [CAST(1 AS BIGINT), 2], ARRAY [NULL, CAST(2 AS BIGINT)])", BooleanType.BOOLEAN, true);
         assertFunction("ARRAYS_OVERLAP(ARRAY [CAST(1 AS BIGINT), 2], ARRAY [CAST(2 AS BIGINT), NULL])", BooleanType.BOOLEAN, true);
@@ -1183,11 +1184,20 @@ public class TestArrayOperators
         assertFunction("ARRAYS_OVERLAP(ARRAY [], ARRAY [])", BooleanType.BOOLEAN, false);
         assertFunction("ARRAYS_OVERLAP(ARRAY [], ARRAY [1, 2])", BooleanType.BOOLEAN, false);
         assertFunction("ARRAYS_OVERLAP(ARRAY [], ARRAY [NULL])", BooleanType.BOOLEAN, false);
+        assertFunction("ARRAYS_OVERLAP(ARRAY [NULL], ARRAY [])", BooleanType.BOOLEAN, false);
+        assertFunction("ARRAYS_OVERLAP(ARRAY [NULL], ARRAY [NULL])", BooleanType.BOOLEAN, null);
 
         assertFunction("ARRAYS_OVERLAP(ARRAY [true], ARRAY [true, false])", BooleanType.BOOLEAN, true);
         assertFunction("ARRAYS_OVERLAP(ARRAY [false], ARRAY [true, true])", BooleanType.BOOLEAN, false);
         assertFunction("ARRAYS_OVERLAP(ARRAY [true, false], ARRAY [NULL])", BooleanType.BOOLEAN, null);
         assertFunction("ARRAYS_OVERLAP(ARRAY [false], ARRAY [true, NULL])", BooleanType.BOOLEAN, null);
+
+        assertFunction("ARRAYS_OVERLAP(ARRAY [2.01], ARRAY [2.01, 9.0, 9.4])", BooleanType.BOOLEAN, true);
+        assertFunction("ARRAYS_OVERLAP(ARRAY [10.1, 9.1], ARRAY [9.09, 9.0])", BooleanType.BOOLEAN, false);
+        assertFunction("ARRAYS_OVERLAP(ARRAY [NULL, 9.1], ARRAY [NULL])", BooleanType.BOOLEAN, null);
+        assertFunction("ARRAYS_OVERLAP(ARRAY [NULL, 9.1], ARRAY [9.1, 10.2, 3.0])", BooleanType.BOOLEAN, true);
+        assertFunction("ARRAYS_OVERLAP(ARRAY [2.4], ARRAY [2.4])", BooleanType.BOOLEAN, true);
+        assertFunction("ARRAYS_OVERLAP(ARRAY [2.4, 9.0, 10.9999999, 9.1, 4.1, 8.1], ARRAY [2.1, 10.999])", BooleanType.BOOLEAN, false);
     }
 
     @Test


### PR DESCRIPTION
## Summary

* Optimize the array overlap func not to use temporary arrays, since it slows down some of the queries. 
* Made the array overlap to follow use nested loop algorithm for smaller dataset, so it does not allocate many temporary memory, which is a common case. Then, fall back to the TypedSet based algorithm for larger data size. (Threshold = 200 is chosen based on the performance of both the algorithm for varied sizes, and considered the big int since it is the common case).

## Test plan - 
Unit tests

## Performance Improvements

### Nested Loop (Smaller Data size) + TypedSet (Larger Data Size) (NEW Implementation)
```
Benchmark                              (elementType)  (typeClass)  Mode  Cnt    Score   Error  Units
BenchmarkArraysOverlap.largeBenchmark         BIGINT      ELEMENT  avgt   20   93.777 ± 0.940  ns/op
BenchmarkArraysOverlap.largeBenchmark         BIGINT        ARRAY  avgt   20   50.080 ± 0.609  ns/op
BenchmarkArraysOverlap.largeBenchmark         DOUBLE      ELEMENT  avgt   20   94.467 ± 1.397  ns/op
BenchmarkArraysOverlap.largeBenchmark         DOUBLE        ARRAY  avgt   20  110.302 ± 1.871  ns/op
BenchmarkArraysOverlap.largeBenchmark        VARCHAR      ELEMENT  avgt   20   33.606 ± 0.764  ns/op
BenchmarkArraysOverlap.largeBenchmark        VARCHAR        ARRAY  avgt   20  170.139 ± 8.727  ns/op
BenchmarkArraysOverlap.largeBenchmark        BOOLEAN      ELEMENT  avgt   20    8.531 ± 0.192  ns/op
BenchmarkArraysOverlap.largeBenchmark        BOOLEAN        ARRAY  avgt   20   51.315 ± 2.417  ns/op
BenchmarkArraysOverlap.smallBenchmark         BIGINT      ELEMENT  avgt   20    7.056 ± 0.215  ns/op
BenchmarkArraysOverlap.smallBenchmark         BIGINT        ARRAY  avgt   20   14.845 ± 0.778  ns/op
BenchmarkArraysOverlap.smallBenchmark         DOUBLE      ELEMENT  avgt   20    9.830 ± 0.399  ns/op
BenchmarkArraysOverlap.smallBenchmark         DOUBLE        ARRAY  avgt   20   15.628 ± 0.875  ns/op
BenchmarkArraysOverlap.smallBenchmark        VARCHAR      ELEMENT  avgt   20   12.367 ± 0.154  ns/op
BenchmarkArraysOverlap.smallBenchmark        VARCHAR        ARRAY  avgt   20   28.179 ± 0.533  ns/op
BenchmarkArraysOverlap.smallBenchmark        BOOLEAN      ELEMENT  avgt   20    2.599 ± 0.136  ns/op
BenchmarkArraysOverlap.smallBenchmark        BOOLEAN        ARRAY  avgt   20   15.331 ± 1.044  ns/op
```


### Quicksort + temp arrays (OLD Implementation)
```
Benchmark                              (elementType)  (typeClass)  Mode  Cnt    Score    Error  Units
BenchmarkArraysOverlap.largeBenchmark         BIGINT      ELEMENT  avgt   20   80.889 ±  1.695  ns/op
BenchmarkArraysOverlap.largeBenchmark         BIGINT        ARRAY  avgt   20  171.598 ±  5.257  ns/op
BenchmarkArraysOverlap.largeBenchmark         DOUBLE      ELEMENT  avgt   20  210.416 ±  3.790  ns/op
BenchmarkArraysOverlap.largeBenchmark         DOUBLE        ARRAY  avgt   20  129.309 ±  5.277  ns/op
BenchmarkArraysOverlap.largeBenchmark        VARCHAR      ELEMENT  avgt   20  137.746 ±  1.707  ns/op
BenchmarkArraysOverlap.largeBenchmark        VARCHAR        ARRAY  avgt   20  604.581 ± 26.720  ns/op
BenchmarkArraysOverlap.largeBenchmark        BOOLEAN      ELEMENT  avgt   20   20.214 ±  0.827  ns/op
BenchmarkArraysOverlap.largeBenchmark        BOOLEAN        ARRAY  avgt   20  109.445 ±  5.429  ns/op
BenchmarkArraysOverlap.smallBenchmark         BIGINT      ELEMENT  avgt   20   30.820 ±  0.648  ns/op
BenchmarkArraysOverlap.smallBenchmark         BIGINT        ARRAY  avgt   20  252.607 ± 13.032  ns/op
BenchmarkArraysOverlap.smallBenchmark         DOUBLE      ELEMENT  avgt   20   77.823 ±  3.515  ns/op
BenchmarkArraysOverlap.smallBenchmark         DOUBLE        ARRAY  avgt   20  274.720 ± 10.587  ns/op
BenchmarkArraysOverlap.smallBenchmark        VARCHAR      ELEMENT  avgt   20  233.945 ±  9.512  ns/op
BenchmarkArraysOverlap.smallBenchmark        VARCHAR        ARRAY  avgt   20  302.206 ±  4.770  ns/op
BenchmarkArraysOverlap.smallBenchmark        BOOLEAN      ELEMENT  avgt   20   65.324 ±  2.530  ns/op
BenchmarkArraysOverlap.smallBenchmark        BOOLEAN        ARRAY  avgt   20  248.100 ± 13.110  ns/op
```

```
== NO RELEASE NOTE ==
```