### PR TITLE
Leverage Block#mayHaveNull() in HashSemiJoinOperator

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/Page.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/Page.java
@@ -309,6 +309,22 @@ public final class Page
         return wrapBlocksWithoutCopy(positionCount, loadedBlocks);
     }
 
+    public Page getLoadedPage(int channel)
+    {
+        return wrapBlocksWithoutCopy(positionCount, new Block[]{this.blocks[channel].getLoadedBlock()});
+    }
+
+    public Page getLoadedPage(int... channels)
+    {
+        requireNonNull(channels, "channels is null");
+
+        Block[] blocks = new Block[channels.length];
+        for (int i = 0; i < channels.length; i++) {
+            blocks[i] = this.blocks[channels[i]].getLoadedBlock();
+        }
+        return wrapBlocksWithoutCopy(positionCount, blocks);
+    }
+
     @Override
     public String toString()
     {

--- a/presto-common/src/main/java/com/facebook/presto/common/block/LazyBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/LazyBlock.java
@@ -263,6 +263,13 @@ public class LazyBlock
         return block.isNull(position);
     }
 
+    @Override
+    public boolean mayHaveNull()
+    {
+        assureLoaded();
+        return block.mayHaveNull();
+    }
+
     public void setBlock(Block block)
     {
         if (this.block != null) {


### PR DESCRIPTION
Consults `Block#mayHaveNull()` outside of the main processing loop in `HashSemiJoinOperator` so that `Block#isNull` checks can be skipped inside the loop when none are necessary. When nulls might be present, it also ensures that `LazyBlock` instances are unwrapped to avoid an unnecessary indirection when checking `Block#isNull`.

Also adds:
- `LazyBlock#mayHaveNull()` implementation to make the `Block#mayHaveNull()` checks like this one more effective
- `Page#getLoadedPage(int... channels)` helper methods to support simultaneous channel extraction and `LazyBlock` unwrapping

`SqlSemiJoinInPredicateBenchmark` results with 200 warmup iterations and 25 measured iterations for the baseline, PR version, PR version with manual loop predication of `HashSemiJoinOperator` summary (full output available in https://pastebin.com/dVn2KbfA):

```
Baseline:
sql_semijoin_in ::  156.141 cpu ms ::    0B peak memory :: in 75.2K,      0B,    481K/s,      0B/s :: out 30.1K,   264KB,    192K/s,  1.65MB/s

PR#16459:
sql_semijoin_in ::  150.445 cpu ms ::    0B peak memory :: in 75.2K,      0B,    500K/s,      0B/s :: out 30.1K,   264KB,    200K/s,  1.71MB/s

PR#16459 (loop isNull check manually unswitched):
sql_semijoin_in ::  150.931 cpu ms ::    0B peak memory :: in 75.2K,      0B,    498K/s,      0B/s :: out 30.1K,   264KB,    199K/s,  1.71MB/s
```


```
== NO RELEASE NOTE ==
```
