### PR TITLE
Improve Decimal Aggregation Performance

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/DecimalSumAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/DecimalSumAggregation.java
@@ -36,6 +36,8 @@ import io.airlift.slice.Slice;
 import java.lang.invoke.MethodHandle;
 import java.util.List;
 
+import static com.facebook.presto.common.type.Decimals.MAX_PRECISION;
+import static com.facebook.presto.common.type.Decimals.MAX_SHORT_PRECISION;
 import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.common.type.UnscaledDecimal128Arithmetic.throwIfOverflows;
 import static com.facebook.presto.common.type.UnscaledDecimal128Arithmetic.throwOverflowException;
@@ -54,12 +56,16 @@ import static com.google.common.collect.Iterables.getOnlyElement;
 public class DecimalSumAggregation
         extends SqlAggregationFunction
 {
+    // Constant references for short/long decimal types for use in operations that only manipulate unscaled values
+    private static final DecimalType LONG_DECIMAL_TYPE = DecimalType.createDecimalType(MAX_PRECISION, 0);
+    private static final DecimalType SHORT_DECIMAL_TYPE = DecimalType.createDecimalType(MAX_SHORT_PRECISION, 0);
+
     public static final DecimalSumAggregation DECIMAL_SUM_AGGREGATION = new DecimalSumAggregation();
     private static final String NAME = "sum";
-    private static final MethodHandle SHORT_DECIMAL_INPUT_FUNCTION = methodHandle(DecimalSumAggregation.class, "inputShortDecimal", Type.class, LongDecimalWithOverflowState.class, Block.class, int.class);
-    private static final MethodHandle LONG_DECIMAL_INPUT_FUNCTION = methodHandle(DecimalSumAggregation.class, "inputLongDecimal", Type.class, LongDecimalWithOverflowState.class, Block.class, int.class);
+    private static final MethodHandle SHORT_DECIMAL_INPUT_FUNCTION = methodHandle(DecimalSumAggregation.class, "inputShortDecimal", LongDecimalWithOverflowState.class, Block.class, int.class);
+    private static final MethodHandle LONG_DECIMAL_INPUT_FUNCTION = methodHandle(DecimalSumAggregation.class, "inputLongDecimal", LongDecimalWithOverflowState.class, Block.class, int.class);
 
-    private static final MethodHandle LONG_DECIMAL_OUTPUT_FUNCTION = methodHandle(DecimalSumAggregation.class, "outputLongDecimal", DecimalType.class, LongDecimalWithOverflowState.class, BlockBuilder.class);
+    private static final MethodHandle LONG_DECIMAL_OUTPUT_FUNCTION = methodHandle(DecimalSumAggregation.class, "outputLongDecimal", LongDecimalWithOverflowState.class, BlockBuilder.class);
 
     private static final MethodHandle COMBINE_FUNCTION = methodHandle(DecimalSumAggregation.class, "combine", LongDecimalWithOverflowState.class, LongDecimalWithOverflowState.class);
 
@@ -106,9 +112,9 @@ public class DecimalSumAggregation
         AggregationMetadata metadata = new AggregationMetadata(
                 generateAggregationName(NAME, outputType.getTypeSignature(), inputTypes.stream().map(Type::getTypeSignature).collect(toImmutableList())),
                 createInputParameterMetadata(inputType),
-                inputFunction.bindTo(inputType),
+                inputFunction,
                 COMBINE_FUNCTION,
-                LONG_DECIMAL_OUTPUT_FUNCTION.bindTo(outputType),
+                LONG_DECIMAL_OUTPUT_FUNCTION,
                 ImmutableList.of(new AccumulatorStateDescriptor(
                         stateInterface,
                         stateSerializer,
@@ -125,24 +131,24 @@ public class DecimalSumAggregation
         return ImmutableList.of(new ParameterMetadata(STATE), new ParameterMetadata(BLOCK_INPUT_CHANNEL, type), new ParameterMetadata(BLOCK_INDEX));
     }
 
-    public static void inputShortDecimal(Type type, LongDecimalWithOverflowState state, Block block, int position)
+    public static void inputShortDecimal(LongDecimalWithOverflowState state, Block block, int position)
     {
         Slice currentSum = state.getLongDecimal();
         if (currentSum == null) {
             currentSum = unscaledDecimal();
             state.setLongDecimal(currentSum);
         }
-        state.addOverflow(UnscaledDecimal128Arithmetic.addWithOverflow(currentSum, unscaledDecimal(type.getLong(block, position)), currentSum));
+        state.addOverflow(UnscaledDecimal128Arithmetic.addWithOverflow(currentSum, unscaledDecimal(SHORT_DECIMAL_TYPE.getLong(block, position)), currentSum));
     }
 
-    public static void inputLongDecimal(Type type, LongDecimalWithOverflowState state, Block block, int position)
+    public static void inputLongDecimal(LongDecimalWithOverflowState state, Block block, int position)
     {
         Slice currentSum = state.getLongDecimal();
         if (currentSum == null) {
             currentSum = unscaledDecimal();
             state.setLongDecimal(currentSum);
         }
-        state.addOverflow(UnscaledDecimal128Arithmetic.addWithOverflow(currentSum, type.getSlice(block, position), currentSum));
+        state.addOverflow(UnscaledDecimal128Arithmetic.addWithOverflow(currentSum, LONG_DECIMAL_TYPE.getSlice(block, position), currentSum));
     }
 
     public static void combine(LongDecimalWithOverflowState state, LongDecimalWithOverflowState otherState)
@@ -159,7 +165,7 @@ public class DecimalSumAggregation
         state.addOverflow(overflowToAdd);
     }
 
-    public static void outputLongDecimal(DecimalType type, LongDecimalWithOverflowState state, BlockBuilder out)
+    public static void outputLongDecimal(LongDecimalWithOverflowState state, BlockBuilder out)
     {
         Slice decimal = state.getLongDecimal();
         if (decimal == null) {
@@ -170,7 +176,7 @@ public class DecimalSumAggregation
                 throwOverflowException();
             }
             throwIfOverflows(decimal);
-            type.writeSlice(out, decimal);
+            LONG_DECIMAL_TYPE.writeSlice(out, decimal);
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/LongDecimalWithOverflowAndLongState.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/LongDecimalWithOverflowAndLongState.java
@@ -22,4 +22,8 @@ public interface LongDecimalWithOverflowAndLongState
     long getLong();
 
     void setLong(long value);
+
+    void addLong(long value);
+
+    void incrementLong();
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/LongDecimalWithOverflowAndLongStateFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/LongDecimalWithOverflowAndLongStateFactory.java
@@ -75,9 +75,21 @@ public class LongDecimalWithOverflowAndLongStateFactory
         }
 
         @Override
+        public void addLong(long value)
+        {
+            longs.add(getGroupId(), value);
+        }
+
+        @Override
+        public void incrementLong()
+        {
+            longs.increment(getGroupId());
+        }
+
+        @Override
         public long getEstimatedSize()
         {
-            return INSTANCE_SIZE + unscaledDecimals.sizeOf() + overflows.sizeOf() + numberOfElements * SingleLongDecimalWithOverflowAndLongState.SIZE;
+            return INSTANCE_SIZE + unscaledDecimals.sizeOf() + (numberOfElements * SingleLongDecimalWithOverflowAndLongState.SIZE) + (overflows == null ? 0 : overflows.sizeOf());
         }
     }
 
@@ -99,6 +111,18 @@ public class LongDecimalWithOverflowAndLongStateFactory
         public void setLong(long longValue)
         {
             this.longValue = longValue;
+        }
+
+        @Override
+        public void addLong(long value)
+        {
+            this.longValue += value;
+        }
+
+        @Override
+        public void incrementLong()
+        {
+            longValue++;
         }
 
         @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/LongDecimalWithOverflowState.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/LongDecimalWithOverflowState.java
@@ -28,4 +28,6 @@ public interface LongDecimalWithOverflowState
     long getOverflow();
 
     void setOverflow(long overflow);
+
+    void addOverflow(long overflow);
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/LongDecimalWithOverflowStateFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/LongDecimalWithOverflowStateFactory.java
@@ -19,6 +19,8 @@ import com.facebook.presto.spi.function.AccumulatorStateFactory;
 import io.airlift.slice.Slice;
 import org.openjdk.jol.info.ClassLayout;
 
+import javax.annotation.Nullable;
+
 import static com.facebook.presto.common.type.UnscaledDecimal128Arithmetic.UNSCALED_DECIMAL_128_SLICE_LENGTH;
 import static java.util.Objects.requireNonNull;
 
@@ -55,14 +57,17 @@ public class LongDecimalWithOverflowStateFactory
     {
         private static final int INSTANCE_SIZE = ClassLayout.parseClass(GroupedLongDecimalWithOverflowState.class).instanceSize();
         protected final ObjectBigArray<Slice> unscaledDecimals = new ObjectBigArray<>();
-        protected final LongBigArray overflows = new LongBigArray();
+        @Nullable
+        protected LongBigArray overflows;
         protected long numberOfElements;
 
         @Override
         public void ensureCapacity(long size)
         {
             unscaledDecimals.ensureCapacity(size);
-            overflows.ensureCapacity(size);
+            if (overflows != null) {
+                overflows.ensureCapacity(size);
+            }
         }
 
         @Override
@@ -75,28 +80,53 @@ public class LongDecimalWithOverflowStateFactory
         public void setLongDecimal(Slice value)
         {
             requireNonNull(value, "value is null");
-            if (getLongDecimal() == null) {
+            if (unscaledDecimals.getAndSet(getGroupId(), value) == null) {
                 numberOfElements++;
             }
-            unscaledDecimals.set(getGroupId(), value);
         }
 
         @Override
         public long getOverflow()
         {
+            if (overflows == null) {
+                return 0;
+            }
             return overflows.get(getGroupId());
         }
 
         @Override
         public void setOverflow(long overflow)
         {
-            overflows.set(getGroupId(), overflow);
+            // setOverflow(0) must overwrite any existing overflow value
+            if (overflow == 0 && overflows == null) {
+                return;
+            }
+            long groupId = getGroupId();
+            if (overflows == null) {
+                overflows = new LongBigArray();
+                overflows.ensureCapacity(unscaledDecimals.getCapacity());
+            }
+            overflows.set(groupId, overflow);
+        }
+
+        @Override
+        public void addOverflow(long overflow)
+        {
+            if (overflow == 0) {
+                return;
+            }
+            long groupId = getGroupId();
+            if (overflows == null) {
+                overflows = new LongBigArray();
+                overflows.ensureCapacity(unscaledDecimals.getCapacity());
+            }
+            overflows.add(groupId, overflow);
         }
 
         @Override
         public long getEstimatedSize()
         {
-            return INSTANCE_SIZE + unscaledDecimals.sizeOf() + overflows.sizeOf() + numberOfElements * SingleLongDecimalWithOverflowState.SIZE;
+            return INSTANCE_SIZE + unscaledDecimals.sizeOf() + (numberOfElements * SingleLongDecimalWithOverflowState.SIZE) + (overflows == null ? 0 : overflows.sizeOf());
         }
     }
 
@@ -131,6 +161,12 @@ public class LongDecimalWithOverflowStateFactory
         public void setOverflow(long overflow)
         {
             this.overflow = overflow;
+        }
+
+        @Override
+        public void addOverflow(long overflow)
+        {
+            this.overflow += overflow;
         }
 
         @Override

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDecimalAverageAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDecimalAverageAggregation.java
@@ -157,6 +157,11 @@ public class TestDecimalAverageAggregation
         BlockBuilder blockBuilder = TYPE.createFixedSizeBlockBuilder(1);
         TYPE.writeSlice(blockBuilder, unscaledDecimal(value));
 
-        DecimalAverageAggregation.inputLongDecimal(TYPE, state, blockBuilder.build(), 0);
+        if (TYPE.isShort()) {
+            DecimalAverageAggregation.inputShortDecimal(state, blockBuilder.build(), 0);
+        }
+        else {
+            DecimalAverageAggregation.inputLongDecimal(state, blockBuilder.build(), 0);
+        }
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDecimalSumAggregation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestDecimalSumAggregation.java
@@ -127,7 +127,7 @@ public class TestDecimalSumAggregation
         addToState(state, TWO.pow(126));
 
         assertEquals(state.getOverflow(), 1);
-        DecimalSumAggregation.outputLongDecimal(TYPE, state, new VariableWidthBlockBuilder(null, 10, 100));
+        DecimalSumAggregation.outputLongDecimal(state, new VariableWidthBlockBuilder(null, 10, 100));
     }
 
     private static void addToState(LongDecimalWithOverflowState state, BigInteger value)
@@ -135,6 +135,11 @@ public class TestDecimalSumAggregation
         BlockBuilder blockBuilder = TYPE.createFixedSizeBlockBuilder(1);
         TYPE.writeSlice(blockBuilder, unscaledDecimal(value));
 
-        DecimalSumAggregation.inputLongDecimal(TYPE, state, blockBuilder.build(), 0);
+        if (TYPE.isShort()) {
+            DecimalSumAggregation.inputShortDecimal(state, blockBuilder.build(), 0);
+        }
+        else {
+            DecimalSumAggregation.inputLongDecimal(state, blockBuilder.build(), 0);
+        }
     }
 }


### PR DESCRIPTION
Extracted changes from https://github.com/trinodb/trino/pull/8878

This set of changes includes improvements to `DecimalSumAggregation` and `DecimalAverageAggregation`, as well as to their state serializers. Since no benchmarks existed for these aggregation operations before in PrestoDB, I'll have to link to the Trino benchmarking results instead.

The overall changes include:
- Avoid repeated access through pairs of BigArray get() / set() calls
- Using constant `DecimalType` instances instead of binding specific `DecimalType` instances to method handles that only manipulate unscaled decimal values
- Leveraging the fixed size nature of intermediate aggregation states to avoid intermediate serialization / deserialization overhead
- Lazily allocating the big array for overflow tracking in grouped accumulations, since overflows are rare and the per-group overhead can be significant.

```
== RELEASE NOTES ==

General Changes
* Improve performance of sum and average aggregations on decimals
```
