### PR TITLE
Dwrf stripe cache hive config

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcDataSourceUtils.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcDataSourceUtils.java
@@ -30,6 +30,8 @@ import static java.lang.Math.toIntExact;
 
 public final class OrcDataSourceUtils
 {
+    public static final int EXPECTED_FOOTER_SIZE_IN_BYTES = 16 * 1024;
+
     private OrcDataSourceUtils()
     {
     }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcCacheConfig.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcCacheConfig.java
@@ -22,8 +22,10 @@ import org.testng.annotations.Test;
 
 import java.util.Map;
 
+import static com.facebook.presto.orc.OrcDataSourceUtils.EXPECTED_FOOTER_SIZE_IN_BYTES;
 import static io.airlift.units.DataSize.Unit.BYTE;
 import static io.airlift.units.DataSize.Unit.GIGABYTE;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -40,7 +42,9 @@ public class TestOrcCacheConfig
                 .setStripeFooterCacheSize(new DataSize(0, BYTE))
                 .setStripeFooterCacheTtlSinceLastAccess(new Duration(0, SECONDS))
                 .setStripeStreamCacheSize(new DataSize(0, BYTE))
-                .setStripeStreamCacheTtlSinceLastAccess(new Duration(0, SECONDS)));
+                .setStripeStreamCacheTtlSinceLastAccess(new Duration(0, SECONDS))
+                .setDwrfStripeCacheEnabled(false)
+                .setExpectedFileTailSize(new DataSize(EXPECTED_FOOTER_SIZE_IN_BYTES, BYTE)));
     }
 
     @Test
@@ -55,6 +59,8 @@ public class TestOrcCacheConfig
                 .put("orc.stripe-footer-cache-ttl-since-last-access", "5m")
                 .put("orc.stripe-stream-cache-size", "3GB")
                 .put("orc.stripe-stream-cache-ttl-since-last-access", "10m")
+                .put("orc.dwrf-stripe-cache-enabled", "true")
+                .put("orc.expected-file-tail-size", "8MB")
                 .build();
 
         OrcCacheConfig expected = new OrcCacheConfig()
@@ -65,7 +71,9 @@ public class TestOrcCacheConfig
                 .setStripeFooterCacheSize(new DataSize(2, GIGABYTE))
                 .setStripeFooterCacheTtlSinceLastAccess(new Duration(5, MINUTES))
                 .setStripeStreamCacheSize(new DataSize(3, GIGABYTE))
-                .setStripeStreamCacheTtlSinceLastAccess(new Duration(10, MINUTES));
+                .setStripeStreamCacheTtlSinceLastAccess(new Duration(10, MINUTES))
+                .setDwrfStripeCacheEnabled(true)
+                .setExpectedFileTailSize(new DataSize(8, MEGABYTE));
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcReaderDwrfStripeCaching.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcReaderDwrfStripeCaching.java
@@ -40,7 +40,7 @@ import static org.testng.Assert.assertTrue;
 public class TestOrcReaderDwrfStripeCaching
         extends AbstractTestDwrfStripeCaching
 {
-    private static final int READ_TAIL_SIZE = 1024 * 1024;
+    private static final int READ_TAIL_SIZE_IN_BYTES = 1024 * 1024;
     private static final OrcDataSourceId TEST_DATA_SOURCE_ID = new OrcDataSourceId("test");
 
     @Test(dataProvider = "Stripe cache for ALL stripes with mode BOTH")
@@ -247,7 +247,7 @@ public class TestOrcReaderDwrfStripeCaching
         new OrcReader(
                 orcDataSource,
                 DWRF,
-                new StorageOrcFileTailSource(READ_TAIL_SIZE, true),
+                new StorageOrcFileTailSource(READ_TAIL_SIZE_IN_BYTES, true),
                 stripeMetadataSourceFactory,
                 NOOP_ORC_AGGREGATED_MEMORY_CONTEXT,
                 OrcReaderTestingUtils.createDefaultTestConfig(),

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcRecordReaderDwrfStripeCaching.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcRecordReaderDwrfStripeCaching.java
@@ -46,7 +46,7 @@ import static org.testng.Assert.fail;
 public class TestOrcRecordReaderDwrfStripeCaching
         extends AbstractTestDwrfStripeCaching
 {
-    private static final int READ_TAIL_SIZE = 64;
+    private static final int READ_TAIL_SIZE_IN_BYTES = 256;
 
     @Test(dataProvider = "Stripe cache for ALL stripes with mode BOTH")
     public void testBothAllStripes(File orcFile)
@@ -149,7 +149,7 @@ public class TestOrcRecordReaderDwrfStripeCaching
             OrcReader orcReader = new OrcReader(
                     orcDataSource,
                     DWRF,
-                    new StorageOrcFileTailSource(READ_TAIL_SIZE, true),
+                    new StorageOrcFileTailSource(READ_TAIL_SIZE_IN_BYTES, true),
                     dwrfAwareFactory,
                     NOOP_ORC_AGGREGATED_MEMORY_CONTEXT,
                     orcReaderOptions,
@@ -174,7 +174,7 @@ public class TestOrcRecordReaderDwrfStripeCaching
             OrcReader orcReader = new OrcReader(
                     orcDataSource,
                     DWRF,
-                    new StorageOrcFileTailSource(READ_TAIL_SIZE, false),
+                    new StorageOrcFileTailSource(READ_TAIL_SIZE_IN_BYTES, false),
                     dwrfAwareFactory,
                     NOOP_ORC_AGGREGATED_MEMORY_CONTEXT,
                     OrcReaderTestingUtils.createDefaultTestConfig(),


### PR DESCRIPTION
Following configs are introduced

1. dwrf-stripe-cache-enabled
    When dwrf stripe cache is available in the Dwrf file, read stripe
footer from dwrf stripe cache.
2. expected-file-tail-size
    Read file footer and stripe cache in one IO, by increasing the
expected-file-tail-size. This reduces 2 IO to 1 IO for most common
use cases.

Test plan - 
Existing tests and added new tests.

```
== NO RELEASE NOTE ==
```
