### PR TITLE
Handle materialized view missing too many partitions

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -195,6 +195,7 @@ public class HiveClientConfig
 
     private boolean executionBasedMemoryAccounting;
     private boolean enableLooseMemoryAccounting;
+    private int materializedViewMissingPartitionsThreshold = 100;
 
     public int getMaxInitialSplits()
     {
@@ -1653,5 +1654,18 @@ public class HiveClientConfig
     {
         this.enableLooseMemoryAccounting = enableLooseMemoryAccounting;
         return this;
+    }
+
+    @Config("hive.materialized-view-missing-partitions-threshold")
+    @ConfigDescription("Materialized views with missing partitions more than this threshold falls back to the base tables at read time")
+    public HiveClientConfig setMaterializedViewMissingPartitionsThreshold(int materializedViewMissingPartitionsThreshold)
+    {
+        this.materializedViewMissingPartitionsThreshold = materializedViewMissingPartitionsThreshold;
+        return this;
+    }
+
+    public int getMaterializedViewMissingPartitionsThreshold()
+    {
+        return this.materializedViewMissingPartitionsThreshold;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -306,6 +306,7 @@ import static com.facebook.presto.spi.MaterializedViewStatus.MaterializedDataPre
 import static com.facebook.presto.spi.MaterializedViewStatus.MaterializedViewState.FULLY_MATERIALIZED;
 import static com.facebook.presto.spi.MaterializedViewStatus.MaterializedViewState.NOT_MATERIALIZED;
 import static com.facebook.presto.spi.MaterializedViewStatus.MaterializedViewState.PARTIALLY_MATERIALIZED;
+import static com.facebook.presto.spi.MaterializedViewStatus.MaterializedViewState.TOO_MANY_PARTITIONS_MISSING;
 import static com.facebook.presto.spi.StandardErrorCode.ALREADY_EXISTS;
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_ANALYZE_PROPERTY;
@@ -2334,6 +2335,12 @@ public class HiveMetadata
 
         for (MaterializedDataPredicates dataPredicates : partitionsFromBaseTables.values()) {
             if (!dataPredicates.getPredicateDisjuncts().isEmpty()) {
+                if (dataPredicates.getPredicateDisjuncts().stream()
+                        .mapToInt(tupleDomain -> tupleDomain.getDomains().isPresent() ? tupleDomain.getDomains().get().size() : 0)
+                        .sum() > HiveSessionProperties.getMaterializedViewMissingPartitionsThreshold(session)) {
+                    return new MaterializedViewStatus(TOO_MANY_PARTITIONS_MISSING, partitionsFromBaseTables);
+                }
+
                 return new MaterializedViewStatus(PARTIALLY_MATERIALIZED, partitionsFromBaseTables);
             }
         }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
@@ -124,6 +124,7 @@ public final class HiveSessionProperties
     public static final String PARTITION_LEASE_DURATION = "partition_lease_duration";
     public static final String CACHE_ENABLED = "cache_enabled";
     public static final String ENABLE_LOOSE_MEMORY_BASED_ACCOUNTING = "enable_loose_memory_based_accounting";
+    public static final String MATERIALIZED_VIEW_MISSING_PARTITIONS_THRESHOLD = "materialized_view_missing_partitions_threshold";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -587,7 +588,12 @@ public final class HiveSessionProperties
                         ENABLE_LOOSE_MEMORY_BASED_ACCOUNTING,
                         "Enable loose memory accounting to avoid OOMing existing queries",
                         hiveClientConfig.isLooseMemoryAccountingEnabled(),
-                        false));
+                        false),
+                integerProperty(
+                        MATERIALIZED_VIEW_MISSING_PARTITIONS_THRESHOLD,
+                        "Materialized views with missing partitions more than this threshold falls back to the base tables at read time",
+                        hiveClientConfig.getMaterializedViewMissingPartitionsThreshold(),
+                        true));
     }
 
     public List<PropertyMetadata<?>> getSessionProperties()
@@ -1026,5 +1032,10 @@ public final class HiveSessionProperties
     public static boolean isExecutionBasedMemoryAccountingEnabled(ConnectorSession session)
     {
         return session.getProperty(ENABLE_LOOSE_MEMORY_BASED_ACCOUNTING, Boolean.class);
+    }
+
+    public static int getMaterializedViewMissingPartitionsThreshold(ConnectorSession session)
+    {
+        return session.getProperty(MATERIALIZED_VIEW_MISSING_PARTITIONS_THRESHOLD, Integer.class);
     }
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
@@ -154,6 +154,7 @@ public class TestHiveClientConfig
                 .setUndoMetastoreOperationsEnabled(true)
                 .setOptimizedPartitionUpdateSerializationEnabled(false)
                 .setPartitionLeaseDuration(new Duration(0, TimeUnit.SECONDS))
+                .setMaterializedViewMissingPartitionsThreshold(100)
                 .setLooseMemoryAccountingEnabled(false));
     }
 
@@ -270,6 +271,7 @@ public class TestHiveClientConfig
                 .put("hive.experimental-optimized-partition-update-serialization-enabled", "true")
                 .put("hive.partition-lease-duration", "4h")
                 .put("hive.loose-memory-accounting-enabled", "true")
+                .put("hive.materialized-view-missing-partitions-threshold", "50")
                 .build();
 
         HiveClientConfig expected = new HiveClientConfig()
@@ -381,6 +383,7 @@ public class TestHiveClientConfig
                 .setUndoMetastoreOperationsEnabled(false)
                 .setOptimizedPartitionUpdateSerializationEnabled(true)
                 .setPartitionLeaseDuration(new Duration(4, TimeUnit.HOURS))
+                .setMaterializedViewMissingPartitionsThreshold(50)
                 .setLooseMemoryAccountingEnabled(true);
 
         ConfigAssertions.assertFullMapping(properties, expected);

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -1343,7 +1343,7 @@ class StatementAnalyzer
                 MaterializedViewStatus materializedViewStatus)
         {
             String materializedViewCreateSql = connectorMaterializedViewDefinition.getOriginalSql();
-            if (materializedViewStatus.isNotMaterialized()) {
+            if (materializedViewStatus.isNotMaterialized() || materializedViewStatus.isTooManyPartitionsMissing()) {
                 return materializedViewCreateSql;
             }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/MaterializedViewStatus.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/MaterializedViewStatus.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import static com.facebook.presto.spi.MaterializedViewStatus.MaterializedViewState.FULLY_MATERIALIZED;
 import static com.facebook.presto.spi.MaterializedViewStatus.MaterializedViewState.NOT_MATERIALIZED;
 import static com.facebook.presto.spi.MaterializedViewStatus.MaterializedViewState.PARTIALLY_MATERIALIZED;
+import static com.facebook.presto.spi.MaterializedViewStatus.MaterializedViewState.TOO_MANY_PARTITIONS_MISSING;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
@@ -31,6 +32,7 @@ public class MaterializedViewStatus
     public enum MaterializedViewState
     {
         NOT_MATERIALIZED,
+        TOO_MANY_PARTITIONS_MISSING,
         PARTIALLY_MATERIALIZED,
         FULLY_MATERIALIZED
     }
@@ -89,6 +91,11 @@ public class MaterializedViewStatus
     public boolean isNotMaterialized()
     {
         return materializedViewState == NOT_MATERIALIZED;
+    }
+
+    public boolean isTooManyPartitionsMissing()
+    {
+        return materializedViewState == TOO_MANY_PARTITIONS_MISSING;
     }
 
     public boolean isPartiallyMaterialized()


### PR DESCRIPTION
**Summary**

Currently, when reading from a materialized view, if the view is partially materialized, then we query the base table for the missing partitions. It has been observed that, if too many partitions are missing, the the query string becomes very large. 

This PR makes changes so that, if the count of missing partitions are beyond a threshold value, then we  consider the view not materialized and proceed as such.

Previous discussion - https://github.com/prestodb/presto/issues/16579

<br/>
<br/>

**Implementation details**
Added new Config - `hive.materialized-view-missing-partitions-threshold` , `default = 100`

Current counting logic, instead of just counting partitions, it counts the total number of predicates, 
As an examples, if missing partitions of the table are as below 
```
/ds=2020-01-01/country=US
/ds=2020-01-01/country=CA
/ds=2020-01-01/country=IN
```
Total count = `6` `< 100` 
The reason for doing this is to get a closer approximation to string length

Test plan - Unit tests


```
== NO RELEASE NOTES ==
```
