### PR TITLE
Add release notes for 0.258

### DIFF
--- a/presto-docs/src/main/sphinx/release.rst
+++ b/presto-docs/src/main/sphinx/release.rst
@@ -5,6 +5,7 @@ Release Notes
 .. toctree::
     :maxdepth: 1
 
+    release/release-0.258
     release/release-0.257
     release/release-0.256
     release/release-0.255

--- a/presto-docs/src/main/sphinx/release/release-0.258.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.258.rst
@@ -1,0 +1,40 @@
+=============
+Release 0.258
+=============
+
+**Details**
+===========
+
+General Changes
+_______________
+* Fix a bug in SQL functions where a query could fail with a compiler error if the function has a lambda variable with the same name as a column or function input.
+* Add Cauchy distribution CDF :func:`cauchy_cdf` and inverse CDF :func:`inverse_cauchy_cdf` functions.
+* Add SQL functions :func:`array_dupes` and :func:`array_as_dupes`.
+* Add additional details to memory exceeded error messages to simplify debugging. Disabled by default. Can be enabled by setting the ``verbose_exceeded_memory_limit_errors_enabled`` session property to ``true``.
+* Support dynamic filtering with comparison operators. Can be enabled by setting the ``enable-dynamic-filtering`` property to ``true``. Disabled by default.
+
+Cassandra Changes
+________________
+* Improve query performance by caching metadata to avoid extra remote calls to the Cassandra server.
+
+Elasticsearch Changes
+_____________________
+* Fix incorrect pushdown of ``IS NULL`` predicate in Elasticsearch.
+
+Hive Changes
+____________
+* Fix a bug in Parquet dereference pushdown that caused inconsistent query results in certain cases.
+* Add support for allowing to match columns between table and partition schemas by names for HUDI tables. This is enabled when configuration property ``hive.parquet.use-column-names`` or the hive catalog session property ``parquet_use_column_names`` is set to ``true``. By default they are mapped by index.
+
+Iceberg Changes
+_________________________
+* Add support for ORC files.
+
+SPI Changes
+___________
+* Add ``getClientTags`` to ``ConnectorSession``.
+
+**Credits**
+===========
+
+Andrii Rosa, Beinan, Chen, Grace Xin, Huameng Jiang, Jalpreet Singh Nanda (:imjalpreet), James Petty, James Sun, Jeremy Craig Sawruk, Julian Zhuoran Zhao, Junyi Huang, Marilyn Beck, Neerad Somanchi, Pranjal Shankhdhar, Roman Zeyde, Rongrong Zhong, Sergey Pershin, Shixuan Fan, Tim Meehan, Venki Korukanti, Xiang Fu, Zhan Yuan, Zhenxiao Luo, derektbrown, jiachen, lijieliang, 护城


### PR DESCRIPTION
# Missing Release Notes

# Extracted Release Notes
- #15818 (Author: Jeremy Craig Sawruk): Add cauchy_cdf and inverse_cauchy_cdf functions
  - Add Cauchy distribution CDF and inverse CDF functions to MathFunctions.java.
- #16104 (Author: 护城): Cassandra Performance Improvement
  - Improve cassandra query performance by adding meta cache to avoid too many remote meta operations to the cassandra server.
- #16287 (Author: Neerad Somanchi): Add client tags info to ConnectorSession
  - Add ``getClientTags`` to ``ConnectorSession``.
- #16297 (Author: Andrii Rosa): Extend memory exceeded errors with more details
  - Add additional details to memory exceeded error messages to simplify debugging. Disabled by default. Can be enabled by setting the "verbose_exceeded_memory_limit_errors_enabled" session property to "true".
- #16314 (Author: Roman Zeyde): Implement collection of min/max values in DynamicFilterSourceOperator
  - Allow dynamic filtering for large number of collected values by converting the predicate into a range.
- #16317 (Author: Pranjal Shankhdhar): Add SQL functions ARRAY_DUPES and ARRAY_HAS_DUPES
  - Add SQL functions :func:`array_dupes` and :func:`array_as_dupes`.
- #16348 (Author: Jalpreet Singh Nanda (:imjalpreet)): Add support for partition schema evolution for HUDI tables
  - Add support for allowing to match columns between table and partition schemas by names for HUDI tables. This is enabled when configuration property ``hive.parquet.use-column-names`` or the hive catalog session property ``parquet_use_column_names`` is set to true. By default they are mapped by index.
- #16365 (Author: Rongrong Zhong): Fix some issues in SQL function
  - Fix issues in SQL functions where query might fail with compiler error when function implementation includes lambda variable that has the same name as column names or function input names.
- #16377 (Author: Chen): Fix column in parquet dereference pushdown
  - Fixes a bug in Parquet dereference pushdown. The issue causes column name not picked up properly, resulting in inconsistent query result in certain cases.
- #16391 (Author: Junyi Huang): Add ORC support for iceberg connector
  - Add ORC support for iceberg connector.
- #16401 (Author: Zhenxiao Luo): Allow dynamic filtering with comparison operators
  - Support dynamic filtering with comparison operators.
- #16428 (Author: Zhenxiao Luo): Fix incorrect pushdown if IS NULL predicate in Elasticsearch
  - Fix incorrect pushdown if IS NULL predicate in Elasticsearch.

# All Commits
- efea31ce8c19d36096376443c1b1c67be7519944 Fix doc issue on deployment page, so that copy command does not include the $. Fixes #15735 (Marilyn Beck)
- 12742bbe09382ae1f448d9fbae41e2c9dd97dc00 Optimize GroupedTopNBuilder (James Petty)
- b6f86bff558eba188fb3b05a376f59187edbe390 Add utility methods to ObjectBigArray (James Petty)
- a4f103e672838538dc17a0b63b7748af80ba186e Avoid boxing in SimplePagesIndexComparator (James Petty)
- a4caff66ef2199c0bbb26b1023f7f700244cfc68 Avoid boxing in SimplePageWithPositionComparator (James Petty)
- 9c0791288ee28b113e40cef4190fbc37425b8e90 Enhance BenchmarkGroupedTopNBuilder (James Petty)
- 4d32a8232f6e3bd08e84ba2d4dac651ef319be3d Simplify PagePartitioner inner loop conditional branching (James Petty)
- 95ab9e9648fe6e4e7c9d2350521bc1d8f9425186 Close systemMemoryContext in PartitionedOutputOperator#close() (James Petty)
- 45d7540a65669051d2e8cfebe0cf3f0f74d8ea2e Implement mayHaveNull() for Dictionary, RLE, and GroupById Blocks (James Petty)
- 9b5a2478b05341f6bc0cf702593004b6796f1167 Allow dynamic filtering with comparison operators (Zhenxiao Luo)
- 396913ef9d9cde62f1d612a82d5522b04d0ba06a Remove redundant function in PredicatePushdown for dynamic filtering (Zhenxiao Luo)
- b0d8a70a55e2d3ad60ffdf2a8f5b5659a7f6741c Extend OperatorType to support dynamic filter comparison operators (Zhenxiao Luo)
- 5633ed8e3087382645bf3157457c7801838a2825 Add Cauchy distribution functions (Jeremy Craig Sawruk)
- c6cfafd15ce2ff41b14deed7cb3f97d09623c96a [thrift connector] Add property to forward user via Thrift Header (derektbrown)
- 1c3d141e1d017e96bb68fb854aac6c800646c4b7 Fix incorrect pushdown if IS NULL predicate in Elasticsearch (Zhenxiao Luo)
- e14ba2b4e6bded261a3c71656098c8df323309bd Order RuntimeStats by metric name in coordinator UI and cli (Zhan Yuan)
- ad538e1c5a0997a201f4b3f5867ff4e5017c3a83 Add task-level RuntimeStats (Zhan Yuan)
- b1f76c64e158e66f9668764e0c6aa6ee91c0fe97 Fall back on shared dictionaries when available (Huameng Jiang)
- d46b497e88450e2dee2a26ccac9f213ac485d7e8 Remove unnecessary locking in SqlStageExecution (Zhenxiao Luo)
- d3823d595a59034cd8959d91cf92c807463c08eb Add ORC support for iceberg connector (Junyi Huang)
- b330d564c7fc23ca2357564ab475b9d4e845e55e Upgrade orc-protobuf version to 12 and add attributes to OrcType (Junyi Huang)
- 509061221c11ef56cdfd2e30a90f86499569411e Add support for partition schema evolution for HUDI tables (Jalpreet Singh Nanda (:imjalpreet))
- 22097e8c8ba17ace2fdfd241163604655b567dc5 Fix SetOperation(UNION/INTERSECT/EXCEPT) for Pinot Connector to pushdown sub-queries (Xiang Fu)
- fc1a5acc67c070f1381262607ccc898373df4358 Fix lambda scope issues in SQL functions (Rongrong Zhong)
- 8dfa3c366413c9555566367936c3e1a872e90baa Move InlineSqlFunctions to beginning of plan optimizers (Rongrong Zhong)
- 7c8bc701b92f817ec044a618e9e50fa19ac11a44 Fix SQL function interpretation in expression interpreters (Rongrong Zhong)
- 79d8a59d5a42baeb41ac3f21c3c9c7323782e30d Resolve enum literal only when dereference expression base type is enum (Rongrong Zhong)
- ab404caca4c6ed76c97878ad5c4d2637baf1485c Add materialized view query optimization utility (Julian Zhuoran Zhao)
- 5d150f76bb8138ad8470bb379a96861e3f308e38 Extend memory exceeded errors with more details (Andrii Rosa)
- 5ff5a3471172cc9cbb759534cf8a8a8a10b0dc7d Implement Z-Order curve search function (Grace Xin)
- 231977904b852e7c84b340dab298ad2487f12bc8 Implement collection of min/max values in DynamicFilterSourceOperator (Roman Zeyde)
- ea8d2677032fd246ac2d9d53a6c3089cdb788959 Add SQL functions for array dupes (Pranjal Shankhdhar)
- 700f324a7730f1e0498f5c2255adc1334ee49f88 Fix dupe expression error in orderings (Pranjal Shankhdhar)
- 6d19caa1706dad86d56252f746dc783b560b66f2 Improve cassandra query performance by adding metadata cache (护城)
- af61b56241d727dad0a5dcd9a5aa4ce99c75869a Fix typo in aggregate.rst (jiachen)
- 6b34a87c1426ba72e0cd0fc9678611553bf7b893 Fix typo in CostCalculatorWithEstimatedExchanges (lijieliang)
- ca3db02657b0a0370a9df9a7b7037e25b8810c2c Ensure server tests are included in CI (Tim Meehan)
- 25de3d7f7465d6fe87e73c95f34afda4517c1f28 Show RuntimeStats in the Presto query Web UI (Zhan Yuan)
- 3cc2a27be4395fb67f37ac49cae90bfd4f650370 Record #bytes read from cache and external (Zhan Yuan)
- c1125e472e38e1dcebbaaa283e64da3c4ce6e7e8 Expose RuntimeStats and aggregate them at query level (Zhan Yuan)
- 8f476648171d82691215cb0ecd78f0014d30f93a Add RuntimeStats to track more operator stats (Zhan Yuan)
- dd24f15d597c4b508f4ce3b0cee9114b4a2cf814 Update README.md (James Xu)
- 3250e9cc52b7a635b0a8dabdc39a2c7742f4ad7c Claim that MODULE_WORKING_DIR can also be used as working dir (护城)
- 109d9a08e4dbbf90a38009da6a07a37a875daf82 Fix column name in parquet dereference pushdown (Chen)
- 91395db1f13f5fcf60b4414d55a610a94b65c9ef Disable flaky test 'testGetQueryInfos'. (Sergey Pershin)
- 40bfcf5b4705c94d30751ad73c33d3e13cd34dc8 add client tags info to ConnectorSession (Neerad Somanchi)