### PR TITLE
Fix incorrect pushdown if IS NULL predicate in Elasticsearch

### DIFF
--- a/presto-elasticsearch/src/main/java/com/facebook/presto/elasticsearch/ElasticsearchQueryBuilder.java
+++ b/presto-elasticsearch/src/main/java/com/facebook/presto/elasticsearch/ElasticsearchQueryBuilder.java
@@ -130,6 +130,9 @@ public final class ElasticsearchQueryBuilder
             }
             queryBuilder.should(rangeQueryBuilder);
         }
+        if (domain.isNullAllowed()) {
+            queryBuilder.should(new BoolQueryBuilder().mustNot(new ExistsQueryBuilder(columnName)));
+        }
         return queryBuilder;
     }
 


### PR DESCRIPTION
Cherry-pick of https://github.com/trinodb/trino/commit/3fe0bc2ab40649a61232414169ce384a22b0cca3

Co-authored-by: Suman <sumannewton@gmail.com>

```
== RELEASE NOTES ==

Elasticsearch Changes
* Fix incorrect pushdown if IS NULL predicate in Elasticsearch
```
