### PR TITLE
Load Hashtables in MAP_AGG

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/block/MapBlockBuilder.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/MapBlockBuilder.java
@@ -470,6 +470,11 @@ public class MapBlockBuilder
                 newNegativeOneFilledArray(newSize * HASH_MULTIPLIER));
     }
 
+    public void loadHashTables()
+    {
+        ensureHashTableLoaded(keyBlockHashCode);
+    }
+
     @Override
     protected void ensureHashTableLoaded(MethodHandle keyBlockHashCode) {}
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/MapAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/MapAggregationFunction.java
@@ -16,6 +16,7 @@ package com.facebook.presto.operator.aggregation;
 import com.facebook.presto.bytecode.DynamicClassLoader;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.block.MapBlockBuilder;
 import com.facebook.presto.common.type.MapType;
 import com.facebook.presto.common.type.StandardTypes;
 import com.facebook.presto.common.type.Type;
@@ -148,6 +149,13 @@ public class MapAggregationFunction
         }
         else {
             pairs.serialize(out);
+        }
+        if (out instanceof MapBlockBuilder) {
+            // MapAggregation is used to ensure broadcast joins in Presto.
+            // Compute hash table once before broad casting. Some large queries
+            // where blocks are copied without hashtables performs upto
+            // 5X worse without this fix.
+            ((MapBlockBuilder) out).loadHashTables();
         }
     }
 }


### PR DESCRIPTION
Broadcast join queries with filter regresses when using lazy
hash tables in MapBlockBuilder. Filter repeatedly computes 
the hash tables instead of computing it once. This PR forces 
the hash tables to be loaded in MAP_AGG to prevent the 
regression. This PR is in preparation of making the hash 
tables lazy in the MapBlockBuilder. 

Test plan - (Please fill in how you tested your changes)
Existing tests.


```
== NO RELEASE NOTE ==
```
