### PR TITLE
Enabling flaky TestQueues test

### DIFF
--- a/presto-tests/src/test/java/com/facebook/presto/execution/TestQueues.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TestQueues.java
@@ -140,7 +140,7 @@ public class TestQueues
         waitForQueryState(queryRunner, secondDashboardQuery, RUNNING);
     }
 
-    @Test(timeOut = 240_000, enabled = false)
+    @Test(timeOut = 60_000)
     public void testExceedSoftLimits()
             throws Exception
     {
@@ -328,8 +328,7 @@ public class TestQueues
         }
     }
 
-    // disabled due to https://github.com/prestodb/presto/issues/16126
-    @Test(timeOut = 240_000, enabled = false)
+    @Test(timeOut = 60_000)
     public void testQueuedQueryInteraction()
             throws Exception
     {


### PR DESCRIPTION
We fixed the test flakyness issue as part of this https://github.com/prestodb/presto/pull/16673
so enabling disabled flaky tests

Fixes https://github.com/prestodb/presto/issues/16126

Test plan - unit tests

```
== NO RELEASE NOTE ==
```
