### PR TITLE
Implement key-based sampling in the planner

### DIFF
--- a/presto-docs/src/main/sphinx/functions/string.rst
+++ b/presto-docs/src/main/sphinx/functions/string.rst
@@ -238,3 +238,9 @@ Unicode Functions
     are replaced with `replace`. The replacement string `replace` must either
     be a single character or empty (in which case invalid characters are
     removed).
+
+.. function:: key_sampling_percent(varchar) -> double
+
+    Generates a double value between 0.0 and 1.0 based on the hash of the given ``varchar``.
+    This function is useful for deterministic sampling of data.
+

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -212,6 +212,9 @@ public final class SystemSessionProperties
 
     //TODO: Prestissimo related session properties that are temporarily put here. They will be relocated in the future
     public static final String PRESTISSIMO_SIMPLIFIED_EXPRESSION_EVALUATION_ENABLED = "simplified_expression_evaluation_enabled";
+    public static final String KEY_BASED_SAMPLING_ENABLED = "key_based_sampling_enabled";
+    public static final String KEY_BASED_SAMPLING_PERCENTAGE = "key_based_sampling_percentage";
+    public static final String KEY_BASED_SAMPLING_FUNCTION = "key_based_sampling_function";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -1142,7 +1145,22 @@ public final class SystemSessionProperties
                         EXCEEDED_MEMORY_LIMIT_HEAP_DUMP_FILE_DIRECTORY,
                         "Directory to which heap snapshot will be dumped, if heap_dump_on_exceeded_memory_limit_enabled",
                         System.getProperty("java.io.tmpdir"),   // This is intended to be used for debugging purposes only and thus we does not need an associated config property
-                        true));
+                        true),
+                booleanProperty(
+                        KEY_BASED_SAMPLING_ENABLED,
+                        "Key based sampling of tables enabled",
+                        false,
+                        false),
+                doubleProperty(
+                        KEY_BASED_SAMPLING_PERCENTAGE,
+                        "Percentage of keys to be sampled",
+                        0.01,
+                        false),
+                stringProperty(
+                        KEY_BASED_SAMPLING_FUNCTION,
+                        "Sampling function for key based sampling",
+                        "key_sampling_percent",
+                        false));
     }
 
     public static boolean isEmptyJoinOptimization(Session session)
@@ -1163,6 +1181,21 @@ public final class SystemSessionProperties
     public static boolean isAllowWindowOrderByLiterals(Session session)
     {
         return session.getSystemProperty(ALLOW_WINDOW_ORDER_BY_LITERALS, Boolean.class);
+    }
+
+    public static boolean isKeyBasedSamplingEnabled(Session session)
+    {
+        return session.getSystemProperty(KEY_BASED_SAMPLING_ENABLED, Boolean.class);
+    }
+
+    public static double getKeyBasedSamplingPercentage(Session session)
+    {
+        return session.getSystemProperty(KEY_BASED_SAMPLING_PERCENTAGE, Double.class);
+    }
+
+    public static String getKeyBasedSamplingFunction(Session session)
+    {
+        return session.getSystemProperty(KEY_BASED_SAMPLING_FUNCTION, String.class);
     }
 
     public List<PropertyMetadata<?>> getSessionProperties()

--- a/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
@@ -166,6 +166,7 @@ import com.facebook.presto.operator.scalar.WilsonInterval;
 import com.facebook.presto.operator.scalar.WordStemFunction;
 import com.facebook.presto.operator.scalar.sql.ArraySqlFunctions;
 import com.facebook.presto.operator.scalar.sql.MapNormalizeFunction;
+import com.facebook.presto.operator.scalar.sql.SimpleSamplingPercent;
 import com.facebook.presto.operator.window.CumulativeDistributionFunction;
 import com.facebook.presto.operator.window.DenseRankFunction;
 import com.facebook.presto.operator.window.FirstValueFunction;
@@ -842,6 +843,7 @@ public class BuiltInTypeAndFunctionNamespaceManager
                 .sqlInvokedScalar(MapNormalizeFunction.class)
                 .sqlInvokedScalars(ArraySqlFunctions.class)
                 .sqlInvokedScalars(ArrayIntersectFunction.class)
+                .sqlInvokedScalars(SimpleSamplingPercent.class)
                 .scalar(DynamicFilterPlaceholderFunction.class)
                 .scalars(EnumCasts.class)
                 .scalars(LongEnumOperators.class)

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/sql/SimpleSamplingPercent.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/sql/SimpleSamplingPercent.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar.sql;
+
+import com.facebook.presto.spi.function.Description;
+import com.facebook.presto.spi.function.SqlInvokedScalarFunction;
+import com.facebook.presto.spi.function.SqlParameter;
+import com.facebook.presto.spi.function.SqlType;
+
+public class SimpleSamplingPercent
+{
+    private SimpleSamplingPercent() {}
+
+    @SqlInvokedScalarFunction(value = "key_sampling_percent", deterministic = true, calledOnNullInput = false)
+    @Description("Returns a value between 0.0 and 1.0 using the hash of the given input string")
+    @SqlParameter(name = "input", type = "varchar")
+    @SqlType("double")
+    public static String keySamplingPercent()
+    {
+        return "return (abs(from_ieee754_64(xxhash64(cast(input as varbinary)))) % 100) / 100. ";
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -121,6 +121,7 @@ import com.facebook.presto.sql.planner.optimizations.CheckSubqueryNodesAreRewrit
 import com.facebook.presto.sql.planner.optimizations.HashGenerationOptimizer;
 import com.facebook.presto.sql.planner.optimizations.ImplementIntersectAndExceptAsUnion;
 import com.facebook.presto.sql.planner.optimizations.IndexJoinOptimizer;
+import com.facebook.presto.sql.planner.optimizations.KeyBasedSampler;
 import com.facebook.presto.sql.planner.optimizations.LimitPushDown;
 import com.facebook.presto.sql.planner.optimizations.MetadataDeleteOptimizer;
 import com.facebook.presto.sql.planner.optimizations.MetadataQueryOptimizer;
@@ -406,6 +407,7 @@ public class PlanOptimizers
                         estimatedExchangesCostCalculator,
                         ImmutableSet.of(new RewriteAggregationIfToFilter(metadata.getFunctionAndTypeManager()))),
                 predicatePushDown,
+                new KeyBasedSampler(metadata, sqlParser),
                 new IterativeOptimizer(
                         ruleStats,
                         statsCalculator,

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/KeyBasedSampler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/KeyBasedSampler.java
@@ -1,0 +1,284 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.common.function.OperatorType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.Varchars;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.PrestoWarning;
+import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.plan.AggregationNode;
+import com.facebook.presto.spi.plan.FilterNode;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
+import com.facebook.presto.spi.plan.ProjectNode;
+import com.facebook.presto.spi.plan.TableScanNode;
+import com.facebook.presto.spi.relation.ConstantExpression;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.planner.PlanVariableAllocator;
+import com.facebook.presto.sql.planner.TypeProvider;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.sql.planner.plan.RowNumberNode;
+import com.facebook.presto.sql.planner.plan.SemiJoinNode;
+import com.facebook.presto.sql.planner.plan.SimplePlanRewriter;
+import com.facebook.presto.sql.planner.plan.TopNRowNumberNode;
+import com.facebook.presto.sql.planner.plan.WindowNode;
+import com.facebook.presto.type.TypeUtils;
+import com.google.common.collect.ImmutableList;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static com.facebook.presto.SystemSessionProperties.getKeyBasedSamplingFunction;
+import static com.facebook.presto.SystemSessionProperties.getKeyBasedSamplingPercentage;
+import static com.facebook.presto.SystemSessionProperties.isKeyBasedSamplingEnabled;
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.metadata.CastType.CAST;
+import static com.facebook.presto.spi.StandardErrorCode.FUNCTION_NOT_FOUND;
+import static com.facebook.presto.spi.StandardWarningCode.SAMPLED_FIELDS;
+import static com.facebook.presto.spi.StandardWarningCode.SEMANTIC_WARNING;
+import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static com.facebook.presto.sql.planner.plan.ChildReplacer.replaceChildren;
+import static com.facebook.presto.sql.relational.Expressions.call;
+import static com.facebook.presto.sql.tree.ComparisonExpression.Operator.LESS_THAN_OR_EQUAL;
+import static java.util.Objects.requireNonNull;
+
+public class KeyBasedSampler
+        implements PlanOptimizer
+{
+    private final Metadata metadata;
+
+    public KeyBasedSampler(Metadata metadata, SqlParser sqlParser)
+    {
+        this.metadata = requireNonNull(metadata, "metadata is null");
+    }
+
+    @Override
+    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, PlanVariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    {
+        if (isKeyBasedSamplingEnabled(session)) {
+            List<String> sampledFields = new ArrayList<>(2);
+            PlanNode rewritten = SimplePlanRewriter.rewriteWith(new Rewriter(session, metadata.getFunctionAndTypeManager(), idAllocator, sampledFields), plan, null);
+            if (!sampledFields.isEmpty()) {
+                warningCollector.add(new PrestoWarning(SAMPLED_FIELDS, String.format("Sampled the following columns/derived columns at %s percent:\n\t%s", getKeyBasedSamplingPercentage(session) * 100., String.join("\n\t", sampledFields))));
+            }
+            else {
+                warningCollector.add(new PrestoWarning(SEMANTIC_WARNING, "Sampling could not be performed due to the query structure"));
+            }
+
+            return rewritten;
+        }
+
+        return plan;
+    }
+
+    private static class Rewriter
+            extends SimplePlanRewriter<Void>
+    {
+        private final Session session;
+        private final FunctionAndTypeManager functionAndTypeManager;
+        private final PlanNodeIdAllocator idAllocator;
+        private final List<String> sampledFields;
+
+        private Rewriter(Session session, FunctionAndTypeManager functionAndTypeManager, PlanNodeIdAllocator idAllocator, List<String> sampledFields)
+        {
+            this.session = requireNonNull(session, "session is null");
+            this.functionAndTypeManager = requireNonNull(functionAndTypeManager, "functionAndTypeManager is null");
+            this.idAllocator = requireNonNull(idAllocator, "idAllocator is null");
+            this.sampledFields = requireNonNull(sampledFields, "sampledFields is null");
+        }
+
+        private PlanNode addSamplingFilter(PlanNode tableScanNode, Optional<VariableReferenceExpression> rowExpressionOptional, FunctionAndTypeManager functionAndTypeManager)
+        {
+            if (!rowExpressionOptional.isPresent()) {
+                return tableScanNode;
+            }
+            RowExpression rowExpression = rowExpressionOptional.get();
+            RowExpression arg;
+            Type type = rowExpression.getType();
+            if (!Varchars.isVarcharType(type)) {
+                arg = call(
+                        "CAST",
+                        functionAndTypeManager.lookupCast(CAST, rowExpression.getType().getTypeSignature(), VARCHAR.getTypeSignature()),
+                        VARCHAR,
+                        rowExpression);
+            }
+            else {
+                arg = rowExpression;
+            }
+
+            RowExpression sampledArg;
+            try {
+                sampledArg = call(
+                        functionAndTypeManager,
+                        getKeyBasedSamplingFunction(session),
+                        DOUBLE,
+                        arg);
+            }
+            catch (PrestoException prestoException) {
+                throw new PrestoException(FUNCTION_NOT_FOUND, String.format("Sampling function: %s not cannot be resolved", getKeyBasedSamplingFunction(session)), prestoException);
+            }
+
+            RowExpression predicate = call(
+                    LESS_THAN_OR_EQUAL.name(),
+                    functionAndTypeManager.resolveOperator(OperatorType.LESS_THAN_OR_EQUAL, fromTypes(DOUBLE, DOUBLE)),
+                    BOOLEAN,
+                    sampledArg,
+                    new ConstantExpression(getKeyBasedSamplingPercentage(session), DOUBLE));
+
+            FilterNode filterNode = new FilterNode(
+                    idAllocator.getNextId(),
+                    tableScanNode,
+                    predicate);
+
+            String tableName;
+            while (tableScanNode instanceof FilterNode || tableScanNode instanceof ProjectNode) {
+                tableScanNode = tableScanNode.getSources().get(0);
+            }
+            if (tableScanNode instanceof TableScanNode) {
+                tableName = ((TableScanNode) tableScanNode).getTable().getConnectorHandle().toString();
+            }
+            else {
+                tableName = "plan node: " + String.valueOf(tableScanNode.getId());
+            }
+
+            sampledFields.add(String.format("%s from %s", rowExpression, tableName));
+            return filterNode;
+        }
+
+        private Optional<VariableReferenceExpression> findSuitableKey(List<VariableReferenceExpression> keys)
+        {
+            Optional<VariableReferenceExpression> variableReferenceExpression = keys.stream()
+                    .filter(x -> TypeUtils.isIntegralType(x.getType().getTypeSignature(), functionAndTypeManager))
+                    .findFirst();
+
+            if (!variableReferenceExpression.isPresent()) {
+                variableReferenceExpression = keys.stream()
+                        .filter(x -> Varchars.isVarcharType(x.getType()))
+                        .findFirst();
+            }
+
+            return variableReferenceExpression;
+        }
+
+        @Override
+        public PlanNode visitJoin(JoinNode node, RewriteContext<Void> context)
+        {
+            PlanNode left = node.getLeft();
+            PlanNode right = node.getRight();
+
+            PlanNode leftRewritten = rewriteWith(this, left);
+            PlanNode rightRewritten = rewriteWith(this, right);
+
+            // If at leasst one of them is unchanged means it had no join. So one side has a table scan.
+            // So we apply filter on both sides.
+            if (left == leftRewritten || right == rightRewritten) {
+                // Find the best equijoin clause so we sample both sides the same way optimally
+
+                // First see if there is a int/bigint key
+                Optional<JoinNode.EquiJoinClause> equiJoinClause = node.getCriteria().stream()
+                        .filter(x -> TypeUtils.isIntegralType(x.getLeft().getType().getTypeSignature(), functionAndTypeManager))
+                        .findFirst();
+                if (!equiJoinClause.isPresent()) {
+                    // See if there is a varchar key
+                    equiJoinClause = node.getCriteria().stream()
+                            .filter(x -> Varchars.isVarcharType(x.getLeft().getType()))
+                            .findFirst();
+                }
+
+                if (equiJoinClause.isPresent()) {
+                    // If one side rewritten, that means one side has another join but not the other side.
+                    leftRewritten = addSamplingFilter(left, Optional.of(equiJoinClause.get().getLeft()), functionAndTypeManager);
+                    rightRewritten = addSamplingFilter(right, Optional.of(equiJoinClause.get().getRight()), functionAndTypeManager);
+                }
+            }
+
+            // We always return new from join so others won't be applied if not needed.
+            return replaceChildren(node, ImmutableList.of(leftRewritten, rightRewritten));
+        }
+
+        @Override
+        public PlanNode visitAggregation(AggregationNode node, RewriteContext<Void> context)
+        {
+            PlanNode source = node.getSource();
+            PlanNode rewrittenSource = rewriteWith(this, source);
+            if (rewrittenSource == source) {
+                // Source not rewritten so we sample here.
+                rewrittenSource = addSamplingFilter(source, findSuitableKey(node.getGroupingKeys()), functionAndTypeManager);
+            }
+
+            // Always return new
+            return replaceChildren(node, ImmutableList.of(rewrittenSource));
+        }
+
+        @Override
+        public PlanNode visitSemiJoin(SemiJoinNode node, RewriteContext<Void> context)
+        {
+            PlanNode source = node.getSource();
+            PlanNode filteringSource = node.getFilteringSource();
+            PlanNode rewrittenSource = rewriteWith(this, source);
+            PlanNode rewrittenFilteringSource = rewriteWith(this, filteringSource);
+            if (rewrittenSource == source || rewrittenFilteringSource == filteringSource) {
+                rewrittenSource = addSamplingFilter(source, findSuitableKey(ImmutableList.of(node.getSourceJoinVariable())), functionAndTypeManager);
+            }
+
+            return replaceChildren(node, ImmutableList.of(rewrittenSource, rewrittenFilteringSource));
+        }
+
+        @Override
+        public PlanNode visitWindow(WindowNode node, RewriteContext<Void> context)
+        {
+            PlanNode source = node.getSource();
+            PlanNode rewrittenSource = rewriteWith(this, source);
+            if (rewrittenSource == source) {
+                rewrittenSource = addSamplingFilter(source, findSuitableKey(node.getPartitionBy()), functionAndTypeManager);
+            }
+
+            return replaceChildren(node, ImmutableList.of(rewrittenSource));
+        }
+
+        @Override
+        public PlanNode visitRowNumber(RowNumberNode node, RewriteContext<Void> context)
+        {
+            PlanNode source = node.getSource();
+            PlanNode rewrittenSource = rewriteWith(this, source);
+            if (rewrittenSource == source) {
+                rewrittenSource = addSamplingFilter(source, findSuitableKey(node.getPartitionBy()), functionAndTypeManager);
+            }
+
+            return replaceChildren(node, ImmutableList.of(rewrittenSource));
+        }
+
+        @Override
+        public PlanNode visitTopNRowNumber(TopNRowNumberNode node, RewriteContext<Void> context)
+        {
+            PlanNode source = node.getSource();
+            PlanNode rewrittenSource = rewriteWith(this, source);
+            if (rewrittenSource == source) {
+                rewrittenSource = addSamplingFilter(source, findSuitableKey(node.getPartitionBy()), functionAndTypeManager);
+            }
+
+            return replaceChildren(node, ImmutableList.of(rewrittenSource));
+        }
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/StandardWarningCode.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/StandardWarningCode.java
@@ -23,6 +23,8 @@ public enum StandardWarningCode
     REDUNDANT_ORDER_BY(0x0000_0005),
     PARTIAL_RESULT_WARNING(0x0000_0006),
     MULTIPLE_ORDER_BY(0x0000_0007),
+    DEFAULT_SAMPLE_FUNCTION(0x0000_0008),
+    SAMPLED_FIELDS(0x0000_0009),
     /**/;
     private final WarningCode warningCode;
 


### PR DESCRIPTION
We have many ad hoc queries working on large datasets that keep failing/running long time/timing out. So for cases when the user just wants to get a sense of the results, we do smart sampling based on mapping hashes of keys to a percent. When the feature is enabled, we traverse the plan for the query and sample the first integer or string key found (in that order)

* both sides of an equi-join
* group by 
* partition by of a window/rownum/topnrownum
* left-side (source) of semijoin

We apply the sampling predicate only once in every branch of graph so that eventually all qualifying scans will be sampled.


Test plan - added tests

Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines. Don't forget to follow our [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution) for any code copied from other projects.

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== RELEASE NOTES ==

General Changes
* Added Smart Sampling feature that samples the tables at query (planning) time. This helps in cases when the user is just exploring the data, testing a pipeline or looking for trends. We sample all the tables (and only tables) in such a way that all "key-based" operations like JOIN/GROUP BY/window functions etc will be complete for the sampled keys. 

```