### PR TITLE
Bug fixing: pinot timeBoundary call json parser

### DIFF
--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotClusterInfoFetcher.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotClusterInfoFetcher.java
@@ -456,12 +456,12 @@ public class PinotClusterInfoFetcher
 
         @JsonCreator
         public TimeBoundary(
-                @JsonProperty String timeColumnName,
-                @JsonProperty String timeColumnValue)
+                @JsonProperty String timeColumn,
+                @JsonProperty String timeValue)
         {
-            if (timeColumnName != null && timeColumnValue != null) {
-                offlineTimePredicate = Optional.of(format("%s < %s", timeColumnName, timeColumnValue));
-                onlineTimePredicate = Optional.of(format("%s >= %s", timeColumnName, timeColumnValue));
+            if (timeColumn != null && timeValue != null) {
+                offlineTimePredicate = Optional.of(format("%s < %s", timeColumn, timeValue));
+                onlineTimePredicate = Optional.of(format("%s >= %s", timeColumn, timeValue));
             }
             else {
                 onlineTimePredicate = Optional.empty();

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotSplitManager.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotSplitManager.java
@@ -93,7 +93,7 @@ public class PinotSplitManager
         String pql = basePql.getQuery().replace(TABLE_NAME_SUFFIX_TEMPLATE, suffix);
         if (timePredicate.isPresent()) {
             String tp = timePredicate.get();
-            pql = pql.replace(TIME_BOUNDARY_FILTER_TEMPLATE, basePql.isHaveFilter() ? tp : " WHERE " + tp);
+            pql = pql.replace(TIME_BOUNDARY_FILTER_TEMPLATE, basePql.isHaveFilter() ? " AND " + tp : " WHERE " + tp);
         }
         else {
             pql = pql.replace(TIME_BOUNDARY_FILTER_TEMPLATE, "");


### PR DESCRIPTION
Fix time boundary call response parser.

Sample pinot time boundary call response:
```
{
  timeColumn: "mergedTimeMillis",
  timeValue: "1630627168000"
}
```
Test plan - (Please fill in how you tested your changes)

```
== NO RELEASE NOTE ==
```
