### PR TITLE
Add new setPartitionLeases metastore API

### DIFF
--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/CachingHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/CachingHiveMetastore.java
@@ -935,6 +935,12 @@ public class CachingHiveMetastore
         return get(tablePrivilegesCache, getCachingKey(metastoreContext, new UserTableKey(principal, databaseName, tableName)));
     }
 
+    @Override
+    public void setPartitionLeases(MetastoreContext metastoreContext, String databaseName, String tableName, Map<String, String> partitionNameToLocation, Duration leaseDuration)
+    {
+        delegate.setPartitionLeases(metastoreContext, databaseName, tableName, partitionNameToLocation, leaseDuration);
+    }
+
     public Set<HivePrivilegeInfo> loadTablePrivileges(KeyAndContext<UserTableKey> loadTablePrivilegesKey)
     {
         return delegate.listTablePrivileges(loadTablePrivilegesKey.getContext(), loadTablePrivilegesKey.getKey().getDatabase(), loadTablePrivilegesKey.getKey().getTable(), loadTablePrivilegesKey.getKey().getPrincipal());

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/ExtendedHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/ExtendedHiveMetastore.java
@@ -19,6 +19,7 @@ import com.facebook.presto.hive.HiveType;
 import com.facebook.presto.spi.security.PrestoPrincipal;
 import com.facebook.presto.spi.security.RoleGrant;
 import com.facebook.presto.spi.statistics.ColumnStatisticType;
+import io.airlift.units.Duration;
 
 import java.util.List;
 import java.util.Map;
@@ -114,4 +115,6 @@ public interface ExtendedHiveMetastore
     void revokeTablePrivileges(MetastoreContext metastoreContext, String databaseName, String tableName, PrestoPrincipal grantee, Set<HivePrivilegeInfo> privileges);
 
     Set<HivePrivilegeInfo> listTablePrivileges(MetastoreContext metastoreContext, String databaseName, String tableName, PrestoPrincipal principal);
+
+    void setPartitionLeases(MetastoreContext metastoreContext, String databaseName, String tableName, Map<String, String> partitionNameToLocation, Duration leaseDuration);
 }

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/RecordingHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/RecordingHiveMetastore.java
@@ -30,6 +30,7 @@ import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import io.airlift.units.Duration;
 import org.weakref.jmx.Managed;
 
 import javax.annotation.concurrent.Immutable;
@@ -473,6 +474,12 @@ public class RecordingHiveMetastore
                 roleGrantsCache,
                 principal,
                 () -> delegate.listRoleGrants(metastoreContext, principal));
+    }
+
+    @Override
+    public void setPartitionLeases(MetastoreContext metastoreContext, String databaseName, String tableName, Map<String, String> partitionNameToLocation, Duration leaseDuration)
+    {
+        throw new UnsupportedOperationException("setPartitionLeases is not supported in RecordingHiveMetastore");
     }
 
     private <K, V> V loadValue(Cache<K, V> cache, K key, Supplier<V> valueSupplier)

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/alluxio/AlluxioHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/alluxio/AlluxioHiveMetastore.java
@@ -46,6 +46,7 @@ import com.facebook.presto.spi.statistics.ColumnStatisticType;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
+import io.airlift.units.Duration;
 
 import java.util.Collections;
 import java.util.List;
@@ -441,5 +442,11 @@ public class AlluxioHiveMetastore
     public Set<HivePrivilegeInfo> listTablePrivileges(MetastoreContext metastoreContext, String databaseName, String tableName, PrestoPrincipal principal)
     {
         throw new UnsupportedOperationException("listTablePrivileges is not supported in AlluxioHiveMetastore");
+    }
+
+    @Override
+    public void setPartitionLeases(MetastoreContext metastoreContext, String databaseName, String tableName, Map<String, String> partitionNameToLocation, Duration leaseDuration)
+    {
+        throw new UnsupportedOperationException("setPartitionLeases is not supported in AlluxioHiveMetastore");
     }
 }

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/file/FileHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/file/FileHiveMetastore.java
@@ -49,6 +49,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.io.ByteStreams;
+import io.airlift.units.Duration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
@@ -994,6 +995,12 @@ public class FileHiveMetastore
         currentPrivileges.removeAll(privileges);
 
         setTablePrivileges(metastoreContext, grantee, databaseName, tableName, currentPrivileges);
+    }
+
+    @Override
+    public synchronized void setPartitionLeases(MetastoreContext metastoreContext, String databaseName, String tableName, Map<String, String> partitionNameToLocation, Duration leaseDuration)
+    {
+        throw new UnsupportedOperationException("setPartitionLeases is not supported in FileHiveMetastore");
     }
 
     private synchronized void setTablePrivileges(

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/glue/GlueHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/glue/GlueHiveMetastore.java
@@ -95,6 +95,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
+import io.airlift.units.Duration;
 import org.apache.hadoop.fs.Path;
 import org.weakref.jmx.Flatten;
 import org.weakref.jmx.Managed;
@@ -991,5 +992,11 @@ public class GlueHiveMetastore
     public Set<HivePrivilegeInfo> listTablePrivileges(MetastoreContext metastoreContext, String databaseName, String tableName, PrestoPrincipal principal)
     {
         throw new PrestoException(NOT_SUPPORTED, "listTablePrivileges is not supported by Glue");
+    }
+
+    @Override
+    public void setPartitionLeases(MetastoreContext metastoreContext, String databaseName, String tableName, Map<String, String> partitionNameToLocation, Duration leaseDuration)
+    {
+        throw new PrestoException(NOT_SUPPORTED, "setPartitionLeases is not supported by Glue");
     }
 }

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/BridgingHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/BridgingHiveMetastore.java
@@ -37,6 +37,7 @@ import com.facebook.presto.spi.security.PrestoPrincipal;
 import com.facebook.presto.spi.security.RoleGrant;
 import com.facebook.presto.spi.statistics.ColumnStatisticType;
 import com.google.common.collect.ImmutableMap;
+import io.airlift.units.Duration;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 
 import javax.inject.Inject;
@@ -370,5 +371,11 @@ public class BridgingHiveMetastore
     public Set<HivePrivilegeInfo> listTablePrivileges(MetastoreContext metastoreContext, String databaseName, String tableName, PrestoPrincipal principal)
     {
         return delegate.listTablePrivileges(metastoreContext, databaseName, tableName, principal);
+    }
+
+    @Override
+    public void setPartitionLeases(MetastoreContext metastoreContext, String databaseName, String tableName, Map<String, String> partitionNameToLocation, Duration leaseDuration)
+    {
+        delegate.setPartitionLeases(metastoreContext, databaseName, tableName, partitionNameToLocation, leaseDuration);
     }
 }

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/HiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/HiveMetastore.java
@@ -27,6 +27,7 @@ import com.facebook.presto.spi.TableNotFoundException;
 import com.facebook.presto.spi.security.PrestoPrincipal;
 import com.facebook.presto.spi.security.RoleGrant;
 import com.facebook.presto.spi.statistics.ColumnStatisticType;
+import io.airlift.units.Duration;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.Partition;
@@ -112,6 +113,11 @@ public interface HiveMetastore
     void revokeTablePrivileges(MetastoreContext metastoreContext, String databaseName, String tableName, PrestoPrincipal grantee, Set<HivePrivilegeInfo> privileges);
 
     Set<HivePrivilegeInfo> listTablePrivileges(MetastoreContext metastoreContext, String databaseName, String tableName, PrestoPrincipal principal);
+
+    default void setPartitionLeases(MetastoreContext metastoreContext, String databaseName, String tableName, Map<String, String> partitionNameToLocation, Duration leaseDuration)
+    {
+        throw new UnsupportedOperationException();
+    }
 
     default boolean isTableOwner(MetastoreContext metastoreContext, String user, String databaseName, String tableName)
     {

--- a/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/UnimplementedHiveMetastore.java
+++ b/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/UnimplementedHiveMetastore.java
@@ -19,6 +19,7 @@ import com.facebook.presto.hive.HiveType;
 import com.facebook.presto.spi.security.PrestoPrincipal;
 import com.facebook.presto.spi.security.RoleGrant;
 import com.facebook.presto.spi.statistics.ColumnStatisticType;
+import io.airlift.units.Duration;
 
 import java.util.List;
 import java.util.Map;
@@ -255,6 +256,12 @@ public class UnimplementedHiveMetastore
 
     @Override
     public Set<RoleGrant> listRoleGrants(MetastoreContext metastoreContext, PrestoPrincipal principal)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setPartitionLeases(MetastoreContext metastoreContext, String databaseName, String tableName, Map<String, String> partitionNameToLocation, Duration leaseDuration)
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -191,6 +191,8 @@ public class HiveClientConfig
 
     private boolean optimizedPartitionUpdateSerializationEnabled;
 
+    private Duration partitionLeaseDuration = new Duration(0, TimeUnit.SECONDS);
+
     public int getMaxInitialSplits()
     {
         return maxInitialSplits;
@@ -1611,16 +1613,29 @@ public class HiveClientConfig
         return undoMetastoreOperationsEnabled;
     }
 
-    public boolean isOptimizedPartitionUpdateSerializationEnabled()
-    {
-        return optimizedPartitionUpdateSerializationEnabled;
-    }
-
     @Config("hive.experimental-optimized-partition-update-serialization-enabled")
     @ConfigDescription("Serialize PartitionUpdate objects using binary SMILE encoding and compress with the ZSTD compression")
     public HiveClientConfig setOptimizedPartitionUpdateSerializationEnabled(boolean optimizedPartitionUpdateSerializationEnabled)
     {
         this.optimizedPartitionUpdateSerializationEnabled = optimizedPartitionUpdateSerializationEnabled;
         return this;
+    }
+
+    public boolean isOptimizedPartitionUpdateSerializationEnabled()
+    {
+        return optimizedPartitionUpdateSerializationEnabled;
+    }
+
+    @Config("hive.partition-lease-duration")
+    @ConfigDescription("Partition lease duration")
+    public HiveClientConfig setPartitionLeaseDuration(Duration partitionLeaseDuration)
+    {
+        this.partitionLeaseDuration = partitionLeaseDuration;
+        return this;
+    }
+
+    public Duration getPartitionLeaseDuration()
+    {
+        return partitionLeaseDuration;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
@@ -20,6 +20,7 @@ import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.facebook.presto.spi.session.PropertyMetadata;
 import com.google.common.collect.ImmutableList;
 import io.airlift.units.DataSize;
+import io.airlift.units.Duration;
 
 import javax.inject.Inject;
 
@@ -119,6 +120,7 @@ public final class HiveSessionProperties
     public static final String MANIFEST_VERIFICATION_ENABLED = "manifest_verification_enabled";
     public static final String NEW_PARTITION_USER_SUPPLIED_PARAMETER = "new_partition_user_supplied_parameter";
     public static final String OPTIMIZED_PARTITION_UPDATE_SERIALIZATION_ENABLED = "optimized_partition_update_serialization_enabled";
+    public static final String PARTITION_LEASE_DURATION = "partition_lease_duration";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -563,7 +565,16 @@ public final class HiveSessionProperties
                         OPTIMIZED_PARTITION_UPDATE_SERIALIZATION_ENABLED,
                         "Serialize PartitionUpdate objects using binary SMILE encoding and compress with the ZSTD compression",
                         hiveClientConfig.isOptimizedPartitionUpdateSerializationEnabled(),
-                        true));
+                        true),
+                new PropertyMetadata<>(
+                        PARTITION_LEASE_DURATION,
+                        "Partition lease duration in seconds, 0 means disabled",
+                        VARCHAR,
+                        Duration.class,
+                        hiveClientConfig.getPartitionLeaseDuration(),
+                        false,
+                        value -> Duration.valueOf((String) value),
+                        Duration::toString));
     }
 
     public List<PropertyMetadata<?>> getSessionProperties()
@@ -987,5 +998,10 @@ public final class HiveSessionProperties
     public static boolean isOptimizedPartitionUpdateSerializationEnabled(ConnectorSession session)
     {
         return session.getProperty(OPTIMIZED_PARTITION_UPDATE_SERIALIZATION_ENABLED, Boolean.class);
+    }
+
+    public static Duration getLeaseDuration(ConnectorSession session)
+    {
+        return session.getProperty(PARTITION_LEASE_DURATION, Duration.class);
     }
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
@@ -152,7 +152,8 @@ public class TestHiveClientConfig
                 .setPreferManifestsToListFiles(false)
                 .setManifestVerificationEnabled(false)
                 .setUndoMetastoreOperationsEnabled(true)
-                .setOptimizedPartitionUpdateSerializationEnabled(false));
+                .setOptimizedPartitionUpdateSerializationEnabled(false)
+                .setPartitionLeaseDuration(new Duration(0, TimeUnit.SECONDS)));
     }
 
     @Test
@@ -266,6 +267,7 @@ public class TestHiveClientConfig
                 .put("hive.manifest-verification-enabled", "true")
                 .put("hive.undo-metastore-operations-enabled", "false")
                 .put("hive.experimental-optimized-partition-update-serialization-enabled", "true")
+                .put("hive.partition-lease-duration", "4h")
                 .build();
 
         HiveClientConfig expected = new HiveClientConfig()
@@ -375,7 +377,8 @@ public class TestHiveClientConfig
                 .setPreferManifestsToListFiles(true)
                 .setManifestVerificationEnabled(true)
                 .setUndoMetastoreOperationsEnabled(false)
-                .setOptimizedPartitionUpdateSerializationEnabled(true);
+                .setOptimizedPartitionUpdateSerializationEnabled(true)
+                .setPartitionLeaseDuration(new Duration(4, TimeUnit.HOURS));
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
This PR is to add a new metastore API setPartitionLeases in Presto when reading partitions. The motivation is to fix Presto queries which fail due to partitions getting dropped in the middle of a query, manifesting in HIVE_CANNOT_OPEN_SPLIT -> FileNotFoundExceptions or HIVE_PARTITION_DROPPED_DURING_QUERY errors.

The idea is to set partition lease for partitions used in table scans (in HiveSplitManager.java). The current lease duration is set to 0s, which means the feature is disabled by default. I plan to use 4h as the lease duration, so each partition read by Presto will be kept not deleted for 4h.

A potential improvement here is to set the lease duration to a smaller value (e.g. 15mins), and periodically refresh the partition leases. However, given most Presto queries finish fast, I don't want to do premature optimizations for now.

```
== RELEASE NOTE ==

General Changes:
* Add support for partition leases. This is controlled and can be enabled by `hive.partition-lease-duration` configuration.
* A session property `partition_lease_duration_seconds` has also been added to control per-session behavior.
```

Depended by https://github.com/facebookexternal/presto-facebook/pull/1648