### PR TITLE
Ensure resource group concurrency tests have enough time time succeed

### DIFF
--- a/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/TestQueuesDb.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/TestQueuesDb.java
@@ -213,7 +213,7 @@ public class TestQueuesDb
         waitForQueryState(queryRunner, secondDashboardQuery, QUEUED);
     }
 
-    //@Test(timeOut = 90_000)
+    @Test(timeOut = 90_000)
     public void testTooManyQueries()
             throws Exception
     {

--- a/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/TestQueuesDb.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/TestQueuesDb.java
@@ -106,8 +106,7 @@ public class TestQueuesDb
         }
     }
 
-    // Disabled, please look at https://github.com/prestodb/presto/issues/16461
-    @Test(timeOut = 60_000, enabled = false)
+    @Test(timeOut = 120_000)
     public void testResourceGroupConcurrencyThreshold()
             throws Exception
     {
@@ -132,7 +131,7 @@ public class TestQueuesDb
         closeQuietly(queryRunner);
     }
 
-    @Test(timeOut = 60_000)
+    @Test(timeOut = 120_000)
     public void testMultiResourceGroupConcurrencyThreshold()
             throws Exception
     {


### PR DESCRIPTION
```
== NO RELEASE NOTE ==
```
