### PR TITLE
Config for DwrfStripeCache in OrcWriter

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriterConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriterConfig.java
@@ -16,6 +16,7 @@ package com.facebook.presto.hive;
 import com.facebook.airlift.configuration.Config;
 import com.facebook.presto.orc.OrcWriterOptions;
 import com.facebook.presto.orc.StreamLayout;
+import com.facebook.presto.orc.metadata.DwrfStripeCacheMode;
 import io.airlift.units.DataSize;
 
 import javax.validation.constraints.NotNull;
@@ -39,6 +40,9 @@ public class OrcFileWriterConfig
     private DataSize stringStatisticsLimit = OrcWriterOptions.DEFAULT_MAX_STRING_STATISTICS_LIMIT;
     private DataSize maxCompressionBufferSize = OrcWriterOptions.DEFAULT_MAX_COMPRESSION_BUFFER_SIZE;
     private StreamLayoutType streamLayoutType = BY_STREAM_SIZE;
+    private boolean isDwrfStripeCacheEnabled;
+    private DataSize dwrfStripeCacheMaxSize = OrcWriterOptions.DEFAULT_DWRF_STRIPE_CACHE_MAX_SIZE;
+    private DwrfStripeCacheMode dwrfStripeCacheMode = OrcWriterOptions.DEFAULT_DWRF_STRIPE_CACHE_MODE;
 
     public OrcWriterOptions.Builder toOrcWriterOptionsBuilder()
     {
@@ -51,7 +55,10 @@ public class OrcFileWriterConfig
                 .withDictionaryMaxMemory(dictionaryMaxMemory)
                 .withMaxStringStatisticsLimit(stringStatisticsLimit)
                 .withMaxCompressionBufferSize(maxCompressionBufferSize)
-                .withStreamLayout(getStreamLayout(streamLayoutType));
+                .withStreamLayout(getStreamLayout(streamLayoutType))
+                .withDwrfStripeCacheEnabled(isDwrfStripeCacheEnabled)
+                .withDwrfStripeCacheMaxSize(dwrfStripeCacheMaxSize)
+                .withDwrfStripeCacheMode(dwrfStripeCacheMode);
     }
 
     @NotNull
@@ -153,6 +160,44 @@ public class OrcFileWriterConfig
     public OrcFileWriterConfig setStreamLayoutType(StreamLayoutType streamLayoutType)
     {
         this.streamLayoutType = streamLayoutType;
+        return this;
+    }
+
+    public boolean getDwrfStripeCacheEnabled()
+    {
+        return isDwrfStripeCacheEnabled;
+    }
+
+    @Config("hive.orc.writer.dwrf-stripe-cache-enabled")
+    public OrcFileWriterConfig setDwrfStripeCacheEnabled(boolean isDwrfStripeCacheEnabled)
+    {
+        this.isDwrfStripeCacheEnabled = isDwrfStripeCacheEnabled;
+        return this;
+    }
+
+    @NotNull
+    public DataSize getDwrfStripeCacheMaxSize()
+    {
+        return dwrfStripeCacheMaxSize;
+    }
+
+    @Config("hive.orc.writer.dwrf-stripe-cache-max-size")
+    public OrcFileWriterConfig setDwrfStripeCacheMaxSize(DataSize dwrfStripeCacheMaxSize)
+    {
+        this.dwrfStripeCacheMaxSize = dwrfStripeCacheMaxSize;
+        return this;
+    }
+
+    @NotNull
+    public DwrfStripeCacheMode getDwrfStripeCacheMode()
+    {
+        return dwrfStripeCacheMode;
+    }
+
+    @Config("hive.orc.writer.dwrf-stripe-cache-mode")
+    public OrcFileWriterConfig setDwrfStripeCacheMode(DwrfStripeCacheMode dwrfStripeCacheMode)
+    {
+        this.dwrfStripeCacheMode = dwrfStripeCacheMode;
         return this;
     }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestOrcFileWriterConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestOrcFileWriterConfig.java
@@ -17,21 +17,27 @@ import com.facebook.presto.hive.OrcFileWriterConfig.StreamLayoutType;
 import com.facebook.presto.orc.OrcWriterOptions;
 import com.facebook.presto.orc.StreamLayout.ByColumnSize;
 import com.facebook.presto.orc.StreamLayout.ByStreamSize;
+import com.facebook.presto.orc.metadata.DwrfStripeCacheMode;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.units.DataSize;
 import org.testng.annotations.Test;
 
 import java.util.Map;
+import java.util.Optional;
 
 import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
 import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
 import static com.facebook.airlift.configuration.testing.ConfigAssertions.recordDefaults;
 import static com.facebook.presto.hive.OrcFileWriterConfig.StreamLayoutType.BY_COLUMN_SIZE;
 import static com.facebook.presto.hive.OrcFileWriterConfig.StreamLayoutType.BY_STREAM_SIZE;
+import static com.facebook.presto.orc.metadata.DwrfStripeCacheMode.FOOTER;
+import static com.facebook.presto.orc.metadata.DwrfStripeCacheMode.INDEX;
+import static com.facebook.presto.orc.metadata.DwrfStripeCacheMode.INDEX_AND_FOOTER;
 import static io.airlift.units.DataSize.Unit.BYTE;
 import static io.airlift.units.DataSize.Unit.KILOBYTE;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotSame;
 import static org.testng.Assert.assertTrue;
 
@@ -48,7 +54,10 @@ public class TestOrcFileWriterConfig
                 .setDictionaryMaxMemory(new DataSize(16, MEGABYTE))
                 .setStringStatisticsLimit(new DataSize(64, BYTE))
                 .setMaxCompressionBufferSize(new DataSize(256, KILOBYTE))
-                .setStreamLayoutType(BY_STREAM_SIZE));
+                .setStreamLayoutType(BY_STREAM_SIZE)
+                .setDwrfStripeCacheEnabled(false)
+                .setDwrfStripeCacheMaxSize(new DataSize(8, MEGABYTE))
+                .setDwrfStripeCacheMode(INDEX_AND_FOOTER));
     }
 
     @Test
@@ -63,6 +72,9 @@ public class TestOrcFileWriterConfig
                 .put("hive.orc.writer.string-statistics-limit", "17MB")
                 .put("hive.orc.writer.max-compression-buffer-size", "19MB")
                 .put("hive.orc.writer.stream-layout-type", "BY_COLUMN_SIZE")
+                .put("hive.orc.writer.dwrf-stripe-cache-enabled", "true")
+                .put("hive.orc.writer.dwrf-stripe-cache-max-size", "10MB")
+                .put("hive.orc.writer.dwrf-stripe-cache-mode", "FOOTER")
                 .build();
 
         OrcFileWriterConfig expected = new OrcFileWriterConfig()
@@ -73,7 +85,10 @@ public class TestOrcFileWriterConfig
                 .setDictionaryMaxMemory(new DataSize(13, MEGABYTE))
                 .setStringStatisticsLimit(new DataSize(17, MEGABYTE))
                 .setMaxCompressionBufferSize(new DataSize(19, MEGABYTE))
-                .setStreamLayoutType(BY_COLUMN_SIZE);
+                .setStreamLayoutType(BY_COLUMN_SIZE)
+                .setDwrfStripeCacheEnabled(true)
+                .setDwrfStripeCacheMaxSize(new DataSize(10, MEGABYTE))
+                .setDwrfStripeCacheMode(FOOTER);
 
         assertFullMapping(properties, expected);
     }
@@ -97,6 +112,8 @@ public class TestOrcFileWriterConfig
         DataSize stringStatisticsLimit = new DataSize(32, BYTE);
         DataSize maxCompressionBufferSize = new DataSize(512, KILOBYTE);
         StreamLayoutType streamLayoutType = BY_STREAM_SIZE;
+        DataSize dwrfStripeCacheMaxSize = new DataSize(4, MEGABYTE);
+        DwrfStripeCacheMode dwrfStripeCacheMode = INDEX;
 
         OrcFileWriterConfig config = new OrcFileWriterConfig()
                 .setStripeMinSize(stripeMinSize)
@@ -106,7 +123,10 @@ public class TestOrcFileWriterConfig
                 .setDictionaryMaxMemory(dictionaryMaxMemory)
                 .setStringStatisticsLimit(stringStatisticsLimit)
                 .setMaxCompressionBufferSize(maxCompressionBufferSize)
-                .setStreamLayoutType(streamLayoutType);
+                .setStreamLayoutType(streamLayoutType)
+                .setDwrfStripeCacheEnabled(false)
+                .setDwrfStripeCacheMaxSize(dwrfStripeCacheMaxSize)
+                .setDwrfStripeCacheMode(dwrfStripeCacheMode);
 
         assertEquals(stripeMinSize, config.getStripeMinSize());
         assertEquals(stripeMaxSize, config.getStripeMaxSize());
@@ -116,6 +136,9 @@ public class TestOrcFileWriterConfig
         assertEquals(stringStatisticsLimit, config.getStringStatisticsLimit());
         assertEquals(maxCompressionBufferSize, config.getMaxCompressionBufferSize());
         assertEquals(streamLayoutType, config.getStreamLayoutType());
+        assertFalse(config.getDwrfStripeCacheEnabled());
+        assertEquals(dwrfStripeCacheMaxSize, config.getDwrfStripeCacheMaxSize());
+        assertEquals(dwrfStripeCacheMode, config.getDwrfStripeCacheMode());
 
         assertNotSame(config.toOrcWriterOptionsBuilder(), config.toOrcWriterOptionsBuilder());
         OrcWriterOptions options = config.toOrcWriterOptionsBuilder().build();
@@ -128,6 +151,7 @@ public class TestOrcFileWriterConfig
         assertEquals(stringStatisticsLimit, options.getMaxStringStatisticsLimit());
         assertEquals(maxCompressionBufferSize, options.getMaxCompressionBufferSize());
         assertTrue(options.getStreamLayout() instanceof ByStreamSize);
+        assertEquals(Optional.empty(), options.getDwrfStripeCacheOptions());
     }
 
     @Test

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
@@ -275,7 +275,7 @@ public class OrcWriter
 
         // set DwrfStripeCacheWriter for DWRF files if it's enabled through the options
         if (orcEncoding == DWRF) {
-            this.dwrfStripeCacheWriter = options.getDwrfWriterOptions()
+            this.dwrfStripeCacheWriter = options.getDwrfStripeCacheOptions()
                     .map(dwrfWriterOptions -> new DwrfStripeCacheWriter(
                             dwrfWriterOptions.getStripeCacheMode(),
                             dwrfWriterOptions.getStripeCacheMaxSize()));

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriterOptions.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriterOptions.java
@@ -147,7 +147,7 @@ public class OrcWriterOptions
         return stringDictionarySortingEnabled;
     }
 
-    public Optional<DwrfStripeCacheOptions> getDwrfWriterOptions()
+    public Optional<DwrfStripeCacheOptions> getDwrfStripeCacheOptions()
     {
         return dwrfWriterOptions;
     }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestDwrfStripeCacheOptions.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestDwrfStripeCacheOptions.java
@@ -31,7 +31,7 @@ public class TestDwrfStripeCacheOptions
                 .withDwrfStripeCacheMaxSize(new DataSize(27, MEGABYTE))
                 .build();
 
-        DwrfStripeCacheOptions dwrfStripeCacheOptions = options.getDwrfWriterOptions().get();
+        DwrfStripeCacheOptions dwrfStripeCacheOptions = options.getDwrfStripeCacheOptions().get();
 
         String expectedString = "DwrfStripeCacheOptions{stripeCacheMode=INDEX_AND_FOOTER, stripeCacheMaxSize=27MB}";
         assertEquals(dwrfStripeCacheOptions.toString(), expectedString);

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcWriterOptions.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcWriterOptions.java
@@ -43,12 +43,12 @@ public class TestOrcWriterOptions
                     .build();
 
             if (value) {
-                DwrfStripeCacheOptions dwrfStripeCacheOptions = options.getDwrfWriterOptions().get();
+                DwrfStripeCacheOptions dwrfStripeCacheOptions = options.getDwrfStripeCacheOptions().get();
                 assertEquals(dwrfStripeCacheOptions.getStripeCacheMode(), DWRF_STRIPE_CACHE_MODE);
                 assertEquals(dwrfStripeCacheOptions.getStripeCacheMaxSize(), DWRF_STRIPE_CACHE_MAX_SIZE);
             }
             else {
-                assertEquals(Optional.empty(), options.getDwrfWriterOptions());
+                assertEquals(Optional.empty(), options.getDwrfStripeCacheOptions());
             }
         }
     }
@@ -94,7 +94,7 @@ public class TestOrcWriterOptions
         assertEquals(streamLayout, options.getStreamLayout());
         assertEquals(integerDictionaryEncodingEnabled, options.isIntegerDictionaryEncodingEnabled());
         assertEquals(stringDictionarySortingEnabled, options.isStringDictionarySortingEnabled());
-        assertEquals(Optional.empty(), options.getDwrfWriterOptions());
+        assertEquals(Optional.empty(), options.getDwrfStripeCacheOptions());
     }
 
     @Test


### PR DESCRIPTION
Add Config for DwrfStripeCache write support
in OrcWriter. The config is disabled by default and
can be enabled to include DwrfStripeCache in files
written by Presto.

Test plan - (Please fill in how you tested your changes)
Added new tests.

```
== NO RELEASE NOTE ==
```
