### PR TITLE
Fix OutOfBound error when stripe is above MAX_INT rows

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/RowGroup.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/RowGroup.java
@@ -16,6 +16,7 @@ package com.facebook.presto.orc;
 import com.facebook.presto.orc.stream.InputStreamSources;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 public class RowGroup
@@ -28,6 +29,8 @@ public class RowGroup
 
     public RowGroup(int groupId, long rowOffset, long rowCount, long minAverageRowBytes, InputStreamSources streamSources)
     {
+        checkArgument(rowOffset >= 0, "Invalid row offset %s for group id %s", rowOffset, groupId);
+        checkArgument(rowCount >= 0, "Invalid row count %s for group id %s", rowCount, groupId);
         this.groupId = groupId;
         this.rowOffset = rowOffset;
         this.rowCount = rowCount;

--- a/presto-orc/src/test/java/com/facebook/presto/orc/StripeReaderTest.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/StripeReaderTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc;
+
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public class StripeReaderTest
+{
+    private static final int MILLION = 1_000_000;
+    private static final int BILLION = 1000 * MILLION;
+    private static final long TEN_BILLION = 10L * BILLION;
+
+    @Test
+    public void testCreateRowGroup()
+    {
+        long numRowsInStripe = TEN_BILLION + MILLION;
+        int rowsInRowGroup = BILLION;
+
+        for (int groupId = 0; groupId < 11; groupId++) {
+            RowGroup rowGroup = StripeReader.createRowGroup(groupId, numRowsInStripe, rowsInRowGroup, 5, ImmutableMap.of(), ImmutableMap.of());
+            assertEquals(rowGroup.getGroupId(), groupId);
+            assertEquals(rowGroup.getRowOffset(), groupId * (long) rowsInRowGroup);
+            int expectedRows = groupId < 10 ? BILLION : MILLION;
+            assertEquals(rowGroup.getRowCount(), expectedRows);
+        }
+    }
+
+    @Test(expectedExceptions = ArithmeticException.class)
+    public void testRowGroupOverflow()
+    {
+        StripeReader.createRowGroup(Integer.MAX_VALUE, Long.MAX_VALUE, Long.MAX_VALUE, 5, ImmutableMap.of(), ImmutableMap.of());
+    }
+}


### PR DESCRIPTION
The calculation of rowGroupId * rowOffset overflows and wraps
around. This causes the rowsInGroup to be calculated incorrectly.
This reads past the last stride resulting in out of bounds error.

Test plan - 
The file I was working on passed.
Added new unit tests.
Validation tests passed.

```
== NO RELEASE NOTE ==
```
