### PR TITLE
Force queries that have 'VALUES (...)' as the only inputs to run directly on coordinator

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -135,6 +135,7 @@ public final class SystemSessionProperties
     public static final String PUSH_PARTIAL_AGGREGATION_THROUGH_JOIN = "push_partial_aggregation_through_join";
     public static final String PARSE_DECIMAL_LITERALS_AS_DOUBLE = "parse_decimal_literals_as_double";
     public static final String FORCE_SINGLE_NODE_OUTPUT = "force_single_node_output";
+    public static final String FORCE_COORDINATOR_NODE_EXECUTION_FOR_VALUES_QUERIES = "force_coordinator_node_execution_for_values_queries";
     public static final String FILTER_AND_PROJECT_MIN_OUTPUT_PAGE_SIZE = "filter_and_project_min_output_page_size";
     public static final String FILTER_AND_PROJECT_MIN_OUTPUT_PAGE_ROW_COUNT = "filter_and_project_min_output_page_row_count";
     public static final String DISTRIBUTED_SORT = "distributed_sort";
@@ -692,6 +693,11 @@ public final class SystemSessionProperties
                         "Force single node output",
                         featuresConfig.isForceSingleNodeOutput(),
                         true),
+                booleanProperty(
+                        FORCE_COORDINATOR_NODE_EXECUTION_FOR_VALUES_QUERIES,
+                        "Force queries that have 'VALUES (...)' as the only inputs to run directly on coordinator",
+                        queryManagerConfig.isForceCoordinatorNodeExecutionForValuesQueries(),
+                        false),
                 new PropertyMetadata<>(
                         FILTER_AND_PROJECT_MIN_OUTPUT_PAGE_SIZE,
                         "Experimental: Minimum output page size for filter and project operators",
@@ -1419,6 +1425,11 @@ public final class SystemSessionProperties
     public static boolean isForceSingleNodeOutput(Session session)
     {
         return session.getSystemProperty(FORCE_SINGLE_NODE_OUTPUT, Boolean.class);
+    }
+
+    public static boolean isForceCoordinatorExecution(Session session)
+    {
+        return session.getSystemProperty(FORCE_COORDINATOR_NODE_EXECUTION_FOR_VALUES_QUERIES, Boolean.class);
     }
 
     public static DataSize getFilterAndProjectMinOutputPageSize(Session session)

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryManagerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryManagerConfig.java
@@ -71,6 +71,7 @@ public class QueryManagerConfig
     private Duration queryMaxRunTime = new Duration(100, TimeUnit.DAYS);
     private Duration queryMaxExecutionTime = new Duration(100, TimeUnit.DAYS);
     private Duration queryMaxCpuTime = new Duration(1_000_000_000, TimeUnit.DAYS);
+    private boolean forceCoordinatorNodeExecutionForValuesQueries;
 
     private DataSize queryMaxScanRawInputBytes = DataSize.succinctDataSize(1000, PETABYTE);
     private DataSize queryMaxOutputSize = DataSize.succinctDataSize(1000, PETABYTE);
@@ -575,6 +576,19 @@ public class QueryManagerConfig
     public QueryManagerConfig setGlobalQueryRetryFailureWindow(Duration globalQueryRetryFailureWindow)
     {
         this.globalQueryRetryFailureWindow = globalQueryRetryFailureWindow;
+        return this;
+    }
+
+    public boolean isForceCoordinatorNodeExecutionForValuesQueries()
+    {
+        return forceCoordinatorNodeExecutionForValuesQueries;
+    }
+
+    @Config("force-coordinator-node-execution-for-values-queries")
+    @ConfigDescription("Force queries that have 'VALUES (...)' as the only inputs to run directly on coordinator")
+    public QueryManagerConfig setForceCoordinatorNodeExecutionForValuesQueries(boolean forceCoordinatorNodeExecutionForValuesQueries)
+    {
+        this.forceCoordinatorNodeExecutionForValuesQueries = forceCoordinatorNodeExecutionForValuesQueries;
         return this;
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestQueryManagerConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestQueryManagerConfig.java
@@ -69,7 +69,8 @@ public class TestQueryManagerConfig
                 .setPerQueryRetryLimit(0)
                 .setPerQueryRetryMaxExecutionTime(new Duration(5, MINUTES))
                 .setGlobalQueryRetryFailureLimit(150)
-                .setGlobalQueryRetryFailureWindow(new Duration(5, MINUTES)));
+                .setGlobalQueryRetryFailureWindow(new Duration(5, MINUTES))
+                .setForceCoordinatorNodeExecutionForValuesQueries(false));
     }
 
     @Test
@@ -112,6 +113,7 @@ public class TestQueryManagerConfig
                 .put("per-query-retry-max-execution-time", "1h")
                 .put("global-query-retry-failure-limit", "200")
                 .put("global-query-retry-failure-window", "1h")
+                .put("force-coordinator-node-execution-for-values-queries", "true")
                 .build();
 
         QueryManagerConfig expected = new QueryManagerConfig()
@@ -150,7 +152,8 @@ public class TestQueryManagerConfig
                 .setPerQueryRetryLimit(10)
                 .setPerQueryRetryMaxExecutionTime(new Duration(1, HOURS))
                 .setGlobalQueryRetryFailureLimit(200)
-                .setGlobalQueryRetryFailureWindow(new Duration(1, HOURS));
+                .setGlobalQueryRetryFailureWindow(new Duration(1, HOURS))
+                .setForceCoordinatorNodeExecutionForValuesQueries(true);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestPlanFragmenter.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestPlanFragmenter.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.execution.NodeTaskMap;
+import com.facebook.presto.execution.scheduler.LegacyNetworkTopology;
+import com.facebook.presto.execution.scheduler.NodeScheduler;
+import com.facebook.presto.execution.scheduler.NodeSchedulerConfig;
+import com.facebook.presto.execution.scheduler.nodeSelection.NodeSelectionStats;
+import com.facebook.presto.metadata.CatalogManager;
+import com.facebook.presto.metadata.InMemoryNodeManager;
+import com.facebook.presto.testing.LocalQueryRunner;
+import com.facebook.presto.tpch.TpchConnectorFactory;
+import com.facebook.presto.util.FinalizerService;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static com.facebook.airlift.testing.Assertions.assertNotEquals;
+import static com.facebook.presto.SystemSessionProperties.FORCE_COORDINATOR_NODE_EXECUTION_FOR_VALUES_QUERIES;
+import static com.facebook.presto.spi.WarningCollector.NOOP;
+import static com.facebook.presto.sql.planner.LogicalPlanner.Stage.OPTIMIZED_AND_VALIDATED;
+import static com.facebook.presto.sql.planner.SystemPartitioningHandle.COORDINATOR_DISTRIBUTION;
+import static com.facebook.presto.testing.TestingSession.createBogusTestingCatalog;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static org.testng.Assert.assertEquals;
+
+public class TestPlanFragmenter
+{
+    private FinalizerService finalizerService;
+    private NodeScheduler nodeScheduler;
+    private LocalQueryRunner queryRunner;
+
+    @BeforeClass
+    public void setUp()
+    {
+        CatalogManager catalogManager = new CatalogManager();
+        catalogManager.registerCatalog(createBogusTestingCatalog("tpch"));
+
+        finalizerService = new FinalizerService();
+        finalizerService.start();
+        nodeScheduler = new NodeScheduler(
+                new LegacyNetworkTopology(),
+                new InMemoryNodeManager(),
+                new NodeSelectionStats(),
+                new NodeSchedulerConfig().setIncludeCoordinator(true),
+                new NodeTaskMap(finalizerService));
+        queryRunner = createQueryRunner(ImmutableMap.of());
+    }
+
+    private static LocalQueryRunner createQueryRunner(Map<String, String> sessionProperties)
+    {
+        Session.SessionBuilder sessionBuilder = testSessionBuilder()
+                .setCatalog("local")
+                .setSchema("tiny")
+                .addPreparedStatement("my_query", "SELECT * FROM nation");
+
+        sessionProperties.entrySet().forEach(entry -> sessionBuilder.setSystemProperty(entry.getKey(), entry.getValue()));
+        LocalQueryRunner queryRunner = new LocalQueryRunner(sessionBuilder.build());
+        queryRunner.createCatalog(queryRunner.getDefaultSession().getCatalog().get(), new TpchConnectorFactory(1), ImmutableMap.of());
+        return queryRunner;
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        finalizerService.destroy();
+        nodeScheduler.stop();
+        nodeScheduler = null;
+        queryRunner.close();
+    }
+
+    private Session createSession(Map<String, String> systemProperties)
+    {
+        Session.SessionBuilder sessionBuilder = Session.builder(queryRunner.getDefaultSession());
+        for (Map.Entry<String, String> property : systemProperties.entrySet()) {
+            sessionBuilder.setSystemProperty(property.getKey(), property.getValue());
+        }
+        return sessionBuilder.build();
+    }
+
+    @Test
+    public void testForceCoordinator()
+    {
+        String[] canForceCoordinatorSqls = new String[]{"select 1+2", "show create table nation", "explain (type distributed) select * from nation", "DESCRIBE INPUT my_query", "DESCRIBE OUTPUT my_query", "SHOW STATS FOR (SELECT * FROM nation)", "SHOW catalogs"};
+        for (String sql : canForceCoordinatorSqls) {
+            SubPlan subPlan = queryRunner.inTransaction(createSession(ImmutableMap.of(FORCE_COORDINATOR_NODE_EXECUTION_FOR_VALUES_QUERIES, "true")), transactionSession -> {
+                Plan plan = queryRunner.createPlan(transactionSession, sql, OPTIMIZED_AND_VALIDATED, false, NOOP);
+                return queryRunner.createSubPlans(transactionSession, plan, false);
+            });
+            PartitioningHandle partitioningHandle = subPlan.getFragment().getPartitioning();
+            assertEquals(partitioningHandle.getConnectorHandle(), COORDINATOR_DISTRIBUTION.getConnectorHandle());
+        }
+    }
+
+    @Test
+    public void testCanNotForceCoordinator()
+    {
+        String[] canForceCoordinatorSqls = new String[]{"SHOW TABLES", "select * from nation "};
+        for (String sql : canForceCoordinatorSqls) {
+            SubPlan subPlan = queryRunner.inTransaction(createSession(ImmutableMap.of(FORCE_COORDINATOR_NODE_EXECUTION_FOR_VALUES_QUERIES, "true")), transactionSession -> {
+                Plan plan = queryRunner.createPlan(transactionSession, sql, OPTIMIZED_AND_VALIDATED, false, NOOP);
+                return queryRunner.createSubPlans(transactionSession, plan, false);
+            });
+            PartitioningHandle partitioningHandle = subPlan.getFragment().getPartitioning();
+            assertNotEquals(partitioningHandle.getConnectorHandle(), COORDINATOR_DISTRIBUTION.getConnectorHandle());
+        }
+    }
+
+    @Test
+    public void testDisableCoordinatorExecution()
+    {
+        String[] canForceCoordinatorSqls = new String[]{"select 1", "show create table nation", "explain select * from nation", "DESCRIBE INPUT my_query", "DESCRIBE OUTPUT my_query", "SHOW STATS FOR (SELECT * FROM nation)", "SHOW catalogs"};
+        for (String sql : canForceCoordinatorSqls) {
+            SubPlan subPlan = queryRunner.inTransaction(queryRunner.getDefaultSession(), transactionSession -> {
+                Plan plan = queryRunner.createPlan(transactionSession, sql, OPTIMIZED_AND_VALIDATED, false, NOOP);
+                return queryRunner.createSubPlans(transactionSession, plan, false);
+            });
+            PartitioningHandle partitioningHandle = subPlan.getFragment().getPartitioning();
+            assertNotEquals(partitioningHandle.getConnectorHandle(), COORDINATOR_DISTRIBUTION.getConnectorHandle());
+        }
+    }
+}


### PR DESCRIPTION
```
== RELEASE NOTES ==

General Changes
* config `force-coordinator-node-execution-for-values-queries` or session property `force_coordinator_node_execution_for_values_queries` to control Force queries that have 'VALUES (...)' as the only inputs to run directly on coordinator
```
