### PR TITLE
Interrupte HivePageSink when driver is done

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSinkProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSinkProvider.java
@@ -127,7 +127,7 @@ public class HivePageSinkProvider
         HiveOutputTableHandle handle = (HiveOutputTableHandle) tableHandle;
         Optional<ConnectorMetadataUpdater> hiveMetadataUpdater = pageSinkContext.getMetadataUpdater();
         checkArgument(hiveMetadataUpdater.isPresent(), "Metadata Updater for HivePageSink is null");
-        return createPageSink(handle, true, session, (HiveMetadataUpdater) hiveMetadataUpdater.get(), pageSinkContext.isCommitRequired(), handle.getAdditionalTableParameters());
+        return createPageSink(handle, true, session, (HiveMetadataUpdater) hiveMetadataUpdater.get(), pageSinkContext.isCommitRequired(), handle.getAdditionalTableParameters(), pageSinkContext);
     }
 
     @Override
@@ -136,10 +136,16 @@ public class HivePageSinkProvider
         HiveInsertTableHandle handle = (HiveInsertTableHandle) tableHandle;
         Optional<ConnectorMetadataUpdater> hiveMetadataUpdater = pageSinkContext.getMetadataUpdater();
         checkArgument(hiveMetadataUpdater.isPresent(), "Metadata Updater for HivePageSink is null");
-        return createPageSink(handle, false, session, (HiveMetadataUpdater) hiveMetadataUpdater.get(), pageSinkContext.isCommitRequired(), ImmutableMap.of());
+        return createPageSink(handle, false, session, (HiveMetadataUpdater) hiveMetadataUpdater.get(), pageSinkContext.isCommitRequired(), ImmutableMap.of(), pageSinkContext);
     }
 
-    private ConnectorPageSink createPageSink(HiveWritableTableHandle handle, boolean isCreateTable, ConnectorSession session, HiveMetadataUpdater hiveMetadataUpdater, boolean commitRequired, Map<String, String> additionalTableParameters)
+    private ConnectorPageSink createPageSink(HiveWritableTableHandle handle,
+                                             boolean isCreateTable,
+                                             ConnectorSession session,
+                                             HiveMetadataUpdater hiveMetadataUpdater,
+                                             boolean commitRequired,
+                                             Map<String, String> additionalTableParameters,
+                                             PageSinkContext pageSinkContext)
     {
         OptionalInt bucketCount = OptionalInt.empty();
         List<SortingColumn> sortedBy;
@@ -199,6 +205,7 @@ public class HivePageSinkProvider
                 partitionUpdateCodec,
                 partitionUpdateSmileCodec,
                 session,
-                hiveMetadataUpdater);
+                hiveMetadataUpdater,
+                pageSinkContext);
     }
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -336,7 +336,16 @@ public abstract class AbstractTestHiveClient
     protected static final String TEST_SERVER_VERSION = "test_version";
 
     protected static final Executor EXECUTOR = Executors.newFixedThreadPool(5);
-    protected static final PageSinkContext TEST_HIVE_PAGE_SINK_CONTEXT = PageSinkContext.builder().setCommitRequired(false).setConnectorMetadataUpdater(new HiveMetadataUpdater(EXECUTOR)).build();
+    protected static final PageSinkContext TEST_HIVE_PAGE_SINK_CONTEXT = PageSinkContext.builder()
+            .setCommitRequired(false)
+            .setConnectorMetadataUpdater(new HiveMetadataUpdater(EXECUTOR))
+            .setDriverDone(() -> false)
+            .build();
+    protected static final PageSinkContext TEST_HIVE_PAGE_SINK_CONTEXT_COMMIT_REQUIRED = PageSinkContext.builder()
+            .setCommitRequired(true)
+            .setConnectorMetadataUpdater(new HiveMetadataUpdater(EXECUTOR))
+            .setDriverDone(() -> false)
+            .build();
 
     private static final Type ARRAY_TYPE = arrayType(createUnboundedVarcharType());
     private static final Type MAP_TYPE = mapType(createUnboundedVarcharType(), BIGINT);
@@ -2742,7 +2751,7 @@ public abstract class AbstractTestHiveClient
             SchemaTableName temporaryCreateTableForPageSinkCommit = temporaryTable("create_table_page_sink_commit");
             try {
                 doCreateTable(temporaryCreateTable, storageFormat, TEST_HIVE_PAGE_SINK_CONTEXT);
-                doCreateTable(temporaryCreateTableForPageSinkCommit, storageFormat, PageSinkContext.builder().setCommitRequired(true).setConnectorMetadataUpdater(new HiveMetadataUpdater(EXECUTOR)).build());
+                doCreateTable(temporaryCreateTableForPageSinkCommit, storageFormat, TEST_HIVE_PAGE_SINK_CONTEXT_COMMIT_REQUIRED);
             }
             finally {
                 dropTable(temporaryCreateTable);
@@ -3056,7 +3065,7 @@ public abstract class AbstractTestHiveClient
             SchemaTableName temporaryInsertTableForPageSinkCommit = temporaryTable("insert_table_page_sink_commit");
             try {
                 doInsert(storageFormat, temporaryInsertTable, TEST_HIVE_PAGE_SINK_CONTEXT);
-                doInsert(storageFormat, temporaryInsertTableForPageSinkCommit, PageSinkContext.builder().setCommitRequired(true).setConnectorMetadataUpdater(new HiveMetadataUpdater(EXECUTOR)).build());
+                doInsert(storageFormat, temporaryInsertTableForPageSinkCommit, TEST_HIVE_PAGE_SINK_CONTEXT_COMMIT_REQUIRED);
             }
             finally {
                 dropTable(temporaryInsertTable);
@@ -3074,7 +3083,7 @@ public abstract class AbstractTestHiveClient
             SchemaTableName temporaryInsertIntoNewPartitionTableForPageSinkCommit = temporaryTable("insert_new_partitioned_page_sink_commit");
             try {
                 doInsertIntoNewPartition(storageFormat, temporaryInsertIntoNewPartitionTable, TEST_HIVE_PAGE_SINK_CONTEXT);
-                doInsertIntoNewPartition(storageFormat, temporaryInsertIntoNewPartitionTableForPageSinkCommit, PageSinkContext.builder().setCommitRequired(true).setConnectorMetadataUpdater(new HiveMetadataUpdater(EXECUTOR)).build());
+                doInsertIntoNewPartition(storageFormat, temporaryInsertIntoNewPartitionTableForPageSinkCommit, TEST_HIVE_PAGE_SINK_CONTEXT_COMMIT_REQUIRED);
             }
             finally {
                 dropTable(temporaryInsertIntoNewPartitionTable);
@@ -3092,7 +3101,7 @@ public abstract class AbstractTestHiveClient
             SchemaTableName temporaryInsertIntoExistingPartitionTableForPageSinkCommit = temporaryTable("insert_existing_partitioned_page_sink_commit");
             try {
                 doInsertIntoExistingPartition(storageFormat, temporaryInsertIntoExistingPartitionTable, TEST_HIVE_PAGE_SINK_CONTEXT);
-                doInsertIntoExistingPartition(storageFormat, temporaryInsertIntoExistingPartitionTableForPageSinkCommit, PageSinkContext.builder().setCommitRequired(true).setConnectorMetadataUpdater(new HiveMetadataUpdater(EXECUTOR)).build());
+                doInsertIntoExistingPartition(storageFormat, temporaryInsertIntoExistingPartitionTableForPageSinkCommit, TEST_HIVE_PAGE_SINK_CONTEXT_COMMIT_REQUIRED);
             }
             finally {
                 dropTable(temporaryInsertIntoExistingPartitionTable);

--- a/presto-main/src/main/java/com/facebook/presto/operator/TableWriterOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TableWriterOperator.java
@@ -133,7 +133,7 @@ public class TableWriterOperator
             boolean statisticsCpuTimerEnabled = !(statisticsAggregationOperator instanceof DevNullOperator) && isStatisticsCpuTimerEnabled(session);
             return new TableWriterOperator(
                     context,
-                    createPageSink(),
+                    createPageSink(driverContext),
                     columnChannels,
                     notNullChannelColumnNames,
                     statisticsAggregationOperator,
@@ -143,7 +143,7 @@ public class TableWriterOperator
                     pageSinkCommitStrategy);
         }
 
-        private ConnectorPageSink createPageSink()
+        private ConnectorPageSink createPageSink(DriverContext driverContext)
         {
             ConnectorId connectorId = getConnectorId(target);
             Optional<ConnectorMetadataUpdater> metadataUpdater = metadataUpdaterManager.getMetadataUpdater(connectorId);
@@ -153,7 +153,8 @@ public class TableWriterOperator
             }
 
             PageSinkContext.Builder pageSinkContextBuilder = PageSinkContext.builder()
-                    .setCommitRequired(pageSinkCommitStrategy.isCommitRequired());
+                    .setCommitRequired(pageSinkCommitStrategy.isCommitRequired())
+                    .setDriverDone(() -> driverContext.isDone());
             metadataUpdater.ifPresent(pageSinkContextBuilder::setConnectorMetadataUpdater);
 
             if (target instanceof CreateHandle) {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/PageSinkContext.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/PageSinkContext.java
@@ -16,6 +16,7 @@ package com.facebook.presto.spi;
 import com.facebook.presto.spi.connector.ConnectorMetadataUpdater;
 
 import java.util.Optional;
+import java.util.function.Supplier;
 
 public class PageSinkContext
 {
@@ -23,11 +24,15 @@ public class PageSinkContext
 
     private final boolean commitRequired;
     private final Optional<ConnectorMetadataUpdater> metadataUpdater;
+    private Supplier<Boolean> isDriverDone;
 
-    private PageSinkContext(boolean commitRequired, Optional<ConnectorMetadataUpdater> metadataUpdater)
+    private PageSinkContext(boolean commitRequired,
+                            Optional<ConnectorMetadataUpdater> metadataUpdater,
+                            Supplier<Boolean> isDriverDone)
     {
         this.commitRequired = commitRequired;
         this.metadataUpdater = metadataUpdater;
+        this.isDriverDone = isDriverDone;
     }
 
     public static PageSinkContext defaultContext()
@@ -45,6 +50,11 @@ public class PageSinkContext
         return metadataUpdater;
     }
 
+    public boolean isDriverDone()
+    {
+        return isDriverDone.get();
+    }
+
     public static Builder builder()
     {
         return new Builder();
@@ -54,6 +64,7 @@ public class PageSinkContext
     {
         private boolean commitRequired;
         private Optional<ConnectorMetadataUpdater> metadataUpdater = Optional.empty();
+        private Supplier<Boolean> isDriverDone;
 
         public Builder setCommitRequired(boolean commitRequired)
         {
@@ -67,9 +78,15 @@ public class PageSinkContext
             return this;
         }
 
+        public Builder setDriverDone(Supplier<Boolean> isDriverDone)
+        {
+            this.isDriverDone = isDriverDone;
+            return this;
+        }
+
         public PageSinkContext build()
         {
-            return new PageSinkContext(commitRequired, metadataUpdater);
+            return new PageSinkContext(commitRequired, metadataUpdater, isDriverDone);
         }
     }
 }


### PR DESCRIPTION
There is a problem in our production environment. When a SQL dynamically writes about 100 partitions, the number of output columns is also about 100. This query takes up a lot of memory and is killed by oomkiller, but even if the kill query is started, the query cannot be ended. Eventually lead to worker oom.

The reason is that many HiveWriters are created during the execution of the current HivePageSink, and it does not consider whether the driver or task has ended during the execution process. Even if the driver or task has ended, it continues to execute, causing HivePageSink to use a lot of memory.

