### PR TITLE
Add stats to track the number of replaced non-alive nodes

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/nodeSelection/NodeSelectionStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/nodeSelection/NodeSelectionStats.java
@@ -28,6 +28,7 @@ public class NodeSelectionStats
 
     private final CounterStat bucketedPreferredNodeSelectedCount = new CounterStat();
     private final CounterStat bucketedNonPreferredNodeSelectedCount = new CounterStat();
+    private final CounterStat bucketedNonAliveNodeReplacedCount = new CounterStat();
 
     private final CounterStat preferredNonAliveNodeSkippedCount = new CounterStat();
 
@@ -54,6 +55,11 @@ public class NodeSelectionStats
     public void incrementBucketedNonPreferredNodeSelectedCount()
     {
         bucketedNonPreferredNodeSelectedCount.update(1);
+    }
+
+    public void incrementBucketedNonAliveNodeReplacedCount()
+    {
+        bucketedNonAliveNodeReplacedCount.update(1);
     }
 
     public void incrementPreferredNonAliveNodeSkippedCount()
@@ -101,5 +107,12 @@ public class NodeSelectionStats
     public CounterStat getPreferredNonAliveNodeSkippedCount()
     {
         return preferredNonAliveNodeSkippedCount;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getBucketedNonAliveNodeReplacedCount()
+    {
+        return bucketedNonAliveNodeReplacedCount;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/NodePartitioningManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/NodePartitioningManager.java
@@ -19,6 +19,7 @@ import com.facebook.presto.execution.scheduler.BucketNodeMap;
 import com.facebook.presto.execution.scheduler.FixedBucketNodeMap;
 import com.facebook.presto.execution.scheduler.NodeScheduler;
 import com.facebook.presto.execution.scheduler.group.DynamicBucketNodeMap;
+import com.facebook.presto.execution.scheduler.nodeSelection.NodeSelectionStats;
 import com.facebook.presto.metadata.InternalNode;
 import com.facebook.presto.metadata.Split;
 import com.facebook.presto.operator.BucketPartitionFunction;
@@ -58,12 +59,14 @@ public class NodePartitioningManager
 {
     private final NodeScheduler nodeScheduler;
     private final PartitioningProviderManager partitioningProviderManager;
+    private final NodeSelectionStats nodeSelectionStats;
 
     @Inject
-    public NodePartitioningManager(NodeScheduler nodeScheduler, PartitioningProviderManager partitioningProviderManager)
+    public NodePartitioningManager(NodeScheduler nodeScheduler, PartitioningProviderManager partitioningProviderManager, NodeSelectionStats nodeSelectionStats)
     {
         this.nodeScheduler = requireNonNull(nodeScheduler, "nodeScheduler is null");
         this.partitioningProviderManager = requireNonNull(partitioningProviderManager, "partitioningProviderManager is null");
+        this.nodeSelectionStats = requireNonNull(nodeSelectionStats, "nodeSelectionStats is null");
     }
 
     public PartitionFunction getPartitionFunction(
@@ -274,6 +277,7 @@ public class NodePartitioningManager
                     node = allNodes.get(index);
                     index = (index + 1) % nodeCount;
                 }
+                nodeSelectionStats.incrementBucketedNonAliveNodeReplacedCount();
             }
             nodeBuilder.add(node);
         }

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -342,7 +342,7 @@ public class LocalQueryRunner
                 catalogManager,
                 notificationExecutor);
         this.partitioningProviderManager = new PartitioningProviderManager();
-        this.nodePartitioningManager = new NodePartitioningManager(nodeScheduler, partitioningProviderManager);
+        this.nodePartitioningManager = new NodePartitioningManager(nodeScheduler, partitioningProviderManager, new NodeSelectionStats());
         this.planOptimizerManager = new ConnectorPlanOptimizerManager();
         this.distributedMetadataManager = new ConnectorMetadataUpdaterManager();
 

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestCostCalculator.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestCostCalculator.java
@@ -136,7 +136,7 @@ public class TestCostCalculator
                 new NodeSchedulerConfig().setIncludeCoordinator(true),
                 new NodeTaskMap(finalizerService));
         PartitioningProviderManager partitioningProviderManager = new PartitioningProviderManager();
-        nodePartitioningManager = new NodePartitioningManager(nodeScheduler, partitioningProviderManager);
+        nodePartitioningManager = new NodePartitioningManager(nodeScheduler, partitioningProviderManager, new NodeSelectionStats());
         planFragmenter = new PlanFragmenter(metadata, nodePartitioningManager, new QueryManagerConfig(), new SqlParser(), new FeaturesConfig());
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
@@ -145,7 +145,7 @@ public final class TaskTestUtils
                 new NodeSchedulerConfig().setIncludeCoordinator(true),
                 new NodeTaskMap(finalizerService));
         PartitioningProviderManager partitioningProviderManager = new PartitioningProviderManager();
-        NodePartitioningManager nodePartitioningManager = new NodePartitioningManager(nodeScheduler, partitioningProviderManager);
+        NodePartitioningManager nodePartitioningManager = new NodePartitioningManager(nodeScheduler, partitioningProviderManager, new NodeSelectionStats());
 
         PageFunctionCompiler pageFunctionCompiler = new PageFunctionCompiler(metadata, 0);
         return new LocalExecutionPlanner(

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/node/PrestoSparkNodePartitioningManager.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/node/PrestoSparkNodePartitioningManager.java
@@ -16,6 +16,7 @@ package com.facebook.presto.spark.node;
 import com.facebook.presto.Session;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.execution.scheduler.BucketNodeMap;
+import com.facebook.presto.execution.scheduler.nodeSelection.NodeSelectionStats;
 import com.facebook.presto.operator.PartitionFunction;
 import com.facebook.presto.spi.connector.ConnectorPartitionHandle;
 import com.facebook.presto.sql.planner.NodePartitionMap;
@@ -37,7 +38,7 @@ public class PrestoSparkNodePartitioningManager
     @Inject
     public PrestoSparkNodePartitioningManager(PartitioningProviderManager partitioningProviderManager)
     {
-        super(new PrestoSparkNodeScheduler(), partitioningProviderManager);
+        super(new PrestoSparkNodeScheduler(), partitioningProviderManager, new NodeSelectionStats());
     }
 
     @Override


### PR DESCRIPTION
When resilient affinity is enabled, we would like to have counter to track the non-alive nodes that were replaced.

```
== NO RELEASE NOTE ==
```
