### PR TITLE
Flush all buffered pages in TempStorageSingleStreamSpiller while doing spill

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/spiller/TempStorageSingleStreamSpiller.java
+++ b/presto-main/src/main/java/com/facebook/presto/spiller/TempStorageSingleStreamSpiller.java
@@ -168,6 +168,10 @@ public class TempStorageSingleStreamSpiller
                     });
         }
 
+        // Flush remaining buffered pages, if any
+        if (!bufferedPages.isEmpty()) {
+            flushBufferedPages();
+        }
         memoryContext.setBytes(bufferedBytes + dataSink.getRetainedSizeInBytes());
     }
 


### PR DESCRIPTION
TempStorageSingleStreamSpiller writePages() method takes a pageIterator
and spill all the pages to a disk. Before flushing the pages, it buffers
`maxBufferSizeInBytes` bytes and perform the spill only when total
buffered data is more than this threshold. However, if the total buffered
data is less than `maxBufferSizeInBytes` bytes, then spilling wont be
triggered and pages are retained in memory. In low memory conditions, this
can trigger EXCEEDED_LOCAL_MEMORY_LIMIT oom.

Test plan 
Tested a big query that would fail with OOM in Generic Spiller. Heapdump shows a large number of pages buffered in memory in TempStorageSingleStreamSpiller. The query passes successfully after the fix.


```
== NO RELEASE NOTE ==
```
