### PR TITLE
Stop unwrapping the IF in the AGG(IF()) rewrite

### DIFF
--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/AggregateIfBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/AggregateIfBenchmark.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark;
+
+import com.facebook.presto.testing.LocalQueryRunner;
+import com.google.common.collect.ImmutableMap;
+
+import static com.facebook.presto.SystemSessionProperties.AGGREGATION_IF_TO_FILTER_REWRITE_ENABLED;
+import static com.facebook.presto.benchmark.BenchmarkQueryRunner.createLocalQueryRunner;
+
+public abstract class AggregateIfBenchmark
+{
+    public static void main(String... args)
+    {
+        LocalQueryRunner localQueryRunnerWithRewrite = createLocalQueryRunner(ImmutableMap.of(AGGREGATION_IF_TO_FILTER_REWRITE_ENABLED, "true"));
+        LocalQueryRunner localQueryRunnerWithoutRewrite = createLocalQueryRunner(ImmutableMap.of(AGGREGATION_IF_TO_FILTER_REWRITE_ENABLED, "false"));
+        new SumIfBenchmark(localQueryRunnerWithoutRewrite, false).runBenchmark(new SimpleLineBenchmarkResultWriter(System.out));
+        new SumIfBenchmark(localQueryRunnerWithRewrite, true).runBenchmark(new SimpleLineBenchmarkResultWriter(System.out));
+        new SumFilterBenchmark(localQueryRunnerWithRewrite).runBenchmark(new SimpleLineBenchmarkResultWriter(System.out));
+    }
+
+    public static class SumIfBenchmark
+            extends AbstractSqlBenchmark
+    {
+        public SumIfBenchmark(LocalQueryRunner localQueryRunner, boolean enableRewrite)
+        {
+            super(
+                    localQueryRunner,
+                    "sum_if_" + (enableRewrite ? "with_rewrite" : "without_rewrite"),
+                    5,
+                    50,
+                    "SELECT SUM(IF(orderstatus = 'F', orderkey)) FROM tpch.sf1.orders");
+        }
+    }
+
+    public static class SumFilterBenchmark
+            extends AbstractSqlBenchmark
+    {
+        public SumFilterBenchmark(LocalQueryRunner localQueryRunner)
+        {
+            super(
+                    localQueryRunner,
+                    "sum_filter",
+                    5,
+                    50,
+                    "SELECT SUM(orderkey) FILTER(WHERE orderstatus = 'F') FROM tpch.sf1.orders");
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -206,7 +206,7 @@ public class FeaturesConfig
     private boolean materializedViewDataConsistencyEnabled = true;
 
     private boolean queryOptimizationWithMaterializedViewEnabled;
-    private boolean aggregationIfToFilterRewriteEnabled = true;
+    private boolean aggregationIfToFilterRewriteEnabled;
 
     public enum PartitioningPrecisionStrategy
     {

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -178,7 +178,7 @@ public class TestFeaturesConfig
                 .setPartialResultsMaxExecutionTimeMultiplier(2.0)
                 .setMaterializedViewDataConsistencyEnabled(true)
                 .setQueryOptimizationWithMaterializedViewEnabled(false)
-                .setAggregationIfToFilterRewriteEnabled(true));
+                .setAggregationIfToFilterRewriteEnabled(false));
     }
 
     @Test
@@ -308,7 +308,7 @@ public class TestFeaturesConfig
                 .put("offset-clause-enabled", "true")
                 .put("materialized-view-data-consistency-enabled", "false")
                 .put("query-optimization-with-materialized-view-enabled", "true")
-                .put("optimizer.aggregation-if-to-filter-rewrite-enabled", "false")
+                .put("optimizer.aggregation-if-to-filter-rewrite-enabled", "true")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -436,7 +436,7 @@ public class TestFeaturesConfig
                 .setPartialResultsMaxExecutionTimeMultiplier(1.5)
                 .setMaterializedViewDataConsistencyEnabled(false)
                 .setQueryOptimizationWithMaterializedViewEnabled(true)
-                .setAggregationIfToFilterRewriteEnabled(false);
+                .setAggregationIfToFilterRewriteEnabled(true);
         assertFullMapping(properties, expected);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/query/TestFilteredAggregations.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/query/TestFilteredAggregations.java
@@ -21,6 +21,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import static com.facebook.presto.SystemSessionProperties.AGGREGATION_IF_TO_FILTER_REWRITE_ENABLED;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.filter;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.tableScan;
@@ -32,6 +33,11 @@ public class TestFilteredAggregations
         extends BasePlanTest
 {
     private QueryAssertions assertions;
+
+    public TestFilteredAggregations()
+    {
+        super(ImmutableMap.of(AGGREGATION_IF_TO_FILTER_REWRITE_ENABLED, "true"));
+    }
 
     @BeforeClass
     public void init()


### PR DESCRIPTION
Disabled the rule of AGG(IF()) rewrite by default. Update it to rewrite
    AGG(IF(condition, expr))
to
    AGG(IF(condition, expr)) FILTER (WHERE condition).

Stop unwrapping the IF expression in the aggregate, because the
true branch might return errors for rows not matching the filters.
For example: IF(CARDINALITY(array) > 0, array[1]))'

Test plan 
Added unit tests.
AggregateIfBenchmark result:

```
    Before:
    sum_if_without_rewrite :: 6514.329 cpu ms ::    0B peak memory :: in  1.5M,      0B,    230K/s,      0B/s :: out     1,      9B,       0/s,      1B/s
    sum_if_with_rewrite :: 5695.211 cpu ms ::    0B peak memory :: in  729K,      0B,    128K/s,      0B/s :: out     1,      9B,       0/s,      1B/s
    sum_filter :: 5771.367 cpu ms ::    0B peak memory :: in  729K,      0B,    126K/s,      0B/s :: out     1,      9B,       0/s,      1B/s

    After:
    sum_if_without_rewrite :: 6298.922 cpu ms :: 0B peak memory :: in 1.5M, 0B, 238K/s, 0B/s :: out 1, 9B, 0/s, 1B/s
    sum_if_with_rewrite :: 5820.618 cpu ms :: 0B peak memory :: in 729K, 0B, 125K/s, 0B/s :: out 1, 9B, 0/s, 1B/s
    sum_filter :: 5537.673 cpu ms :: 0B peak memory :: in 729K, 0B, 132K/s, 0B/s :: out 1, 9B, 0/s, 1B/s
```

```
== RELEASE NOTES ==

General Changes
* Disabled the Aggregation IF to FILTER rewrite rule by default. Updated the rule to stop unwrapping the IF expression instead Aggregation.
```