### PR TITLE
Handle pushdown predicates in MetadataQueryOptimizer

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -2722,7 +2722,8 @@ public class HiveMetadata
                 tablePartitioning,
                 Optional.empty(),
                 discretePredicates,
-                ImmutableList.of());
+                ImmutableList.of(),
+                Optional.of(hiveLayoutHandle.getRemainingPredicate()));
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/metadata/TableLayout.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/TableLayout.java
@@ -23,6 +23,7 @@ import com.facebook.presto.spi.DiscretePredicates;
 import com.facebook.presto.spi.LocalProperty;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.sql.planner.PartitioningHandle;
 import com.google.common.collect.ImmutableList;
 
@@ -65,6 +66,11 @@ public class TableLayout
     public TupleDomain<ColumnHandle> getPredicate()
     {
         return layout.getPredicate();
+    }
+
+    public Optional<RowExpression> getRemainingPredicate()
+    {
+        return layout.getRemainingPredicate();
     }
 
     public List<LocalProperty<ColumnHandle>> getLocalProperties()


### PR DESCRIPTION
Previously, the pushdown predicates are not exposed to the optimizer.
The MetadataQueryOptimizer might rewrites a table scan with pushdown
predicates which could drop the filters and return incorrect results.

This commit exposes the pushdown predicate through SPI and disables the
metadata query rewrite if it references non-partition columns.

```
== NO RELEASE NOTE ==
```
