### PR TITLE
Support Filter/Limit/TopN pushdown for JDBC Connectors

### DIFF
--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcClient.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcClient.java
@@ -14,6 +14,8 @@
 package com.facebook.presto.plugin.jdbc;
 
 import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.plugin.jdbc.optimization.JdbcQueryGeneratorContext;
+import com.facebook.presto.plugin.jdbc.optimization.JdbcSortItem;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.ConnectorSession;
@@ -37,6 +39,12 @@ public interface JdbcClient
     {
         return getSchemaNames(identity).contains(schema);
     }
+
+    boolean supportsLimit();
+
+    boolean supportsTopN(List<JdbcSortItem> sortItems);
+
+    String applyQueryTransformations(String query, JdbcQueryGeneratorContext context);
 
     String getIdentifierQuote();
 

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcConnector.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcConnector.java
@@ -15,6 +15,7 @@ package com.facebook.presto.plugin.jdbc;
 
 import com.facebook.airlift.bootstrap.LifeCycleManager;
 import com.facebook.airlift.log.Logger;
+import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.plugin.jdbc.optimization.JdbcPlanOptimizerProvider;
 import com.facebook.presto.spi.connector.Connector;
 import com.facebook.presto.spi.connector.ConnectorAccessControl;
@@ -63,6 +64,7 @@ public class JdbcConnector
     private final FunctionMetadataManager functionManager;
     private final StandardFunctionResolution functionResolution;
     private final RowExpressionService rowExpressionService;
+    private final TypeManager typeManager;
     private final JdbcClient jdbcClient;
 
     @Inject
@@ -77,6 +79,7 @@ public class JdbcConnector
             FunctionMetadataManager functionManager,
             StandardFunctionResolution functionResolution,
             RowExpressionService rowExpressionService,
+            TypeManager typeManager,
             JdbcClient jdbcClient)
     {
         this.lifeCycleManager = requireNonNull(lifeCycleManager, "lifeCycleManager is null");
@@ -89,6 +92,7 @@ public class JdbcConnector
         this.functionManager = requireNonNull(functionManager, "functionManager is null");
         this.functionResolution = requireNonNull(functionResolution, "functionResolution is null");
         this.rowExpressionService = requireNonNull(rowExpressionService, "rowExpressionService is null");
+        this.typeManager = requireNonNull(typeManager, "typeManager is null");
         this.jdbcClient = requireNonNull(jdbcClient, "jdbcClient is null");
     }
 
@@ -97,6 +101,7 @@ public class JdbcConnector
     {
         return new JdbcPlanOptimizerProvider(
                 jdbcClient,
+                typeManager,
                 functionManager,
                 functionResolution,
                 rowExpressionService.getDeterminismEvaluator(),

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcConnectorFactory.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcConnectorFactory.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.plugin.jdbc;
 
 import com.facebook.airlift.bootstrap.Bootstrap;
+import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.spi.ConnectorHandleResolver;
 import com.facebook.presto.spi.classloader.ThreadContextClassLoader;
 import com.facebook.presto.spi.connector.Connector;
@@ -67,6 +68,7 @@ public class JdbcConnectorFactory
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             Bootstrap app = new Bootstrap(
                     binder -> {
+                        binder.bind(TypeManager.class).toInstance(context.getTypeManager());
                         binder.bind(FunctionMetadataManager.class).toInstance(context.getFunctionMetadataManager());
                         binder.bind(StandardFunctionResolution.class).toInstance(context.getStandardFunctionResolution());
                         binder.bind(RowExpressionService.class).toInstance(context.getRowExpressionService());

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcMetadata.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcMetadata.java
@@ -85,7 +85,7 @@ public class JdbcMetadata
     public List<ConnectorTableLayoutResult> getTableLayouts(ConnectorSession session, ConnectorTableHandle table, Constraint<ColumnHandle> constraint, Optional<Set<ColumnHandle>> desiredColumns)
     {
         JdbcTableHandle tableHandle = (JdbcTableHandle) table;
-        ConnectorTableLayout layout = new ConnectorTableLayout(new JdbcTableLayoutHandle(tableHandle, constraint.getSummary(), Optional.empty()));
+        ConnectorTableLayout layout = new ConnectorTableLayout(new JdbcTableLayoutHandle(tableHandle, constraint.getSummary()));
         return ImmutableList.of(new ConnectorTableLayoutResult(layout, constraint.getSummary()));
     }
 

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcSplit.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcSplit.java
@@ -14,7 +14,7 @@
 package com.facebook.presto.plugin.jdbc;
 
 import com.facebook.presto.common.predicate.TupleDomain;
-import com.facebook.presto.plugin.jdbc.optimization.JdbcExpression;
+import com.facebook.presto.plugin.jdbc.optimization.JdbcQueryGeneratorContext;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
@@ -39,7 +39,7 @@ public class JdbcSplit
     private final String schemaName;
     private final String tableName;
     private final TupleDomain<ColumnHandle> tupleDomain;
-    private final Optional<JdbcExpression> additionalPredicate;
+    private final Optional<JdbcQueryGeneratorContext> context;
 
     @JsonCreator
     public JdbcSplit(
@@ -48,14 +48,14 @@ public class JdbcSplit
             @JsonProperty("schemaName") @Nullable String schemaName,
             @JsonProperty("tableName") String tableName,
             @JsonProperty("tupleDomain") TupleDomain<ColumnHandle> tupleDomain,
-            @JsonProperty("additionalProperty") Optional<JdbcExpression> additionalPredicate)
+            @JsonProperty("context") Optional<JdbcQueryGeneratorContext> context)
     {
         this.connectorId = requireNonNull(connectorId, "connector id is null");
         this.catalogName = catalogName;
         this.schemaName = schemaName;
         this.tableName = requireNonNull(tableName, "table name is null");
         this.tupleDomain = requireNonNull(tupleDomain, "tupleDomain is null");
-        this.additionalPredicate = requireNonNull(additionalPredicate, "additionalPredicate is null");
+        this.context = requireNonNull(context, "context is null");
     }
 
     @JsonProperty
@@ -91,9 +91,9 @@ public class JdbcSplit
     }
 
     @JsonProperty
-    public Optional<JdbcExpression> getAdditionalPredicate()
+    public Optional<JdbcQueryGeneratorContext> getContext()
     {
-        return additionalPredicate;
+        return context;
     }
 
     @Override

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcTableHandle.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcTableHandle.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.plugin.jdbc;
 
+import com.facebook.presto.plugin.jdbc.optimization.JdbcQueryGeneratorContext;
 import com.facebook.presto.spi.ConnectorTableHandle;
 import com.facebook.presto.spi.SchemaTableName;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -22,6 +23,7 @@ import com.google.common.base.Joiner;
 import javax.annotation.Nullable;
 
 import java.util.Objects;
+import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 
@@ -35,6 +37,7 @@ public final class JdbcTableHandle
     private final String catalogName;
     private final String schemaName;
     private final String tableName;
+    private final Optional<JdbcQueryGeneratorContext> context;
 
     @JsonCreator
     public JdbcTableHandle(
@@ -42,13 +45,15 @@ public final class JdbcTableHandle
             @JsonProperty("schemaTableName") SchemaTableName schemaTableName,
             @JsonProperty("catalogName") @Nullable String catalogName,
             @JsonProperty("schemaName") @Nullable String schemaName,
-            @JsonProperty("tableName") String tableName)
+            @JsonProperty("tableName") String tableName,
+            @JsonProperty("context") Optional<JdbcQueryGeneratorContext> context)
     {
         this.connectorId = requireNonNull(connectorId, "connectorId is null");
         this.schemaTableName = requireNonNull(schemaTableName, "schemaTableName is null");
         this.catalogName = catalogName;
         this.schemaName = schemaName;
         this.tableName = requireNonNull(tableName, "tableName is null");
+        this.context = requireNonNull(context, "context is null");
     }
 
     @JsonProperty
@@ -81,6 +86,12 @@ public final class JdbcTableHandle
     public String getTableName()
     {
         return tableName;
+    }
+
+    @JsonProperty
+    public Optional<JdbcQueryGeneratorContext> getContext()
+    {
+        return context;
     }
 
     @Override

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcTypeHandle.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcTypeHandle.java
@@ -17,22 +17,26 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Objects;
+import java.util.Optional;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 
 public final class JdbcTypeHandle
 {
     private final int jdbcType;
+    private final Optional<String> jdbcTypeName;
     private final int columnSize;
     private final int decimalDigits;
 
     @JsonCreator
     public JdbcTypeHandle(
             @JsonProperty("jdbcType") int jdbcType,
+            @JsonProperty("jdbcTypeName") Optional<String> jdbcTypeName,
             @JsonProperty("columnSize") int columnSize,
             @JsonProperty("decimalDigits") int decimalDigits)
     {
         this.jdbcType = jdbcType;
+        this.jdbcTypeName = jdbcTypeName;
         this.columnSize = columnSize;
         this.decimalDigits = decimalDigits;
     }
@@ -41,6 +45,12 @@ public final class JdbcTypeHandle
     public int getJdbcType()
     {
         return jdbcType;
+    }
+
+    @JsonProperty
+    public Optional<String> getJdbcTypeName()
+    {
+        return jdbcTypeName;
     }
 
     @JsonProperty
@@ -58,7 +68,7 @@ public final class JdbcTypeHandle
     @Override
     public int hashCode()
     {
-        return Objects.hash(jdbcType, columnSize, decimalDigits);
+        return Objects.hash(jdbcType, jdbcTypeName, columnSize, decimalDigits);
     }
 
     @Override
@@ -72,6 +82,7 @@ public final class JdbcTypeHandle
         }
         JdbcTypeHandle that = (JdbcTypeHandle) o;
         return jdbcType == that.jdbcType &&
+                jdbcTypeName == that.jdbcTypeName &&
                 columnSize == that.columnSize &&
                 decimalDigits == that.decimalDigits;
     }
@@ -81,6 +92,7 @@ public final class JdbcTypeHandle
     {
         return toStringHelper(this)
                 .add("jdbcType", jdbcType)
+                .add("jdbcTypeName", jdbcTypeName)
                 .add("columnSize", columnSize)
                 .add("decimalDigits", decimalDigits)
                 .toString();

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/optimization/JdbcComputePushdown.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/optimization/JdbcComputePushdown.java
@@ -13,49 +13,67 @@
  */
 package com.facebook.presto.plugin.jdbc.optimization;
 
+import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.expressions.LogicalRowExpressions;
 import com.facebook.presto.expressions.translator.TranslatedExpression;
+import com.facebook.presto.plugin.jdbc.JdbcClient;
+import com.facebook.presto.plugin.jdbc.JdbcColumnHandle;
 import com.facebook.presto.plugin.jdbc.JdbcTableHandle;
 import com.facebook.presto.plugin.jdbc.JdbcTableLayoutHandle;
+import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorPlanOptimizer;
 import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ConnectorTableLayoutHandle;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.VariableAllocator;
 import com.facebook.presto.spi.function.FunctionMetadataManager;
 import com.facebook.presto.spi.function.StandardFunctionResolution;
+import com.facebook.presto.spi.plan.Assignments;
 import com.facebook.presto.spi.plan.FilterNode;
+import com.facebook.presto.spi.plan.LimitNode;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.spi.plan.PlanVisitor;
+import com.facebook.presto.spi.plan.ProjectNode;
 import com.facebook.presto.spi.plan.TableScanNode;
+import com.facebook.presto.spi.plan.TopNNode;
 import com.facebook.presto.spi.relation.ConstantExpression;
 import com.facebook.presto.spi.relation.DeterminismEvaluator;
 import com.facebook.presto.spi.relation.ExpressionOptimizer;
 import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static com.facebook.presto.expressions.translator.FunctionTranslator.buildFunctionTranslator;
 import static com.facebook.presto.expressions.translator.RowExpressionTreeTranslator.translateWith;
 import static com.facebook.presto.plugin.jdbc.optimization.function.JdbcTranslationUtil.mergeSqlBodies;
 import static com.facebook.presto.plugin.jdbc.optimization.function.JdbcTranslationUtil.mergeVariableBindings;
-import static com.facebook.presto.spi.relation.ExpressionOptimizer.Level.OPTIMIZED;
+import static com.google.common.base.Verify.verify;
+import static com.google.common.collect.Maps.immutableEntry;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public class JdbcComputePushdown
         implements ConnectorPlanOptimizer
 {
+    private final JdbcClient jdbcClient;
     private final ExpressionOptimizer expressionOptimizer;
     private final JdbcFilterToSqlTranslator jdbcFilterToSqlTranslator;
     private final LogicalRowExpressions logicalRowExpressions;
 
     public JdbcComputePushdown(
+            JdbcClient jdbcClient,
+            TypeManager typeManager,
             FunctionMetadataManager functionMetadataManager,
             StandardFunctionResolution functionResolution,
             DeterminismEvaluator determinismEvaluator,
@@ -68,11 +86,15 @@ public class JdbcComputePushdown
         requireNonNull(functionTranslators, "functionTranslators is null");
         requireNonNull(determinismEvaluator, "determinismEvaluator is null");
         requireNonNull(functionResolution, "functionResolution is null");
+        requireNonNull(typeManager, "typeManager is null");
 
+        this.jdbcClient = requireNonNull(jdbcClient, "jdbcClient is null");
         this.expressionOptimizer = requireNonNull(expressionOptimizer, "expressionOptimizer is null");
         this.jdbcFilterToSqlTranslator = new JdbcFilterToSqlTranslator(
+                typeManager,
                 functionMetadataManager,
                 buildFunctionTranslator(functionTranslators),
+                functionResolution,
                 identifierQuote);
         this.logicalRowExpressions = new LogicalRowExpressions(
                 determinismEvaluator,
@@ -87,11 +109,12 @@ public class JdbcComputePushdown
             VariableAllocator variableAllocator,
             PlanNodeIdAllocator idAllocator)
     {
-        return maxSubplan.accept(new Visitor(session, idAllocator), null);
+        JdbcQueryGeneratorContext context = new JdbcQueryGeneratorContext();
+        return maxSubplan.accept(new Visitor(session, idAllocator), context);
     }
 
     private class Visitor
-            extends PlanVisitor<PlanNode, Void>
+            extends PlanVisitor<PlanNode, JdbcQueryGeneratorContext>
     {
         private final ConnectorSession session;
         private final PlanNodeIdAllocator idAllocator;
@@ -103,12 +126,12 @@ public class JdbcComputePushdown
         }
 
         @Override
-        public PlanNode visitPlan(PlanNode node, Void context)
+        public PlanNode visitPlan(PlanNode node, JdbcQueryGeneratorContext context)
         {
             ImmutableList.Builder<PlanNode> children = ImmutableList.builder();
             boolean changed = false;
             for (PlanNode child : node.getSources()) {
-                PlanNode newChild = child.accept(this, null);
+                PlanNode newChild = child.accept(this, context);
                 if (newChild != child) {
                     changed = true;
                 }
@@ -122,7 +145,114 @@ public class JdbcComputePushdown
         }
 
         @Override
-        public PlanNode visitFilter(FilterNode node, Void context)
+        public PlanNode visitProject(ProjectNode node, JdbcQueryGeneratorContext context)
+        {
+            PlanNode planNode = node.getSource().accept(this, context);
+            if (!(planNode instanceof TableScanNode)) {
+                if (node.getSource() == planNode) {
+                    return node;
+                }
+                else {
+                    return node.replaceChildren(ImmutableList.of(planNode));
+                }
+            }
+
+            Assignments assignments = node.getAssignments();
+            boolean allVariableReferenceExpression = assignments.entrySet().stream()
+                    .allMatch(assignment -> assignment.getValue() instanceof VariableReferenceExpression);
+
+            if (allVariableReferenceExpression) {
+                TableScanNode oldTableScanNode = (TableScanNode) planNode;
+                LinkedHashMap<VariableReferenceExpression, ColumnHandle> newAssignments = node.getAssignments().getMap().entrySet()
+                        .stream()
+                        .map(assignment -> {
+                            VariableReferenceExpression value = (VariableReferenceExpression) assignment.getValue();
+                            return immutableEntry(assignment.getKey(), oldTableScanNode.getAssignments().get(value));
+                        }).collect(Collectors.toMap(Map.Entry::getKey,
+                                Map.Entry::getValue,
+                                (val1, val2) -> val1,
+                                LinkedHashMap::new));
+
+                return new TableScanNode(
+                        idAllocator.getNextId(),
+                        oldTableScanNode.getTable(),
+                        node.getOutputVariables(),
+                        newAssignments,
+                        oldTableScanNode.getCurrentConstraint(),
+                        oldTableScanNode.getEnforcedConstraint());
+            }
+
+            return node;
+        }
+
+        @Override
+        public PlanNode visitLimit(LimitNode node, JdbcQueryGeneratorContext context)
+        {
+            PlanNode planNode = node.getSource().accept(this, context);
+            if (!(planNode instanceof TableScanNode)) {
+                if (node.getSource() == planNode) {
+                    return node;
+                }
+                else {
+                    return node.replaceChildren(ImmutableList.of(planNode));
+                }
+            }
+
+            if (!jdbcClient.supportsLimit()) {
+                return new LimitNode(idAllocator.getNextId(), planNode, node.getCount(), node.getStep());
+            }
+
+            long count = node.getCount();
+            TableScanNode tableScanNode = (TableScanNode) planNode;
+            TableHandle handle = tableScanNode.getTable();
+            Optional<ConnectorTableLayoutHandle> oldLayout = handle.getLayout();
+            if (oldLayout.isPresent()) {
+                JdbcTableHandle oldConnectorTable = (JdbcTableHandle) handle.getConnectorHandle();
+                return createNewTableScanNode(tableScanNode, handle, oldConnectorTable, context.withLimit(OptionalLong.of(count)));
+            }
+
+            return node;
+        }
+
+        @Override
+        public PlanNode visitTopN(TopNNode node, JdbcQueryGeneratorContext context)
+        {
+            PlanNode planNode = node.getSource().accept(this, context);
+            if (!(planNode instanceof TableScanNode)) {
+                if (node.getSource() == planNode) {
+                    return node;
+                }
+                else {
+                    return node.replaceChildren(ImmutableList.of(planNode));
+                }
+            }
+
+            TableScanNode tableScanNode = (TableScanNode) planNode;
+            Map<VariableReferenceExpression, ColumnHandle> assignments = tableScanNode.getAssignments();
+            List<JdbcSortItem> sortItems = node.getOrderingScheme().getOrderByVariables().stream()
+                    .map(orderBy -> {
+                        verify(assignments.containsKey(orderBy), "assignments does not contain order by item: %s", orderBy.getName());
+                        JdbcColumnHandle columnHandle = (JdbcColumnHandle) assignments.get(orderBy);
+                        return new JdbcSortItem(columnHandle, node.getOrderingScheme().getOrdering(orderBy));
+                    }).collect(Collectors.toList());
+
+            if (!jdbcClient.supportsTopN(sortItems)) {
+                return new TopNNode(idAllocator.getNextId(), planNode, node.getCount(), node.getOrderingScheme(), node.getStep());
+            }
+
+            long count = node.getCount();
+            TableHandle handle = tableScanNode.getTable();
+            Optional<ConnectorTableLayoutHandle> oldLayout = handle.getLayout();
+            if (oldLayout.isPresent()) {
+                JdbcTableHandle oldConnectorTable = (JdbcTableHandle) handle.getConnectorHandle();
+                return createNewTableScanNode(tableScanNode, handle, oldConnectorTable, context.withTopN(Optional.of(sortItems), OptionalLong.of(count)));
+            }
+
+            return node;
+        }
+
+        @Override
+        public PlanNode visitFilter(FilterNode node, JdbcQueryGeneratorContext context)
         {
             if (!(node.getSource() instanceof TableScanNode)) {
                 return node;
@@ -134,8 +264,7 @@ public class JdbcComputePushdown
                 return node;
             }
 
-            RowExpression predicate = expressionOptimizer.optimize(node.getPredicate(), OPTIMIZED, session);
-            predicate = logicalRowExpressions.convertToConjunctiveNormalForm(predicate);
+            RowExpression predicate = logicalRowExpressions.convertToConjunctiveNormalForm(node.getPredicate());
             TranslatedExpression<JdbcExpression> jdbcExpression = translateWith(
                     predicate,
                     jdbcFilterToSqlTranslator,
@@ -145,7 +274,7 @@ public class JdbcComputePushdown
             JdbcTableHandle oldConnectorTable = (JdbcTableHandle) oldTableHandle.getConnectorHandle();
             // All filter can be pushed down
             if (translated.isPresent()) {
-                return createNewTableScanNode(oldTableScanNode, oldTableHandle, oldConnectorTable, translated);
+                return createNewTableScanNode(oldTableScanNode, oldTableHandle, oldConnectorTable, context.withFilter(translated));
             }
 
             // Find out which parts can be pushed down
@@ -175,7 +304,8 @@ public class JdbcComputePushdown
             List<String> sqlBodies = mergeSqlBodies(translatedExpressions);
             List<ConstantExpression> variableBindings = mergeVariableBindings(translatedExpressions);
             translated = Optional.of(new JdbcExpression(format("%s", Joiner.on(" AND ").join(sqlBodies)), variableBindings));
-            TableScanNode newTableScanNode = createNewTableScanNode(oldTableScanNode, oldTableHandle, oldConnectorTable, translated);
+            TableScanNode newTableScanNode = createNewTableScanNode(oldTableScanNode, oldTableHandle,
+                    oldConnectorTable, context.withFilter(translated));
 
             return new FilterNode(idAllocator.getNextId(), newTableScanNode, logicalRowExpressions.combineConjuncts(remainingExpressions));
         }
@@ -184,17 +314,24 @@ public class JdbcComputePushdown
                 TableScanNode oldTableScanNode,
                 TableHandle oldTableHandle,
                 JdbcTableHandle oldConnectorTable,
-                Optional<JdbcExpression> additionalPredicate)
+                JdbcQueryGeneratorContext context)
         {
+            JdbcTableHandle newJdbcTableHandle = new JdbcTableHandle(
+                    oldConnectorTable.getConnectorId(),
+                    oldConnectorTable.getSchemaTableName(),
+                    oldConnectorTable.getCatalogName(),
+                    oldConnectorTable.getSchemaName(),
+                    oldConnectorTable.getTableName(),
+                    Optional.of(context));
+
             JdbcTableLayoutHandle oldTableLayoutHandle = (JdbcTableLayoutHandle) oldTableHandle.getLayout().get();
             JdbcTableLayoutHandle newTableLayoutHandle = new JdbcTableLayoutHandle(
-                    oldConnectorTable,
-                    oldTableLayoutHandle.getTupleDomain(),
-                    additionalPredicate);
+                    newJdbcTableHandle,
+                    oldTableLayoutHandle.getTupleDomain());
 
             TableHandle tableHandle = new TableHandle(
                     oldTableHandle.getConnectorId(),
-                    oldTableHandle.getConnectorHandle(),
+                    newJdbcTableHandle,
                     oldTableHandle.getTransaction(),
                     Optional.of(newTableLayoutHandle));
 

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/optimization/JdbcQueryGeneratorContext.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/optimization/JdbcQueryGeneratorContext.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.jdbc.optimization;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalLong;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+public class JdbcQueryGeneratorContext
+{
+    private Optional<JdbcExpression> additionalPredicate;
+    private Optional<List<JdbcSortItem>> sortOrder;
+    private OptionalLong limit;
+
+    public JdbcQueryGeneratorContext()
+    {
+        this(Optional.empty(), Optional.empty(), OptionalLong.empty());
+    }
+
+    @JsonCreator
+    public JdbcQueryGeneratorContext(
+            @JsonProperty("additionalPredicate") Optional<JdbcExpression> additionalPredicate,
+            @JsonProperty("sortOrder") Optional<List<JdbcSortItem>> sortOrder,
+            @JsonProperty("limit") OptionalLong limit)
+    {
+        this.additionalPredicate = requireNonNull(additionalPredicate, "additionalPredicate is null");
+        this.sortOrder = requireNonNull(sortOrder, "sortOrder is null");
+        this.limit = requireNonNull(limit, "limit is null");
+    }
+
+    JdbcQueryGeneratorContext withLimit(OptionalLong limit)
+    {
+        checkState(!hasLimit(), "Limit already exists. Jdbc datasources doesn't support limit on top of another limit");
+        this.limit = limit;
+        return this;
+    }
+
+    JdbcQueryGeneratorContext withTopN(Optional<List<JdbcSortItem>> sortOrder, OptionalLong limit)
+    {
+        checkState(!hasLimit(), "Limit already exists. Jdbc datasources doesn't support limit on top of another limit");
+        this.sortOrder = sortOrder;
+        this.limit = limit;
+        return this;
+    }
+
+    JdbcQueryGeneratorContext withFilter(Optional<JdbcExpression> additionalPredicate)
+    {
+        checkState(!hasFilter(), "The filter has been set!");
+        this.additionalPredicate = additionalPredicate;
+        return this;
+    }
+
+    @JsonProperty
+    public Optional<JdbcExpression> getAdditionalPredicate()
+    {
+        return additionalPredicate;
+    }
+
+    @JsonProperty
+    public OptionalLong getLimit()
+    {
+        return limit;
+    }
+
+    @JsonProperty
+    public Optional<List<JdbcSortItem>> getSortOrder()
+    {
+        return sortOrder;
+    }
+
+    private boolean hasLimit()
+    {
+        return limit.isPresent();
+    }
+
+    private boolean hasFilter()
+    {
+        return additionalPredicate.isPresent();
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        JdbcQueryGeneratorContext context = (JdbcQueryGeneratorContext) o;
+        return Objects.equals(additionalPredicate, context.additionalPredicate) &&
+                Objects.equals(sortOrder, context.sortOrder) &&
+                Objects.equals(limit, context.limit);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(additionalPredicate, sortOrder, limit);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("additionalPredicate", additionalPredicate)
+                .add("sortOrder", sortOrder)
+                .add("limit", limit)
+                .toString();
+    }
+}

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/optimization/JdbcSortItem.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/optimization/JdbcSortItem.java
@@ -11,43 +11,42 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.plugin.jdbc;
+package com.facebook.presto.plugin.jdbc.optimization;
 
-import com.facebook.presto.common.predicate.TupleDomain;
-import com.facebook.presto.spi.ColumnHandle;
-import com.facebook.presto.spi.ConnectorTableLayoutHandle;
+import com.facebook.presto.common.block.SortOrder;
+import com.facebook.presto.plugin.jdbc.JdbcColumnHandle;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.annotation.concurrent.Immutable;
 
 import java.util.Objects;
 
 import static java.util.Objects.requireNonNull;
 
-public class JdbcTableLayoutHandle
-        implements ConnectorTableLayoutHandle
+@Immutable
+public final class JdbcSortItem
 {
-    private final JdbcTableHandle table;
-    private final TupleDomain<ColumnHandle> tupleDomain;
+    private final JdbcColumnHandle column;
+    private final SortOrder sortOrder;
 
     @JsonCreator
-    public JdbcTableLayoutHandle(
-            @JsonProperty("table") JdbcTableHandle table,
-            @JsonProperty("tupleDomain") TupleDomain<ColumnHandle> domain)
+    public JdbcSortItem(JdbcColumnHandle column, SortOrder sortOrder)
     {
-        this.table = requireNonNull(table, "table is null");
-        this.tupleDomain = requireNonNull(domain, "tupleDomain is null");
+        this.column = requireNonNull(column, "column is null");
+        this.sortOrder = requireNonNull(sortOrder, "sortOrder is null");
     }
 
     @JsonProperty
-    public JdbcTableHandle getTable()
+    public JdbcColumnHandle getColumn()
     {
-        return table;
+        return column;
     }
 
     @JsonProperty
-    public TupleDomain<ColumnHandle> getTupleDomain()
+    public SortOrder getSortOrder()
     {
-        return tupleDomain;
+        return sortOrder;
     }
 
     @Override
@@ -59,20 +58,20 @@ public class JdbcTableLayoutHandle
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        JdbcTableLayoutHandle that = (JdbcTableLayoutHandle) o;
-        return Objects.equals(table, that.table) &&
-                Objects.equals(tupleDomain, that.tupleDomain);
+        JdbcSortItem that = (JdbcSortItem) o;
+        return sortOrder == that.sortOrder &&
+                Objects.equals(column, that.column);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(table, tupleDomain);
+        return Objects.hash(column, sortOrder);
     }
 
     @Override
     public String toString()
     {
-        return table.toString();
+        return column + " " + sortOrder;
     }
 }

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/optimization/function/JdbcTranslationUtil.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/optimization/function/JdbcTranslationUtil.java
@@ -43,7 +43,6 @@ public class JdbcTranslationUtil
     {
         return jdbcExpressions.stream()
                 .map(JdbcExpression::getExpression)
-                .map(sql -> '(' + sql + ')')
                 .collect(toImmutableList());
     }
 

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/optimization/function/OperatorTranslators.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/optimization/function/OperatorTranslators.java
@@ -20,6 +20,7 @@ import com.facebook.presto.spi.function.ScalarOperator;
 import com.facebook.presto.spi.function.SqlType;
 
 import static com.facebook.presto.common.function.OperatorType.ADD;
+import static com.facebook.presto.common.function.OperatorType.CAST;
 import static com.facebook.presto.common.function.OperatorType.EQUAL;
 import static com.facebook.presto.common.function.OperatorType.NOT_EQUAL;
 import static com.facebook.presto.common.function.OperatorType.SUBTRACT;
@@ -65,5 +66,26 @@ public class OperatorTranslators
     public static JdbcExpression not(@SqlType(StandardTypes.BOOLEAN) JdbcExpression expression)
     {
         return new JdbcExpression(String.format("(NOT(%s))", expression.getExpression()), expression.getBoundConstantValues());
+    }
+
+    @ScalarFunction("like")
+    @SqlType(StandardTypes.BOOLEAN)
+    public static JdbcExpression like(@SqlType(StandardTypes.VARCHAR) JdbcExpression left, @SqlType("LikePattern") JdbcExpression right)
+    {
+        return new JdbcExpression(infixOperation("LIKE", left, right), forwardBindVariables(left, right));
+    }
+
+    @ScalarFunction("like_pattern")
+    @SqlType("LikePattern")
+    public static JdbcExpression likePattern(@SqlType(StandardTypes.VARCHAR) JdbcExpression left, @SqlType(StandardTypes.VARCHAR) JdbcExpression right)
+    {
+        return new JdbcExpression(String.format("%s ESCAPE %s", left.getExpression(), right.getExpression()), forwardBindVariables(left, right));
+    }
+
+    @ScalarOperator(CAST)
+    @SqlType("LikePattern")
+    public static JdbcExpression cast(@SqlType(StandardTypes.VARCHAR) JdbcExpression expression)
+    {
+        return expression;
     }
 }

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcMetadata.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcMetadata.java
@@ -91,8 +91,8 @@ public class TestJdbcMetadata
                 "value", new JdbcColumnHandle(CONNECTOR_ID, "VALUE", JDBC_BIGINT, BIGINT, true)));
 
         // unknown table
-        unknownTableColumnHandle(new JdbcTableHandle(CONNECTOR_ID, new SchemaTableName("unknown", "unknown"), "unknown", "unknown", "unknown"));
-        unknownTableColumnHandle(new JdbcTableHandle(CONNECTOR_ID, new SchemaTableName("example", "numbers"), null, "example", "unknown"));
+        unknownTableColumnHandle(new JdbcTableHandle(CONNECTOR_ID, new SchemaTableName("unknown", "unknown"), "unknown", "unknown", "unknown", Optional.empty()));
+        unknownTableColumnHandle(new JdbcTableHandle(CONNECTOR_ID, new SchemaTableName("example", "numbers"), null, "example", "unknown", Optional.empty()));
     }
 
     private void unknownTableColumnHandle(JdbcTableHandle tableHandle)
@@ -125,9 +125,9 @@ public class TestJdbcMetadata
                 new ColumnMetadata("va%ue", BIGINT)));
 
         // unknown tables should produce null
-        unknownTableMetadata(new JdbcTableHandle(CONNECTOR_ID, new SchemaTableName("u", "numbers"), null, "unknown", "unknown"));
-        unknownTableMetadata(new JdbcTableHandle(CONNECTOR_ID, new SchemaTableName("example", "numbers"), null, "example", "unknown"));
-        unknownTableMetadata(new JdbcTableHandle(CONNECTOR_ID, new SchemaTableName("example", "numbers"), null, "unknown", "numbers"));
+        unknownTableMetadata(new JdbcTableHandle(CONNECTOR_ID, new SchemaTableName("u", "numbers"), null, "unknown", "unknown", Optional.empty()));
+        unknownTableMetadata(new JdbcTableHandle(CONNECTOR_ID, new SchemaTableName("example", "numbers"), null, "example", "unknown", Optional.empty()));
+        unknownTableMetadata(new JdbcTableHandle(CONNECTOR_ID, new SchemaTableName("example", "numbers"), null, "unknown", "numbers", Optional.empty()));
     }
 
     private void unknownTableMetadata(JdbcTableHandle tableHandle)

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcRecordSetProvider.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcRecordSetProvider.java
@@ -32,7 +32,6 @@ import org.testng.annotations.Test;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import static com.facebook.airlift.concurrent.MoreFutures.getFutureValue;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
@@ -181,7 +180,7 @@ public class TestJdbcRecordSetProvider
 
     private RecordCursor getCursor(JdbcTableHandle jdbcTableHandle, List<JdbcColumnHandle> columns, TupleDomain<ColumnHandle> domain)
     {
-        JdbcTableLayoutHandle layoutHandle = new JdbcTableLayoutHandle(jdbcTableHandle, domain, Optional.empty());
+        JdbcTableLayoutHandle layoutHandle = new JdbcTableLayoutHandle(jdbcTableHandle, domain);
         ConnectorSplitSource splits = jdbcClient.getSplits(IDENTITY, layoutHandle);
         JdbcSplit split = (JdbcSplit) getOnlyElement(getFutureValue(splits.getNextBatch(NOT_PARTITIONED, 1000)).getSplits());
 

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcTableHandle.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcTableHandle.java
@@ -17,6 +17,8 @@ import com.facebook.airlift.testing.EquivalenceTester;
 import com.facebook.presto.spi.SchemaTableName;
 import org.testng.annotations.Test;
 
+import java.util.Optional;
+
 import static com.facebook.presto.plugin.jdbc.MetadataUtil.TABLE_CODEC;
 import static com.facebook.presto.plugin.jdbc.MetadataUtil.assertJsonRoundTrip;
 
@@ -25,7 +27,7 @@ public class TestJdbcTableHandle
     @Test
     public void testJsonRoundTrip()
     {
-        assertJsonRoundTrip(TABLE_CODEC, new JdbcTableHandle("connectorId", new SchemaTableName("schema", "table"), "jdbcCatalog", "jdbcSchema", "jdbcTable"));
+        assertJsonRoundTrip(TABLE_CODEC, new JdbcTableHandle("connectorId", new SchemaTableName("schema", "table"), "jdbcCatalog", "jdbcSchema", "jdbcTable", Optional.empty()));
     }
 
     @Test
@@ -33,20 +35,20 @@ public class TestJdbcTableHandle
     {
         EquivalenceTester.equivalenceTester()
                 .addEquivalentGroup(
-                        new JdbcTableHandle("connectorId", new SchemaTableName("schema", "table"), "jdbcCatalog", "jdbcSchema", "jdbcTable"),
-                        new JdbcTableHandle("connectorId", new SchemaTableName("schema", "table"), "jdbcCatalogX", "jdbcSchema", "jdbcTable"),
-                        new JdbcTableHandle("connectorId", new SchemaTableName("schema", "table"), "jdbcCatalog", "jdbcSchemaX", "jdbcTable"),
-                        new JdbcTableHandle("connectorId", new SchemaTableName("schema", "table"), "jdbcCatalog", "jdbcSchema", "jdbcTableX"))
+                        new JdbcTableHandle("connectorId", new SchemaTableName("schema", "table"), "jdbcCatalog", "jdbcSchema", "jdbcTable", Optional.empty()),
+                        new JdbcTableHandle("connectorId", new SchemaTableName("schema", "table"), "jdbcCatalogX", "jdbcSchema", "jdbcTable", Optional.empty()),
+                        new JdbcTableHandle("connectorId", new SchemaTableName("schema", "table"), "jdbcCatalog", "jdbcSchemaX", "jdbcTable", Optional.empty()),
+                        new JdbcTableHandle("connectorId", new SchemaTableName("schema", "table"), "jdbcCatalog", "jdbcSchema", "jdbcTableX", Optional.empty()))
                 .addEquivalentGroup(
-                        new JdbcTableHandle("connectorIdX", new SchemaTableName("schema", "table"), "jdbcCatalog", "jdbcSchema", "jdbcTable"),
-                        new JdbcTableHandle("connectorIdX", new SchemaTableName("schema", "table"), "jdbcCatalogX", "jdbcSchema", "jdbcTable"),
-                        new JdbcTableHandle("connectorIdX", new SchemaTableName("schema", "table"), "jdbcCatalog", "jdbcSchemaX", "jdbcTable"),
-                        new JdbcTableHandle("connectorIdX", new SchemaTableName("schema", "table"), "jdbcCatalog", "jdbcSchema", "jdbcTableX"))
+                        new JdbcTableHandle("connectorIdX", new SchemaTableName("schema", "table"), "jdbcCatalog", "jdbcSchema", "jdbcTable", Optional.empty()),
+                        new JdbcTableHandle("connectorIdX", new SchemaTableName("schema", "table"), "jdbcCatalogX", "jdbcSchema", "jdbcTable", Optional.empty()),
+                        new JdbcTableHandle("connectorIdX", new SchemaTableName("schema", "table"), "jdbcCatalog", "jdbcSchemaX", "jdbcTable", Optional.empty()),
+                        new JdbcTableHandle("connectorIdX", new SchemaTableName("schema", "table"), "jdbcCatalog", "jdbcSchema", "jdbcTableX", Optional.empty()))
                 .addEquivalentGroup(
-                        new JdbcTableHandle("connectorId", new SchemaTableName("schemaX", "table"), "jdbcCatalog", "jdbcSchema", "jdbcTable"),
-                        new JdbcTableHandle("connectorId", new SchemaTableName("schemaX", "table"), "jdbcCatalogX", "jdbcSchema", "jdbcTable"),
-                        new JdbcTableHandle("connectorId", new SchemaTableName("schemaX", "table"), "jdbcCatalog", "jdbcSchemaX", "jdbcTable"),
-                        new JdbcTableHandle("connectorId", new SchemaTableName("schemaX", "table"), "jdbcCatalog", "jdbcSchema", "jdbcTableX"))
+                        new JdbcTableHandle("connectorId", new SchemaTableName("schemaX", "table"), "jdbcCatalog", "jdbcSchema", "jdbcTable", Optional.empty()),
+                        new JdbcTableHandle("connectorId", new SchemaTableName("schemaX", "table"), "jdbcCatalogX", "jdbcSchema", "jdbcTable", Optional.empty()),
+                        new JdbcTableHandle("connectorId", new SchemaTableName("schemaX", "table"), "jdbcCatalog", "jdbcSchemaX", "jdbcTable", Optional.empty()),
+                        new JdbcTableHandle("connectorId", new SchemaTableName("schemaX", "table"), "jdbcCatalog", "jdbcSchema", "jdbcTableX", Optional.empty()))
                 .check();
     }
 }

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestingBaseJdbcClient.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestingBaseJdbcClient.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.plugin.jdbc;
+
+import com.facebook.presto.plugin.jdbc.optimization.JdbcSortItem;
+
+import java.util.List;
+
+public class TestingBaseJdbcClient
+        extends BaseJdbcClient
+{
+    public TestingBaseJdbcClient(JdbcConnectorId connectorId, BaseJdbcConfig config,
+            String identifierQuote, ConnectionFactory connectionFactory)
+    {
+        super(connectorId, config, identifierQuote, connectionFactory);
+    }
+
+    @Override
+    public boolean supportsLimit()
+    {
+        return true;
+    }
+
+    @Override
+    public boolean supportsTopN(List<JdbcSortItem> sortItems)
+    {
+        return true;
+    }
+}

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestingDatabase.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestingDatabase.java
@@ -101,7 +101,7 @@ final class TestingDatabase
     {
         JdbcIdentity identity = JdbcIdentity.from(session);
         JdbcTableHandle jdbcTableHandle = jdbcClient.getTableHandle(identity, new SchemaTableName(schemaName, tableName));
-        JdbcTableLayoutHandle jdbcLayoutHandle = new JdbcTableLayoutHandle(jdbcTableHandle, TupleDomain.all(), Optional.empty());
+        JdbcTableLayoutHandle jdbcLayoutHandle = new JdbcTableLayoutHandle(jdbcTableHandle, TupleDomain.all());
         ConnectorSplitSource splits = jdbcClient.getSplits(identity, jdbcLayoutHandle);
         return (JdbcSplit) getOnlyElement(getFutureValue(splits.getNextBatch(NOT_PARTITIONED, 1000)).getSplits());
     }

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestingJdbcTypeHandle.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestingJdbcTypeHandle.java
@@ -14,25 +14,26 @@
 package com.facebook.presto.plugin.jdbc;
 
 import java.sql.Types;
+import java.util.Optional;
 
 public final class TestingJdbcTypeHandle
 {
     private TestingJdbcTypeHandle() {}
 
-    public static final JdbcTypeHandle JDBC_BOOLEAN = new JdbcTypeHandle(Types.BOOLEAN, 1, 0);
+    public static final JdbcTypeHandle JDBC_BOOLEAN = new JdbcTypeHandle(Types.BOOLEAN, Optional.of("boolean"), 1, 0);
 
-    public static final JdbcTypeHandle JDBC_SMALLINT = new JdbcTypeHandle(Types.SMALLINT, 1, 0);
-    public static final JdbcTypeHandle JDBC_TINYINT = new JdbcTypeHandle(Types.TINYINT, 2, 0);
-    public static final JdbcTypeHandle JDBC_INTEGER = new JdbcTypeHandle(Types.INTEGER, 4, 0);
-    public static final JdbcTypeHandle JDBC_BIGINT = new JdbcTypeHandle(Types.BIGINT, 8, 0);
+    public static final JdbcTypeHandle JDBC_SMALLINT = new JdbcTypeHandle(Types.SMALLINT, Optional.of("smallint"), 1, 0);
+    public static final JdbcTypeHandle JDBC_TINYINT = new JdbcTypeHandle(Types.TINYINT, Optional.of("tinyint"), 2, 0);
+    public static final JdbcTypeHandle JDBC_INTEGER = new JdbcTypeHandle(Types.INTEGER, Optional.of("integer"), 4, 0);
+    public static final JdbcTypeHandle JDBC_BIGINT = new JdbcTypeHandle(Types.BIGINT, Optional.of("bigint"), 8, 0);
 
-    public static final JdbcTypeHandle JDBC_REAL = new JdbcTypeHandle(Types.REAL, 8, 0);
-    public static final JdbcTypeHandle JDBC_DOUBLE = new JdbcTypeHandle(Types.DOUBLE, 8, 0);
+    public static final JdbcTypeHandle JDBC_REAL = new JdbcTypeHandle(Types.REAL, Optional.of("real"), 8, 0);
+    public static final JdbcTypeHandle JDBC_DOUBLE = new JdbcTypeHandle(Types.DOUBLE, Optional.of("double"), 8, 0);
 
-    public static final JdbcTypeHandle JDBC_CHAR = new JdbcTypeHandle(Types.CHAR, 10, 0);
-    public static final JdbcTypeHandle JDBC_VARCHAR = new JdbcTypeHandle(Types.VARCHAR, 10, 0);
+    public static final JdbcTypeHandle JDBC_CHAR = new JdbcTypeHandle(Types.CHAR, Optional.of("char"), 10, 0);
+    public static final JdbcTypeHandle JDBC_VARCHAR = new JdbcTypeHandle(Types.VARCHAR, Optional.of("varchar"), 10, 0);
 
-    public static final JdbcTypeHandle JDBC_DATE = new JdbcTypeHandle(Types.DATE, 8, 0);
-    public static final JdbcTypeHandle JDBC_TIME = new JdbcTypeHandle(Types.TIME, 4, 0);
-    public static final JdbcTypeHandle JDBC_TIMESTAMP = new JdbcTypeHandle(Types.TIMESTAMP, 8, 0);
+    public static final JdbcTypeHandle JDBC_DATE = new JdbcTypeHandle(Types.DATE, Optional.of("date"), 8, 0);
+    public static final JdbcTypeHandle JDBC_TIME = new JdbcTypeHandle(Types.TIME, Optional.of("time"), 4, 0);
+    public static final JdbcTypeHandle JDBC_TIMESTAMP = new JdbcTypeHandle(Types.TIMESTAMP, Optional.of("timestamp"), 8, 0);
 }

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/optimization/TestJdbcComputePushdown.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/optimization/TestJdbcComputePushdown.java
@@ -14,6 +14,8 @@
 package com.facebook.presto.plugin.jdbc.optimization;
 
 import com.facebook.presto.Session;
+import com.facebook.presto.common.QualifiedObjectName;
+import com.facebook.presto.common.block.SortOrder;
 import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.cost.PlanNodeStatsEstimate;
@@ -22,10 +24,14 @@ import com.facebook.presto.cost.StatsProvider;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.plugin.jdbc.BaseJdbcConfig;
+import com.facebook.presto.plugin.jdbc.DriverConnectionFactory;
+import com.facebook.presto.plugin.jdbc.JdbcClient;
 import com.facebook.presto.plugin.jdbc.JdbcColumnHandle;
+import com.facebook.presto.plugin.jdbc.JdbcConnectorId;
 import com.facebook.presto.plugin.jdbc.JdbcTableHandle;
 import com.facebook.presto.plugin.jdbc.JdbcTableLayoutHandle;
-import com.facebook.presto.plugin.jdbc.JdbcTypeHandle;
+import com.facebook.presto.plugin.jdbc.TestingBaseJdbcClient;
 import com.facebook.presto.plugin.jdbc.optimization.function.OperatorTranslators;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorId;
@@ -33,11 +39,23 @@ import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.facebook.presto.spi.function.FunctionHandle;
+import com.facebook.presto.spi.function.Parameter;
+import com.facebook.presto.spi.function.RoutineCharacteristics;
+import com.facebook.presto.spi.function.SqlFunctionId;
+import com.facebook.presto.spi.function.SqlInvokedFunction;
 import com.facebook.presto.spi.function.StandardFunctionResolution;
+import com.facebook.presto.spi.plan.Assignments;
 import com.facebook.presto.spi.plan.FilterNode;
+import com.facebook.presto.spi.plan.LimitNode;
+import com.facebook.presto.spi.plan.Ordering;
+import com.facebook.presto.spi.plan.OrderingScheme;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
+import com.facebook.presto.spi.plan.ProjectNode;
 import com.facebook.presto.spi.plan.TableScanNode;
+import com.facebook.presto.spi.plan.TopNNode;
+import com.facebook.presto.spi.relation.CallExpression;
 import com.facebook.presto.spi.relation.ConstantExpression;
 import com.facebook.presto.spi.relation.DeterminismEvaluator;
 import com.facebook.presto.spi.relation.RowExpression;
@@ -45,6 +63,7 @@ import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.TestingRowExpressionTranslator;
 import com.facebook.presto.sql.planner.Plan;
 import com.facebook.presto.sql.planner.TypeProvider;
+import com.facebook.presto.sql.planner.assertions.ExpressionMatcher;
 import com.facebook.presto.sql.planner.assertions.MatchResult;
 import com.facebook.presto.sql.planner.assertions.Matcher;
 import com.facebook.presto.sql.planner.assertions.PlanAssert;
@@ -59,23 +78,51 @@ import com.facebook.presto.testing.TestingConnectorSession;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import io.airlift.slice.Slices;
+import org.h2.Driver;
 import org.testng.annotations.Test;
 
-import java.sql.Types;
 import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.common.type.CharType.createCharType;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.common.type.VarcharType.createVarcharType;
+import static com.facebook.presto.metadata.FunctionAndTypeManager.createTestFunctionAndTypeManager;
+import static com.facebook.presto.plugin.jdbc.TestingJdbcTypeHandle.JDBC_BIGINT;
+import static com.facebook.presto.plugin.jdbc.TestingJdbcTypeHandle.JDBC_BOOLEAN;
+import static com.facebook.presto.plugin.jdbc.TestingJdbcTypeHandle.JDBC_CHAR;
+import static com.facebook.presto.plugin.jdbc.TestingJdbcTypeHandle.JDBC_DOUBLE;
+import static com.facebook.presto.plugin.jdbc.TestingJdbcTypeHandle.JDBC_VARCHAR;
+import static com.facebook.presto.spi.function.FunctionVersion.notVersioned;
+import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.node;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.sort;
 import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.expression;
+import static com.facebook.presto.sql.tree.SortItem.NullOrdering.FIRST;
+import static com.facebook.presto.sql.tree.SortItem.Ordering.ASCENDING;
+import static com.facebook.presto.sql.tree.SortItem.Ordering.DESCENDING;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.Maps.immutableEntry;
 import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toMap;
 
@@ -87,9 +134,21 @@ public class TestJdbcComputePushdown
     private static final String CATALOG_NAME = "Jdbc";
     private static final String CONNECTOR_ID = new ConnectorId(CATALOG_NAME).toString();
 
+    private static List<JdbcColumnHandle> jdbcColumnHandles = Lists.newArrayList(
+            new JdbcColumnHandle(CONNECTOR_ID, "l_orderkey", JDBC_BIGINT, BIGINT, false),
+            new JdbcColumnHandle(CONNECTOR_ID, "l_partkey", JDBC_BIGINT, BIGINT, false),
+            new JdbcColumnHandle(CONNECTOR_ID, "l_quantity", JDBC_DOUBLE, DOUBLE, false),
+            new JdbcColumnHandle(CONNECTOR_ID, "l_extendedprice", JDBC_DOUBLE, DOUBLE, false),
+            new JdbcColumnHandle(CONNECTOR_ID, "l_returnflag", JDBC_CHAR, createCharType(1), false),
+            new JdbcColumnHandle(CONNECTOR_ID, "l_shipdate", JDBC_VARCHAR, VARCHAR, false),
+            new JdbcColumnHandle(CONNECTOR_ID, "l_commitdate", JDBC_VARCHAR, VARCHAR, false),
+            new JdbcColumnHandle(CONNECTOR_ID, "l_receiptdate", JDBC_VARCHAR, VARCHAR, false));
+
     private final TestingRowExpressionTranslator sqlToRowExpressionTranslator;
 
     private final JdbcComputePushdown jdbcComputePushdown;
+    private final FunctionAndTypeManager typeManager = createTestFunctionAndTypeManager();
+    private final JdbcClient jdbcClient;
 
     public TestJdbcComputePushdown()
     {
@@ -98,7 +157,16 @@ public class TestJdbcComputePushdown
         StandardFunctionResolution functionResolution = new FunctionResolution(functionAndTypeManager);
         DeterminismEvaluator determinismEvaluator = new RowExpressionDeterminismEvaluator(functionAndTypeManager);
 
+        String connectionUrl = "jdbc:h2:mem:test" + System.nanoTime();
+        jdbcClient = new TestingBaseJdbcClient(
+                new JdbcConnectorId(CONNECTOR_ID),
+                new BaseJdbcConfig(),
+                "\"",
+                new DriverConnectionFactory(new Driver(), connectionUrl, Optional.empty(), Optional.empty(), new Properties()));
+
         this.jdbcComputePushdown = new JdbcComputePushdown(
+                jdbcClient,
+                typeManager,
                 functionAndTypeManager,
                 functionResolution,
                 determinismEvaluator,
@@ -119,8 +187,10 @@ public class TestJdbcComputePushdown
         Set<ColumnHandle> columns = Stream.of("c1", "c2").map(TestJdbcComputePushdown::integerJdbcColumnHandle).collect(Collectors.toSet());
         PlanNode original = filter(jdbcTableScan(schema, table, BIGINT, "c1", "c2"), rowExpression);
 
-        JdbcTableHandle jdbcTableHandle = new JdbcTableHandle(CONNECTOR_ID, new SchemaTableName(schema, table), CATALOG_NAME, schema, table);
-        JdbcTableLayoutHandle jdbcTableLayoutHandle = new JdbcTableLayoutHandle(jdbcTableHandle, TupleDomain.none(), Optional.of(new JdbcExpression("(('c1' + 'c2') - 'c2')")));
+        Optional<JdbcQueryGeneratorContext> context = getJdbcQueryGeneratorContext(
+                new JdbcExpression("(('c1' + 'c2') - 'c2')"));
+        JdbcTableHandle jdbcTableHandle = new JdbcTableHandle(CONNECTOR_ID, new SchemaTableName(schema, table), CATALOG_NAME, schema, table, context);
+        JdbcTableLayoutHandle jdbcTableLayoutHandle = new JdbcTableLayoutHandle(jdbcTableHandle, TupleDomain.none());
 
         ConnectorSession session = new TestingConnectorSession(ImmutableList.of());
         PlanNode actual = this.jdbcComputePushdown.optimize(original, session, null, ID_ALLOCATOR);
@@ -141,11 +211,12 @@ public class TestJdbcComputePushdown
         Set<ColumnHandle> columns = Stream.of("c1", "c2").map(TestJdbcComputePushdown::integerJdbcColumnHandle).collect(Collectors.toSet());
         PlanNode original = filter(jdbcTableScan(schema, table, BIGINT, "c1", "c2"), rowExpression);
 
-        JdbcTableHandle jdbcTableHandle = new JdbcTableHandle(CONNECTOR_ID, new SchemaTableName(schema, table), CATALOG_NAME, schema, table);
+        Optional<JdbcQueryGeneratorContext> context = getJdbcQueryGeneratorContext(
+                new JdbcExpression("((((('c1' + 'c2') - 'c2') <> 'c2') OR ('c2' = 'c1')) AND ('c1' <> 'c2'))"));
+        JdbcTableHandle jdbcTableHandle = new JdbcTableHandle(CONNECTOR_ID, new SchemaTableName(schema, table), CATALOG_NAME, schema, table, context);
         JdbcTableLayoutHandle jdbcTableLayoutHandle = new JdbcTableLayoutHandle(
                 jdbcTableHandle,
-                TupleDomain.none(),
-                Optional.of(new JdbcExpression("((((((('c1' + 'c2') - 'c2') <> 'c2')) OR (('c2' = 'c1')))) AND (('c1' <> 'c2')))")));
+                TupleDomain.none());
 
         ConnectorSession session = new TestingConnectorSession(ImmutableList.of());
         PlanNode actual = this.jdbcComputePushdown.optimize(original, session, null, ID_ALLOCATOR);
@@ -155,7 +226,7 @@ public class TestJdbcComputePushdown
     }
 
     @Test
-    public void testJdbcComputePushdownUnsupported()
+    public void testJdbcComputePushdownGreaterThen()
     {
         String table = "test_table";
         String schema = "test_schema";
@@ -166,15 +237,17 @@ public class TestJdbcComputePushdown
         Set<ColumnHandle> columns = Stream.of("c1", "c2").map(TestJdbcComputePushdown::integerJdbcColumnHandle).collect(Collectors.toSet());
         PlanNode original = filter(jdbcTableScan(schema, table, BIGINT, "c1", "c2"), rowExpression);
 
-        JdbcTableHandle jdbcTableHandle = new JdbcTableHandle(CONNECTOR_ID, new SchemaTableName(schema, table), CATALOG_NAME, schema, table);
-        // Test should expect an empty entry for translatedSql since > is an unsupported function currently in the optimizer
-        JdbcTableLayoutHandle jdbcTableLayoutHandle = new JdbcTableLayoutHandle(jdbcTableHandle, TupleDomain.none(), Optional.empty());
+        Optional<JdbcQueryGeneratorContext> context = getJdbcQueryGeneratorContext(
+                new JdbcExpression("('c1' + 'c2') > 'c2'"));
+
+        JdbcTableHandle jdbcTableHandle = new JdbcTableHandle(CONNECTOR_ID, new SchemaTableName(schema, table), CATALOG_NAME, schema, table, context);
+        JdbcTableLayoutHandle jdbcTableLayoutHandle = new JdbcTableLayoutHandle(
+                jdbcTableHandle,
+                TupleDomain.none());
 
         ConnectorSession session = new TestingConnectorSession(ImmutableList.of());
         PlanNode actual = this.jdbcComputePushdown.optimize(original, session, null, ID_ALLOCATOR);
-        assertPlanMatch(actual, PlanMatchPattern.filter(
-                expression,
-                JdbcTableScanMatcher.jdbcTableScanPattern(jdbcTableLayoutHandle, columns)));
+        assertPlanMatch(actual, JdbcTableScanMatcher.jdbcTableScanPattern(jdbcTableLayoutHandle, columns));
     }
 
     @Test
@@ -189,11 +262,13 @@ public class TestJdbcComputePushdown
         Set<ColumnHandle> columns = Stream.of("c1", "c2").map(TestJdbcComputePushdown::integerJdbcColumnHandle).collect(Collectors.toSet());
         PlanNode original = filter(jdbcTableScan(schema, table, BIGINT, "c1", "c2"), rowExpression);
 
-        JdbcTableHandle jdbcTableHandle = new JdbcTableHandle(CONNECTOR_ID, new SchemaTableName(schema, table), CATALOG_NAME, schema, table);
+        Optional<JdbcQueryGeneratorContext> context = getJdbcQueryGeneratorContext(
+                new JdbcExpression("(('c1' + 'c2') = ?)", ImmutableList.of(new ConstantExpression(3L, INTEGER))));
+
+        JdbcTableHandle jdbcTableHandle = new JdbcTableHandle(CONNECTOR_ID, new SchemaTableName(schema, table), CATALOG_NAME, schema, table, context);
         JdbcTableLayoutHandle jdbcTableLayoutHandle = new JdbcTableLayoutHandle(
                 jdbcTableHandle,
-                TupleDomain.none(),
-                Optional.of(new JdbcExpression("(('c1' + 'c2') = ?)", ImmutableList.of(new ConstantExpression(Long.valueOf(3), INTEGER)))));
+                TupleDomain.none());
 
         ConnectorSession session = new TestingConnectorSession(ImmutableList.of());
         PlanNode actual = this.jdbcComputePushdown.optimize(original, session, null, ID_ALLOCATOR);
@@ -211,12 +286,13 @@ public class TestJdbcComputePushdown
         RowExpression rowExpression = sqlToRowExpressionTranslator.translateAndOptimize(expression(expression), typeProvider);
         PlanNode original = filter(jdbcTableScan(schema, table, BOOLEAN, "c1", "c2"), rowExpression);
 
+        Optional<JdbcQueryGeneratorContext> context = getJdbcQueryGeneratorContext(
+                new JdbcExpression("('c1' AND (NOT('c2')))"));
         Set<ColumnHandle> columns = Stream.of("c1", "c2").map(TestJdbcComputePushdown::booleanJdbcColumnHandle).collect(Collectors.toSet());
-        JdbcTableHandle jdbcTableHandle = new JdbcTableHandle(CONNECTOR_ID, new SchemaTableName(schema, table), CATALOG_NAME, schema, table);
+        JdbcTableHandle jdbcTableHandle = new JdbcTableHandle(CONNECTOR_ID, new SchemaTableName(schema, table), CATALOG_NAME, schema, table, context);
         JdbcTableLayoutHandle jdbcTableLayoutHandle = new JdbcTableLayoutHandle(
                 jdbcTableHandle,
-                TupleDomain.none(),
-                Optional.of(new JdbcExpression("(('c1') AND ((NOT('c2'))))")));
+                TupleDomain.none());
 
         ConnectorSession session = new TestingConnectorSession(ImmutableList.of());
         PlanNode actual = this.jdbcComputePushdown.optimize(original, session, null, ID_ALLOCATOR);
@@ -235,12 +311,13 @@ public class TestJdbcComputePushdown
         RowExpression rowExpression = sqlToRowExpressionTranslator.translateAndOptimize(expression(expression), typeProvider);
         PlanNode original = filter(jdbcTableScan(schema, table, BIGINT, "c1", "c2"), rowExpression);
 
+        Optional<JdbcQueryGeneratorContext> context = getJdbcQueryGeneratorContext(
+                new JdbcExpression("(('c1' + 'c2') = ?)", ImmutableList.of(new ConstantExpression(3L, INTEGER))));
         Set<ColumnHandle> columns = Stream.of("c1", "c2").map(TestJdbcComputePushdown::booleanJdbcColumnHandle).collect(Collectors.toSet());
-        JdbcTableHandle jdbcTableHandle = new JdbcTableHandle(CONNECTOR_ID, new SchemaTableName(schema, table), CATALOG_NAME, schema, table);
+        JdbcTableHandle jdbcTableHandle = new JdbcTableHandle(CONNECTOR_ID, new SchemaTableName(schema, table), CATALOG_NAME, schema, table, context);
         JdbcTableLayoutHandle jdbcTableLayoutHandle = new JdbcTableLayoutHandle(
                 jdbcTableHandle,
-                TupleDomain.none(),
-                Optional.of(new JdbcExpression("((('c1' + 'c2') = ?))", ImmutableList.of(new ConstantExpression(3L, INTEGER)))));
+                TupleDomain.none());
 
         ConnectorSession session = new TestingConnectorSession(ImmutableList.of());
         PlanNode actual = this.jdbcComputePushdown.optimize(original, session, null, ID_ALLOCATOR);
@@ -261,12 +338,13 @@ public class TestJdbcComputePushdown
         RowExpression rowExpression = sqlToRowExpressionTranslator.translateAndOptimize(expression(expression), typeProvider);
         PlanNode original = filter(jdbcTableScan(schema, table, BIGINT, "c1", "c2"), rowExpression);
 
+        Optional<JdbcQueryGeneratorContext> context = getJdbcQueryGeneratorContext(
+                new JdbcExpression("((('c1' + 'c2') = ?) OR ('c1' <> 'c2'))", ImmutableList.of(new ConstantExpression(3L, INTEGER))));
         Set<ColumnHandle> columns = Stream.of("c1", "c2").map(TestJdbcComputePushdown::booleanJdbcColumnHandle).collect(Collectors.toSet());
-        JdbcTableHandle jdbcTableHandle = new JdbcTableHandle(CONNECTOR_ID, new SchemaTableName(schema, table), CATALOG_NAME, schema, table);
+        JdbcTableHandle jdbcTableHandle = new JdbcTableHandle(CONNECTOR_ID, new SchemaTableName(schema, table), CATALOG_NAME, schema, table, context);
         JdbcTableLayoutHandle jdbcTableLayoutHandle = new JdbcTableLayoutHandle(
                 jdbcTableHandle,
-                TupleDomain.none(),
-                Optional.of(new JdbcExpression("((((('c1' + 'c2') = ?)) OR (('c1' <> 'c2'))))", ImmutableList.of(new ConstantExpression(3L, INTEGER)))));
+                TupleDomain.none());
 
         ConnectorSession session = new TestingConnectorSession(ImmutableList.of());
         PlanNode actual = this.jdbcComputePushdown.optimize(original, session, null, ID_ALLOCATOR);
@@ -282,23 +360,302 @@ public class TestJdbcComputePushdown
         String schema = "test_schema";
 
         // no filter can be pushed down
-        String expression = "CAST(c1 AS varchar(1024)) = '123' and ((c1 - c2) > c2 or c1 <> c2)";
+        String expression = "CAST(c1 AS varchar(1024)) = '123' and ((c1 - c2) > c2 or CAST(c2 AS varchar(1024)) = '456')";
         TypeProvider typeProvider = TypeProvider.copyOf(ImmutableMap.of("c1", BIGINT, "c2", BIGINT));
         RowExpression rowExpression = sqlToRowExpressionTranslator.translateAndOptimize(expression(expression), typeProvider);
         PlanNode original = filter(jdbcTableScan(schema, table, BIGINT, "c1", "c2"), rowExpression);
 
         Set<ColumnHandle> columns = Stream.of("c1", "c2").map(TestJdbcComputePushdown::booleanJdbcColumnHandle).collect(Collectors.toSet());
-        JdbcTableHandle jdbcTableHandle = new JdbcTableHandle(CONNECTOR_ID, new SchemaTableName(schema, table), CATALOG_NAME, schema, table);
+        JdbcTableHandle jdbcTableHandle = new JdbcTableHandle(CONNECTOR_ID, new SchemaTableName(schema, table), CATALOG_NAME, schema, table, Optional.empty());
         JdbcTableLayoutHandle jdbcTableLayoutHandle = new JdbcTableLayoutHandle(
                 jdbcTableHandle,
-                TupleDomain.none(),
-                Optional.empty());
+                TupleDomain.none());
 
         ConnectorSession session = new TestingConnectorSession(ImmutableList.of());
         PlanNode actual = this.jdbcComputePushdown.optimize(original, session, null, ID_ALLOCATOR);
         assertPlanMatch(actual, PlanMatchPattern.filter(
                 expression,
                 JdbcTableScanMatcher.jdbcTableScanPattern(jdbcTableLayoutHandle, columns)));
+    }
+
+    @Test
+    public void testJdbcComputeLimitPushdownWithoutFilter()
+    {
+        String table = "test_table";
+        String schema = "test_schema";
+
+        PlanNode original = limit(8, jdbcTableScan(schema, table, BIGINT, "c1", "c2"));
+
+        Optional<JdbcQueryGeneratorContext> context = getJdbcQueryGeneratorContext(Optional.empty(), OptionalLong.of(8));
+        Set<ColumnHandle> columns = Stream.of("c1", "c2").map(TestJdbcComputePushdown::booleanJdbcColumnHandle).collect(Collectors.toSet());
+        JdbcTableHandle jdbcTableHandle = new JdbcTableHandle(CONNECTOR_ID, new SchemaTableName(schema, table), CATALOG_NAME, schema, table, context);
+        JdbcTableLayoutHandle jdbcTableLayoutHandle = new JdbcTableLayoutHandle(
+                jdbcTableHandle,
+                TupleDomain.none());
+
+        ConnectorSession session = new TestingConnectorSession(ImmutableList.of());
+        PlanNode actual = this.jdbcComputePushdown.optimize(original, session, null, ID_ALLOCATOR);
+        assertPlanMatch(actual, JdbcTableScanMatcher.jdbcTableScanPattern(jdbcTableLayoutHandle, columns));
+    }
+
+    @Test
+    public void testJdbcComputeLimitPushdownWithFilter()
+    {
+        String table = "test_table";
+        String schema = "test_schema";
+
+        String expression = "c1 + c2 = 3";
+        TypeProvider typeProvider = TypeProvider.copyOf(ImmutableMap.of("c1", BIGINT, "c2", BIGINT));
+        RowExpression rowExpression = sqlToRowExpressionTranslator.translateAndOptimize(expression(expression), typeProvider);
+        FilterNode filter = filter(jdbcTableScan(schema, table, BIGINT, "c1", "c2"), rowExpression);
+        PlanNode original = limit(8, filter);
+
+        Optional<JdbcQueryGeneratorContext> context = getJdbcQueryGeneratorContext(
+                new JdbcExpression("(('c1' + 'c2') = ?)", ImmutableList.of(new ConstantExpression(3L, INTEGER))),
+                8L);
+        Set<ColumnHandle> columns = Stream.of("c1", "c2").map(TestJdbcComputePushdown::booleanJdbcColumnHandle).collect(Collectors.toSet());
+        JdbcTableHandle jdbcTableHandle = new JdbcTableHandle(CONNECTOR_ID, new SchemaTableName(schema, table), CATALOG_NAME, schema, table, context);
+        JdbcTableLayoutHandle jdbcTableLayoutHandle = new JdbcTableLayoutHandle(
+                jdbcTableHandle,
+                TupleDomain.none());
+
+        ConnectorSession session = new TestingConnectorSession(ImmutableList.of());
+        PlanNode actual = this.jdbcComputePushdown.optimize(original, session, null, ID_ALLOCATOR);
+        assertPlanMatch(actual, JdbcTableScanMatcher.jdbcTableScanPattern(jdbcTableLayoutHandle, columns));
+    }
+
+    @Test
+    public void testJdbcComputeLimitNotPushdownWithFilter()
+    {
+        String table = "test_table";
+        String schema = "test_schema";
+
+        String expression = "CAST(c1 AS varchar(1024)) = '123' and c1 + c2 = 3";
+        TypeProvider typeProvider = TypeProvider.copyOf(ImmutableMap.of("c1", BIGINT, "c2", BIGINT));
+        RowExpression rowExpression = sqlToRowExpressionTranslator.translateAndOptimize(expression(expression), typeProvider);
+        FilterNode filter = filter(jdbcTableScan(schema, table, BIGINT, "c1", "c2"), rowExpression);
+        PlanNode original = limit(8, filter);
+
+        Optional<JdbcQueryGeneratorContext> context = getJdbcQueryGeneratorContext(
+                new JdbcExpression("(('c1' + 'c2') = ?)", ImmutableList.of(new ConstantExpression(3L, INTEGER))));
+        Set<ColumnHandle> columns = Stream.of("c1", "c2").map(TestJdbcComputePushdown::booleanJdbcColumnHandle).collect(Collectors.toSet());
+        JdbcTableHandle jdbcTableHandle = new JdbcTableHandle(CONNECTOR_ID, new SchemaTableName(schema, table), CATALOG_NAME, schema, table, context);
+        JdbcTableLayoutHandle jdbcTableLayoutHandle = new JdbcTableLayoutHandle(
+                jdbcTableHandle,
+                TupleDomain.none());
+
+        ConnectorSession session = new TestingConnectorSession(ImmutableList.of());
+        PlanNode actual = this.jdbcComputePushdown.optimize(original, session, null, ID_ALLOCATOR);
+
+        assertPlanMatch(actual, PlanMatchPattern.limit(8L,
+                PlanMatchPattern.filter(
+                        "CAST(c1 AS varchar(1024)) = '123'",
+                        JdbcTableScanMatcher.jdbcTableScanPattern(jdbcTableLayoutHandle, columns))));
+    }
+
+    @Test
+    public void testSimpleOrderByLimitPushdown()
+    {
+        ImmutableList<JdbcSortItem> expected = ImmutableList.of(new JdbcSortItem(getColumnHandleForVariable("l_orderkey", jdbcColumnHandles), SortOrder.DESC_NULLS_FIRST));
+        simpleOrderByLimitPushdownCommon(ImmutableList.of("l_orderkey"), ImmutableList.of(false), expected);
+
+        expected = ImmutableList.of(new JdbcSortItem(getColumnHandleForVariable("l_orderkey", jdbcColumnHandles), SortOrder.DESC_NULLS_FIRST),
+                new JdbcSortItem(getColumnHandleForVariable("l_extendedprice", jdbcColumnHandles), SortOrder.ASC_NULLS_FIRST));
+        simpleOrderByLimitPushdownCommon(ImmutableList.of("l_orderkey", "l_extendedprice"), ImmutableList.of(false, true), expected);
+    }
+
+    private void simpleOrderByLimitPushdownCommon(List<String> orderingColumns, List<Boolean> ascending, List<JdbcSortItem> expected)
+    {
+        String table = "test_table";
+        String schema = "test_schema";
+
+        TableScanNode tableScanNode = jdbcTableScan();
+        PlanNode original = topN(8, orderingColumns, ascending, tableScanNode);
+
+        Optional<JdbcQueryGeneratorContext> context = getJdbcQueryGeneratorContext(
+                Optional.empty(),
+                Optional.of(expected),
+                OptionalLong.of(8));
+
+        JdbcTableHandle jdbcTableHandle = new JdbcTableHandle(CONNECTOR_ID, new SchemaTableName(schema, table), CATALOG_NAME, schema, table, context);
+        JdbcTableLayoutHandle jdbcTableLayoutHandle = new JdbcTableLayoutHandle(
+                jdbcTableHandle,
+                TupleDomain.none());
+
+        ConnectorSession session = new TestingConnectorSession(ImmutableList.of());
+        PlanNode actual = this.jdbcComputePushdown.optimize(original, session, null, ID_ALLOCATOR);
+        assertPlanMatch(actual, JdbcTableScanMatcher.jdbcTableScanPattern(jdbcTableLayoutHandle, Sets.newHashSet(jdbcColumnHandles)));
+    }
+
+    @Test
+    public void testOrderByLimitWithFilterPushdown()
+    {
+        String table = "test_table";
+        String schema = "test_schema";
+
+        String expression = "l_orderkey = 3 and l_commitdate between '2021-07-19' and '2021-07-20'";
+        TableScanNode tableScanNode = jdbcTableScan();
+        TypeProvider typeProvider = TypeProvider.fromVariables(tableScanNode.getOutputVariables());
+        RowExpression rowExpression = sqlToRowExpressionTranslator.translateAndOptimize(expression(expression), typeProvider);
+
+        FilterNode filter = filter(tableScanNode, rowExpression);
+        PlanNode original = topN(8, ImmutableList.of("l_orderkey", "l_extendedprice"), ImmutableList.of(false, true), filter);
+
+        List<ConstantExpression> constantBindValues = ImmutableList.of(new ConstantExpression(3L, INTEGER),
+                new ConstantExpression(Slices.utf8Slice("2021-07-19"), createVarcharType(10)),
+                new ConstantExpression(Slices.utf8Slice("2021-07-20"), createVarcharType(10)));
+
+        List<JdbcSortItem> sortOrder = ImmutableList.of(new JdbcSortItem(getColumnHandleForVariable("l_orderkey", jdbcColumnHandles), SortOrder.DESC_NULLS_FIRST),
+                new JdbcSortItem(getColumnHandleForVariable("l_extendedprice", jdbcColumnHandles), SortOrder.ASC_NULLS_FIRST));
+
+        Optional<JdbcQueryGeneratorContext> context = getJdbcQueryGeneratorContext(
+                Optional.of(new JdbcExpression("(('l_orderkey' = ?) AND ('l_commitdate' BETWEEN ? AND ?))", constantBindValues)),
+                Optional.of(sortOrder),
+                OptionalLong.of(8));
+
+        JdbcTableHandle jdbcTableHandle = new JdbcTableHandle(CONNECTOR_ID, new SchemaTableName(schema, table), CATALOG_NAME, schema, table, context);
+        JdbcTableLayoutHandle jdbcTableLayoutHandle = new JdbcTableLayoutHandle(
+                jdbcTableHandle,
+                TupleDomain.none());
+
+        ConnectorSession session = new TestingConnectorSession(ImmutableList.of());
+        PlanNode actual = this.jdbcComputePushdown.optimize(original, session, null, ID_ALLOCATOR);
+        assertPlanMatch(actual, JdbcTableScanMatcher.jdbcTableScanPattern(jdbcTableLayoutHandle, Sets.newHashSet(jdbcColumnHandles)));
+    }
+
+    @Test
+    public void testOrderByLimitNotPushdown()
+    {
+        String table = "test_table";
+        String schema = "test_schema";
+
+        TableScanNode tableScanNode = jdbcTableScan();
+        Map<VariableReferenceExpression, RowExpression> assignments = tableScanNode.getOutputVariables().stream()
+                .map(v -> immutableEntry(v, v))
+                .collect(toMap(Map.Entry::getKey,
+                        Map.Entry::getValue,
+                        (val1, val2) -> val1,
+                        LinkedHashMap::new));
+
+        Map<SqlFunctionId, SqlInvokedFunction> functions = ImmutableMap.of(getSqlFunctionId(), getSqlInvokedFunction());
+
+        FunctionHandle functionHandle = typeManager.resolveFunction(
+                Optional.of(functions),
+                Optional.empty(),
+                getSqlFunctionId().getFunctionName(),
+                fromTypes(VARCHAR, BIGINT, BIGINT));
+
+        List<RowExpression> arguments = Lists.newArrayList(new VariableReferenceExpression("l_commitdate", VARCHAR),
+                new ConstantExpression(1L, BIGINT),
+                new ConstantExpression(2L, BIGINT));
+        assignments.put(new VariableReferenceExpression("substring", VARCHAR),
+                new CallExpression("substring", functionHandle, VARCHAR, arguments));
+
+        ProjectNode project = project(Assignments.copyOf(assignments), tableScanNode);
+        PlanNode original = topN(8, ImmutableList.of("substring", "l_orderkey"), ImmutableList.of(false, true), project);
+
+        JdbcTableHandle jdbcTableHandle = new JdbcTableHandle(CONNECTOR_ID, new SchemaTableName(schema, table), CATALOG_NAME, schema, table, Optional.empty());
+        JdbcTableLayoutHandle jdbcTableLayoutHandle = new JdbcTableLayoutHandle(
+                jdbcTableHandle,
+                TupleDomain.none());
+
+        ConnectorSession session = new TestingConnectorSession(ImmutableList.of());
+        PlanNode actual = this.jdbcComputePushdown.optimize(original, session, null, ID_ALLOCATOR);
+
+        Map<String, ExpressionMatcher> assignmentsMap = tableScanNode.getOutputVariables().stream().map(v ->
+                immutableEntry(v.getName(), PlanMatchPattern.expression(v.getName())))
+                .collect(toMap(Map.Entry::getKey,
+                        Map.Entry::getValue,
+                        (val1, val2) -> val1,
+                        LinkedHashMap::new));
+
+        assignmentsMap.put("substring", PlanMatchPattern.expression("substring(l_commitdate, 1, 2)"));
+        List<PlanMatchPattern.Ordering> orderBy = ImmutableList.of(sort("substring", DESCENDING, FIRST), sort("l_orderkey", ASCENDING, FIRST));
+
+        assertPlanMatch(actual,
+                PlanMatchPattern.topN(8, orderBy,
+                        PlanMatchPattern.project(assignmentsMap,
+                                JdbcTableScanMatcher.jdbcTableScanPattern(jdbcTableLayoutHandle, Sets.newHashSet(jdbcColumnHandles)))));
+    }
+
+    @Test
+    public void testOrderByLimitWithFilterNotPushdown()
+    {
+        String table = "test_table";
+        String schema = "test_schema";
+
+        String expression = "l_orderkey = 3 and substring(l_commitdate, 1, 2) = '20'";
+        TableScanNode tableScanNode = jdbcTableScan();
+        TypeProvider typeProvider = TypeProvider.fromVariables(tableScanNode.getOutputVariables());
+        RowExpression rowExpression = sqlToRowExpressionTranslator.translateAndOptimize(expression(expression), typeProvider, createSessionWithTempFunctionSubstring());
+
+        FilterNode filter = filter(tableScanNode, rowExpression);
+        PlanNode original = topN(8, ImmutableList.of("l_orderkey", "l_extendedprice"), ImmutableList.of(false, true), filter);
+        Optional<JdbcQueryGeneratorContext> context = getJdbcQueryGeneratorContext(
+                Optional.of(new JdbcExpression("('l_orderkey' = ?)", ImmutableList.of(new ConstantExpression(3L, INTEGER)))),
+                Optional.empty(),
+                OptionalLong.empty());
+
+        JdbcTableHandle jdbcTableHandle = new JdbcTableHandle(CONNECTOR_ID, new SchemaTableName(schema, table), CATALOG_NAME, schema, table, context);
+        JdbcTableLayoutHandle jdbcTableLayoutHandle = new JdbcTableLayoutHandle(
+                jdbcTableHandle,
+                TupleDomain.none());
+
+        ConnectorSession session = new TestingConnectorSession(ImmutableList.of());
+        PlanNode actual = this.jdbcComputePushdown.optimize(original, session, null, ID_ALLOCATOR);
+
+        List<PlanMatchPattern.Ordering> orderBy = ImmutableList.of(sort("l_orderkey", DESCENDING, FIRST), sort("l_extendedprice", ASCENDING, FIRST));
+        assertPlanMatch(actual,
+                PlanMatchPattern.topN(8, orderBy,
+                        PlanMatchPattern.filter("substring(l_commitdate, 1, 2) = '20'",
+                                JdbcTableScanMatcher.jdbcTableScanPattern(jdbcTableLayoutHandle, Sets.newHashSet(jdbcColumnHandles)))));
+    }
+
+    private Session createSessionWithTempFunctionSubstring()
+    {
+        return testSessionBuilder()
+                .addSessionFunction(getSqlFunctionId(), getSqlInvokedFunction())
+                .build();
+    }
+
+    private SqlFunctionId getSqlFunctionId()
+    {
+        return new SqlFunctionId(QualifiedObjectName.valueOf("presto.default.substring"),
+                ImmutableList.of(parseTypeSignature("varchar"), parseTypeSignature("bigint"), parseTypeSignature("bigint")));
+    }
+
+    private SqlInvokedFunction getSqlInvokedFunction()
+    {
+        return new SqlInvokedFunction(
+                getSqlFunctionId().getFunctionName(),
+                ImmutableList.of(new Parameter("x", parseTypeSignature("varchar")),
+                        new Parameter("y", parseTypeSignature("bigint")),
+                        new Parameter("z", parseTypeSignature("bigint"))),
+                parseTypeSignature("varchar"),
+                "",
+                RoutineCharacteristics.builder().build(),
+                "",
+                notVersioned());
+    }
+
+    private Optional<JdbcQueryGeneratorContext> getJdbcQueryGeneratorContext(JdbcExpression jdbcExpression, Long limit)
+    {
+        return getJdbcQueryGeneratorContext(Optional.of(jdbcExpression), OptionalLong.of(limit));
+    }
+
+    private Optional<JdbcQueryGeneratorContext> getJdbcQueryGeneratorContext(JdbcExpression jdbcExpression)
+    {
+        return getJdbcQueryGeneratorContext(Optional.of(jdbcExpression), OptionalLong.empty());
+    }
+
+    private Optional<JdbcQueryGeneratorContext> getJdbcQueryGeneratorContext(Optional<JdbcExpression> jdbcExpression, OptionalLong limit)
+    {
+        return getJdbcQueryGeneratorContext(jdbcExpression, Optional.empty(), limit);
+    }
+
+    private Optional<JdbcQueryGeneratorContext> getJdbcQueryGeneratorContext(Optional<JdbcExpression> jdbcExpression, Optional<List<JdbcSortItem>> sortOrder, OptionalLong limit)
+    {
+        return Optional.of(new JdbcQueryGeneratorContext(jdbcExpression, sortOrder, limit));
     }
 
     private Set<Class<?>> getFunctionTranslators()
@@ -313,12 +670,19 @@ public class TestJdbcComputePushdown
 
     private static JdbcColumnHandle integerJdbcColumnHandle(String name)
     {
-        return new JdbcColumnHandle(CONNECTOR_ID, name, new JdbcTypeHandle(Types.BIGINT, 10, 0), BIGINT, false);
+        return new JdbcColumnHandle(CONNECTOR_ID, name, JDBC_BIGINT, BIGINT, false);
     }
 
     private static JdbcColumnHandle booleanJdbcColumnHandle(String name)
     {
-        return new JdbcColumnHandle(CONNECTOR_ID, name, new JdbcTypeHandle(Types.BOOLEAN, 1, 0), BOOLEAN, false);
+        return new JdbcColumnHandle(CONNECTOR_ID, name, JDBC_BOOLEAN, BOOLEAN, false);
+    }
+
+    private static JdbcColumnHandle getColumnHandleForVariable(String name, List<JdbcColumnHandle> jdbcColumnHandles)
+    {
+        return jdbcColumnHandles.stream()
+                .filter(h -> h.getColumnName().equalsIgnoreCase(name))
+                .findFirst().orElseThrow(() -> new IllegalArgumentException("Cannot find jdbcColumnHandle " + name));
     }
 
     private static JdbcColumnHandle getColumnHandleForVariable(String name, Type type)
@@ -343,8 +707,8 @@ public class TestJdbcComputePushdown
 
     private TableScanNode jdbcTableScan(String schema, String table, Type type, String... columnNames)
     {
-        JdbcTableHandle jdbcTableHandle = new JdbcTableHandle(CONNECTOR_ID, new SchemaTableName(schema, table), CATALOG_NAME, schema, table);
-        JdbcTableLayoutHandle jdbcTableLayoutHandle = new JdbcTableLayoutHandle(jdbcTableHandle, TupleDomain.none(), Optional.empty());
+        JdbcTableHandle jdbcTableHandle = new JdbcTableHandle(CONNECTOR_ID, new SchemaTableName(schema, table), CATALOG_NAME, schema, table, Optional.empty());
+        JdbcTableLayoutHandle jdbcTableLayoutHandle = new JdbcTableLayoutHandle(jdbcTableHandle, TupleDomain.none());
         TableHandle tableHandle = new TableHandle(new ConnectorId(CATALOG_NAME), jdbcTableHandle, new ConnectorTransactionHandle() {}, Optional.of(jdbcTableLayoutHandle));
 
         return PLAN_BUILDER.tableScan(
@@ -355,9 +719,51 @@ public class TestJdbcComputePushdown
                         .collect(toMap(identity(), entry -> getColumnHandleForVariable(entry.getName(), type))));
     }
 
+    private TableScanNode jdbcTableScan()
+    {
+        String table = "test_table";
+        String schema = "test_schema";
+        JdbcTableHandle jdbcTableHandle = new JdbcTableHandle(CONNECTOR_ID, new SchemaTableName(schema, table), CATALOG_NAME, schema, table, Optional.empty());
+        JdbcTableLayoutHandle jdbcTableLayoutHandle = new JdbcTableLayoutHandle(jdbcTableHandle, TupleDomain.none());
+        TableHandle tableHandle = new TableHandle(new ConnectorId(CATALOG_NAME), jdbcTableHandle, new ConnectorTransactionHandle() {}, Optional.of(jdbcTableLayoutHandle));
+
+        return PLAN_BUILDER.tableScan(
+                tableHandle,
+                jdbcColumnHandles.stream().map(column -> newVariable(column.getColumnName(), column.getColumnType())).collect(toImmutableList()),
+                jdbcColumnHandles.stream()
+                        .map(column -> newVariable(column.getColumnName(), column.getColumnType()))
+                        .collect(toMap(identity(), entry -> getColumnHandleForVariable(entry.getName(), jdbcColumnHandles))));
+    }
+
+    private ProjectNode project(Assignments assignments, PlanNode source)
+    {
+        return PLAN_BUILDER.project(assignments, source);
+    }
+
     private FilterNode filter(PlanNode source, RowExpression predicate)
     {
         return PLAN_BUILDER.filter(predicate, source);
+    }
+
+    private LimitNode limit(long count, PlanNode source)
+    {
+        return PLAN_BUILDER.limit(count, source);
+    }
+
+    private TopNNode topN(long count, List<String> orderingColumns, List<Boolean> ascending, PlanNode source)
+    {
+        ImmutableList<Ordering> ordering = IntStream.range(0, orderingColumns.size())
+                .boxed()
+                .map(i -> new Ordering(variable(source.getOutputVariables(), orderingColumns.get(i)), ascending.get(i) ? SortOrder.ASC_NULLS_FIRST : SortOrder.DESC_NULLS_FIRST))
+                .collect(toImmutableList());
+
+        return new TopNNode(PLAN_BUILDER.getIdAllocator().getNextId(), source, count, new OrderingScheme(ordering), TopNNode.Step.PARTIAL);
+    }
+
+    private VariableReferenceExpression variable(List<VariableReferenceExpression> outputVariables, String name)
+    {
+        return outputVariables.stream().filter(v -> v.getName().equals(name))
+                .findFirst().orElseThrow(() -> new IllegalArgumentException("Cannot find variable " + name));
     }
 
     private static final class JdbcTableScanMatcher
@@ -390,16 +796,20 @@ public class TestJdbcComputePushdown
 
             TableScanNode tableScanNode = (TableScanNode) node;
             JdbcTableLayoutHandle layoutHandle = (JdbcTableLayoutHandle) tableScanNode.getTable().getLayout().get();
+
+            JdbcTableHandle expectedTableHandle = jdbcTableLayoutHandle.getTable();
+            JdbcTableHandle actualTableHandle = layoutHandle.getTable();
+
             if (jdbcTableLayoutHandle.getTable().equals(layoutHandle.getTable())
                     && jdbcTableLayoutHandle.getTupleDomain().equals(layoutHandle.getTupleDomain())
-                    && ((!jdbcTableLayoutHandle.getAdditionalPredicate().isPresent() && !layoutHandle.getAdditionalPredicate().isPresent())
-                        || jdbcTableLayoutHandle.getAdditionalPredicate().get().getExpression().equals(layoutHandle.getAdditionalPredicate().get().getExpression()))) {
+                    && ((!expectedTableHandle.getContext().isPresent() && !actualTableHandle.getContext().isPresent())
+                    || expectedTableHandle.getContext().get().equals(actualTableHandle.getContext().get()))) {
                 return MatchResult.match(
                         SymbolAliases.builder().putAll(
-                        columns.stream()
-                                .map(column -> ((JdbcColumnHandle) column).getColumnName())
-                                .collect(toMap(identity(), SymbolReference::new)))
-                        .build());
+                                columns.stream()
+                                        .map(column -> ((JdbcColumnHandle) column).getColumnName())
+                                        .collect(toMap(identity(), SymbolReference::new)))
+                                .build());
             }
 
             return MatchResult.NO_MATCH;


### PR DESCRIPTION
The corresponding issue is #16466.

Here is the optimized logical plan: 
![image](https://user-images.githubusercontent.com/5170878/128338856-9edf56d1-2b82-429b-b8d2-63f115d27edb.png)

```
== RELEASE NOTES ==

JDBC Changes
* Add support for Filter/Limit/TopN pushdown to MySQL/PostgreSql/SqlServer connections.
```

