### PR TITLE
Improve performance for row and array blocks without nulls

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/block/AbstractArrayBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/AbstractArrayBlock.java
@@ -26,6 +26,7 @@ import static com.facebook.presto.common.block.BlockUtil.checkValidRegion;
 import static com.facebook.presto.common.block.BlockUtil.compactArray;
 import static com.facebook.presto.common.block.BlockUtil.compactOffsets;
 import static com.facebook.presto.common.block.BlockUtil.internalPositionInRange;
+import static com.facebook.presto.common.block.MapBlockBuilder.verify;
 
 public abstract class AbstractArrayBlock
         implements Block
@@ -36,10 +37,13 @@ public abstract class AbstractArrayBlock
 
     public abstract int getOffsetBase();
 
+    /**
+     * @return the underlying valueIsNull array, or null when all values are guaranteed to be non-null
+     */
     @Nullable
     protected abstract boolean[] getValueIsNull();
 
-    int getOffset(int position)
+    final int getOffset(int position)
     {
         return getOffsets()[position + getOffsetBase()];
     }
@@ -51,35 +55,45 @@ public abstract class AbstractArrayBlock
     }
 
     @Override
-    public Block copyPositions(int[] positions, int offset, int length)
+    public final Block copyPositions(int[] positions, int offset, int length)
     {
         checkArrayRange(positions, offset, length);
 
         int[] newOffsets = new int[length + 1];
-        boolean[] newValueIsNull = new boolean[length];
-
-        IntArrayList valuesPositions = new IntArrayList();
-        int newPosition = 0;
-        for (int i = offset; i < offset + length; ++i) {
-            int position = positions[i];
+        boolean[] newValueIsNull = mayHaveNull() ? new boolean[length] : null;
+        // First traversal will populate newValueIsNull mask (if present) and
+        // newOffsets to determine the total number of value positions involved
+        for (int i = 0; i < length; i++) {
+            int position = positions[i + offset];
+            newOffsets[i + 1] = newOffsets[i] + (getOffset(position + 1) - getOffset(position));
             if (isNull(position)) {
-                newValueIsNull[newPosition] = true;
-                newOffsets[newPosition + 1] = newOffsets[newPosition];
+                // newValueIsNull will be present unless mayHaveNull() and isNull() implementations are inconsistent
+                newValueIsNull[i] = true;
             }
-            else {
-                int valuesStartOffset = getOffset(position);
-                int valuesEndOffset = getOffset(position + 1);
-                int valuesLength = valuesEndOffset - valuesStartOffset;
+        }
 
-                newOffsets[newPosition + 1] = newOffsets[newPosition] + valuesLength;
+        int totalElements = newOffsets[length];
+        if (totalElements == 0) {
+            // No elements selected
+            Block newValues = getRawElementBlock().copyRegion(getOffsetBase(), 0);
+            return createArrayBlockInternal(0, length, newValueIsNull, newOffsets, newValues);
+        }
 
-                for (int elementIndex = valuesStartOffset; elementIndex < valuesEndOffset; elementIndex++) {
-                    valuesPositions.add(elementIndex);
+        // Second traversal will use the newOffsets and total element positions to
+        // populate a correctly sized values position selection array
+        int[] elementPositions = new int[totalElements];
+        int currentOffset = 0;
+        for (int i = 0; i < length; i++) {
+            int elementsLength = newOffsets[i + 1] - newOffsets[i];
+            if (elementsLength > 0) {
+                int valuesStartOffset = getOffset(positions[i + offset]);
+                for (int j = 0; j < elementsLength; j++) {
+                    elementPositions[currentOffset++] = valuesStartOffset + j;
                 }
             }
-            newPosition++;
         }
-        Block newValues = getRawElementBlock().copyPositions(valuesPositions.elements(), 0, valuesPositions.size());
+        verify(currentOffset == elementPositions.length, "unexpected element positions");
+        Block newValues = getRawElementBlock().copyPositions(elementPositions, 0, elementPositions.length);
         return createArrayBlockInternal(0, length, newValueIsNull, newOffsets, newValues);
     }
 
@@ -220,7 +234,7 @@ public abstract class AbstractArrayBlock
         return createArrayBlockInternal(
                 0,
                 1,
-                new boolean[] {isNull(position)},
+                isNull(position) ? new boolean[] {true} : null,
                 new int[] {0, valueLength},
                 newValues);
     }
@@ -251,14 +265,6 @@ public abstract class AbstractArrayBlock
         return getValueIsNull() != null;
     }
 
-    @Override
-    public boolean isNull(int position)
-    {
-        checkReadablePosition(position);
-        boolean[] valueIsNull = getValueIsNull();
-        return valueIsNull == null ? false : valueIsNull[position + getOffsetBase()];
-    }
-
     public <T> T apply(ArrayBlockFunction<T> function, int position)
     {
         checkReadablePosition(position);
@@ -268,7 +274,7 @@ public abstract class AbstractArrayBlock
         return function.apply(getRawElementBlock(), startValueOffset, endValueOffset - startValueOffset);
     }
 
-    private void checkReadablePosition(int position)
+    protected final void checkReadablePosition(int position)
     {
         if (position < 0 || position >= getPositionCount()) {
             throw new IllegalArgumentException("position is not valid");

--- a/presto-common/src/main/java/com/facebook/presto/common/block/ArrayBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/ArrayBlock.java
@@ -43,9 +43,10 @@ public class ArrayBlock
      * Create an array block directly from columnar nulls, values, and offsets into the values.
      * A null array must have no entries.
      */
-    public static Block fromElementBlock(int positionCount, Optional<boolean[]> valueIsNull, int[] arrayOffset, Block values)
+    public static Block fromElementBlock(int positionCount, Optional<boolean[]> valueIsNullOptional, int[] arrayOffset, Block values)
     {
-        validateConstructorArguments(0, positionCount, valueIsNull.orElse(null), arrayOffset, values);
+        boolean[] valueIsNull = valueIsNullOptional.orElse(null);
+        validateConstructorArguments(0, positionCount, valueIsNull, arrayOffset, values);
         // for performance reasons per element checks are only performed on the public construction
         for (int i = 0; i < positionCount; i++) {
             int offset = arrayOffset[i];
@@ -53,11 +54,11 @@ public class ArrayBlock
             if (length < 0) {
                 throw new IllegalArgumentException(format("Offset is not monotonically ascending. offsets[%s]=%s, offsets[%s]=%s", i, arrayOffset[i], i + 1, arrayOffset[i + 1]));
             }
-            if (valueIsNull.isPresent() && valueIsNull.get()[i] && length != 0) {
+            if (valueIsNull != null && valueIsNull[i] && length != 0) {
                 throw new IllegalArgumentException("A null array must have zero entries");
             }
         }
-        return new ArrayBlock(0, positionCount, valueIsNull.orElse(null), arrayOffset, values);
+        return new ArrayBlock(0, positionCount, valueIsNull, arrayOffset, values);
     }
 
     /**
@@ -185,6 +186,19 @@ public class ArrayBlock
     protected boolean[] getValueIsNull()
     {
         return valueIsNull;
+    }
+
+    @Override
+    public boolean mayHaveNull()
+    {
+        return valueIsNull != null;
+    }
+
+    @Override
+    public boolean isNull(int position)
+    {
+        checkReadablePosition(position);
+        return valueIsNull != null && valueIsNull[position + arrayOffset];
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/block/ArrayBlockBuilder.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/ArrayBlockBuilder.java
@@ -135,10 +135,24 @@ public class ArrayBlockBuilder
         return 0;
     }
 
+    @Nullable
     @Override
     protected boolean[] getValueIsNull()
     {
-        return valueIsNull;
+        return hasNullValue ? valueIsNull : null;
+    }
+
+    @Override
+    public boolean mayHaveNull()
+    {
+        return hasNullValue;
+    }
+
+    @Override
+    public boolean isNull(int position)
+    {
+        checkReadablePosition(position);
+        return hasNullValue && valueIsNull[position];
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/block/RowBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/RowBlock.java
@@ -57,9 +57,16 @@ public class RowBlock
         }
         else {
             // Check for nulls when computing field block offsets
-            fieldBlockOffsets[0] = 0;
+            int currentOffset = 0;
             for (int position = 0; position < positionCount; position++) {
-                fieldBlockOffsets[position + 1] = fieldBlockOffsets[position] + (rowIsNull[position] ? 0 : 1);
+                fieldBlockOffsets[position] = currentOffset;
+                currentOffset += (rowIsNull[position] ? 0 : 1);
+            }
+            // fieldBlockOffsets is positionCount + 1 in length
+            fieldBlockOffsets[positionCount] = currentOffset;
+            if (currentOffset == positionCount) {
+                // No nulls encountered, discard the null mask
+                rowIsNull = null;
             }
         }
 

--- a/presto-common/src/main/java/com/facebook/presto/common/block/RowBlockBuilder.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/RowBlockBuilder.java
@@ -43,6 +43,7 @@ public class RowBlockBuilder
     private int positionCount;
     private int[] fieldBlockOffsets;
     private boolean[] rowIsNull;
+    private boolean hasNullRow;
     private final BlockBuilder[] fieldBlockBuilders;
 
     private boolean currentEntryOpened;
@@ -95,10 +96,24 @@ public class RowBlockBuilder
         return 0;
     }
 
+    @Nullable
     @Override
     protected boolean[] getRowIsNull()
     {
-        return rowIsNull;
+        return hasNullRow ? rowIsNull : null;
+    }
+
+    @Override
+    public boolean mayHaveNull()
+    {
+        return hasNullRow;
+    }
+
+    @Override
+    public boolean isNull(int position)
+    {
+        checkReadablePosition(position);
+        return hasNullRow && rowIsNull[position];
     }
 
     @Override
@@ -205,6 +220,7 @@ public class RowBlockBuilder
             fieldBlockOffsets[positionCount + 1] = fieldBlockOffsets[positionCount] + 1;
         }
         rowIsNull[positionCount] = isNull;
+        hasNullRow |= isNull;
         positionCount++;
 
         for (int i = 0; i < numFields; i++) {
@@ -228,7 +244,7 @@ public class RowBlockBuilder
         for (int i = 0; i < numFields; i++) {
             fieldBlocks[i] = fieldBlockBuilders[i].build();
         }
-        return createRowBlockInternal(0, positionCount, rowIsNull, fieldBlockOffsets, fieldBlocks);
+        return createRowBlockInternal(0, positionCount, hasNullRow ? rowIsNull : null, fieldBlockOffsets, fieldBlocks);
     }
 
     @Override

--- a/presto-main/src/test/java/com/facebook/presto/block/TestRowBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestRowBlock.java
@@ -25,6 +25,7 @@ import it.unimi.dsi.fastutil.ints.IntArrayList;
 import org.testng.annotations.Test;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -72,6 +73,29 @@ public class TestRowBlock
             assertEquals(blockBuilder.getEstimatedDataSizeForStats(i), expectedSize);
             assertEquals(block.getEstimatedDataSizeForStats(i), expectedSize);
         }
+    }
+
+    @Test
+    public void testFromFieldBlocksNoNullsDetection()
+    {
+        Block emptyBlock = new ByteArrayBlock(0, Optional.empty(), new byte[0]);
+        Block fieldBlock = new ByteArrayBlock(5, Optional.empty(), createExpectedValue(5).getBytes());
+
+        boolean[] rowIsNull = new boolean[fieldBlock.getPositionCount()];
+        Arrays.fill(rowIsNull, false);
+
+        // Blocks may discard the null mask during creation if no values are null
+        assertFalse(fromFieldBlocks(5, Optional.of(rowIsNull), new Block[]{fieldBlock}).mayHaveNull());
+        // Last position is null must retain the nulls mask
+        rowIsNull[rowIsNull.length - 1] = true;
+        assertTrue(fromFieldBlocks(5, Optional.of(rowIsNull), new Block[]{fieldBlock}).mayHaveNull());
+        // Empty blocks have no nulls and can also discard their null mask
+        assertFalse(fromFieldBlocks(0, Optional.of(new boolean[0]), new Block[]{emptyBlock}).mayHaveNull());
+
+        // Normal blocks should have null masks preserved
+        List<Type> fieldTypes = ImmutableList.of(VARCHAR, BIGINT);
+        Block hasNullsBlock = createBlockBuilderWithValues(fieldTypes, alternatingNullValues(generateTestRows(fieldTypes, 100))).build();
+        assertTrue(hasNullsBlock.mayHaveNull());
     }
 
     private int getExpectedEstimatedDataSize(List<Object> row)

--- a/presto-main/src/test/java/com/facebook/presto/block/TestRowBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestRowBlock.java
@@ -241,7 +241,7 @@ public class TestRowBlock
         // null rows are handled by assertPositionValue
         requireNonNull(row, "row is null");
 
-        assertFalse(rowBlock.isNullUnchecked(internalPosition));
+        assertFalse(rowBlock.mayHaveNull() && rowBlock.isNullUnchecked(internalPosition));
         SingleRowBlock singleRowBlock = (SingleRowBlock) rowBlock.getBlockUnchecked(internalPosition);
         assertEquals(singleRowBlock.getPositionCount(), row.size());
 


### PR DESCRIPTION
BenchmarkBlocks.benchmarkCopyPositions result summary for `ARRAY(ARRAY(BIGINT))` (full results of the latest iteration available at [jmh.morethan.io](https://jmh.morethan.io/?sources=https://gist.githubusercontent.com/pettyjamesm/816ad333656bab1cce4d9cb572f1b467/raw/1facbc25334162782bf7f013d2a042bee059486c/baseline_blocks.json,https://gist.githubusercontent.com/pettyjamesm/816ad333656bab1cce4d9cb572f1b467/raw/077dd152d3daebe49e62cf583e7c542b14535df6/improved_blocks_v2.json))

BEFORE
```
Benchmark                               (encodings)  (nestedNullRate)  (positionCount)  (primitiveNullRate)       (typeSignature)  (useBlockView)  Mode  Cnt      Score     Error  Units
BenchmarkBlocks.benchmarkCopyPositions         NONE              0.0f              256                 0.0f  ARRAY(ARRAY(BIGINT))            true  avgt    8  21687.932 ± 330.720  ns/op
BenchmarkBlocks.benchmarkCopyPositions         NONE              0.0f              256                 0.5f  ARRAY(ARRAY(BIGINT))            true  avgt    8  22573.464 ± 137.285  ns/op
BenchmarkBlocks.benchmarkCopyPositions         NONE             0.25f              256                 0.0f  ARRAY(ARRAY(BIGINT))            true  avgt    8  13351.485 ±  59.630  ns/op
BenchmarkBlocks.benchmarkCopyPositions         NONE             0.25f              256                 0.5f  ARRAY(ARRAY(BIGINT))            true  avgt    8  14558.172 ± 409.044  ns/op
BenchmarkBlocks.benchmarkCopyPositions         NONE              0.5f              256                 0.0f  ARRAY(ARRAY(BIGINT))            true  avgt    8   9559.983 ± 239.692  ns/op
BenchmarkBlocks.benchmarkCopyPositions         NONE              0.5f              256                 0.5f  ARRAY(ARRAY(BIGINT))            true  avgt    8   8485.457 ±  40.062  ns/op
BenchmarkBlocks.benchmarkCopyPositions         NONE             0.75f              256                 0.0f  ARRAY(ARRAY(BIGINT))            true  avgt    8   4256.374 ± 137.984  ns/op
BenchmarkBlocks.benchmarkCopyPositions         NONE             0.75f              256                 0.5f  ARRAY(ARRAY(BIGINT))            true  avgt    8   4110.957 ± 110.467  ns/op
```

AFTER
```
Benchmark                               (encodings)  (nestedNullRate)  (positionCount)  (primitiveNullRate)       (typeSignature)  (useBlockView)  Mode  Cnt      Score     Error  Units
BenchmarkBlocks.benchmarkCopyPositions         NONE              0.0f              256                 0.0f  ARRAY(ARRAY(BIGINT))            true  avgt    8  11823.971 ±  47.903  ns/op
BenchmarkBlocks.benchmarkCopyPositions         NONE              0.0f              256                 0.5f  ARRAY(ARRAY(BIGINT))            true  avgt    8  13759.607 ±  93.183  ns/op
BenchmarkBlocks.benchmarkCopyPositions         NONE             0.25f              256                 0.0f  ARRAY(ARRAY(BIGINT))            true  avgt    8   8674.597 ±  51.881  ns/op
BenchmarkBlocks.benchmarkCopyPositions         NONE             0.25f              256                 0.5f  ARRAY(ARRAY(BIGINT))            true  avgt    8   9391.782 ±  38.823  ns/op
BenchmarkBlocks.benchmarkCopyPositions         NONE              0.5f              256                 0.0f  ARRAY(ARRAY(BIGINT))            true  avgt    8   5687.830 ±  42.380  ns/op
BenchmarkBlocks.benchmarkCopyPositions         NONE              0.5f              256                 0.5f  ARRAY(ARRAY(BIGINT))            true  avgt    8   6138.722 ± 163.047  ns/op
BenchmarkBlocks.benchmarkCopyPositions         NONE             0.75f              256                 0.0f  ARRAY(ARRAY(BIGINT))            true  avgt    8   2438.037 ±  68.450  ns/op
BenchmarkBlocks.benchmarkCopyPositions         NONE             0.75f              256                 0.5f  ARRAY(ARRAY(BIGINT))            true  avgt    8   2568.161 ±  74.092  ns/op
```

```
== NO RELEASE NOTE ==
```
