### PR TITLE
Add stats for materialized view query rewrite

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/RuntimeMetricName.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/RuntimeMetricName.java
@@ -26,4 +26,5 @@ public class RuntimeMetricName
 
     public static final String DRIVER_COUNT_PER_TASK = "driverCountPerTask";
     public static final String TASK_ELAPSED_TIME_NANOS = "taskElapsedTimeNanos";
+    public static final String OPTIMIZED_WITH_MATERIALIZED_VIEW = "optimizedWithMaterializedView";
 }

--- a/presto-main/src/main/java/com/facebook/presto/Session.java
+++ b/presto-main/src/main/java/com/facebook/presto/Session.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto;
 
+import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.common.function.SqlFunctionProperties;
 import com.facebook.presto.common.type.TimeZoneKey;
 import com.facebook.presto.metadata.SessionPropertyManager;
@@ -87,6 +88,8 @@ public final class Session
     private final Map<String, String> preparedStatements;
     private final Map<SqlFunctionId, SqlInvokedFunction> sessionFunctions;
     private final AccessControlContext context;
+
+    private final RuntimeStats runtimeStats = new RuntimeStats();
 
     public Session(
             QueryId queryId,
@@ -292,6 +295,11 @@ public final class Session
     public AccessControlContext getAccessControlContext()
     {
         return context;
+    }
+
+    public RuntimeStats getRuntimeStats()
+    {
+        return runtimeStats;
     }
 
     public Session beginTransactionId(TransactionId transactionId, TransactionManager transactionManager, AccessControl accessControl)

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
@@ -472,7 +472,8 @@ public class QueryStateMachine
                 succinctBytes(getPeakTotalMemoryInBytes()),
                 succinctBytes(getPeakTaskUserMemory()),
                 succinctBytes(getPeakTaskTotalMemory()),
-                succinctBytes(getPeakNodeTotalMemory()));
+                succinctBytes(getPeakNodeTotalMemory()),
+                session.getRuntimeStats());
     }
 
     public VersionedMemoryPoolId getMemoryPool()

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryStats.java
@@ -278,7 +278,8 @@ public class QueryStats
             DataSize peakTotalMemoryReservation,
             DataSize peakTaskUserMemory,
             DataSize peakTaskTotalMemory,
-            DataSize peakNodeTotalMemory)
+            DataSize peakNodeTotalMemory,
+            RuntimeStats runtimeStats)
     {
         int totalTasks = 0;
         int runningTasks = 0;
@@ -324,7 +325,7 @@ public class QueryStats
 
         ImmutableList.Builder<OperatorStats> operatorStatsSummary = ImmutableList.builder();
         boolean completeInfo = true;
-        RuntimeStats mergedRuntimeStats = new RuntimeStats();
+        RuntimeStats mergedRuntimeStats = RuntimeStats.copyOf(runtimeStats);
         for (StageInfo stageInfo : getAllStages(rootStage)) {
             StageExecutionStats stageExecutionStats = stageInfo.getLatestAttemptExecutionInfo().getStats();
             totalTasks += stageExecutionStats.getTotalTasks();

--- a/presto-main/src/main/java/com/facebook/presto/sql/rewrite/MaterializedViewOptimizationRewriteUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/rewrite/MaterializedViewOptimizationRewriteUtils.java
@@ -28,6 +28,8 @@ import com.facebook.presto.sql.tree.Table;
 
 import java.util.Set;
 
+import static com.facebook.presto.common.RuntimeMetricName.OPTIMIZED_WITH_MATERIALIZED_VIEW;
+
 public class MaterializedViewOptimizationRewriteUtils
 {
     private MaterializedViewOptimizationRewriteUtils() {}
@@ -47,6 +49,7 @@ public class MaterializedViewOptimizationRewriteUtils
         for (QualifiedObjectName candidate : materializedViewCandidates) {
             Query optimizedQuery = getQueryWithMaterializedViewOptimization(metadata, session, sqlParser, accessControl, node, candidate);
             if (node != optimizedQuery) {
+                session.getRuntimeStats().addMetricValue(OPTIMIZED_WITH_MATERIALIZED_VIEW, 1);
                 return optimizedQuery;
             }
         }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
@@ -647,7 +647,8 @@ public class PrestoSparkQueryExecutionFactory
                 succinctBytes(peakTotalMemoryReservationInBytes),
                 succinctBytes(peakTaskUserMemoryInBytes),
                 succinctBytes(peakTaskTotalMemoryInBytes),
-                succinctBytes(peakNodeTotalMemoryInBytes));
+                succinctBytes(peakNodeTotalMemoryInBytes),
+                session.getRuntimeStats());
 
         return new QueryInfo(
                 session.getQueryId(),


### PR DESCRIPTION
Resolves #16782 

Query rewrite happens at the coordinator level. At the moment the only visible shared context within rewrite is `session`. Therefore the `RuntimeStats` is added in `session` and recorded in the rewrite class.

```
== NO RELEASE NOTE ==
```
