### PR TITLE
Streamline Joni regexp functions usage of blocks and slices

### DIFF
--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/SqlJoniRegexpBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/SqlJoniRegexpBenchmark.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark;
+
+import com.facebook.presto.testing.LocalQueryRunner;
+
+import static com.facebook.presto.benchmark.BenchmarkQueryRunner.createLocalQueryRunner;
+
+public class SqlJoniRegexpBenchmark
+        extends AbstractSqlBenchmark
+{
+    public SqlJoniRegexpBenchmark(LocalQueryRunner localQueryRunner, String query, String name)
+    {
+        super(localQueryRunner, name, 4, 5, query);
+    }
+
+    public static void main(String[] args)
+    {
+        new SqlJoniRegexpBenchmark(createLocalQueryRunner(), "SELECT array_agg(regexp_extract_all(comment||cast(random() as varchar), '[a-z]* ')) FROM orders cross join unnest(sequence(1, 10))", "sql_regexp_extract_alll").runBenchmark(new SimpleLineBenchmarkResultWriter(System.out));
+        new SqlJoniRegexpBenchmark(createLocalQueryRunner(), "SELECT array_agg(regexp_replace(comment||cast(random() as varchar), '[a-z]* ', cast(random() as varchar))) FROM orders cross join unnest(sequence(1, 10))", "sql_regexp_replace").runBenchmark(new SimpleLineBenchmarkResultWriter(System.out));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/JoniRegexpFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/JoniRegexpFunctions.java
@@ -16,6 +16,7 @@ package com.facebook.presto.operator.scalar;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockBuilder;
 import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.common.type.VarcharType;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.function.Description;
 import com.facebook.presto.spi.function.LiteralParameters;
@@ -25,7 +26,6 @@ import com.facebook.presto.spi.function.SqlType;
 import com.facebook.presto.type.Constraint;
 import com.facebook.presto.type.JoniRegexpType;
 import io.airlift.joni.Matcher;
-import io.airlift.joni.Option;
 import io.airlift.joni.Regex;
 import io.airlift.joni.Region;
 import io.airlift.joni.exception.ValueException;
@@ -35,15 +35,19 @@ import io.airlift.slice.SliceOutput;
 import io.airlift.slice.Slices;
 
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_USER_ERROR;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static io.airlift.joni.Option.DEFAULT;
+import static io.airlift.joni.Option.DONT_CAPTURE_GROUP;
 import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 
 public final class JoniRegexpFunctions
 {
+    private static final Block EMPTY_BLOCK = VarcharType.VARCHAR.createBlockBuilder(null, 0).build();
     private JoniRegexpFunctions()
     {
     }
@@ -211,34 +215,43 @@ public final class JoniRegexpFunctions
     public static Block regexpExtractAll(@SqlType("varchar(x)") Slice source, @SqlType(JoniRegexpType.NAME) Regex pattern, @SqlType(StandardTypes.BIGINT) long groupIndex)
     {
         Matcher matcher = pattern.matcher(source.getBytes());
-        validateGroup(groupIndex, matcher.getEagerRegion());
-        BlockBuilder blockBuilder = VARCHAR.createBlockBuilder(null, 32);
-        int group = toIntExact(groupIndex);
-
         int nextStart = 0;
-        while (true) {
-            int offset = getMatchingOffset(matcher, nextStart, source.length());
-            if (offset == -1) {
-                break;
-            }
-            if (matcher.getEnd() == matcher.getBegin()) {
-                nextStart = matcher.getEnd() + 1;
+        int offset = getMatchingOffset(matcher, nextStart, source.length(), false);
+        if (offset == -1) {
+            return EMPTY_BLOCK;
+        }
+
+        validateGroup(groupIndex, matcher.getEagerRegion());
+        ArrayList<Integer> matches = new ArrayList<>(10);
+        int group = toIntExact(groupIndex);
+        do {
+            int beg = matcher.getBegin();
+            int end = matcher.getEnd();
+            if (end == beg) {
+                nextStart = beg + 1;
             }
             else {
-                nextStart = matcher.getEnd();
+                nextStart = end;
             }
             Region region = matcher.getEagerRegion();
-            int beg = region.beg[group];
-            int end = region.end[group];
+            matches.add(region.beg[group]);
+            matches.add(region.end[group]);
+            offset = getMatchingOffset(matcher, nextStart, source.length(), false);
+        } while (offset != -1);
+
+        BlockBuilder blockBuilder = VARCHAR.createBlockBuilder(null, matches.size());
+        for (int i = 0; i < matches.size(); i += 2) {
+            int beg = matches.get(i);
+            int end = matches.get(i + 1);
             if (beg == -1 || end == -1) {
                 blockBuilder.appendNull();
             }
             else {
-                Slice slice = source.slice(beg, end - beg);
-                VARCHAR.writeSlice(blockBuilder, slice);
+                VARCHAR.writeSlice(blockBuilder, source, beg, end - beg);
             }
         }
-        return blockBuilder.build();
+
+        return blockBuilder;
     }
 
     @SqlNullable
@@ -259,13 +272,14 @@ public final class JoniRegexpFunctions
     public static Slice regexpExtract(@SqlType("varchar(x)") Slice source, @SqlType(JoniRegexpType.NAME) Regex pattern, @SqlType(StandardTypes.BIGINT) long groupIndex)
     {
         Matcher matcher = pattern.matcher(source.getBytes());
-        validateGroup(groupIndex, matcher.getEagerRegion());
         int group = toIntExact(groupIndex);
 
-        int offset = getMatchingOffset(matcher, 0, source.length());
+        int offset = getMatchingOffset(matcher, 0, source.length(), false);
         if (offset == -1) {
             return null;
         }
+
+        validateGroup(groupIndex, matcher.getEagerRegion());
         Region region = matcher.getEagerRegion();
         int beg = region.beg[group];
         int end = region.end[group];
@@ -274,8 +288,7 @@ public final class JoniRegexpFunctions
             return null;
         }
 
-        Slice slice = source.slice(beg, end - beg);
-        return slice;
+        return source.slice(beg, end - beg);
     }
 
     @ScalarFunction
@@ -289,30 +302,37 @@ public final class JoniRegexpFunctions
 
         int lastEnd = 0;
         int nextStart = 0;
-        while (true) {
-            int offset = getMatchingOffset(matcher, nextStart, source.length());
-            if (offset == -1) {
-                break;
-            }
+        int offset = getMatchingOffset(matcher, nextStart, source.length());
+        if (offset == -1) {
+            VARCHAR.writeSlice(blockBuilder, source);
+            return blockBuilder.build();
+        }
+
+        do {
             if (matcher.getEnd() == matcher.getBegin()) {
                 nextStart = matcher.getEnd() + 1;
             }
             else {
                 nextStart = matcher.getEnd();
             }
-            Slice slice = source.slice(lastEnd, matcher.getBegin() - lastEnd);
+            VARCHAR.writeSlice(blockBuilder, source, lastEnd, matcher.getBegin() - lastEnd);
             lastEnd = matcher.getEnd();
-            VARCHAR.writeSlice(blockBuilder, slice);
-        }
-        VARCHAR.writeSlice(blockBuilder, source.slice(lastEnd, source.length() - lastEnd));
+            offset = getMatchingOffset(matcher, nextStart, source.length());
+        } while (offset != -1);
 
+        VARCHAR.writeSlice(blockBuilder, source.slice(lastEnd, source.length() - lastEnd));
         return blockBuilder.build();
     }
 
     private static int getMatchingOffset(Matcher matcher, int at, int range)
     {
+        return getMatchingOffset(matcher, at, range, true);
+    }
+
+    private static int getMatchingOffset(Matcher matcher, int at, int range, boolean noGroups)
+    {
         try {
-            return matcher.searchInterruptible(at, range, Option.DEFAULT);
+            return matcher.searchInterruptible(at, range, noGroups ? DONT_CAPTURE_GROUP : DEFAULT);
         }
         catch (InterruptedException interruptedException) {
             throw new PrestoException(GENERIC_USER_ERROR, "Regexp matching interrupted");


### PR DESCRIPTION
Recently we have seen some really simple regexp_extract_all timing out. And this streamlined code helps alleviate that as it returns empty fast when there is no match and also builds the final block in a single tight loop.

Similarly regexp_replace was creating many slice objects - one for each replace so we fixed it to use a more efficient API that does not create new slices.

Benchmark results:

New:
```
sql_regexp_extract_alll ::  791.912 cpu ms ::    0B peak memory :: in   15K,      0B,   18.9K/s,      0B/s :: out     1,  10.7MB,       1/s,  13.5MB/s
sql_regexp_replace ::  737.442 cpu ms ::    0B peak memory :: in   15K,      0B,   20.3K/s,      0B/s :: out     1,  21.7MB,       1/s,  29.4MB/s
```

Old:
```
sql_regexp_extract_alll ::  971.138 cpu ms ::    0B peak memory :: in   15K,      0B,   15.4K/s,      0B/s :: out     1,  10.7MB,       1/s,    11MB/s
sql_regexp_replace :: 1180.955 cpu ms ::    0B peak memory :: in   15K,      0B,   12.7K/s,      0B/s :: out     1,  21.7MB,       0/s,  18.4MB/s
```


Test plan - Tests already exist

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.


```
== NO RELEASE NOTE ==
```
