### PR TITLE
Support hive scalar function

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,6 +174,7 @@
         <module>presto-node-ttl-fetchers</module>
         <module>presto-cluster-ttl-providers</module>
         <module>presto-google-sheets</module>
+        <module>presto-hive-function-namespace</module>
     </modules>
 
     <dependencyManagement>
@@ -244,6 +245,12 @@
             <dependency>
                 <groupId>com.facebook.presto</groupId>
                 <artifactId>presto-cluster-ttl-providers</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.facebook.presto</groupId>
+                <artifactId>presto-hive-function-namespace</artifactId>
                 <version>${project.version}</version>
             </dependency>
 

--- a/presto-common/src/main/java/com/facebook/presto/common/type/MapType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/MapType.java
@@ -100,6 +100,16 @@ public class MapType
         return valueType.isComparable();
     }
 
+    public MethodHandle getKeyBlockEquals()
+    {
+        return keyBlockEquals;
+    }
+
+    public MethodHandle getKeyBlockHashCode()
+    {
+        return keyBlockHashCode;
+    }
+
     @Override
     public long hash(Block block, int position)
     {

--- a/presto-hive-function-namespace/pom.xml
+++ b/presto-hive-function-namespace/pom.xml
@@ -82,6 +82,26 @@
             <artifactId>presto-bytecode</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>configuration</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>bootstrap</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+        </dependency>
+
         <!-- for testing -->
         <dependency>
             <groupId>org.testng</groupId>
@@ -99,6 +119,12 @@
         <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-main</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-tests</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/presto-hive-function-namespace/pom.xml
+++ b/presto-hive-function-namespace/pom.xml
@@ -72,6 +72,16 @@
             <scope>provided</scope>
         </dependency>
 
+        <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>log</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-bytecode</artifactId>
+        </dependency>
+
         <!-- for testing -->
         <dependency>
             <groupId>org.testng</groupId>

--- a/presto-hive-function-namespace/pom.xml
+++ b/presto-hive-function-namespace/pom.xml
@@ -16,6 +16,15 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto.hadoop</groupId>
+            <artifactId>hadoop-apache2</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -61,6 +70,32 @@
             <groupId>io.airlift</groupId>
             <artifactId>units</artifactId>
             <scope>provided</scope>
+        </dependency>
+
+        <!-- for testing -->
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-common</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-main</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-memory</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/presto-hive-function-namespace/pom.xml
+++ b/presto-hive-function-namespace/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>presto-root</artifactId>
+        <groupId>com.facebook.presto</groupId>
+        <version>0.268-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>presto-hive-function-namespace</artifactId>
+    <description>Hive functions for Presto</description>
+    <packaging>presto-plugin</packaging>
+
+    <properties>
+        <air.main.basedir>${project.parent.basedir}</air.main.basedir>
+    </properties>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.inject</groupId>
+            <artifactId>javax.inject</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto.hive</groupId>
+            <artifactId>hive-apache</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-spi</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-common</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.drift</groupId>
+            <artifactId>drift-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>slice</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.airlift</groupId>
+            <artifactId>units</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/ForHiveFunction.java
+++ b/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/ForHiveFunction.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.functions;
+
+import javax.inject.Qualifier;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target({FIELD, PARAMETER, METHOD})
+@Qualifier
+public @interface ForHiveFunction {}

--- a/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/FunctionRegistry.java
+++ b/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/FunctionRegistry.java
@@ -1,0 +1,285 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.hive.functions;
+
+import org.apache.hadoop.hive.ql.exec.FunctionInfo;
+import org.apache.hadoop.hive.ql.exec.Registry;
+import org.apache.hadoop.hive.ql.parse.SemanticException;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFAbs;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFAddMonths;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFAesDecrypt;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFAesEncrypt;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFArray;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFArrayContains;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFAssertTrue;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFAssertTrueOOM;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFBRound;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFBetween;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFCardinalityViolation;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFCase;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFCbrt;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFCeil;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFCharacterLength;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFCoalesce;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFConcat;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFConcatWS;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFCurrentDate;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFCurrentGroups;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFCurrentTimestamp;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFCurrentUser;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFDate;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFDateAdd;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFDateDiff;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFDateFormat;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFDateSub;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFDecode;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFElt;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFEncode;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFEnforceConstraint;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFEpochMilli;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFExtractUnion;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFFactorial;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFField;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFFloor;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFFormatNumber;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFFromUtcTimestamp;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFGreatest;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFGrouping;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFHash;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFInBloomFilter;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFInFile;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFIndex;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFInitCap;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFInstr;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFInternalInterval;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFLTrim;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFLag;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFLastDay;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFLead;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFLeast;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFLength;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFLevenshtein;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFLikeAll;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFLikeAny;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFLocate;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFLoggedInUser;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFLower;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFLpad;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFMap;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFMapKeys;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFMapValues;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFMonthsBetween;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFMurmurHash;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFNamedStruct;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFNextDay;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFNullif;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFNvl;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFOPFalse;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFOPNegative;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFOPNotFalse;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFOPNotNull;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFOPNotTrue;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFOPNull;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFOPPositive;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFOPTrue;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFOctetLength;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFPosMod;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFPower;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFPrintf;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFQuarter;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFRTrim;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFReflect;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFReflect2;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFRegExp;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFRestrictInformationSchema;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFRound;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFRpad;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFSQCountCheck;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFSentences;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFSha2;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFSize;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFSortArray;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFSortArrayByField;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFSoundex;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFSplit;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFStringToMap;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFStruct;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFSubstringIndex;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFTimestamp;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFToBinary;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFToChar;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFToDate;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFToDecimal;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFToIntervalDayTime;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFToIntervalYearMonth;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFToTimestampLocalTZ;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFToUnixTimeStamp;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFToUtcTimestamp;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFToVarchar;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFTranslate;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFTrim;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFTrunc;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFUnion;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFUnixTimeStamp;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFUpper;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFWhen;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFWidthBucket;
+import org.apache.hadoop.hive.ql.udf.generic.UDFCurrentDB;
+import org.apache.hadoop.hive.ql.udf.xml.GenericUDFXPath;
+
+public final class FunctionRegistry
+{
+    private FunctionRegistry() {}
+
+    // registry for hive functions
+    private static final Registry system = new Registry(true);
+
+    static {
+        // register genericUDF
+        system.registerGenericUDF("concat", GenericUDFConcat.class);
+        system.registerGenericUDF("substring_index", GenericUDFSubstringIndex.class);
+        system.registerGenericUDF("lpad", GenericUDFLpad.class);
+        system.registerGenericUDF("rpad", GenericUDFRpad.class);
+        system.registerGenericUDF("levenshtein", GenericUDFLevenshtein.class);
+        system.registerGenericUDF("soundex", GenericUDFSoundex.class);
+        system.registerGenericUDF("size", GenericUDFSize.class);
+        system.registerGenericUDF("round", GenericUDFRound.class);
+        system.registerGenericUDF("bround", GenericUDFBRound.class);
+        system.registerGenericUDF("floor", GenericUDFFloor.class);
+        system.registerGenericUDF("cbrt", GenericUDFCbrt.class);
+        system.registerGenericUDF("ceil", GenericUDFCeil.class);
+        system.registerGenericUDF("ceiling", GenericUDFCeil.class);
+        system.registerGenericUDF("abs", GenericUDFAbs.class);
+        system.registerGenericUDF("sq_count_check", GenericUDFSQCountCheck.class);
+        system.registerGenericUDF("enforce_constraint", GenericUDFEnforceConstraint.class);
+        system.registerGenericUDF("pmod", GenericUDFPosMod.class);
+        system.registerGenericUDF("power", GenericUDFPower.class);
+        system.registerGenericUDF("pow", GenericUDFPower.class);
+        system.registerGenericUDF("factorial", GenericUDFFactorial.class);
+        system.registerGenericUDF("sha2", GenericUDFSha2.class);
+        system.registerGenericUDF("aes_encrypt", GenericUDFAesEncrypt.class);
+        system.registerGenericUDF("aes_decrypt", GenericUDFAesDecrypt.class);
+        system.registerGenericUDF("encode", GenericUDFEncode.class);
+        system.registerGenericUDF("decode", GenericUDFDecode.class);
+        system.registerGenericUDF("upper", GenericUDFUpper.class);
+        system.registerGenericUDF("lower", GenericUDFLower.class);
+        system.registerGenericUDF("ucase", GenericUDFUpper.class);
+        system.registerGenericUDF("lcase", GenericUDFLower.class);
+        system.registerGenericUDF("trim", GenericUDFTrim.class);
+        system.registerGenericUDF("ltrim", GenericUDFLTrim.class);
+        system.registerGenericUDF("rtrim", GenericUDFRTrim.class);
+        system.registerGenericUDF("length", GenericUDFLength.class);
+        system.registerGenericUDF("character_length", GenericUDFCharacterLength.class);
+        system.registerGenericUDF("char_length", GenericUDFCharacterLength.class);
+        system.registerGenericUDF("octet_length", GenericUDFOctetLength.class);
+        system.registerGenericUDF("field", GenericUDFField.class);
+        system.registerGenericUDF("initcap", GenericUDFInitCap.class);
+        system.registerGenericUDF("likeany", GenericUDFLikeAny.class);
+        system.registerGenericUDF("likeall", GenericUDFLikeAll.class);
+        system.registerGenericUDF("rlike", GenericUDFRegExp.class);
+        system.registerGenericUDF("regexp", GenericUDFRegExp.class);
+        system.registerGenericUDF("nvl", GenericUDFNvl.class);
+        system.registerGenericUDF("split", GenericUDFSplit.class);
+        system.registerGenericUDF("str_to_map", GenericUDFStringToMap.class);
+        system.registerGenericUDF("translate", GenericUDFTranslate.class);
+        system.registerGenericUDF("positive", GenericUDFOPPositive.class);
+        system.registerGenericUDF("negative", GenericUDFOPNegative.class);
+        system.registerGenericUDF("quarter", GenericUDFQuarter.class);
+        system.registerGenericUDF("to_date", GenericUDFDate.class);
+        system.registerGenericUDF("last_day", GenericUDFLastDay.class);
+        system.registerGenericUDF("next_day", GenericUDFNextDay.class);
+        system.registerGenericUDF("trunc", GenericUDFTrunc.class);
+        system.registerGenericUDF("date_format", GenericUDFDateFormat.class);
+        system.registerGenericUDF("date_add", GenericUDFDateAdd.class);
+        system.registerGenericUDF("date_sub", GenericUDFDateSub.class);
+        system.registerGenericUDF("datediff", GenericUDFDateDiff.class);
+        system.registerGenericUDF("add_months", GenericUDFAddMonths.class);
+        system.registerGenericUDF("months_between", GenericUDFMonthsBetween.class);
+        system.registerGenericUDF("xpath", GenericUDFXPath.class);
+        system.registerGenericUDF("grouping", GenericUDFGrouping.class);
+        system.registerGenericUDF("current_database", UDFCurrentDB.class);
+        system.registerGenericUDF("current_date", GenericUDFCurrentDate.class);
+        system.registerGenericUDF("current_timestamp", GenericUDFCurrentTimestamp.class);
+        system.registerGenericUDF("current_user", GenericUDFCurrentUser.class);
+        system.registerGenericUDF("current_groups", GenericUDFCurrentGroups.class);
+        system.registerGenericUDF("logged_in_user", GenericUDFLoggedInUser.class);
+        system.registerGenericUDF("restrict_information_schema", GenericUDFRestrictInformationSchema.class);
+        system.registerGenericUDF("isnull", GenericUDFOPNull.class);
+        system.registerGenericUDF("isnotnull", GenericUDFOPNotNull.class);
+        system.registerGenericUDF("istrue", GenericUDFOPTrue.class);
+        system.registerGenericUDF("isnottrue", GenericUDFOPNotTrue.class);
+        system.registerGenericUDF("isfalse", GenericUDFOPFalse.class);
+        system.registerGenericUDF("isnotfalse", GenericUDFOPNotFalse.class);
+        system.registerGenericUDF("between", GenericUDFBetween.class);
+        system.registerGenericUDF("in_bloom_filter", GenericUDFInBloomFilter.class);
+        system.registerGenericUDF("date", GenericUDFToDate.class);
+        system.registerGenericUDF("timestamp", GenericUDFTimestamp.class);
+        system.registerGenericUDF("timestamp with local time zone", GenericUDFToTimestampLocalTZ.class);
+        system.registerGenericUDF("interval_year_month", GenericUDFToIntervalYearMonth.class);
+        system.registerGenericUDF("interval_day_time", GenericUDFToIntervalDayTime.class);
+        system.registerGenericUDF("binary", GenericUDFToBinary.class);
+        system.registerGenericUDF("decimal", GenericUDFToDecimal.class);
+        system.registerGenericUDF("varchar", GenericUDFToVarchar.class);
+        system.registerGenericUDF("char", GenericUDFToChar.class);
+        system.registerGenericUDF("reflect", GenericUDFReflect.class);
+        system.registerGenericUDF("reflect2", GenericUDFReflect2.class);
+        system.registerGenericUDF("java_method", GenericUDFReflect.class);
+        system.registerGenericUDF("array", GenericUDFArray.class);
+        system.registerGenericUDF("assert_true", GenericUDFAssertTrue.class);
+        system.registerGenericUDF("assert_true_oom", GenericUDFAssertTrueOOM.class);
+        system.registerGenericUDF("map", GenericUDFMap.class);
+        system.registerGenericUDF("struct", GenericUDFStruct.class);
+        system.registerGenericUDF("named_struct", GenericUDFNamedStruct.class);
+        system.registerGenericUDF("create_union", GenericUDFUnion.class);
+        system.registerGenericUDF("extract_union", GenericUDFExtractUnion.class);
+        system.registerGenericUDF("case", GenericUDFCase.class);
+        system.registerGenericUDF("when", GenericUDFWhen.class);
+        system.registerGenericUDF("nullif", GenericUDFNullif.class);
+        system.registerGenericUDF("hash", GenericUDFHash.class);
+        system.registerGenericUDF("murmur_hash", GenericUDFMurmurHash.class);
+        system.registerGenericUDF("coalesce", GenericUDFCoalesce.class);
+        system.registerGenericUDF("index", GenericUDFIndex.class);
+        system.registerGenericUDF("in_file", GenericUDFInFile.class);
+        system.registerGenericUDF("instr", GenericUDFInstr.class);
+        system.registerGenericUDF("locate", GenericUDFLocate.class);
+        system.registerGenericUDF("elt", GenericUDFElt.class);
+        system.registerGenericUDF("concat_ws", GenericUDFConcatWS.class);
+        system.registerGenericUDF("sort_array", GenericUDFSortArray.class);
+        system.registerGenericUDF("sort_array_by", GenericUDFSortArrayByField.class);
+        system.registerGenericUDF("array_contains", GenericUDFArrayContains.class);
+        system.registerGenericUDF("sentences", GenericUDFSentences.class);
+        system.registerGenericUDF("map_keys", GenericUDFMapKeys.class);
+        system.registerGenericUDF("map_values", GenericUDFMapValues.class);
+        system.registerGenericUDF("format_number", GenericUDFFormatNumber.class);
+        system.registerGenericUDF("printf", GenericUDFPrintf.class);
+        system.registerGenericUDF("greatest", GenericUDFGreatest.class);
+        system.registerGenericUDF("least", GenericUDFLeast.class);
+        system.registerGenericUDF("cardinality_violation", GenericUDFCardinalityViolation.class);
+        system.registerGenericUDF("width_bucket", GenericUDFWidthBucket.class);
+        system.registerGenericUDF("from_utc_timestamp", GenericUDFFromUtcTimestamp.class);
+        system.registerGenericUDF("to_utc_timestamp", GenericUDFToUtcTimestamp.class);
+        system.registerGenericUDF("unix_timestamp", GenericUDFUnixTimeStamp.class);
+        system.registerGenericUDF("to_unix_timestamp", GenericUDFToUnixTimeStamp.class);
+        system.registerGenericUDF("internal_interval", GenericUDFInternalInterval.class);
+        system.registerGenericUDF("to_epoch_milli", GenericUDFEpochMilli.class);
+        system.registerGenericUDF("lead", GenericUDFLead.class);
+        system.registerGenericUDF("lag", GenericUDFLag.class);
+    }
+
+    public static FunctionInfo getFunctionInfo(String functionName) throws SemanticException
+    {
+        return system.getFunctionInfo(functionName);
+    }
+}

--- a/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/FunctionRegistry.java
+++ b/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/FunctionRegistry.java
@@ -139,6 +139,8 @@ import org.apache.hadoop.hive.ql.udf.generic.GenericUDFWidthBucket;
 import org.apache.hadoop.hive.ql.udf.generic.UDFCurrentDB;
 import org.apache.hadoop.hive.ql.udf.xml.GenericUDFXPath;
 
+import java.util.Set;
+
 public final class FunctionRegistry
 {
     private FunctionRegistry() {}
@@ -281,5 +283,10 @@ public final class FunctionRegistry
     public static FunctionInfo getFunctionInfo(String functionName) throws SemanticException
     {
         return system.getFunctionInfo(functionName);
+    }
+
+    public static Set<String> getCurrentFunctionNames()
+    {
+        return system.getCurrentFunctionNames();
     }
 }

--- a/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/HiveFunction.java
+++ b/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/HiveFunction.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.hive.functions;
+
+import com.facebook.presto.common.QualifiedObjectName;
+import com.facebook.presto.spi.function.FunctionMetadata;
+import com.facebook.presto.spi.function.Signature;
+import com.facebook.presto.spi.function.SqlFunction;
+
+import static java.util.Objects.requireNonNull;
+
+public abstract class HiveFunction
+        implements SqlFunction
+{
+    private final QualifiedObjectName name;
+    private final Signature signature;
+    private final boolean hidden;
+    private final boolean deterministic;
+    private final boolean calledOnNullInput;
+    private final String description;
+
+    public HiveFunction(QualifiedObjectName name,
+                        Signature signature,
+                        boolean hidden,
+                        boolean deterministic,
+                        boolean calledOnNullInput,
+                        String description)
+    {
+        this.name = requireNonNull(name, "name is null");
+        this.signature = requireNonNull(signature, "signature is null");
+        this.hidden = hidden;
+        this.deterministic = deterministic;
+        this.calledOnNullInput = calledOnNullInput;
+        this.description = requireNonNull(description, "description is null");
+    }
+
+    public QualifiedObjectName getName()
+    {
+        return name;
+    }
+
+    @Override
+    public Signature getSignature()
+    {
+        return signature;
+    }
+
+    @Override
+    public boolean isDeterministic()
+    {
+        return deterministic;
+    }
+
+    @Override
+    public boolean isCalledOnNullInput()
+    {
+        return calledOnNullInput;
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return description;
+    }
+
+    public abstract FunctionMetadata getFunctionMetadata();
+}

--- a/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/HiveFunctionErrorCode.java
+++ b/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/HiveFunctionErrorCode.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.hive.functions;
+
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.TypeSignature;
+import com.facebook.presto.spi.ErrorCode;
+import com.facebook.presto.spi.ErrorCodeSupplier;
+import com.facebook.presto.spi.ErrorType;
+import com.facebook.presto.spi.PrestoException;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+
+import static com.facebook.presto.spi.ErrorType.EXTERNAL;
+import static com.facebook.presto.spi.StandardErrorCode.FUNCTION_NOT_FOUND;
+import static java.lang.String.format;
+
+public enum HiveFunctionErrorCode
+        implements ErrorCodeSupplier
+{
+    HIVE_FUNCTION_UNSUPPORTED_HIVE_TYPE(0, EXTERNAL),
+    HIVE_FUNCTION_UNSUPPORTED_PRESTO_TYPE(1, EXTERNAL),
+    HIVE_FUNCTION_UNSUPPORTED_FUNCTION_TYPE(2, EXTERNAL),
+    HIVE_FUNCTION_INITIALIZATION_ERROR(3, EXTERNAL),
+    HIVE_FUNCTION_EXECUTION_ERROR(4, EXTERNAL),
+    /**/;
+
+    private static final int ERROR_CODE_MASK = 0x0110_0000;
+
+    private final ErrorCode errorCode;
+
+    HiveFunctionErrorCode(int code, ErrorType type)
+    {
+        errorCode = new ErrorCode(code + ERROR_CODE_MASK, name(), type);
+    }
+
+    @Override
+    public ErrorCode toErrorCode()
+    {
+        return errorCode;
+    }
+
+    public static PrestoException unsupportedType(Type type)
+    {
+        return new PrestoException(HIVE_FUNCTION_UNSUPPORTED_PRESTO_TYPE, "Unsupported Presto type " + type);
+    }
+
+    public static PrestoException unsupportedType(TypeSignature type)
+    {
+        return new PrestoException(HIVE_FUNCTION_UNSUPPORTED_PRESTO_TYPE, "Unsupported Presto type " + type);
+    }
+
+    public static PrestoException unsupportedType(ObjectInspector inspector)
+    {
+        return new PrestoException(HIVE_FUNCTION_UNSUPPORTED_HIVE_TYPE, "Unsupported Hive type " + inspector);
+    }
+
+    public static PrestoException unsupportedFunctionType(Class<?> cls)
+    {
+        return new PrestoException(HIVE_FUNCTION_UNSUPPORTED_FUNCTION_TYPE,
+                format("Unsupported function type %s / %s", cls.getName(), cls.getSuperclass().getName()));
+    }
+
+    public static PrestoException unsupportedFunctionType(Class<?> cls, Throwable t)
+    {
+        return new PrestoException(HIVE_FUNCTION_UNSUPPORTED_FUNCTION_TYPE,
+                format("Unsupported function type %s / %s", cls.getName(), cls.getSuperclass().getName()), t);
+    }
+
+    public static PrestoException functionNotFound(String name)
+    {
+        return new PrestoException(FUNCTION_NOT_FOUND, format("Function %s not registered", name));
+    }
+
+    public static PrestoException initializationError(Throwable t)
+    {
+        return new PrestoException(HIVE_FUNCTION_INITIALIZATION_ERROR, t);
+    }
+
+    public static PrestoException executionError(Throwable t)
+    {
+        return new PrestoException(HIVE_FUNCTION_EXECUTION_ERROR, t);
+    }
+}

--- a/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/HiveFunctionHandle.java
+++ b/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/HiveFunctionHandle.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.hive.functions;
+
+import com.facebook.presto.common.CatalogSchemaName;
+import com.facebook.presto.spi.function.FunctionHandle;
+import com.facebook.presto.spi.function.Signature;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+
+public class HiveFunctionHandle
+        implements FunctionHandle
+{
+    private final Signature signature;
+
+    @JsonCreator
+    public HiveFunctionHandle(@JsonProperty("signature") Signature signature)
+    {
+        this.signature = requireNonNull(signature, "signature is null");
+    }
+
+    @Override
+    public CatalogSchemaName getCatalogSchemaName()
+    {
+        return signature.getName().getCatalogSchemaName();
+    }
+
+    @JsonProperty
+    public Signature getSignature()
+    {
+        return signature;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        HiveFunctionHandle that = (HiveFunctionHandle) o;
+        return Objects.equals(signature, that.signature);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(signature);
+    }
+
+    @Override
+    public String toString()
+    {
+        return signature.toString();
+    }
+}

--- a/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/HiveFunctionHandleResolver.java
+++ b/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/HiveFunctionHandleResolver.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.hive.functions;
+
+import com.facebook.presto.spi.function.FunctionHandle;
+import com.facebook.presto.spi.function.FunctionHandleResolver;
+
+public class HiveFunctionHandleResolver
+        implements FunctionHandleResolver
+{
+    @Override
+    public Class<? extends FunctionHandle> getFunctionHandleClass()
+    {
+        return HiveFunctionHandle.class;
+    }
+}

--- a/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/HiveFunctionModule.java
+++ b/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/HiveFunctionModule.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.hive.functions;
+
+import com.facebook.airlift.configuration.AbstractConfigurationAwareModule;
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.spi.function.FunctionNamespaceManager;
+import com.google.inject.Binder;
+import com.google.inject.Provides;
+import com.google.inject.Scopes;
+import com.google.inject.Singleton;
+import com.google.inject.TypeLiteral;
+
+import static java.util.Objects.requireNonNull;
+
+public class HiveFunctionModule
+        extends AbstractConfigurationAwareModule
+{
+    private final String catalogName;
+    private final ClassLoader classLoader;
+    private final TypeManager typeManager;
+
+    public HiveFunctionModule(String catalogName, ClassLoader classLoader, TypeManager typeManager)
+    {
+        this.catalogName = requireNonNull(catalogName, "catalogName is null");
+        this.classLoader = requireNonNull(classLoader, "classLoader is null");
+        this.typeManager = requireNonNull(typeManager, "typeManager is null");
+    }
+
+    @Override
+    protected void setup(Binder binder)
+    {
+        binder.bind(new TypeLiteral<String>() {}).annotatedWith(ForHiveFunction.class).toInstance(catalogName);
+        binder.bind(HiveFunctionRegistry.class).to(StaticHiveFunctionRegistry.class).in(Scopes.SINGLETON);
+        binder.bind(TypeManager.class).toInstance(typeManager);
+        binder.bind(FunctionNamespaceManager.class).to(HiveFunctionNamespaceManager.class).in(Scopes.SINGLETON);
+    }
+
+    @Provides
+    @Singleton
+    @ForHiveFunction
+    public ClassLoader getClassLoader()
+    {
+        return classLoader;
+    }
+}

--- a/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/HiveFunctionNamespaceManager.java
+++ b/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/HiveFunctionNamespaceManager.java
@@ -1,0 +1,305 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.hive.functions;
+
+import com.facebook.presto.common.Page;
+import com.facebook.presto.common.QualifiedObjectName;
+import com.facebook.presto.common.block.BlockEncodingSerde;
+import com.facebook.presto.common.function.SqlFunctionResult;
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.common.type.TypeSignature;
+import com.facebook.presto.common.type.UserDefinedType;
+import com.facebook.presto.hive.functions.scalar.HiveScalarFunction;
+import com.facebook.presto.spi.classloader.ThreadContextClassLoader;
+import com.facebook.presto.spi.function.AlterRoutineCharacteristics;
+import com.facebook.presto.spi.function.FunctionHandle;
+import com.facebook.presto.spi.function.FunctionMetadata;
+import com.facebook.presto.spi.function.FunctionNamespaceManager;
+import com.facebook.presto.spi.function.FunctionNamespaceTransactionHandle;
+import com.facebook.presto.spi.function.ScalarFunctionImplementation;
+import com.facebook.presto.spi.function.Signature;
+import com.facebook.presto.spi.function.SqlFunctionVisibility;
+import com.facebook.presto.spi.function.SqlInvokedFunction;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.collect.ImmutableList;
+import org.apache.hadoop.hive.ql.exec.UDF;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDF;
+
+import javax.inject.Inject;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Stream;
+
+import static com.facebook.presto.hive.functions.FunctionRegistry.getCurrentFunctionNames;
+import static com.facebook.presto.hive.functions.HiveFunctionErrorCode.functionNotFound;
+import static com.facebook.presto.hive.functions.HiveFunctionErrorCode.unsupportedFunctionType;
+import static com.facebook.presto.hive.functions.scalar.HiveScalarFunction.createHiveScalarFunction;
+import static com.facebook.presto.spi.function.FunctionKind.SCALAR;
+import static com.facebook.presto.spi.function.SqlFunctionVisibility.PUBLIC;
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class HiveFunctionNamespaceManager
+        implements FunctionNamespaceManager<HiveFunction>
+{
+    public static final String ID = "hive-functions";
+
+    private final String catalogName;
+    private final ClassLoader classLoader;
+    private final LoadingCache<FunctionKey, HiveFunction> functions;
+    private final HiveFunctionRegistry hiveFunctionRegistry;
+    private final TypeManager typeManager;
+
+    @Inject
+    public HiveFunctionNamespaceManager(
+            @ForHiveFunction String catalogName,
+            @ForHiveFunction ClassLoader classLoader,
+            HiveFunctionRegistry hiveFunctionRegistry,
+            TypeManager typeManager)
+    {
+        this.catalogName = requireNonNull(catalogName, "catalogName is null");
+        this.hiveFunctionRegistry = requireNonNull(hiveFunctionRegistry, "hiveFunctionRegistry is null");
+        this.classLoader = requireNonNull(classLoader, "classLoader is null");
+        this.typeManager = requireNonNull(typeManager, "typeManager is null");
+        this.functions = CacheBuilder.newBuilder().maximumSize(1000)
+                .build(CacheLoader.from(this::initializeFunction));
+    }
+
+    @Override
+    public void setBlockEncodingSerde(BlockEncodingSerde blockEncodingSerde)
+    {
+        return;
+    }
+
+    /**
+     * this function namespace manager does not support transaction.
+     */
+    public FunctionNamespaceTransactionHandle beginTransaction()
+    {
+        return new EmptyTransactionHandle();
+    }
+
+    public void commit(FunctionNamespaceTransactionHandle transactionHandle)
+    {
+    }
+
+    public void abort(FunctionNamespaceTransactionHandle transactionHandle)
+    {
+    }
+
+    public void createFunction(SqlInvokedFunction function, boolean replace)
+    {
+        throw new IllegalStateException(format("Cannot create function in hive function namespace: %s", function.getSignature().getName()));
+    }
+
+    public void alterFunction(QualifiedObjectName functionName, Optional<List<TypeSignature>> parameterTypes, AlterRoutineCharacteristics alterRoutineCharacteristics)
+    {
+        throw new IllegalStateException(format("Cannot alter function in hive function namespace: %s", functionName));
+    }
+
+    public void dropFunction(QualifiedObjectName functionName, Optional<List<TypeSignature>> parameterTypes, boolean exists)
+    {
+        throw new IllegalStateException(format("Cannot drop function in hive function namespace: %s", functionName));
+    }
+
+    @Override
+    public Collection<HiveFunction> listFunctions(Optional<String> likePattern, Optional<String> escape)
+    {
+        return getCurrentFunctionNames().stream().map(functionName -> createDummyHiveScalarFunction(functionName)).collect(toImmutableList());
+    }
+
+    public Collection<HiveFunction> getFunctions(Optional<? extends FunctionNamespaceTransactionHandle> transactionHandle, QualifiedObjectName functionName)
+    {
+        throw new IllegalStateException("Get function is not supported");
+    }
+
+    public FunctionHandle getFunctionHandle(Optional<? extends FunctionNamespaceTransactionHandle> transactionHandle, Signature signature)
+    {
+        throw new IllegalStateException("Get function handle is not supported");
+    }
+
+    public FunctionHandle resolveFunction(Optional<? extends FunctionNamespaceTransactionHandle> transactionHandle, QualifiedObjectName functionName, List<TypeSignature> parameterTypes)
+    {
+        return new HiveFunctionHandle(initializeFunction(FunctionKey.of(functionName, parameterTypes)).getSignature());
+    }
+
+    public FunctionMetadata getFunctionMetadata(FunctionHandle functionHandle)
+    {
+        checkArgument(functionHandle instanceof HiveFunctionHandle);
+        HiveFunction function = functions.getUnchecked(FunctionKey.from((HiveFunctionHandle) functionHandle));
+        return function.getFunctionMetadata();
+    }
+
+    public ScalarFunctionImplementation getScalarFunctionImplementation(FunctionHandle functionHandle)
+    {
+        checkArgument(functionHandle instanceof HiveFunctionHandle);
+        HiveFunction function = functions.getUnchecked(FunctionKey.from((HiveFunctionHandle) functionHandle));
+        checkState(function instanceof HiveScalarFunction);
+        return ((HiveScalarFunction) function).getJavaScalarFunctionImplementation();
+    }
+
+    @Override
+    public CompletableFuture<SqlFunctionResult> executeFunction(String source, FunctionHandle functionHandle, Page input, List<Integer> channels, TypeManager typeManager)
+    {
+        throw new IllegalStateException("Execute function is not supported");
+    }
+
+    @Override
+    public void addUserDefinedType(UserDefinedType userDefinedType)
+    {
+        throw new IllegalStateException("User defined type is not supported");
+    }
+
+    @Override
+    public Optional<UserDefinedType> getUserDefinedType(QualifiedObjectName typeName)
+    {
+        throw new IllegalStateException("User defined type is not supported");
+    }
+
+    @Override
+    public boolean canResolveFunction()
+    {
+        return true;
+    }
+
+    private HiveFunction initializeFunction(FunctionKey key)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            QualifiedObjectName name = key.getName();
+            try {
+                Class<?> functionClass = hiveFunctionRegistry.getClass(name);
+                if (anyAssignableFrom(functionClass, GenericUDF.class, UDF.class)) {
+                    return createHiveScalarFunction(functionClass, name, key.getArgumentTypes(), typeManager);
+                }
+                else {
+                    throw unsupportedFunctionType(functionClass);
+                }
+            }
+            catch (ClassNotFoundException e) {
+                throw functionNotFound(name.toString());
+            }
+        }
+    }
+
+    private HiveFunction createDummyHiveScalarFunction(String functionName)
+    {
+        QualifiedObjectName hiveFunctionName = QualifiedObjectName.valueOf(catalogName, "default", functionName);
+        Signature signature = new Signature(hiveFunctionName, SCALAR, TypeSignature.parseTypeSignature("T"));
+        return new DummyHiveScalarFunction(signature);
+    }
+
+    private static boolean anyAssignableFrom(Class<?> cls, Class<?>... supers)
+    {
+        return Stream.of(supers).anyMatch(s -> s.isAssignableFrom(cls));
+    }
+
+    private static class DummyHiveScalarFunction
+            extends HiveFunction
+    {
+        public DummyHiveScalarFunction(Signature signature)
+        {
+            super(signature.getName(), signature, false, true, true, "");
+        }
+
+        @Override
+        public FunctionMetadata getFunctionMetadata()
+        {
+            throw new IllegalStateException("Get function metadata is not supported");
+        }
+
+        @Override
+        public SqlFunctionVisibility getVisibility()
+        {
+            return PUBLIC;
+        }
+    }
+
+    private static class EmptyTransactionHandle
+            implements FunctionNamespaceTransactionHandle
+    {
+    }
+
+    private static class FunctionKey
+    {
+        private final QualifiedObjectName name;
+        private final List<TypeSignature> argumentTypes;
+
+        public static FunctionKey from(HiveFunctionHandle handle)
+        {
+            Signature signature = handle.getSignature();
+            return FunctionKey.of(signature.getName(), signature.getArgumentTypes());
+        }
+
+        private static FunctionKey of(QualifiedObjectName name, List<TypeSignature> argumentTypes)
+        {
+            return new FunctionKey(name, argumentTypes);
+        }
+
+        private FunctionKey(QualifiedObjectName name, List<TypeSignature> argumentTypes)
+        {
+            this.name = requireNonNull(name, "name is null");
+            this.argumentTypes = ImmutableList.copyOf(requireNonNull(argumentTypes, "argumentTypes is null"));
+        }
+
+        public QualifiedObjectName getName()
+        {
+            return name;
+        }
+
+        public List<TypeSignature> getArgumentTypes()
+        {
+            return argumentTypes;
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            FunctionKey that = (FunctionKey) o;
+            return Objects.equals(name, that.name) &&
+                    Objects.equals(argumentTypes, that.argumentTypes);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(name, argumentTypes);
+        }
+
+        @Override
+        public String toString()
+        {
+            return toStringHelper(this)
+                    .add("name", name)
+                    .add("arguments", argumentTypes)
+                    .toString();
+        }
+    }
+}

--- a/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/HiveFunctionNamespaceManagerFactory.java
+++ b/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/HiveFunctionNamespaceManagerFactory.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.hive.functions;
+
+import com.facebook.airlift.bootstrap.Bootstrap;
+import com.facebook.presto.spi.classloader.ThreadContextClassLoader;
+import com.facebook.presto.spi.function.FunctionHandleResolver;
+import com.facebook.presto.spi.function.FunctionNamespaceManager;
+import com.facebook.presto.spi.function.FunctionNamespaceManagerContext;
+import com.facebook.presto.spi.function.FunctionNamespaceManagerFactory;
+import com.google.inject.Injector;
+
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+public class HiveFunctionNamespaceManagerFactory
+        implements FunctionNamespaceManagerFactory
+{
+    private final ClassLoader classLoader;
+    private final FunctionHandleResolver functionHandleResolver;
+
+    public static final String NAME = "hive-functions";
+
+    public HiveFunctionNamespaceManagerFactory(ClassLoader classLoader)
+    {
+        this.classLoader = requireNonNull(classLoader, "classLoader is null");
+        this.functionHandleResolver = new HiveFunctionHandleResolver();
+    }
+
+    @Override
+    public String getName()
+    {
+        return NAME;
+    }
+
+    @Override
+    public FunctionHandleResolver getHandleResolver()
+    {
+        return functionHandleResolver;
+    }
+
+    @Override
+    public FunctionNamespaceManager<?> create(String catalogName, Map<String, String> config, FunctionNamespaceManagerContext context)
+    {
+        requireNonNull(config, "config is null");
+
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            Bootstrap app = new Bootstrap(
+                    new HiveFunctionModule(catalogName, classLoader, context.getTypeManager()));
+
+            Injector injector = app
+                    .noStrictConfig()
+                    .doNotInitializeLogging()
+                    .setRequiredConfigurationProperties(config)
+                    .quiet()
+                    .initialize();
+            return injector.getInstance(FunctionNamespaceManager.class);
+        }
+    }
+}

--- a/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/HiveFunctionNamespacePlugin.java
+++ b/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/HiveFunctionNamespacePlugin.java
@@ -15,6 +15,7 @@ package com.facebook.presto.hive.functions;
 
 import com.facebook.presto.spi.Plugin;
 import com.facebook.presto.spi.function.FunctionNamespaceManagerFactory;
+import com.google.common.collect.ImmutableList;
 
 public class HiveFunctionNamespacePlugin
         implements Plugin
@@ -22,6 +23,15 @@ public class HiveFunctionNamespacePlugin
     @Override
     public Iterable<FunctionNamespaceManagerFactory> getFunctionNamespaceManagerFactories()
     {
-        return null;
+        return ImmutableList.of(new HiveFunctionNamespaceManagerFactory(getClassLoader()));
+    }
+
+    private static ClassLoader getClassLoader()
+    {
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        if (classLoader == null) {
+            classLoader = HiveFunctionNamespacePlugin.class.getClassLoader();
+        }
+        return classLoader;
     }
 }

--- a/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/HiveFunctionNamespacePlugin.java
+++ b/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/HiveFunctionNamespacePlugin.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.functions;
+
+import com.facebook.presto.spi.Plugin;
+import com.facebook.presto.spi.function.FunctionNamespaceManagerFactory;
+
+public class HiveFunctionNamespacePlugin
+        implements Plugin
+{
+    @Override
+    public Iterable<FunctionNamespaceManagerFactory> getFunctionNamespaceManagerFactories()
+    {
+        return null;
+    }
+}

--- a/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/HiveFunctionRegistry.java
+++ b/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/HiveFunctionRegistry.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.functions;
+
+import com.facebook.presto.common.QualifiedObjectName;
+
+public interface HiveFunctionRegistry
+{
+    Class<?> getClass(QualifiedObjectName name)
+            throws ClassNotFoundException;
+}

--- a/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/StaticHiveFunctionRegistry.java
+++ b/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/StaticHiveFunctionRegistry.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.hive.functions;
+
+import com.facebook.presto.common.QualifiedObjectName;
+import com.facebook.presto.spi.classloader.ThreadContextClassLoader;
+import org.apache.hadoop.hive.ql.parse.SemanticException;
+
+import javax.inject.Inject;
+
+import static com.facebook.presto.hive.functions.FunctionRegistry.getFunctionInfo;
+import static java.util.Objects.requireNonNull;
+
+public class StaticHiveFunctionRegistry
+        implements HiveFunctionRegistry
+{
+    private final ClassLoader classLoader;
+
+    @Inject
+    public StaticHiveFunctionRegistry(@ForHiveFunction ClassLoader classLoader)
+    {
+        this.classLoader = requireNonNull(classLoader, "classLoader is null");
+    }
+
+    @Override
+    public Class<?> getClass(QualifiedObjectName name)
+            throws ClassNotFoundException
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return getFunctionInfo(name.getObjectName()).getFunctionClass();
+        }
+        catch (SemanticException | NullPointerException e) {
+            throw new ClassNotFoundException("Class of function " + name + " not found", e);
+        }
+    }
+}

--- a/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/gen/CompilerUtils.java
+++ b/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/gen/CompilerUtils.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.hive.functions.gen;
+
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.bytecode.ClassDefinition;
+import com.facebook.presto.bytecode.DynamicClassLoader;
+import com.facebook.presto.bytecode.ParameterizedType;
+
+import java.io.PrintWriter;
+import java.lang.invoke.MethodHandle;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static com.facebook.presto.bytecode.BytecodeUtils.toJavaIdentifierString;
+import static com.facebook.presto.bytecode.ClassGenerator.classGenerator;
+import static com.facebook.presto.bytecode.ParameterizedType.typeFromJavaClassName;
+import static java.time.ZoneOffset.UTC;
+
+public final class CompilerUtils
+{
+    private static final Logger log = Logger.get(CompilerUtils.class);
+
+    private static final AtomicLong CLASS_ID = new AtomicLong();
+    private static final DateTimeFormatter TIMESTAMP_FORMAT = DateTimeFormatter.ofPattern("YYYYMMdd_HHmmss");
+
+    private CompilerUtils() {}
+
+    public static ParameterizedType makeClassName(String baseName, Optional<String> suffix)
+    {
+        String className = baseName
+                + "_" + suffix.orElseGet(() -> Instant.now().atZone(UTC).format(TIMESTAMP_FORMAT))
+                + "_" + CLASS_ID.incrementAndGet();
+        return typeFromJavaClassName("com.facebook.hive.function.$gen." + toJavaIdentifierString(className));
+    }
+
+    public static ParameterizedType makeClassName(String baseName)
+    {
+        return makeClassName(baseName, Optional.empty());
+    }
+
+    public static <T> Class<? extends T> defineClass(ClassDefinition classDefinition, Class<T> superType, Map<Long, MethodHandle> callSiteBindings, ClassLoader parentClassLoader)
+    {
+        return defineClass(classDefinition, superType, new DynamicClassLoader(parentClassLoader, callSiteBindings));
+    }
+
+    public static <T> Class<? extends T> defineClass(ClassDefinition classDefinition, Class<T> superType, DynamicClassLoader classLoader)
+    {
+        log.debug("Defining class: %s", classDefinition.getName());
+        if (log.isDebugEnabled()) {
+            Path dumpPath = Paths.get(System.getProperty("java.io.tmpdir", "/tmp"), "classes");
+            log.debug("Dumping to %s", dumpPath);
+            return classGenerator(classLoader)
+                    .outputTo(new PrintWriter(System.err))
+                    .dumpRawBytecode(true)
+                    .dumpClassFilesTo(dumpPath)
+                    .defineClass(classDefinition, superType);
+        }
+        return classGenerator(classLoader).defineClass(classDefinition, superType);
+    }
+}

--- a/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/gen/ScalarMethodHandles.java
+++ b/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/gen/ScalarMethodHandles.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.hive.functions.gen;
+
+import com.facebook.presto.bytecode.ClassDefinition;
+import com.facebook.presto.bytecode.MethodDefinition;
+import com.facebook.presto.bytecode.Parameter;
+import com.facebook.presto.bytecode.ParameterizedType;
+import com.facebook.presto.bytecode.expression.BytecodeExpression;
+import com.facebook.presto.common.predicate.Primitives;
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.common.type.TypeSignature;
+import com.facebook.presto.hive.functions.scalar.ScalarFunctionInvoker;
+import com.facebook.presto.spi.function.Signature;
+
+import java.lang.invoke.MethodHandle;
+import java.util.Collections;
+import java.util.List;
+
+import static com.facebook.presto.bytecode.Access.FINAL;
+import static com.facebook.presto.bytecode.Access.PRIVATE;
+import static com.facebook.presto.bytecode.Access.PUBLIC;
+import static com.facebook.presto.bytecode.Access.STATIC;
+import static com.facebook.presto.bytecode.Access.a;
+import static com.facebook.presto.bytecode.Parameter.arg;
+import static com.facebook.presto.bytecode.ParameterizedType.type;
+import static com.facebook.presto.bytecode.expression.BytecodeExpressions.newArray;
+import static com.facebook.presto.common.block.MethodHandleUtil.methodHandle;
+import static com.facebook.presto.hive.functions.gen.CompilerUtils.defineClass;
+import static com.facebook.presto.hive.functions.gen.CompilerUtils.makeClassName;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+
+public final class ScalarMethodHandles
+{
+    private static final String CLASS_NAME = "HiveScalarFunction";
+    private static final String METHOD_NAME = "callEvaluate";
+
+    private ScalarMethodHandles() {}
+
+    /**
+     * Generates an unbound MethodHandle by {@code signature}.
+     * <p>
+     * For example, if {@code signature} describes a method like
+     * <pre>
+     * {@code
+     * IntegerType func(
+     *              IntegerType i,
+     *              VarcharType j)
+     * }
+     * </pre>,
+     * a method is generated as
+     * <pre>
+     * {@code
+     * static Long callEvaluate(
+     *              ScalarFunctionInvoker invoker,
+     *              Long input_0,
+     *              Slice input_1) {
+     * return (Long) Invoker.evaluate(input_0, input_1);
+     * }
+     * }
+     * </pre>,
+     * and its MethodHandle returns.
+     */
+    public static MethodHandle generateUnbound(Signature signature, TypeManager typeManager)
+    {
+        Class<?> returnType = Primitives.wrap(typeManager.getType(signature.getReturnType()).getJavaType());
+        List<TypeSignature> argumentTypes = signature.getArgumentTypes();
+        List<Class<?>> argumentJavaTypes = argumentTypes.stream()
+                .map(t -> typeManager.getType(t).getJavaType())
+                .map(Primitives::wrap)
+                .collect(toImmutableList());
+
+        ClassDefinition definition = new ClassDefinition(
+                a(PUBLIC, FINAL),
+                makeClassName(CLASS_NAME),
+                ParameterizedType.type(Object.class));
+
+        // Step 1: Declare default constructor
+        definition.declareDefaultConstructor(a(PRIVATE));
+
+        // Step 2: Declare method
+        Parameter[] declareParameters = new Parameter[argumentTypes.size() + 1];
+        declareParameters[0] = arg("invoker", ScalarFunctionInvoker.class);
+        for (int i = 0; i < argumentTypes.size(); i++) {
+            declareParameters[i + 1] = arg("input_" + i, argumentJavaTypes.get(i));
+        }
+        MethodDefinition method = definition.declareMethod(
+                a(PUBLIC, STATIC),
+                METHOD_NAME,
+                ParameterizedType.type(returnType),
+                declareParameters);
+
+        // Step 3: Implement method body
+        BytecodeExpression[] evaluateInputs = new BytecodeExpression[argumentTypes.size()];
+        for (int i = 0; i < argumentTypes.size(); i++) {
+            evaluateInputs[i] = declareParameters[i + 1];
+        }
+        method.getBody().append(declareParameters[0].invoke("evaluate",
+                Object.class,
+                newArray(type(Object[].class), evaluateInputs))
+                .cast(returnType)
+                .ret());
+
+        // Step 4: Generate class
+        Class<?> generatedClass = defineClass(definition,
+                Object.class,
+                Collections.emptyMap(),
+                ScalarMethodHandles.class.getClassLoader());
+
+        // Step 5: Lookup MethodHandle
+        Class<?>[] lookupClasses = new Class[argumentTypes.size() + 1];
+        lookupClasses[0] = ScalarFunctionInvoker.class;
+        for (int i = 0; i < argumentTypes.size(); i++) {
+            lookupClasses[i + 1] = Primitives.wrap(typeManager.getType(argumentTypes.get(i)).getJavaType());
+        }
+        return methodHandle(generatedClass, METHOD_NAME, lookupClasses);
+    }
+}

--- a/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/scalar/HiveScalarFunction.java
+++ b/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/scalar/HiveScalarFunction.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.functions.scalar;
+
+import com.facebook.presto.common.QualifiedObjectName;
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.common.type.TypeSignature;
+import com.facebook.presto.hive.functions.HiveFunction;
+import com.facebook.presto.hive.functions.gen.ScalarMethodHandles;
+import com.facebook.presto.spi.function.FunctionImplementationType;
+import com.facebook.presto.spi.function.FunctionMetadata;
+import com.facebook.presto.spi.function.InvocationConvention;
+import com.facebook.presto.spi.function.JavaScalarFunctionImplementation;
+import com.facebook.presto.spi.function.Signature;
+import com.facebook.presto.spi.function.SqlFunctionVisibility;
+
+import java.lang.invoke.MethodHandle;
+import java.util.List;
+
+import static com.facebook.presto.hive.functions.scalar.HiveScalarFunctionInvoker.createFunctionInvoker;
+import static com.facebook.presto.spi.function.FunctionKind.SCALAR;
+import static com.facebook.presto.spi.function.InvocationConvention.InvocationArgumentConvention.BOXED_NULLABLE;
+import static com.facebook.presto.spi.function.SqlFunctionVisibility.PUBLIC;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNull;
+
+public class HiveScalarFunction
+        extends HiveFunction
+{
+    private final JavaScalarFunctionImplementation implementation;
+    private final FunctionMetadata functionMetadata;
+
+    private HiveScalarFunction(FunctionMetadata metadata,
+                               Signature signature,
+                               String description,
+                               JavaScalarFunctionImplementation implementation)
+    {
+        super(metadata.getName(),
+                signature,
+                false,
+                metadata.isDeterministic(),
+                metadata.isCalledOnNullInput(),
+                description);
+
+        this.functionMetadata = requireNonNull(metadata, "metadata is null");
+        this.implementation = requireNonNull(implementation, "implementation is null");
+    }
+
+    public static HiveScalarFunction createHiveScalarFunction(Class<?> cls, QualifiedObjectName name, List<TypeSignature> argumentTypes, TypeManager typeManager)
+    {
+        HiveScalarFunctionInvoker invoker = createFunctionInvoker(cls, name, argumentTypes, typeManager);
+        MethodHandle methodHandle = ScalarMethodHandles.generateUnbound(invoker.getSignature(), typeManager).bindTo(invoker);
+        Signature signature = invoker.getSignature();
+        FunctionMetadata functionMetadata = new FunctionMetadata(name,
+                signature.getArgumentTypes(),
+                signature.getReturnType(),
+                SCALAR,
+                FunctionImplementationType.JAVA,
+                true,
+                true);
+        InvocationConvention invocationConvention = new InvocationConvention(
+                signature.getArgumentTypes().stream().map(t -> BOXED_NULLABLE).collect(toImmutableList()),
+                InvocationConvention.InvocationReturnConvention.NULLABLE_RETURN,
+                false);
+        JavaScalarFunctionImplementation implementation = new HiveScalarFunctionImplementation(methodHandle, invocationConvention);
+        return new HiveScalarFunction(functionMetadata, signature, name.getObjectName(), implementation);
+    }
+
+    public FunctionMetadata getFunctionMetadata()
+    {
+        return functionMetadata;
+    }
+
+    public JavaScalarFunctionImplementation getJavaScalarFunctionImplementation()
+    {
+        return implementation;
+    }
+
+    @Override
+    public SqlFunctionVisibility getVisibility()
+    {
+        return PUBLIC;
+    }
+
+    private static class HiveScalarFunctionImplementation
+            implements JavaScalarFunctionImplementation
+    {
+        private final MethodHandle methodHandle;
+        private final InvocationConvention invocationConvention;
+
+        private HiveScalarFunctionImplementation(MethodHandle methodHandle, InvocationConvention invocationConvention)
+        {
+            this.methodHandle = requireNonNull(methodHandle, "methodHandle is null");
+            this.invocationConvention = requireNonNull(invocationConvention, "invocationConvention is null");
+        }
+
+        public InvocationConvention getInvocationConvention()
+        {
+            return invocationConvention;
+        }
+
+        public MethodHandle getMethodHandle()
+        {
+            return methodHandle;
+        }
+    }
+}

--- a/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/scalar/HiveScalarFunctionInvoker.java
+++ b/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/scalar/HiveScalarFunctionInvoker.java
@@ -1,0 +1,151 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.functions.scalar;
+
+import com.facebook.presto.common.QualifiedObjectName;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.common.type.TypeSignature;
+import com.facebook.presto.hive.functions.type.ObjectEncoder;
+import com.facebook.presto.hive.functions.type.ObjectInputDecoder;
+import com.facebook.presto.hive.functions.type.ObjectInspectors;
+import com.facebook.presto.hive.functions.type.PrestoTypes;
+import com.facebook.presto.spi.classloader.ThreadContextClassLoader;
+import com.facebook.presto.spi.function.Signature;
+import org.apache.hadoop.hive.ql.exec.UDF;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDF;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDF.DeferredJavaObject;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDF.DeferredObject;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFBridge;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.hive.functions.HiveFunctionErrorCode.executionError;
+import static com.facebook.presto.hive.functions.HiveFunctionErrorCode.initializationError;
+import static com.facebook.presto.hive.functions.HiveFunctionErrorCode.unsupportedFunctionType;
+import static com.facebook.presto.hive.functions.type.ObjectEncoders.createEncoder;
+import static com.facebook.presto.hive.functions.type.ObjectInputDecoders.createDecoder;
+import static com.facebook.presto.spi.function.FunctionKind.SCALAR;
+import static java.util.Objects.requireNonNull;
+
+public class HiveScalarFunctionInvoker
+        implements ScalarFunctionInvoker
+{
+    private final Signature signature;
+    private final Supplier<GenericUDF> udfSupplier;
+    private final ObjectInputDecoder[] argumentDecoders;
+    private final ObjectEncoder objectEncoder;
+
+    public HiveScalarFunctionInvoker(Signature signature,
+                                     Supplier<GenericUDF> udfSupplier,
+                                     ObjectInputDecoder[] argumentDecoders,
+                                     ObjectEncoder objectEncoder)
+    {
+        this.signature = requireNonNull(signature, "signature is null");
+        this.udfSupplier = requireNonNull(udfSupplier, "udfSupplier is null");
+        this.argumentDecoders = requireNonNull(argumentDecoders, "argumentDecoders is null");
+        this.objectEncoder = requireNonNull(objectEncoder, "objectEncoder is null");
+    }
+
+    public static HiveScalarFunctionInvoker createFunctionInvoker(Class<?> cls, QualifiedObjectName name, List<TypeSignature> arguments, TypeManager typeManager)
+    {
+        final List<Type> argumentTypes = arguments.stream()
+                .map(typeManager::getType)
+                .collect(Collectors.toList());
+
+        try {
+            // Step 1: Create function instance
+            final GenericUDF udf = createGenericUDF(name, cls);
+
+            // Step 2: Initialize function
+            ObjectInspector[] inputInspectors = argumentTypes.stream()
+                    .map(argumentType -> ObjectInspectors.create(argumentType, typeManager))
+                    .toArray(ObjectInspector[]::new);
+            ObjectInspector resultInspector = udf.initialize(inputInspectors);
+
+            // Step 3: Create invoker
+            Type resultType = PrestoTypes.fromObjectInspector(resultInspector, typeManager);
+            ObjectInputDecoder[] argumentDecoders = argumentTypes.stream()
+                    .map(argumentsType -> createDecoder(argumentsType, typeManager))
+                    .toArray(ObjectInputDecoder[]::new);
+            ObjectEncoder resultEncoder = createEncoder(resultType, resultInspector);
+            Signature signature = new Signature(name,
+                    SCALAR,
+                    resultType.getTypeSignature(),
+                    arguments);
+
+            // Step 4: Create ThreadLocal GenericUDF
+            final ThreadLocal<GenericUDF> genericUDFSupplier = ThreadLocal.withInitial(() -> {
+                try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(cls.getClassLoader())) {
+                    GenericUDF ret = createGenericUDF(name, cls);
+                    ret.initialize(inputInspectors);
+                    return ret;
+                }
+                catch (Exception e) {
+                    throw initializationError(e);
+                }
+            });
+            return new HiveScalarFunctionInvoker(signature,
+                    genericUDFSupplier::get,
+                    argumentDecoders,
+                    resultEncoder);
+        }
+        catch (Exception e) {
+            throw initializationError(e);
+        }
+    }
+
+    private static GenericUDF createGenericUDF(QualifiedObjectName name, Class<?> cls)
+            throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException
+    {
+        if (GenericUDF.class.isAssignableFrom(cls)) {
+            Constructor<?> constructor = cls.getConstructor();
+            return (GenericUDF) constructor.newInstance();
+        }
+        else if (UDF.class.isAssignableFrom(cls)) {
+            return new GenericUDFBridge(name.getObjectName(), false, cls.getName());
+        }
+
+        throw unsupportedFunctionType(cls);
+    }
+
+    @Override
+    public Signature getSignature()
+    {
+        return signature;
+    }
+
+    @Override
+    public Object evaluate(Object... inputs)
+    {
+        try {
+            DeferredObject[] objects = new DeferredObject[inputs.length];
+            for (int i = 0; i < inputs.length; i++) {
+                objects[i] = inputs[i] == null ? new DeferredJavaObject(null) :
+                        new DeferredJavaObject(argumentDecoders[i].decode(inputs[i]));
+            }
+            Object evaluated = udfSupplier.get().evaluate(objects);
+            return objectEncoder.encode(evaluated);
+        }
+        catch (HiveException e) {
+            throw executionError(e);
+        }
+    }
+}

--- a/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/scalar/ScalarFunctionInvoker.java
+++ b/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/scalar/ScalarFunctionInvoker.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.functions.scalar;
+
+import com.facebook.presto.spi.function.Signature;
+
+public interface ScalarFunctionInvoker
+{
+    Signature getSignature();
+
+    Object evaluate(Object... inputs);
+}

--- a/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/type/BlockInputDecoder.java
+++ b/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/type/BlockInputDecoder.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.hive.functions.type;
+
+import com.facebook.presto.common.block.Block;
+
+public interface BlockInputDecoder
+{
+    /**
+     * Get object from block at position and convert it to
+     * internal object used in Hive functions.
+     */
+    Object decode(Block block, int position);
+}

--- a/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/type/BlockInputDecoders.java
+++ b/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/type/BlockInputDecoders.java
@@ -1,0 +1,324 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.hive.functions.type;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.SingleMapBlock;
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.DecimalType;
+import com.facebook.presto.common.type.MapType;
+import com.facebook.presto.common.type.RowType;
+import com.facebook.presto.common.type.Type;
+import com.google.common.collect.Streams;
+import org.apache.hadoop.hive.serde2.io.ByteWritable;
+import org.apache.hadoop.hive.serde2.io.DateWritable;
+import org.apache.hadoop.hive.serde2.io.DoubleWritable;
+import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
+import org.apache.hadoop.hive.serde2.io.ShortWritable;
+import org.apache.hadoop.hive.serde2.io.TimestampWritable;
+import org.apache.hadoop.hive.serde2.objectinspector.ConstantObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.ListObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.MapObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.SettableStructObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.StandardStructObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.StructField;
+import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.BinaryObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.BooleanObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.ByteObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.DateObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.DoubleObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.FloatObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.HiveDecimalObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.IntObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.JavaDateObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.JavaHiveCharObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.JavaHiveDecimalObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.JavaHiveVarcharObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.JavaTimestampObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.LongObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.ShortObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.StringObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.TimestampObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.VoidObjectInspector;
+import org.apache.hadoop.io.BooleanWritable;
+import org.apache.hadoop.io.BytesWritable;
+import org.apache.hadoop.io.FloatWritable;
+import org.apache.hadoop.io.IntWritable;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.Text;
+
+import java.sql.Date;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.hive.functions.HiveFunctionErrorCode.unsupportedType;
+import static com.facebook.presto.hive.functions.type.DateTimeUtils.createDate;
+import static com.facebook.presto.hive.functions.type.DecimalUtils.readHiveDecimal;
+import static com.facebook.presto.hive.functions.type.HiveTypes.createHiveChar;
+import static com.facebook.presto.hive.functions.type.HiveTypes.createHiveVarChar;
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.Float.intBitsToFloat;
+
+public final class BlockInputDecoders
+{
+    private BlockInputDecoders() {}
+
+    public static BlockInputDecoder createBlockInputDecoder(ObjectInspector inspector, Type type)
+    {
+        if (inspector instanceof ConstantObjectInspector) {
+            Object constant = ((ConstantObjectInspector) inspector).getWritableConstantValue();
+            return (b, i) -> constant;
+        }
+        if (inspector instanceof PrimitiveObjectInspector) {
+            return createForPrimitive(((PrimitiveObjectInspector) inspector), type);
+        }
+        else if (inspector instanceof StandardStructObjectInspector) {
+            checkArgument(type instanceof RowType);
+            return createForStruct(((StandardStructObjectInspector) inspector), ((RowType) type));
+        }
+        else if (inspector instanceof SettableStructObjectInspector) {
+            return createForStruct(((SettableStructObjectInspector) inspector), ((RowType) type));
+        }
+        else if (inspector instanceof StructObjectInspector) {
+            return createForStruct(((StructObjectInspector) inspector), ((RowType) type));
+        }
+        else if (inspector instanceof ListObjectInspector) {
+            checkArgument(type instanceof ArrayType);
+            return createForList(((ListObjectInspector) inspector), ((ArrayType) type));
+        }
+        else if (inspector instanceof MapObjectInspector) {
+            checkArgument(type instanceof MapType);
+            return createForMap(((MapObjectInspector) inspector), ((MapType) type));
+        }
+        throw unsupportedType(inspector);
+    }
+
+    private static BlockInputDecoder createForPrimitive(PrimitiveObjectInspector inspector, Type type)
+    {
+        boolean preferWritable = inspector.preferWritable();
+        if (inspector instanceof StringObjectInspector) {
+            return preferWritable ?
+                    (b, i) -> b.isNull(i) ? null : new Text(type.getSlice(b, i).getBytes()) :
+                    (b, i) -> b.isNull(i) ? null : type.getSlice(b, i).toStringUtf8();
+        }
+        else if (inspector instanceof IntObjectInspector) {
+            return preferWritable ?
+                    (b, i) -> b.isNull(i) ? null : new IntWritable(((int) type.getLong(b, i))) :
+                    (b, i) -> b.isNull(i) ? null : ((int) type.getLong(b, i));
+        }
+        else if (inspector instanceof BooleanObjectInspector) {
+            return preferWritable ?
+                    (b, i) -> b.isNull(i) ? null : new BooleanWritable(type.getBoolean(b, i)) :
+                    (b, i) -> b.isNull(i) ? null : type.getBoolean(b, i);
+        }
+        else if (inspector instanceof FloatObjectInspector) {
+            return preferWritable ?
+                    (b, i) -> b.isNull(i) ? null : new FloatWritable(intBitsToFloat((int) type.getLong(b, i))) :
+                    (b, i) -> b.isNull(i) ? null : intBitsToFloat((int) type.getLong(b, i));
+        }
+        else if (inspector instanceof DoubleObjectInspector) {
+            return preferWritable ?
+                    (b, i) -> b.isNull(i) ? null : new DoubleWritable(type.getDouble(b, i)) :
+                    (b, i) -> b.isNull(i) ? null : type.getDouble(b, i);
+        }
+        else if (inspector instanceof LongObjectInspector) {
+            return preferWritable ?
+                    (b, i) -> b.isNull(i) ? null : new LongWritable(type.getLong(b, i)) :
+                    (b, i) -> b.isNull(i) ? null : type.getLong(b, i);
+        }
+        else if (inspector instanceof ShortObjectInspector) {
+            return preferWritable ?
+                    (b, i) -> b.isNull(i) ? null : new ShortWritable(((short) type.getLong(b, i))) :
+                    (b, i) -> b.isNull(i) ? null : ((short) type.getLong(b, i));
+        }
+        else if (inspector instanceof ByteObjectInspector) {
+            return preferWritable ?
+                    (b, i) -> b.isNull(i) ? null : new ByteWritable(((byte) type.getLong(b, i))) :
+                    (b, i) -> b.isNull(i) ? null : ((byte) type.getLong(b, i));
+        }
+        else if (inspector instanceof JavaHiveVarcharObjectInspector) {
+            return (b, i) -> b.isNull(i) ? null : createHiveVarChar(type.getSlice(b, i).toStringUtf8());
+        }
+        else if (inspector instanceof JavaHiveCharObjectInspector) {
+            return (b, i) -> b.isNull(i) ? null : createHiveChar(type.getSlice(b, i).toStringUtf8());
+        }
+        else if (inspector instanceof JavaHiveDecimalObjectInspector) {
+            checkArgument(type instanceof DecimalType);
+            return (b, i) -> b.isNull(i) ? null : readHiveDecimal(((DecimalType) type), b, i);
+        }
+        else if (inspector instanceof JavaDateObjectInspector) {
+            return (b, i) -> b.isNull(i) ? null : new Date(TimeUnit.DAYS.toMillis(type.getLong(b, i)));
+        }
+        else if (inspector instanceof JavaTimestampObjectInspector) {
+            return (b, i) -> b.isNull(i) ? null : new Timestamp(type.getLong(b, i));
+        }
+        else if (inspector instanceof HiveDecimalObjectInspector) {
+            checkArgument(type instanceof DecimalType);
+            return preferWritable ?
+                    (b, i) -> b.isNull(i) ? null : new HiveDecimalWritable(readHiveDecimal(((DecimalType) type), b, i)) :
+                    (b, i) -> b.isNull(i) ? null : readHiveDecimal(((DecimalType) type), b, i);
+        }
+        else if (inspector instanceof BinaryObjectInspector) {
+            return preferWritable ?
+                    (b, i) -> b.isNull(i) ? null : new BytesWritable(type.getSlice(b, i).getBytes()) :
+                    (b, i) -> b.isNull(i) ? null : type.getSlice(b, i).getBytes();
+        }
+        else if (inspector instanceof DateObjectInspector) {
+            return preferWritable ?
+                    (b, i) -> b.isNull(i) ? null : new DateWritable(((int) type.getLong(b, i))) :
+                    (b, i) -> b.isNull(i) ? null : createDate(((int) type.getLong(b, i)));
+        }
+        else if (inspector instanceof TimestampObjectInspector) {
+            return preferWritable ?
+                    (b, i) -> b.isNull(i) ? null : new TimestampWritable(new Timestamp(type.getLong(b, i))) :
+                    (b, i) -> b.isNull(i) ? null : new Timestamp(type.getLong(b, i));
+        }
+        else if (inspector instanceof VoidObjectInspector) {
+            return (b, i) -> null;
+        }
+        throw unsupportedType(inspector);
+    }
+
+    private static BlockInputDecoder createForStruct(StandardStructObjectInspector structInspector, RowType rowType)
+    {
+        List<? extends StructField> structFields = structInspector.getAllStructFieldRefs();
+        List<RowType.Field> rowFields = rowType.getFields();
+        checkArgument(rowFields.size() == structFields.size());
+        List<BlockInputDecoder> fieldDecoders = Streams.zip(
+                structFields.stream(),
+                rowFields.stream(),
+                (sf, rf) -> createBlockInputDecoder(sf.getFieldObjectInspector(), rf.getType()))
+                .collect(Collectors.toList());
+        final int numFields = structFields.size();
+        return (b, i) -> {
+            if (b.isNull(i)) {
+                return null;
+            }
+            Block row = b.getBlock(i);
+            Object result = structInspector.create();
+            for (int j = 0; j < numFields; j++) {
+                structInspector.setStructFieldData(result,
+                        structFields.get(j),
+                        fieldDecoders.get(j).decode(row, j));
+            }
+            return result;
+        };
+    }
+
+    /**
+     * TODO: Remove this function? pretty similar to createForStruct(StandardStructObjectInspector, RowType)
+     */
+    private static BlockInputDecoder createForStruct(SettableStructObjectInspector structInspector, RowType rowType)
+    {
+        List<? extends StructField> structFields = structInspector.getAllStructFieldRefs();
+        List<RowType.Field> rowFields = rowType.getFields();
+        checkArgument(rowFields.size() == structFields.size());
+        List<BlockInputDecoder> fieldDecoders = Streams.zip(
+                structFields.stream(),
+                rowFields.stream(),
+                (sf, rf) -> createBlockInputDecoder(sf.getFieldObjectInspector(), rf.getType()))
+                .collect(Collectors.toList());
+        final int numFields = structFields.size();
+        return (b, i) -> {
+            if (b.isNull(i)) {
+                return null;
+            }
+            Block row = b.getBlock(i);
+            Object result = structInspector.create();
+            for (int j = 0; j < numFields; j++) {
+                structInspector.setStructFieldData(result,
+                        structFields.get(j),
+                        fieldDecoders.get(j).decode(row, j));
+            }
+            return result;
+        };
+    }
+
+    private static BlockInputDecoder createForStruct(StructObjectInspector structInspector, RowType rowType)
+    {
+        List<? extends StructField> structFields = structInspector.getAllStructFieldRefs();
+        List<RowType.Field> rowFields = rowType.getFields();
+        checkArgument(rowFields.size() == structFields.size());
+        List<BlockInputDecoder> fieldDecoders = Streams.zip(
+                structFields.stream(),
+                rowFields.stream(),
+                (sf, rf) -> createBlockInputDecoder(sf.getFieldObjectInspector(), rf.getType()))
+                .collect(Collectors.toList());
+        final int numFields = structFields.size();
+        return (b, i) -> {
+            if (b.isNull(i)) {
+                return null;
+            }
+            Block row = b.getBlock(i);
+            ArrayList<Object> result = new ArrayList<>(numFields);
+            for (int j = 0; j < numFields; j++) {
+                result.add(fieldDecoders.get(j).decode(row, j));
+            }
+            return result;
+        };
+    }
+
+    private static BlockInputDecoder createForList(ListObjectInspector inspector, ArrayType arrayType)
+    {
+        Type elementType = arrayType.getElementType();
+        ObjectInspector elementInspector = inspector.getListElementObjectInspector();
+        BlockInputDecoder decoder = createBlockInputDecoder(elementInspector, elementType);
+        return (b, i) -> {
+            if (b.isNull(i)) {
+                return null;
+            }
+            Block array = b.getBlock(i);
+            int positions = array.getPositionCount();
+            ArrayList<Object> result = new ArrayList<>(positions);
+            for (int j = 0; j < positions; j++) {
+                result.add(decoder.decode(array, j));
+            }
+            return result;
+        };
+    }
+
+    private static BlockInputDecoder createForMap(MapObjectInspector inspector, MapType mapType)
+    {
+        Type keyType = mapType.getKeyType();
+        Type valueType = mapType.getValueType();
+        ObjectInspector keyInspector = inspector.getMapKeyObjectInspector();
+        ObjectInspector valueInspector = inspector.getMapValueObjectInspector();
+        BlockInputDecoder keyDecoder = createBlockInputDecoder(keyInspector, keyType);
+        BlockInputDecoder valueDecoder = createBlockInputDecoder(valueInspector, valueType);
+        return (b, i) -> {
+            if (b.isNull(i)) {
+                return null;
+            }
+            SingleMapBlock single = (SingleMapBlock) b.getBlock(i);
+            int positions = single.getPositionCount();
+            HashMap<Object, Object> result = new HashMap<>();
+            for (int j = 0; j < positions; j += 2) {
+                Object key = keyDecoder.decode(single, j);
+                Object value = valueDecoder.decode(single, j + 1);
+                if (key != null) {
+                    result.put(key, value);
+                }
+            }
+            return result;
+        };
+    }
+}

--- a/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/type/DateTimeUtils.java
+++ b/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/type/DateTimeUtils.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.hive.functions.type;
+
+import java.sql.Date;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.concurrent.TimeUnit;
+
+public final class DateTimeUtils
+{
+    private DateTimeUtils() {}
+
+    public static Date createDate(Object days)
+    {
+        long millis = TimeUnit.DAYS.toMillis(((long) days));
+        Instant instant = Instant.ofEpochMilli((millis));
+        OffsetDateTime dt = OffsetDateTime.ofInstant(instant, ZoneId.of("UTC"));
+        // A trick to prevent including zone info
+        return new Date(dt.getYear() - 1900, dt.getMonthValue() - 1, dt.getDayOfMonth());
+    }
+}

--- a/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/type/DecimalUtils.java
+++ b/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/type/DecimalUtils.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.hive.functions.type;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.type.DecimalType;
+import io.airlift.slice.Slice;
+import org.apache.hadoop.hive.common.type.HiveDecimal;
+
+import java.math.BigDecimal;
+
+import static com.facebook.presto.common.type.Decimals.encodeScaledValue;
+import static com.facebook.presto.common.type.Decimals.readBigDecimal;
+import static com.facebook.presto.common.type.Decimals.rescale;
+
+public final class DecimalUtils
+{
+    private DecimalUtils() {}
+
+    public static long encodeToLong(BigDecimal decimal, DecimalType type)
+    {
+        return rescale(decimal, type).unscaledValue().longValue();
+    }
+
+    public static Slice encodeToSlice(BigDecimal decimal, DecimalType type)
+    {
+        return encodeScaledValue(rescale(decimal, type));
+    }
+
+    public static HiveDecimal readHiveDecimal(DecimalType type, Block block, int position)
+    {
+        BigDecimal bigDecimal = readBigDecimal(type, block, position);
+        return HiveDecimal.create(bigDecimal);
+    }
+}

--- a/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/type/HiveTypes.java
+++ b/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/type/HiveTypes.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.hive.functions.type;
+
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.CharType;
+import com.facebook.presto.common.type.DecimalType;
+import com.facebook.presto.common.type.MapType;
+import com.facebook.presto.common.type.RowType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.TypeSignature;
+import com.facebook.presto.common.type.VarcharType;
+import io.airlift.slice.Slice;
+import org.apache.hadoop.hive.common.type.HiveChar;
+import org.apache.hadoop.hive.common.type.HiveVarchar;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.facebook.presto.common.type.StandardTypes.ARRAY;
+import static com.facebook.presto.common.type.StandardTypes.BIGINT;
+import static com.facebook.presto.common.type.StandardTypes.BOOLEAN;
+import static com.facebook.presto.common.type.StandardTypes.CHAR;
+import static com.facebook.presto.common.type.StandardTypes.DATE;
+import static com.facebook.presto.common.type.StandardTypes.DECIMAL;
+import static com.facebook.presto.common.type.StandardTypes.DOUBLE;
+import static com.facebook.presto.common.type.StandardTypes.INTEGER;
+import static com.facebook.presto.common.type.StandardTypes.MAP;
+import static com.facebook.presto.common.type.StandardTypes.REAL;
+import static com.facebook.presto.common.type.StandardTypes.ROW;
+import static com.facebook.presto.common.type.StandardTypes.SMALLINT;
+import static com.facebook.presto.common.type.StandardTypes.TIMESTAMP;
+import static com.facebook.presto.common.type.StandardTypes.TINYINT;
+import static com.facebook.presto.common.type.StandardTypes.VARBINARY;
+import static com.facebook.presto.common.type.StandardTypes.VARCHAR;
+import static com.facebook.presto.hive.functions.HiveFunctionErrorCode.unsupportedType;
+import static org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory.binaryTypeInfo;
+import static org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory.booleanTypeInfo;
+import static org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory.byteTypeInfo;
+import static org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory.dateTypeInfo;
+import static org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory.doubleTypeInfo;
+import static org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory.floatTypeInfo;
+import static org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory.getCharTypeInfo;
+import static org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory.getDecimalTypeInfo;
+import static org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory.getListTypeInfo;
+import static org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory.getMapTypeInfo;
+import static org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory.getStructTypeInfo;
+import static org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory.getVarcharTypeInfo;
+import static org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory.intTypeInfo;
+import static org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory.longTypeInfo;
+import static org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory.shortTypeInfo;
+import static org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory.timestampTypeInfo;
+import static org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory.varcharTypeInfo;
+
+public final class HiveTypes
+{
+    private HiveTypes() {}
+
+    public static HiveVarchar createHiveVarChar(String s)
+    {
+        return new HiveVarchar(s, s.length());
+    }
+
+    public static HiveVarchar createHiveVarChar(Slice slice)
+    {
+        String str = slice.toStringUtf8();
+        return new HiveVarchar(str, str.length());
+    }
+
+    public static HiveChar createHiveChar(String s)
+    {
+        return new HiveChar(s, s.length());
+    }
+
+    public static HiveChar createHiveChar(Slice slice)
+    {
+        String str = slice.toStringUtf8();
+        return new HiveChar(str, str.length());
+    }
+
+    public static TypeInfo toTypeInfo(Type type)
+    {
+        TypeSignature signature = type.getTypeSignature();
+        switch (type.getTypeSignature().getBase()) {
+            case BIGINT:
+                return longTypeInfo;
+            case INTEGER:
+                return intTypeInfo;
+            case SMALLINT:
+                return shortTypeInfo;
+            case TINYINT:
+                return byteTypeInfo;
+            case BOOLEAN:
+                return booleanTypeInfo;
+            case DATE:
+                return dateTypeInfo;
+            case DECIMAL:
+                return toDecimalTypeInfo(type);
+            case REAL:
+                return floatTypeInfo;
+            case DOUBLE:
+                return doubleTypeInfo;
+            case TIMESTAMP:
+                return timestampTypeInfo;
+            case VARBINARY:
+                return binaryTypeInfo;
+            case VARCHAR:
+                return toVarcharTypeInfo(type);
+            case CHAR:
+                return toCharTypeInfo(type);
+            case ROW:
+                return toStructTypeInfo(type);
+            case ARRAY:
+                return toListTypeInfo(type);
+            case MAP:
+                return toMapTypeInfo(type);
+        }
+        throw unsupportedType(signature);
+    }
+
+    private static TypeInfo toDecimalTypeInfo(Type type)
+    {
+        if (type instanceof DecimalType) {
+            DecimalType decimal = (DecimalType) type;
+            return getDecimalTypeInfo(decimal.getPrecision(), decimal.getScale());
+        }
+        throw unsupportedType(type);
+    }
+
+    private static TypeInfo toVarcharTypeInfo(Type type)
+    {
+        if (type instanceof VarcharType) {
+            VarcharType varchar = (VarcharType) type;
+            if (varchar.isUnbounded()) {
+                return varcharTypeInfo;
+            }
+            return getVarcharTypeInfo(varchar.getLengthSafe());
+        }
+        throw unsupportedType(type);
+    }
+
+    private static TypeInfo toCharTypeInfo(Type type)
+    {
+        if (type instanceof CharType) {
+            CharType chars = (CharType) type;
+            return getCharTypeInfo(chars.getLength());
+        }
+        throw unsupportedType(type);
+    }
+
+    private static TypeInfo toStructTypeInfo(Type type)
+    {
+        if (type instanceof RowType) {
+            RowType row = (RowType) type;
+            List<RowType.Field> fields = row.getFields();
+            List<String> fieldNames = new ArrayList<>(fields.size());
+            List<TypeInfo> fieldTypes = new ArrayList<>(fields.size());
+            for (int i = 0; i < fields.size(); i++) {
+                RowType.Field field = fields.get(i);
+                fieldNames.add(field.getName().orElse("col" + i));
+                fieldTypes.add(toTypeInfo(field.getType()));
+            }
+            return getStructTypeInfo(fieldNames, fieldTypes);
+        }
+        throw unsupportedType(type);
+    }
+
+    private static TypeInfo toListTypeInfo(Type type)
+    {
+        if (type instanceof ArrayType) {
+            ArrayType array = (ArrayType) type;
+            Type element = array.getElementType();
+            return getListTypeInfo(toTypeInfo(element));
+        }
+        throw unsupportedType(type);
+    }
+
+    private static TypeInfo toMapTypeInfo(Type type)
+    {
+        if (type instanceof MapType) {
+            MapType map = (MapType) type;
+            return getMapTypeInfo(toTypeInfo(map.getKeyType()), toTypeInfo(map.getValueType()));
+        }
+        throw unsupportedType(type);
+    }
+}

--- a/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/type/ObjectEncoder.java
+++ b/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/type/ObjectEncoder.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.hive.functions.type;
+
+public interface ObjectEncoder
+{
+    /**
+     * Transforms object return by Hive function to
+     * object adapted to Presto function
+     */
+    Object encode(Object object);
+}

--- a/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/type/ObjectEncoders.java
+++ b/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/type/ObjectEncoders.java
@@ -1,0 +1,361 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.hive.functions.type;
+
+import com.facebook.presto.common.PageBuilder;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.block.DuplicateMapKeyException;
+import com.facebook.presto.common.block.MapBlockBuilder;
+import com.facebook.presto.common.block.RowBlockBuilder;
+import com.facebook.presto.common.block.SingleRowBlockWriter;
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.DecimalType;
+import com.facebook.presto.common.type.Decimals;
+import com.facebook.presto.common.type.MapType;
+import com.facebook.presto.common.type.RowType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.spi.PrestoException;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Streams;
+import io.airlift.slice.Slices;
+import org.apache.hadoop.hive.serde2.objectinspector.ListObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.MapObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.StructField;
+import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.BinaryObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.HiveCharObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.HiveDecimalObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.HiveVarcharObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.StringObjectInspector;
+
+import java.math.BigDecimal;
+import java.sql.Date;
+import java.sql.Timestamp;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.common.type.StandardTypes.ARRAY;
+import static com.facebook.presto.common.type.StandardTypes.BIGINT;
+import static com.facebook.presto.common.type.StandardTypes.BOOLEAN;
+import static com.facebook.presto.common.type.StandardTypes.CHAR;
+import static com.facebook.presto.common.type.StandardTypes.DATE;
+import static com.facebook.presto.common.type.StandardTypes.DECIMAL;
+import static com.facebook.presto.common.type.StandardTypes.DOUBLE;
+import static com.facebook.presto.common.type.StandardTypes.INTEGER;
+import static com.facebook.presto.common.type.StandardTypes.MAP;
+import static com.facebook.presto.common.type.StandardTypes.REAL;
+import static com.facebook.presto.common.type.StandardTypes.ROW;
+import static com.facebook.presto.common.type.StandardTypes.SMALLINT;
+import static com.facebook.presto.common.type.StandardTypes.TIMESTAMP;
+import static com.facebook.presto.common.type.StandardTypes.TINYINT;
+import static com.facebook.presto.common.type.StandardTypes.VARBINARY;
+import static com.facebook.presto.common.type.StandardTypes.VARCHAR;
+import static com.facebook.presto.common.type.TypeUtils.writeNativeValue;
+import static com.facebook.presto.hive.functions.HiveFunctionErrorCode.unsupportedType;
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.Float.floatToRawIntBits;
+import static java.util.Objects.requireNonNull;
+
+public final class ObjectEncoders
+{
+    private ObjectEncoders() {}
+
+    public static ObjectEncoder createEncoder(Type type, ObjectInspector inspector)
+    {
+        String base = type.getTypeSignature().getBase();
+        switch (base) {
+            case BIGINT:
+                checkArgument(inspector instanceof PrimitiveObjectInspector);
+                return compose(primitive(inspector), o -> ((Long) o));
+            case INTEGER:
+                checkArgument(inspector instanceof PrimitiveObjectInspector);
+                return compose(primitive(inspector), o -> ((Integer) o).longValue());
+            case SMALLINT:
+                checkArgument(inspector instanceof PrimitiveObjectInspector);
+                return compose(primitive(inspector), o -> ((Short) o).longValue());
+            case TINYINT:
+                checkArgument(inspector instanceof PrimitiveObjectInspector);
+                return compose(primitive(inspector), o -> ((Byte) o).longValue());
+            case BOOLEAN:
+                checkArgument(inspector instanceof PrimitiveObjectInspector);
+                return compose(primitive(inspector), o -> ((Boolean) o));
+            case DATE:
+                checkArgument(inspector instanceof PrimitiveObjectInspector);
+                return compose(primitive(inspector), o -> ((Date) o).getTime());
+            case DECIMAL:
+                if (Decimals.isShortDecimal(type)) {
+                    DecimalType decimalType = (DecimalType) type;
+                    return compose(decimal(inspector), o -> DecimalUtils.encodeToLong((BigDecimal) o, decimalType));
+                }
+                else if (Decimals.isLongDecimal(type)) {
+                    DecimalType decimalType = (DecimalType) type;
+                    return compose(decimal(inspector), o -> DecimalUtils.encodeToSlice((BigDecimal) o, decimalType));
+                }
+                break;
+            case REAL:
+                checkArgument(inspector instanceof PrimitiveObjectInspector);
+                return compose(primitive(inspector), o -> floatToRawIntBits(((Number) o).floatValue()));
+            case DOUBLE:
+                checkArgument(inspector instanceof PrimitiveObjectInspector);
+                return compose(primitive(inspector), o -> (Double) o);
+            case TIMESTAMP:
+                checkArgument(inspector instanceof PrimitiveObjectInspector);
+                return compose(primitive(inspector), o -> ((Timestamp) o).getTime());
+            case VARBINARY:
+                if (inspector instanceof BinaryObjectInspector) {
+                    return compose(primitive(inspector), o -> Slices.wrappedBuffer(((byte[]) o)));
+                }
+                break;
+            case VARCHAR:
+                if (inspector instanceof StringObjectInspector) {
+                    return compose(primitive(inspector), o -> Slices.utf8Slice(o.toString()));
+                }
+                else if (inspector instanceof HiveVarcharObjectInspector) {
+                    return compose(o -> ((HiveVarcharObjectInspector) inspector).getPrimitiveJavaObject(o).getValue(),
+                            o -> Slices.utf8Slice(((String) o)));
+                }
+                break;
+            case CHAR:
+                if (inspector instanceof StringObjectInspector) {
+                    return compose(primitive(inspector), o -> Slices.utf8Slice(o.toString()));
+                }
+                else if (inspector instanceof HiveCharObjectInspector) {
+                    return compose(o -> ((HiveCharObjectInspector) inspector).getPrimitiveJavaObject(o).getValue(),
+                            o -> Slices.utf8Slice(((String) o)));
+                }
+                break;
+            case ROW:
+                return StructObjectEncoder.create(type, inspector);
+            case ARRAY:
+                return ListObjectEncoder.create(type, inspector);
+            case MAP:
+                return MapObjectEncoder.create(type, inspector);
+        }
+        throw unsupportedType(type);
+    }
+
+    private static ObjectEncoder compose(Function<Object, Object> inspector, Function<Object, Object> encoder)
+    {
+        return o -> {
+            if (o != null) {
+                Object inspected = inspector.apply(o);
+                if (inspected != null) {
+                    return encoder.apply(inspected);
+                }
+            }
+            return null;
+        };
+    }
+
+    private static Function<Object, Object> primitive(ObjectInspector inspector)
+    {
+        return ((PrimitiveObjectInspector) inspector)::getPrimitiveJavaObject;
+    }
+
+    private static Function<Object, Object> decimal(ObjectInspector inspector)
+    {
+        return o -> ((HiveDecimalObjectInspector) inspector).getPrimitiveJavaObject(o).bigDecimalValue();
+    }
+
+    public static class ListObjectEncoder
+            implements ObjectEncoder
+    {
+        private final ListObjectInspector listInspector;
+        private final Type elementType;
+        private final BlockObjectWriter writer;
+
+        public static ListObjectEncoder create(Type type, ObjectInspector inspector)
+        {
+            checkArgument(inspector instanceof ListObjectInspector && type instanceof ArrayType);
+
+            Type elementType = ((ArrayType) type).getElementType();
+            ListObjectInspector listInspector = (ListObjectInspector) inspector;
+            ObjectEncoder elementEncoder = createEncoder(elementType,
+                    listInspector.getListElementObjectInspector());
+            return new ListObjectEncoder(listInspector, elementType, elementEncoder);
+        }
+
+        private ListObjectEncoder(ListObjectInspector listInspector, Type elementType, ObjectEncoder elementEncoder)
+        {
+            this.listInspector = requireNonNull(listInspector, "listInspector is null");
+            this.elementType = requireNonNull(elementType, "elementType is null");
+            this.writer = new SimpleBlockObjectWriter(elementEncoder, elementType);
+        }
+
+        @Override
+        public Object encode(Object o)
+        {
+            if (o == null) {
+                return null;
+            }
+            final int length = listInspector.getListLength(o);
+            final BlockBuilder blockBuilder = elementType.createBlockBuilder(null, length);
+            for (int i = 0; i < length; i++) {
+                writer.write(blockBuilder, listInspector.getListElement(o, i));
+            }
+            return blockBuilder.build();
+        }
+    }
+
+    public static class MapObjectEncoder
+            implements ObjectEncoder
+    {
+        private final MapType mapType;
+        private final MapObjectInspector mapObjectInspector;
+        private final BlockObjectWriter keyWriter;
+        private final BlockObjectWriter valueWriter;
+
+        public static MapObjectEncoder create(Type type, Object inspector)
+        {
+            checkArgument(type instanceof MapType &&
+                    inspector instanceof MapObjectInspector);
+            return new MapObjectEncoder(((MapType) type), ((MapObjectInspector) inspector));
+        }
+
+        private MapObjectEncoder(MapType type, MapObjectInspector inspector)
+        {
+            this.mapType = requireNonNull(type, "mapType is null");
+            this.mapObjectInspector = requireNonNull(inspector, "inspector is null");
+            Type keyType = type.getKeyType();
+            Type valueType = type.getValueType();
+            ObjectEncoder keyEncoder = createEncoder(keyType, inspector.getMapKeyObjectInspector());
+            ObjectEncoder valueEncoder = createEncoder(valueType, inspector.getMapValueObjectInspector());
+            this.keyWriter = requireNonNull(createBlockObjectWriter(keyEncoder, keyType), "keyWriter is null");
+            this.valueWriter = requireNonNull(createBlockObjectWriter(valueEncoder, valueType), "valueWriter is null");
+        }
+
+        @Override
+        public Object encode(Object object)
+        {
+            if (object == null) {
+                return null;
+            }
+            Map<?, ?> rawMap = mapObjectInspector.getMap(object);
+
+            MapBlockBuilder mapBlockBuilder = (MapBlockBuilder) mapType.createBlockBuilder(null, rawMap.size());
+            BlockBuilder blockBuilder = mapBlockBuilder.beginBlockEntry();
+            for (Entry<?, ?> entry : rawMap.entrySet()) {
+                if (entry.getKey() == null) {
+                    mapBlockBuilder.closeEntry();
+                    throw new PrestoException(INVALID_FUNCTION_ARGUMENT, "map key cannot be null");
+                }
+                // TODO check indeterminate
+                keyWriter.write(blockBuilder, entry.getKey());
+                valueWriter.write(blockBuilder, entry.getValue());
+            }
+            try {
+                mapBlockBuilder.closeEntryStrict(mapType.getKeyBlockEquals(), mapType.getKeyBlockHashCode());
+            }
+            catch (DuplicateMapKeyException e) {
+                throw new PrestoException(INVALID_FUNCTION_ARGUMENT, e);
+            }
+            return mapType.getObject(mapBlockBuilder, mapBlockBuilder.getPositionCount() - 1);
+        }
+    }
+
+    public static class StructObjectEncoder
+            implements ObjectEncoder
+    {
+        private final RowType type;
+        private final StructObjectInspector inspector;
+        private final List<BlockObjectWriter> fieldWriters;
+
+        public static StructObjectEncoder create(Type type, Object inspector)
+        {
+            checkArgument((type instanceof RowType) && (inspector instanceof StructObjectInspector));
+            return new StructObjectEncoder((RowType) type, (StructObjectInspector) inspector);
+        }
+
+        private static BlockObjectWriter createFieldBlockObjectWriter(Type type, StructField field)
+        {
+            ObjectEncoder encoder = createEncoder(type, field.getFieldObjectInspector());
+            return createBlockObjectWriter(encoder, type);
+        }
+
+        public StructObjectEncoder(RowType type, StructObjectInspector inspector)
+        {
+            this.type = requireNonNull(type, "type is null");
+            this.inspector = requireNonNull(inspector, "inspector is null");
+            this.fieldWriters = Streams.zip(
+                    type.getFields().stream().map(RowType.Field::getType),
+                    inspector.getAllStructFieldRefs().stream(),
+                    StructObjectEncoder::createFieldBlockObjectWriter)
+                    .collect(Collectors.toList());
+        }
+
+        @Override
+        public Object encode(Object object)
+        {
+            if (object == null) {
+                return null;
+            }
+
+            PageBuilder pageBuilder = new PageBuilder(ImmutableList.of(type));
+            RowBlockBuilder rowBlockBuilder = (RowBlockBuilder) pageBuilder.getBlockBuilder(0);
+            SingleRowBlockWriter blockBuilder = rowBlockBuilder.beginBlockEntry();
+            List<Object> fieldObjects = inspector.getStructFieldsDataAsList(object);
+            final int totalNumField = fieldWriters.size();
+            final int numField = fieldObjects.size();
+            for (int i = 0; i < totalNumField; i++) {
+                fieldWriters.get(i).write(blockBuilder, i < numField ? fieldObjects.get(i) : null);
+            }
+            rowBlockBuilder.closeEntry();
+            pageBuilder.declarePosition();
+            return type.getObject(rowBlockBuilder, rowBlockBuilder.getPositionCount() - 1);
+        }
+    }
+
+    private static BlockObjectWriter createBlockObjectWriter(ObjectEncoder encoder, Type type)
+    {
+        return new SimpleBlockObjectWriter(encoder, type);
+    }
+
+    private interface BlockObjectWriter
+    {
+        void write(BlockBuilder out, Object object);
+    }
+
+    private static class SimpleBlockObjectWriter
+            implements BlockObjectWriter
+    {
+        private final ObjectEncoder objectEncoder;
+        private final Type objectType;
+
+        private SimpleBlockObjectWriter(ObjectEncoder objectEncoder, Type objectType)
+        {
+            this.objectEncoder = requireNonNull(objectEncoder, "objectEncoder is null");
+            this.objectType = requireNonNull(objectType, "objectType is null");
+        }
+
+        @Override
+        public void write(BlockBuilder out, Object object)
+        {
+            if (object != null) {
+                Object encoded = objectEncoder.encode(object);
+                if (encoded != null) {
+                    writeNativeValue(objectType, out, encoded);
+                    return;
+                }
+            }
+            out.appendNull();
+        }
+    }
+}

--- a/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/type/ObjectInputDecoder.java
+++ b/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/type/ObjectInputDecoder.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.hive.functions.type;
+
+public interface ObjectInputDecoder
+{
+    /**
+     * Decodes Presto function internal object
+     * (ie. boolean/long/double/slice/block)
+     * to Hive function internal object.
+     */
+    Object decode(Object object);
+}

--- a/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/type/ObjectInputDecoders.java
+++ b/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/type/ObjectInputDecoders.java
@@ -1,0 +1,223 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.hive.functions.type;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.DecimalType;
+import com.facebook.presto.common.type.Decimals;
+import com.facebook.presto.common.type.MapType;
+import com.facebook.presto.common.type.RowType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.common.type.UnknownType;
+import io.airlift.slice.Slice;
+import org.apache.hadoop.hive.common.type.HiveDecimal;
+
+import java.math.BigInteger;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.common.type.StandardTypes.ARRAY;
+import static com.facebook.presto.common.type.StandardTypes.BIGINT;
+import static com.facebook.presto.common.type.StandardTypes.BOOLEAN;
+import static com.facebook.presto.common.type.StandardTypes.CHAR;
+import static com.facebook.presto.common.type.StandardTypes.DATE;
+import static com.facebook.presto.common.type.StandardTypes.DECIMAL;
+import static com.facebook.presto.common.type.StandardTypes.DOUBLE;
+import static com.facebook.presto.common.type.StandardTypes.INTEGER;
+import static com.facebook.presto.common.type.StandardTypes.MAP;
+import static com.facebook.presto.common.type.StandardTypes.REAL;
+import static com.facebook.presto.common.type.StandardTypes.ROW;
+import static com.facebook.presto.common.type.StandardTypes.SMALLINT;
+import static com.facebook.presto.common.type.StandardTypes.TIMESTAMP;
+import static com.facebook.presto.common.type.StandardTypes.TINYINT;
+import static com.facebook.presto.common.type.StandardTypes.VARBINARY;
+import static com.facebook.presto.common.type.StandardTypes.VARCHAR;
+import static com.facebook.presto.hive.functions.HiveFunctionErrorCode.unsupportedType;
+import static java.lang.Float.intBitsToFloat;
+import static java.util.Objects.requireNonNull;
+
+public final class ObjectInputDecoders
+{
+    private ObjectInputDecoders() {}
+
+    public static ObjectInputDecoder createDecoder(Type type, TypeManager typeManager)
+    {
+        String base = type.getTypeSignature().getBase();
+        switch (base) {
+            case UnknownType.NAME:
+                return o -> o;
+            case BIGINT:
+                return o -> (Long) o;
+            case INTEGER:
+                return o -> ((Long) o).intValue();
+            case SMALLINT:
+                return o -> ((Long) o).shortValue();
+            case TINYINT:
+                return o -> ((Long) o).byteValue();
+            case BOOLEAN:
+                return o -> (Boolean) o;
+            case DATE:
+                return DateTimeUtils::createDate;
+            case DECIMAL:
+                if (Decimals.isShortDecimal(type)) {
+                    final int scale = ((DecimalType) type).getScale();
+                    return o -> HiveDecimal.create(BigInteger.valueOf((long) o), scale);
+                }
+                else if (Decimals.isLongDecimal(type)) {
+                    final int scale = ((DecimalType) type).getScale();
+                    return o -> HiveDecimal.create(Decimals.decodeUnscaledValue((Slice) o), scale);
+                }
+                break;
+            case REAL:
+                return o -> intBitsToFloat(((Number) o).intValue());
+            case DOUBLE:
+                return o -> ((Double) o);
+            case TIMESTAMP:
+                return o -> new Timestamp(((long) o));
+            case VARBINARY:
+                return o -> ((Slice) o).getBytes();
+            case VARCHAR:
+                return o -> ((Slice) o).toStringUtf8();
+            case CHAR:
+                return o -> ((Slice) o).toStringUtf8();
+            case ROW:
+                return RowObjectInputDecoder.create(((RowType) type), typeManager);
+            case ARRAY:
+                return ArrayObjectInputDecoder.create(((ArrayType) type), typeManager);
+            case MAP:
+                return MapObjectInputDecoder.create(((MapType) type), typeManager);
+        }
+
+        throw unsupportedType(type);
+    }
+
+    public static BlockInputDecoder createBlockInputDecoder(Type type, TypeManager typeManager)
+    {
+        return BlockInputDecoders.createBlockInputDecoder(ObjectInspectors.create(type, typeManager), type);
+    }
+
+    public static class RowObjectInputDecoder
+            implements ObjectInputDecoder
+    {
+        private final List<BlockInputDecoder> fieldDecoders;
+
+        private static RowObjectInputDecoder create(RowType type, TypeManager typeManager)
+        {
+            List<BlockInputDecoder> fieldDecoders = type
+                    .getFields()
+                    .stream()
+                    .map(f -> createBlockInputDecoder(f.getType(), typeManager))
+                    .collect(Collectors.toList());
+            return new RowObjectInputDecoder(fieldDecoders);
+        }
+
+        private RowObjectInputDecoder(List<BlockInputDecoder> fieldDecoders)
+        {
+            this.fieldDecoders = requireNonNull(fieldDecoders, "fieldDecoders is null");
+        }
+
+        @Override
+        public Object decode(Object object)
+        {
+            if (object == null) {
+                return null;
+            }
+            Block block = (Block) object;
+            List<Object> list = new ArrayList<>(fieldDecoders.size());
+            int numField = fieldDecoders.size();
+            for (int i = 0; i < numField; i++) {
+                list.add(fieldDecoders.get(i).decode(block, i));
+            }
+            return list;
+        }
+    }
+
+    public static class ArrayObjectInputDecoder
+            implements ObjectInputDecoder
+    {
+        private final BlockInputDecoder elementDecoder;
+
+        private static ArrayObjectInputDecoder create(ArrayType type, TypeManager typeManager)
+        {
+            return new ArrayObjectInputDecoder(createBlockInputDecoder(type.getElementType(), typeManager));
+        }
+
+        private ArrayObjectInputDecoder(BlockInputDecoder elementDecoder)
+        {
+            this.elementDecoder = requireNonNull(elementDecoder, "elementDecoder is null");
+        }
+
+        @SuppressWarnings({"rawtypes", "unchecked"})
+        @Override
+        public Object decode(Object object)
+        {
+            if (object == null) {
+                return null;
+            }
+            Block block = (Block) object;
+            int count = block.getPositionCount();
+            List list = new ArrayList(count);
+            for (int i = 0; i < count; i++) {
+                list.add(elementDecoder.decode(block, i));
+            }
+            return list;
+        }
+    }
+
+    public static class MapObjectInputDecoder
+            implements ObjectInputDecoder
+    {
+        private final BlockInputDecoder keyDecoder;
+        private final BlockInputDecoder valueDecoder;
+
+        private static MapObjectInputDecoder create(MapType type, TypeManager typeManager)
+        {
+            return new MapObjectInputDecoder(
+                    createBlockInputDecoder(type.getKeyType(), typeManager),
+                    createBlockInputDecoder(type.getValueType(), typeManager));
+        }
+
+        private MapObjectInputDecoder(BlockInputDecoder keyDecoder, BlockInputDecoder valueDecoder)
+        {
+            this.keyDecoder = requireNonNull(keyDecoder, "keyDecoder is null");
+            this.valueDecoder = requireNonNull(valueDecoder, "valueDecoder is null");
+        }
+
+        @SuppressWarnings({"rawtypes", "unchecked"})
+        @Override
+        public Object decode(Object object)
+        {
+            if (object == null) {
+                return null;
+            }
+            Block block = (Block) object;
+            Map map = new HashMap();
+            for (int i = 0; i < block.getPositionCount(); i += 2) {
+                Object key = keyDecoder.decode(block, i);
+                if (key != null) {
+                    Object value = valueDecoder.decode(block, i + 1);
+                    map.put(key, value);
+                }
+            }
+            return map;
+        }
+    }
+}

--- a/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/type/ObjectInspectors.java
+++ b/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/type/ObjectInspectors.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.hive.functions.type;
+
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.DecimalType;
+import com.facebook.presto.common.type.MapType;
+import com.facebook.presto.common.type.RowType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.common.type.TypeSignature;
+import com.facebook.presto.common.type.UnknownType;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.JavaHiveDecimalObjectInspector;
+import org.apache.hadoop.hive.serde2.typeinfo.DecimalTypeInfo;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.facebook.presto.common.type.StandardTypes.ARRAY;
+import static com.facebook.presto.common.type.StandardTypes.BIGINT;
+import static com.facebook.presto.common.type.StandardTypes.BOOLEAN;
+import static com.facebook.presto.common.type.StandardTypes.CHAR;
+import static com.facebook.presto.common.type.StandardTypes.DATE;
+import static com.facebook.presto.common.type.StandardTypes.DECIMAL;
+import static com.facebook.presto.common.type.StandardTypes.DOUBLE;
+import static com.facebook.presto.common.type.StandardTypes.INTEGER;
+import static com.facebook.presto.common.type.StandardTypes.MAP;
+import static com.facebook.presto.common.type.StandardTypes.REAL;
+import static com.facebook.presto.common.type.StandardTypes.ROW;
+import static com.facebook.presto.common.type.StandardTypes.SMALLINT;
+import static com.facebook.presto.common.type.StandardTypes.TIMESTAMP;
+import static com.facebook.presto.common.type.StandardTypes.TINYINT;
+import static com.facebook.presto.common.type.StandardTypes.VARBINARY;
+import static com.facebook.presto.common.type.StandardTypes.VARCHAR;
+import static com.facebook.presto.hive.functions.HiveFunctionErrorCode.unsupportedType;
+import static org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory.getStandardListObjectInspector;
+import static org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory.getStandardMapObjectInspector;
+import static org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory.getStandardStructObjectInspector;
+import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.javaBooleanObjectInspector;
+import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.javaByteArrayObjectInspector;
+import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.javaByteObjectInspector;
+import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.javaDateObjectInspector;
+import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.javaDoubleObjectInspector;
+import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.javaFloatObjectInspector;
+import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.javaIntObjectInspector;
+import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.javaLongObjectInspector;
+import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.javaShortObjectInspector;
+import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.javaStringObjectInspector;
+import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.javaTimestampObjectInspector;
+import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.javaVoidObjectInspector;
+
+public final class ObjectInspectors
+{
+    private ObjectInspectors() {}
+
+    public static ObjectInspector create(Type type, TypeManager typeManager)
+    {
+        TypeSignature typeSignature = type.getTypeSignature();
+        switch (typeSignature.getBase()) {
+            case UnknownType.NAME:
+                return javaVoidObjectInspector;
+            case BIGINT:
+                return javaLongObjectInspector;
+            case INTEGER:
+                return javaIntObjectInspector;
+            case SMALLINT:
+                return javaShortObjectInspector;
+            case TINYINT:
+                return javaByteObjectInspector;
+            case BOOLEAN:
+                return javaBooleanObjectInspector;
+            case DATE:
+                return javaDateObjectInspector;
+            case DECIMAL:
+                DecimalType dt = PrestoTypes.createDecimalType(typeSignature);
+                return new JavaHiveDecimalObjectInspector(
+                        new DecimalTypeInfo(dt.getPrecision(), dt.getScale()));
+            case REAL:
+                return javaFloatObjectInspector;
+            case DOUBLE:
+                return javaDoubleObjectInspector;
+            case TIMESTAMP:
+                return javaTimestampObjectInspector;
+            case VARBINARY:
+                return javaByteArrayObjectInspector;
+            case VARCHAR:
+                return javaStringObjectInspector;
+            case CHAR:
+                return javaStringObjectInspector;
+            case ROW:
+                if (type instanceof RowType) {
+                    return createForRow(((RowType) type), typeManager);
+                }
+                break;
+            case ARRAY:
+                if (type instanceof ArrayType) {
+                    return createForArray(((ArrayType) type), typeManager);
+                }
+                break;
+            case MAP:
+                if (type instanceof MapType) {
+                    return createForMap(((MapType) type), typeManager);
+                }
+                break;
+        }
+        throw unsupportedType(type);
+    }
+
+    private static ObjectInspector createForRow(RowType rowType, TypeManager typeManager)
+    {
+        List<RowType.Field> fields = rowType.getFields();
+        int numField = fields.size();
+        List<String> fieldNames = new ArrayList<>(numField);
+        List<ObjectInspector> fieldInspectors = new ArrayList<>(numField);
+        List<String> comments = new ArrayList<>(numField);
+
+        for (int i = 0; i < numField; i++) {
+            RowType.Field field = fields.get(i);
+            String fieldName = field.getName().orElse("col" + i);
+            fieldNames.add(fieldName);
+            fieldInspectors.add(ObjectInspectors.create(field.getType(), typeManager));
+            comments.add(fieldName);
+        }
+
+        return getStandardStructObjectInspector(fieldNames, fieldInspectors, comments);
+    }
+
+    private static ObjectInspector createForMap(MapType mapType, TypeManager typeManager)
+    {
+        ObjectInspector keyInspector = ObjectInspectors.create(mapType.getKeyType(), typeManager);
+        ObjectInspector valueInspector = ObjectInspectors.create(mapType.getValueType(), typeManager);
+        return getStandardMapObjectInspector(keyInspector, valueInspector);
+    }
+
+    private static ObjectInspector createForArray(ArrayType arrayType, TypeManager typeManager)
+    {
+        return getStandardListObjectInspector(ObjectInspectors.create(arrayType.getElementType(), typeManager));
+    }
+}

--- a/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/type/PrestoTypes.java
+++ b/presto-hive-function-namespace/src/main/java/com/facebook/presto/hive/functions/type/PrestoTypes.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.hive.functions.type;
+
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.BigintType;
+import com.facebook.presto.common.type.BooleanType;
+import com.facebook.presto.common.type.CharType;
+import com.facebook.presto.common.type.DateType;
+import com.facebook.presto.common.type.DecimalType;
+import com.facebook.presto.common.type.DoubleType;
+import com.facebook.presto.common.type.IntegerType;
+import com.facebook.presto.common.type.RealType;
+import com.facebook.presto.common.type.RowType;
+import com.facebook.presto.common.type.SmallintType;
+import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.common.type.TimestampType;
+import com.facebook.presto.common.type.TinyintType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.common.type.TypeSignature;
+import com.facebook.presto.common.type.TypeSignatureParameter;
+import com.facebook.presto.common.type.VarbinaryType;
+import com.facebook.presto.common.type.VarcharType;
+import org.apache.hadoop.hive.serde2.objectinspector.ListObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.MapObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
+import org.apache.hadoop.hive.serde2.typeinfo.CharTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.DecimalTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.PrimitiveTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.VarcharTypeInfo;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.common.type.StandardTypes.DECIMAL;
+import static com.facebook.presto.hive.functions.HiveFunctionErrorCode.unsupportedType;
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+public final class PrestoTypes
+{
+    private PrestoTypes() {}
+
+    public static DecimalType createDecimalType(TypeSignature type)
+    {
+        requireNonNull(type);
+        checkArgument(DECIMAL.equals(type.getBase()) && type.getParameters().size() == 2,
+                "Invalid decimal type " + type);
+        int precision = type.getParameters().get(0).getLongLiteral().intValue();
+        int scale = type.getParameters().get(1).getLongLiteral().intValue();
+        return DecimalType.createDecimalType(precision, scale);
+    }
+
+    public static Type fromObjectInspector(ObjectInspector inspector, TypeManager typeManager)
+    {
+        switch (inspector.getCategory()) {
+            case PRIMITIVE:
+                checkArgument(inspector instanceof PrimitiveObjectInspector);
+                return fromPrimitive((PrimitiveObjectInspector) inspector);
+            case LIST:
+                checkArgument(inspector instanceof ListObjectInspector);
+                return fromList(((ListObjectInspector) inspector), typeManager);
+            case MAP:
+                checkArgument(inspector instanceof MapObjectInspector);
+                return fromMap(((MapObjectInspector) inspector), typeManager);
+            case STRUCT:
+                checkArgument(inspector instanceof StructObjectInspector);
+                return fromStruct(((StructObjectInspector) inspector), typeManager);
+        }
+        throw unsupportedType(inspector);
+    }
+
+    private static Type fromPrimitive(PrimitiveObjectInspector inspector)
+    {
+        switch (inspector.getPrimitiveCategory()) {
+            case BOOLEAN:
+                return BooleanType.BOOLEAN;
+            case BYTE:
+                return TinyintType.TINYINT;
+            case SHORT:
+                return SmallintType.SMALLINT;
+            case INT:
+                return IntegerType.INTEGER;
+            case LONG:
+                return BigintType.BIGINT;
+            case FLOAT:
+                return RealType.REAL;
+            case DOUBLE:
+                return DoubleType.DOUBLE;
+            case STRING:
+                return VarcharType.VARCHAR;
+            case DATE:
+                return DateType.DATE;
+            case TIMESTAMP:
+                return TimestampType.TIMESTAMP;
+            case BINARY:
+                return VarbinaryType.VARBINARY;
+        }
+        PrimitiveTypeInfo typeInfo = inspector.getTypeInfo();
+        if (typeInfo instanceof CharTypeInfo) {
+            int length = ((CharTypeInfo) typeInfo).getLength();
+            return CharType.createCharType(length);
+        }
+        else if (typeInfo instanceof VarcharTypeInfo) {
+            int length = ((VarcharTypeInfo) typeInfo).getLength();
+            return VarcharType.createVarcharType(length);
+        }
+        else if (typeInfo instanceof DecimalTypeInfo) {
+            final DecimalTypeInfo decimal = (DecimalTypeInfo) typeInfo;
+            return DecimalType.createDecimalType(decimal.getPrecision(),
+                    decimal.getScale());
+        }
+        throw unsupportedType(inspector);
+    }
+
+    private static Type fromList(ListObjectInspector inspector, TypeManager typeManager)
+    {
+        ObjectInspector elementInspector = inspector.getListElementObjectInspector();
+        return new ArrayType(fromObjectInspector(elementInspector, typeManager));
+    }
+
+    private static Type fromMap(MapObjectInspector inspector, TypeManager typeManager)
+    {
+        Type keyType = fromObjectInspector(inspector.getMapKeyObjectInspector(), typeManager);
+        Type valueType = fromObjectInspector(inspector.getMapValueObjectInspector(), typeManager);
+        return typeManager.getType(new TypeSignature(StandardTypes.MAP,
+                TypeSignatureParameter.of(keyType.getTypeSignature()),
+                TypeSignatureParameter.of(valueType.getTypeSignature())));
+    }
+
+    private static Type fromStruct(StructObjectInspector inspector, TypeManager typeManager)
+    {
+        List<RowType.Field> fields = ((StructObjectInspector) inspector)
+                .getAllStructFieldRefs()
+                .stream()
+                .map(sf -> RowType.field(sf.getFieldName(), fromObjectInspector(sf.getFieldObjectInspector(), typeManager)))
+                .collect(Collectors.toList());
+        return RowType.from(fields);
+    }
+}

--- a/presto-hive-function-namespace/src/test/java/com/facebook/presto/hive/functions/AbstractTestHiveFunctions.java
+++ b/presto-hive-function-namespace/src/test/java/com/facebook/presto/hive/functions/AbstractTestHiveFunctions.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.hive.functions;
+
+import com.facebook.airlift.log.Logger;
+import com.facebook.presto.common.type.TimeZoneKey;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.server.testing.TestingPrestoServer;
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.testing.MaterializedRow;
+import com.facebook.presto.tests.TestingPrestoClient;
+import com.google.common.base.Splitter;
+import com.google.common.io.Files;
+import com.google.inject.Key;
+import org.intellij.lang.annotations.Language;
+import org.testng.annotations.BeforeClass;
+
+import java.io.File;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.hive.functions.HiveFunctionsTestUtils.createTestingPrestoServer;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.String.format;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+public abstract class AbstractTestHiveFunctions
+{
+    private static final Logger log = Logger.get(AbstractTestHiveFunctions.class);
+
+    protected TestingPrestoServer server;
+    protected TestingPrestoClient client;
+    protected TypeManager typeManager;
+
+    @BeforeClass
+    public void setup()
+            throws Exception
+    {
+        // TODO: Use DistributedQueryRunner to perform query
+        server = createTestingPrestoServer();
+        client = new TestingPrestoClient(server, testSessionBuilder()
+                .setTimeZoneKey(TimeZoneKey.getTimeZoneKey("America/Bahia_Banderas"))
+                .build());
+        typeManager = server.getInstance(Key.get(TypeManager.class));
+
+        if (getInitScript().isPresent()) {
+            String sql = Files.asCharSource(getInitScript().get(), UTF_8).read();
+            Iterable<String> initQueries = Splitter.on("----\n").omitEmptyStrings().trimResults().split(sql);
+            for (@Language("SQL") String query : initQueries) {
+                log.debug("Executing %s", query);
+                client.execute(query);
+            }
+        }
+    }
+
+    public void assertFunction(String expr, Type type, Object value)
+    {
+        assertQuery("SELECT " + expr, Column.of(type, value));
+    }
+
+    public void assertInvalidFunction(String expr, String exceptionPattern)
+    {
+        try {
+            client.execute("SELECT " + expr);
+            fail("Function expected to fail but not");
+        }
+        catch (Exception e) {
+            if (!(e.getMessage().matches(exceptionPattern))) {
+                fail(format("Expected exception message '%s' to match '%s' but not",
+                        e.getMessage(), exceptionPattern));
+            }
+        }
+    }
+
+    public void assertQuery(@Language("SQL") String sql, Column... cols)
+    {
+        checkArgument(cols != null && cols.length > 0);
+        int numColumns = cols.length;
+        int numRows = cols[0].values.length;
+        checkArgument(Stream.of(cols).allMatch(c -> c != null && c.values.length == numRows));
+
+        MaterializedResult result = client.execute(sql).getResult();
+        assertEquals(result.getRowCount(), numRows);
+
+        for (int i = 0; i < numColumns; i++) {
+            assertEquals(result.getTypes().get(i), cols[i].type);
+        }
+        List<MaterializedRow> rows = result.getMaterializedRows();
+        for (int i = 0; i < numRows; i++) {
+            for (int j = 0; j < numColumns; j++) {
+                Object actual = rows.get(i).getField(j);
+                Object expected = cols[j].values[i];
+                if (cols[j].type == DOUBLE) {
+                    assertEquals(((Number) actual).doubleValue(), ((double) expected), 0.000001);
+                }
+                else {
+                    assertEquals(actual, expected);
+                }
+            }
+        }
+    }
+
+    protected Optional<File> getInitScript()
+    {
+        return Optional.empty();
+    }
+
+    public static class Column
+    {
+        private final Type type;
+
+        private final Object[] values;
+
+        public static Column of(Type type, Object... values)
+        {
+            return new Column(type, values);
+        }
+
+        private Column(Type type, Object[] values)
+        {
+            this.type = type;
+            this.values = values;
+        }
+    }
+}

--- a/presto-hive-function-namespace/src/test/java/com/facebook/presto/hive/functions/HiveFunctionsTestUtils.java
+++ b/presto-hive-function-namespace/src/test/java/com/facebook/presto/hive/functions/HiveFunctionsTestUtils.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.hive.functions;
+
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.plugin.memory.MemoryPlugin;
+import com.facebook.presto.server.testing.TestingPrestoServer;
+import com.google.inject.Key;
+
+import java.util.Collections;
+import java.util.Map;
+
+public final class HiveFunctionsTestUtils
+{
+    private HiveFunctionsTestUtils() {}
+
+    public static TestingPrestoServer createTestingPrestoServer()
+            throws Exception
+    {
+        TestingPrestoServer server = new TestingPrestoServer();
+        server.installPlugin(new MemoryPlugin());
+        server.installPlugin(new HiveFunctionNamespacePlugin());
+        server.createCatalog("memory", "memory");
+        FunctionAndTypeManager functionAndTypeManager = server.getInstance(Key.get(FunctionAndTypeManager.class));
+        functionAndTypeManager.loadFunctionNamespaceManager(
+                "hive-functions",
+                "hive",
+                getNamespaceManagerCreationProperties());
+        server.refreshNodes();
+        return server;
+    }
+
+    public static Map<String, String> getNamespaceManagerCreationProperties()
+    {
+        return Collections.emptyMap();
+    }
+}

--- a/presto-hive-function-namespace/src/test/java/com/facebook/presto/hive/functions/TestHiveScalarFunctions.java
+++ b/presto-hive-function-namespace/src/test/java/com/facebook/presto/hive/functions/TestHiveScalarFunctions.java
@@ -1,0 +1,207 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.functions;
+
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.RealType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.testing.MaterializedResult;
+import com.google.common.collect.ImmutableMap;
+import org.intellij.lang.annotations.Language;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.math.BigDecimal;
+import java.util.Optional;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.common.type.DecimalType.createDecimalType;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.google.common.math.DoubleMath.fuzzyEquals;
+import static java.util.Arrays.asList;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+@SuppressWarnings("UnknownLanguage")
+public class TestHiveScalarFunctions
+        extends AbstractTestHiveFunctions
+{
+    private static final String FUNCTION_PREFIX = "hive.default.";
+    private static final String TABLE_NAME = "memory.default.function_testing";
+    private static final Type INTEGER_ARRAY = new ArrayType(INTEGER);
+    private static final Type VARCHAR_ARRAY = new ArrayType(VARCHAR);
+
+    @Override
+    protected Optional<File> getInitScript()
+    {
+        return Optional.of(new File("src/test/sql/function-testing.sql"));
+    }
+
+    @Test
+    public void genericFunction()
+    {
+        check(select("isnull", "null"), BOOLEAN, true);
+        check(select("isnull", "1"), BOOLEAN, false);
+        check(selectF("isnull", "c_varchar_null"), BOOLEAN, true);
+        check(select("isnotnull", "1"), BOOLEAN, true);
+        check(select("isnotnull", "null"), BOOLEAN, false);
+        check(selectF("isnotnull", "c_varchar_null"), BOOLEAN, false);
+        check(select("nvl", "null", "'2'"), VARCHAR, "2");
+        check(selectF("nvl", "c_varchar_null", "'2'"), VARCHAR, "2");
+
+        // Primitive numbers
+        check(selectF("abs", "c_bigint"), BIGINT, 1L);
+        check(selectF("abs", "c_integer"), INTEGER, 1);
+        check(selectF("abs", "c_smallint"), INTEGER, 1);
+        check(selectF("abs", "c_tinyint"), INTEGER, 1);
+        check(selectF("abs", "c_decimal_52"), createDecimalType(5, 2), BigDecimal.valueOf(12345, 2));
+        check(selectF("abs", "c_real"), DOUBLE, 123.45f);
+        check(selectF("abs", "c_double"), DOUBLE, 123.45);
+
+        // Primitive string
+        check(selectF("upper", "c_varchar"), VARCHAR, "VARCHAR");
+        check(selectF("upper", "c_varchar_10"), VARCHAR, "VARCHAR10");
+        check(selectF("upper", "c_char_10"), VARCHAR, "CHAR10");
+    }
+
+    @Test
+    public void genericArrayFunction()
+    {
+        check(selectF("coalesce", "c_varchar_null", "c_varchar_a", "c_varchar_10"), VARCHAR, "a");
+        check(select("coalesce", "null", "10"), INTEGER, 10);
+
+        check(select("size", "null"), INTEGER, -1);
+        check(select("size", "array []"), INTEGER, 0);
+        check(select("size", "array [1, 2]"), INTEGER, 2);
+        check(select("size", "array [array [1, 2], null][1]"), INTEGER, 2);
+        check(select("size", "array [array [1, 2], null][2]"), INTEGER, -1);
+
+        check(select("array", "1", "2"), INTEGER_ARRAY, asList(1, 2));
+        check(select("array", "'1'", "'2'"), VARCHAR_ARRAY, asList("1", "2"));
+        check(selectF("array", "c_varchar", "c_varchar_10"), VARCHAR_ARRAY, asList("varchar", "varchar10"));
+
+        check(selectF("array_contains", "c_array_integer", "2"), BOOLEAN, true);
+        check(selectF("array_contains", "c_array_integer", "4"), BOOLEAN, false);
+        check(selectF("array_contains", "c_array_varchar", "cast('a' as VARCHAR)"), BOOLEAN, true);
+        check(selectF("array_contains", "c_array_varchar", "c_varchar_a"), BOOLEAN, true);
+        check(selectF("array_contains", "c_array_varchar", "c_varchar_z"), BOOLEAN, false);
+
+        check(selectF("sort_array", "ARRAY ['b', 'd', 'c', 'a']"), VARCHAR_ARRAY, asList("a", "b", "c", "d"));
+        check(selectF("sort_array", "ARRAY [2, 4, 3, 1]"), INTEGER_ARRAY, asList(1, 2, 3, 4));
+
+        check(select("split", "'oneAtwoBthree'", "'[ABC]'"), VARCHAR_ARRAY, asList("one", "two", "three"));
+
+        check(select("concat", "'aa'", "'bb'"), VARCHAR, "aabb");
+        check(select("concat_ws", "'.'", "'www'", "ARRAY ['facebook', 'com']"), VARCHAR, "www.facebook.com");
+        check(select("elt", "1", "'face'", "'book'"), VARCHAR, "face");
+        check(select("index", "ARRAY ['face', 'book']", "1"), VARCHAR, "book");
+        check(selectF("index", "c_array_varchar", "1"), VARCHAR, "b");
+    }
+
+    @Test
+    public void genericDateTimeFunction()
+    {
+        check(selectF("add_months", "c_date", "1"), VARCHAR, "2020-05-28");
+        check(selectF("add_months", "c_timestamp", "1"), VARCHAR, "2020-05-28");
+        check(select("add_months", "'2009-08-31'", "1"), VARCHAR, "2009-09-30");
+        check(select("add_months", "'2009-08-31 12:01:05'", "1"), VARCHAR, "2009-09-30");
+        check(select("datediff", "'2009-07-30'", "'2009-07-31'"), INTEGER, -1);
+        check(select("datediff", "'2009-07-30 12:01:05'", "'2009-07-31 12:01:05'"), INTEGER, -1);
+    }
+
+    @Test
+    public void genericMapFunction()
+    {
+        check(selectF("map_values", "c_map_varchar_integer"), INTEGER_ARRAY, asList(1, 2, 3));
+        check(selectF("map_values", "c_map_varchar_varchar"), VARCHAR_ARRAY, asList("1", "2", "3"));
+
+        check(selectF("index", "c_map_string_string", "cast('a' as varchar)"), VARCHAR, "1");
+        check(selectF("index", "c_map_varchar_integer", "'a'"), INTEGER, 1);
+        check(selectF("index", "c_map_varchar_varchar", "'a'"), VARCHAR, "1");
+
+        check(select("str_to_map", "'a:1,b:2'"), typeOf("map(varchar,varchar)"),
+                ImmutableMap.of("a", "1", "b", "2"));
+        check(select("str_to_map", "'a=1;b=2'", "';'", "'='"), typeOf("map(varchar,varchar)"),
+                ImmutableMap.of("a", "1", "b", "2"));
+
+        check(select("struct", "'a'", "1"), typeOf("row(col1 varchar,col2 integer)"), asList("a", 1));
+    }
+
+    public void check(@Language("SQL") String query, Type expectedType, Object expectedValue)
+    {
+        MaterializedResult result = client.execute(query).getResult();
+        assertEquals(result.getRowCount(), 1);
+        assertEquals(result.getTypes().get(0), expectedType);
+        Object actual = result.getMaterializedRows().get(0).getField(0);
+
+        if (expectedType.equals(DOUBLE) || expectedType.equals(RealType.REAL)) {
+            if (expectedValue == null) {
+                assertNaN(actual);
+            }
+            else {
+                assertTrue(fuzzyEquals(((Number) actual).doubleValue(), ((Number) expectedValue).doubleValue(), 0.000001));
+            }
+        }
+        else {
+            assertEquals(actual, expectedValue);
+        }
+    }
+
+    private Type typeOf(String signature)
+    {
+        return typeManager.getType(parseTypeSignature(signature));
+    }
+
+    private static void assertNaN(Object o)
+    {
+        if (o instanceof Double) {
+            assertEquals((Double) o, Double.NaN);
+        }
+        else if (o instanceof Float) {
+            assertEquals((Float) o, Float.NaN);
+        }
+        else {
+            fail("Unexpected " + o);
+        }
+    }
+
+    private static String select(String function, String... args)
+    {
+        StringBuilder builder = new StringBuilder();
+        builder.append("SELECT ").append(FUNCTION_PREFIX).append(function);
+        builder.append("(");
+        if (args != null) {
+            builder.append(String.join(", ", args));
+        }
+        builder.append(")");
+        return builder.toString();
+    }
+
+    private static String selectF(String function, String... args)
+    {
+        StringBuilder builder = new StringBuilder();
+        builder.append("SELECT ").append(FUNCTION_PREFIX).append(function);
+        builder.append("(");
+        if (args != null) {
+            builder.append(String.join(", ", args));
+        }
+        builder.append(")").append(" FROM ").append(TABLE_NAME);
+        return builder.toString();
+    }
+}

--- a/presto-hive-function-namespace/src/test/java/com/facebook/presto/hive/functions/TestScalarMethodHandles.java
+++ b/presto-hive-function-namespace/src/test/java/com/facebook/presto/hive/functions/TestScalarMethodHandles.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.functions;
+
+import com.facebook.presto.common.QualifiedObjectName;
+import com.facebook.presto.common.block.ArrayBlock;
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.ByteArrayBlock;
+import com.facebook.presto.common.block.MapBlock;
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.common.type.TypeSignature;
+import com.facebook.presto.hive.functions.scalar.ScalarFunctionInvoker;
+import com.facebook.presto.server.testing.TestingPrestoServer;
+import com.facebook.presto.spi.function.FunctionKind;
+import com.facebook.presto.spi.function.Signature;
+import com.google.inject.Key;
+import io.airlift.slice.Slices;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.lang.invoke.MethodHandle;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.hive.functions.HiveFunctionsTestUtils.createTestingPrestoServer;
+import static com.facebook.presto.hive.functions.gen.ScalarMethodHandles.generateUnbound;
+import static org.testng.Assert.assertEquals;
+
+public class TestScalarMethodHandles
+{
+    private AtomicInteger number;
+    private TestingPrestoServer server;
+    private TypeManager typeManager;
+
+    @BeforeClass
+    public void setup()
+            throws Exception
+    {
+        this.number = new AtomicInteger(0);
+        this.server = createTestingPrestoServer();
+        this.typeManager = server.getInstance(Key.get(TypeManager.class));
+    }
+
+    @Test
+    public void generateUnboundTest()
+            throws Throwable
+    {
+        runCase("boolean", tokens("boolean"), true, false);
+        runCase("bigint", tokens("bigint,bigint"), 3L, 2L, 1L);
+        runCase("varchar", tokens("varchar,double"), Slices.utf8Slice("output"), Slices.utf8Slice("input"), 2.1);
+        runCase("array(bigint)", tokens("bigint,bigint"), createArrayBlock(), 2L, 1L);
+        runCase("map(varchar,varchar)", tokens("varchar,varchar"), createMapBlock(), Slices.utf8Slice("a"), Slices.utf8Slice("b"));
+    }
+
+    private void runCase(String resultType, String[] argumentTypes, Object result, Object... arguments)
+            throws Throwable
+    {
+        Signature signature = createScalarSignature(resultType, argumentTypes);
+        MethodHandle methodHandle = generateUnbound(signature, typeManager);
+        TestingScalarFunctionInvoker invoker = new TestingScalarFunctionInvoker(signature, result);
+        final Object output;
+        if (arguments.length == 1) {
+            output = methodHandle.invoke(invoker, arguments[0]);
+        }
+        else if (arguments.length == 2) {
+            output = methodHandle.invoke(invoker, arguments[0], arguments[1]);
+        }
+        else if (arguments.length == 3) {
+            output = methodHandle.invoke(invoker, arguments[0], arguments[1], arguments[2]);
+        }
+        else if (arguments.length == 4) {
+            output = methodHandle.invoke(invoker, arguments[0], arguments[1], arguments[2], arguments[3]);
+        }
+        else {
+            throw new RuntimeException("Not supported yet");
+        }
+        Object[] inputs = invoker.getInputs();
+
+        assertEquals(output, result);
+        assertEquals(inputs, arguments);
+    }
+
+    private String[] tokens(String s)
+    {
+        return s.split(",");
+    }
+
+    private Signature createScalarSignature(String returnType, String... argumentTypes)
+    {
+        return new Signature(QualifiedObjectName.valueOf("hive.default.testing_" + number.incrementAndGet()),
+                FunctionKind.SCALAR,
+                parseTypeSignature(returnType),
+                Stream.of(argumentTypes)
+                        .map(TypeSignature::parseTypeSignature)
+                        .toArray(TypeSignature[]::new));
+    }
+
+    private static class TestingScalarFunctionInvoker
+            implements ScalarFunctionInvoker
+    {
+        private final Signature signature;
+        private final Object result;
+        private Object[] inputs;
+
+        public TestingScalarFunctionInvoker(Signature signature, Object result)
+        {
+            this.signature = signature;
+            this.result = result;
+        }
+
+        @Override
+        public Signature getSignature()
+        {
+            return signature;
+        }
+
+        @Override
+        public Object evaluate(Object... inputs)
+        {
+            this.inputs = inputs;
+            return result;
+        }
+
+        public Object[] getInputs()
+        {
+            return inputs;
+        }
+    }
+
+    private Block createEmptyBlock()
+    {
+        return new ByteArrayBlock(0, Optional.empty(), new byte[0]);
+    }
+
+    private Block createArrayBlock()
+    {
+        Block emptyValueBlock = createEmptyBlock();
+        return ArrayBlock.fromElementBlock(1, Optional.empty(), IntStream.range(0, 2).toArray(), emptyValueBlock);
+    }
+
+    private Block createMapBlock()
+    {
+        Block emptyKeyBlock = createEmptyBlock();
+        Block emptyValueBlock = createEmptyBlock();
+        return MapBlock.fromKeyValueBlock(1, Optional.empty(), IntStream.range(0, 2).toArray(), emptyKeyBlock, emptyValueBlock);
+    }
+}

--- a/presto-hive-function-namespace/src/test/java/com/facebook/presto/hive/functions/type/TestObjectEncoders.java
+++ b/presto-hive-function-namespace/src/test/java/com/facebook/presto/hive/functions/type/TestObjectEncoders.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.functions.type;
+
+import com.facebook.presto.common.block.LongArrayBlock;
+import com.facebook.presto.common.block.SingleMapBlock;
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.MapType;
+import com.facebook.presto.common.type.TestRowType;
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.server.testing.TestingPrestoServer;
+import com.google.inject.Key;
+import io.airlift.slice.Slice;
+import org.apache.hadoop.hive.serde2.io.DateWritable;
+import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
+import org.apache.hadoop.hive.serde2.io.ShortWritable;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.io.BooleanWritable;
+import org.apache.hadoop.io.ByteWritable;
+import org.apache.hadoop.io.BytesWritable;
+import org.apache.hadoop.io.DoubleWritable;
+import org.apache.hadoop.io.IntWritable;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.Text;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.HashMap;
+
+import static com.facebook.presto.common.block.MethodHandleUtil.methodHandle;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.common.type.CharType.createCharType;
+import static com.facebook.presto.common.type.DateType.DATE;
+import static com.facebook.presto.common.type.DecimalType.createDecimalType;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.common.type.SmallintType.SMALLINT;
+import static com.facebook.presto.common.type.TinyintType.TINYINT;
+import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.hive.functions.HiveFunctionsTestUtils.createTestingPrestoServer;
+import static com.facebook.presto.hive.functions.type.ObjectEncoders.createEncoder;
+import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.writableBinaryObjectInspector;
+import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.writableBooleanObjectInspector;
+import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.writableByteObjectInspector;
+import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.writableDateObjectInspector;
+import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.writableDoubleObjectInspector;
+import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.writableHiveDecimalObjectInspector;
+import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.writableIntObjectInspector;
+import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.writableLongObjectInspector;
+import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.writableShortObjectInspector;
+import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory.writableStringObjectInspector;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class TestObjectEncoders
+{
+    private TestingPrestoServer server;
+    private TypeManager typeManager;
+
+    @BeforeClass
+    public void setup()
+            throws Exception
+    {
+        this.server = createTestingPrestoServer();
+        this.typeManager = server.getInstance(Key.get(TypeManager.class));
+    }
+
+    @Test
+    public void testPrimitiveObjectEncoders()
+    {
+        ObjectInspector inspector;
+        ObjectEncoder encoder;
+
+        inspector = writableLongObjectInspector;
+        encoder = createEncoder(BIGINT, inspector);
+        assertTrue(encoder.encode(new LongWritable(123456L)) instanceof Long);
+
+        inspector = writableIntObjectInspector;
+        encoder = createEncoder(INTEGER, inspector);
+        assertTrue(encoder.encode(new IntWritable(12345)) instanceof Long);
+
+        inspector = writableShortObjectInspector;
+        encoder = createEncoder(SMALLINT, inspector);
+        assertTrue(encoder.encode(new ShortWritable((short) 1234)) instanceof Long);
+
+        inspector = writableByteObjectInspector;
+        encoder = createEncoder(TINYINT, inspector);
+        assertTrue(encoder.encode(new ByteWritable((byte) 123)) instanceof Long);
+
+        inspector = writableBooleanObjectInspector;
+        encoder = createEncoder(BOOLEAN, inspector);
+        assertTrue(encoder.encode(new BooleanWritable(true)) instanceof Boolean);
+
+        inspector = writableDoubleObjectInspector;
+        encoder = createEncoder(DOUBLE, inspector);
+        assertTrue(encoder.encode(new DoubleWritable(0.1)) instanceof Double);
+
+        inspector = writableDateObjectInspector;
+        encoder = createEncoder(DATE, inspector);
+        assertTrue(encoder.encode(new DateWritable(DateTimeUtils.createDate(18380L))) instanceof Long);
+
+        inspector = writableHiveDecimalObjectInspector;
+        encoder = createEncoder(createDecimalType(11, 10), inspector);
+        assertTrue(encoder.encode(new HiveDecimalWritable("1.2345678910")) instanceof Long);
+
+        encoder = createEncoder(createDecimalType(34, 33), inspector);
+        assertTrue(encoder.encode(new HiveDecimalWritable("1.281734081274028174012432412423134")) instanceof Slice);
+    }
+
+    @Test
+    public void testTextObjectEncoders()
+    {
+        ObjectInspector inspector;
+        ObjectEncoder encoder;
+
+        inspector = writableBinaryObjectInspector;
+        encoder = createEncoder(VARBINARY, inspector);
+        assertTrue(encoder.encode(new BytesWritable(new byte[] {12, 34, 56})) instanceof Slice);
+
+        inspector = writableStringObjectInspector;
+        encoder = createEncoder(VARCHAR, inspector);
+        assertTrue(encoder.encode(new Text("test_varchar")) instanceof Slice);
+
+        inspector = writableStringObjectInspector;
+        encoder = createEncoder(createCharType(10), inspector);
+        assertTrue(encoder.encode(new Text("test_char")) instanceof Slice);
+    }
+
+    @Test
+    public void testComplexObjectEncoders()
+    {
+        ObjectInspector inspector;
+        ObjectEncoder encoder;
+
+        inspector = ObjectInspectors.create(new ArrayType(BIGINT), typeManager);
+        encoder = createEncoder(new ArrayType(BIGINT), inspector);
+        assertTrue(encoder instanceof ObjectEncoders.ListObjectEncoder);
+        Object arrayObject = encoder.encode(new Long[]{1L, 2L, 3L});
+        assertTrue(arrayObject instanceof LongArrayBlock);
+        assertEquals(((LongArrayBlock) arrayObject).getLong(0), 1L);
+        assertEquals(((LongArrayBlock) arrayObject).getLong(1), 2L);
+        assertEquals(((LongArrayBlock) arrayObject).getLong(2), 3L);
+
+        inspector = ObjectInspectors.create(new MapType(
+                VARCHAR,
+                BIGINT,
+                methodHandle(TestRowType.class, "throwUnsupportedOperation"),
+                methodHandle(TestRowType.class, "throwUnsupportedOperation")), typeManager);
+        encoder = createEncoder(new MapType(
+                VARCHAR,
+                BIGINT,
+                methodHandle(TestRowType.class, "throwUnsupportedOperation"),
+                methodHandle(TestRowType.class, "throwUnsupportedOperation")), inspector);
+        assertTrue(encoder instanceof ObjectEncoders.MapObjectEncoder);
+        assertTrue(encoder.encode(new HashMap<String, Long>(){}) instanceof SingleMapBlock);
+    }
+}

--- a/presto-hive-function-namespace/src/test/java/com/facebook/presto/hive/functions/type/TestObjectInputDecoders.java
+++ b/presto-hive-function-namespace/src/test/java/com/facebook/presto/hive/functions/type/TestObjectInputDecoders.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.functions.type;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.LongArrayBlock;
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.MapType;
+import com.facebook.presto.common.type.TestRowType;
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.server.testing.TestingPrestoServer;
+import com.google.inject.Key;
+import io.airlift.slice.Slices;
+import org.apache.hadoop.hive.common.type.HiveDecimal;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.sql.Date;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Optional;
+
+import static com.facebook.presto.common.block.MethodHandleUtil.methodHandle;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.common.type.CharType.createCharType;
+import static com.facebook.presto.common.type.DecimalType.createDecimalType;
+import static com.facebook.presto.common.type.Decimals.parseIncludeLeadingZerosInPrecision;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.common.type.RealType.REAL;
+import static com.facebook.presto.common.type.SmallintType.SMALLINT;
+import static com.facebook.presto.common.type.TinyintType.TINYINT;
+import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.hive.functions.HiveFunctionsTestUtils.createTestingPrestoServer;
+import static com.facebook.presto.hive.functions.type.ObjectInputDecoders.createDecoder;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class TestObjectInputDecoders
+{
+    private TestingPrestoServer server;
+    private TypeManager typeManager;
+
+    @BeforeClass
+    public void setup()
+            throws Exception
+    {
+        this.server = createTestingPrestoServer();
+        this.typeManager = server.getInstance(Key.get(TypeManager.class));
+    }
+
+    @Test
+    public void testToDate()
+    {
+        Date date = DateTimeUtils.createDate(18380L);
+        assertEquals(date.getYear(), 2020 - 1900);
+        assertEquals(date.getMonth(), 4 - 1);
+        assertEquals(date.getDate(), 28);
+    }
+
+    @Test
+    public void testPrimitiveObjectDecoders()
+    {
+        ObjectInputDecoder decoder;
+
+        decoder = createDecoder(BIGINT, typeManager);
+        assertTrue(decoder.decode(123456L) instanceof Long);
+
+        decoder = createDecoder(INTEGER, typeManager);
+        assertTrue(decoder.decode(12345L) instanceof Integer);
+
+        decoder = createDecoder(SMALLINT, typeManager);
+        assertTrue(decoder.decode(1234L) instanceof Short);
+
+        decoder = createDecoder(TINYINT, typeManager);
+        assertTrue(decoder.decode(123L) instanceof Byte);
+
+        decoder = createDecoder(BOOLEAN, typeManager);
+        assertTrue(decoder.decode(true) instanceof Boolean);
+
+        decoder = createDecoder(REAL, typeManager);
+        assertTrue(decoder.decode(((float) 0.2)) instanceof Float);
+
+        decoder = createDecoder(DOUBLE, typeManager);
+        assertTrue(decoder.decode(0.1) instanceof Double);
+    }
+
+    @Test
+    public void testDecimalObjectDecoders()
+    {
+        ObjectInputDecoder decoder;
+
+        // short decimal
+        decoder = createDecoder(createDecimalType(11, 10), typeManager);
+        assertTrue(decoder.decode(decimal("1.2345678910")) instanceof HiveDecimal);
+
+        // long decimal
+        decoder = createDecoder(createDecimalType(34, 33), typeManager);
+        assertTrue(decoder.decode(decimal("1.281734081274028174012432412423134")) instanceof HiveDecimal);
+    }
+
+    @Test
+    public void testSliceObjectDecoders()
+    {
+        ObjectInputDecoder decoder;
+
+        decoder = createDecoder(VARBINARY, typeManager);
+        assertTrue(decoder.decode(Slices.wrappedBuffer(new byte[] {12, 34, 56})) instanceof byte[]);
+
+        decoder = createDecoder(VARCHAR, typeManager);
+        assertTrue(decoder.decode(Slices.utf8Slice("test_varchar")) instanceof String);
+
+        decoder = createDecoder(createCharType(10), typeManager);
+        assertTrue(decoder.decode(Slices.utf8Slice("test_char")) instanceof String);
+    }
+
+    @Test
+    public void testBlockObjectDecoders()
+    {
+        ObjectInputDecoder decoder;
+
+        decoder = createDecoder(new ArrayType(BIGINT), typeManager);
+        assertTrue(decoder instanceof ObjectInputDecoders.ArrayObjectInputDecoder);
+        assertEquals(((ArrayList) decoder.decode(createLongArrayBlock())).get(0), 2L);
+
+        decoder = createDecoder(new MapType(
+                BIGINT,
+                BIGINT,
+                methodHandle(TestRowType.class, "throwUnsupportedOperation"),
+                methodHandle(TestRowType.class, "throwUnsupportedOperation")), typeManager);
+        assertTrue(decoder instanceof ObjectInputDecoders.MapObjectInputDecoder);
+        HashMap map = (HashMap) decoder.decode(createLongArrayBlock());
+        assertEquals(map.get(2L), 1L);
+    }
+
+    private Block createLongArrayBlock()
+    {
+        return new LongArrayBlock(2, Optional.empty(), new long[] {2L, 1L});
+    }
+
+    private Object decimal(String decimalString)
+    {
+        return parseIncludeLeadingZerosInPrecision(decimalString).getObject();
+    }
+}

--- a/presto-hive-function-namespace/src/test/sql/function-testing.sql
+++ b/presto-hive-function-namespace/src/test/sql/function-testing.sql
@@ -1,0 +1,51 @@
+----
+CREATE TABLE memory.default.function_testing (
+    c_bigint bigint,
+    c_integer integer,
+    c_smallint smallint,
+    c_tinyint tinyint,
+    c_boolean boolean,
+    c_date date,
+    c_decimal_52 decimal(5,2),
+    c_real real,
+    c_double double,
+    c_timestamp timestamp,
+    c_varchar varchar,
+    c_varchar_a varchar,
+    c_varchar_z varchar,
+    c_varchar_null varchar,
+    c_varchar_10 varchar(10),
+    c_char_10 char(10),
+    c_array_integer array(integer),
+    c_array_varchar array(varchar),
+    c_array_varchar10 array(varchar(10)),
+    c_map_varchar_integer map(varchar(10), integer),
+    c_map_string_string map(varchar, varchar),
+    c_map_varchar_varchar map(varchar(10), varchar(10))
+)
+
+----
+INSERT INTO memory.default.function_testing VALUES (
+    BIGINT '1',
+    INTEGER '1',
+    SMALLINT '1',
+    TINYINT '1',
+    BOOLEAN 'false',
+    DATE '2020-04-28',
+    DECIMAL '123.45',
+    REAL '123.45',
+    DOUBLE '123.45',
+    TIMESTAMP '2020-04-28 15:54',
+    'varchar',
+    'a',
+    'z',
+    null,
+    'varchar10',
+    'char10',
+    ARRAY [1, 2, 3],
+    ARRAY ['a', 'b', 'c'],
+    ARRAY ['a', 'b', 'c'],
+    map(ARRAY['a', 'b', 'c'], ARRAY[1, 2, 3]),
+    map(ARRAY[cast('a' as varchar), 'b', 'c'], ARRAY[cast('1' as varchar), '2', '3']),
+    map(ARRAY['a', 'b', 'c'], ARRAY['1', '2', '3'])
+)

--- a/presto-main/etc/config.properties
+++ b/presto-main/etc/config.properties
@@ -47,7 +47,8 @@ plugin.bundles=\
   ../presto-druid/pom.xml,\
   ../presto-iceberg/pom.xml,\
   ../presto-cluster-ttl-providers/pom.xml,\
-  ../presto-node-ttl-fetchers/pom.xml
+  ../presto-node-ttl-fetchers/pom.xml,\
+  ../presto-hive-function-namespace/pom.xml
 
 presto.version=testversion
 node-scheduler.include-coordinator=true

--- a/presto-main/etc/function-namespace/hive.properties
+++ b/presto-main/etc/function-namespace/hive.properties
@@ -1,0 +1,15 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+function-namespace-manager.name=hive-functions

--- a/presto-server/pom.xml
+++ b/presto-server/pom.xml
@@ -50,7 +50,7 @@
             <type>tar.gz</type>
             <scope>provided</scope>
         </dependency>
-        
+
         <!-- plugins -->
         <dependency>
             <groupId>com.facebook.presto</groupId>
@@ -347,6 +347,14 @@
             <type>zip</type>
             <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-hive-function-namespace</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -383,7 +391,7 @@
                     </execution>
                 </executions>
             </plugin>
-            
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>

--- a/presto-server/src/main/assembly/presto.xml
+++ b/presto-server/src/main/assembly/presto.xml
@@ -200,5 +200,9 @@
             <directory>${project.build.directory}/dependency/presto-iceberg-${project.version}</directory>
             <outputDirectory>plugin/iceberg</outputDirectory>
         </fileSet>
+        <fileSet>
+            <directory>${project.build.directory}/dependency/presto-hive-function-namespace-${project.version}</directory>
+            <outputDirectory>plugin/hive-function-namespace</outputDirectory>
+        </fileSet>
     </fileSets>
 </assembly>


### PR DESCRIPTION
Support Hive built-in scalar function in Presto. 

These functions are already in Presto dependency(com.facebook.presto.hive:hive-apache).  There are several steps to reuse Hive function :

- Convert the type of parameters between presto function and Hive.
- Bridge the instance of hive function into presto function. 
- Load hive function by using the feature of function namespace to load hive function namespace.

The overall changes are very less intrusive to the original code and when users don't use hive function namespace i.e.`hive.default.function_name`, no behavior changes. 

Related issue: #16478
Proposal: #16592 
Design doc: https://bytedance.feishu.cn/docs/doccnA5uuqTrBFIc1SiwrahulGh

## Framework
![image](https://user-images.githubusercontent.com/86234715/135050763-7b61afbf-ae36-497f-a787-d357d1cfed37.png)

## Description of Changes
#### Add a new plugin `presto-hive-functions`
Introduce `HiveFunctionRegistry` interface to registry hive function. We can implement different FunctionRegistries to get different function classes (e.g. hive built-in function  /  user-defined hive function which stored in external storage).
Implement `SimpleHiveFunctionRegistry` to get hive scalar function class through FunctionRegistry which likes `org.apache.hadoop.hive.ql.exec.FunctionRegistry`.
Introduce encoder / decoder to convert type between Presto and Hive.
Introduce `HiveScalarFunctionInvoker` to create、initialize and bridge Hive scalar function instance. At last the real execution of Hive Function will be called through reflection i.e.Invoker.evaluate.
Introduce `HiveFunctionNamespaceManager` to load HiveFunctionNamespace.

## Usage
It will load the hive built-in function at runtime when using the hive function namespace i.e.`hive.default.function_name`, but when users don't use hive catalog function namespace, no behavior changes.  

For example:

Similar function which have the same function name:
```
select hive.default.concat('f', 'b'); Hive#substr
select concat('f', 'b'); Presto#substr
```
Hive function:
```
presto> SELECT hive.default.isnull(null);
      _col0       
------------------
true
(1 row)
```
```
presto> SELECT hive.default.str_to_map('a:1,b:2,c:3', ',', ':');
      _col0      
-----------------
 {a=1, b=2, c=3} 
(1 row)
```

## Roadmap
It's the first PR which supports hive built-in scalar function. And then we will support hive built-in aggregation function and user-defined hive function which stored in external storage in later Prs.
- **support hive built-in scalar function.**
- support hive built-in aggregation function.
- support user-defined hive function which stored in external storage.
- support AUTOMATIC mode to invoke hive udf.
- support hive simpleUdf / simpleUdaf (the FunctionRegestry in hive-3.x can not be initialize).
- support constant type.

Test plan

- Added unit tests

- Verified  in online cluster for one year(300k ~ 500k sql / day)

```
== RELEASE NOTES ==
General Changes
* Support Hive scalar function
```
