### PR TITLE
Handle Identifiers within different nodes

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewQueryOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewQueryOptimizer.java
@@ -42,8 +42,6 @@ import com.facebook.presto.sql.tree.FunctionCall;
 import com.facebook.presto.sql.tree.GroupBy;
 import com.facebook.presto.sql.tree.GroupingElement;
 import com.facebook.presto.sql.tree.Identifier;
-import com.facebook.presto.sql.tree.IfExpression;
-import com.facebook.presto.sql.tree.InPredicate;
 import com.facebook.presto.sql.tree.LogicalBinaryExpression;
 import com.facebook.presto.sql.tree.Node;
 import com.facebook.presto.sql.tree.OrderBy;
@@ -141,26 +139,11 @@ public class MaterializedViewQueryOptimizer
     }
 
     @Override
-    protected Node visitInPredicate(InPredicate node, Void context)
-    {
-        process(node.getValue(), context);
-        return node;
-    }
-
-    @Override
-    protected Node visitIfExpression(IfExpression node, Void context)
-    {
-        process(node.getCondition());
-        process(node.getTrueValue());
-        if (node.getFalseValue().isPresent()) {
-            process((node.getFalseValue().get()));
-        }
-        return node;
-    }
-
-    @Override
     protected Node visitNode(Node node, Void context)
     {
+        for (Node child : node.getChildren()) {
+            process(child, context);
+        }
         return node;
     }
 


### PR DESCRIPTION
Previously we found an issue that, if an identifier is present in a node that the optimizer cannot handle, it can bypass the check even it may not be included in the materialized view.

For example:
```SQL
-- Materialized View definition
CREATE MATERIALIZED VIEW mv
SELECT a, b, c FROM base;

-- The following query is able to pass the check simply because the optimizer doesn't process the 
-- nodes like InPredicate, IfPredicate, etc. (the optimizer just returns them directly).
SELECT a, b, c FROM base WHERE x IN (1, 2) AND IF(y > 0, 1, 0) = 1 AND NOT(z IS NULL);
```

The [commit](https://github.com/prestodb/presto/commit/2d0e848bc7fa4f5eb12c87b8d57c4faf5ace0941) was submitted to process identifiers inside `IF` and `IN`, but was not sufficient. There are so many more nodes like `NotExpression` and `IsNullPredicate` where uncovered identifiers can hide.

Therefore, instead of process these nodes case by case, let's make it simple: if a node is not handled explicitly by the optimizer, then the optimizer should at least visit its children.

```
== NO RELEASE NOTE ==
```
