### PR TITLE
Add Identity to checkCanSetUser

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/security/AccessControl.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/AccessControl.java
@@ -33,7 +33,7 @@ public interface AccessControl
      *
      * @throws com.facebook.presto.spi.security.AccessDeniedException if not allowed
      */
-    void checkCanSetUser(AccessControlContext accessControlContext, Optional<Principal> principal, String userName);
+    void checkCanSetUser(Identity identity, AccessControlContext accessControlContext, Optional<Principal> principal, String userName);
 
     /**
      * Check if the query is unexpectedly modified using the credentials passed in the identity.

--- a/presto-main/src/main/java/com/facebook/presto/security/AccessControlManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/AccessControlManager.java
@@ -154,12 +154,12 @@ public class AccessControlManager
     }
 
     @Override
-    public void checkCanSetUser(AccessControlContext context, Optional<Principal> principal, String userName)
+    public void checkCanSetUser(Identity identity, AccessControlContext context, Optional<Principal> principal, String userName)
     {
         requireNonNull(principal, "principal is null");
         requireNonNull(userName, "userName is null");
 
-        authenticationCheck(() -> systemAccessControl.get().checkCanSetUser(context, principal, userName));
+        authenticationCheck(() -> systemAccessControl.get().checkCanSetUser(identity, context, principal, userName));
     }
 
     @Override
@@ -786,7 +786,7 @@ public class AccessControlManager
         }
 
         @Override
-        public void checkCanSetUser(AccessControlContext context, Optional<Principal> principal, String userName)
+        public void checkCanSetUser(Identity identity, AccessControlContext context, Optional<Principal> principal, String userName)
         {
             throw new PrestoException(SERVER_STARTING_UP, "Presto server is still initializing");
         }

--- a/presto-main/src/main/java/com/facebook/presto/security/AllowAllAccessControl.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/AllowAllAccessControl.java
@@ -30,7 +30,7 @@ public class AllowAllAccessControl
         implements AccessControl
 {
     @Override
-    public void checkCanSetUser(AccessControlContext context, Optional<Principal> principal, String userName)
+    public void checkCanSetUser(Identity identity, AccessControlContext context, Optional<Principal> principal, String userName)
     {
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/security/AllowAllSystemAccessControl.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/AllowAllSystemAccessControl.java
@@ -62,7 +62,7 @@ public class AllowAllSystemAccessControl
     }
 
     @Override
-    public void checkCanSetUser(AccessControlContext context, Optional<Principal> principal, String userName)
+    public void checkCanSetUser(Identity identity, AccessControlContext context, Optional<Principal> principal, String userName)
     {
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/security/DenyAllAccessControl.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/DenyAllAccessControl.java
@@ -64,7 +64,7 @@ public class DenyAllAccessControl
         implements AccessControl
 {
     @Override
-    public void checkCanSetUser(AccessControlContext context, Optional<Principal> principal, String userName)
+    public void checkCanSetUser(Identity identity, AccessControlContext context, Optional<Principal> principal, String userName)
     {
         denySetUser(principal, userName);
     }

--- a/presto-main/src/main/java/com/facebook/presto/security/FileBasedSystemAccessControl.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/FileBasedSystemAccessControl.java
@@ -152,7 +152,7 @@ public class FileBasedSystemAccessControl
     }
 
     @Override
-    public void checkCanSetUser(AccessControlContext context, Optional<Principal> principal, String userName)
+    public void checkCanSetUser(Identity identity, AccessControlContext context, Optional<Principal> principal, String userName)
     {
         requireNonNull(principal, "principal is null");
         requireNonNull(userName, "userName is null");

--- a/presto-main/src/main/java/com/facebook/presto/security/ReadOnlySystemAccessControl.java
+++ b/presto-main/src/main/java/com/facebook/presto/security/ReadOnlySystemAccessControl.java
@@ -55,7 +55,7 @@ public class ReadOnlySystemAccessControl
     }
 
     @Override
-    public void checkCanSetUser(AccessControlContext context, Optional<Principal> principal, String userName)
+    public void checkCanSetUser(Identity identity, AccessControlContext context, Optional<Principal> principal, String userName)
     {
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/server/QuerySessionSupplier.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/QuerySessionSupplier.java
@@ -64,8 +64,9 @@ public class QuerySessionSupplier
     public Session createSession(QueryId queryId, SessionContext context)
     {
         Identity identity = context.getIdentity();
-        accessControl.checkCanSetUser(new AccessControlContext(queryId, Optional.ofNullable(context.getClientInfo()), Optional.ofNullable(context.getSource())),
-                identity.getPrincipal(), identity.getUser());
+        accessControl.checkCanSetUser(
+                identity,
+                new AccessControlContext(queryId, Optional.ofNullable(context.getClientInfo()), Optional.ofNullable(context.getSource())), identity.getPrincipal(), identity.getUser());
 
         SessionBuilder sessionBuilder = Session.builder(sessionPropertyManager)
                 .setQueryId(queryId)

--- a/presto-main/src/main/java/com/facebook/presto/testing/TestingAccessControlManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/TestingAccessControlManager.java
@@ -103,13 +103,13 @@ public class TestingAccessControlManager
     }
 
     @Override
-    public void checkCanSetUser(AccessControlContext context, Optional<Principal> principal, String userName)
+    public void checkCanSetUser(Identity identity, AccessControlContext context, Optional<Principal> principal, String userName)
     {
         if (shouldDenyPrivilege(userName, userName, SET_USER)) {
             denySetUser(principal, userName);
         }
         if (denyPrivileges.isEmpty()) {
-            super.checkCanSetUser(context, principal, userName);
+            super.checkCanSetUser(identity, context, principal, userName);
         }
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/security/TestAccessControlManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/security/TestAccessControlManager.java
@@ -74,7 +74,11 @@ public class TestAccessControlManager
     public void testInitializing()
     {
         AccessControlManager accessControlManager = new AccessControlManager(createTestTransactionManager());
-        accessControlManager.checkCanSetUser(new AccessControlContext(new QueryId(QUERY_ID), Optional.empty(), Optional.empty()), Optional.empty(), "foo");
+        accessControlManager.checkCanSetUser(
+                new Identity(USER_NAME, Optional.of(PRINCIPAL)),
+                new AccessControlContext(new QueryId(QUERY_ID), Optional.empty(), Optional.empty()),
+                Optional.empty(),
+                "foo");
     }
 
     @Test
@@ -82,7 +86,11 @@ public class TestAccessControlManager
     {
         AccessControlManager accessControlManager = new AccessControlManager(createTestTransactionManager());
         accessControlManager.setSystemAccessControl(AllowAllSystemAccessControl.NAME, ImmutableMap.of());
-        accessControlManager.checkCanSetUser(new AccessControlContext(new QueryId(QUERY_ID), Optional.empty(), Optional.empty()), Optional.empty(), USER_NAME);
+        accessControlManager.checkCanSetUser(
+                new Identity(USER_NAME, Optional.of(PRINCIPAL)),
+                new AccessControlContext(new QueryId(QUERY_ID), Optional.empty(), Optional.empty()),
+                Optional.empty(),
+                USER_NAME);
     }
 
     @Test
@@ -95,7 +103,7 @@ public class TestAccessControlManager
         AccessControlContext context = new AccessControlContext(new QueryId(QUERY_ID), Optional.empty(), Optional.empty());
 
         accessControlManager.setSystemAccessControl(ReadOnlySystemAccessControl.NAME, ImmutableMap.of());
-        accessControlManager.checkCanSetUser(context, Optional.of(PRINCIPAL), USER_NAME);
+        accessControlManager.checkCanSetUser(identity, context, Optional.of(PRINCIPAL), USER_NAME);
         accessControlManager.checkCanSetSystemSessionProperty(identity, context, "property");
 
         transaction(transactionManager, accessControlManager)
@@ -133,7 +141,11 @@ public class TestAccessControlManager
         accessControlManager.addSystemAccessControlFactory(accessControlFactory);
         accessControlManager.setSystemAccessControl("test", ImmutableMap.of());
 
-        accessControlManager.checkCanSetUser(new AccessControlContext(new QueryId(QUERY_ID), Optional.empty(), Optional.empty()), Optional.of(PRINCIPAL), USER_NAME);
+        accessControlManager.checkCanSetUser(
+                new Identity(USER_NAME, Optional.of(PRINCIPAL)),
+                new AccessControlContext(new QueryId(QUERY_ID), Optional.empty(), Optional.empty()),
+                Optional.of(PRINCIPAL),
+                USER_NAME);
         assertEquals(accessControlFactory.getCheckedUserName(), USER_NAME);
         assertEquals(accessControlFactory.getCheckedPrincipal(), Optional.of(PRINCIPAL));
     }
@@ -309,7 +321,7 @@ public class TestAccessControlManager
             return new SystemAccessControl()
             {
                 @Override
-                public void checkCanSetUser(AccessControlContext context, Optional<Principal> principal, String userName)
+                public void checkCanSetUser(Identity identity, AccessControlContext context, Optional<Principal> principal, String userName)
                 {
                     checkedPrincipal = principal;
                     checkedUserName = userName;

--- a/presto-main/src/test/java/com/facebook/presto/security/TestFileBasedSystemAccessControl.java
+++ b/presto-main/src/test/java/com/facebook/presto/security/TestFileBasedSystemAccessControl.java
@@ -74,33 +74,33 @@ public class TestFileBasedSystemAccessControl
         AccessControlManager accessControlManager = newAccessControlManager(transactionManager, "catalog_principal.json");
 
         try {
-            accessControlManager.checkCanSetUser(context, Optional.empty(), alice.getUser());
+            accessControlManager.checkCanSetUser(alice, context, Optional.empty(), alice.getUser());
             throw new AssertionError("expected AccessDeniedExeption");
         }
         catch (AccessDeniedException expected) {
         }
 
-        accessControlManager.checkCanSetUser(context, kerberosValidAlice.getPrincipal(), kerberosValidAlice.getUser());
-        accessControlManager.checkCanSetUser(context, kerberosValidNonAsciiUser.getPrincipal(), kerberosValidNonAsciiUser.getUser());
+        accessControlManager.checkCanSetUser(kerberosValidAlice, context, kerberosValidAlice.getPrincipal(), kerberosValidAlice.getUser());
+        accessControlManager.checkCanSetUser(kerberosValidNonAsciiUser, context, kerberosValidNonAsciiUser.getPrincipal(), kerberosValidNonAsciiUser.getUser());
         try {
-            accessControlManager.checkCanSetUser(context, kerberosInvalidAlice.getPrincipal(), kerberosInvalidAlice.getUser());
+            accessControlManager.checkCanSetUser(kerberosInvalidAlice, context, kerberosInvalidAlice.getPrincipal(), kerberosInvalidAlice.getUser());
             throw new AssertionError("expected AccessDeniedExeption");
         }
         catch (AccessDeniedException expected) {
         }
 
-        accessControlManager.checkCanSetUser(context, kerberosValidShare.getPrincipal(), kerberosValidShare.getUser());
+        accessControlManager.checkCanSetUser(kerberosValidShare, context, kerberosValidShare.getPrincipal(), kerberosValidShare.getUser());
         try {
-            accessControlManager.checkCanSetUser(context, kerberosInValidShare.getPrincipal(), kerberosInValidShare.getUser());
+            accessControlManager.checkCanSetUser(kerberosInValidShare, context, kerberosInValidShare.getPrincipal(), kerberosInValidShare.getUser());
             throw new AssertionError("expected AccessDeniedExeption");
         }
         catch (AccessDeniedException expected) {
         }
 
-        accessControlManager.checkCanSetUser(context, validSpecialRegexWildDot.getPrincipal(), validSpecialRegexWildDot.getUser());
-        accessControlManager.checkCanSetUser(context, validSpecialRegexEndQuote.getPrincipal(), validSpecialRegexEndQuote.getUser());
+        accessControlManager.checkCanSetUser(validSpecialRegexWildDot, context, validSpecialRegexWildDot.getPrincipal(), validSpecialRegexWildDot.getUser());
+        accessControlManager.checkCanSetUser(validSpecialRegexEndQuote, context, validSpecialRegexEndQuote.getPrincipal(), validSpecialRegexEndQuote.getUser());
         try {
-            accessControlManager.checkCanSetUser(context, invalidSpecialRegex.getPrincipal(), invalidSpecialRegex.getUser());
+            accessControlManager.checkCanSetUser(invalidSpecialRegex, context, invalidSpecialRegex.getPrincipal(), invalidSpecialRegex.getUser());
             throw new AssertionError("expected AccessDeniedExeption");
         }
         catch (AccessDeniedException expected) {
@@ -108,7 +108,7 @@ public class TestFileBasedSystemAccessControl
 
         TransactionManager transactionManagerNoPatterns = createTestTransactionManager();
         AccessControlManager accessControlManagerNoPatterns = newAccessControlManager(transactionManager, "catalog.json");
-        accessControlManagerNoPatterns.checkCanSetUser(context, kerberosValidAlice.getPrincipal(), kerberosValidAlice.getUser());
+        accessControlManagerNoPatterns.checkCanSetUser(kerberosValidAlice, context, kerberosValidAlice.getPrincipal(), kerberosValidAlice.getUser());
     }
 
     @Test

--- a/presto-plugin-toolkit/src/main/java/com/facebook/presto/plugin/base/security/ForwardingSystemAccessControl.java
+++ b/presto-plugin-toolkit/src/main/java/com/facebook/presto/plugin/base/security/ForwardingSystemAccessControl.java
@@ -48,9 +48,9 @@ public abstract class ForwardingSystemAccessControl
     protected abstract SystemAccessControl delegate();
 
     @Override
-    public void checkCanSetUser(AccessControlContext context, Optional<Principal> principal, String userName)
+    public void checkCanSetUser(Identity identity, AccessControlContext context, Optional<Principal> principal, String userName)
     {
-        delegate().checkCanSetUser(context, principal, userName);
+        delegate().checkCanSetUser(identity, context, principal, userName);
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/security/SystemAccessControl.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/security/SystemAccessControl.java
@@ -51,7 +51,7 @@ public interface SystemAccessControl
      *
      * @throws AccessDeniedException if not allowed
      */
-    void checkCanSetUser(AccessControlContext context, Optional<Principal> principal, String userName);
+    void checkCanSetUser(Identity identity, AccessControlContext context, Optional<Principal> principal, String userName);
 
     /**
      * Check if the query is unexpectedly modified using the credentials passed in the identity.


### PR DESCRIPTION
Depends on https://github.com/facebookexternal/presto-facebook/pull/1650
```
== RELEASE NOTES ==

SPI Changes
* Add ``Identity`` field to ``checkCanSetUser`` for finer granularity of system access control.
```

