### PR TITLE
Weighted Split Scheduling

### DIFF
--- a/presto-docs/src/main/sphinx/admin/properties.rst
+++ b/presto-docs/src/main/sphinx/admin/properties.rst
@@ -555,14 +555,19 @@ Node Scheduler Properties
     * **Type:** ``integer``
     * **Default value:** ``100``
 
-    The target value for the total number of splits that can be running for
-    each worker node.
+    The target value for the number of splits that can be running for
+    each worker node, assuming all splits have the standard split weight.
 
     Using a higher value is recommended if queries are submitted in large batches
     (e.g., running a large group of reports periodically) or for connectors that
-    produce many splits that complete quickly. Increasing this value may improve
-    query latency by ensuring that the workers have enough splits to keep them
-    fully utilized.
+    produce many splits that complete quickly but do not support assigning split
+    weight values to express that to the split scheduler. Increasing this value
+    may improve query latency by ensuring that the workers have enough splits to
+    keep them fully utilized.
+
+    When connectors do support weight based split scheduling, the number of splits
+    assigned will depend on the weight of the individual splits. If splits are
+    small, more of them are allowed to be assigned to each worker to compensate.
 
     Setting this too high will waste memory and may result in lower performance
     due to splits not being balanced across workers. Ideally, it should be set
@@ -575,10 +580,10 @@ Node Scheduler Properties
     * **Type:** ``integer``
     * **Default value:** ``10``
 
-    The number of outstanding splits that can be queued for each worker node
-    for a single stage of a query, even when the node is already at the limit for
-    total number of splits. Allowing a minimum number of splits per stage is
-    required to prevent starvation and deadlocks.
+    The number of outstanding splits with the standard split weight that can be
+    queued for each worker node for a single stage of a query, even when the
+    node is already at the limit for total number of splits. Allowing a minimum
+    number of splits per stage is required to prevent starvation and deadlocks.
 
     This value must be smaller than ``node-scheduler.max-splits-per-node``,
     will usually be increased for the same reasons, and has similar drawbacks

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -198,6 +198,9 @@ public class HiveClientConfig
 
     private boolean verboseRuntimeStatsEnabled;
 
+    private boolean sizeBasedSplitWeightsEnabled = true;
+    private double minimumAssignedSplitWeight = 0.05;
+
     public int getMaxInitialSplits()
     {
         return maxInitialSplits;
@@ -1681,5 +1684,32 @@ public class HiveClientConfig
     public int getMaterializedViewMissingPartitionsThreshold()
     {
         return this.materializedViewMissingPartitionsThreshold;
+    }
+
+    @Config("hive.size-based-split-weights-enabled")
+    public HiveClientConfig setSizeBasedSplitWeightsEnabled(boolean sizeBasedSplitWeightsEnabled)
+    {
+        this.sizeBasedSplitWeightsEnabled = sizeBasedSplitWeightsEnabled;
+        return this;
+    }
+
+    public boolean isSizeBasedSplitWeightsEnabled()
+    {
+        return sizeBasedSplitWeightsEnabled;
+    }
+
+    @Config("hive.minimum-assigned-split-weight")
+    @ConfigDescription("Minimum weight that a split can be assigned when size based split weights are enabled")
+    public HiveClientConfig setMinimumAssignedSplitWeight(double minimumAssignedSplitWeight)
+    {
+        this.minimumAssignedSplitWeight = minimumAssignedSplitWeight;
+        return this;
+    }
+
+    @DecimalMax("1.0") // standard split weight
+    @DecimalMin(value = "0", inclusive = false)
+    public double getMinimumAssignedSplitWeight()
+    {
+        return minimumAssignedSplitWeight;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplit.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplit.java
@@ -18,6 +18,7 @@ import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
 import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.SplitWeight;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -65,6 +66,7 @@ public class HiveSplit
     private final Optional<EncryptionInformation> encryptionInformation;
     private final Map<String, String> customSplitInfo;
     private final Set<ColumnHandle> redundantColumnDomains;
+    private final SplitWeight splitWeight;
 
     @JsonCreator
     public HiveSplit(
@@ -90,7 +92,8 @@ public class HiveSplit
             @JsonProperty("cacheQuota") CacheQuotaRequirement cacheQuotaRequirement,
             @JsonProperty("encryptionMetadata") Optional<EncryptionInformation> encryptionInformation,
             @JsonProperty("customSplitInfo") Map<String, String> customSplitInfo,
-            @JsonProperty("redundantColumnDomains") Set<ColumnHandle> redundantColumnDomains)
+            @JsonProperty("redundantColumnDomains") Set<ColumnHandle> redundantColumnDomains,
+            @JsonProperty("splitWeight") SplitWeight splitWeight)
     {
         checkArgument(start >= 0, "start must be positive");
         checkArgument(length >= 0, "length must be positive");
@@ -136,6 +139,7 @@ public class HiveSplit
         this.encryptionInformation = encryptionInformation;
         this.customSplitInfo = ImmutableMap.copyOf(requireNonNull(customSplitInfo, "customSplitInfo is null"));
         this.redundantColumnDomains = ImmutableSet.copyOf(redundantColumnDomains);
+        this.splitWeight = requireNonNull(splitWeight, "splitWeight is null");
     }
 
     @JsonProperty
@@ -294,6 +298,13 @@ public class HiveSplit
     public Set<ColumnHandle> getRedundantColumnDomains()
     {
         return redundantColumnDomains;
+    }
+
+    @JsonProperty
+    @Override
+    public SplitWeight getSplitWeight()
+    {
+        return splitWeight;
     }
 
     @Override

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitSource.java
@@ -18,6 +18,7 @@ import com.facebook.airlift.stats.CounterStat;
 import com.facebook.presto.hive.InternalHiveSplit.InternalHiveBlock;
 import com.facebook.presto.hive.util.AsyncQueue;
 import com.facebook.presto.hive.util.AsyncQueue.BorrowResult;
+import com.facebook.presto.hive.util.SizeBasedSplitWeightProvider;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.ConnectorSplitSource;
@@ -55,6 +56,8 @@ import static com.facebook.presto.hive.HiveErrorCode.HIVE_FILE_NOT_FOUND;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_UNKNOWN_ERROR;
 import static com.facebook.presto.hive.HiveSessionProperties.getMaxInitialSplitSize;
 import static com.facebook.presto.hive.HiveSessionProperties.getMaxSplitSize;
+import static com.facebook.presto.hive.HiveSessionProperties.getMinimumAssignedSplitWeight;
+import static com.facebook.presto.hive.HiveSessionProperties.isSizeBasedSplitWeightsEnabled;
 import static com.facebook.presto.hive.HiveSplitSource.StateKind.CLOSED;
 import static com.facebook.presto.hive.HiveSplitSource.StateKind.FAILED;
 import static com.facebook.presto.hive.HiveSplitSource.StateKind.INITIAL;
@@ -94,6 +97,7 @@ class HiveSplitSource
 
     private final CounterStat highMemorySplitSourceCounter;
     private final AtomicBoolean loggedHighMemoryWarning = new AtomicBoolean();
+    private final HiveSplitWeightProvider splitWeightProvider;
 
     private HiveSplitSource(
             ConnectorSession session,
@@ -121,6 +125,7 @@ class HiveSplitSource
         this.maxInitialSplitSize = getMaxInitialSplitSize(session);
         this.useRewindableSplitSource = useRewindableSplitSource;
         this.remainingInitialSplits = new AtomicInteger(maxInitialSplits);
+        this.splitWeightProvider = isSizeBasedSplitWeightsEnabled(session) ? new SizeBasedSplitWeightProvider(getMinimumAssignedSplitWeight(session), maxSplitSize) : HiveSplitWeightProvider.uniformStandardWeightProvider();
     }
 
     public static HiveSplitSource allAtOnce(
@@ -506,7 +511,8 @@ class HiveSplitSource
                         cacheQuotaRequirement,
                         internalSplit.getEncryptionInformation(),
                         internalSplit.getCustomSplitInfo(),
-                        internalSplit.getPartitionInfo().getRedundantColumnDomains()));
+                        internalSplit.getPartitionInfo().getRedundantColumnDomains(),
+                        splitWeightProvider.weightForSplitSizeInBytes(splitBytes)));
 
                 internalSplit.increaseStart(splitBytes);
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitWeightProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitWeightProvider.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.spi.SplitWeight;
+
+public interface HiveSplitWeightProvider
+{
+    SplitWeight weightForSplitSizeInBytes(long splitSizeInBytes);
+
+    static HiveSplitWeightProvider uniformStandardWeightProvider()
+    {
+        return (splitSizeInBytes) -> SplitWeight.standard();
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/util/SizeBasedSplitWeightProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/util/SizeBasedSplitWeightProvider.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.util;
+
+import com.facebook.presto.hive.HiveSplitWeightProvider;
+import com.facebook.presto.spi.SplitWeight;
+import io.airlift.units.DataSize;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+public class SizeBasedSplitWeightProvider
+        implements HiveSplitWeightProvider
+{
+    private final double minimumWeight;
+    // The configured size for being used to break files into splits,
+    // this size corresponds to a "standard" weight proportion of 1.0
+    private final double targetSplitSizeInBytes;
+
+    public SizeBasedSplitWeightProvider(double minimumWeight, DataSize targetSplitSize)
+    {
+        checkArgument(Double.isFinite(minimumWeight) && minimumWeight > 0 && minimumWeight <= 1, "minimumWeight must be > 0 and <= 1, found: %s", minimumWeight);
+        this.minimumWeight = minimumWeight;
+        long targetSizeInBytes = requireNonNull(targetSplitSize, "targetSplitSize is null").toBytes();
+        checkArgument(targetSizeInBytes > 0, "targetSplitSize must be > 0, found: %s", targetSplitSize);
+        this.targetSplitSizeInBytes = (double) targetSizeInBytes;
+    }
+
+    @Override
+    public SplitWeight weightForSplitSizeInBytes(long splitSizeInBytes)
+    {
+        // Clamp the value be between the minimum weight and 1.0 (standard weight)
+        return SplitWeight.fromProportion(Math.min(Math.max(splitSizeInBytes / targetSplitSizeInBytes, minimumWeight), 1.0));
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestDynamicPruning.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestDynamicPruning.java
@@ -27,6 +27,7 @@ import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.ConnectorPageSource;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.SplitContext;
+import com.facebook.presto.spi.SplitWeight;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.testing.TestingConnectorSession;
 import com.google.common.collect.ImmutableList;
@@ -153,7 +154,8 @@ public class TestDynamicPruning
                 NO_CACHE_REQUIREMENT,
                 Optional.empty(),
                 ImmutableMap.of(),
-                ImmutableSet.of());
+                ImmutableSet.of(),
+                SplitWeight.standard());
 
         TableHandle tableHandle = new TableHandle(
                 new ConnectorId(HIVE_CATALOG),

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
@@ -156,7 +156,9 @@ public class TestHiveClientConfig
                 .setVerboseRuntimeStatsEnabled(false)
                 .setPartitionLeaseDuration(new Duration(0, TimeUnit.SECONDS))
                 .setMaterializedViewMissingPartitionsThreshold(100)
-                .setLooseMemoryAccountingEnabled(false));
+                .setLooseMemoryAccountingEnabled(false)
+                .setSizeBasedSplitWeightsEnabled(true)
+                .setMinimumAssignedSplitWeight(0.05));
     }
 
     @Test
@@ -274,6 +276,8 @@ public class TestHiveClientConfig
                 .put("hive.loose-memory-accounting-enabled", "true")
                 .put("hive.verbose-runtime-stats-enabled", "true")
                 .put("hive.materialized-view-missing-partitions-threshold", "50")
+                .put("hive.size-based-split-weights-enabled", "false")
+                .put("hive.minimum-assigned-split-weight", "1.0")
                 .build();
 
         HiveClientConfig expected = new HiveClientConfig()
@@ -387,7 +391,9 @@ public class TestHiveClientConfig
                 .setVerboseRuntimeStatsEnabled(true)
                 .setPartitionLeaseDuration(new Duration(4, TimeUnit.HOURS))
                 .setMaterializedViewMissingPartitionsThreshold(50)
-                .setLooseMemoryAccountingEnabled(true);
+                .setLooseMemoryAccountingEnabled(true)
+                .setSizeBasedSplitWeightsEnabled(false)
+                .setMinimumAssignedSplitWeight(1.0);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSink.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSink.java
@@ -31,6 +31,7 @@ import com.facebook.presto.spi.ConnectorPageSink;
 import com.facebook.presto.spi.ConnectorPageSource;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.SplitWeight;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.gen.JoinCompiler;
@@ -255,7 +256,8 @@ public class TestHivePageSink
                 NO_CACHE_REQUIREMENT,
                 Optional.empty(),
                 ImmutableMap.of(),
-                ImmutableSet.of());
+                ImmutableSet.of(),
+                SplitWeight.standard());
 
         TableHandle tableHandle = new TableHandle(
                 new ConnectorId(HIVE_CATALOG),

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSourceProvider.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSourceProvider.java
@@ -15,6 +15,7 @@ package com.facebook.presto.hive;
 
 import com.facebook.presto.hive.metastore.Storage;
 import com.facebook.presto.hive.metastore.StorageFormat;
+import com.facebook.presto.spi.SplitWeight;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -71,7 +72,8 @@ public class TestHivePageSourceProvider
                 NO_CACHE_REQUIREMENT,
                 Optional.empty(),
                 ImmutableMap.of(),
-                ImmutableSet.of());
+                ImmutableSet.of(),
+                SplitWeight.standard());
 
         CacheQuota cacheQuota = HivePageSourceProvider.generateCacheQuota(split);
         CacheQuota expectedCacheQuota = new CacheQuota(".", Optional.empty());
@@ -106,7 +108,8 @@ public class TestHivePageSourceProvider
                 new CacheQuotaRequirement(PARTITION, Optional.of(DataSize.succinctDataSize(1, DataSize.Unit.MEGABYTE))),
                 Optional.empty(),
                 ImmutableMap.of(),
-                ImmutableSet.of());
+                ImmutableSet.of(),
+                SplitWeight.standard());
 
         cacheQuota = HivePageSourceProvider.generateCacheQuota(split);
         expectedCacheQuota = new CacheQuota(SCHEMA_NAME + "." + TABLE_NAME + "." + PARTITION_NAME, Optional.of(DataSize.succinctDataSize(1, DataSize.Unit.MEGABYTE)));

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplit.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplit.java
@@ -31,6 +31,7 @@ import com.facebook.presto.metadata.HandleJsonModule;
 import com.facebook.presto.metadata.HandleResolver;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.SplitWeight;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.type.TypeDeserializer;
 import com.google.common.collect.ImmutableList;
@@ -115,7 +116,8 @@ public class TestHiveSplit
                         "test_algo",
                         "test_provider"))),
                 customSplitInfo,
-                redundantColumnDomains);
+                redundantColumnDomains,
+                SplitWeight.fromProportion(2.0)); // some non-standard value
 
         JsonCodec<HiveSplit> codec = getJsonCodec();
         String json = codec.toJson(expected);
@@ -140,6 +142,7 @@ public class TestHiveSplit
         assertEquals(actual.getCacheQuotaRequirement(), expected.getCacheQuotaRequirement());
         assertEquals(actual.getEncryptionInformation(), expected.getEncryptionInformation());
         assertEquals(actual.getCustomSplitInfo(), expected.getCustomSplitInfo());
+        assertEquals(actual.getSplitWeight(), expected.getSplitWeight());
     }
 
     private JsonCodec<HiveSplit> getJsonCodec()

--- a/presto-hive/src/test/java/com/facebook/presto/hive/util/TestSizeBasedSplitWeightProvider.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/util/TestSizeBasedSplitWeightProvider.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.util;
+
+import com.facebook.presto.spi.SplitWeight;
+import io.airlift.units.DataSize;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestSizeBasedSplitWeightProvider
+{
+    private static final long STANDARD_SPLIT_WEIGHT = SplitWeight.standard().getRawValue();
+
+    @Test
+    public void testSimpleProportions()
+    {
+        SizeBasedSplitWeightProvider provider = new SizeBasedSplitWeightProvider(0.01, DataSize.succinctBytes(megabytesToBytes(64)));
+        assertEquals(provider.weightForSplitSizeInBytes(megabytesToBytes(64)), SplitWeight.fromRawValue(STANDARD_SPLIT_WEIGHT));
+        assertEquals(provider.weightForSplitSizeInBytes(megabytesToBytes(32)), SplitWeight.fromRawValue(STANDARD_SPLIT_WEIGHT / 2));
+        assertEquals(provider.weightForSplitSizeInBytes(megabytesToBytes(16)), SplitWeight.fromRawValue(STANDARD_SPLIT_WEIGHT / 4));
+    }
+
+    @Test
+    public void testMinimumAndMaximumSplitWeightHandling()
+    {
+        DataSize targetSplitSize = DataSize.succinctBytes(megabytesToBytes(64));
+        SizeBasedSplitWeightProvider provider = new SizeBasedSplitWeightProvider(0.05, targetSplitSize);
+        assertEquals(provider.weightForSplitSizeInBytes(1), SplitWeight.fromRawValue(5));
+
+        DataSize largerThanTarget = DataSize.succinctBytes(megabytesToBytes(128));
+        assertEquals(provider.weightForSplitSizeInBytes(largerThanTarget.toBytes()), SplitWeight.fromRawValue(STANDARD_SPLIT_WEIGHT));
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "^minimumWeight must be > 0 and <= 1, found: 1\\.01$")
+    public void testInvalidMinimumWeight()
+    {
+        new SizeBasedSplitWeightProvider(1.01, DataSize.succinctBytes(megabytesToBytes(64)));
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "^targetSplitSize must be > 0, found:.*$")
+    public void testInvalidTargetSplitSize()
+    {
+        new SizeBasedSplitWeightProvider(0.01, DataSize.succinctBytes(0));
+    }
+
+    private static long megabytesToBytes(int megabytes)
+    {
+        return ((long) megabytes) * 1024 * 1024;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/execution/PartitionedSplitsInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/PartitionedSplitsInfo.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+
+public final class PartitionedSplitsInfo
+{
+    private static final PartitionedSplitsInfo NO_SPLITS_INFO = new PartitionedSplitsInfo(0, 0);
+
+    private final int count;
+    private final long weightSum;
+
+    private PartitionedSplitsInfo(int splitCount, long splitsWeightSum)
+    {
+        this.count = splitCount;
+        this.weightSum = splitsWeightSum;
+    }
+
+    public int getCount()
+    {
+        return count;
+    }
+
+    public long getWeightSum()
+    {
+        return weightSum;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return (count * 31) + Long.hashCode(weightSum);
+    }
+
+    @Override
+    public boolean equals(Object other)
+    {
+        if (!(other instanceof PartitionedSplitsInfo)) {
+            return false;
+        }
+        PartitionedSplitsInfo otherInfo = (PartitionedSplitsInfo) other;
+        return this == otherInfo || (this.count == otherInfo.count && this.weightSum == otherInfo.weightSum);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("count", count)
+                .add("weightSum", weightSum)
+                .toString();
+    }
+
+    public static PartitionedSplitsInfo forSplitCountAndWeightSum(int splitCount, long weightSum)
+    {
+        // Avoid allocating for the "no splits" case, also mask potential race condition between
+        // count and weight updates that might yield a positive weight with a count of 0
+        return splitCount == 0 ? NO_SPLITS_INFO : new PartitionedSplitsInfo(splitCount, weightSum);
+    }
+
+    public static PartitionedSplitsInfo forZeroSplits()
+    {
+        return NO_SPLITS_INFO;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/execution/RemoteTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/RemoteTask.java
@@ -64,15 +64,15 @@ public interface RemoteTask
      */
     void addFinalTaskInfoListener(StateChangeListener<TaskInfo> stateChangeListener);
 
-    ListenableFuture<?> whenSplitQueueHasSpace(int threshold);
+    ListenableFuture<?> whenSplitQueueHasSpace(long weightThreshold);
 
     void cancel();
 
     void abort();
 
-    int getPartitionedSplitCount();
+    PartitionedSplitsInfo getPartitionedSplitsInfo();
 
-    int getQueuedPartitionedSplitCount();
+    PartitionedSplitsInfo getQueuedPartitionedSplitsInfo();
 
     int getUnacknowledgedPartitionedSplitCount();
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlTask.java
@@ -266,7 +266,9 @@ public class SqlTask
         }
 
         int queuedPartitionedDrivers = 0;
+        long queuedPartitionedSplitsWeight = 0L;
         int runningPartitionedDrivers = 0;
+        long runningPartitionedSplitsWeight = 0L;
         long physicalWrittenDataSizeInBytes = 0L;
         long userMemoryReservationInBytes = 0L;
         long systemMemoryReservationInBytes = 0L;
@@ -278,7 +280,9 @@ public class SqlTask
         if (taskHolder.getFinalTaskInfo() != null) {
             TaskStats taskStats = taskHolder.getFinalTaskInfo().getStats();
             queuedPartitionedDrivers = taskStats.getQueuedPartitionedDrivers();
+            queuedPartitionedSplitsWeight = taskStats.getQueuedPartitionedSplitsWeight();
             runningPartitionedDrivers = taskStats.getRunningPartitionedDrivers();
+            runningPartitionedSplitsWeight = taskStats.getRunningPartitionedSplitsWeight();
             physicalWrittenDataSizeInBytes = taskStats.getPhysicalWrittenDataSizeInBytes();
             userMemoryReservationInBytes = taskStats.getUserMemoryReservationInBytes();
             systemMemoryReservationInBytes = taskStats.getSystemMemoryReservationInBytes();
@@ -292,7 +296,9 @@ public class SqlTask
             for (PipelineContext pipelineContext : taskContext.getPipelineContexts()) {
                 PipelineStatus pipelineStatus = pipelineContext.getPipelineStatus();
                 queuedPartitionedDrivers += pipelineStatus.getQueuedPartitionedDrivers();
+                queuedPartitionedSplitsWeight += pipelineStatus.getQueuedPartitionedSplitsWeight();
                 runningPartitionedDrivers += pipelineStatus.getRunningPartitionedDrivers();
+                runningPartitionedSplitsWeight += pipelineStatus.getRunningPartitionedSplitsWeight();
                 physicalWrittenBytes += pipelineContext.getPhysicalWrittenDataSize();
                 totalCpuTimeInNanos += pipelineContext.getPipelineStats().getTotalCpuTimeInNanos();
             }
@@ -323,7 +329,9 @@ public class SqlTask
                 fullGcCount,
                 fullGcTimeInMillis,
                 totalCpuTimeInNanos,
-                taskStatusAgeInMilis);
+                taskStatusAgeInMilis,
+                queuedPartitionedSplitsWeight,
+                runningPartitionedSplitsWeight);
     }
 
     private TaskStats getTaskStats(TaskHolder taskHolder)

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskExecution.java
@@ -28,6 +28,7 @@ import com.facebook.presto.operator.PipelineContext;
 import com.facebook.presto.operator.PipelineExecutionStrategy;
 import com.facebook.presto.operator.StageExecutionDescriptor;
 import com.facebook.presto.operator.TaskContext;
+import com.facebook.presto.spi.SplitWeight;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.sql.planner.LocalExecutionPlanner.LocalExecutionPlan;
 import com.google.common.collect.AbstractIterator;
@@ -372,7 +373,7 @@ public class SqlTaskExecution
         DriverSplitRunnerFactory partitionedDriverFactory = driverRunnerFactoriesWithSplitLifeCycle.get(planNodeId);
         PendingSplitsForPlanNode pendingSplitsForPlanNode = pendingSplitsByPlanNode.get(planNodeId);
 
-        partitionedDriverFactory.splitsAdded(scheduledSplits.size());
+        partitionedDriverFactory.splitsAdded(scheduledSplits.size(), SplitWeight.rawValueSum(scheduledSplits, scheduledSplit -> scheduledSplit.getSplit().getSplitWeight()));
         for (ScheduledSplit scheduledSplit : scheduledSplits) {
             Lifespan lifespan = scheduledSplit.getSplit().getLifespan();
             checkLifespan(partitionedDriverFactory.getPipelineExecutionStrategy(), lifespan);
@@ -934,7 +935,8 @@ public class SqlTaskExecution
             status.incrementPendingCreation(pipelineContext.getPipelineId(), lifespan);
             // create driver context immediately so the driver existence is recorded in the stats
             // the number of drivers is used to balance work across nodes
-            DriverContext driverContext = pipelineContext.addDriverContext(lifespan, driverFactory.getFragmentResultCacheContext());
+            long splitWeight = partitionedSplit == null ? 0 : partitionedSplit.getSplit().getSplitWeight().getRawValue();
+            DriverContext driverContext = pipelineContext.addDriverContext(splitWeight, lifespan, driverFactory.getFragmentResultCacheContext());
             return new DriverSplitRunner(this, driverContext, partitionedSplit, lifespan);
         }
 
@@ -1004,9 +1006,9 @@ public class SqlTaskExecution
             return driverFactory.getDriverInstances();
         }
 
-        public void splitsAdded(int count)
+        public void splitsAdded(int count, long weightSum)
         {
-            pipelineContext.splitsAdded(count);
+            pipelineContext.splitsAdded(count, weightSum);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskStatus.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskStatus.java
@@ -59,7 +59,9 @@ public class TaskStatus
     private final Set<Lifespan> completedDriverGroups;
 
     private final int queuedPartitionedDrivers;
+    private final long queuedPartitionedSplitsWeight;
     private final int runningPartitionedDrivers;
+    private final long runningPartitionedSplitsWeight;
 
     private final double outputBufferUtilization;
     private final boolean outputBufferOverutilized;
@@ -98,7 +100,9 @@ public class TaskStatus
             @JsonProperty("fullGcCount") long fullGcCount,
             @JsonProperty("fullGcTimeInMillis") long fullGcTimeInMillis,
             @JsonProperty("totalCpuTimeInNanos") long totalCpuTimeInNanos,
-            @JsonProperty("taskAgeInMillis") long taskAgeInMillis)
+            @JsonProperty("taskAgeInMillis") long taskAgeInMillis,
+            @JsonProperty("queuedPartitionedSplitsWeight") long queuedPartitionedSplitsWeight,
+            @JsonProperty("runningPartitionedSplitsWeight") long runningPartitionedSplitsWeight)
     {
         this.taskInstanceIdLeastSignificantBits = taskInstanceIdLeastSignificantBits;
         this.taskInstanceIdMostSignificantBits = taskInstanceIdMostSignificantBits;
@@ -110,9 +114,13 @@ public class TaskStatus
 
         checkArgument(queuedPartitionedDrivers >= 0, "queuedPartitionedDrivers must be positive");
         this.queuedPartitionedDrivers = queuedPartitionedDrivers;
+        checkArgument(queuedPartitionedSplitsWeight >= 0, "queuedPartitionedSplitsWeight must be positive");
+        this.queuedPartitionedSplitsWeight = queuedPartitionedSplitsWeight;
 
         checkArgument(runningPartitionedDrivers >= 0, "runningPartitionedDrivers must be positive");
         this.runningPartitionedDrivers = runningPartitionedDrivers;
+        checkArgument(runningPartitionedSplitsWeight >= 0, "runningPartitionedSplitsWeight must be positive");
+        this.runningPartitionedSplitsWeight = runningPartitionedSplitsWeight;
 
         this.outputBufferUtilization = outputBufferUtilization;
         this.outputBufferOverutilized = outputBufferOverutilized;
@@ -264,6 +272,20 @@ public class TaskStatus
         return taskAgeInMillis;
     }
 
+    @JsonProperty
+    @ThriftField(20)
+    public long getQueuedPartitionedSplitsWeight()
+    {
+        return queuedPartitionedSplitsWeight;
+    }
+
+    @JsonProperty
+    @ThriftField(21)
+    public long getRunningPartitionedSplitsWeight()
+    {
+        return runningPartitionedSplitsWeight;
+    }
+
     @Override
     public String toString()
     {
@@ -293,7 +315,9 @@ public class TaskStatus
                 0,
                 0,
                 0,
-                0);
+                0,
+                0L,
+                0L);
     }
 
     public static TaskStatus failWith(TaskStatus taskStatus, TaskState state, List<ExecutionFailureInfo> exceptions)
@@ -317,6 +341,8 @@ public class TaskStatus
                 taskStatus.getFullGcCount(),
                 taskStatus.getFullGcTimeInMillis(),
                 taskStatus.getTotalCpuTimeInNanos(),
-                taskStatus.getTaskAgeInMillis());
+                taskStatus.getTaskAgeInMillis(),
+                taskStatus.getQueuedPartitionedSplitsWeight(),
+                taskStatus.getRunningPartitionedSplitsWeight());
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NodeSchedulerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NodeSchedulerConfig.java
@@ -79,6 +79,7 @@ public class NodeSchedulerConfig
 
     @Config("node-scheduler.max-pending-splits-per-task")
     @LegacyConfig({"node-scheduler.max-pending-splits-per-node-per-task", "node-scheduler.max-pending-splits-per-node-per-stage"})
+    @ConfigDescription("The number of splits weighted at the standard split weight that can be assigned and queued for each task")
     public NodeSchedulerConfig setMaxPendingSplitsPerTask(int maxPendingSplitsPerTask)
     {
         this.maxPendingSplitsPerTask = maxPendingSplitsPerTask;
@@ -96,6 +97,7 @@ public class NodeSchedulerConfig
     }
 
     @Config("node-scheduler.max-splits-per-node")
+    @ConfigDescription("The number of splits weighted at the standard split weight that are allowed to be scheduled on each node")
     public NodeSchedulerConfig setMaxSplitsPerNode(int maxSplitsPerNode)
     {
         this.maxSplitsPerNode = maxSplitsPerNode;

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/nodeSelection/SimpleNodeSelector.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/nodeSelection/SimpleNodeSelector.java
@@ -27,6 +27,7 @@ import com.facebook.presto.metadata.Split;
 import com.facebook.presto.spi.HostAddress;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SplitContext;
+import com.facebook.presto.spi.SplitWeight;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.HashMultimap;
@@ -41,9 +42,10 @@ import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.ToIntFunction;
+import java.util.function.ToLongFunction;
 
 import static com.facebook.presto.execution.scheduler.NodeScheduler.calculateLowWatermark;
+import static com.facebook.presto.execution.scheduler.NodeScheduler.canAssignSplitBasedOnWeight;
 import static com.facebook.presto.execution.scheduler.NodeScheduler.randomizedNodes;
 import static com.facebook.presto.execution.scheduler.NodeScheduler.selectDistributionNodes;
 import static com.facebook.presto.execution.scheduler.NodeScheduler.selectExactNodes;
@@ -72,8 +74,8 @@ public class SimpleNodeSelector
     private final boolean includeCoordinator;
     private final AtomicReference<Supplier<NodeMap>> nodeMap;
     private final int minCandidates;
-    private final int maxSplitsPerNode;
-    private final int maxPendingSplitsPerTask;
+    private final long maxSplitsWeightPerNode;
+    private final long maxPendingSplitsWeightPerTask;
     private final int maxUnacknowledgedSplitsPerTask;
     private final int maxTasksPerStage;
 
@@ -84,8 +86,8 @@ public class SimpleNodeSelector
             boolean includeCoordinator,
             Supplier<NodeMap> nodeMap,
             int minCandidates,
-            int maxSplitsPerNode,
-            int maxPendingSplitsPerTask,
+            long maxSplitsWeightPerNode,
+            long maxPendingSplitsWeightPerTask,
             int maxUnacknowledgedSplitsPerTask,
             int maxTasksPerStage)
     {
@@ -95,8 +97,8 @@ public class SimpleNodeSelector
         this.includeCoordinator = includeCoordinator;
         this.nodeMap = new AtomicReference<>(nodeMap);
         this.minCandidates = minCandidates;
-        this.maxSplitsPerNode = maxSplitsPerNode;
-        this.maxPendingSplitsPerTask = maxPendingSplitsPerTask;
+        this.maxSplitsWeightPerNode = maxSplitsWeightPerNode;
+        this.maxPendingSplitsWeightPerTask = maxPendingSplitsWeightPerTask;
         this.maxUnacknowledgedSplitsPerTask = maxUnacknowledgedSplitsPerTask;
         checkArgument(maxUnacknowledgedSplitsPerTask > 0, "maxUnacknowledgedSplitsPerTask must be > 0, found: %s", maxUnacknowledgedSplitsPerTask);
         this.maxTasksPerStage = maxTasksPerStage;
@@ -181,9 +183,10 @@ public class SimpleNodeSelector
                 throw new PrestoException(NO_NODES_AVAILABLE, "No nodes available to run query");
             }
 
-            Optional<InternalNodeInfo> chosenNodeInfo = chooseLeastBusyNode(candidateNodes, assignmentStats::getTotalSplitCount, preferredNodeCount, maxSplitsPerNode, assignmentStats);
+            SplitWeight splitWeight = split.getSplitWeight();
+            Optional<InternalNodeInfo> chosenNodeInfo = chooseLeastBusyNode(splitWeight, candidateNodes, assignmentStats::getTotalSplitsWeight, preferredNodeCount, maxSplitsWeightPerNode, assignmentStats);
             if (!chosenNodeInfo.isPresent()) {
-                chosenNodeInfo = chooseLeastBusyNode(candidateNodes, assignmentStats::getQueuedSplitCountForStage, preferredNodeCount, maxPendingSplitsPerTask, assignmentStats);
+                chosenNodeInfo = chooseLeastBusyNode(splitWeight, candidateNodes, assignmentStats::getQueuedSplitsWeightForStage, preferredNodeCount, maxPendingSplitsWeightPerTask, assignmentStats);
             }
 
             if (chosenNodeInfo.isPresent()) {
@@ -196,7 +199,7 @@ public class SimpleNodeSelector
 
                 InternalNode chosenNode = chosenNodeInfo.get().getInternalNode();
                 assignment.put(chosenNode, split);
-                assignmentStats.addAssignedSplit(chosenNode);
+                assignmentStats.addAssignedSplit(chosenNode, splitWeight);
             }
             else {
                 if (split.getNodeSelectionStrategy() != HARD_AFFINITY) {
@@ -211,10 +214,10 @@ public class SimpleNodeSelector
 
         ListenableFuture<?> blocked;
         if (splitWaitingForAnyNode) {
-            blocked = toWhenHasSplitQueueSpaceFuture(existingTasks, calculateLowWatermark(maxPendingSplitsPerTask));
+            blocked = toWhenHasSplitQueueSpaceFuture(existingTasks, calculateLowWatermark(maxPendingSplitsWeightPerTask));
         }
         else {
-            blocked = toWhenHasSplitQueueSpaceFuture(blockedExactNodes, existingTasks, calculateLowWatermark(maxPendingSplitsPerTask));
+            blocked = toWhenHasSplitQueueSpaceFuture(blockedExactNodes, existingTasks, calculateLowWatermark(maxPendingSplitsWeightPerTask));
         }
         return new SplitPlacementResult(blocked, assignment);
     }
@@ -222,12 +225,12 @@ public class SimpleNodeSelector
     @Override
     public SplitPlacementResult computeAssignments(Set<Split> splits, List<RemoteTask> existingTasks, BucketNodeMap bucketNodeMap)
     {
-        return selectDistributionNodes(nodeMap.get().get(), nodeTaskMap, maxSplitsPerNode, maxPendingSplitsPerTask, maxUnacknowledgedSplitsPerTask, splits, existingTasks, bucketNodeMap, nodeSelectionStats);
+        return selectDistributionNodes(nodeMap.get().get(), nodeTaskMap, maxSplitsWeightPerNode, maxPendingSplitsWeightPerTask, maxUnacknowledgedSplitsPerTask, splits, existingTasks, bucketNodeMap, nodeSelectionStats);
     }
 
-    protected Optional<InternalNodeInfo> chooseLeastBusyNode(List<InternalNode> candidateNodes, ToIntFunction<InternalNode> splitCountProvider, OptionalInt preferredNodeCount, int maxSplitCount, NodeAssignmentStats assignmentStats)
+    protected Optional<InternalNodeInfo> chooseLeastBusyNode(SplitWeight splitWeight, List<InternalNode> candidateNodes, ToLongFunction<InternalNode> splitWeightProvider, OptionalInt preferredNodeCount, long maxSplitsWeight, NodeAssignmentStats assignmentStats)
     {
-        int min = Integer.MAX_VALUE;
+        long minWeight = Long.MAX_VALUE;
         InternalNode chosenNode = null;
         for (int i = 0; i < candidateNodes.size(); i++) {
             InternalNode node = candidateNodes.get(i);
@@ -242,10 +245,11 @@ public class SimpleNodeSelector
             if (assignmentStats.getUnacknowledgedSplitCountForStage(node) >= maxUnacknowledgedSplitsPerTask) {
                 continue;
             }
-            int splitCount = splitCountProvider.applyAsInt(node);
+            long currentWeight = splitWeightProvider.applyAsLong(node);
+            boolean canAssignToNode = canAssignSplitBasedOnWeight(currentWeight, maxSplitsWeight, splitWeight);
 
             // choose the preferred node first as long as they're not busy
-            if (preferredNodeCount.isPresent() && i < preferredNodeCount.getAsInt() && splitCount < maxSplitCount) {
+            if (preferredNodeCount.isPresent() && i < preferredNodeCount.getAsInt() && canAssignToNode) {
                 if (i == 0) {
                     nodeSelectionStats.incrementPrimaryPreferredNodeSelectedCount();
                 }
@@ -255,9 +259,9 @@ public class SimpleNodeSelector
                 return Optional.of(new InternalNodeInfo(node, true));
             }
             // fallback to choosing the least busy nodes
-            if (splitCount < min && splitCount < maxSplitCount) {
+            if (canAssignToNode && currentWeight < minWeight) {
                 chosenNode = node;
-                min = splitCount;
+                minWeight = currentWeight;
             }
         }
         if (chosenNode == null) {

--- a/presto-main/src/main/java/com/facebook/presto/metadata/Split.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/Split.java
@@ -18,6 +18,7 @@ import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
 import com.facebook.presto.spi.SplitContext;
+import com.facebook.presto.spi.SplitWeight;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -107,6 +108,11 @@ public final class Split
     public SplitIdentifier getSplitIdentifier()
     {
         return new SplitIdentifier(connectorId, connectorSplit.getSplitIdentifier());
+    }
+
+    public SplitWeight getSplitWeight()
+    {
+        return connectorSplit.getSplitWeight();
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/DriverContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/DriverContext.java
@@ -84,6 +84,7 @@ public class DriverContext
     private final List<OperatorContext> operatorContexts = new CopyOnWriteArrayList<>();
     private final Lifespan lifespan;
     private final Optional<FragmentResultCacheContext> fragmentResultCacheContext;
+    private final long splitWeight;
 
     public DriverContext(
             PipelineContext pipelineContext,
@@ -91,7 +92,8 @@ public class DriverContext
             ScheduledExecutorService yieldExecutor,
             MemoryTrackingContext driverMemoryContext,
             Lifespan lifespan,
-            Optional<FragmentResultCacheContext> fragmentResultCacheContext)
+            Optional<FragmentResultCacheContext> fragmentResultCacheContext,
+            long splitWeight)
     {
         this.pipelineContext = requireNonNull(pipelineContext, "pipelineContext is null");
         this.notificationExecutor = requireNonNull(notificationExecutor, "notificationExecutor is null");
@@ -100,11 +102,18 @@ public class DriverContext
         this.lifespan = requireNonNull(lifespan, "lifespan is null");
         this.fragmentResultCacheContext = requireNonNull(fragmentResultCacheContext, "fragmentResultCacheContext is null");
         this.yieldSignal = new DriverYieldSignal();
+        this.splitWeight = splitWeight;
+        checkArgument(splitWeight >= 0, "splitWeight must be >= 0, found: %s", splitWeight);
     }
 
     public TaskId getTaskId()
     {
         return pipelineContext.getTaskId();
+    }
+
+    public long getSplitWeight()
+    {
+        return splitWeight;
     }
 
     public OperatorContext addOperatorContext(int operatorId, PlanNodeId planNodeId, String operatorType)

--- a/presto-main/src/main/java/com/facebook/presto/operator/PipelineContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PipelineContext.java
@@ -65,7 +65,9 @@ public class PipelineContext
     private final List<DriverContext> drivers = new CopyOnWriteArrayList<>();
 
     private final AtomicInteger totalSplits = new AtomicInteger();
+    private final AtomicLong totalSplitsWeight = new AtomicLong();
     private final AtomicInteger completedDrivers = new AtomicInteger();
+    private final AtomicLong completedSplitsWeight = new AtomicLong();
 
     private final AtomicReference<DateTime> executionStartTime = new AtomicReference<>();
     private final AtomicReference<DateTime> lastExecutionStartTime = new AtomicReference<>();
@@ -136,18 +138,20 @@ public class PipelineContext
 
     public DriverContext addDriverContext()
     {
-        return addDriverContext(Lifespan.taskWide(), Optional.empty());
+        return addDriverContext(0, Lifespan.taskWide(), Optional.empty());
     }
 
-    public DriverContext addDriverContext(Lifespan lifespan, Optional<FragmentResultCacheContext> fragmentResultCacheContext)
+    public DriverContext addDriverContext(long splitWeight, Lifespan lifespan, Optional<FragmentResultCacheContext> fragmentResultCacheContext)
     {
+        checkArgument(partitioned || splitWeight == 0, "Only partitioned splits should have weights");
         DriverContext driverContext = new DriverContext(
                 this,
                 notificationExecutor,
                 yieldExecutor,
                 pipelineMemoryContext.newMemoryTrackingContext(),
                 lifespan,
-                fragmentResultCacheContext);
+                fragmentResultCacheContext,
+                splitWeight);
         drivers.add(driverContext);
         return driverContext;
     }
@@ -157,10 +161,14 @@ public class PipelineContext
         return taskContext.getSession();
     }
 
-    public void splitsAdded(int count)
+    public void splitsAdded(int count, long weightSum)
     {
         checkArgument(count >= 0);
+        checkArgument(weightSum >= 0);
         totalSplits.addAndGet(count);
+        if (partitioned && weightSum != 0) {
+            totalSplitsWeight.addAndGet(weightSum);
+        }
     }
 
     public void driverFinished(DriverContext driverContext)
@@ -177,6 +185,9 @@ public class PipelineContext
         DriverStats driverStats = driverContext.getDriverStats();
 
         completedDrivers.getAndIncrement();
+        if (partitioned) {
+            completedSplitsWeight.addAndGet(driverContext.getSplitWeight());
+        }
 
         queuedTime.add(driverStats.getQueuedTime().roundTo(NANOSECONDS));
         elapsedTime.add(driverStats.getElapsedTime().roundTo(NANOSECONDS));
@@ -316,7 +327,15 @@ public class PipelineContext
 
     public PipelineStatus getPipelineStatus()
     {
-        return getPipelineStatus(drivers.iterator(), totalSplits.get(), completedDrivers.get(), partitioned);
+        return getPipelineStatus(drivers.iterator(), totalSplits.get(), completedDrivers.get(), getActivePartitionedSplitsWeight(), partitioned);
+    }
+
+    private long getActivePartitionedSplitsWeight()
+    {
+        if (partitioned) {
+            return totalSplitsWeight.get() - completedSplitsWeight.get();
+        }
+        return 0;
     }
 
     public PipelineStats getPipelineStats()
@@ -332,7 +351,7 @@ public class PipelineContext
         int completedDrivers = this.completedDrivers.get();
         List<DriverContext> driverContexts = ImmutableList.copyOf(this.drivers);
         int totalSplits = this.totalSplits.get();
-        PipelineStatusBuilder pipelineStatusBuilder = new PipelineStatusBuilder(totalSplits, completedDrivers, partitioned);
+        PipelineStatusBuilder pipelineStatusBuilder = new PipelineStatusBuilder(totalSplits, completedDrivers, getActivePartitionedSplitsWeight(), partitioned);
         int totalDrivers = completedDrivers + driverContexts.size();
 
         Distribution queuedTime = new Distribution(this.queuedTime);
@@ -365,7 +384,7 @@ public class PipelineContext
         for (DriverContext driverContext : driverContexts) {
             DriverStats driverStats = driverContext.getDriverStats();
             drivers.add(driverStats);
-            pipelineStatusBuilder.accumulate(driverStats);
+            pipelineStatusBuilder.accumulate(driverStats, driverContext.getSplitWeight());
             if (driverStats.getStartTime() != null && driverStats.getEndTime() == null) {
                 // driver has started running, but not yet completed
                 hasUnfinishedDrivers = true;
@@ -434,8 +453,10 @@ public class PipelineContext
                 totalDrivers,
                 pipelineStatus.getQueuedDrivers(),
                 pipelineStatus.getQueuedPartitionedDrivers(),
+                pipelineStatus.getQueuedPartitionedSplitsWeight(),
                 pipelineStatus.getRunningDrivers(),
                 pipelineStatus.getRunningPartitionedDrivers(),
+                pipelineStatus.getRunningPartitionedSplitsWeight(),
                 pipelineStatus.getBlockedDrivers(),
                 completedDrivers,
 
@@ -487,9 +508,9 @@ public class PipelineContext
         return pipelineMemoryContext;
     }
 
-    private static PipelineStatus getPipelineStatus(Iterator<DriverContext> driverContextsIterator, int totalSplits, int completedDrivers, boolean partitioned)
+    private static PipelineStatus getPipelineStatus(Iterator<DriverContext> driverContextsIterator, int totalSplits, int completedDrivers, long activePartitionedSplitsWeight, boolean partitioned)
     {
-        PipelineStatusBuilder builder = new PipelineStatusBuilder(totalSplits, completedDrivers, partitioned);
+        PipelineStatusBuilder builder = new PipelineStatusBuilder(totalSplits, completedDrivers, activePartitionedSplitsWeight, partitioned);
         while (driverContextsIterator.hasNext()) {
             builder.accumulate(driverContextsIterator.next());
         }
@@ -507,9 +528,12 @@ public class PipelineContext
     {
         private final int totalSplits;
         private final int completedDrivers;
+        private final long activePartitionedSplitsWeight;
         private final boolean partitioned;
         private int runningDrivers;
         private int blockedDrivers;
+        private long runningSplitsWeight;
+        private long blockedSplitsWeight;
         // When a split for a partitioned pipeline is delivered to a worker,
         // conceptually, the worker would have an additional driver.
         // The queuedDrivers field in PipelineStatus is supposed to represent this.
@@ -519,11 +543,12 @@ public class PipelineContext
         // conceptually queued drivers: includes assigned splits that haven't been turned into a driver
         private int physicallyQueuedDrivers;
 
-        private PipelineStatusBuilder(int totalSplits, int completedDrivers, boolean partitioned)
+        private PipelineStatusBuilder(int totalSplits, int completedDrivers, long activePartitionedSplitsWeight, boolean partitioned)
         {
             this.totalSplits = totalSplits;
             this.partitioned = partitioned;
             this.completedDrivers = completedDrivers;
+            this.activePartitionedSplitsWeight = activePartitionedSplitsWeight;
         }
 
         public void accumulate(DriverContext driverContext)
@@ -533,13 +558,15 @@ public class PipelineContext
             }
             else if (driverContext.isFullyBlocked()) {
                 blockedDrivers++;
+                blockedSplitsWeight += driverContext.getSplitWeight();
             }
             else {
                 runningDrivers++;
+                runningSplitsWeight += driverContext.getSplitWeight();
             }
         }
 
-        public void accumulate(DriverStats driverStats)
+        public void accumulate(DriverStats driverStats, long splitWeight)
         {
             if (driverStats.getStartTime() == null) {
                 // driver has not started running
@@ -547,26 +574,44 @@ public class PipelineContext
             }
             else if (driverStats.isFullyBlocked()) {
                 blockedDrivers++;
+                blockedSplitsWeight += splitWeight;
             }
             else {
                 runningDrivers++;
+                runningSplitsWeight += splitWeight;
             }
         }
 
         public PipelineStatus build()
         {
             int queuedDrivers;
+            int queuedPartitionedSplits;
+            int runningPartitionedSplits;
+            long queuedPartitionedSplitsWeight;
+            long runningPartitionedSplitsWeight;
             if (partitioned) {
                 queuedDrivers = totalSplits - runningDrivers - blockedDrivers - completedDrivers;
                 if (queuedDrivers < 0) {
-                    // It is possible to observe negative here because inputs to passed into the constructor are not taken in a snapshot
+                    // It is possible to observe negative here because inputs to the above expression was not taken in a snapshot.
                     queuedDrivers = 0;
                 }
+                queuedPartitionedSplitsWeight = activePartitionedSplitsWeight - runningSplitsWeight - blockedSplitsWeight;
+                if (queuedDrivers == 0 || queuedPartitionedSplitsWeight < 0) {
+                    // negative or inconsistent count vs weight inputs might occur
+                    queuedPartitionedSplitsWeight = 0;
+                }
+                queuedPartitionedSplits = queuedDrivers;
+                runningPartitionedSplits = runningDrivers;
+                runningPartitionedSplitsWeight = runningSplitsWeight;
             }
             else {
                 queuedDrivers = physicallyQueuedDrivers;
+                queuedPartitionedSplits = 0;
+                queuedPartitionedSplitsWeight = 0;
+                runningPartitionedSplits = 0;
+                runningPartitionedSplitsWeight = 0;
             }
-            return new PipelineStatus(queuedDrivers, runningDrivers, blockedDrivers, partitioned ? queuedDrivers : 0, partitioned ? runningDrivers : 0);
+            return new PipelineStatus(queuedDrivers, runningDrivers, blockedDrivers, queuedPartitionedSplits, queuedPartitionedSplitsWeight, runningPartitionedSplits, runningPartitionedSplitsWeight);
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/PipelineStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PipelineStats.java
@@ -44,8 +44,10 @@ public class PipelineStats
     private final int totalDrivers;
     private final int queuedDrivers;
     private final int queuedPartitionedDrivers;
+    private final long queuedPartitionedSplitsWeight;
     private final int runningDrivers;
     private final int runningPartitionedDrivers;
+    private final long runningPartitionedSplitsWeight;
     private final int blockedDrivers;
     private final int completedDrivers;
 
@@ -92,8 +94,10 @@ public class PipelineStats
             @JsonProperty("totalDrivers") int totalDrivers,
             @JsonProperty("queuedDrivers") int queuedDrivers,
             @JsonProperty("queuedPartitionedDrivers") int queuedPartitionedDrivers,
+            @JsonProperty("queuedPartitionedSplitsWeight") long queuedPartitionedSplitsWeight,
             @JsonProperty("runningDrivers") int runningDrivers,
             @JsonProperty("runningPartitionedDrivers") int runningPartitionedDrivers,
+            @JsonProperty("runningPartitionedSplitsWeight") long runningPartitionedSplitsWeight,
             @JsonProperty("blockedDrivers") int blockedDrivers,
             @JsonProperty("completedDrivers") int completedDrivers,
 
@@ -141,10 +145,14 @@ public class PipelineStats
         this.queuedDrivers = queuedDrivers;
         checkArgument(queuedPartitionedDrivers >= 0, "queuedPartitionedDrivers is negative");
         this.queuedPartitionedDrivers = queuedPartitionedDrivers;
+        checkArgument(queuedPartitionedSplitsWeight >= 0, "queuedPartitionedSplitsWeight must be positive");
+        this.queuedPartitionedSplitsWeight = queuedPartitionedSplitsWeight;
         checkArgument(runningDrivers >= 0, "runningDrivers is negative");
         this.runningDrivers = runningDrivers;
         checkArgument(runningPartitionedDrivers >= 0, "runningPartitionedDrivers is negative");
         this.runningPartitionedDrivers = runningPartitionedDrivers;
+        checkArgument(runningPartitionedSplitsWeight >= 0, "runningPartitionedSplitsWeight must be positive");
+        this.runningPartitionedSplitsWeight = runningPartitionedSplitsWeight;
         checkArgument(blockedDrivers >= 0, "blockedDrivers is negative");
         this.blockedDrivers = blockedDrivers;
         checkArgument(completedDrivers >= 0, "completedDrivers is negative");
@@ -241,6 +249,12 @@ public class PipelineStats
     }
 
     @JsonProperty
+    public long getQueuedPartitionedSplitsWeight()
+    {
+        return queuedPartitionedSplitsWeight;
+    }
+
+    @JsonProperty
     public int getRunningDrivers()
     {
         return runningDrivers;
@@ -250,6 +264,12 @@ public class PipelineStats
     public int getRunningPartitionedDrivers()
     {
         return runningPartitionedDrivers;
+    }
+
+    @JsonProperty
+    public long getRunningPartitionedSplitsWeight()
+    {
+        return runningPartitionedSplitsWeight;
     }
 
     @JsonProperty
@@ -396,8 +416,10 @@ public class PipelineStats
                 totalDrivers,
                 queuedDrivers,
                 queuedPartitionedDrivers,
+                queuedPartitionedSplitsWeight,
                 runningDrivers,
                 runningPartitionedDrivers,
+                runningPartitionedSplitsWeight,
                 blockedDrivers,
                 completedDrivers,
                 userMemoryReservationInBytes,

--- a/presto-main/src/main/java/com/facebook/presto/operator/PipelineStatus.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PipelineStatus.java
@@ -22,15 +22,19 @@ public final class PipelineStatus
     private final int runningDrivers;
     private final int blockedDrivers;
     private final int queuedPartitionedDrivers;
+    private final long queuedPartitionedSplitsWeight;
     private final int runningPartitionedDrivers;
+    private final long runningPartitionedSplitsWeight;
 
-    public PipelineStatus(int queuedDrivers, int runningDrivers, int blockedDrivers, int queuedPartitionedDrivers, int runningPartitionedDrivers)
+    public PipelineStatus(int queuedDrivers, int runningDrivers, int blockedDrivers, int queuedPartitionedDrivers, long queuedPartitionedSplitsWeight, int runningPartitionedDrivers, long runningPartitionedSplitsWeight)
     {
         this.queuedDrivers = queuedDrivers;
         this.runningDrivers = runningDrivers;
         this.blockedDrivers = blockedDrivers;
         this.queuedPartitionedDrivers = queuedPartitionedDrivers;
+        this.queuedPartitionedSplitsWeight = queuedPartitionedSplitsWeight;
         this.runningPartitionedDrivers = runningPartitionedDrivers;
+        this.runningPartitionedSplitsWeight = runningPartitionedSplitsWeight;
     }
 
     public int getQueuedDrivers()
@@ -53,8 +57,18 @@ public final class PipelineStatus
         return queuedPartitionedDrivers;
     }
 
+    public long getQueuedPartitionedSplitsWeight()
+    {
+        return queuedPartitionedSplitsWeight;
+    }
+
     public int getRunningPartitionedDrivers()
     {
         return runningPartitionedDrivers;
+    }
+
+    public long getRunningPartitionedSplitsWeight()
+    {
+        return runningPartitionedSplitsWeight;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/TaskContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TaskContext.java
@@ -459,8 +459,10 @@ public class TaskContext
         int totalDrivers = 0;
         int queuedDrivers = 0;
         int queuedPartitionedDrivers = 0;
+        long queuedPartitionedSplitsWeight = 0;
         int runningDrivers = 0;
         int runningPartitionedDrivers = 0;
+        long runningPartitionedSplitsWeight = 0;
         int blockedDrivers = 0;
         int completedDrivers = 0;
 
@@ -500,8 +502,10 @@ public class TaskContext
             totalDrivers += pipeline.getTotalDrivers();
             queuedDrivers += pipeline.getQueuedDrivers();
             queuedPartitionedDrivers += pipeline.getQueuedPartitionedDrivers();
+            queuedPartitionedSplitsWeight += pipeline.getQueuedPartitionedSplitsWeight();
             runningDrivers += pipeline.getRunningDrivers();
             runningPartitionedDrivers += pipeline.getRunningPartitionedDrivers();
+            runningPartitionedSplitsWeight += pipeline.getRunningPartitionedSplitsWeight();
             blockedDrivers += pipeline.getBlockedDrivers();
             completedDrivers += pipeline.getCompletedDrivers();
 
@@ -579,8 +583,10 @@ public class TaskContext
                 totalDrivers,
                 queuedDrivers,
                 queuedPartitionedDrivers,
+                queuedPartitionedSplitsWeight,
                 runningDrivers,
                 runningPartitionedDrivers,
+                runningPartitionedSplitsWeight,
                 blockedDrivers,
                 completedDrivers,
                 cumulativeUserMemory.get(),

--- a/presto-main/src/main/java/com/facebook/presto/operator/TaskStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TaskStats.java
@@ -42,8 +42,10 @@ public class TaskStats
     private final int totalDrivers;
     private final int queuedDrivers;
     private final int queuedPartitionedDrivers;
+    private final long queuedPartitionedSplitsWeight;
     private final int runningDrivers;
     private final int runningPartitionedDrivers;
+    private final long runningPartitionedSplitsWeight;
     private final int blockedDrivers;
     private final int completedDrivers;
 
@@ -97,8 +99,10 @@ public class TaskStats
                 0,
                 0,
                 0,
+                0L,
                 0,
                 0,
+                0L,
                 0,
                 0,
                 0.0,
@@ -141,8 +145,10 @@ public class TaskStats
             @JsonProperty("totalDrivers") int totalDrivers,
             @JsonProperty("queuedDrivers") int queuedDrivers,
             @JsonProperty("queuedPartitionedDrivers") int queuedPartitionedDrivers,
+            @JsonProperty("queuedPartitionedSplitsWeight") long queuedPartitionedSplitsWeight,
             @JsonProperty("runningDrivers") int runningDrivers,
             @JsonProperty("runningPartitionedDrivers") int runningPartitionedDrivers,
+            @JsonProperty("runningPartitionedSplitsWeight") long runningPartitionedSplitsWeight,
             @JsonProperty("blockedDrivers") int blockedDrivers,
             @JsonProperty("completedDrivers") int completedDrivers,
 
@@ -195,11 +201,15 @@ public class TaskStats
         this.queuedDrivers = queuedDrivers;
         checkArgument(queuedPartitionedDrivers >= 0, "queuedPartitionedDrivers is negative");
         this.queuedPartitionedDrivers = queuedPartitionedDrivers;
+        checkArgument(queuedPartitionedSplitsWeight >= 0, "queuedPartitionedSplitsWeight must be positive");
+        this.queuedPartitionedSplitsWeight = queuedPartitionedSplitsWeight;
 
         checkArgument(runningDrivers >= 0, "runningDrivers is negative");
         this.runningDrivers = runningDrivers;
         checkArgument(runningPartitionedDrivers >= 0, "runningPartitionedDrivers is negative");
         this.runningPartitionedDrivers = runningPartitionedDrivers;
+        checkArgument(runningPartitionedSplitsWeight >= 0, "runningPartitionedSplitsWeight must be positive");
+        this.runningPartitionedSplitsWeight = runningPartitionedSplitsWeight;
 
         checkArgument(blockedDrivers >= 0, "blockedDrivers is negative");
         this.blockedDrivers = blockedDrivers;
@@ -462,9 +472,21 @@ public class TaskStats
     }
 
     @JsonProperty
+    public long getQueuedPartitionedSplitsWeight()
+    {
+        return queuedPartitionedSplitsWeight;
+    }
+
+    @JsonProperty
     public int getRunningPartitionedDrivers()
     {
         return runningPartitionedDrivers;
+    }
+
+    @JsonProperty
+    public long getRunningPartitionedSplitsWeight()
+    {
+        return runningPartitionedSplitsWeight;
     }
 
     @JsonProperty
@@ -498,8 +520,10 @@ public class TaskStats
                 totalDrivers,
                 queuedDrivers,
                 queuedPartitionedDrivers,
+                queuedPartitionedSplitsWeight,
                 runningDrivers,
                 runningPartitionedDrivers,
+                runningPartitionedSplitsWeight,
                 blockedDrivers,
                 completedDrivers,
                 cumulativeUserMemory,
@@ -542,8 +566,10 @@ public class TaskStats
                 totalDrivers,
                 queuedDrivers,
                 queuedPartitionedDrivers,
+                queuedPartitionedSplitsWeight,
                 runningDrivers,
                 runningPartitionedDrivers,
+                runningPartitionedSplitsWeight,
                 blockedDrivers,
                 completedDrivers,
                 cumulativeUserMemory,

--- a/presto-main/src/test/java/com/facebook/presto/execution/MockRemoteTaskFactory.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/MockRemoteTaskFactory.java
@@ -33,6 +33,7 @@ import com.facebook.presto.operator.TaskContext;
 import com.facebook.presto.operator.TaskMemoryReservationSummary;
 import com.facebook.presto.operator.TaskStats;
 import com.facebook.presto.spi.ConnectorId;
+import com.facebook.presto.spi.SplitWeight;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.memory.MemoryPoolId;
 import com.facebook.presto.spi.plan.PlanNode;
@@ -94,6 +95,7 @@ import static com.google.common.util.concurrent.Futures.nonCancellationPropagati
 import static io.airlift.units.DataSize.Unit.BYTE;
 import static io.airlift.units.DataSize.Unit.GIGABYTE;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static java.lang.Math.addExact;
 import static java.util.Objects.requireNonNull;
 
 public class MockRemoteTaskFactory
@@ -290,7 +292,9 @@ public class MockRemoteTaskFactory
                             0,
                             0,
                             0,
-                            System.currentTimeMillis() + 100 - stats.getCreateTime().getMillis()),
+                            System.currentTimeMillis() + 100 - stats.getCreateTime().getMillis(),
+                            0L,
+                            0L),
                     DateTime.now(),
                     outputBuffer.getInfo(),
                     ImmutableSet.of(),
@@ -310,6 +314,8 @@ public class MockRemoteTaskFactory
         public TaskStatus getTaskStatus()
         {
             TaskStats stats = taskContext.getTaskStats();
+            PartitionedSplitsInfo combinedSplitsInfo = getPartitionedSplitsInfo();
+            PartitionedSplitsInfo queuedSplitsInfo = getQueuedPartitionedSplitsInfo();
             return new TaskStatus(
                     TASK_INSTANCE_ID.getLeastSignificantBits(),
                     TASK_INSTANCE_ID.getMostSignificantBits(),
@@ -318,8 +324,8 @@ public class MockRemoteTaskFactory
                     location,
                     ImmutableSet.of(),
                     ImmutableList.of(),
-                    stats.getQueuedPartitionedDrivers(),
-                    stats.getRunningPartitionedDrivers(),
+                    queuedSplitsInfo.getCount(),
+                    combinedSplitsInfo.getCount() - queuedSplitsInfo.getCount(),
                     0.0,
                     false,
                     stats.getPhysicalWrittenDataSizeInBytes(),
@@ -330,19 +336,21 @@ public class MockRemoteTaskFactory
                     0,
                     stats.getTotalCpuTimeInNanos(),
                     // Adding 100 millis to make sure task age > 0 for testing
-                    System.currentTimeMillis() + 100 - stats.getCreateTime().getMillis());
+                    System.currentTimeMillis() + 100 - stats.getCreateTime().getMillis(),
+                    queuedSplitsInfo.getWeightSum(),
+                    combinedSplitsInfo.getWeightSum() - queuedSplitsInfo.getWeightSum());
         }
 
         private void updateTaskStats()
         {
             TaskStatus taskStatus = getTaskStatus();
             if (taskStatus.getState().isDone()) {
-                nodeStatsTracker.setPartitionedSplitCount(0);
+                nodeStatsTracker.setPartitionedSplits(PartitionedSplitsInfo.forZeroSplits());
                 nodeStatsTracker.setMemoryUsage(0);
                 nodeStatsTracker.setCpuUsage(taskStatus.getTaskAgeInMillis(), 0);
             }
             else {
-                nodeStatsTracker.setPartitionedSplitCount(getPartitionedSplitCount());
+                nodeStatsTracker.setPartitionedSplits(getPartitionedSplitsInfo());
                 // setting some values for testing
                 nodeStatsTracker.setMemoryUsage(100);
                 long ageOffset = nextAgeOffset.addAndGet(1);
@@ -352,7 +360,7 @@ public class MockRemoteTaskFactory
 
         private synchronized void updateSplitQueueSpace()
         {
-            if (unacknowledgedSplits < maxUnacknowledgedSplits && getQueuedPartitionedSplitCount() < 9) {
+            if (unacknowledgedSplits < maxUnacknowledgedSplits && getQueuedPartitionedSplitsInfo().getWeightSum() < 900L) {
                 if (!whenSplitQueueHasSpace.isDone()) {
                     whenSplitQueueHasSpace.set(null);
                 }
@@ -481,7 +489,7 @@ public class MockRemoteTaskFactory
         }
 
         @Override
-        public synchronized ListenableFuture<?> whenSplitQueueHasSpace(int threshold)
+        public synchronized ListenableFuture<?> whenSplitQueueHasSpace(long weightThreshold)
         {
             return nonCancellationPropagating(whenSplitQueueHasSpace);
         }
@@ -500,28 +508,45 @@ public class MockRemoteTaskFactory
         }
 
         @Override
-        public int getPartitionedSplitCount()
+        public PartitionedSplitsInfo getPartitionedSplitsInfo()
         {
             if (taskStateMachine.getState().isDone()) {
-                return 0;
+                return PartitionedSplitsInfo.forZeroSplits();
             }
             synchronized (this) {
                 int count = 0;
+                long weight = 0;
                 for (PlanNodeId tableScanPlanNodeId : fragment.getTableScanSchedulingOrder()) {
                     Collection<Split> partitionedSplits = splits.get(tableScanPlanNodeId);
                     count += partitionedSplits.size();
+                    weight = addExact(weight, SplitWeight.rawValueSum(partitionedSplits, Split::getSplitWeight));
                 }
-                return count;
+                return PartitionedSplitsInfo.forSplitCountAndWeightSum(count, weight);
             }
         }
 
         @Override
-        public synchronized int getQueuedPartitionedSplitCount()
+        public synchronized PartitionedSplitsInfo getQueuedPartitionedSplitsInfo()
         {
             if (taskStateMachine.getState().isDone()) {
-                return 0;
+                return PartitionedSplitsInfo.forZeroSplits();
             }
-            return getPartitionedSplitCount() - runningDrivers;
+            // Let's consider the first drivers encountered to be "running"
+            int remainingRunning = runningDrivers;
+            int queuedCount = 0;
+            long queuedWeight = 0;
+            for (PlanNodeId tableScanPlanNodeId : fragment.getTableScanSchedulingOrder()) {
+                for (Split split : splits.get(tableScanPlanNodeId)) {
+                    if (remainingRunning > 0) {
+                        remainingRunning--;
+                    }
+                    else {
+                        queuedCount++;
+                        queuedWeight = addExact(queuedWeight, split.getSplitWeight().getRawValue());
+                    }
+                }
+            }
+            return PartitionedSplitsInfo.forSplitCountAndWeightSum(queuedCount, queuedWeight);
         }
 
         @Override

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestThriftTaskStatus.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestThriftTaskStatus.java
@@ -26,6 +26,7 @@ import com.facebook.drift.protocol.TTransport;
 import com.facebook.presto.spi.HostAddress;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.PrestoTransportException;
+import com.facebook.presto.spi.SplitWeight;
 import com.facebook.presto.sql.parser.ParsingException;
 import com.facebook.presto.sql.tree.NodeLocation;
 import com.facebook.presto.util.Failures;
@@ -66,7 +67,9 @@ public class TestThriftTaskStatus
     public static final URI SELF_URI = java.net.URI.create("fake://task/" + "1");
     public static final Set<Lifespan> LIFESPANS = ImmutableSet.of(Lifespan.taskWide(), Lifespan.driverGroup(100));
     public static final int QUEUED_PARTITIONED_DRIVERS = 100;
+    public static final long QUEUED_PARTITIONED_WEIGHT = SplitWeight.rawValueForStandardSplitCount(QUEUED_PARTITIONED_DRIVERS);
     public static final int RUNNING_PARTITIONED_DRIVERS = 200;
+    public static final long RUNNING_PARTITIONED_WEIGHT = SplitWeight.rawValueForStandardSplitCount(RUNNING_PARTITIONED_DRIVERS);
     public static final double OUTPUT_BUFFER_UTILIZATION = 99.9;
     public static final boolean OUTPUT_BUFFER_OVERUTILIZED = true;
     public static final int PHYSICAL_WRITTEN_DATA_SIZE_IN_BYTES = 1024 * 1024;
@@ -130,7 +133,9 @@ public class TestThriftTaskStatus
         assertEquals(taskStatus.getSelf(), SELF_URI);
         assertEquals(taskStatus.getCompletedDriverGroups(), LIFESPANS);
         assertEquals(taskStatus.getQueuedPartitionedDrivers(), QUEUED_PARTITIONED_DRIVERS);
+        assertEquals(taskStatus.getQueuedPartitionedSplitsWeight(), QUEUED_PARTITIONED_WEIGHT);
         assertEquals(taskStatus.getRunningPartitionedDrivers(), RUNNING_PARTITIONED_DRIVERS);
+        assertEquals(taskStatus.getRunningPartitionedSplitsWeight(), RUNNING_PARTITIONED_WEIGHT);
         assertEquals(taskStatus.getOutputBufferUtilization(), OUTPUT_BUFFER_UTILIZATION);
         assertEquals(taskStatus.isOutputBufferOverutilized(), OUTPUT_BUFFER_OVERUTILIZED);
         assertEquals(taskStatus.getPhysicalWrittenDataSizeInBytes(), PHYSICAL_WRITTEN_DATA_SIZE_IN_BYTES);
@@ -202,7 +207,9 @@ public class TestThriftTaskStatus
                 FULL_GC_COUNT,
                 FULL_GC_TIME_IN_MILLIS,
                 TOTAL_CPU_TIME_IN_NANOS,
-                TASK_AGE);
+                TASK_AGE,
+                QUEUED_PARTITIONED_WEIGHT,
+                RUNNING_PARTITIONED_WEIGHT);
     }
 
     private List<ExecutionFailureInfo> getExecutionFailureInfos()

--- a/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestSourcePartitionedScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestSourcePartitionedScheduler.java
@@ -21,6 +21,7 @@ import com.facebook.presto.execution.LocationFactory;
 import com.facebook.presto.execution.MockRemoteTaskFactory;
 import com.facebook.presto.execution.MockRemoteTaskFactory.MockRemoteTask;
 import com.facebook.presto.execution.NodeTaskMap;
+import com.facebook.presto.execution.PartitionedSplitsInfo;
 import com.facebook.presto.execution.RemoteTask;
 import com.facebook.presto.execution.SqlStageExecution;
 import com.facebook.presto.execution.StageExecutionId;
@@ -182,7 +183,8 @@ public class TestSourcePartitionedScheduler
         }
 
         for (RemoteTask remoteTask : stage.getAllTasks()) {
-            assertEquals(remoteTask.getPartitionedSplitCount(), 20);
+            PartitionedSplitsInfo splitsInfo = remoteTask.getPartitionedSplitsInfo();
+            assertEquals(splitsInfo.getCount(), 20);
         }
 
         stage.abort();
@@ -219,7 +221,8 @@ public class TestSourcePartitionedScheduler
         }
 
         for (RemoteTask remoteTask : stage.getAllTasks()) {
-            assertEquals(remoteTask.getPartitionedSplitCount(), 20);
+            PartitionedSplitsInfo splitsInfo = remoteTask.getPartitionedSplitsInfo();
+            assertEquals(splitsInfo.getCount(), 20);
         }
 
         stage.abort();
@@ -251,7 +254,8 @@ public class TestSourcePartitionedScheduler
         }
 
         for (RemoteTask remoteTask : stage.getAllTasks()) {
-            assertEquals(remoteTask.getPartitionedSplitCount(), 20);
+            PartitionedSplitsInfo splitsInfo = remoteTask.getPartitionedSplitsInfo();
+            assertEquals(splitsInfo.getCount(), 20);
         }
 
         // todo rewrite MockRemoteTask to fire a tate transition when splits are cleared, and then validate blocked future completes
@@ -283,7 +287,8 @@ public class TestSourcePartitionedScheduler
         }
 
         for (RemoteTask remoteTask : stage.getAllTasks()) {
-            assertEquals(remoteTask.getPartitionedSplitCount(), 20);
+            PartitionedSplitsInfo splitsInfo = remoteTask.getPartitionedSplitsInfo();
+            assertEquals(splitsInfo.getCount(), 20);
         }
 
         stage.abort();
@@ -366,7 +371,8 @@ public class TestSourcePartitionedScheduler
         assertEquals(scheduleResult.getNewTasks().size(), 3);
         assertEquals(firstStage.getAllTasks().size(), 3);
         for (RemoteTask remoteTask : firstStage.getAllTasks()) {
-            assertEquals(remoteTask.getPartitionedSplitCount(), 5);
+            PartitionedSplitsInfo splitsInfo = remoteTask.getPartitionedSplitsInfo();
+            assertEquals(splitsInfo.getCount(), 5);
         }
 
         // Add new node
@@ -384,7 +390,7 @@ public class TestSourcePartitionedScheduler
         assertEquals(scheduleResult.getNewTasks().size(), 1);
         assertEquals(secondStage.getAllTasks().size(), 1);
         RemoteTask task = secondStage.getAllTasks().get(0);
-        assertEquals(task.getPartitionedSplitCount(), 5);
+        assertEquals(task.getPartitionedSplitsInfo().getCount(), 5);
 
         firstStage.abort();
         secondStage.abort();
@@ -406,7 +412,8 @@ public class TestSourcePartitionedScheduler
         assertEquals(scheduleResult.getNewTasks().size(), 3);
         assertEquals(firstStage.getAllTasks().size(), 3);
         for (RemoteTask remoteTask : firstStage.getAllTasks()) {
-            assertEquals(remoteTask.getPartitionedSplitCount(), 20);
+            PartitionedSplitsInfo splitsInfo = remoteTask.getPartitionedSplitsInfo();
+            assertEquals(splitsInfo.getCount(), 20);
         }
 
         // Schedule more splits in another query, which will block since all nodes are full
@@ -420,7 +427,8 @@ public class TestSourcePartitionedScheduler
         assertEquals(scheduleResult.getNewTasks().size(), 3);
         assertEquals(secondStage.getAllTasks().size(), 3);
         for (RemoteTask remoteTask : secondStage.getAllTasks()) {
-            assertEquals(remoteTask.getPartitionedSplitCount(), 0);
+            PartitionedSplitsInfo splitsInfo = remoteTask.getPartitionedSplitsInfo();
+            assertEquals(splitsInfo.getCount(), 0);
         }
 
         firstStage.abort();
@@ -429,7 +437,7 @@ public class TestSourcePartitionedScheduler
 
     private static void assertPartitionedSplitCount(SqlStageExecution stage, int expectedPartitionedSplitCount)
     {
-        assertEquals(stage.getAllTasks().stream().mapToInt(RemoteTask::getPartitionedSplitCount).sum(), expectedPartitionedSplitCount);
+        assertEquals(stage.getAllTasks().stream().mapToInt(remoteTask -> remoteTask.getPartitionedSplitsInfo().getCount()).sum(), expectedPartitionedSplitCount);
     }
 
     private static void assertEffectivelyFinished(ScheduleResult scheduleResult, StageScheduler scheduler)

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestDriver.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestDriver.java
@@ -421,7 +421,7 @@ public class TestDriver
         // Create a new driver and test cache hit
         driverContextWithFragmentResultCacheContext = createTaskContext(executor, scheduledExecutor, TEST_SESSION)
                 .addPipelineContext(0, true, true, false)
-                .addDriverContext(Lifespan.taskWide(), Optional.of(TESTING_FRAGMENT_RESULT_CACHE_CONTEXT));
+                .addDriverContext(0, Lifespan.taskWide(), Optional.of(TESTING_FRAGMENT_RESULT_CACHE_CONTEXT));
         processSourceDriver(driverContextWithFragmentResultCacheContext);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestPipelineStats.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestPipelineStats.java
@@ -41,8 +41,10 @@ public class TestPipelineStats
             1,
             2,
             1,
+            21L,
             3,
             2,
+            22L,
             19,
             4,
 
@@ -97,8 +99,10 @@ public class TestPipelineStats
         assertEquals(actual.getTotalDrivers(), 1);
         assertEquals(actual.getQueuedDrivers(), 2);
         assertEquals(actual.getQueuedPartitionedDrivers(), 1);
+        assertEquals(actual.getQueuedPartitionedSplitsWeight(), 21L);
         assertEquals(actual.getRunningDrivers(), 3);
         assertEquals(actual.getRunningPartitionedDrivers(), 2);
+        assertEquals(actual.getRunningPartitionedSplitsWeight(), 22L);
         assertEquals(actual.getBlockedDrivers(), 19);
         assertEquals(actual.getCompletedDrivers(), 4);
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestTaskStats.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestTaskStats.java
@@ -38,8 +38,10 @@ public class TestTaskStats
             6,
             7,
             5,
+            28L,
             8,
             6,
+            29L,
             24,
             10,
 
@@ -100,8 +102,10 @@ public class TestTaskStats
         assertEquals(actual.getTotalDrivers(), 6);
         assertEquals(actual.getQueuedDrivers(), 7);
         assertEquals(actual.getQueuedPartitionedDrivers(), 5);
+        assertEquals(actual.getQueuedPartitionedSplitsWeight(), 28L);
         assertEquals(actual.getRunningDrivers(), 8);
         assertEquals(actual.getRunningPartitionedDrivers(), 6);
+        assertEquals(actual.getRunningPartitionedSplitsWeight(), 29L);
         assertEquals(actual.getBlockedDrivers(), 24);
         assertEquals(actual.getCompletedDrivers(), 10);
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestingOperatorContext.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestingOperatorContext.java
@@ -55,7 +55,8 @@ public class TestingOperatorContext
                 scheduledExecutor,
                 pipelineMemoryContext,
                 Lifespan.taskWide(),
-                Optional.empty());
+                Optional.empty(),
+                0L);
 
         OperatorContext operatorContext = driverContext.addOperatorContext(
                 1,

--- a/presto-main/src/test/java/com/facebook/presto/server/remotetask/TestHttpRemoteTask.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/remotetask/TestHttpRemoteTask.java
@@ -570,7 +570,9 @@ public class TestHttpRemoteTask
                     initialTaskStatus.getFullGcCount(),
                     initialTaskStatus.getFullGcTimeInMillis(),
                     initialTaskStatus.getTotalCpuTimeInNanos(),
-                    initialTaskStatus.getTaskAgeInMillis());
+                    initialTaskStatus.getTaskAgeInMillis(),
+                    initialTaskStatus.getQueuedPartitionedSplitsWeight(),
+                    initialTaskStatus.getRunningPartitionedSplitsWeight());
         }
     }
 }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkTaskExecution.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkTaskExecution.java
@@ -29,6 +29,7 @@ import com.facebook.presto.operator.DriverFactory;
 import com.facebook.presto.operator.DriverStats;
 import com.facebook.presto.operator.PipelineContext;
 import com.facebook.presto.operator.TaskContext;
+import com.facebook.presto.spi.SplitWeight;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.sql.planner.LocalExecutionPlanner.LocalExecutionPlan;
 import com.google.common.collect.ArrayListMultimap;
@@ -214,7 +215,7 @@ public class PrestoSparkTaskExecution
 
     private synchronized void scheduleTableScanSource(DriverSplitRunnerFactory factory, List<ScheduledSplit> splits)
     {
-        factory.splitsAdded(splits.size());
+        factory.splitsAdded(splits.size(), SplitWeight.rawValueSum(splits, scheduledSplit -> scheduledSplit.getSplit().getSplitWeight()));
 
         // Enqueue driver runners with split lifecycle for this plan node and driver life cycle combination.
         ImmutableList.Builder<DriverSplitRunner> runners = ImmutableList.builder();
@@ -339,7 +340,8 @@ public class PrestoSparkTaskExecution
             pendingCreation.incrementAndGet();
             // create driver context immediately so the driver existence is recorded in the stats
             // the number of drivers is used to balance work across nodes
-            DriverContext driverContext = pipelineContext.addDriverContext(Lifespan.taskWide(), driverFactory.getFragmentResultCacheContext());
+            long splitWeight = partitionedSplit == null ? 0 : partitionedSplit.getSplit().getSplitWeight().getRawValue();
+            DriverContext driverContext = pipelineContext.addDriverContext(splitWeight, Lifespan.taskWide(), driverFactory.getFragmentResultCacheContext());
             return new DriverSplitRunner(this, driverContext, partitionedSplit);
         }
 
@@ -394,9 +396,9 @@ public class PrestoSparkTaskExecution
             return driverFactory.getDriverInstances();
         }
 
-        public void splitsAdded(int count)
+        public void splitsAdded(int count, long weightSum)
         {
-            pipelineContext.splitsAdded(count);
+            pipelineContext.splitsAdded(count, weightSum);
         }
     }
 

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkTaskExecutorFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkTaskExecutorFactory.java
@@ -879,7 +879,9 @@ public class PrestoSparkTaskExecutorFactory
                     taskStats.getFullGcCount(),
                     taskStats.getFullGcTimeInMillis(),
                     taskStats.getTotalCpuTimeInNanos(),
-                    System.currentTimeMillis() - taskStats.getCreateTime().getMillis());
+                    System.currentTimeMillis() - taskStats.getCreateTime().getMillis(),
+                    taskStats.getQueuedPartitionedSplitsWeight(),
+                    taskStats.getRunningPartitionedSplitsWeight());
 
             OutputBufferInfo outputBufferInfo = new OutputBufferInfo(
                     outputBufferType.name(),

--- a/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorSplit.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorSplit.java
@@ -48,4 +48,9 @@ public interface ConnectorSplit
     {
         return OptionalLong.empty();
     }
+
+    default SplitWeight getSplitWeight()
+    {
+        return SplitWeight.standard();
+    }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/SplitWeight.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/SplitWeight.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.math.BigDecimal;
+import java.util.Collection;
+import java.util.function.Function;
+
+import static java.lang.Math.addExact;
+import static java.lang.Math.multiplyExact;
+
+public final class SplitWeight
+{
+    private static final long UNIT_VALUE = 100;
+    private static final int UNIT_SCALE = 2; // Decimal scale such that (10 ^ UNIT_SCALE) == UNIT_VALUE
+    private static final SplitWeight STANDARD_WEIGHT = new SplitWeight(UNIT_VALUE);
+
+    private final long value;
+
+    private SplitWeight(long value)
+    {
+        if (value <= 0) {
+            throw new IllegalArgumentException("value must be > 0, found: " + value);
+        }
+        this.value = value;
+    }
+
+    /**
+     * @return The internal integer representation for this weight value
+     */
+    @JsonValue
+    public long getRawValue()
+    {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object other)
+    {
+        if (!(other instanceof SplitWeight)) {
+            return false;
+        }
+        return this.value == ((SplitWeight) other).value;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Long.hashCode(value);
+    }
+
+    @Override
+    public String toString()
+    {
+        if (value == UNIT_VALUE) {
+            return "1";
+        }
+        return BigDecimal.valueOf(value, -UNIT_SCALE).stripTrailingZeros().toPlainString();
+    }
+
+    @JsonCreator
+    public static SplitWeight fromRawValue(long value)
+    {
+        return value == UNIT_VALUE ? STANDARD_WEIGHT : new SplitWeight(value);
+    }
+
+    public static SplitWeight standard()
+    {
+        return STANDARD_WEIGHT;
+    }
+
+    public static SplitWeight fromProportion(double weight)
+    {
+        if (weight <= 0 || !Double.isFinite(weight)) {
+            throw new IllegalArgumentException("Invalid weight: " + weight);
+        }
+        // Must round up to avoid small weights rounding to 0
+        return fromRawValue((long) Math.ceil(weight * UNIT_VALUE));
+    }
+
+    public static long rawValueForStandardSplitCount(int splitCount)
+    {
+        if (splitCount < 0) {
+            throw new IllegalArgumentException("splitCount must be >= 0, found: " + splitCount);
+        }
+        return multiplyExact(splitCount, UNIT_VALUE);
+    }
+
+    public static <T> long rawValueSum(Collection<T> collection, Function<T, SplitWeight> getter)
+    {
+        long sum = 0;
+        for (T item : collection) {
+            long value = getter.apply(item).getRawValue();
+            sum = addExact(sum, value);
+        }
+        return sum;
+    }
+}


### PR DESCRIPTION
Docs are pending but basically this change:
- Adds a `SplitWeight` field to `ConnectorSplit` which allows connectors to indicate “this split is smaller than normal by a factor of X” (for hive, the current only implementation, this is based on “size in bytes”, ie: small files)
- Changes `NodeScheduler` and related classes to assign splits workers based on their weight instead of just the split count alone

The effect of the above means that when splits are sized appropriately, no behavior changes- but when splits are small (ie: when the hive connector is processing small files) the worker split queues are allowed to be deeper to compensate which significantly improves performance.

## Description of Changes

### Changes to `presto-spi` and `presto-main`
ConnectorSplits now carry a `SplitWeight`, which by default returns a "standard" split weight but which can be overridden by connector implementations to influence split scheduling behaviors.

All NodeScheduler split assignment decisions are now based on node total and task queued split weight totals instead of split counts, except for "task unacknowledged split counts" (a pre-existing behavior controlled by `NodeSchedulerConfig(node-scheduler.max-unacknowledged-splits-per-task)`). That configuration is now much more significant since it can be used to control how large individual task update requests sent from the coordinator to workers can get when a large number of splits with small weights are scheduled.

### Changes to `presto-hive`
A version of split weighting for the hive connector is included, which is enabled by default but can be disabled by
setting the Hive session property `size_based_split_weights_enabled=false` or the hive configuration property `hive.size-based-split-weights-enabled=false`. When disabled, all splits are assigned the standard weight.

When enabled, splits are assigned their weight based on their size in bytes relative to `hive.max-split-size`. Splits that are 1/2 of the max split size will be weighted as 1/2 of the standard split weight. In this implementation, no split will be
assigned a weight smaller than the value set by the `minimum_assigned_split_weight` hive session property or the
`hive.minimum-assigned-split-weight` configuration property (default: 5). This provides a mechanism to control how aggressively the scheduler will respond to the presence of small files. With the current standard split
weight of 100, this means that split queues will at most be scheduled 20x deeper when all splits are smaller than 1/20th of the max split size.

Currently, splits that are greater than the `hive.max-split-size` value (eg: unsplittable files) are also assigned the standard split weight, such that any given assigned weight will always fall between the minimum assigned and standard weight. This is an implementation choice for the Hive connector, but not a strict requirement on the behavior that connectors might choose to implement in the future.

## Benchmarks
TPCH scale factor 10GB suite datasets were generated in both Parquet and JSON:

Dataset | Rows Per-File | Typical Resulting File Size | Compression
-- | -- | -- | --
Parquet Normal | 10M | 210MB | Snappy
Parquet Small | 3,000 | 140KB | Snappy
JSON Normal | 10M | 2GB | Uncompressed
JSON Small | 3,000 | 1MB | Uncompressed

- The relatively small 10GB scale factor was chosen because otherwise the small file datasets generated way too many S3 objects and the data generation process would fail because of S3 throttling
- The JSON files were uncompressed so that the normal files dataset splits would still be considered splittable. Compressed files are not splittable and sending a few large splits to workers for single threaded processing on workers would not have been effective at comparing the effect of scheduler behavior.

TPCH suite execution time geomean measurements, collected on a cluster of [r5.8xlarge](https://aws.amazon.com/ec2/instance-types/r5/#Product_Details) instances, with 5 worker nodes (and one coordinator):

**Baseline**

File Format | Small File Geomean | Normal File Geomean
-- | -- | --
Parquet | 32.86 | 2.6
JSON | 32.18 | 5.4

**Improved**

File Format | Small File Geomean | Small File Imrovement | Normal File Geomean | Normal File Improvement
-- | -- | -- | -- | --
Parquet | 14.04 | ~2.34x | 2.61 | unchanged
JSON | 8.73 | ~3.68x | 5.33 | unchanged

Note, that before weighted scheduling, both parquet and JSON small files performed about the same because were bottlenecked on split scheduling throughput and latency. With weighted scheduling enabled, the bottleneck becomes worker I/O and decoding throughput so parquet and JSON perform differently as a result.


```
== RELEASE NOTES ==

General Changes
* Add support for scheduling splits to workers based using a computed weight for each split

Hive Changes
* Add support for weighing splits according to their file size, allowing deeper worker split queues when files are small
```
