### PR TITLE
Fix infinite loop during planning caused by PickTableLayout

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/block/AbstractMapBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/AbstractMapBlock.java
@@ -21,6 +21,7 @@ import javax.annotation.Nullable;
 
 import java.lang.invoke.MethodHandle;
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.Optional;
 
 import static com.facebook.presto.common.block.BlockUtil.appendNullToIsNullArray;
@@ -467,6 +468,26 @@ public abstract class AbstractMapBlock
                         keyCount * HASH_MULTIPLIER);
             }
             set(hashTables);
+        }
+
+        @Override
+        public boolean equals(Object obj)
+        {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null || getClass() != obj.getClass()) {
+                return false;
+            }
+            HashTables other = (HashTables) obj;
+            return Arrays.equals(this.hashTables, other.hashTables) &&
+                    Objects.equals(this.expectedHashTableCount, other.expectedHashTableCount);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(Arrays.hashCode(hashTables), expectedHashTableCount);
         }
     }
 

--- a/presto-common/src/main/java/com/facebook/presto/common/block/ArrayBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/ArrayBlock.java
@@ -17,6 +17,8 @@ import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
 
+import java.util.Arrays;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 
@@ -222,5 +224,38 @@ public class ArrayBlock
         }
 
         return getSingleValueBlockInternal(position);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        ArrayBlock other = (ArrayBlock) obj;
+        return Objects.equals(this.arrayOffset, other.arrayOffset) &&
+                Objects.equals(this.positionCount, other.positionCount) &&
+                Arrays.equals(this.valueIsNull, other.valueIsNull) &&
+                Objects.equals(this.values, other.values) &&
+                Arrays.equals(this.offsets, other.offsets) &&
+                Objects.equals(this.sizeInBytes, other.sizeInBytes) &&
+                Objects.equals(this.logicalSizeInBytes, other.logicalSizeInBytes) &&
+                Objects.equals(this.retainedSizeInBytes, other.retainedSizeInBytes);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(arrayOffset,
+                positionCount,
+                Arrays.hashCode(valueIsNull),
+                values,
+                Arrays.hashCode(offsets),
+                sizeInBytes,
+                logicalSizeInBytes,
+                retainedSizeInBytes);
     }
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/block/ByteArrayBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/ByteArrayBlock.java
@@ -18,6 +18,8 @@ import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
 
+import java.util.Arrays;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 
@@ -263,5 +265,34 @@ public class ByteArrayBlock
         byte[] newValues = ensureCapacity(values, arrayOffset + positionCount + 1);
 
         return new ByteArrayBlock(arrayOffset, positionCount + 1, newValueIsNull, newValues);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        ByteArrayBlock other = (ByteArrayBlock) obj;
+        return Objects.equals(this.arrayOffset, other.arrayOffset) &&
+                Objects.equals(this.positionCount, other.positionCount) &&
+                Arrays.equals(this.valueIsNull, other.valueIsNull) &&
+                Arrays.equals(this.values, other.values) &&
+                Objects.equals(this.sizeInBytes, other.sizeInBytes) &&
+                Objects.equals(this.retainedSizeInBytes, other.retainedSizeInBytes);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(arrayOffset,
+                positionCount,
+                Arrays.hashCode(valueIsNull),
+                Arrays.hashCode(values),
+                sizeInBytes,
+                retainedSizeInBytes);
     }
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/block/DictionaryBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/DictionaryBlock.java
@@ -21,6 +21,7 @@ import org.openjdk.jol.info.ClassLayout;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.BiConsumer;
 
 import static com.facebook.presto.common.block.BlockUtil.checkArrayRange;
@@ -607,5 +608,40 @@ public class DictionaryBlock
         }
 
         return new DictionaryBlock(idsOffset, positionCount + 1, newDictionary, newIds, isCompact(), getDictionarySourceId());
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        DictionaryBlock other = (DictionaryBlock) obj;
+        return Objects.equals(this.positionCount, other.positionCount) &&
+                Objects.equals(this.dictionary, other.dictionary) &&
+                Objects.equals(this.idsOffset, other.idsOffset) &&
+                Arrays.equals(this.ids, other.ids) &&
+                Objects.equals(this.retainedSizeInBytes, other.retainedSizeInBytes) &&
+                Objects.equals(this.sizeInBytes, other.sizeInBytes) &&
+                Objects.equals(this.logicalSizeInBytes, other.logicalSizeInBytes) &&
+                Objects.equals(this.uniqueIds, other.uniqueIds) &&
+                Objects.equals(this.dictionarySourceId, other.dictionarySourceId);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(positionCount,
+                dictionary,
+                idsOffset,
+                Arrays.hashCode(ids),
+                retainedSizeInBytes,
+                sizeInBytes,
+                logicalSizeInBytes,
+                uniqueIds,
+                dictionarySourceId);
     }
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/block/Int128ArrayBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/Int128ArrayBlock.java
@@ -20,6 +20,8 @@ import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
 
+import java.util.Arrays;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 
@@ -358,5 +360,34 @@ public class Int128ArrayBlock
         boolean[] newValueIsNull = appendNullToIsNullArray(valueIsNull, positionOffset, positionCount);
         long[] newValues = ensureCapacity(values, (positionOffset + positionCount + 1) * 2);
         return new Int128ArrayBlock(positionOffset, positionCount + 1, newValueIsNull, newValues);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        Int128ArrayBlock other = (Int128ArrayBlock) obj;
+        return Objects.equals(this.positionOffset, other.positionOffset) &&
+                Objects.equals(this.positionCount, other.positionCount) &&
+                Arrays.equals(this.valueIsNull, other.valueIsNull) &&
+                Arrays.equals(this.values, other.values) &&
+                Objects.equals(this.sizeInBytes, other.sizeInBytes) &&
+                Objects.equals(this.retainedSizeInBytes, other.retainedSizeInBytes);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(positionOffset,
+                positionCount,
+                Arrays.hashCode(valueIsNull),
+                Arrays.hashCode(values),
+                sizeInBytes,
+                retainedSizeInBytes);
     }
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/block/LongArrayBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/LongArrayBlock.java
@@ -18,6 +18,8 @@ import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
 
+import java.util.Arrays;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 
@@ -301,5 +303,34 @@ public class LongArrayBlock
         long[] newValues = ensureCapacity(values, arrayOffset + positionCount + 1);
 
         return new LongArrayBlock(arrayOffset, positionCount + 1, newValueIsNull, newValues);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        LongArrayBlock other = (LongArrayBlock) obj;
+        return Objects.equals(this.arrayOffset, other.arrayOffset) &&
+                Objects.equals(this.positionCount, other.positionCount) &&
+                Arrays.equals(this.valueIsNull, other.valueIsNull) &&
+                Arrays.equals(this.values, other.values) &&
+                Objects.equals(this.sizeInBytes, other.sizeInBytes) &&
+                Objects.equals(this.retainedSizeInBytes, other.retainedSizeInBytes);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(arrayOffset,
+                positionCount,
+                Arrays.hashCode(valueIsNull),
+                Arrays.hashCode(values),
+                sizeInBytes,
+                retainedSizeInBytes);
     }
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/block/MapBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/MapBlock.java
@@ -19,6 +19,8 @@ import org.openjdk.jol.info.ClassLayout;
 import javax.annotation.Nullable;
 
 import java.lang.invoke.MethodHandle;
+import java.util.Arrays;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 
@@ -299,5 +301,40 @@ public class MapBlock
                 hashTables.loadHashTables(hashTables.getExpectedHashTableCount(), offsets, mapIsNull, getRawKeyBlock(), keyBlockHashCode);
             }
         }
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        MapBlock other = (MapBlock) obj;
+        return Objects.equals(this.startOffset, other.startOffset) &&
+                Objects.equals(this.positionCount, other.positionCount) &&
+                Arrays.equals(this.mapIsNull, other.mapIsNull) &&
+                Arrays.equals(this.offsets, other.offsets) &&
+                Objects.equals(this.keyBlock, other.keyBlock) &&
+                Objects.equals(this.valueBlock, other.valueBlock) &&
+                Objects.equals(this.hashTables, other.hashTables) &&
+                Objects.equals(this.retainedSizeInBytesExceptHashtable, other.retainedSizeInBytesExceptHashtable) &&
+                Objects.equals(this.sizeInBytes, other.sizeInBytes);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(startOffset,
+                positionCount,
+                Arrays.hashCode(mapIsNull),
+                Arrays.hashCode(offsets),
+                keyBlock,
+                valueBlock,
+                hashTables,
+                retainedSizeInBytesExceptHashtable,
+                sizeInBytes);
     }
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/block/RowBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/RowBlock.java
@@ -17,6 +17,8 @@ import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
 
+import java.util.Arrays;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 
@@ -239,5 +241,38 @@ public class RowBlock
                 rowIsNull,
                 fieldBlockOffsets,
                 loadedFieldBlocks);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        RowBlock other = (RowBlock) obj;
+        return Objects.equals(this.startOffset, other.startOffset) &&
+                Objects.equals(this.positionCount, other.positionCount) &&
+                Arrays.equals(this.rowIsNull, other.rowIsNull) &&
+                Arrays.equals(this.fieldBlockOffsets, other.fieldBlockOffsets) &&
+                Arrays.equals(this.fieldBlocks, other.fieldBlocks) &&
+                Objects.equals(this.sizeInBytes, other.sizeInBytes) &&
+                Objects.equals(this.logicalSizeInBytes, other.logicalSizeInBytes) &&
+                Objects.equals(this.retainedSizeInBytes, other.retainedSizeInBytes);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(startOffset,
+                positionCount,
+                Arrays.hashCode(rowIsNull),
+                Arrays.hashCode(fieldBlockOffsets),
+                Arrays.hashCode(fieldBlocks),
+                sizeInBytes,
+                logicalSizeInBytes,
+                retainedSizeInBytes);
     }
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/block/RunLengthEncodedBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/RunLengthEncodedBlock.java
@@ -19,6 +19,7 @@ import io.airlift.slice.Slice;
 import io.airlift.slice.SliceOutput;
 import org.openjdk.jol.info.ClassLayout;
 
+import java.util.Objects;
 import java.util.function.BiConsumer;
 
 import static com.facebook.presto.common.block.BlockUtil.checkArrayRange;
@@ -410,5 +411,25 @@ public class RunLengthEncodedBlock
             ids[positionCount] = 1;
             return new DictionaryBlock(dictionary, ids);
         }
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        RunLengthEncodedBlock other = (RunLengthEncodedBlock) obj;
+        return Objects.equals(this.value, other.value) &&
+                Objects.equals(this.positionCount, other.positionCount);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(value, positionCount);
     }
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/block/ShortArrayBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/ShortArrayBlock.java
@@ -18,6 +18,8 @@ import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
 
+import java.util.Arrays;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 
@@ -262,5 +264,34 @@ public class ShortArrayBlock
         boolean[] newValueIsNull = appendNullToIsNullArray(valueIsNull, arrayOffset, positionCount);
         short[] newValues = ensureCapacity(values, arrayOffset + positionCount + 1);
         return new ShortArrayBlock(arrayOffset, positionCount + 1, newValueIsNull, newValues);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        ShortArrayBlock other = (ShortArrayBlock) obj;
+        return Objects.equals(this.arrayOffset, other.arrayOffset) &&
+                Objects.equals(this.positionCount, other.positionCount) &&
+                Arrays.equals(this.valueIsNull, other.valueIsNull) &&
+                Arrays.equals(this.values, other.values) &&
+                Objects.equals(this.sizeInBytes, other.sizeInBytes) &&
+                Objects.equals(this.retainedSizeInBytes, other.retainedSizeInBytes);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(arrayOffset,
+                positionCount,
+                Arrays.hashCode(valueIsNull),
+                Arrays.hashCode(values),
+                sizeInBytes,
+                retainedSizeInBytes);
     }
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/block/SingleMapBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/SingleMapBlock.java
@@ -22,6 +22,7 @@ import org.openjdk.jol.info.ClassLayout;
 import javax.annotation.Nullable;
 
 import java.lang.invoke.MethodHandle;
+import java.util.Objects;
 import java.util.function.BiConsumer;
 
 import static com.facebook.presto.common.block.AbstractMapBlock.HASH_MULTIPLIER;
@@ -450,5 +451,30 @@ public class SingleMapBlock
         if (equalsResult == null) {
             throw new NotSupportedException("map key cannot be null or contain nulls");
         }
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        SingleMapBlock other = (SingleMapBlock) obj;
+        return Objects.equals(this.positionInMap, other.positionInMap) &&
+                Objects.equals(this.offset, other.offset) &&
+                Objects.equals(this.positionCount, other.positionCount) &&
+                Objects.equals(this.mapBlock, other.mapBlock);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(positionInMap,
+                offset,
+                positionCount,
+                mapBlock);
     }
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/block/SingleRowBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/SingleRowBlock.java
@@ -16,6 +16,7 @@ package com.facebook.presto.common.block;
 
 import org.openjdk.jol.info.ClassLayout;
 
+import java.util.Arrays;
 import java.util.function.BiConsumer;
 
 import static java.lang.String.format;
@@ -119,5 +120,24 @@ public class SingleRowBlock
     public Block appendNull()
     {
         throw new UnsupportedOperationException("SingleRowBlock does not support appendNull()");
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        SingleRowBlock other = (SingleRowBlock) obj;
+        return Arrays.equals(this.fieldBlocks, other.fieldBlocks);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Arrays.hashCode(fieldBlocks);
     }
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/block/VariableWidthBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/VariableWidthBlock.java
@@ -21,6 +21,8 @@ import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
 
+import java.util.Arrays;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 
@@ -294,5 +296,36 @@ public class VariableWidthBlock
         int[] newOffsets = appendNullToOffsetsArray(offsets, arrayOffset, positionCount);
 
         return new VariableWidthBlock(arrayOffset, positionCount + 1, slice, newOffsets, newValueIsNull);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        VariableWidthBlock other = (VariableWidthBlock) obj;
+        return Objects.equals(this.arrayOffset, other.arrayOffset) &&
+                Objects.equals(this.positionCount, other.positionCount) &&
+                Objects.equals(this.slice, other.slice) &&
+                Arrays.equals(this.offsets, other.offsets) &&
+                Arrays.equals(this.valueIsNull, other.valueIsNull) &&
+                Objects.equals(this.retainedSizeInBytes, other.retainedSizeInBytes) &&
+                Objects.equals(this.sizeInBytes, other.sizeInBytes);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(arrayOffset,
+                positionCount,
+                slice,
+                Arrays.hashCode(offsets),
+                Arrays.hashCode(valueIsNull),
+                retainedSizeInBytes,
+                sizeInBytes);
     }
 }


### PR DESCRIPTION
This diff is a fix for an edge case that causes infinite loops in the PickTableLayout$pushPredicateIntoTableScan.
Specifically, if a presto query contains a predicate that compares a complex field (array, map, ...) with a value of the
same type e.g. some_array_field <> array[], pushPredicateIntoTableScan will infinitely loop until it times out or until
a stackoverflowerror. The fact that these are complex fields might not matter, it's just that the value of these
types are generally already blocks.

While the planning timing out makes sense, the stackoverflowerror needs a bit of explaining. In the constructor
of TableScanNode, it wraps the output and assignment collections in unmodifiablecollections. While this is fine
on it's own, it becomes a problem when you have an infinite loop in pushPredicateIntoTableScan. Looking at the
implementation of pushPredicateIntoTableScan, each the it's called, it creates a new TableScanNode by passing in
values for the previous TableScanNodes. This creates N-depth wrapped unmodifiableCollections where N is the number
of pushPredicateIntoTableScan called on the same node. Because of how unmodifiablecollections are implemented,
this then causes N calls to stream(), toArray(), iterator(), ... each time one is called.

Now, that we know the end result is an infinite loop that causes a timeout or a stackoverflow, the remaining
question is why does this happen in the first place. After some investigation, this seems to happen because of
how domains are gathered during the pushPredicateIntoTableScan. Specifically, using a BASIC_COLUMN_EXTRACTOR,
predicates are extracted as domains if they take the from of a simple <VariableReferenceExpression, Anything>.
This also explains why predicates like map_key(<some_map>) = array[] still work since it'll be more complex than
the pattern above so they won't be pulled in as a domain. When creating a domain, the values are then converted to
their native block types. However, since these fields are generally not hive partitions, when a layout is generated,
they'll be considered as unenforcedConstraints. However, due to the processing of predicate -> domain -> predicate,
the resultingPredicates will have the same value but they're actually different objects. Since these Block subclasses don't
override equals, when the PickTableLayout checks if there has been some transformation (the optimization produced
a different plan structure), it'll always think something has changed. However, the only thing that changed was the
object, but the information contained by the blocks are still the same.

The fix here is just to override equals and hashcode of blocks.

tldr; Marker creation in Domain creation constructs new blocks from old blocks. This causes issues when checking for
block equality as blocks don't override equals.

Note: this wasn't tested against the latest version of Presto.