### PR TITLE
Improve Block#getLoadedBlock() and Page#getLoadedPage()

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/Page.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/Page.java
@@ -291,22 +291,20 @@ public final class Page
      */
     public Page getLoadedPage()
     {
-        Block[] loadedBlocks = null;
         for (int i = 0; i < blocks.length; i++) {
             Block loaded = blocks[i].getLoadedBlock();
             if (loaded != blocks[i]) {
-                if (loadedBlocks == null) {
-                    loadedBlocks = blocks.clone();
+                // Transition to new block creation mode after the first newly loaded block is encountered
+                Block[] loadedBlocks = blocks.clone();
+                loadedBlocks[i++] = loaded;
+                for (; i < blocks.length; i++) {
+                    loadedBlocks[i] = blocks[i].getLoadedBlock();
                 }
-                loadedBlocks[i] = loaded;
+                return wrapBlocksWithoutCopy(positionCount, loadedBlocks);
             }
         }
-
-        if (loadedBlocks == null) {
-            return this;
-        }
-
-        return wrapBlocksWithoutCopy(positionCount, loadedBlocks);
+        // No newly loaded blocks
+        return this;
     }
 
     public Page getLoadedPage(int channel)

--- a/presto-common/src/main/java/com/facebook/presto/common/block/BlockUtil.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/BlockUtil.java
@@ -326,4 +326,25 @@ public final class BlockUtil
         }
         return num128Integers;
     }
+
+    /**
+     * Returns the input blocks array if all blocks are already loaded, otherwise returns a new blocks array with all blocks loaded
+     */
+    static Block[] ensureBlocksAreLoaded(Block[] blocks)
+    {
+        for (int i = 0; i < blocks.length; i++) {
+            Block loaded = blocks[i].getLoadedBlock();
+            if (loaded != blocks[i]) {
+                // Transition to new block creation mode after the first newly loaded block is encountered
+                Block[] loadedBlocks = blocks.clone();
+                loadedBlocks[i++] = loaded;
+                for (; i < blocks.length; i++) {
+                    loadedBlocks[i] = blocks[i].getLoadedBlock();
+                }
+                return loadedBlocks;
+            }
+        }
+        // No newly loaded blocks
+        return blocks;
+    }
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/block/RowBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/RowBlock.java
@@ -20,6 +20,7 @@ import javax.annotation.Nullable;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 
+import static com.facebook.presto.common.block.BlockUtil.ensureBlocksAreLoaded;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -220,17 +221,9 @@ public class RowBlock
     @Override
     public Block getLoadedBlock()
     {
-        boolean allLoaded = true;
-        Block[] loadedFieldBlocks = new Block[fieldBlocks.length];
-
-        for (int i = 0; i < fieldBlocks.length; i++) {
-            loadedFieldBlocks[i] = fieldBlocks[i].getLoadedBlock();
-            if (loadedFieldBlocks[i] != fieldBlocks[i]) {
-                allLoaded = false;
-            }
-        }
-
-        if (allLoaded) {
+        Block[] loadedFieldBlocks = ensureBlocksAreLoaded(fieldBlocks);
+        if (loadedFieldBlocks == fieldBlocks) {
+            // All blocks are already loaded
             return this;
         }
         return createRowBlockInternal(

--- a/presto-common/src/main/java/com/facebook/presto/common/block/SingleRowBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/SingleRowBlock.java
@@ -18,6 +18,7 @@ import org.openjdk.jol.info.ClassLayout;
 
 import java.util.function.BiConsumer;
 
+import static com.facebook.presto.common.block.BlockUtil.ensureBlocksAreLoaded;
 import static java.lang.String.format;
 
 public class SingleRowBlock
@@ -99,17 +100,9 @@ public class SingleRowBlock
     @Override
     public Block getLoadedBlock()
     {
-        boolean allLoaded = true;
-        Block[] loadedFieldBlocks = new Block[fieldBlocks.length];
-
-        for (int i = 0; i < fieldBlocks.length; i++) {
-            loadedFieldBlocks[i] = fieldBlocks[i].getLoadedBlock();
-            if (loadedFieldBlocks[i] != fieldBlocks[i]) {
-                allLoaded = false;
-            }
-        }
-
-        if (allLoaded) {
+        Block[] loadedFieldBlocks = ensureBlocksAreLoaded(fieldBlocks);
+        if (loadedFieldBlocks == fieldBlocks) {
+            // All blocks are already loaded
             return this;
         }
         return new SingleRowBlock(rowIndex, loadedFieldBlocks);


### PR DESCRIPTION
Improves the implementations for `Block#getLoadedBlock()` in `RowBlock` and `SingleRowBlock` to avoid unnecessary allocations when all blocks are already loaded. Also refactors the implementation of `Page#getLoadedPage()` to match.

This follows up on changes made in https://github.com/prestodb/presto/pull/16617 that will call `Page#getLoadedPage` more frequently and could regress performance when a large number of `RowBlock` columns were present.

```
== NO RELEASE NOTE ==
```
