### PR TITLE
Enable instance and custom credential provider for glue

### DIFF
--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -231,6 +231,10 @@ Property Name                                        Description
 
 ``hive.metastore.glue.default-warehouse-dir``        Hive Glue metastore default warehouse directory
 
+``hive.metastore.glue.aws-credentials-provider``     Fully qualified name of the Java class to use for obtaining
+                                                     AWS credentials. Can be used to supply a custom credentials
+                                                     provider.
+
 ``hive.metastore.glue.aws-access-key``               AWS access key to use to connect to the Glue Catalog. If
                                                      specified along with ``hive.metastore.glue.aws-secret-key``,
                                                      this parameter takes precedence over

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/glue/GlueHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/glue/GlueHiveMetastore.java
@@ -138,6 +138,7 @@ import static com.facebook.presto.spi.security.PrincipalType.USER;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.collect.Comparators.lexicographical;
+import static java.lang.String.format;
 import static java.util.Comparator.comparing;
 import static java.util.Objects.requireNonNull;
 import static java.util.function.UnaryOperator.identity;
@@ -216,13 +217,30 @@ public class GlueHiveMetastore
             return new AWSStaticCredentialsProvider(
                     new BasicAWSCredentials(config.getAwsAccessKey().get(), config.getAwsSecretKey().get()));
         }
-        else if (config.getIamRole().isPresent()) {
+        if (config.getIamRole().isPresent()) {
             return new STSAssumeRoleSessionCredentialsProvider
                     .Builder(config.getIamRole().get(), "roleSessionName")
                     .build();
         }
+        if (config.getAwsCredentialsProvider().isPresent()) {
+            return getCustomAWSCredentialsProvider(config.getAwsCredentialsProvider().get());
+        }
 
         return DefaultAWSCredentialsProviderChain.getInstance();
+    }
+
+    private static AWSCredentialsProvider getCustomAWSCredentialsProvider(String providerClass)
+    {
+        try {
+            Object instance = Class.forName(providerClass).getConstructor().newInstance();
+            if (!(instance instanceof AWSCredentialsProvider)) {
+                throw new RuntimeException("Invalid credentials provider class: " + instance.getClass().getName());
+            }
+            return (AWSCredentialsProvider) instance;
+        }
+        catch (ReflectiveOperationException e) {
+            throw new RuntimeException(format("Error creating an instance of %s", providerClass), e);
+        }
     }
 
     @Managed

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/glue/GlueHiveMetastoreConfig.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/glue/GlueHiveMetastoreConfig.java
@@ -36,6 +36,7 @@ public class GlueHiveMetastoreConfig
     private Optional<String> iamRole = Optional.empty();
     private Optional<String> awsAccessKey = Optional.empty();
     private Optional<String> awsSecretKey = Optional.empty();
+    private Optional<String> awsCredentialsProvider = Optional.empty();
 
     public Optional<String> getGlueRegion()
     {
@@ -195,6 +196,18 @@ public class GlueHiveMetastoreConfig
     public GlueHiveMetastoreConfig setAwsSecretKey(String awsSecretKey)
     {
         this.awsSecretKey = Optional.ofNullable(awsSecretKey);
+        return this;
+    }
+
+    public Optional<String> getAwsCredentialsProvider()
+    {
+        return awsCredentialsProvider;
+    }
+
+    @Config("hive.metastore.glue.aws-credentials-provider")
+    public GlueHiveMetastoreConfig setAwsCredentialsProvider(String awsCredentialsProvider)
+    {
+        this.awsCredentialsProvider = Optional.ofNullable(awsCredentialsProvider);
         return this;
     }
 }

--- a/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/glue/TestGlueHiveMetastoreConfig.java
+++ b/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/glue/TestGlueHiveMetastoreConfig.java
@@ -39,7 +39,8 @@ public class TestGlueHiveMetastoreConfig
                 .setGetPartitionThreads(20)
                 .setIamRole(null)
                 .setAwsAccessKey(null)
-                .setAwsSecretKey(null));
+                .setAwsSecretKey(null)
+                .setAwsCredentialsProvider(null));
     }
 
     @Test
@@ -58,6 +59,7 @@ public class TestGlueHiveMetastoreConfig
                 .put("hive.metastore.glue.iam-role", "role")
                 .put("hive.metastore.glue.aws-access-key", "ABC")
                 .put("hive.metastore.glue.aws-secret-key", "DEF")
+                .put("hive.metastore.glue.aws-credentials-provider", "custom")
                 .build();
 
         GlueHiveMetastoreConfig expected = new GlueHiveMetastoreConfig()
@@ -72,7 +74,8 @@ public class TestGlueHiveMetastoreConfig
                 .setGetPartitionThreads(42)
                 .setIamRole("role")
                 .setAwsAccessKey("ABC")
-                .setAwsSecretKey("DEF");
+                .setAwsSecretKey("DEF")
+                .setAwsCredentialsProvider("custom");
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
Add config hive.metastore.glue.aws-credentials-provider for glue
Cherry-pick of trinodb/trino#1363,
trinodb/trino#741 and
trinodb/trino#3689

Add config hive.metastore.glue.aws-credentials-provider for glue
credential provider. where value is fully qualified class name of
custom AWS credential provider implementation.

```
== RELEASE NOTES ==

AWS Changes
* Enable instance and custom credential provider for glue
  Add configuration property
  ``hive.metastore.glue.aws-credentials-provider`` to supply a 
  custom credential provider.
```
