### PR TITLE
Remove state in map/array scalar functions 

### DIFF
--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/SqlArrayConcatBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/SqlArrayConcatBenchmark.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.benchmark;
+
+import com.facebook.presto.testing.LocalQueryRunner;
+
+import static com.facebook.presto.benchmark.BenchmarkQueryRunner.createLocalQueryRunner;
+
+public class SqlArrayConcatBenchmark
+        extends AbstractSqlBenchmark
+{
+    public SqlArrayConcatBenchmark(LocalQueryRunner localQueryRunner, String query, String name)
+    {
+        super(localQueryRunner, name, 4, 5, query);
+    }
+
+    public static void main(String[] args)
+    {
+        new SqlArrayConcatBenchmark(createLocalQueryRunner(), "SELECT (SEQUENCE(1, random(1000)) || SEQUENCE(1, random(1000))) AS x FROM (SELECT 1) CROSS JOIN UNNEST(SEQUENCE(1, 10000)) T(x)", "sql_array_concat_1k").runBenchmark(new SimpleLineBenchmarkResultWriter(System.out));
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayConcatFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayConcatFunction.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.operator.scalar;
 
 import com.facebook.presto.annotation.UsedByGeneratedCode;
-import com.facebook.presto.common.PageBuilder;
 import com.facebook.presto.common.QualifiedObjectName;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockBuilder;
@@ -30,7 +29,6 @@ import com.facebook.presto.sql.gen.VarArgsToArrayAdapterGenerator;
 import com.google.common.collect.ImmutableList;
 
 import java.lang.invoke.MethodHandle;
-import java.util.Optional;
 
 import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.metadata.BuiltInTypeAndFunctionNamespaceManager.DEFAULT_NAMESPACE;
@@ -51,8 +49,7 @@ public final class ArrayConcatFunction
     private static final String FUNCTION_NAME = "concat";
     private static final String DESCRIPTION = "Concatenates given arrays";
 
-    private static final MethodHandle METHOD_HANDLE = methodHandle(ArrayConcatFunction.class, "concat", Type.class, Object.class, Block[].class);
-    private static final MethodHandle USER_STATE_FACTORY = methodHandle(ArrayConcatFunction.class, "createState", Type.class);
+    private static final MethodHandle METHOD_HANDLE = methodHandle(ArrayConcatFunction.class, "concat", Type.class, Block[].class);
 
     private ArrayConcatFunction()
     {
@@ -93,28 +90,20 @@ public final class ArrayConcatFunction
 
         Type elementType = boundVariables.getTypeVariable("E");
 
-        VarArgsToArrayAdapterGenerator.MethodHandleAndConstructor methodHandleAndConstructor = generateVarArgsToArrayAdapter(
+        VarArgsToArrayAdapterGenerator.VarArgMethodHandle varArgMethodHandle = generateVarArgsToArrayAdapter(
                 Block.class,
                 Block.class,
                 arity,
-                METHOD_HANDLE.bindTo(elementType),
-                USER_STATE_FACTORY.bindTo(elementType));
+                METHOD_HANDLE.bindTo(elementType));
 
         return new BuiltInScalarFunctionImplementation(
                 false,
                 nCopies(arity, valueTypeArgumentProperty(RETURN_NULL_ON_NULL)),
-                methodHandleAndConstructor.getMethodHandle(),
-                Optional.of(methodHandleAndConstructor.getConstructor()));
+                varArgMethodHandle.getMethodHandle());
     }
 
     @UsedByGeneratedCode
-    public static Object createState(Type elementType)
-    {
-        return new PageBuilder(ImmutableList.of(elementType));
-    }
-
-    @UsedByGeneratedCode
-    public static Block concat(Type elementType, Object state, Block[] blocks)
+    public static Block concat(Type elementType, Block[] blocks)
     {
         int resultPositionCount = 0;
 
@@ -133,19 +122,13 @@ public final class ArrayConcatFunction
             return nonEmptyBlock;
         }
 
-        PageBuilder pageBuilder = (PageBuilder) state;
-        if (pageBuilder.isFull()) {
-            pageBuilder.reset();
-        }
-
-        BlockBuilder blockBuilder = pageBuilder.getBlockBuilder(0);
+        BlockBuilder blockBuilder = elementType.createBlockBuilder(null, resultPositionCount);
         for (int blockIndex = 0; blockIndex < blocks.length; blockIndex++) {
             Block block = blocks[blockIndex];
             for (int i = 0; i < block.getPositionCount(); i++) {
                 elementType.appendTo(block, i, blockBuilder);
             }
         }
-        pageBuilder.declarePositions(resultPositionCount);
-        return blockBuilder.getRegion(blockBuilder.getPositionCount() - resultPositionCount, resultPositionCount);
+        return blockBuilder.build();
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayRemoveFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayRemoveFunction.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.operator.scalar;
 
-import com.facebook.presto.common.PageBuilder;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockBuilder;
 import com.facebook.presto.common.type.Type;
@@ -23,11 +22,8 @@ import com.facebook.presto.spi.function.OperatorDependency;
 import com.facebook.presto.spi.function.ScalarFunction;
 import com.facebook.presto.spi.function.SqlType;
 import com.facebook.presto.spi.function.TypeParameter;
-import com.google.common.collect.ImmutableList;
 
 import java.lang.invoke.MethodHandle;
-import java.util.ArrayList;
-import java.util.List;
 
 import static com.facebook.presto.common.function.OperatorType.EQUAL;
 import static com.facebook.presto.common.type.TypeUtils.readNativeValue;
@@ -38,13 +34,8 @@ import static com.facebook.presto.util.Failures.internalError;
 @Description("Remove specified values from the given array")
 public final class ArrayRemoveFunction
 {
-    private final PageBuilder pageBuilder;
-
     @TypeParameter("E")
-    public ArrayRemoveFunction(@TypeParameter("E") Type elementType)
-    {
-        pageBuilder = new PageBuilder(ImmutableList.of(elementType));
-    }
+    public ArrayRemoveFunction(@TypeParameter("E") Type elementType) {}
 
     @TypeParameter("E")
     @SqlType("array(E)")
@@ -87,22 +78,22 @@ public final class ArrayRemoveFunction
             @SqlType("array(E)") Block array,
             @SqlType("E") Object value)
     {
-        List<Integer> positions = new ArrayList<>();
-
+        BlockBuilder blockBuilder = type.createBlockBuilder(null, array.getPositionCount());
         for (int i = 0; i < array.getPositionCount(); i++) {
             Object element = readNativeValue(type, array, i);
-
+            if (element == null) {
+                blockBuilder.appendNull();
+                continue;
+            }
             try {
-                if (element == null) {
-                    positions.add(i);
-                    continue;
-                }
                 Boolean result = (Boolean) equalsFunction.invoke(element, value);
+
                 if (result == null) {
                     throw new PrestoException(NOT_SUPPORTED, "array_remove does not support arrays with elements that are null or contain null");
                 }
+
                 if (!result) {
-                    positions.add(i);
+                    type.appendTo(array, i, blockBuilder);
                 }
             }
             catch (Throwable t) {
@@ -110,20 +101,6 @@ public final class ArrayRemoveFunction
             }
         }
 
-        if (array.getPositionCount() == positions.size()) {
-            return array;
-        }
-
-        if (pageBuilder.isFull()) {
-            pageBuilder.reset();
-        }
-        BlockBuilder blockBuilder = pageBuilder.getBlockBuilder(0);
-
-        for (int position : positions) {
-            type.appendTo(array, position, blockBuilder);
-        }
-
-        pageBuilder.declarePositions(positions.size());
-        return blockBuilder.getRegion(blockBuilder.getPositionCount() - positions.size(), positions.size());
+        return blockBuilder.build();
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayReverseFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayReverseFunction.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.operator.scalar;
 
-import com.facebook.presto.common.PageBuilder;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockBuilder;
 import com.facebook.presto.common.type.Type;
@@ -21,19 +20,13 @@ import com.facebook.presto.spi.function.Description;
 import com.facebook.presto.spi.function.ScalarFunction;
 import com.facebook.presto.spi.function.SqlType;
 import com.facebook.presto.spi.function.TypeParameter;
-import com.google.common.collect.ImmutableList;
 
 @ScalarFunction("reverse")
 @Description("Returns an array which has the reversed order of the given array.")
 public final class ArrayReverseFunction
 {
-    private final PageBuilder pageBuilder;
-
     @TypeParameter("E")
-    public ArrayReverseFunction(@TypeParameter("E") Type elementType)
-    {
-        pageBuilder = new PageBuilder(ImmutableList.of(elementType));
-    }
+    public ArrayReverseFunction(@TypeParameter("E") Type elementType) {}
 
     @TypeParameter("E")
     @SqlType("array(E)")
@@ -47,16 +40,10 @@ public final class ArrayReverseFunction
             return block;
         }
 
-        if (pageBuilder.isFull()) {
-            pageBuilder.reset();
-        }
-
-        BlockBuilder blockBuilder = pageBuilder.getBlockBuilder(0);
+        BlockBuilder blockBuilder = type.createBlockBuilder(null, block.getPositionCount());
         for (int i = arrayLength - 1; i >= 0; i--) {
             type.appendTo(block, i, blockBuilder);
         }
-        pageBuilder.declarePositions(arrayLength);
-
-        return blockBuilder.getRegion(blockBuilder.getPositionCount() - arrayLength, arrayLength);
+        return blockBuilder.build();
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArraySliceFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArraySliceFunction.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.operator.scalar;
 
 import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
 import com.facebook.presto.common.type.StandardTypes;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.spi.function.Description;
@@ -56,6 +57,11 @@ public final class ArraySliceFunction
             return type.createBlockBuilder(null, 0).build();
         }
 
-        return array.getRegion((int) (fromIndex - 1), (int) (toIndex - fromIndex));
+        BlockBuilder blockBuilder = type.createBlockBuilder(null, (int) (toIndex - fromIndex));
+        for (int i = (int) fromIndex - 1; i < toIndex - 1; i++) {
+            type.appendTo(array, i, blockBuilder);
+        }
+
+        return blockBuilder.build();
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/JoniRegexpReplaceLambdaFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/JoniRegexpReplaceLambdaFunction.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.operator.scalar;
 
-import com.facebook.presto.common.PageBuilder;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockBuilder;
 import com.facebook.presto.spi.function.Description;
@@ -23,7 +22,6 @@ import com.facebook.presto.spi.function.SqlNullable;
 import com.facebook.presto.spi.function.SqlType;
 import com.facebook.presto.sql.gen.lambda.UnaryFunctionInterface;
 import com.facebook.presto.type.JoniRegexpType;
-import com.google.common.collect.ImmutableList;
 import io.airlift.joni.Matcher;
 import io.airlift.joni.Option;
 import io.airlift.joni.Regex;
@@ -38,8 +36,6 @@ import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 @Description("replaces substrings matching a regular expression using a lambda function")
 public final class JoniRegexpReplaceLambdaFunction
 {
-    private final PageBuilder pageBuilder = new PageBuilder(ImmutableList.of(VARCHAR));
-
     @LiteralParameters("x")
     @SqlType("varchar")
     @SqlNullable
@@ -58,10 +54,7 @@ public final class JoniRegexpReplaceLambdaFunction
 
         // Prepare a BlockBuilder that will be used to create the target block
         // that will be passed to the lambda function.
-        if (pageBuilder.isFull()) {
-            pageBuilder.reset();
-        }
-        BlockBuilder blockBuilder = pageBuilder.getBlockBuilder(0);
+        BlockBuilder blockBuilder = VARCHAR.createBlockBuilder(null, 0);
 
         int groupCount = pattern.numberOfCaptures();
         int appendPosition = 0;
@@ -93,7 +86,6 @@ public final class JoniRegexpReplaceLambdaFunction
                     blockBuilder.appendNull();
                 }
             }
-            pageBuilder.declarePositions(groupCount);
             Block target = blockBuilder.getRegion(blockBuilder.getPositionCount() - groupCount, groupCount);
 
             // Call the lambda function to replace the block, and append the result to output

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapConcatFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapConcatFunction.java
@@ -14,7 +14,6 @@
 package com.facebook.presto.operator.scalar;
 
 import com.facebook.presto.annotation.UsedByGeneratedCode;
-import com.facebook.presto.common.PageBuilder;
 import com.facebook.presto.common.QualifiedObjectName;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockBuilder;
@@ -32,12 +31,11 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.function.FunctionKind;
 import com.facebook.presto.spi.function.Signature;
 import com.facebook.presto.spi.function.SqlFunctionVisibility;
-import com.facebook.presto.sql.gen.VarArgsToArrayAdapterGenerator.MethodHandleAndConstructor;
+import com.facebook.presto.sql.gen.VarArgsToArrayAdapterGenerator.VarArgMethodHandle;
 import com.google.common.collect.ImmutableList;
 
 import java.lang.invoke.MethodHandle;
 import java.util.List;
-import java.util.Optional;
 
 import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.metadata.BuiltInTypeAndFunctionNamespaceManager.DEFAULT_NAMESPACE;
@@ -59,8 +57,7 @@ public final class MapConcatFunction
     private static final String FUNCTION_NAME = "map_concat";
     private static final String DESCRIPTION = "Concatenates given maps";
 
-    private static final MethodHandle USER_STATE_FACTORY = methodHandle(MapConcatFunction.class, "createMapState", MapType.class);
-    private static final MethodHandle METHOD_HANDLE = methodHandle(MapConcatFunction.class, "mapConcat", MapType.class, Object.class, Block[].class);
+    private static final MethodHandle METHOD_HANDLE = methodHandle(MapConcatFunction.class, "mapConcat", MapType.class, Block[].class);
 
     private MapConcatFunction()
     {
@@ -105,28 +102,20 @@ public final class MapConcatFunction
                 TypeSignatureParameter.of(keyType.getTypeSignature()),
                 TypeSignatureParameter.of(valueType.getTypeSignature())));
 
-        MethodHandleAndConstructor methodHandleAndConstructor = generateVarArgsToArrayAdapter(
+        VarArgMethodHandle varArgMethodHandle = generateVarArgsToArrayAdapter(
                 Block.class,
                 Block.class,
                 arity,
-                METHOD_HANDLE.bindTo(mapType),
-                USER_STATE_FACTORY.bindTo(mapType));
+                METHOD_HANDLE.bindTo(mapType));
 
         return new BuiltInScalarFunctionImplementation(
                 false,
                 nCopies(arity, valueTypeArgumentProperty(RETURN_NULL_ON_NULL)),
-                methodHandleAndConstructor.getMethodHandle(),
-                Optional.of(methodHandleAndConstructor.getConstructor()));
+                varArgMethodHandle.getMethodHandle());
     }
 
     @UsedByGeneratedCode
-    public static Object createMapState(MapType mapType)
-    {
-        return new PageBuilder(ImmutableList.of(mapType));
-    }
-
-    @UsedByGeneratedCode
-    public static Block mapConcat(MapType mapType, Object state, Block[] maps)
+    public static Block mapConcat(MapType mapType, Block[] maps)
     {
         int entries = 0;
         int lastMapIndex = maps.length - 1;
@@ -147,7 +136,6 @@ public final class MapConcatFunction
 
         // We need to divide the entries by 2 because the maps array is SingleMapBlocks and it had the positionCount twice as large as a normal Block
         OptimizedTypedSet typedSet = new OptimizedTypedSet(keyType, maps.length, entries / 2);
-
         for (int i = lastMapIndex; i >= firstMapIndex; i--) {
             SingleMapBlock singleMapBlock = (SingleMapBlock) maps[i];
             Block keyBlock = singleMapBlock.getKeyBlock();
@@ -155,12 +143,7 @@ public final class MapConcatFunction
         }
 
         List<SelectedPositions> selectedPositionsList = typedSet.getPositionsForBlocks();
-
-        PageBuilder pageBuilder = (PageBuilder) state;
-        if (pageBuilder.isFull()) {
-            pageBuilder.reset();
-        }
-        BlockBuilder mapBlockBuilder = pageBuilder.getBlockBuilder(0);
+        BlockBuilder mapBlockBuilder = mapType.createBlockBuilder(null, selectedPositionsList.size());
         BlockBuilder blockBuilder = mapBlockBuilder.beginBlockEntry();
 
         for (int i = lastMapIndex; i >= firstMapIndex; i--) {
@@ -178,7 +161,6 @@ public final class MapConcatFunction
         }
 
         mapBlockBuilder.closeEntry();
-        pageBuilder.declarePosition();
         return mapType.getObject(mapBlockBuilder, mapBlockBuilder.getPositionCount() - 1);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapConstructor.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapConstructor.java
@@ -15,7 +15,6 @@ package com.facebook.presto.operator.scalar;
 
 import com.facebook.presto.annotation.UsedByGeneratedCode;
 import com.facebook.presto.common.NotSupportedException;
-import com.facebook.presto.common.PageBuilder;
 import com.facebook.presto.common.QualifiedObjectName;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockBuilder;
@@ -56,7 +55,6 @@ import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypeSig
 import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
 import static com.facebook.presto.util.Failures.checkCondition;
 import static com.facebook.presto.util.Failures.internalError;
-import static com.facebook.presto.util.Reflection.constructorMethodHandle;
 import static com.facebook.presto.util.Reflection.methodHandle;
 
 public final class MapConstructor
@@ -68,10 +66,11 @@ public final class MapConstructor
             MapConstructor.class,
             "createMap",
             MapType.class,
+            Type.class,
+            Type.class,
             MethodHandle.class,
             MethodHandle.class,
             MethodHandle.class,
-            State.class,
             SqlFunctionProperties.class,
             Block.class,
             Block.class);
@@ -121,55 +120,52 @@ public final class MapConstructor
         MethodHandle keyBlockEquals = compose(keyNativeEquals, nativeValueGetter(keyType), nativeValueGetter(keyType));
         MethodHandle keyIndeterminate = functionAndTypeManager.getBuiltInScalarFunctionImplementation(
                 functionAndTypeManager.resolveOperator(INDETERMINATE, fromTypeSignatures((keyType.getTypeSignature())))).getMethodHandle();
-        MethodHandle instanceFactory = constructorMethodHandle(State.class, MapType.class).bindTo(mapType);
 
         return new BuiltInScalarFunctionImplementation(
                 false,
                 ImmutableList.of(
                         valueTypeArgumentProperty(RETURN_NULL_ON_NULL),
                         valueTypeArgumentProperty(RETURN_NULL_ON_NULL)),
-                METHOD_HANDLE.bindTo(mapType).bindTo(keyBlockEquals).bindTo(keyBlockHashCode).bindTo(keyIndeterminate),
-                Optional.of(instanceFactory));
+                METHOD_HANDLE.bindTo(mapType).bindTo(keyType).bindTo(valueType).bindTo(keyBlockEquals).bindTo(keyBlockHashCode).bindTo(keyIndeterminate),
+                Optional.empty());
     }
 
     @UsedByGeneratedCode
     public static Block createMap(
             MapType mapType,
+            Type keyType,
+            Type valueType,
             MethodHandle keyBlockEqual,
             MethodHandle keyBlockHashCode,
             MethodHandle keyIndeterminate,
-            State state,
             SqlFunctionProperties properties,
             Block keyBlock,
             Block valueBlock)
     {
         checkCondition(keyBlock.getPositionCount() == valueBlock.getPositionCount(), INVALID_FUNCTION_ARGUMENT, "Key and value arrays must be the same length");
-        PageBuilder pageBuilder = state.getPageBuilder();
-        if (pageBuilder.isFull()) {
-            pageBuilder.reset();
-        }
-
-        MapBlockBuilder mapBlockBuilder = (MapBlockBuilder) pageBuilder.getBlockBuilder(0);
+        MapBlockBuilder mapBlockBuilder = (MapBlockBuilder) mapType.createBlockBuilder(null, keyBlock.getPositionCount() * 2);
         BlockBuilder blockBuilder = mapBlockBuilder.beginBlockEntry();
+
         for (int i = 0; i < keyBlock.getPositionCount(); i++) {
             if (keyBlock.isNull(i)) {
-                // close block builder before throwing as we may be in a TRY() call
-                // so that subsequent calls do not find it in an inconsistent state
-                mapBlockBuilder.closeEntry();
                 throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "map key cannot be null");
             }
-            Object keyObject = readNativeValue(mapType.getKeyType(), keyBlock, i);
-            try {
-                if ((boolean) keyIndeterminate.invoke(keyObject, false)) {
-                    throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "map key cannot be indeterminate: " + mapType.getKeyType().getObjectValue(properties, keyBlock, i));
+
+            if (keyType.getJavaType() == Block.class) {
+                // If it's nto primitive or string, we need to look for nulls in the block.
+                Object keyObject = readNativeValue(mapType.getKeyType(), keyBlock, i);
+                try {
+                    if ((boolean) keyIndeterminate.invoke(keyObject, false)) {
+                        throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "map key cannot be indeterminate: " + mapType.getKeyType().getObjectValue(properties, keyBlock, i));
+                    }
+                }
+                catch (Throwable t) {
+                    throw internalError(t);
                 }
             }
-            catch (Throwable t) {
-                mapBlockBuilder.closeEntry();
-                throw internalError(t);
-            }
-            mapType.getKeyType().appendTo(keyBlock, i, blockBuilder);
-            mapType.getValueType().appendTo(valueBlock, i, blockBuilder);
+
+            keyType.appendTo(keyBlock, i, blockBuilder);
+            valueType.appendTo(valueBlock, i, blockBuilder);
         }
         try {
             mapBlockBuilder.closeEntryStrict(keyBlockEqual, keyBlockHashCode);
@@ -180,25 +176,7 @@ public final class MapConstructor
         catch (NotSupportedException e) {
             throw new PrestoException(NOT_SUPPORTED, e.getMessage(), e);
         }
-        finally {
-            pageBuilder.declarePosition();
-        }
 
         return mapType.getObject(mapBlockBuilder, mapBlockBuilder.getPositionCount() - 1);
-    }
-
-    public static final class State
-    {
-        private final PageBuilder pageBuilder;
-
-        public State(MapType mapType)
-        {
-            pageBuilder = new PageBuilder(ImmutableList.of(mapType));
-        }
-
-        public PageBuilder getPageBuilder()
-        {
-            return pageBuilder;
-        }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapEntriesFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapEntriesFunction.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.operator.scalar;
 
-import com.facebook.presto.common.PageBuilder;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockBuilder;
 import com.facebook.presto.common.type.ArrayType;
@@ -23,7 +22,6 @@ import com.facebook.presto.spi.function.Description;
 import com.facebook.presto.spi.function.ScalarFunction;
 import com.facebook.presto.spi.function.SqlType;
 import com.facebook.presto.spi.function.TypeParameter;
-import com.google.common.collect.ImmutableList;
 
 import static com.google.common.base.Verify.verify;
 
@@ -31,14 +29,9 @@ import static com.google.common.base.Verify.verify;
 @Description("construct an array of entries from a given map")
 public class MapEntriesFunction
 {
-    private final PageBuilder pageBuilder;
-
     @TypeParameter("K")
     @TypeParameter("V")
-    public MapEntriesFunction(@TypeParameter("array(row(K,V))") Type arrayType)
-    {
-        pageBuilder = new PageBuilder(ImmutableList.of(arrayType));
-    }
+    public MapEntriesFunction(@TypeParameter("array(row(K,V))") Type arrayType) {}
 
     @TypeParameter("K")
     @TypeParameter("V")
@@ -53,13 +46,8 @@ public class MapEntriesFunction
         Type keyType = rowType.getTypeParameters().get(0);
         Type valueType = rowType.getTypeParameters().get(1);
         ArrayType arrayType = new ArrayType(rowType);
-
-        if (pageBuilder.isFull()) {
-            pageBuilder.reset();
-        }
-
         int entryCount = block.getPositionCount() / 2;
-        BlockBuilder blockBuilder = pageBuilder.getBlockBuilder(0);
+        BlockBuilder blockBuilder = arrayType.createBlockBuilder(null, entryCount);
         BlockBuilder entryBuilder = blockBuilder.beginBlockEntry();
         for (int i = 0; i < entryCount; i++) {
             BlockBuilder rowBuilder = entryBuilder.beginBlockEntry();
@@ -69,7 +57,6 @@ public class MapEntriesFunction
         }
 
         blockBuilder.closeEntry();
-        pageBuilder.declarePosition();
         return arrayType.getObject(blockBuilder, blockBuilder.getPositionCount() - 1);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/SplitToMultimapFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/SplitToMultimapFunction.java
@@ -14,7 +14,6 @@
 
 package com.facebook.presto.operator.scalar;
 
-import com.facebook.presto.common.PageBuilder;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockBuilder;
 import com.facebook.presto.common.type.StandardTypes;
@@ -25,7 +24,6 @@ import com.facebook.presto.spi.function.ScalarFunction;
 import com.facebook.presto.spi.function.SqlType;
 import com.facebook.presto.spi.function.TypeParameter;
 import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Multimap;
 import io.airlift.slice.Slice;
 
@@ -40,12 +38,7 @@ import static com.facebook.presto.util.Failures.checkCondition;
 @ScalarFunction("split_to_multimap")
 public class SplitToMultimapFunction
 {
-    private final PageBuilder pageBuilder;
-
-    public SplitToMultimapFunction(@TypeParameter("map(varchar,array(varchar))") Type mapType)
-    {
-        pageBuilder = new PageBuilder(ImmutableList.of(mapType));
-    }
+    public SplitToMultimapFunction(@TypeParameter("map(varchar,array(varchar))") Type mapType) {}
 
     @SqlType("map(varchar,array(varchar))")
     public Block splitToMultimap(
@@ -95,12 +88,7 @@ public class SplitToMultimapFunction
             entryStart = entryEnd + entryDelimiter.length();
         }
 
-        if (pageBuilder.isFull()) {
-            pageBuilder.reset();
-        }
-
-        pageBuilder.declarePosition();
-        BlockBuilder blockBuilder = pageBuilder.getBlockBuilder(0);
+        BlockBuilder blockBuilder = mapType.createBlockBuilder(null, 10);
         BlockBuilder singleMapBlockBuilder = blockBuilder.beginBlockEntry();
         for (Map.Entry<Slice, Collection<Slice>> entry : multimap.asMap().entrySet()) {
             VARCHAR.writeSlice(singleMapBlockBuilder, entry.getKey());

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/VarArgsToArrayAdapterGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/VarArgsToArrayAdapterGenerator.java
@@ -13,12 +13,12 @@
  */
 package com.facebook.presto.sql.gen;
 
-import com.facebook.presto.annotation.UsedByGeneratedCode;
 import com.facebook.presto.bytecode.BytecodeBlock;
 import com.facebook.presto.bytecode.ClassDefinition;
 import com.facebook.presto.bytecode.MethodDefinition;
 import com.facebook.presto.bytecode.Parameter;
-import com.facebook.presto.bytecode.expression.BytecodeExpression;
+import com.facebook.presto.bytecode.ParameterizedType;
+import com.facebook.presto.bytecode.expression.BytecodeExpressions;
 import com.facebook.presto.util.Reflection;
 import com.google.common.collect.ImmutableList;
 
@@ -33,8 +33,6 @@ import static com.facebook.presto.bytecode.Access.STATIC;
 import static com.facebook.presto.bytecode.Access.a;
 import static com.facebook.presto.bytecode.Parameter.arg;
 import static com.facebook.presto.bytecode.ParameterizedType.type;
-import static com.facebook.presto.bytecode.expression.BytecodeExpressions.newArray;
-import static com.facebook.presto.bytecode.expression.BytecodeExpressions.newInstance;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.sql.gen.BytecodeUtils.loadConstant;
 import static com.facebook.presto.util.CompilerUtils.defineClass;
@@ -50,116 +48,68 @@ public class VarArgsToArrayAdapterGenerator
     {
     }
 
-    public static class MethodHandleAndConstructor
+    public static class VarArgMethodHandle
     {
         private final MethodHandle methodHandle;
-        private final MethodHandle constructor;
 
-        private MethodHandleAndConstructor(MethodHandle methodHandle, MethodHandle constructor)
+        private VarArgMethodHandle(MethodHandle methodHandle)
         {
             this.methodHandle = requireNonNull(methodHandle, "methodHandle is null");
-            this.constructor = requireNonNull(constructor, "constructor is null");
         }
 
         public MethodHandle getMethodHandle()
         {
             return methodHandle;
         }
-
-        public MethodHandle getConstructor()
-        {
-            return constructor;
-        }
     }
 
-    @UsedByGeneratedCode
-    public static final class VarArgsToArrayAdapterState
-    {
-        /**
-         * User state created by provided user state factory
-         */
-        public final Object userState;
-
-        /**
-         * Array of argument, such as long[], Block[]
-         */
-        public final Object args;
-
-        public VarArgsToArrayAdapterState(Object userState, Object args)
-        {
-            this.userState = userState;
-            this.args = requireNonNull(args, "args is null");
-        }
-    }
-
-    public static MethodHandleAndConstructor generateVarArgsToArrayAdapter(
+    public static VarArgMethodHandle generateVarArgsToArrayAdapter(
             Class<?> returnType,
             Class<?> javaType,
             int argsLength,
-            MethodHandle function,
-            MethodHandle userStateFactory)
+            MethodHandle function)
     {
         requireNonNull(returnType, "returnType is null");
         requireNonNull(javaType, "javaType is null");
         requireNonNull(function, "function is null");
-        requireNonNull(userStateFactory, "userStateFactory is null");
 
-        checkCondition(argsLength <= 253, NOT_SUPPORTED, "Too many arguments for vararg function");
+        checkCondition(argsLength <= 254, NOT_SUPPORTED, "Too many arguments for vararg function");
 
         MethodType methodType = function.type();
         Class<?> javaArrayType = toArrayClass(javaType);
         checkArgument(methodType.returnType() == returnType, "returnType does not match");
-        checkArgument(methodType.parameterList().equals(ImmutableList.of(Object.class, javaArrayType)), "parameter types do not match");
+        checkArgument(methodType.parameterList().equals(ImmutableList.of(javaArrayType)), "parameter types do not match");
 
         CallSiteBinder callSiteBinder = new CallSiteBinder();
         ClassDefinition classDefinition = new ClassDefinition(a(PUBLIC, FINAL), makeClassName("VarArgsToListAdapter"), type(Object.class));
         classDefinition.declareDefaultConstructor(a(PRIVATE));
 
-        // generate userState constructor
-        MethodDefinition stateFactoryDefinition = classDefinition.declareMethod(a(PUBLIC, STATIC), "createState", type(VarArgsToArrayAdapterState.class));
-
-        stateFactoryDefinition.getBody()
-                .comment("create userState for current instance")
-                .append(
-                        newInstance(
-                                VarArgsToArrayAdapterState.class,
-                                loadConstant(callSiteBinder, userStateFactory, MethodHandle.class).invoke("invokeExact", Object.class),
-                                newArray(type(javaArrayType), argsLength).cast(Object.class)).ret());
-
         // generate adapter method
         ImmutableList.Builder<Parameter> parameterListBuilder = ImmutableList.builder();
-        parameterListBuilder.add(arg("userState", VarArgsToArrayAdapterState.class));
         for (int i = 0; i < argsLength; i++) {
             parameterListBuilder.add(arg("input_" + i, javaType));
         }
         ImmutableList<Parameter> parameterList = parameterListBuilder.build();
-
         MethodDefinition methodDefinition = classDefinition.declareMethod(a(PUBLIC, STATIC), "varArgsToArray", type(returnType), parameterList);
         BytecodeBlock body = methodDefinition.getBody();
-
-        BytecodeExpression userState = parameterList.get(0).getField("userState", Object.class);
-        BytecodeExpression args = parameterList.get(0).getField("args", Object.class).cast(javaArrayType);
-        for (int i = 0; i < argsLength; i++) {
-            body.append(args.setElement(i, parameterList.get(i + 1)));
-        }
-
         body.append(
                 loadConstant(callSiteBinder, function, MethodHandle.class)
-                        .invoke("invokeExact", returnType, userState, args)
+                        .invoke(
+                                "invokeExact",
+                                returnType,
+                                BytecodeExpressions.newArray(ParameterizedType.type(javaArrayType), parameterList))
                         .ret());
 
         // define class
         Class<?> generatedClass = defineClass(classDefinition, Object.class, callSiteBinder.getBindings(), VarArgsToArrayAdapterGenerator.class.getClassLoader());
-        return new MethodHandleAndConstructor(
+        return new VarArgMethodHandle(
                 Reflection.methodHandle(
                         generatedClass,
                         "varArgsToArray",
                         ImmutableList.builder()
-                                .add(VarArgsToArrayAdapterState.class)
                                 .addAll(nCopies(argsLength, javaType))
                                 .build()
-                                .toArray(new Class<?>[argsLength])),
-                Reflection.methodHandle(generatedClass, "createState"));
+                                .toArray(new Class<?>[argsLength])));
     }
 
     private static Class<?> toArrayClass(Class<?> elementType)

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestArrayFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestArrayFunctions.java
@@ -38,7 +38,7 @@ public class TestArrayFunctions
     {
         assertFunction("CONCAT(" + Joiner.on(", ").join(nCopies(253, "array[1]")) + ")", new ArrayType(INTEGER), nCopies(253, 1));
         assertNotSupported(
-                "CONCAT(" + Joiner.on(", ").join(nCopies(254, "array[1]")) + ")",
+                "CONCAT(" + Joiner.on(", ").join(nCopies(255, "array[1]")) + ")",
                 "Too many arguments for vararg function");
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/TestVarArgsToArrayAdapterGenerator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/TestVarArgsToArrayAdapterGenerator.java
@@ -29,7 +29,6 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.lang.invoke.MethodHandle;
-import java.util.Optional;
 import java.util.stream.IntStream;
 
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
@@ -74,9 +73,7 @@ public class TestVarArgsToArrayAdapterGenerator
     {
         public static final TestVarArgsSum VAR_ARGS_SUM = new TestVarArgsSum();
 
-        private static final MethodHandle METHOD_HANDLE = methodHandle(TestVarArgsSum.class, "varArgsSum", Object.class, long[].class);
-        private static final MethodHandle USER_STATE_FACTORY = methodHandle(TestVarArgsSum.class, "createState");
-
+        private static final MethodHandle METHOD_HANDLE = methodHandle(TestVarArgsSum.class, "varArgsSum", long[].class);
         private TestVarArgsSum()
         {
             super(new Signature(
@@ -110,27 +107,19 @@ public class TestVarArgsToArrayAdapterGenerator
         @Override
         public BuiltInScalarFunctionImplementation specialize(BoundVariables boundVariables, int arity, FunctionAndTypeManager functionAndTypeManager)
         {
-            VarArgsToArrayAdapterGenerator.MethodHandleAndConstructor methodHandleAndConstructor = generateVarArgsToArrayAdapter(
+            VarArgsToArrayAdapterGenerator.VarArgMethodHandle varArgMethodHandle = generateVarArgsToArrayAdapter(
                     long.class,
                     long.class,
                     arity,
-                    METHOD_HANDLE,
-                    USER_STATE_FACTORY);
+                    METHOD_HANDLE);
             return new BuiltInScalarFunctionImplementation(
                     false,
                     nCopies(arity, valueTypeArgumentProperty(RETURN_NULL_ON_NULL)),
-                    methodHandleAndConstructor.getMethodHandle(),
-                    Optional.of(methodHandleAndConstructor.getConstructor()));
+                    varArgMethodHandle.getMethodHandle());
         }
 
         @UsedByGeneratedCode
-        public static Object createState()
-        {
-            return null;
-        }
-
-        @UsedByGeneratedCode
-        public static long varArgsSum(Object state, long[] values)
+        public static long varArgsSum(long[] values)
         {
             long sum = 0;
             for (long value : values) {

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -5806,4 +5806,11 @@ public abstract class AbstractTestQueries
                 .build();
         assertQuerySucceeds(sessionWithIntermediateAggEnabled, "select reduce_agg(x, map(), (s,x)->map_zip_with( s, x, (k1,v1,v2)->if(v1>v2,v1,v2)), (s,x)->map_zip_with( s, x, (k1,v1,v2)->if(v1>v2,v1,v2))) from (select map(array['k1', 'k2'], array[1e-2, 0.06]) x union all select map(array['k1', 'k2'], array[2e-05, 1e-2]) x)");
     }
+
+    @Test
+    public void testReduceAggWithArrayConcat()
+    {
+        assertQuerySucceeds("select sum(cardinality(s)) from (SELECT REDUCE_AGG(x, cast(array[] as array<bigint>), (x,y)->x||sequence(1, y), (x,y)->x||y) s FROM (SELECT x FROM (SELECT 1) CROSS JOIN UNNEST(SEQUENCE(1, 7000)) T(x)) group by random(100))");
+        assertQuerySucceeds("select sum(cardinality(s)) from (SELECT REDUCE_AGG(x, cast(map() as map<bigint, bigint>), (x,y) -> map_concat(x, map(sequence(1, y), repeat(1, cast(y as int)))), (x,y)->map_concat(x,y)) s FROM (SELECT x FROM (SELECT 1) CROSS JOIN UNNEST(SEQUENCE(1, 7000)) T(x)) group by random(100))");
+    }
 }


### PR DESCRIPTION
Addressing issue:

https://github.com/prestodb/presto/issues/16728

to get rid of the PageBuilder objects that constitute the state as it is violating the general immutability constraint on runtime objects. In that process looks like array_concat actually got faster/more efficient! See the benchmarks. Also fixed MAP_ZIP_WITH for the same issue with state.

Test plan - Added tests and benchmarks

```
== NO RELEASE NOTE ==
```
