### PR TITLE
Upgrade Iceberg version to 0.11.1

### DIFF
--- a/presto-iceberg/pom.xml
+++ b/presto-iceberg/pom.xml
@@ -12,7 +12,7 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <dep.iceberg.version>0.9.0</dep.iceberg.version>
+        <dep.iceberg.version>0.11.1</dep.iceberg.version>
     </properties>
 
     <dependencies>
@@ -274,7 +274,7 @@
 
         <dependency>
             <groupId>org.apache.iceberg</groupId>
-            <artifactId>iceberg-hive</artifactId>
+            <artifactId>iceberg-hive-metastore</artifactId>
             <version>${dep.iceberg.version}</version>
         </dependency>
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/HiveTableOperations.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/HiveTableOperations.java
@@ -38,7 +38,7 @@ import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableMetadataParser;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.exceptions.CommitFailedException;
-import org.apache.iceberg.hive.HiveTypeConverter;
+import org.apache.iceberg.hive.HiveSchemaUtil;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.LocationProvider;
 import org.apache.iceberg.io.OutputFile;
@@ -394,7 +394,7 @@ public class HiveTableOperations
         return columns.stream()
                 .map(column -> new Column(
                         column.name(),
-                        HiveType.valueOf(HiveTypeConverter.convert(column.type())),
+                        HiveType.toHiveType(HiveSchemaUtil.convert(column.type())),
                         Optional.empty()))
                 .collect(toImmutableList());
     }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionTable.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionTable.java
@@ -165,8 +165,9 @@ public class PartitionTable
 
             for (FileScanTask fileScanTask : fileScanTasks) {
                 DataFile dataFile = fileScanTask.file();
+                Types.StructType structType = fileScanTask.spec().partitionType();
                 StructLike partitionStruct = dataFile.partition();
-                StructLikeWrapper partitionWrapper = StructLikeWrapper.wrap(partitionStruct);
+                StructLikeWrapper partitionWrapper = StructLikeWrapper.forType(structType).set(partitionStruct);
 
                 if (!partitions.containsKey(partitionWrapper)) {
                     Partition partition = new Partition(


### PR DESCRIPTION
Hi, this is Jack from AWS Athena and I am a committer for Apache Iceberg. We would like to contribute our internal Iceberg features to PrestoDB, and as a first step, this PR upgrades Iceberg version to 0.11.1.

0.12.0 is currently in voting stage, I would expect a few more weeks for it to be released and stabilized. There is no change in the interfaces used here from 0.11.1 to 0.12.0, so this should be good enough to unblock our other feature contributions.

```
== RELEASE NOTES ==

Iceberg Changes
* upgrade Iceberg version to 0.11.1

```

@zhenxiao @ChunxuTang @pettyjamesm 
