### PR TITLE
Fix argument length error in TestSpatialPartitioningInternalAggregation

### DIFF
--- a/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestSpatialPartitioningInternalAggregation.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestSpatialPartitioningInternalAggregation.java
@@ -105,7 +105,7 @@ public class TestSpatialPartitioningInternalAggregation
         Block partitionCountBlock = BlockAssertions.createRLEBlock(10, 0);
         Page page = new Page(geometryBlock, partitionCountBlock);
 
-        AccumulatorFactory accumulatorFactory = function.bind(Ints.asList(0, 1, 2), Optional.empty());
+        AccumulatorFactory accumulatorFactory = function.bind(Ints.asList(0, 1), Optional.empty());
         Accumulator accumulator = accumulatorFactory.createAccumulator(UpdateMemory.NOOP);
         accumulator.addInput(page);
         try {


### PR DESCRIPTION
I failed to notice another occurrence of the incorrect argument length error in `TestSpatialPartitioningInternalAggregation` in the first PR (https://github.com/prestodb/presto/pull/16726). Just to be certain, I cherry picked this change into the Draft PR https://github.com/prestodb/presto/pull/16722 and am waiting for the tests to run so that I know for sure that there aren't any other issues after this one.

```
== NO RELEASE NOTE ==
```
