### PR TITLE
Handle fully filter pushdown for metadata query rewrite

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/BenchmarkParquetPageSource.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/BenchmarkParquetPageSource.java
@@ -15,6 +15,7 @@ package com.facebook.presto.hive.parquet;
 
 import com.facebook.presto.Session;
 import com.facebook.presto.common.Page;
+import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.common.type.StandardTypes;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.VarcharType;
@@ -291,7 +292,7 @@ public class BenchmarkParquetPageSource
 
             ParquetReader parquetReader = new ParquetReader(messageColumnIO, parquetMetadata.getBlocks(), dataSource, newSimpleAggregatedMemoryContext(), new DataSize(16, MEGABYTE), batchReadEnabled, enableVerification);
 
-            return new ParquetPageSource(parquetReader, Collections.nCopies(channelCount, type), fields, columnNames);
+            return new ParquetPageSource(parquetReader, Collections.nCopies(channelCount, type), fields, columnNames, new RuntimeStats());
         }
 
         private Optional<RowExpression> filterConjunction()

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -483,6 +483,9 @@ public class PlanOptimizers
                         new RewriteFilterWithExternalFunctionToProject(metadata.getFunctionAndTypeManager()),
                         new PlanRemotePojections(metadata.getFunctionAndTypeManager()))));
 
+        // This rule must be applied before the connector optimizer rules which might fully push down filters to the connector.
+        builder.add(new MetadataQueryOptimizer(metadata));
+
         // Pass a supplier so that we pickup connector optimizers that are installed later
         builder.add(
                 new ApplyConnectorOptimization(() -> planOptimizerManager.getOptimizers(LOGICAL)),
@@ -498,8 +501,6 @@ public class PlanOptimizers
 
         builder.add(predicatePushDown); // Run predicate push down one more time in case we can leverage new information from layouts' effective predicate
         builder.add(simplifyRowExpressionOptimizer); // Should be always run after PredicatePushDown
-
-        builder.add(new MetadataQueryOptimizer(metadata));
 
         // This can pull up Filter and Project nodes from between Joins, so we need to push them down again
         builder.add(


### PR DESCRIPTION
Previously, the metadata query rewrite rule was applied after the filter
pushdown rule. If a filter on a non-partition column was fully pushed
down to the connector, the metadata query rewrite rule was not aware of
it and could incorrectly enable the rewrite.

This PR moves the metadata query rewrite rule before the filter
pushdown rule to avoid this issue.

Test plan
Added unit test.

```
== RELEASE NOTES ==

General Changes
* Fix a correctness bug which could be triggered for queries with aggregations on partitioning columns and filters on non-partitioning columns when both optimizing metadata queries and filter pushdown are enabled.
```
