### PR TITLE
Add release notes for 0.261

### DIFF
--- a/presto-docs/src/main/sphinx/release.rst
+++ b/presto-docs/src/main/sphinx/release.rst
@@ -5,6 +5,7 @@ Release Notes
 .. toctree::
     :maxdepth: 1
 
+    release/release-0.261
     release/release-0.260.1
     release/release-0.260
     release/release-0.259.1

--- a/presto-docs/src/main/sphinx/release/release-0.261.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.261.rst
@@ -1,0 +1,47 @@
+=============
+Release 0.261
+=============
+
+**Highlights**
+==============
+* Improve performance of :func:`SUM` and :func:`AVG` aggregate functions when used with ``DECIMAL`` type.
+* Add column comment to metadata in JDBC based connector
+* Add hidden column ``$file_modified_time`` which is the time the file containing the row was last modified.
+* Add hidden column ``$file_size`` which is the size of the file containing the row.
+* Add support to write data to paths defined by Iceberg's ``LocationProvider`` instead of a hard-coded table root directory.
+
+**Details**
+===========
+
+General Changes
+_______________
+* Fix query failures for queries with shape ``AGG(IF(condition, expr))`` where expr could return exceptions for rows not matching ``condition``. These failures occurred when configuration property ``optimizer.aggregation-if-to-filter-rewrite-enabled`` was enabled.
+* Improve performance of :func:`SUM` and :func:`AVG` aggregate functions when used with ``DECIMAL`` type.
+* Disable configuration property ``optimizer.aggregation-if-to-filter-rewrite-enabled`` by default.
+
+SPI Changes
+___________
+* Add ``Identity`` field to ``checkCanSetUser`` for finer granularity of system access control.
+
+Hive Changes
+____________
+* Add hidden column ``$file_modified_time`` which is the time the file containing the row was last modified.
+* Add hidden column ``$file_size`` which is the size of the file containing the row.
+* Add CPU usage statistics for file metadata reading to ``RuntimeStats`` table in the coordinator UI and debug mode of presto-cli.
+
+Iceberg Changes
+_______________
+* Add support to write data to paths defined by Iceberg's ``LocationProvider`` instead of a hard-coded table root directory.
+
+JDBC Changes
+____________
+* Add column comment to metadata in JDBC based connector.
+
+Prometheus Changes
+____________
+* Fix startup error by reducing the default value of configuration property ``prometheus.query-chunk-duration`` from ``1d`` to ``10m``.
+
+**Credits**
+===========
+
+Andrii Rosa, Arunachalam Thirupathi, Beinan, Dongliang Chen, George Wang, Jack Ye, James Petty, James Sun, Reetika Agrawal, Rongrong Zhong, Shixuan Fan, Sreeni Viswanadha, Swapnil Tailor, Timothy Meehan, Ying, Zhan Yuan, Zhongting Hu, linzebing


### PR DESCRIPTION
# Missing Release Notes
## Jack Ye
- [x] https://github.com/prestodb/presto/pull/16609 Resolve Iceberg write path using LocationProvider (Merged by: Beinan)

## linzebing
- [x] https://github.com/prestodb/presto/pull/16630 Add new setPartitionLeases metastore API (Merged by: Andrii Rosa)

# Extracted Release Notes
- #16055 (Author: Reetika Agrawal): Add hidden column $file_modified_time and $filesize in Hive
  - Add hidden column ``$file_size``.
  - Add hidden column ``$file_modified_time ``.
- #16193 (Author: Reetika Agrawal): Show column comment with metadata in JDBC based connector
  - Show column comment with metadata in JDBC based connector.
- #16565 (Author: Swapnil Tailor): Mark coordinator ACTIVE when minimum resource managers and Coordinators available in a cluster
  - Mark coordinator active when minimum resource managers and coordinators available in a cluster.
- #16610 (Author: James Petty): Improve Decimal Aggregation Performance
  - Improve performance of sum and average aggregations on decimals.
- #16650 (Author: James Sun): Add Identity to checkCanSetUser
  - Add ``Identity`` field to ``checkCanSetUser`` for finer granularity of system access control.
- #16661 (Author: Zhan Yuan): Stop unwrapping the IF in the AGG(IF()) rewrite
  - Disabled the Aggregation IF to FILTER rewrite rule by default. Updated the rule to stop unwrapping the IF expression instead Aggregation.

# All Commits
- e5df31a1591a055f52feb6054e43f18108e3bc60 Donot unwrap the IF in the AGG(IF()) rewrite (Zhan Yuan)
- 8c1644bd730d8a29e0667a59a3b8fe63017d8441 Make RuntimeStats and RuntimeMetric thread-safe (Zhan Yuan)
- 6425b6c0674707008e8128e666860ed20bbc6214 Improve Decimal Aggregation State Serializer Performance (James Petty)
- d5c395a78a7f4e43e0a9a0eb7f7f2c5afe4565cc Use unbound method references for input functions (James Petty)
- e7533aaf0f3ec49e12e5b04014650b2843d863bf Improve Decimal sum and average aggregation performance (James Petty)
- 0ad84b2c24f2102948db6dfe22f306801438227f Record operator output before addPage in LocalExchangeSink (James Petty)
- bfd946f97ea1b964054be83aa7d83e6c58751e35 Improve PartitioningExchanger performance (James Petty)
- 703fe7413f7e0c896f77ac10f6943d903e8a5e90 Ensure blocks are fully loaded by when enforcing output layouts (James Petty)
- 54cc9b13aa5c13b8e78a6c8afda8cb8da97f45e1 Upgrade orc-protobuf to Version 13 (Arunachalam Thirupathi)
- 6568f393b8fe63ac7bc87473c908051032233224 Track CPU usages for MetadataReaders (Zhan Yuan)
- 513b5dbf711e1a7ab5db3e7efc3d4a902c77c125 fix prometheus property default for query-chunk-duration (George Wang)
- 3d6040a1928e0c3ab618e22b2bcab532c8d99f74 Add modication time for hive split (Zhongting Hu)
- c36680f16f89af4e78d5f736af591863de9d9d57 Add Identity to checkCanSetUser (James Sun)
- 9d86016b1908df907819d0e41a43e5cc2fda497a Add NodeState to ServerInfoResource and the API to enable/disable it (Dongliang Chen)
- 4175e4748bbc206ef9bc2eb8fd132b0822bf11b6 Fixing flaky behavior of TestMemoryManager test (Swapnil Tailor)
- 4c1321e14f5470c463b3d275b0028214353d394c Add new setPartitionLeases metastore API (linzebing)
- 0a67a01f1948c3062204b45747ec32d16d962ccd Show column comment with metadata (Reetika Agrawal)
- b42b0262732cfceaa3f283530c0a35d2e22e3efb Mark coordinator ACTIVE when enough RM and Coordinators available in a cluster (Swapnil Tailor)
- 7bf529b1d3b09b5af76abb46c807eb56406b9a05 Streamline regexp_extract_all to not call blockBuilder too many times (Sreeni Viswanadha)
- a14add244fa41d479152d9ba094e43605e86f240 Resolve Iceberg write path using LocationProvider (Jack Ye)
- 431ba102cc512c7cd1360b75b3f8ef8a3ab36d5b Documentation for Extra Hidden Columns in Hive tables (Reetika Agrawal)
- 6762a174c4aada662119a21e1ea8e65da370224d Expose RuntimeStats for ScanFilterAndProjectOperator (Zhan Yuan)
- 896cd013680570faa47d3dd2b6f8edd51c7a59e5 Add hidden column $file_modified_time with Hive table (Reetika Agrawal)
- 971ecdd1e1d753543003d85eaa55f092172a9ba1 Add hidden column $filesize with Hive table (Reetika Agrawal)