### PR TITLE
Fix unsafe cast in RowExpressionFormatter

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/RowExpressionFormatter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/RowExpressionFormatter.java
@@ -85,20 +85,25 @@ public final class RowExpressionFormatter
             }
             else if (standardFunctionResolution.isLikeFunction(node.getFunctionHandle())) {
                 RowExpression value = node.getArguments().get(0);
-                CallExpression patternCallExpression = (CallExpression) node.getArguments().get(1);
+                RowExpression patternRowExpression = node.getArguments().get(1);
 
-                // second LIKE argument is:
-                //  CAST(pattern as LikePattern), if escape is not present
-                //  LIKE_PATTERN(pattern, escape), if escape is present
-                if (standardFunctionResolution.isCastFunction(patternCallExpression.getFunctionHandle())) {
-                    RowExpression pattern = patternCallExpression.getArguments().get(0);
-                    return String.format("%s LIKE %s", formatRowExpression(session, value), formatRowExpression(session, pattern));
+                if (patternRowExpression instanceof CallExpression) {
+                    CallExpression patternCallExpression = (CallExpression) patternRowExpression;
+                    // second LIKE argument is:
+                    //  CAST(pattern as LikePattern), if escape is not present
+                    //  LIKE_PATTERN(pattern, escape), if escape is present
+                    if (standardFunctionResolution.isCastFunction(patternCallExpression.getFunctionHandle())) {
+                        RowExpression pattern = patternCallExpression.getArguments().get(0);
+                        return String.format("%s LIKE %s", formatRowExpression(session, value), formatRowExpression(session, pattern));
+                    }
+                    else if (standardFunctionResolution.isLikePatternFunction(patternCallExpression.getFunctionHandle())) {
+                        RowExpression pattern = patternCallExpression.getArguments().get(0);
+                        RowExpression escape = patternCallExpression.getArguments().get(1);
+                        return String.format("%s LIKE %s ESCAPE %s", formatRowExpression(session, value), formatRowExpression(session, pattern), formatRowExpression(session, escape));
+                    }
                 }
-                else {
-                    RowExpression pattern = patternCallExpression.getArguments().get(0);
-                    RowExpression escape = patternCallExpression.getArguments().get(1);
-                    return String.format("%s LIKE %s ESCAPE %s", formatRowExpression(session, value), formatRowExpression(session, pattern), formatRowExpression(session, escape));
-                }
+
+                return String.format("%s LIKE %s", formatRowExpression(session, value), formatRowExpression(session, patternRowExpression));
             }
             FunctionMetadata metadata = functionMetadataManager.getFunctionMetadata(node.getFunctionHandle());
             return node.getDisplayName() + (metadata.getVersion().hasVersion() ? ":" + metadata.getVersion() : "") + "(" + String.join(", ", formatRowExpressions(session, node.getArguments())) + ")";

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/FunctionResolution.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/FunctionResolution.java
@@ -86,14 +86,22 @@ public final class FunctionResolution
         return functionAndTypeManager.lookupFunction("LIKE", fromTypes(valueType, LIKE_PATTERN));
     }
 
+    @Override
     public boolean isLikeFunction(FunctionHandle functionHandle)
     {
         return functionAndTypeManager.getFunctionMetadata(functionHandle).getName().equals(QualifiedObjectName.valueOf(DEFAULT_NAMESPACE, "LIKE"));
     }
 
+    @Override
     public FunctionHandle likePatternFunction()
     {
         return functionAndTypeManager.lookupFunction("LIKE_PATTERN", fromTypes(VARCHAR, VARCHAR));
+    }
+
+    @Override
+    public boolean isLikePatternFunction(FunctionHandle functionHandle)
+    {
+        return functionAndTypeManager.getFunctionMetadata(functionHandle).getName().equals(QualifiedObjectName.valueOf(DEFAULT_NAMESPACE, "LIKE_PATTERN"));
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/StandardFunctionResolution.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/StandardFunctionResolution.java
@@ -34,6 +34,10 @@ public interface StandardFunctionResolution
 
     boolean isLikeFunction(FunctionHandle functionHandle);
 
+    FunctionHandle likePatternFunction();
+
+    boolean isLikePatternFunction(FunctionHandle functionHandle);
+
     FunctionHandle arrayConstructor(List<? extends Type> argumentTypes);
 
     FunctionHandle arithmeticFunction(OperatorType operator, Type leftType, Type rightType);


### PR DESCRIPTION
Fixed the ClassCastException that occurs when the RowExpression containing a compiled LIKE predicate (RowExpressionInterpreter.tryHandleLike()) is printed with RowExpressionFormatter.

Test plan: unit tests
```
== RELEASE NOTES ==

General Changes
* Fixed a casting error that sometimes occurred for EXPLAIN queries when the query plan contains LIKE predicates
```