### PR TITLE
Use a default execution time estimate in SimpleTtlNodeSelector

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NodeScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NodeScheduler.java
@@ -22,6 +22,7 @@ import com.facebook.presto.execution.scheduler.nodeSelection.NodeSelectionStats;
 import com.facebook.presto.execution.scheduler.nodeSelection.NodeSelector;
 import com.facebook.presto.execution.scheduler.nodeSelection.SimpleNodeSelector;
 import com.facebook.presto.execution.scheduler.nodeSelection.SimpleTtlNodeSelector;
+import com.facebook.presto.execution.scheduler.nodeSelection.SimpleTtlNodeSelectorConfig;
 import com.facebook.presto.execution.scheduler.nodeSelection.TopologyAwareNodeSelector;
 import com.facebook.presto.metadata.InternalNode;
 import com.facebook.presto.metadata.InternalNodeManager;
@@ -88,6 +89,7 @@ public class NodeScheduler
     private final Duration nodeMapRefreshInterval;
     private final NodeTtlFetcherManager nodeTtlFetcherManager;
     private final QueryManager queryManager;
+    private final SimpleTtlNodeSelectorConfig simpleTtlNodeSelectorConfig;
 
     @Inject
     public NodeScheduler(
@@ -97,7 +99,8 @@ public class NodeScheduler
             NodeSchedulerConfig config,
             NodeTaskMap nodeTaskMap,
             NodeTtlFetcherManager nodeTtlFetcherManager,
-            QueryManager queryManager)
+            QueryManager queryManager,
+            SimpleTtlNodeSelectorConfig simpleTtlNodeSelectorConfig)
     {
         this(new NetworkLocationCache(networkTopology),
                 networkTopology,
@@ -107,7 +110,8 @@ public class NodeScheduler
                 nodeTaskMap,
                 new Duration(5, SECONDS),
                 nodeTtlFetcherManager,
-                queryManager);
+                queryManager,
+                simpleTtlNodeSelectorConfig);
     }
 
     public NodeScheduler(
@@ -119,7 +123,8 @@ public class NodeScheduler
             NodeTaskMap nodeTaskMap,
             Duration nodeMapRefreshInterval,
             NodeTtlFetcherManager nodeTtlFetcherManager,
-            QueryManager queryManager)
+            QueryManager queryManager,
+            SimpleTtlNodeSelectorConfig simpleTtlNodeSelectorConfig)
     {
         this.networkLocationCache = networkLocationCache;
         this.nodeManager = nodeManager;
@@ -146,6 +151,7 @@ public class NodeScheduler
         this.nodeMapRefreshInterval = requireNonNull(nodeMapRefreshInterval, "nodeMapRefreshInterval is null");
         this.nodeTtlFetcherManager = requireNonNull(nodeTtlFetcherManager, "nodeTtlFetcherManager is null");
         this.queryManager = requireNonNull(queryManager, "queryManager is null");
+        this.simpleTtlNodeSelectorConfig = requireNonNull(simpleTtlNodeSelectorConfig, "simpleTtlNodeSelectorConfig is null");
     }
 
     @PreDestroy
@@ -208,6 +214,7 @@ public class NodeScheduler
         if (resourceAwareSchedulingStrategy == TTL) {
             return new SimpleTtlNodeSelector(
                     simpleNodeSelector,
+                    simpleTtlNodeSelectorConfig,
                     nodeTaskMap,
                     nodeMap,
                     minCandidates,

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/nodeSelection/SimpleTtlNodeSelector.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/nodeSelection/SimpleTtlNodeSelector.java
@@ -84,6 +84,7 @@ public class SimpleTtlNodeSelector
 
     public SimpleTtlNodeSelector(
             SimpleNodeSelector simpleNodeSelector,
+            SimpleTtlNodeSelectorConfig config,
             NodeTaskMap nodeTaskMap,
             Supplier<NodeMap> nodeMap,
             int minCandidates,
@@ -106,8 +107,9 @@ public class SimpleTtlNodeSelector
         this.nodeTtlFetcherManager = requireNonNull(ttlFetcherManager, "ttlFetcherManager is null");
         this.queryManager = requireNonNull(queryManager, "queryManager is null");
         this.session = requireNonNull(session, "session is null");
-        checkArgument(session.getResourceEstimates().getExecutionTime().isPresent(), "Estimated execution time is not present");
-        estimatedExecutionTime = session.getResourceEstimates().getExecutionTime().get();
+        requireNonNull(config, "config is null");
+        checkArgument(session.getResourceEstimates().getExecutionTime().isPresent() || config.getUseDefaultExecutionTimeEstimateAsFallback(), "Estimated execution time is not present");
+        estimatedExecutionTime = session.getResourceEstimates().getExecutionTime().orElse(config.getDefaultExecutionTimeEstimate());
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/nodeSelection/SimpleTtlNodeSelectorConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/nodeSelection/SimpleTtlNodeSelectorConfig.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.scheduler.nodeSelection;
+
+import com.facebook.airlift.configuration.Config;
+import io.airlift.units.Duration;
+
+import java.util.concurrent.TimeUnit;
+
+public class SimpleTtlNodeSelectorConfig
+{
+    private boolean useDefaultExecutionTimeEstimateAsFallback;
+    private Duration defaultExecutionTimeEstimate = new Duration(30, TimeUnit.MINUTES);
+
+    public boolean getUseDefaultExecutionTimeEstimateAsFallback()
+    {
+        return useDefaultExecutionTimeEstimateAsFallback;
+    }
+
+    @Config("simple-ttl-node-selector.use-default-execution-time-estimate-as-fallback")
+    public SimpleTtlNodeSelectorConfig setUseDefaultExecutionTimeEstimateAsFallback(boolean useDefaultExecutionTimeEstimateAsFallback)
+    {
+        this.useDefaultExecutionTimeEstimateAsFallback = useDefaultExecutionTimeEstimateAsFallback;
+        return this;
+    }
+
+    public Duration getDefaultExecutionTimeEstimate()
+    {
+        return defaultExecutionTimeEstimate;
+    }
+
+    @Config("simple-ttl-node-selector.default-execution-time-estimate")
+    public SimpleTtlNodeSelectorConfig setDefaultExecutionTimeEstimate(Duration defaultExecutionTimeEstimate)
+    {
+        this.defaultExecutionTimeEstimate = defaultExecutionTimeEstimate;
+        return this;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ServerMainModule.java
@@ -67,6 +67,7 @@ import com.facebook.presto.execution.scheduler.NodeScheduler;
 import com.facebook.presto.execution.scheduler.NodeSchedulerConfig;
 import com.facebook.presto.execution.scheduler.NodeSchedulerExporter;
 import com.facebook.presto.execution.scheduler.nodeSelection.NodeSelectionStats;
+import com.facebook.presto.execution.scheduler.nodeSelection.SimpleTtlNodeSelectorConfig;
 import com.facebook.presto.index.IndexManager;
 import com.facebook.presto.memory.LocalMemoryManager;
 import com.facebook.presto.memory.LocalMemoryManagerExporter;
@@ -328,6 +329,7 @@ public class ServerMainModule
         // node scheduler
         // TODO: remove from NodePartitioningManager and move to CoordinatorModule
         configBinder(binder).bindConfig(NodeSchedulerConfig.class);
+        configBinder(binder).bindConfig(SimpleTtlNodeSelectorConfig.class);
         binder.bind(NodeScheduler.class).in(Scopes.SINGLETON);
         binder.bind(NodeSelectionStats.class).in(Scopes.SINGLETON);
         newExporter(binder).export(NodeSelectionStats.class).withGeneratedName();

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -79,6 +79,7 @@ import com.facebook.presto.execution.scheduler.NodeSchedulerConfig;
 import com.facebook.presto.execution.scheduler.StreamingPlanSection;
 import com.facebook.presto.execution.scheduler.StreamingSubPlan;
 import com.facebook.presto.execution.scheduler.nodeSelection.NodeSelectionStats;
+import com.facebook.presto.execution.scheduler.nodeSelection.SimpleTtlNodeSelectorConfig;
 import com.facebook.presto.execution.warnings.DefaultWarningCollector;
 import com.facebook.presto.execution.warnings.WarningCollectorConfig;
 import com.facebook.presto.index.IndexManager;
@@ -345,7 +346,8 @@ public class LocalQueryRunner
                 nodeSchedulerConfig,
                 new NodeTaskMap(finalizerService),
                 new ThrowingNodeTtlFetcherManager(),
-                new NoOpQueryManager());
+                new NoOpQueryManager(),
+                new SimpleTtlNodeSelectorConfig());
         this.pageSinkManager = new PageSinkManager();
         CatalogManager catalogManager = new CatalogManager();
         this.transactionManager = InMemoryTransactionManager.create(

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestCostCalculator.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestCostCalculator.java
@@ -23,6 +23,7 @@ import com.facebook.presto.execution.scheduler.LegacyNetworkTopology;
 import com.facebook.presto.execution.scheduler.NodeScheduler;
 import com.facebook.presto.execution.scheduler.NodeSchedulerConfig;
 import com.facebook.presto.execution.scheduler.nodeSelection.NodeSelectionStats;
+import com.facebook.presto.execution.scheduler.nodeSelection.SimpleTtlNodeSelectorConfig;
 import com.facebook.presto.metadata.CatalogManager;
 import com.facebook.presto.metadata.InMemoryNodeManager;
 import com.facebook.presto.metadata.MetadataManager;
@@ -138,7 +139,8 @@ public class TestCostCalculator
                 new NodeSchedulerConfig().setIncludeCoordinator(true),
                 new NodeTaskMap(finalizerService),
                 new ThrowingNodeTtlFetcherManager(),
-                new NoOpQueryManager());
+                new NoOpQueryManager(),
+                new SimpleTtlNodeSelectorConfig());
         PartitioningProviderManager partitioningProviderManager = new PartitioningProviderManager();
         nodePartitioningManager = new NodePartitioningManager(nodeScheduler, partitioningProviderManager, new NodeSelectionStats());
         planFragmenter = new PlanFragmenter(metadata, nodePartitioningManager, new QueryManagerConfig(), new SqlParser(), new FeaturesConfig());

--- a/presto-main/src/test/java/com/facebook/presto/execution/BenchmarkNodeScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/BenchmarkNodeScheduler.java
@@ -24,6 +24,7 @@ import com.facebook.presto.execution.scheduler.NodeScheduler;
 import com.facebook.presto.execution.scheduler.NodeSchedulerConfig;
 import com.facebook.presto.execution.scheduler.nodeSelection.NodeSelectionStats;
 import com.facebook.presto.execution.scheduler.nodeSelection.NodeSelector;
+import com.facebook.presto.execution.scheduler.nodeSelection.SimpleTtlNodeSelectorConfig;
 import com.facebook.presto.metadata.InMemoryNodeManager;
 import com.facebook.presto.metadata.InternalNode;
 import com.facebook.presto.metadata.Split;
@@ -178,7 +179,7 @@ public class BenchmarkNodeScheduler
 
             InMemoryNodeManager nodeManager = new InMemoryNodeManager();
             nodeManager.addNode(CONNECTOR_ID, nodes);
-            NodeScheduler nodeScheduler = new NodeScheduler(getNetworkTopology(), nodeManager, new NodeSelectionStats(), getNodeSchedulerConfig(), nodeTaskMap, new ThrowingNodeTtlFetcherManager(), new NoOpQueryManager());
+            NodeScheduler nodeScheduler = new NodeScheduler(getNetworkTopology(), nodeManager, new NodeSelectionStats(), getNodeSchedulerConfig(), nodeTaskMap, new ThrowingNodeTtlFetcherManager(), new NoOpQueryManager(), new SimpleTtlNodeSelectorConfig());
             Session session = TestingSession.testSessionBuilder()
                     .setSystemProperty(MAX_UNACKNOWLEDGED_SPLITS_PER_TASK, Integer.toString(Integer.MAX_VALUE))
                     .build();

--- a/presto-main/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
@@ -27,6 +27,7 @@ import com.facebook.presto.execution.scheduler.NodeScheduler;
 import com.facebook.presto.execution.scheduler.NodeSchedulerConfig;
 import com.facebook.presto.execution.scheduler.TableWriteInfo;
 import com.facebook.presto.execution.scheduler.nodeSelection.NodeSelectionStats;
+import com.facebook.presto.execution.scheduler.nodeSelection.SimpleTtlNodeSelectorConfig;
 import com.facebook.presto.index.IndexManager;
 import com.facebook.presto.memory.MemoryManagerConfig;
 import com.facebook.presto.metadata.ConnectorMetadataUpdaterManager;
@@ -146,7 +147,8 @@ public final class TaskTestUtils
                 new NodeSchedulerConfig().setIncludeCoordinator(true),
                 new NodeTaskMap(finalizerService),
                 new ThrowingNodeTtlFetcherManager(),
-                new NoOpQueryManager());
+                new NoOpQueryManager(),
+                new SimpleTtlNodeSelectorConfig());
         PartitioningProviderManager partitioningProviderManager = new PartitioningProviderManager();
         NodePartitioningManager nodePartitioningManager = new NodePartitioningManager(nodeScheduler, partitioningProviderManager, new NodeSelectionStats());
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestNodeScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestNodeScheduler.java
@@ -25,6 +25,7 @@ import com.facebook.presto.execution.scheduler.NodeSchedulerConfig;
 import com.facebook.presto.execution.scheduler.SplitPlacementResult;
 import com.facebook.presto.execution.scheduler.nodeSelection.NodeSelectionStats;
 import com.facebook.presto.execution.scheduler.nodeSelection.NodeSelector;
+import com.facebook.presto.execution.scheduler.nodeSelection.SimpleTtlNodeSelectorConfig;
 import com.facebook.presto.metadata.InMemoryNodeManager;
 import com.facebook.presto.metadata.InternalNode;
 import com.facebook.presto.metadata.Split;
@@ -136,7 +137,8 @@ public class TestNodeScheduler
                 nodeSchedulerConfig,
                 nodeTaskMap,
                 new ThrowingNodeTtlFetcherManager(),
-                new NoOpQueryManager());
+                new NoOpQueryManager(),
+                new SimpleTtlNodeSelectorConfig());
         // contents of taskMap indicate the node-task map for the current stage
         taskMap = new HashMap<>();
         nodeSelector = nodeScheduler.createNodeSelector(session, CONNECTOR_ID);
@@ -276,7 +278,7 @@ public class TestNodeScheduler
                 }
             }
         };
-        NodeScheduler nodeScheduler = new NodeScheduler(locationCache, topology, nodeManager, new NodeSelectionStats(), nodeSchedulerConfig, nodeTaskMap, new Duration(5, SECONDS), new ThrowingNodeTtlFetcherManager(), new NoOpQueryManager());
+        NodeScheduler nodeScheduler = new NodeScheduler(locationCache, topology, nodeManager, new NodeSelectionStats(), nodeSchedulerConfig, nodeTaskMap, new Duration(5, SECONDS), new ThrowingNodeTtlFetcherManager(), new NoOpQueryManager(), new SimpleTtlNodeSelectorConfig());
         NodeSelector nodeSelector = nodeScheduler.createNodeSelector(session, CONNECTOR_ID);
 
         // Fill up the nodes with non-local data
@@ -424,7 +426,8 @@ public class TestNodeScheduler
                 nodeSchedulerConfig,
                 nodeTaskMap,
                 nodeTtlFetcherManager,
-                queryManager);
+                queryManager,
+                new SimpleTtlNodeSelectorConfig());
 
         // Query is estimated to take 20 mins and has been executing for 3 mins, i.e, 17 mins left
         // So only node2 and node3 have enough TTL to run additional work
@@ -522,7 +525,7 @@ public class TestNodeScheduler
                 .setIncludeCoordinator(false)
                 .setMaxPendingSplitsPerTask(10);
 
-        NodeScheduler nodeScheduler = new NodeScheduler(new LegacyNetworkTopology(), nodeManager, new NodeSelectionStats(), nodeSchedulerConfig, nodeTaskMap, new ThrowingNodeTtlFetcherManager(), new NoOpQueryManager());
+        NodeScheduler nodeScheduler = new NodeScheduler(new LegacyNetworkTopology(), nodeManager, new NodeSelectionStats(), nodeSchedulerConfig, nodeTaskMap, new ThrowingNodeTtlFetcherManager(), new NoOpQueryManager(), new SimpleTtlNodeSelectorConfig());
         NodeSelector nodeSelector = nodeScheduler.createNodeSelector(session, CONNECTOR_ID, 2);
 
         Set<Split> splits = new HashSet<>();
@@ -545,7 +548,7 @@ public class TestNodeScheduler
                 .setIncludeCoordinator(false)
                 .setMaxPendingSplitsPerTask(10);
 
-        NodeScheduler nodeScheduler = new NodeScheduler(new LegacyNetworkTopology(), nodeManager, new NodeSelectionStats(), nodeSchedulerConfig, nodeTaskMap, new ThrowingNodeTtlFetcherManager(), new NoOpQueryManager());
+        NodeScheduler nodeScheduler = new NodeScheduler(new LegacyNetworkTopology(), nodeManager, new NodeSelectionStats(), nodeSchedulerConfig, nodeTaskMap, new ThrowingNodeTtlFetcherManager(), new NoOpQueryManager(), new SimpleTtlNodeSelectorConfig());
         NodeSelector nodeSelector = nodeScheduler.createNodeSelector(session, CONNECTOR_ID, 3);
 
         Set<Split> splits = new HashSet<>();
@@ -583,7 +586,7 @@ public class TestNodeScheduler
                 .setIncludeCoordinator(false)
                 .setMaxPendingSplitsPerTask(10);
 
-        NodeScheduler nodeScheduler = new NodeScheduler(new LegacyNetworkTopology(), nodeManager, new NodeSelectionStats(), nodeSchedulerConfig, nodeTaskMap, new ThrowingNodeTtlFetcherManager(), new NoOpQueryManager());
+        NodeScheduler nodeScheduler = new NodeScheduler(new LegacyNetworkTopology(), nodeManager, new NodeSelectionStats(), nodeSchedulerConfig, nodeTaskMap, new ThrowingNodeTtlFetcherManager(), new NoOpQueryManager(), new SimpleTtlNodeSelectorConfig());
         NodeSelector nodeSelector = nodeScheduler.createNodeSelector(session, CONNECTOR_ID, 3);
 
         Set<Split> splits = new HashSet<>();
@@ -886,7 +889,7 @@ public class TestNodeScheduler
                 .setIncludeCoordinator(false)
                 .setMaxPendingSplitsPerTask(10);
 
-        NodeScheduler nodeScheduler = new NodeScheduler(new LegacyNetworkTopology(), nodeManager, new NodeSelectionStats(), nodeSchedulerConfig, nodeTaskMap, new ThrowingNodeTtlFetcherManager(), new NoOpQueryManager());
+        NodeScheduler nodeScheduler = new NodeScheduler(new LegacyNetworkTopology(), nodeManager, new NodeSelectionStats(), nodeSchedulerConfig, nodeTaskMap, new ThrowingNodeTtlFetcherManager(), new NoOpQueryManager(), new SimpleTtlNodeSelectorConfig());
         NodeSelector nodeSelector = nodeScheduler.createNodeSelector(session, CONNECTOR_ID, 2);
 
         Set<Split> splits = new HashSet<>();
@@ -924,7 +927,7 @@ public class TestNodeScheduler
 
         LegacyNetworkTopology networkTopology = new LegacyNetworkTopology();
         // refresh interval is 1 nanosecond
-        NodeScheduler nodeScheduler = new NodeScheduler(new NetworkLocationCache(networkTopology), networkTopology, nodeManager, new NodeSelectionStats(), nodeSchedulerConfig, nodeTaskMap, Duration.valueOf("0s"), new ThrowingNodeTtlFetcherManager(), new NoOpQueryManager());
+        NodeScheduler nodeScheduler = new NodeScheduler(new NetworkLocationCache(networkTopology), networkTopology, nodeManager, new NodeSelectionStats(), nodeSchedulerConfig, nodeTaskMap, Duration.valueOf("0s"), new ThrowingNodeTtlFetcherManager(), new NoOpQueryManager(), new SimpleTtlNodeSelectorConfig());
         NodeSelector nodeSelector = nodeScheduler.createNodeSelector(session, CONNECTOR_ID, 2);
 
         Set<Split> splits = new HashSet<>();

--- a/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestSourcePartitionedScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestSourcePartitionedScheduler.java
@@ -28,6 +28,7 @@ import com.facebook.presto.execution.StageId;
 import com.facebook.presto.execution.TestSqlTaskManager.MockLocationFactory;
 import com.facebook.presto.execution.buffer.OutputBuffers.OutputBufferId;
 import com.facebook.presto.execution.scheduler.nodeSelection.NodeSelectionStats;
+import com.facebook.presto.execution.scheduler.nodeSelection.SimpleTtlNodeSelectorConfig;
 import com.facebook.presto.failureDetector.NoOpFailureDetector;
 import com.facebook.presto.metadata.InMemoryNodeManager;
 import com.facebook.presto.metadata.InternalNode;
@@ -322,7 +323,8 @@ public class TestSourcePartitionedScheduler
                     new NodeSchedulerConfig().setIncludeCoordinator(false),
                     nodeTaskMap,
                     new ThrowingNodeTtlFetcherManager(),
-                    new NoOpQueryManager());
+                    new NoOpQueryManager(),
+                    new SimpleTtlNodeSelectorConfig());
 
             SubPlan plan = createPlan();
             SqlStageExecution stage = createSqlStageExecution(plan, nodeTaskMap);
@@ -463,7 +465,8 @@ public class TestSourcePartitionedScheduler
                 nodeSchedulerConfig,
                 nodeTaskMap,
                 new ThrowingNodeTtlFetcherManager(),
-                new NoOpQueryManager());
+                new NoOpQueryManager(),
+                new SimpleTtlNodeSelectorConfig());
         SplitSource splitSource = new ConnectorAwareSplitSource(CONNECTOR_ID, TestingTransactionHandle.create(), connectorSplitSource);
         SplitPlacementPolicy placementPolicy = new DynamicSplitPlacementPolicy(nodeScheduler.createNodeSelector(TestingSession.testSessionBuilder().build(), splitSource.getConnectorId()), stage::getAllTasks);
         return newSourcePartitionedSchedulerAsStageScheduler(stage, TABLE_SCAN_NODE_ID, splitSource, placementPolicy, splitBatchSize);

--- a/presto-main/src/test/java/com/facebook/presto/execution/scheduler/nodeselection/TestSimpleTtlNodeSelectorConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/scheduler/nodeselection/TestSimpleTtlNodeSelectorConfig.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.scheduler.nodeselection;
+
+import com.facebook.airlift.configuration.testing.ConfigAssertions;
+import com.facebook.presto.execution.scheduler.nodeSelection.SimpleTtlNodeSelectorConfig;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.units.Duration;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+public class TestSimpleTtlNodeSelectorConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        ConfigAssertions.assertRecordedDefaults(ConfigAssertions.recordDefaults(SimpleTtlNodeSelectorConfig.class)
+                .setUseDefaultExecutionTimeEstimateAsFallback(false)
+                .setDefaultExecutionTimeEstimate(new Duration(30, TimeUnit.MINUTES)));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("simple-ttl-node-selector.use-default-execution-time-estimate-as-fallback", "true")
+                .put("simple-ttl-node-selector.default-execution-time-estimate", "1h")
+                .build();
+
+        SimpleTtlNodeSelectorConfig expected = new SimpleTtlNodeSelectorConfig()
+                .setUseDefaultExecutionTimeEstimateAsFallback(true)
+                .setDefaultExecutionTimeEstimate(new Duration(1, TimeUnit.HOURS));
+
+        ConfigAssertions.assertFullMapping(properties, expected);
+    }
+}

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkModule.java
@@ -61,6 +61,7 @@ import com.facebook.presto.execution.resourceGroups.InternalResourceGroupManager
 import com.facebook.presto.execution.resourceGroups.LegacyResourceGroupConfigurationManager;
 import com.facebook.presto.execution.resourceGroups.ResourceGroupManager;
 import com.facebook.presto.execution.scheduler.NodeSchedulerConfig;
+import com.facebook.presto.execution.scheduler.nodeSelection.SimpleTtlNodeSelectorConfig;
 import com.facebook.presto.execution.warnings.WarningCollectorConfig;
 import com.facebook.presto.index.IndexManager;
 import com.facebook.presto.memory.MemoryManagerConfig;
@@ -215,6 +216,7 @@ public class PrestoSparkModule
         // configs
         // TODO: decouple configuration properties that don't make sense on Spark
         configBinder(binder).bindConfig(NodeSchedulerConfig.class);
+        configBinder(binder).bindConfig(SimpleTtlNodeSelectorConfig.class);
         configBinder(binder).bindConfig(QueryManagerConfig.class);
         configBinder(binder).bindConfigGlobalDefaults(QueryManagerConfig.class, PrestoSparkSettingsRequirements::setDefaults);
         configBinder(binder).bindConfig(FeaturesConfig.class);

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/node/PrestoSparkNodeScheduler.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/node/PrestoSparkNodeScheduler.java
@@ -23,6 +23,7 @@ import com.facebook.presto.execution.scheduler.NodeScheduler;
 import com.facebook.presto.execution.scheduler.NodeSchedulerConfig;
 import com.facebook.presto.execution.scheduler.nodeSelection.NodeSelectionStats;
 import com.facebook.presto.execution.scheduler.nodeSelection.NodeSelector;
+import com.facebook.presto.execution.scheduler.nodeSelection.SimpleTtlNodeSelectorConfig;
 import com.facebook.presto.metadata.InMemoryNodeManager;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.ttl.nodettlfetchermanagers.ThrowingNodeTtlFetcherManager;
@@ -50,7 +51,8 @@ public class PrestoSparkNodeScheduler
                 new NodeTaskMap(new FinalizerService()),
                 new Duration(5, SECONDS),
                 new ThrowingNodeTtlFetcherManager(),
-                new NoOpQueryManager());
+                new NoOpQueryManager(),
+                new SimpleTtlNodeSelectorConfig());
     }
 
     @Override


### PR DESCRIPTION
Currently, the SimpleTtlNodeSelector fails if a query does not have any execution time estimates. This PR adds support to use a default execution time estimate if no such estimate has been provided by the user. 

```
== RELEASE NOTES ==

General Changes
* Add configuration properties ``simple-ttl-node-selector.use-default-execution-time-estimate-as-fallback`` and ``simple-ttl-node-selector.default-execution-time-estimate``. 
  The former configures ``SimpleTtlNodeSelector`` to use a default execution time estimate when there is no corresponding user-provided estimate. The latter configures the value of the default execution time estimate.
