### PR TITLE
Introduce pool concept for nodes

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/DiscoveryNodeManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/DiscoveryNodeManager.java
@@ -162,7 +162,7 @@ public final class DiscoveryNodeManager
             OptionalInt thriftPort = getThriftServerPort(service);
             NodeVersion nodeVersion = getNodeVersion(service);
             if (uri != null && nodeVersion != null) {
-                InternalNode node = new InternalNode(service.getNodeId(), uri, thriftPort, nodeVersion, isCoordinator(service), isResourceManager(service), ALIVE);
+                InternalNode node = new InternalNode(service.getNodeId(), uri, thriftPort, nodeVersion, isCoordinator(service), isResourceManager(service), ALIVE, service.getPool());
 
                 if (node.getNodeIdentifier().equals(currentNodeId)) {
                     checkState(
@@ -284,7 +284,7 @@ public final class DiscoveryNodeManager
             boolean coordinator = isCoordinator(service);
             boolean resourceManager = isResourceManager(service);
             if (uri != null && nodeVersion != null) {
-                InternalNode node = new InternalNode(service.getNodeId(), uri, thriftPort, nodeVersion, coordinator, resourceManager, ALIVE);
+                InternalNode node = new InternalNode(service.getNodeId(), uri, thriftPort, nodeVersion, coordinator, resourceManager, ALIVE, service.getPool());
                 NodeState nodeState = getNodeState(node);
 
                 switch (nodeState) {
@@ -348,7 +348,7 @@ public final class DiscoveryNodeManager
                 InternalNode deadNode = nodes.get(nodeId);
                 Set<ConnectorId> deadNodeConnectorIds = connectorIdsByNodeId.get(nodeId);
                 for (ConnectorId id : deadNodeConnectorIds) {
-                    byConnectorIdBuilder.put(id, new InternalNode(deadNode.getNodeIdentifier(), deadNode.getInternalUri(), deadNode.getThriftPort(), deadNode.getNodeVersion(), deadNode.isCoordinator(), deadNode.isResourceManager(), DEAD));
+                    byConnectorIdBuilder.put(id, new InternalNode(deadNode.getNodeIdentifier(), deadNode.getInternalUri(), deadNode.getThriftPort(), deadNode.getNodeVersion(), deadNode.isCoordinator(), deadNode.isResourceManager(), DEAD, deadNode.getPool()));
                 }
             }
         }

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestClusterSizeMonitor.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestClusterSizeMonitor.java
@@ -30,6 +30,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.facebook.airlift.concurrent.MoreFutures.addExceptionCallback;
 import static com.facebook.airlift.concurrent.MoreFutures.addSuccessCallback;
+import static com.facebook.airlift.discovery.client.ServiceSelectorConfig.DEFAULT_POOL;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -172,6 +173,6 @@ public class TestClusterSizeMonitor
     private void addResourceManager(InMemoryNodeManager nodeManager)
     {
         String identifier = "resource_manager/" + numResourceManagers.incrementAndGet();
-        nodeManager.addNode(CONNECTOR_ID, new InternalNode(identifier, URI.create("localhost/" + identifier), new NodeVersion("1"), false, true));
+        nodeManager.addNode(CONNECTOR_ID, new InternalNode(identifier, URI.create("localhost/" + identifier), new NodeVersion("1"), false, true, DEFAULT_POOL));
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestPartialResultQueryTaskTracker.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestPartialResultQueryTaskTracker.java
@@ -34,6 +34,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 
 import static com.facebook.airlift.concurrent.Threads.daemonThreadsNamed;
+import static com.facebook.airlift.discovery.client.ServiceSelectorConfig.DEFAULT_POOL;
 import static com.facebook.presto.execution.warnings.WarningHandlingLevel.NORMAL;
 import static com.facebook.presto.spi.StandardWarningCode.PARTIAL_RESULT_WARNING;
 import static java.util.concurrent.Executors.newCachedThreadPool;
@@ -66,8 +67,8 @@ public class TestPartialResultQueryTaskTracker
             throws Exception
     {
         PartialResultQueryTaskTracker tracker = new PartialResultQueryTaskTracker(partialResultQueryManager, 0.50, 2.0, warningCollector);
-        InternalNode node1 = new InternalNode(UUID.randomUUID().toString(), URI.create("https://192.0.2.8"), new NodeVersion("1"), false, false);
-        InternalNode node2 = new InternalNode(UUID.randomUUID().toString(), URI.create("https://192.0.2.9"), new NodeVersion("1"), false, false);
+        InternalNode node1 = new InternalNode(UUID.randomUUID().toString(), URI.create("https://192.0.2.8"), new NodeVersion("1"), false, false, DEFAULT_POOL);
+        InternalNode node2 = new InternalNode(UUID.randomUUID().toString(), URI.create("https://192.0.2.9"), new NodeVersion("1"), false, false, DEFAULT_POOL);
         TaskId taskId1 = new TaskId("test1", 1, 0, 1);
         TaskId taskId2 = new TaskId("test2", 2, 0, 1);
         RemoteTask task1 = taskFactory.createTableScanTask(taskId1, node1, ImmutableList.of(), new NodeTaskMap.NodeStatsTracker(delta -> {}, delta -> {}, (age, delta) -> {}));

--- a/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestRandomResourceManagerAddressSelector.java
+++ b/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestRandomResourceManagerAddressSelector.java
@@ -24,6 +24,7 @@ import java.net.URI;
 import java.util.Optional;
 import java.util.OptionalInt;
 
+import static com.facebook.airlift.discovery.client.ServiceSelectorConfig.DEFAULT_POOL;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -58,9 +59,9 @@ public class TestRandomResourceManagerAddressSelector
         InMemoryNodeManager internalNodeManager = new InMemoryNodeManager();
         RandomResourceManagerAddressSelector selector = new RandomResourceManagerAddressSelector(internalNodeManager, hostAndPorts -> Optional.of(hostAndPorts.get(0)));
 
-        internalNodeManager.addNode(CONNECTOR_ID, new InternalNode("1", URI.create("local://localhost:123/1"), OptionalInt.empty(), "1", false, true));
-        internalNodeManager.addNode(CONNECTOR_ID, new InternalNode("2", URI.create("local://localhost:456/1"), OptionalInt.of(2), "1", false, true));
-        internalNodeManager.addNode(CONNECTOR_ID, new InternalNode("3", URI.create("local://localhost:789/2"), OptionalInt.of(3), "1", false, true));
+        internalNodeManager.addNode(CONNECTOR_ID, new InternalNode("1", URI.create("local://localhost:123/1"), OptionalInt.empty(), "1", false, true, DEFAULT_POOL));
+        internalNodeManager.addNode(CONNECTOR_ID, new InternalNode("2", URI.create("local://localhost:456/1"), OptionalInt.of(2), "1", false, true, DEFAULT_POOL));
+        internalNodeManager.addNode(CONNECTOR_ID, new InternalNode("3", URI.create("local://localhost:789/2"), OptionalInt.of(3), "1", false, true, DEFAULT_POOL));
 
         Optional<SimpleAddressSelector.SimpleAddress> address = selector.selectAddress(Optional.empty());
         assertTrue(address.isPresent());

--- a/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStatusSender.java
+++ b/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStatusSender.java
@@ -30,6 +30,7 @@ import org.testng.annotations.Test;
 import java.net.URI;
 import java.util.OptionalInt;
 
+import static com.facebook.airlift.discovery.client.ServiceSelectorConfig.DEFAULT_POOL;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static java.lang.String.format;
 import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
@@ -67,7 +68,7 @@ public class TestResourceManagerClusterStatusSender
     {
         resourceManagerClient = new TestingResourceManagerClient();
         InMemoryNodeManager nodeManager = new InMemoryNodeManager();
-        nodeManager.addNode(CONNECTOR_ID, new InternalNode("identifier", URI.create("http://localhost:80/identifier"), OptionalInt.of(1), "1", false, true));
+        nodeManager.addNode(CONNECTOR_ID, new InternalNode("identifier", URI.create("http://localhost:80/identifier"), OptionalInt.of(1), "1", false, true, DEFAULT_POOL));
 
         sender = new ResourceManagerClusterStatusSender(
                 (addressSelectionContext, headers) -> resourceManagerClient,

--- a/presto-spi/src/main/java/com/facebook/presto/spi/Node.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/Node.java
@@ -34,4 +34,6 @@ public interface Node
     boolean isCoordinator();
 
     boolean isResourceManager();
+
+    String getPool();
 }


### PR DESCRIPTION
We have few workloads where we want to utilize a particular type of worker nodes. During scheduling time, we want to understand if a node belongs to a particular pool. As part of this PR, we have introduced the following changes

1. Introduce pool property in InternalNode. We are already populating pool information into [ServiceDescriptor](https://github.com/prestodb/airlift/blob/master/discovery/src/main/java/com/facebook/airlift/discovery/client/ServiceDescriptor.java#L174)
2.  Support discovery of pool information for nodes.

Test plan - 

```
== RELEASE NOTES ==

General Changes
*  Introduce pool property for nodes
```
