### PR TITLE
Add custom headers to JDBC driver

### DIFF
--- a/presto-benchmark-driver/src/main/java/com/facebook/presto/benchmark/driver/BenchmarkDriverOptions.java
+++ b/presto-benchmark-driver/src/main/java/com/facebook/presto/benchmark/driver/BenchmarkDriverOptions.java
@@ -109,6 +109,7 @@ public class BenchmarkDriverOptions
                 null,
                 clientRequestTimeout,
                 disableCompression,
+                ImmutableMap.of(),
                 ImmutableMap.of());
     }
 

--- a/presto-cli/src/main/java/com/facebook/presto/cli/ClientOptions.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/ClientOptions.java
@@ -175,6 +175,7 @@ public class ClientOptions
                 null,
                 clientRequestTimeout,
                 disableCompression,
+                emptyMap(),
                 emptyMap());
     }
 

--- a/presto-cli/src/test/java/com/facebook/presto/cli/AbstractCliTest.java
+++ b/presto-cli/src/test/java/com/facebook/presto/cli/AbstractCliTest.java
@@ -83,6 +83,7 @@ public abstract class AbstractCliTest
                 null,
                 new Duration(2, MINUTES),
                 true,
+                ImmutableMap.of(),
                 ImmutableMap.of());
     }
 

--- a/presto-client/src/main/java/com/facebook/presto/client/ClientSession.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/ClientSession.java
@@ -49,6 +49,7 @@ public class ClientSession
     private final Map<String, String> preparedStatements;
     private final Map<String, SelectedRole> roles;
     private final Map<String, String> extraCredentials;
+    private final Map<String, String> customHeaders;
     private final String transactionId;
     private final Duration clientRequestTimeout;
     private final boolean compressionDisabled;
@@ -85,7 +86,8 @@ public class ClientSession
             String transactionId,
             Duration clientRequestTimeout,
             boolean compressionDisabled,
-            Map<String, String> sessionFunctions)
+            Map<String, String> sessionFunctions,
+            Map<String, String> customHeaders)
     {
         this.server = requireNonNull(server, "server is null");
         this.user = user;
@@ -103,6 +105,7 @@ public class ClientSession
         this.preparedStatements = ImmutableMap.copyOf(requireNonNull(preparedStatements, "preparedStatements is null"));
         this.roles = ImmutableMap.copyOf(requireNonNull(roles, "roles is null"));
         this.extraCredentials = ImmutableMap.copyOf(requireNonNull(extraCredentials, "extraCredentials is null"));
+        this.customHeaders = ImmutableMap.copyOf(requireNonNull(customHeaders, "customHeaders is null"));
         this.clientRequestTimeout = clientRequestTimeout;
         this.compressionDisabled = compressionDisabled;
         this.sessionFunctions = ImmutableMap.copyOf(requireNonNull(sessionFunctions, "sessionFunctions is null"));
@@ -133,6 +136,14 @@ public class ClientSession
             checkArgument(entry.getKey().indexOf('=') < 0, "Credential name must not contain '=': %s", entry.getKey());
             checkArgument(charsetEncoder.canEncode(entry.getKey()), "Credential name is not US_ASCII: %s", entry.getKey());
             checkArgument(charsetEncoder.canEncode(entry.getValue()), "Credential value is not US_ASCII: %s", entry.getValue());
+        }
+
+        // verify the custom headers are valid
+        for (Entry<String, String> entry : customHeaders.entrySet()) {
+            checkArgument(!entry.getKey().isEmpty(), "Custom header name is empty");
+            checkArgument(entry.getKey().indexOf('=') < 0, "Custom header must not contain '=': %s", entry.getKey());
+            checkArgument(charsetEncoder.canEncode(entry.getKey()), "Custom header name is not US_ASCII: %s", entry.getKey());
+            checkArgument(charsetEncoder.canEncode(entry.getValue()), "Custom header value is not US_ASCII: %s", entry.getValue());
         }
     }
 
@@ -214,6 +225,11 @@ public class ClientSession
         return extraCredentials;
     }
 
+    public Map<String, String> getCustomHeaders()
+    {
+        return customHeaders;
+    }
+
     public String getTransactionId()
     {
         return transactionId;
@@ -275,6 +291,7 @@ public class ClientSession
         private Map<String, String> preparedStatements;
         private Map<String, SelectedRole> roles;
         private Map<String, String> credentials;
+        private Map<String, String> customHeaders;
         private String transactionId;
         private Duration clientRequestTimeout;
         private boolean compressionDisabled;
@@ -298,6 +315,7 @@ public class ClientSession
             preparedStatements = clientSession.getPreparedStatements();
             roles = clientSession.getRoles();
             credentials = clientSession.getExtraCredentials();
+            customHeaders = clientSession.getCustomHeaders();
             transactionId = clientSession.getTransactionId();
             clientRequestTimeout = clientSession.getClientRequestTimeout();
             compressionDisabled = clientSession.isCompressionDisabled();
@@ -331,6 +349,12 @@ public class ClientSession
         public Builder withCredentials(Map<String, String> credentials)
         {
             this.credentials = requireNonNull(credentials, "extraCredentials is null");
+            return this;
+        }
+
+        public Builder withCustomHeaders(Map<String, String> customHeaders)
+        {
+            this.customHeaders = requireNonNull(customHeaders, "customHeaders is null");
             return this;
         }
 
@@ -385,7 +409,8 @@ public class ClientSession
                     transactionId,
                     clientRequestTimeout,
                     compressionDisabled,
-                    sessionFunctions);
+                    sessionFunctions,
+                    customHeaders);
         }
     }
 }

--- a/presto-client/src/main/java/com/facebook/presto/client/StatementClientV1.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/StatementClientV1.java
@@ -152,6 +152,11 @@ class StatementClientV1
         Request.Builder builder = prepareRequest(url)
                 .post(RequestBody.create(MEDIA_TYPE_TEXT, query));
 
+        Map<String, String> customHeaders = session.getCustomHeaders();
+        for (Entry<String, String> entry : customHeaders.entrySet()) {
+            builder.addHeader(entry.getKey(), entry.getValue());
+        }
+
         if (session.getSource() != null) {
             builder.addHeader(PRESTO_SOURCE, session.getSource());
         }

--- a/presto-docs/src/main/sphinx/installation/jdbc.rst
+++ b/presto-docs/src/main/sphinx/installation/jdbc.rst
@@ -103,4 +103,8 @@ Name                              Description
 ``extraCredentials``              Extra credentials for connecting to external services. The
                                   extraCredentials is a list of key-value pairs. Example:
                                   ``foo:bar;abc:xyz`` will create credentials ``abc=xyz`` and ``foo=bar``
+``customHeaders``                 Custom headers to inject through JDBC driver. The
+                                  customHeaders is a list of key-value pairs. Example:
+                                  ``testHeaderKey:testHeaderValue`` will inject the header ``testHeaderKey``
+                                  with value ``testHeaderValue``. Values should be percent encoded.
 ================================= =======================================================================

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/ConnectionProperties.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/ConnectionProperties.java
@@ -55,6 +55,7 @@ final class ConnectionProperties
     public static final ConnectionProperty<File> KERBEROS_CREDENTIAL_CACHE_PATH = new KerberosCredentialCachePath();
     public static final ConnectionProperty<String> ACCESS_TOKEN = new AccessToken();
     public static final ConnectionProperty<Map<String, String>> EXTRA_CREDENTIALS = new ExtraCredentials();
+    public static final ConnectionProperty<Map<String, String>> CUSTOM_HEADERS = new CustomHeaders();
     public static final ConnectionProperty<Map<String, String>> SESSION_PROPERTIES = new SessionProperties();
     public static final ConnectionProperty<List<Protocol>> HTTP_PROTOCOLS = new HttpProtocols();
     public static final ConnectionProperty<List<QueryInterceptor>> QUERY_INTERCEPTORS = new QueryInterceptors();
@@ -79,6 +80,7 @@ final class ConnectionProperties
             .add(KERBEROS_CREDENTIAL_CACHE_PATH)
             .add(ACCESS_TOKEN)
             .add(EXTRA_CREDENTIALS)
+            .add(CUSTOM_HEADERS)
             .add(SESSION_PROPERTIES)
             .add(HTTP_PROTOCOLS)
             .add(QUERY_INTERCEPTORS)
@@ -308,6 +310,14 @@ final class ConnectionProperties
         }
     }
 
+    private static class CustomHeaders
+            extends AbstractConnectionProperty<Map<String, String>>
+    {
+        public CustomHeaders()
+        {
+            super("customHeaders", NOT_REQUIRED, ALLOWED, STRING_MAP_CONVERTER);
+        }
+    }
     private static class SessionProperties
             extends AbstractConnectionProperty<Map<String, String>>
     {

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoConnection.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoConnection.java
@@ -88,6 +88,7 @@ public class PrestoConnection
     private final String user;
     private final boolean compressionDisabled;
     private final Map<String, String> extraCredentials;
+    private final Map<String, String> customHeaders;
     private final Map<String, String> sessionProperties;
     private final Properties connectionProperties;
     private final Optional<String> applicationNamePrefix;
@@ -112,6 +113,7 @@ public class PrestoConnection
         this.compressionDisabled = uri.isCompressionDisabled();
 
         this.extraCredentials = uri.getExtraCredentials();
+        this.customHeaders = uri.getCustomHeaders();
         this.sessionProperties = new ConcurrentHashMap<>(uri.getSessionProperties());
         this.connectionProperties = uri.getProperties();
         this.queryExecutor = requireNonNull(queryExecutor, "queryExecutor is null");
@@ -676,6 +678,12 @@ public class PrestoConnection
         return ImmutableMap.copyOf(sessionProperties);
     }
 
+    @VisibleForTesting
+    public Map<String, String> getCustomHeaders()
+    {
+        return ImmutableMap.copyOf(customHeaders);
+    }
+
     ServerInfo getServerInfo()
             throws SQLException
     {
@@ -754,7 +762,8 @@ public class PrestoConnection
                 transactionId.get(),
                 timeout,
                 compressionDisabled,
-                ImmutableMap.of());
+                ImmutableMap.of(),
+                customHeaders);
 
         return queryExecutor.startQuery(session, sql);
     }

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoDriverUri.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoDriverUri.java
@@ -46,6 +46,7 @@ import static com.facebook.presto.client.OkHttpUtil.setupSsl;
 import static com.facebook.presto.client.OkHttpUtil.tokenAuth;
 import static com.facebook.presto.jdbc.ConnectionProperties.ACCESS_TOKEN;
 import static com.facebook.presto.jdbc.ConnectionProperties.APPLICATION_NAME_PREFIX;
+import static com.facebook.presto.jdbc.ConnectionProperties.CUSTOM_HEADERS;
 import static com.facebook.presto.jdbc.ConnectionProperties.DISABLE_COMPRESSION;
 import static com.facebook.presto.jdbc.ConnectionProperties.EXTRA_CREDENTIALS;
 import static com.facebook.presto.jdbc.ConnectionProperties.HTTP_PROTOCOLS;
@@ -152,6 +153,12 @@ final class PrestoDriverUri
             throws SQLException
     {
         return EXTRA_CREDENTIALS.getValue(properties).orElse(ImmutableMap.of());
+    }
+
+    public Map<String, String> getCustomHeaders()
+            throws SQLException
+    {
+        return CUSTOM_HEADERS.getValue(properties).orElse(ImmutableMap.of());
     }
 
     public Map<String, String> getSessionProperties()

--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestJdbcConnection.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestJdbcConnection.java
@@ -32,8 +32,12 @@ import com.google.inject.Module;
 import com.google.inject.Scopes;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
@@ -60,6 +64,12 @@ import static org.testng.Assert.assertTrue;
 public class TestJdbcConnection
 {
     private TestingPrestoServer server;
+
+    @DataProvider(name = "customHeaderWithSpecialCharacter")
+    public static Object[][] customHeaderWithSpecialCharacter()
+    {
+        return new Object[][] {{"test.com:1234"}, {"test@test.com"}};
+    }
 
     @BeforeClass
     public void setupServer()
@@ -245,6 +255,32 @@ public class TestJdbcConnection
         PrestoConnection prestoConnection = connection.unwrap(PrestoConnection.class);
         assertEquals(prestoConnection.getExtraCredentials(), credentials);
         assertEquals(listExtraCredentials(connection), credentials);
+    }
+
+    @Test
+    public void testCustomHeaders()
+            throws SQLException, UnsupportedEncodingException
+    {
+        Map<String, String> customHeadersMap = ImmutableMap.of("testHeaderKey", "testHeaderValue");
+        String customHeaders = "testHeaderKey:testHeaderValue";
+        String encodedCustomHeaders = URLEncoder.encode(customHeaders, StandardCharsets.UTF_8.toString());
+        Connection connection = createConnection("customHeaders=" + encodedCustomHeaders);
+        assertTrue(connection instanceof PrestoConnection);
+        PrestoConnection prestoConnection = connection.unwrap(PrestoConnection.class);
+        assertEquals(prestoConnection.getCustomHeaders(), customHeadersMap);
+    }
+
+    @Test(dataProvider = "customHeaderWithSpecialCharacter")
+    public void testCustomHeadersWithSpecialCharacters(String testHeaderValue)
+            throws SQLException, UnsupportedEncodingException
+    {
+        Map<String, String> customHeadersMap = ImmutableMap.of("testHeaderKey", URLEncoder.encode(testHeaderValue, StandardCharsets.UTF_8.toString()));
+        String customHeaders = "testHeaderKey:" + URLEncoder.encode(testHeaderValue, StandardCharsets.UTF_8.toString()) + "";
+        String encodedCustomHeaders = URLEncoder.encode(customHeaders, StandardCharsets.UTF_8.toString());
+        Connection connection = createConnection("customHeaders=" + encodedCustomHeaders);
+        assertTrue(connection instanceof PrestoConnection);
+        PrestoConnection prestoConnection = connection.unwrap(PrestoConnection.class);
+        assertEquals(prestoConnection.getCustomHeaders(), customHeadersMap);
     }
 
     @Test

--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestPrestoDriverUri.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestPrestoDriverUri.java
@@ -22,6 +22,7 @@ import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.util.Properties;
 
+import static com.facebook.presto.jdbc.ConnectionProperties.CUSTOM_HEADERS;
 import static com.facebook.presto.jdbc.ConnectionProperties.DISABLE_COMPRESSION;
 import static com.facebook.presto.jdbc.ConnectionProperties.EXTRA_CREDENTIALS;
 import static com.facebook.presto.jdbc.ConnectionProperties.HTTP_PROTOCOLS;
@@ -254,6 +255,17 @@ public class TestPrestoDriverUri
         PrestoDriverUri parameters = createDriverUri("presto://localhost:8080?extraCredentials=" + encodedExtraCredentials);
         Properties properties = parameters.getProperties();
         assertEquals(properties.getProperty(EXTRA_CREDENTIALS.getKey()), extraCredentials);
+    }
+
+    @Test
+    public void testUriWithCustomHeaders()
+            throws SQLException, UnsupportedEncodingException
+    {
+        String customHeaders = "testHeaderKey:testHeaderValue";
+        String encodedCustomHeaders = URLEncoder.encode(customHeaders, StandardCharsets.UTF_8.toString());
+        PrestoDriverUri parameters = createDriverUri("presto://localhost:8080?customHeaders=" + encodedCustomHeaders);
+        Properties properties = parameters.getProperties();
+        assertEquals(properties.getProperty(CUSTOM_HEADERS.getKey()), customHeaders);
     }
 
     @Test

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestingPrestoClient.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestingPrestoClient.java
@@ -171,7 +171,8 @@ public abstract class AbstractTestingPrestoClient<T>
                 session.getTransactionId().map(Object::toString).orElse(null),
                 clientRequestTimeout,
                 true,
-                serializedSessionFunctions);
+                serializedSessionFunctions,
+                ImmutableMap.of());
     }
 
     public List<QualifiedObjectName> listTables(Session session, String catalog, String schema)

--- a/presto-tests/src/test/java/com/facebook/presto/execution/TestFinalQueryInfo.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TestFinalQueryInfo.java
@@ -81,6 +81,7 @@ public class TestFinalQueryInfo
                     null,
                     new Duration(2, MINUTES),
                     true,
+                    ImmutableMap.of(),
                     ImmutableMap.of());
 
             // start query


### PR DESCRIPTION
Currently, there is no way to inject custom header to JDBC driver (using REST API). This will enable JDBC driver to take customHeaders field with Key/Value mappings. Keys will be header fields and Values will be value mapping of corresponding header.

Test plan - (Please fill in how you tested your changes)
Added unit test to check (with edge cases)

Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines. Don't forget to follow our [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution) for any code copied from other projects.

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

== NO RELEASE NOTE ==
