### PR TITLE
Fix incorrect dwrf file raw size

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
@@ -477,6 +477,7 @@ public class OrcWriter
         try {
             // add stripe data
             outputData.addAll(bufferStripeData(stripeStartOffset, flushReason));
+            rawSize += stripeRawSize;
             // if the file is being closed, add the file footer
             if (flushReason == CLOSED) {
                 outputData.addAll(bufferFileFooter());
@@ -491,7 +492,6 @@ public class OrcWriter
             dictionaryCompressionOptimizer.reset();
             rowGroupRowCount = 0;
             stripeRowCount = 0;
-            rawSize += stripeRawSize;
             stripeRawSize = 0;
             bufferedBytes = toIntExact(columnWriters.stream().mapToLong(ColumnWriter::getBufferedBytes).sum());
         }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/writer/TestWriterBlockRawSize.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/writer/TestWriterBlockRawSize.java
@@ -291,7 +291,7 @@ public class TestWriterBlockRawSize
         int numBlocksPerRowGroup = 3;
         int numBlocksPerStripe = numBlocksPerRowGroup * 5;
         int numStripes = 4;
-        int numBlocksPerFile = numBlocksPerStripe * numStripes;
+        int numBlocksPerFile = numBlocksPerStripe * numStripes + 1;
 
         BlockBuilder blockBuilder = type.createBlockBuilder(null, NUM_ELEMENTS * 2);
         for (int i = 0; i < NUM_ELEMENTS; i++) {
@@ -323,10 +323,13 @@ public class TestWriterBlockRawSize
 
                 Footer footer = OrcTester.getFileMetadata(tempFile.getFile(), encoding).getFooter();
                 verifyValue(encoding, footer.getRawSize(), blockRawSize * numBlocksPerFile);
-                assertEquals(footer.getStripes().size(), numStripes);
+                assertEquals(footer.getStripes().size(), numStripes + 1);
 
+                int numBlocksRemaining = numBlocksPerFile;
                 for (StripeInformation stripeInfo : footer.getStripes()) {
-                    verifyValue(encoding, stripeInfo.getRawDataSize(), blockRawSize * numBlocksPerStripe);
+                    int numBlocksInStripe = Math.min(numBlocksRemaining, numBlocksPerStripe);
+                    verifyValue(encoding, stripeInfo.getRawDataSize(), blockRawSize * numBlocksInStripe);
+                    numBlocksRemaining -= numBlocksInStripe;
                 }
             }
         }


### PR DESCRIPTION
Dwrf file raw size is calculated incorrectly, when stripe has
outstanding rows. Last stripe raw size was not included in the
file size. 

Test plan - 
Modified the test to account for this.
Will also modify the validation service
to include this use case.

```
== NO RELEASE NOTE ==
```
