### PR TITLE
Fix TestSpatialPartitioningInternalAggregation

### DIFF
--- a/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestSpatialPartitioningInternalAggregation.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestSpatialPartitioningInternalAggregation.java
@@ -82,7 +82,7 @@ public class TestSpatialPartitioningInternalAggregation
 
         String expectedValue = getSpatialPartitioning(geometries, partitionCount);
 
-        AccumulatorFactory accumulatorFactory = function.bind(Ints.asList(0, 1, 2), Optional.empty());
+        AccumulatorFactory accumulatorFactory = function.bind(Ints.asList(0, 1), Optional.empty());
         Page page = new Page(geometryBlock, partitionCountBlock);
 
         Accumulator accumulator = accumulatorFactory.createAccumulator(UpdateMemory.NOOP);


### PR DESCRIPTION
The test accidentally passed an additional input channel element in the input channels argument to the aggregation function. Currently the AccumulatorCompiler generated class accepts inputChannels argument lists that are longer than the number of inputs, so the test works anyway, but changes in https://github.com/prestodb/presto/pull/16722 that validate the input channels length cause the test to fail.

```
== NO RELEASE NOTE ==
```
