### PR TITLE
Fix bug in DictionaryColumnWriter.getRetainedBytes

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/DictionaryColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/DictionaryColumnWriter.java
@@ -284,7 +284,7 @@ public abstract class DictionaryColumnWriter
         ColumnStatistics statistics = createColumnStatistics();
         DictionaryRowGroup rowGroup = new DictionaryRowGroup(rowGroupIndexes, rowGroupValueCount, statistics);
         rowGroups.add(rowGroup);
-        columnStatisticsRetainedSizeInBytes += rowGroup.getColumnStatistics().getRetainedSizeInBytes();
+        columnStatisticsRetainedSizeInBytes += rowGroup.getColumnStatistics().getRetainedSizeInBytes() + sizeOf(rowGroup.getDictionaryIndexes());
         rowGroupValueCount = 0;
         return ImmutableMap.of(column, statistics);
     }


### PR DESCRIPTION
In our production environment, worker OOM occasionally occurs, but the reserve memory is relatively small. After analysis, one of the reasons is that the dictionaryIndexes in the DictionaryRowGroup in the DictionaryColumnWriter are not counted.