### PR TITLE
Track CPU usages for MetadataReaders

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcBatchPageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcBatchPageSource.java
@@ -81,7 +81,7 @@ public class OrcBatchPageSource
         int size = requireNonNull(columns, "columns is null").size();
 
         this.stats = requireNonNull(stats, "stats is null");
-        this.runtimeStats = runtimeStats;
+        this.runtimeStats = requireNonNull(runtimeStats, "runtimeStats is null");
 
         this.constantBlocks = new Block[size];
         this.hiveColumnIndexes = new int[size];

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcBatchPageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcBatchPageSourceFactory.java
@@ -259,7 +259,8 @@ public class OrcBatchPageSourceFactory
                     orcReaderOptions,
                     hiveFileContext.isCacheable(),
                     dwrfEncryptionProvider,
-                    dwrfKeyProvider);
+                    dwrfKeyProvider,
+                    hiveFileContext.getStats());
 
             List<HiveColumnHandle> physicalColumns = getPhysicalHiveColumnHandles(columns, useOrcColumnNames, reader.getTypes(), path);
             ImmutableMap.Builder<Integer, Type> includedColumns = ImmutableMap.builder();

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcSelectivePageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcSelectivePageSourceFactory.java
@@ -333,7 +333,8 @@ public class OrcSelectivePageSourceFactory
                     orcReaderOptions,
                     hiveFileContext.isCacheable(),
                     dwrfEncryptionProvider,
-                    dwrfKeyProvider);
+                    dwrfKeyProvider,
+                    hiveFileContext.getStats());
 
             List<HiveColumnHandle> physicalColumns = getPhysicalHiveColumnHandles(columns, useOrcColumnNames, reader.getTypes(), path);
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/util/TempFileReader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/util/TempFileReader.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.hive.util;
 
 import com.facebook.presto.common.Page;
+import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.hive.HiveOrcAggregatedMemoryContext;
@@ -68,7 +69,8 @@ public class TempFileReader
                             false),
                     false,
                     NO_ENCRYPTION,
-                    DwrfKeyProvider.EMPTY);
+                    DwrfKeyProvider.EMPTY,
+                    new RuntimeStats());
 
             Map<Integer, Type> includedColumns = new HashMap<>();
             for (int i = 0; i < types.size(); i++) {

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSourceProvider.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSourceProvider.java
@@ -455,6 +455,7 @@ public class IcebergPageSourceProvider
 
             // Todo: pass real columns to ProjectionBasedDwrfKeyProvider instead of ImmutableList.of()
             DwrfKeyProvider dwrfKeyProvider = new ProjectionBasedDwrfKeyProvider(encryptionInformation, ImmutableList.of(), true, path);
+            RuntimeStats runtimeStats = new RuntimeStats();
             OrcReader reader = new OrcReader(
                     orcDataSource,
                     orcEncoding,
@@ -464,7 +465,8 @@ public class IcebergPageSourceProvider
                     options,
                     isCacheable,
                     dwrfEncryptionProvider,
-                    dwrfKeyProvider);
+                    dwrfKeyProvider,
+                    runtimeStats);
 
             List<HiveColumnHandle> physicalColumnHandles = new ArrayList<>(regularColumns.size());
             ImmutableMap.Builder<Integer, Type> includedColumns = ImmutableMap.builder();
@@ -572,7 +574,7 @@ public class IcebergPageSourceProvider
                     typeManager,
                     systemMemoryUsage,
                     stats,
-                    new RuntimeStats());
+                    runtimeStats);
         }
         catch (Exception e) {
             if (orcDataSource != null) {

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcEncoding.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcEncoding.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.orc;
 
+import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.orc.metadata.DwrfMetadataReader;
 import com.facebook.presto.orc.metadata.DwrfMetadataWriter;
 import com.facebook.presto.orc.metadata.MetadataReader;
@@ -24,9 +25,9 @@ public enum OrcEncoding
 {
     ORC {
         @Override
-        public MetadataReader createMetadataReader()
+        public MetadataReader createMetadataReader(RuntimeStats runtimeStats)
         {
-            return new OrcMetadataReader();
+            return new OrcMetadataReader(runtimeStats);
         }
 
         @Override
@@ -37,9 +38,9 @@ public enum OrcEncoding
     },
     DWRF {
         @Override
-        public MetadataReader createMetadataReader()
+        public MetadataReader createMetadataReader(RuntimeStats runtimeStats)
         {
-            return new DwrfMetadataReader();
+            return new DwrfMetadataReader(runtimeStats);
         }
 
         @Override
@@ -49,7 +50,7 @@ public enum OrcEncoding
         }
     };
 
-    public abstract MetadataReader createMetadataReader();
+    public abstract MetadataReader createMetadataReader(RuntimeStats runtimeStats);
 
     public abstract MetadataWriter createMetadataWriter();
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfMetadataReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfMetadataReader.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.orc.metadata;
 
+import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.orc.DwrfDataEncryptor;
 import com.facebook.presto.orc.DwrfEncryptionProvider;
 import com.facebook.presto.orc.DwrfKeyProvider;
@@ -42,11 +43,13 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Iterables;
+import com.sun.management.ThreadMXBean;
 import io.airlift.slice.BasicSliceInput;
 import io.airlift.slice.Slice;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.management.ManagementFactory;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -81,10 +84,20 @@ import static java.util.Objects.requireNonNull;
 public class DwrfMetadataReader
         implements MetadataReader
 {
+    private static final ThreadMXBean THREAD_MX_BEAN = (ThreadMXBean) ManagementFactory.getThreadMXBean();
+
+    private final RuntimeStats runtimeStats;
+
+    public DwrfMetadataReader(RuntimeStats runtimeStats)
+    {
+        this.runtimeStats = requireNonNull(runtimeStats, "runtimeStats is null");
+    }
+
     @Override
     public PostScript readPostScript(byte[] data, int offset, int length)
             throws IOException
     {
+        long cpuStart = THREAD_MX_BEAN.getCurrentThreadCpuTime();
         CodedInputStream input = CodedInputStream.newInstance(data, offset, length);
         DwrfProto.PostScript postScript = DwrfProto.PostScript.parseFrom(input);
 
@@ -96,6 +109,7 @@ public class DwrfMetadataReader
             stripeCacheLength = OptionalInt.of(postScript.getCacheSize());
             stripeCacheMode = Optional.of(toStripeCacheMode(postScript.getCacheMode()));
         }
+        runtimeStats.addMetricValue("DwrfReadPostScriptTimeNanos", THREAD_MX_BEAN.getCurrentThreadCpuTime() - cpuStart);
 
         return new PostScript(
                 ImmutableList.of(),
@@ -123,6 +137,7 @@ public class DwrfMetadataReader
             Optional<OrcDecompressor> decompressor)
             throws IOException
     {
+        long cpuStart = THREAD_MX_BEAN.getCurrentThreadCpuTime();
         CodedInputStream input = CodedInputStream.newInstance(inputStream);
         DwrfProto.Footer footer = DwrfProto.Footer.parseFrom(input);
         List<ColumnStatistics> fileStats = toColumnStatistics(hiveWriterVersion, footer.getStatisticsList(), false);
@@ -136,6 +151,7 @@ public class DwrfMetadataReader
             EncryptionLibrary encryptionLibrary = dwrfEncryptionProvider.getEncryptionLibrary(encryption.get().getKeyProvider());
             fileStats = decryptAndCombineFileStatistics(hiveWriterVersion, encryption.get(), encryptionLibrary, fileStats, fileStripes, keys, orcDataSource, decompressor);
         }
+        runtimeStats.addMetricValue("DwrfReadFooterTimeNanos", THREAD_MX_BEAN.getCurrentThreadCpuTime() - cpuStart);
 
         return new Footer(
                 footer.getNumberOfRows(),
@@ -298,8 +314,10 @@ public class DwrfMetadataReader
     public StripeFooter readStripeFooter(OrcDataSourceId orcDataSourceId, List<OrcType> types, InputStream inputStream)
             throws IOException
     {
+        long cpuStart = THREAD_MX_BEAN.getCurrentThreadCpuTime();
         CodedInputStream input = CodedInputStream.newInstance(inputStream);
         DwrfProto.StripeFooter stripeFooter = DwrfProto.StripeFooter.parseFrom(input);
+        runtimeStats.addMetricValue("DwrfReadStripeFooterTimeNanos", THREAD_MX_BEAN.getCurrentThreadCpuTime() - cpuStart);
         return new StripeFooter(
                 toStream(orcDataSourceId, stripeFooter.getStreamsList()),
                 toColumnEncoding(types, stripeFooter.getColumnsList()),
@@ -402,8 +420,10 @@ public class DwrfMetadataReader
     public List<RowGroupIndex> readRowIndexes(HiveWriterVersion hiveWriterVersion, InputStream inputStream)
             throws IOException
     {
+        long cpuStart = THREAD_MX_BEAN.getCurrentThreadCpuTime();
         CodedInputStream input = CodedInputStream.newInstance(inputStream);
         DwrfProto.RowIndex rowIndex = DwrfProto.RowIndex.parseFrom(input);
+        runtimeStats.addMetricValue("DwrfReadRowIndexesTimeNanos", THREAD_MX_BEAN.getCurrentThreadCpuTime() - cpuStart);
         return ImmutableList.copyOf(Iterables.transform(rowIndex.getEntryList(), rowIndexEntry -> toRowGroupIndex(hiveWriterVersion, rowIndexEntry)));
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcMetadataReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcMetadataReader.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.orc.metadata;
 
+import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.orc.DwrfEncryptionProvider;
 import com.facebook.presto.orc.DwrfKeyProvider;
 import com.facebook.presto.orc.OrcDataSource;
@@ -39,12 +40,14 @@ import com.facebook.presto.orc.protobuf.CodedInputStream;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.sun.management.ThreadMXBean;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import io.airlift.units.DataSize;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.management.ManagementFactory;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
@@ -75,19 +78,30 @@ import static io.airlift.slice.SliceUtf8.tryGetCodePointAt;
 import static io.airlift.units.DataSize.Unit.GIGABYTE;
 import static java.lang.Character.MIN_SUPPLEMENTARY_CODE_POINT;
 import static java.lang.Math.toIntExact;
+import static java.util.Objects.requireNonNull;
 
 public class OrcMetadataReader
         implements MetadataReader
 {
     private static final int REPLACEMENT_CHARACTER_CODE_POINT = 0xFFFD;
     private static final int PROTOBUF_MESSAGE_MAX_LIMIT = toIntExact(new DataSize(1, GIGABYTE).toBytes());
+    private static final ThreadMXBean THREAD_MX_BEAN = (ThreadMXBean) ManagementFactory.getThreadMXBean();
+
+    private final RuntimeStats runtimeStats;
+
+    public OrcMetadataReader(RuntimeStats runtimeStats)
+    {
+        this.runtimeStats = requireNonNull(runtimeStats, "runtimeStats is null");
+    }
 
     @Override
     public PostScript readPostScript(byte[] data, int offset, int length)
             throws IOException
     {
+        long cpuStart = THREAD_MX_BEAN.getCurrentThreadCpuTime();
         CodedInputStream input = CodedInputStream.newInstance(data, offset, length);
         OrcProto.PostScript postScript = OrcProto.PostScript.parseFrom(input);
+        runtimeStats.addMetricValue("OrcReadPostScriptTimeNanos", THREAD_MX_BEAN.getCurrentThreadCpuTime() - cpuStart);
 
         return new PostScript(
                 postScript.getVersionList(),
@@ -112,9 +126,11 @@ public class OrcMetadataReader
     public Metadata readMetadata(HiveWriterVersion hiveWriterVersion, InputStream inputStream)
             throws IOException
     {
+        long cpuStart = THREAD_MX_BEAN.getCurrentThreadCpuTime();
         CodedInputStream input = CodedInputStream.newInstance(inputStream);
         input.setSizeLimit(PROTOBUF_MESSAGE_MAX_LIMIT);
         OrcProto.Metadata metadata = OrcProto.Metadata.parseFrom(input);
+        runtimeStats.addMetricValue("OrcReadMetadataTimeNanos", THREAD_MX_BEAN.getCurrentThreadCpuTime() - cpuStart);
         return new Metadata(toStripeStatistics(hiveWriterVersion, metadata.getStripeStatsList()));
     }
 
@@ -139,9 +155,11 @@ public class OrcMetadataReader
             Optional<OrcDecompressor> decompressor)
             throws IOException
     {
+        long cpuStart = THREAD_MX_BEAN.getCurrentThreadCpuTime();
         CodedInputStream input = CodedInputStream.newInstance(inputStream);
         input.setSizeLimit(PROTOBUF_MESSAGE_MAX_LIMIT);
         OrcProto.Footer footer = OrcProto.Footer.parseFrom(input);
+        runtimeStats.addMetricValue("OrcReadFooterTimeNanos", THREAD_MX_BEAN.getCurrentThreadCpuTime() - cpuStart);
         return new Footer(
                 footer.getNumberOfRows(),
                 footer.getRowIndexStride(),
@@ -175,8 +193,10 @@ public class OrcMetadataReader
     public StripeFooter readStripeFooter(OrcDataSourceId orcDataSourceId, List<OrcType> types, InputStream inputStream)
             throws IOException
     {
+        long cpuStart = THREAD_MX_BEAN.getCurrentThreadCpuTime();
         CodedInputStream input = CodedInputStream.newInstance(inputStream);
         OrcProto.StripeFooter stripeFooter = OrcProto.StripeFooter.parseFrom(input);
+        runtimeStats.addMetricValue("OrcReadStripeFooterTimeNanos", THREAD_MX_BEAN.getCurrentThreadCpuTime() - cpuStart);
         return new StripeFooter(toStream(stripeFooter.getStreamsList()), toColumnEncoding(stripeFooter.getColumnsList()), ImmutableList.of());
     }
 
@@ -208,8 +228,10 @@ public class OrcMetadataReader
     public List<RowGroupIndex> readRowIndexes(HiveWriterVersion hiveWriterVersion, InputStream inputStream)
             throws IOException
     {
+        long cpuStart = THREAD_MX_BEAN.getCurrentThreadCpuTime();
         CodedInputStream input = CodedInputStream.newInstance(inputStream);
         OrcProto.RowIndex rowIndex = OrcProto.RowIndex.parseFrom(input);
+        runtimeStats.addMetricValue("OrcReadRowIndexesTimeNanos", THREAD_MX_BEAN.getCurrentThreadCpuTime() - cpuStart);
         return rowIndex.getEntryList().stream()
                 .map(rowIndexEntry -> toRowGroupIndex(hiveWriterVersion, rowIndexEntry))
                 .collect(toImmutableList());

--- a/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkBatchStreamReaders.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkBatchStreamReaders.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.orc;
 
+import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.type.DecimalType;
 import com.facebook.presto.common.type.SqlDecimal;
@@ -212,7 +213,8 @@ public class BenchmarkBatchStreamReaders
                     OrcReaderTestingUtils.createDefaultTestConfig(),
                     false,
                     NO_ENCRYPTION,
-                    DwrfKeyProvider.EMPTY);
+                    DwrfKeyProvider.EMPTY,
+                    new RuntimeStats());
             return orcReader.createBatchRecordReader(
                     ImmutableMap.of(0, type),
                     OrcPredicate.TRUE,

--- a/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkBatchStreamReadersWithZstd.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkBatchStreamReadersWithZstd.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.orc;
 
+import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.type.DecimalType;
 import com.facebook.presto.common.type.SqlDecimal;
@@ -224,7 +225,8 @@ public class BenchmarkBatchStreamReadersWithZstd
                     OrcReaderTestingUtils.createTestingReaderOptions(zstdJniDecompressionEnabled),
                     false,
                     NO_ENCRYPTION,
-                    DwrfKeyProvider.EMPTY);
+                    DwrfKeyProvider.EMPTY,
+                    new RuntimeStats());
             return orcReader.createBatchRecordReader(
                     ImmutableMap.of(0, type),
                     OrcPredicate.TRUE,

--- a/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkSelectiveStreamReaders.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkSelectiveStreamReaders.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.orc;
 
 import com.facebook.presto.common.Page;
+import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.common.Subfield;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.type.DecimalType;
@@ -289,7 +290,8 @@ public class BenchmarkSelectiveStreamReaders
                     OrcReaderTestingUtils.createDefaultTestConfig(),
                     false,
                     NO_ENCRYPTION,
-                    DwrfKeyProvider.EMPTY);
+                    DwrfKeyProvider.EMPTY,
+                    new RuntimeStats());
 
             return orcReader.createSelectiveRecordReader(
                     IntStream.range(0, channelCount).boxed().collect(Collectors.toMap(Function.identity(), i -> type)),

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestCachingOrcDataSource.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestCachingOrcDataSource.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.orc;
 
+import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.orc.OrcTester.Format;
 import com.facebook.presto.orc.cache.StorageOrcFileTailSource;
@@ -242,7 +243,8 @@ public class TestCachingOrcDataSource
                 new OrcReaderOptions(maxMergeDistance, tinyStripeThreshold, new DataSize(1, Unit.MEGABYTE), false),
                 false,
                 NO_ENCRYPTION,
-                DwrfKeyProvider.EMPTY);
+                DwrfKeyProvider.EMPTY,
+                new RuntimeStats());
         // 1 for reading file footer
         assertEquals(orcDataSource.getReadCount(), 1);
         List<StripeInformation> stripes = orcReader.getFooter().getStripes();

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestDecryption.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestDecryption.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.orc;
 
+import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.common.Subfield;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.orc.cache.StorageOrcFileTailSource;
@@ -493,7 +494,8 @@ public class TestDecryption
                         false),
                 false,
                 new DwrfEncryptionProvider(new UnsupportedEncryptionLibrary(), new TestingPlainKeyEncryptionLibrary()),
-                DwrfKeyProvider.of(ImmutableMap.of(0, Slices.utf8Slice("key"))));
+                DwrfKeyProvider.of(ImmutableMap.of(0, Slices.utf8Slice("key"))),
+                new RuntimeStats());
 
         int offset = 10;
         try (OrcSelectiveRecordReader recordReader = getSelectiveRecordReader(orcDataSource, orcReader, offset)) {

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestMapFlatBatchStreamReader.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestMapFlatBatchStreamReader.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.orc;
 
+import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.type.BigintType;
 import com.facebook.presto.common.type.BooleanType;
@@ -452,7 +453,8 @@ public class TestMapFlatBatchStreamReader
                 OrcReaderTestingUtils.createDefaultTestConfig(),
                 false,
                 NO_ENCRYPTION,
-                DwrfKeyProvider.EMPTY);
+                DwrfKeyProvider.EMPTY,
+                new RuntimeStats());
         Type mapType = FUNCTION_AND_TYPE_MANAGER.getParameterizedType(
                 StandardTypes.MAP,
                 ImmutableList.of(

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcBloomFilters.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcBloomFilters.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.orc;
 
+import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.common.predicate.Domain;
 import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.common.type.Type;
@@ -121,7 +122,7 @@ public class TestOrcBloomFilters
 
         // Read through method
         InputStream inputStream = new ByteArrayInputStream(bytes);
-        OrcMetadataReader metadataReader = new OrcMetadataReader();
+        OrcMetadataReader metadataReader = new OrcMetadataReader(new RuntimeStats());
         List<HiveBloomFilter> bloomFilters = metadataReader.readBloomFilterIndexes(inputStream);
 
         assertEquals(bloomFilters.size(), 1);

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcLz4.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcLz4.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.orc;
 
+import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.orc.cache.StorageOrcFileTailSource;
@@ -61,7 +62,8 @@ public class TestOrcLz4
                         false),
                 false,
                 NO_ENCRYPTION,
-                DwrfKeyProvider.EMPTY);
+                DwrfKeyProvider.EMPTY,
+                new RuntimeStats());
 
         assertEquals(orcReader.getCompressionKind(), LZ4);
         assertEquals(orcReader.getFooter().getNumberOfRows(), 10_000);

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcReaderDwrfStripeCaching.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcReaderDwrfStripeCaching.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.orc;
 
+import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.orc.StripeReader.StripeId;
 import com.facebook.presto.orc.cache.StorageOrcFileTailSource;
 import com.facebook.presto.orc.metadata.DwrfStripeCache;
@@ -252,7 +253,8 @@ public class TestOrcReaderDwrfStripeCaching
                 OrcReaderTestingUtils.createDefaultTestConfig(),
                 false,
                 NO_ENCRYPTION,
-                DwrfKeyProvider.EMPTY);
+                DwrfKeyProvider.EMPTY,
+                new RuntimeStats());
         return stripeMetadataSourceFactory.getDwrfStripeCache();
     }
 

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcReaderPositions.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcReaderPositions.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.orc;
 
+import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.orc.cache.StorageOrcFileTailSource;
 import com.facebook.presto.orc.metadata.CompressionKind;
@@ -309,7 +310,8 @@ public class TestOrcReaderPositions
                     OrcReaderTestingUtils.createDefaultTestConfig(),
                     false,
                     NO_ENCRYPTION,
-                    DwrfKeyProvider.EMPTY);
+                    DwrfKeyProvider.EMPTY,
+                    new RuntimeStats());
             Footer footer = orcReader.getFooter();
             Map<String, String> readMetadata = Maps.transformValues(footer.getUserMetadata(), Slice::toStringAscii);
             assertEquals(readMetadata, metadata);

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcRecordReaderDwrfStripeCaching.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcRecordReaderDwrfStripeCaching.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.orc;
 
 import com.facebook.presto.common.Page;
+import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.orc.cache.StorageOrcFileTailSource;
 import com.facebook.presto.orc.metadata.DwrfStripeCacheMode;
@@ -154,7 +155,8 @@ public class TestOrcRecordReaderDwrfStripeCaching
                     orcReaderOptions,
                     false,
                     NO_ENCRYPTION,
-                    DwrfKeyProvider.EMPTY);
+                    DwrfKeyProvider.EMPTY,
+                    new RuntimeStats());
 
             assertRecordValues(orcDataSource, orcReader);
 
@@ -178,7 +180,8 @@ public class TestOrcRecordReaderDwrfStripeCaching
                     OrcReaderTestingUtils.createDefaultTestConfig(),
                     false,
                     NO_ENCRYPTION,
-                    DwrfKeyProvider.EMPTY);
+                    DwrfKeyProvider.EMPTY,
+                    new RuntimeStats());
 
             assertRecordValues(orcDataSource, orcReader);
         }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestReadBloomFilter.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestReadBloomFilter.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.orc;
 
+import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.common.predicate.NullableValue;
 import com.facebook.presto.common.type.SqlVarbinary;
 import com.facebook.presto.common.type.Type;
@@ -123,7 +124,8 @@ public class TestReadBloomFilter
                 OrcReaderTestingUtils.createDefaultTestConfig(),
                 false,
                 NO_ENCRYPTION,
-                DwrfKeyProvider.EMPTY);
+                DwrfKeyProvider.EMPTY,
+                new RuntimeStats());
 
         assertEquals(orcReader.getColumnNames(), ImmutableList.of("test"));
         assertEquals(orcReader.getFooter().getRowsInRowGroup(), 10_000);

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestStorageOrcFileTailSource.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestStorageOrcFileTailSource.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.orc;
 
+import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.orc.cache.StorageOrcFileTailSource;
 import com.facebook.presto.orc.metadata.DwrfMetadataReader;
 import com.facebook.presto.orc.metadata.DwrfStripeCacheData;
@@ -55,7 +56,7 @@ public class TestStorageOrcFileTailSource
             throws Exception
     {
         this.file = new TempFile();
-        this.metadataReader = new DwrfMetadataReader();
+        this.metadataReader = new DwrfMetadataReader(new RuntimeStats());
     }
 
     @AfterMethod(alwaysRun = true)

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestStructBatchStreamReader.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestStructBatchStreamReader.java
@@ -15,6 +15,7 @@
 package com.facebook.presto.orc;
 
 import com.facebook.presto.common.Page;
+import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockBuilder;
 import com.facebook.presto.common.block.RowBlock;
@@ -283,7 +284,8 @@ public class TestStructBatchStreamReader
                         false),
                 false,
                 NO_ENCRYPTION,
-                DwrfKeyProvider.EMPTY);
+                DwrfKeyProvider.EMPTY,
+                new RuntimeStats());
 
         Map<Integer, Type> includedColumns = new HashMap<>();
         includedColumns.put(0, readerType);

--- a/presto-orc/src/test/java/com/facebook/presto/orc/metadata/TestDwrfMetadataReader.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/metadata/TestDwrfMetadataReader.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.orc.metadata;
 
+import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.orc.DwrfEncryptionProvider;
 import com.facebook.presto.orc.DwrfKeyProvider;
 import com.facebook.presto.orc.OrcCorruptionException;
@@ -49,7 +50,7 @@ public class TestDwrfMetadataReader
 {
     private final long footerLength = 10;
     private final long compressionBlockSize = 8192;
-    private final DwrfMetadataReader dwrfMetadataReader = new DwrfMetadataReader();
+    private final DwrfMetadataReader dwrfMetadataReader = new DwrfMetadataReader(new RuntimeStats());
     private final DwrfProto.PostScript baseProtoPostScript = DwrfProto.PostScript.newBuilder()
             .setWriterVersion(HiveWriterVersion.ORC_HIVE_8732.getOrcWriterVersion())
             .setFooterLength(footerLength)

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcFileRewriter.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcFileRewriter.java
@@ -17,6 +17,7 @@ import com.facebook.airlift.json.JsonCodec;
 import com.facebook.airlift.log.Logger;
 import com.facebook.presto.common.NotSupportedException;
 import com.facebook.presto.common.Page;
+import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeManager;
@@ -115,7 +116,8 @@ public final class OrcFileRewriter
                     new OrcReaderOptions(readerAttributes.getMaxMergeDistance(), readerAttributes.getTinyStripeThreshold(), HUGE_MAX_READ_BLOCK_SIZE, readerAttributes.isZstdJniDecompressionEnabled()),
                     false,
                     NO_ENCRYPTION,
-                    DwrfKeyProvider.EMPTY);
+                    DwrfKeyProvider.EMPTY,
+                    new RuntimeStats());
 
             if (reader.getFooter().getNumberOfRows() < rowsToDelete.length()) {
                 throw new IOException("File has fewer rows than deletion vector");

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcStorageManager.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcStorageManager.java
@@ -15,6 +15,7 @@ package com.facebook.presto.raptor.storage;
 
 import com.facebook.airlift.json.JsonCodec;
 import com.facebook.presto.common.Page;
+import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.io.DataSink;
 import com.facebook.presto.common.predicate.TupleDomain;
@@ -298,7 +299,8 @@ public class OrcStorageManager
                     new OrcReaderOptions(readerAttributes.getMaxMergeDistance(), readerAttributes.getTinyStripeThreshold(), HUGE_MAX_READ_BLOCK_SIZE, readerAttributes.isZstdJniDecompressionEnabled()),
                     hiveFileContext.isCacheable(),
                     NO_ENCRYPTION,
-                    DwrfKeyProvider.EMPTY);
+                    DwrfKeyProvider.EMPTY,
+                    new RuntimeStats());
 
             Map<Long, Integer> indexMap = columnIdIndex(reader.getColumnNames());
             ImmutableMap.Builder<Integer, Type> includedColumns = ImmutableMap.builder();
@@ -393,7 +395,8 @@ public class OrcStorageManager
                             defaultReaderAttributes.isZstdJniDecompressionEnabled()),
                     false,
                     NO_ENCRYPTION,
-                    DwrfKeyProvider.EMPTY);
+                    DwrfKeyProvider.EMPTY,
+                    new RuntimeStats());
 
             if (reader.getFooter().getNumberOfRows() >= Integer.MAX_VALUE) {
                 throw new IOException("File has too many rows");
@@ -558,7 +561,8 @@ public class OrcStorageManager
                     new OrcReaderOptions(defaultReaderAttributes.getMaxMergeDistance(), defaultReaderAttributes.getTinyStripeThreshold(), HUGE_MAX_READ_BLOCK_SIZE, defaultReaderAttributes.isZstdJniDecompressionEnabled()),
                     false,
                     NO_ENCRYPTION,
-                    DwrfKeyProvider.EMPTY);
+                    DwrfKeyProvider.EMPTY,
+                    new RuntimeStats());
 
             ImmutableList.Builder<ColumnStats> list = ImmutableList.builder();
             for (ColumnInfo info : getColumnInfo(reader)) {

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/OrcTestingUtil.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/OrcTestingUtil.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.raptor.storage;
 
+import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.common.io.OutputStreamDataSink;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
@@ -72,7 +73,8 @@ final class OrcTestingUtil
                 createDefaultTestConfig(),
                 false,
                 NO_ENCRYPTION,
-                DwrfKeyProvider.EMPTY);
+                DwrfKeyProvider.EMPTY,
+                new RuntimeStats());
 
         List<String> columnNames = orcReader.getColumnNames();
         assertEquals(columnNames.size(), columnIds.size());

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestOrcFileRewriter.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/storage/TestOrcFileRewriter.java
@@ -15,6 +15,7 @@ package com.facebook.presto.raptor.storage;
 
 import com.facebook.airlift.json.JsonCodec;
 import com.facebook.presto.common.Page;
+import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.io.OutputStreamDataSink;
 import com.facebook.presto.common.predicate.TupleDomain;
@@ -505,7 +506,8 @@ public class TestOrcFileRewriter
                 OrcTestingUtil.createDefaultTestConfig(),
                 false,
                 NO_ENCRYPTION,
-                DwrfKeyProvider.EMPTY);
+                DwrfKeyProvider.EMPTY,
+                new RuntimeStats());
         orcReader.getColumnNames().equals(ImmutableList.of("7"));
 
         // Add a column with the different ID with different type


### PR DESCRIPTION
These MetadataReader calls involve deserializing protos which could be
expensive. Track their CPU usage can help us better understand their
costs.

Test plan 
Test it locally:
![image](https://user-images.githubusercontent.com/67174152/130865528-87108c10-c3ed-4741-8c18-8ab8011ba65c.png)

```
== NO RELEASE NOTE ==
```
