### PR TITLE
Set a default limit of 100MB on size of broadcast join build side

### DIFF
--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q03.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q03.plan.txt
@@ -4,12 +4,13 @@ local exchange (GATHER, SINGLE, [])
             local exchange (GATHER, SINGLE, [])
                 remote exchange (REPARTITION, HASH, [d_year, i_brand, i_brand_id])
                     partial aggregation over (d_year, i_brand, i_brand_id)
-                        join (INNER, REPLICATED):
-                            join (INNER, REPLICATED):
-                                scan store_sales
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPLICATE, BROADCAST, [])
-                                        scan item
+                        join (INNER, PARTITIONED):
+                            remote exchange (REPARTITION, HASH, [ss_sold_date_sk])
+                                join (INNER, REPLICATED):
+                                    scan store_sales
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPLICATE, BROADCAST, [])
+                                            scan item
                             local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPLICATE, BROADCAST, [])
+                                remote exchange (REPARTITION, HASH, [d_date_sk])
                                     scan date_dim

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q04.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q04.plan.txt
@@ -12,14 +12,15 @@ local exchange (GATHER, SINGLE, [])
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPARTITION, HASH, [c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag, d_year])
                                                     partial aggregation over (c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag, d_year)
-                                                        join (INNER, REPLICATED):
-                                                            join (INNER, REPLICATED):
-                                                                scan store_sales
-                                                                local exchange (GATHER, SINGLE, [])
-                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan date_dim
+                                                        join (INNER, PARTITIONED):
+                                                            remote exchange (REPARTITION, HASH, [ss_customer_sk])
+                                                                join (INNER, REPLICATED):
+                                                                    scan store_sales
+                                                                    local exchange (GATHER, SINGLE, [])
+                                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                                            scan date_dim
                                                             local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                                remote exchange (REPARTITION, HASH, [c_customer_sk])
                                                                     scan customer
                                     remote exchange (REPARTITION, HASH, [c_customer_id_29])
                                         single aggregation over (c_birth_country_42, c_customer_id_29, c_email_address_44, c_first_name_36, c_last_name_37, c_login_43, c_preferred_cust_flag_38, d_year_52)
@@ -41,14 +42,15 @@ local exchange (GATHER, SINGLE, [])
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPARTITION, HASH, [c_birth_country_260, c_customer_id_247, c_email_address_262, c_first_name_254, c_last_name_255, c_login_261, c_preferred_cust_flag_256, d_year_293])
                                                     partial aggregation over (c_birth_country_260, c_customer_id_247, c_email_address_262, c_first_name_254, c_last_name_255, c_login_261, c_preferred_cust_flag_256, d_year_293)
-                                                        join (INNER, REPLICATED):
-                                                            join (INNER, REPLICATED):
-                                                                scan store_sales
-                                                                local exchange (GATHER, SINGLE, [])
-                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan date_dim
+                                                        join (INNER, PARTITIONED):
+                                                            remote exchange (REPARTITION, HASH, [ss_customer_sk_267])
+                                                                join (INNER, REPLICATED):
+                                                                    scan store_sales
+                                                                    local exchange (GATHER, SINGLE, [])
+                                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                                            scan date_dim
                                                             local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                                remote exchange (REPARTITION, HASH, [c_customer_sk_246])
                                                                     scan customer
                                     remote exchange (REPARTITION, HASH, [c_customer_id_354])
                                         single aggregation over (c_birth_country_367, c_customer_id_354, c_email_address_369, c_first_name_361, c_last_name_362, c_login_368, c_preferred_cust_flag_363, d_year_411)
@@ -77,14 +79,15 @@ local exchange (GATHER, SINGLE, [])
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPARTITION, HASH, [c_birth_country_760, c_customer_id_747, c_email_address_762, c_first_name_754, c_last_name_755, c_login_761, c_preferred_cust_flag_756, d_year_804])
                                                 partial aggregation over (c_birth_country_760, c_customer_id_747, c_email_address_762, c_first_name_754, c_last_name_755, c_login_761, c_preferred_cust_flag_756, d_year_804)
-                                                    join (INNER, REPLICATED):
-                                                        join (INNER, REPLICATED):
-                                                            scan catalog_sales
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan date_dim
+                                                    join (INNER, PARTITIONED):
+                                                        remote exchange (REPARTITION, HASH, [cs_bill_customer_sk_767])
+                                                            join (INNER, REPLICATED):
+                                                                scan catalog_sales
+                                                                local exchange (GATHER, SINGLE, [])
+                                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                                        scan date_dim
                                                         local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                            remote exchange (REPARTITION, HASH, [c_customer_sk_746])
                                                                 scan customer
                                 remote exchange (REPARTITION, HASH, [c_customer_id_875])
                                     single aggregation over (c_birth_country_888, c_customer_id_875, c_email_address_890, c_first_name_882, c_last_name_883, c_login_889, c_preferred_cust_flag_884, d_year_932)
@@ -106,14 +109,15 @@ local exchange (GATHER, SINGLE, [])
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, [c_birth_country_1153, c_customer_id_1140, c_email_address_1155, c_first_name_1147, c_last_name_1148, c_login_1154, c_preferred_cust_flag_1149, d_year_1197])
                                             partial aggregation over (c_birth_country_1153, c_customer_id_1140, c_email_address_1155, c_first_name_1147, c_last_name_1148, c_login_1154, c_preferred_cust_flag_1149, d_year_1197)
-                                                join (INNER, REPLICATED):
-                                                    join (INNER, REPLICATED):
-                                                        scan catalog_sales
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan date_dim
+                                                join (INNER, PARTITIONED):
+                                                    remote exchange (REPARTITION, HASH, [cs_bill_customer_sk_1160])
+                                                        join (INNER, REPLICATED):
+                                                            scan catalog_sales
+                                                            local exchange (GATHER, SINGLE, [])
+                                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                                    scan date_dim
                                                     local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                        remote exchange (REPARTITION, HASH, [c_customer_sk_1139])
                                                             scan customer
                             remote exchange (REPARTITION, HASH, [c_customer_id_1268])
                                 single aggregation over (c_birth_country_1281, c_customer_id_1268, c_email_address_1283, c_first_name_1275, c_last_name_1276, c_login_1282, c_preferred_cust_flag_1277, d_year_1325)

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q10.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q10.plan.txt
@@ -27,10 +27,11 @@ local exchange (GATHER, SINGLE, [])
                                                                 scan date_dim
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, [c_customer_sk])
-                                            join (INNER, REPLICATED):
-                                                scan customer_demographics
+                                            join (INNER, PARTITIONED):
+                                                remote exchange (REPARTITION, HASH, [cd_demo_sk])
+                                                    scan customer_demographics
                                                 local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                    remote exchange (REPARTITION, HASH, [c_current_cdemo_sk])
                                                         join (INNER, PARTITIONED):
                                                             final aggregation over (ss_customer_sk)
                                                                 local exchange (GATHER, SINGLE, [])

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q11.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q11.plan.txt
@@ -9,14 +9,15 @@ local exchange (GATHER, SINGLE, [])
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPARTITION, HASH, [c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag, d_year])
                                         partial aggregation over (c_birth_country, c_customer_id, c_email_address, c_first_name, c_last_name, c_login, c_preferred_cust_flag, d_year)
-                                            join (INNER, REPLICATED):
-                                                join (INNER, REPLICATED):
-                                                    scan store_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
+                                            join (INNER, PARTITIONED):
+                                                remote exchange (REPARTITION, HASH, [ss_customer_sk])
+                                                    join (INNER, REPLICATED):
+                                                        scan store_sales
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                scan date_dim
                                                 local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                    remote exchange (REPARTITION, HASH, [c_customer_sk])
                                                         scan customer
                         remote exchange (REPARTITION, HASH, [c_customer_id_29])
                             single aggregation over (c_birth_country_42, c_customer_id_29, c_email_address_44, c_first_name_36, c_last_name_37, c_login_43, c_preferred_cust_flag_38, d_year_52)
@@ -31,14 +32,15 @@ local exchange (GATHER, SINGLE, [])
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPARTITION, HASH, [c_birth_country_166, c_customer_id_153, c_email_address_168, c_first_name_160, c_last_name_161, c_login_167, c_preferred_cust_flag_162, d_year_199])
                                         partial aggregation over (c_birth_country_166, c_customer_id_153, c_email_address_168, c_first_name_160, c_last_name_161, c_login_167, c_preferred_cust_flag_162, d_year_199)
-                                            join (INNER, REPLICATED):
-                                                join (INNER, REPLICATED):
-                                                    scan store_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
+                                            join (INNER, PARTITIONED):
+                                                remote exchange (REPARTITION, HASH, [ss_customer_sk_173])
+                                                    join (INNER, REPLICATED):
+                                                        scan store_sales
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                scan date_dim
                                                 local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                    remote exchange (REPARTITION, HASH, [c_customer_sk_152])
                                                         scan customer
                         remote exchange (REPARTITION, HASH, [c_customer_id_260])
                             single aggregation over (c_birth_country_273, c_customer_id_260, c_email_address_275, c_first_name_267, c_last_name_268, c_login_274, c_preferred_cust_flag_269, d_year_317)

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q13.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q13.plan.txt
@@ -5,15 +5,16 @@ final aggregation over ()
                 join (INNER, REPLICATED):
                     join (INNER, REPLICATED):
                         join (INNER, REPLICATED):
-                            join (INNER, REPLICATED):
-                                join (INNER, REPLICATED):
-                                    scan store_sales
-                                    local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPLICATE, BROADCAST, [])
-                                            scan customer_address
+                            join (INNER, PARTITIONED):
+                                remote exchange (REPARTITION, HASH, [ss_addr_sk])
+                                    join (INNER, REPLICATED):
+                                        scan store_sales
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                scan date_dim
                                 local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPLICATE, BROADCAST, [])
-                                        scan date_dim
+                                    remote exchange (REPARTITION, HASH, [ca_address_sk])
+                                        scan customer_address
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPLICATE, BROADCAST, [])
                                     scan household_demographics

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q19.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q19.plan.txt
@@ -15,15 +15,16 @@ local exchange (GATHER, SINGLE, [])
                                                 scan customer
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPARTITION, HASH, [ss_customer_sk])
-                                                    join (INNER, REPLICATED):
-                                                        join (INNER, REPLICATED):
-                                                            scan store_sales
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan date_dim
+                                                    join (INNER, PARTITIONED):
+                                                        remote exchange (REPARTITION, HASH, [ss_sold_date_sk])
+                                                            join (INNER, REPLICATED):
+                                                                scan store_sales
+                                                                local exchange (GATHER, SINGLE, [])
+                                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                                        scan item
                                                         local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan item
+                                                            remote exchange (REPARTITION, HASH, [d_date_sk])
+                                                                scan date_dim
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPLICATE, BROADCAST, [])
                                     scan store

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q23_1.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q23_1.plan.txt
@@ -31,13 +31,13 @@ final aggregation over ()
                             cross join:
                                 final aggregation over (c_customer_sk)
                                     local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPARTITION, HASH, [c_customer_sk])
-                                            partial aggregation over (c_customer_sk)
-                                                join (INNER, REPLICATED):
+                                        partial aggregation over (c_customer_sk)
+                                            join (INNER, PARTITIONED):
+                                                remote exchange (REPARTITION, HASH, [ss_customer_sk_60])
                                                     scan store_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan customer
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (REPARTITION, HASH, [c_customer_sk])
+                                                        scan customer
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPLICATE, BROADCAST, [])
                                         final aggregation over ()
@@ -46,17 +46,17 @@ final aggregation over ()
                                                     partial aggregation over ()
                                                         final aggregation over (c_customer_sk_110)
                                                             local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPARTITION, HASH, [c_customer_sk_110])
-                                                                    partial aggregation over (c_customer_sk_110)
-                                                                        join (INNER, REPLICATED):
+                                                                partial aggregation over (c_customer_sk_110)
+                                                                    join (INNER, PARTITIONED):
+                                                                        remote exchange (REPARTITION, HASH, [ss_customer_sk_90])
                                                                             join (INNER, REPLICATED):
                                                                                 scan store_sales
                                                                                 local exchange (GATHER, SINGLE, [])
                                                                                     remote exchange (REPLICATE, BROADCAST, [])
                                                                                         scan date_dim
-                                                                            local exchange (GATHER, SINGLE, [])
-                                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                                    scan customer
+                                                                        local exchange (GATHER, SINGLE, [])
+                                                                            remote exchange (REPARTITION, HASH, [c_customer_sk_110])
+                                                                                scan customer
             partial aggregation over ()
                 semijoin (PARTITIONED):
                     remote exchange (REPARTITION, HASH, [ws_bill_customer_sk])
@@ -87,13 +87,13 @@ final aggregation over ()
                             cross join:
                                 final aggregation over (c_customer_sk_355)
                                     local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPARTITION, HASH, [c_customer_sk_355])
-                                            partial aggregation over (c_customer_sk_355)
-                                                join (INNER, REPLICATED):
+                                        partial aggregation over (c_customer_sk_355)
+                                            join (INNER, PARTITIONED):
+                                                remote exchange (REPARTITION, HASH, [ss_customer_sk_335])
                                                     scan store_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan customer
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (REPARTITION, HASH, [c_customer_sk_355])
+                                                        scan customer
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPLICATE, BROADCAST, [])
                                         final aggregation over ()
@@ -102,14 +102,14 @@ final aggregation over ()
                                                     partial aggregation over ()
                                                         final aggregation over (c_customer_sk_405)
                                                             local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPARTITION, HASH, [c_customer_sk_405])
-                                                                    partial aggregation over (c_customer_sk_405)
-                                                                        join (INNER, REPLICATED):
+                                                                partial aggregation over (c_customer_sk_405)
+                                                                    join (INNER, PARTITIONED):
+                                                                        remote exchange (REPARTITION, HASH, [ss_customer_sk_385])
                                                                             join (INNER, REPLICATED):
                                                                                 scan store_sales
                                                                                 local exchange (GATHER, SINGLE, [])
                                                                                     remote exchange (REPLICATE, BROADCAST, [])
                                                                                         scan date_dim
-                                                                            local exchange (GATHER, SINGLE, [])
-                                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                                    scan customer
+                                                                        local exchange (GATHER, SINGLE, [])
+                                                                            remote exchange (REPARTITION, HASH, [c_customer_sk_405])
+                                                                                scan customer

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q23_2.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q23_2.plan.txt
@@ -38,13 +38,13 @@ local exchange (GATHER, SINGLE, [])
                                     cross join:
                                         final aggregation over (c_customer_sk_80)
                                             local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, [c_customer_sk_80])
-                                                    partial aggregation over (c_customer_sk_80)
-                                                        join (INNER, REPLICATED):
+                                                partial aggregation over (c_customer_sk_80)
+                                                    join (INNER, PARTITIONED):
+                                                        remote exchange (REPARTITION, HASH, [ss_customer_sk_60])
                                                             scan store_sales
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan customer
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPARTITION, HASH, [c_customer_sk_80])
+                                                                scan customer
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
                                                 final aggregation over ()
@@ -53,17 +53,17 @@ local exchange (GATHER, SINGLE, [])
                                                             partial aggregation over ()
                                                                 final aggregation over (c_customer_sk_128)
                                                                     local exchange (GATHER, SINGLE, [])
-                                                                        remote exchange (REPARTITION, HASH, [c_customer_sk_128])
-                                                                            partial aggregation over (c_customer_sk_128)
-                                                                                join (INNER, REPLICATED):
+                                                                        partial aggregation over (c_customer_sk_128)
+                                                                            join (INNER, PARTITIONED):
+                                                                                remote exchange (REPARTITION, HASH, [ss_customer_sk_108])
                                                                                     join (INNER, REPLICATED):
                                                                                         scan store_sales
                                                                                         local exchange (GATHER, SINGLE, [])
                                                                                             remote exchange (REPLICATE, BROADCAST, [])
                                                                                                 scan date_dim
-                                                                                    local exchange (GATHER, SINGLE, [])
-                                                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                                                            scan customer
+                                                                                local exchange (GATHER, SINGLE, [])
+                                                                                    remote exchange (REPARTITION, HASH, [c_customer_sk_128])
+                                                                                        scan customer
         final aggregation over (c_first_name_229, c_last_name_230)
             local exchange (GATHER, SINGLE, [])
                 remote exchange (REPARTITION, HASH, [c_first_name_229, c_last_name_230])
@@ -102,13 +102,13 @@ local exchange (GATHER, SINGLE, [])
                                     cross join:
                                         final aggregation over (c_customer_sk_399)
                                             local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPARTITION, HASH, [c_customer_sk_399])
-                                                    partial aggregation over (c_customer_sk_399)
-                                                        join (INNER, REPLICATED):
+                                                partial aggregation over (c_customer_sk_399)
+                                                    join (INNER, PARTITIONED):
+                                                        remote exchange (REPARTITION, HASH, [ss_customer_sk_379])
                                                             scan store_sales
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan customer
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPARTITION, HASH, [c_customer_sk_399])
+                                                                scan customer
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
                                                 final aggregation over ()
@@ -117,14 +117,14 @@ local exchange (GATHER, SINGLE, [])
                                                             partial aggregation over ()
                                                                 final aggregation over (c_customer_sk_449)
                                                                     local exchange (GATHER, SINGLE, [])
-                                                                        remote exchange (REPARTITION, HASH, [c_customer_sk_449])
-                                                                            partial aggregation over (c_customer_sk_449)
-                                                                                join (INNER, REPLICATED):
+                                                                        partial aggregation over (c_customer_sk_449)
+                                                                            join (INNER, PARTITIONED):
+                                                                                remote exchange (REPARTITION, HASH, [ss_customer_sk_429])
                                                                                     join (INNER, REPLICATED):
                                                                                         scan store_sales
                                                                                         local exchange (GATHER, SINGLE, [])
                                                                                             remote exchange (REPLICATE, BROADCAST, [])
                                                                                                 scan date_dim
-                                                                                    local exchange (GATHER, SINGLE, [])
-                                                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                                                            scan customer
+                                                                                local exchange (GATHER, SINGLE, [])
+                                                                                    remote exchange (REPARTITION, HASH, [c_customer_sk_449])
+                                                                                        scan customer

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q24_1.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q24_1.plan.txt
@@ -12,19 +12,20 @@ remote exchange (GATHER, SINGLE, [])
                                             remote exchange (REPARTITION, HASH, [c_birth_country, s_zip])
                                                 join (INNER, PARTITIONED):
                                                     remote exchange (REPARTITION, HASH, [ss_customer_sk])
-                                                        join (INNER, REPLICATED):
-                                                            join (INNER, REPLICATED):
-                                                                scan store_sales
-                                                                local exchange (GATHER, SINGLE, [])
-                                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        join (INNER, PARTITIONED):
+                                                            remote exchange (REPARTITION, HASH, [sr_item_sk, sr_ticket_number])
+                                                                scan store_returns
+                                                            local exchange (GATHER, SINGLE, [])
+                                                                remote exchange (REPARTITION, HASH, [i_item_sk, ss_ticket_number])
+                                                                    join (INNER, REPLICATED):
                                                                         join (INNER, REPLICATED):
-                                                                            scan store_returns
+                                                                            scan store_sales
                                                                             local exchange (GATHER, SINGLE, [])
                                                                                 remote exchange (REPLICATE, BROADCAST, [])
                                                                                     scan item
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan store
+                                                                        local exchange (GATHER, SINGLE, [])
+                                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                                scan store
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPARTITION, HASH, [c_customer_sk])
                                                             scan customer
@@ -41,25 +42,27 @@ remote exchange (GATHER, SINGLE, [])
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, [c_first_name_181, c_last_name_182, ca_state_199, i_color_168, i_current_price_156, i_manager_id_171, i_size_166, i_units_169, s_state_146, s_store_name_127])
                                             partial aggregation over (c_first_name_181, c_last_name_182, ca_state_199, i_color_168, i_current_price_156, i_manager_id_171, i_size_166, i_units_169, s_state_146, s_store_name_127)
-                                                join (INNER, REPLICATED):
-                                                    join (INNER, REPLICATED):
+                                                join (INNER, PARTITIONED):
+                                                    remote exchange (REPARTITION, HASH, [c_birth_country_187, s_zip_147])
                                                         join (INNER, REPLICATED):
                                                             join (INNER, PARTITIONED):
-                                                                remote exchange (REPARTITION, HASH, [ss_item_sk_81, ss_ticket_number_88])
-                                                                    join (INNER, REPLICATED):
-                                                                        scan store_sales
+                                                                remote exchange (REPARTITION, HASH, [ss_customer_sk_82])
+                                                                    join (INNER, PARTITIONED):
+                                                                        remote exchange (REPARTITION, HASH, [ss_item_sk_81, ss_ticket_number_88])
+                                                                            join (INNER, REPLICATED):
+                                                                                scan store_sales
+                                                                                local exchange (GATHER, SINGLE, [])
+                                                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                                                        scan store
                                                                         local exchange (GATHER, SINGLE, [])
-                                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                                scan store
+                                                                            remote exchange (REPARTITION, HASH, [sr_item_sk_104, sr_ticket_number_111])
+                                                                                scan store_returns
                                                                 local exchange (GATHER, SINGLE, [])
-                                                                    remote exchange (REPARTITION, HASH, [sr_item_sk_104, sr_ticket_number_111])
-                                                                        scan store_returns
+                                                                    remote exchange (REPARTITION, HASH, [c_customer_sk_173])
+                                                                        scan customer
                                                             local exchange (GATHER, SINGLE, [])
                                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan customer
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan item
+                                                                    scan item
                                                     local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                        remote exchange (REPARTITION, HASH, [ca_zip_200, upper_302])
                                                             scan customer_address

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q24_2.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q24_2.plan.txt
@@ -12,19 +12,20 @@ remote exchange (GATHER, SINGLE, [])
                                             remote exchange (REPARTITION, HASH, [c_birth_country, s_zip])
                                                 join (INNER, PARTITIONED):
                                                     remote exchange (REPARTITION, HASH, [ss_customer_sk])
-                                                        join (INNER, REPLICATED):
-                                                            join (INNER, REPLICATED):
-                                                                scan store_sales
-                                                                local exchange (GATHER, SINGLE, [])
-                                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        join (INNER, PARTITIONED):
+                                                            remote exchange (REPARTITION, HASH, [sr_item_sk, sr_ticket_number])
+                                                                scan store_returns
+                                                            local exchange (GATHER, SINGLE, [])
+                                                                remote exchange (REPARTITION, HASH, [i_item_sk, ss_ticket_number])
+                                                                    join (INNER, REPLICATED):
                                                                         join (INNER, REPLICATED):
-                                                                            scan store_returns
+                                                                            scan store_sales
                                                                             local exchange (GATHER, SINGLE, [])
                                                                                 remote exchange (REPLICATE, BROADCAST, [])
                                                                                     scan item
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan store
+                                                                        local exchange (GATHER, SINGLE, [])
+                                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                                scan store
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPARTITION, HASH, [c_customer_sk])
                                                             scan customer
@@ -41,25 +42,27 @@ remote exchange (GATHER, SINGLE, [])
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, [c_first_name_181, c_last_name_182, ca_state_199, i_color_168, i_current_price_156, i_manager_id_171, i_size_166, i_units_169, s_state_146, s_store_name_127])
                                             partial aggregation over (c_first_name_181, c_last_name_182, ca_state_199, i_color_168, i_current_price_156, i_manager_id_171, i_size_166, i_units_169, s_state_146, s_store_name_127)
-                                                join (INNER, REPLICATED):
-                                                    join (INNER, REPLICATED):
+                                                join (INNER, PARTITIONED):
+                                                    remote exchange (REPARTITION, HASH, [c_birth_country_187, s_zip_147])
                                                         join (INNER, REPLICATED):
                                                             join (INNER, PARTITIONED):
-                                                                remote exchange (REPARTITION, HASH, [ss_item_sk_81, ss_ticket_number_88])
-                                                                    join (INNER, REPLICATED):
-                                                                        scan store_sales
+                                                                remote exchange (REPARTITION, HASH, [ss_customer_sk_82])
+                                                                    join (INNER, PARTITIONED):
+                                                                        remote exchange (REPARTITION, HASH, [ss_item_sk_81, ss_ticket_number_88])
+                                                                            join (INNER, REPLICATED):
+                                                                                scan store_sales
+                                                                                local exchange (GATHER, SINGLE, [])
+                                                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                                                        scan store
                                                                         local exchange (GATHER, SINGLE, [])
-                                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                                scan store
+                                                                            remote exchange (REPARTITION, HASH, [sr_item_sk_104, sr_ticket_number_111])
+                                                                                scan store_returns
                                                                 local exchange (GATHER, SINGLE, [])
-                                                                    remote exchange (REPARTITION, HASH, [sr_item_sk_104, sr_ticket_number_111])
-                                                                        scan store_returns
+                                                                    remote exchange (REPARTITION, HASH, [c_customer_sk_173])
+                                                                        scan customer
                                                             local exchange (GATHER, SINGLE, [])
                                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan customer
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan item
+                                                                    scan item
                                                     local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                        remote exchange (REPARTITION, HASH, [ca_zip_200, upper_302])
                                                             scan customer_address

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q31.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q31.plan.txt
@@ -8,14 +8,15 @@ remote exchange (GATHER, SINGLE, [])
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, [ca_county_81, d_qoy_56, d_year_52])
                                     partial aggregation over (ca_county_81, d_qoy_56, d_year_52)
-                                        join (INNER, REPLICATED):
-                                            join (INNER, REPLICATED):
-                                                scan store_sales
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan date_dim
+                                        join (INNER, PARTITIONED):
+                                            remote exchange (REPARTITION, HASH, [ss_addr_sk_29])
+                                                join (INNER, REPLICATED):
+                                                    scan store_sales
+                                                    local exchange (GATHER, SINGLE, [])
+                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                            scan date_dim
                                             local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                remote exchange (REPARTITION, HASH, [ca_address_sk_74])
                                                     scan customer_address
                         local exchange (GATHER, SINGLE, [])
                             remote exchange (REPARTITION, HASH, [2, 2000, ca_county_173])
@@ -23,28 +24,30 @@ remote exchange (GATHER, SINGLE, [])
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, [ca_county_173, d_qoy_148, d_year_144])
                                             partial aggregation over (ca_county_173, d_qoy_148, d_year_144)
-                                                join (INNER, REPLICATED):
-                                                    join (INNER, REPLICATED):
-                                                        scan store_sales
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan date_dim
+                                                join (INNER, PARTITIONED):
+                                                    remote exchange (REPARTITION, HASH, [ss_addr_sk_121])
+                                                        join (INNER, REPLICATED):
+                                                            scan store_sales
+                                                            local exchange (GATHER, SINGLE, [])
+                                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                                    scan date_dim
                                                     local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                        remote exchange (REPARTITION, HASH, [ca_address_sk_166])
                                                             scan customer_address
                     join (INNER, PARTITIONED):
                         final aggregation over (ca_county_345, d_qoy_320, d_year_316)
                             local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, [ca_county_345, d_qoy_320, d_year_316])
                                     partial aggregation over (ca_county_345, d_qoy_320, d_year_316)
-                                        join (INNER, REPLICATED):
-                                            join (INNER, REPLICATED):
-                                                scan web_sales
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan date_dim
+                                        join (INNER, PARTITIONED):
+                                            remote exchange (REPARTITION, HASH, [ws_bill_addr_sk_283])
+                                                join (INNER, REPLICATED):
+                                                    scan web_sales
+                                                    local exchange (GATHER, SINGLE, [])
+                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                            scan date_dim
                                             local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                remote exchange (REPARTITION, HASH, [ca_address_sk_338])
                                                     scan customer_address
                         local exchange (GATHER, SINGLE, [])
                             remote exchange (REPARTITION, HASH, [2, 2000, ca_county_448])
@@ -52,14 +55,15 @@ remote exchange (GATHER, SINGLE, [])
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, [ca_county_448, d_qoy_423, d_year_419])
                                             partial aggregation over (ca_county_448, d_qoy_423, d_year_419)
-                                                join (INNER, REPLICATED):
-                                                    join (INNER, REPLICATED):
-                                                        scan web_sales
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan date_dim
+                                                join (INNER, PARTITIONED):
+                                                    remote exchange (REPARTITION, HASH, [ws_bill_addr_sk_386])
+                                                        join (INNER, REPLICATED):
+                                                            scan web_sales
+                                                            local exchange (GATHER, SINGLE, [])
+                                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                                    scan date_dim
                                                     local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                        remote exchange (REPARTITION, HASH, [ca_address_sk_441])
                                                             scan customer_address
                 local exchange (GATHER, SINGLE, [])
                     remote exchange (REPARTITION, HASH, [2, 2000, ca_county])
@@ -68,25 +72,27 @@ remote exchange (GATHER, SINGLE, [])
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPARTITION, HASH, [ca_county, d_qoy, d_year])
                                         partial aggregation over (ca_county, d_qoy, d_year)
-                                            join (INNER, REPLICATED):
-                                                join (INNER, REPLICATED):
-                                                    scan store_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
+                                            join (INNER, PARTITIONED):
+                                                remote exchange (REPARTITION, HASH, [ss_addr_sk])
+                                                    join (INNER, REPLICATED):
+                                                        scan store_sales
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                scan date_dim
                                                 local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                    remote exchange (REPARTITION, HASH, [ca_address_sk])
                                                         scan customer_address
                             final aggregation over (ca_county_242, d_qoy_217, d_year_213)
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPARTITION, HASH, [ca_county_242, d_qoy_217, d_year_213])
                                         partial aggregation over (ca_county_242, d_qoy_217, d_year_213)
-                                            join (INNER, REPLICATED):
-                                                join (INNER, REPLICATED):
-                                                    scan web_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
+                                            join (INNER, PARTITIONED):
+                                                remote exchange (REPARTITION, HASH, [ws_bill_addr_sk])
+                                                    join (INNER, REPLICATED):
+                                                        scan web_sales
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                scan date_dim
                                                 local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                    remote exchange (REPARTITION, HASH, [ca_address_sk_235])
                                                         scan customer_address

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q37.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q37.plan.txt
@@ -4,16 +4,17 @@ local exchange (GATHER, SINGLE, [])
             local exchange (GATHER, SINGLE, [])
                 remote exchange (REPARTITION, HASH, [i_current_price, i_item_desc, i_item_id])
                     partial aggregation over (i_current_price, i_item_desc, i_item_id)
-                        join (INNER, REPLICATED):
-                            scan catalog_sales
+                        join (INNER, PARTITIONED):
+                            remote exchange (REPARTITION, HASH, [cs_item_sk])
+                                scan catalog_sales
                             local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPLICATE, BROADCAST, [])
-                                    join (INNER, REPLICATED):
+                                join (INNER, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, [inv_item_sk])
                                         join (INNER, REPLICATED):
                                             scan inventory
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan item
-                                        local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                scan date_dim
+                                                    scan date_dim
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, [i_item_sk])
+                                            scan item

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q38.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q38.plan.txt
@@ -9,14 +9,15 @@ final aggregation over ()
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPARTITION, HASH, [c_first_name, c_last_name, d_date])
                                         partial aggregation over (c_first_name, c_last_name, d_date)
-                                            join (INNER, REPLICATED):
-                                                join (INNER, REPLICATED):
-                                                    scan store_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
+                                            join (INNER, PARTITIONED):
+                                                remote exchange (REPARTITION, HASH, [ss_customer_sk])
+                                                    join (INNER, REPLICATED):
+                                                        scan store_sales
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                scan date_dim
                                                 local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                    remote exchange (REPARTITION, HASH, [c_customer_sk])
                                                         scan customer
                         partial aggregation over (c_first_name_42, c_last_name_43, d_date_8)
                             final aggregation over (c_first_name_42, c_last_name_43, d_date_8)

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q40.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q40.plan.txt
@@ -7,10 +7,11 @@ local exchange (GATHER, SINGLE, [])
                         join (INNER, REPLICATED):
                             join (INNER, REPLICATED):
                                 join (INNER, REPLICATED):
-                                    join (LEFT, REPLICATED):
-                                        scan catalog_sales
+                                    join (LEFT, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, [cs_item_sk, cs_order_number])
+                                            scan catalog_sales
                                         local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPLICATE, BROADCAST, [])
+                                            remote exchange (REPARTITION, HASH, [cr_item_sk, cr_order_number])
                                                 scan catalog_returns
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q42.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q42.plan.txt
@@ -4,12 +4,13 @@ local exchange (GATHER, SINGLE, [])
             local exchange (GATHER, SINGLE, [])
                 remote exchange (REPARTITION, HASH, [d_year, i_category, i_category_id])
                     partial aggregation over (d_year, i_category, i_category_id)
-                        join (INNER, REPLICATED):
-                            join (INNER, REPLICATED):
-                                scan store_sales
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPLICATE, BROADCAST, [])
-                                        scan item
+                        join (INNER, PARTITIONED):
+                            remote exchange (REPARTITION, HASH, [ss_sold_date_sk])
+                                join (INNER, REPLICATED):
+                                    scan store_sales
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPLICATE, BROADCAST, [])
+                                            scan item
                             local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPLICATE, BROADCAST, [])
+                                remote exchange (REPARTITION, HASH, [d_date_sk])
                                     scan date_dim

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q47.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q47.plan.txt
@@ -9,18 +9,19 @@ local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, [d_moy, d_year, i_brand, i_category, s_company_name, s_store_name])
                                     partial aggregation over (d_moy, d_year, i_brand, i_category, s_company_name, s_store_name)
                                         join (INNER, REPLICATED):
-                                            join (INNER, REPLICATED):
-                                                join (INNER, REPLICATED):
-                                                    scan store_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
+                                            join (INNER, PARTITIONED):
+                                                remote exchange (REPARTITION, HASH, [ss_item_sk])
+                                                    join (INNER, REPLICATED):
+                                                        scan store_sales
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                scan date_dim
                                                 local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan store
+                                                    remote exchange (REPARTITION, HASH, [i_item_sk])
+                                                        scan item
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan item
+                                                    scan store
                 local exchange (GATHER, SINGLE, [])
                     remote exchange (REPARTITION, HASH, [i_brand_73, i_category_77, s_company_name_155, s_store_name_143])
                         final aggregation over (d_moy_118, d_year_116, i_brand_73, i_category_77, s_company_name_155, s_store_name_143)
@@ -28,18 +29,19 @@ local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, [d_moy_118, d_year_116, i_brand_73, i_category_77, s_company_name_155, s_store_name_143])
                                     partial aggregation over (d_moy_118, d_year_116, i_brand_73, i_category_77, s_company_name_155, s_store_name_143)
                                         join (INNER, REPLICATED):
-                                            join (INNER, REPLICATED):
-                                                join (INNER, REPLICATED):
-                                                    scan store_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
+                                            join (INNER, PARTITIONED):
+                                                remote exchange (REPARTITION, HASH, [ss_item_sk_89])
+                                                    join (INNER, REPLICATED):
+                                                        scan store_sales
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                scan date_dim
                                                 local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan store
+                                                    remote exchange (REPARTITION, HASH, [i_item_sk_65])
+                                                        scan item
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan item
+                                                    scan store
             local exchange (GATHER, SINGLE, [])
                 remote exchange (REPARTITION, HASH, [i_brand_250, i_category_254, s_company_name_332, s_store_name_320])
                     final aggregation over (d_moy_295, d_year_293, i_brand_250, i_category_254, s_company_name_332, s_store_name_320)
@@ -47,15 +49,16 @@ local exchange (GATHER, SINGLE, [])
                             remote exchange (REPARTITION, HASH, [d_moy_295, d_year_293, i_brand_250, i_category_254, s_company_name_332, s_store_name_320])
                                 partial aggregation over (d_moy_295, d_year_293, i_brand_250, i_category_254, s_company_name_332, s_store_name_320)
                                     join (INNER, REPLICATED):
-                                        join (INNER, REPLICATED):
-                                            join (INNER, REPLICATED):
-                                                scan store_sales
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan date_dim
+                                        join (INNER, PARTITIONED):
+                                            remote exchange (REPARTITION, HASH, [ss_item_sk_266])
+                                                join (INNER, REPLICATED):
+                                                    scan store_sales
+                                                    local exchange (GATHER, SINGLE, [])
+                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                            scan date_dim
                                             local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan store
+                                                remote exchange (REPARTITION, HASH, [i_item_sk_242])
+                                                    scan item
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan item
+                                                scan store

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q50.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q50.plan.txt
@@ -6,10 +6,11 @@ local exchange (GATHER, SINGLE, [])
                     partial aggregation over (s_city, s_company_id, s_county, s_state, s_store_name, s_street_name, s_street_number, s_street_type, s_suite_number, s_zip)
                         join (INNER, REPLICATED):
                             join (INNER, REPLICATED):
-                                join (INNER, REPLICATED):
-                                    scan store_sales
+                                join (INNER, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, [ss_customer_sk, ss_item_sk, ss_ticket_number])
+                                        scan store_sales
                                     local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPLICATE, BROADCAST, [])
+                                        remote exchange (REPARTITION, HASH, [sr_customer_sk, sr_item_sk, sr_ticket_number])
                                             join (INNER, REPLICATED):
                                                 scan store_returns
                                                 local exchange (GATHER, SINGLE, [])

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q52.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q52.plan.txt
@@ -4,12 +4,13 @@ local exchange (GATHER, SINGLE, [])
             local exchange (GATHER, SINGLE, [])
                 remote exchange (REPARTITION, HASH, [d_year, i_brand, i_brand_id])
                     partial aggregation over (d_year, i_brand, i_brand_id)
-                        join (INNER, REPLICATED):
-                            join (INNER, REPLICATED):
-                                scan store_sales
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPLICATE, BROADCAST, [])
-                                        scan date_dim
+                        join (INNER, PARTITIONED):
+                            remote exchange (REPARTITION, HASH, [ss_sold_date_sk])
+                                join (INNER, REPLICATED):
+                                    scan store_sales
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPLICATE, BROADCAST, [])
+                                            scan item
                             local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPLICATE, BROADCAST, [])
-                                    scan item
+                                remote exchange (REPARTITION, HASH, [d_date_sk])
+                                    scan date_dim

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q53.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q53.plan.txt
@@ -7,15 +7,16 @@ local exchange (GATHER, SINGLE, [])
                         remote exchange (REPARTITION, HASH, [d_qoy, i_manufact_id])
                             partial aggregation over (d_qoy, i_manufact_id)
                                 join (INNER, REPLICATED):
-                                    join (INNER, REPLICATED):
-                                        join (INNER, REPLICATED):
-                                            scan store_sales
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan item
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, [ss_item_sk])
+                                            join (INNER, REPLICATED):
+                                                scan store_sales
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        scan date_dim
                                         local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                scan date_dim
+                                            remote exchange (REPARTITION, HASH, [i_item_sk])
+                                                scan item
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
                                             scan store

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q54.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q54.plan.txt
@@ -6,60 +6,60 @@ local exchange (GATHER, SINGLE, [])
                     partial aggregation over (expr_134)
                         final aggregation over (c_customer_sk)
                             local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPARTITION, HASH, [c_customer_sk])
-                                    partial aggregation over (c_customer_sk)
+                                partial aggregation over (c_customer_sk)
+                                    cross join:
                                         cross join:
-                                            cross join:
-                                                join (INNER, REPLICATED):
-                                                    join (INNER, REPLICATED):
+                                            join (INNER, REPLICATED):
+                                                join (INNER, PARTITIONED):
+                                                    remote exchange (REPARTITION, HASH, [ss_customer_sk])
                                                         scan store_sales
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                    local exchange (GATHER, SINGLE, [])
+                                                        remote exchange (REPARTITION, HASH, [c_customer_sk])
+                                                            join (INNER, REPLICATED):
                                                                 join (INNER, REPLICATED):
-                                                                    join (INNER, REPLICATED):
-                                                                        scan customer_address
-                                                                        local exchange (GATHER, SINGLE, [])
-                                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                                final aggregation over (c_current_addr_sk, c_customer_sk)
-                                                                                    local exchange (GATHER, SINGLE, [])
-                                                                                        remote exchange (REPARTITION, HASH, [c_current_addr_sk, c_customer_sk])
-                                                                                            partial aggregation over (c_current_addr_sk, c_customer_sk)
-                                                                                                join (INNER, REPLICATED):
-                                                                                                    scan customer
-                                                                                                    local exchange (GATHER, SINGLE, [])
-                                                                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                                                                            join (INNER, REPLICATED):
-                                                                                                                join (INNER, REPLICATED):
-                                                                                                                    remote exchange (REPARTITION, ROUND_ROBIN, [])
-                                                                                                                        scan catalog_sales
-                                                                                                                        scan web_sales
-                                                                                                                    local exchange (GATHER, SINGLE, [])
-                                                                                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                                                                                            scan item
-                                                                                                                local exchange (GATHER, SINGLE, [])
-                                                                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                                                                        scan date_dim
+                                                                    scan customer_address
                                                                     local exchange (GATHER, SINGLE, [])
                                                                         remote exchange (REPLICATE, BROADCAST, [])
                                                                             scan store
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
+                                                                local exchange (GATHER, SINGLE, [])
+                                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                                        final aggregation over (c_current_addr_sk, c_customer_sk)
+                                                                            local exchange (GATHER, SINGLE, [])
+                                                                                partial aggregation over (c_current_addr_sk, c_customer_sk)
+                                                                                    join (INNER, PARTITIONED):
+                                                                                        remote exchange (REPARTITION, HASH, [c_customer_sk])
+                                                                                            scan customer
+                                                                                        local exchange (GATHER, SINGLE, [])
+                                                                                            remote exchange (REPARTITION, HASH, [cs_bill_customer_sk_13])
+                                                                                                join (INNER, REPLICATED):
+                                                                                                    join (INNER, REPLICATED):
+                                                                                                        remote exchange (REPARTITION, ROUND_ROBIN, [])
+                                                                                                            scan catalog_sales
+                                                                                                            scan web_sales
+                                                                                                        local exchange (GATHER, SINGLE, [])
+                                                                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                                                                scan item
+                                                                                                    local exchange (GATHER, SINGLE, [])
+                                                                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                                                                            scan date_dim
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (GATHER, SINGLE, [])
-                                                                final aggregation over (expr_86)
-                                                                    local exchange (GATHER, SINGLE, [])
-                                                                        remote exchange (REPARTITION, HASH, [expr_86])
-                                                                            partial aggregation over (expr_86)
-                                                                                scan date_dim
+                                                        scan date_dim
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (GATHER, SINGLE, [])
-                                                            final aggregation over (expr_118)
+                                                            final aggregation over (expr_86)
                                                                 local exchange (GATHER, SINGLE, [])
-                                                                    remote exchange (REPARTITION, HASH, [expr_118])
-                                                                        partial aggregation over (expr_118)
+                                                                    remote exchange (REPARTITION, HASH, [expr_86])
+                                                                        partial aggregation over (expr_86)
                                                                             scan date_dim
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (GATHER, SINGLE, [])
+                                                        final aggregation over (expr_118)
+                                                            local exchange (GATHER, SINGLE, [])
+                                                                remote exchange (REPARTITION, HASH, [expr_118])
+                                                                    partial aggregation over (expr_118)
+                                                                        scan date_dim

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q55.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q55.plan.txt
@@ -4,12 +4,13 @@ local exchange (GATHER, SINGLE, [])
             local exchange (GATHER, SINGLE, [])
                 remote exchange (REPARTITION, HASH, [i_brand, i_brand_id])
                     partial aggregation over (i_brand, i_brand_id)
-                        join (INNER, REPLICATED):
-                            join (INNER, REPLICATED):
-                                scan store_sales
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPLICATE, BROADCAST, [])
-                                        scan date_dim
+                        join (INNER, PARTITIONED):
+                            remote exchange (REPARTITION, HASH, [ss_sold_date_sk])
+                                join (INNER, REPLICATED):
+                                    scan store_sales
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPLICATE, BROADCAST, [])
+                                            scan item
                             local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPLICATE, BROADCAST, [])
-                                    scan item
+                                remote exchange (REPARTITION, HASH, [d_date_sk])
+                                    scan date_dim

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q57.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q57.plan.txt
@@ -9,14 +9,15 @@ local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, [cc_name, d_moy, d_year, i_brand, i_category])
                                     partial aggregation over (cc_name, d_moy, d_year, i_brand, i_category)
                                         join (INNER, REPLICATED):
-                                            join (INNER, REPLICATED):
-                                                join (INNER, REPLICATED):
-                                                    scan catalog_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
+                                            join (INNER, PARTITIONED):
+                                                remote exchange (REPARTITION, HASH, [cs_item_sk])
+                                                    join (INNER, REPLICATED):
+                                                        scan catalog_sales
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                scan date_dim
                                                 local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                    remote exchange (REPARTITION, HASH, [i_item_sk])
                                                         scan item
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
@@ -28,14 +29,15 @@ local exchange (GATHER, SINGLE, [])
                                 remote exchange (REPARTITION, HASH, [cc_name_147, d_moy_121, d_year_119, i_brand_65, i_category_69])
                                     partial aggregation over (cc_name_147, d_moy_121, d_year_119, i_brand_65, i_category_69)
                                         join (INNER, REPLICATED):
-                                            join (INNER, REPLICATED):
-                                                join (INNER, REPLICATED):
-                                                    scan catalog_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
+                                            join (INNER, PARTITIONED):
+                                                remote exchange (REPARTITION, HASH, [cs_item_sk_94])
+                                                    join (INNER, REPLICATED):
+                                                        scan catalog_sales
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                scan date_dim
                                                 local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                    remote exchange (REPARTITION, HASH, [i_item_sk_57])
                                                         scan item
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
@@ -47,14 +49,15 @@ local exchange (GATHER, SINGLE, [])
                             remote exchange (REPARTITION, HASH, [cc_name_328, d_moy_302, d_year_300, i_brand_246, i_category_250])
                                 partial aggregation over (cc_name_328, d_moy_302, d_year_300, i_brand_246, i_category_250)
                                     join (INNER, REPLICATED):
-                                        join (INNER, REPLICATED):
-                                            join (INNER, REPLICATED):
-                                                scan catalog_sales
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan date_dim
+                                        join (INNER, PARTITIONED):
+                                            remote exchange (REPARTITION, HASH, [cs_item_sk_275])
+                                                join (INNER, REPLICATED):
+                                                    scan catalog_sales
+                                                    local exchange (GATHER, SINGLE, [])
+                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                            scan date_dim
                                             local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                remote exchange (REPARTITION, HASH, [i_item_sk_238])
                                                     scan item
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q63.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q63.plan.txt
@@ -7,15 +7,16 @@ local exchange (GATHER, SINGLE, [])
                         remote exchange (REPARTITION, HASH, [d_moy, i_manager_id])
                             partial aggregation over (d_moy, i_manager_id)
                                 join (INNER, REPLICATED):
-                                    join (INNER, REPLICATED):
-                                        join (INNER, REPLICATED):
-                                            scan store_sales
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan item
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, [ss_item_sk])
+                                            join (INNER, REPLICATED):
+                                                scan store_sales
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        scan date_dim
                                         local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                scan date_dim
+                                            remote exchange (REPARTITION, HASH, [i_item_sk])
+                                                scan item
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
                                             scan store

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q64.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q64.plan.txt
@@ -37,10 +37,11 @@ remote exchange (GATHER, SINGLE, [])
                                                                                                                                                 remote exchange (REPARTITION, HASH, [ss_sold_date_sk])
                                                                                                                                                     join (INNER, PARTITIONED):
                                                                                                                                                         remote exchange (REPARTITION, HASH, [sr_item_sk])
-                                                                                                                                                            join (INNER, REPLICATED):
-                                                                                                                                                                scan store_sales
+                                                                                                                                                            join (INNER, PARTITIONED):
+                                                                                                                                                                remote exchange (REPARTITION, HASH, [ss_item_sk, ss_ticket_number])
+                                                                                                                                                                    scan store_sales
                                                                                                                                                                 local exchange (GATHER, SINGLE, [])
-                                                                                                                                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                                                                                                                                    remote exchange (REPARTITION, HASH, [sr_item_sk, sr_ticket_number])
                                                                                                                                                                         scan store_returns
                                                                                                                                                         final aggregation over (cs_item_sk)
                                                                                                                                                             local exchange (GATHER, SINGLE, [])
@@ -132,10 +133,11 @@ remote exchange (GATHER, SINGLE, [])
                                                                                                                                                 remote exchange (REPARTITION, HASH, [ss_sold_date_sk_234])
                                                                                                                                                     join (INNER, PARTITIONED):
                                                                                                                                                         remote exchange (REPARTITION, HASH, [sr_item_sk_259])
-                                                                                                                                                            join (INNER, REPLICATED):
-                                                                                                                                                                scan store_sales
+                                                                                                                                                            join (INNER, PARTITIONED):
+                                                                                                                                                                remote exchange (REPARTITION, HASH, [ss_item_sk_236, ss_ticket_number_243])
+                                                                                                                                                                    scan store_sales
                                                                                                                                                                 local exchange (GATHER, SINGLE, [])
-                                                                                                                                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                                                                                                                                    remote exchange (REPARTITION, HASH, [sr_item_sk_259, sr_ticket_number_266])
                                                                                                                                                                         scan store_returns
                                                                                                                                                         final aggregation over (cs_item_sk_292)
                                                                                                                                                             local exchange (GATHER, SINGLE, [])

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q65.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q65.plan.txt
@@ -1,34 +1,34 @@
 local exchange (GATHER, SINGLE, [])
     remote exchange (GATHER, SINGLE, [])
         join (INNER, REPLICATED):
-            join (INNER, REPLICATED):
-                final aggregation over (ss_item_sk_26, ss_store_sk_31)
-                    local exchange (GATHER, SINGLE, [])
-                        remote exchange (REPARTITION, HASH, [ss_item_sk_26, ss_store_sk_31])
-                            partial aggregation over (ss_item_sk_26, ss_store_sk_31)
-                                join (INNER, REPLICATED):
-                                    scan store_sales
-                                    local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPLICATE, BROADCAST, [])
-                                            scan date_dim
+            join (INNER, PARTITIONED):
+                remote exchange (REPARTITION, HASH, [ss_store_sk_31])
+                    final aggregation over (ss_item_sk_26, ss_store_sk_31)
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, [ss_item_sk_26, ss_store_sk_31])
+                                partial aggregation over (ss_item_sk_26, ss_store_sk_31)
+                                    join (INNER, REPLICATED):
+                                        scan store_sales
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                scan date_dim
                 local exchange (GATHER, SINGLE, [])
-                    remote exchange (REPLICATE, BROADCAST, [])
-                        join (INNER, PARTITIONED):
-                            remote exchange (REPARTITION, HASH, [s_store_sk])
-                                scan store
-                            final aggregation over (ss_store_sk)
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPARTITION, HASH, [ss_store_sk])
-                                        partial aggregation over (ss_store_sk)
-                                            final aggregation over (ss_item_sk, ss_store_sk)
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, [ss_item_sk, ss_store_sk])
-                                                        partial aggregation over (ss_item_sk, ss_store_sk)
-                                                            join (INNER, REPLICATED):
-                                                                scan store_sales
-                                                                local exchange (GATHER, SINGLE, [])
-                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan date_dim
+                    join (INNER, PARTITIONED):
+                        remote exchange (REPARTITION, HASH, [s_store_sk])
+                            scan store
+                        final aggregation over (ss_store_sk)
+                            local exchange (GATHER, SINGLE, [])
+                                remote exchange (REPARTITION, HASH, [ss_store_sk])
+                                    partial aggregation over (ss_store_sk)
+                                        final aggregation over (ss_item_sk, ss_store_sk)
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPARTITION, HASH, [ss_item_sk, ss_store_sk])
+                                                    partial aggregation over (ss_item_sk, ss_store_sk)
+                                                        join (INNER, REPLICATED):
+                                                            scan store_sales
+                                                            local exchange (GATHER, SINGLE, [])
+                                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                                    scan date_dim
             local exchange (GATHER, SINGLE, [])
                 remote exchange (REPLICATE, BROADCAST, [])
                     scan item

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q71.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q71.plan.txt
@@ -6,25 +6,28 @@ remote exchange (GATHER, SINGLE, [])
                     remote exchange (REPARTITION, HASH, [i_brand, i_brand_id, t_hour, t_minute])
                         partial aggregation over (i_brand, i_brand_id, t_hour, t_minute)
                             join (INNER, REPLICATED):
-                                join (INNER, REPLICATED):
-                                    remote exchange (REPARTITION, ROUND_ROBIN, [])
-                                        join (INNER, REPLICATED):
-                                            scan web_sales
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan date_dim
-                                        join (INNER, REPLICATED):
-                                            scan catalog_sales
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan date_dim
-                                        join (INNER, REPLICATED):
-                                            scan store_sales
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan date_dim
+                                join (INNER, PARTITIONED):
+                                    local exchange (REPARTITION, ROUND_ROBIN, [])
+                                        remote exchange (REPARTITION, HASH, [ws_item_sk])
+                                            join (INNER, REPLICATED):
+                                                scan web_sales
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        scan date_dim
+                                        remote exchange (REPARTITION, HASH, [cs_item_sk])
+                                            join (INNER, REPLICATED):
+                                                scan catalog_sales
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        scan date_dim
+                                        remote exchange (REPARTITION, HASH, [ss_item_sk])
+                                            join (INNER, REPLICATED):
+                                                scan store_sales
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        scan date_dim
                                     local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPLICATE, BROADCAST, [])
+                                        remote exchange (REPARTITION, HASH, [i_item_sk])
                                             scan item
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPLICATE, BROADCAST, [])

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q72.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q72.plan.txt
@@ -4,45 +4,46 @@ local exchange (GATHER, SINGLE, [])
             local exchange (GATHER, SINGLE, [])
                 remote exchange (REPARTITION, HASH, [d_week_seq, i_item_desc, w_warehouse_name])
                     partial aggregation over (d_week_seq, i_item_desc, w_warehouse_name)
-                        join (LEFT, REPLICATED):
-                            join (LEFT, REPLICATED):
-                                join (INNER, PARTITIONED):
-                                    remote exchange (REPARTITION, HASH, [d_week_seq_15, inv_item_sk])
-                                        join (INNER, REPLICATED):
-                                            join (INNER, REPLICATED):
-                                                scan inventory
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan date_dim
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan warehouse
-                                    local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPARTITION, HASH, [cs_item_sk, d_week_seq])
+                        join (LEFT, PARTITIONED):
+                            remote exchange (REPARTITION, HASH, [cs_item_sk, cs_order_number])
+                                join (LEFT, REPLICATED):
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, [d_week_seq_15, inv_item_sk])
                                             join (INNER, REPLICATED):
                                                 join (INNER, REPLICATED):
-                                                    join (INNER, REPLICATED):
-                                                        join (INNER, REPLICATED):
-                                                            join (INNER, REPLICATED):
-                                                                scan catalog_sales
-                                                                local exchange (GATHER, SINGLE, [])
-                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan customer_demographics
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan household_demographics
-                                                        local exchange (GATHER, SINGLE, [])
-                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                scan date_dim
+                                                    scan inventory
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
                                                             scan date_dim
                                                 local exchange (GATHER, SINGLE, [])
                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan item
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPLICATE, BROADCAST, [])
-                                        scan promotion
+                                                        scan warehouse
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, [cs_item_sk, d_week_seq])
+                                                join (INNER, REPLICATED):
+                                                    join (INNER, REPLICATED):
+                                                        join (INNER, REPLICATED):
+                                                            join (INNER, REPLICATED):
+                                                                join (INNER, REPLICATED):
+                                                                    scan catalog_sales
+                                                                    local exchange (GATHER, SINGLE, [])
+                                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                                            scan customer_demographics
+                                                                local exchange (GATHER, SINGLE, [])
+                                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                                        scan household_demographics
+                                                            local exchange (GATHER, SINGLE, [])
+                                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                                    scan date_dim
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                scan date_dim
+                                                    local exchange (GATHER, SINGLE, [])
+                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                            scan item
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPLICATE, BROADCAST, [])
+                                            scan promotion
                             local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPLICATE, BROADCAST, [])
+                                remote exchange (REPARTITION, HASH, [cr_item_sk, cr_order_number])
                                     scan catalog_returns

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q74.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q74.plan.txt
@@ -9,14 +9,15 @@ local exchange (GATHER, SINGLE, [])
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPARTITION, HASH, [c_customer_id, c_first_name, c_last_name, d_year])
                                         partial aggregation over (c_customer_id, c_first_name, c_last_name, d_year)
-                                            join (INNER, REPLICATED):
-                                                join (INNER, REPLICATED):
-                                                    scan store_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
+                                            join (INNER, PARTITIONED):
+                                                remote exchange (REPARTITION, HASH, [ss_customer_sk])
+                                                    join (INNER, REPLICATED):
+                                                        scan store_sales
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                scan date_dim
                                                 local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                    remote exchange (REPARTITION, HASH, [c_customer_sk])
                                                         scan customer
                         remote exchange (REPARTITION, HASH, [c_customer_id_17])
                             single aggregation over (c_customer_id_17, c_first_name_24, c_last_name_25, d_year_40)
@@ -31,14 +32,15 @@ local exchange (GATHER, SINGLE, [])
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPARTITION, HASH, [c_customer_id_109, c_first_name_116, c_last_name_117, d_year_155])
                                         partial aggregation over (c_customer_id_109, c_first_name_116, c_last_name_117, d_year_155)
-                                            join (INNER, REPLICATED):
-                                                join (INNER, REPLICATED):
-                                                    scan store_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
+                                            join (INNER, PARTITIONED):
+                                                remote exchange (REPARTITION, HASH, [ss_customer_sk_129])
+                                                    join (INNER, REPLICATED):
+                                                        scan store_sales
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                scan date_dim
                                                 local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                    remote exchange (REPARTITION, HASH, [c_customer_sk_108])
                                                         scan customer
                         remote exchange (REPARTITION, HASH, [c_customer_id_200])
                             single aggregation over (c_customer_id_200, c_first_name_207, c_last_name_208, d_year_257)

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q78.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q78.plan.txt
@@ -8,10 +8,11 @@ local exchange (GATHER, SINGLE, [])
                             remote exchange (REPARTITION, HASH, [d_year, ss_customer_sk, ss_item_sk])
                                 partial aggregation over (d_year, ss_customer_sk, ss_item_sk)
                                     join (INNER, REPLICATED):
-                                        join (LEFT, REPLICATED):
-                                            scan store_sales
+                                        join (LEFT, PARTITIONED):
+                                            remote exchange (REPARTITION, HASH, [ss_item_sk, ss_ticket_number])
+                                                scan store_sales
                                             local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                remote exchange (REPARTITION, HASH, [sr_item_sk, sr_ticket_number])
                                                     scan store_returns
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
@@ -21,10 +22,11 @@ local exchange (GATHER, SINGLE, [])
                             remote exchange (REPARTITION, HASH, [d_year_53, ws_bill_customer_sk, ws_item_sk])
                                 partial aggregation over (d_year_53, ws_bill_customer_sk, ws_item_sk)
                                     join (INNER, REPLICATED):
-                                        join (LEFT, REPLICATED):
-                                            scan web_sales
+                                        join (LEFT, PARTITIONED):
+                                            remote exchange (REPARTITION, HASH, [ws_item_sk, ws_order_number])
+                                                scan web_sales
                                             local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                remote exchange (REPARTITION, HASH, [wr_item_sk, wr_order_number])
                                                     scan web_returns
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
@@ -36,10 +38,11 @@ local exchange (GATHER, SINGLE, [])
                             remote exchange (REPARTITION, HASH, [cs_bill_customer_sk, cs_item_sk, d_year_130])
                                 partial aggregation over (cs_bill_customer_sk, cs_item_sk, d_year_130)
                                     join (INNER, REPLICATED):
-                                        join (LEFT, REPLICATED):
-                                            scan catalog_sales
+                                        join (LEFT, PARTITIONED):
+                                            remote exchange (REPARTITION, HASH, [cs_item_sk, cs_order_number])
+                                                scan catalog_sales
                                             local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                remote exchange (REPARTITION, HASH, [cr_item_sk, cr_order_number])
                                                     scan catalog_returns
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q79.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q79.plan.txt
@@ -1,23 +1,24 @@
 local exchange (GATHER, SINGLE, [])
     remote exchange (GATHER, SINGLE, [])
-        join (INNER, REPLICATED):
-            final aggregation over (s_city, ss_addr_sk, ss_customer_sk, ss_ticket_number)
-                local exchange (GATHER, SINGLE, [])
-                    remote exchange (REPARTITION, HASH, [s_city, ss_addr_sk, ss_customer_sk, ss_ticket_number])
-                        partial aggregation over (s_city, ss_addr_sk, ss_customer_sk, ss_ticket_number)
-                            join (INNER, REPLICATED):
+        join (INNER, PARTITIONED):
+            remote exchange (REPARTITION, HASH, [ss_customer_sk])
+                final aggregation over (s_city, ss_addr_sk, ss_customer_sk, ss_ticket_number)
+                    local exchange (GATHER, SINGLE, [])
+                        remote exchange (REPARTITION, HASH, [s_city, ss_addr_sk, ss_customer_sk, ss_ticket_number])
+                            partial aggregation over (s_city, ss_addr_sk, ss_customer_sk, ss_ticket_number)
                                 join (INNER, REPLICATED):
                                     join (INNER, REPLICATED):
-                                        scan store_sales
+                                        join (INNER, REPLICATED):
+                                            scan store_sales
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                    scan date_dim
                                         local exchange (GATHER, SINGLE, [])
                                             remote exchange (REPLICATE, BROADCAST, [])
-                                                scan date_dim
+                                                scan household_demographics
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
-                                            scan household_demographics
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPLICATE, BROADCAST, [])
-                                        scan store
+                                            scan store
             local exchange (GATHER, SINGLE, [])
-                remote exchange (REPLICATE, BROADCAST, [])
+                remote exchange (REPARTITION, HASH, [c_customer_sk])
                     scan customer

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q80.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q80.plan.txt
@@ -13,10 +13,11 @@ local exchange (GATHER, SINGLE, [])
                                                 join (INNER, REPLICATED):
                                                     join (INNER, REPLICATED):
                                                         join (INNER, REPLICATED):
-                                                            join (LEFT, REPLICATED):
-                                                                scan store_sales
+                                                            join (LEFT, PARTITIONED):
+                                                                remote exchange (REPARTITION, HASH, [ss_item_sk, ss_ticket_number])
+                                                                    scan store_sales
                                                                 local exchange (GATHER, SINGLE, [])
-                                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                                    remote exchange (REPARTITION, HASH, [sr_item_sk, sr_ticket_number])
                                                                         scan store_returns
                                                             local exchange (GATHER, SINGLE, [])
                                                                 remote exchange (REPLICATE, BROADCAST, [])
@@ -38,10 +39,11 @@ local exchange (GATHER, SINGLE, [])
                                                 join (INNER, REPLICATED):
                                                     join (INNER, REPLICATED):
                                                         join (INNER, REPLICATED):
-                                                            join (LEFT, REPLICATED):
-                                                                scan catalog_sales
+                                                            join (LEFT, PARTITIONED):
+                                                                remote exchange (REPARTITION, HASH, [cs_item_sk, cs_order_number])
+                                                                    scan catalog_sales
                                                                 local exchange (GATHER, SINGLE, [])
-                                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                                    remote exchange (REPARTITION, HASH, [cr_item_sk, cr_order_number])
                                                                         scan catalog_returns
                                                             local exchange (GATHER, SINGLE, [])
                                                                 remote exchange (REPLICATE, BROADCAST, [])
@@ -63,10 +65,11 @@ local exchange (GATHER, SINGLE, [])
                                                 join (INNER, REPLICATED):
                                                     join (INNER, REPLICATED):
                                                         join (INNER, REPLICATED):
-                                                            join (LEFT, REPLICATED):
-                                                                scan web_sales
+                                                            join (LEFT, PARTITIONED):
+                                                                remote exchange (REPARTITION, HASH, [ws_item_sk, ws_order_number])
+                                                                    scan web_sales
                                                                 local exchange (GATHER, SINGLE, [])
-                                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                                    remote exchange (REPARTITION, HASH, [wr_item_sk, wr_order_number])
                                                                         scan web_returns
                                                             local exchange (GATHER, SINGLE, [])
                                                                 remote exchange (REPLICATE, BROADCAST, [])

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q81.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q81.plan.txt
@@ -2,22 +2,24 @@ local exchange (GATHER, SINGLE, [])
     remote exchange (GATHER, SINGLE, [])
         cross join:
             join (LEFT, REPLICATED):
-                join (INNER, REPLICATED):
-                    final aggregation over (ca_state, cr_returning_customer_sk)
-                        local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, [ca_state, cr_returning_customer_sk])
-                                partial aggregation over (ca_state, cr_returning_customer_sk)
-                                    join (INNER, REPLICATED):
-                                        join (INNER, REPLICATED):
-                                            scan catalog_returns
+                join (INNER, PARTITIONED):
+                    remote exchange (REPARTITION, HASH, [cr_returning_customer_sk])
+                        final aggregation over (ca_state, cr_returning_customer_sk)
+                            local exchange (GATHER, SINGLE, [])
+                                remote exchange (REPARTITION, HASH, [ca_state, cr_returning_customer_sk])
+                                    partial aggregation over (ca_state, cr_returning_customer_sk)
+                                        join (INNER, PARTITIONED):
+                                            remote exchange (REPARTITION, HASH, [cr_returning_addr_sk])
+                                                join (INNER, REPLICATED):
+                                                    scan catalog_returns
+                                                    local exchange (GATHER, SINGLE, [])
+                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                            scan date_dim
                                             local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan date_dim
-                                        local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                scan customer_address
+                                                remote exchange (REPARTITION, HASH, [ca_address_sk])
+                                                    scan customer_address
                     local exchange (GATHER, SINGLE, [])
-                        remote exchange (REPLICATE, BROADCAST, [])
+                        remote exchange (REPARTITION, HASH, [c_customer_sk])
                             join (INNER, REPLICATED):
                                 scan customer
                                 local exchange (GATHER, SINGLE, [])
@@ -33,14 +35,15 @@ local exchange (GATHER, SINGLE, [])
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPARTITION, HASH, [ca_state_93, cr_returning_customer_sk_37])
                                                     partial aggregation over (ca_state_93, cr_returning_customer_sk_37)
-                                                        join (INNER, REPLICATED):
-                                                            join (INNER, REPLICATED):
-                                                                scan catalog_returns
-                                                                local exchange (GATHER, SINGLE, [])
-                                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan date_dim
+                                                        join (INNER, PARTITIONED):
+                                                            remote exchange (REPARTITION, HASH, [cr_returning_addr_sk_40])
+                                                                join (INNER, REPLICATED):
+                                                                    scan catalog_returns
+                                                                    local exchange (GATHER, SINGLE, [])
+                                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                                            scan date_dim
                                                             local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                                remote exchange (REPARTITION, HASH, [ca_address_sk_85])
                                                                     scan customer_address
             local exchange (GATHER, SINGLE, [])
                 remote exchange (REPLICATE, BROADCAST, [])

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q82.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q82.plan.txt
@@ -4,16 +4,17 @@ local exchange (GATHER, SINGLE, [])
             local exchange (GATHER, SINGLE, [])
                 remote exchange (REPARTITION, HASH, [i_current_price, i_item_desc, i_item_id])
                     partial aggregation over (i_current_price, i_item_desc, i_item_id)
-                        join (INNER, REPLICATED):
-                            scan store_sales
+                        join (INNER, PARTITIONED):
+                            remote exchange (REPARTITION, HASH, [ss_item_sk])
+                                scan store_sales
                             local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPLICATE, BROADCAST, [])
-                                    join (INNER, REPLICATED):
+                                join (INNER, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, [inv_item_sk])
                                         join (INNER, REPLICATED):
                                             scan inventory
                                             local exchange (GATHER, SINGLE, [])
                                                 remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan item
-                                        local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                scan date_dim
+                                                    scan date_dim
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, [i_item_sk])
+                                            scan item

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q84.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q84.plan.txt
@@ -1,9 +1,10 @@
 local exchange (GATHER, SINGLE, [])
     remote exchange (GATHER, SINGLE, [])
-        join (INNER, REPLICATED):
-            scan store_returns
+        join (INNER, PARTITIONED):
+            remote exchange (REPARTITION, HASH, [sr_cdemo_sk])
+                scan store_returns
             local exchange (GATHER, SINGLE, [])
-                remote exchange (REPLICATE, BROADCAST, [])
+                remote exchange (REPARTITION, HASH, [c_current_cdemo_sk])
                     join (INNER, REPLICATED):
                         scan customer_demographics
                         local exchange (GATHER, SINGLE, [])

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q85.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q85.plan.txt
@@ -11,24 +11,25 @@ local exchange (GATHER, SINGLE, [])
                                         scan customer_demographics
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, [cd_education_status, cd_marital_status, wr_returning_cdemo_sk])
-                                            join (INNER, REPLICATED):
-                                                join (INNER, PARTITIONED):
-                                                    remote exchange (REPARTITION, HASH, [ws_item_sk, ws_order_number])
-                                                        join (INNER, REPLICATED):
-                                                            scan web_sales
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                    scan date_dim
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPARTITION, HASH, [wr_item_sk, wr_order_number])
+                                            join (INNER, PARTITIONED):
+                                                remote exchange (REPARTITION, HASH, [wr_refunded_addr_sk])
+                                                    join (INNER, PARTITIONED):
+                                                        remote exchange (REPARTITION, HASH, [ws_item_sk, ws_order_number])
                                                             join (INNER, REPLICATED):
-                                                                scan web_returns
+                                                                scan web_sales
                                                                 local exchange (GATHER, SINGLE, [])
                                                                     remote exchange (REPLICATE, BROADCAST, [])
-                                                                        scan customer_address
+                                                                        scan date_dim
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPARTITION, HASH, [wr_item_sk, wr_order_number])
+                                                                join (INNER, REPLICATED):
+                                                                    scan web_returns
+                                                                    local exchange (GATHER, SINGLE, [])
+                                                                        remote exchange (REPLICATE, BROADCAST, [])
+                                                                            scan customer_demographics
                                                 local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        scan customer_demographics
+                                                    remote exchange (REPARTITION, HASH, [ca_address_sk])
+                                                        scan customer_address
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPLICATE, BROADCAST, [])
                                         scan web_page

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q87.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q87.plan.txt
@@ -9,14 +9,15 @@ final aggregation over ()
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPARTITION, HASH, [c_first_name, c_last_name, d_date])
                                         partial aggregation over (c_first_name, c_last_name, d_date)
-                                            join (INNER, REPLICATED):
-                                                join (INNER, REPLICATED):
-                                                    scan store_sales
-                                                    local exchange (GATHER, SINGLE, [])
-                                                        remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan date_dim
+                                            join (INNER, PARTITIONED):
+                                                remote exchange (REPARTITION, HASH, [ss_customer_sk])
+                                                    join (INNER, REPLICATED):
+                                                        scan store_sales
+                                                        local exchange (GATHER, SINGLE, [])
+                                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                                scan date_dim
                                                 local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                    remote exchange (REPARTITION, HASH, [c_customer_sk])
                                                         scan customer
                         partial aggregation over (c_first_name_47, c_last_name_48, d_date_13)
                             final aggregation over (c_first_name_47, c_last_name_48, d_date_13)

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q89.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q89.plan.txt
@@ -7,15 +7,16 @@ local exchange (GATHER, SINGLE, [])
                         remote exchange (REPARTITION, HASH, [d_moy, i_brand, i_category, i_class, s_company_name, s_store_name])
                             partial aggregation over (d_moy, i_brand, i_category, i_class, s_company_name, s_store_name)
                                 join (INNER, REPLICATED):
-                                    join (INNER, REPLICATED):
-                                        join (INNER, REPLICATED):
-                                            scan store_sales
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan item
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, [ss_item_sk])
+                                            join (INNER, REPLICATED):
+                                                scan store_sales
+                                                local exchange (GATHER, SINGLE, [])
+                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                        scan date_dim
                                         local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                scan date_dim
+                                            remote exchange (REPARTITION, HASH, [i_item_sk])
+                                                scan item
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPLICATE, BROADCAST, [])
                                             scan store

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q95.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpcds/q95.plan.txt
@@ -30,12 +30,12 @@ final aggregation over ()
                         local exchange (GATHER, SINGLE, [])
                             remote exchange (REPARTITION, HASH, [wr_order_number])
                                 join (INNER, PARTITIONED):
-                                    remote exchange (REPARTITION, HASH, [wr_order_number])
-                                        join (INNER, REPLICATED):
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, [ws_order_number_107])
                                             scan web_sales
-                                            local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                    scan web_returns
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, [wr_order_number])
+                                                scan web_returns
                                     local exchange (GATHER, SINGLE, [])
                                         remote exchange (REPARTITION, HASH, [ws_order_number_141])
                                             scan web_sales

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q02.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q02.plan.txt
@@ -24,10 +24,11 @@ remote exchange (GATHER, SINGLE, [])
                         remote exchange (REPARTITION, HASH, [partkey])
                             join (INNER, PARTITIONED):
                                 remote exchange (REPARTITION, HASH, [suppkey_4])
-                                    join (INNER, REPLICATED):
-                                        scan partsupp
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, [partkey_3])
+                                            scan partsupp
                                         local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPLICATE, BROADCAST, [])
+                                            remote exchange (REPARTITION, HASH, [partkey])
                                                 scan part
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPARTITION, HASH, [suppkey])

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q03.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q03.plan.txt
@@ -2,14 +2,15 @@ local exchange (GATHER, SINGLE, [])
     remote exchange (GATHER, SINGLE, [])
         final aggregation over (orderdate, orderkey_3, shippriority)
             local exchange (GATHER, SINGLE, [])
-                remote exchange (REPARTITION, HASH, [orderdate, orderkey_3, shippriority])
-                    partial aggregation over (orderdate, orderkey_3, shippriority)
-                        join (INNER, REPLICATED):
+                partial aggregation over (orderdate, orderkey_3, shippriority)
+                    join (INNER, PARTITIONED):
+                        remote exchange (REPARTITION, HASH, [orderkey_3])
                             scan lineitem
-                            local exchange (GATHER, SINGLE, [])
-                                remote exchange (REPLICATE, BROADCAST, [])
-                                    join (INNER, REPLICATED):
+                        local exchange (GATHER, SINGLE, [])
+                            remote exchange (REPARTITION, HASH, [orderkey])
+                                join (INNER, PARTITIONED):
+                                    remote exchange (REPARTITION, HASH, [custkey_0])
                                         scan orders
-                                        local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                scan customer
+                                    local exchange (GATHER, SINGLE, [])
+                                        remote exchange (REPARTITION, HASH, [custkey])
+                                            scan customer

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q05.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q05.plan.txt
@@ -5,25 +5,27 @@ remote exchange (GATHER, SINGLE, [])
                 local exchange (GATHER, SINGLE, [])
                     remote exchange (REPARTITION, HASH, [name_15])
                         partial aggregation over (name_15)
-                            join (INNER, REPLICATED):
-                                join (INNER, REPLICATED):
-                                    scan lineitem
-                                    local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPLICATE, BROADCAST, [])
-                                            join (INNER, PARTITIONED):
-                                                remote exchange (REPARTITION, HASH, [custkey_0])
-                                                    scan orders
-                                                local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPARTITION, HASH, [custkey])
-                                                        join (INNER, REPLICATED):
-                                                            scan customer
-                                                            local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                    join (INNER, REPLICATED):
-                                                                        scan nation
-                                                                        local exchange (GATHER, SINGLE, [])
-                                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                                scan region
+                            join (INNER, PARTITIONED):
+                                remote exchange (REPARTITION, HASH, [nationkey, suppkey])
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, [orderkey_3])
+                                            scan lineitem
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPARTITION, HASH, [orderkey])
+                                                join (INNER, PARTITIONED):
+                                                    remote exchange (REPARTITION, HASH, [custkey_0])
+                                                        scan orders
+                                                    local exchange (GATHER, SINGLE, [])
+                                                        remote exchange (REPARTITION, HASH, [custkey])
+                                                            join (INNER, REPLICATED):
+                                                                scan customer
+                                                                local exchange (GATHER, SINGLE, [])
+                                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                                        join (INNER, REPLICATED):
+                                                                            scan nation
+                                                                            local exchange (GATHER, SINGLE, [])
+                                                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                                                    scan region
                                 local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPLICATE, BROADCAST, [])
+                                    remote exchange (REPARTITION, HASH, [nationkey_9, suppkey_6])
                                         scan supplier

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q07.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q07.plan.txt
@@ -7,10 +7,11 @@ remote exchange (GATHER, SINGLE, [])
                         partial aggregation over (expr_24, name_15, name_19)
                             join (INNER, PARTITIONED):
                                 remote exchange (REPARTITION, HASH, [orderkey])
-                                    join (INNER, REPLICATED):
-                                        scan lineitem
+                                    join (INNER, PARTITIONED):
+                                        remote exchange (REPARTITION, HASH, [suppkey_0])
+                                            scan lineitem
                                         local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPLICATE, BROADCAST, [])
+                                            remote exchange (REPARTITION, HASH, [suppkey])
                                                 join (INNER, REPLICATED):
                                                     scan supplier
                                                     local exchange (GATHER, SINGLE, [])
@@ -18,10 +19,11 @@ remote exchange (GATHER, SINGLE, [])
                                                             scan nation
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPARTITION, HASH, [orderkey_3])
-                                        join (INNER, REPLICATED):
-                                            scan orders
+                                        join (INNER, PARTITIONED):
+                                            remote exchange (REPARTITION, HASH, [custkey])
+                                                scan orders
                                             local exchange (GATHER, SINGLE, [])
-                                                remote exchange (REPLICATE, BROADCAST, [])
+                                                remote exchange (REPARTITION, HASH, [custkey_6])
                                                     join (INNER, REPLICATED):
                                                         scan customer
                                                         local exchange (GATHER, SINGLE, [])

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q08.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q08.plan.txt
@@ -8,27 +8,29 @@ remote exchange (GATHER, SINGLE, [])
                             join (INNER, PARTITIONED):
                                 remote exchange (REPARTITION, HASH, [suppkey_4])
                                     join (INNER, PARTITIONED):
-                                        remote exchange (REPARTITION, HASH, [orderkey_7])
-                                            join (INNER, REPLICATED):
-                                                scan orders
+                                        remote exchange (REPARTITION, HASH, [custkey])
+                                            join (INNER, PARTITIONED):
+                                                remote exchange (REPARTITION, HASH, [orderkey_7])
+                                                    scan orders
                                                 local exchange (GATHER, SINGLE, [])
-                                                    remote exchange (REPLICATE, BROADCAST, [])
-                                                        join (INNER, REPLICATED):
-                                                            scan customer
+                                                    remote exchange (REPARTITION, HASH, [orderkey])
+                                                        join (INNER, PARTITIONED):
+                                                            remote exchange (REPARTITION, HASH, [partkey_3])
+                                                                scan lineitem
                                                             local exchange (GATHER, SINGLE, [])
-                                                                remote exchange (REPLICATE, BROADCAST, [])
-                                                                    join (INNER, REPLICATED):
-                                                                        scan nation
-                                                                        local exchange (GATHER, SINGLE, [])
-                                                                            remote exchange (REPLICATE, BROADCAST, [])
-                                                                                scan region
+                                                                remote exchange (REPARTITION, HASH, [partkey])
+                                                                    scan part
                                         local exchange (GATHER, SINGLE, [])
-                                            remote exchange (REPARTITION, HASH, [orderkey])
+                                            remote exchange (REPARTITION, HASH, [custkey_10])
                                                 join (INNER, REPLICATED):
-                                                    scan lineitem
+                                                    scan customer
                                                     local exchange (GATHER, SINGLE, [])
                                                         remote exchange (REPLICATE, BROADCAST, [])
-                                                            scan part
+                                                            join (INNER, REPLICATED):
+                                                                scan nation
+                                                                local exchange (GATHER, SINGLE, [])
+                                                                    remote exchange (REPLICATE, BROADCAST, [])
+                                                                        scan region
                                 local exchange (GATHER, SINGLE, [])
                                     remote exchange (REPARTITION, HASH, [suppkey])
                                         join (INNER, REPLICATED):

--- a/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q10.plan.txt
+++ b/presto-benchto-benchmarks/src/test/resources/sql/presto/tpch/q10.plan.txt
@@ -2,18 +2,20 @@ local exchange (GATHER, SINGLE, [])
     remote exchange (GATHER, SINGLE, [])
         final aggregation over (acctbal, address, comment_4, custkey_3, name, name_7, phone)
             local exchange (GATHER, SINGLE, [])
-                partial aggregation over (acctbal, address, comment_4, custkey_3, name, name_7, phone)
-                    join (INNER, PARTITIONED):
-                        remote exchange (REPARTITION, HASH, [custkey_3])
-                            join (INNER, REPLICATED):
-                                scan customer
-                                local exchange (GATHER, SINGLE, [])
-                                    remote exchange (REPLICATE, BROADCAST, [])
-                                        scan nation
-                        local exchange (GATHER, SINGLE, [])
-                            remote exchange (REPARTITION, HASH, [custkey])
-                                join (INNER, REPLICATED):
-                                    scan lineitem
-                                    local exchange (GATHER, SINGLE, [])
-                                        remote exchange (REPLICATE, BROADCAST, [])
-                                            scan orders
+                remote exchange (REPARTITION, HASH, [acctbal, address, comment_4, custkey_3, name, name_7, phone])
+                    partial aggregation over (acctbal, address, comment_4, custkey_3, name, name_7, phone)
+                        join (INNER, PARTITIONED):
+                            remote exchange (REPARTITION, HASH, [orderkey])
+                                scan lineitem
+                            local exchange (GATHER, SINGLE, [])
+                                remote exchange (REPARTITION, HASH, [orderkey_0])
+                                    join (INNER, REPLICATED):
+                                        join (INNER, PARTITIONED):
+                                            remote exchange (REPARTITION, HASH, [custkey_3])
+                                                scan customer
+                                            local exchange (GATHER, SINGLE, [])
+                                                remote exchange (REPARTITION, HASH, [custkey])
+                                                    scan orders
+                                        local exchange (GATHER, SINGLE, [])
+                                            remote exchange (REPLICATE, BROADCAST, [])
+                                                scan nation

--- a/presto-docs/src/main/sphinx/optimizer/cost-based-optimizations.rst
+++ b/presto-docs/src/main/sphinx/optimizer/cost-based-optimizations.rst
@@ -69,6 +69,18 @@ The valid values are:
  * ``BROADCAST`` - broadcast join distribution is used for all joins
  * ``PARTITIONED`` (default) - partitioned join distribution is used for all join
 
+Capping replicated table size
+-----------------------------
+
+Join distribution type will be chosen automatically when join reordering strategy
+is set to ``COST_BASED`` or when join distribution type is set to ``AUTOMATIC``.
+In such case it is possible to cap the maximum size of replicated table via
+``join-max-broadcast-table-size`` config property (e.g. ``join-max-broadcast-table-size=100MB``)
+or via ``join_max_broadcast_table_size`` session property (e.g. ``set session join_max_broadcast_table_size='100MB';``)
+This allows improving cluster concurrency and prevents bad plans when CBO misestimates size of joined tables.
+
+By default replicated table size is capped to 100MB.
+
 Connector Implementations
 -------------------------
 

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -1160,9 +1160,9 @@ public final class SystemSessionProperties
         return session.getSystemProperty(JOIN_DISTRIBUTION_TYPE, JoinDistributionType.class);
     }
 
-    public static Optional<DataSize> getJoinMaxBroadcastTableSize(Session session)
+    public static DataSize getJoinMaxBroadcastTableSize(Session session)
     {
-        return Optional.ofNullable(session.getSystemProperty(JOIN_MAX_BROADCAST_TABLE_SIZE, DataSize.class));
+        return session.getSystemProperty(JOIN_MAX_BROADCAST_TABLE_SIZE, DataSize.class);
     }
 
     public static boolean isDistributedIndexJoinEnabled(Session session)

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -71,7 +71,7 @@ public class FeaturesConfig
     private double networkCostWeight = 15;
     private boolean distributedIndexJoinsEnabled;
     private JoinDistributionType joinDistributionType = PARTITIONED;
-    private DataSize joinMaxBroadcastTableSize;
+    private DataSize joinMaxBroadcastTableSize = new DataSize(100, MEGABYTE);
     private boolean colocatedJoinsEnabled = true;
     private boolean groupedExecutionEnabled = true;
     private boolean recoverableGroupedExecutionEnabled;
@@ -458,6 +458,7 @@ public class FeaturesConfig
         return this;
     }
 
+    @NotNull
     public DataSize getJoinMaxBroadcastTableSize()
     {
         return joinMaxBroadcastTableSize;

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/DetermineJoinDistributionType.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/DetermineJoinDistributionType.java
@@ -30,7 +30,6 @@ import io.airlift.units.DataSize;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 import static com.facebook.presto.SystemSessionProperties.getJoinDistributionType;
 import static com.facebook.presto.SystemSessionProperties.getJoinMaxBroadcastTableSize;
@@ -74,15 +73,12 @@ public class DetermineJoinDistributionType
 
     public static boolean isBelowMaxBroadcastSize(JoinNode joinNode, Context context)
     {
-        Optional<DataSize> joinMaxBroadcastTableSize = getJoinMaxBroadcastTableSize(context.getSession());
-        if (!joinMaxBroadcastTableSize.isPresent()) {
-            return true;
-        }
+        DataSize joinMaxBroadcastTableSize = getJoinMaxBroadcastTableSize(context.getSession());
 
         PlanNode buildSide = joinNode.getRight();
         PlanNodeStatsEstimate buildSideStatsEstimate = context.getStatsProvider().getStats(buildSide);
         double buildSideSizeInBytes = buildSideStatsEstimate.getOutputSizeInBytes(buildSide.getOutputVariables());
-        return buildSideSizeInBytes <= joinMaxBroadcastTableSize.get().toBytes();
+        return buildSideSizeInBytes <= joinMaxBroadcastTableSize.toBytes();
     }
 
     private PlanNode getCostBasedJoin(JoinNode joinNode, Context context)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/DetermineSemiJoinDistributionType.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/DetermineSemiJoinDistributionType.java
@@ -43,7 +43,6 @@ import io.airlift.units.DataSize;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 import static com.facebook.presto.SystemSessionProperties.getJoinDistributionType;
 import static com.facebook.presto.SystemSessionProperties.getJoinMaxBroadcastTableSize;
@@ -115,15 +114,12 @@ public class DetermineSemiJoinDistributionType
 
     private boolean canReplicate(SemiJoinNode node, Context context)
     {
-        Optional<DataSize> joinMaxBroadcastTableSize = getJoinMaxBroadcastTableSize(context.getSession());
-        if (!joinMaxBroadcastTableSize.isPresent()) {
-            return true;
-        }
+        DataSize joinMaxBroadcastTableSize = getJoinMaxBroadcastTableSize(context.getSession());
 
         PlanNode buildSide = node.getFilteringSource();
         PlanNodeStatsEstimate buildSideStatsEstimate = context.getStatsProvider().getStats(buildSide);
         double buildSideSizeInBytes = buildSideStatsEstimate.getOutputSizeInBytes(buildSide.getOutputVariables());
-        return buildSideSizeInBytes <= joinMaxBroadcastTableSize.get().toBytes();
+        return buildSideSizeInBytes <= joinMaxBroadcastTableSize.toBytes();
     }
 
     private PlanNodeWithCost getSemiJoinNodeWithCost(SemiJoinNode possibleJoinNode, Context context)

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -61,7 +61,7 @@ public class TestFeaturesConfig
                 .setNetworkCostWeight(15)
                 .setDistributedIndexJoinsEnabled(false)
                 .setJoinDistributionType(PARTITIONED)
-                .setJoinMaxBroadcastTableSize(null)
+                .setJoinMaxBroadcastTableSize(new DataSize(100, MEGABYTE))
                 .setGroupedExecutionEnabled(true)
                 .setRecoverableGroupedExecutionEnabled(false)
                 .setMaxFailedTaskPercentage(0.3)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestDetermineJoinDistributionType.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestDetermineJoinDistributionType.java
@@ -631,6 +631,7 @@ public class TestDetermineJoinDistributionType
         int bRows = 1_0;
         assertDetermineJoinDistributionType(new CostComparator(75, 10, 15))
                 .setSystemProperty(JOIN_DISTRIBUTION_TYPE, JoinDistributionType.AUTOMATIC.name())
+                .setSystemProperty(JOIN_MAX_BROADCAST_TABLE_SIZE, "1PB")
                 .overrideStats("valuesA", PlanNodeStatsEstimate.builder()
                         .setOutputRowCount(aRows)
                         .addVariableStatistics(ImmutableMap.of(new VariableReferenceExpression("A1", BIGINT), new VariableStatsEstimate(0, 100, 0, 640000, 100)))

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestReorderJoins.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestReorderJoins.java
@@ -120,6 +120,7 @@ public class TestReorderJoins
     public void testReplicatesAndFlipsWhenOneTableMuchSmaller()
     {
         assertReorderJoins()
+                .setSystemProperty(JOIN_MAX_BROADCAST_TABLE_SIZE, "1PB")
                 .on(p ->
                         p.join(
                                 INNER,


### PR DESCRIPTION
Cherry pick of:
	https://github.com/trinodb/trino/pull/2527/commits/3ae63af6578ec31c151245cfb1526f5e23955125
	https://github.com/trinodb/trino/pull/2527/commits/f72105bc3d0eb42edc2c8bc92d43f0196d36d9f1

Co-Authored-By:  Karol Sobczak <karol.sobczak@karolsobczak.com>

Fixes #16646 

```
== RELEASE NOTES ==

General Changes
* Add default size limit (100MB) to build side of broadcast join 

```
