### PR TITLE
Fix distinct aggregation input filtering when input mask has nulls

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/GenericAccumulatorFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/GenericAccumulatorFactory.java
@@ -353,14 +353,19 @@ public class GenericAccumulatorFactory
 
     private static Page filter(Page page, Block mask)
     {
+        boolean mayHaveNull = mask.mayHaveNull();
         int[] ids = new int[mask.getPositionCount()];
         int next = 0;
         for (int i = 0; i < page.getPositionCount(); ++i) {
-            if (BOOLEAN.getBoolean(mask, i)) {
+            boolean isNull = mayHaveNull && mask.isNull(i);
+            if (!isNull && BOOLEAN.getBoolean(mask, i)) {
                 ids[next++] = i;
             }
         }
 
+        if (next == ids.length) {
+            return page; // no rows were eliminated by the filter
+        }
         return page.getPositions(ids, 0, next);
     }
 


### PR DESCRIPTION
Similar to https://github.com/prestodb/presto/pull/13852, distinct accumulators were not checking for nulls in their input masks, which might allow null positions to pass the filter check incorrectly.

```
== RELEASE NOTES ==

General Changes
* Fix a potential correctness bug in distinct aggregations when combined with a filtering mask containing null values
```
