### PR TITLE
Upgrade orc-protobuf to Version 13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -622,7 +622,7 @@
             <dependency>
                 <groupId>com.facebook.presto.orc</groupId>
                 <artifactId>orc-protobuf</artifactId>
-                <version>12</version>
+                <version>13</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
orc-protobuf version 13 is required for size and rawSize
stats in the Dwrf format.

Test plan - (Please fill in how you tested your changes)
Existing tests.

```
== NO RELEASE NOTE ==
```
