### PR TITLE
Pass ConnectorTableLayoutHandle to ConnectorRecordSetProvider.

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/split/RecordPageSourceProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/split/RecordPageSourceProvider.java
@@ -17,6 +17,7 @@ import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorPageSource;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ConnectorSplit;
+import com.facebook.presto.spi.ConnectorTableLayoutHandle;
 import com.facebook.presto.spi.RecordPageSource;
 import com.facebook.presto.spi.SplitContext;
 import com.facebook.presto.spi.connector.ConnectorPageSourceProvider;
@@ -46,5 +47,17 @@ public class RecordPageSourceProvider
             SplitContext splitContext)
     {
         return new RecordPageSource(recordSetProvider.getRecordSet(transactionHandle, session, split, columns));
+    }
+
+    @Override
+    public ConnectorPageSource createPageSource(
+            ConnectorTransactionHandle transactionHandle,
+            ConnectorSession session,
+            ConnectorSplit split,
+            ConnectorTableLayoutHandle layout,
+            List<ColumnHandle> columns,
+            SplitContext splitContext)
+    {
+        return new RecordPageSource(recordSetProvider.getRecordSet(transactionHandle, session, split, layout, columns));
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorRecordSetProvider.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorRecordSetProvider.java
@@ -16,11 +16,26 @@ package com.facebook.presto.spi.connector;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ConnectorSplit;
+import com.facebook.presto.spi.ConnectorTableLayoutHandle;
 import com.facebook.presto.spi.RecordSet;
 
 import java.util.List;
 
 public interface ConnectorRecordSetProvider
 {
-    RecordSet getRecordSet(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorSplit split, List<? extends ColumnHandle> columns);
+    RecordSet getRecordSet(
+            ConnectorTransactionHandle transactionHandle,
+            ConnectorSession session,
+            ConnectorSplit split,
+            List<? extends ColumnHandle> columns);
+
+    default RecordSet getRecordSet(
+            ConnectorTransactionHandle transactionHandle,
+            ConnectorSession session,
+            ConnectorSplit split,
+            ConnectorTableLayoutHandle layout,
+            List<? extends ColumnHandle> columns)
+    {
+        return getRecordSet(transactionHandle, session, split, columns);
+    }
 }


### PR DESCRIPTION
Currently, Pushed down information used to be transported from coordinator to workers via splits. For complex filter expressions, serializing these expressions for each split consumed a lot of CPU on the coordinator and made it non-responsive. This change is to remove pushed down information from the split and propagate it via TableHandle#layout which is sent only once for each task as part of the plan fragment (TableScanNode#table).

With this MR, we can get TableHandle#layout  information via ConnectorRecordSetProvider#getRecordSet.
```
== RELEASE NOTES ==

SPI Changes
* Add `ConnectorTableLayoutHandle` parameter to `ConnectorRecordSetProvider#getRecordSet` method. This gives connector access to `ConnectorTableLayoutHandle` during execution.
```
