### PR TITLE
Added runningTasks to BasicQueryStats

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
@@ -349,6 +349,7 @@ public class QueryStateMachine
                 queryStateTimer.getElapsedTime(),
                 queryStateTimer.getExecutionTime(),
 
+                getCurrentRunningTaskCount(),
                 getPeakRunningTaskCount(),
 
                 stageStats.getTotalDrivers(),

--- a/presto-main/src/main/java/com/facebook/presto/resourcemanager/DistributedClusterStatsResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/resourcemanager/DistributedClusterStatsResource.java
@@ -69,6 +69,7 @@ public class DistributedClusterStatsResource
         activeNodes -= internalNodeManager.getResourceManagers().size();
 
         long runningDrivers = 0;
+        long runningTasks = 0;
         double memoryReservation = 0;
 
         long totalInputRows = 0;
@@ -95,6 +96,7 @@ public class DistributedClusterStatsResource
 
                 memoryReservation += query.getQueryStats().getUserMemoryReservation().toBytes();
                 runningDrivers += query.getQueryStats().getRunningDrivers();
+                runningTasks += query.getQueryStats().getRunningTasks();
             }
         }
         //TODO compute adjusted queue size on RM
@@ -104,6 +106,7 @@ public class DistributedClusterStatsResource
                 queuedQueries,
                 activeNodes,
                 runningDrivers,
+                runningTasks,
                 memoryReservation,
                 totalInputRows,
                 totalInputBytes,

--- a/presto-main/src/main/java/com/facebook/presto/server/BasicQueryStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/BasicQueryStats.java
@@ -51,6 +51,7 @@ public class BasicQueryStats
     private final Duration elapsedTime;
     private final Duration executionTime;
 
+    private final int runningTasks;
     private final int peakRunningTasks;
 
     private final int totalDrivers;
@@ -88,6 +89,7 @@ public class BasicQueryStats
             @JsonProperty("queuedTime") Duration queuedTime,
             @JsonProperty("elapsedTime") Duration elapsedTime,
             @JsonProperty("executionTime") Duration executionTime,
+            @JsonProperty("runningTasks") int runningTasks,
             @JsonProperty("peakRunningTasks") int peakRunningTasks,
             @JsonProperty("totalDrivers") int totalDrivers,
             @JsonProperty("queuedDrivers") int queuedDrivers,
@@ -118,6 +120,7 @@ public class BasicQueryStats
         this.elapsedTime = requireNonNull(elapsedTime, "elapsedTime is null");
         this.executionTime = requireNonNull(executionTime, "executionTime is null");
 
+        this.runningTasks = runningTasks;
         this.peakRunningTasks = peakRunningTasks;
 
         checkArgument(totalDrivers >= 0, "totalDrivers is negative");
@@ -159,6 +162,7 @@ public class BasicQueryStats
                 queryStats.getQueuedTime(),
                 queryStats.getElapsedTime(),
                 queryStats.getExecutionTime(),
+                queryStats.getRunningTasks(),
                 queryStats.getPeakRunningTasks(),
                 queryStats.getTotalDrivers(),
                 queryStats.getQueuedDrivers(),
@@ -192,6 +196,7 @@ public class BasicQueryStats
                 new Duration(0, MILLISECONDS),
                 new Duration(0, MILLISECONDS),
                 new Duration(0, MILLISECONDS),
+                0,
                 0,
                 0,
                 0,
@@ -401,5 +406,12 @@ public class BasicQueryStats
     public double getCumulativeTotalMemory()
     {
         return cumulativeTotalMemory;
+    }
+
+    @ThriftField(28)
+    @JsonProperty
+    public int getRunningTasks()
+    {
+        return runningTasks;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/ClusterStatsResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ClusterStatsResource.java
@@ -109,6 +109,7 @@ public class ClusterStatsResource
         }
 
         long runningDrivers = 0;
+        long runningTasks = 0;
         double memoryReservation = 0;
 
         long totalInputRows = dispatchManager.getStats().getConsumedInputRows().getTotalCount();
@@ -135,6 +136,7 @@ public class ClusterStatsResource
 
                 memoryReservation += query.getQueryStats().getUserMemoryReservation().toBytes();
                 runningDrivers += query.getQueryStats().getRunningDrivers();
+                runningTasks += query.getQueryStats().getRunningTasks();
             }
         }
 
@@ -144,6 +146,7 @@ public class ClusterStatsResource
                 queuedQueries,
                 activeNodes,
                 runningDrivers,
+                runningTasks,
                 memoryReservation,
                 totalInputRows,
                 totalInputBytes,
@@ -207,6 +210,7 @@ public class ClusterStatsResource
 
         private final long activeWorkers;
         private final long runningDrivers;
+        private final long runningTasks;
         private final double reservedMemory;
 
         private final long totalInputRows;
@@ -221,6 +225,7 @@ public class ClusterStatsResource
                 @JsonProperty("queuedQueries") long queuedQueries,
                 @JsonProperty("activeWorkers") long activeWorkers,
                 @JsonProperty("runningDrivers") long runningDrivers,
+                @JsonProperty("runningTasks") long runningTasks,
                 @JsonProperty("reservedMemory") double reservedMemory,
                 @JsonProperty("totalInputRows") long totalInputRows,
                 @JsonProperty("totalInputBytes") long totalInputBytes,
@@ -232,6 +237,7 @@ public class ClusterStatsResource
             this.queuedQueries = queuedQueries;
             this.activeWorkers = activeWorkers;
             this.runningDrivers = runningDrivers;
+            this.runningTasks = runningTasks;
             this.reservedMemory = reservedMemory;
             this.totalInputRows = totalInputRows;
             this.totalInputBytes = totalInputBytes;
@@ -267,6 +273,12 @@ public class ClusterStatsResource
         public long getRunningDrivers()
         {
             return runningDrivers;
+        }
+
+        @JsonProperty
+        public long getRunningTasks()
+        {
+            return runningTasks;
         }
 
         @JsonProperty

--- a/presto-main/src/test/java/com/facebook/presto/execution/MockManagedQueryExecution.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/MockManagedQueryExecution.java
@@ -124,6 +124,7 @@ public class MockManagedQueryExecution
                         new Duration(4, NANOSECONDS),
                         new Duration(5, NANOSECONDS),
                         5,
+                        5,
                         6,
                         7,
                         8,

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestNodeScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestNodeScheduler.java
@@ -177,6 +177,7 @@ public class TestNodeScheduler
                     0,
                     0,
                     0,
+                    0,
                     DataSize.valueOf("1MB"),
                     0,
                     0,

--- a/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStateProvider.java
+++ b/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStateProvider.java
@@ -618,6 +618,7 @@ public class TestResourceManagerClusterStateProvider
                         Duration.valueOf("8m"),
                         Duration.valueOf("7m"),
                         Duration.valueOf("34m"),
+                        11,
                         12,
                         13,
                         14,

--- a/presto-tests/src/test/java/com/facebook/presto/memory/TestClusterMemoryLeakDetector.java
+++ b/presto-tests/src/test/java/com/facebook/presto/memory/TestClusterMemoryLeakDetector.java
@@ -84,6 +84,7 @@ public class TestClusterMemoryLeakDetector
                         Duration.valueOf("8m"),
                         Duration.valueOf("7m"),
                         Duration.valueOf("34m"),
+                        11,
                         12,
                         13,
                         14,

--- a/presto-tests/src/test/java/com/facebook/presto/resourcemanager/TestDistributedClusterStatsResource.java
+++ b/presto-tests/src/test/java/com/facebook/presto/resourcemanager/TestDistributedClusterStatsResource.java
@@ -95,6 +95,7 @@ public class TestDistributedClusterStatsResource
         assertEquals(clusterStats.getRunningQueries(), 1);
         assertEquals(clusterStats.getBlockedQueries(), 0);
         assertEquals(clusterStats.getQueuedQueries(), 0);
+        assertEquals(clusterStats.getRunningTasks(), 4);
     }
 
     private ClusterStatsResource.ClusterStats getClusterStats(boolean followRedirects)


### PR DESCRIPTION
Add runningTasks to BasicQueryStats and added cluster level aggregated runningTasks to v1/cluster. This would help in monitoring total number of running tasks on the cluster. 

```
== RELEASE NOTES ==
General Changes
* Add support for running task count ``runningTasks`` at the cluster level via ``v1/cluster`` endpoint
```
