### PR TITLE
Add configuration for materialized view consistency

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -197,6 +197,7 @@ public final class SystemSessionProperties
     public static final String PARTIAL_RESULTS_MAX_EXECUTION_TIME_MULTIPLIER = "partial_results_max_execution_time_multiplier";
     public static final String OFFSET_CLAUSE_ENABLED = "offset_clause_enabled";
     public static final String VERBOSE_EXCEEDED_MEMORY_LIMIT_ERRORS_ENABLED = "verbose_exceeded_memory_limit_errors_enabled";
+    public static final String MATERIALIZED_VIEW_DATA_CONSISTENCY_ENABLED = "materialized_view_data_consistency_enabled";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -1054,6 +1055,11 @@ public final class SystemSessionProperties
                         VERBOSE_EXCEEDED_MEMORY_LIMIT_ERRORS_ENABLED,
                         "When enabled the error message for exceeded memory limit errors will contain additional operator memory allocation details",
                         nodeMemoryConfig.isVerboseExceededMemoryLimitErrorsEnabled(),
+                        false),
+                booleanProperty(
+                        MATERIALIZED_VIEW_DATA_CONSISTENCY_ENABLED,
+                        "When enabled and reading from materialized view, partition stitching is applied to achieve data consistency",
+                        featuresConfig.isMaterializedViewDataConsistencyEnabled(),
                         false));
     }
 
@@ -1778,5 +1784,10 @@ public final class SystemSessionProperties
     public static boolean isVerboseExceededMemoryLimitErrorsEnabled(Session session)
     {
         return session.getSystemProperty(VERBOSE_EXCEEDED_MEMORY_LIMIT_ERRORS_ENABLED, Boolean.class);
+    }
+
+    public static boolean isMaterializedViewDataConsistencyEnabled(Session session)
+    {
+        return session.getSystemProperty(MATERIALIZED_VIEW_DATA_CONSISTENCY_ENABLED, Boolean.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -200,6 +200,7 @@ public class FeaturesConfig
     private double partialResultsMaxExecutionTimeMultiplier = 2.0;
 
     private boolean offsetClauseEnabled;
+    private boolean materializedViewDataConsistencyEnabled = true;
 
     public enum PartitioningPrecisionStrategy
     {
@@ -1755,6 +1756,19 @@ public class FeaturesConfig
     public FeaturesConfig setOffsetClauseEnabled(boolean offsetClauseEnabled)
     {
         this.offsetClauseEnabled = offsetClauseEnabled;
+        return this;
+    }
+
+    public boolean isMaterializedViewDataConsistencyEnabled()
+    {
+        return materializedViewDataConsistencyEnabled;
+    }
+
+    @Config("materialized-view-data-consistency-enabled")
+    @ConfigDescription("When enabled and reading from materialized view, partition stitching is applied to achieve data consistency")
+    public FeaturesConfig setMaterializedViewDataConsistencyEnabled(boolean materializedViewDataConsistencyEnabled)
+    {
+        this.materializedViewDataConsistencyEnabled = materializedViewDataConsistencyEnabled;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -175,6 +175,7 @@ import java.util.stream.Collectors;
 
 import static com.facebook.presto.SystemSessionProperties.getMaxGroupingSets;
 import static com.facebook.presto.SystemSessionProperties.isAllowWindowOrderByLiterals;
+import static com.facebook.presto.SystemSessionProperties.isMaterializedViewDataConsistencyEnabled;
 import static com.facebook.presto.common.predicate.TupleDomain.extractFixedValues;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
@@ -1207,7 +1208,7 @@ class StatementAnalyzer
 
             Optional<ConnectorMaterializedViewDefinition> optionalMaterializedView = metadata.getMaterializedView(session, name);
             Statement statement = analysis.getStatement();
-            if (optionalMaterializedView.isPresent() && statement instanceof Query) {
+            if (isMaterializedViewDataConsistencyEnabled(session) && optionalMaterializedView.isPresent() && statement instanceof Query) {
                 // When the materialized view has already been expanded, do not process it. Just use it as a table.
                 MaterializedViewAnalysisState materializedViewAnalysisState = analysis.getMaterializedViewAnalysisState(table);
                 QualifiedObjectName materializedViewName = createQualifiedObjectName(session, table, table.getName());

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -172,7 +172,8 @@ public class TestFeaturesConfig
                 .setPartialResultsEnabled(false)
                 .setPartialResultsCompletionRatioThreshold(0.5)
                 .setOffsetClauseEnabled(false)
-                .setPartialResultsMaxExecutionTimeMultiplier(2.0));
+                .setPartialResultsMaxExecutionTimeMultiplier(2.0)
+                .setMaterializedViewDataConsistencyEnabled(true));
     }
 
     @Test
@@ -297,6 +298,7 @@ public class TestFeaturesConfig
                 .put("partial-results-completion-ratio-threshold", "0.9")
                 .put("partial-results-max-execution-time-multiplier", "1.5")
                 .put("offset-clause-enabled", "true")
+                .put("materialized-view-data-consistency-enabled", "false")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -418,7 +420,8 @@ public class TestFeaturesConfig
                 .setPartialResultsEnabled(true)
                 .setPartialResultsCompletionRatioThreshold(0.9)
                 .setOffsetClauseEnabled(true)
-                .setPartialResultsMaxExecutionTimeMultiplier(1.5);
+                .setPartialResultsMaxExecutionTimeMultiplier(1.5)
+                .setMaterializedViewDataConsistencyEnabled(false);
         assertFullMapping(properties, expected);
     }
 


### PR DESCRIPTION
Changes include:
1. Create a configuration `materialized_view_data_consistency_enabled` to control partition stitching. This config is on by default.
2. Update the corresponding unit test.