### PR TITLE
Add Parquet Stats to OperatorSummaries

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSource.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.hive.parquet;
 
 import com.facebook.presto.common.Page;
+import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.LazyBlock;
 import com.facebook.presto.common.block.LazyBlockLoader;
@@ -49,16 +50,26 @@ public class ParquetPageSource
     private long completedPositions;
     private boolean closed;
 
+    private final RuntimeStats runtimeStats;
+
     public ParquetPageSource(
             ParquetReader parquetReader,
             List<Type> types,
             List<Optional<Field>> fields,
-            List<String> columnNames)
+            List<String> columnNames,
+            RuntimeStats runtimeStats)
     {
         this.parquetReader = requireNonNull(parquetReader, "parquetReader is null");
         this.types = ImmutableList.copyOf(requireNonNull(types, "types is null"));
         this.fields = ImmutableList.copyOf(requireNonNull(fields, "fields is null"));
         this.columnNames = ImmutableList.copyOf(requireNonNull(columnNames, "columnNames is null"));
+        this.runtimeStats = requireNonNull(runtimeStats, "runtimeStats is null");
+    }
+
+    @Override
+    public RuntimeStats getRuntimeStats()
+    {
+        return runtimeStats;
     }
 
     @Override

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSourceProvider.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSourceProvider.java
@@ -368,7 +368,7 @@ public class IcebergPageSourceProvider
                 }
             }
 
-            return new ParquetPageSource(parquetReader, prestoTypes.build(), internalFields.build(), namesBuilder.build());
+            return new ParquetPageSource(parquetReader, prestoTypes.build(), internalFields.build(), namesBuilder.build(), new RuntimeStats());
         }
         catch (Exception e) {
             try {

--- a/presto-main/src/main/java/com/facebook/presto/operator/ScanFilterAndProjectOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ScanFilterAndProjectOperator.java
@@ -287,6 +287,9 @@ public class ScanFilterAndProjectOperator
                 mergingOutput.addInput(output);
             }
 
+            // stats update
+            recordInputStats();
+
             if (finishing) {
                 mergingOutput.finish();
             }
@@ -364,8 +367,6 @@ public class ScanFilterAndProjectOperator
                 blockSizeSum += block.getSizeInBytes();
             }
         }
-        // stats update
-        recordInputStats();
 
         return (blocks == null) ? page : new Page(page.getPositionCount(), blocks);
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/TableScanOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TableScanOperator.java
@@ -253,10 +253,10 @@ public class TableScanOperator
         if (page != null) {
             // assure the page is in memory before handing to another operator
             page = page.getLoadedPage();
-
-            // update operator stats
-            recordInputStats();
         }
+
+        // update operator stats
+        recordInputStats();
 
         // updating system memory usage should happen after page is loaded.
         systemMemoryContext.setBytes(source.getSystemMemoryUsage());


### PR DESCRIPTION
Test plan - Tested in presto environment.

This PR includes changes to add parquet stats to the operator summary with RuntimeStats. Specifically, it adds stats related to blocks read / skipped from the ParquetPageSourceFactory. Since some of these metrics are associated with blocks that won't be read, changes in TableScanOperator and ScanFilterAndProjectOperator were made to always call recordInputStats() even if page is null.

```
== NO RELEASE NOTE ==
```