### PR TITLE
Documentation: two new sections for probability distribution functions

### DIFF
--- a/presto-docs/src/main/sphinx/functions/math.rst
+++ b/presto-docs/src/main/sphinx/functions/math.rst
@@ -22,17 +22,6 @@ Mathematical Functions
 
     Returns the absolute value of ``x``.
 
-.. function:: binomial_cdf(numberOfTrials, successProbability, value) -> double
-
-    Compute the Binomial cdf with given numberOfTrials and successProbability (for a single trial):  P(N < value).
-    The successProbability must be real value in [0, 1], numberOfTrials and value must be
-    positive integers with numberOfTrials greater or equal to value.
-
-.. function:: cauchy_cdf(median, scale, value) -> double
-
-    Compute the Cauchy cdf with given parameters median and scale (gamma): P(N; median, scale).
-    The scale parameter must be a positive double. The value parameter must be a double on the interval [0, 1].
-
 .. function:: cbrt(x) -> double
 
     Returns the cube root of ``x``.
@@ -44,11 +33,6 @@ Mathematical Functions
 .. function:: ceiling(x) -> [same as input]
 
     Returns ``x`` rounded up to the nearest integer.
-
-.. function:: chi_squared_cdf(df, value) -> double
-
-    Compute the Chi-square cdf with given df (degrees of freedom) parameter:  P(N < value; df).
-    The df parameter must be a positive real number, and value must be a non-negative real value (both of type DOUBLE).
 
 .. function:: cosine_similarity(x, y) -> double
 
@@ -76,62 +60,6 @@ Mathematical Functions
 
     Returns the value of ``string`` interpreted as a base-``radix`` number.
 
-.. function:: inverse_binomial_cdf(numberOfTrials, successProbability, p) -> int
-
-    Compute the inverse of the Binomial cdf with given numberOfTrials and successProbability (of a single trial) the
-    cumulative probability (p):  P(N <= n).
-    The successProbability and p must be real values in [0, 1] and the numberOfTrials must be
-    a positive integer.
-
-.. function:: inverse_cauchy_cdf(median, scale, p) -> double
-
-    Compute the inverse of the Cauchy cdf with given parameters median and scale (gamma) for the probability p.
-    The scale parameter must be a positive double. The probability p must be a double on the interval [0, 1].
-
-.. function:: inverse_chi_squared_cdf(df, p) -> double
-
-    Compute the inverse of the Chi-square cdf with given df (degrees of freedom) parameter for the cumulative
-    probability (p): P(N < n). The df parameter must be positive real values.
-    The probability p must lie on the interval [0, 1].
-
-.. function:: inverse_normal_cdf(mean, sd, p) -> double
-
-    Compute the inverse of the Normal cdf with given mean and standard
-    deviation (sd) for the cumulative probability (p): P(N < n). The mean must be
-    a real value and the standard deviation must be a real and positive value (both of type DOUBLE).
-    The probability p must lie on the interval (0, 1).
-
-.. function:: inverse_poisson_cdf(lambda, p) -> integer
-
-    Compute the inverse of the Poisson cdf with given lambda (mean) parameter for the cumulative
-    probability (p). It returns the value of n so that: P(N <= n; lambda) = p.
-    The lambda parameter must be a positive real number (of type DOUBLE).
-    The probability p must lie on the interval [0, 1).
-
-.. function:: inverse_weibull_cdf(a, b, p) -> double
-
-    Compute the inverse of the Weibull cdf with given parameters ``a``, ``b`` for the probability ``p``.
-    The ``a``, ``b`` parameters must be positive double values. The probability ``p`` must be a double
-    on the interval [0, 1].
-
-.. function:: normal_cdf(mean, sd, value) -> double
-
-    Compute the Normal cdf with given mean and standard deviation (sd):  P(N < value; mean, sd).
-    The mean and value must be real values and the standard deviation must be a real
-    and positive value (all of type DOUBLE).
-
-.. function:: inverse_beta_cdf(a, b, p) -> double
-
-    Compute the inverse of the Beta cdf with given a, b parameters for the cumulative
-    probability (p): P(N < n). The a, b parameters must be positive real values (all of type DOUBLE).
-    The probability p must lie on the interval [0, 1].
-
-.. function:: beta_cdf(a, b, value) -> double
-
-    Compute the Beta cdf with given a, b parameters:  P(N < value; a, b).
-    The a, b parameters must be positive real numbers and value must be a real value (all of type DOUBLE).
-    The value must lie on the interval [0, 1].
-
 .. function:: ln(x) -> double
 
     Returns the natural logarithm of ``x``.
@@ -151,11 +79,6 @@ Mathematical Functions
 .. function:: pi() -> double
 
     Returns the constant Pi.
-
-.. function:: poisson_cdf(lambda, value) -> double
-
-    Compute the Poisson cdf with given lambda (mean) parameter:  P(N <= value; lambda).
-    The lambda parameter must be a positive real number (of type DOUBLE) and value must be a non-negative integer.
 
 .. function:: pow(x, p) -> double
 
@@ -225,11 +148,6 @@ Mathematical Functions
     ``truncate(REAL '12.333', 0)``  -> result is 12.0
     ``truncate(REAL '12.333', 1)``  -> result is 12.3
 
-.. function:: weibull_cdf(a, b, value) -> double
-
-    Compute the Weibull cdf with given parameters a, b: P(N <= value). The ``a``
-    and ``b`` parameters must be positive doubles and ``value`` must also be a double.
-
 .. function:: width_bucket(x, bound1, bound2, n) -> bigint
 
     Returns the bin number of ``x`` in an equi-width histogram with the
@@ -240,6 +158,96 @@ Mathematical Functions
     Returns the bin number of ``x`` according to the bins specified by the
     array ``bins``. The ``bins`` parameter must be an array of doubles and is
     assumed to be in sorted ascending order.
+
+Probability Functions: cdf
+-----------------------
+
+.. function:: beta_cdf(a, b, value) -> double
+
+    Compute the Beta cdf with given a, b parameters:  P(N < value; a, b).
+    The a, b parameters must be positive real numbers and value must be a real value (all of type DOUBLE).
+    The value must lie on the interval [0, 1].
+
+.. function:: binomial_cdf(numberOfTrials, successProbability, value) -> double
+
+    Compute the Binomial cdf with given numberOfTrials and successProbability (for a single trial):  P(N < value).
+    The successProbability must be real value in [0, 1], numberOfTrials and value must be
+    positive integers with numberOfTrials greater or equal to value.
+
+.. function:: cauchy_cdf(median, scale, value) -> double
+
+    Compute the Cauchy cdf with given parameters median and scale (gamma): P(N; median, scale).
+    The scale parameter must be a positive double. The value parameter must be a double on the interval [0, 1].
+
+.. function:: chi_squared_cdf(df, value) -> double
+
+    Compute the Chi-square cdf with given df (degrees of freedom) parameter:  P(N < value; df).
+    The df parameter must be a positive real number, and value must be a non-negative real value (both of type DOUBLE).
+
+.. function:: normal_cdf(mean, sd, value) -> double
+
+    Compute the Normal cdf with given mean and standard deviation (sd):  P(N < value; mean, sd).
+    The mean and value must be real values and the standard deviation must be a real
+    and positive value (all of type DOUBLE).
+
+.. function:: poisson_cdf(lambda, value) -> double
+
+    Compute the Poisson cdf with given lambda (mean) parameter:  P(N <= value; lambda).
+    The lambda parameter must be a positive real number (of type DOUBLE) and value must be a non-negative integer.
+
+.. function:: weibull_cdf(a, b, value) -> double
+
+    Compute the Weibull cdf with given parameters a, b: P(N <= value). The ``a``
+    and ``b`` parameters must be positive doubles and ``value`` must also be a double.
+
+
+Probability Functions: inverse_cdf
+-----------------------
+
+.. function:: inverse_beta_cdf(a, b, p) -> double
+
+    Compute the inverse of the Beta cdf with given a, b parameters for the cumulative
+    probability (p): P(N < n). The a, b parameters must be positive real values (all of type DOUBLE).
+    The probability p must lie on the interval [0, 1].
+
+.. function:: inverse_binomial_cdf(numberOfTrials, successProbability, p) -> int
+
+    Compute the inverse of the Binomial cdf with given numberOfTrials and successProbability (of a single trial) the
+    cumulative probability (p):  P(N <= n).
+    The successProbability and p must be real values in [0, 1] and the numberOfTrials must be
+    a positive integer.
+
+.. function:: inverse_cauchy_cdf(median, scale, p) -> double
+
+    Compute the inverse of the Cauchy cdf with given parameters median and scale (gamma) for the probability p.
+    The scale parameter must be a positive double. The probability p must be a double on the interval [0, 1].
+
+.. function:: inverse_chi_squared_cdf(df, p) -> double
+
+    Compute the inverse of the Chi-square cdf with given df (degrees of freedom) parameter for the cumulative
+    probability (p): P(N < n). The df parameter must be positive real values.
+    The probability p must lie on the interval [0, 1].
+
+.. function:: inverse_normal_cdf(mean, sd, p) -> double
+
+    Compute the inverse of the Normal cdf with given mean and standard
+    deviation (sd) for the cumulative probability (p): P(N < n). The mean must be
+    a real value and the standard deviation must be a real and positive value (both of type DOUBLE).
+    The probability p must lie on the interval (0, 1).
+
+.. function:: inverse_poisson_cdf(lambda, p) -> integer
+
+    Compute the inverse of the Poisson cdf with given lambda (mean) parameter for the cumulative
+    probability (p). It returns the value of n so that: P(N <= n; lambda) = p.
+    The lambda parameter must be a positive real number (of type DOUBLE).
+    The probability p must lie on the interval [0, 1).
+
+.. function:: inverse_weibull_cdf(a, b, p) -> double
+
+    Compute the inverse of the Weibull cdf with given parameters ``a``, ``b`` for the probability ``p``.
+    The ``a``, ``b`` parameters must be positive double values. The probability ``p`` must be a double
+    on the interval [0, 1].
+
 
 Statistical Functions
 -----------------------


### PR DESCRIPTION
The documentation of the probability distribution functions was a bit of a mess. The function names should have been organized based on alphabetical order, but they were not. Also, bucketing probability distribution functions to their own sections should make it easier to find them (and is a good ground work for future functions that will be added)


== Test plan ==

Followed the steps here:
https://github.com/prestodb/presto/blob/master/presto-docs/README.md
Ran:
```
cd presto-docs
./build
```
Then
```
open target/html/index.html
```
Then went to the relevant page, and it's looking good (see screenshots):

![image](https://user-images.githubusercontent.com/976006/132372321-18739157-b20c-43b9-8b5f-2d6b2cebbe4f.png)

![image](https://user-images.githubusercontent.com/976006/132372375-8be9d278-5673-4d82-8877-8f3e06e0389f.png)




== RELEASE NOTES ==

General Changes
* Documentation: moved information about the probability distribution functions into their own sections in math.rst
