### PR TITLE
Duplicate access control check on create view

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/CreateViewTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/CreateViewTask.java
@@ -81,8 +81,6 @@ public class CreateViewTask
         Session session = stateMachine.getSession();
         QualifiedObjectName name = createQualifiedObjectName(session, statement, statement.getName());
 
-        accessControl.checkCanCreateView(session.getRequiredTransactionId(), session.getIdentity(), session.getAccessControlContext(), name);
-
         String sql = getFormattedSql(statement.getQuery(), sqlParser, Optional.of(parameters));
 
         Analysis analysis = analyzeStatement(statement, session, metadata, accessControl, parameters, stateMachine.getWarningCollector());


### PR DESCRIPTION
Duplicate call on access control method checkCanCreateView while creating presto views :-

1st call in CreateViewTask.java line 84
2nd call in StatementAnalyzer.java inside method visitCreateView line 664

1. For statements like "createtable", access control check "checkCanCreateTable" is called only once in StatementAnalyzer.java
2. Also, all the other access control checks for different actions are done in StatementAnalyzer.java.

Taking above 2 points into consideration, removing the access control check in CreateViewTask.java for creating views as it is not necessary.

Test plan - (Please fill in how you tested your changes)

Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines. Don't forget to follow our [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution) for any code copied from other projects.

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== RELEASE NOTES ==

General Changes
* ...
* ...

Hive Changes
* ...
* ...
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```
