### PR TITLE
Fix CachingFileSystem to include missing override

### DIFF
--- a/presto-cache/src/main/java/com/facebook/presto/cache/CachingFileSystem.java
+++ b/presto-cache/src/main/java/com/facebook/presto/cache/CachingFileSystem.java
@@ -238,6 +238,13 @@ public abstract class CachingFileSystem
     }
 
     @Override
+    public RemoteIterator<LocatedFileStatus> listLocatedStatus(Path f)
+            throws IOException
+    {
+        return dataTier.listLocatedStatus(f);
+    }
+
+    @Override
     public RemoteIterator<FileStatus> listStatusIterator(Path path)
             throws IOException
     {

--- a/presto-cache/src/main/java/com/facebook/presto/cache/CachingFileSystem.java
+++ b/presto-cache/src/main/java/com/facebook/presto/cache/CachingFileSystem.java
@@ -231,17 +231,17 @@ public abstract class CachingFileSystem
     }
 
     @Override
+    public RemoteIterator<LocatedFileStatus> listLocatedStatus(Path path)
+            throws IOException
+    {
+        return dataTier.listLocatedStatus(path);
+    }
+
+    @Override
     public FileStatus[] listStatus(Path path)
             throws IOException
     {
         return dataTier.listStatus(path);
-    }
-
-    @Override
-    public RemoteIterator<LocatedFileStatus> listLocatedStatus(Path f)
-            throws IOException
-    {
-        return dataTier.listLocatedStatus(f);
     }
 
     @Override


### PR DESCRIPTION
Test plan - (Please fill in how you tested your changes)
Production Test

This PR is fixed the CachgingFileSystem has not implemented the listlocatedStatus which will be using when namenode listing, this Actually will mistake invoke Filesystem#ListLocatedStatus instead of using DFS's one.
