### PR TITLE
Compute adjusted queue size in resource manager

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/NoOpResourceGroupManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/NoOpResourceGroupManager.java
@@ -65,4 +65,10 @@ public final class NoOpResourceGroupManager
     {
         throw new UnsupportedOperationException();
     }
+
+    @Override
+    public List<ResourceGroupRuntimeInfo> getResourceGroupRuntimeInfos()
+    {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/ResourceGroupManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/ResourceGroupManager.java
@@ -45,4 +45,6 @@ public interface ResourceGroupManager<C>
 
     void loadConfigurationManager()
             throws Exception;
+
+    List<ResourceGroupRuntimeInfo> getResourceGroupRuntimeInfos();
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/ResourceGroupRuntimeInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/ResourceGroupRuntimeInfo.java
@@ -18,6 +18,8 @@ import com.facebook.drift.annotations.ThriftField;
 import com.facebook.drift.annotations.ThriftStruct;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
 
+import java.util.Optional;
+
 import static java.lang.Math.addExact;
 import static java.util.Objects.requireNonNull;
 
@@ -30,9 +32,10 @@ public class ResourceGroupRuntimeInfo
     private final int descendantQueuedQueries;
     private final int runningQueries;
     private final int descendantRunningQueries;
+    private final Optional<ResourceGroupSpecInfo> resourceGroupConfigSpec;
 
     @ThriftConstructor
-    public ResourceGroupRuntimeInfo(ResourceGroupId resourceGroupId, long memoryUsageBytes, int queuedQueries, int descendantQueuedQueries, int runningQueries, int descendantRunningQueries)
+    public ResourceGroupRuntimeInfo(ResourceGroupId resourceGroupId, long memoryUsageBytes, int queuedQueries, int descendantQueuedQueries, int runningQueries, int descendantRunningQueries, Optional<ResourceGroupSpecInfo> resourceGroupConfigSpec)
     {
         this.resourceGroupId = requireNonNull(resourceGroupId, "resourceGroupId is null");
         this.memoryUsageBytes = memoryUsageBytes;
@@ -40,6 +43,7 @@ public class ResourceGroupRuntimeInfo
         this.descendantQueuedQueries = descendantQueuedQueries;
         this.runningQueries = runningQueries;
         this.descendantRunningQueries = descendantRunningQueries;
+        this.resourceGroupConfigSpec = requireNonNull(resourceGroupConfigSpec, "resourceGroupConfigSpec is null");
     }
 
     public static Builder builder(ResourceGroupId resourceGroupId)
@@ -83,10 +87,16 @@ public class ResourceGroupRuntimeInfo
         return descendantRunningQueries;
     }
 
+    @ThriftField(7)
+    public Optional<ResourceGroupSpecInfo> getResourceGroupConfigSpec()
+    {
+        return resourceGroupConfigSpec;
+    }
+
     public static class Builder
     {
         private final ResourceGroupId resourceGroupId;
-
+        private ResourceGroupSpecInfo resourceGroupSpecInfo;
         private long userMemoryReservationBytes;
         private int queuedQueries;
         private int descendantQueuedQueries;
@@ -128,9 +138,16 @@ public class ResourceGroupRuntimeInfo
             return this;
         }
 
+        public Builder setResourceGroupSpecInfo(ResourceGroupSpecInfo resourceGroupSpecInfo)
+        {
+            this.resourceGroupSpecInfo = resourceGroupSpecInfo;
+            return this;
+        }
+
         public ResourceGroupRuntimeInfo build()
         {
-            return new ResourceGroupRuntimeInfo(resourceGroupId, userMemoryReservationBytes, queuedQueries, descendantQueuedQueries, runningQueries, descendantRunningQueries);
+            return new ResourceGroupRuntimeInfo(resourceGroupId, userMemoryReservationBytes, queuedQueries, descendantQueuedQueries, runningQueries, descendantRunningQueries,
+                    Optional.ofNullable(resourceGroupSpecInfo));
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/ResourceGroupSpecInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/ResourceGroupSpecInfo.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.resourceGroups;
+
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
+
+@ThriftStruct
+public class ResourceGroupSpecInfo
+{
+    private final int softConcurrencyLimit;
+
+    @ThriftConstructor
+    public ResourceGroupSpecInfo(int softConcurrencyLimit)
+    {
+        this.softConcurrencyLimit = softConcurrencyLimit;
+    }
+
+    @ThriftField(1)
+    public int getSoftConcurrencyLimit()
+    {
+        return softConcurrencyLimit;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/resourcemanager/DistributedClusterStatsResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/resourcemanager/DistributedClusterStatsResource.java
@@ -99,7 +99,6 @@ public class DistributedClusterStatsResource
                 runningTasks += query.getQueryStats().getRunningTasks();
             }
         }
-        //TODO compute adjusted queue size on RM
         return Response.ok(new ClusterStatsResource.ClusterStats(
                 runningQueries,
                 blockedQueries,
@@ -111,7 +110,7 @@ public class DistributedClusterStatsResource
                 totalInputRows,
                 totalInputBytes,
                 totalCpuTimeSecs,
-                0))
+                clusterStateProvider.getAdjustedQueueSize()))
                 .build();
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/resourcemanager/ResourceManagerClient.java
+++ b/presto-main/src/main/java/com/facebook/presto/resourcemanager/ResourceManagerClient.java
@@ -39,4 +39,7 @@ public interface ResourceManagerClient
 
     @ThriftMethod
     Map<MemoryPoolId, ClusterMemoryPoolInfo> getMemoryPoolInfo();
+
+    @ThriftMethod
+    void resourceGroupRuntimeHeartbeat(String node, List<ResourceGroupRuntimeInfo> resourceGroupRuntimeInfo);
 }

--- a/presto-main/src/main/java/com/facebook/presto/resourcemanager/ResourceManagerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/resourcemanager/ResourceManagerConfig.java
@@ -20,6 +20,8 @@ import io.airlift.units.MinDuration;
 
 import javax.validation.constraints.Min;
 
+import java.util.concurrent.TimeUnit;
+
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -32,8 +34,9 @@ public class ResourceManagerConfig
     private Duration memoryPoolInfoRefreshDuration = new Duration(1, SECONDS);
     private Duration queryHeartbeatInterval = new Duration(1, SECONDS);
     private Duration nodeHeartbeatInterval = new Duration(1, SECONDS);
-    private int heartbeatThreads = 3;
-    private int heartbeatConcurrency = 3;
+    private Duration resourceGroupRuntimeHeartbeatInterval = new Duration(1, TimeUnit.SECONDS);
+    private int heartbeatThreads = 4;
+    private int heartbeatConcurrency = 4;
     private int resourceManagerExecutorThreads = 1000;
     private Duration proxyAsyncTimeout = new Duration(60, SECONDS);
     private Duration memoryPoolFetchInterval = new Duration(1, SECONDS);
@@ -127,6 +130,19 @@ public class ResourceManagerConfig
 
     @Config("resource-manager.node-heartbeat-interval")
     public ResourceManagerConfig setNodeHeartbeatInterval(Duration nodeHeartbeatInterval)
+    {
+        this.nodeHeartbeatInterval = nodeHeartbeatInterval;
+        return this;
+    }
+
+    @MinDuration("1ms")
+    public Duration getResourceGroupRuntimeHeartbeatInterval()
+    {
+        return nodeHeartbeatInterval;
+    }
+
+    @Config("resource-manager.resource-group-runtimeinfo-heartbeat-interval")
+    public ResourceManagerConfig setResourceGroupRuntimeHeartbeatInterval(Duration nodeHeartbeatInterval)
     {
         this.nodeHeartbeatInterval = nodeHeartbeatInterval;
         return this;

--- a/presto-main/src/main/java/com/facebook/presto/resourcemanager/ResourceManagerServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/resourcemanager/ResourceManagerServer.java
@@ -81,4 +81,10 @@ public class ResourceManagerServer
     {
         executor.execute(() -> clusterStateProvider.registerNodeHeartbeat(nodeStatus));
     }
+
+    @ThriftMethod
+    public void resourceGroupRuntimeHeartbeat(String node, List<ResourceGroupRuntimeInfo> resourceGroupRuntimeInfos)
+    {
+        executor.execute(() -> clusterStateProvider.registerResourceGroupRuntimeHeartbeat(node, resourceGroupRuntimeInfos));
+    }
 }

--- a/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStatusSender.java
+++ b/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStatusSender.java
@@ -15,10 +15,12 @@ package com.facebook.presto.resourcemanager;
 
 import com.facebook.presto.client.NodeVersion;
 import com.facebook.presto.execution.MockManagedQueryExecution;
+import com.facebook.presto.execution.resourceGroups.NoOpResourceGroupManager;
 import com.facebook.presto.memory.MemoryInfo;
 import com.facebook.presto.metadata.InMemoryNodeManager;
 import com.facebook.presto.metadata.InternalNode;
 import com.facebook.presto.server.NodeStatus;
+import com.facebook.presto.server.ServerConfig;
 import com.facebook.presto.spi.ConnectorId;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.units.DataSize;
@@ -76,7 +78,9 @@ public class TestResourceManagerClusterStatusSender
                 newSingleThreadScheduledExecutor(),
                 new ResourceManagerConfig()
                         .setNodeHeartbeatInterval(new Duration(HEARTBEAT_INTERVAL, MILLISECONDS))
-                        .setQueryHeartbeatInterval(new Duration(HEARTBEAT_INTERVAL, MILLISECONDS)));
+                        .setQueryHeartbeatInterval(new Duration(HEARTBEAT_INTERVAL, MILLISECONDS)),
+                new ServerConfig().setCoordinator(false),
+                new NoOpResourceGroupManager());
     }
 
     @AfterTest

--- a/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerConfig.java
@@ -35,8 +35,8 @@ public class TestResourceManagerConfig
                 .setCompletedQueryExpirationTimeout(new Duration(10, MINUTES))
                 .setQueryExpirationTimeout(new Duration(10, SECONDS))
                 .setMaxCompletedQueries(100)
-                .setHeartbeatConcurrency(3)
-                .setHeartbeatThreads(3)
+                .setHeartbeatConcurrency(4)
+                .setHeartbeatThreads(4)
                 .setNodeStatusTimeout(new Duration(30, SECONDS))
                 .setMemoryPoolInfoRefreshDuration(new Duration(1, SECONDS))
                 .setResourceManagerExecutorThreads(1000)
@@ -46,7 +46,8 @@ public class TestResourceManagerConfig
                 .setMemoryPoolFetchInterval(new Duration(1, SECONDS))
                 .setResourceGroupServiceCacheEnabled(false)
                 .setResourceGroupServiceCacheExpireInterval(new Duration(10, SECONDS))
-                .setResourceGroupServiceCacheRefreshInterval(new Duration(1, SECONDS)));
+                .setResourceGroupServiceCacheRefreshInterval(new Duration(1, SECONDS))
+                .setResourceGroupRuntimeHeartbeatInterval(new Duration(1, SECONDS)));
     }
 
     @Test
@@ -68,6 +69,7 @@ public class TestResourceManagerConfig
                 .put("resource-manager.resource-group-service-cache-enabled", "true")
                 .put("resource-manager.resource-group-service-cache-expire-interval", "1m")
                 .put("resource-manager.resource-group-service-cache-refresh-interval", "10m")
+                .put("resource-manager.resource-group-runtimeinfo-heartbeat-interval", "6m")
                 .build();
 
         ResourceManagerConfig expected = new ResourceManagerConfig()
@@ -85,7 +87,8 @@ public class TestResourceManagerConfig
                 .setMemoryPoolFetchInterval(new Duration(6, MINUTES))
                 .setResourceGroupServiceCacheEnabled(true)
                 .setResourceGroupServiceCacheExpireInterval(new Duration(1, MINUTES))
-                .setResourceGroupServiceCacheRefreshInterval(new Duration(10, MINUTES));
+                .setResourceGroupServiceCacheRefreshInterval(new Duration(10, MINUTES))
+                .setResourceGroupRuntimeHeartbeatInterval(new Duration(6, MINUTES));
 
         assertFullMapping(properties, expected);
     }

--- a/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerResourceGroupService.java
+++ b/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerResourceGroupService.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
 
 import java.util.List;
+import java.util.Optional;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.testng.Assert.assertEquals;
@@ -41,7 +42,7 @@ public class TestResourceManagerResourceGroupService
         assertTrue(resourceGroupInfos.isEmpty());
         assertEquals(resourceManagerClient.getResourceGroupInfoCalls("local"), 1);
 
-        resourceManagerClient.setResourceGroupRuntimeInfos(ImmutableList.of(new ResourceGroupRuntimeInfo(new ResourceGroupId("global"), 1, 2, 3, 0, 1)));
+        resourceManagerClient.setResourceGroupRuntimeInfos(ImmutableList.of(new ResourceGroupRuntimeInfo(new ResourceGroupId("global"), 1, 2, 3, 0, 1, Optional.empty())));
 
         Thread.sleep(SECONDS.toMillis(2));
 

--- a/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestingResourceManagerClient.java
+++ b/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestingResourceManagerClient.java
@@ -31,6 +31,7 @@ class TestingResourceManagerClient
 {
     private final AtomicInteger queryHeartbeats = new AtomicInteger();
     private final AtomicInteger nodeHeartbeats = new AtomicInteger();
+    private final AtomicInteger resourceGroupRuntimeHeartbeats = new AtomicInteger();
     private final Map<String, Integer> resourceGroupInfoCalls = new ConcurrentHashMap<>();
 
     private volatile List<ResourceGroupRuntimeInfo> resourceGroupRuntimeInfos = ImmutableList.of();
@@ -66,6 +67,12 @@ class TestingResourceManagerClient
         return ImmutableMap.of();
     }
 
+    @Override
+    public void resourceGroupRuntimeHeartbeat(String node, List<ResourceGroupRuntimeInfo> resourceGroupRuntimeInfo)
+    {
+        resourceGroupRuntimeHeartbeats.incrementAndGet();
+    }
+
     public int getQueryHeartbeats()
     {
         return queryHeartbeats.get();
@@ -79,5 +86,10 @@ class TestingResourceManagerClient
     public int getResourceGroupInfoCalls(String identifier)
     {
         return resourceGroupInfoCalls.get(identifier);
+    }
+
+    public int getResourceGroupRuntimeHeartbeats()
+    {
+        return resourceGroupRuntimeHeartbeats.get();
     }
 }


### PR DESCRIPTION
As part of this PR, we are making changes to compute adjusted queue size in resource manager. Coordinator will heartbeat required local resource group information at a regular interval to resource manager. Also fixed flaky issue with TestDistributedClusterStatsResource and enabled the test.

Test plan - unit test

```
== NO RELEASE NOTE ==
```

