### PR TITLE
Fix query state filter in /v1/query endpoint

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/QueryResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/QueryResource.java
@@ -132,7 +132,7 @@ public class QueryResource
         // Filter list by the query state (if specified).
         if (stateFilter != null) {
             QueryState expectedState = QueryState.valueOf(stateFilter.toUpperCase(Locale.ENGLISH));
-            queries.removeIf(item -> item.getState() == expectedState);
+            queries.removeIf(item -> item.getState() != expectedState);
         }
 
         // If limit is smaller than number of queries, then ensure that the more recent items are at the front.


### PR DESCRIPTION
Test plan
Without the fix

`curl 127.0.0.1:8080/v1/query?state=RUNNING` shows all except `RUNNING` . In this case `FINISHED` queries

```
[
    {
        "memoryPool": "general",
        "query": "select * from orders limit 1",
        "queryId": "20210809_214552_00000_74f6d",
        "queryStats": {
            "blockedReasons": [],
            "completedDrivers": 50,
            "createTime": "2021-08-09T21:45:52.700Z",
            "cumulativeTotalMemory": 6405783937.989668,
            "cumulativeUserMemory": 0.0,
            "elapsedTime": "4.39s",
            "endTime": "2021-08-09T21:45:57.086Z",
            "executionTime": "4.28s",
            "fullyBlocked": true,
            "peakNodeTotalMemorReservation": "2.04MB",
            "peakTaskTotalMemoryReservation": "2.03MB",
            "peakTotalMemoryReservation": "7.60MB",
            "peakUserMemoryReservation": "0B",
            "progressPercentage": 72.46376811594203,
            "queuedDrivers": 3,
            "queuedTime": "5.12ms",
            "rawInputDataSize": "0B",
            "rawInputPositions": 363294,
            "runningDrivers": 16,
            "totalAllocation": "0B",
            "totalCpuTime": "13.49s",
            "totalDrivers": 69,
            "totalMemoryReservation": "2.54MB",
            "totalScheduledTime": "52.36s",
            "userMemoryReservation": "0B",
            "waitingForPrerequisitesTime": "6.75ms"
        },
        "queryType": "SELECT",
        "resourceGroupId": [
            "global"
        ],
        "scheduled": true,
        "self": "http://127.0.0.1:8080/v1/query/20210809_214552_00000_74f6d",
        "session": {
            "catalog": "tpch",
            "catalogProperties": {},
            "clientTags": [],
            "clientTransactionSupport": true,
            "locale": "en_US",
            "preparedStatements": {},
            "queryId": "20210809_214552_00000_74f6d",
            "remoteUserAddress": "127.0.0.1",
            "resourceEstimates": {},
            "roles": {},
            "schema": "sf100",
            "sessionFunctions": {},
            "source": "presto-cli",
            "startTime": 1628545552519,
            "systemProperties": {},
            "timeZoneKey": 1825,
            "transactionId": "06c0f8b8-c06f-4c11-a5b4-9e873a16c106",
            "unprocessedCatalogProperties": {},
            "user": "ajaygeorge",
            "userAgent": "StatementClientV1/0.255-SNAPSHOT-cd14d7f"
        },
        "state": "FINISHED",
        "warnings": []
    }
]
```

with the fix

`curl 127.0.0.1:8080/v1/query?state=RUNNING` shows the `RUNNING` queries
```
[
    {
        "memoryPool": "general",
        "query": "select count(*) from orders",
        "queryId": "20210809_214808_00000_pfffx",
        "queryStats": {
            "blockedReasons": [],
            "completedDrivers": 0,
            "createTime": "2021-08-09T21:48:08.812Z",
            "cumulativeTotalMemory": 0.0,
            "cumulativeUserMemory": 0.0,
            "elapsedTime": "7.87s",
            "executionTime": "7.63s",
            "fullyBlocked": false,
            "peakNodeTotalMemorReservation": "0B",
            "peakTaskTotalMemoryReservation": "0B",
            "peakTotalMemoryReservation": "0B",
            "peakUserMemoryReservation": "0B",
            "progressPercentage": 0.0,
            "queuedDrivers": 48,
            "queuedTime": "16.41ms",
            "rawInputDataSize": "0B",
            "rawInputPositions": 0,
            "runningDrivers": 16,
            "totalAllocation": "0B",
            "totalCpuTime": "18.48s",
            "totalDrivers": 69,
            "totalMemoryReservation": "0B",
            "totalScheduledTime": "1.43m",
            "userMemoryReservation": "0B",
            "waitingForPrerequisitesTime": "17.16ms"
        },
        "queryType": "SELECT",
        "resourceGroupId": [
            "global"
        ],
        "scheduled": true,
        "self": "http://127.0.0.1:8080/v1/query/20210809_214808_00000_pfffx",
        "session": {
            "catalog": "tpch",
            "catalogProperties": {},
            "clientTags": [],
            "clientTransactionSupport": true,
            "locale": "en_US",
            "preparedStatements": {},
            "queryId": "20210809_214808_00000_pfffx",
            "remoteUserAddress": "127.0.0.1",
            "resourceEstimates": {},
            "roles": {},
            "schema": "sf100",
            "sessionFunctions": {},
            "source": "presto-cli",
            "startTime": 1628545688380,
            "systemProperties": {},
            "timeZoneKey": 1825,
            "transactionId": "7f93eb70-aaf9-40d3-8039-6d9dfb62fa5f",
            "unprocessedCatalogProperties": {},
            "user": "ajaygeorge",
            "userAgent": "StatementClientV1/0.255-SNAPSHOT-cd14d7f"
        },
        "state": "RUNNING",
        "warnings": []
    }
]
```

```
== NO RELEASE NOTE ==
```
