### PR TITLE
Fix coordinator - resource manager proxy communication

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/resourcemanager/DistributedQueryResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/resourcemanager/DistributedQueryResource.java
@@ -23,7 +23,6 @@ import javax.inject.Inject;
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
-import javax.ws.rs.HeaderParam;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -41,7 +40,6 @@ import java.util.Optional;
 import static com.facebook.airlift.http.client.HttpUriBuilder.uriBuilderFrom;
 import static com.facebook.presto.server.security.RoleType.ADMIN;
 import static com.facebook.presto.server.security.RoleType.USER;
-import static com.google.common.net.HttpHeaders.X_FORWARDED_PROTO;
 import static java.util.Objects.requireNonNull;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
 import static javax.ws.rs.core.Response.Status.NOT_FOUND;
@@ -84,7 +82,6 @@ public class DistributedQueryResource
     @Path("{queryId}")
     public void getQueryInfo(
             @PathParam("queryId") QueryId queryId,
-            @HeaderParam(X_FORWARDED_PROTO) String xForwardedProto,
             @Context UriInfo uriInfo,
             @Context HttpServletRequest servletRequest,
             @Suspended AsyncResponse asyncResponse)
@@ -96,7 +93,6 @@ public class DistributedQueryResource
     @Path("{queryId}")
     public void cancelQuery(
             @PathParam("queryId") QueryId queryId,
-            @HeaderParam(X_FORWARDED_PROTO) String xForwardedProto,
             @Context UriInfo uriInfo,
             @Context HttpServletRequest servletRequest,
             @Suspended AsyncResponse asyncResponse)
@@ -109,7 +105,6 @@ public class DistributedQueryResource
     public void killQuery(
             @PathParam("queryId") QueryId queryId,
             String message,
-            @HeaderParam(X_FORWARDED_PROTO) String xForwardedProto,
             @Context UriInfo uriInfo,
             @Context HttpServletRequest servletRequest,
             @Suspended AsyncResponse asyncResponse)
@@ -122,7 +117,6 @@ public class DistributedQueryResource
     public void preemptQuery(
             @PathParam("queryId") QueryId queryId,
             String message,
-            @HeaderParam(X_FORWARDED_PROTO) String xForwardedProto,
             @Context UriInfo uriInfo,
             @Context HttpServletRequest servletRequest,
             @Suspended AsyncResponse asyncResponse)

--- a/presto-main/src/main/java/com/facebook/presto/server/ClusterStatsResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ClusterStatsResource.java
@@ -47,7 +47,6 @@ import java.util.Optional;
 import static com.facebook.presto.server.security.RoleType.ADMIN;
 import static com.facebook.presto.server.security.RoleType.USER;
 import static com.google.common.base.Preconditions.checkState;
-import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.net.HttpHeaders.X_FORWARDED_PROTO;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -187,10 +186,9 @@ public class ClusterStatsResource
                 return;
             }
             InternalNode resourceManagerNode = resourceManagers.next();
-            String scheme = isNullOrEmpty(xForwardedProto) ? uriInfo.getRequestUri().getScheme() : xForwardedProto;
 
             URI uri = uriInfo.getRequestUriBuilder()
-                    .scheme(scheme)
+                    .scheme(resourceManagerNode.getInternalUri().getScheme())
                     .host(resourceManagerNode.getHostAndPort().toInetAddress().getHostName())
                     .port(resourceManagerNode.getInternalUri().getPort())
                     .build();

--- a/presto-main/src/main/java/com/facebook/presto/server/QueryResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/QueryResource.java
@@ -60,7 +60,6 @@ import static com.facebook.presto.server.security.RoleType.ADMIN;
 import static com.facebook.presto.server.security.RoleType.USER;
 import static com.google.common.base.MoreObjects.firstNonNull;
 import static com.google.common.base.Preconditions.checkState;
-import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.net.HttpHeaders.X_FORWARDED_PROTO;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -285,10 +284,9 @@ public class QueryResource
                 return;
             }
             InternalNode resourceManagerNode = resourceManagers.next();
-            String scheme = isNullOrEmpty(xForwardedProto) ? uriInfo.getRequestUri().getScheme() : xForwardedProto;
 
             URI uri = uriInfo.getRequestUriBuilder()
-                    .scheme(scheme)
+                    .scheme(resourceManagerNode.getInternalUri().getScheme())
                     .host(resourceManagerNode.getHostAndPort().toInetAddress().getHostName())
                     .port(resourceManagerNode.getInternalUri().getPort())
                     .build();

--- a/presto-main/src/main/java/com/facebook/presto/server/QueryStateInfoResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/QueryStateInfoResource.java
@@ -159,10 +159,9 @@ public class QueryStateInfoResource
                 return;
             }
             InternalNode resourceManagerNode = resourceManagers.next();
-            String scheme = isNullOrEmpty(xForwardedProto) ? uriInfo.getRequestUri().getScheme() : xForwardedProto;
 
             URI uri = uriInfo.getRequestUriBuilder()
-                    .scheme(scheme)
+                    .scheme(resourceManagerNode.getInternalUri().getScheme())
                     .host(resourceManagerNode.getHostAndPort().toInetAddress().getHostName())
                     .port(resourceManagerNode.getInternalUri().getPort())
                     .build();

--- a/presto-main/src/main/java/com/facebook/presto/server/ResourceGroupStateInfoResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ResourceGroupStateInfoResource.java
@@ -136,10 +136,9 @@ public class ResourceGroupStateInfoResource
                 return;
             }
             InternalNode resourceManagerNode = resourceManagers.next();
-            String scheme = isNullOrEmpty(xForwardedProto) ? uriInfo.getRequestUri().getScheme() : xForwardedProto;
 
             URI uri = uriInfo.getRequestUriBuilder()
-                    .scheme(scheme)
+                    .scheme(resourceManagerNode.getInternalUri().getScheme())
                     .host(resourceManagerNode.getHostAndPort().toInetAddress().getHostName())
                     .port(resourceManagerNode.getInternalUri().getPort())
                     .build();


### PR DESCRIPTION
When https communication is enabled internally between coordinator - rm,
all http requests to coordinator fails when it needs to reach out to rm for info.
Reason: Coordinator uses http schema from the request and make a call to resource mamanger on secure port.
We are fixing the behavior and always use the schema supported by resource manager.

Test plan - Verified in test cluster

```
== NO RELEASE NOTE ==
```
