### PR TITLE
Ignore Hadoop marker files when reading from S3.

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/s3/PrestoS3FileSystem.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/s3/PrestoS3FileSystem.java
@@ -602,6 +602,7 @@ public class PrestoS3FileSystem
         return objects.stream()
                 .filter(object -> !object.getKey().endsWith(PATH_SEPARATOR))
                 .filter(object -> !skipGlacierObjects || !isGlacierObject(object))
+                .filter(object -> !isHadoopFolderMarker(object))
                 .map(object -> new FileStatus(
                         object.getSize(),
                         false,
@@ -616,6 +617,11 @@ public class PrestoS3FileSystem
     private boolean isGlacierObject(S3ObjectSummary object)
     {
         return Glacier.toString().equals(object.getStorageClass());
+    }
+
+    private boolean isHadoopFolderMarker(S3ObjectSummary object)
+    {
+        return (object.getKey().endsWith(DIRECTORY_SUFFIX) && (object.getSize() == 0));
     }
 
     /**

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystem.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystem.java
@@ -120,7 +120,7 @@ import static org.testng.Assert.assertTrue;
 
 public abstract class AbstractTestHiveFileSystem
 {
-    private static final HdfsContext TESTING_CONTEXT = new HdfsContext(new ConnectorIdentity("test", Optional.empty(), Optional.empty()));
+    protected static final HdfsContext TESTING_CONTEXT = new HdfsContext(new ConnectorIdentity("test", Optional.empty(), Optional.empty()));
     public static final SplitSchedulingContext SPLIT_SCHEDULING_CONTEXT = new SplitSchedulingContext(UNGROUPED_SCHEDULING, false, WarningCollector.NOOP);
 
     protected String database;

--- a/presto-hive/src/test/java/com/facebook/presto/hive/s3/MockAmazonS3.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/s3/MockAmazonS3.java
@@ -42,6 +42,7 @@ public class MockAmazonS3
     private GetObjectMetadataRequest getObjectMetadataRequest;
     private CannedAccessControlList acl;
     private boolean hasGlacierObjects;
+    private boolean hasHadoopFolderMarkerObjects;
 
     public void setGetObjectHttpErrorCode(int getObjectHttpErrorCode)
     {
@@ -61,6 +62,11 @@ public class MockAmazonS3
     public void setHasGlacierObjects(boolean hasGlacierObjects)
     {
         this.hasGlacierObjects = hasGlacierObjects;
+    }
+
+    public void setHasHadoopFolderMarkerObjects(boolean hasHadoopFolderMarkerObjects)
+    {
+        this.hasHadoopFolderMarkerObjects = hasHadoopFolderMarkerObjects;
     }
 
     public GetObjectMetadataRequest getGetObjectMetadataRequest()
@@ -114,6 +120,14 @@ public class MockAmazonS3
         standard.setKey(STANDARD_OBJECT_KEY);
         standard.setLastModified(new Date());
         listing.getObjectSummaries().add(standard);
+
+        if (hasHadoopFolderMarkerObjects) {
+            S3ObjectSummary hadoopFolderMarker = new S3ObjectSummary();
+            hadoopFolderMarker.setStorageClass(StorageClass.Standard.toString());
+            hadoopFolderMarker.setKey("test/test_$folder$");
+            hadoopFolderMarker.setLastModified(new Date());
+            listing.getObjectSummaries().add(hadoopFolderMarker);
+        }
 
         if (hasGlacierObjects) {
             S3ObjectSummary glacier = new S3ObjectSummary();

--- a/presto-hive/src/test/java/com/facebook/presto/hive/s3/TestPrestoS3FileSystem.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/s3/TestPrestoS3FileSystem.java
@@ -634,6 +634,22 @@ public class TestPrestoS3FileSystem
         }
     }
 
+    @Test
+    public void testSkipHadoopFolderMarkerObjectsEnabled()
+            throws Exception
+    {
+        Configuration config = new Configuration(false);
+
+        try (PrestoS3FileSystem fs = new PrestoS3FileSystem()) {
+            MockAmazonS3 s3 = new MockAmazonS3();
+            s3.setHasHadoopFolderMarkerObjects(true);
+            fs.initialize(new URI("s3n://test-bucket/"), config);
+            fs.setS3Client(s3);
+            FileStatus[] statuses = fs.listStatus(new Path("s3n://test-bucket/test"));
+            assertEquals(statuses.length, 1);
+        }
+    }
+
     private void testEmptyDirectoryWithContentType(String s3ObjectContentType)
             throws Exception
     {


### PR DESCRIPTION
Hadoop creates empty placeholders (which ends with $folder$) files during mkdir operation. More details here - https://aws.amazon.com/premiumsupport/knowledge-center/emr-s3-empty-files/ . Presto-Spark job fails as it expects the files to be parquet but this is an empty file
Solution is to ignore these files while reading objects from S3

Cherry-pick of   https://github.com/trinodb/trino/pull/4552

Co-authored-by: Alexander Jo  <jo.alex2144@gmail.com>

Test plan - 
Before Fix - Job failed with below error
```
com.facebook.presto.spi.PrestoException: s3://<s3Path>/year=2019/month=09/day=24/hour=20/part=0/part=0_$folder$ is not a valid Parquet File
at com.facebook.presto.hive.parquet.ParquetPageSourceFactory.createParquetPageSource(ParquetPageSourceFactory.java:315)
at com.facebook.presto.hive.parquet.ParquetPageSourceFactory.createPageSource(ParquetPageSourceFactory.java:172)
at com.facebook.presto.hive.HivePageSourceProvider.createHivePageSource(HivePageSourceProvider.java:394)
at com.facebook.presto.hive.HivePageSourceProvider.createPageSource(HivePageSourceProvider.java:184)
at co

```
After fix - Job completes fine


```
== NO RELEASE NOTE ==
```
