### PR TITLE
Fix multithread writing for fragment result cache

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/FileFragmentResultCacheConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/FileFragmentResultCacheConfig.java
@@ -25,6 +25,7 @@ import javax.validation.constraints.Min;
 import java.net.URI;
 
 import static io.airlift.units.DataSize.Unit.GIGABYTE;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static java.util.concurrent.TimeUnit.DAYS;
 
 public class FileFragmentResultCacheConfig
@@ -36,6 +37,7 @@ public class FileFragmentResultCacheConfig
     private int maxCachedEntries = 10_000;
     private Duration cacheTtl = new Duration(2, DAYS);
     private DataSize maxInFlightSize = new DataSize(1, GIGABYTE);
+    private DataSize maxSinglePagesSize = new DataSize(500, MEGABYTE);
 
     public boolean isCachingEnabled()
     {
@@ -115,6 +117,20 @@ public class FileFragmentResultCacheConfig
     public FileFragmentResultCacheConfig setMaxInFlightSize(DataSize maxInFlightSize)
     {
         this.maxInFlightSize = maxInFlightSize;
+        return this;
+    }
+
+    @MinDataSize("0B")
+    public DataSize getMaxSinglePagesSize()
+    {
+        return maxSinglePagesSize;
+    }
+
+    @Config("fragment-result-cache.max-single-pages-size")
+    @ConfigDescription("Maximum size of pages write to flushed")
+    public FileFragmentResultCacheConfig setMaxSinglePagesSize(DataSize maxSinglePagesSize)
+    {
+        this.maxSinglePagesSize = maxSinglePagesSize;
         return this;
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestFileFragmentResultCacheConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestFileFragmentResultCacheConfig.java
@@ -25,6 +25,7 @@ import static com.facebook.airlift.configuration.testing.ConfigAssertions.assert
 import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static com.facebook.airlift.configuration.testing.ConfigAssertions.recordDefaults;
 import static io.airlift.units.DataSize.Unit.GIGABYTE;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static java.util.concurrent.TimeUnit.DAYS;
 
 public class TestFileFragmentResultCacheConfig
@@ -38,7 +39,8 @@ public class TestFileFragmentResultCacheConfig
                 .setBlockEncodingCompressionEnabled(false)
                 .setMaxCachedEntries(10_000)
                 .setCacheTtl(new Duration(2, DAYS))
-                .setMaxInFlightSize(new DataSize(1, GIGABYTE)));
+                .setMaxInFlightSize(new DataSize(1, GIGABYTE))
+                .setMaxSinglePagesSize(new DataSize(500, MEGABYTE)));
     }
 
     @Test
@@ -52,6 +54,7 @@ public class TestFileFragmentResultCacheConfig
                 .put("fragment-result-cache.max-cached-entries", "100000")
                 .put("fragment-result-cache.cache-ttl", "1d")
                 .put("fragment-result-cache.max-in-flight-size", "2GB")
+                .put("fragment-result-cache.max-single-pages-size", "200MB")
                 .build();
 
         FileFragmentResultCacheConfig expected = new FileFragmentResultCacheConfig()
@@ -60,7 +63,8 @@ public class TestFileFragmentResultCacheConfig
                 .setBlockEncodingCompressionEnabled(true)
                 .setMaxCachedEntries(100000)
                 .setCacheTtl(new Duration(1, DAYS))
-                .setMaxInFlightSize(new DataSize(2, GIGABYTE));
+                .setMaxInFlightSize(new DataSize(2, GIGABYTE))
+                .setMaxSinglePagesSize(new DataSize(200, MEGABYTE));
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
== RELEASE NOTES ==

General Changes
* Fix multithread writing for fragment result cache  #16455 
* add config `fragment-result-cache.max-single-pages-size` to control the max fragement cache file size
