### PR TITLE
Move Bootstrap to presto-main

### DIFF
--- a/presto-bytecode/src/main/java/com/facebook/presto/bytecode/BytecodeUtils.java
+++ b/presto-bytecode/src/main/java/com/facebook/presto/bytecode/BytecodeUtils.java
@@ -16,18 +16,11 @@ package com.facebook.presto.bytecode;
 import com.google.common.base.CharMatcher;
 
 import java.io.StringWriter;
-import java.lang.invoke.CallSite;
-import java.lang.invoke.ConstantCallSite;
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
-import java.lang.reflect.Method;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static java.time.ZoneOffset.UTC;
 
 public final class BytecodeUtils
@@ -65,33 +58,5 @@ public final class BytecodeUtils
         StringWriter writer = new StringWriter();
         new DumpBytecodeVisitor(writer).visitClass(classDefinition);
         return writer.toString();
-    }
-
-    public static final class Bootstrap
-    {
-        public static final Method BOOTSTRAP_METHOD;
-
-        static {
-            try {
-                BOOTSTRAP_METHOD = Bootstrap.class.getMethod("bootstrap", MethodHandles.Lookup.class, String.class, MethodType.class, long.class);
-            }
-            catch (NoSuchMethodException e) {
-                throw new AssertionError(e);
-            }
-        }
-
-        private Bootstrap() {}
-
-        public static CallSite bootstrap(MethodHandles.Lookup callerLookup, String name, MethodType type, long bindingId)
-        {
-            ClassLoader classLoader = callerLookup.lookupClass().getClassLoader();
-            checkArgument(classLoader instanceof DynamicClassLoader, "Expected %s's classloader to be of type %s", callerLookup.lookupClass().getName(), DynamicClassLoader.class.getName());
-
-            DynamicClassLoader dynamicClassLoader = (DynamicClassLoader) classLoader;
-            MethodHandle target = dynamicClassLoader.getCallSiteBindings().get(bindingId);
-            checkArgument(target != null, "Binding %s for function %s%s not found", bindingId, name, type.parameterList());
-
-            return new ConstantCallSite(target);
-        }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AccumulatorCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AccumulatorCompiler.java
@@ -54,7 +54,6 @@ import static com.facebook.presto.bytecode.Access.FINAL;
 import static com.facebook.presto.bytecode.Access.PRIVATE;
 import static com.facebook.presto.bytecode.Access.PUBLIC;
 import static com.facebook.presto.bytecode.Access.a;
-import static com.facebook.presto.bytecode.BytecodeUtils.Bootstrap.BOOTSTRAP_METHOD;
 import static com.facebook.presto.bytecode.Parameter.arg;
 import static com.facebook.presto.bytecode.ParameterizedType.type;
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.and;
@@ -67,6 +66,7 @@ import static com.facebook.presto.bytecode.expression.BytecodeExpressions.invoke
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.not;
 import static com.facebook.presto.operator.aggregation.AggregationMetadata.ParameterMetadata;
 import static com.facebook.presto.operator.aggregation.AggregationMetadata.countInputChannels;
+import static com.facebook.presto.sql.gen.Bootstrap.BOOTSTRAP_METHOD;
 import static com.facebook.presto.sql.gen.BytecodeUtils.invoke;
 import static com.facebook.presto.sql.gen.SqlTypeBytecodeExpression.constantType;
 import static com.facebook.presto.util.CompilerUtils.defineClass;

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/Bootstrap.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/Bootstrap.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.gen;
+
+import com.facebook.presto.bytecode.DynamicClassLoader;
+
+import java.lang.invoke.CallSite;
+import java.lang.invoke.ConstantCallSite;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.reflect.Method;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+public final class Bootstrap
+{
+    public static final Method BOOTSTRAP_METHOD;
+
+    static {
+        try {
+            BOOTSTRAP_METHOD = Bootstrap.class.getMethod("bootstrap", MethodHandles.Lookup.class, String.class, MethodType.class, long.class);
+        }
+        catch (NoSuchMethodException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    private Bootstrap() {}
+
+    public static CallSite bootstrap(MethodHandles.Lookup callerLookup, String name, MethodType type, long bindingId)
+    {
+        ClassLoader classLoader = callerLookup.lookupClass().getClassLoader();
+        checkArgument(classLoader instanceof DynamicClassLoader, "Expected %s's classloader to be of type %s", callerLookup.lookupClass().getName(), DynamicClassLoader.class.getName());
+
+        DynamicClassLoader dynamicClassLoader = (DynamicClassLoader) classLoader;
+        MethodHandle target = dynamicClassLoader.getCallSiteBindings().get(bindingId);
+        checkArgument(target != null, "Binding %s for function %s%s not found", bindingId, name, type.parameterList());
+
+        return new ConstantCallSite(target);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/BytecodeUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/BytecodeUtils.java
@@ -42,13 +42,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import static com.facebook.presto.bytecode.BytecodeUtils.Bootstrap.BOOTSTRAP_METHOD;
 import static com.facebook.presto.bytecode.OpCode.NOP;
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.constantFalse;
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.constantTrue;
 import static com.facebook.presto.bytecode.expression.BytecodeExpressions.invokeDynamic;
 import static com.facebook.presto.operator.scalar.BuiltInScalarFunctionImplementation.ArgumentType.VALUE_TYPE;
 import static com.facebook.presto.operator.scalar.BuiltInScalarFunctionImplementation.ReturnPlaceConvention.PROVIDED_BLOCKBUILDER;
+import static com.facebook.presto.sql.gen.Bootstrap.BOOTSTRAP_METHOD;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static java.lang.String.format;

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/SqlTypeBytecodeExpression.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/SqlTypeBytecodeExpression.java
@@ -20,7 +20,7 @@ import com.facebook.presto.common.type.Type;
 
 import java.lang.reflect.Method;
 
-import static com.facebook.presto.bytecode.BytecodeUtils.Bootstrap.BOOTSTRAP_METHOD;
+import static com.facebook.presto.sql.gen.Bootstrap.BOOTSTRAP_METHOD;
 import static java.util.Objects.requireNonNull;
 
 public class SqlTypeBytecodeExpression


### PR DESCRIPTION
Move Bootstrap to presto-main, as currently no plugins can use it due to classloader isolation

```
== NO RELEASE NOTE ==
```
