### PR TITLE
Add column positional mode to InterpretedHashGenerator

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/MergeHashSort.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/MergeHashSort.java
@@ -49,7 +49,7 @@ public class MergeHashSort
      */
     public WorkProcessor<Page> merge(List<Type> keyTypes, List<Type> allTypes, List<WorkProcessor<Page>> channels, DriverYieldSignal driverYieldSignal)
     {
-        InterpretedHashGenerator hashGenerator = createHashGenerator(keyTypes);
+        InterpretedHashGenerator hashGenerator = InterpretedHashGenerator.createPositionalWithTypes(keyTypes);
         return mergeSortedPages(
                 channels,
                 createHashPageWithPositionComparator(hashGenerator),
@@ -85,14 +85,5 @@ public class MergeHashSort
 
             return Long.compare(leftHash, rightHash);
         };
-    }
-
-    private static InterpretedHashGenerator createHashGenerator(List<Type> keyTypes)
-    {
-        int[] hashChannels = new int[keyTypes.size()];
-        for (int i = 0; i < keyTypes.size(); i++) {
-            hashChannels[i] = i;
-        }
-        return new InterpretedHashGenerator(keyTypes, hashChannels);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/PartitionedLookupSource.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PartitionedLookupSource.java
@@ -92,11 +92,7 @@ public class PartitionedLookupSource
 
         // this generator is only used for getJoinPosition without a rawHash and in this case
         // the hash channels are always packed in a page without extra columns
-        int[] hashChannels = new int[hashChannelTypes.size()];
-        for (int i = 0; i < hashChannels.length; i++) {
-            hashChannels[i] = i;
-        }
-        this.partitionGenerator = new LocalPartitionGenerator(new InterpretedHashGenerator(hashChannelTypes, hashChannels), lookupSources.size());
+        this.partitionGenerator = new LocalPartitionGenerator(InterpretedHashGenerator.createPositionalWithTypes(hashChannelTypes), lookupSources.size());
 
         this.partitionMask = lookupSources.size() - 1;
         this.shiftSize = numberOfTrailingZeros(lookupSources.size()) + 1;

--- a/presto-main/src/main/java/com/facebook/presto/operator/exchange/LocalExchange.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/exchange/LocalExchange.java
@@ -45,7 +45,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
-import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static com.facebook.presto.operator.PipelineExecutionStrategy.UNGROUPED_EXECUTION;
@@ -165,7 +164,7 @@ public class LocalExchange
                 hashGenerator = new PrecomputedHashGenerator(0);
             }
             else {
-                hashGenerator = new InterpretedHashGenerator(partitioningChannelTypes, IntStream.range(0, partitioningChannelTypes.size()).toArray());
+                hashGenerator = InterpretedHashGenerator.createPositionalWithTypes(partitioningChannelTypes);
             }
             return new LocalPartitionGenerator(hashGenerator, partitionCount);
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/SystemPartitioningHandle.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/SystemPartitioningHandle.java
@@ -199,12 +199,7 @@ public final class SystemPartitioningHandle
                     return new HashBucketFunction(new PrecomputedHashGenerator(0), bucketCount);
                 }
                 else {
-                    int[] hashChannels = new int[partitionChannelTypes.size()];
-                    for (int i = 0; i < partitionChannelTypes.size(); i++) {
-                        hashChannels[i] = i;
-                    }
-
-                    return new HashBucketFunction(new InterpretedHashGenerator(partitionChannelTypes, hashChannels), bucketCount);
+                    return new HashBucketFunction(InterpretedHashGenerator.createPositionalWithTypes(partitionChannelTypes), bucketCount);
                 }
             }
         },

--- a/presto-main/src/main/java/com/facebook/presto/type/TypeUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/TypeUtils.java
@@ -140,11 +140,7 @@ public final class TypeUtils
 
     public static long getHashPosition(List<? extends Type> hashTypes, Block[] hashBlocks, int position)
     {
-        int[] hashChannels = new int[hashBlocks.length];
-        for (int i = 0; i < hashBlocks.length; i++) {
-            hashChannels[i] = i;
-        }
-        HashGenerator hashGenerator = new InterpretedHashGenerator(ImmutableList.copyOf(hashTypes), hashChannels);
+        HashGenerator hashGenerator = InterpretedHashGenerator.createPositionalWithTypes(ImmutableList.copyOf(hashTypes));
         Page page = new Page(hashBlocks);
         return hashGenerator.hashPosition(position, page);
     }
@@ -152,11 +148,7 @@ public final class TypeUtils
     public static Block getHashBlock(List<? extends Type> hashTypes, Block... hashBlocks)
     {
         checkArgument(hashTypes.size() == hashBlocks.length);
-        int[] hashChannels = new int[hashBlocks.length];
-        for (int i = 0; i < hashBlocks.length; i++) {
-            hashChannels[i] = i;
-        }
-        HashGenerator hashGenerator = new InterpretedHashGenerator(ImmutableList.copyOf(hashTypes), hashChannels);
+        HashGenerator hashGenerator = InterpretedHashGenerator.createPositionalWithTypes(ImmutableList.copyOf(hashTypes));
         int positionCount = hashBlocks[0].getPositionCount();
         BlockBuilder builder = BIGINT.createFixedSizeBlockBuilder(positionCount);
         Page page = new Page(hashBlocks);

--- a/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkGroupByHash.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkGroupByHash.java
@@ -17,6 +17,7 @@ import com.facebook.presto.array.LongBigArray;
 import com.facebook.presto.common.Page;
 import com.facebook.presto.common.PageBuilder;
 import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.LongArrayBlock;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
@@ -79,7 +80,13 @@ public class BenchmarkGroupByHash
     public Object groupByHashPreCompute(BenchmarkData data)
     {
         GroupByHash groupByHash = new MultiChannelGroupByHash(data.getTypes(), data.getChannels(), data.getHashChannel(), EXPECTED_SIZE, false, getJoinCompiler(data.isGroupByUsesEqual()), NOOP);
-        data.getPages().forEach(p -> groupByHash.getGroupIds(p).process());
+        for (Page page : data.getPages()) {
+            Work<?> work = groupByHash.addPage(page);
+            boolean finished;
+            do {
+                finished = work.process();
+            } while (!finished);
+        }
 
         ImmutableList.Builder<Page> pages = ImmutableList.builder();
         PageBuilder pageBuilder = new PageBuilder(groupByHash.getTypes());
@@ -97,10 +104,32 @@ public class BenchmarkGroupByHash
 
     @Benchmark
     @OperationsPerInvocation(POSITIONS)
+    public List<Page> benchmarkHashPosition(BenchmarkData data)
+    {
+        InterpretedHashGenerator hashGenerator = new InterpretedHashGenerator(data.getTypes(), data.getChannels());
+        ImmutableList.Builder<Page> results = ImmutableList.builderWithExpectedSize(data.getPages().size());
+        for (Page page : data.getPages()) {
+            long[] hashes = new long[page.getPositionCount()];
+            for (int position = 0; position < page.getPositionCount(); position++) {
+                hashes[position] = hashGenerator.hashPosition(position, page);
+            }
+            results.add(page.appendColumn(new LongArrayBlock(page.getPositionCount(), Optional.empty(), hashes)));
+        }
+        return results.build();
+    }
+
+    @Benchmark
+    @OperationsPerInvocation(POSITIONS)
     public Object addPagePreCompute(BenchmarkData data)
     {
         GroupByHash groupByHash = new MultiChannelGroupByHash(data.getTypes(), data.getChannels(), data.getHashChannel(), EXPECTED_SIZE, false, getJoinCompiler(data.isGroupByUsesEqual()), NOOP);
-        data.getPages().forEach(p -> groupByHash.addPage(p).process());
+        for (Page page : data.getPages()) {
+            Work<?> work = groupByHash.addPage(page);
+            boolean finished;
+            do {
+                finished = work.process();
+            } while (!finished);
+        }
 
         ImmutableList.Builder<Page> pages = ImmutableList.builder();
         PageBuilder pageBuilder = new PageBuilder(groupByHash.getTypes());
@@ -121,7 +150,13 @@ public class BenchmarkGroupByHash
     public Object bigintGroupByHash(SingleChannelBenchmarkData data)
     {
         GroupByHash groupByHash = new BigintGroupByHash(0, data.getHashEnabled(), EXPECTED_SIZE, NOOP);
-        data.getPages().forEach(p -> groupByHash.addPage(p).process());
+        for (Page page : data.getPages()) {
+            Work<?> work = groupByHash.addPage(page);
+            boolean finished;
+            do {
+                finished = work.process();
+            } while (!finished);
+        }
 
         ImmutableList.Builder<Page> pages = ImmutableList.builder();
         PageBuilder pageBuilder = new PageBuilder(groupByHash.getTypes());


### PR DESCRIPTION
Changes adapted from https://github.com/trinodb/trino/pull/9014

Adds support for creating `InterpretedHashGenerator` instances that read blocks out of the input page sequentially starting from `0`. This allows a couple benefits:
- This is a very common idiom as evidenced by the usage sites changed. Those places no longer need to manufacture a redundant channels array.
- The JIT can identify and specialize code for when the block accesses are sequential, which is more predictable in terms of access patterns than the `int[]` indirection form.

Also changed in this PR:
- Removed per invocation lambda creation in `InterpretedHashGenerator#hashPosition(int position, Page page)` in favor of slight duplication
- Switched from using `List<Type>` to `Type[]` to avoid an extra indirection

Benchmarks: [jmh.morethan.io](https://jmh.morethan.io/?sources=https://gist.githubusercontent.com/pettyjamesm/7915122e54d7ced83b824ab062aea2cf/raw/026a3e4c6ebb030445103136f90f85da48f2707f/baseline_prestodb_hash.json,https://gist.githubusercontent.com/pettyjamesm/7915122e54d7ced83b824ab062aea2cf/raw/026a3e4c6ebb030445103136f90f85da48f2707f/improved_prestodb_hash.json)

```
== NO RELEASE NOTE ==
```
