### PR TITLE
Add release notes for 0.259

### DIFF
--- a/presto-docs/src/main/sphinx/release.rst
+++ b/presto-docs/src/main/sphinx/release.rst
@@ -6,6 +6,7 @@ Release Notes
     :maxdepth: 1
 
     release/release-0.259
+    release/release-0.259
     release/release-0.258
     release/release-0.257
     release/release-0.256

--- a/presto-docs/src/main/sphinx/release/release-0.259.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.259.rst
@@ -15,10 +15,6 @@ JDBC Driver Changes
 ___________________
 * Add ``getConnectionProperties`` method to ``PrestoConnection`` to retrieve connection properties after a connection is established. (:pr:`16329`)
 
-JDBC Connector Changes
-______________________
-* Add support for partial pushdown of JDBC filters.
-
 Resource Groups Changes
 _______________________
 * Add support for specifying query limits (cpu time, total memory and execution time) at the resource group level. See :doc:`/admin/resource-groups`.

--- a/presto-docs/src/main/sphinx/release/release-0.259.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.259.rst
@@ -2,26 +2,35 @@
 Release 0.259
 =============
 
+**Highlights**
+==============
+
 **Details**
 ===========
 
 General Changes
 _______________
-* Fix ``ClassCastException`` that sometimes occurred for ``EXPLAIN`` queries when the query contained ``LIKE`` predicates.
-* Add Weibull distribution CDF :func:`weibull_cdf` and inverse CDF :func:`inverse_weibull_cdf` functions.
-* Enable verbose error messages for ``EXCEEDED_LOCAL_MEMORY_LIMIT`` by default.  This can be disabled by setting the configuration property ``memory.verbose-exceeded-memory-limit-errors-enabled`` to ``false``.
-
-JDBC Driver Changes
-___________________
-* Add ``getConnectionProperties`` method to ``PrestoConnection`` to retrieve connection properties after a connection is established. (:pr:`16329`)
+* Fixed a casting error that sometimes occurred for EXPLAIN queries when the query plan contains LIKE predicates.
+* Add Weibull distribution CDF and inverse CDF functions to MathFunctions.java.
+* Enable verbose memory exceeded errors by default.
+* Support CREATE TYPE syntax.
 
 Resource Groups Changes
 _______________________
-* Add support for specifying query limits (cpu time, total memory and execution time) at the resource group level. See :doc:`/admin/resource-groups`.
+* Add support to specify query limits (Cpu time, total memory and execution time) at the resource group level. See :doc:`/admin/resource-groups`.
 
 SPI Changes
 ___________
-* Add ``ResourceGroupQueryLimits`` to the SPI and the corresponding getter and setter functions in ``ResourceGroups``.
+* Add `ResourceGroupQueryLimits` to the SPI and the corresponding getter and setter functions in `ResourceGroups`.
+
+JDBC Changes
+____________
+* Add method ``getConnectionProperties`` to PrestoConnection to allow for connection properties retrieval after a connection establishes. (:pr:`16329`).
+* Support partial pushdown of JDBC filters.
+
+Kafka Changes
+_____________
+* Extract pluggable interface for kafka cluster supplier.
 
 **Credits**
 ===========


### PR DESCRIPTION
# Missing Release Notes

# Extracted Release Notes
- #15820 (Author: Jeremy Craig Sawruk): Add weibull_cdf and inverse_weibull_cdf functions
  - Add Weibull distribution CDF and inverse CDF functions to MathFunctions.java.
- #16272 (Author: Yang Yang): Extract pluggable interface for kafka cluster supplier
  - Extract pluggable interface for kafka cluster supplier.
- #16303 (Author: Kyle B Campbell): Introduce query limits at the resource group level
  - Add support to specify query limits (Cpu time, total memory and execution time) at the resource group level. See :doc:`/admin/resource-groups`.
  - Add `ResourceGroupQueryLimits` to the SPI and the corresponding getter and setter functions in `ResourceGroups`.
- #16329 (Author: Ivan Millan): Add PrestoConnection getProperties method to presto-jdbc
  - Add method ``getConnectionProperties`` to PrestoConnection to allow for connection properties retrieval after a connection establishes. (:pr:`16329`).
- #16392 (Author: Pranjal Shankhdhar): Support CREATE TYPE syntax
  - Support CREATE TYPE syntax.
- #16412 (Author: yangping.wyp): Supports pushing down part of the filters when all filters cannot be pushed down
  - Support partial pushdown of JDBC filters.
- #16458 (Author: Andrii Rosa): Enable verbose memory exceeded errors by default
  - Enable verbose memory exceeded errors by default.
- #16550 (Author: Seba Villalobos): Fix unsafe cast in RowExpressionFormatter
  - Fixed a casting error that sometimes occurred for EXPLAIN queries when the query plan contains LIKE predicates.

# All Commits
- 334397c3ad97843607f1d5b50deb790101f26800 Fix unsafe cast in RowExpressionFormatter (Seba Villalobos)
- 1d620696a8bff7a0f6c6965c970f551ec9a82b24 Disabling Flaky Test to unblock release (Swapnil Tailor)
- 254a02e5c889fa05fe75863a14e9028b3c48bc98 Add stats to track the number of replaced non-alive nodes (Nikhil Collooru)
- 587cf7287da736d63aaceb13a4d5b24a04a5416c Add more information to CONTRIBUTING.md (Tim Meehan)
- dc0271b20e2cf7a75cb933e3cf9b0a460e53f2f4 Update CODE_OF_CONDUCT.md (Tim Meehan)
- b27df48aca216bd8761f21a4d2badc28aa48f1de Support DWRF stripes above MAX_INT rows in reader (Arunachalam Thirupathi)
- 09a152fbc61b9fe126c5b17e401dc7e430a99884 Improve HashSemiJoinOperator (James Petty)
- 404a8871b71cdbcc3b4a94db9abc5b97f5332b25 Add Page#getLoadedPage(int... channels) helper methods (James Petty)
- d253bd8b4dc2585b6a69ef31b780aa0e11dd9a68 Implement LazyBlock#mayHaveNull() (James Petty)
- 69ec7605a1e4e373dcfc6b40b0149a673cedb8b4 Hive integration test infra changes to run with version 3.x (Naveen Kumar Mahadevuni)
- 2399c645324f3bc339c0a3c91eec5298069a0546 Fix FileMergeCacheManager unit test failure (Arunachalam Thirupathi)
- 31266f523b74f23c6caebd15677b82972df222ad Support partial pushdown of JDBC filters. (yangping.wyp)
- b52ed288cb4f42268be44d71c0ceee13537961d7 Support multiple search ranges for ZOrder library (Grace Xin)
- 7a9cc115480922c5f9242769142aec32c64f1b5f Support filtering in FunctionNamespaceManager for SHOW FUNCTIONS like (Rongrong Zhong)
- 9a5dd7935a7fce79c6228b3c92d8c5d6fdcfe483 Extract pluggable interface for kafka cluster supplier (Yang Yang)
- 41230af8cf267db9e545b5b965c6567c69ae6748 Disable flaky test testResourceGroupConcurrencyThreshold (Arunachalam Thirupathi)
- 2abb1326c11ced6ecade5c0634ef3b56bf91b51e Optimize getSingleValueBlock in Map and Array (Arunachalam Thirupathi)
- 5296d67e977c3b43dfc03a19c456370759e0aab9 Revert "Revert "Fix Size Calculation in MapBlock"" (Arunachalam Thirupathi)
- 73aa0ee6be06838539a62aa49960cfea74d84bd3 Redo Make HashTable computation Lazy in MapBlockBuilder (Arunachalam Thirupathi)
- 14eb4fc60eb21414259a4efd4e265e30bba5efab Load Hashtables in MAP_AGG (Arunachalam Thirupathi)
- 1708113fa827dfe0907ddc83bed54fb18c3a257f Support negative integers for ZOrdering (Grace Xin)
- 743849abf618b067fbbf67f3ae024a4a2fd674d9 Use segmented Slice in SliceDictionaryWriter (Arunachalam Thirupathi)
- 749c884076f2fe6f9f6efc38bc868dd771f3a6c2 Enable verbose memory exceeded errors by default (Andrii Rosa)
- 0b626091a9d4261f6bbdcbf77278dde1f3696bd1 Use doubles for T-Digest weights (Tim Meehan)
- 2bdff631b1e692df4e1837c78bf0b1419d8eb09d Improved string concat for code size and performance when it's used for concatenating more than 5 strings. (Sreeni Viswanadha)
- 14126619596162e18ec8099f4f911f9e5836880b Support CREATE TYPE syntax (Pranjal Shankhdhar)
- 6f734e11bb985413068181d114907a877fd7163f cleaning up array overlap func to avoid temp arrays (Suryadev Sahadevan Rajesh)
- 2211630c30c7c5eefce80ec017b9cbae54a337cc Enforce ResourceGroup level query limits (Kyle B Campbell)
- d9c7c31ce8921db08c3c15172fa7afe37480a333 Support passing per query limits in resource group configuration (Kyle B Campbell)
- 6c63b364156aeb19e6fff5455b29d9d9a6fc7d45 Add PrestoConnection getProperties method to presto-jdbc (Ivan Millan)
- c771bf6f21639f56fcde401ff9392a42e5fe2d78 Merge encode/decode and search classes (Grace Xin)
- a107ee4b6a8fce544f14c6bf1a4d5c158b0407c7 Refactor search curve code (Grace Xin)
- 5dd94fe7c70c98960c57782ef9f53fad3eb4218d Add Weibull distribution functions (Jeremy Craig Sawruk)
- 43b96f02c41d721f22760364f44f0e2fc78c8ea1 Add query optimization using materialized view (Julian Zhuoran Zhao)
- 84e58cab95fac8f4610a2c8bb8c074d978424eb1 Add configuration for materialized view consistency (Zac Wen)