### PR TITLE
Remove unnecessary locking in SqlStageExecution

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlStageExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlStageExecution.java
@@ -328,7 +328,7 @@ public final class SqlStageExecution
         return stateMachine.getTotalMemoryReservation();
     }
 
-    public synchronized Duration getTotalCpuTime()
+    public Duration getTotalCpuTime()
     {
         long millis = getAllTasks().stream()
                 .mapToLong(task -> NANOSECONDS.toMillis(task.getTaskInfo().getStats().getTotalCpuTimeInNanos()))


### PR DESCRIPTION
The lock on getTotalCputime causes contention for periodic CPU updates
for InternalResourceGroupManager. The method does not access any variables
that need to be guarded by the intrinsic lock.

Cherry-pick of https://github.com/trinodb/trino/commit/77a24a07beed1752014d28ec7cc4294ab4875d36

Co-authored-by: Pratham Desai <prathamd94@gmail.com>

```
== NO RELEASE NOTE ==
```
