### PR TITLE
Expose more counters for coordinator

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/RuntimeMetricName.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/RuntimeMetricName.java
@@ -29,4 +29,12 @@ public class RuntimeMetricName
     public static final String OPTIMIZED_WITH_MATERIALIZED_VIEW = "optimizedWithMaterializedView";
     public static final String FRAGMENT_RESULT_CACHE_HIT = "fragmentResultCacheHitCount";
     public static final String FRAGMENT_RESULT_CACHE_MISS = "fragmentResultCacheMissCount";
+    public static final String GET_VIEW_TIME_NANOS = "getViewTimeNanos";
+    public static final String GET_MATERIALIZED_VIEW_TIME_NANOS = "getMaterializedViewTimeNanos";
+    public static final String GET_TABLE_HANDLE_TIME_NANOS = "getTableHandleTimeNanos";
+    public static final String GET_TABLE_METADATA_TIME_NANOS = "getTableMetadataTimeNanos";
+    public static final String GET_SPLITS_TIME_NANOS = "getSplitsTimeNanos";
+    public static final String LOGICAL_PLANNER_TIME_NANOS = "logicalPlannerTimeNanos";
+    public static final String FRAGMENT_PLAN_TIME_NANOS = "fragmentPlanTimeNanos";
+    public static final String GET_LAYOUT_TIME_NANOS = "getLayoutTimeNanos";
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/RuntimeStats.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/RuntimeStats.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.function.Supplier;
 
 import static java.util.Objects.requireNonNull;
 
@@ -112,5 +113,13 @@ public class RuntimeStats
             return;
         }
         stats.getMetrics().forEach((name, newMetric) -> metrics.computeIfAbsent(name, RuntimeMetric::new).set(newMetric));
+    }
+
+    public <V> V profileNanos(String tag, Supplier<V> supplier)
+    {
+        long startTime = System.nanoTime();
+        V result = supplier.get();
+        addMetricValue(tag, System.nanoTime() - startTime);
+        return result;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -211,6 +211,7 @@ public final class SystemSessionProperties
     public static final String HEAP_DUMP_ON_EXCEEDED_MEMORY_LIMIT_ENABLED = "heap_dump_on_exceeded_memory_limit_enabled";
     public static final String EXCEEDED_MEMORY_LIMIT_HEAP_DUMP_FILE_DIRECTORY = "exceeded_memory_limit_heap_dump_file_directory";
     public static final String ENABLE_DISTRIBUTED_TRACING = "enable_distributed_tracing";
+    public static final String VERBOSE_RUNTIME_STATS_ENABLED = "verbose_runtime_stats_enabled";
 
     //TODO: Prestissimo related session properties that are temporarily put here. They will be relocated in the future
     public static final String PRESTISSIMO_SIMPLIFIED_EXPRESSION_EVALUATION_ENABLED = "simplified_expression_evaluation_enabled";
@@ -1116,6 +1117,11 @@ public final class SystemSessionProperties
                         "Enable distributed tracing of the query",
                         tracingConfig.getEnableDistributedTracing(),
                         false),
+                booleanProperty(
+                        VERBOSE_RUNTIME_STATS_ENABLED,
+                        "Enable logging all runtime stats",
+                        featuresConfig.isVerboseRuntimeStatsEnabled(),
+                        false),
                 new PropertyMetadata<>(
                         AGGREGATION_IF_TO_FILTER_REWRITE_STRATEGY,
                         format("Set the strategy used to rewrite AGG IF to AGG FILTER. Options are %s",
@@ -1938,6 +1944,11 @@ public final class SystemSessionProperties
     public static boolean isQueryOptimizationWithMaterializedViewEnabled(Session session)
     {
         return session.getSystemProperty(QUERY_OPTIMIZATION_WITH_MATERIALIZED_VIEW_ENABLED, Boolean.class);
+    }
+
+    public static boolean isVerboseRuntimeStatsEnabled(Session session)
+    {
+        return session.getSystemProperty(VERBOSE_RUNTIME_STATS_ENABLED, Boolean.class);
     }
 
     public static AggregationIfToFilterRewriteStrategy getAggregationIfToFilterRewriteStrategy(Session session)

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
@@ -80,6 +80,8 @@ import java.util.function.Consumer;
 
 import static com.facebook.presto.SystemSessionProperties.isSpoolingOutputBufferEnabled;
 import static com.facebook.presto.SystemSessionProperties.isUseLegacyScheduler;
+import static com.facebook.presto.common.RuntimeMetricName.FRAGMENT_PLAN_TIME_NANOS;
+import static com.facebook.presto.common.RuntimeMetricName.LOGICAL_PLANNER_TIME_NANOS;
 import static com.facebook.presto.execution.buffer.OutputBuffers.BROADCAST_PARTITION_ID;
 import static com.facebook.presto.execution.buffer.OutputBuffers.createInitialEmptyOutputBuffers;
 import static com.facebook.presto.execution.buffer.OutputBuffers.createSpoolingOutputBuffers;
@@ -438,7 +440,9 @@ public class SqlQueryExecution
 
         // plan query
         LogicalPlanner logicalPlanner = new LogicalPlanner(false, stateMachine.getSession(), planOptimizers, idAllocator, metadata, sqlParser, statsCalculator, costCalculator, stateMachine.getWarningCollector(), planChecker);
-        Plan plan = logicalPlanner.plan(analysis);
+        Plan plan = getSession().getRuntimeStats().profileNanos(
+                LOGICAL_PLANNER_TIME_NANOS,
+                () -> logicalPlanner.plan(analysis));
         queryPlan.set(plan);
 
         // extract inputs
@@ -452,7 +456,9 @@ public class SqlQueryExecution
         // fragment the plan
         // the variableAllocator is finally passed to SqlQueryScheduler for runtime cost-based optimizations
         variableAllocator.set(new PlanVariableAllocator(plan.getTypes().allVariables()));
-        SubPlan fragmentedPlan = planFragmenter.createSubPlans(stateMachine.getSession(), plan, false, idAllocator, variableAllocator.get(), stateMachine.getWarningCollector());
+        SubPlan fragmentedPlan = getSession().getRuntimeStats().profileNanos(
+                FRAGMENT_PLAN_TIME_NANOS,
+                () -> planFragmenter.createSubPlans(stateMachine.getSession(), plan, false, idAllocator, variableAllocator.get(), stateMachine.getWarningCollector()));
 
         // record analysis time
         stateMachine.endAnalysis();

--- a/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
@@ -99,6 +99,7 @@ import java.util.concurrent.ConcurrentMap;
 
 import static com.facebook.airlift.concurrent.MoreFutures.toListenableFuture;
 import static com.facebook.presto.SystemSessionProperties.isIgnoreStatsCalculatorFailures;
+import static com.facebook.presto.common.RuntimeMetricName.GET_LAYOUT_TIME_NANOS;
 import static com.facebook.presto.common.function.OperatorType.BETWEEN;
 import static com.facebook.presto.common.function.OperatorType.EQUAL;
 import static com.facebook.presto.common.function.OperatorType.GREATER_THAN;
@@ -383,6 +384,7 @@ public class MetadataManager
     @Override
     public TableLayoutResult getLayout(Session session, TableHandle table, Constraint<ColumnHandle> constraint, Optional<Set<ColumnHandle>> desiredColumns)
     {
+        long startTime = System.nanoTime();
         checkArgument(!constraint.getSummary().isNone(), "Cannot get Layout if constraint is none");
 
         ConnectorId connectorId = table.getConnectorId();
@@ -392,6 +394,7 @@ public class MetadataManager
         ConnectorMetadata metadata = catalogMetadata.getMetadataFor(connectorId);
         ConnectorSession connectorSession = session.toConnectorSession(connectorId);
         List<ConnectorTableLayoutResult> layouts = metadata.getTableLayouts(connectorSession, connectorTable, constraint, desiredColumns);
+        session.getRuntimeStats().addMetricValue(GET_LAYOUT_TIME_NANOS, System.nanoTime() - startTime);
 
         if (layouts.size() != 1) {
             throw new PrestoException(NOT_SUPPORTED, "Connector returned multiple layouts for table " + table);

--- a/presto-main/src/main/java/com/facebook/presto/split/SplitManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/split/SplitManager.java
@@ -36,6 +36,7 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+import static com.facebook.presto.common.RuntimeMetricName.GET_SPLITS_TIME_NANOS;
 import static com.facebook.presto.execution.scheduler.NodeSchedulerConfig.NetworkTopologyType.LEGACY;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
@@ -70,6 +71,7 @@ public class SplitManager
 
     public SplitSource getSplits(Session session, TableHandle table, SplitSchedulingStrategy splitSchedulingStrategy, WarningCollector warningCollector)
     {
+        long startTime = System.nanoTime();
         ConnectorId connectorId = table.getConnectorId();
         ConnectorSplitManager splitManager = getConnectorSplitManager(connectorId);
 
@@ -95,6 +97,7 @@ public class SplitManager
         if (minScheduleSplitBatchSize > 1) {
             splitSource = new BufferingSplitSource(splitSource, minScheduleSplitBatchSize);
         }
+        session.getRuntimeStats().addMetricValue(GET_SPLITS_TIME_NANOS, System.nanoTime() - startTime);
         return splitSource;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -207,6 +207,7 @@ public class FeaturesConfig
 
     private boolean queryOptimizationWithMaterializedViewEnabled;
     private AggregationIfToFilterRewriteStrategy aggregationIfToFilterRewriteStrategy = AggregationIfToFilterRewriteStrategy.DISABLED;
+    private boolean verboseRuntimeStatsEnabled;
 
     public enum PartitioningPrecisionStrategy
     {
@@ -1829,6 +1830,19 @@ public class FeaturesConfig
     public FeaturesConfig setQueryOptimizationWithMaterializedViewEnabled(boolean value)
     {
         this.queryOptimizationWithMaterializedViewEnabled = value;
+        return this;
+    }
+
+    public boolean isVerboseRuntimeStatsEnabled()
+    {
+        return verboseRuntimeStatsEnabled;
+    }
+
+    @Config("verbose-runtime-stats-enabled")
+    @ConfigDescription("Enable logging all runtime stats.")
+    public FeaturesConfig setVerboseRuntimeStatsEnabled(boolean value)
+    {
+        this.verboseRuntimeStatsEnabled = value;
         return this;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/IterativeOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/IterativeOptimizer.java
@@ -173,6 +173,9 @@ public class IterativeOptimizer
             throw e;
         }
         stats.record(rule, duration, !result.isEmpty());
+        if (SystemSessionProperties.isVerboseRuntimeStatsEnabled(context.session)) {
+            context.session.getRuntimeStats().addMetricValue(String.format("rule%sTimeNanos", rule.getClass().getSimpleName()), duration);
+        }
 
         return result;
     }

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -179,6 +179,7 @@ public class TestFeaturesConfig
                 .setPartialResultsMaxExecutionTimeMultiplier(2.0)
                 .setMaterializedViewDataConsistencyEnabled(true)
                 .setQueryOptimizationWithMaterializedViewEnabled(false)
+                .setVerboseRuntimeStatsEnabled(false)
                 .setAggregationIfToFilterRewriteStrategy(AggregationIfToFilterRewriteStrategy.DISABLED));
     }
 
@@ -309,6 +310,7 @@ public class TestFeaturesConfig
                 .put("offset-clause-enabled", "true")
                 .put("materialized-view-data-consistency-enabled", "false")
                 .put("query-optimization-with-materialized-view-enabled", "true")
+                .put("verbose-runtime-stats-enabled", "true")
                 .put("optimizer.aggregation-if-to-filter-rewrite-strategy", "filter_with_if")
                 .build();
 
@@ -437,6 +439,7 @@ public class TestFeaturesConfig
                 .setPartialResultsMaxExecutionTimeMultiplier(1.5)
                 .setMaterializedViewDataConsistencyEnabled(false)
                 .setQueryOptimizationWithMaterializedViewEnabled(true)
+                .setVerboseRuntimeStatsEnabled(true)
                 .setAggregationIfToFilterRewriteStrategy(AggregationIfToFilterRewriteStrategy.FILTER_WITH_IF);
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
This will get a detailed breakdown of the time spent in the Coordinator.

Added the following counters:
- getViewTimeNanos: Time spent in getting views from metastore.
- getMaterializedViewTimeNanos: Time spent in getting materialized views
  from metastore.
- getTableHandleTimeNanos: Time spent in getting table handle.
- getTableMetadataTimeNanos: Time spent in getting table metadata from
  metastore.
- getSplitsTimeNanos: Time spent in Splits generation.
- logicalPlannerTimeNanos: Time spent in applying all optimizer rules.
- fragmentPlanTimeNanos: Time spent in fragmenting the plan.

Also added stats for rules in the IterativeOptimizer.

Test plan
Ran it locally:
<img width="650" alt="Screen Shot 2021-10-05 at 10 35 13 PM" src="https://user-images.githubusercontent.com/67174152/136146380-4a471c4c-2ce3-4980-b8c5-24f2a4b75c39.png">

```
== NO RELEASE NOTE ==
```
