### PR TITLE
Add release notes for 0.260

### DIFF
--- a/presto-docs/src/main/sphinx/release.rst
+++ b/presto-docs/src/main/sphinx/release.rst
@@ -5,6 +5,7 @@ Release Notes
 .. toctree::
     :maxdepth: 1
 
+    release/release-0.260
     release/release-0.259.1
     release/release-0.259
     release/release-0.258

--- a/presto-docs/src/main/sphinx/release/release-0.260.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.260.rst
@@ -1,0 +1,37 @@
+=============
+Release 0.260
+=============
+
+**Details**
+===========
+
+General Changes
+_______________
+* Fix a bug in SQL functions that would cause compiler error when session property ``inline_sql_function`` is set to ``false`` and SQL function references input in lambda expression.
+* Fix a bug in fragment result cache that caused query failures.
+* Add :ref:`uuid_type` type to represent UUIDs.
+* Add configuration property ``experimental.aggregation-spill-enabled`` and session property ``aggregation_spill_enabled`` to control aggregate spills explicitly.
+* Add configuration property ``experimental.order-by-spill-enabled`` and session property ``order_by_spill_enabled`` to control order by spills explicitly.
+* Add configuration property ``experimental.window-spill-enabled`` and session property ``window_spill_enabled`` to control window spills explicitly.
+* Add configuration property ``fragment-result-cache.max-single-pages-size`` to control the max fragement cache file size.
+* Add session property ``query_max_revocable_memory_per_node`` to override existing configuration property ``experimental.max-revocable-memory-per-node``.
+* Add configuration property ``optimizer.aggregation-if-to-filter-rewrite-enabled`` and session property ``aggregation_if_to_filter_rewrite_enabled`` to toggle an optimizer rule which improves the performance of ``IF`` expressions inside aggregation functions.
+* Enable join spilling by default when spill is enabled.  This can be disabled by setting the configuration property ``experimental.join-spill-enabled`` or session property ``join_spill_enabled`` to ``false``.
+
+Hive Connector Changes
+______________________
+* Add support to create files for empty buckets when writing data.
+  This can be configured by ``hive.create-empty-bucket-files`` configuration property or the ``create_empty_bucket_files`` session property.
+
+Iceberg Connector Changes
+_________________________
+* Upgrade Iceberg version to 0.11.1.
+
+Prometheus Connector Changes
+____________________________
+* Added Prometheus Connector. See :doc:`/connector/prometheus`
+
+**Credits**
+===========
+
+Andrii Rosa, Ariel Weisberg, Arjun Gupta, Arunachalam Thirupathi, Basar Hamdi Onat, Beinan Wang, Bin Fan, Bin Fan, George Wang, Jack Ye, James Sun, Julian Zhuoran Zhao, Maria Basmanova, Mayank Garg, Rebecca Schlussel, Rongrong Zhong, Shixuan Fan, Timothy Meehan, Zac Wen, Zhan Yuan, Zhenxiao Luo, gxin@fb.com, linzebing, shenh062326, superqtqt, v-jizhang, vaishnavibatni


### PR DESCRIPTION
# Missing Release Notes
## Bin Fan
- [x] https://github.com/prestodb/presto/pull/16576 Fix CachingFileSystem to include missing override (Merged by: Bin Fan)

## vaishnavibatni
- [x] https://github.com/prestodb/presto/pull/16606 Updating release notes  for 0.259 and 0.259.1 (Merged by: Rongrong Zhong)
- [x] https://github.com/prestodb/presto/pull/16604 Revert "Supports pushing down part of the filters when all filters cannot be pushed down" (Merged by: Maria Basmanova)

# Extracted Release Notes
- #15194 (Author: George Wang): Add support for Prometheus plugin
  - Add support for Prometheus connector plugin.
- #16456 (Author: v-jizhang): Allow multiple or missing Hive bucket files
  - Allow multiple or missing Hive bucket files This can be configured by using Hive Configuration Property ``hive.create-empty-bucket-files``. Changes are also made to use Hive naming convention for bucket file names when computing bucket file name.
- #16534 (Author: Zhan Yuan): Rewrite AGG(IF()) to AGG() FILTER()
  - Introduce a new config ``optimizer.aggregation-if-to-filter-rewrite-enabled`` and its corresponding session property ``aggregation_if_to_filter_rewrite_enabled`` to enable or disable an optimizer rule to improve the query performance of ``IF`` expressions inside aggregation functions.
- #16546 (Author: superqtqt): Fix multithread writing for fragment result cache
  - Fix multithread writing for fragment result cache  #16455.
  - Add config `fragment-result-cache.max-single-pages-size` to control the max fragement cache file size.
- #16560 (Author: Rebecca Schlussel): Set experimental.join-spill-enabled to true by default
  - When spill is enabled, enable join spilling by default.  This can be disabled by setting the configuration property ``experimental.join-spill-enabled`` or session property ``join_spill_enabled`` to ``false``.
- #16564 (Author: Rebecca Schlussel): Improvements to disabling spill for distinct and order by aggregations
  - Add session property ``query_max_revocable_memory_per_node`` to override existing configuration property ``experimental.max-revocable-memory-per-node``.
- #16573 (Author: v-jizhang): Add UUID type and operators
  - Add UUID type and operators.
- #16577 (Author: Rongrong Zhong): Fix lambda desugar for sql functions
  - Fix a bug in desugar lambda expression in sql functions that would cause compiler error when sql function references input in lambda expression when session property ``inline_sql_function`` is set to ``false``.
- #16581 (Author: Arjun Gupta): Add configs to control aggregate/Window/Orderby Spilling
  - Add a new configuration property ``experimental.aggregation-spill-enabled`` to control aggregate spills explicitly. This can be overridden by ``aggregation_spill_enabled`` session property.
  - Add a new configuration property ``experimental.window-spill-enabled`` to control window spills explicitly. This can be overridden by ``window_spill_enabled`` session property.
  - Add a new configuration property ``experimental.order-by-spill-enabled`` to control order by spills explicitly. This can be overridden by ``order_by_spill_enabled`` session property.
- #16603 (Author: Jack Ye): Upgrade Iceberg version to 0.11.1
  - Upgrade Iceberg version to 0.11.1.

# All Commits
- a6f1d0fb9c4c90af8ed5ed3ad971bacba343a62c Add custom headers to JDBC driver (Basar Hamdi Onat)
- ccfb095a036376347fad80c63243a96a572a312a Fix session property removed in verifier (Mayank Garg)
- 247a020e65a8f68edc5c2884a692063a2b673826 Revert "Skip empty bucket creation by default" (Ariel Weisberg)
- 495e4d0eea590df420a06b8af3e2e3186ffc183b Updating release notes of 0.259 (vaishnavibatni)
- ebeb8c61eb658213a9d16f4e05fcf20b6d1a2744 Upgrade Iceberg version to 0.11.1 (Jack Ye)
- d28a1fc8207a56a11cddbef3ff019e47b46c81bc Revert "Support partial pushdown of JDBC filters." (vaishnavibatni)
- fda59c305f6dc8b6a78637a8a82e1cfa62a7c66e Fix multithread writing for fragment result cache (superqtqt)
- 2b4d50ce721fa05cfcb1a95752dca26d763dfdf9 Add configs to control aggregate/Window/Orderby Spilling (Arjun Gupta)
- a1f14ed9e1d3aecc004acd9b5c96eb4fb293cd79 Enhance unit tests by validating query plan (Zac Wen)
- 77d7a0c61ef4a6a82325bb91a4ffae831bc0dc18 Return TIMESTAMP WITH TIME ZONE from Prometheus connector (George Wang)
- 8805ba9326714d5efec85050f0a05248a0482dcd Add support for Prometheus plugin (George Wang)
- 84247f74ca2fd76af5ac7ec14e3182533b2eeb86 Miscellaneous formatting changes (Rebecca Schlussel)
- a7781928bced489b84548d87f061255653857095 Always create hive target directory if not present (Rebecca Schlussel)
- 0138bb4466aee209bd1ddc93a602a22a647936b7 Validate table directory exists in FileHiveMetastore (Rebecca Schlussel)
- f14cbe13441ca9b679ec8639679466595fac6e7e Use absolute uris for QueryRunners using the FileHiveMetastore (Rebecca Schlussel)
- dbc3d7514d48d496117bf64f3567b964e63fc685 Fix OutOfBounds error when strip has above MAX_INT rows (Arunachalam Thirupathi)
- f06f460813139f746d8163c97d672577341aaebc Improve window function documentation (Rebecca Schlussel)
- ce71526d71555083a8eb729af6276cb55d047137 Disable metadata query rewrite for incomplete stats (Zhan Yuan)
- bf8b8a3c433dd5c35fadf451e3d52781e34daeed Add UUID type and operators (v-jizhang)
- 6386e9ba649f562e858a37cf50e7fc18ff32a3f9 Update CachingFileSystem.java (Bin Fan)
- 6cd2b9dac6bada7370b2be97b232b51b6c182c96 Fix CachingFileSystem to include missing override (Zhongting Hu)
- d4d852b65e47a34b807f72859ced09392695d5df Fix Out Of Bound error in selective reader (Arunachalam Thirupathi)
- 3cc496decaf4a9b0c78b2c364728bd494082af93 Fix memory accounting of DictionaryRowGroup (linzebing)
- 69f63c51f04ba411c1a0f583cb630f568390e8c2 Document Hive create empty buckets config (v-jizhang)
- 0e23ca5cc1a6ff5de9d847185d561cbb44f5db0b Skip empty bucket creation by default (v-jizhang)
- bd666e3ff050dc40a4ff09504b9b7d4fb62e8a86 Allow multiple or missing Hive bucket files (v-jizhang)
- ff786601cdef5e6a42303983797c1c716ff0a646 Fix lambda desugar for sql functions (Rongrong Zhong)
- b8e105fe68c35df60e4fe4a1681f28b205aacbbd Disable AGG(IF()) rewrite for nondeterministic functions (Zhan Yuan)
- 72644f6dc5c7eb8ed0572aafff4686829817c650 Disable AGG(IF()) rewrite for AGG applied on NULLs (Zhan Yuan)
- 16b910e14552a2acab2e03475b43c144044ab12f Update documentation for spill (Rebecca Schlussel)
- 1aeef5b560d897d7a3384dea2c2ac8c8306693d0 Fix tests for disabling distinct + order by aggregation spill (Rebecca Schlussel)
- f6b301f885a175441515dd9f9ea338d7fbdfa1ba Remove unnecessary session property from spill test setup (Rebecca Schlussel)
- 066db664ecdb99493c965804eadb25505afc7d50 Add session property of max revocable memory per-node (Rebecca Schlussel)
- 220210ba9d9ee78e09428f0663e3fbc50eecb0ae Improve how spill is disabled for disinct/order by aggregations (Rebecca Schlussel)
- b62c3ce226b60bb3125febace9ea020d64a8ebd9 Restrict functions for Materialized view optimization (Julian Zhuoran Zhao)
- ceee614fd75d1b58120c82bcdf05aa0aa04f1d6e Fix compile error of upgrading alluxio to 2.6.1 (Beinan Wang)
- 4ac8e65767703bf741dd6576903d086c76632bba Support exclusively positive integer columns (gxin@fb.com)
- 029e3fc6dbc9b8ceecc7bd6b881f376ee8f89135 Add queryId to Hive temporary table names (shenh062326)
- 3127c281f5359ef2144fbadc5e52dec98aeed4c8 Set experimental.join-spill-enabled to true by default (Rebecca Schlussel)
- e67f97c7d9ed65e783c410347085e96260d32cc0 Introduce commit API for Spiller (Arjun Gupta)
- 18542b59f0c08c5bb228bd92662285473cdb0a97 Get materialized views from base table metadata (Zac Wen)
- 5cb2b9139566b0321c30a0dd61ed4bfd61e7befb Add a helper to parse SchemaTableName (Zac Wen)
- 39cc9422dcad2dfc41b4e457943ab4a9936aae13 Add session property and config to control AGG IF rewrite (Zhan Yuan)
- 9ab02853813ac98ac0472785659cbb700757f959 Rewrite AGG(IF()) to AGG() FILTER() (Zhan Yuan)
- 28b43b70281541b0db0bfd363626abef92f0552f Allow and/or to take subclasses of RowExpression (Zhan Yuan)
- b1e22922c520747e4ab4fa4a41f67037fdf89cbf Fix aggregation mask matcher (Zhan Yuan)
- f88060853289257d2edecf65744d67efaad5424c Add filter validation for query optimization (Julian Zhuoran Zhao)