### PR TITLE
ACL enforcement for refresh materialized view

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveDistributedQueries.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveDistributedQueries.java
@@ -43,6 +43,12 @@ public class TestHiveDistributedQueries
     }
 
     @Override
+    protected boolean supportsMaterializedViews()
+    {
+        return true;
+    }
+
+    @Override
     protected boolean supportsNotNullColumns()
     {
         return false;


### PR DESCRIPTION
Refresh materialized view will check on the view owner's permission instead of the invoker's permission.

For the base tables, it will require the SELECT permission. For the view table, it will require the INSERT permission.

Rationale is triggering refresh materialized view would not cause data corruption or leak, since the materialized view is written in a controlled manner. We just need to make sure the owner still has SELECT permission on the base tables.