### PR TITLE
fix Stage state transitionToRunning on schedulingComplete()

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlStageExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlStageExecution.java
@@ -286,7 +286,7 @@ public final class SqlStageExecution
             return;
         }
 
-        if (getAllTasks().stream().anyMatch(task -> getState() == StageExecutionState.RUNNING)) {
+        if (getAllTasks().stream().anyMatch(task -> task.getTaskStatus().getState() == TaskState.RUNNING)) {
             stateMachine.transitionToRunning();
         }
         if (finishedTasks.size() == allTasks.size()) {

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlStageExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlStageExecution.java
@@ -286,9 +286,6 @@ public final class SqlStageExecution
             return;
         }
 
-        if (getAllTasks().stream().anyMatch(task -> task.getTaskStatus().getState() == TaskState.RUNNING)) {
-            stateMachine.transitionToRunning();
-        }
         if (finishedTasks.size() == allTasks.size()) {
             stateMachine.transitionToFinished();
         }


### PR DESCRIPTION
fix Stage state transitionToRunning on schedulingComplete(), origin is dead code.

It would be possible to make Stage transition to RUNNING on schedulingComplete(), which maybe earlier than StageTaskListener#stateChanged()