### PR TITLE
Simplify SqlInvokedScalarFunction

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/annotations/SqlInvokedScalarFromAnnotationsParser.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/annotations/SqlInvokedScalarFromAnnotationsParser.java
@@ -103,8 +103,8 @@ public final class SqlInvokedScalarFromAnnotationsParser
     {
         Set<Method> methods = findPublicStaticMethods(
                 clazz,
-                ImmutableSet.of(SqlInvokedScalarFunction.class, SqlType.class, SqlParameter.class, SqlParameters.class, Description.class),
-                ImmutableSet.of(ScalarFunction.class, ScalarOperator.class, CodegenScalarFunction.class));
+                ImmutableSet.of(SqlInvokedScalarFunction.class),
+                ImmutableSet.of());
         for (Method method : methods) {
             checkCondition(
                     method.isAnnotationPresent(SqlInvokedScalarFunction.class) && method.isAnnotationPresent(SqlType.class),


### PR DESCRIPTION
Simplify SqlInvokedScalarFunction annotation parser

We only need to look at functions tagged with @SqlInvokedScalarFunction and assert they have @SqlType on them. Previous method did overcomplicated check that it has @SqlInvokedScalarFunction OR @SqlType and must not be @ScalarFunction etc.


== NO RELEASE NOTE ==
```
