### PR TITLE
Support filtering nodes based on applicable pool types

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/DynamicSplitPlacementPolicy.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/DynamicSplitPlacementPolicy.java
@@ -14,7 +14,7 @@
 package com.facebook.presto.execution.scheduler;
 
 import com.facebook.presto.execution.RemoteTask;
-import com.facebook.presto.execution.scheduler.nodeSelection.NodeSelector;
+import com.facebook.presto.execution.scheduler.nodeselection.NodeSelector;
 import com.facebook.presto.metadata.InternalNode;
 import com.facebook.presto.metadata.Split;
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/FixedSourcePartitionedScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/FixedSourcePartitionedScheduler.java
@@ -22,7 +22,7 @@ import com.facebook.presto.execution.scheduler.ScheduleResult.BlockedReason;
 import com.facebook.presto.execution.scheduler.group.DynamicLifespanScheduler;
 import com.facebook.presto.execution.scheduler.group.FixedLifespanScheduler;
 import com.facebook.presto.execution.scheduler.group.LifespanScheduler;
-import com.facebook.presto.execution.scheduler.nodeSelection.NodeSelector;
+import com.facebook.presto.execution.scheduler.nodeselection.NodeSelector;
 import com.facebook.presto.metadata.InternalNode;
 import com.facebook.presto.metadata.Split;
 import com.facebook.presto.operator.StageExecutionDescriptor;

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/ScaledWriterScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/ScaledWriterScheduler.java
@@ -16,7 +16,7 @@ package com.facebook.presto.execution.scheduler;
 import com.facebook.presto.execution.RemoteTask;
 import com.facebook.presto.execution.SqlStageExecution;
 import com.facebook.presto.execution.TaskStatus;
-import com.facebook.presto.execution.scheduler.nodeSelection.NodeSelector;
+import com.facebook.presto.execution.scheduler.nodeselection.NodeSelector;
 import com.facebook.presto.metadata.InternalNode;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.SettableFuture;

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SectionExecutionFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SectionExecutionFactory.java
@@ -25,7 +25,7 @@ import com.facebook.presto.execution.StageExecutionState;
 import com.facebook.presto.execution.StageId;
 import com.facebook.presto.execution.TaskStatus;
 import com.facebook.presto.execution.buffer.OutputBuffers;
-import com.facebook.presto.execution.scheduler.nodeSelection.NodeSelector;
+import com.facebook.presto.execution.scheduler.nodeselection.NodeSelector;
 import com.facebook.presto.failureDetector.FailureDetector;
 import com.facebook.presto.metadata.InternalNode;
 import com.facebook.presto.metadata.Metadata;

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/nodeselection/AbstractNodeSelectionConfigurationManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/nodeselection/AbstractNodeSelectionConfigurationManager.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.scheduler.nodeselection;
+
+import com.facebook.presto.execution.scheduler.nodeselection.NodeSelectionConfigurationSpec.NodeSelectionCriteriaSpec;
+
+import java.util.Optional;
+import java.util.Set;
+
+public abstract class AbstractNodeSelectionConfigurationManager
+        implements NodeSelectionConfigurationManager
+{
+    public Optional<Set<String>> getApplicablePools(NodeSelectionCriteria nodeSelectionCriteria)
+    {
+        //There could be different ways to load the spec, so abstract it out to inject custom implementation for loading the spec.
+        NodeSelectionConfigurationSpec nodeSelectionConfigurationSpec = loadNodeSelectionConfigurationSpec();
+
+        return Optional.of(nodeSelectionConfigurationSpec.getNodeSelectionCriteriaSpecs().stream()
+                .map(criteriaSpec -> match(criteriaSpec, nodeSelectionCriteria))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .findFirst().orElse(nodeSelectionConfigurationSpec.getDefaultApplicablePools()));
+    }
+
+    private Optional<Set<String>> match(NodeSelectionCriteriaSpec criteriaSpec, NodeSelectionCriteria nodeSelectionCriteria)
+    {
+        if (criteriaSpec.getClientTags().isPresent() && criteriaSpec.getClientTags().get().containsAll(nodeSelectionCriteria.getClientTags())) {
+            return Optional.of(criteriaSpec.getPools());
+        }
+        return Optional.empty();
+    }
+
+    protected abstract NodeSelectionConfigurationSpec loadNodeSelectionConfigurationSpec();
+}

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/nodeselection/FileBasedNodeSelectionConfigurationManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/nodeselection/FileBasedNodeSelectionConfigurationManager.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.scheduler.nodeselection;
+
+import com.facebook.airlift.json.JsonCodec;
+
+import javax.inject.Inject;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import static java.util.Objects.requireNonNull;
+
+public class FileBasedNodeSelectionConfigurationManager
+        extends AbstractNodeSelectionConfigurationManager
+{
+    private final NodeSelectionConfigurationSpec nodeSelectionConfigurationSpecs;
+
+    @Inject
+    public FileBasedNodeSelectionConfigurationManager(JsonCodec<NodeSelectionConfigurationSpec> nodeFilterConfigurationJsonCodec, NodeSelectionConfig nodeSelectionConfig)
+    {
+        try {
+            this.nodeSelectionConfigurationSpecs = requireNonNull(nodeFilterConfigurationJsonCodec.fromJson(Files.readAllBytes(Paths.get(nodeSelectionConfig.getConfigFile()))), "nodeFilterConfigurationSpecs is null");
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    protected NodeSelectionConfigurationSpec loadNodeSelectionConfigurationSpec()
+    {
+        return nodeSelectionConfigurationSpecs;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/nodeselection/NoOpNodeSelectionConfigurationManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/nodeselection/NoOpNodeSelectionConfigurationManager.java
@@ -11,20 +11,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.execution.scheduler.nodeSelection;
+package com.facebook.presto.execution.scheduler.nodeselection;
 
-import com.facebook.presto.metadata.InternalNode;
-import com.facebook.presto.metadata.Split;
+import java.util.Optional;
+import java.util.Set;
 
-import java.util.List;
-
-public interface NodeSelection
+public class NoOpNodeSelectionConfigurationManager
+        implements NodeSelectionConfigurationManager
 {
-    /**
-     *
-     * Pick nodes according to different strategies for a split
-     * @param split
-     * @return picked nodes
-     */
-    List<InternalNode> pickNodes(Split split);
+    @Override
+    public Optional<Set<String>> getApplicablePools(NodeSelectionCriteria nodeSelectionCriteria)
+    {
+        return Optional.empty();
+    }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/nodeselection/NodeSelection.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/nodeselection/NodeSelection.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.scheduler.nodeselection;
+
+import com.facebook.presto.metadata.InternalNode;
+import com.facebook.presto.metadata.Split;
+
+import java.util.List;
+
+public interface NodeSelection
+{
+    /**
+     *
+     * Pick nodes according to different strategies for a split
+     * @param split
+     * @return picked nodes
+     */
+    List<InternalNode> pickNodes(Split split);
+}

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/nodeselection/NodeSelectionConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/nodeselection/NodeSelectionConfig.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.scheduler.nodeselection;
+
+import com.facebook.airlift.configuration.Config;
+
+import javax.validation.constraints.NotNull;
+
+public class NodeSelectionConfig
+{
+    private String configFile;
+
+    @NotNull
+    public String getConfigFile()
+    {
+        return configFile;
+    }
+
+    @Config("node-selection.config-file")
+    public NodeSelectionConfig setConfigFile(String configFile)
+    {
+        this.configFile = configFile;
+        return this;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/nodeselection/NodeSelectionConfigurationManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/nodeselection/NodeSelectionConfigurationManager.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.scheduler.nodeselection;
+
+import java.util.Optional;
+import java.util.Set;
+
+public interface NodeSelectionConfigurationManager
+{
+    /**
+     * Method to get applicable pools given node selection criteria
+     *
+     * @param nodeSelectionCriteria Node selection criteria
+     * @return Applicable pools for the given node selection criteria
+     */
+    Optional<Set<String>> getApplicablePools(NodeSelectionCriteria nodeSelectionCriteria);
+}

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/nodeselection/NodeSelectionConfigurationSpec.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/nodeselection/NodeSelectionConfigurationSpec.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.scheduler.nodeselection;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableSet;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
+
+public class NodeSelectionConfigurationSpec
+{
+    private Set<String> defaultApplicablePools;
+    private List<NodeSelectionCriteriaSpec> nodeSelectionCriteriaSpecs;
+
+    @JsonCreator
+    public NodeSelectionConfigurationSpec(@JsonProperty("defaultApplicablePools") Set<String> defaultApplicablePools, @JsonProperty("nodeSelectionCriteria") List<NodeSelectionCriteriaSpec> nodeSelectionCriteriaSpecs)
+    {
+        this.defaultApplicablePools = requireNonNull(defaultApplicablePools, "defaultApplicablePools is null");
+        this.nodeSelectionCriteriaSpecs = requireNonNull(nodeSelectionCriteriaSpecs, "nodeSelectionCriteriaSpecs is null");
+    }
+
+    @JsonProperty
+    public List<NodeSelectionCriteriaSpec> getNodeSelectionCriteriaSpecs()
+    {
+        return nodeSelectionCriteriaSpecs;
+    }
+
+    @JsonProperty
+    public Set<String> getDefaultApplicablePools()
+    {
+        return defaultApplicablePools;
+    }
+
+    public static class NodeSelectionCriteriaSpec
+    {
+        private final Optional<Set<String>> clientTags;
+        private final Set<String> pools;
+
+        @JsonCreator
+        public NodeSelectionCriteriaSpec(@JsonProperty("clientTags") Optional<Set<String>> clientTags, @JsonProperty("pools") Set<String> pools)
+        {
+            this.clientTags = requireNonNull(clientTags, "clientTags is null");
+            this.pools = ImmutableSet.copyOf(requireNonNull(pools, "pools is null"));
+        }
+
+        @JsonProperty
+        public Optional<Set<String>> getClientTags()
+        {
+            return clientTags;
+        }
+
+        @JsonProperty
+        public Set<String> getPools()
+        {
+            return pools;
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/nodeselection/NodeSelectionCriteria.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/nodeselection/NodeSelectionCriteria.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.scheduler.nodeselection;
+
+import com.google.common.collect.ImmutableSet;
+
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
+
+public class NodeSelectionCriteria
+{
+    private final Set<String> clientTags;
+
+    public NodeSelectionCriteria(Set<String> clientTags)
+    {
+        this.clientTags = ImmutableSet.copyOf(requireNonNull(clientTags, "clientTags is null"));
+    }
+
+    public Set<String> getClientTags()
+    {
+        return clientTags;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/nodeselection/NodeSelectionStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/nodeselection/NodeSelectionStats.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.execution.scheduler.nodeSelection;
+package com.facebook.presto.execution.scheduler.nodeselection;
 
 import com.facebook.airlift.stats.CounterStat;
 import org.weakref.jmx.Managed;

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/nodeselection/NodeSelector.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/nodeselection/NodeSelector.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.execution.scheduler.nodeSelection;
+package com.facebook.presto.execution.scheduler.nodeselection;
 
 import com.facebook.presto.execution.RemoteTask;
 import com.facebook.presto.execution.scheduler.BucketNodeMap;

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/nodeselection/RandomNodeSelection.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/nodeselection/RandomNodeSelection.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.execution.scheduler.nodeSelection;
+package com.facebook.presto.execution.scheduler.nodeselection;
 
 import com.facebook.presto.execution.scheduler.ResettableRandomizedIterator;
 import com.facebook.presto.metadata.InternalNode;

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/nodeselection/SimpleNodeSelector.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/nodeselection/SimpleNodeSelector.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.execution.scheduler.nodeSelection;
+package com.facebook.presto.execution.scheduler.nodeselection;
 
 import com.facebook.airlift.log.Logger;
 import com.facebook.presto.execution.NodeTaskMap;

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/nodeselection/SimpleTtlNodeSelector.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/nodeselection/SimpleTtlNodeSelector.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.execution.scheduler.nodeSelection;
+package com.facebook.presto.execution.scheduler.nodeselection;
 
 import com.facebook.airlift.log.Logger;
 import com.facebook.presto.Session;

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/nodeselection/TopologyAwareNodeSelector.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/nodeselection/TopologyAwareNodeSelector.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.execution.scheduler.nodeSelection;
+package com.facebook.presto.execution.scheduler.nodeselection;
 
 import com.facebook.airlift.log.Logger;
 import com.facebook.airlift.stats.CounterStat;

--- a/presto-main/src/main/java/com/facebook/presto/metadata/DiscoveryNodeManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/DiscoveryNodeManager.java
@@ -162,7 +162,7 @@ public final class DiscoveryNodeManager
             OptionalInt thriftPort = getThriftServerPort(service);
             NodeVersion nodeVersion = getNodeVersion(service);
             if (uri != null && nodeVersion != null) {
-                InternalNode node = new InternalNode(service.getNodeId(), uri, thriftPort, nodeVersion, isCoordinator(service), isResourceManager(service), ALIVE);
+                InternalNode node = new InternalNode(service.getNodeId(), uri, thriftPort, nodeVersion, isCoordinator(service), isResourceManager(service), ALIVE, service.getPool());
 
                 if (node.getNodeIdentifier().equals(currentNodeId)) {
                     checkState(
@@ -284,7 +284,7 @@ public final class DiscoveryNodeManager
             boolean coordinator = isCoordinator(service);
             boolean resourceManager = isResourceManager(service);
             if (uri != null && nodeVersion != null) {
-                InternalNode node = new InternalNode(service.getNodeId(), uri, thriftPort, nodeVersion, coordinator, resourceManager, ALIVE);
+                InternalNode node = new InternalNode(service.getNodeId(), uri, thriftPort, nodeVersion, coordinator, resourceManager, ALIVE, service.getPool());
                 NodeState nodeState = getNodeState(node);
 
                 switch (nodeState) {
@@ -348,7 +348,7 @@ public final class DiscoveryNodeManager
                 InternalNode deadNode = nodes.get(nodeId);
                 Set<ConnectorId> deadNodeConnectorIds = connectorIdsByNodeId.get(nodeId);
                 for (ConnectorId id : deadNodeConnectorIds) {
-                    byConnectorIdBuilder.put(id, new InternalNode(deadNode.getNodeIdentifier(), deadNode.getInternalUri(), deadNode.getThriftPort(), deadNode.getNodeVersion(), deadNode.isCoordinator(), deadNode.isResourceManager(), DEAD));
+                    byConnectorIdBuilder.put(id, new InternalNode(deadNode.getNodeIdentifier(), deadNode.getInternalUri(), deadNode.getThriftPort(), deadNode.getNodeVersion(), deadNode.isCoordinator(), deadNode.isResourceManager(), DEAD, deadNode.getPool()));
                 }
             }
         }

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerConfig.java
@@ -31,6 +31,7 @@ public class ServerConfig
     private Duration gracePeriod = new Duration(2, MINUTES);
     private boolean enhancedErrorReporting = true;
     private boolean queryResultsCompressionEnabled = true;
+    private boolean nodeFilterEnabled;
 
     public boolean isResourceManager()
     {
@@ -143,6 +144,18 @@ public class ServerConfig
     public ServerConfig setQueryResultsCompressionEnabled(boolean queryResultsCompressionEnabled)
     {
         this.queryResultsCompressionEnabled = queryResultsCompressionEnabled;
+        return this;
+    }
+
+    public boolean isNodeFilterEnabled()
+    {
+        return nodeFilterEnabled;
+    }
+
+    @Config("node-filter.enabled")
+    public ServerConfig setNodeFilterEnabled(boolean nodeFilterEnabled)
+    {
+        this.nodeFilterEnabled = nodeFilterEnabled;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -66,7 +66,9 @@ import com.facebook.presto.execution.scheduler.NetworkTopology;
 import com.facebook.presto.execution.scheduler.NodeScheduler;
 import com.facebook.presto.execution.scheduler.NodeSchedulerConfig;
 import com.facebook.presto.execution.scheduler.NodeSchedulerExporter;
-import com.facebook.presto.execution.scheduler.nodeSelection.NodeSelectionStats;
+import com.facebook.presto.execution.scheduler.nodeselection.NoOpNodeSelectionConfigurationManager;
+import com.facebook.presto.execution.scheduler.nodeselection.NodeSelectionConfigurationManager;
+import com.facebook.presto.execution.scheduler.nodeselection.NodeSelectionStats;
 import com.facebook.presto.index.IndexManager;
 import com.facebook.presto.memory.LocalMemoryManager;
 import com.facebook.presto.memory.LocalMemoryManagerExporter;
@@ -322,6 +324,9 @@ public class ServerMainModule
         // node scheduler
         // TODO: remove from NodePartitioningManager and move to CoordinatorModule
         configBinder(binder).bindConfig(NodeSchedulerConfig.class);
+        if (!serverConfig.isNodeFilterEnabled()) {
+            binder.bind(NodeSelectionConfigurationManager.class).to(NoOpNodeSelectionConfigurationManager.class).in(Scopes.SINGLETON);
+        }
         binder.bind(NodeScheduler.class).in(Scopes.SINGLETON);
         binder.bind(NodeSelectionStats.class).in(Scopes.SINGLETON);
         newExporter(binder).export(NodeSelectionStats.class).withGeneratedName();

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/NodePartitioningManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/NodePartitioningManager.java
@@ -19,7 +19,7 @@ import com.facebook.presto.execution.scheduler.BucketNodeMap;
 import com.facebook.presto.execution.scheduler.FixedBucketNodeMap;
 import com.facebook.presto.execution.scheduler.NodeScheduler;
 import com.facebook.presto.execution.scheduler.group.DynamicBucketNodeMap;
-import com.facebook.presto.execution.scheduler.nodeSelection.NodeSelectionStats;
+import com.facebook.presto.execution.scheduler.nodeselection.NodeSelectionStats;
 import com.facebook.presto.metadata.InternalNode;
 import com.facebook.presto.metadata.Split;
 import com.facebook.presto.operator.BucketPartitionFunction;

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/SystemPartitioningHandle.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/SystemPartitioningHandle.java
@@ -17,7 +17,7 @@ import com.facebook.presto.Session;
 import com.facebook.presto.common.Page;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.execution.scheduler.NodeScheduler;
-import com.facebook.presto.execution.scheduler.nodeSelection.NodeSelector;
+import com.facebook.presto.execution.scheduler.nodeselection.NodeSelector;
 import com.facebook.presto.metadata.InternalNode;
 import com.facebook.presto.operator.BucketPartitionFunction;
 import com.facebook.presto.operator.HashGenerator;

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -78,7 +78,8 @@ import com.facebook.presto.execution.scheduler.NodeScheduler;
 import com.facebook.presto.execution.scheduler.NodeSchedulerConfig;
 import com.facebook.presto.execution.scheduler.StreamingPlanSection;
 import com.facebook.presto.execution.scheduler.StreamingSubPlan;
-import com.facebook.presto.execution.scheduler.nodeSelection.NodeSelectionStats;
+import com.facebook.presto.execution.scheduler.nodeselection.NoOpNodeSelectionConfigurationManager;
+import com.facebook.presto.execution.scheduler.nodeselection.NodeSelectionStats;
 import com.facebook.presto.execution.warnings.DefaultWarningCollector;
 import com.facebook.presto.execution.warnings.WarningCollectorConfig;
 import com.facebook.presto.index.IndexManager;
@@ -344,7 +345,8 @@ public class LocalQueryRunner
                 nodeSchedulerConfig,
                 new NodeTaskMap(finalizerService),
                 new ThrowingNodeTtlFetcherManager(),
-                new NoOpQueryManager());
+                new NoOpQueryManager(),
+                new NoOpNodeSelectionConfigurationManager());
         this.pageSinkManager = new PageSinkManager();
         CatalogManager catalogManager = new CatalogManager();
         this.transactionManager = InMemoryTransactionManager.create(

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestCostCalculator.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestCostCalculator.java
@@ -22,7 +22,8 @@ import com.facebook.presto.execution.QueryManagerConfig;
 import com.facebook.presto.execution.scheduler.LegacyNetworkTopology;
 import com.facebook.presto.execution.scheduler.NodeScheduler;
 import com.facebook.presto.execution.scheduler.NodeSchedulerConfig;
-import com.facebook.presto.execution.scheduler.nodeSelection.NodeSelectionStats;
+import com.facebook.presto.execution.scheduler.nodeselection.NoOpNodeSelectionConfigurationManager;
+import com.facebook.presto.execution.scheduler.nodeselection.NodeSelectionStats;
 import com.facebook.presto.metadata.CatalogManager;
 import com.facebook.presto.metadata.InMemoryNodeManager;
 import com.facebook.presto.metadata.MetadataManager;
@@ -138,7 +139,8 @@ public class TestCostCalculator
                 new NodeSchedulerConfig().setIncludeCoordinator(true),
                 new NodeTaskMap(finalizerService),
                 new ThrowingNodeTtlFetcherManager(),
-                new NoOpQueryManager());
+                new NoOpQueryManager(),
+                new NoOpNodeSelectionConfigurationManager());
         PartitioningProviderManager partitioningProviderManager = new PartitioningProviderManager();
         nodePartitioningManager = new NodePartitioningManager(nodeScheduler, partitioningProviderManager, new NodeSelectionStats());
         planFragmenter = new PlanFragmenter(metadata, nodePartitioningManager, new QueryManagerConfig(), new SqlParser(), new FeaturesConfig());

--- a/presto-main/src/test/java/com/facebook/presto/execution/BenchmarkNodeScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/BenchmarkNodeScheduler.java
@@ -22,8 +22,9 @@ import com.facebook.presto.execution.scheduler.NetworkLocation;
 import com.facebook.presto.execution.scheduler.NetworkTopology;
 import com.facebook.presto.execution.scheduler.NodeScheduler;
 import com.facebook.presto.execution.scheduler.NodeSchedulerConfig;
-import com.facebook.presto.execution.scheduler.nodeSelection.NodeSelectionStats;
-import com.facebook.presto.execution.scheduler.nodeSelection.NodeSelector;
+import com.facebook.presto.execution.scheduler.nodeselection.NoOpNodeSelectionConfigurationManager;
+import com.facebook.presto.execution.scheduler.nodeselection.NodeSelectionStats;
+import com.facebook.presto.execution.scheduler.nodeselection.NodeSelector;
 import com.facebook.presto.metadata.InMemoryNodeManager;
 import com.facebook.presto.metadata.InternalNode;
 import com.facebook.presto.metadata.Split;
@@ -178,7 +179,7 @@ public class BenchmarkNodeScheduler
 
             InMemoryNodeManager nodeManager = new InMemoryNodeManager();
             nodeManager.addNode(CONNECTOR_ID, nodes);
-            NodeScheduler nodeScheduler = new NodeScheduler(getNetworkTopology(), nodeManager, new NodeSelectionStats(), getNodeSchedulerConfig(), nodeTaskMap, new ThrowingNodeTtlFetcherManager(), new NoOpQueryManager());
+            NodeScheduler nodeScheduler = new NodeScheduler(getNetworkTopology(), nodeManager, new NodeSelectionStats(), getNodeSchedulerConfig(), nodeTaskMap, new ThrowingNodeTtlFetcherManager(), new NoOpQueryManager(), new NoOpNodeSelectionConfigurationManager());
             Session session = TestingSession.testSessionBuilder()
                     .setSystemProperty(MAX_UNACKNOWLEDGED_SPLITS_PER_TASK, Integer.toString(Integer.MAX_VALUE))
                     .build();

--- a/presto-main/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
@@ -26,7 +26,8 @@ import com.facebook.presto.execution.scheduler.LegacyNetworkTopology;
 import com.facebook.presto.execution.scheduler.NodeScheduler;
 import com.facebook.presto.execution.scheduler.NodeSchedulerConfig;
 import com.facebook.presto.execution.scheduler.TableWriteInfo;
-import com.facebook.presto.execution.scheduler.nodeSelection.NodeSelectionStats;
+import com.facebook.presto.execution.scheduler.nodeselection.NoOpNodeSelectionConfigurationManager;
+import com.facebook.presto.execution.scheduler.nodeselection.NodeSelectionStats;
 import com.facebook.presto.index.IndexManager;
 import com.facebook.presto.memory.MemoryManagerConfig;
 import com.facebook.presto.metadata.ConnectorMetadataUpdaterManager;
@@ -146,7 +147,8 @@ public final class TaskTestUtils
                 new NodeSchedulerConfig().setIncludeCoordinator(true),
                 new NodeTaskMap(finalizerService),
                 new ThrowingNodeTtlFetcherManager(),
-                new NoOpQueryManager());
+                new NoOpQueryManager(),
+                new NoOpNodeSelectionConfigurationManager());
         PartitioningProviderManager partitioningProviderManager = new PartitioningProviderManager();
         NodePartitioningManager nodePartitioningManager = new NodePartitioningManager(nodeScheduler, partitioningProviderManager, new NodeSelectionStats());
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestClusterSizeMonitor.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestClusterSizeMonitor.java
@@ -30,6 +30,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.facebook.airlift.concurrent.MoreFutures.addExceptionCallback;
 import static com.facebook.airlift.concurrent.MoreFutures.addSuccessCallback;
+import static com.facebook.airlift.discovery.client.ServiceSelectorConfig.DEFAULT_POOL;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -172,6 +173,6 @@ public class TestClusterSizeMonitor
     private void addResourceManager(InMemoryNodeManager nodeManager)
     {
         String identifier = "resource_manager/" + numResourceManagers.incrementAndGet();
-        nodeManager.addNode(CONNECTOR_ID, new InternalNode(identifier, URI.create("localhost/" + identifier), new NodeVersion("1"), false, true));
+        nodeManager.addNode(CONNECTOR_ID, new InternalNode(identifier, URI.create("localhost/" + identifier), new NodeVersion("1"), false, true, DEFAULT_POOL));
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestPartialResultQueryTaskTracker.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestPartialResultQueryTaskTracker.java
@@ -34,6 +34,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
 
 import static com.facebook.airlift.concurrent.Threads.daemonThreadsNamed;
+import static com.facebook.airlift.discovery.client.ServiceSelectorConfig.DEFAULT_POOL;
 import static com.facebook.presto.execution.warnings.WarningHandlingLevel.NORMAL;
 import static com.facebook.presto.spi.StandardWarningCode.PARTIAL_RESULT_WARNING;
 import static java.util.concurrent.Executors.newCachedThreadPool;
@@ -66,8 +67,8 @@ public class TestPartialResultQueryTaskTracker
             throws Exception
     {
         PartialResultQueryTaskTracker tracker = new PartialResultQueryTaskTracker(partialResultQueryManager, 0.50, 2.0, warningCollector);
-        InternalNode node1 = new InternalNode(UUID.randomUUID().toString(), URI.create("https://192.0.2.8"), new NodeVersion("1"), false, false);
-        InternalNode node2 = new InternalNode(UUID.randomUUID().toString(), URI.create("https://192.0.2.9"), new NodeVersion("1"), false, false);
+        InternalNode node1 = new InternalNode(UUID.randomUUID().toString(), URI.create("https://192.0.2.8"), new NodeVersion("1"), false, false, DEFAULT_POOL);
+        InternalNode node2 = new InternalNode(UUID.randomUUID().toString(), URI.create("https://192.0.2.9"), new NodeVersion("1"), false, false, DEFAULT_POOL);
         TaskId taskId1 = new TaskId("test1", 1, 0, 1);
         TaskId taskId2 = new TaskId("test2", 2, 0, 1);
         RemoteTask task1 = taskFactory.createTableScanTask(taskId1, node1, ImmutableList.of(), new NodeTaskMap.NodeStatsTracker(delta -> {}, delta -> {}, (age, delta) -> {}));

--- a/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestSourcePartitionedScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestSourcePartitionedScheduler.java
@@ -27,7 +27,8 @@ import com.facebook.presto.execution.StageExecutionId;
 import com.facebook.presto.execution.StageId;
 import com.facebook.presto.execution.TestSqlTaskManager.MockLocationFactory;
 import com.facebook.presto.execution.buffer.OutputBuffers.OutputBufferId;
-import com.facebook.presto.execution.scheduler.nodeSelection.NodeSelectionStats;
+import com.facebook.presto.execution.scheduler.nodeselection.NoOpNodeSelectionConfigurationManager;
+import com.facebook.presto.execution.scheduler.nodeselection.NodeSelectionStats;
 import com.facebook.presto.failureDetector.NoOpFailureDetector;
 import com.facebook.presto.metadata.InMemoryNodeManager;
 import com.facebook.presto.metadata.InternalNode;
@@ -322,7 +323,8 @@ public class TestSourcePartitionedScheduler
                     new NodeSchedulerConfig().setIncludeCoordinator(false),
                     nodeTaskMap,
                     new ThrowingNodeTtlFetcherManager(),
-                    new NoOpQueryManager());
+                    new NoOpQueryManager(),
+                    new NoOpNodeSelectionConfigurationManager());
 
             SubPlan plan = createPlan();
             SqlStageExecution stage = createSqlStageExecution(plan, nodeTaskMap);
@@ -463,7 +465,8 @@ public class TestSourcePartitionedScheduler
                 nodeSchedulerConfig,
                 nodeTaskMap,
                 new ThrowingNodeTtlFetcherManager(),
-                new NoOpQueryManager());
+                new NoOpQueryManager(),
+                new NoOpNodeSelectionConfigurationManager());
         SplitSource splitSource = new ConnectorAwareSplitSource(CONNECTOR_ID, TestingTransactionHandle.create(), connectorSplitSource);
         SplitPlacementPolicy placementPolicy = new DynamicSplitPlacementPolicy(nodeScheduler.createNodeSelector(TestingSession.testSessionBuilder().build(), splitSource.getConnectorId()), stage::getAllTasks);
         return newSourcePartitionedSchedulerAsStageScheduler(stage, TABLE_SCAN_NODE_ID, splitSource, placementPolicy, splitBatchSize);

--- a/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestRandomResourceManagerAddressSelector.java
+++ b/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestRandomResourceManagerAddressSelector.java
@@ -24,6 +24,7 @@ import java.net.URI;
 import java.util.Optional;
 import java.util.OptionalInt;
 
+import static com.facebook.airlift.discovery.client.ServiceSelectorConfig.DEFAULT_POOL;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -58,9 +59,9 @@ public class TestRandomResourceManagerAddressSelector
         InMemoryNodeManager internalNodeManager = new InMemoryNodeManager();
         RandomResourceManagerAddressSelector selector = new RandomResourceManagerAddressSelector(internalNodeManager, hostAndPorts -> Optional.of(hostAndPorts.get(0)));
 
-        internalNodeManager.addNode(CONNECTOR_ID, new InternalNode("1", URI.create("local://localhost:123/1"), OptionalInt.empty(), "1", false, true));
-        internalNodeManager.addNode(CONNECTOR_ID, new InternalNode("2", URI.create("local://localhost:456/1"), OptionalInt.of(2), "1", false, true));
-        internalNodeManager.addNode(CONNECTOR_ID, new InternalNode("3", URI.create("local://localhost:789/2"), OptionalInt.of(3), "1", false, true));
+        internalNodeManager.addNode(CONNECTOR_ID, new InternalNode("1", URI.create("local://localhost:123/1"), OptionalInt.empty(), "1", false, true, DEFAULT_POOL));
+        internalNodeManager.addNode(CONNECTOR_ID, new InternalNode("2", URI.create("local://localhost:456/1"), OptionalInt.of(2), "1", false, true, DEFAULT_POOL));
+        internalNodeManager.addNode(CONNECTOR_ID, new InternalNode("3", URI.create("local://localhost:789/2"), OptionalInt.of(3), "1", false, true, DEFAULT_POOL));
 
         Optional<SimpleAddressSelector.SimpleAddress> address = selector.selectAddress(Optional.empty());
         assertTrue(address.isPresent());

--- a/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStatusSender.java
+++ b/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStatusSender.java
@@ -30,6 +30,7 @@ import org.testng.annotations.Test;
 import java.net.URI;
 import java.util.OptionalInt;
 
+import static com.facebook.airlift.discovery.client.ServiceSelectorConfig.DEFAULT_POOL;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static java.lang.String.format;
 import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
@@ -67,7 +68,7 @@ public class TestResourceManagerClusterStatusSender
     {
         resourceManagerClient = new TestingResourceManagerClient();
         InMemoryNodeManager nodeManager = new InMemoryNodeManager();
-        nodeManager.addNode(CONNECTOR_ID, new InternalNode("identifier", URI.create("http://localhost:80/identifier"), OptionalInt.of(1), "1", false, true));
+        nodeManager.addNode(CONNECTOR_ID, new InternalNode("identifier", URI.create("http://localhost:80/identifier"), OptionalInt.of(1), "1", false, true, DEFAULT_POOL));
 
         sender = new ResourceManagerClusterStatusSender(
                 (addressSelectionContext, headers) -> resourceManagerClient,

--- a/presto-main/src/test/java/com/facebook/presto/server/TestServerConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestServerConfig.java
@@ -38,7 +38,8 @@ public class TestServerConfig
                 .setEnhancedErrorReporting(true)
                 .setQueryResultsCompressionEnabled(true)
                 .setResourceManagerEnabled(false)
-                .setResourceManager(false));
+                .setResourceManager(false)
+                .setNodeFilterEnabled(false));
     }
 
     @Test
@@ -54,6 +55,7 @@ public class TestServerConfig
                 .put("query-results.compression-enabled", "false")
                 .put("resource-manager-enabled", "true")
                 .put("resource-manager", "true")
+                .put("node-filter.enabled", "true")
                 .build();
 
         ServerConfig expected = new ServerConfig()
@@ -65,7 +67,8 @@ public class TestServerConfig
                 .setEnhancedErrorReporting(false)
                 .setQueryResultsCompressionEnabled(false)
                 .setResourceManagerEnabled(true)
-                .setResourceManager(true);
+                .setResourceManager(true)
+                .setNodeFilterEnabled(true);
 
         assertFullMapping(properties, expected);
     }

--- a/presto-main/src/test/resources/node_selection_config.json
+++ b/presto-main/src/test/resources/node_selection_config.json
@@ -1,0 +1,22 @@
+{
+  "defaultApplicablePools" : ["pool3"],
+  "nodeSelectionCriteria": [
+    {
+      "clientTags": [
+        "tag_for_pool_1_2"
+      ],
+      "pools": [
+        "pool1",
+        "pool2"
+      ]
+    },
+    {
+      "clientTags": [
+        "tag_for_pool_1_2_3"
+      ],
+      "pools": [
+        "pool3"
+      ]
+    }
+  ]
+}

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/node/PrestoSparkNodePartitioningManager.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/node/PrestoSparkNodePartitioningManager.java
@@ -16,7 +16,7 @@ package com.facebook.presto.spark.node;
 import com.facebook.presto.Session;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.execution.scheduler.BucketNodeMap;
-import com.facebook.presto.execution.scheduler.nodeSelection.NodeSelectionStats;
+import com.facebook.presto.execution.scheduler.nodeselection.NodeSelectionStats;
 import com.facebook.presto.operator.PartitionFunction;
 import com.facebook.presto.spi.connector.ConnectorPartitionHandle;
 import com.facebook.presto.sql.planner.NodePartitionMap;

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/node/PrestoSparkNodeScheduler.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/node/PrestoSparkNodeScheduler.java
@@ -21,8 +21,9 @@ import com.facebook.presto.execution.scheduler.LegacyNetworkTopology;
 import com.facebook.presto.execution.scheduler.NetworkLocationCache;
 import com.facebook.presto.execution.scheduler.NodeScheduler;
 import com.facebook.presto.execution.scheduler.NodeSchedulerConfig;
-import com.facebook.presto.execution.scheduler.nodeSelection.NodeSelectionStats;
-import com.facebook.presto.execution.scheduler.nodeSelection.NodeSelector;
+import com.facebook.presto.execution.scheduler.nodeselection.NoOpNodeSelectionConfigurationManager;
+import com.facebook.presto.execution.scheduler.nodeselection.NodeSelectionStats;
+import com.facebook.presto.execution.scheduler.nodeselection.NodeSelector;
 import com.facebook.presto.metadata.InMemoryNodeManager;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.ttl.nodettlfetchermanagers.ThrowingNodeTtlFetcherManager;
@@ -50,7 +51,8 @@ public class PrestoSparkNodeScheduler
                 new NodeTaskMap(new FinalizerService()),
                 new Duration(5, SECONDS),
                 new ThrowingNodeTtlFetcherManager(),
-                new NoOpQueryManager());
+                new NoOpQueryManager(),
+                new NoOpNodeSelectionConfigurationManager());
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/Node.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/Node.java
@@ -34,4 +34,6 @@ public interface Node
     boolean isCoordinator();
 
     boolean isResourceManager();
+
+    String getPool();
 }


### PR DESCRIPTION
We have few workloads where we want to utilize a particular type of worker nodes. As part of this PR, we are providing way to filter nodes based on pool types applicable for certain types of queries. This PR is stacked on top of [presto/#/16670](https://github.com/prestodb/presto/pull/16670). 

**Note:** The commit "Introduce pool concept for nodes" has already been reviewed under PR#16670 

Test plan - unit test


```
== RELEASE NOTES ==

General Changes
* Provide capability to filter nodes based on pool type
```
