### PR TITLE
Handle materialized view missing too many partitions

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -196,6 +196,8 @@ public class HiveClientConfig
     private boolean executionBasedMemoryAccounting;
     private boolean enableLooseMemoryAccounting;
 
+    private int materializedViewMissingPartitionPredicateCountThreshold = 100;
+
     public int getMaxInitialSplits()
     {
         return maxInitialSplits;
@@ -1653,5 +1655,18 @@ public class HiveClientConfig
     {
         this.enableLooseMemoryAccounting = enableLooseMemoryAccounting;
         return this;
+    }
+
+    @Config("hive.materialized-view-missing-partition-predicate-count-threshold")
+    @ConfigDescription("Max number of partitions allowed for missing predicates in the materialized view for query optimization.")
+    public HiveClientConfig setMaterializedViewMissingPartitionPredicateCountThreshold(int materializedViewMissingPartitionPredicateCountThreshold)
+    {
+        this.materializedViewMissingPartitionPredicateCountThreshold = materializedViewMissingPartitionPredicateCountThreshold;
+        return this;
+    }
+
+    public int getMaterializedViewMissingPartitionPredicateCountThreshold()
+    {
+        return this.materializedViewMissingPartitionPredicateCountThreshold;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
@@ -124,6 +124,7 @@ public final class HiveSessionProperties
     public static final String PARTITION_LEASE_DURATION = "partition_lease_duration";
     public static final String CACHE_ENABLED = "cache_enabled";
     public static final String ENABLE_LOOSE_MEMORY_BASED_ACCOUNTING = "enable_loose_memory_based_accounting";
+    public static final String MATERIALIZED_VIEW_MISSING_PARTITION_PREDICATE_COUNT_THRESHOLD = "materialized_view_missing_partition_predicate_count_threshold";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -587,7 +588,12 @@ public final class HiveSessionProperties
                         ENABLE_LOOSE_MEMORY_BASED_ACCOUNTING,
                         "Enable loose memory accounting to avoid OOMing existing queries",
                         hiveClientConfig.isLooseMemoryAccountingEnabled(),
-                        false));
+                        false),
+                integerProperty(
+                        MATERIALIZED_VIEW_MISSING_PARTITION_PREDICATE_COUNT_THRESHOLD,
+                        "Max number of partitions allowed for missing predicates in the materialized view for query optimization",
+                        hiveClientConfig.getMaterializedViewMissingPartitionPredicateCountThreshold(),
+                        true));
     }
 
     public List<PropertyMetadata<?>> getSessionProperties()
@@ -1026,5 +1032,10 @@ public final class HiveSessionProperties
     public static boolean isExecutionBasedMemoryAccountingEnabled(ConnectorSession session)
     {
         return session.getProperty(ENABLE_LOOSE_MEMORY_BASED_ACCOUNTING, Boolean.class);
+    }
+
+    public static int getMaterializedViewMissingPartitionPredicateCountThreshold(ConnectorSession session)
+    {
+        return session.getProperty(MATERIALIZED_VIEW_MISSING_PARTITION_PREDICATE_COUNT_THRESHOLD, Integer.class);
     }
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveLogicalPlanner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveLogicalPlanner.java
@@ -102,6 +102,7 @@ import static com.facebook.presto.hive.HiveColumnHandle.isPushedDownSubfield;
 import static com.facebook.presto.hive.HiveMetadata.REFERENCED_MATERIALIZED_VIEWS;
 import static com.facebook.presto.hive.HiveQueryRunner.HIVE_CATALOG;
 import static com.facebook.presto.hive.HiveSessionProperties.COLLECT_COLUMN_STATISTICS_ON_WRITE;
+import static com.facebook.presto.hive.HiveSessionProperties.MATERIALIZED_VIEW_MISSING_PARTITION_PREDICATE_COUNT_THRESHOLD;
 import static com.facebook.presto.hive.HiveSessionProperties.PARQUET_DEREFERENCE_PUSHDOWN_ENABLED;
 import static com.facebook.presto.hive.HiveSessionProperties.PARTIAL_AGGREGATION_PUSHDOWN_ENABLED;
 import static com.facebook.presto.hive.HiveSessionProperties.PARTIAL_AGGREGATION_PUSHDOWN_FOR_VARIABLE_LENGTH_DATATYPES_ENABLED;
@@ -1433,6 +1434,59 @@ public class TestHiveLogicalPlanner
             assertEquals(viewTable, baseTable);
 
             assertPlan(getSession(), viewQuery, anyTree(
+                    filter("orderkey < BIGINT'10000'", PlanMatchPattern.constrainedTableScan(table, ImmutableMap.of(), ImmutableMap.of("orderkey", "orderkey")))));
+        }
+        finally {
+            queryRunner.execute("DROP MATERIALIZED VIEW IF EXISTS " + view);
+            queryRunner.execute("DROP TABLE IF EXISTS " + table);
+        }
+    }
+
+    @Test
+    public void testMaterializedTooManyMissingPartitionsMaterialized()
+    {
+        String table = "orders_partitioned_not_materialized";
+        String view = "orders_partitioned_view_not_materialized";
+
+        Session session = Session.builder(getQueryRunner().getDefaultSession())
+                .setCatalogSessionProperty(HIVE_CATALOG, MATERIALIZED_VIEW_MISSING_PARTITION_PREDICATE_COUNT_THRESHOLD, Integer.toString(2))
+                .build();
+
+        QueryRunner queryRunner = getQueryRunner();
+        try {
+            queryRunner.execute(format("CREATE TABLE %s WITH (partitioned_by = ARRAY['ds']) AS " +
+                    "SELECT orderkey, orderpriority, '2020-01-01' as ds FROM orders WHERE orderkey < 1000 " +
+                    "UNION ALL " +
+                    "SELECT orderkey, orderpriority, '2019-01-02' as ds FROM orders WHERE orderkey >= 1000 and orderkey < 2000 " +
+                    "UNION ALL " +
+                    "SELECT orderkey, orderpriority, '2019-02-02' as ds FROM orders WHERE orderkey >= 2000 and orderkey < 3000 " +
+                    "UNION ALL " +
+                    "SELECT orderkey, orderpriority, '2019-03-02' as ds FROM orders WHERE orderkey >= 3000 and orderkey < 4000 " +
+                    "UNION ALL " +
+                    "SELECT orderkey, orderpriority, '2019-04-02' as ds FROM orders WHERE orderkey >= 4000 and orderkey < 5000 " +
+                    "UNION ALL " +
+                    "SELECT orderkey, orderpriority, '2019-05-02' as ds FROM orders WHERE orderkey >= 5000 and orderkey < 6000 " +
+                    "UNION ALL " +
+                    "SELECT orderkey, orderpriority, '2019-06-02' as ds FROM orders WHERE orderkey >= 6000 and orderkey < 7000 " +
+                    "UNION ALL " +
+                    "SELECT orderkey, orderpriority, '2019-07-02' as ds FROM orders WHERE orderkey >= 7000 and orderkey < 8000 ", table));
+
+            assertUpdate(format("CREATE MATERIALIZED VIEW %s WITH (partitioned_by = ARRAY['ds']) " +
+                    "AS SELECT orderkey, orderpriority, ds FROM %s", view, table));
+            assertTrue(getQueryRunner().tableExists(getSession(), view));
+
+            assertUpdate(format("REFRESH MATERIALIZED VIEW %s WHERE ds = '2020-01-01'", view), 255);
+            assertUpdate(format("REFRESH MATERIALIZED VIEW %s WHERE ds = '2019-02-02'", view), 248);
+            assertUpdate(format("REFRESH MATERIALIZED VIEW %s WHERE ds = '2019-03-02'", view), 248);
+
+            String viewQuery = format("SELECT orderkey from %s where orderkey < 10000 ORDER BY orderkey", view);
+            String baseQuery = format("SELECT orderkey from %s where orderkey < 10000 ORDER BY orderkey", table);
+
+            MaterializedResult viewTable = computeActual(viewQuery);
+            MaterializedResult baseTable = computeActual(baseQuery);
+            assertEquals(viewTable, baseTable);
+
+            assertPlan(session, baseQuery, anyTree(
                     filter("orderkey < BIGINT'10000'", PlanMatchPattern.constrainedTableScan(table, ImmutableMap.of(), ImmutableMap.of("orderkey", "orderkey")))));
         }
         finally {

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -1343,7 +1343,7 @@ class StatementAnalyzer
                 MaterializedViewStatus materializedViewStatus)
         {
             String materializedViewCreateSql = connectorMaterializedViewDefinition.getOriginalSql();
-            if (materializedViewStatus.isNotMaterialized()) {
+            if (materializedViewStatus.isNotMaterialized() || materializedViewStatus.isTooManyPartitionsMissing()) {
                 return materializedViewCreateSql;
             }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/MaterializedViewStatus.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/MaterializedViewStatus.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import static com.facebook.presto.spi.MaterializedViewStatus.MaterializedViewState.FULLY_MATERIALIZED;
 import static com.facebook.presto.spi.MaterializedViewStatus.MaterializedViewState.NOT_MATERIALIZED;
 import static com.facebook.presto.spi.MaterializedViewStatus.MaterializedViewState.PARTIALLY_MATERIALIZED;
+import static com.facebook.presto.spi.MaterializedViewStatus.MaterializedViewState.TOO_MANY_PARTITIONS_MISSING;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
@@ -31,6 +32,7 @@ public class MaterializedViewStatus
     public enum MaterializedViewState
     {
         NOT_MATERIALIZED,
+        TOO_MANY_PARTITIONS_MISSING,
         PARTIALLY_MATERIALIZED,
         FULLY_MATERIALIZED
     }
@@ -89,6 +91,11 @@ public class MaterializedViewStatus
     public boolean isNotMaterialized()
     {
         return materializedViewState == NOT_MATERIALIZED;
+    }
+
+    public boolean isTooManyPartitionsMissing()
+    {
+        return materializedViewState == TOO_MANY_PARTITIONS_MISSING;
     }
 
     public boolean isPartiallyMaterialized()


### PR DESCRIPTION
Changes to resolve https://github.com/prestodb/presto/issues/16579

Test plan - Unit tests


```
== RELEASE NOTES ==

Hive Changes
* Add session property ``materialized-view-missing-partition-predicate-count-threshold`` and configuration property
  ``hive.materialized-view-missing-partition-predicate-count-threshold`` to set the threshold for missing predicate count, before the base table query for the missing predicates becomes too long. 
```

