### PR TITLE
document null vs nan

### DIFF
--- a/presto-docs/src/main/sphinx/functions/comparison.rst
+++ b/presto-docs/src/main/sphinx/functions/comparison.rst
@@ -66,6 +66,10 @@ Using ``NULL`` with ``IS NULL`` evaluates to true::
 But any other constant does not::
 
     SELECT 3.0 IS NULL; -- false
+    
+Note that ``nan()`` is different to ``NULL``, and counts as ``NOT NULL``::
+
+    SELECT nan() IS NULL; -- false
 
 IS DISTINCT FROM and IS NOT DISTINCT FROM
 -----------------------------------------

--- a/presto-docs/src/main/sphinx/functions/conditional.rst
+++ b/presto-docs/src/main/sphinx/functions/conditional.rst
@@ -79,6 +79,7 @@ COALESCE
 
     Returns the first non-null ``value`` in the argument list.
     Like a ``CASE`` expression, arguments are only evaluated if necessary.
+    Note that not-a-number (``nan()``) counts as non-null.
 
 NULLIF
 ------

--- a/presto-docs/src/main/sphinx/functions/math.rst
+++ b/presto-docs/src/main/sphinx/functions/math.rst
@@ -322,7 +322,11 @@ Floating Point Functions
 .. function:: is_nan(x) -> boolean
 
     Determine if ``x`` is not-a-number.
+    Note that not-a-number is different to ``NULL``.
+    ``is_nan(NULL)`` returns ``NULL``.
 
 .. function:: nan() -> double
 
     Returns the constant representing not-a-number.
+    Note that not-a-number is different to ``NULL``.
+    For example, ``nan() is NULL`` returns ``false``.


### PR DESCRIPTION
Fixes #16739

This clarifies in the docs that NaN and NULL are different.

I'm not sure whether the text should say `nan()` or `NaN`.