### PR TITLE
Add murmur3_x64_128 UDF

### DIFF
--- a/presto-docs/src/main/sphinx/functions/binary.rst
+++ b/presto-docs/src/main/sphinx/functions/binary.rst
@@ -118,6 +118,10 @@ Binary Functions
 
     Computes the md5 hash of ``binary``.
 
+.. function:: murmur3_x64_128(binary) -> varbinary
+
+    Computes a hash of ``binary`` that is equivalent to C++ MurmurHash3_x64_128 (Murmur3F) of the same ``binary``.
+
 .. function:: sha1(binary) -> varbinary
 
     Computes the sha1 hash of ``binary``.

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/VarbinaryFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/VarbinaryFunctions.java
@@ -252,6 +252,14 @@ public final class VarbinaryFunctions
         return computeHash(Hashing.md5(), slice);
     }
 
+    @Description("compute a hash equivalent to MurmurHash3_x64_128 (Murmur3F) in C++")
+    @ScalarFunction("murmur3_x64_128")
+    @SqlType(StandardTypes.VARBINARY)
+    public static Slice murmur3X64128(@SqlType(StandardTypes.VARBINARY) Slice slice)
+    {
+        return computeHash(Hashing.murmur3_128(), slice);
+    }
+
     @Description("compute sha1 hash")
     @ScalarFunction
     @SqlType(StandardTypes.VARBINARY)

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestVarbinaryFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestVarbinaryFunctions.java
@@ -305,6 +305,13 @@ public class TestVarbinaryFunctions
     }
 
     @Test
+    public void testMurmur3()
+    {
+        assertFunction("murmur3_x64_128(CAST('' AS VARBINARY))", VARBINARY, sqlVarbinaryHex("00000000000000000000000000000000"));
+        assertFunction("murmur3_x64_128(CAST('hashme' AS VARBINARY))", VARBINARY, sqlVarbinaryHex("93192FE805BE23041C8318F67EC4F2BC"));
+    }
+
+    @Test
     public void testSha1()
     {
         assertFunction("sha1(CAST('' AS VARBINARY))", VARBINARY, sqlVarbinaryHex("DA39A3EE5E6B4B0D3255BFEF95601890AFD80709"));


### PR DESCRIPTION
Add `murmur3_x64_128` UDF


Test plan -  Unit tests

```
== RELEASE NOTES ==

General Changes
* Add :func:`murmur3_x64_128` UDF that computes a hash equivalent to MurmurHash3_x64_128 (Murmur3F) in C++

```
