### PR TITLE
Google Sheet Connector

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,6 +173,7 @@
         <module>presto-testng-services</module>
         <module>presto-node-ttl-fetchers</module>
         <module>presto-cluster-ttl-providers</module>
+        <module>presto-google-sheets</module>
     </modules>
 
     <dependencyManagement>

--- a/presto-docs/src/main/sphinx/connector.rst
+++ b/presto-docs/src/main/sphinx/connector.rst
@@ -14,6 +14,7 @@ from different data sources.
     connector/cassandra
     connector/druid
     connector/elasticsearch
+    connector/gsheets
     connector/hive
     connector/hive-security
     connector/iceberg

--- a/presto-docs/src/main/sphinx/connector/googlesheets.rst
+++ b/presto-docs/src/main/sphinx/connector/googlesheets.rst
@@ -1,0 +1,104 @@
+=======================
+Google Sheets connector
+=======================
+
+The Google Sheets connector allows reading `Google Sheets <https://www.google.com/sheets/about/>`_ spreadsheets as tables in Presto.
+
+Configuration
+-------------
+
+Create ``etc/catalog/gsheets.properties``
+to mount the Google Sheets connector as the ``gsheets`` catalog,
+replacing the properties as appropriate:
+
+.. code-block:: text
+
+    connector.name=gsheets
+    credentials-path=/path/to/google-sheets-credentials.json
+    metadata-sheet-id=exampleId
+
+Configuration properties
+------------------------
+
+The following configuration properties are available:
+
+=================================== =====================================================================
+Property Name                       Description
+=================================== =====================================================================
+``credentials-path``                Path to the Google API JSON key file
+``metadata-sheet-id``               Sheet ID of the spreadsheet, that contains the table mapping
+``sheets-data-max-cache-size``      Maximum number of spreadsheets to cache, defaults to ``1000``
+``sheets-data-expire-after-write``  How long to cache spreadsheet data or metadata, defaults to ``5m``
+=================================== =====================================================================
+
+Credentials
+-----------
+
+The connector requires credentials in order to access the Google Sheets API.
+
+1. Open the `Google Sheets API <https://console.developers.google.com/apis/library/sheets.googleapis.com>`_
+   page and click the *Enable* button. This takes you to the API manager page.
+
+2. Select a project using the drop down menu at the top of the page.
+   Create a new project, if you do not already have one.
+
+3. Choose *Credentials* in the left panel.
+
+4. Click *Manage service accounts*, then create a service account for the connector.
+   On the *Create key* step, create and download a key in JSON format.
+
+The key file needs to be available on the Presto coordinator and workers.
+Set the ``credentials-path`` configuration property to point to this file.
+The exact name of the file does not matter -- it can be named anything.
+
+Metadata sheet
+--------------
+
+The metadata sheet is used to map table names to sheet IDs.
+Create a new metadata sheet. The first row must be a header row
+containing the following columns in this order:
+
+* Table Name
+* Sheet ID
+* Owner
+* Notes
+
+See this `example sheet <https://docs.google.com/spreadsheets/d/1Es4HhWALUQjoa-bQh4a8B5HROz7dpGMfq_HbfoaW5LM>`_
+as a reference.
+
+The metadata sheet must be shared with the service account user,
+the one for which the key credentials file was created. Click the *Share*
+button to share the sheet with the email address of the service account.
+
+Set the ``metadata-sheet-id`` configuration property to the ID of this sheet.
+
+Querying sheets
+---------------
+
+The service account user must have access to the sheet in order for Presto
+to query it. Click the *Share* button to share the sheet with the email
+address of the service account.
+
+The sheet needs to be mapped to a Presto table name. Specify a table name
+(column A) and the sheet ID (column B) in the metadata sheet. To refer
+to a specific tab in the sheet, add the tab name after the sheet ID, separated
+with ``#``. If tab name is not provided, connector loads only 10,000 rows by default from
+the first tab in the sheet.
+
+API usage limits
+----------------
+
+The Google Sheets API has `usage limits <https://developers.google.com/sheets/api/limits>`_,
+that may impact the usage of this connector. Increasing the cache duration and/or size
+may prevent the limit from being reached. Running queries on the ``information_schema.columns``
+table without a schema and table name filter may lead to hitting the limit, as this requires
+fetching the sheet data for every table, unless it is already cached.
+
+.. _google-sheets-sql-support:
+
+SQL support
+-----------
+
+The connector provides :ref:`globally available <sql-globally-available>` and
+:ref:`read operation <sql-read-operations>` statements to access data and
+metadata in Google Sheets.

--- a/presto-google-sheets/pom.xml
+++ b/presto-google-sheets/pom.xml
@@ -1,0 +1,161 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.facebook.presto</groupId>
+        <artifactId>presto-root</artifactId>
+        <version>0.267-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>presto-google-sheets</artifactId>
+    <description>Presto - Google Sheets Connector</description>
+    <packaging>presto-plugin</packaging>
+
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-common</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-tests</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.apis</groupId>
+            <artifactId>google-api-services-sheets</artifactId>
+            <version>v4-rev516-1.23.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava-jdk5</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>log</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>json</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-spi</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>bootstrap</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>configuration</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>units</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.oauth-client</groupId>
+            <artifactId>google-oauth-client</artifactId>
+            <version>1.27.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.http-client</groupId>
+            <artifactId>google-http-client</artifactId>
+            <version>1.27.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.http-client</groupId>
+            <artifactId>google-http-client-jackson2</artifactId>
+            <version>1.27.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>slice</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.api-client</groupId>
+            <artifactId>google-api-client</artifactId>
+            <version>1.27.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava-jdk5</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-main</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/presto-google-sheets/src/main/java/com/facebook/presto/google/sheets/SheetsClient.java
+++ b/presto-google-sheets/src/main/java/com/facebook/presto/google/sheets/SheetsClient.java
@@ -1,0 +1,227 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.google.sheets;
+
+import com.facebook.airlift.json.JsonCodec;
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.common.type.VarcharType;
+import com.facebook.presto.spi.PrestoException;
+import com.google.api.client.auth.oauth2.Credential;
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.services.sheets.v4.Sheets;
+import com.google.api.services.sheets.v4.SheetsScopes;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.UncheckedExecutionException;
+
+import javax.inject.Inject;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.GeneralSecurityException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.facebook.presto.google.sheets.SheetsErrorCode.SHEETS_BAD_CREDENTIALS_ERROR;
+import static com.facebook.presto.google.sheets.SheetsErrorCode.SHEETS_METASTORE_ERROR;
+import static com.facebook.presto.google.sheets.SheetsErrorCode.SHEETS_TABLE_LOAD_ERROR;
+import static com.facebook.presto.google.sheets.SheetsErrorCode.SHEETS_UNKNOWN_TABLE_ERROR;
+import static com.google.api.client.googleapis.javanet.GoogleNetHttpTransport.newTrustedTransport;
+import static com.google.common.cache.CacheLoader.from;
+import static java.util.Locale.ENGLISH;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+public class SheetsClient
+{
+    private static final Logger log = Logger.get(SheetsClient.class);
+
+    private static final String APPLICATION_NAME = "Presto google sheets integration";
+    private static final JsonFactory JSON_FACTORY = JacksonFactory.getDefaultInstance();
+
+    private static final List<String> SCOPES = ImmutableList.of(SheetsScopes.SPREADSHEETS_READONLY);
+
+    private final LoadingCache<String, Optional<String>> tableSheetMappingCache;
+    private final LoadingCache<String, List<List<Object>>> sheetDataCache;
+
+    private final String metadataSheetId;
+    private final String credentialsFilePath;
+
+    private final Sheets sheetsService;
+
+    @Inject
+    public SheetsClient(SheetsConfig config, JsonCodec<Map<String, List<SheetsTable>>> catalogCodec)
+    {
+        requireNonNull(config, "config is null");
+        requireNonNull(catalogCodec, "catalogCodec is null");
+
+        this.metadataSheetId = config.getMetadataSheetId();
+        this.credentialsFilePath = config.getCredentialsFilePath();
+
+        try {
+            this.sheetsService = new Sheets.Builder(newTrustedTransport(), JSON_FACTORY, getCredentials()).setApplicationName(APPLICATION_NAME).build();
+        }
+        catch (GeneralSecurityException | IOException e) {
+            throw new PrestoException(SHEETS_BAD_CREDENTIALS_ERROR, e);
+        }
+        long expiresAfterWriteMillis = config.getSheetsDataExpireAfterWrite().toMillis();
+        long maxCacheSize = config.getSheetsDataMaxCacheSize();
+
+        this.tableSheetMappingCache = newCacheBuilder(expiresAfterWriteMillis, maxCacheSize)
+                .build(new CacheLoader<String, Optional<String>>()
+                {
+                    @Override
+                    public Optional<String> load(String tableName)
+                    {
+                        return getSheetExpressionForTable(tableName);
+                    }
+                });
+
+        this.sheetDataCache = newCacheBuilder(expiresAfterWriteMillis, maxCacheSize).build(from(this::readAllValuesFromSheetExpression));
+    }
+
+    public Optional<SheetsTable> getTable(String tableName)
+    {
+        List<List<Object>> values = readAllValues(tableName);
+        if (values.size() > 0) {
+            ImmutableList.Builder<SheetsColumn> columns = ImmutableList.builder();
+            Set<String> columnNames = new HashSet<>();
+            // Assuming 1st line is always header
+            List<Object> header = values.get(0);
+            int count = 0;
+            for (Object column : header) {
+                String columnValue = column.toString().toLowerCase(ENGLISH);
+                // when empty or repeated column header, adding a placeholder column name
+                if (columnValue.isEmpty() || columnNames.contains(columnValue)) {
+                    columnValue = "column_" + ++count;
+                }
+                columnNames.add(columnValue);
+                columns.add(new SheetsColumn(columnValue, VarcharType.VARCHAR));
+            }
+            List<List<Object>> dataValues = values.subList(1, values.size()); // removing header info
+            return Optional.of(new SheetsTable(tableName, columns.build(), dataValues));
+        }
+        return Optional.empty();
+    }
+
+    public Set<String> getTableNames()
+    {
+        ImmutableSet.Builder<String> tables = ImmutableSet.builder();
+        try {
+            List<List<Object>> tableMetadata = sheetDataCache.getUnchecked(metadataSheetId);
+            for (int i = 1; i < tableMetadata.size(); i++) {
+                if (tableMetadata.get(i).size() > 0) {
+                    tables.add(String.valueOf(tableMetadata.get(i).get(0)));
+                }
+            }
+            return tables.build();
+        }
+        catch (UncheckedExecutionException e) {
+            throwIfInstanceOf(e.getCause(), PrestoException.class);
+            throw new PrestoException(SHEETS_METASTORE_ERROR, e);
+        }
+    }
+
+    public List<List<Object>> readAllValues(String tableName)
+    {
+        try {
+            Optional<String> sheetExpression = tableSheetMappingCache.getUnchecked(tableName);
+            if (!sheetExpression.isPresent()) {
+                throw new PrestoException(SHEETS_UNKNOWN_TABLE_ERROR, "Sheet expression not found for table " + tableName);
+            }
+            return sheetDataCache.getUnchecked(sheetExpression.get());
+        }
+        catch (UncheckedExecutionException e) {
+            throwIfInstanceOf(e.getCause(), PrestoException.class);
+            throw new PrestoException(SHEETS_TABLE_LOAD_ERROR, "Error loading data for table: " + tableName, e);
+        }
+    }
+
+    private Optional<String> getSheetExpressionForTable(String tableName)
+    {
+        Map<String, Optional<String>> tableSheetMap = getAllTableSheetExpressionMapping();
+        if (!tableSheetMap.containsKey(tableName)) {
+            return Optional.empty();
+        }
+        return tableSheetMap.get(tableName);
+    }
+
+    private Map<String, Optional<String>> getAllTableSheetExpressionMapping()
+    {
+        ImmutableMap.Builder<String, Optional<String>> tableSheetMap = ImmutableMap.builder();
+        List<List<Object>> data = readAllValuesFromSheetExpression(metadataSheetId);
+        // first line is assumed to be sheet header
+        for (int i = 1; i < data.size(); i++) {
+            if (data.get(i).size() >= 2) {
+                String tableId = String.valueOf(data.get(i).get(0));
+                String sheetId = String.valueOf(data.get(i).get(1));
+                tableSheetMap.put(tableId.toLowerCase(Locale.ENGLISH), Optional.of(sheetId));
+            }
+        }
+        return tableSheetMap.build();
+    }
+
+    private Credential getCredentials()
+    {
+        try (InputStream in = new FileInputStream(credentialsFilePath)) {
+            return GoogleCredential.fromStream(in).createScoped(SCOPES);
+        }
+        catch (IOException e) {
+            throw new PrestoException(SHEETS_BAD_CREDENTIALS_ERROR, e);
+        }
+    }
+
+    private List<List<Object>> readAllValuesFromSheetExpression(String sheetExpression)
+    {
+        try {
+            // by default loading up to 10k rows from the first tab of the sheet
+            String defaultRange = "$1:$10000";
+            String[] tableOptions = sheetExpression.split("#");
+            String sheetId = tableOptions[0];
+            if (tableOptions.length > 1) {
+                defaultRange = tableOptions[1];
+            }
+            log.debug("Accessing sheet id [%s] with range [%s]", sheetId, defaultRange);
+            return sheetsService.spreadsheets().values().get(sheetId, defaultRange).execute().getValues();
+        }
+        catch (IOException e) {
+            throw new PrestoException(SHEETS_UNKNOWN_TABLE_ERROR, "Failed reading data from sheet: " + sheetExpression, e);
+        }
+    }
+
+    private static CacheBuilder<Object, Object> newCacheBuilder(long expiresAfterWriteMillis, long maximumSize)
+    {
+        return CacheBuilder.newBuilder().expireAfterWrite(expiresAfterWriteMillis, MILLISECONDS).maximumSize(maximumSize);
+    }
+
+    private static <X extends Throwable> void throwIfInstanceOf(
+            Throwable throwable, Class<X> declaredType) throws X
+    {
+        requireNonNull(throwable);
+        if (declaredType.isInstance(throwable)) {
+            throw declaredType.cast(throwable);
+        }
+    }
+}

--- a/presto-google-sheets/src/main/java/com/facebook/presto/google/sheets/SheetsColumn.java
+++ b/presto-google-sheets/src/main/java/com/facebook/presto/google/sheets/SheetsColumn.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.google.sheets;
+
+import com.facebook.presto.common.type.Type;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static java.util.Objects.requireNonNull;
+
+public class SheetsColumn
+{
+    private final String name;
+    private final Type type;
+
+    @JsonCreator
+    public SheetsColumn(
+            @JsonProperty("name") String name,
+            @JsonProperty("type") Type type)
+    {
+        checkArgument(!isNullOrEmpty(name), "name is null or is empty");
+        this.name = name;
+        this.type = requireNonNull(type, "type is null");
+    }
+
+    @JsonProperty
+    public String getName()
+    {
+        return name;
+    }
+
+    @JsonProperty
+    public Type getType()
+    {
+        return type;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(name, type);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+
+        SheetsColumn other = (SheetsColumn) obj;
+        return Objects.equals(this.name, other.name) &&
+                Objects.equals(this.type, other.type);
+    }
+
+    @Override
+    public String toString()
+    {
+        return name + ":" + type;
+    }
+}

--- a/presto-google-sheets/src/main/java/com/facebook/presto/google/sheets/SheetsColumnHandle.java
+++ b/presto-google-sheets/src/main/java/com/facebook/presto/google/sheets/SheetsColumnHandle.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.google.sheets;
+
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ColumnMetadata;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static java.util.Objects.hash;
+import static java.util.Objects.requireNonNull;
+
+public class SheetsColumnHandle
+        implements ColumnHandle
+{
+    private final String columnName;
+    private final Type columnType;
+    private final int ordinalPosition;
+
+    @JsonCreator
+    public SheetsColumnHandle(
+            @JsonProperty("columnName") String columnName,
+            @JsonProperty("columnType") Type columnType,
+            @JsonProperty("ordinalPosition") int ordinalPosition)
+    {
+        this.columnName = requireNonNull(columnName, "columnName is null");
+        this.columnType = requireNonNull(columnType, "columnType is null");
+        this.ordinalPosition = ordinalPosition;
+    }
+
+    @JsonProperty
+    public String getColumnName()
+    {
+        return columnName;
+    }
+
+    @JsonProperty
+    public Type getColumnType()
+    {
+        return columnType;
+    }
+
+    @JsonProperty
+    public int getOrdinalPosition()
+    {
+        return ordinalPosition;
+    }
+
+    public ColumnMetadata getColumnMetadata()
+    {
+        return new ColumnMetadata(columnName, columnType);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return hash(columnName, columnType, ordinalPosition);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if ((obj == null) || (getClass() != obj.getClass())) {
+            return false;
+        }
+
+        SheetsColumnHandle other = (SheetsColumnHandle) obj;
+        return Objects.equals(this.columnName, other.columnName);
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("columnName", columnName)
+                .add("columnType", columnType)
+                .add("ordinalPosition", ordinalPosition)
+                .toString();
+    }
+}

--- a/presto-google-sheets/src/main/java/com/facebook/presto/google/sheets/SheetsConfig.java
+++ b/presto-google-sheets/src/main/java/com/facebook/presto/google/sheets/SheetsConfig.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.google.sheets;
+
+import com.facebook.airlift.configuration.Config;
+import com.facebook.airlift.configuration.ConfigDescription;
+import io.airlift.units.Duration;
+import io.airlift.units.MinDuration;
+
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+
+import java.util.concurrent.TimeUnit;
+
+public class SheetsConfig
+{
+    private String credentialsFilePath;
+    private String metadataSheetId;
+    private int sheetsDataMaxCacheSize = 1000;
+    private Duration sheetsDataExpireAfterWrite = new Duration(5, TimeUnit.MINUTES);
+
+    @NotNull
+    public String getCredentialsFilePath()
+    {
+        return credentialsFilePath;
+    }
+
+    @Config("credentials-path")
+    @ConfigDescription("Credential file path to google service account")
+    public SheetsConfig setCredentialsFilePath(String credentialsFilePath)
+    {
+        this.credentialsFilePath = credentialsFilePath;
+        return this;
+    }
+
+    @NotNull
+    public String getMetadataSheetId()
+    {
+        return metadataSheetId;
+    }
+
+    @Config("metadata-sheet-id")
+    @ConfigDescription("Metadata sheet id containing table sheet mapping")
+    public SheetsConfig setMetadataSheetId(String metadataSheetId)
+    {
+        this.metadataSheetId = metadataSheetId;
+        return this;
+    }
+
+    @Min(1)
+    public int getSheetsDataMaxCacheSize()
+    {
+        return sheetsDataMaxCacheSize;
+    }
+
+    @Config("sheets-data-max-cache-size")
+    @ConfigDescription("Sheet data max cache size")
+    public SheetsConfig setSheetsDataMaxCacheSize(int sheetsDataMaxCacheSize)
+    {
+        this.sheetsDataMaxCacheSize = sheetsDataMaxCacheSize;
+        return this;
+    }
+
+    @MinDuration("1m")
+    public Duration getSheetsDataExpireAfterWrite()
+    {
+        return sheetsDataExpireAfterWrite;
+    }
+
+    @Config("sheets-data-expire-after-write")
+    @ConfigDescription("Sheets data expire after write duration")
+    public SheetsConfig setSheetsDataExpireAfterWrite(Duration sheetsDataExpireAfterWriteMinutes)
+    {
+        this.sheetsDataExpireAfterWrite = sheetsDataExpireAfterWriteMinutes;
+        return this;
+    }
+}

--- a/presto-google-sheets/src/main/java/com/facebook/presto/google/sheets/SheetsConnector.java
+++ b/presto-google-sheets/src/main/java/com/facebook/presto/google/sheets/SheetsConnector.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.google.sheets;
+
+import com.facebook.airlift.bootstrap.LifeCycleManager;
+import com.facebook.presto.spi.connector.Connector;
+import com.facebook.presto.spi.connector.ConnectorMetadata;
+import com.facebook.presto.spi.connector.ConnectorRecordSetProvider;
+import com.facebook.presto.spi.connector.ConnectorSplitManager;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.facebook.presto.spi.transaction.IsolationLevel;
+
+import javax.inject.Inject;
+
+import static java.util.Objects.requireNonNull;
+
+public class SheetsConnector
+        implements Connector
+{
+    private final LifeCycleManager lifeCycleManager;
+    private final SheetsMetadata metadata;
+    private final SheetsSplitManager splitManager;
+    private final SheetsRecordSetProvider recordSetProvider;
+
+    @Inject
+    public SheetsConnector(
+            LifeCycleManager lifeCycleManager,
+            SheetsMetadata metadata,
+            SheetsSplitManager splitManager,
+            SheetsRecordSetProvider recordSetProvider)
+    {
+        this.lifeCycleManager = requireNonNull(lifeCycleManager, "lifeCycleManager is null");
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.splitManager = requireNonNull(splitManager, "splitManager is null");
+        this.recordSetProvider = requireNonNull(recordSetProvider, "recordSetProvider is null");
+    }
+
+    @Override
+    public ConnectorTransactionHandle beginTransaction(IsolationLevel isolationLevel, boolean readOnly)
+    {
+        return SheetsTransactionHandle.INSTANCE;
+    }
+
+    @Override
+    public ConnectorMetadata getMetadata(ConnectorTransactionHandle transactionHandle)
+    {
+        return metadata;
+    }
+
+    @Override
+    public ConnectorSplitManager getSplitManager()
+    {
+        return splitManager;
+    }
+
+    @Override
+    public ConnectorRecordSetProvider getRecordSetProvider()
+    {
+        return recordSetProvider;
+    }
+
+    @Override
+    public final void shutdown()
+    {
+        lifeCycleManager.stop();
+    }
+}

--- a/presto-google-sheets/src/main/java/com/facebook/presto/google/sheets/SheetsConnectorFactory.java
+++ b/presto-google-sheets/src/main/java/com/facebook/presto/google/sheets/SheetsConnectorFactory.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.google.sheets;
+
+import com.facebook.airlift.bootstrap.Bootstrap;
+import com.facebook.airlift.json.JsonModule;
+import com.facebook.presto.spi.ConnectorHandleResolver;
+import com.facebook.presto.spi.connector.Connector;
+import com.facebook.presto.spi.connector.ConnectorContext;
+import com.facebook.presto.spi.connector.ConnectorFactory;
+import com.google.inject.Injector;
+
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+public class SheetsConnectorFactory
+        implements ConnectorFactory
+{
+    @Override
+    public String getName()
+    {
+        return "gsheets";
+    }
+
+    @Override
+    public ConnectorHandleResolver getHandleResolver()
+    {
+        return new SheetsHandleResolver();
+    }
+
+    @Override
+    public Connector create(String catalogName, Map<String, String> config, ConnectorContext context)
+    {
+        requireNonNull(config, "config is null");
+
+        Bootstrap app = new Bootstrap(
+                new JsonModule(),
+                new SheetsModule(context.getTypeManager()));
+
+        Injector injector = app
+                .doNotInitializeLogging()
+                .setRequiredConfigurationProperties(config)
+                .initialize();
+
+        return injector.getInstance(SheetsConnector.class);
+    }
+}

--- a/presto-google-sheets/src/main/java/com/facebook/presto/google/sheets/SheetsErrorCode.java
+++ b/presto-google-sheets/src/main/java/com/facebook/presto/google/sheets/SheetsErrorCode.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.google.sheets;
+
+import com.facebook.presto.spi.ErrorCode;
+import com.facebook.presto.spi.ErrorCodeSupplier;
+import com.facebook.presto.spi.ErrorType;
+
+import static com.facebook.presto.spi.ErrorType.EXTERNAL;
+import static com.facebook.presto.spi.ErrorType.INTERNAL_ERROR;
+import static com.facebook.presto.spi.ErrorType.USER_ERROR;
+
+public enum SheetsErrorCode
+        implements ErrorCodeSupplier
+{
+    SHEETS_BAD_CREDENTIALS_ERROR(0, EXTERNAL),
+    SHEETS_METASTORE_ERROR(1, EXTERNAL),
+    SHEETS_UNKNOWN_TABLE_ERROR(2, USER_ERROR),
+    SHEETS_TABLE_LOAD_ERROR(3, INTERNAL_ERROR);
+
+    private final ErrorCode errorCode;
+
+    SheetsErrorCode(int code, ErrorType type)
+    {
+        errorCode = new ErrorCode(code + 0x0508_0000, name(), type);
+    }
+
+    @Override
+    public ErrorCode toErrorCode()
+    {
+        return errorCode;
+    }
+}

--- a/presto-google-sheets/src/main/java/com/facebook/presto/google/sheets/SheetsHandleResolver.java
+++ b/presto-google-sheets/src/main/java/com/facebook/presto/google/sheets/SheetsHandleResolver.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.google.sheets;
+
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ConnectorHandleResolver;
+import com.facebook.presto.spi.ConnectorSplit;
+import com.facebook.presto.spi.ConnectorTableHandle;
+import com.facebook.presto.spi.ConnectorTableLayoutHandle;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+
+public class SheetsHandleResolver
+        implements ConnectorHandleResolver
+{
+    @Override
+    public Class<? extends ConnectorTableHandle> getTableHandleClass()
+    {
+        return SheetsTableHandle.class;
+    }
+
+    @Override
+    public Class<? extends ConnectorTableLayoutHandle> getTableLayoutHandleClass()
+    {
+        return SheetsTableLayoutHandle.class;
+    }
+
+    @Override
+    public Class<? extends ColumnHandle> getColumnHandleClass()
+    {
+        return SheetsColumnHandle.class;
+    }
+
+    @Override
+    public Class<? extends ConnectorSplit> getSplitClass()
+    {
+        return SheetsSplit.class;
+    }
+
+    @Override
+    public Class<? extends ConnectorTransactionHandle> getTransactionHandleClass()
+    {
+        return SheetsTransactionHandle.class;
+    }
+}

--- a/presto-google-sheets/src/main/java/com/facebook/presto/google/sheets/SheetsMetadata.java
+++ b/presto-google-sheets/src/main/java/com/facebook/presto/google/sheets/SheetsMetadata.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.google.sheets;
+
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ColumnMetadata;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ConnectorTableHandle;
+import com.facebook.presto.spi.ConnectorTableLayout;
+import com.facebook.presto.spi.ConnectorTableLayoutHandle;
+import com.facebook.presto.spi.ConnectorTableLayoutResult;
+import com.facebook.presto.spi.ConnectorTableMetadata;
+import com.facebook.presto.spi.Constraint;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.SchemaTablePrefix;
+import com.facebook.presto.spi.TableNotFoundException;
+import com.facebook.presto.spi.connector.ConnectorMetadata;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import javax.inject.Inject;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.facebook.presto.google.sheets.SheetsErrorCode.SHEETS_UNKNOWN_TABLE_ERROR;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static java.util.Objects.requireNonNull;
+
+public class SheetsMetadata
+        implements ConnectorMetadata
+{
+    private final SheetsClient sheetsClient;
+    private static final List<String> SCHEMAS = ImmutableList.of("default");
+
+    @Inject
+    public SheetsMetadata(SheetsClient sheetsClient)
+    {
+        this.sheetsClient = requireNonNull(sheetsClient, "sheetsClient is null");
+    }
+
+    @Override
+    public List<String> listSchemaNames(ConnectorSession session)
+    {
+        return listSchemaNames();
+    }
+
+    public List<String> listSchemaNames()
+    {
+        return SCHEMAS;
+    }
+
+    @Override
+    public SheetsTableHandle getTableHandle(ConnectorSession session, SchemaTableName tableName)
+    {
+        requireNonNull(tableName, "tableName is null");
+        if (!listSchemaNames(session).contains(tableName.getSchemaName())) {
+            return null;
+        }
+
+        Optional<SheetsTable> table = sheetsClient.getTable(tableName.getTableName());
+        if (!table.isPresent()) {
+            return null;
+        }
+
+        return new SheetsTableHandle(tableName.getSchemaName(), tableName.getTableName());
+    }
+
+    @Override
+    public List<ConnectorTableLayoutResult> getTableLayouts(
+            ConnectorSession session, ConnectorTableHandle table,
+            Constraint<ColumnHandle> constraint, Optional<Set<ColumnHandle>> desiredColumns)
+    {
+        SheetsTableHandle tableHandle = (SheetsTableHandle) table;
+        ConnectorTableLayout layout = new ConnectorTableLayout(new SheetsTableLayoutHandle(tableHandle));
+        return ImmutableList.of(new ConnectorTableLayoutResult(layout, constraint.getSummary()));
+    }
+
+    @Override
+    public ConnectorTableLayout getTableLayout(ConnectorSession session, ConnectorTableLayoutHandle handle)
+    {
+        return new ConnectorTableLayout(handle);
+    }
+
+    @Override
+    public ConnectorTableMetadata getTableMetadata(ConnectorSession session, ConnectorTableHandle table)
+    {
+        Optional<ConnectorTableMetadata> connectorTableMetadata = getTableMetadata(((SheetsTableHandle) table).toSchemaTableName());
+        if (!connectorTableMetadata.isPresent()) {
+            throw new PrestoException(SHEETS_UNKNOWN_TABLE_ERROR, "Metadata not found for table " + ((SheetsTableHandle) table).getTableName());
+        }
+        return connectorTableMetadata.get();
+    }
+
+    private Optional<ConnectorTableMetadata> getTableMetadata(SchemaTableName tableName)
+    {
+        if (!listSchemaNames().contains(tableName.getSchemaName())) {
+            return Optional.empty();
+        }
+        Optional<SheetsTable> table = sheetsClient.getTable(tableName.getTableName());
+        if (table.isPresent()) {
+            return Optional.of(new ConnectorTableMetadata(tableName, table.get().getColumnsMetadata()));
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public Map<String, ColumnHandle> getColumnHandles(ConnectorSession session, ConnectorTableHandle tableHandle)
+    {
+        SheetsTableHandle sheetsTableHandle = (SheetsTableHandle) tableHandle;
+        Optional<SheetsTable> table = sheetsClient.getTable(sheetsTableHandle.getTableName());
+        if (!table.isPresent()) {
+            throw new TableNotFoundException(sheetsTableHandle.toSchemaTableName());
+        }
+
+        ImmutableMap.Builder<String, ColumnHandle> columnHandles = ImmutableMap.builder();
+        int index = 0;
+        for (ColumnMetadata column : table.get().getColumnsMetadata()) {
+            columnHandles.put(column.getName(), new SheetsColumnHandle(column.getName(), column.getType(), index));
+            index++;
+        }
+        return columnHandles.build();
+    }
+
+    @Override
+    public ColumnMetadata getColumnMetadata(ConnectorSession session, ConnectorTableHandle tableHandle, ColumnHandle columnHandle)
+    {
+        return ((SheetsColumnHandle) columnHandle).getColumnMetadata();
+    }
+
+    @Override
+    public Map<SchemaTableName, List<ColumnMetadata>> listTableColumns(ConnectorSession session, SchemaTablePrefix prefix)
+    {
+        requireNonNull(prefix, "prefix is null");
+        ImmutableMap.Builder<SchemaTableName, List<ColumnMetadata>> columns = ImmutableMap.builder();
+        for (SchemaTableName tableName : listTables(session, Optional.of(prefix.getSchemaName()))) {
+            Optional<ConnectorTableMetadata> tableMetadata = getTableMetadata(tableName);
+            // table can disappear during listing operation
+            if (tableMetadata.isPresent()) {
+                columns.put(tableName, tableMetadata.get().getColumns());
+            }
+        }
+        return columns.build();
+    }
+
+    @Override
+    public List<SchemaTableName> listTables(ConnectorSession session, Optional<String> schemaName)
+    {
+        String schema = schemaName.orElse(getOnlyElement(SCHEMAS));
+
+        if (listSchemaNames().contains(schema)) {
+            return sheetsClient.getTableNames().stream()
+                    .map(tableName -> new SchemaTableName(schema, tableName))
+                    .collect(toImmutableList());
+        }
+        return ImmutableList.of();
+    }
+}

--- a/presto-google-sheets/src/main/java/com/facebook/presto/google/sheets/SheetsModule.java
+++ b/presto-google-sheets/src/main/java/com/facebook/presto/google/sheets/SheetsModule.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.google.sheets;
+
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.TypeManager;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.FromStringDeserializer;
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+
+import javax.inject.Inject;
+
+import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
+import static com.facebook.airlift.json.JsonBinder.jsonBinder;
+import static com.facebook.airlift.json.JsonCodec.listJsonCodec;
+import static com.facebook.airlift.json.JsonCodecBinder.jsonCodecBinder;
+import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
+import static java.util.Objects.requireNonNull;
+
+public class SheetsModule
+        implements Module
+{
+    private final TypeManager typeManager;
+
+    public SheetsModule(TypeManager typeManager)
+    {
+        this.typeManager = requireNonNull(typeManager, "typeManager is null");
+    }
+
+    @Override
+    public void configure(Binder binder)
+    {
+        binder.bind(TypeManager.class).toInstance(typeManager);
+        binder.bind(SheetsConnector.class).in(Scopes.SINGLETON);
+        binder.bind(SheetsMetadata.class).in(Scopes.SINGLETON);
+        binder.bind(SheetsClient.class).in(Scopes.SINGLETON);
+        binder.bind(SheetsSplitManager.class).in(Scopes.SINGLETON);
+        binder.bind(SheetsRecordSetProvider.class).in(Scopes.SINGLETON);
+
+        configBinder(binder).bindConfig(SheetsConfig.class);
+
+        jsonBinder(binder).addDeserializerBinding(Type.class).to(TypeDeserializer.class);
+        jsonCodecBinder(binder).bindMapJsonCodec(String.class, listJsonCodec(SheetsTable.class));
+    }
+
+    public static final class TypeDeserializer
+            extends FromStringDeserializer<Type>
+    {
+        private final TypeManager typeManager;
+
+        @Inject
+        public TypeDeserializer(TypeManager typeManager)
+        {
+            super(Type.class);
+            this.typeManager = requireNonNull(typeManager, "typeManager is null");
+        }
+
+        @Override
+        protected Type _deserialize(String value, DeserializationContext context)
+        {
+            return typeManager.getType(parseTypeSignature(value));
+        }
+    }
+}

--- a/presto-google-sheets/src/main/java/com/facebook/presto/google/sheets/SheetsPlugin.java
+++ b/presto-google-sheets/src/main/java/com/facebook/presto/google/sheets/SheetsPlugin.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.google.sheets;
+
+import com.facebook.presto.spi.Plugin;
+import com.facebook.presto.spi.connector.ConnectorFactory;
+import com.google.common.collect.ImmutableList;
+
+public class SheetsPlugin
+        implements Plugin
+{
+    @Override
+    public Iterable<ConnectorFactory> getConnectorFactories()
+    {
+        return ImmutableList.of(new SheetsConnectorFactory());
+    }
+}

--- a/presto-google-sheets/src/main/java/com/facebook/presto/google/sheets/SheetsRecordCursor.java
+++ b/presto-google-sheets/src/main/java/com/facebook/presto/google/sheets/SheetsRecordCursor.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.google.sheets;
+
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.spi.RecordCursor;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.VarcharType.createUnboundedVarcharType;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+public class SheetsRecordCursor
+        implements RecordCursor
+{
+    private final List<SheetsColumnHandle> columnHandles;
+    private final long totalBytes;
+    private final List<List<Object>> dataValues;
+
+    private List<String> fields;
+    private int currentIndex;
+
+    public SheetsRecordCursor(List<SheetsColumnHandle> columnHandles, List<List<Object>> dataValues)
+    {
+        requireNonNull(columnHandles, "columnHandles is null");
+        requireNonNull(dataValues, "dataValues is null");
+
+        this.columnHandles = ImmutableList.copyOf(columnHandles);
+        this.dataValues = ImmutableList.copyOf(dataValues);
+        long inputLength = 0;
+        for (List<Object> objList : dataValues) {
+            for (Object obj : objList) {
+                inputLength += String.valueOf(obj).length();
+            }
+        }
+        totalBytes = inputLength;
+    }
+
+    @Override
+    public long getCompletedBytes()
+    {
+        return totalBytes;
+    }
+
+    @Override
+    public long getReadTimeNanos()
+    {
+        return 0;
+    }
+
+    @Override
+    public Type getType(int field)
+    {
+        checkArgument(field < columnHandles.size(), "Invalid field index");
+        return columnHandles.get(field).getColumnType();
+    }
+
+    @Override
+    public boolean advanceNextPosition()
+    {
+        List<Object> currentVals = null;
+        // Skip empty rows from sheet
+        while (currentVals == null || currentVals.size() == 0) {
+            if (currentIndex == dataValues.size()) {
+                return false;
+            }
+            currentVals = dataValues.get(currentIndex++);
+        }
+        // Populate incomplete columns with null
+        String[] allFields = new String[columnHandles.size()];
+
+        for (int i = 0; i < allFields.length; i++) {
+            int ordinalPos = columnHandles.get(i).getOrdinalPosition();
+            if (currentVals.size() > ordinalPos) {
+                allFields[i] = String.valueOf(currentVals.get(ordinalPos));
+            }
+        }
+        fields = Arrays.asList(allFields);
+        return true;
+    }
+
+    private String getFieldValue(int field)
+    {
+        checkState(fields != null, "Cursor has not been advanced yet");
+        return fields.get(field);
+    }
+
+    @Override
+    public boolean getBoolean(int field)
+    {
+        checkFieldType(field, BOOLEAN);
+        return Boolean.parseBoolean(getFieldValue(field));
+    }
+
+    @Override
+    public long getLong(int field)
+    {
+        checkFieldType(field, BIGINT);
+        return Long.parseLong(getFieldValue(field));
+    }
+
+    @Override
+    public double getDouble(int field)
+    {
+        checkFieldType(field, DOUBLE);
+        return Double.parseDouble(getFieldValue(field));
+    }
+
+    @Override
+    public Slice getSlice(int field)
+    {
+        checkFieldType(field, createUnboundedVarcharType());
+        return Slices.utf8Slice(getFieldValue(field));
+    }
+
+    @Override
+    public Object getObject(int field)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isNull(int field)
+    {
+        checkArgument(field < columnHandles.size(), "Invalid field index");
+        return Strings.isNullOrEmpty(getFieldValue(field));
+    }
+
+    private void checkFieldType(int field, Type expected)
+    {
+        Type actual = getType(field);
+        checkArgument(actual.equals(expected), "Expected field %s to be type %s but is %s", field, expected, actual);
+    }
+
+    @Override
+    public void close()
+    {
+    }
+}

--- a/presto-google-sheets/src/main/java/com/facebook/presto/google/sheets/SheetsRecordSet.java
+++ b/presto-google-sheets/src/main/java/com/facebook/presto/google/sheets/SheetsRecordSet.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.google.sheets;
+
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.spi.RecordCursor;
+import com.facebook.presto.spi.RecordSet;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static java.util.Objects.requireNonNull;
+
+public class SheetsRecordSet
+        implements RecordSet
+{
+    private final List<SheetsColumnHandle> columnHandles;
+    private final List<Type> columnTypes;
+    private final List<List<Object>> values;
+
+    public SheetsRecordSet(SheetsSplit split, List<SheetsColumnHandle> columnHandles)
+    {
+        requireNonNull(split, "split is null");
+        this.columnHandles = requireNonNull(columnHandles, "columnHandles is null");
+        this.values = split.getValues();
+        this.columnTypes = columnHandles.stream().map(SheetsColumnHandle::getColumnType).collect(Collectors.toList());
+    }
+
+    @Override
+    public List<Type> getColumnTypes()
+    {
+        return columnTypes;
+    }
+
+    @Override
+    public RecordCursor cursor()
+    {
+        return new SheetsRecordCursor(columnHandles, values);
+    }
+}

--- a/presto-google-sheets/src/main/java/com/facebook/presto/google/sheets/SheetsRecordSetProvider.java
+++ b/presto-google-sheets/src/main/java/com/facebook/presto/google/sheets/SheetsRecordSetProvider.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.google.sheets;
+
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ConnectorSplit;
+import com.facebook.presto.spi.RecordSet;
+import com.facebook.presto.spi.connector.ConnectorRecordSetProvider;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static java.util.Objects.requireNonNull;
+
+public class SheetsRecordSetProvider
+        implements ConnectorRecordSetProvider
+{
+    @Override
+    public RecordSet getRecordSet(ConnectorTransactionHandle transactionHandle,
+                                  ConnectorSession session,
+                                  ConnectorSplit split,
+                                  List<? extends ColumnHandle> columns)
+    {
+        requireNonNull(split, "split is null");
+        SheetsSplit sheetsSplit = (SheetsSplit) split;
+
+        List<SheetsColumnHandle> handles = columns.stream().map(c -> (SheetsColumnHandle) c).collect(Collectors.toList());
+        return new SheetsRecordSet(sheetsSplit, handles);
+    }
+}

--- a/presto-google-sheets/src/main/java/com/facebook/presto/google/sheets/SheetsSplit.java
+++ b/presto-google-sheets/src/main/java/com/facebook/presto/google/sheets/SheetsSplit.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.google.sheets;
+
+import com.facebook.presto.spi.ConnectorSplit;
+import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+public class SheetsSplit
+        implements ConnectorSplit
+{
+    private final String schemaName;
+    private final String tableName;
+    private final List<List<Object>> values;
+    private final List<HostAddress> hostAddresses;
+
+    @JsonCreator
+    public SheetsSplit(
+            @JsonProperty("schemaName") String schemaName,
+            @JsonProperty("tableName") String tableName,
+            @JsonProperty("values") List<List<Object>> values)
+    {
+        this.schemaName = requireNonNull(schemaName, "schemaName is null");
+        this.tableName = requireNonNull(tableName, "tableName is null");
+        this.values = requireNonNull(values, "values is null");
+        this.hostAddresses = ImmutableList.of();
+    }
+
+    @JsonProperty
+    public String getSchemaName()
+    {
+        return schemaName;
+    }
+
+    @JsonProperty
+    public String getTableName()
+    {
+        return tableName;
+    }
+
+    @JsonProperty
+    public List<List<Object>> getValues()
+    {
+        return values;
+    }
+
+    @Override
+    public NodeSelectionStrategy getNodeSelectionStrategy()
+    {
+        return NodeSelectionStrategy.NO_PREFERENCE;
+    }
+
+    @Override
+    public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+    {
+        return hostAddresses;
+    }
+
+    @Override
+    public Object getInfo()
+    {
+        return ImmutableMap.builder()
+                .put("schemaName", schemaName)
+                .put("tableName", tableName)
+                .put("hostAddresses", hostAddresses)
+                .build();
+    }
+}

--- a/presto-google-sheets/src/main/java/com/facebook/presto/google/sheets/SheetsSplitManager.java
+++ b/presto-google-sheets/src/main/java/com/facebook/presto/google/sheets/SheetsSplitManager.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.google.sheets;
+
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ConnectorSplit;
+import com.facebook.presto.spi.ConnectorSplitSource;
+import com.facebook.presto.spi.ConnectorTableLayoutHandle;
+import com.facebook.presto.spi.FixedSplitSource;
+import com.facebook.presto.spi.TableNotFoundException;
+import com.facebook.presto.spi.connector.ConnectorSplitManager;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+
+import javax.inject.Inject;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class SheetsSplitManager
+        implements ConnectorSplitManager
+{
+    private final SheetsClient sheetsClient;
+
+    @Inject
+    public SheetsSplitManager(SheetsClient sheetsClient)
+    {
+        this.sheetsClient = requireNonNull(sheetsClient, "sheetsClient is null");
+    }
+
+    @Override
+    public ConnectorSplitSource getSplits(
+            ConnectorTransactionHandle transactionHandle,
+            ConnectorSession session,
+            ConnectorTableLayoutHandle layout,
+            SplitSchedulingContext splitSchedulingContext)
+    {
+        SheetsTableLayoutHandle layoutHandle = (SheetsTableLayoutHandle) layout;
+        SheetsTableHandle tableHandle = layoutHandle.getTable();
+        Optional<SheetsTable> table = sheetsClient.getTable(tableHandle.getTableName());
+
+        // this can happen if table is removed during a query
+        if (!table.isPresent()) {
+            throw new TableNotFoundException(tableHandle.toSchemaTableName());
+        }
+
+        List<ConnectorSplit> splits = new ArrayList<>();
+        splits.add(new SheetsSplit(tableHandle.getSchemaName(), tableHandle.getTableName(), table.get().getValues()));
+        Collections.shuffle(splits);
+        return new FixedSplitSource(splits);
+    }
+}

--- a/presto-google-sheets/src/main/java/com/facebook/presto/google/sheets/SheetsTable.java
+++ b/presto-google-sheets/src/main/java/com/facebook/presto/google/sheets/SheetsTable.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.google.sheets;
+
+import com.facebook.presto.spi.ColumnMetadata;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static java.util.Objects.requireNonNull;
+
+public class SheetsTable
+{
+    private final List<ColumnMetadata> columnsMetadata;
+    private final List<List<Object>> values;
+
+    @JsonCreator
+    public SheetsTable(
+            @JsonProperty("name") String name,
+            @JsonProperty("columns") List<SheetsColumn> columns,
+            @JsonProperty("values") List<List<Object>> values)
+    {
+        checkArgument(!isNullOrEmpty(name), "name is null or is empty");
+        requireNonNull(columns, "columns is null");
+
+        ImmutableList.Builder<ColumnMetadata> columnsMetadata = ImmutableList.builder();
+        for (SheetsColumn column : columns) {
+            columnsMetadata.add(new ColumnMetadata(column.getName(), column.getType()));
+        }
+        this.columnsMetadata = columnsMetadata.build();
+        this.values = values;
+    }
+
+    @JsonProperty
+    public List<List<Object>> getValues()
+    {
+        return values;
+    }
+
+    public List<ColumnMetadata> getColumnsMetadata()
+    {
+        return columnsMetadata;
+    }
+}

--- a/presto-google-sheets/src/main/java/com/facebook/presto/google/sheets/SheetsTableHandle.java
+++ b/presto-google-sheets/src/main/java/com/facebook/presto/google/sheets/SheetsTableHandle.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.google.sheets;
+
+import com.facebook.presto.spi.ConnectorTableHandle;
+import com.facebook.presto.spi.SchemaTableName;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+
+public class SheetsTableHandle
+        implements ConnectorTableHandle
+{
+    private final SchemaTableName schemaTableName;
+
+    @JsonCreator
+    public SheetsTableHandle(
+            @JsonProperty("schemaName") String schemaName,
+            @JsonProperty("tableName") String tableName)
+    {
+        requireNonNull(schemaName, "schemaName is null");
+        requireNonNull(tableName, "tableName is null");
+        this.schemaTableName = new SchemaTableName(schemaName, tableName);
+    }
+
+    @JsonProperty
+    public String getSchemaName()
+    {
+        return schemaTableName.getSchemaName();
+    }
+
+    @JsonProperty
+    public String getTableName()
+    {
+        return schemaTableName.getTableName();
+    }
+
+    public SchemaTableName toSchemaTableName()
+    {
+        return schemaTableName;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(schemaTableName);
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if ((obj == null) || (getClass() != obj.getClass())) {
+            return false;
+        }
+
+        SheetsTableHandle other = (SheetsTableHandle) obj;
+        return Objects.equals(this.schemaTableName, other.schemaTableName);
+    }
+
+    @Override
+    public String toString()
+    {
+        return schemaTableName.toString();
+    }
+}

--- a/presto-google-sheets/src/main/java/com/facebook/presto/google/sheets/SheetsTableLayoutHandle.java
+++ b/presto-google-sheets/src/main/java/com/facebook/presto/google/sheets/SheetsTableLayoutHandle.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.google.sheets;
+
+import com.facebook.presto.spi.ConnectorTableLayoutHandle;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class SheetsTableLayoutHandle
+        implements ConnectorTableLayoutHandle
+{
+    private final SheetsTableHandle table;
+
+    @JsonCreator
+    public SheetsTableLayoutHandle(@JsonProperty("table") SheetsTableHandle table)
+    {
+        this.table = table;
+    }
+
+    @JsonProperty
+    public SheetsTableHandle getTable()
+    {
+        return table;
+    }
+
+    @Override
+    public String toString()
+    {
+        return table.toString();
+    }
+}

--- a/presto-google-sheets/src/main/java/com/facebook/presto/google/sheets/SheetsTransactionHandle.java
+++ b/presto-google-sheets/src/main/java/com/facebook/presto/google/sheets/SheetsTransactionHandle.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.google.sheets;
+
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+
+public enum SheetsTransactionHandle
+        implements ConnectorTransactionHandle
+{
+    INSTANCE
+}

--- a/presto-google-sheets/src/test/java/com/facebook/presto/google/sheets/TestGoogleSheets.java
+++ b/presto-google-sheets/src/test/java/com/facebook/presto/google/sheets/TestGoogleSheets.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.google.sheets;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.google.sheets.TestSheetsPlugin.TEST_METADATA_SHEET_ID;
+import static com.facebook.presto.google.sheets.TestSheetsPlugin.getTestCredentialsPath;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static org.testng.Assert.assertEquals;
+
+public class TestGoogleSheets
+        extends AbstractTestQueryFramework
+{
+    protected static final String GOOGLE_SHEETS = "gsheets";
+
+    private static Session createSession()
+    {
+        return testSessionBuilder()
+                .setCatalog(GOOGLE_SHEETS)
+                .setSchema("default")
+                .build();
+    }
+
+    @Override
+    protected QueryRunner createQueryRunner()
+    {
+        QueryRunner queryRunner;
+        try {
+            SheetsPlugin sheetsPlugin = new SheetsPlugin();
+            queryRunner = DistributedQueryRunner.builder(createSession()).build();
+            queryRunner.installPlugin(sheetsPlugin);
+            queryRunner.createCatalog(GOOGLE_SHEETS, GOOGLE_SHEETS, ImmutableMap.of(
+                    "credentials-path", getTestCredentialsPath(),
+                    "metadata-sheet-id", TEST_METADATA_SHEET_ID,
+                    "sheets-data-max-cache-size", "1000",
+                    "sheets-data-expire-after-write", "5m"));
+        }
+        catch (Exception e) {
+            throw new IllegalStateException(e.getMessage());
+        }
+        return queryRunner;
+    }
+
+    @Test
+    public void testListTable()
+    {
+        assertQuery("show tables", "SELECT * FROM (VALUES 'metadata_table', 'number_text', 'table_with_duplicate_and_missing_column_names')");
+        assertQueryReturnsEmptyResult("SHOW TABLES IN gsheets.information_schema LIKE 'number_text'");
+        assertQuery("select table_name from gsheets.information_schema.tables WHERE table_schema <> 'information_schema'", "SELECT * FROM (VALUES 'metadata_table', 'number_text', 'table_with_duplicate_and_missing_column_names')");
+        assertQuery("select table_name from gsheets.information_schema.tables WHERE table_schema <> 'information_schema' LIMIT 1000", "SELECT * FROM (VALUES 'metadata_table', 'number_text', 'table_with_duplicate_and_missing_column_names')");
+        assertEquals(getQueryRunner().execute("select table_name from gsheets.information_schema.tables WHERE table_schema = 'unknown_schema'").getRowCount(), 0);
+    }
+
+    @Test
+    public void testDescTable()
+    {
+        assertQuery("desc number_text", "SELECT * FROM (VALUES('number','varchar','',''), ('text','varchar','',''))");
+        assertQuery("desc metadata_table", "SELECT * FROM (VALUES('table name','varchar','',''), ('sheetid_sheetname','varchar','',''), "
+                + "('owner','varchar','',''), ('notes','varchar','',''))");
+    }
+
+    @Test
+    public void testSelectFromTable()
+    {
+        assertQuery("SELECT count(*) FROM number_text", "SELECT 5");
+        assertQuery("SELECT number FROM number_text", "SELECT * FROM (VALUES '1','2','3','4','5')");
+        assertQuery("SELECT text FROM number_text", "SELECT * FROM (VALUES 'one','two','three','four','five')");
+        assertQuery("SELECT * FROM number_text", "SELECT * FROM (VALUES ('1','one'), ('2','two'), ('3','three'), ('4','four'), ('5','five'))");
+    }
+
+    @Test
+    public void testSelectFromTableIgnoreCase()
+    {
+        assertQuery("SELECT count(*) FROM NUMBER_TEXT", "SELECT 5");
+        assertQuery("SELECT number FROM Number_Text", "SELECT * FROM (VALUES '1','2','3','4','5')");
+    }
+
+    @Test
+    public void testQueryingUnknownSchemaAndTable()
+    {
+        assertQueryFails("select * from gsheets.foo.bar", "line 1:15: Schema foo does not exist");
+        assertQueryFails("select * from gsheets.default.foo_bar_table", "Sheet expression not found for table foo_bar_table");
+    }
+
+    @Test
+    public void testTableWithRepeatedAndMissingColumnNames()
+    {
+        assertQuery("desc table_with_duplicate_and_missing_column_names", "SELECT * FROM (VALUES('a','varchar','','')," +
+                " ('column_1','varchar','',''), ('column_2','varchar','',''), ('c','varchar','',''))");
+    }
+}

--- a/presto-google-sheets/src/test/java/com/facebook/presto/google/sheets/TestSheetsConfig.java
+++ b/presto-google-sheets/src/test/java/com/facebook/presto/google/sheets/TestSheetsConfig.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.google.sheets;
+
+import com.google.common.collect.ImmutableMap;
+import io.airlift.units.Duration;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+
+public class TestSheetsConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(SheetsConfig.class)
+                .setCredentialsFilePath(null)
+                .setMetadataSheetId(null)
+                .setSheetsDataMaxCacheSize(1000)
+                .setSheetsDataExpireAfterWrite(new Duration(5, TimeUnit.MINUTES)));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+            throws IOException
+    {
+        Path credentialsFile = Files.createTempFile(null, null);
+
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("credentials-path", credentialsFile.toString())
+                .put("metadata-sheet-id", "foo_bar_sheet_id#Sheet1")
+                .put("sheets-data-max-cache-size", "2000")
+                .put("sheets-data-expire-after-write", "10m")
+                .build();
+
+        SheetsConfig expected = new SheetsConfig()
+                .setCredentialsFilePath(credentialsFile.toString())
+                .setMetadataSheetId("foo_bar_sheet_id#Sheet1")
+                .setSheetsDataMaxCacheSize(2000)
+                .setSheetsDataExpireAfterWrite(new Duration(10, TimeUnit.MINUTES));
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/presto-google-sheets/src/test/java/com/facebook/presto/google/sheets/TestSheetsPlugin.java
+++ b/presto-google-sheets/src/test/java/com/facebook/presto/google/sheets/TestSheetsPlugin.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.google.sheets;
+
+import com.facebook.presto.spi.Plugin;
+import com.facebook.presto.spi.connector.Connector;
+import com.facebook.presto.spi.connector.ConnectorFactory;
+import com.facebook.presto.testing.TestingConnectorContext;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.Resources;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.google.sheets.TestGoogleSheets.GOOGLE_SHEETS;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static org.testng.Assert.assertNotNull;
+
+public class TestSheetsPlugin
+{
+    static final String TEST_METADATA_SHEET_ID = "1fu6qjHrOARa7Rqezfgd9C--XPCUOkN_vhvwpxZ4INGE#Tables";
+
+    static String getTestCredentialsPath()
+    {
+        return Resources.getResource("gsheet-test-account.json").getPath();
+    }
+
+    @Test
+    public void testCreateConnector()
+            throws Exception
+    {
+        Plugin plugin = new SheetsPlugin();
+        ConnectorFactory factory = getOnlyElement(plugin.getConnectorFactories());
+        ImmutableMap.Builder<String, String> propertiesMap = new ImmutableMap.Builder<String, String>().put("credentials-path", getTestCredentialsPath()).put("metadata-sheet-id", TEST_METADATA_SHEET_ID);
+        Connector connector = factory.create(GOOGLE_SHEETS, propertiesMap.build(), new TestingConnectorContext());
+        assertNotNull(connector);
+        connector.shutdown();
+    }
+}

--- a/presto-google-sheets/src/test/resources/gsheet-test-account.json
+++ b/presto-google-sheets/src/test/resources/gsheet-test-account.json
@@ -1,0 +1,12 @@
+{
+  "type": "service_account",
+  "project_id": "prestodb-test",
+  "private_key_id": "754861ecca198a31117be3b5fd9c45e1467a4b90",
+  "private_key": "-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQC6DapML8vrdYmp\nZBLAO29fSWhvAEyGujKZpaW/nFKXWuTn3G9lZCEJgubh8C8a/lmbJgB55lyX/oTG\nRqMO299mZTZPhFet0qtqhHqhmMuKgI8VSFR/8bUHiD1LbEtZ7ejfdlx8Q1kVCsPN\nntMQBi45fYAVcrp0nfx6v/c+4ppCEzGxee6ZrC8Rs7VJRlpofId5oD6/Eie7Ak37\nQCB/4ang1HcEIHt8sg68Ofwl9w6WR1a77MfwPQ97yI5bIquf1lXBnHsHd2rqNpEO\n9RaM52X0GnFAXP0p/i7MldbL+8LW3ehnlGASEMJY+u9nzYXnLpnuv/lMxEh/cJeV\n5MHSYRxLAgMBAAECggEAIaR370fTRVPfHSCp3VXB+UZyWmQA8nm3zZ2s3316V8EJ\nVD3BbOGSscAYVLGUKvrkJBBWlLRJePh+dMXwFS8/8amKjQ1et2E5Os0Syaax420E\nsnH+SZZgyChkAP/nji7dZY7nAVdCQ/JK3qMCAktDz4R4hShWO+EXdvDAWgAqqZi0\nv1JTmzwFnpYWDbqERENz5eOv92rCDQUnHDF0CFYldG8dmdzl20Bq4JYwurCvKTnS\nwpGUTSUt6hNeLEYGoavhr8PJPK7W1/FdaS2bXUVpUutHL4dhfMq3HR3UMkVAN+Vv\n5ETjBbILRR9XnRUof9ajL/uQ37BpbIjAZ9/wFItzzQKBgQDsGUMhPmHoNmwuMT0v\nekat/740Y1g7FcfCPE6UHPGTWu2e87RVmooQcHpF5JPukr64BAmyFCMiQJr73Wmg\npybAH7V9YlXyuv67/incOlm//yIXLaj62bjwkQFCMvXsktkt3UPPxgch4a0il3Ab\nNYccGGNE0vWhMQSD5rtz33UjjwKBgQDJvHummbfvHaYGUJbsVNE7iHk9PZuKja13\n2nPyYFHw23/+cP8NAUTGnY5SZo5dl/QoSP6IvKB8tY+ItoLrgNBC5E8SSW/7qWhu\nIQGRYg7UNiG6pqr1DoTdSNWxv4UAB+gAgZeTUdCY2PoeKN1E6UycA24hZpXvD2Hk\ngzQmX6KthQKBgC5RUmseKuT8cEKrpD5BNcaC6pSqfK+yuSqw3BWQjBAFgaJyWwmE\nNNu+xS4bBq6CGWpOWHyYGMBqfj01FbjPsfl0/wznEsd4yeqllR7AT8Urz0tOyNzV\ng8OmHuIWz0onEPY/d0M2rUWHWYj0vqiH2sa3PhpNbKS/0gvyYwn7Z6afAoGBAKEy\nQZ+S7t1bVIFxPddjwriOSUo9Ax9ILBc78C/49SC/U9vtUG+E1v7ZgJKpLhLtS4Qx\nJ2n9R0O/FA0KwTwK9t6sbd5P3fI6oJ53MziHIRBCnNr3OF2OF252N4LLZSvsJV7a\nLlLiKgsoPVuCDaR1wuha+VIpFZ8rLG6axD3xZxy9AoGBALY0fbkDpXX1zglYZFFC\nRSJRgjo6slICLmp72coC6bOPaVB759osZFoQZjuwy1/YbPTVOqsD0Yicwn2jc1QO\nxGdknXarCdXZkLg0hWkXthMrg5/BUVO4WZ5dtWJoqp8YGstMNvtEErqMYBnIAGMV\npv2SfpIZWiTXcBRd5l5U7b5r\n-----END PRIVATE KEY-----\n",
+  "client_email": "prestodbtest@prestodb-test.iam.gserviceaccount.com",
+  "client_id": "112191298789532837231",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/prestodbtest%40prestodb-test.iam.gserviceaccount.com"
+}


### PR DESCRIPTION
Trino has introduced google sheet connector in this [PR](https://github.com/trinodb/trino/pull/1030).

Note that currently Trino google sheet connector only supports read queries, and doesn't support inserts.

This open WIP [PR](https://github.com/trinodb/trino/pull/5011) in Trino attempts to add insert functionality. I plan to follow up in next PR. 

Related ticket https://github.com/prestodb/presto/issues/16516

```
== RELEASE NOTES ==

General Changes
* Introduce Google sheet connector, supporting read queries