### PR TITLE
Support DWRF stripes above MAX_INT rows in reader

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/AbstractOrcRecordReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/AbstractOrcRecordReader.java
@@ -689,7 +689,7 @@ abstract class AbstractOrcRecordReader<T extends StreamReader>
         }
     }
 
-    private void validateWriteStripe(int rowCount)
+    private void validateWriteStripe(long rowCount)
     {
         if (writeChecksumBuilder.isPresent()) {
             writeChecksumBuilder.get().addStripe(rowCount);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriteValidation.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriteValidation.java
@@ -481,10 +481,10 @@ public class OrcWriteValidation
             return new WriteChecksumBuilder(types.build());
         }
 
-        public void addStripe(int rowCount)
+        public void addStripe(long rowCount)
         {
-            longSlice.setInt(0, rowCount);
-            stripeHash.update(longBuffer, 0, Integer.BYTES);
+            longSlice.setLong(0, rowCount);
+            stripeHash.update(longBuffer, 0, Long.BYTES);
         }
 
         public void addPage(Page page)
@@ -888,7 +888,7 @@ public class OrcWriteValidation
             return this;
         }
 
-        public OrcWriteValidationBuilder addStripe(int rowCount)
+        public OrcWriteValidationBuilder addStripe(long rowCount)
         {
             checksum.addStripe(rowCount);
             return this;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriterFlushStats.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriterFlushStats.java
@@ -57,7 +57,7 @@ public class OrcWriterFlushStats
         return dictionaryBytes;
     }
 
-    public void recordStripeWritten(long stripeBytes, int stripeRows, int dictionaryBytes)
+    public void recordStripeWritten(long stripeBytes, long stripeRows, int dictionaryBytes)
     {
         this.stripeBytes.add(stripeBytes);
         this.stripeRows.add(stripeRows);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriterStats.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriterStats.java
@@ -45,7 +45,7 @@ public class OrcWriterStats
             StripeInformation stripeInformation)
     {
         long stripeBytes = stripeInformation.getTotalLength();
-        int stripeRows = stripeInformation.getNumberOfRows();
+        long stripeRows = stripeInformation.getNumberOfRows();
         getFlushStats(flushReason).recordStripeWritten(stripeBytes, stripeRows, dictionaryBytes);
         allFlush.recordStripeWritten(stripeBytes, stripeRows, dictionaryBytes);
     }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/StripeReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/StripeReader.java
@@ -420,7 +420,7 @@ public class StripeReader
     }
 
     private List<RowGroup> createRowGroups(
-            int rowsInStripe,
+            long rowsInStripe,
             Map<StreamId, Stream> streams,
             Map<StreamId, ValueInputStream<?>> valueStreams,
             Map<StreamId, List<RowGroupIndex>> columnIndexes,
@@ -433,7 +433,7 @@ public class StripeReader
         for (int rowGroupId : selectedRowGroups) {
             Map<StreamId, StreamCheckpoint> checkpoints = getStreamCheckpoints(includedOrcColumns, types, decompressor.isPresent(), rowGroupId, encodings, streams, columnIndexes);
             int rowOffset = rowGroupId * rowsInRowGroup;
-            int rowsInGroup = Math.min(rowsInStripe - rowOffset, rowsInRowGroup);
+            int rowsInGroup = toIntExact(Math.min(rowsInStripe - rowOffset, rowsInRowGroup));
             long minAverageRowBytes = columnIndexes
                     .entrySet()
                     .stream()
@@ -536,13 +536,13 @@ public class StripeReader
 
     private Set<Integer> selectRowGroups(StripeInformation stripe, Map<StreamId, List<RowGroupIndex>> columnIndexes)
     {
-        int rowsInStripe = toIntExact(stripe.getNumberOfRows());
+        long rowsInStripe = stripe.getNumberOfRows();
         int groupsInStripe = ceil(rowsInStripe, rowsInRowGroup);
 
         ImmutableSet.Builder<Integer> selectedRowGroups = ImmutableSet.builder();
-        int remainingRows = rowsInStripe;
+        long remainingRows = rowsInStripe;
         for (int rowGroup = 0; rowGroup < groupsInStripe; ++rowGroup) {
-            int rows = Math.min(remainingRows, rowsInRowGroup);
+            int rows = toIntExact(Math.min(remainingRows, rowsInRowGroup));
             Map<Integer, ColumnStatistics> statistics = getRowGroupStatistics(types.get(0), columnIndexes, rowGroup);
             if (predicate.matches(rows, statistics)) {
                 selectedRowGroups.add(rowGroup);
@@ -613,9 +613,10 @@ public class StripeReader
     /**
      * Ceiling of integer division
      */
-    private static int ceil(int dividend, int divisor)
+    private static int ceil(long dividend, int divisor)
     {
-        return ((dividend + divisor) - 1) / divisor;
+        long ceil = ((dividend + divisor) - 1) / divisor;
+        return toIntExact(ceil);
     }
 
     public static class StripeId

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfMetadataReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfMetadataReader.java
@@ -286,7 +286,7 @@ public class DwrfMetadataReader
             keyMetadata = previousKeyMetadata;
         }
         return new StripeInformation(
-                toIntExact(stripeInformation.getNumberOfRows()),
+                stripeInformation.getNumberOfRows(),
                 stripeInformation.getOffset(),
                 stripeInformation.getIndexLength(),
                 stripeInformation.getDataLength(),

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfMetadataWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfMetadataWriter.java
@@ -24,6 +24,7 @@ import com.facebook.presto.orc.proto.DwrfProto.Type.Builder;
 import com.facebook.presto.orc.proto.DwrfProto.UserMetadataItem;
 import com.facebook.presto.orc.protobuf.ByteString;
 import com.facebook.presto.orc.protobuf.MessageLite;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.CountingOutputStream;
@@ -136,7 +137,8 @@ public class DwrfMetadataWriter
         return writeProtobufObject(output, footerProtobuf.build());
     }
 
-    private static DwrfProto.StripeInformation toStripeInformation(StripeInformation stripe)
+    @VisibleForTesting
+    static DwrfProto.StripeInformation toStripeInformation(StripeInformation stripe)
     {
         return DwrfProto.StripeInformation.newBuilder()
                 .setNumberOfRows(stripe.getNumberOfRows())

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcMetadataReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcMetadataReader.java
@@ -163,7 +163,7 @@ public class OrcMetadataReader
     private static StripeInformation toStripeInformation(OrcProto.StripeInformation stripeInformation)
     {
         return new StripeInformation(
-                toIntExact(stripeInformation.getNumberOfRows()),
+                stripeInformation.getNumberOfRows(),
                 stripeInformation.getOffset(),
                 stripeInformation.getIndexLength(),
                 stripeInformation.getDataLength(),

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/StripeInformation.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/StripeInformation.java
@@ -23,7 +23,7 @@ import static java.util.Objects.requireNonNull;
 
 public class StripeInformation
 {
-    private final int numberOfRows;
+    private final long numberOfRows;
     private final long offset;
     private final long indexLength;
     private final long dataLength;
@@ -34,7 +34,7 @@ public class StripeInformation
     // only set for run start, and reuse until next run
     private final List<byte[]> keyMetadata;
 
-    public StripeInformation(int numberOfRows, long offset, long indexLength, long dataLength, long footerLength, List<byte[]> keyMetadata)
+    public StripeInformation(long numberOfRows, long offset, long indexLength, long dataLength, long footerLength, List<byte[]> keyMetadata)
     {
         // dataLength can be zero when the stripe only contains empty flat maps.
         checkArgument(numberOfRows > 0, "Stripe must have at least one row");
@@ -48,7 +48,7 @@ public class StripeInformation
         this.keyMetadata = ImmutableList.copyOf(requireNonNull(keyMetadata, "keyMetadata is null"));
     }
 
-    public int getNumberOfRows()
+    public long getNumberOfRows()
     {
         return numberOfRows;
     }


### PR DESCRIPTION
OrcReader fails when the stripe has more than INT32_MAX rows.
Both ORC/DWRF format uses long for stripe number of rows.
We ran into this edge case on a file with only string as a column
and file is produced by a different writer, but compatible with
DWRF spec.

Test plan 
Existing tests.
Validation service did not identify new issues (8hour run)
File that failed to be read was successfully read.


```
== NO RELEASE NOTE ==
```
