### PR TITLE
Add release notes for 0.262

### DIFF
--- a/presto-docs/src/main/sphinx/release.rst
+++ b/presto-docs/src/main/sphinx/release.rst
@@ -5,6 +5,7 @@ Release Notes
 .. toctree::
     :maxdepth: 1
 
+    release/release-0.262
     release/release-0.261
     release/release-0.260.1
     release/release-0.260

--- a/presto-docs/src/main/sphinx/release/release-0.262.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.262.rst
@@ -1,0 +1,38 @@
+=============
+Release 0.262
+=============
+
+**Highlights**
+==============
+* Fix a correctness bug which could be triggered for queries with aggregations on partitioning columns and filters on non-partitioning columns when both optimizing
+  metadata queries and filter pushdown are enabled.
+* Add support for elastic workers by implementing time-to-live based node scheduling for queries with execution time estimates. See :pr:`16409`
+
+**Details**
+===========
+
+General Changes
+_______________
+* Fix :func:`reduce_agg` to allow ``NULL`` as the result of input/combine functions, while also allowing only constant expressions and not ``NULL`` as the initial value.
+* Fix a correctness bug which could be triggered for queries with aggregations on partitioning columns and filters on non-partitioning columns when both optimizing
+  metadata queries and filter pushdown are enabled.
+* Add default size limit (100MB) to build side of broadcast join.
+* Add support for elastic workers by implementing time-to-live based node scheduling for queries with execution time estimates. This can be enabled by setting either the
+  ``resource_aware_scheduling_strategy`` session property or the ``experimental.resource-aware-scheduling-strategy`` configuration property to ``TTL``. See :pr:`16409`.
+* Add adjusted queue size information to the ``v1/cluster`` endpoint.
+
+SPI Changes
+___________
+* Add support for custom node time-to-live (TTL) fetchers (to fetch TTLs of nodes) and cluster TTL providers (to compute the TTL of a cluster) through the
+  ``NodeTtlFetcher`` and ``ClusterTtlProvider`` interfaces respectively. See :pr:`16409`.
+
+Hive Changes
+____________
+* Fix issue while reading Apache HUDI tables when ``PrestoFileSystemCache`` is refreshed. The issue occurs because ``HoodieROTablePathFilter`` is cached with default
+  ``Configuration`` object (:pr:`16611`).
+* Add session property ``hive.cache_enabled`` to allow turning on and off data cache per query.
+
+**Credits**
+===========
+
+Ajay George, Ariel Weisberg, Arunachalam Thirupathi, Brian Li, Jalpreet Singh Nanda (:imjalpreet), James Petty, James Sun, Neerad Somanchi, Shixuan Fan, Sreeni Viswanadha, Swapnil Tailor, Tal Galili, Timothy Meehan, Vivek, Xiang Fu, Ying, Zac Wen, Zhan Yuan, Zhenxiao Luo, Zhongting Hu, abhiseksaikia


### PR DESCRIPTION
# Missing Release Notes
## Ariel Weisberg
- [x] https://github.com/prestodb/presto/pull/16687 Revert "Fix memory accounting of DictionaryRowGroup" (Merged by: Shixuan Fan)

## Tal Galili
- [x] https://github.com/prestodb/presto/pull/16696 Documentation: two new sections for probability distribution functions (Merged by: Timothy Meehan)

## Zhan Yuan
- [x] bbd583430b25a26054ce830c0d070474ed48f45e Revert "Handle fully filter pushdown for metadata query rewrite"

# Extracted Release Notes
- #16409 (Author: Neerad Somanchi): Simple TTL based scheduling
  - Add support for simple TTL based scheduling where the scheduler picks workers for query execution based on their availability estimates and query execution time estimates. This can be enabled by setting either the ``resource_aware_scheduling_strategy`` session property or the ``experimental.resource-aware-scheduling-strategy`` configuration property to ``TTL``. See :pr:`16409`.
  - Add support for custom Node TTL fetchers and Cluster TTL providers through the ``NodeTtlFetcher`` and ``ClusterTtlProvider`` interfaces respectively. See :pr:`16409`.
- #16474 (Author: Zhongting Hu): Add cache_enabled session property into hive
  - Add session property `hive.cache_enabled` to allow turning on and off data cache per query.
- #16611 (Author: Jalpreet Singh Nanda (:imjalpreet)): Replace Supplier by LoadingCache for caching PathFilter when loading partition splits of HUDI tables
  - Fix issue while reading Apache HUDI tables when PrestoFileSystemCache is refreshed (:pr:`16611`).
- #16624 (Author: abhiseksaikia): Provide adjusted queue size while serving cluster stats
  - Provide adjusted queue size information for v1/cluster endpoint.
- #16672 (Author: Sreeni Viswanadha): Simplify reduce_agg implementation
  - REDUCE_AGG is now fixed to allow only constant expressions and not null as the initial value and handle combine/input functions producing null results.
- #16673 (Author: Swapnil Tailor): Fix resource group distributed queuing
  - Fix for queries getting stuck in queue state in disaggregated coordinator cluster.
- #16704 (Author: Vivek): Set a default limit of 100MB on size of broadcast join build side
  - Add default size limit (100MB) to build side of broadcast join.
- #16730 (Author: Zhan Yuan): Handle fully filter pushdown for metadata query rewrite
  - Fix a correctness bug which could be triggered for queries with aggregations on partitioning columns and filters on non-partitioning columns when both optimizing metadata queries and filter pushdown are enabled.

# All Commits
- bbd583430b25a26054ce830c0d070474ed48f45e Revert "Handle fully filter pushdown for metadata query rewrite" (Zhan Yuan)
- 13716f57d8bc9426a0defaee24b205918ce618dd Simple TTL based scheduling (Neerad Somanchi)
- e01769844c0f4dd29649e8cb4d7357c44fe1f73f Node TTL Fetchers and Cluster TTL Providers (Neerad Somanchi)
- 911ec4014849a0c4d0b30751e7549033e10d2374 Replace Supplier by LoadingCache for caching HoodieROTablePathFilter (Jalpreet Singh Nanda (:imjalpreet))
- 2b70fc8cbfb1431cb13633b9aada7c6fa3515f5c Cleanup parquet ColumnChunk and PageReader (James Petty)
- 9a14d4225b838ae8714d1e9e2c62ddfffca97fe5 Rename DwrfWriterOptions to DwrfStripeCacheOptions (Arunachalam Thirupathi)
- bbb626cec1a7155ad0cec10c1828bb47802d8eaf Refactor DwrfWriterOptions (Arunachalam Thirupathi)
- 4d13f4032a44f60c1d81baf2d987d4b837d3db94 Add NotNull to OrcFileWriterConfig (Arunachalam Thirupathi)
- 975db7dae8c166d66d4184c61c17792ab75e053c [presto-orc] Support Column Layout in HiveWriter (Arunachalam Thirupathi)
- 2eeaf68ed36768adb504617b0e41a30253a94b4a Fix resource group distributed queuing (Swapnil Tailor)
- de9e4577a5615676afe6ff39d0d9ff714cc0251e Replace Supplier by LoadingCache for caching HoodieROTablePathFilter (Jalpreet Singh Nanda (:imjalpreet))
- 1a2cf0521dbd9c8ee6536fdb88407c227ec87933 Re-organize the probability functions to their own sections (Tal Galili)
- ca0ff8f6e6d777f2b6667e3ec254f618d22b1119 Unwrap IF for more cases in AGG IF to FILTER rewrite (Zhan Yuan)
- 932aed8582dceebb687cb30eb772f4bad5f87285 Simplify reduce_agg implementation (Sreeni Viswanadha)
- e0e68cbad18cd05635f47b6842febc821215a9cc Handle fully filter pushdown for metadata query rewrite (Zhan Yuan)
- 1c5d013b01dbb72fdff0de1a4cba4074f1611b60 Fix merge conflict in BenchmarkParquetPageSource (Vivek)
- 911431f78c72cd7c2157b21fc65f41709381ea39 Parquet benchmark for multi column readers (Vivek)
- bc7b98748f110c9047681b44d7dc73fc3e37844b Rename writeParquetColumnPresto to writeParquetFileFromPresto (Vivek)
- 0fc654c792852ec8918f7f0c8888e6d967b673be Fix another argument length error in TestSpatialPartitioningInternalAggregation (James Petty)
- 98b9ead80c6467739f6b7a4b2696c0b756d68c02 Fix TestSpatialPartitioningInternalAggregation (James Petty)
- 48c0676b49d4a38cb6ecd3ecc9cb76c892f3d6fc Improve Verifier retries (Ajay George)
- 98378005bec7464d6d3e087715fe788a400ec664 Fixing the documentation of several distributions (normal, beta, chi-square) (Tal Galili)
- ce1f8ac8c432945b107acb47c862bd63fa35d5bb Add Parquet Block Stats to RuntimeStats (Brian Li)
- 46c3de43be74d72855f9d593795167bc87229cb6 Always update OperatorStats in getOutput() (Brian Li)
- 7fb8c4606c3d60d0f594df38b6f68e33d9b3436b Optimize MarkDistinctHash for faster distinct mask creation (James Petty)
- 68ef151c90804bcabfe0210123e3fc13a8eea26f Add direct block construction helpers to BooleanType (James Petty)
- 5dee883cb300e4edb2cd26b482feb4fe4b37a68d Set a default limit of 100MB on size of broadcast join build side (Vivek)
- 40e8a07cd6e61ed65465e9038ada5fe61e7c2fc3 Add counters for the number of skipped stripes and total stripes (Zhan Yuan)
- 950316c4adc96c7b00f8e5edabd34247b24951c7 Pass RuntimeStats into StripeReader (Zhan Yuan)
- 30d664287b40dd56494b27022a0666a019687aae Change tracer interface to have noop tracer getter (tanjialiang)
- c127d801c1cf150598392f35785e37104a427691 Add benchmarkHashPosition to BenchmarkGroupByHash (James Petty)
- dd42968b6d14a6799d442b96359f91c0f975cbc0 Add positional only utility for InterpretedHashGenerator creation (James Petty)
- 818d07d445ff06ec9d388efa4891298f5add60cf Provide adjusted queue size while serving cluster stats (abhiseksaikia)
- 96b37221a2e06a1b5d6fa8a560a8992a69d099da Add a fast path for unwrapping if in AGG IF to FILTER rewrite (Zhan Yuan)
- d444fcd187da2bc5debda911a4e8a3750f5b20a3 Improve Block#getLoadedBlock() and Page#getLoadedPage() (James Petty)
- 95f29f37b46853d0273301b503d01aaa9ae6ef86 Support RawSize in the DwrfFileFooter (Arunachalam Thirupathi)
- 91a52a36f0f14b18705484022d9d343982663bd9 fixing pinot timeBoundary call json properties (Xiang Fu)
- 21c4be91975ea6caf14ca82db0d245fd23495aa9 Revert "Fix memory accounting of DictionaryRowGroup" (Ariel Weisberg)
- 8c67b57d2690eb1bf839bd869008d7d3888d1d78 Add cache_enabled session property into hive (Zhongting Hu)
- 91d64824364daa2ded1abd5c44de6ef976f1684a Handle table alias for query rewrite optimization (Zac Wen)
- cca4158c41f123fb44956da7b6cd2250f91929cb Add query distributed tracing interface (tanjialiang)
- 1dd19ffe0f3209081a6c961e8b42f9d9296cf577 Use blockBuilders.length in PageBuilder#reset() loop (James Petty)
- 0ddd13fc1b05499c87e6a57dca1425e02751067c Improve LookupJoinPageBuilder (James Petty)
- 2cf93c1a86716481c22f8350b3a1caf3fa365e8a Improve JoinProbe (James Petty)