### PR TITLE
Introduce commit API for Spiller

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/builder/SpillableHashAggregationBuilder.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/builder/SpillableHashAggregationBuilder.java
@@ -176,6 +176,10 @@ public class SpillableHashAggregationBuilder
     @Override
     public void finishMemoryRevoke()
     {
+        if (spiller.isPresent()) {
+            checkState(spillInProgress.isDone());
+            spiller.get().commit();
+        }
         updateMemory();
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/spiller/GenericSpiller.java
+++ b/presto-main/src/main/java/com/facebook/presto/spiller/GenericSpiller.java
@@ -77,6 +77,13 @@ public class GenericSpiller
     }
 
     @Override
+    public void commit()
+    {
+        checkNoSpillInProgress();
+        singleStreamSpillers.stream().forEach(SingleStreamSpiller::commit);
+    }
+
+    @Override
     public void close()
     {
         try {

--- a/presto-main/src/main/java/com/facebook/presto/spiller/SingleStreamSpiller.java
+++ b/presto-main/src/main/java/com/facebook/presto/spiller/SingleStreamSpiller.java
@@ -42,8 +42,9 @@ public interface SingleStreamSpiller
     }
 
     /**
-     * Returns list of previously spilled Pages as a single stream. Pages are in the same order
-     * as they were spilled. Method requires the issued spill request to be completed.
+     * Returns list of previously spilled Pages as a single stream. Commits the spill file automatically
+     * if not committed. Pages are in the same order as they were spilled. Method requires the
+     * issued spill request to be completed.
      */
     Iterator<Page> getSpilledPages();
 
@@ -53,9 +54,16 @@ public interface SingleStreamSpiller
     long getSpilledPagesInMemorySize();
 
     /**
-     * Initiates read of previously spilled pages. The returned {@link Future} will be complete once all pages are read.
+     * Initiates read of previously spilled pages. Commits the spill file automatically if not committed
+     * The returned {@link Future} will be complete once all pages are read.
      */
     ListenableFuture<List<Page>> getAllSpilledPages();
+
+    /**
+     * Commit the spill file. Once committed, the spill file can no longer be modified
+     * If the spill file is already committed, invoking this method has no effect
+     */
+    void commit();
 
     /**
      * Close releases/removes all underlying resources used during spilling

--- a/presto-main/src/main/java/com/facebook/presto/spiller/Spiller.java
+++ b/presto-main/src/main/java/com/facebook/presto/spiller/Spiller.java
@@ -29,9 +29,16 @@ public interface Spiller
     ListenableFuture<?> spill(Iterator<Page> pageIterator);
 
     /**
-     * Returns list of previously spilled Pages streams.
+     * Returns list of previously spilled Pages streams. Commits the spill file automatically
+     * if not committed
      */
     List<Iterator<Page>> getSpills();
+
+    /**
+     * Commit the spill file. Once committed, the spill file can no longer be modified
+     * If the spill file is already committed, invoking this method has no effect
+     */
+    void commit();
 
     /**
      * Close releases/removes all underlying resources used during spilling

--- a/presto-main/src/main/java/com/facebook/presto/spiller/TempStorageSingleStreamSpiller.java
+++ b/presto-main/src/main/java/com/facebook/presto/spiller/TempStorageSingleStreamSpiller.java
@@ -72,6 +72,7 @@ public class TempStorageSingleStreamSpiller
     private final Closer closer = Closer.create();
 
     private boolean writable = true;
+    private boolean committed;
     private final TempDataSink dataSink;
     private TempStorageHandle tempStorageHandle;
     private int bufferedBytes;
@@ -145,10 +146,29 @@ public class TempStorageSingleStreamSpiller
         return executor.submit(() -> ImmutableList.copyOf(getSpilledPages()));
     }
 
+    @Override
+    public void commit()
+    {
+        if (committed) {
+            return;
+        }
+
+        try {
+            if (!bufferedPages.isEmpty()) {
+                flushBufferedPages();
+            }
+            tempStorageHandle = dataSink.commit();
+            committed = true;
+        }
+        catch (IOException e) {
+            throw new PrestoException(GENERIC_INTERNAL_ERROR, "Failed to commit spill file", e);
+        }
+    }
+
     private void writePages(Iterator<Page> pageIterator)
     {
         checkState(writable, "Spilling no longer allowed. The spiller has been made non-writable on first read for subsequent reads to be consistent");
-
+        checkState(!committed, "Spilling no longer allowed. Spill file is already committed");
         while (pageIterator.hasNext()) {
             Page page = pageIterator.next();
             spilledPagesInMemorySize += page.getSizeInBytes();
@@ -167,7 +187,6 @@ public class TempStorageSingleStreamSpiller
                         }
                     });
         }
-
         memoryContext.setBytes(bufferedBytes + dataSink.getRetainedSizeInBytes());
     }
 
@@ -175,13 +194,12 @@ public class TempStorageSingleStreamSpiller
     {
         checkState(writable, "Repeated reads are disallowed to prevent potential resource leaks");
         writable = false;
-
         try {
-            if (!bufferedPages.isEmpty()) {
-                flushBufferedPages();
+            if (!committed) {
+                commit();
             }
-            tempStorageHandle = dataSink.commit();
 
+            checkState(committed, "Cannot read pages since spill file is not committed");
             InputStream input = closer.register(tempStorage.open(tempDataOperationContext, tempStorageHandle));
             Iterator<Page> deserializedPages = PagesSerdeUtil.readPages(serde, new InputStreamSliceInput(input));
             Iterator<Page> compactPages = transform(deserializedPages, Page::compact);

--- a/presto-main/src/test/java/com/facebook/presto/operator/DummySpillerFactory.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/DummySpillerFactory.java
@@ -57,6 +57,11 @@ public class DummySpillerFactory
             }
 
             @Override
+            public void commit()
+            {
+            }
+
+            @Override
             public void close()
             {
                 spills.clear();

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashAggregationOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashAggregationOperator.java
@@ -819,6 +819,11 @@ public class TestHashAggregationOperator
                 }
 
                 @Override
+                public void commit()
+                {
+                }
+
+                @Override
                 public void close()
                 {
                 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
@@ -1792,6 +1792,12 @@ public class TestHashJoinOperator
                 }
 
                 @Override
+                public void commit()
+                {
+                    writing = false;
+                }
+
+                @Override
                 public void close()
                 {
                     writing = false;


### PR DESCRIPTION
Currently, Spillers provide two APIs:
1. spill() which is write API
2. getSpills() which is read API

The write API opens a spill file but does not close it once write is finished.
It is closed when read is triggred. Since, we do not commit the spill file,
sometimes pages are retained in memory buffers which accumulates together if spilling
is triggered too frequently. In low memory situation, this can trigger an OOM
This PR introduces a commit() API in Spiller interface which can be called
after write is done and before read is invoked. This API will flush the
buffers to spill file and close the stream so that resources can be released.

Test plan 
Tested a big query that would fail with OOM in Generic Spiller. Heapdump shows a large number of pages buffered in memory in TempStorageSingleStreamSpiller. The query passes successfully after the fix.

```
== NO RELEASE NOTE ==
```
