### PR TITLE
Updating release notes  for 0.259 and 0.259.1

### DIFF
--- a/presto-docs/src/main/sphinx/release.rst
+++ b/presto-docs/src/main/sphinx/release.rst
@@ -5,6 +5,7 @@ Release Notes
 .. toctree::
     :maxdepth: 1
 
+    release/release-0.259.1
     release/release-0.259
     release/release-0.258
     release/release-0.257

--- a/presto-docs/src/main/sphinx/release/release-0.259.1.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.259.1.rst
@@ -1,0 +1,7 @@
+===============
+Release 0.259.1
+===============
+
+JDBC Connector Changes
+______________________
+* Revert partial pushdown of JDBC filters (:pr:16412)

--- a/presto-docs/src/main/sphinx/release/release-0.259.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.259.rst
@@ -2,6 +2,9 @@
 Release 0.259
 =============
 
+.. warning::
+This release includes a regression on jdbc connector.
+
 **Details**
 ===========
 


### PR DESCRIPTION
Since we reverted PR #16408 in #16604, we are removing the PR's release notes.
