### PR TITLE
Fix flaky resource group concurrency test

### DIFF
--- a/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/TestQueuesDb.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/TestQueuesDb.java
@@ -106,8 +106,7 @@ public class TestQueuesDb
         }
     }
 
-    // Disabled, please look at https://github.com/prestodb/presto/issues/16461
-    @Test(timeOut = 60_000, enabled = false)
+    @Test(timeOut = 60_000)
     public void testResourceGroupConcurrencyThreshold()
             throws Exception
     {
@@ -123,7 +122,6 @@ public class TestQueuesDb
 
         QueryId secondAdhocQuery = createQuery(queryRunner, adhocSession(), LONG_LASTING_QUERY);
         // wait for the second "dashboard" query to be queued ("dashboard.${USER}" queue strategy only allows one "dashboard" query to be accepted for execution)
-        MILLISECONDS.sleep(100);
         waitForQueryState(queryRunner, secondAdhocQuery, QUEUED);
         MILLISECONDS.sleep(500);
         waitForQueryState(queryRunner, secondAdhocQuery, RUNNING);


### PR DESCRIPTION
Test plan - Verified running couple of times locally to make sure it won't fail. Without the change out 3-4 run 1 fails.

Going to run on jenkins multiple times to make sure tests passes all the time.

Fixes Issue: https://github.com/prestodb/presto/issues/16461
```
== NO RELEASE NOTE ==
```
