### PR TITLE
Add counters for skipped stripes and total stripes

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcBatchRecordReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcBatchRecordReader.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.orc;
 
 import com.facebook.presto.common.Page;
+import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.orc.metadata.MetadataReader;
@@ -64,7 +65,8 @@ public class OrcBatchRecordReader
             Optional<OrcWriteValidation> writeValidation,
             int initialBatchSize,
             StripeMetadataSource stripeMetadataSource,
-            boolean cacheable)
+            boolean cacheable,
+            RuntimeStats runtimeStats)
             throws OrcCorruptionException
 
     {
@@ -101,7 +103,8 @@ public class OrcBatchRecordReader
                 writeValidation,
                 initialBatchSize,
                 stripeMetadataSource,
-                cacheable);
+                cacheable,
+                runtimeStats);
     }
 
     public int nextBatch()

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcReader.java
@@ -331,7 +331,8 @@ public class OrcReader
                 writeValidation,
                 initialBatchSize,
                 stripeMetadataSource,
-                cacheable);
+                cacheable,
+                runtimeStats);
     }
 
     public OrcSelectiveRecordReader createSelectiveRecordReader(
@@ -385,7 +386,8 @@ public class OrcReader
                 writeValidation,
                 initialBatchSize,
                 stripeMetadataSource,
-                cacheable);
+                cacheable,
+                runtimeStats);
     }
 
     private static OrcDataSource wrapWithCacheIfTiny(OrcDataSource dataSource, DataSize maxCacheSize, OrcAggregatedMemoryContext systemMemoryContext)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcSelectiveRecordReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcSelectiveRecordReader.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.orc;
 
 import com.facebook.presto.common.Page;
+import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.common.Subfield;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockLease;
@@ -178,7 +179,8 @@ public class OrcSelectiveRecordReader
             Optional<OrcWriteValidation> writeValidation,
             int initialBatchSize,
             StripeMetadataSource stripeMetadataSource,
-            boolean cacheable)
+            boolean cacheable,
+            RuntimeStats runtimeStats)
     {
         super(includedColumns,
                 requiredSubfields,
@@ -220,7 +222,8 @@ public class OrcSelectiveRecordReader
                 writeValidation,
                 initialBatchSize,
                 stripeMetadataSource,
-                cacheable);
+                cacheable,
+                runtimeStats);
 
         // Hive column indices can't be used to index into arrays because they are negative
         // for partition and hidden columns. Hence, we create synthetic zero-based indices.

--- a/presto-orc/src/main/java/com/facebook/presto/orc/StripeReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/StripeReader.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.orc;
 
+import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.orc.checkpoint.InvalidCheckpointException;
 import com.facebook.presto.orc.checkpoint.StreamCheckpoint;
 import com.facebook.presto.orc.metadata.ColumnEncoding;
@@ -96,6 +97,7 @@ public class StripeReader
     private final StripeMetadataSource stripeMetadataSource;
     private final boolean cacheable;
     private final Multimap<Integer, Integer> dwrfEncryptionGroupColumns;
+    private final RuntimeStats runtimeStats;
 
     public StripeReader(
             OrcDataSource orcDataSource,
@@ -109,7 +111,8 @@ public class StripeReader
             Optional<OrcWriteValidation> writeValidation,
             StripeMetadataSource stripeMetadataSource,
             boolean cacheable,
-            Map<Integer, Integer> dwrfEncryptionGroupMap)
+            Map<Integer, Integer> dwrfEncryptionGroupMap,
+            RuntimeStats runtimeStats)
     {
         this.orcDataSource = requireNonNull(orcDataSource, "orcDataSource is null");
         this.decompressor = requireNonNull(decompressor, "decompressor is null");
@@ -121,8 +124,9 @@ public class StripeReader
         this.metadataReader = requireNonNull(metadataReader, "metadataReader is null");
         this.writeValidation = requireNonNull(writeValidation, "writeValidation is null");
         this.stripeMetadataSource = requireNonNull(stripeMetadataSource, "stripeMetadataSource is null");
-        this.cacheable = requireNonNull(cacheable, "hiveFileContext is null");
+        this.cacheable = cacheable;
         this.dwrfEncryptionGroupColumns = invertEncryptionGroupMap(requireNonNull(dwrfEncryptionGroupMap, "dwrfEncryptionGroupMap is null"));
+        this.runtimeStats = requireNonNull(runtimeStats, "runtimeStats is null");
     }
 
     private Multimap<Integer, Integer> invertEncryptionGroupMap(Map<Integer, Integer> dwrfEncryptionGroupMap)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/StripeReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/StripeReader.java
@@ -150,6 +150,7 @@ public class StripeReader
             SharedBuffer sharedDecompressionBuffer)
             throws IOException
     {
+        runtimeStats.addMetricValue("OrcStripeCount", 1);
         StripeId stripeId = new StripeId(orcDataSource.getId(), stripe.getOffset());
 
         // read the stripe footer
@@ -201,6 +202,7 @@ public class StripeReader
 
             // if all row groups are skipped, return null
             if (selectedRowGroups.isEmpty()) {
+                runtimeStats.addMetricValue("OrcSkippedStripe", 1);
                 // set accounted memory usage to zero
                 systemMemoryUsage.close();
                 return null;


### PR DESCRIPTION
    Add counters for the number of skipped stripes and total stripes

    The StripeReader currently always opens all row group protos. We observe
    >10% CPU spent in deserializing the protos for some prod workload. One
    potential optimization is to make the row group loading lazy and only
    open them for the filtered columns if the entire stripe is skipped.

    Adding these counters to estimate the potential impact of this
    optimization to help decide whether it is worth implementing it.

Test plan 
Tested it locally:
![image](https://user-images.githubusercontent.com/67174152/132537224-84e8d6d8-dce5-4904-b4e3-56ceaa2be889.png)



```
== NO RELEASE NOTE ==
```
