### PR TITLE
Support JSON CLI output format

### DIFF
--- a/presto-cli/pom.xml
+++ b/presto-cli/pom.xml
@@ -98,6 +98,11 @@
             <artifactId>okhttp</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+
         <!-- for testing -->
         <dependency>
             <groupId>org.testng</groupId>

--- a/presto-cli/src/main/java/com/facebook/presto/cli/ClientOptions.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/ClientOptions.java
@@ -116,7 +116,7 @@ public class ClientOptions
     @Option(name = "--execute", title = "execute", description = "Execute specified statements and exit")
     public String execute;
 
-    @Option(name = "--output-format", title = "output-format", description = "Output format for batch mode [ALIGNED, VERTICAL, CSV, TSV, CSV_HEADER, TSV_HEADER, NULL] (default: CSV)")
+    @Option(name = "--output-format", title = "output-format", description = "Output format for batch mode [ALIGNED, VERTICAL, JSON, CSV, TSV, CSV_HEADER, TSV_HEADER, NULL] (default: CSV)")
     public OutputFormat outputFormat = OutputFormat.CSV;
 
     @Option(name = "--resource-estimate", title = "resource-estimate", description = "Resource estimate (property can be used multiple times; format is key=value)")
@@ -147,6 +147,7 @@ public class ClientOptions
     {
         ALIGNED,
         VERTICAL,
+        JSON,
         CSV,
         TSV,
         CSV_HEADER,

--- a/presto-cli/src/main/java/com/facebook/presto/cli/JsonPrinter.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/JsonPrinter.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.cli;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.google.common.collect.ImmutableList;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.List;
+
+import static com.facebook.presto.cli.AlignedTablePrinter.formatHexDump;
+import static java.util.Objects.requireNonNull;
+
+public class JsonPrinter
+        implements OutputPrinter
+{
+    private final List<String> fieldNames;
+    private final Writer writer;
+
+    public JsonPrinter(List<String> fieldNames, Writer writer)
+    {
+        this.fieldNames = ImmutableList.copyOf(requireNonNull(fieldNames, "fieldNames is null"));
+        this.writer = requireNonNull(writer, "writer is null");
+    }
+
+    @Override
+    public void printRows(List<List<?>> rows, boolean complete)
+            throws IOException
+    {
+        JsonFactory jsonFactory = new JsonFactory();
+        for (List<?> row : rows) {
+            JsonGenerator jsonGenerator = jsonFactory.createGenerator(writer);
+            jsonGenerator.writeStartObject();
+            for (int position = 0; position < row.size(); position++) {
+                String columnName = fieldNames.get(position);
+                jsonGenerator.writeObjectField(columnName, formatValue(row.get(position)));
+            }
+            jsonGenerator.writeEndObject();
+            jsonGenerator.writeRaw('\n');
+            jsonGenerator.flush();
+        }
+    }
+
+    @Override
+    public void finish()
+            throws IOException
+    {
+        writer.flush();
+    }
+
+    private static Object formatValue(Object o)
+    {
+        if (o instanceof byte[]) {
+            return formatHexDump((byte[]) o);
+        }
+        return o;
+    }
+}

--- a/presto-cli/src/main/java/com/facebook/presto/cli/Query.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/Query.java
@@ -308,6 +308,8 @@ public class Query
                 return new AlignedTablePrinter(fieldNames, writer);
             case VERTICAL:
                 return new VerticalRecordPrinter(fieldNames, writer);
+            case JSON:
+                return new JsonPrinter(fieldNames, writer);
             case CSV:
                 return new CsvPrinter(fieldNames, writer, false);
             case CSV_HEADER:

--- a/presto-cli/src/test/java/com/facebook/presto/cli/TestJsonPrinter.java
+++ b/presto-cli/src/test/java/com/facebook/presto/cli/TestJsonPrinter.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.cli;
+
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.List;
+
+import static com.facebook.presto.cli.TestAlignedTablePrinter.row;
+import static com.facebook.presto.cli.TestAlignedTablePrinter.rows;
+import static org.testng.Assert.assertEquals;
+
+public class TestJsonPrinter
+{
+    @Test
+    public void testJsonPrinting()
+            throws Exception
+    {
+        StringWriter writer = new StringWriter();
+        List<String> fieldNames = ImmutableList.of("first", "last", "quantity");
+        OutputPrinter printer = new JsonPrinter(fieldNames, writer);
+
+        printer.printRows(rows(
+                        row("hello", "world", 123),
+                        row("a", null, 4.5),
+                        row("some long\ntext\tdone", "more\ntext", 4567),
+                        row("bye", "done", -15)),
+                true);
+        printer.finish();
+
+        String expected = "" +
+                "{\"first\":\"hello\",\"last\":\"world\",\"quantity\":123}\n" +
+                "{\"first\":\"a\",\"last\":null,\"quantity\":4.5}\n" +
+                "{\"first\":\"some long\\ntext\\tdone\",\"last\":\"more\\ntext\",\"quantity\":4567}\n" +
+                "{\"first\":\"bye\",\"last\":\"done\",\"quantity\":-15}\n";
+
+        assertEquals(writer.getBuffer().toString(), expected);
+    }
+
+    @Test
+    public void testJsonPrintingNoRows()
+            throws Exception
+    {
+        StringWriter writer = new StringWriter();
+        List<String> fieldNames = ImmutableList.of("first", "last");
+        OutputPrinter printer = new JsonPrinter(fieldNames, writer);
+
+        printer.finish();
+
+        assertEquals(writer.getBuffer().toString(), "");
+    }
+
+    @Test
+    public void testJsonVarbinaryPrinting()
+            throws IOException
+    {
+        StringWriter writer = new StringWriter();
+        List<String> fieldNames = ImmutableList.of("first", "last", "quantity");
+        OutputPrinter printer = new JsonPrinter(fieldNames, writer);
+
+        printer.printRows(rows(row("hello".getBytes(), null, 123)), true);
+        printer.finish();
+
+        String expected = "{\"first\":\"68 65 6c 6c 6f\",\"last\":null,\"quantity\":123}\n";
+
+        assertEquals(writer.getBuffer().toString(), expected);
+    }
+}


### PR DESCRIPTION
Fixes #16548 

How to use?

`presto --output-format=JSON --execute 'describe tpch.sf1.region;' | jq`

**OUTPUT**

```
{
  "Column": "regionkey",
  "Type": "bigint",
  "Extra": "",
  "Comment": ""
}
{
  "Column": "name",
  "Type": "varchar(25)",
  "Extra": "",
  "Comment": ""
}
{
  "Column": "comment",
  "Type": "varchar(152)",
  "Extra": "",
  "Comment": ""
}
```

```
== RELEASE NOTES ==

General Changes
* Add support for JSON CLI output format
```