### PR TITLE
Improve block encoding performance

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/block/ArrayBlockEncoding.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/ArrayBlockEncoding.java
@@ -62,7 +62,7 @@ public class ArrayBlockEncoding
         int positionCount = sliceInput.readInt();
         int[] offsets = new int[positionCount + 1];
         sliceInput.readBytes(Slices.wrappedIntArray(offsets));
-        boolean[] valueIsNull = decodeNullBits(sliceInput, positionCount).orElseGet(() -> new boolean[positionCount]);
+        boolean[] valueIsNull = decodeNullBits(sliceInput, positionCount).orElse(null);
         return createArrayBlockInternal(0, positionCount, valueIsNull, offsets, values);
     }
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/block/ByteArrayBlockEncoding.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/ByteArrayBlockEncoding.java
@@ -38,8 +38,9 @@ public class ByteArrayBlockEncoding
 
         encodeNullsAsBits(sliceOutput, block);
 
+        boolean mayHaveNull = block.mayHaveNull();
         for (int position = 0; position < positionCount; position++) {
-            if (!block.isNull(position)) {
+            if (!mayHaveNull || !block.isNull(position)) {
                 sliceOutput.writeByte(block.getByte(position));
             }
         }

--- a/presto-common/src/main/java/com/facebook/presto/common/block/ByteArrayBlockEncoding.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/ByteArrayBlockEncoding.java
@@ -53,9 +53,15 @@ public class ByteArrayBlockEncoding
         boolean[] valueIsNull = decodeNullBits(sliceInput, positionCount).orElse(null);
 
         byte[] values = new byte[positionCount];
-        for (int position = 0; position < positionCount; position++) {
-            if (valueIsNull == null || !valueIsNull[position]) {
-                values[position] = sliceInput.readByte();
+        if (valueIsNull == null) {
+            // No nulls present, read values array directly from input
+            sliceInput.readBytes(values, 0, values.length);
+        }
+        else {
+            for (int position = 0; position < values.length; position++) {
+                if (!valueIsNull[position]) {
+                    values[position] = sliceInput.readByte();
+                }
             }
         }
 

--- a/presto-common/src/main/java/com/facebook/presto/common/block/Int128ArrayBlockEncoding.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/Int128ArrayBlockEncoding.java
@@ -15,6 +15,7 @@ package com.facebook.presto.common.block;
 
 import io.airlift.slice.SliceInput;
 import io.airlift.slice.SliceOutput;
+import io.airlift.slice.Slices;
 
 import static com.facebook.presto.common.block.EncoderUtil.decodeNullBits;
 import static com.facebook.presto.common.block.EncoderUtil.encodeNullsAsBits;
@@ -54,10 +55,16 @@ public class Int128ArrayBlockEncoding
         boolean[] valueIsNull = decodeNullBits(sliceInput, positionCount).orElse(null);
 
         long[] values = new long[positionCount * 2];
-        for (int position = 0; position < positionCount; position++) {
-            if (valueIsNull == null || !valueIsNull[position]) {
-                values[position * 2] = sliceInput.readLong();
-                values[(position * 2) + 1] = sliceInput.readLong();
+        if (valueIsNull == null) {
+            // No nulls present, read values array directly from input
+            sliceInput.readBytes(Slices.wrappedLongArray(values));
+        }
+        else {
+            for (int position = 0, index = 0; index < values.length; position++, index += 2) {
+                if (!valueIsNull[position]) {
+                    values[index] = sliceInput.readLong();
+                    values[index + 1] = sliceInput.readLong();
+                }
             }
         }
 

--- a/presto-common/src/main/java/com/facebook/presto/common/block/Int128ArrayBlockEncoding.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/Int128ArrayBlockEncoding.java
@@ -39,8 +39,9 @@ public class Int128ArrayBlockEncoding
 
         encodeNullsAsBits(sliceOutput, block);
 
+        boolean mayHaveNull = block.mayHaveNull();
         for (int position = 0; position < positionCount; position++) {
-            if (!block.isNull(position)) {
+            if (!mayHaveNull || !block.isNull(position)) {
                 sliceOutput.writeLong(block.getLong(position, 0));
                 sliceOutput.writeLong(block.getLong(position, 8));
             }

--- a/presto-common/src/main/java/com/facebook/presto/common/block/IntArrayBlockEncoding.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/IntArrayBlockEncoding.java
@@ -39,8 +39,9 @@ public class IntArrayBlockEncoding
 
         encodeNullsAsBits(sliceOutput, block);
 
+        boolean mayHaveNull = block.mayHaveNull();
         for (int position = 0; position < positionCount; position++) {
-            if (!block.isNull(position)) {
+            if (!mayHaveNull || !block.isNull(position)) {
                 sliceOutput.writeInt(block.getInt(position));
             }
         }

--- a/presto-common/src/main/java/com/facebook/presto/common/block/IntArrayBlockEncoding.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/IntArrayBlockEncoding.java
@@ -15,6 +15,7 @@ package com.facebook.presto.common.block;
 
 import io.airlift.slice.SliceInput;
 import io.airlift.slice.SliceOutput;
+import io.airlift.slice.Slices;
 
 import static com.facebook.presto.common.block.EncoderUtil.decodeNullBits;
 import static com.facebook.presto.common.block.EncoderUtil.encodeNullsAsBits;
@@ -53,9 +54,15 @@ public class IntArrayBlockEncoding
         boolean[] valueIsNull = decodeNullBits(sliceInput, positionCount).orElse(null);
 
         int[] values = new int[positionCount];
-        for (int position = 0; position < positionCount; position++) {
-            if (valueIsNull == null || !valueIsNull[position]) {
-                values[position] = sliceInput.readInt();
+        if (valueIsNull == null) {
+            // No nulls present, read values array directly from input
+            sliceInput.readBytes(Slices.wrappedIntArray(values));
+        }
+        else {
+            for (int position = 0; position < values.length; position++) {
+                if (!valueIsNull[position]) {
+                    values[position] = sliceInput.readInt();
+                }
             }
         }
 

--- a/presto-common/src/main/java/com/facebook/presto/common/block/LongArrayBlockEncoding.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/LongArrayBlockEncoding.java
@@ -15,6 +15,7 @@ package com.facebook.presto.common.block;
 
 import io.airlift.slice.SliceInput;
 import io.airlift.slice.SliceOutput;
+import io.airlift.slice.Slices;
 
 import static com.facebook.presto.common.block.EncoderUtil.decodeNullBits;
 import static com.facebook.presto.common.block.EncoderUtil.encodeNullsAsBits;
@@ -53,9 +54,15 @@ public class LongArrayBlockEncoding
         boolean[] valueIsNull = decodeNullBits(sliceInput, positionCount).orElse(null);
 
         long[] values = new long[positionCount];
-        for (int position = 0; position < positionCount; position++) {
-            if (valueIsNull == null || !valueIsNull[position]) {
-                values[position] = sliceInput.readLong();
+        if (valueIsNull == null) {
+            // No nulls present, read values array directly from input
+            sliceInput.readBytes(Slices.wrappedLongArray(values));
+        }
+        else {
+            for (int position = 0; position < values.length; position++) {
+                if (!valueIsNull[position]) {
+                    values[position] = sliceInput.readLong();
+                }
             }
         }
 

--- a/presto-common/src/main/java/com/facebook/presto/common/block/LongArrayBlockEncoding.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/LongArrayBlockEncoding.java
@@ -39,8 +39,9 @@ public class LongArrayBlockEncoding
 
         encodeNullsAsBits(sliceOutput, block);
 
+        boolean mayHaveNull = block.mayHaveNull();
         for (int position = 0; position < positionCount; position++) {
-            if (!block.isNull(position)) {
+            if (!mayHaveNull || !block.isNull(position)) {
                 sliceOutput.writeLong(block.getLong(position));
             }
         }

--- a/presto-common/src/main/java/com/facebook/presto/common/block/RowBlockEncoding.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/RowBlockEncoding.java
@@ -68,7 +68,7 @@ public class RowBlockEncoding
         int positionCount = sliceInput.readInt();
         int[] fieldBlockOffsets = new int[positionCount + 1];
         sliceInput.readBytes(wrappedIntArray(fieldBlockOffsets));
-        boolean[] rowIsNull = EncoderUtil.decodeNullBits(sliceInput, positionCount).orElseGet(() -> new boolean[positionCount]);
+        boolean[] rowIsNull = EncoderUtil.decodeNullBits(sliceInput, positionCount).orElse(null);
         return createRowBlockInternal(0, positionCount, rowIsNull, fieldBlockOffsets, fieldBlocks);
     }
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/block/ShortArrayBlockEncoding.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/ShortArrayBlockEncoding.java
@@ -39,8 +39,9 @@ public class ShortArrayBlockEncoding
 
         encodeNullsAsBits(sliceOutput, block);
 
+        boolean mayHaveNull = block.mayHaveNull();
         for (int position = 0; position < positionCount; position++) {
-            if (!block.isNull(position)) {
+            if (!mayHaveNull || !block.isNull(position)) {
                 sliceOutput.writeShort(block.getShort(position));
             }
         }

--- a/presto-common/src/main/java/com/facebook/presto/common/block/ShortArrayBlockEncoding.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/ShortArrayBlockEncoding.java
@@ -15,6 +15,7 @@ package com.facebook.presto.common.block;
 
 import io.airlift.slice.SliceInput;
 import io.airlift.slice.SliceOutput;
+import io.airlift.slice.Slices;
 
 import static com.facebook.presto.common.block.EncoderUtil.decodeNullBits;
 import static com.facebook.presto.common.block.EncoderUtil.encodeNullsAsBits;
@@ -53,9 +54,15 @@ public class ShortArrayBlockEncoding
         boolean[] valueIsNull = decodeNullBits(sliceInput, positionCount).orElse(null);
 
         short[] values = new short[positionCount];
-        for (int position = 0; position < positionCount; position++) {
-            if (valueIsNull == null || !valueIsNull[position]) {
-                values[position] = sliceInput.readShort();
+        if (valueIsNull == null) {
+            // No nulls present, read values array directly from input
+            sliceInput.readBytes(Slices.wrappedShortArray(values));
+        }
+        else {
+            for (int position = 0; position < values.length; position++) {
+                if (!valueIsNull[position]) {
+                    values[position] = sliceInput.readShort();
+                }
             }
         }
 


### PR DESCRIPTION
Improves performance of some block encodings by:
- Avoiding `valueIsNull` boolean array creation when no values are null for `ArrayBlockEncoding` and `RowBlockEncoding`
- Using `block.mayHaveNull()` to skip `block.isNull` checks for elligible block serialization logic
- Deserializing primitive value arrays via direct memory copy when no positions are null

JMH Microbenchmark Results for Pages of `(BIGINT, BOOLEAN, VARCHAR)`:
```
## Baseline
Benchmark                        (nullRate)  (pages)  (rowsPerPage)  (types)   Mode  Cnt    Score   Error  Units
BenchmarkPagesSerde.deserialize           0      100          10000    MIXED  thrpt   10  201.449 ± 2.095  ops/s
BenchmarkPagesSerde.deserialize        0.05      100          10000    MIXED  thrpt   10  146.223 ± 8.895  ops/s

## Improved
Benchmark                        (nullRate)  (pages)  (rowsPerPage)  (types)   Mode  Cnt    Score    Error  Units
BenchmarkPagesSerde.deserialize           0      100          10000    MIXED  thrpt   10  691.259 ± 38.307  ops/s
BenchmarkPagesSerde.deserialize        0.05      100          10000    MIXED  thrpt   10  200.869 ±  3.001  ops/s
```

```
== NO RELEASE NOTE ==
```
