### PR TITLE
Support Consistent hash based Affinity Scheduling

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -204,6 +204,7 @@ public final class SystemSessionProperties
     public static final String MATERIALIZED_VIEW_DATA_CONSISTENCY_ENABLED = "materialized_view_data_consistency_enabled";
     public static final String QUERY_OPTIMIZATION_WITH_MATERIALIZED_VIEW_ENABLED = "query_optimization_with_materialized_view_enabled";
     public static final String AGGREGATION_IF_TO_FILTER_REWRITE_ENABLED = "aggregation_if_to_filter_rewrite_enabled";
+    public static final String CONSISTENT_HASHING_AFFINITY_SCHEDULING_ENABLED = "consistent_hashing_affinity_scheduling_enabled";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -1859,5 +1860,10 @@ public final class SystemSessionProperties
     public static boolean isAggregationIfToFilterRewriteEnabled(Session session)
     {
         return session.getSystemProperty(AGGREGATION_IF_TO_FILTER_REWRITE_ENABLED, Boolean.class);
+    }
+
+    public static boolean isConsistentHashingAffinitySchedulingEnabled(Session session)
+    {
+        return session.getSystemProperty(CONSISTENT_HASHING_AFFINITY_SCHEDULING_ENABLED, Boolean.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NodeScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NodeScheduler.java
@@ -80,7 +80,7 @@ public class NodeScheduler
     private final NodeTaskMap nodeTaskMap;
     private final boolean useNetworkTopology;
     private final Duration nodeMapRefreshInterval;
-    private final boolean consistentHashSoftAffinitySchedulingEnabled;
+    private final boolean consistentHashAffinitySchedulingEnabled;
     private final int consistentHashReplicas;
 
     @Inject
@@ -108,7 +108,7 @@ public class NodeScheduler
         this.nodeTaskMap = requireNonNull(nodeTaskMap, "nodeTaskMap is null");
         checkArgument(maxSplitsPerNode >= maxPendingSplitsPerTask, "maxSplitsPerNode must be > maxPendingSplitsPerTask");
         this.useNetworkTopology = !config.getNetworkTopology().equals(NetworkTopologyType.LEGACY);
-        this.consistentHashSoftAffinitySchedulingEnabled = config.isConsistentHashSoftAffinitySchedulingEnabled();
+        this.consistentHashAffinitySchedulingEnabled = config.isConsistentHashAffinitySchedulingEnabled();
         this.consistentHashReplicas = config.getConsistentHashReplicas();
 
         ImmutableList.Builder<CounterStat> builder = ImmutableList.builder();
@@ -166,10 +166,22 @@ public class NodeScheduler
                     maxUnacknowledgedSplitsPerTask,
                     topologicalSplitCounters,
                     networkLocationSegmentNames,
-                    networkLocationCache);
+                    networkLocationCache,
+                    consistentHashAffinitySchedulingEnabled);
         }
         else {
-            return new SimpleNodeSelector(nodeManager, nodeSelectionStats, nodeTaskMap, includeCoordinator, nodeMap, minCandidates, maxSplitsPerNode, maxPendingSplitsPerTask, maxUnacknowledgedSplitsPerTask, maxTasksPerStage, consistentHashSoftAffinitySchedulingEnabled);
+            return new SimpleNodeSelector(
+                    nodeManager,
+                    nodeSelectionStats,
+                    nodeTaskMap,
+                    includeCoordinator,
+                    nodeMap,
+                    minCandidates,
+                    maxSplitsPerNode,
+                    maxPendingSplitsPerTask,
+                    maxUnacknowledgedSplitsPerTask,
+                    maxTasksPerStage,
+                    consistentHashAffinitySchedulingEnabled);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NodeSchedulerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NodeSchedulerConfig.java
@@ -37,7 +37,7 @@ public class NodeSchedulerConfig
     private int maxPendingSplitsPerTask = 10;
     private int maxUnacknowledgedSplitsPerTask = 500;
     private String networkTopology = NetworkTopologyType.LEGACY;
-    private boolean consistentHashSoftAffinitySchedulingEnabled = false;
+    private boolean consistentHashAffinitySchedulingEnabled;
     private int consistentHashReplicas = 10;
 
     @NotNull
@@ -117,16 +117,16 @@ public class NodeSchedulerConfig
         return this;
     }
 
-    public boolean isConsistentHashSoftAffinitySchedulingEnabled()
+    public boolean isConsistentHashAffinitySchedulingEnabled()
     {
-        return consistentHashSoftAffinitySchedulingEnabled;
+        return consistentHashAffinitySchedulingEnabled;
     }
 
-    @Config("experimental.node-scheduler.consistent-hash-soft-affinity-enabled")
-    @ConfigDescription("Use consistent hash algorithm for soft affinity scheduling")
-    public NodeSchedulerConfig setConsistentHashSoftAffinitySchedulingEnabled(boolean enabled)
+    @Config("experimental.node-scheduler.consistent-hash-affinity-enabled")
+    @ConfigDescription("Use consistent hash algorithm for affinity scheduling")
+    public NodeSchedulerConfig setConsistentHashAffinitySchedulingEnabled(boolean enabled)
     {
-        this.consistentHashSoftAffinitySchedulingEnabled = enabled;
+        this.consistentHashAffinitySchedulingEnabled = enabled;
         return this;
     }
 
@@ -136,7 +136,7 @@ public class NodeSchedulerConfig
     }
 
     @Config("experimental.node-scheduler.consistent-hash-replicas")
-    @ConfigDescription("the node replica of consistent hash algorithm for soft affinity scheduling")
+    @ConfigDescription("the node replica of consistent hash algorithm for affinity scheduling")
     public NodeSchedulerConfig setConsistentHashReplicas(int replicas)
     {
         this.consistentHashReplicas = replicas;

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NodeSchedulerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NodeSchedulerConfig.java
@@ -37,6 +37,8 @@ public class NodeSchedulerConfig
     private int maxPendingSplitsPerTask = 10;
     private int maxUnacknowledgedSplitsPerTask = 500;
     private String networkTopology = NetworkTopologyType.LEGACY;
+    private boolean consistentHashSoftAffinitySchedulingEnabled = false;
+    private int consistentHashReplicas = 10;
 
     @NotNull
     public String getNetworkTopology()
@@ -112,6 +114,32 @@ public class NodeSchedulerConfig
     public NodeSchedulerConfig setMaxUnacknowledgedSplitsPerTask(int maxUnacknowledgedSplitsPerTask)
     {
         this.maxUnacknowledgedSplitsPerTask = maxUnacknowledgedSplitsPerTask;
+        return this;
+    }
+
+    public boolean isConsistentHashSoftAffinitySchedulingEnabled()
+    {
+        return consistentHashSoftAffinitySchedulingEnabled;
+    }
+
+    @Config("experimental.node-scheduler.consistent-hash-soft-affinity-enabled")
+    @ConfigDescription("Use consistent hash algorithm for soft affinity scheduling")
+    public NodeSchedulerConfig setConsistentHashSoftAffinitySchedulingEnabled(boolean enabled)
+    {
+        this.consistentHashSoftAffinitySchedulingEnabled = enabled;
+        return this;
+    }
+
+    public int getConsistentHashReplicas()
+    {
+        return consistentHashReplicas;
+    }
+
+    @Config("experimental.node-scheduler.consistent-hash-replicas")
+    @ConfigDescription("the node replica of consistent hash algorithm for soft affinity scheduling")
+    public NodeSchedulerConfig setConsistentHashReplicas(int replicas)
+    {
+        this.consistentHashReplicas = replicas;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/nodeSelection/NodeSelector.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/nodeSelection/NodeSelector.java
@@ -18,6 +18,8 @@ import com.facebook.presto.execution.scheduler.BucketNodeMap;
 import com.facebook.presto.execution.scheduler.SplitPlacementResult;
 import com.facebook.presto.metadata.InternalNode;
 import com.facebook.presto.metadata.Split;
+import com.facebook.presto.spi.Node;
+import com.facebook.presto.spi.hashing.ConsistentHashSelector;
 import com.google.common.collect.ImmutableSet;
 
 import java.util.List;
@@ -32,6 +34,8 @@ public interface NodeSelector
     List<InternalNode> getAllNodes();
 
     InternalNode selectCurrentNode();
+
+    ConsistentHashSelector<Node> getConsistentHashingRing();
 
     default List<InternalNode> selectRandomNodes(int limit)
     {

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/nodeSelection/SimpleNodeSelector.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/nodeSelection/SimpleNodeSelector.java
@@ -25,8 +25,10 @@ import com.facebook.presto.metadata.InternalNode;
 import com.facebook.presto.metadata.InternalNodeManager;
 import com.facebook.presto.metadata.Split;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.Node;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SplitContext;
+import com.facebook.presto.spi.hashing.ConsistentHashSelector;
 import com.google.common.base.Supplier;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.HashMultimap;
@@ -72,7 +74,7 @@ public class SimpleNodeSelector
     private final int maxPendingSplitsPerTask;
     private final int maxUnacknowledgedSplitsPerTask;
     private final int maxTasksPerStage;
-    private final boolean consistentHashSoftAffinitySchedulingEnabled;
+    private final boolean consistentHashAffinitySchedulingEnabled;
 
     public SimpleNodeSelector(
             InternalNodeManager nodeManager,
@@ -85,7 +87,7 @@ public class SimpleNodeSelector
             int maxPendingSplitsPerTask,
             int maxUnacknowledgedSplitsPerTask,
             int maxTasksPerStage,
-            boolean consistentHashSoftAffinitySchedulingEnabled)
+            boolean consistentHashAffinitySchedulingEnabled)
     {
         this.nodeManager = requireNonNull(nodeManager, "nodeManager is null");
         this.nodeSelectionStats = requireNonNull(nodeSelectionStats, "nodeSelectionStats is null");
@@ -98,7 +100,7 @@ public class SimpleNodeSelector
         this.maxUnacknowledgedSplitsPerTask = maxUnacknowledgedSplitsPerTask;
         checkArgument(maxUnacknowledgedSplitsPerTask > 0, "maxUnacknowledgedSplitsPerTask must be > 0, found: %s", maxUnacknowledgedSplitsPerTask);
         this.maxTasksPerStage = maxTasksPerStage;
-        this.consistentHashSoftAffinitySchedulingEnabled = consistentHashSoftAffinitySchedulingEnabled;
+        this.consistentHashAffinitySchedulingEnabled = consistentHashAffinitySchedulingEnabled;
     }
 
     @Override
@@ -117,6 +119,12 @@ public class SimpleNodeSelector
     public List<InternalNode> getAllNodes()
     {
         return ImmutableList.copyOf(nodeMap.get().get().getAllNodes());
+    }
+
+    @Override
+    public ConsistentHashSelector<Node> getConsistentHashingRing()
+    {
+        return nodeMap.get().get().getActiveNodesInHashRing();
     }
 
     @Override
@@ -156,11 +164,16 @@ public class SimpleNodeSelector
             List<InternalNode> candidateNodes;
             switch (split.getNodeSelectionStrategy()) {
                 case HARD_AFFINITY:
-                    candidateNodes = selectExactNodes(nodeMap, split.getPreferredNodes(activeCandidates), includeCoordinator);
+                    if (consistentHashAffinitySchedulingEnabled) {
+                        candidateNodes = selectExactNodes(nodeMap, split.getPreferredNodes(activeCandidates, nodeMap.getActiveNodesInHashRing()), includeCoordinator);
+                    }
+                    else {
+                        candidateNodes = selectExactNodes(nodeMap, split.getPreferredNodes(allCandidates), includeCoordinator);
+                    }
                     preferredNodeCount = OptionalInt.of(candidateNodes.size());
                     break;
                 case SOFT_AFFINITY:
-                    if (consistentHashSoftAffinitySchedulingEnabled) {
+                    if (consistentHashAffinitySchedulingEnabled) {
                         candidateNodes = selectExactNodes(nodeMap, split.getPreferredNodes(activeCandidates, nodeMap.getActiveNodesInHashRing()), includeCoordinator);
                     }
                     else {

--- a/presto-main/src/main/java/com/facebook/presto/metadata/Split.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/Split.java
@@ -17,8 +17,10 @@ import com.facebook.presto.execution.Lifespan;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.Node;
 import com.facebook.presto.spi.SplitContext;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.facebook.presto.spi.hashing.ConsistentHashSelector;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -97,6 +99,11 @@ public final class Split
     public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
     {
         return connectorSplit.getPreferredNodes(sortedCandidates);
+    }
+
+    public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates, ConsistentHashSelector<Node> hashSelector)
+    {
+        return connectorSplit.getPreferredNodes(sortedCandidates, hashSelector);
     }
 
     public NodeSelectionStrategy getNodeSelectionStrategy()

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestNodeScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestNodeScheduler.java
@@ -401,7 +401,7 @@ public class TestNodeScheduler
                 .setMaxSplitsPerNode(20)
                 .setIncludeCoordinator(false)
                 .setMaxPendingSplitsPerTask(10)
-                .setConsistentHashSoftAffinitySchedulingEnabled(true);
+                .setConsistentHashAffinitySchedulingEnabled(true);
 
         NodeScheduler nodeScheduler = new NodeScheduler(new LegacyNetworkTopology(), nodeManager, new NodeSelectionStats(), nodeSchedulerConfig, nodeTaskMap);
         NodeSelector nodeSelector = nodeScheduler.createNodeSelector(session, CONNECTOR_ID, 3);
@@ -422,7 +422,7 @@ public class TestNodeScheduler
         nodes.add(hashSelector.getN("p2", 1).get(0));
         assertEquals(internalNodesSecondCall.size(), nodes.size());
 
-        while(true) {
+        while (true) {
             String path = "p" + new Random().nextInt();
             if (!nodes.contains(hashSelector.getN(path, 1).get(0))) {
                 splits.add(new Split(CONNECTOR_ID, transactionHandle, new TestAffinitySplitRemoteWithConsistentHashing(path)));
@@ -484,7 +484,7 @@ public class TestNodeScheduler
                 .setMaxSplitsPerNode(200)
                 .setIncludeCoordinator(false)
                 .setMaxPendingSplitsPerTask(100)
-                .setConsistentHashSoftAffinitySchedulingEnabled(true);
+                .setConsistentHashAffinitySchedulingEnabled(true);
 
         NodeScheduler nodeScheduler = new NodeScheduler(new LegacyNetworkTopology(), nodeManager, new NodeSelectionStats(), nodeSchedulerConfig, nodeTaskMap);
         NodeSelector nodeSelector = nodeScheduler.createNodeSelector(session, CONNECTOR_ID, 100);

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestNodeSchedulerConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestNodeSchedulerConfig.java
@@ -34,7 +34,8 @@ public class TestNodeSchedulerConfig
                 .setMaxPendingSplitsPerTask(10)
                 .setMaxUnacknowledgedSplitsPerTask(500)
                 .setIncludeCoordinator(true)
-                .setConsistentHashSoftAffinitySchedulingEnabled(false));
+                .setConsistentHashAffinitySchedulingEnabled(false)
+                .setConsistentHashReplicas(10));
     }
 
     @Test
@@ -47,7 +48,8 @@ public class TestNodeSchedulerConfig
                 .put("node-scheduler.max-pending-splits-per-task", "11")
                 .put("node-scheduler.max-unacknowledged-splits-per-task", "501")
                 .put("node-scheduler.max-splits-per-node", "101")
-                .put("experimental.node-scheduler.consistent-hash-soft-affinity-enabled", "true")
+                .put("experimental.node-scheduler.consistent-hash-affinity-enabled", "true")
+                .put("experimental.node-scheduler.consistent-hash-replicas", "20")
                 .build();
 
         NodeSchedulerConfig expected = new NodeSchedulerConfig()
@@ -57,7 +59,8 @@ public class TestNodeSchedulerConfig
                 .setMaxPendingSplitsPerTask(11)
                 .setMaxUnacknowledgedSplitsPerTask(501)
                 .setMinCandidates(11)
-                .setConsistentHashSoftAffinitySchedulingEnabled(true);
+                .setConsistentHashAffinitySchedulingEnabled(true)
+                .setConsistentHashReplicas(20);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestNodeSchedulerConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestNodeSchedulerConfig.java
@@ -33,7 +33,8 @@ public class TestNodeSchedulerConfig
                 .setMaxSplitsPerNode(100)
                 .setMaxPendingSplitsPerTask(10)
                 .setMaxUnacknowledgedSplitsPerTask(500)
-                .setIncludeCoordinator(true));
+                .setIncludeCoordinator(true)
+                .setConsistentHashSoftAffinitySchedulingEnabled(false));
     }
 
     @Test
@@ -46,6 +47,7 @@ public class TestNodeSchedulerConfig
                 .put("node-scheduler.max-pending-splits-per-task", "11")
                 .put("node-scheduler.max-unacknowledged-splits-per-task", "501")
                 .put("node-scheduler.max-splits-per-node", "101")
+                .put("experimental.node-scheduler.consistent-hash-soft-affinity-enabled", "true")
                 .build();
 
         NodeSchedulerConfig expected = new NodeSchedulerConfig()
@@ -54,7 +56,8 @@ public class TestNodeSchedulerConfig
                 .setMaxSplitsPerNode(101)
                 .setMaxPendingSplitsPerTask(11)
                 .setMaxUnacknowledgedSplitsPerTask(501)
-                .setMinCandidates(11);
+                .setMinCandidates(11)
+                .setConsistentHashSoftAffinitySchedulingEnabled(true);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-spi/pom.xml
+++ b/presto-spi/pom.xml
@@ -44,6 +44,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
         </dependency>
@@ -82,12 +88,6 @@
         <dependency>
             <groupId>it.unimi.dsi</groupId>
             <artifactId>fastutil</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorSplit.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorSplit.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.spi;
 
+import com.facebook.presto.spi.hashing.ConsistentHashSelector;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 
 import java.util.List;
@@ -47,5 +48,10 @@ public interface ConnectorSplit
     default OptionalLong getSplitSizeInBytes()
     {
         return OptionalLong.empty();
+    }
+
+    default List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates, ConsistentHashSelector<Node> hashSelector)
+    {
+        throw new UnsupportedOperationException();
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorNodePartitioningProvider.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorNodePartitioningProvider.java
@@ -18,6 +18,7 @@ import com.facebook.presto.spi.BucketFunction;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.Node;
+import com.facebook.presto.spi.hashing.ConsistentHashSelector;
 
 import java.util.List;
 import java.util.function.ToIntFunction;
@@ -42,6 +43,11 @@ public interface ConnectorNodePartitioningProvider
     }
 
     ConnectorBucketNodeMap getBucketNodeMap(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorPartitioningHandle partitioningHandle, List<Node> sortedNodes);
+
+    default ConnectorBucketNodeMap getBucketNodeMap(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorPartitioningHandle partitioningHandle, ConsistentHashSelector<Node> selector)
+    {
+        throw new UnsupportedOperationException();
+    }
 
     ToIntFunction<ConnectorSplit> getSplitBucketFunction(ConnectorTransactionHandle transactionHandle, ConnectorSession session, ConnectorPartitioningHandle partitioningHandle);
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/hashing/ConsistentHashNodeKeySupplier.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/hashing/ConsistentHashNodeKeySupplier.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.hashing;
+
+@FunctionalInterface
+public interface ConsistentHashNodeKeySupplier<I, K>
+{
+    K getKey(I instance);
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/hashing/ConsistentHashSelector.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/hashing/ConsistentHashSelector.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.hashing;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import static com.google.common.hash.Hashing.md5;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public class ConsistentHashSelector<T>
+{
+    private final SortedMap<Long, T> circle = new TreeMap();
+    private static final HashFunction hashFunction = key -> md5().hashString(key, UTF_8).asLong();
+    private final ConsistentHashNodeKeySupplier<T, String> keySupplier;
+    private final int replicas;
+
+    public ConsistentHashSelector(List<T> nodes, int replicas, ConsistentHashNodeKeySupplier<T, String> keySupplier)
+    {
+        this.keySupplier = keySupplier;
+        this.replicas = replicas;
+        nodes.stream().forEach(node -> add(node));
+    }
+
+    public void add(T node)
+    {
+        for (int i = 0; i < replicas; i++) {
+            this.circle.put(hashFunction.hash(keySupplier.getKey(node) + "_" + i), node);
+        }
+    }
+
+    public void remove(T node)
+    {
+        for (int i = 0; i < replicas; i++) {
+            this.circle.remove(hashFunction.hash(keySupplier.getKey(node) + "_" + i));
+        }
+    }
+
+    public List<T> getN(String data, int n)
+    {
+        List<T> results = new ArrayList<>();
+        for (int i = 0; i < n; i++) {
+            results.add(get(data + "_" + i));
+        }
+        return results;
+    }
+
+    public T get(String data)
+    {
+        if (this.circle.isEmpty()) {
+            return null;
+        }
+        else {
+            long hash = hashFunction.hash(data);
+            if (!circle.containsKey(hash)) {
+                SortedMap<Long, T> tailMap = this.circle.tailMap(hash);
+                hash = tailMap.isEmpty() ? this.circle.firstKey() : tailMap.firstKey();
+            }
+            return circle.get(hash);
+        }
+    }
+
+    private interface HashFunction
+    {
+        long hash(String key);
+    }
+}

--- a/presto-spi/src/test/java/com/facebook/presto/spi/hashing/TestConsistentHashSelector.java
+++ b/presto-spi/src/test/java/com/facebook/presto/spi/hashing/TestConsistentHashSelector.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.hashing;
+
+import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.Node;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.google.common.math.Quantiles.percentiles;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertTrue;
+
+public class TestConsistentHashSelector
+{
+    private ConsistentHashSelector<TestNode> hashSelector;
+
+    @BeforeMethod
+    public void setUp()
+    {
+        ImmutableList.Builder<TestNode> nodeBuilder = ImmutableList.builder();
+        for (int i = 1; i < 10; i++) {
+            nodeBuilder.add(new TestNode("node" + i));
+        }
+        List<TestNode> nodes = nodeBuilder.build();
+        hashSelector = new ConsistentHashSelector<>(nodes, 10, TestNode::getNodeIdentifier);
+    }
+
+    @Test
+    public void testInsertNodes()
+    {
+        assertEquals(hashSelector.getN("key", 3).size(), 3);
+        Map<String, TestNode> mapping = new HashMap<>();
+        for (int i = 0; i < 100; i++) {
+            String key = "key" + i;
+            mapping.put(key, hashSelector.get(key));
+        }
+        hashSelector.add(new TestNode("newNode"));
+        int count = 0;
+        for (int i = 0; i < 100; i++) {
+            String key = "key" + i;
+            TestNode previousNode = mapping.get(key);
+            TestNode currentNode = hashSelector.get(key);
+            if (previousNode != currentNode) {
+                count++;
+            }
+        }
+        assertTrue(count <= 10);
+    }
+
+    @Test
+    public void testRemoveNodes()
+    {
+        Map<String, TestNode> mapping = new HashMap<>();
+        for (int i = 0; i < 100; i++) {
+            String key = "key" + i;
+            mapping.put(key, hashSelector.get(key));
+        }
+        TestNode selectedNode = hashSelector.get("key1");
+        hashSelector.remove(selectedNode);
+        for (int i = 0; i < 100; i++) {
+            String key = "key" + i;
+            TestNode previousNode = mapping.get(key);
+            TestNode currentNode = hashSelector.get(key);
+            if (previousNode == selectedNode) {
+                assertNotEquals(currentNode, previousNode);
+            }
+            else {
+                assertEquals(currentNode, previousNode);
+            }
+        }
+    }
+
+    @Test
+    public void testStress()
+    {
+        Map<Integer, Double> result10 = runStressWith(400, 100_000, 10);
+        Map<Integer, Double> result30 = runStressWith(400, 100_000, 30);
+        Map<Integer, Double> result60 = runStressWith(400, 100_000, 60);
+        assertTrue(Math.abs(result60.get(50) - 250) <= Math.abs(result30.get(50) - 250));
+        assertTrue(Math.abs(result30.get(50) - 250) <= Math.abs(result10.get(50) - 250));
+    }
+
+    private Map<Integer, Double> runStressWith(int nodeNumber, int splits, int replicas)
+    {
+        ImmutableList.Builder<TestNode> nodeBuilder = ImmutableList.builder();
+        for (int i = 1; i < nodeNumber; i++) {
+            nodeBuilder.add(new TestNode("node" + i));
+        }
+        List<TestNode> nodes = nodeBuilder.build();
+        hashSelector = new ConsistentHashSelector<>(nodes, replicas, TestNode::getNodeIdentifier);
+
+        Map<TestNode, Integer> mapping = new HashMap<>();
+        for (int i = 0; i < splits; i++) {
+            String key = "key" + i;
+            TestNode node = hashSelector.get(key);
+            mapping.put(node, mapping.getOrDefault(node, 0) + 1);
+        }
+        Map<Integer, Double> myPercentiles =
+                percentiles().indexes(50, 90, 99).compute(mapping.values());
+        return myPercentiles;
+    }
+
+    private static class TestNode
+            implements Node
+    {
+        private String id;
+
+        public TestNode(String id)
+        {
+            this.id = id;
+        }
+
+        @Override
+        public String getHost()
+        {
+            return null;
+        }
+
+        @Override
+        public HostAddress getHostAndPort()
+        {
+            return null;
+        }
+
+        @Override
+        public URI getHttpUri()
+        {
+            return null;
+        }
+
+        @Override
+        public String getNodeIdentifier()
+        {
+            return id;
+        }
+
+        @Override
+        public String getVersion()
+        {
+            return "UNKNOWN";
+        }
+
+        @Override
+        public boolean isCoordinator()
+        {
+            return false;
+        }
+
+        @Override
+        public boolean isResourceManager()
+        {
+            return false;
+        }
+
+        @Override
+        public String toString()
+        {
+            return id;
+        }
+    }
+}


### PR DESCRIPTION
This change is to enable the Support Consistent hash based Affinity Scheduling
```
== RELEASE NOTES ==

General Changes
* experimental.node-scheduler.consistent-hash-affinity-enabled to enable the cosistent hash based affinity scheduling
* experimental.node-scheduler.consistent-hash-replicas to control the number of replica nodes.
