### PR TITLE
Use doubles for T-Digest weights

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/TDigestFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/TDigestFunctions.java
@@ -119,7 +119,7 @@ public final class TDigestFunctions
         BlockBuilder meansBuilder = DOUBLE.createBlockBuilder(null, tDigest.centroidCount());
         BlockBuilder weightsBuilder = INTEGER.createBlockBuilder(null, tDigest.centroidCount());
         for (Centroid centroid : tDigest.centroids()) {
-            int weight = centroid.getWeight();
+            int weight = (int) centroid.getWeight();
             DOUBLE.writeDouble(meansBuilder, centroid.getMean());
             INTEGER.writeLong(weightsBuilder, weight);
         }

--- a/presto-main/src/main/java/com/facebook/presto/tdigest/Centroid.java
+++ b/presto-main/src/main/java/com/facebook/presto/tdigest/Centroid.java
@@ -48,7 +48,7 @@ public class Centroid
     private static final AtomicInteger uniqueCount = new AtomicInteger(1);
 
     private double centroid;
-    private int count;
+    private double count;
 
     // The ID is transient because it must be unique within a given JVM. A new
     // ID should be generated from uniqueCount when a Centroid is deserialized.
@@ -59,23 +59,23 @@ public class Centroid
         start(x, 1, uniqueCount.getAndIncrement());
     }
 
-    public Centroid(double x, int w)
+    public Centroid(double x, double w)
     {
         start(x, w, uniqueCount.getAndIncrement());
     }
 
-    public Centroid(double x, int w, int id)
+    public Centroid(double x, double w, int id)
     {
         start(x, w, id);
     }
 
-    private void start(double x, int w, int id)
+    private void start(double x, double w, int id)
     {
         this.id = id;
         add(x, w);
     }
 
-    public void add(double x, int w)
+    public void add(double x, double w)
     {
         count += w;
         centroid += w * (x - centroid) / count;
@@ -86,7 +86,7 @@ public class Centroid
         return centroid;
     }
 
-    public int getWeight()
+    public double getWeight()
     {
         return count;
     }

--- a/presto-main/src/main/java/com/facebook/presto/tdigest/TDigest.java
+++ b/presto-main/src/main/java/com/facebook/presto/tdigest/TDigest.java
@@ -96,6 +96,7 @@ public class TDigest
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(TDigest.class).instanceSize();
     private static final double MAX_COMPRESSION_FACTOR = 1_000;
     private static final double sizeFudge = 30;
+    private static final double EPSILON = 0.001;
 
     private double min = Double.POSITIVE_INFINITY;
     private double max = Double.NEGATIVE_INFINITY;
@@ -197,7 +198,7 @@ public class TDigest
         add(x, 1);
     }
 
-    public void add(double x, long w)
+    public void add(double x, double w)
     {
         checkArgument(!isNaN(x), "Cannot add NaN to t-digest");
         checkArgument(w > 0L, "weight must be > 0");
@@ -334,7 +335,7 @@ public class TDigest
             sumWeights += weight[i];
         }
 
-        checkArgument(sumWeights == totalWeight, "Sum must equal the total weight, but sum:%s != totalWeight:%s", sumWeights, totalWeight);
+        checkArgument(Math.abs(sumWeights - totalWeight) < EPSILON, "Sum must equal the total weight, but sum:%s != totalWeight:%s", sumWeights, totalWeight);
         if (runBackwards) {
             reverse(mean, 0, activeCentroids);
             reverse(weight, 0, activeCentroids);
@@ -593,7 +594,7 @@ public class TDigest
                     @Override
                     public Centroid next()
                     {
-                        Centroid rc = new Centroid(mean[i], (int) weight[i]);
+                        Centroid rc = new Centroid(mean[i], weight[i]);
                         i++;
                         return rc;
                     }

--- a/presto-main/src/test/java/com/facebook/presto/tdigest/TestTDigest.java
+++ b/presto-main/src/test/java/com/facebook/presto/tdigest/TestTDigest.java
@@ -164,6 +164,23 @@ public class TestTDigest
     }
 
     @Test
+    public void testLargeScalePreservesWeights()
+    {
+        TDigest tDigest = createTDigest(STANDARD_COMPRESSION_FACTOR);
+        NormalDistribution normal = new NormalDistribution(1000, 100);
+
+        for (int i = 0; i < NUMBER_OF_ENTRIES; i++) {
+            tDigest.add(normal.sample());
+        }
+
+        tDigest.scale(Integer.MAX_VALUE * 2.0);
+
+        for (Centroid centroid : tDigest.centroids()) {
+            assertTrue(centroid.getWeight() > Integer.MAX_VALUE);
+        }
+    }
+
+    @Test
     public void testNormalDistributionHighVariance()
     {
         TDigest tDigest = createTDigest(STANDARD_COMPRESSION_FACTOR);


### PR DESCRIPTION
Integer conversion in TDigest#centroids can cause skew during merge.

```
== NO RELEASE NOTE ==
```
