### PR TITLE
Resolve Iceberg write path using LocationProvider

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
@@ -33,6 +33,7 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.TableScan;
 import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.io.LocationProvider;
 
 import java.util.List;
 import java.util.Locale;
@@ -43,14 +44,17 @@ import java.util.regex.Pattern;
 import static com.facebook.presto.hive.HiveMetadata.TABLE_COMMENT;
 import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_INVALID_SNAPSHOT_ID;
 import static com.facebook.presto.iceberg.TypeConverter.toPrestoType;
+import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.Lists.reverse;
 import static com.google.common.collect.Streams.stream;
 import static java.lang.String.format;
 import static org.apache.iceberg.BaseMetastoreTableOperations.ICEBERG_TABLE_TYPE_VALUE;
 import static org.apache.iceberg.BaseMetastoreTableOperations.TABLE_TYPE_PROP;
+import static org.apache.iceberg.LocationProviders.locationsFor;
 import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT;
 import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT_DEFAULT;
+import static org.apache.iceberg.TableProperties.WRITE_LOCATION_PROVIDER_IMPL;
 
 final class IcebergUtil
 {
@@ -113,14 +117,6 @@ final class IcebergUtil
         return columns.build();
     }
 
-    public static String getDataPath(String location)
-    {
-        if (!location.endsWith("/")) {
-            location += "/";
-        }
-        return location + "data";
-    }
-
     public static FileFormat getFileFormat(Table table)
     {
         return FileFormat.valueOf(table.properties()
@@ -159,5 +155,14 @@ final class IcebergUtil
     {
         return stream(icebergTable.snapshots())
                 .anyMatch(snapshot -> snapshot.snapshotId() == id);
+    }
+
+    public static LocationProvider getLocationProvider(SchemaTableName schemaTableName, String tableLocation, Map<String, String> storageProperties)
+    {
+        if (storageProperties.containsKey(WRITE_LOCATION_PROVIDER_IMPL)) {
+            throw new PrestoException(NOT_SUPPORTED, "Table " + schemaTableName + " specifies " + storageProperties.get(WRITE_LOCATION_PROVIDER_IMPL) +
+                    " as a location provider. Writing to Iceberg tables with custom location provider is not supported.");
+        }
+        return locationsFor(tableLocation, storageProperties);
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergWritableTableHandle.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergWritableTableHandle.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableList;
 import org.apache.iceberg.FileFormat;
 
 import java.util.List;
+import java.util.Map;
 
 import static java.util.Objects.requireNonNull;
 
@@ -34,6 +35,7 @@ public class IcebergWritableTableHandle
     private final List<IcebergColumnHandle> inputColumns;
     private final String outputPath;
     private final FileFormat fileFormat;
+    private final Map<String, String> storageProperties;
 
     @JsonCreator
     public IcebergWritableTableHandle(
@@ -43,7 +45,8 @@ public class IcebergWritableTableHandle
             @JsonProperty("partitionSpecAsJson") String partitionSpecAsJson,
             @JsonProperty("inputColumns") List<IcebergColumnHandle> inputColumns,
             @JsonProperty("outputPath") String outputPath,
-            @JsonProperty("fileFormat") FileFormat fileFormat)
+            @JsonProperty("fileFormat") FileFormat fileFormat,
+            @JsonProperty("storageProperties") Map<String, String> storageProperties)
     {
         this.schemaName = requireNonNull(schemaName, "schemaName is null");
         this.tableName = requireNonNull(tableName, "tableName is null");
@@ -52,6 +55,7 @@ public class IcebergWritableTableHandle
         this.inputColumns = ImmutableList.copyOf(requireNonNull(inputColumns, "inputColumns is null"));
         this.outputPath = requireNonNull(outputPath, "filePrefix is null");
         this.fileFormat = requireNonNull(fileFormat, "fileFormat is null");
+        this.storageProperties = requireNonNull(storageProperties, "storageProperties is null");
     }
 
     @JsonProperty
@@ -94,6 +98,12 @@ public class IcebergWritableTableHandle
     public FileFormat getFileFormat()
     {
         return fileFormat;
+    }
+
+    @JsonProperty
+    public Map<String, String> getStorageProperties()
+    {
+        return storageProperties;
     }
 
     @Override


### PR DESCRIPTION
This PR changes Iceberg connector to write data files to paths defined by Iceberg's LocationProvider. This is especially important for cloud object storage users who leverage Iceberg's ObjectStorageLocationProvider to write data to hashed file paths to avoid throttling. 

Because this change allows Iceberg to write data to a location different from the table's root location, this will cause drop table to not clean up all files. So currently if we see path override Iceberg properties exist, we will block the table drop operation.

I will put a subsequent PR to support creating and dropping such tables natively in Presto.

Test plan: basic unit tests pass. No new test is added because we just need to make sure there is no change of behavior for existing write operations. There is also no way to create tables with path override directly through Presto yet. This is mostly oriented for users who create tables through Spark or Hive and want to read and write through Presto.

```
== RELEASE NOTES ==

Iceberg Changes
* Iceberg data files are now written to paths defined by Iceberg's LocationProvider instead of hard-coded table root directory
```

@zhenxiao @ChunxuTang @beinan @pettyjamesm
