### PR TITLE
Include orderByChannel in InputChannels list for Ordering accumulator

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/GenericAccumulatorFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/GenericAccumulatorFactory.java
@@ -40,6 +40,7 @@ import com.facebook.presto.operator.aggregation.AggregationMetadata.AccumulatorS
 import com.facebook.presto.spi.function.WindowIndex;
 import com.facebook.presto.sql.gen.JoinCompiler;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.primitives.Ints;
 import org.openjdk.jol.info.ClassLayout;
 
@@ -178,10 +179,11 @@ public class GenericAccumulatorFactory
         }
 
         checkState(accumulator instanceof FinalOnlyGroupedAccumulator);
-        ImmutableList.Builder<Integer> aggregateInputChannels = ImmutableList.builder();
+        ImmutableSet.Builder<Integer> aggregateInputChannels = ImmutableSet.builder();
         aggregateInputChannels.addAll(inputChannels);
         maskChannel.ifPresent(aggregateInputChannels::add);
-        return new SpillableFinalOnlyGroupedAccumulator(sourceTypes, aggregateInputChannels.build(), (FinalOnlyGroupedAccumulator) accumulator);
+        aggregateInputChannels.addAll(orderByChannels);
+        return new SpillableFinalOnlyGroupedAccumulator(sourceTypes, aggregateInputChannels.build().asList(), (FinalOnlyGroupedAccumulator) accumulator);
     }
 
     @Override

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestSpilledAggregations.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestSpilledAggregations.java
@@ -88,6 +88,12 @@ public class TestSpilledAggregations
     }
 
     @Test
+    public void testDistinctAndOrderBySpillingWithDifferentOrderByColumn()
+    {
+        assertQuery("Select custkey, orderpriority, sum(custkey), array_agg(orderkey ORDER BY orderdate) from orders WHERE custkey = 1499 group by custkey, orderpriority");
+    }
+
+    @Test
     public void testDistinctSpillingCount()
     {
         assertQuery("SELECT orderpriority, custkey, sum(custkey), count(DISTINCT totalprice) FROM orders GROUP BY orderpriority, custkey ORDER BY 1, 2");


### PR DESCRIPTION
SpillableFinalOnlyGroupedAccumulator uses `aggregateInputChannels` to identify the columns
that will be consumed by the underlying accumulator and only preserves data in these channels.
Other channel are replaces by Null blocks. Currently, only inputChannel and maskChannel are
passed. We should pass orderbyChannels as well for Ordering aggregates.

Test plan - Added a unit test that capture this specific case

```
== NO RELEASE NOTE ==
```
