### PR TITLE
Disabling flaky TestQueues test

### DIFF
--- a/presto-tests/src/test/java/com/facebook/presto/execution/TestQueues.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TestQueues.java
@@ -140,7 +140,7 @@ public class TestQueues
         waitForQueryState(queryRunner, secondDashboardQuery, RUNNING);
     }
 
-    @Test(timeOut = 60_000)
+    @Test(timeOut = 60_000, enabled = false)
     public void testExceedSoftLimits()
             throws Exception
     {


### PR DESCRIPTION
Test times out some times and causing the failure. Disabling for now to unblock master

Test plan - test disabled.

```
== NO RELEASE NOTE ==
```
