### PR TITLE
Support GROUP BY in materialized view rewriting

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveLogicalPlanner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveLogicalPlanner.java
@@ -148,6 +148,7 @@ import static io.airlift.tpch.TpchTable.NATION;
 import static io.airlift.tpch.TpchTable.ORDERS;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.joining;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
@@ -1799,8 +1800,7 @@ public class TestHiveLogicalPlanner
                             "ds as mvds, shipmode FROM %s group by ds, shipmode",
                     view, table));
             assertTrue(getQueryRunner().tableExists(getSession(), view));
-            ExtendedHiveMetastore metastore = replicateHiveMetastore((DistributedQueryRunner) queryRunner);
-            appendTableParameter(metastore, table, REFERENCED_MATERIALIZED_VIEWS, format("%s.%s", getSession().getSchema().orElse(""), view));
+            setReferencedMaterializedViews((DistributedQueryRunner) queryRunner, table, ImmutableList.of(view));
             assertUpdate(format("REFRESH MATERIALIZED VIEW %s where mvds='2020-01-01'", view), 7);
             String baseQuery = format(
                     "SELECT sum(discount * extendedprice) as _discount_multi_extendedprice_ , MAX(discount*extendedprice) as _max_discount_multi_extendedprice_ , " +
@@ -1823,6 +1823,54 @@ public class TestHiveLogicalPlanner
                             "shipmode", multipleValues(createVarcharType(10), utf8Slices("AIR", "FOB", "MAIL", "RAIL", "REG AIR", "SHIP", "TRUCK")),
                             "ds", singleValue(createVarcharType(10), utf8Slice("2020-01-02"))))),
                     anyTree(PlanMatchPattern.constrainedTableScan(view, ImmutableMap.of()))));
+        }
+        finally {
+            queryRunner.execute("DROP MATERIALIZED VIEW IF EXISTS " + view);
+            queryRunner.execute("DROP TABLE IF EXISTS " + table);
+        }
+    }
+
+    @Test
+    public void testBaseToViewConversionWithGroupBy()
+    {
+        Session queryOptimizationWithMaterializedView = Session.builder(getSession())
+                .setSystemProperty(QUERY_OPTIMIZATION_WITH_MATERIALIZED_VIEW_ENABLED, "true")
+                .build();
+        QueryRunner queryRunner = getQueryRunner();
+        String table = "lineitem_partitioned_derived_fields";
+        String view = "lineitem_partitioned_view_derived_fields";
+        try {
+            queryRunner.execute(format(
+                    "CREATE TABLE %s WITH (partitioned_by = ARRAY['ds', 'shipmode']) AS " +
+                            "SELECT discount, extendedprice, '2020-01-01' as ds, shipmode FROM lineitem WHERE orderkey < 1000 " +
+                            "UNION ALL " +
+                            "SELECT discount, extendedprice, '2020-01-02' as ds, shipmode FROM lineitem WHERE orderkey > 1000",
+                    table));
+            assertUpdate(format(
+                    "CREATE MATERIALIZED VIEW %s WITH (partitioned_by = ARRAY['ds', 'shipmode']) AS " +
+                            "SELECT SUM(discount * extendedprice) as _discount_multi_extendedprice_ , MAX(discount*extendedprice) as _max_discount_multi_extendedprice_ , " +
+                            "ds, shipmode FROM %s group by ds, shipmode",
+                    view, table));
+            assertTrue(getQueryRunner().tableExists(getSession(), view));
+
+            setReferencedMaterializedViews((DistributedQueryRunner) queryRunner, table, ImmutableList.of(view));
+
+            assertUpdate(format("REFRESH MATERIALIZED VIEW %s where ds='2020-01-01'", view), 7);
+            String baseQuery = format(
+                    "SELECT SUM(discount * extendedprice) as _discount_multi_extendedprice_, MAX(discount*extendedprice) as _max_discount_multi_extendedprice_ FROM %s", table);
+            String viewQuery = format(
+                    "SELECT SUM(_discount_multi_extendedprice_), MAX(_max_discount_multi_extendedprice_) FROM %s", view);
+            MaterializedResult optimizedQueryResult = computeActual(queryOptimizationWithMaterializedView, baseQuery);
+            MaterializedResult baseQueryResult = computeActual(baseQuery);
+            assertEquals(optimizedQueryResult, baseQueryResult);
+
+            PlanMatchPattern expectedPattern = anyTree(
+                    anyTree(PlanMatchPattern.constrainedTableScan(table, ImmutableMap.of(
+                            "shipmode", multipleValues(createVarcharType(10), utf8Slices("AIR", "FOB", "MAIL", "RAIL", "REG AIR", "SHIP", "TRUCK")),
+                            "ds", singleValue(createVarcharType(10), utf8Slice("2020-01-02"))))),
+                    anyTree(PlanMatchPattern.constrainedTableScan(view, ImmutableMap.of())));
+            assertPlan(getSession(), viewQuery, expectedPattern);
+            assertPlan(queryOptimizationWithMaterializedView, baseQuery, expectedPattern);
         }
         finally {
             queryRunner.execute("DROP MATERIALIZED VIEW IF EXISTS " + view);
@@ -2667,6 +2715,14 @@ public class TestHiveLogicalPlanner
         Set<String> requestedColumnsSet = ImmutableSet.copyOf(actualRequestedColumns);
         assertEquals(requestedColumnsSet.size(), actualRequestedColumns.size(), "There should be no duplicates in the requested column list");
         assertEquals(requestedColumnsSet, expectedRequestedColumns);
+    }
+
+    private void setReferencedMaterializedViews(DistributedQueryRunner queryRunner, String tableName, List<String> referencedMaterializedViews)
+    {
+        appendTableParameter(replicateHiveMetastore(queryRunner),
+                tableName,
+                REFERENCED_MATERIALIZED_VIEWS,
+                referencedMaterializedViews.stream().map(view -> format("%s.%s", getSession().getSchema().orElse(""), view)).collect(joining(",")));
     }
 
     private ExtendedHiveMetastore replicateHiveMetastore(DistributedQueryRunner queryRunner)

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewInformationExtractor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewInformationExtractor.java
@@ -100,7 +100,7 @@ public class MaterializedViewInformationExtractor
         private final Map<Expression, Identifier> baseToViewColumnMap = new HashMap<>();
         private Optional<Relation> baseTable = Optional.empty();
         private Optional<Expression> whereClause = Optional.empty();
-        private Optional<Set<GroupingElement>> groupBy = Optional.empty();
+        private Optional<Set<Expression>> groupBy = Optional.empty();
         private boolean isDistinct;
         private Optional<Identifier> removablePrefix = Optional.empty();
 
@@ -119,7 +119,7 @@ public class MaterializedViewInformationExtractor
             if (!groupBy.isPresent()) {
                 groupBy = Optional.of(new HashSet<>());
             }
-            groupBy.get().add(removeGroupingElementPrefix(groupingElement, removablePrefix));
+            groupBy.get().addAll(removeGroupingElementPrefix(groupingElement, removablePrefix).getExpressions());
         }
 
         private void setBaseTable(Relation baseTable)
@@ -159,11 +159,6 @@ public class MaterializedViewInformationExtractor
             return ImmutableMap.copyOf(baseToViewColumnMap);
         }
 
-        public Optional<Set<GroupingElement>> getGroupBy()
-        {
-            return groupBy;
-        }
-
         public Optional<Expression> getWhereClause()
         {
             return whereClause;
@@ -172,6 +167,11 @@ public class MaterializedViewInformationExtractor
         public boolean isDistinct()
         {
             return isDistinct;
+        }
+
+        public Optional<Set<Expression>> getGroupBy()
+        {
+            return groupBy;
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewQueryOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewQueryOptimizer.java
@@ -100,6 +100,7 @@ public class MaterializedViewQueryOptimizer
 
     private MaterializedViewInfo materializedViewInfo;
     private Optional<Identifier> removablePrefix = Optional.empty();
+    private Optional<Set<Expression>> expressionsInGroupBy = Optional.empty();
 
     public MaterializedViewQueryOptimizer(
             Metadata metadata,
@@ -192,8 +193,21 @@ public class MaterializedViewQueryOptimizer
         if (!removablePrefix.isPresent()) {
             removablePrefix = Optional.of(new Identifier(baseTable.getName().toString()));
         }
-        if (materializedViewInfo.getGroupBy().isPresent() && !node.getGroupBy().isPresent()) {
-            throw new IllegalStateException("Query with no groupBy clause is not rewritable by materialized view with groupBy clause");
+        if (node.getGroupBy().isPresent()) {
+            ImmutableSet.Builder<Expression> expressionsInGroupByBuilder = ImmutableSet.builder();
+            for (GroupingElement element : node.getGroupBy().get().getGroupingElements()) {
+                element = removeGroupingElementPrefix(element, removablePrefix);
+                Optional<Set<Expression>> groupByOfMaterializedView = materializedViewInfo.getGroupBy();
+                if (groupByOfMaterializedView.isPresent()) {
+                    for (Expression expression : element.getExpressions()) {
+                        if (!groupByOfMaterializedView.get().contains(expression) || !materializedViewInfo.getBaseToViewColumnMap().containsKey(expression)) {
+                            throw new IllegalStateException(format("Grouping element %s is not present in materialized view groupBy field", element));
+                        }
+                    }
+                }
+                expressionsInGroupByBuilder.addAll(element.getExpressions());
+            }
+            expressionsInGroupBy = Optional.of(expressionsInGroupByBuilder.build());
         }
         // TODO: Add HAVING validation to the validator https://github.com/prestodb/presto/issues/16406
         if (node.getHaving().isPresent()) {
@@ -271,10 +285,19 @@ public class MaterializedViewQueryOptimizer
     @Override
     protected Node visitSingleColumn(SingleColumn node, Void context)
     {
+        node = removeSingleColumnPrefix(node, removablePrefix);
+        Expression expression = node.getExpression();
+        Optional<Set<Expression>> groupByOfMaterializedView = materializedViewInfo.getGroupBy();
+        // TODO: Replace this logic with rule-based validation framework.
+        if (groupByOfMaterializedView.isPresent() &&
+                validateExpressionForGroupBy(groupByOfMaterializedView.get(), expression) &&
+                (!expressionsInGroupBy.isPresent() || !expressionsInGroupBy.get().contains(expression))) {
+            throw new IllegalStateException("Query a column presents in materialized view group by: " + expression.toString());
+        }
         // For a single table, without sub-queries, the column prefix is unnecessary. Here It is removed so that it can be mapped to the view column properly.
         // For relations other than single table, it needs to be reserved to differentiate columns from different tables.
         // One way to do so is to process the prefix within `visitDereferenceExpression()` since the prefix information is saved as `base` in `DereferenceExpression` node.
-        return new SingleColumn((Expression) process(removeSingleColumnPrefix(node, removablePrefix).getExpression(), context), node.getAlias());
+        return new SingleColumn((Expression) process(expression, context), node.getAlias());
     }
 
     @Override
@@ -372,11 +395,7 @@ public class MaterializedViewQueryOptimizer
     {
         ImmutableList.Builder<GroupingElement> rewrittenGroupBy = ImmutableList.builder();
         for (GroupingElement element : node.getGroupingElements()) {
-            element = removeGroupingElementPrefix(element, removablePrefix);
-            if (materializedViewInfo.getGroupBy().isPresent() && !materializedViewInfo.getGroupBy().get().contains(element)) {
-                throw new IllegalStateException(format("Grouping element %s is not present in materialized view groupBy field", element));
-            }
-            rewrittenGroupBy.add((GroupingElement) process(element, context));
+            rewrittenGroupBy.add((GroupingElement) process(removeGroupingElementPrefix(element, removablePrefix), context));
         }
         return new GroupBy(node.isDistinct(), rewrittenGroupBy.build());
     }
@@ -409,6 +428,13 @@ public class MaterializedViewQueryOptimizer
             rewrittenSimpleGroupBy.add((Expression) process(removeExpressionPrefix(column, removablePrefix), context));
         }
         return new SimpleGroupBy(rewrittenSimpleGroupBy.build());
+    }
+
+    private boolean validateExpressionForGroupBy(Set<Expression> groupByOfMaterializedView, Expression expression)
+    {
+        // If a selected column is not present in GROUP BY node of the query.
+        // It must be 1) be selected in the materialized view and 2) not present in GROUP BY node of the materialized view
+        return groupByOfMaterializedView.contains(expression) || !materializedViewInfo.getBaseToViewColumnMap().containsKey(expression);
     }
 
     private RowExpression convertToRowExpression(Expression expression, Scope scope)

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewQueryOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewQueryOptimizer.java
@@ -42,6 +42,8 @@ import com.facebook.presto.sql.tree.FunctionCall;
 import com.facebook.presto.sql.tree.GroupBy;
 import com.facebook.presto.sql.tree.GroupingElement;
 import com.facebook.presto.sql.tree.Identifier;
+import com.facebook.presto.sql.tree.IfExpression;
+import com.facebook.presto.sql.tree.InPredicate;
 import com.facebook.presto.sql.tree.LogicalBinaryExpression;
 import com.facebook.presto.sql.tree.Node;
 import com.facebook.presto.sql.tree.OrderBy;
@@ -135,6 +137,24 @@ public class MaterializedViewQueryOptimizer
             logger.warn(ex.getMessage());
             return node;
         }
+    }
+
+    @Override
+    protected Node visitInPredicate(InPredicate node, Void context)
+    {
+        process(node.getValue(), context);
+        return node;
+    }
+
+    @Override
+    protected Node visitIfExpression(IfExpression node, Void context)
+    {
+        process(node.getCondition());
+        process(node.getTrueValue());
+        if (node.getFalseValue().isPresent()) {
+            process((node.getFalseValue().get()));
+        }
+        return node;
     }
 
     @Override


### PR DESCRIPTION
Resolves: #16702

At this moment if base query doesn't have `GROUP BY` clause while materialized view has one, the rewriting would be simply rejected, even when the rewriting is possible.

However we want to handle more cases for `GROUP BY` so more queries can be optimized using materialized view.

Considering the following examples:
```SQL
-- Materialized View definition
CREATE MATERIALIZED VIEW mv
SELECT SUM(a) AS a, SUM(b*c) AS bc, d, e FROM base GROUP BY d, e;

-- Queries can be rewritten using materialized view
SELECT SUM(a) FROM base;
  -- > SELECT SUM(a) FROM mv;
SELECT SUM(b*c) FROM base WHERE d > 10;
  -- > SELECT SUM(bc) FROM mv WHERE d > 10;
SELECT SUM(a), d FROM base GROUP BY d;
  -- > SELECT SUM(a), d FROM mv GROUP BY d;
SELECT SUM(a), SUM(b*c), d FROM base GROUP BY d;
  -- > SELECT SUM(a), SUM(bc), d FROM mv GROUP BY d;
SELECT SUM(a), SUM(b*c), d, e FROM base GROUP BY d, e;
  -- > SELECT SUM(a), SUM(bc), d, e FROM mv GROUP BY d, e;

-- Queries can NOT be rewritten using materialized view
SELECT d, e FROM base;
  -- > d, e is in GROUP BY of the materialized view, but not in GROUP BY of base query itself
SELECT SUM(d) FROM base GROUP BY e;
  -- > SUM(d) is not in GROUP BY of MV, but it is not selected by the materialized view
SELECT SUM(a) FROM base WHERE x > 10;
  -- > Unknown Identifier x
SELECT SUM(a), x FROM base GROUP BY x;
  -- > Unknown Identifier x
```

In addition to our current code, there is one rule need to be added: if the materialized view definition has `GROUP BY`
=> _Columns being selected by the base query must NOT be present in `GROUP BY` of the materialized view (unless they are present in `GROUP BY` of base query itself)_
1) For single fields, simply check their presence.
2) For function calls, they must be present in `SELECT` of the materialized view.




```
== NO RELEASE NOTE ==
```
