### PR TITLE
upgrade pinot lib to 0.8.0 to support new features introduced in Apache Pinot 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1817,7 +1817,7 @@
             <dependency>
                 <groupId>com.facebook.presto.pinot</groupId>
                 <artifactId>pinot-driver</artifactId>
-                <version>0.1.2</version>
+                <version>0.1.3-SNAPSHOT</version>
                 <exclusions>
                     <exclusion>
                         <groupId> org.slf4j</groupId>
@@ -1860,8 +1860,20 @@
                         <artifactId>lucene-analyzers-common</artifactId>
                     </exclusion>
                     <exclusion>
+                        <groupId>org.glassfish.hk2.external</groupId>
+                        <artifactId>jakarta.inject</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>jakarta.ws.rs</groupId>
+                        <artifactId>jakarta.ws.rs-api</artifactId>
+                    </exclusion>
+                    <exclusion>
                         <groupId>org.roaringbitmap</groupId>
                         <artifactId>RoaringBitmap</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>com.github.luben</groupId>
+                        <artifactId>zstd-jni</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotBrokerPageSourceBase.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotBrokerPageSourceBase.java
@@ -25,6 +25,7 @@ import com.facebook.presto.common.type.DecimalType;
 import com.facebook.presto.common.type.DoubleType;
 import com.facebook.presto.common.type.FixedWidthType;
 import com.facebook.presto.common.type.IntegerType;
+import com.facebook.presto.common.type.JsonType;
 import com.facebook.presto.common.type.SmallintType;
 import com.facebook.presto.common.type.TimestampType;
 import com.facebook.presto.common.type.TinyintType;
@@ -41,6 +42,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
+import org.apache.pinot.spi.utils.TimestampUtils;
 
 import java.net.URI;
 import java.util.ArrayList;
@@ -145,7 +147,7 @@ public abstract class PinotBrokerPageSourceBase
             blockBuilder.appendNull();
             return;
         }
-        if (!(type instanceof FixedWidthType) && !(type instanceof VarcharType)) {
+        if (!(type instanceof FixedWidthType) && !(type instanceof VarcharType) && !(type instanceof JsonType)) {
             throw new PinotException(PINOT_UNSUPPORTED_COLUMN_TYPE, Optional.empty(), "type '" + type + "' not supported");
         }
         if (type instanceof FixedWidthType) {
@@ -169,7 +171,7 @@ public abstract class PinotBrokerPageSourceBase
                 type.writeDouble(blockBuilder, parseDouble(value));
             }
             else if (type instanceof TimestampType) {
-                type.writeLong(blockBuilder, parseLong(value));
+                type.writeLong(blockBuilder, parseTimestamp(value));
             }
             else if (type instanceof DateType) {
                 type.writeLong(blockBuilder, parseLong(value));
@@ -182,6 +184,16 @@ public abstract class PinotBrokerPageSourceBase
             Slice slice = Slices.utf8Slice(value);
             blockBuilder.writeBytes(slice, 0, slice.length()).closeEntry();
             completedBytes += slice.length();
+        }
+    }
+
+    private long parseTimestamp(String value)
+    {
+        try {
+            return parseLong(value);
+        }
+        catch (Exception e) {
+            return TimestampUtils.toMillisSinceEpoch(value);
         }
     }
 

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotColumnUtils.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotColumnUtils.java
@@ -19,6 +19,7 @@ import com.facebook.presto.common.type.BooleanType;
 import com.facebook.presto.common.type.DateType;
 import com.facebook.presto.common.type.DoubleType;
 import com.facebook.presto.common.type.IntegerType;
+import com.facebook.presto.common.type.JsonType;
 import com.facebook.presto.common.type.TimestampType;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.VarbinaryType;
@@ -128,6 +129,10 @@ public class PinotColumnUtils
                 return VarcharType.VARCHAR;
             case BYTES:
                 return VarbinaryType.VARBINARY;
+            case TIMESTAMP:
+                return TimestampType.TIMESTAMP;
+            case JSON:
+                return JsonType.JSON;
             default:
                 break;
         }

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotSegmentPageSource.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotSegmentPageSource.java
@@ -27,6 +27,7 @@ import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.DataTable;
+import org.apache.pinot.spi.data.FieldSpec;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -39,6 +40,7 @@ import java.util.stream.IntStream;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.common.type.JsonType.JSON;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.pinot.PinotErrorCode.PINOT_DATA_FETCH_EXCEPTION;
 import static com.facebook.presto.pinot.PinotErrorCode.PINOT_EXCEPTION;
@@ -284,7 +286,12 @@ public class PinotSegmentPageSource
             writeBooleanBlock(blockBuilder, columnType, columnIndex);
         }
         else if (javaType.equals(long.class)) {
-            writeLongBlock(blockBuilder, columnType, columnIndex);
+            if (pinotColumnType.toDataType().equals(FieldSpec.DataType.TIMESTAMP)) {
+                writeTimestampBlock(blockBuilder, columnType, columnIndex);
+            }
+            else {
+                writeLongBlock(blockBuilder, columnType, columnIndex);
+            }
         }
         else if (javaType.equals(double.class)) {
             writeDoubleBlock(blockBuilder, columnType, columnIndex);
@@ -393,6 +400,14 @@ public class PinotSegmentPageSource
         }
     }
 
+    private void writeTimestampBlock(BlockBuilder blockBuilder, Type columnType, int columnIndex)
+    {
+        for (int i = 0; i < currentDataTable.getDataTable().getNumberOfRows(); i++) {
+            columnType.writeLong(blockBuilder, getLong(i, columnIndex));
+            completedBytes += Long.BYTES;
+        }
+    }
+
     private void writeDoubleBlock(BlockBuilder blockBuilder, Type columnType, int columnIndex)
     {
         for (int i = 0; i < currentDataTable.getDataTable().getNumberOfRows(); i++) {
@@ -412,7 +427,7 @@ public class PinotSegmentPageSource
 
     private boolean getBoolean(int rowIndex, int columnIndex)
     {
-        return Boolean.getBoolean(currentDataTable.getDataTable().getString(rowIndex, columnIndex));
+        return Boolean.getBoolean(currentDataTable.getDataTable().getObject(rowIndex, columnIndex).toString());
     }
 
     private long getLong(int rowIndex, int columnIndex)
@@ -445,7 +460,9 @@ public class PinotSegmentPageSource
 
     private Slice getSlice(int rowIndex, int columnIndex)
     {
-        checkColumnType(columnIndex, VARCHAR);
+        checkColumnType(columnIndex, new Type[] {
+                VARCHAR, JSON
+        });
         DataSchema.ColumnDataType columnType = currentDataTable.getDataTable().getDataSchema().getColumnDataType(columnIndex);
         switch (columnType) {
             case INT_ARRAY:
@@ -498,11 +515,17 @@ public class PinotSegmentPageSource
         return pinotConfig.getEstimatedSizeInBytesForNonNumericColumn();
     }
 
-    private void checkColumnType(int columnIndex, Type expected)
+    private void checkColumnType(int columnIndex, Type[] expectedTypes)
     {
         checkArgument(columnIndex < split.getExpectedColumnHandles().size(), "Invalid field index");
         Type actual = split.getExpectedColumnHandles().get(columnIndex).getDataType();
-        checkArgument(actual.equals(expected), "Expected column %s to be type %s but is %s", columnIndex, expected, actual);
+        boolean matches = false;
+        for (Type expectedType : expectedTypes) {
+            if (actual.equals(expectedType)) {
+                matches = true;
+            }
+        }
+        checkArgument(matches, "Expected column %s to be type %s but is %s", columnIndex, expectedTypes, actual);
     }
 
     protected static Type getTypeForBlock(PinotColumnHandle pinotColumnHandle)

--- a/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotColumnMetadata.java
+++ b/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotColumnMetadata.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.common.type.DoubleType.DOUBLE;
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
@@ -76,14 +77,14 @@ public class TestPinotColumnMetadata
                 .put("singleValueFloatDimension", DOUBLE)
                 .put("singleValueDoubleDimension", DOUBLE)
                 .put("singleValueBytesDimension", VARBINARY)
-                .put("singleValueBooleanDimension", VARCHAR)
+                .put("singleValueBooleanDimension", BOOLEAN)
                 .put("singleValueStringDimension", VARCHAR)
                 .put("multiValueIntDimension", new ArrayType(INTEGER))
                 .put("multiValueLongDimension", new ArrayType(BIGINT))
                 .put("multiValueFloatDimension", new ArrayType(DOUBLE))
                 .put("multiValueDoubleDimension", new ArrayType(DOUBLE))
                 .put("multiValueBytesDimension", new ArrayType(VARBINARY))
-                .put("multiValueBooleanDimension", new ArrayType(VARCHAR))
+                .put("multiValueBooleanDimension", new ArrayType(BOOLEAN))
                 .put("multiValueStringDimension", new ArrayType(VARCHAR))
                 .put("intMetric", INTEGER)
                 .put("longMetric", BIGINT)

--- a/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotSegmentPageSource.java
+++ b/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotSegmentPageSource.java
@@ -87,6 +87,8 @@ public class TestPinotSegmentPageSource
     protected FieldSpec getFieldSpec(String columnName, DataSchema.ColumnDataType columnDataType)
     {
         switch (columnDataType) {
+            case BOOLEAN:
+                return new DimensionFieldSpec(columnName, FieldSpec.DataType.BOOLEAN, true);
             case INT:
                 return new DimensionFieldSpec(columnName, FieldSpec.DataType.INT, true);
             case LONG:
@@ -99,6 +101,10 @@ public class TestPinotSegmentPageSource
                 return new DimensionFieldSpec(columnName, FieldSpec.DataType.STRING, true);
             case BYTES:
                 return new DimensionFieldSpec(columnName, FieldSpec.DataType.BYTES, true);
+            case TIMESTAMP:
+                return new DimensionFieldSpec(columnName, FieldSpec.DataType.TIMESTAMP, true);
+            case JSON:
+                return new DimensionFieldSpec(columnName, FieldSpec.DataType.JSON, true);
             case INT_ARRAY:
                 return new DimensionFieldSpec(columnName, FieldSpec.DataType.INT, false);
             case LONG_ARRAY:
@@ -165,6 +171,12 @@ public class TestPinotSegmentPageSource
         public void addException(ProcessingException e)
         {
             throw new UnsupportedOperationException("Unsupported", e);
+        }
+
+        @Override
+        public Map<Integer, String> getExceptions()
+        {
+            return null;
         }
 
         @Override
@@ -305,10 +317,16 @@ public class TestPinotSegmentPageSource
         for (int rowId = 0; rowId < NUM_ROWS; rowId++) {
             for (int colId = 0; colId < numColumns; colId++) {
                 switch (columnDataTypes[colId]) {
+                    case BOOLEAN:
+                        dataTable.set(rowId, colId, RANDOM.nextBoolean());
+                        break;
                     case INT:
                         dataTable.set(rowId, colId, RANDOM.nextInt());
                         break;
                     case LONG:
+                        dataTable.set(rowId, colId, RANDOM.nextLong());
+                        break;
+                    case TIMESTAMP:
                         dataTable.set(rowId, colId, RANDOM.nextLong());
                         break;
                     case FLOAT:
@@ -363,6 +381,11 @@ public class TestPinotSegmentPageSource
                         }
                         dataTable.set(rowId, colId, stringArray);
                         break;
+                    case JSON:
+                        dataTable.set(rowId, colId, "{ " + generateRandomStringWithLength(RANDOM.nextInt(5)) + " : " + generateRandomStringWithLength(RANDOM.nextInt(10)) + " }");
+                        break;
+                    default:
+                        throw new RuntimeException("Unsupported type - " + columnDataTypes[colId]);
                 }
             }
         }


### PR DESCRIPTION
Upgrade Apache Pinot lib to 0.8.0 to support new features introduced.
1. New native data types supported in Pinot: BOOLEAN/TIMESTAMP/JSON
2. Handles new Pinot DataTable version upgrade, so Presto can work seamlessly with new Pinot releases without explicitly configs change on the Pinot side. https://github.com/apache/pinot/issues/7183

Relies on new presto-pinot-driver lib published by this PR: https://github.com/prestodb/presto-pinot-driver/pull/7

Test plan - (Please fill in how you tested your changes)
Unit tests and local test with pinot quickstart

```
== RELEASE NOTES ==

Pinot Changes
1. Upgrade to Pinot 0.8.0 lib
2. Support Pinot data types: BOOLEAN/TIMESTAMP/JSON natively
```
