### PR TITLE
Avoid redundant string.format in verify

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/ManifestPartitionLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/ManifestPartitionLoader.java
@@ -103,7 +103,7 @@ public class ManifestPartitionLoader
 
         // TODO: Add support for more manifest versions
         // Verify the manifest version
-        verify(VERSION_1.equals(parameters.get(MANIFEST_VERSION)), format("Manifest version is not equal to %s", VERSION_1));
+        verify(VERSION_1.equals(parameters.get(MANIFEST_VERSION)), "Manifest version is not equal to %s", VERSION_1);
 
         List<String> fileNames = decompressFileNames(parameters.get(FILE_NAMES));
         List<Long> fileSizes = decompressFileSizes(parameters.get(FILE_SIZES));


### PR DESCRIPTION
When `ManifestPartitionLoader#loadPartition` is called many times, `verify` will be called frequently. This use of `verify` will cause early-construction of `string.format`, leading to the degradation of the performance. However, string will be printed only when the condition is false.

```
== NO RELEASE NOTE ==