### PR TITLE
Fix Resource Group Distributed Queuing

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroup.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/InternalResourceGroup.java
@@ -742,7 +742,6 @@ public class InternalResourceGroup
                 }
             }
             parent.get().updateEligibility();
-            isDirty.set(false);
         }
     }
 
@@ -821,8 +820,9 @@ public class InternalResourceGroup
                     if (!subGroup.isDirty()) {
                         iterator.remove();
                     }
-                    if (oldMemoryUsageBytes != subGroup.cachedMemoryUsageBytes || isDirty.get()) {
+                    if (oldMemoryUsageBytes != subGroup.cachedMemoryUsageBytes || subGroup.isDirty.get()) {
                         subGroup.updateEligibility();
+                        subGroup.isDirty.set(false);
                     }
                 }
             }


### PR DESCRIPTION
When a resource group has multiple subGroup and first subGourp has no query to run,
internalRefreshStats method reset the parent subGroup isDirty flag as part of subGroup.updateEligiblity.
This leads the next subGroup updateEligiblity not called as we check for the parent group isDirty flag.

In this PR we are fixing that by checking the subGroup.isDirty flag and also reseting the flag once we
process all dirtySubGroup for the given group.

Test plan - Verifying in test cluster.

```
== NO RELEASE NOTE ==
```
