### PR TITLE
Expose per-query FRC hit rate

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/RuntimeMetricName.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/RuntimeMetricName.java
@@ -27,4 +27,6 @@ public class RuntimeMetricName
     public static final String DRIVER_COUNT_PER_TASK = "driverCountPerTask";
     public static final String TASK_ELAPSED_TIME_NANOS = "taskElapsedTimeNanos";
     public static final String OPTIMIZED_WITH_MATERIALIZED_VIEW = "optimizedWithMaterializedView";
+    public static final String FRAGMENT_RESULT_CACHE_HIT = "fragmentResultCacheHitCount";
+    public static final String FRAGMENT_RESULT_CACHE_MISS = "fragmentResultCacheMissCount";
 }


### PR DESCRIPTION
This PR change adds two metrics to display FRC cache hit and miss counters. The FRC cache hit and miss counters already exist but as a server level metrics. This PR changes expose them on a per query basis. 


Test plan - (Please fill in how you tested your changes)
Please find the counter metrics displayed on a local terminal. This also has been verified visually on the web console.
```
presto:sf1> select count(*) from customer;
 _col0  
--------
 150000 
(1 row)

Query 20211006_164349_00018_wjsf6, FINISHED, 4 nodes
http://localhost:8080/ui/query.html?20211006_164349_00018_wjsf6
Splits: 69 total, 69 done (100.00%)
CPU Time: 1.1s total,  132K rows/s,     0B/s, 49% active
Per Node: 0.9 parallelism,  118K rows/s,     0B/s
Parallelism: 3.6
Peak User Memory: 0B
Peak Total Memory: 0B
Peak Task Total Memory: 0B
S0-driverCountPerTask: sum=5 count=1 min=5 max=5
S0-taskElapsedTimeNanos: sum=223ms count=1 min=223ms max=223ms
S1-driverCountPerTask: sum=64 count=4 min=16 max=16
S1-frcCacheMissCount: sum=64 count=64 min=1 max=1
S1-taskElapsedTimeNanos: sum=0:01 count=4 min=209ms max=214ms
318ms [150K rows, 0B] [472K rows/s, 0B/s]

presto:sf1> select count(*) from customer;
 _col0  
--------
 150000 
(1 row)

Query 20211006_164357_00019_wjsf6, FINISHED, 4 nodes
http://localhost:8080/ui/query.html?20211006_164357_00019_wjsf6
Splits: 69 total, 69 done (100.00%)
CPU Time: 0.0s total,     0 rows/s,     0B/s, 75% active
Per Node: 0.0 parallelism,     0 rows/s,     0B/s
Parallelism: 0.2
Peak User Memory: 0B
Peak Total Memory: 0B
Peak Task Total Memory: 0B
S0-driverCountPerTask: sum=5 count=1 min=5 max=5
S0-taskElapsedTimeNanos: sum=46ms count=1 min=46ms max=46ms
S1-driverCountPerTask: sum=64 count=4 min=16 max=16
S1-frcCacheHitCount: sum=64 count=64 min=1 max=1
S1-taskElapsedTimeNanos: sum=177ms count=4 min=40ms max=48ms
115ms [0 rows, 0B] [0 rows/s, 0B/s]
````
<img width="863" alt="cache miss counter" src="https://user-images.githubusercontent.com/91983672/136254096-064af260-9616-4ef7-8b44-b72794d5047d.png">
<img width="916" alt="Cache hit counter" src="https://user-images.githubusercontent.com/91983672/136254099-a788720f-dbdb-4a9f-b21b-b57f1b299947.png">



```
== NO RELEASE NOTE ==
```
