### PR TITLE
Allow no row for Pinot SQL

### DIFF
--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotBrokerPageSourceSql.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotBrokerPageSourceSql.java
@@ -27,7 +27,6 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static com.facebook.presto.pinot.PinotErrorCode.PINOT_UNEXPECTED_RESPONSE;
-import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
 public class PinotBrokerPageSourceSql
@@ -115,7 +114,6 @@ public class PinotBrokerPageSourceSql
             }
 
             JsonNode rows = resultTable.get("rows");
-            checkState(rows.size() >= 1, "Expected at least one row to be present");
             setRows(sql, blockBuilders, types, rows);
             return rows.size();
         }

--- a/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotBrokerPageSourceSql.java
+++ b/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotBrokerPageSourceSql.java
@@ -153,6 +153,12 @@ public class TestPinotBrokerPageSourceSql
                     "{ \"resultTable\": { \"dataSchema\": { \"columnDataTypes\": [\"BIGINT\"], \"columnNames\": [\"tag_nums\"] }, \"rows\": [ [[\"1\"]], [[\"1\", \"2\"]], [[\"3\", \"2\"]], [[\"0\"]], [[\"4\", \"5\", \"6\", \"7\"]], [[\"0\"]] ] }, \"exceptions\": [], \"numServersQueried\": 1, \"numServersResponded\": 1, \"numSegmentsQueried\": 1, \"numSegmentsProcessed\": 1, \"numSegmentsMatched\": 1, \"numConsumingSegmentsQueried\": 1, \"numDocsScanned\": 10, \"numEntriesScannedInFilter\": 0, \"numEntriesScannedPostFilter\": 100, \"numGroupsLimitReached\": false, \"totalDocs\": 1425, \"timeUsedMs\": 10, \"segmentStatistics\": [], \"traceInfo\": {}, \"minConsumingFreshnessTimeMs\": 1592910063563 }",
                     ImmutableList.of(array(BIGINT, "tag_nums")),
                     ImmutableList.of(0),
+                    Optional.empty()},
+                {
+                    "select group_country from meetupRsvp where group_country IN ('az')",
+                    "{ \"resultTable\": { \"dataSchema\": { \"columnNames\": [\"group_country\"], \"columnDataTypes\": [\"STRING\"] }, \"rows\": [] }, \"exceptions\": [], \"numServersQueried\": 1, \"numServersResponded\": 1, \"numSegmentsQueried\": 5, \"numSegmentsProcessed\": 4, \"numSegmentsMatched\": 4, \"numConsumingSegmentsQueried\": 1, \"numDocsScanned\": 67077, \"numEntriesScannedInFilter\": 0, \"numEntriesScannedPostFilter\": 67077, \"numGroupsLimitReached\": false, \"totalDocs\": 67077, \"timeUsedMs\": 44, \"segmentStatistics\": [], \"traceInfo\": {}, \"minConsumingFreshnessTimeMs\": 9223372036854775807 }",
+                    ImmutableList.of(groupCountry),
+                    ImmutableList.of(0),
                     Optional.empty()}
         };
     }


### PR DESCRIPTION
Test plan
Tested with query with empty results: 
`SELECT COUNT(workflowuuid) AS totalOrders, SUM(checkoutsubtotallocal) AS sales, eventhourlocal AS split FROM ( SELECT workflowuuid, checkoutsubtotallocal, eventhourlocal FROM rta.rta.rta_hp_restaurant_gateway_notifier_order_event WHERE restaurantuuid IN ('c543df0c-af41-431e-9a63-2003639b5e91','c786f957-3683-4f9e-8874-411b14c4cc1a','e1e7f317-df8a-4729-9b4a-70d27e96368c','6f7bab48-78c9-45ba-aa23-76e559303228','35072ed5-b5b6-403e-98b4-c8ea3b383ed8','75b152be-1dd6-47f9-bbfe-3ebb9d906ca4','8fef0fcc-bb0d-411e-bdb4-a0049672f638','5099fbd1-dc53-4ae6-a849-ecab616d7bf9','fce0ca05-8fa5-49da-b634-348668fa9bc6','73ae9392-d990-4be3-ac7a-c30cbdf40a5d','34652f66-6fda-4f68-8737-15a7242b8105','e24e1fb1-3729-4e36-a47c-50aa9fa1c289','a9e6d770-dd41-47fc-a557-b1e6c82020dd','c7111bbb-92fa-49c5-a684-dc5648ee578e','4098bd46-beac-40d8-99b8-d8fbade8ee28','96fa6f5d-f7ba-46da-be44-e4a2527fdc0c','099c84b2-d853-44cf-94d6-aa06f754c4eb','27db8573-be48-492f-a12d-792905c7153e','64221512-67b0-4731-805e-7435f715f973','a599b98e-66e6-487b-b481-f79ed47749b9','3e8b7220-d149-4638-adc1-ad2a40a206d5','bdfdb44b-9400-4d38-b63e-c5168e03d8b1','a484efbb-1082-4426-8e23-cd0fa7d418f0','aaadba05-c26e-4ea3-854b-0201221b4c18','84b48bf8-c39d-48d0-88a3-733b47bd8580','65c12757-1458-4d32-b28b-7f9fa1e2fecd') AND eventdatelocal = '2021-05-25' AND state IN ('COMPLETED', 'DELIVERY_FAILED') GROUP BY workflowuuid, checkoutsubtotallocal, eventhourlocal ) filtered GROUP BY eventhourlocal`

results:
`{
  "id": "20210728_174855_00006_hpny6",
  "infoUri": "//localhost:8080/ui/query.html?20210728_174855_00006_hpny6",
  "columns": [
    {
      "name": "totalOrders",
      "type": "bigint",
      "typeSignature": {
        "rawType": "bigint",
        "typeArguments": [],
        "literalArguments": [],
        "arguments": []
      }
    },
    {
      "name": "sales",
      "type": "double",
      "typeSignature": {
        "rawType": "double",
        "typeArguments": [],
        "literalArguments": [],
        "arguments": []
      }
    },
    {
      "name": "split",
      "type": "varchar",
      "typeSignature": {
        "rawType": "varchar",
        "typeArguments": [],
        "literalArguments": [],
        "arguments": [
          {
            "kind": "LONG_LITERAL",
            "value": 2147483647
          }
        ]
      }
    }
  ],
  "stats": {
    "state": "FINISHED",
    "queued": false,
    "scheduled": true,
    "nodes": 1,
    "totalSplits": 1,
    "queuedSplits": 0,
    "runningSplits": 0,
    "completedSplits": 1,
    "cpuTimeMillis": 1,
    "wallTimeMillis": 74,
    "queuedTimeMillis": 0,
    "elapsedTimeMillis": 122,
    "processedRows": 0,
    "processedBytes": 0,
    "peakMemoryBytes": 0,
    "peakTotalMemoryBytes": 0,
    "peakTaskTotalMemoryBytes": 0,
    "spilledBytes": 0,
    "rootStage": {
      "stageId": "0",
      "state": "FINISHED",
      "done": true,
      "nodes": 1,
      "totalSplits": 1,
      "queuedSplits": 0,
      "runningSplits": 0,
      "completedSplits": 1,
      "cpuTimeMillis": 1,
      "wallTimeMillis": 74,
      "processedRows": 0,
      "processedBytes": 0,
      "subStages": []
    },
    "progressPercentage": 100
  },
  "warnings": []
}`


```
== RELEASE NOTES ==
Pinot Connector Changes
* Add a unit test to test empty results for Pinot SQL in TestPinotBrokerSourceSql.java
* Remove check for no row results in PinotBrokerPageSourceSql.java

