### PR TITLE
Simplify reduce_agg implementation

### DIFF
--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/SqlReduceAggregationBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/SqlReduceAggregationBenchmark.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark;
+
+import com.facebook.presto.testing.LocalQueryRunner;
+
+import static com.facebook.presto.benchmark.BenchmarkQueryRunner.createLocalQueryRunner;
+
+public class SqlReduceAggregationBenchmark
+        extends AbstractSqlBenchmark
+{
+    public SqlReduceAggregationBenchmark(LocalQueryRunner localQueryRunner, String query, String name)
+    {
+        super(localQueryRunner, name, 4, 5, query);
+    }
+
+    public static void main(String[] args)
+    {
+        new SqlReduceAggregationBenchmark(createLocalQueryRunner(), "SELECT REDUCE_AGG(x, 0, (x,y)->x+y, (x,y)->x+y) FROM (SELECT x * y AS x FROM (SELECT 1) CROSS JOIN UNNEST(SEQUENCE(1, 10000)) T(x)  CROSS JOIN UNNEST(SEQUENCE(1, 1000)) AS T2(y))", "sql_reduce_agg_long_sum").runBenchmark(new SimpleLineBenchmarkResultWriter(System.out));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/ReduceAggregationState.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/ReduceAggregationState.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.state;
+
+import com.facebook.presto.spi.function.AccumulatorState;
+
+public interface ReduceAggregationState
+        extends AccumulatorState
+{
+    Object getValue();
+
+    void setValue(Object value);
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/ReduceAggregationStateFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/ReduceAggregationStateFactory.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.state;
+
+import com.facebook.presto.array.ObjectBigArray;
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.spi.function.AccumulatorStateFactory;
+import io.airlift.slice.Slice;
+import org.openjdk.jol.info.ClassLayout;
+
+public class ReduceAggregationStateFactory
+        implements AccumulatorStateFactory<ReduceAggregationState>
+{
+    @Override
+    public ReduceAggregationState createSingleState()
+    {
+        return new SingleState();
+    }
+
+    @Override
+    public Class<? extends ReduceAggregationState> getSingleStateClass()
+    {
+        return SingleState.class;
+    }
+
+    @Override
+    public ReduceAggregationState createGroupedState()
+    {
+        return new GroupedState();
+    }
+
+    @Override
+    public Class<? extends ReduceAggregationState> getGroupedStateClass()
+    {
+        return GroupedState.class;
+    }
+
+    private static long getObjectSizeInBytes(Object value)
+    {
+        if (value instanceof Block) {
+            return ((Block) value).getRetainedSizeInBytes();
+        }
+
+        if (value instanceof Slice) {
+            return ((Slice) value).getRetainedSize();
+        }
+
+        return 0;
+    }
+
+    public static class GroupedState
+            extends AbstractGroupedAccumulatorState
+            implements ReduceAggregationState
+    {
+        private static final int INSTANCE_SIZE = ClassLayout.parseClass(GroupedState.class).instanceSize();
+
+        private final ObjectBigArray<Object> values = new ObjectBigArray<>();
+        private long size = INSTANCE_SIZE;
+
+        @Override
+        public long getEstimatedSize()
+        {
+            return size + values.sizeOf();
+        }
+
+        @Override
+        public Object getValue()
+        {
+            return values.get(getGroupId());
+        }
+
+        @Override
+        public void setValue(Object value)
+        {
+            size += getObjectSizeInBytes(value) - getObjectSizeInBytes(getValue());
+            values.set(getGroupId(), value);
+        }
+
+        @Override
+        public void ensureCapacity(long size)
+        {
+            values.ensureCapacity(size);
+        }
+    }
+
+    public static class SingleState
+            implements ReduceAggregationState
+    {
+        private static final int INSTANCE_SIZE = ClassLayout.parseClass(GroupedState.class).instanceSize();
+
+        private Object value;
+
+        @Override
+        public Object getValue()
+        {
+            return value;
+        }
+
+        @Override
+        public void setValue(Object value)
+        {
+            this.value = value;
+        }
+
+        @Override
+        public long getEstimatedSize()
+        {
+            return getObjectSizeInBytes(value) + INSTANCE_SIZE;
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/ReduceAggregationStateSerializer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/ReduceAggregationStateSerializer.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation.state;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.TypeUtils;
+import com.facebook.presto.spi.function.AccumulatorStateSerializer;
+
+import static com.facebook.presto.common.type.TypeUtils.writeNativeValue;
+
+public class ReduceAggregationStateSerializer
+        implements AccumulatorStateSerializer<ReduceAggregationState>
+{
+    private final Type type;
+
+    public ReduceAggregationStateSerializer(Type type)
+    {
+        this.type = type;
+    }
+
+    @Override
+    public Type getSerializedType()
+    {
+        return type;
+    }
+
+    @Override
+    public void serialize(ReduceAggregationState state, BlockBuilder blockBuilder)
+    {
+        writeNativeValue(type, blockBuilder, state.getValue());
+    }
+
+    @Override
+    public void deserialize(Block block, int index, ReduceAggregationState state)
+    {
+        state.setValue(TypeUtils.readNativeValue(type, block, index));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
@@ -38,6 +38,7 @@ import com.facebook.presto.spi.StandardErrorCode;
 import com.facebook.presto.spi.StandardWarningCode;
 import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.function.FunctionHandle;
+import com.facebook.presto.spi.function.FunctionImplementationType;
 import com.facebook.presto.spi.function.FunctionMetadata;
 import com.facebook.presto.spi.function.SqlFunctionId;
 import com.facebook.presto.spi.function.SqlInvokedFunction;
@@ -144,6 +145,7 @@ import static com.facebook.presto.metadata.FunctionAndTypeManager.qualifyObjectN
 import static com.facebook.presto.sql.NodeUtils.getSortItemsFromOrderBy;
 import static com.facebook.presto.sql.analyzer.Analyzer.verifyNoAggregateWindowOrGroupingFunctions;
 import static com.facebook.presto.sql.analyzer.Analyzer.verifyNoExternalFunctions;
+import static com.facebook.presto.sql.analyzer.ExpressionTreeUtils.isNonNullConstant;
 import static com.facebook.presto.sql.analyzer.ExpressionTreeUtils.tryResolveEnumLiteralType;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.EXPRESSION_NOT_CONSTANT;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.INVALID_LITERAL;
@@ -969,6 +971,14 @@ public class ExpressionAnalyzer
             }
             resolvedFunctions.put(NodeRef.of(node), function);
 
+            if (functionMetadata.getImplementationType() == FunctionImplementationType.BUILTIN && functionMetadata.getName().getObjectName().equalsIgnoreCase("REDUCE_AGG")) {
+                Expression initialValueArg = (Expression) node.getArguments().get(1);
+                // For builtin reduce_agg, we make sure the initial value is not null as we cannot handle null properly now.
+
+                if (!isNonNullConstant(initialValueArg)) {
+                    throw new SemanticException(INVALID_PROCEDURE_ARGUMENTS, initialValueArg, "REDUCE_AGG only supports non-NULL literal as the initial value", initialValueArg);
+                }
+            }
             Type type = functionAndTypeManager.getType(functionMetadata.getReturnType());
             return setExpressionType(node, type);
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionTreeUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionTreeUtils.java
@@ -18,14 +18,19 @@ import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeWithName;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
 import com.facebook.presto.spi.function.FunctionHandle;
+import com.facebook.presto.sql.tree.ArrayConstructor;
+import com.facebook.presto.sql.tree.Cast;
 import com.facebook.presto.sql.tree.ComparisonExpression;
 import com.facebook.presto.sql.tree.DefaultExpressionTraversalVisitor;
 import com.facebook.presto.sql.tree.DereferenceExpression;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.sql.tree.Literal;
 import com.facebook.presto.sql.tree.Node;
 import com.facebook.presto.sql.tree.NodeRef;
+import com.facebook.presto.sql.tree.NullLiteral;
 import com.facebook.presto.sql.tree.QualifiedName;
+import com.facebook.presto.sql.tree.Row;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Multimap;
 
@@ -164,5 +169,47 @@ public final class ExpressionTreeUtils
         checkState(columnReferences.get(NodeRef.of(expression)).size() == 1, "Multiple field references for expression");
 
         return columnReferences.get(NodeRef.of(expression)).iterator().next();
+    }
+
+    public static boolean isNonNullConstant(Expression expression)
+    {
+        Expression tempExpression = expression;
+        while (tempExpression instanceof Cast) {
+            tempExpression = ((Cast) tempExpression).getExpression();
+        }
+
+        if (tempExpression instanceof NullLiteral) {
+            return false;
+        }
+
+        // now allow for things like ARRAY, ROW(...) where null is OK
+        return isConstant(tempExpression);
+    }
+
+    public static boolean isConstant(Expression expression)
+    {
+        Expression tempExpression = expression;
+        while (tempExpression instanceof Cast) {
+            tempExpression = ((Cast) tempExpression).getExpression();
+        }
+
+        if (tempExpression instanceof Literal || tempExpression instanceof ArrayConstructor) {
+            return true;
+        }
+
+        // ROW an MAP are special so we explicitly do that here.
+        if (tempExpression instanceof Row) {
+            return !(((Row) tempExpression).getItems().stream().filter(x -> !isConstant(expression)).findAny().isPresent());
+        }
+
+        if (tempExpression instanceof FunctionCall) {
+            // Hack to just allow map constructor
+            if (((FunctionCall) tempExpression).getName().getSuffix().equalsIgnoreCase("map")) {
+                return !((FunctionCall) tempExpression).getArguments().stream().filter(x -> !isConstant(expression)).findAny().isPresent();
+            }
+        }
+
+        // Everything else is considered non-const
+        return false;
     }
 }


### PR DESCRIPTION
REDUCE_AGG is now fixed to allow NULLs as the result of input/combine functions to make it more generally applicable. For now, we added a check in the expression analyzer that the initialValue is
* Not null, or CAST(null AS ...)
* Literal 
* ARRAY/MAP constructor
* ROW constructor

where all the arguments to the ARRAY/ROW are constants in turn (can be NULL as well) possibly with CAST.

It now has a single version of input that just takes Object type as the BinaryFunctionInterface is already taking only Object so specializing it for long/double etc is not very useful.

Test plan - Added tests

Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines. Don't forget to follow our [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution) for any code copied from other projects.

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== RELEASE NOTES ==

General Changes
* REDUCE_AGG is now fixed to allow only constant expressions and not null as the initial value and handle combine/input functions producing null results
```
