### PR TITLE
Disable metadata query rewrite for partitions with incomplete stats

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/MetadataQueryOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/MetadataQueryOptimizer.java
@@ -26,6 +26,7 @@ import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.Constraint;
 import com.facebook.presto.spi.DiscretePredicates;
+import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.function.FunctionMetadata;
 import com.facebook.presto.spi.plan.AggregationNode;
@@ -40,8 +41,10 @@ import com.facebook.presto.spi.plan.ProjectNode;
 import com.facebook.presto.spi.plan.TableScanNode;
 import com.facebook.presto.spi.plan.TopNNode;
 import com.facebook.presto.spi.plan.ValuesNode;
+import com.facebook.presto.spi.relation.ConstantExpression;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.spi.statistics.TableStatistics;
 import com.facebook.presto.sql.planner.PlanVariableAllocator;
 import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.planner.plan.SimplePlanRewriter;
@@ -54,6 +57,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -181,7 +185,19 @@ public class MetadataQueryOptimizer
 
             if (isReducible(node, inputs)) {
                 // Fold min/max aggregations to a constant value
-                return reduce(node, inputs, columns, context, discretePredicates);
+                return reduce(node, inputs, columns, context, discretePredicates, tableScan.getTable());
+            }
+
+            // Partition Stats stored in metastore may be incomplete or missing, if stats collection timeout. So even if the metastore has a stats indicating that the partition is
+            // empty, it may not be empty on disk. We need to disable this rewrite for this case as it could change the behavior.
+            // Thus, to be safe, we only do the rewrite if the partition stats has positive row count.
+            // This check is done separately for the two code paths:
+            //  - When the query is reducible, we only check the result partition in reduce().
+            //  - When the query is not reducible, we have to check all involved partitions below.
+            for (TupleDomain<ColumnHandle> tupleDomain : discretePredicates.getPredicates()) {
+                if (!hasPositiveRowCount(tableScan.getTable(), tupleDomain)) {
+                    return context.defaultRewrite(node);
+                }
             }
 
             ImmutableList.Builder<List<RowExpression>> rowsBuilder = ImmutableList.builder();
@@ -233,12 +249,17 @@ public class MetadataQueryOptimizer
                 List<VariableReferenceExpression> inputs,
                 Map<VariableReferenceExpression, ColumnHandle> columns,
                 RewriteContext<Void> context,
-                DiscretePredicates predicates)
+                DiscretePredicates predicates,
+                TableHandle table)
         {
             // Fold min/max aggregations to a constant value
             ImmutableMap.Builder<VariableReferenceExpression, List<RowExpression>> inputColumnValuesBuilder = ImmutableMap.builder();
+            // For each input partition column, we keep one tuple domain for each constant value. When we get the resulting value, we will get the corresponding tuple domain and
+            // check if the partition stats can be trusted.
+            ImmutableMap.Builder<VariableReferenceExpression, Map<RowExpression, TupleDomain<ColumnHandle>>> inputValueToDomainBuilder = ImmutableMap.builder();
             for (VariableReferenceExpression input : inputs) {
                 ImmutableList.Builder<RowExpression> arguments = ImmutableList.builder();
+                Map<RowExpression, TupleDomain<ColumnHandle>> valueToDomain = new HashMap<>();
                 ColumnHandle column = columns.get(input);
                 // for each input column, add a literal expression using the entry value
                 for (TupleDomain<ColumnHandle> domain : predicates.getPredicates()) {
@@ -254,25 +275,47 @@ public class MetadataQueryOptimizer
                     // min/max ignores null value
                     else if (value.getValue() != null) {
                         Type type = input.getType();
-                        arguments.add(constant(value.getValue(), type));
+                        ConstantExpression constantExpression = constant(value.getValue(), type);
+                        arguments.add(constantExpression);
+                        valueToDomain.putIfAbsent(constantExpression, domain);
                     }
                 }
                 inputColumnValuesBuilder.put(input, arguments.build());
+                inputValueToDomainBuilder.put(input, valueToDomain);
             }
             Map<VariableReferenceExpression, List<RowExpression>> inputColumnValues = inputColumnValuesBuilder.build();
+            Map<VariableReferenceExpression, Map<RowExpression, TupleDomain<ColumnHandle>>> inputValueToDomain = inputValueToDomainBuilder.build();
 
             Assignments.Builder assignmentsBuilder = Assignments.builder();
             for (VariableReferenceExpression outputVariable : node.getOutputVariables()) {
                 Aggregation aggregation = node.getAggregations().get(outputVariable);
-                assignmentsBuilder.put(
-                        outputVariable,
-                        evaluateMinMax(
-                                metadata.getFunctionAndTypeManager().getFunctionMetadata(node.getAggregations().get(outputVariable).getFunctionHandle()),
-                                inputColumnValues.get(getOnlyElement(aggregation.getArguments()))));
+                RowExpression inputVariable = getOnlyElement(aggregation.getArguments());
+                RowExpression result = evaluateMinMax(
+                        metadata.getFunctionAndTypeManager().getFunctionMetadata(node.getAggregations().get(outputVariable).getFunctionHandle()),
+                        inputColumnValues.get(inputVariable));
+                assignmentsBuilder.put(outputVariable, result);
+
+                // Partition Stats stored in metastore may be incomplete or missing, if stats collection timeout. So even if the metastore has a stats indicating that the partition is
+                // empty, it may not be empty on disk. We need to disable this rewrite for this case as it could change the behavior.
+                // Thus, to be safe, we only do the rewrite if the result partition has positive row count in its stats.
+                TupleDomain<ColumnHandle> tupleDomain = inputValueToDomain.get(inputVariable).get(result);
+                if (!hasPositiveRowCount(table, tupleDomain)) {
+                    return context.defaultRewrite(node);
+                }
             }
             Assignments assignments = assignmentsBuilder.build();
             ValuesNode valuesNode = new ValuesNode(idAllocator.getNextId(), node.getOutputVariables(), ImmutableList.of(new ArrayList<>(assignments.getExpressions())));
             return new ProjectNode(idAllocator.getNextId(), valuesNode, assignments, LOCAL);
+        }
+
+        /**
+         * Returns true if the metadata indicates that {@code table} has positive row count for the rows matching {@code tupleDomain}.
+         * This function could be expensive as it involves a blocking operation to obtain the table metadata.
+         */
+        private boolean hasPositiveRowCount(TableHandle table, TupleDomain<ColumnHandle> tupleDomain)
+        {
+            TableStatistics tableStatistics = metadata.getTableStatistics(session, table, ImmutableList.of(), new Constraint<>(tupleDomain));
+            return !tableStatistics.getRowCount().isUnknown() && tableStatistics.getRowCount().getValue() > 0;
         }
 
         private RowExpression evaluateMinMax(FunctionMetadata aggregationFunctionMetadata, List<RowExpression> arguments)


### PR DESCRIPTION
Partition Stats stored in metastore may be incomplete or missing, if
stats collection timeout. So even if the metastore has a stats
indicating that the partition is empty, it may not be empty on disk.
This commit disables the metadata query optimization for this case as it
could change the behavior.
To be safe, we only do the rewrite if the stats indicates that the
partition is non-empty. This is the normal case and should cover most
queries in practice.

Test plan
Added query tests.

```
== NO RELEASE NOTE ==
```
