### PR TITLE
Revert "Unwrap lazy blocks before expensive remote and local exchange operations" PR

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/exchange/LocalExchangeSinkOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/exchange/LocalExchangeSinkOperator.java
@@ -149,8 +149,8 @@ public class LocalExchangeSinkOperator
     {
         requireNonNull(page, "page is null");
         page = pagePreprocessor.apply(page);
-        operatorContext.recordOutput(page.getSizeInBytes(), page.getPositionCount());
         sink.addPage(page);
+        operatorContext.recordOutput(page.getSizeInBytes(), page.getPositionCount());
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/exchange/PageChannelSelector.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/exchange/PageChannelSelector.java
@@ -24,9 +24,6 @@ import static java.util.Objects.requireNonNull;
 public class PageChannelSelector
         implements Function<Page, Page>
 {
-    // No channels need to be remapped, only ensure that all page blocks are loaded
-    private static final Function<Page, Page> GET_LOADED_PAGE = Page::getLoadedPage;
-
     private final int[] channels;
 
     public PageChannelSelector(int... channels)
@@ -38,12 +35,6 @@ public class PageChannelSelector
     @Override
     public Page apply(Page page)
     {
-        // Ensure the channels that are emitted are fully loaded and in the correct order
-        return requireNonNull(page, "page is null").getLoadedPage(channels);
-    }
-
-    public static Function<Page, Page> identitySelection()
-    {
-        return GET_LOADED_PAGE;
+        return requireNonNull(page, "page is null").extractChannels(channels);
     }
 }


### PR DESCRIPTION
This reverts https://github.com/prestodb/presto/pull/16617

The commits were causing previously successful queries to fail with EXCEEDED_LOCAL_MEMORY_LIMIT errors.

```
== NO RELEASE NOTE ==
```
