### PR TITLE
Improve LookupJoin Performance

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/PageBuilder.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/PageBuilder.java
@@ -94,7 +94,7 @@ public class PageBuilder
 
         declaredPositions = 0;
 
-        for (int i = 0; i < types.size(); i++) {
+        for (int i = 0; i < blockBuilders.length; i++) {
             blockBuilders[i] = blockBuilders[i].newBlockBuilderLike(pageBuilderStatus.createBlockBuilderStatus());
         }
     }


### PR DESCRIPTION
Changes extracted and adapted from https://github.com/trinodb/trino/pull/8974

Improves lookup join performance via changes in `LookupJoinPageBuilder` and `JoinProbe`.

Improves `JoinProbe` by:
- Avoiding boxing the hash channel Block, preferring a `@Nullable` field instead
- Avoiding boxing of the `probeJoinChannels` and probeHashChannel arguments in `JoinProbeFactory`
- Using the `Page#getLoadedPage(int...channels)` helper to ensure probePage LazyBlocks are loaded and unwrapped before entering the main probe loop
- Leveraging `Block#mayHaveNull()` to bypass `Block#isNull()` checks on the probe page blocks

Improves `LookupJoinPageBuilder` by:
- Storing the previous join probe position directly to avoid repeating `probeIndexBuilder.getInt(probeIndexBuilder.size() - 1)` calls
- Storing the estimated probe size in bytes per row to avoid doing a looping integer division / sum per output column on each row joined
- Unswitching the `LookupJoinPageBuilder#build(JoinProbe)` loop so that sequential probe position joins can bypass copying the probeIndexBuilder contents into a new int[] when it won't be used
- Bypassing `buildPageBuilder.build()` in favor of using each individual `BlockBuilder#build()`. This avoids an unnecessary intermediate page creation that is quickly discarded

Benchmarks for [BenchmarkHashBuildAndJoinOperators.benchmarkJoinHash](https://jmh.morethan.io/?sources=https://gist.githubusercontent.com/pettyjamesm/4433598a243df755ba13138e67c7005d/raw/ae11a47d63e71c0cd5f4a71a4422b4202b000320/baseline_join.json,https://gist.githubusercontent.com/pettyjamesm/4433598a243df755ba13138e67c7005d/raw/ae11a47d63e71c0cd5f4a71a4422b4202b000320/improved_join.json) improve by 0-10% depending on the scenario.

```
== NO RELEASE NOTE ==
```
