### PR TITLE
Fix IpAddressType.compareTo

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/type/IpAddressType.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/IpAddressType.java
@@ -33,6 +33,7 @@ import java.net.UnknownHostException;
 import static com.facebook.presto.common.block.Int128ArrayBlock.INT128_BYTES;
 import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
+import static java.lang.Long.reverseBytes;
 
 public class IpAddressType
         extends AbstractType
@@ -100,13 +101,11 @@ public class IpAddressType
     @Override
     public int compareTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
     {
-        // compare high order bits
-        int compare = Long.compare(leftBlock.getLong(leftPosition, SIZE_OF_LONG), rightBlock.getLong(rightPosition, SIZE_OF_LONG));
+        int compare = Long.compareUnsigned(reverseBytes(leftBlock.getLong(leftPosition, 0)), reverseBytes(rightBlock.getLong(rightPosition, 0)));
         if (compare != 0) {
             return compare;
         }
-        // compare low order bits
-        return Long.compare(leftBlock.getLong(leftPosition, 0), rightBlock.getLong(rightPosition, 0));
+        return Long.compareUnsigned(reverseBytes(leftBlock.getLong(leftPosition, SIZE_OF_LONG)), reverseBytes(rightBlock.getLong(rightPosition, SIZE_OF_LONG)));
     }
 
     @Override

--- a/presto-main/src/test/java/com/facebook/presto/type/TestIpAddressType.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestIpAddressType.java
@@ -21,7 +21,6 @@ import io.airlift.slice.Slices;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.type.IpAddressType.IPADDRESS;
-import static com.google.common.base.Preconditions.checkState;
 import static org.testng.Assert.assertEquals;
 
 public class TestIpAddressType
@@ -52,7 +51,8 @@ public class TestIpAddressType
     protected Object getGreaterValue(Object value)
     {
         byte[] address = ((Slice) value).getBytes();
-        checkState(++address[address.length - 1] != 0, "Last byte of address is 0xff");
+        address[0] = (byte) 0xff;
+        address[15] = (byte) 0x0;
         return Slices.wrappedBuffer(address);
     }
 


### PR DESCRIPTION
Test plan - unit test

Fixes #16830

```
== RELEASE NOTES ==

General Changes
* Fix an issue where queries ORDER BY IPADDRESS would give wrong results.
```