### PR TITLE
Add presto-function-namespace-manager to plugin

### DIFF
--- a/presto-server/pom.xml
+++ b/presto-server/pom.xml
@@ -339,6 +339,14 @@
             <type>zip</type>
             <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-function-namespace-managers</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
Currently, presto-function-namespace-manager is not getting added to the plugin, which is causing the below error while starting the server when we try to enable  function-namespace-manager -

`2021-10-07T11:23:46.459+0530	ERROR	main	com.facebook.presto.server.PrestoServer	No factory for function namespace manager mysql
java.lang.IllegalStateException: No factory for function namespace manager mysql
	at com.google.common.base.Preconditions.checkState(Preconditions.java:588)
	at com.facebook.presto.metadata.FunctionAndTypeManager.loadFunctionNamespaceManager(FunctionAndTypeManager.java:165)
	at com.facebook.presto.metadata.StaticFunctionNamespaceStore.loadFunctionNamespaceManager(StaticFunctionNamespaceStore.java:81)
	at com.facebook.presto.metadata.StaticFunctionNamespaceStore.loadFunctionNamespaceManagers(StaticFunctionNamespaceStore.java:63)
	at com.facebook.presto.server.PrestoServer.run(PrestoServer.java:165)
	at com.facebook.presto.server.PrestoServer.main(PrestoServer.java:85)`
