### PR TITLE
Expose RuntimeStats for ScanFilterAndProjectOperator

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/ScanFilterAndProjectOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ScanFilterAndProjectOperator.java
@@ -341,6 +341,7 @@ public class ScanFilterAndProjectOperator
         long positionCount = endCompletedPositions - completedPositions;
         operatorContext.recordProcessedInput(inputBytes, positionCount);
         operatorContext.recordRawInputWithTiming(inputBytes, positionCount, endReadTimeNanos - readTimeNanos);
+        operatorContext.updateStats(pageSource.getRuntimeStats());
         completedBytes = endCompletedBytes;
         completedPositions = endCompletedPositions;
         readTimeNanos = endReadTimeNanos;


### PR DESCRIPTION
This is required to expose the ConnectorPageSource RuntimeStats for the
queries using ScanFilterAndProjectOperator. Previous implementation only
exposed the RuntimeStats for TableScanOperator.

Test plan - 
Tested this by starting a presto server locally and ran the following query which previously didn't expose the CacheBytesRequestedExternal and CachePageReadExternalTimeNanos metrics:

select mktsegment, count(*) from customer group by mktsegment order by mktsegment;
Query 20210817_164026_00002_9zwrn, FINISHED, 4 nodes
http://localhost:8080/ui/query.html?20210817_164026_00002_9zwrn
Splits: 61 total, 61 done (100.00%)
CPU Time: 0.5s total, 2.85K rows/s,  177KB/s, 27% active
Per Node: 0.1 parallelism,   142 rows/s, 8.84KB/s
Parallelism: 0.2
Peak User Memory: 0B
Peak Total Memory: 0B
Peak Task Total Memory: 0B
S0-driverCountPerTask: sum=1 count=1 min=1 max=1
S0-taskElapsedTimeNanos: sum=0:01 count=1 min=0:01 max=0:01
S1-driverCountPerTask: sum=20 count=4 min=5 max=5
S1-taskElapsedTimeNanos: sum=0:03 count=4 min=0:01 max=0:01
S2-driverCountPerTask: sum=32 count=4 min=8 max=8
S2-taskElapsedTimeNanos: sum=0:03 count=4 min=0:01 max=0:01
**S3-CacheBytesRequestedExternal: sum=95.3K count=8 min=6.84K max=17.7K
S3-CachePageReadExternalTimeNanos: sum=15ms count=8 min=1ms max=2ms**
S3-driverCountPerTask: sum=8 count=3 min=1 max=5
S3-taskElapsedTimeNanos: sum=0:01 count=3 min=311ms max=326ms
0:03 [1.5K rows, 93.1KB] [569 rows/s, 35.4KB/s]


```
== NO RELEASE NOTE ==
```
