### PR TITLE
Add a fast path for unwrapping IF in AGG IF to FILTER rewrite

### DIFF
--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/AggregateIfBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/AggregateIfBenchmark.java
@@ -16,15 +16,15 @@ package com.facebook.presto.benchmark;
 import com.facebook.presto.testing.LocalQueryRunner;
 import com.google.common.collect.ImmutableMap;
 
-import static com.facebook.presto.SystemSessionProperties.AGGREGATION_IF_TO_FILTER_REWRITE_ENABLED;
+import static com.facebook.presto.SystemSessionProperties.AGGREGATION_IF_TO_FILTER_REWRITE_STRATEGY;
 import static com.facebook.presto.benchmark.BenchmarkQueryRunner.createLocalQueryRunner;
 
 public abstract class AggregateIfBenchmark
 {
     public static void main(String... args)
     {
-        LocalQueryRunner localQueryRunnerWithRewrite = createLocalQueryRunner(ImmutableMap.of(AGGREGATION_IF_TO_FILTER_REWRITE_ENABLED, "true"));
-        LocalQueryRunner localQueryRunnerWithoutRewrite = createLocalQueryRunner(ImmutableMap.of(AGGREGATION_IF_TO_FILTER_REWRITE_ENABLED, "false"));
+        LocalQueryRunner localQueryRunnerWithRewrite = createLocalQueryRunner(ImmutableMap.of(AGGREGATION_IF_TO_FILTER_REWRITE_STRATEGY, "filter_with_if"));
+        LocalQueryRunner localQueryRunnerWithoutRewrite = createLocalQueryRunner(ImmutableMap.of(AGGREGATION_IF_TO_FILTER_REWRITE_STRATEGY, "disabled"));
         new SumIfBenchmark(localQueryRunnerWithoutRewrite, false).runBenchmark(new SimpleLineBenchmarkResultWriter(System.out));
         new SumIfBenchmark(localQueryRunnerWithRewrite, true).runBenchmark(new SimpleLineBenchmarkResultWriter(System.out));
         new SumFilterBenchmark(localQueryRunnerWithRewrite).runBenchmark(new SimpleLineBenchmarkResultWriter(System.out));

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -206,7 +206,7 @@ public class FeaturesConfig
     private boolean materializedViewDataConsistencyEnabled = true;
 
     private boolean queryOptimizationWithMaterializedViewEnabled;
-    private boolean aggregationIfToFilterRewriteEnabled;
+    private AggregationIfToFilterRewriteStrategy aggregationIfToFilterRewriteStrategy = AggregationIfToFilterRewriteStrategy.DISABLED;
 
     public enum PartitioningPrecisionStrategy
     {
@@ -281,6 +281,13 @@ public class FeaturesConfig
         ALWAYS, // Always do partial aggregation
         NEVER, // Never do partial aggregation
         AUTOMATIC // Let the optimizer decide for each aggregation
+    }
+
+    public enum AggregationIfToFilterRewriteStrategy
+    {
+        DISABLED,
+        FILTER_WITH_IF, // Rewrites AGG(IF(condition, expr)) to AGG(IF(condition, expr)) FILTER (WHERE condition).
+        UNWRAP_IF // Rewrites AGG(IF(condition, expr)) to AGG(expr) FILTER (WHERE condition).
     }
 
     public double getCpuCostWeight()
@@ -1824,16 +1831,16 @@ public class FeaturesConfig
         return this;
     }
 
-    public boolean isAggregationIfToFilterRewriteEnabled()
+    public AggregationIfToFilterRewriteStrategy getAggregationIfToFilterRewriteStrategy()
     {
-        return aggregationIfToFilterRewriteEnabled;
+        return aggregationIfToFilterRewriteStrategy;
     }
 
-    @Config("optimizer.aggregation-if-to-filter-rewrite-enabled")
-    @ConfigDescription("Enable rewriting the IF expression inside an aggregation function to a filter clause outside the aggregation")
-    public FeaturesConfig setAggregationIfToFilterRewriteEnabled(boolean value)
+    @Config("optimizer.aggregation-if-to-filter-rewrite-strategy")
+    @ConfigDescription("Set the strategy used to rewrite AGG IF to AGG FILTER")
+    public FeaturesConfig setAggregationIfToFilterRewriteStrategy(AggregationIfToFilterRewriteStrategy strategy)
     {
-        this.aggregationIfToFilterRewriteEnabled = value;
+        this.aggregationIfToFilterRewriteStrategy = strategy;
         return this;
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -18,6 +18,7 @@ import com.facebook.airlift.configuration.testing.ConfigAssertions;
 import com.facebook.presto.operator.aggregation.arrayagg.ArrayAggGroupImplementation;
 import com.facebook.presto.operator.aggregation.histogram.HistogramGroupImplementation;
 import com.facebook.presto.operator.aggregation.multimapagg.MultimapAggGroupImplementation;
+import com.facebook.presto.sql.analyzer.FeaturesConfig.AggregationIfToFilterRewriteStrategy;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.PartialAggregationStrategy;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.PartitioningPrecisionStrategy;
 import com.facebook.presto.sql.analyzer.FeaturesConfig.SingleStreamSpillerChoice;
@@ -178,7 +179,7 @@ public class TestFeaturesConfig
                 .setPartialResultsMaxExecutionTimeMultiplier(2.0)
                 .setMaterializedViewDataConsistencyEnabled(true)
                 .setQueryOptimizationWithMaterializedViewEnabled(false)
-                .setAggregationIfToFilterRewriteEnabled(false));
+                .setAggregationIfToFilterRewriteStrategy(AggregationIfToFilterRewriteStrategy.DISABLED));
     }
 
     @Test
@@ -308,7 +309,7 @@ public class TestFeaturesConfig
                 .put("offset-clause-enabled", "true")
                 .put("materialized-view-data-consistency-enabled", "false")
                 .put("query-optimization-with-materialized-view-enabled", "true")
-                .put("optimizer.aggregation-if-to-filter-rewrite-enabled", "true")
+                .put("optimizer.aggregation-if-to-filter-rewrite-strategy", "filter_with_if")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -436,7 +437,7 @@ public class TestFeaturesConfig
                 .setPartialResultsMaxExecutionTimeMultiplier(1.5)
                 .setMaterializedViewDataConsistencyEnabled(false)
                 .setQueryOptimizationWithMaterializedViewEnabled(true)
-                .setAggregationIfToFilterRewriteEnabled(true);
+                .setAggregationIfToFilterRewriteStrategy(AggregationIfToFilterRewriteStrategy.FILTER_WITH_IF);
         assertFullMapping(properties, expected);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/RowExpressionVerifier.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/RowExpressionVerifier.java
@@ -50,6 +50,7 @@ import com.facebook.presto.sql.tree.NotExpression;
 import com.facebook.presto.sql.tree.NullLiteral;
 import com.facebook.presto.sql.tree.SimpleCaseExpression;
 import com.facebook.presto.sql.tree.StringLiteral;
+import com.facebook.presto.sql.tree.SubscriptExpression;
 import com.facebook.presto.sql.tree.SymbolReference;
 import com.facebook.presto.sql.tree.TryExpression;
 import com.facebook.presto.sql.tree.WhenClause;
@@ -161,6 +162,16 @@ final class RowExpressionVerifier
         return process(expected.getCondition(), ((SpecialFormExpression) actual).getArguments().get(0)) &&
                 process(expected.getTrueValue(), ((SpecialFormExpression) actual).getArguments().get(1)) &&
                 process(expected.getFalseValue().orElse(new NullLiteral()), ((SpecialFormExpression) actual).getArguments().get(2));
+    }
+
+    @Override
+    protected Boolean visitSubscriptExpression(SubscriptExpression expected, RowExpression actual)
+    {
+        if (!(actual instanceof CallExpression) || !functionResolution.isSubscriptFunction(((CallExpression) actual).getFunctionHandle())) {
+            return false;
+        }
+        return process(expected.getBase(), ((CallExpression) actual).getArguments().get(0)) &&
+                process(expected.getIndex(), ((CallExpression) actual).getArguments().get(1));
     }
 
     @Override

--- a/presto-main/src/test/java/com/facebook/presto/sql/query/TestFilteredAggregations.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/query/TestFilteredAggregations.java
@@ -21,7 +21,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import static com.facebook.presto.SystemSessionProperties.AGGREGATION_IF_TO_FILTER_REWRITE_ENABLED;
+import static com.facebook.presto.SystemSessionProperties.AGGREGATION_IF_TO_FILTER_REWRITE_STRATEGY;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.filter;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.tableScan;
@@ -36,7 +36,7 @@ public class TestFilteredAggregations
 
     public TestFilteredAggregations()
     {
-        super(ImmutableMap.of(AGGREGATION_IF_TO_FILTER_REWRITE_ENABLED, "true"));
+        super(ImmutableMap.of(AGGREGATION_IF_TO_FILTER_REWRITE_STRATEGY, "filter_with_if"));
     }
 
     @BeforeClass


### PR DESCRIPTION
The optimization of unwrapping if has a large impact on the query
performance. For example, here is the improvement of this optimization
for one specific prod query:
Original CPU with this rule disabled: 1.79h
CPU with this rule enabled without unwrapping IF: 1.42h
CPU with this rule enabled with unwrapping IF: 17m

Thus it seems worth adding a fast path for the IF unwrapping.
This commit adds a new session property to enable/disable this feature.
This also adds the logic to disable IF unwrapping for some query
patterns with known issues, e.g., array[1] and a/b which could return
exceptions. We can add more query patterns to the block list if
necessary.

We are not planning to enable this fast path by default. It will only be
enabled for specific clusters like Deltoid which don't have query
patterns with these issues.

Test plan
Added unit tests.

```
== NO RELEASE NOTE ==
```
