### PR TITLE
Disable AGG(IF()) rewrite for some corner cases

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/arrayagg/SetAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/arrayagg/SetAggregationFunction.java
@@ -83,6 +83,12 @@ public class SetAggregationFunction
         return generateAggregation(type, outputType);
     }
 
+    @Override
+    public boolean isCalledOnNullInput()
+    {
+        return true;
+    }
+
     private static InternalAggregationFunction generateAggregation(Type type, ArrayType outputType)
     {
         DynamicClassLoader classLoader = new DynamicClassLoader(SetAggregationFunction.class.getClassLoader());

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/arrayagg/SetUnionFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/arrayagg/SetUnionFunction.java
@@ -138,6 +138,12 @@ public class SetUnionFunction
         }
     }
 
+    @Override
+    public boolean isCalledOnNullInput()
+    {
+        return true;
+    }
+
     public static void output(SetAggregationState state, BlockBuilder out)
     {
         SetOfValues set = state.get();

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -404,7 +404,7 @@ public class PlanOptimizers
                         ruleStats,
                         statsCalculator,
                         estimatedExchangesCostCalculator,
-                        ImmutableSet.of(new RewriteAggregationIfToFilter())),
+                        ImmutableSet.of(new RewriteAggregationIfToFilter(metadata.getFunctionAndTypeManager()))),
                 predicatePushDown,
                 new IterativeOptimizer(
                         ruleStats,

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestRewriteAggregationIfToFilter.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestRewriteAggregationIfToFilter.java
@@ -44,7 +44,7 @@ public class TestRewriteAggregationIfToFilter
     public void testDoesNotFireForNonIf()
     {
         // The aggregation expression is not an if expression.
-        tester().assertThat(new RewriteAggregationIfToFilter())
+        tester().assertThat(new RewriteAggregationIfToFilter(getFunctionManager()))
                 .on(p -> {
                     VariableReferenceExpression a = p.variable("a", BooleanType.BOOLEAN);
                     VariableReferenceExpression ds = p.variable("ds", VARCHAR);
@@ -60,7 +60,7 @@ public class TestRewriteAggregationIfToFilter
     public void testDoesNotFireForIfWithElse()
     {
         // The if expression has an else branch. We cannot rewrite it.
-        tester().assertThat(new RewriteAggregationIfToFilter())
+        tester().assertThat(new RewriteAggregationIfToFilter(getFunctionManager()))
                 .on(p -> {
                     VariableReferenceExpression a = p.variable("a");
                     VariableReferenceExpression ds = p.variable("ds", VARCHAR);
@@ -75,7 +75,7 @@ public class TestRewriteAggregationIfToFilter
     @Test
     public void testFireOneAggregation()
     {
-        tester().assertThat(new RewriteAggregationIfToFilter())
+        tester().assertThat(new RewriteAggregationIfToFilter(getFunctionManager()))
                 .on(p -> {
                     VariableReferenceExpression a = p.variable("a");
                     VariableReferenceExpression ds = p.variable("ds", VARCHAR);
@@ -104,7 +104,7 @@ public class TestRewriteAggregationIfToFilter
     @Test
     public void testFireTwoAggregations()
     {
-        tester().assertThat(new RewriteAggregationIfToFilter())
+        tester().assertThat(new RewriteAggregationIfToFilter(getFunctionManager()))
                 .on(p -> {
                     VariableReferenceExpression a = p.variable("a");
                     VariableReferenceExpression b = p.variable("b");
@@ -145,7 +145,7 @@ public class TestRewriteAggregationIfToFilter
     @Test
     public void testFireTwoAggregationsWithSharedInput()
     {
-        tester().assertThat(new RewriteAggregationIfToFilter())
+        tester().assertThat(new RewriteAggregationIfToFilter(getFunctionManager()))
                 .on(p -> {
                     VariableReferenceExpression a = p.variable("a");
                     VariableReferenceExpression ds = p.variable("ds", VARCHAR);
@@ -181,7 +181,7 @@ public class TestRewriteAggregationIfToFilter
     @Test
     public void testFireForOneOfTwoAggregations()
     {
-        tester().assertThat(new RewriteAggregationIfToFilter())
+        tester().assertThat(new RewriteAggregationIfToFilter(getFunctionManager()))
                 .on(p -> {
                     VariableReferenceExpression a = p.variable("a");
                     VariableReferenceExpression b = p.variable("b");


### PR DESCRIPTION
The rewrite could change the behavior of certain aggregations such as
set_agg(). See the added tests for example. To be safe, we disable it
for all aggregation functions returning arrays.

Test plan
Added query tests in TestFilteredAggregations.java.

```
== NO RELEASE NOTE ==
```
