### PR TITLE
[WIP] Enable table level cache metrics (won't merge until alluxio 2.6.2 release)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <dep.nexus-staging-plugin.version>1.6.8</dep.nexus-staging-plugin.version>
         <dep.asm.version>9.0</dep.asm.version>
         <dep.gcs.version>1.9.17</dep.gcs.version>
-        <dep.alluxio.version>2.6.1</dep.alluxio.version>
+        <dep.alluxio.version>2.7.0-SNAPSHOT</dep.alluxio.version>
         <dep.kafka.version>2.3.1</dep.kafka.version>
         <dep.druid.version>0.19.0</dep.druid.version>
         <dep.jaxb.version>2.3.1</dep.jaxb.version>

--- a/presto-cache/src/main/java/com/facebook/presto/cache/alluxio/AlluxioCacheConfig.java
+++ b/presto-cache/src/main/java/com/facebook/presto/cache/alluxio/AlluxioCacheConfig.java
@@ -35,6 +35,8 @@ public class AlluxioCacheConfig
     private int timeoutThreads = 64;
     private int evictionRetries = 10;
     private EvictionPolicy evictionPolicy = EvictionPolicy.LRU;
+    private boolean metricsBreakdownEnabled;
+    private boolean shadowMetricsBreakdownEnabled;
 
     public boolean isMetricsCollectionEnabled()
     {
@@ -189,6 +191,32 @@ public class AlluxioCacheConfig
     public AlluxioCacheConfig setCacheQuotaEnabled(boolean cacheQuotaEnabled)
     {
         this.cacheQuotaEnabled = cacheQuotaEnabled;
+        return this;
+    }
+
+    public boolean isMetricsBreakdownEnabled()
+    {
+        return metricsBreakdownEnabled;
+    }
+
+    @Config("cache.alluxio.metrics-breakdown-enabled")
+    @ConfigDescription("Whether to enable the metrics breakdown for local cache")
+    public AlluxioCacheConfig setMetricsBreakdownEnabled(boolean metricsBreakdownEnabled)
+    {
+        this.metricsBreakdownEnabled = metricsBreakdownEnabled;
+        return this;
+    }
+
+    public boolean isShadowMetricsBreakdownEnabled()
+    {
+        return shadowMetricsBreakdownEnabled;
+    }
+
+    @Config("cache.alluxio.shadow-metrics-breakdown-enabled")
+    @ConfigDescription("Whether to enable the metrics breakdown for shadow cache")
+    public AlluxioCacheConfig setShadowMetricsBreakdownEnabled(boolean shadowMetricsBreakdownEnabled)
+    {
+        this.shadowMetricsBreakdownEnabled = shadowMetricsBreakdownEnabled;
         return this;
     }
 }

--- a/presto-cache/src/main/java/com/facebook/presto/cache/alluxio/AlluxioCacheMetrics.java
+++ b/presto-cache/src/main/java/com/facebook/presto/cache/alluxio/AlluxioCacheMetrics.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.cache.alluxio;
+
+import alluxio.client.metrics.LocalCacheMetrics;
+import alluxio.hadoop.HadoopUtils;
+import org.apache.hadoop.conf.Configuration;
+
+public class AlluxioCacheMetrics
+{
+    private AlluxioCacheMetrics()
+    {
+    }
+
+    public static LocalCacheMetrics getCacheMetrics(Configuration configuration)
+    {
+        return LocalCacheMetrics.Factory.get(HadoopUtils.toAlluxioConf(configuration));
+    }
+}

--- a/presto-cache/src/main/java/com/facebook/presto/cache/alluxio/AlluxioCachingConfigurationProvider.java
+++ b/presto-cache/src/main/java/com/facebook/presto/cache/alluxio/AlluxioCachingConfigurationProvider.java
@@ -61,6 +61,8 @@ public class AlluxioCachingConfigurationProvider
             else {
                 configuration.set("alluxio.user.client.cache.timeout.duration", "-1");
             }
+            configuration.set("alluxio.user.client.cache.metrics.breakdown.enabled", String.valueOf(alluxioCacheConfig.isMetricsBreakdownEnabled()));
+            configuration.set("alluxio.user.client.cache.shadow.metrics.breakdown.enabled", String.valueOf(alluxioCacheConfig.isShadowMetricsBreakdownEnabled()));
         }
     }
 }

--- a/presto-cache/src/main/java/com/facebook/presto/cache/alluxio/PrestoCacheContext.java
+++ b/presto-cache/src/main/java/com/facebook/presto/cache/alluxio/PrestoCacheContext.java
@@ -42,6 +42,7 @@ public class PrestoCacheContext
         }
         return context;
     }
+
     private PrestoCacheContext(HiveFileContext hiveFileContext)
     {
         this.hiveFileContext = requireNonNull(hiveFileContext, "hiveFileContext is null");

--- a/presto-cache/src/test/java/com/facebook/presto/cache/alluxio/TestAlluxioCacheConfig.java
+++ b/presto-cache/src/test/java/com/facebook/presto/cache/alluxio/TestAlluxioCacheConfig.java
@@ -44,7 +44,9 @@ public class TestAlluxioCacheConfig
                 .setTimeoutDuration(new Duration(60, SECONDS))
                 .setTimeoutEnabled(true)
                 .setTimeoutThreads(64)
-                .setCacheQuotaEnabled(false));
+                .setCacheQuotaEnabled(false)
+                .setMetricsBreakdownEnabled(false)
+                .setShadowMetricsBreakdownEnabled(false));
     }
 
     @Test
@@ -63,6 +65,8 @@ public class TestAlluxioCacheConfig
                 .put("cache.alluxio.timeout-enabled", "false")
                 .put("cache.alluxio.timeout-threads", "512")
                 .put("cache.alluxio.quota-enabled", "true")
+                .put("cache.alluxio.metrics-breakdown-enabled", "true")
+                .put("cache.alluxio.shadow-metrics-breakdown-enabled", "true")
                 .build();
 
         AlluxioCacheConfig expected = new AlluxioCacheConfig()
@@ -77,7 +81,9 @@ public class TestAlluxioCacheConfig
                 .setTimeoutDuration(new Duration(120, SECONDS))
                 .setTimeoutEnabled(false)
                 .setTimeoutThreads(512)
-                .setCacheQuotaEnabled(true);
+                .setCacheQuotaEnabled(true)
+                .setMetricsBreakdownEnabled(true)
+                .setShadowMetricsBreakdownEnabled(true);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
Hello @kewang1024 
This PR add two cache configs to enable the table level cache metrics breakdown. (implemented in https://github.com/Alluxio/alluxio/pull/13899)

You could put the two configs below to catalogs/hive.properties

```
cache.alluxio.metrics-breakdown-enabled=true
cache.alluxio.shadow-metrics-breakdown-enabled=true
```

The metrics could be retrieved by AlluxioCacheMetrics.getCacheMetrics(Configuration configuration). (this one is a static method)


```
== NO RELEASE NOTE ==
```
