### PR TITLE
Improve performance of fast inequality joins

### DIFF
--- a/presto-benchmark/src/test/java/com/facebook/presto/benchmark/BenchmarkInequalityJoin.java
+++ b/presto-benchmark/src/test/java/com/facebook/presto/benchmark/BenchmarkInequalityJoin.java
@@ -31,6 +31,7 @@ import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openjdk.jmh.runner.options.VerboseMode;
+import org.testng.annotations.Test;
 
 import java.util.List;
 
@@ -60,16 +61,16 @@ public class BenchmarkInequalityJoin
         private MemoryLocalQueryRunner queryRunner;
 
         @Param({"true", "false"})
-        private String fastInequalityJoins;
+        private String fastInequalityJoins = "true";
 
         // number of buckets. The smaller number of buckets, the longer position links chain
         @Param({"100", "1000", "10000", "60000"})
-        private int buckets;
+        private int buckets = 1000;
 
         // How many positions out of 1000 will be actually joined
         // 10 means 1 - 10/1000 = 99/100 positions will be filtered out
         @Param("10")
-        private int filterOutCoefficient;
+        private int filterOutCoefficient = 10;
 
         public MemoryLocalQueryRunner getQueryRunner()
         {
@@ -134,6 +135,19 @@ public class BenchmarkInequalityJoin
     {
         return context.getQueryRunner()
                 .execute("SELECT count(*) FROM t1 JOIN t2 on (t1.bucket = t2.bucket) AND t1.val1 + 1 < t2.val2 AND t2.val2 < t1.val1 + 5 ");
+    }
+
+    @Test
+    public void verifyJoinBenchmark()
+    {
+        Context context = new Context();
+        try {
+            context.setUp();
+            benchmarkJoin(context);
+        }
+        finally {
+            context.tearDown();
+        }
     }
 
     public static void main(String[] args)

--- a/presto-main/src/main/java/com/facebook/presto/operator/ArrayPositionLinks.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ArrayPositionLinks.java
@@ -69,9 +69,9 @@ public final class ArrayPositionLinks
         }
 
         @Override
-        public int size()
+        public boolean isEmpty()
         {
-            return size;
+            return size == 0;
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/PositionLinks.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PositionLinks.java
@@ -48,15 +48,7 @@ public interface PositionLinks
 
         Factory build();
 
-        /**
-         * @return number of linked elements
-         */
-        int size();
-
-        default boolean isEmpty()
-        {
-            return size() == 0;
-        }
+        boolean isEmpty();
     }
 
     interface Factory

--- a/presto-main/src/main/java/com/facebook/presto/operator/SortedPositionLinks.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/SortedPositionLinks.java
@@ -19,10 +19,13 @@ import com.google.common.collect.ImmutableList;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntArrays;
 import it.unimi.dsi.fastutil.ints.IntComparator;
 import org.openjdk.jol.info.ClassLayout;
 
+import java.util.Iterator;
 import java.util.List;
+import java.util.function.IntFunction;
 
 import static com.facebook.presto.operator.SyntheticAddress.decodePosition;
 import static com.facebook.presto.operator.SyntheticAddress.decodeSliceIndex;
@@ -44,9 +47,13 @@ public final class SortedPositionLinks
     public static class FactoryBuilder
             implements PositionLinks.FactoryBuilder
     {
-        private final Int2ObjectMap<IntArrayList> positionLinks;
+        // Cache lambda instance for use with createIfAbsent that ensures the method resolves to computeIfAbsent(int, IntFunction<T>)
+        // instead of computeIfAbsent(int, Int2ObjectFunction<T>) which does (slightly) more work internally
+        private static final IntFunction<IntArrayList> NEW_INT_LIST = (ignored) -> new IntArrayList();
+
+        private final Int2ObjectOpenHashMap<IntArrayList> positionLinks;
         private final int size;
-        private final IntComparator comparator;
+        private final PositionComparator comparator;
         private final PagesHashStrategy pagesHashStrategy;
         private final AdaptiveLongBigArray addresses;
 
@@ -78,8 +85,7 @@ public final class SortedPositionLinks
             // make sure that from value is the smaller one
             if (comparator.compare(from, to) > 0) {
                 // _from_ is larger so, just add to current chain _to_
-                List<Integer> links = positionLinks.computeIfAbsent(to, key -> new IntArrayList());
-                links.add(from);
+                positionLinks.computeIfAbsent(to, NEW_INT_LIST).add(from);
                 return to;
             }
             else {
@@ -89,7 +95,7 @@ public final class SortedPositionLinks
                     links = new IntArrayList();
                 }
                 links.add(to);
-                checkState(positionLinks.putIfAbsent(from, links) == null, "sorted links is corrupted");
+                checkState(positionLinks.put(from, links) == null, "sorted links is corrupted");
                 return from;
             }
         }
@@ -108,31 +114,42 @@ public final class SortedPositionLinks
             ArrayPositionLinks.FactoryBuilder arrayPositionLinksFactoryBuilder = ArrayPositionLinks.builder(size);
             int[][] sortedPositionLinks = new int[size][];
 
-            for (Int2ObjectMap.Entry<IntArrayList> entry : positionLinks.int2ObjectEntrySet()) {
+            Iterator<Int2ObjectMap.Entry<IntArrayList>> iterator = positionLinks.int2ObjectEntrySet().fastIterator();
+            while (iterator.hasNext()) {
+                Int2ObjectOpenHashMap.Entry<IntArrayList> entry = iterator.next();
                 int key = entry.getIntKey();
-                IntArrayList positions = entry.getValue();
-                positions.sort(comparator);
+                IntArrayList positionsList = entry.getValue();
 
-                sortedPositionLinks[key] = new int[positions.size()];
-                for (int i = 0; i < positions.size(); i++) {
-                    sortedPositionLinks[key][i] = positions.get(i);
-                }
+                int[] positions = positionsList.toIntArray();
+                sortedPositionLinks[key] = positions;
 
-                // ArrayPositionsLinks.Builder::link builds position links from
-                // tail to head, so we must add them in descending order to have
-                // smallest element as a head
-                for (int i = positions.size() - 2; i >= 0; i--) {
-                    arrayPositionLinksFactoryBuilder.link(positions.get(i), positions.get(i + 1));
-                }
-
-                // add link from starting position to position links chain
-                if (!positions.isEmpty()) {
-                    arrayPositionLinksFactoryBuilder.link(key, positions.get(0));
+                if (positions.length > 0) {
+                    // Use the positionsList array for the merge sort temporary work buffer to avoid an extra redundant
+                    // copy. This works because we know that initially it has the same values as the array being sorted
+                    IntArrays.mergeSort(positions, 0, positions.length, comparator, positionsList.elements());
+                    // add link from starting position to position links chain
+                    arrayPositionLinksFactoryBuilder.link(key, positions[0]);
+                    // add links for the sorted internal elements
+                    for (int i = 0; i < positions.length - 1; i++) {
+                        arrayPositionLinksFactoryBuilder.link(positions[i], positions[i + 1]);
+                    }
                 }
             }
 
-            Factory arrayPositionLinksFactory = arrayPositionLinksFactoryBuilder.build();
+            return createFactory(sortedPositionLinks, arrayPositionLinksFactoryBuilder.build());
+        }
 
+        @Override
+        public int size()
+        {
+            return positionLinks.size();
+        }
+
+        // Separate static method to avoid embedding references to "this"
+        private static Factory createFactory(int[][] sortedPositionLinks, Factory arrayPositionLinksFactory)
+        {
+            requireNonNull(sortedPositionLinks, "sortedPositionLinks is null");
+            requireNonNull(arrayPositionLinksFactory, "arrayPositionLinksFactory is null");
             return new Factory()
             {
                 @Override
@@ -152,12 +169,6 @@ public final class SortedPositionLinks
                 }
             };
         }
-
-        @Override
-        public int size()
-        {
-            return positionLinks.size();
-        }
     }
 
     private final PositionLinks positionLinks;
@@ -172,10 +183,10 @@ public final class SortedPositionLinks
         this.sizeInBytes = INSTANCE_SIZE + positionLinks.getSizeInBytes() + sizeOfPositionLinks(sortedPositionLinks);
         requireNonNull(searchFunctions, "searchFunctions is null");
         checkState(!searchFunctions.isEmpty(), "Using sortedPositionLinks with no search functions");
-        this.searchFunctions = searchFunctions.stream().toArray(JoinFilterFunction[]::new);
+        this.searchFunctions = searchFunctions.toArray(new JoinFilterFunction[0]);
     }
 
-    private long sizeOfPositionLinks(int[][] sortedPositionLinks)
+    private static long sizeOfPositionLinks(int[][] sortedPositionLinks)
     {
         long retainedSize = sizeOf(sortedPositionLinks);
         for (int[] element : sortedPositionLinks) {
@@ -187,6 +198,12 @@ public final class SortedPositionLinks
     public static FactoryBuilder builder(int size, PagesHashStrategy pagesHashStrategy, AdaptiveLongBigArray addresses)
     {
         return new FactoryBuilder(size, pagesHashStrategy, addresses);
+    }
+
+    @Override
+    public long getSizeInBytes()
+    {
+        return sizeInBytes;
     }
 
     @Override
@@ -234,7 +251,7 @@ public final class SortedPositionLinks
         return true;
     }
 
-    private int findStartPositionForFunction(JoinFilterFunction searchFunction, int[] links, int startOffset, int probePosition, Page allProbeChannelsPage)
+    private static int findStartPositionForFunction(JoinFilterFunction searchFunction, int[] links, int startOffset, int probePosition, Page allProbeChannelsPage)
     {
         if (applySearchFunction(searchFunction, links, startOffset, probePosition, allProbeChannelsPage)) {
             // MAJOR HACK: if searchFunction is of shape `f(probe) > build_symbol` it is not fit for binary search below,
@@ -256,7 +273,7 @@ public final class SortedPositionLinks
     /**
      * Find the first element in position links that is NOT smaller than probePosition
      */
-    private int lowerBound(JoinFilterFunction searchFunction, int[] links, int first, int last, int probePosition, Page allProbeChannelsPage)
+    private static int lowerBound(JoinFilterFunction searchFunction, int[] links, int first, int last, int probePosition, Page allProbeChannelsPage)
     {
         int middle;
         int step;
@@ -275,23 +292,17 @@ public final class SortedPositionLinks
         return first;
     }
 
-    @Override
-    public long getSizeInBytes()
+    private static boolean applySearchFunction(JoinFilterFunction searchFunction, int[] links, int linkOffset, int probePosition, Page allProbeChannelsPage)
     {
-        return sizeInBytes;
+        return searchFunction.filter(links[linkOffset], probePosition, allProbeChannelsPage);
     }
 
-    private boolean applySearchFunction(JoinFilterFunction searchFunction, int[] links, int linkOffset, int probePosition, Page allProbeChannelsPage)
+    private static boolean applySearchFunction(JoinFilterFunction searchFunction, int buildPosition, int probePosition, Page allProbeChannelsPage)
     {
-        return applySearchFunction(searchFunction, links[linkOffset], probePosition, allProbeChannelsPage);
+        return searchFunction.filter(buildPosition, probePosition, allProbeChannelsPage);
     }
 
-    private boolean applySearchFunction(JoinFilterFunction searchFunction, long buildPosition, int probePosition, Page allProbeChannelsPage)
-    {
-        return searchFunction.filter((int) buildPosition, probePosition, allProbeChannelsPage);
-    }
-
-    private static class PositionComparator
+    private static final class PositionComparator
             implements IntComparator
     {
         private final PagesHashStrategy pagesHashStrategy;

--- a/presto-main/src/main/java/com/facebook/presto/operator/SortedPositionLinks.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/SortedPositionLinks.java
@@ -140,9 +140,9 @@ public final class SortedPositionLinks
         }
 
         @Override
-        public int size()
+        public boolean isEmpty()
         {
-            return positionLinks.size();
+            return positionLinks.isEmpty();
         }
 
         // Separate static method to avoid embedding references to "this"


### PR DESCRIPTION
Improves the performance of inequality joins (specifically, building `SortedPositionLinks.Factory` instances by:
- Avoiding boxing the values to and from `Integer` while loading and extracting positions from `IntArrayList`
- Using `Int2ObjectOpenHashMap.fastIterator()` to avoid extra allocations inside of the entry set traversal
- Reusing the `IntArrayList` elements array as a temporary buffer for `IntArrays.mergeSort` (which was the implementation being called by `IntArrayList.sort`, but would make an extra copy of the array being sorted internally on each invocation)
- Making methods that used no instance state static

```
== NO RELEASE NOTE ==
```
