### PR TITLE
Get materialized views from base table metadata

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/CachingDirectoryLister.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/CachingDirectoryLister.java
@@ -68,13 +68,6 @@ public class CachingDirectoryLister
         this.cachedTableChecker = new CachedTableChecker(requireNonNull(tables, "tables is null"));
     }
 
-    private static SchemaTableName parseTableName(String tableName)
-    {
-        String[] parts = tableName.split("\\.");
-        checkArgument(parts.length == 2, "Invalid schemaTableName: %s", tableName);
-        return new SchemaTableName(parts[0], parts[1]);
-    }
-
     @Override
     public Iterator<HiveFileInfo> list(
             ExtendedFileSystem fileSystem,
@@ -174,7 +167,7 @@ public class CachingDirectoryLister
             }
             else {
                 this.cachedTableNames = cachedTables.stream()
-                        .map(CachingDirectoryLister::parseTableName)
+                        .map(SchemaTableName::valueOf)
                         .collect(toImmutableSet());
             }
         }

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/schema/file/FileTableDescriptionSupplier.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/schema/file/FileTableDescriptionSupplier.java
@@ -22,7 +22,6 @@ import com.facebook.presto.kafka.KafkaTopicFieldGroup;
 import com.facebook.presto.kafka.schema.MapBasedTableDescriptionSupplier;
 import com.facebook.presto.kafka.schema.TableDescriptionSupplier;
 import com.facebook.presto.spi.SchemaTableName;
-import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -38,8 +37,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.nio.file.Files.readAllBytes;
 import static java.util.Arrays.asList;
 import static java.util.Objects.requireNonNull;
@@ -99,7 +96,7 @@ public class FileTableDescriptionSupplier
             for (String definedTable : tableNames) {
                 SchemaTableName tableName;
                 try {
-                    tableName = parseTableName(definedTable);
+                    tableName = SchemaTableName.valueOf(definedTable);
                 }
                 catch (IllegalArgumentException iae) {
                     tableName = new SchemaTableName(defaultSchema, definedTable);
@@ -140,13 +137,5 @@ public class FileTableDescriptionSupplier
             }
         }
         return ImmutableList.of();
-    }
-
-    private static SchemaTableName parseTableName(String schemaTableName)
-    {
-        checkArgument(!isNullOrEmpty(schemaTableName), "schemaTableName is null or is empty");
-        List<String> parts = Splitter.on('.').splitToList(schemaTableName);
-        checkArgument(parts.size() == 2, "Invalid schemaTableName: %s", schemaTableName);
-        return new SchemaTableName(parts.get(0), parts.get(1));
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
@@ -389,6 +389,11 @@ public interface Metadata
     Optional<ConnectorOutputMetadata> finishRefreshMaterializedView(Session session, InsertTableHandle tableHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics);
 
     /**
+     * Gets the referenced materialized views for a give table
+     */
+    List<QualifiedObjectName> getReferencedMaterializedViews(Session session, QualifiedObjectName tableName);
+
+    /**
      * Try to locate a table index that can lookup results by indexableColumns and provide the requested outputColumns.
      */
     Optional<ResolvedIndex> resolveIndex(Session session, TableHandle tableHandle, Set<ColumnHandle> indexableColumns, Set<ColumnHandle> outputColumns, TupleDomain<ColumnHandle> tupleDomain);

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewCandidateExtractor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewCandidateExtractor.java
@@ -15,13 +15,12 @@ package com.facebook.presto.sql.analyzer;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.common.QualifiedObjectName;
+import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.sql.tree.DefaultTraversalVisitor;
 import com.facebook.presto.sql.tree.Table;
 
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 import static com.facebook.presto.metadata.MetadataUtil.createQualifiedObjectName;
@@ -31,14 +30,13 @@ public class MaterializedViewCandidateExtractor
         extends DefaultTraversalVisitor<Void, Void>
 {
     private final Set<QualifiedObjectName> tableNames = new HashSet<>();
-    private final Map<QualifiedObjectName, List<QualifiedObjectName>> baseTableToMaterializedViews;
-
+    private final Metadata metadata;
     private final Session session;
 
-    public MaterializedViewCandidateExtractor(Session session, Map<QualifiedObjectName, List<QualifiedObjectName>> baseTableToMaterializedViews)
+    public MaterializedViewCandidateExtractor(Session session, Metadata metadata)
     {
         this.session = requireNonNull(session, "session is null");
-        this.baseTableToMaterializedViews = requireNonNull(baseTableToMaterializedViews, "base table to materialized view mapping is null");
+        this.metadata = requireNonNull(metadata, "metadata is null");
     }
 
     @Override
@@ -53,7 +51,7 @@ public class MaterializedViewCandidateExtractor
         Set<QualifiedObjectName> materializedViewCandidates = new HashSet<>();
 
         for (QualifiedObjectName baseTable : tableNames) {
-            List<QualifiedObjectName> materializedViews = baseTableToMaterializedViews.getOrDefault(baseTable, new ArrayList<>());
+            List<QualifiedObjectName> materializedViews = metadata.getReferencedMaterializedViews(session, baseTable);
 
             if (materializedViewCandidates.isEmpty()) {
                 materializedViewCandidates.addAll(materializedViews);

--- a/presto-main/src/main/java/com/facebook/presto/sql/rewrite/MaterializedViewOptimizationRewriteUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/rewrite/MaterializedViewOptimizationRewriteUtils.java
@@ -25,10 +25,7 @@ import com.facebook.presto.sql.relational.RowExpressionDomainTranslator;
 import com.facebook.presto.sql.tree.QualifiedName;
 import com.facebook.presto.sql.tree.Query;
 import com.facebook.presto.sql.tree.Table;
-import com.google.common.collect.ImmutableMap;
 
-import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
 public class MaterializedViewOptimizationRewriteUtils
@@ -42,8 +39,7 @@ public class MaterializedViewOptimizationRewriteUtils
             AccessControl accessControl,
             Query node)
     {
-        Map<QualifiedObjectName, List<QualifiedObjectName>> baseTableToMaterializedViews = getBaseTableToMaterializedViews();
-        MaterializedViewCandidateExtractor materializedViewCandidateExtractor = new MaterializedViewCandidateExtractor(session, baseTableToMaterializedViews);
+        MaterializedViewCandidateExtractor materializedViewCandidateExtractor = new MaterializedViewCandidateExtractor(session, metadata);
         materializedViewCandidateExtractor.process(node);
         Set<QualifiedObjectName> materializedViewCandidates = materializedViewCandidateExtractor.getMaterializedViewCandidates();
         if (materializedViewCandidates.isEmpty()) {
@@ -67,11 +63,5 @@ public class MaterializedViewOptimizationRewriteUtils
 
         Query materializedViewDefinition = (Query) sqlParser.createStatement(materializedView.getOriginalSql());
         return (Query) new MaterializedViewQueryOptimizer(metadata, session, sqlParser, accessControl, new RowExpressionDomainTranslator(metadata), materializedViewTable, materializedViewDefinition).rewrite(statement);
-    }
-
-    // TODO: The mapping should be fetched from metastore https://github.com/prestodb/presto/issues/16430
-    private static Map<QualifiedObjectName, List<QualifiedObjectName>> getBaseTableToMaterializedViews()
-    {
-        return ImmutableMap.of();
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/metadata/AbstractMockMetadata.java
+++ b/presto-main/src/test/java/com/facebook/presto/metadata/AbstractMockMetadata.java
@@ -445,6 +445,12 @@ public abstract class AbstractMockMetadata
     }
 
     @Override
+    public List<QualifiedObjectName> getReferencedMaterializedViews(Session session, QualifiedObjectName tableName)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public Optional<ResolvedIndex> resolveIndex(Session session, TableHandle tableHandle, Set<ColumnHandle> indexableColumns, Set<ColumnHandle> outputColumns, TupleDomain<ColumnHandle> tupleDomain)
     {
         throw new UnsupportedOperationException();

--- a/presto-redis/src/main/java/com/facebook/presto/redis/RedisTableDescriptionSupplier.java
+++ b/presto-redis/src/main/java/com/facebook/presto/redis/RedisTableDescriptionSupplier.java
@@ -17,7 +17,6 @@ import com.facebook.airlift.json.JsonCodec;
 import com.facebook.airlift.log.Logger;
 import com.facebook.presto.decoder.dummy.DummyRowDecoder;
 import com.facebook.presto.spi.SchemaTableName;
-import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
@@ -31,8 +30,6 @@ import java.util.Map;
 import java.util.function.Supplier;
 
 import static com.google.common.base.MoreObjects.firstNonNull;
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.nio.file.Files.readAllBytes;
 import static java.util.Arrays.asList;
 import static java.util.Objects.requireNonNull;
@@ -75,7 +72,7 @@ public class RedisTableDescriptionSupplier
             for (String definedTable : redisConnectorConfig.getTableNames()) {
                 SchemaTableName tableName;
                 try {
-                    tableName = parseTableName(definedTable);
+                    tableName = SchemaTableName.valueOf(definedTable);
                 }
                 catch (IllegalArgumentException iae) {
                     tableName = new SchemaTableName(redisConnectorConfig.getDefaultSchema(), definedTable);
@@ -114,13 +111,5 @@ public class RedisTableDescriptionSupplier
             }
         }
         return ImmutableList.of();
-    }
-
-    private static SchemaTableName parseTableName(String schemaTableName)
-    {
-        checkArgument(!isNullOrEmpty(schemaTableName), "schemaTableName is null or is empty");
-        List<String> parts = Splitter.on('.').splitToList(schemaTableName);
-        checkArgument(parts.size() == 2, "Invalid schemaTableName: %s", schemaTableName);
-        return new SchemaTableName(parts.get(0), parts.get(1));
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/SchemaTableName.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/SchemaTableName.java
@@ -33,6 +33,17 @@ public class SchemaTableName
         this.tableName = checkNotEmpty(tableName, "tableName").toLowerCase(ENGLISH);
     }
 
+    public static SchemaTableName valueOf(String schemaTableName)
+    {
+        checkNotEmpty(schemaTableName, "schemaTableName").toLowerCase(ENGLISH);
+
+        String[] parts = schemaTableName.split("\\.");
+        if (parts.length != 2) {
+            throw new IllegalArgumentException("SchemaTableName should have exactly 2 parts");
+        }
+        return new SchemaTableName(parts[0], parts[1]);
+    }
+
     @JsonProperty("schema")
     public String getSchemaName()
     {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
@@ -611,6 +611,14 @@ public interface ConnectorMetadata
     }
 
     /**
+     * Gets the referenced materialized views for a give table
+     */
+    default List<SchemaTableName> getReferencedMaterializedViews(ConnectorSession session, SchemaTableName tableName)
+    {
+        return emptyList();
+    }
+
+    /**
      * @return whether delete without table scan is supported
      */
     default boolean supportsMetadataDelete(ConnectorSession session, ConnectorTableHandle tableHandle, Optional<ConnectorTableLayoutHandle> tableLayoutHandle)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -270,6 +270,14 @@ public class ClassLoaderSafeConnectorMetadata
     }
 
     @Override
+    public List<SchemaTableName> getReferencedMaterializedViews(ConnectorSession session, SchemaTableName tableName)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.getReferencedMaterializedViews(session, tableName);
+        }
+    }
+
+    @Override
     public Map<String, ColumnHandle> getColumnHandles(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {


### PR DESCRIPTION
If materialized view information is present in the base table metadata, then it should be used to optimize the queries.
Adding a method to retrieve the list of supported materialized views from base table metadata.

Reference: #16438
Depended by: [facebookexternal/presto-facebook#1621](https://github.com/facebookexternal/presto-facebook/pull/1621)
```
== NO RELEASE NOTE ==
```