### PR TITLE
Enhance unit tests by validating query plan

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
@@ -1109,8 +1109,10 @@ public class MetadataManager
         if (catalog.isPresent()) {
             ConnectorMetadata metadata = catalog.get().getMetadata();
             ConnectorSession connectorSession = session.toConnectorSession(catalog.get().getConnectorId());
-            List<SchemaTableName> materializedViews = metadata.getReferencedMaterializedViews(connectorSession, toSchemaTableName(tableName));
-            return materializedViews.stream().map(convertFromSchemaTableName(tableName.getCatalogName())).collect(toImmutableList());
+            Optional<List<SchemaTableName>> materializedViews = metadata.getReferencedMaterializedViews(connectorSession, toSchemaTableName(tableName));
+            if (materializedViews.isPresent()) {
+                return materializedViews.get().stream().map(convertFromSchemaTableName(tableName.getCatalogName())).collect(toImmutableList());
+            }
         }
         return ImmutableList.of();
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
@@ -613,9 +613,9 @@ public interface ConnectorMetadata
     /**
      * Gets the referenced materialized views for a give table
      */
-    default List<SchemaTableName> getReferencedMaterializedViews(ConnectorSession session, SchemaTableName tableName)
+    default Optional<List<SchemaTableName>> getReferencedMaterializedViews(ConnectorSession session, SchemaTableName tableName)
     {
-        return emptyList();
+        return Optional.empty();
     }
 
     /**

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -270,7 +270,7 @@ public class ClassLoaderSafeConnectorMetadata
     }
 
     @Override
-    public List<SchemaTableName> getReferencedMaterializedViews(ConnectorSession session, SchemaTableName tableName)
+    public Optional<List<SchemaTableName>> getReferencedMaterializedViews(ConnectorSession session, SchemaTableName tableName)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             return delegate.getReferencedMaterializedViews(session, tableName);


### PR DESCRIPTION
Currently most tests in `com.facebook.presto.hive.TestHiveLogicalPlanner` only compare the query results. In order to check if query optimization works properly, validation on the actual query plans is added.

Resolves #16031 
Depends on facebookexternal/presto-facebook#1638

```
== NO RELEASE NOTE ==
```
