### PR TITLE
[presto-orc] Support Column Layout in HiveWriter

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriterConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriterConfig.java
@@ -54,6 +54,7 @@ public class OrcFileWriterConfig
                 .withStreamLayout(getStreamLayout(streamLayoutType));
     }
 
+    @NotNull
     public DataSize getStripeMinSize()
     {
         return stripeMinSize;
@@ -66,6 +67,7 @@ public class OrcFileWriterConfig
         return this;
     }
 
+    @NotNull
     public DataSize getStripeMaxSize()
     {
         return this.stripeMaxSize;
@@ -102,6 +104,7 @@ public class OrcFileWriterConfig
         return this;
     }
 
+    @NotNull
     public DataSize getDictionaryMaxMemory()
     {
         return dictionaryMaxMemory;
@@ -114,6 +117,7 @@ public class OrcFileWriterConfig
         return this;
     }
 
+    @NotNull
     public DataSize getStringStatisticsLimit()
     {
         return stringStatisticsLimit;
@@ -126,6 +130,7 @@ public class OrcFileWriterConfig
         return this;
     }
 
+    @NotNull
     public DataSize getMaxCompressionBufferSize()
     {
         return maxCompressionBufferSize;

--- a/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriterConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriterConfig.java
@@ -15,11 +15,22 @@ package com.facebook.presto.hive;
 
 import com.facebook.airlift.configuration.Config;
 import com.facebook.presto.orc.OrcWriterOptions;
+import com.facebook.presto.orc.StreamLayout;
 import io.airlift.units.DataSize;
+
+import javax.validation.constraints.NotNull;
+
+import static com.facebook.presto.hive.OrcFileWriterConfig.StreamLayoutType.BY_STREAM_SIZE;
 
 @SuppressWarnings("unused")
 public class OrcFileWriterConfig
 {
+    public enum StreamLayoutType
+    {
+        BY_STREAM_SIZE,
+        BY_COLUMN_SIZE,
+    }
+
     private DataSize stripeMinSize = OrcWriterOptions.DEFAULT_STRIPE_MIN_SIZE;
     private DataSize stripeMaxSize = OrcWriterOptions.DEFAULT_STRIPE_MAX_SIZE;
     private int stripeMaxRowCount = OrcWriterOptions.DEFAULT_STRIPE_MAX_ROW_COUNT;
@@ -27,6 +38,7 @@ public class OrcFileWriterConfig
     private DataSize dictionaryMaxMemory = OrcWriterOptions.DEFAULT_DICTIONARY_MAX_MEMORY;
     private DataSize stringStatisticsLimit = OrcWriterOptions.DEFAULT_MAX_STRING_STATISTICS_LIMIT;
     private DataSize maxCompressionBufferSize = OrcWriterOptions.DEFAULT_MAX_COMPRESSION_BUFFER_SIZE;
+    private StreamLayoutType streamLayoutType = BY_STREAM_SIZE;
 
     public OrcWriterOptions.Builder toOrcWriterOptionsBuilder()
     {
@@ -38,7 +50,8 @@ public class OrcFileWriterConfig
                 .withRowGroupMaxRowCount(rowGroupMaxRowCount)
                 .withDictionaryMaxMemory(dictionaryMaxMemory)
                 .withMaxStringStatisticsLimit(stringStatisticsLimit)
-                .withMaxCompressionBufferSize(maxCompressionBufferSize);
+                .withMaxCompressionBufferSize(maxCompressionBufferSize)
+                .withStreamLayout(getStreamLayout(streamLayoutType));
     }
 
     public DataSize getStripeMinSize()
@@ -123,5 +136,30 @@ public class OrcFileWriterConfig
     {
         this.maxCompressionBufferSize = maxCompressionBufferSize;
         return this;
+    }
+
+    @NotNull
+    public StreamLayoutType getStreamLayoutType()
+    {
+        return streamLayoutType;
+    }
+
+    @Config("hive.orc.writer.stream-layout-type")
+    public OrcFileWriterConfig setStreamLayoutType(StreamLayoutType streamLayoutType)
+    {
+        this.streamLayoutType = streamLayoutType;
+        return this;
+    }
+
+    private static StreamLayout getStreamLayout(StreamLayoutType type)
+    {
+        switch (type) {
+            case BY_COLUMN_SIZE:
+                return new StreamLayout.ByColumnSize();
+            case BY_STREAM_SIZE:
+                return new StreamLayout.ByStreamSize();
+            default:
+                throw new RuntimeException("Unrecognized type " + type);
+        }
     }
 }


### PR DESCRIPTION
OrcWriter uses multiple stream to represent a column.
Default OrcWriter policy is to layout the streams in the
increasing order of the size. But this spreads the reader
IO as all streams of a column are accessed together.
This change makes the ColumnLayout configurable.

Test plan - (Please fill in how you tested your changes)
Added new tests.

```
== NO RELEASE NOTE ==
```
