### PR TITLE
Run queries successfully without OOM via loose memory accounting

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -193,6 +193,9 @@ public class HiveClientConfig
 
     private Duration partitionLeaseDuration = new Duration(0, TimeUnit.SECONDS);
 
+    private boolean executionBasedMemoryAccounting;
+    private boolean enableLooseMemoryAccounting;
+
     public int getMaxInitialSplits()
     {
         return maxInitialSplits;
@@ -1637,5 +1640,18 @@ public class HiveClientConfig
     public Duration getPartitionLeaseDuration()
     {
         return partitionLeaseDuration;
+    }
+
+    public boolean isLooseMemoryAccountingEnabled()
+    {
+        return enableLooseMemoryAccounting;
+    }
+
+    @Config("hive.loose-memory-accounting-enabled")
+    @ConfigDescription("When enabled relaxes memory accounting for queries violating memory limits to run that previously honored memory thresholds.")
+    public HiveClientConfig setLooseMemoryAccountingEnabled(boolean enableLooseMemoryAccounting)
+    {
+        this.enableLooseMemoryAccounting = enableLooseMemoryAccounting;
+        return this;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
@@ -123,6 +123,7 @@ public final class HiveSessionProperties
     public static final String OPTIMIZED_PARTITION_UPDATE_SERIALIZATION_ENABLED = "optimized_partition_update_serialization_enabled";
     public static final String PARTITION_LEASE_DURATION = "partition_lease_duration";
     public static final String CACHE_ENABLED = "cache_enabled";
+    public static final String ENABLE_LOOSE_MEMORY_BASED_ACCOUNTING = "enable_loose_memory_based_accounting";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -581,6 +582,11 @@ public final class HiveSessionProperties
                         CACHE_ENABLED,
                         "Enable cache for hive",
                         cacheConfig.isCachingEnabled(),
+                        false),
+                booleanProperty(
+                        ENABLE_LOOSE_MEMORY_BASED_ACCOUNTING,
+                        "Enable loose memory accounting to avoid OOMing existing queries",
+                        hiveClientConfig.isLooseMemoryAccountingEnabled(),
                         false));
     }
 
@@ -1015,5 +1021,10 @@ public final class HiveSessionProperties
     public static boolean isCacheEnabled(ConnectorSession session)
     {
         return session.getProperty(CACHE_ENABLED, Boolean.class);
+    }
+
+    public static boolean isExecutionBasedMemoryAccountingEnabled(ConnectorSession session)
+    {
+        return session.getProperty(ENABLE_LOOSE_MEMORY_BASED_ACCOUNTING, Boolean.class);
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriterFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriterFactory.java
@@ -68,6 +68,7 @@ import static com.facebook.presto.hive.HiveSessionProperties.getOrcOptimizedWrit
 import static com.facebook.presto.hive.HiveSessionProperties.getOrcOptimizedWriterValidateMode;
 import static com.facebook.presto.hive.HiveSessionProperties.getOrcStreamBufferSize;
 import static com.facebook.presto.hive.HiveSessionProperties.getOrcStringStatisticsLimit;
+import static com.facebook.presto.hive.HiveSessionProperties.isExecutionBasedMemoryAccountingEnabled;
 import static com.facebook.presto.hive.HiveType.toHiveTypes;
 import static com.facebook.presto.orc.OrcEncoding.DWRF;
 import static com.facebook.presto.orc.OrcEncoding.ORC;
@@ -226,6 +227,7 @@ public class OrcFileWriterFactory
                             .withStripeMaxRowCount(getOrcOptimizedWriterMaxStripeRows(session))
                             .withDictionaryMaxMemory(getOrcOptimizedWriterMaxDictionaryMemory(session))
                             .withMaxStringStatisticsLimit(getOrcStringStatisticsLimit(session))
+                            .setIgnoreDictionaryRowGroupSizes(isExecutionBasedMemoryAccountingEnabled(session))
                             .build(),
                     fileInputColumnIndexes,
                     ImmutableMap.<String, String>builder()

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
@@ -153,7 +153,8 @@ public class TestHiveClientConfig
                 .setManifestVerificationEnabled(false)
                 .setUndoMetastoreOperationsEnabled(true)
                 .setOptimizedPartitionUpdateSerializationEnabled(false)
-                .setPartitionLeaseDuration(new Duration(0, TimeUnit.SECONDS)));
+                .setPartitionLeaseDuration(new Duration(0, TimeUnit.SECONDS))
+                .setLooseMemoryAccountingEnabled(false));
     }
 
     @Test
@@ -268,6 +269,7 @@ public class TestHiveClientConfig
                 .put("hive.undo-metastore-operations-enabled", "false")
                 .put("hive.experimental-optimized-partition-update-serialization-enabled", "true")
                 .put("hive.partition-lease-duration", "4h")
+                .put("hive.loose-memory-accounting-enabled", "true")
                 .build();
 
         HiveClientConfig expected = new HiveClientConfig()
@@ -378,7 +380,8 @@ public class TestHiveClientConfig
                 .setManifestVerificationEnabled(true)
                 .setUndoMetastoreOperationsEnabled(false)
                 .setOptimizedPartitionUpdateSerializationEnabled(true)
-                .setPartitionLeaseDuration(new Duration(4, TimeUnit.HOURS));
+                .setPartitionLeaseDuration(new Duration(4, TimeUnit.HOURS))
+                .setLooseMemoryAccountingEnabled(true);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/ColumnWriterOptions.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/ColumnWriterOptions.java
@@ -31,6 +31,7 @@ public class ColumnWriterOptions
     private final DataSize stringStatisticsLimit;
     private final boolean integerDictionaryEncodingEnabled;
     private final boolean stringDictionarySortingEnabled;
+    private final boolean ignoreDictionaryRowGroupSizes;
 
     public ColumnWriterOptions(
             CompressionKind compressionKind,
@@ -38,7 +39,8 @@ public class ColumnWriterOptions
             DataSize compressionMaxBufferSize,
             DataSize stringStatisticsLimit,
             boolean integerDictionaryEncodingEnabled,
-            boolean stringDictionarySortingEnabled)
+            boolean stringDictionarySortingEnabled,
+            boolean ignoreDictionaryRowGroupSizes)
     {
         this.compressionKind = requireNonNull(compressionKind, "compressionKind is null");
         this.compressionLevel = requireNonNull(compressionLevel, "compressionLevel is null");
@@ -47,6 +49,7 @@ public class ColumnWriterOptions
         this.stringStatisticsLimit = requireNonNull(stringStatisticsLimit, "stringStatisticsLimit is null");
         this.integerDictionaryEncodingEnabled = integerDictionaryEncodingEnabled;
         this.stringDictionarySortingEnabled = stringDictionarySortingEnabled;
+        this.ignoreDictionaryRowGroupSizes = ignoreDictionaryRowGroupSizes;
     }
 
     public CompressionKind getCompressionKind()
@@ -79,6 +82,11 @@ public class ColumnWriterOptions
         return stringDictionarySortingEnabled;
     }
 
+    public boolean isIgnoreDictionaryRowGroupSizes()
+    {
+        return ignoreDictionaryRowGroupSizes;
+    }
+
     public static Builder builder()
     {
         return new Builder();
@@ -92,6 +100,7 @@ public class ColumnWriterOptions
         private DataSize stringStatisticsLimit = DEFAULT_MAX_STRING_STATISTICS_LIMIT;
         private boolean integerDictionaryEncodingEnabled;
         private boolean stringDictionarySortingEnabled = true;
+        private boolean ignoreDictionaryRowGroupSizes;
 
         private Builder() {}
 
@@ -131,6 +140,12 @@ public class ColumnWriterOptions
             return this;
         }
 
+        public Builder setIgnoreDictionaryRowGroupSizes(boolean ignoreDictionaryRowGroupSizes)
+        {
+            this.ignoreDictionaryRowGroupSizes = ignoreDictionaryRowGroupSizes;
+            return this;
+        }
+
         public ColumnWriterOptions build()
         {
             return new ColumnWriterOptions(
@@ -139,7 +154,8 @@ public class ColumnWriterOptions
                     compressionMaxBufferSize,
                     stringStatisticsLimit,
                     integerDictionaryEncodingEnabled,
-                    stringDictionarySortingEnabled);
+                    stringDictionarySortingEnabled,
+                    ignoreDictionaryRowGroupSizes);
         }
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
@@ -213,6 +213,7 @@ public class OrcWriter
                 .setStringStatisticsLimit(options.getMaxStringStatisticsLimit())
                 .setIntegerDictionaryEncodingEnabled(options.isIntegerDictionaryEncodingEnabled())
                 .setStringDictionarySortingEnabled(options.isStringDictionarySortingEnabled())
+                .setIgnoreDictionaryRowGroupSizes(options.isIgnoreDictionaryRowGroupSizes())
                 .build();
         recordValidation(validation -> validation.setCompression(compressionKind));
 
@@ -402,7 +403,6 @@ public class OrcWriter
             else {
                 page = null;
             }
-
             writeChunk(chunk);
         }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriterOptions.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriterOptions.java
@@ -51,6 +51,11 @@ public class OrcWriterOptions
     private final StreamLayout streamLayout;
     private final boolean integerDictionaryEncodingEnabled;
     private final boolean stringDictionarySortingEnabled;
+    // TODO: Originally the dictionary row group sizes were not included in memory accounting due
+    //  to a bug. Fixing the bug causes certain queries to OOM. When enabled this flag maintains the
+    //  previous behavior so previously working queries will not OOM. The OOMs caused due to the
+    //  additional memory accounting need to be fixed as well as the flag removed.
+    private final boolean ignoreDictionaryRowGroupSizes;
     private final Optional<DwrfStripeCacheOptions> dwrfWriterOptions;
 
     private OrcWriterOptions(
@@ -65,7 +70,8 @@ public class OrcWriterOptions
             StreamLayout streamLayout,
             boolean integerDictionaryEncodingEnabled,
             boolean stringDictionarySortingEnabled,
-            Optional<DwrfStripeCacheOptions> dwrfWriterOptions)
+            Optional<DwrfStripeCacheOptions> dwrfWriterOptions,
+            boolean ignoreDictionaryRowGroupSizes)
     {
         requireNonNull(stripeMinSize, "stripeMinSize is null");
         requireNonNull(stripeMaxSize, "stripeMaxSize is null");
@@ -90,6 +96,7 @@ public class OrcWriterOptions
         this.integerDictionaryEncodingEnabled = integerDictionaryEncodingEnabled;
         this.stringDictionarySortingEnabled = stringDictionarySortingEnabled;
         this.dwrfWriterOptions = dwrfWriterOptions;
+        this.ignoreDictionaryRowGroupSizes = ignoreDictionaryRowGroupSizes;
     }
 
     public DataSize getStripeMinSize()
@@ -152,6 +159,11 @@ public class OrcWriterOptions
         return dwrfWriterOptions;
     }
 
+    public boolean isIgnoreDictionaryRowGroupSizes()
+    {
+        return ignoreDictionaryRowGroupSizes;
+    }
+
     @Override
     public String toString()
     {
@@ -168,6 +180,7 @@ public class OrcWriterOptions
                 .add("integerDictionaryEncodingEnabled", integerDictionaryEncodingEnabled)
                 .add("stringDictionarySortingEnabled", stringDictionarySortingEnabled)
                 .add("dwrfWriterOptions", dwrfWriterOptions)
+                .add("ignoreDictionaryRowGroupSizes", ignoreDictionaryRowGroupSizes)
                 .toString();
     }
 
@@ -192,6 +205,7 @@ public class OrcWriterOptions
         private boolean dwrfStripeCacheEnabled;
         private DwrfStripeCacheMode dwrfStripeCacheMode = DEFAULT_DWRF_STRIPE_CACHE_MODE;
         private DataSize dwrfStripeCacheMaxSize = DEFAULT_DWRF_STRIPE_CACHE_MAX_SIZE;
+        private boolean ignoreDictionaryRowGroupSizes;
 
         public Builder withStripeMinSize(DataSize stripeMinSize)
         {
@@ -279,6 +293,12 @@ public class OrcWriterOptions
             return this;
         }
 
+        public Builder setIgnoreDictionaryRowGroupSizes(boolean ignoreDictionaryRowGroupSizes)
+        {
+            this.ignoreDictionaryRowGroupSizes = ignoreDictionaryRowGroupSizes;
+            return this;
+        }
+
         public OrcWriterOptions build()
         {
             Optional<DwrfStripeCacheOptions> dwrfWriterOptions;
@@ -301,7 +321,8 @@ public class OrcWriterOptions
                     streamLayout,
                     integerDictionaryEncodingEnabled,
                     stringDictionarySortingEnabled,
-                    dwrfWriterOptions);
+                    dwrfWriterOptions,
+                    ignoreDictionaryRowGroupSizes);
         }
     }
 }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcWriterOptions.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcWriterOptions.java
@@ -135,7 +135,8 @@ public class TestOrcWriterOptions
                 + "rowGroupMaxRowCount=15000, dictionaryMaxMemory=13000kB, maxStringStatisticsLimit=128B, "
                 + "maxCompressionBufferSize=512kB, compressionLevel=OptionalInt[5], streamLayout=ByColumnSize{}, "
                 + "integerDictionaryEncodingEnabled=false, stringDictionarySortingEnabled=true, "
-                + "dwrfWriterOptions=Optional[DwrfStripeCacheOptions{stripeCacheMode=INDEX_AND_FOOTER, stripeCacheMaxSize=4MB}]}";
+                + "dwrfWriterOptions=Optional[DwrfStripeCacheOptions{stripeCacheMode=INDEX_AND_FOOTER, stripeCacheMaxSize=4MB}], "
+                + "ignoreDictionaryRowGroupSizes=false}";
         assertEquals(expectedString, writerOptions.toString());
     }
 }


### PR DESCRIPTION
Memory accounting changes caused some queries to overshoot the memory
limits resulting in OOMs. To ensure that previously running queries do
not fail, a flag is introduced which triggers previous or loose memory
accounting and there by ensures the queries do not fail.

Test plan :
Added unit test which compares between the two memory accounting
mechanism and tests that the memory is returned correctly based on
the flag.

== RELEASE NOTES ==
Hive Changes
* hive.loose-memory-accounting-enabled has been added to enable/disable
loose memory accounting to ensure queries which previously ran do not
fail via OOM
