### PR TITLE
Add the filter pushdown on the conditions of timestamp and partitions to Kafka connector

### DIFF
--- a/presto-docs/src/main/sphinx/connector/kafka.rst
+++ b/presto-docs/src/main/sphinx/connector/kafka.rst
@@ -48,18 +48,20 @@ Configuration Properties
 
 The following configuration properties are available:
 
-=================================== ==============================================================
-Property Name                       Description
-=================================== ==============================================================
-``kafka.table-names``               List of all tables provided by the catalog
-``kafka.default-schema``            Default schema name for tables
-``kafka.nodes``                     List of nodes in the Kafka cluster
-``kafka.connect-timeout``           Timeout for connecting to the Kafka cluster
-``kafka.max-poll-records``          Maximum number of records per poll
-``kafka.max-partition-fetch-bytes`` Maximum number of bytes from one partition per poll
-``kafka.table-description-dir``     Directory containing topic description files
-``kafka.hide-internal-columns``     Controls whether internal columns are part of the table schema or not
-=================================== ==============================================================
+========================================================== ==============================================================
+Property Name                                              Description
+========================================================== ==============================================================
+``kafka.table-names``                                      List of all tables provided by the catalog
+``kafka.default-schema``                                   Default schema name for tables
+``kafka.nodes``                                            List of nodes in the Kafka cluster
+``kafka.connect-timeout``                                  Timeout for connecting to the Kafka cluster
+``kafka.max-poll-records``                                 Maximum number of records per poll
+``kafka.max-partition-fetch-bytes``                        Maximum number of bytes from one partition per poll
+``kafka.table-description-dir``                            Directory containing topic description files
+``kafka.hide-internal-columns``                            Controls whether internal columns are part of the table schema or not
+``kafka.messages-per-split``                               Number of messages that are processed by each Presto split, defaults to 100000
+``kafka.timestamp-upper-bound-force-push-down-enabled``    Controls if upper bound timestamp push down is enabled for topics using ``CreateTime`` mode
+========================================================== ==============================================================
 
 ``kafka.table-names``
 ^^^^^^^^^^^^^^^^^^^^^
@@ -126,6 +128,20 @@ References a folder within Presto deployment that holds one or more JSON
 files (must end with ``.json``) which contain table description files.
 
 This property is optional; the default is ``etc/kafka``.
+
+``kafka.timestamp-upper-bound-force-push-down-enabled``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The upper bound predicate on ``_timestamp`` column
+is pushed down only for topics using ``LogAppendTime`` mode.
+
+For topics using ``CreateTime`` mode, upper bound push down must be explicitly
+allowed via ``kafka.timestamp-upper-bound-force-push-down-enabled`` config property
+or ``timestamp_upper_bound_force_push_down_enabled`` session property. Note that
+in ``CreateTime`` mode, messages might not be stored in increasing order of the timestamp,
+and therefore the pushdown may not give the accurate result.
+
+This property is optional; the default is ``false``.
 
 ``kafka.hide-internal-columns``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/presto-kafka/pom.xml
+++ b/presto-kafka/pom.xml
@@ -230,6 +230,17 @@
             <version>${scala.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>net.jodah</groupId>
+            <artifactId>failsafe</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaAdminManager.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaAdminManager.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kafka;
+
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.spi.HostAddress;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.KafkaAdminClient;
+
+import javax.inject.Inject;
+
+import java.util.Properties;
+
+import static java.util.Objects.requireNonNull;
+import static org.apache.kafka.clients.admin.AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG;
+
+public class KafkaAdminManager
+{
+    private static final Logger log = Logger.get(KafkaAdminManager.class);
+
+    @Inject
+    public KafkaAdminManager(KafkaConnectorConfig kafkaConnectorConfig)
+    {
+        requireNonNull(kafkaConnectorConfig, "kafkaConnectorConfig is null");
+    }
+
+    AdminClient createAdmin(HostAddress hostAddress)
+    {
+        Properties properties = new Properties();
+        properties.setProperty(BOOTSTRAP_SERVERS_CONFIG, hostAddress.toString());
+        return KafkaAdminClient.create(properties);
+    }
+}

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaConnector.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaConnector.java
@@ -21,9 +21,12 @@ import com.facebook.presto.spi.connector.ConnectorPageSinkProvider;
 import com.facebook.presto.spi.connector.ConnectorRecordSetProvider;
 import com.facebook.presto.spi.connector.ConnectorSplitManager;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.facebook.presto.spi.session.PropertyMetadata;
 import com.facebook.presto.spi.transaction.IsolationLevel;
 
 import javax.inject.Inject;
+
+import java.util.List;
 
 import static com.facebook.presto.spi.transaction.IsolationLevel.READ_COMMITTED;
 import static com.facebook.presto.spi.transaction.IsolationLevel.checkConnectorSupports;
@@ -42,6 +45,7 @@ public class KafkaConnector
     private final KafkaSplitManager splitManager;
     private final KafkaRecordSetProvider recordSetProvider;
     private final KafkaPageSinkProvider pageSinkProvider;
+    private final KafkaSessionProperties sessionProperties;
 
     @Inject
     public KafkaConnector(
@@ -49,13 +53,15 @@ public class KafkaConnector
             KafkaMetadata metadata,
             KafkaSplitManager splitManager,
             KafkaRecordSetProvider recordSetProvider,
-            KafkaPageSinkProvider pageSinkProvider)
+            KafkaPageSinkProvider pageSinkProvider,
+            KafkaSessionProperties sessionProperties)
     {
         this.lifeCycleManager = requireNonNull(lifeCycleManager, "lifeCycleManager is null");
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.splitManager = requireNonNull(splitManager, "splitManager is null");
         this.recordSetProvider = requireNonNull(recordSetProvider, "recordSetProvider is null");
         this.pageSinkProvider = requireNonNull(pageSinkProvider, "pageSinkProvider is null");
+        this.sessionProperties = requireNonNull(sessionProperties, "sessionProperties is null");
     }
 
     @Override
@@ -87,6 +93,12 @@ public class KafkaConnector
     public ConnectorPageSinkProvider getPageSinkProvider()
     {
         return pageSinkProvider;
+    }
+
+    @Override
+    public List<PropertyMetadata<?>> getSessionProperties()
+    {
+        return sessionProperties.getSessionProperties();
     }
 
     @Override

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaConnectorConfig.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaConnectorConfig.java
@@ -19,6 +19,7 @@ import com.facebook.presto.kafka.server.file.FileKafkaClusterMetadataSupplier;
 import io.airlift.units.Duration;
 import io.airlift.units.MinDuration;
 
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 
 public class KafkaConnectorConfig
@@ -57,6 +58,16 @@ public class KafkaConnectorConfig
      * The kafka cluster metadata supplier to use, default is FILE
      */
     private String clusterMetadataSupplier = FileKafkaClusterMetadataSupplier.NAME;
+
+    /**
+     * Count of Kafka messages to be processed by single Kafka connector split
+     */
+    private int messagesPerSplit = 100_000;
+
+    /**
+     * If the time stamp upper bound condition shall be pushed down
+     */
+    private boolean timestampUpperBoundPushDownEnabled;
 
     @NotNull
     public String getDefaultSchema()
@@ -143,6 +154,31 @@ public class KafkaConnectorConfig
     public KafkaConnectorConfig setHideInternalColumns(boolean hideInternalColumns)
     {
         this.hideInternalColumns = hideInternalColumns;
+        return this;
+    }
+
+    public boolean isTimestampUpperBoundPushDownEnabled()
+    {
+        return timestampUpperBoundPushDownEnabled;
+    }
+
+    @Config("kafka.timestamp-upper-bound-force-push-down-enabled")
+    public KafkaConnectorConfig setTimestampUpperBoundPushDownEnabled(boolean timestampUpperBoundPushDownEnabled)
+    {
+        this.timestampUpperBoundPushDownEnabled = timestampUpperBoundPushDownEnabled;
+        return this;
+    }
+
+    @Min(1)
+    public int getMessagesPerSplit()
+    {
+        return messagesPerSplit;
+    }
+
+    @Config("kafka.messages-per-split")
+    public KafkaConnectorConfig setMessagesPerSplit(int messagesPerSplit)
+    {
+        this.messagesPerSplit = messagesPerSplit;
         return this;
     }
 }

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaConnectorModule.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaConnectorModule.java
@@ -54,8 +54,9 @@ public class KafkaConnectorModule
         binder.bind(KafkaSplitManager.class).in(Scopes.SINGLETON);
         binder.bind(KafkaRecordSetProvider.class).in(Scopes.SINGLETON);
         binder.bind(KafkaPageSinkProvider.class).in(Scopes.SINGLETON);
-
+        binder.bind(KafkaSessionProperties.class).in(Scopes.SINGLETON);
         binder.bind(KafkaConsumerManager.class).in(Scopes.SINGLETON);
+        binder.bind(KafkaAdminManager.class).in(Scopes.SINGLETON);
         configBinder(binder).bindConfig(KafkaConnectorConfig.class);
         bindTopicSchemaProviderModule(FileTableDescriptionSupplier.NAME, new FileTableDescriptionSupplierModule(), KafkaConnectorConfig::getTableDescriptionSupplier);
         bindTopicSchemaProviderModule(FileKafkaClusterMetadataSupplier.NAME, new FileKafkaClusterMetadataSupplierModule(), KafkaConnectorConfig::getClusterMetadataSupplier);

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaFilterManager.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaFilterManager.java
@@ -1,0 +1,312 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kafka;
+
+import com.facebook.presto.common.predicate.Domain;
+import com.facebook.presto.common.predicate.Marker;
+import com.facebook.presto.common.predicate.Ranges;
+import com.facebook.presto.common.predicate.SortedRangeSet;
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.common.predicate.ValueSet;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.PrestoException;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.Config;
+import org.apache.kafka.clients.admin.DescribeConfigsResult;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.config.ConfigResource;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+
+import static com.facebook.presto.kafka.KafkaErrorCode.KAFKA_SPLIT_ERROR;
+import static com.facebook.presto.kafka.KafkaInternalFieldDescription.OFFSET_TIMESTAMP_FIELD;
+import static com.facebook.presto.kafka.KafkaInternalFieldDescription.PARTITION_ID_FIELD;
+import static com.facebook.presto.kafka.KafkaInternalFieldDescription.PARTITION_OFFSET_FIELD;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class KafkaFilterManager
+{
+    private KafkaFilterManager() {}
+
+    private static final long INVALID_KAFKA_RANGE_INDEX = -1;
+    private static final String TOPIC_CONFIG_TIMESTAMP_KEY = "message.timestamp.type";
+    private static final String TOPIC_CONFIG_TIMESTAMP_VALUE_LOG_APPEND_TIME = "LogAppendTime";
+
+    public static KafkaFilterResult getKafkaFilterResult(
+            KafkaConsumer<byte[], byte[]> kafkaConsumer,
+            AdminClient adminClient,
+            ConnectorSession session,
+            KafkaTableHandle kafkaTableHandle,
+            List<PartitionInfo> partitionInfos,
+            Map<TopicPartition, Long> partitionBeginOffsets,
+            Map<TopicPartition, Long> partitionEndOffsets)
+    {
+        requireNonNull(kafkaConsumer, "kafkaConsumer is null");
+        requireNonNull(adminClient, "adminClient is null");
+        requireNonNull(session, "session is null");
+        requireNonNull(kafkaTableHandle, "kafkaTableHandle is null");
+        requireNonNull(partitionInfos, "partitionInfos is null");
+        requireNonNull(partitionBeginOffsets, "partitionBeginOffsets is null");
+        requireNonNull(partitionEndOffsets, "partitionEndOffsets is null");
+
+        TupleDomain<ColumnHandle> constraint = kafkaTableHandle.getConstraint();
+
+        if (!constraint.isAll() && !constraint.isNone()) {
+            Set<Long> partitionIds = partitionInfos.stream().map(partitionInfo -> (long) partitionInfo.partition()).collect(toImmutableSet());
+            Optional<Range> offsetRanged = Optional.empty();
+            Optional<Range> offsetTimestampRanged = Optional.empty();
+            Set<Long> partitionIdsFiltered = partitionIds;
+            Optional<Map<ColumnHandle, Domain>> domains = constraint.getDomains();
+
+            for (Map.Entry<ColumnHandle, Domain> entry : domains.get().entrySet()) {
+                KafkaColumnHandle columnHandle = (KafkaColumnHandle) entry.getKey();
+                if (!columnHandle.isInternal()) {
+                    continue;
+                }
+                if (columnHandle.getName().equals(PARTITION_OFFSET_FIELD.getColumnName())) {
+                    offsetRanged = filterRangeByDomain(entry.getValue());
+                }
+                else if (columnHandle.getName().equals(PARTITION_ID_FIELD.getColumnName())) {
+                    partitionIdsFiltered = filterValuesByDomain(entry.getValue(), partitionIds);
+                }
+                else if (columnHandle.getName().equals(OFFSET_TIMESTAMP_FIELD.getColumnName())) {
+                    offsetTimestampRanged = filterRangeByDomain(entry.getValue());
+                }
+            }
+
+            // push down offset
+            if (offsetRanged.isPresent()) {
+                Range range = offsetRanged.get();
+                partitionBeginOffsets = overridePartitionBeginOffsets(partitionBeginOffsets,
+                        partition -> (range.getBegin() != INVALID_KAFKA_RANGE_INDEX) ? Optional.of(range.getBegin()) : Optional.empty());
+                partitionEndOffsets = overridePartitionEndOffsets(partitionEndOffsets,
+                        partition -> (range.getEnd() != INVALID_KAFKA_RANGE_INDEX) ? Optional.of(range.getEnd()) : Optional.empty());
+            }
+
+            // push down timestamp if possible
+            if (offsetTimestampRanged.isPresent()) {
+                Optional<Range> finalOffsetTimestampRanged = offsetTimestampRanged;
+                partitionBeginOffsets = overridePartitionBeginOffsets(partitionBeginOffsets,
+                        partition -> findOffsetsForTimestampGreaterOrEqual(kafkaConsumer, partition, finalOffsetTimestampRanged.get().getBegin()));
+                if (isTimestampUpperBoundPushdownEnabled(adminClient, session, kafkaTableHandle.getTopicName())) {
+                    partitionEndOffsets = overridePartitionEndOffsets(partitionEndOffsets,
+                            partition -> findOffsetsForTimestampGreaterOrEqual(kafkaConsumer, partition, finalOffsetTimestampRanged.get().getEnd()));
+                }
+            }
+
+            // push down partitions
+            final Set<Long> finalPartitionIdsFiltered = partitionIdsFiltered;
+            List<PartitionInfo> partitionFilteredInfos = partitionInfos.stream()
+                    .filter(partitionInfo -> finalPartitionIdsFiltered.contains((long) partitionInfo.partition()))
+                    .collect(toImmutableList());
+            return new KafkaFilterResult(partitionFilteredInfos, partitionBeginOffsets, partitionEndOffsets);
+        }
+        return new KafkaFilterResult(partitionInfos, partitionBeginOffsets, partitionEndOffsets);
+    }
+
+    private static boolean isTimestampUpperBoundPushdownEnabled(AdminClient adminClient, ConnectorSession session, String topic)
+    {
+        try {
+            ConfigResource topicResource = new ConfigResource(ConfigResource.Type.TOPIC, topic);
+
+            DescribeConfigsResult describeResult = adminClient.describeConfigs(Collections.singleton(topicResource));
+            Map<ConfigResource, Config> configMap = describeResult.all().get();
+
+            if (configMap != null) {
+                Config config = configMap.get(topicResource);
+                String timestampType = config.get(TOPIC_CONFIG_TIMESTAMP_KEY).value();
+                if (TOPIC_CONFIG_TIMESTAMP_VALUE_LOG_APPEND_TIME.equals(timestampType)) {
+                    return true;
+                }
+            }
+        }
+        catch (Exception e) {
+            throw new PrestoException(KAFKA_SPLIT_ERROR, format("Failed to get configuration for topic '%s'", topic), e);
+        }
+        return KafkaSessionProperties.isTimestampUpperBoundPushdownEnabled(session);
+    }
+
+    private static Optional<Long> findOffsetsForTimestampGreaterOrEqual(KafkaConsumer<byte[], byte[]> kafkaConsumer, TopicPartition topicPartition, long timestamp)
+    {
+        Map<TopicPartition, OffsetAndTimestamp> topicPartitionOffsets = kafkaConsumer.offsetsForTimes(ImmutableMap.of(topicPartition, timestamp));
+        return Optional.ofNullable(getOnlyElement(topicPartitionOffsets.values(), null)).map(OffsetAndTimestamp::offset);
+    }
+
+    private static Map<TopicPartition, Long> overridePartitionBeginOffsets(Map<TopicPartition, Long> partitionBeginOffsets,
+            Function<TopicPartition, Optional<Long>> overrideFunction)
+    {
+        ImmutableMap.Builder<TopicPartition, Long> partitionFilteredBeginOffsetsBuilder = ImmutableMap.builder();
+        partitionBeginOffsets.forEach((partition, partitionIndex) -> {
+            Optional<Long> newOffset = overrideFunction.apply(partition);
+            partitionFilteredBeginOffsetsBuilder.put(partition, newOffset.map(index -> Long.max(partitionIndex, index)).orElse(partitionIndex));
+        });
+        return partitionFilteredBeginOffsetsBuilder.build();
+    }
+
+    private static Map<TopicPartition, Long> overridePartitionEndOffsets(Map<TopicPartition, Long> partitionEndOffsets,
+            Function<TopicPartition, Optional<Long>> overrideFunction)
+    {
+        ImmutableMap.Builder<TopicPartition, Long> partitionFilteredEndOffsetsBuilder = ImmutableMap.builder();
+        partitionEndOffsets.forEach((partition, partitionIndex) -> {
+            Optional<Long> newOffset = overrideFunction.apply(partition);
+            partitionFilteredEndOffsetsBuilder.put(partition, newOffset.map(index -> Long.min(partitionIndex, index)).orElse(partitionIndex));
+        });
+        return partitionFilteredEndOffsetsBuilder.build();
+    }
+
+    @VisibleForTesting
+    public static Optional<Range> filterRangeByDomain(Domain domain)
+    {
+        Long low = INVALID_KAFKA_RANGE_INDEX;
+        Long high = INVALID_KAFKA_RANGE_INDEX;
+        if (domain.isSingleValue()) {
+            // still return range for single value case like (_partition_offset=XXX or _timestamp=XXX)
+            low = (long) domain.getSingleValue();
+            high = (long) domain.getSingleValue();
+        }
+        else {
+            ValueSet valueSet = domain.getValues();
+            if (valueSet instanceof SortedRangeSet) {
+                // still return range for single value case like (_partition_offset in (XXX1,XXX2) or _timestamp in XXX1, XXX2)
+                Ranges ranges = ((SortedRangeSet) valueSet).getRanges();
+                List<com.facebook.presto.common.predicate.Range> rangeList = ranges.getOrderedRanges();
+                if (rangeList.stream().allMatch(com.facebook.presto.common.predicate.Range::isSingleValue)) {
+                    List<Long> values = rangeList.stream()
+                            .map(range -> (Long) range.getSingleValue())
+                            .collect(toImmutableList());
+                    low = Collections.min(values);
+                    high = Collections.max(values);
+                }
+                else {
+                    Marker lowMark = ranges.getSpan().getLow();
+                    low = getLowByLowMark(lowMark).orElse(low);
+                    Marker highMark = ranges.getSpan().getHigh();
+                    high = getHighByHighMark(highMark).orElse(high);
+                }
+            }
+        }
+        if (high != INVALID_KAFKA_RANGE_INDEX) {
+            high = high + 1;
+        }
+        return Optional.of(new Range(low, high));
+    }
+
+    @VisibleForTesting
+    public static Set<Long> filterValuesByDomain(Domain domain, Set<Long> sourceValues)
+    {
+        requireNonNull(sourceValues, "sourceValues is none");
+        if (domain.isSingleValue()) {
+            long singleValue = (long) domain.getSingleValue();
+            return sourceValues.stream().filter(sourceValue -> sourceValue == singleValue).collect(toImmutableSet());
+        }
+        else {
+            ValueSet valueSet = domain.getValues();
+            if (valueSet instanceof SortedRangeSet) {
+                Ranges ranges = ((SortedRangeSet) valueSet).getRanges();
+                List<com.facebook.presto.common.predicate.Range> rangeList = ranges.getOrderedRanges();
+                if (rangeList.stream().allMatch(com.facebook.presto.common.predicate.Range::isSingleValue)) {
+                    return rangeList.stream()
+                            .map(range -> (Long) range.getSingleValue())
+                            .filter(sourceValues::contains)
+                            .collect(toImmutableSet());
+                }
+                else {
+                    // still return values for range case like (_partition_id > 1)
+                    long low = 0;
+                    long high = Long.MAX_VALUE;
+
+                    Marker lowMark = ranges.getSpan().getLow();
+                    low = maxLow(low, lowMark);
+                    Marker highMark = ranges.getSpan().getHigh();
+                    high = minHigh(high, highMark);
+                    final long finalLow = low;
+                    final long finalHigh = high;
+                    return sourceValues.stream()
+                            .filter(item -> item >= finalLow && item <= finalHigh)
+                            .collect(toImmutableSet());
+                }
+            }
+        }
+        return sourceValues;
+    }
+
+    private static long minHigh(long high, Marker highMark)
+    {
+        Optional<Long> highByHighMark = getHighByHighMark(highMark);
+        if (highByHighMark.isPresent()) {
+            high = Long.min(highByHighMark.get(), high);
+        }
+        return high;
+    }
+
+    private static long maxLow(long low, Marker lowMark)
+    {
+        Optional<Long> lowByLowMark = getLowByLowMark(lowMark);
+        if (lowByLowMark.isPresent()) {
+            low = Long.max(lowByLowMark.get(), low);
+        }
+        return low;
+    }
+
+    private static Optional<Long> getHighByHighMark(Marker highMark)
+    {
+        if (!highMark.isUpperUnbounded()) {
+            long high = (Long) highMark.getValue();
+            switch (highMark.getBound()) {
+                case EXACTLY:
+                    break;
+                case BELOW:
+                    high--;
+                    break;
+                default:
+                    throw new AssertionError("Unhandled bound: " + highMark.getBound());
+            }
+            return Optional.of(high);
+        }
+        return Optional.empty();
+    }
+
+    private static Optional<Long> getLowByLowMark(Marker lowMark)
+    {
+        if (!lowMark.isLowerUnbounded()) {
+            long low = (Long) lowMark.getValue();
+            switch (lowMark.getBound()) {
+                case EXACTLY:
+                    break;
+                case ABOVE:
+                    low++;
+                    break;
+                default:
+                    throw new AssertionError("Unhandled bound: " + lowMark.getBound());
+            }
+            return Optional.of(low);
+        }
+        return Optional.empty();
+    }
+}

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaFilterResult.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaFilterResult.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kafka;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+
+import java.util.List;
+import java.util.Map;
+
+public class KafkaFilterResult
+{
+    private final List<PartitionInfo> partitionInfos;
+    private final Map<TopicPartition, Long> partitionBeginOffsets;
+    private final Map<TopicPartition, Long> partitionEndOffsets;
+
+    public KafkaFilterResult(List<PartitionInfo> partitionInfos,
+            Map<TopicPartition, Long> partitionBeginOffsets,
+            Map<TopicPartition, Long> partitionEndOffsets)
+    {
+        this.partitionInfos = ImmutableList.copyOf(partitionInfos);
+        this.partitionBeginOffsets = ImmutableMap.copyOf(partitionBeginOffsets);
+        this.partitionEndOffsets = ImmutableMap.copyOf(partitionEndOffsets);
+    }
+
+    public List<PartitionInfo> getPartitionInfos()
+    {
+        return partitionInfos;
+    }
+
+    public Map<TopicPartition, Long> getPartitionBeginOffsets()
+    {
+        return partitionBeginOffsets;
+    }
+
+    public Map<TopicPartition, Long> getPartitionEndOffsets()
+    {
+        return partitionEndOffsets;
+    }
+}

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaMetadata.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaMetadata.java
@@ -13,9 +13,7 @@
  */
 package com.facebook.presto.kafka;
 
-import com.facebook.presto.common.predicate.Domain;
-import com.facebook.presto.common.predicate.Marker;
-import com.facebook.presto.common.predicate.Range;
+import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.decoder.dummy.DummyRowDecoder;
 import com.facebook.presto.kafka.schema.TableDescriptionSupplier;
 import com.facebook.presto.spi.ColumnHandle;
@@ -101,7 +99,8 @@ public class KafkaMetadata
                         kafkaTopicDescription.getMessage().flatMap(KafkaTopicFieldGroup::getDataSchema),
                         getColumnHandles(schemaTableName).values().stream()
                                 .map(KafkaColumnHandle.class::cast)
-                                .collect(toImmutableList())))
+                                .collect(toImmutableList()),
+                        TupleDomain.all()))
                 .orElse(null);
     }
 
@@ -204,27 +203,12 @@ public class KafkaMetadata
     public List<ConnectorTableLayoutResult> getTableLayouts(ConnectorSession session, ConnectorTableHandle table, Constraint<ColumnHandle> constraint, Optional<Set<ColumnHandle>> desiredColumns)
     {
         KafkaTableHandle handle = convertTableHandle(table);
-        long startTimestamp = 0;
-        long endTimestamp = 0;
-        Optional<Map<ColumnHandle, Domain>> domains = constraint.getSummary().getDomains();
-        if (domains.isPresent()) {
-            Map<ColumnHandle, Domain> columnHandleDomainMap = domains.get();
-            for (Map.Entry<ColumnHandle, Domain> entry : columnHandleDomainMap.entrySet()) {
-                if (entry.getKey() instanceof KafkaColumnHandle && ((KafkaColumnHandle) entry.getKey()).getName().equals(KafkaInternalFieldDescription.OFFSET_TIMESTAMP_FIELD.getColumnName())) {
-                    Range span = entry.getValue().getValues().getRanges().getSpan();
-                    Marker low = span.getLow();
-                    Marker high = span.getHigh();
-                    if (!low.isLowerUnbounded()) {
-                        startTimestamp = (long) low.getValue();
-                    }
-                    if (!high.isUpperUnbounded()) {
-                        endTimestamp = (long) high.getValue();
-                    }
-                }
-            }
-        }
+        TupleDomain<ColumnHandle> oldDomain = handle.getConstraint();
+        TupleDomain<ColumnHandle> newDomain = oldDomain.intersect(constraint.getSummary());
 
-        ConnectorTableLayout layout = new ConnectorTableLayout(new KafkaTableLayoutHandle(handle, startTimestamp, endTimestamp));
+        handle.setConstraint(newDomain);
+
+        ConnectorTableLayout layout = new ConnectorTableLayout(new KafkaTableLayoutHandle(handle));
         return ImmutableList.of(new ConnectorTableLayoutResult(layout, constraint.getSummary()));
     }
 
@@ -283,7 +267,8 @@ public class KafkaMetadata
                 table.getMessageDataFormat(),
                 table.getKeyDataSchemaLocation(),
                 table.getMessageDataSchemaLocation(),
-                actualColumns);
+                actualColumns,
+                TupleDomain.none());
     }
 
     @Override

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaPlugin.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaPlugin.java
@@ -27,11 +27,12 @@ import static java.util.Objects.requireNonNull;
 public class KafkaPlugin
         implements Plugin
 {
+    public static final Module DEFAULT_EXTENSION = Modules.EMPTY_MODULE;
     private final Module extension;
 
     public KafkaPlugin()
     {
-        this(Modules.EMPTY_MODULE);
+        this(DEFAULT_EXTENSION);
     }
 
     public KafkaPlugin(Module extension)

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaRecordSet.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaRecordSet.java
@@ -196,7 +196,6 @@ public class KafkaRecordSet
                             currentRowValuesMap.put(columnHandle, longValueProvider(keyData.length));
                             break;
                         case OFFSET_TIMESTAMP_FIELD:
-                            timeStamp = TimeUnit.SECONDS.toMillis(timeStamp);
                             currentRowValuesMap.put(columnHandle, longValueProvider(timeStamp));
                             break;
                         case KEY_CORRUPT_FIELD:

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaSessionProperties.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaSessionProperties.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kafka;
+
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.session.PropertyMetadata;
+import com.google.common.collect.ImmutableList;
+
+import javax.inject.Inject;
+
+import java.util.List;
+
+public final class KafkaSessionProperties
+{
+    private static final String TIMESTAMP_UPPER_BOUND_FORCE_PUSH_DOWN_ENABLED = "timestamp_upper_bound_force_push_down_enabled";
+    private final List<PropertyMetadata<?>> sessionProperties;
+
+    @Inject
+    public KafkaSessionProperties(KafkaConnectorConfig kafkaConfig)
+    {
+        sessionProperties = ImmutableList.of(PropertyMetadata.booleanProperty(
+                TIMESTAMP_UPPER_BOUND_FORCE_PUSH_DOWN_ENABLED,
+                "Enable or disable timestamp upper bound push down for topic createTime mode",
+                kafkaConfig.isTimestampUpperBoundPushDownEnabled(), false));
+    }
+
+    public List<PropertyMetadata<?>> getSessionProperties()
+    {
+        return sessionProperties;
+    }
+
+    /**
+     * If predicate specifies lower bound on _timestamp column (_timestamp > XXXX), it is always pushed down.
+     * The upper bound predicate is pushed down only for topics using ``LogAppendTime`` mode.
+     * For topics using ``CreateTime`` mode, upper bound push down must be explicitly
+     *  allowed via ``kafka.timestamp-upper-bound-force-push-down-enabled`` config property
+     *  or ``timestamp_upper_bound_force_push_down_enabled`` session property.
+     */
+    public static boolean isTimestampUpperBoundPushdownEnabled(ConnectorSession session)
+    {
+        return session.getProperty(TIMESTAMP_UPPER_BOUND_FORCE_PUSH_DOWN_ENABLED, Boolean.class);
+    }
+}

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaSplit.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaSplit.java
@@ -34,58 +34,34 @@ import static java.util.Objects.requireNonNull;
 public class KafkaSplit
         implements ConnectorSplit
 {
-    private final String connectorId;
     private final String topicName;
     private final String keyDataFormat;
     private final String messageDataFormat;
     private final Optional<String> keyDataSchemaContents;
     private final Optional<String> messageDataSchemaContents;
     private final int partitionId;
-    private final long start;
-    private final long end;
+    private final Range messagesRange;
     private final HostAddress leader;
 
     @JsonCreator
     public KafkaSplit(
-            @JsonProperty("connectorId") String connectorId,
             @JsonProperty("topicName") String topicName,
             @JsonProperty("keyDataFormat") String keyDataFormat,
             @JsonProperty("messageDataFormat") String messageDataFormat,
             @JsonProperty("keyDataSchemaContents") Optional<String> keyDataSchemaContents,
             @JsonProperty("messageDataSchemaContents") Optional<String> messageDataSchemaContents,
             @JsonProperty("partitionId") int partitionId,
-            @JsonProperty("start") long start,
-            @JsonProperty("end") long end,
+            @JsonProperty("messagesRange") Range messagesRange,
             @JsonProperty("leader") HostAddress leader)
     {
-        this.connectorId = requireNonNull(connectorId, "connector id is null");
         this.topicName = requireNonNull(topicName, "topicName is null");
         this.keyDataFormat = requireNonNull(keyDataFormat, "dataFormat is null");
         this.messageDataFormat = requireNonNull(messageDataFormat, "messageDataFormat is null");
         this.keyDataSchemaContents = keyDataSchemaContents;
         this.messageDataSchemaContents = messageDataSchemaContents;
         this.partitionId = partitionId;
-        this.start = start;
-        this.end = end;
+        this.messagesRange = requireNonNull(messagesRange, "messagesRange is null");
         this.leader = requireNonNull(leader, "leader address is null");
-    }
-
-    @JsonProperty
-    public String getConnectorId()
-    {
-        return connectorId;
-    }
-
-    @JsonProperty
-    public long getStart()
-    {
-        return start;
-    }
-
-    @JsonProperty
-    public long getEnd()
-    {
-        return end;
     }
 
     @JsonProperty
@@ -125,6 +101,12 @@ public class KafkaSplit
     }
 
     @JsonProperty
+    public Range getMessagesRange()
+    {
+        return messagesRange;
+    }
+
+    @JsonProperty
     public HostAddress getLeader()
     {
         return leader;
@@ -152,15 +134,13 @@ public class KafkaSplit
     public String toString()
     {
         return toStringHelper(this)
-                .add("connectorId", connectorId)
                 .add("topicName", topicName)
                 .add("keyDataFormat", keyDataFormat)
                 .add("messageDataFormat", messageDataFormat)
                 .add("keyDataSchemaContents", keyDataSchemaContents)
                 .add("messageDataSchemaContents", messageDataSchemaContents)
                 .add("partitionId", partitionId)
-                .add("start", start)
-                .add("end", end)
+                .add("messagesRange", messagesRange)
                 .add("leader", leader)
                 .toString();
     }

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaTableHandle.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaTableHandle.java
@@ -13,6 +13,8 @@
  */
 package com.facebook.presto.kafka;
 
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorInsertTableHandle;
 import com.facebook.presto.spi.ConnectorTableHandle;
 import com.facebook.presto.spi.SchemaTableName;
@@ -59,6 +61,7 @@ public final class KafkaTableHandle
     private final Optional<String> keyDataSchemaLocation;
     private final Optional<String> messageDataSchemaLocation;
     private final List<KafkaColumnHandle> columns;
+    private TupleDomain<ColumnHandle> constraint;
 
     @JsonCreator
     public KafkaTableHandle(
@@ -70,7 +73,8 @@ public final class KafkaTableHandle
             @JsonProperty("messageDataFormat") String messageDataFormat,
             @JsonProperty("keyDataSchemaLocation") Optional<String> keyDataSchemaLocation,
             @JsonProperty("messageDataSchemaLocation") Optional<String> messageDataSchemaLocation,
-            @JsonProperty("columns") List<KafkaColumnHandle> columns)
+            @JsonProperty("columns") List<KafkaColumnHandle> columns,
+            @JsonProperty("constraint") TupleDomain<ColumnHandle> constraint)
     {
         this.connectorId = requireNonNull(connectorId, "connectorId is null");
         this.schemaName = requireNonNull(schemaName, "schemaName is null");
@@ -81,6 +85,7 @@ public final class KafkaTableHandle
         this.keyDataSchemaLocation = requireNonNull(keyDataSchemaLocation, "keyDataSchemaLocation is null");
         this.messageDataSchemaLocation = requireNonNull(messageDataSchemaLocation, "messageDataSchemaLocation is null");
         this.columns = requireNonNull(ImmutableList.copyOf(columns), "columns is null");
+        this.constraint = requireNonNull(constraint, "constraint is null");
     }
 
     @JsonProperty
@@ -137,6 +142,17 @@ public final class KafkaTableHandle
         return columns;
     }
 
+    @JsonProperty
+    public TupleDomain<ColumnHandle> getConstraint()
+    {
+        return constraint;
+    }
+
+    public void setConstraint(TupleDomain<ColumnHandle> constraint)
+    {
+        this.constraint = constraint;
+    }
+
     public SchemaTableName toSchemaTableName()
     {
         return new SchemaTableName(schemaName, tableName);
@@ -145,7 +161,7 @@ public final class KafkaTableHandle
     @Override
     public int hashCode()
     {
-        return Objects.hash(connectorId, schemaName, tableName, topicName, keyDataFormat, messageDataFormat, keyDataSchemaLocation, messageDataSchemaLocation, columns);
+        return Objects.hash(connectorId, schemaName, tableName, topicName, keyDataFormat, messageDataFormat, keyDataSchemaLocation, messageDataSchemaLocation, columns, constraint);
     }
 
     @Override
@@ -167,7 +183,8 @@ public final class KafkaTableHandle
                 && Objects.equals(this.messageDataFormat, other.messageDataFormat)
                 && Objects.equals(this.keyDataSchemaLocation, other.keyDataSchemaLocation)
                 && Objects.equals(this.messageDataSchemaLocation, other.messageDataSchemaLocation)
-                && Objects.equals(this.columns, other.columns);
+                && Objects.equals(this.columns, other.columns)
+                && Objects.equals(this.constraint, other.constraint);
     }
 
     @Override
@@ -183,6 +200,7 @@ public final class KafkaTableHandle
                 .add("keyDataSchemaLocation", keyDataSchemaLocation)
                 .add("messageDataSchemaLocation", messageDataSchemaLocation)
                 .add("columns", columns)
+                .add("constraint", constraint)
                 .toString();
     }
 }

--- a/presto-kafka/src/test/java/com/facebook/presto/kafka/KafkaQueryRunnerBuilder.java
+++ b/presto-kafka/src/test/java/com/facebook/presto/kafka/KafkaQueryRunnerBuilder.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kafka;
+
+import com.facebook.airlift.log.Level;
+import com.facebook.airlift.log.Logging;
+import com.facebook.presto.kafka.util.EmbeddedKafka;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Module;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.facebook.airlift.testing.Closeables.closeAllSuppress;
+import static com.facebook.presto.kafka.KafkaPlugin.DEFAULT_EXTENSION;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static java.util.Objects.requireNonNull;
+
+public abstract class KafkaQueryRunnerBuilder
+        extends DistributedQueryRunner.Builder
+{
+    protected final EmbeddedKafka embeddedKafka;
+    protected Map<String, String> extraKafkaProperties = ImmutableMap.of();
+    protected Module extension = DEFAULT_EXTENSION;
+
+    protected KafkaQueryRunnerBuilder(EmbeddedKafka embeddedKafka, String defaultSessionSchema)
+    {
+        super(testSessionBuilder()
+                .setCatalog("kafka")
+                .setSchema(defaultSessionSchema)
+                .build());
+        this.embeddedKafka = requireNonNull(embeddedKafka, "embeddedKafka is null");
+    }
+
+    public KafkaQueryRunnerBuilder setExtraKafkaProperties(Map<String, String> extraKafkaProperties)
+    {
+        this.extraKafkaProperties = ImmutableMap.copyOf(requireNonNull(extraKafkaProperties, "extraKafkaProperties is null"));
+        return this;
+    }
+
+    public KafkaQueryRunnerBuilder setExtension(Module extension)
+    {
+        this.extension = requireNonNull(extension, "extension is null");
+        return this;
+    }
+
+    @Override
+    public final DistributedQueryRunner build()
+            throws Exception
+    {
+        Logging logging = Logging.initialize();
+        logging.setLevel("org.apache.kafka", Level.WARN);
+
+        DistributedQueryRunner queryRunner = super.build();
+        try {
+            embeddedKafka.start();
+            preInit(queryRunner);
+            queryRunner.installPlugin(new KafkaPlugin(extension));
+            Map<String, String> kafkaProperties = new HashMap<>(ImmutableMap.copyOf(extraKafkaProperties));
+            kafkaProperties.putIfAbsent("kafka.nodes", embeddedKafka.getConnectString());
+            kafkaProperties.putIfAbsent("kafka.messages-per-split", "1000");
+            queryRunner.createCatalog("kafka", "kafka", kafkaProperties);
+            postInit(queryRunner);
+            return queryRunner;
+        }
+        catch (RuntimeException e) {
+            closeAllSuppress(e, queryRunner);
+            throw e;
+        }
+    }
+
+    protected void preInit(DistributedQueryRunner queryRunner)
+            throws Exception
+    {}
+
+    protected void postInit(DistributedQueryRunner queryRunner) {}
+}

--- a/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaConnectorConfig.java
+++ b/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaConnectorConfig.java
@@ -32,7 +32,9 @@ public class TestKafkaConnectorConfig
                 .setTableDescriptionSupplier(FileTableDescriptionSupplier.NAME)
                 .setHideInternalColumns(true)
                 .setMaxPartitionFetchBytes(1048576)
-                .setMaxPollRecords(500));
+                .setMaxPollRecords(500)
+                .setMessagesPerSplit(100000)
+                .setTimestampUpperBoundPushDownEnabled(false));
     }
 
     @Test
@@ -46,6 +48,8 @@ public class TestKafkaConnectorConfig
                 .put("kafka.hide-internal-columns", "false")
                 .put("kafka.max-partition-fetch-bytes", "1024")
                 .put("kafka.max-poll-records", "1000")
+                .put("kafka.messages-per-split", "1")
+                .put("kafka.timestamp-upper-bound-force-push-down-enabled", "true")
                 .build();
 
         KafkaConnectorConfig expected = new KafkaConnectorConfig()
@@ -55,7 +59,9 @@ public class TestKafkaConnectorConfig
                 .setKafkaConnectTimeout("1h")
                 .setHideInternalColumns(false)
                 .setMaxPartitionFetchBytes(1024)
-                .setMaxPollRecords(1000);
+                .setMaxPollRecords(1000)
+                .setMessagesPerSplit(1)
+                .setTimestampUpperBoundPushDownEnabled(true);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaDistributed.java
+++ b/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaDistributed.java
@@ -20,9 +20,10 @@ import com.facebook.presto.tests.AbstractTestQueries;
 import com.facebook.presto.tests.DistributedQueryRunner;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.tpch.TpchTable;
-import java.io.IOException;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
+
+import java.io.IOException;
 
 import static com.facebook.presto.kafka.util.EmbeddedKafka.createEmbeddedKafka;
 

--- a/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaFilterManager.java
+++ b/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaFilterManager.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kafka;
+
+import com.facebook.presto.common.predicate.Domain;
+import com.facebook.presto.common.predicate.Range;
+import com.facebook.presto.common.predicate.SortedRangeSet;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Sets;
+import org.testng.annotations.Test;
+
+import java.util.Set;
+
+import static com.facebook.presto.common.predicate.Domain.multipleValues;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class TestKafkaFilterManager
+{
+    @Test
+    public void testFilterValuesByDomain()
+    {
+        Set<Long> source = Sets.newHashSet(1L, 2L, 3L, 4L, 5L, 6L);
+
+        Domain testDomain = Domain.singleValue(BIGINT, 1L);
+        assertEquals(KafkaFilterManager.filterValuesByDomain(testDomain, source), Sets.newHashSet(1L));
+
+        testDomain = multipleValues(BIGINT, ImmutableList.of(3L, 8L));
+        assertEquals(KafkaFilterManager.filterValuesByDomain(testDomain, source), Sets.newHashSet(3L));
+
+        testDomain = Domain.create(SortedRangeSet.copyOf(BIGINT,
+                ImmutableList.of(
+                        Range.range(BIGINT, 2L, true, 4L, true))),
+                false);
+
+        assertEquals(KafkaFilterManager.filterValuesByDomain(testDomain, source), Sets.newHashSet(2L, 3L, 4L));
+    }
+
+    @Test
+    public void testFilterRangeByDomain()
+    {
+        Domain testDomain = Domain.singleValue(BIGINT, 1L);
+        assertTrue(KafkaFilterManager.filterRangeByDomain(testDomain).isPresent());
+        assertEquals(KafkaFilterManager.filterRangeByDomain(testDomain).get().getBegin(), 1L);
+        assertEquals(KafkaFilterManager.filterRangeByDomain(testDomain).get().getEnd(), 2L);
+
+        testDomain = multipleValues(BIGINT, ImmutableList.of(3L, 8L));
+        assertTrue(KafkaFilterManager.filterRangeByDomain(testDomain).isPresent());
+        assertEquals(KafkaFilterManager.filterRangeByDomain(testDomain).get().getBegin(), 3L);
+        assertEquals(KafkaFilterManager.filterRangeByDomain(testDomain).get().getEnd(), 9L);
+
+        testDomain = Domain.create(SortedRangeSet.copyOf(BIGINT,
+                ImmutableList.of(
+                        Range.range(BIGINT, 2L, true, 4L, true))),
+                false);
+
+        assertTrue(KafkaFilterManager.filterRangeByDomain(testDomain).isPresent());
+        assertEquals(KafkaFilterManager.filterRangeByDomain(testDomain).get().getBegin(), 2L);
+        assertEquals(KafkaFilterManager.filterRangeByDomain(testDomain).get().getEnd(), 5L);
+    }
+}

--- a/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaIntegrationPushDown.java
+++ b/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaIntegrationPushDown.java
@@ -1,0 +1,234 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.kafka;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.execution.QueryInfo;
+import com.facebook.presto.kafka.util.EmbeddedKafka;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import com.facebook.presto.tests.ResultWithQueryId;
+import com.google.common.collect.ImmutableMap;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.testng.annotations.Test;
+
+import java.util.UUID;
+import java.util.stream.IntStream;
+import java.util.stream.LongStream;
+import java.util.stream.Stream;
+
+import static com.facebook.presto.kafka.util.TestUtils.createEmptyTopicDescription;
+import static com.facebook.presto.testing.assertions.Assert.assertEventually;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testng.Assert.assertEquals;
+
+@Test(singleThreaded = true)
+public class TestKafkaIntegrationPushDown
+        extends AbstractTestQueryFramework
+{
+    private static final int MESSAGE_NUM = 1000;
+    private static final int TIMESTAMP_TEST_COUNT = 6;
+    private static final int TIMESTAMP_TEST_START_INDEX = 2;
+    private static final int TIMESTAMP_TEST_END_INDEX = 4;
+
+    private static EmbeddedKafka embeddedKafka;
+    private static String topicNamePartition;
+    private static String topicNameOffset;
+    private static String topicNameCreateTime;
+    private static String topicNameLogAppend;
+
+    public TestKafkaIntegrationPushDown()
+    {
+    }
+
+    @Override
+    protected QueryRunner createQueryRunner()
+        throws Exception
+    {
+        return createKafkaQueryRunner();
+    }
+
+    protected static QueryRunner createKafkaQueryRunner()
+            throws Exception
+    {
+        embeddedKafka = EmbeddedKafka.createEmbeddedKafka();
+        topicNamePartition = "test_push_down_partition_" + UUID.randomUUID().toString().replaceAll("-", "_");
+        topicNameOffset = "test_push_down_offset_" + UUID.randomUUID().toString().replaceAll("-", "_");
+        topicNameCreateTime = "test_push_down_create_time_" + UUID.randomUUID().toString().replaceAll("-", "_");
+        topicNameLogAppend = "test_push_down_log_append_" + UUID.randomUUID().toString().replaceAll("-", "_");
+
+        QueryRunner queryRunner = KafkaQueryRunner.builder(embeddedKafka)
+                .setExtraTopicDescription(ImmutableMap.<SchemaTableName, KafkaTopicDescription>builder()
+                        .put(createEmptyTopicDescription(topicNamePartition, new SchemaTableName("default", topicNamePartition)))
+                        .put(createEmptyTopicDescription(topicNameOffset, new SchemaTableName("default", topicNameOffset)))
+                        .put(createEmptyTopicDescription(topicNameCreateTime, new SchemaTableName("default", topicNameCreateTime)))
+                        .put(createEmptyTopicDescription(topicNameLogAppend, new SchemaTableName("default", topicNameLogAppend)))
+                        .build())
+                .setExtraKafkaProperties(ImmutableMap.<String, String>builder()
+                        .put("kafka.messages-per-split", "100")
+                        .build())
+                .build();
+        embeddedKafka.createTopicWithConfig(2, 1, topicNamePartition, false);
+        embeddedKafka.createTopicWithConfig(2, 1, topicNameOffset, false);
+        embeddedKafka.createTopicWithConfig(1, 1, topicNameCreateTime, false);
+        embeddedKafka.createTopicWithConfig(1, 1, topicNameLogAppend, true);
+        return queryRunner;
+    }
+
+    DistributedQueryRunner getDistributedQueryRunner()
+    {
+        return (DistributedQueryRunner) getQueryRunner();
+    }
+
+    @Test
+    public void testPartitionPushDown()
+    {
+        createMessages(topicNamePartition);
+        String sql = format("SELECT count(*) FROM default.%s WHERE _partition_id=1", topicNamePartition);
+
+        assertEventually(() -> {
+            ResultWithQueryId<MaterializedResult> queryResult = getDistributedQueryRunner().executeWithQueryId(getSession(), sql);
+            assertEquals(getQueryInfo(getDistributedQueryRunner(), queryResult).getQueryStats().getProcessedInputPositions(), MESSAGE_NUM / 2);
+        });
+    }
+
+    @Test
+    public void testOffsetPushDown()
+    {
+        createMessages(topicNameOffset);
+        assertProcessedInputPossitions(format("SELECT count(*) FROM default.%s WHERE _partition_offset between 2 and 10", topicNameOffset), 18);
+        assertProcessedInputPossitions(format("SELECT count(*) FROM default.%s WHERE _partition_offset > 2 and _partition_offset < 10", topicNameOffset), 14);
+        assertProcessedInputPossitions(format("SELECT count(*) FROM default.%s WHERE _partition_offset = 3", topicNameOffset), 2);
+    }
+
+    private void assertProcessedInputPossitions(String sql, long expectedProcessedInputPositions)
+    {
+        DistributedQueryRunner queryRunner = getDistributedQueryRunner();
+        assertEventually(() -> {
+            ResultWithQueryId<MaterializedResult> queryResult = queryRunner.executeWithQueryId(getSession(), sql);
+            assertEquals(getQueryInfo(queryRunner, queryResult).getQueryStats().getProcessedInputPositions(), expectedProcessedInputPositions);
+        });
+    }
+
+    @Test
+    public void testTimestampCreateTimeModePushDown()
+            throws Exception
+    {
+        RecordMessage recordMessage = createTimestampTestMessages(topicNameCreateTime);
+        DistributedQueryRunner queryRunner = getDistributedQueryRunner();
+        // ">= startTime" insure including index 2, "< endTime"  insure excluding index 4;
+        // TODO support the pushdown of timestamp to unix time conversion
+        // "SELECT count(*) FROM default.%s WHERE _timestamp >= timestamp '%s' and _timestamp < timestamp '%s'"
+        String sql = format(
+                "SELECT count(*) FROM default.%s WHERE _timestamp >= %d AND _timestamp < %d",
+                topicNameCreateTime,
+                recordMessage.startTime,
+                recordMessage.endTime);
+
+        // timestamp_upper_bound_force_push_down_enabled default as false.
+        assertEventually(() -> {
+            ResultWithQueryId<MaterializedResult> queryResult = queryRunner.executeWithQueryId(getSession(), sql);
+            assertThat(getQueryInfo(queryRunner, queryResult).getQueryStats().getProcessedInputPositions())
+                    .isEqualTo(998);
+        });
+
+        // timestamp_upper_bound_force_push_down_enabled set as true.
+        assertEventually(() -> {
+            // timestamp_upper_bound_force_push_down_enabled set as true.
+            Session sessionWithUpperBoundPushDownEnabled = Session.builder(getSession())
+                    .setSystemProperty("kafka.timestamp_upper_bound_force_push_down_enabled", "true")
+                    .build();
+
+            ResultWithQueryId<MaterializedResult> queryResult = queryRunner.executeWithQueryId(sessionWithUpperBoundPushDownEnabled, sql);
+            assertThat(getQueryInfo(queryRunner, queryResult).getQueryStats().getProcessedInputPositions())
+                    .isEqualTo(2);
+        });
+    }
+
+    @Test
+    public void testTimestampLogAppendModePushDown()
+            throws Exception
+    {
+        RecordMessage recordMessage = createTimestampTestMessages(topicNameLogAppend);
+        DistributedQueryRunner queryRunner = getDistributedQueryRunner();
+        // ">= startTime" insure including index 2, "< endTime"  insure excluding index 4;
+        // TODO support the pushdown of timestamp to unix time conversion
+        // "SELECT count(*) FROM default.%s WHERE _timestamp >= to_unixtime(timestamp '%s') and _timestamp < to_unixtime(timestamp '%s')",
+        String sql = format(
+                "SELECT count(*) FROM default.%s WHERE _timestamp >= %d AND _timestamp < %d",
+                topicNameLogAppend,
+                recordMessage.startTime,
+                recordMessage.endTime);
+
+        assertEventually(() -> {
+            ResultWithQueryId<MaterializedResult> queryResult = queryRunner.executeWithQueryId(getSession(), sql);
+            assertThat(getQueryInfo(queryRunner, queryResult).getQueryStats().getProcessedInputPositions())
+                    .isEqualTo(2);
+        });
+    }
+
+    private static QueryInfo getQueryInfo(DistributedQueryRunner queryRunner, ResultWithQueryId<MaterializedResult> queryResult)
+    {
+        return queryRunner.getCoordinator().getQueryManager().getFullQueryInfo(queryResult.getQueryId());
+    }
+
+    private RecordMessage createTimestampTestMessages(String topicName)
+            throws Exception
+    {
+        long startTime = 0;
+        long endTime = 0;
+        for (int messageNum = 0; messageNum < TIMESTAMP_TEST_COUNT; messageNum++) {
+            long value = messageNum;
+            RecordMetadata recordMetadata = embeddedKafka.sendMessages(Stream.of(new ProducerRecord<>(topicName, null, value)));
+            if (messageNum == TIMESTAMP_TEST_START_INDEX) {
+                startTime = recordMetadata.timestamp();
+            }
+            else if (messageNum == TIMESTAMP_TEST_END_INDEX) {
+                endTime = recordMetadata.timestamp();
+            }
+
+            // Sleep for a while to ensure different timestamps for different messages..
+            Thread.sleep(100);
+        }
+        embeddedKafka.sendMessages(
+                LongStream.range(TIMESTAMP_TEST_COUNT, MESSAGE_NUM)
+                        .mapToObj(id -> new ProducerRecord<>(topicName, null, id)));
+        return new RecordMessage(startTime, endTime);
+    }
+
+    private void createMessages(String topicName)
+    {
+        embeddedKafka.sendMessages(
+                IntStream.range(0, MESSAGE_NUM)
+                        .mapToObj(id -> new ProducerRecord<>(topicName, null, (long) id)));
+    }
+
+    private static class RecordMessage
+    {
+        private final long startTime;
+        private final long endTime;
+
+        public RecordMessage(long startTime, long endTime)
+        {
+            this.startTime = requireNonNull(startTime, "startTime result is none");
+            this.endTime = requireNonNull(endTime, "endTime result is none");
+        }
+    }
+}

--- a/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaIntegrationPushDown.java
+++ b/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaIntegrationPushDown.java
@@ -60,7 +60,7 @@ public class TestKafkaIntegrationPushDown
 
     @Override
     protected QueryRunner createQueryRunner()
-        throws Exception
+            throws Exception
     {
         return createKafkaQueryRunner();
     }

--- a/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaIntegrationSmokeTest.java
+++ b/presto-kafka/src/test/java/com/facebook/presto/kafka/TestKafkaIntegrationSmokeTest.java
@@ -20,12 +20,13 @@ import com.facebook.presto.tests.AbstractTestIntegrationSmokeTest;
 import com.facebook.presto.tests.DistributedQueryRunner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import java.io.IOException;
-import java.util.List;
-import java.util.stream.Collectors;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static com.facebook.presto.kafka.util.EmbeddedKafka.createEmbeddedKafka;
 import static com.facebook.presto.testing.TestngUtils.toDataProvider;

--- a/presto-kafka/src/test/resources/read_test/all_datatypes_json.json
+++ b/presto-kafka/src/test/resources/read_test/all_datatypes_json.json
@@ -1,0 +1,170 @@
+{
+  "tableName": "all_datatypes_json",
+  "schemaName": "product_tests",
+  "topicName": "all_datatypes_json",
+  "message": {
+    "dataFormat": "json",
+    "fields": [
+      {
+        "name": "c_varchar",
+        "type": "VARCHAR",
+        "mapping": "j_varchar"
+      },
+      {
+        "name": "c_bigint",
+        "type": "BIGINT",
+        "mapping": "j_bigint"
+      },
+      {
+        "name": "c_integer",
+        "type": "INTEGER",
+        "mapping": "j_integer"
+      },
+      {
+        "name": "c_smallint",
+        "type": "SMALLINT",
+        "mapping": "j_smallint"
+      },
+      {
+        "name": "c_tinyint",
+        "type": "TINYINT",
+        "mapping": "j_tinyint"
+      },
+      {
+        "name": "c_double",
+        "type": "DOUBLE",
+        "mapping": "j_double"
+      },
+      {
+        "name": "c_boolean",
+        "type": "BOOLEAN",
+        "mapping": "j_boolean"
+      },
+      {
+        "name": "c_timestamp_milliseconds_since_epoch",
+        "type": "TIMESTAMP",
+        "mapping": "j_timestamp_milliseconds_since_epoch",
+        "dataFormat": "milliseconds-since-epoch"
+      },
+      {
+        "name": "c_timestamp_seconds_since_epoch",
+        "type": "TIMESTAMP",
+        "mapping": "j_timestamp_seconds_since_epoch",
+        "dataFormat": "seconds-since-epoch"
+      },
+      {
+        "name": "c_timestamp_iso8601",
+        "type": "TIMESTAMP",
+        "mapping": "j_timestamp_iso8601",
+        "dataFormat": "iso8601"
+      },
+      {
+        "name": "c_timestamp_rfc2822",
+        "type": "TIMESTAMP",
+        "mapping": "j_timestamp_rfc2822",
+        "dataFormat": "rfc2822"
+      },
+      {
+        "name": "c_timestamp_custom",
+        "type": "TIMESTAMP",
+        "mapping": "j_timestamp_custom",
+        "dataFormat": "custom-date-time",
+        "formatHint": "MM/yyyy/dd H:m:s"
+      },
+      {
+        "name": "c_date_iso8601",
+        "type": "DATE",
+        "mapping": "j_date_iso8601",
+        "dataFormat": "iso8601"
+      },
+      {
+        "name": "c_date_custom",
+        "type": "DATE",
+        "mapping": "j_date_custom",
+        "dataFormat": "custom-date-time",
+        "formatHint": "yyyy/dd/MM"
+      },
+      {
+        "name": "c_time_milliseconds_since_epoch",
+        "type": "TIME",
+        "mapping": "j_time_milliseconds_since_epoch",
+        "dataFormat": "milliseconds-since-epoch"
+      },
+      {
+        "name": "c_time_seconds_since_epoch",
+        "type": "TIME",
+        "mapping": "j_time_seconds_since_epoch",
+        "dataFormat": "seconds-since-epoch"
+      },
+      {
+        "name": "c_time_iso8601",
+        "type": "TIME",
+        "mapping": "j_time_iso8601",
+        "dataFormat": "iso8601"
+      },
+      {
+        "name": "c_time_custom",
+        "type": "TIME",
+        "mapping": "j_time_custom",
+        "dataFormat": "custom-date-time",
+        "formatHint": "mm:HH:ss"
+      },
+      {
+        "name": "c_timestamptz_milliseconds_since_epoch",
+        "type": "TIMESTAMP WITH TIME ZONE",
+        "mapping": "j_timestamptz_milliseconds_since_epoch",
+        "dataFormat": "milliseconds-since-epoch"
+      },
+      {
+        "name": "c_timestamptz_seconds_since_epoch",
+        "type": "TIMESTAMP WITH TIME ZONE",
+        "mapping": "j_timestamptz_seconds_since_epoch",
+        "dataFormat": "seconds-since-epoch"
+      },
+      {
+        "name": "c_timestamptz_iso8601",
+        "type": "TIMESTAMP WITH TIME ZONE",
+        "mapping": "j_timestamptz_iso8601",
+        "dataFormat": "iso8601"
+      },
+      {
+        "name": "c_timestamptz_rfc2822",
+        "type": "TIMESTAMP WITH TIME ZONE",
+        "mapping": "j_timestamptz_rfc2822",
+        "dataFormat": "rfc2822"
+      },
+      {
+        "name": "c_timestamptz_custom",
+        "type": "TIMESTAMP WITH TIME ZONE",
+        "mapping": "j_timestamptz_custom",
+        "dataFormat": "custom-date-time",
+        "formatHint": "MM/yyyy/dd H:m:s"
+      },
+      {
+        "name": "c_timetz_milliseconds_since_epoch",
+        "type": "TIME WITH TIME ZONE",
+        "mapping": "j_timetz_milliseconds_since_epoch",
+        "dataFormat": "milliseconds-since-epoch"
+      },
+      {
+        "name": "c_timetz_seconds_since_epoch",
+        "type": "TIME WITH TIME ZONE",
+        "mapping": "j_timetz_seconds_since_epoch",
+        "dataFormat": "seconds-since-epoch"
+      },
+      {
+        "name": "c_timetz_iso8601",
+        "type": "TIME WITH TIME ZONE",
+        "mapping": "j_timetz_iso8601",
+        "dataFormat": "iso8601"
+      },
+      {
+        "name": "c_timetz_custom",
+        "type": "TIME WITH TIME ZONE",
+        "mapping": "j_timetz_custom",
+        "dataFormat": "custom-date-time",
+        "formatHint": "mm:HH:ss"
+      }
+    ]
+  }
+}

--- a/presto-main/etc/catalog/kafka.properties
+++ b/presto-main/etc/catalog/kafka.properties
@@ -1,0 +1,11 @@
+#
+# WARNING
+# ^^^^^^^
+# This configuration file is for development only and should NOT be used be
+# used in production. For example configuration, see the Presto documentation.
+#
+
+connector.name=kafka
+kafka.nodes=localhost:9092
+kafka.table-names=kafka-availability-dca1d
+kafka.hide-internal-columns=false

--- a/presto-main/src/main/java/com/facebook/presto/testing/assertions/Assert.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/assertions/Assert.java
@@ -13,6 +13,10 @@
  */
 package com.facebook.presto.testing.assertions;
 
+import io.airlift.units.Duration;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
 /**
  * This class provides replacements for TestNG's faulty assertion methods.
  * <p>
@@ -45,6 +49,34 @@ public class Assert
             org.testng.Assert.assertEquals(actual, expected, message);
             //if we're here, the Iterables differ on their fields. Use the original error message.
             throw error;
+        }
+    }
+
+    public static void assertEventually(Runnable assertion)
+    {
+        assertEventually(new Duration(30, SECONDS), assertion);
+    }
+
+    public static void assertEventually(Duration timeout, Runnable assertion)
+    {
+        long start = System.nanoTime();
+        while (!Thread.currentThread().isInterrupted()) {
+            try {
+                assertion.run();
+                return;
+            }
+            catch (Exception | AssertionError e) {
+                if (Duration.nanosSince(start).compareTo(timeout) > 0) {
+                    throw e;
+                }
+            }
+            try {
+                Thread.sleep(50);
+            }
+            catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
         }
     }
 }


### PR DESCRIPTION
Part of the change is from this PR: https://github.com/trinodb/trino/commit/a2ec0e357c0c7301e38fa595233248ff1d9dc391

The change includes
 - Add the filter pushdown on the conditions of timestamp and partitions to Kafka connector
 - Add integration tests for kafka pushdown
 - Also reorganized the KafkaQueryRunner for set up

Test plan - (Please fill in how you tested your changes)
Unit tests and integration tests

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== RELEASE NOTES ==
Kafka Changes
* Add the filter pushdown on the conditions of timestamp and partitions to Kafka connector
```
