### PR TITLE
Add a new JDBC driver parameter - timeZoneID

### DIFF
--- a/presto-docs/src/main/sphinx/installation/jdbc.rst
+++ b/presto-docs/src/main/sphinx/installation/jdbc.rst
@@ -83,6 +83,8 @@ Name                              Description
                                   If neither this property nor ``ApplicationName`` are set, the source
                                   for the query will be ``presto-jdbc``.
 ``accessToken``                   Access token for token based authentication.
+``timeZoneId``                    Timezone to be used for timestamp columns in query output.
+                                  Example: ``timeZoneId=UTC``.
 ``SSL``                           Use HTTPS for connections
 ``SSLKeyStorePath``               The location of the Java KeyStore file that contains the certificate
                                   and private key to use for authentication.

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/ConnectionProperties.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/ConnectionProperties.java
@@ -54,6 +54,7 @@ final class ConnectionProperties
     public static final ConnectionProperty<File> KERBEROS_KEYTAB_PATH = new KerberosKeytabPath();
     public static final ConnectionProperty<File> KERBEROS_CREDENTIAL_CACHE_PATH = new KerberosCredentialCachePath();
     public static final ConnectionProperty<String> ACCESS_TOKEN = new AccessToken();
+    public static final ConnectionProperty<String> TIMEZONE_ID = new TimeZoneId();
     public static final ConnectionProperty<Map<String, String>> EXTRA_CREDENTIALS = new ExtraCredentials();
     public static final ConnectionProperty<Map<String, String>> CUSTOM_HEADERS = new CustomHeaders();
     public static final ConnectionProperty<Map<String, String>> SESSION_PROPERTIES = new SessionProperties();
@@ -79,6 +80,7 @@ final class ConnectionProperties
             .add(KERBEROS_KEYTAB_PATH)
             .add(KERBEROS_CREDENTIAL_CACHE_PATH)
             .add(ACCESS_TOKEN)
+            .add(TIMEZONE_ID)
             .add(EXTRA_CREDENTIALS)
             .add(CUSTOM_HEADERS)
             .add(SESSION_PROPERTIES)
@@ -298,6 +300,15 @@ final class ConnectionProperties
         public AccessToken()
         {
             super("accessToken", NOT_REQUIRED, ALLOWED, STRING_CONVERTER);
+        }
+    }
+
+    private static class TimeZoneId
+            extends AbstractConnectionProperty<String>
+    {
+        public TimeZoneId()
+        {
+            super("timeZoneId", NOT_REQUIRED, ALLOWED, STRING_CONVERTER);
         }
     }
 

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoConnection.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoConnection.java
@@ -50,7 +50,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
-import java.util.TimeZone;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -118,7 +117,7 @@ public class PrestoConnection
         this.connectionProperties = uri.getProperties();
         this.queryExecutor = requireNonNull(queryExecutor, "queryExecutor is null");
 
-        timeZoneId.set(TimeZone.getDefault().getID());
+        timeZoneId.set(uri.getTimeZoneId());
         locale.set(Locale.getDefault());
 
         this.queryInterceptorInstances = ImmutableList.copyOf(uri.getQueryInterceptors());

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoDriverUri.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoDriverUri.java
@@ -27,12 +27,14 @@ import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.sql.SQLException;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.TimeZone;
 
 import static com.facebook.presto.client.GCSOAuthInterceptor.GCS_CREDENTIALS_PATH_KEY;
 import static com.facebook.presto.client.GCSOAuthInterceptor.GCS_OAUTH_SCOPES_KEY;
@@ -66,6 +68,7 @@ import static com.facebook.presto.jdbc.ConnectionProperties.SSL_KEY_STORE_PASSWO
 import static com.facebook.presto.jdbc.ConnectionProperties.SSL_KEY_STORE_PATH;
 import static com.facebook.presto.jdbc.ConnectionProperties.SSL_TRUST_STORE_PASSWORD;
 import static com.facebook.presto.jdbc.ConnectionProperties.SSL_TRUST_STORE_PATH;
+import static com.facebook.presto.jdbc.ConnectionProperties.TIMEZONE_ID;
 import static com.facebook.presto.jdbc.ConnectionProperties.USER;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.lang.String.format;
@@ -147,6 +150,21 @@ final class PrestoDriverUri
     public Properties getProperties()
     {
         return properties;
+    }
+
+    public String getTimeZoneId()
+            throws SQLException
+    {
+        Optional<String> timezone = TIMEZONE_ID.getValue(properties);
+
+        if (timezone.isPresent()) {
+            List<String> timeZoneIds = Arrays.asList(TimeZone.getAvailableIDs());
+            if (!timeZoneIds.contains(timezone.get())) {
+                throw new SQLException("Specified timeZoneId is not supported: " + timezone.get());
+            }
+            return timezone.get();
+        }
+        return TimeZone.getDefault().getID();
     }
 
     public Map<String, String> getExtraCredentials()

--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestPrestoDriver.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestPrestoDriver.java
@@ -1680,6 +1680,22 @@ public class TestPrestoDriver
         assertTrue(isValidSessionValue);
     }
 
+    @Test
+    public void testTimeZoneIdParameter()
+            throws Exception
+    {
+        String sql = "SELECT current_timezone() zone, TIMESTAMP '2001-02-03 3:04:05' ts";
+
+        try (Connection connection = createConnectionWithParameter("timeZoneId=UTC")) {
+            try (Statement statement = connection.createStatement();
+                    ResultSet rs = statement.executeQuery(sql)) {
+                assertTrue(rs.next());
+                assertEquals(rs.getString("zone"), "UTC");
+                assertEquals(rs.getTimestamp("ts"), new Timestamp(new DateTime(2001, 2, 3, 3, 4, 5, DateTimeZone.UTC).getMillis()));
+            }
+        }
+    }
+
     private QueryState getQueryState(String queryId)
             throws SQLException
     {
@@ -1726,6 +1742,13 @@ public class TestPrestoDriver
             throws SQLException
     {
         String url = format("jdbc:presto://%s/%s/%s", server.getAddress(), catalog, schema);
+        return DriverManager.getConnection(url, "test", null);
+    }
+
+    private Connection createConnectionWithParameter(String parameter)
+            throws SQLException
+    {
+        String url = format("jdbc:presto://%s?%s", server.getAddress(), parameter);
         return DriverManager.getConnection(url, "test", null);
     }
 

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestBrutalShutdown.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestBrutalShutdown.java
@@ -42,7 +42,7 @@ import static org.testng.Assert.fail;
 @Test(singleThreaded = true)
 public class TestBrutalShutdown
 {
-    private static final long SHUTDOWN_TIMEOUT_MILLIS = 240_000;
+    private static final long SHUTDOWN_TIMEOUT_MILLIS = 600_000;
     private static final Session TINY_SESSION = testSessionBuilder()
             .setCatalog("tpch")
             .setSchema("tiny")


### PR DESCRIPTION
Cherry-pick of https://github.com/trinodb/trino/pull/7252

Co-authored-by: Shashikant Jaiswal <shashi@okera.com>

Test plan - Added test TestPrestoDriver$testTimeZoneIdParameter
Solves #16680 

```
== RELEASE NOTES ==

General Changes
* Add a new JDBC driver parameter - timeZoneID
:doc:`/installation/jdbc`
:issue:`16680`
```

