### PR TITLE
Change System.currentTimeMillis() to System.nanoTime() in SimpleTracer

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/tracing/SimpleTracerBlock.java
+++ b/presto-main/src/main/java/com/facebook/presto/tracing/SimpleTracerBlock.java
@@ -21,7 +21,7 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 public class SimpleTracerBlock
 {
     private final List<SimpleTracerPoint> points = new CopyOnWriteArrayList<>();
-    private final long startTime = System.currentTimeMillis();
+    private final long startTime = System.nanoTime();
     private long endTime;
 
     public SimpleTracerBlock(String annotation)
@@ -36,7 +36,7 @@ public class SimpleTracerBlock
 
     public void end(String annotation)
     {
-        endTime = System.currentTimeMillis();
+        endTime = System.nanoTime();
         if (startTime > endTime) {
             throw new RuntimeException("Block start time " + startTime + " is greater than end time " + endTime);
         }

--- a/presto-main/src/main/java/com/facebook/presto/tracing/SimpleTracerPoint.java
+++ b/presto-main/src/main/java/com/facebook/presto/tracing/SimpleTracerPoint.java
@@ -19,7 +19,7 @@ import static java.util.Objects.requireNonNull;
 public class SimpleTracerPoint
 {
     private final String annotation;
-    private final long time = System.currentTimeMillis();
+    private final long time = System.nanoTime();
 
     public SimpleTracerPoint(String annotation)
     {


### PR DESCRIPTION
System.currentTimeMillis() is the current wall clock time, and importantly for the purposes of tracing: is not monotonic. That means that things like an NTP update or daylight savings time on the host clock can skew measured time. Prefer System.nanoTime() instead which is monotonic (but might return negative values, so System.nanoTime() - startTime is the preferred way to determine elapsed time).

```
== NO RELEASE NOTE ==
```
