### PR TITLE
[WIP]support insert into hdfs

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveTypeTranslator.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveTypeTranslator.java
@@ -111,7 +111,7 @@ public class HiveTypeTranslator
             throw new PrestoException(NOT_SUPPORTED, format("Unsupported Hive type: %s. Supported CHAR types: CHAR(<=%d).",
                     type, HiveChar.MAX_CHAR_LENGTH));
         }
-        if (VARBINARY.equals(type)) {
+        if (VARBINARY.equals(type) || type.getTypeSignature().getBase().equalsIgnoreCase("unknown")) {
             return HIVE_BINARY.getTypeInfo();
         }
         if (DATE.equals(type)) {

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -199,6 +199,8 @@ public final class SystemSessionProperties
     public static final String VERBOSE_EXCEEDED_MEMORY_LIMIT_ERRORS_ENABLED = "verbose_exceeded_memory_limit_errors_enabled";
     public static final String MATERIALIZED_VIEW_DATA_CONSISTENCY_ENABLED = "materialized_view_data_consistency_enabled";
     public static final String QUERY_OPTIMIZATION_WITH_MATERIALIZED_VIEW_ENABLED = "query_optimization_with_materialized_view_enabled";
+    public static final String INSERT_INTO_HDFS_ENABLED = "insert_into_hdfs_enabled";
+    public static final String INSERT_INTO_HDFS_PATH = "insert_into_hdfs_path";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -1066,6 +1068,16 @@ public final class SystemSessionProperties
                         QUERY_OPTIMIZATION_WITH_MATERIALIZED_VIEW_ENABLED,
                         "Enable query optimization with materialized view",
                         featuresConfig.isQueryOptimizationWithMaterializedViewEnabled(),
+                        true),
+                booleanProperty(
+                        INSERT_INTO_HDFS_ENABLED,
+                        "Enable sink to query result to hdfs",
+                        false,
+                        true),
+                stringProperty(
+                        INSERT_INTO_HDFS_PATH,
+                        "Path of insert into Hdfs",
+                        null,
                         true));
     }
 
@@ -1800,5 +1812,15 @@ public final class SystemSessionProperties
     public static boolean isQueryOptimizationWithMaterializedViewEnabled(Session session)
     {
         return session.getSystemProperty(QUERY_OPTIMIZATION_WITH_MATERIALIZED_VIEW_ENABLED, Boolean.class);
+    }
+
+    public static boolean isInsertIntoHdfsEnabled(Session session)
+    {
+        return session.getSystemProperty(INSERT_INTO_HDFS_ENABLED, Boolean.class);
+    }
+
+    public static String getInsertIntoHdfsPath(Session session)
+    {
+        return session.getSystemProperty(INSERT_INTO_HDFS_PATH, String.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/FileCommitOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/FileCommitOperator.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.common.Page;
+import com.facebook.presto.common.PageBuilder;
+import com.facebook.presto.spi.plan.PlanNodeId;
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slices;
+
+import java.util.Optional;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+public class FileCommitOperator
+        implements Operator
+{
+    public static class FileFinishOperatorFactory
+            implements OperatorFactory
+    {
+        private final int operatorId;
+        private final PlanNodeId planNodeId;
+        private final Session session;
+        private final Optional<String> schema;
+        private boolean closed;
+
+        public FileFinishOperatorFactory(
+                int operatorId,
+                PlanNodeId planNodeId,
+                Optional<String> schema,
+                Session session)
+        {
+            this.operatorId = operatorId;
+            this.planNodeId = requireNonNull(planNodeId, "planNodeId is null");
+            this.schema = requireNonNull(schema, "schema is null");
+            this.session = requireNonNull(session, "session is null");
+        }
+
+        @Override
+        public Operator createOperator(DriverContext driverContext)
+        {
+            checkState(!closed, "Factory is already closed");
+            OperatorContext context = driverContext.addOperatorContext(operatorId, planNodeId, TableFinishOperator.class.getSimpleName());
+            return new FileCommitOperator(context, schema);
+        }
+
+        @Override
+        public void noMoreOperators()
+        {
+            closed = true;
+        }
+
+        @Override
+        public OperatorFactory duplicate()
+        {
+            return new FileFinishOperatorFactory(operatorId, planNodeId, schema, session);
+        }
+    }
+
+    private enum State
+    {
+        RUNNING, FINISHING, FINISHED
+    }
+
+    private final OperatorContext operatorContext;
+    private final Optional<String> schema;
+    private State state = State.RUNNING;
+    private long rowCount;
+
+    public FileCommitOperator(OperatorContext operatorContext, Optional<String> schema)
+    {
+        this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
+        this.schema = requireNonNull(schema, "schema is null");
+    }
+
+    @Override
+    public OperatorContext getOperatorContext()
+    {
+        return operatorContext;
+    }
+
+    @Override
+    public boolean needsInput()
+    {
+        return state == State.RUNNING;
+    }
+
+    @Override
+    public void addInput(Page page)
+    {
+        requireNonNull(page, "page is null");
+        checkState(state == State.RUNNING, "Operator is %s", state);
+        rowCount += BIGINT.getLong(page.getBlock(0), 0);
+    }
+
+    @Override
+    public Page getOutput()
+    {
+        if (state != State.FINISHING) {
+            return null;
+        }
+        state = State.FINISHED;
+        PageBuilder page;
+        if (schema.isPresent()) {
+            page = new PageBuilder(1, ImmutableList.of(BIGINT, VARCHAR));
+            page.declarePosition();
+            BIGINT.writeLong(page.getBlockBuilder(0), rowCount);
+            VARCHAR.writeSlice(page.getBlockBuilder(1), Slices.utf8Slice(schema.get()));
+        }
+        else {
+            page = new PageBuilder(1, ImmutableList.of(BIGINT));
+            page.declarePosition();
+            BIGINT.writeLong(page.getBlockBuilder(0), rowCount);
+        }
+        return page.build();
+    }
+
+    @Override
+    public void finish()
+    {
+        if (state == State.RUNNING) {
+            state = State.FINISHING;
+        }
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return state == State.FINISHED;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/FileWriterOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/FileWriterOperator.java
@@ -1,0 +1,195 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.common.Page;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.spi.ConnectorPageSink;
+import com.facebook.presto.spi.plan.PlanNodeId;
+import com.facebook.presto.split.PageSinkManager;
+import com.google.common.util.concurrent.ListenableFuture;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+
+import static com.facebook.airlift.concurrent.MoreFutures.toListenableFuture;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.PageSinkContext.defaultContext;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.util.concurrent.Futures.allAsList;
+import static java.util.Objects.requireNonNull;
+
+public class FileWriterOperator
+        implements Operator
+{
+    public static class FileWriterOperatorFactory
+            implements OperatorFactory
+    {
+        private final int operatorId;
+        private final PlanNodeId planNodeId;
+        private final PageSinkManager pageSinkManager;
+        private final Session session;
+        private boolean closed;
+        private final String path;
+        private final List<String> columnsNames;
+        private final List<Type> columnTypes;
+        private final Function<Page, Page> pagePreprocessor;
+
+        public FileWriterOperatorFactory(
+                int operatorId,
+                PlanNodeId planNodeId,
+                PageSinkManager pageSinkManager,
+                Session session,
+                String path,
+                List<String> columnNames,
+                List<Type> columnTypes,
+                Function<Page, Page> pagePreprocessor)
+        {
+            this.operatorId = operatorId;
+            this.planNodeId = requireNonNull(planNodeId, "planNodeId is null");
+            this.pageSinkManager = requireNonNull(pageSinkManager, "pageSinkManager is null");
+            this.session = session;
+            this.path = requireNonNull(path, "path is null");
+            this.columnsNames = requireNonNull(columnNames, "columnsNames is null");
+            this.columnTypes = requireNonNull(columnTypes, "columnsTypes is null");
+            this.pagePreprocessor = requireNonNull(pagePreprocessor, "pagePreprocessor is null");
+        }
+
+        @Override
+        public Operator createOperator(DriverContext driverContext)
+        {
+            checkState(!closed, "Factory is already closed");
+            OperatorContext context = driverContext.addOperatorContext(operatorId, planNodeId, TableWriterOperator.class.getSimpleName());
+            return new FileWriterOperator(
+                    context,
+                    createPageSink(),
+                    pagePreprocessor);
+        }
+
+        private ConnectorPageSink createPageSink()
+        {
+            return pageSinkManager.createPageSink(session, path, columnsNames, columnTypes, defaultContext());
+        }
+
+        @Override
+        public void noMoreOperators()
+        {
+            closed = true;
+        }
+
+        @Override
+        public OperatorFactory duplicate()
+        {
+            return new FileWriterOperatorFactory(operatorId, planNodeId, pageSinkManager, session, path, columnsNames, columnTypes, pagePreprocessor);
+        }
+    }
+
+    private enum State
+    {
+        RUNNING, FINISHING, FINISHED
+    }
+
+    private final OperatorContext operatorContext;
+    private final ConnectorPageSink pageSink;
+    private ListenableFuture<?> blocked = NOT_BLOCKED;
+    private State state = State.RUNNING;
+    private long rowCount;
+    private boolean closed;
+    private final Function<Page, Page> pagePreprocessor;
+
+    public FileWriterOperator(
+            OperatorContext operatorContext,
+            ConnectorPageSink pageSink,
+            Function<Page, Page> pagePreprocessor)
+    {
+        this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
+        this.pageSink = requireNonNull(pageSink, "pageSink is null");
+        this.pagePreprocessor = requireNonNull(pagePreprocessor, "pagePreprocessor is null");
+    }
+
+    @Override
+    public OperatorContext getOperatorContext()
+    {
+        return operatorContext;
+    }
+
+    @Override
+    public void finish()
+    {
+        ListenableFuture<?> currentlyBlocked = blocked;
+        ListenableFuture<?> blockedOnFinish = NOT_BLOCKED;
+        if (state == State.RUNNING) {
+            state = State.FINISHING;
+            blockedOnFinish = toListenableFuture(pageSink.finish());
+        }
+        this.blocked = allAsList(currentlyBlocked, blockedOnFinish);
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return state == State.FINISHED && blocked.isDone();
+    }
+
+    @Override
+    public ListenableFuture<?> isBlocked()
+    {
+        return blocked;
+    }
+
+    @Override
+    public boolean needsInput()
+    {
+        if (state != State.RUNNING || !blocked.isDone()) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void addInput(Page page)
+    {
+        requireNonNull(page, "page is null");
+        checkState(needsInput(), "Operator does not need input");
+
+        if (page.getChannelCount() <= 0) {
+            return;
+        }
+        page = pagePreprocessor.apply(page);
+
+        CompletableFuture<?> future = pageSink.appendPage(page);
+        blocked = toListenableFuture(future);
+        rowCount += page.getPositionCount();
+    }
+
+    @Override
+    public Page getOutput()
+    {
+        if (!blocked.isDone()) {
+            return null;
+        }
+
+        if (state != State.FINISHING) {
+            return null;
+        }
+
+        state = State.FINISHED;
+        BlockBuilder rowsBuilder = BIGINT.createBlockBuilder(null, 1);
+        BIGINT.writeLong(rowsBuilder, rowCount);
+        return new Page(1, rowsBuilder.build());
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/split/PageSinkManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/split/PageSinkManager.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.split;
 
 import com.facebook.presto.Session;
+import com.facebook.presto.common.type.Type;
 import com.facebook.presto.metadata.InsertTableHandle;
 import com.facebook.presto.metadata.OutputTableHandle;
 import com.facebook.presto.spi.ConnectorId;
@@ -22,6 +23,7 @@ import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.PageSinkContext;
 import com.facebook.presto.spi.connector.ConnectorPageSinkProvider;
 
+import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -60,6 +62,13 @@ public class PageSinkManager
         // assumes connectorId and catalog are the same
         ConnectorSession connectorSession = session.toConnectorSession(tableHandle.getConnectorId());
         return providerFor(tableHandle.getConnectorId()).createPageSink(tableHandle.getTransactionHandle(), connectorSession, tableHandle.getConnectorHandle(), pageSinkContext);
+    }
+
+    public ConnectorPageSink createPageSink(Session session, String path, List<String> columnNames, List<Type> columnTypes, PageSinkContext pageSinkContext)
+    {
+        ConnectorId connectorId = new ConnectorId("lf_hl_hive");
+        ConnectorSession connectorSession = session.toConnectorSession(connectorId);
+        return providerFor(connectorId).createPageSink(connectorSession, path, columnNames, columnTypes, pageSinkContext);
     }
 
     private ConnectorPageSinkProvider providerFor(ConnectorId connectorId)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/SplitSourceFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/SplitSourceFactory.java
@@ -42,6 +42,8 @@ import com.facebook.presto.sql.planner.plan.EnforceSingleRowNode;
 import com.facebook.presto.sql.planner.plan.ExchangeNode;
 import com.facebook.presto.sql.planner.plan.ExplainAnalyzeNode;
 import com.facebook.presto.sql.planner.plan.GroupIdNode;
+import com.facebook.presto.sql.planner.plan.HdfsFinishNode;
+import com.facebook.presto.sql.planner.plan.HdfsWriterNode;
 import com.facebook.presto.sql.planner.plan.IndexJoinNode;
 import com.facebook.presto.sql.planner.plan.InternalPlanVisitor;
 import com.facebook.presto.sql.planner.plan.JoinNode;
@@ -343,6 +345,12 @@ public class SplitSourceFactory
         }
 
         @Override
+        public Map<PlanNodeId, SplitSource> visitHdfsWriter(HdfsWriterNode node, Context context)
+        {
+            return node.getSource().accept(this, context);
+        }
+
+        @Override
         public Map<PlanNodeId, SplitSource> visitTableWriteMerge(TableWriterMergeNode node, Context context)
         {
             return node.getSource().accept(this, context);
@@ -350,6 +358,12 @@ public class SplitSourceFactory
 
         @Override
         public Map<PlanNodeId, SplitSource> visitTableFinish(TableFinishNode node, Context context)
+        {
+            return node.getSource().accept(this, context);
+        }
+
+        @Override
+        public Map<PlanNodeId, SplitSource> visitHdfsFinish(HdfsFinishNode node, Context context)
         {
             return node.getSource().accept(this, context);
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddLocalExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddLocalExchanges.java
@@ -39,6 +39,8 @@ import com.facebook.presto.sql.planner.plan.ApplyNode;
 import com.facebook.presto.sql.planner.plan.EnforceSingleRowNode;
 import com.facebook.presto.sql.planner.plan.ExchangeNode;
 import com.facebook.presto.sql.planner.plan.ExplainAnalyzeNode;
+import com.facebook.presto.sql.planner.plan.HdfsFinishNode;
+import com.facebook.presto.sql.planner.plan.HdfsWriterNode;
 import com.facebook.presto.sql.planner.plan.IndexJoinNode;
 import com.facebook.presto.sql.planner.plan.InternalPlanVisitor;
 import com.facebook.presto.sql.planner.plan.JoinNode;
@@ -218,6 +220,12 @@ public class AddLocalExchanges
         {
             // table commit requires that all data be in one stream
             // this node changes the input organization completely, so we do not pass through parent preferences
+            return planAndEnforceChildren(node, singleStream(), defaultParallelism(session));
+        }
+
+        @Override
+        public PlanWithProperties visitHdfsFinish(HdfsFinishNode node, StreamPreferredProperties parentPreferences)
+        {
             return planAndEnforceChildren(node, singleStream(), defaultParallelism(session));
         }
 
@@ -479,6 +487,12 @@ public class AddLocalExchanges
             }
 
             return planAndEnforceChildren(node, requiredProperties, requiredProperties);
+        }
+
+        @Override
+        public PlanWithProperties visitHdfsWriter(HdfsWriterNode originalHdfsWriterNode, StreamPreferredProperties parentPreferences)
+        {
+            return planAndEnforceChildren(originalHdfsWriterNode, fixedParallelism(), fixedParallelism());
         }
 
         //

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PushdownSubfields.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PushdownSubfields.java
@@ -48,6 +48,7 @@ import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.planner.plan.ApplyNode;
 import com.facebook.presto.sql.planner.plan.ExplainAnalyzeNode;
 import com.facebook.presto.sql.planner.plan.GroupIdNode;
+import com.facebook.presto.sql.planner.plan.HdfsWriterNode;
 import com.facebook.presto.sql.planner.plan.IndexJoinNode;
 import com.facebook.presto.sql.planner.plan.JoinNode;
 import com.facebook.presto.sql.planner.plan.OutputNode;
@@ -337,6 +338,13 @@ public class PushdownSubfields
 
         @Override
         public PlanNode visitTableWriter(TableWriterNode node, RewriteContext<Context> context)
+        {
+            context.get().variables.addAll(node.getColumns());
+            return context.defaultRewrite(node, context.get());
+        }
+
+        @Override
+        public PlanNode visitHdfsWriter(HdfsWriterNode node, RewriteContext<Context> context)
         {
             context.get().variables.addAll(node.getColumns());
             return context.defaultRewrite(node, context.get());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/StreamPropertyDerivations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/StreamPropertyDerivations.java
@@ -40,6 +40,8 @@ import com.facebook.presto.sql.planner.plan.EnforceSingleRowNode;
 import com.facebook.presto.sql.planner.plan.ExchangeNode;
 import com.facebook.presto.sql.planner.plan.ExplainAnalyzeNode;
 import com.facebook.presto.sql.planner.plan.GroupIdNode;
+import com.facebook.presto.sql.planner.plan.HdfsFinishNode;
+import com.facebook.presto.sql.planner.plan.HdfsWriterNode;
 import com.facebook.presto.sql.planner.plan.IndexJoinNode;
 import com.facebook.presto.sql.planner.plan.IndexSourceNode;
 import com.facebook.presto.sql.planner.plan.InternalPlanVisitor;
@@ -406,6 +408,14 @@ public final class StreamPropertyDerivations
         }
 
         @Override
+        public StreamProperties visitHdfsFinish(HdfsFinishNode node, List<StreamProperties> inputProperties)
+        {
+            StreamProperties properties = Iterables.getOnlyElement(inputProperties);
+            // table finish only outputs the row count
+            return properties.withUnspecifiedPartitioning();
+        }
+
+        @Override
         public StreamProperties visitDelete(DeleteNode node, List<StreamProperties> inputProperties)
         {
             StreamProperties properties = Iterables.getOnlyElement(inputProperties);
@@ -418,6 +428,14 @@ public final class StreamPropertyDerivations
         {
             StreamProperties properties = Iterables.getOnlyElement(inputProperties);
             // table writer only outputs the row count
+            return properties.withUnspecifiedPartitioning();
+        }
+
+        @Override
+        public StreamProperties visitHdfsWriter(HdfsWriterNode node, List<StreamProperties> inputProperties)
+        {
+            StreamProperties properties = Iterables.getOnlyElement(inputProperties);
+            // hdfs writer only outputs the row count
             return properties.withUnspecifiedPartitioning();
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/UnaliasSymbolReferences.java
@@ -51,6 +51,8 @@ import com.facebook.presto.sql.planner.plan.EnforceSingleRowNode;
 import com.facebook.presto.sql.planner.plan.ExchangeNode;
 import com.facebook.presto.sql.planner.plan.ExplainAnalyzeNode;
 import com.facebook.presto.sql.planner.plan.GroupIdNode;
+import com.facebook.presto.sql.planner.plan.HdfsFinishNode;
+import com.facebook.presto.sql.planner.plan.HdfsWriterNode;
 import com.facebook.presto.sql.planner.plan.IndexJoinNode;
 import com.facebook.presto.sql.planner.plan.IndexSourceNode;
 import com.facebook.presto.sql.planner.plan.JoinNode;
@@ -428,6 +430,14 @@ public class UnaliasSymbolReferences
         }
 
         @Override
+        public PlanNode visitHdfsFinish(HdfsFinishNode node, RewriteContext<Void> context)
+        {
+            PlanNode source = context.rewrite(node.getSource());
+            SymbolMapper mapper = new SymbolMapper(mapping, types, warningCollector);
+            return mapper.map(node, source);
+        }
+
+        @Override
         public PlanNode visitRowNumber(RowNumberNode node, RewriteContext<Void> context)
         {
             return new RowNumberNode(node.getId(), context.rewrite(node.getSource()), canonicalizeAndDistinct(node.getPartitionBy()), canonicalize(node.getRowNumberVariable()), node.getMaxRowCountPerPartition(), canonicalize(node.getHashVariable()));
@@ -639,6 +649,14 @@ public class UnaliasSymbolReferences
 
         @Override
         public PlanNode visitTableWriteMerge(TableWriterMergeNode node, RewriteContext<Void> context)
+        {
+            PlanNode source = context.rewrite(node.getSource());
+            SymbolMapper mapper = new SymbolMapper(mapping, types, warningCollector);
+            return mapper.map(node, source);
+        }
+
+        @Override
+        public PlanNode visitHdfsWriter(HdfsWriterNode node, RewriteContext<Void> context)
         {
             PlanNode source = context.rewrite(node.getSource());
             SymbolMapper mapper = new SymbolMapper(mapping, types, warningCollector);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/HdfsFinishNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/HdfsFinishNode.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.plan;
+
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.PlanNodeId;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+
+import javax.annotation.concurrent.Immutable;
+
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+@Immutable
+public class HdfsFinishNode
+        extends InternalPlanNode
+{
+    private final PlanNode source;
+    private final Optional<String> schema;
+    private final Optional<VariableReferenceExpression> schemaVariable;
+    private final VariableReferenceExpression rowCountVariable;
+
+    @JsonCreator
+    public HdfsFinishNode(
+            @JsonProperty("id") PlanNodeId id,
+            @JsonProperty("source") PlanNode source,
+            @JsonProperty("schema") Optional<String> schema,
+            @JsonProperty("schemaVariable") Optional<VariableReferenceExpression> schemaVariable,
+            @JsonProperty("rowCountVariable") VariableReferenceExpression rowCountVariable)
+    {
+        super(id);
+        this.source = requireNonNull(source, "source is null");
+        this.schema = requireNonNull(schema, "schema is null");
+        this.schemaVariable = requireNonNull(schemaVariable, "schemaVariable is null");
+        this.rowCountVariable = requireNonNull(rowCountVariable, "rowCountVariable is null");
+    }
+
+    @JsonProperty
+    public PlanNode getSource()
+    {
+        return source;
+    }
+
+    @JsonProperty
+    public Optional<String> getSchema()
+    {
+        return schema;
+    }
+
+    @JsonProperty
+    public Optional<VariableReferenceExpression> getSchemaVariable()
+    {
+        return schemaVariable;
+    }
+
+    @JsonProperty
+    public VariableReferenceExpression getRowCountVariable()
+    {
+        return rowCountVariable;
+    }
+
+    @Override
+    public List<PlanNode> getSources()
+    {
+        return ImmutableList.of(source);
+    }
+
+    @Override
+    public List<VariableReferenceExpression> getOutputVariables()
+    {
+        return schemaVariable.isPresent() ? ImmutableList.of(rowCountVariable, schemaVariable.get()) : ImmutableList.of(rowCountVariable);
+    }
+
+    @Override
+    public PlanNode replaceChildren(List<PlanNode> newChildren)
+    {
+        return new HdfsFinishNode(
+                getId(),
+                Iterables.getOnlyElement(newChildren),
+                schema,
+                schemaVariable,
+                rowCountVariable);
+    }
+
+    @Override
+    public <R, C> R accept(InternalPlanVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitHdfsFinish(this, context);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/HdfsWriterNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/HdfsWriterNode.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.plan;
+
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.PlanNodeId;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+
+import javax.annotation.concurrent.Immutable;
+
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+@Immutable
+public class HdfsWriterNode
+        extends InternalPlanNode
+{
+    private final PlanNode source;
+    private final String path;
+    private final VariableReferenceExpression rowCountVariable;
+    private final List<VariableReferenceExpression> columns;
+    private final List<String> columnNames;
+
+    @JsonCreator
+    public HdfsWriterNode(
+            @JsonProperty("id") PlanNodeId id,
+            @JsonProperty("source") PlanNode source,
+            @JsonProperty("path") String path,
+            @JsonProperty("columns") List<VariableReferenceExpression> columns,
+            @JsonProperty("columnNames") List<String> columnNames,
+            @JsonProperty("rowCountVariable") VariableReferenceExpression rowCountVariable)
+    {
+        super(id);
+
+        requireNonNull(columns, "columns is null");
+        requireNonNull(columnNames, "columnNames is null");
+        checkArgument(columns.size() == columnNames.size(), "columns and columnNames sizes don't match");
+
+        this.source = requireNonNull(source, "source is null");
+        this.path = requireNonNull(path, "path is null");
+        this.rowCountVariable = requireNonNull(rowCountVariable, "rowCountVariable is null");
+        this.columns = ImmutableList.copyOf(columns);
+        this.columnNames = ImmutableList.copyOf(columnNames);
+    }
+
+    @JsonProperty
+    public PlanNode getSource()
+    {
+        return source;
+    }
+
+    @JsonProperty
+    public String getPath()
+    {
+        return path;
+    }
+
+    @JsonProperty
+    public VariableReferenceExpression getRowCountVariable()
+    {
+        return rowCountVariable;
+    }
+
+    @JsonProperty
+    public List<VariableReferenceExpression> getColumns()
+    {
+        return columns;
+    }
+
+    @JsonProperty
+    public List<String> getColumnNames()
+    {
+        return columnNames;
+    }
+
+    @Override
+    public List<PlanNode> getSources()
+    {
+        return ImmutableList.of(source);
+    }
+
+    @Override
+    public List<VariableReferenceExpression> getOutputVariables()
+    {
+        return ImmutableList.of(rowCountVariable);
+    }
+
+    @Override
+    public <R, C> R accept(InternalPlanVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitHdfsWriter(this, context);
+    }
+
+    @Override
+    public PlanNode replaceChildren(List<PlanNode> newChildren)
+    {
+        return new HdfsWriterNode(
+                getId(),
+                Iterables.getOnlyElement(newChildren),
+                path,
+                columns,
+                columnNames,
+                rowCountVariable);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/InternalPlanVisitor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/InternalPlanVisitor.java
@@ -105,6 +105,16 @@ public abstract class InternalPlanVisitor<R, C>
         return visitPlan(node, context);
     }
 
+    public R visitHdfsWriter(HdfsWriterNode node, C context)
+    {
+        return visitPlan(node, context);
+    }
+
+    public R visitHdfsFinish(HdfsFinishNode node, C context)
+    {
+        return visitPlan(node, context);
+    }
+
     public R visitStatisticsWriterNode(StatisticsWriterNode node, C context)
     {
         return visitPlan(node, context);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/IOPlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/IOPlanPrinter.java
@@ -35,6 +35,7 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.TableScanNode;
+import com.facebook.presto.sql.planner.plan.HdfsFinishNode;
 import com.facebook.presto.sql.planner.plan.InternalPlanVisitor;
 import com.facebook.presto.sql.planner.plan.TableFinishNode;
 import com.facebook.presto.sql.planner.plan.TableWriterNode.WriterTarget;
@@ -489,6 +490,12 @@ public class IOPlanPrinter
                     writerTarget.getConnectorId().getCatalogName(),
                     writerTarget.getSchemaTableName().getSchemaName(),
                     writerTarget.getSchemaTableName().getTableName()));
+            return processChildren(node, context);
+        }
+
+        @Override
+        public Void visitHdfsFinish(HdfsFinishNode node, IOPlanBuilder context)
+        {
             return processChildren(node, context);
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
@@ -68,6 +68,8 @@ import com.facebook.presto.sql.planner.plan.EnforceSingleRowNode;
 import com.facebook.presto.sql.planner.plan.ExchangeNode;
 import com.facebook.presto.sql.planner.plan.ExplainAnalyzeNode;
 import com.facebook.presto.sql.planner.plan.GroupIdNode;
+import com.facebook.presto.sql.planner.plan.HdfsFinishNode;
+import com.facebook.presto.sql.planner.plan.HdfsWriterNode;
 import com.facebook.presto.sql.planner.plan.IndexJoinNode;
 import com.facebook.presto.sql.planner.plan.IndexSourceNode;
 import com.facebook.presto.sql.planner.plan.InternalPlanVisitor;
@@ -1047,6 +1049,18 @@ public class PlanPrinter
         }
 
         @Override
+        public Void visitHdfsWriter(HdfsWriterNode node, Void context)
+        {
+            NodeRepresentation nodeOutput = addNode(node, "HdfsWriter");
+            for (int i = 0; i < node.getColumnNames().size(); i++) {
+                String name = node.getColumnNames().get(i);
+                VariableReferenceExpression variable = node.getColumns().get(i);
+                nodeOutput.appendDetailsLine("%s := %s", name, variable);
+            }
+            return processChildren(node, context);
+        }
+
+        @Override
         public Void visitTableWriteMerge(TableWriterMergeNode node, Void context)
         {
             addNode(node, "TableWriterMerge");
@@ -1064,6 +1078,13 @@ public class PlanPrinter
         public Void visitTableFinish(TableFinishNode node, Void context)
         {
             addNode(node, "TableCommit", format("[%s]", node.getTarget()));
+            return processChildren(node, context);
+        }
+
+        @Override
+        public Void visitHdfsFinish(HdfsFinishNode node, Void context)
+        {
+            addNode(node, "HdfsFinish");
             return processChildren(node, context);
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateDependenciesChecker.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateDependenciesChecker.java
@@ -44,6 +44,8 @@ import com.facebook.presto.sql.planner.plan.EnforceSingleRowNode;
 import com.facebook.presto.sql.planner.plan.ExchangeNode;
 import com.facebook.presto.sql.planner.plan.ExplainAnalyzeNode;
 import com.facebook.presto.sql.planner.plan.GroupIdNode;
+import com.facebook.presto.sql.planner.plan.HdfsFinishNode;
+import com.facebook.presto.sql.planner.plan.HdfsWriterNode;
 import com.facebook.presto.sql.planner.plan.IndexJoinNode;
 import com.facebook.presto.sql.planner.plan.IndexSourceNode;
 import com.facebook.presto.sql.planner.plan.InternalPlanVisitor;
@@ -584,6 +586,15 @@ public final class ValidateDependenciesChecker
         }
 
         @Override
+        public Void visitHdfsWriter(HdfsWriterNode node, Set<VariableReferenceExpression> boundVariables)
+        {
+            PlanNode source = node.getSource();
+            source.accept(this, boundVariables); // visit child
+
+            return null;
+        }
+
+        @Override
         public Void visitTableWriteMerge(TableWriterMergeNode node, Set<VariableReferenceExpression> boundVariables)
         {
             PlanNode source = node.getSource();
@@ -627,6 +638,14 @@ public final class ValidateDependenciesChecker
 
         @Override
         public Void visitTableFinish(TableFinishNode node, Set<VariableReferenceExpression> boundVariables)
+        {
+            node.getSource().accept(this, boundVariables); // visit child
+
+            return null;
+        }
+
+        @Override
+        public Void visitHdfsFinish(HdfsFinishNode node, Set<VariableReferenceExpression> boundVariables)
         {
             node.getSource().accept(this, boundVariables); // visit child
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/VerifyNoOriginalExpression.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/VerifyNoOriginalExpression.java
@@ -26,6 +26,8 @@ import com.facebook.presto.sql.parser.SqlParser;
 import com.facebook.presto.sql.planner.SimplePlanVisitor;
 import com.facebook.presto.sql.planner.TypeProvider;
 import com.facebook.presto.sql.planner.plan.ApplyNode;
+import com.facebook.presto.sql.planner.plan.HdfsFinishNode;
+import com.facebook.presto.sql.planner.plan.HdfsWriterNode;
 import com.facebook.presto.sql.planner.plan.JoinNode;
 import com.facebook.presto.sql.planner.plan.SpatialJoinNode;
 import com.facebook.presto.sql.planner.plan.StatisticAggregations;
@@ -139,6 +141,20 @@ public class VerifyNoOriginalExpression
             visitPlan(node, context);
 
             checkStatisticsAggregation(node.getStatisticsAggregation());
+            return null;
+        }
+
+        @Override
+        public Void visitHdfsWriter(HdfsWriterNode node, Void context)
+        {
+            visitPlan(node, context);
+            return null;
+        }
+
+        @Override
+        public Void visitHdfsFinish(HdfsFinishNode node, Void context)
+        {
+            visitPlan(node, context);
             return null;
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/util/StatementUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/StatementUtils.java
@@ -42,6 +42,7 @@ import com.facebook.presto.sql.tree.Explain;
 import com.facebook.presto.sql.tree.Grant;
 import com.facebook.presto.sql.tree.GrantRoles;
 import com.facebook.presto.sql.tree.Insert;
+import com.facebook.presto.sql.tree.InsertDirectory;
 import com.facebook.presto.sql.tree.Prepare;
 import com.facebook.presto.sql.tree.Query;
 import com.facebook.presto.sql.tree.RefreshMaterializedView;
@@ -90,6 +91,7 @@ public final class StatementUtils
         builder.put(CreateTableAsSelect.class, QueryType.INSERT);
         builder.put(Insert.class, QueryType.INSERT);
         builder.put(RefreshMaterializedView.class, QueryType.INSERT);
+        builder.put(InsertDirectory.class, QueryType.INSERT);
 
         builder.put(Delete.class, QueryType.DELETE);
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestFileWriterOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestFileWriterOperator.java
@@ -1,0 +1,216 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.common.Page;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.spi.ConnectorId;
+import com.facebook.presto.spi.ConnectorInsertTableHandle;
+import com.facebook.presto.spi.ConnectorOutputTableHandle;
+import com.facebook.presto.spi.ConnectorPageSink;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.PageSinkContext;
+import com.facebook.presto.spi.connector.ConnectorPageSinkProvider;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.facebook.presto.spi.plan.PlanNodeId;
+import com.facebook.presto.split.PageSinkManager;
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Function;
+
+import static com.facebook.airlift.concurrent.Threads.daemonThreadsNamed;
+import static com.facebook.presto.RowPagesBuilder.rowPagesBuilder;
+import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.operator.PageAssertions.assertPageEquals;
+import static com.facebook.presto.testing.TestingTaskContext.createTaskContext;
+import static java.util.concurrent.Executors.newCachedThreadPool;
+import static java.util.concurrent.Executors.newScheduledThreadPool;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+public class TestFileWriterOperator
+{
+    private static final ConnectorId CONNECTOR_ID = new ConnectorId("lf_hl_hive");
+    private ExecutorService executor;
+    private ScheduledExecutorService scheduledExecutor;
+
+    @BeforeMethod
+    public void setUp()
+    {
+        executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%s"));
+        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%s"));
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void tearDown()
+    {
+        executor.shutdownNow();
+        scheduledExecutor.shutdownNow();
+    }
+
+    @Test
+    public void testBlockedPageSink()
+    {
+        BlockingPageSink blockingPageSink = new BlockingPageSink();
+        Operator operator = createFileWriterOperator(blockingPageSink, TEST_SESSION);
+
+        // initial state validation
+        assertTrue(operator.isBlocked().isDone());
+        assertFalse(operator.isFinished());
+        assertTrue(operator.needsInput());
+
+        // blockingPageSink that will return blocked future
+        operator.addInput(rowPagesBuilder(BIGINT).row(42).build().get(0));
+
+        assertFalse(operator.isBlocked().isDone());
+        assertFalse(operator.isFinished());
+        assertFalse(operator.needsInput());
+        assertNull(operator.getOutput());
+
+        // complete previously blocked future
+        blockingPageSink.complete();
+
+        assertTrue(operator.isBlocked().isDone());
+        assertFalse(operator.isFinished());
+        assertTrue(operator.needsInput());
+
+        // add second page
+        operator.addInput(rowPagesBuilder(BIGINT).row(44).build().get(0));
+
+        assertFalse(operator.isBlocked().isDone());
+        assertFalse(operator.isFinished());
+        assertFalse(operator.needsInput());
+
+        // finish operator, state hasn't changed
+        operator.finish();
+
+        assertFalse(operator.isBlocked().isDone());
+        assertFalse(operator.isFinished());
+        assertFalse(operator.needsInput());
+
+        // complete previously blocked future
+        blockingPageSink.complete();
+        // and getOutput which actually finishes the operator
+        List<Type> expectedTypes = ImmutableList.of(BIGINT);
+        assertPageEquals(expectedTypes, operator.getOutput(), rowPagesBuilder(expectedTypes).row(2).build().get(0));
+
+        assertTrue(operator.isBlocked().isDone());
+        assertTrue(operator.isFinished());
+        assertFalse(operator.needsInput());
+    }
+
+    private Operator createFileWriterOperator(BlockingPageSink blockingPageSink, Session session)
+    {
+        PageSinkManager pageSinkManager = new PageSinkManager();
+        pageSinkManager.addConnectorPageSinkProvider(CONNECTOR_ID, new ConstantPageSinkProvider(blockingPageSink));
+        DriverContext driverContext = createTaskContext(executor, scheduledExecutor, session)
+                .addPipelineContext(0, true, true, false)
+                .addDriverContext();
+        return createFileWriterOperator(pageSinkManager, session, "", new ArrayList<>(), new ArrayList<>(), driverContext);
+    }
+
+    private Operator createFileWriterOperator(
+            PageSinkManager pageSinkManager,
+            Session session,
+            String path,
+            List<String> columnsNames,
+            List<Type> columnTypes,
+            DriverContext driverContext)
+    {
+        FileWriterOperator.FileWriterOperatorFactory factory = new FileWriterOperator.FileWriterOperatorFactory(
+                0,
+                new PlanNodeId("test"),
+                pageSinkManager,
+                session,
+                path,
+                columnsNames,
+                columnTypes,
+                Function.identity());
+        return factory.createOperator(driverContext);
+    }
+
+    private static class ConstantPageSinkProvider
+            implements ConnectorPageSinkProvider
+    {
+        private final ConnectorPageSink pageSink;
+
+        private ConstantPageSinkProvider(ConnectorPageSink pageSink)
+        {
+            this.pageSink = pageSink;
+        }
+
+        @Override
+        public ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorOutputTableHandle outputTableHandle, PageSinkContext pageSinkContext)
+        {
+            return pageSink;
+        }
+
+        @Override
+        public ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorInsertTableHandle insertTableHandle, PageSinkContext pageSinkContext)
+        {
+            return pageSink;
+        }
+
+        @Override
+        public ConnectorPageSink createPageSink(ConnectorSession session, String path, List<String> columnsNames, List<Type> columnTypes, PageSinkContext pageSinkContext)
+        {
+            return pageSink;
+        }
+    }
+
+    private static class BlockingPageSink
+            implements ConnectorPageSink
+    {
+        private CompletableFuture<?> future = new CompletableFuture<>();
+        private CompletableFuture<Collection<Slice>> finishFuture = new CompletableFuture<>();
+
+        @Override
+        public CompletableFuture<?> appendPage(Page page)
+        {
+            future = new CompletableFuture<>();
+            return future;
+        }
+
+        @Override
+        public CompletableFuture<Collection<Slice>> finish()
+        {
+            finishFuture = new CompletableFuture<>();
+            return finishFuture;
+        }
+
+        @Override
+        public void abort()
+        {
+        }
+
+        void complete()
+        {
+            future.complete(null);
+            finishFuture.complete(ImmutableList.of());
+        }
+    }
+}

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/AstVisitor.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/AstVisitor.java
@@ -642,6 +642,11 @@ public abstract class AstVisitor<R, C>
         return visitStatement(node, context);
     }
 
+    protected R visitInsertDirectory(InsertDirectory node, C context)
+    {
+        return visitStatement(node, context);
+    }
+
     protected R visitCall(Call node, C context)
     {
         return visitStatement(node, context);

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/InsertDirectory.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/InsertDirectory.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.tree;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.requireNonNull;
+
+public final class InsertDirectory
+        extends Statement
+{
+    private final Query query;
+    private final Identifier path;
+
+    public InsertDirectory(Identifier path, Query query)
+    {
+        this(Optional.empty(), path, query);
+    }
+
+    public InsertDirectory(Optional<NodeLocation> location, Identifier path, Query query)
+    {
+        super(location);
+        this.query = requireNonNull(query, "query is null");
+        this.path = requireNonNull(path, "path is null");
+    }
+
+    public Query getQuery()
+    {
+        return query;
+    }
+
+    public Identifier getPath()
+    {
+        return path;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context)
+    {
+        return visitor.visitInsertDirectory(this, context);
+    }
+
+    @Override
+    public List<? extends Node> getChildren()
+    {
+        return ImmutableList.of(query);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(path, query);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if ((obj == null) || (getClass() != obj.getClass())) {
+            return false;
+        }
+        InsertDirectory o = (InsertDirectory) obj;
+        return Objects.equals(path, o.path) &&
+                Objects.equals(query, o.query);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("path", path)
+                .add("query", query)
+                .toString();
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorPageSinkProvider.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorPageSinkProvider.java
@@ -13,15 +13,23 @@
  */
 package com.facebook.presto.spi.connector;
 
+import com.facebook.presto.common.type.Type;
 import com.facebook.presto.spi.ConnectorInsertTableHandle;
 import com.facebook.presto.spi.ConnectorOutputTableHandle;
 import com.facebook.presto.spi.ConnectorPageSink;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.PageSinkContext;
 
+import java.util.List;
+
 public interface ConnectorPageSinkProvider
 {
     ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorOutputTableHandle outputTableHandle, PageSinkContext pageSinkContext);
 
     ConnectorPageSink createPageSink(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorInsertTableHandle insertTableHandle, PageSinkContext pageSinkContext);
+
+    default ConnectorPageSink createPageSink(ConnectorSession session, String path, List<String> columnsNames, List<Type> columnTypes, PageSinkContext pageSinkContext)
+    {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorPageSinkProvider.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorPageSinkProvider.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.spi.connector.classloader;
 
+import com.facebook.presto.common.type.Type;
 import com.facebook.presto.spi.ConnectorInsertTableHandle;
 import com.facebook.presto.spi.ConnectorOutputTableHandle;
 import com.facebook.presto.spi.ConnectorPageSink;
@@ -21,6 +22,8 @@ import com.facebook.presto.spi.PageSinkContext;
 import com.facebook.presto.spi.classloader.ThreadContextClassLoader;
 import com.facebook.presto.spi.connector.ConnectorPageSinkProvider;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+
+import java.util.List;
 
 import static java.util.Objects.requireNonNull;
 
@@ -49,6 +52,14 @@ public final class ClassLoaderSafeConnectorPageSinkProvider
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             return new ClassLoaderSafeConnectorPageSink(delegate.createPageSink(transactionHandle, session, insertTableHandle, pageSinkContext), classLoader);
+        }
+    }
+
+    @Override
+    public ConnectorPageSink createPageSink(ConnectorSession session, String path, List<String> columnsNames, List<Type> columnTypes, PageSinkContext pageSinkContext)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return new ClassLoaderSafeConnectorPageSink(delegate.createPageSink(session, path, columnsNames, columnTypes, pageSinkContext), classLoader);
         }
     }
 }


### PR DESCRIPTION
It supports the syntax: `Insert overwrite directory "hdfs_path" query`, which write the query data(HIVE) into HDFS. It is usually used for data exchange, and Hive/Spark also support this syntax.
Currently, the parquet format is supported by default.
Example:
SQL:
insert overwrite directory "~/IdeaProjects/prestodb/presto-main/haruna/test" select user from table where date = '20201012' and hour = '12';
Logical plan: 
![image](https://user-images.githubusercontent.com/86234715/131455126-1d56e9a5-91ec-4718-9567-60e7183a177d.png)
Solve:
- Add InsertDirectory node for `insert overwrite directory` syntax when building AST.
- HdfsWriteNode and HdfsCommitNode will be generated for InsertDirectory node when constructing the logical plan. HdfsWriteNode is used to write data into HDFS, HdfsCommitNode is used to summarize the total number of rows.
- FileWriterOperatorFactory generate the FileWriterOperator, which will generate HivePageSink to write data into Hdfs.