### PR TITLE
[DEMO]Optimize split generation

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/ConcurrentMultipleHivePageSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/ConcurrentMultipleHivePageSource.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.common.Page;
+import com.facebook.presto.spi.ConnectorPageSource;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+
+import static com.facebook.airlift.concurrent.Threads.daemonThreadsNamed;
+import static java.util.Objects.requireNonNull;
+
+public class ConcurrentMultipleHivePageSource
+        implements ConnectorPageSource
+{
+    private final List<ConnectorPageSource> delegates;
+    private final LinkedBlockingQueue<Optional<Page>> resultQueue;
+    private final ExecutorService executorService;
+    private int currentPageIndex;
+
+    public ConcurrentMultipleHivePageSource(
+            List<ConnectorPageSource> delegates,
+            int parallelism)
+    {
+        this.delegates = requireNonNull(delegates, "delegate is null");
+        resultQueue = new LinkedBlockingQueue<>(parallelism * 5);
+        executorService = Executors.newFixedThreadPool(parallelism, daemonThreadsNamed("concurrent-small-file-read-%s"));
+        startFetchPages(parallelism);
+    }
+
+    @Override
+    public long getCompletedBytes()
+    {
+        return delegates.stream().mapToLong(ConnectorPageSource::getCompletedBytes).sum();
+    }
+
+    @Override
+    public long getCompletedPositions()
+    {
+        return delegates.stream().mapToLong(ConnectorPageSource::getCompletedPositions).sum();
+    }
+
+    @Override
+    public long getReadTimeNanos()
+    {
+        return delegates.stream().mapToLong(ConnectorPageSource::getReadTimeNanos).sum();
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return delegates.stream().allMatch(ConnectorPageSource::isFinished) && resultQueue.isEmpty();
+    }
+
+    @Override
+    public Page getNextPage()
+    {
+        Optional<Page> dataPage = Optional.empty();
+        if (isFinished()) {
+            return null;
+        }
+        try {
+            dataPage = resultQueue.take();
+        }
+        catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+        return dataPage == null ? null : dataPage.orElseGet(() -> null);
+    }
+
+    @Override
+    public long getSystemMemoryUsage()
+    {
+        return delegates.stream().mapToLong(ConnectorPageSource::getSystemMemoryUsage).sum();
+    }
+
+    @Override
+    public void close() throws IOException
+    {
+        try {
+            for (ConnectorPageSource delegate : delegates) {
+                delegate.close();
+            }
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        finally {
+            executorService.shutdown();
+        }
+    }
+
+    public synchronized void startFetchPages(int num)
+    {
+        while (currentPageIndex < delegates.size() && num-- > 0) {
+            executorService.submit(new FetchPagesTask(delegates.get(currentPageIndex++)));
+        }
+    }
+
+    private class FetchPagesTask
+            implements Runnable
+    {
+        private ConnectorPageSource delegate;
+
+        public FetchPagesTask(ConnectorPageSource deledage)
+        {
+            this.delegate = deledage;
+        }
+
+        @Override
+        public void run()
+        {
+            try {
+                while (!delegate.isFinished()) {
+                    Page dataPage = delegate.getNextPage();
+                    if (dataPage != null) {
+                        dataPage = dataPage.getLoadedPage();
+                    }
+                    resultQueue.put(dataPage == null ? Optional.empty() : Optional.of(dataPage));
+                }
+                if (delegate.isFinished()) {
+                    synchronized (ConcurrentMultipleHivePageSource.this) {
+                        if (currentPageIndex < delegates.size()) {
+                            executorService.submit(new FetchPagesTask(delegates.get(currentPageIndex++)));
+                        }
+                    }
+                }
+            }
+            catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -197,6 +197,11 @@ public class HiveClientConfig
     private boolean enableLooseMemoryAccounting;
     private int materializedViewMissingPartitionsThreshold = 100;
 
+    private boolean concurrentSmallFileReadEnabled;
+    private int concurrentSmallFileReadParallelism = 5;
+    private long concurrentSmallFileReadFileCountThreshold = 10000;
+    private long concurrentSmallFileReadFileSizeThreshold = 1 * 1024 * 1024;
+
     public int getMaxInitialSplits()
     {
         return maxInitialSplits;
@@ -1667,5 +1672,53 @@ public class HiveClientConfig
     public int getMaterializedViewMissingPartitionsThreshold()
     {
         return this.materializedViewMissingPartitionsThreshold;
+    }
+
+    public boolean isConcurrentSmallFileReadEnabled()
+    {
+        return concurrentSmallFileReadEnabled;
+    }
+
+    @Config("hive.concurrent-small-file-read-enabled")
+    public HiveClientConfig setConcurrentSmallFileReadEnabled(boolean concurrentSmallFileReadEnabled)
+    {
+        this.concurrentSmallFileReadEnabled = concurrentSmallFileReadEnabled;
+        return this;
+    }
+
+    public int getConcurrentSmallFileReadParallelism()
+    {
+        return concurrentSmallFileReadParallelism;
+    }
+
+    @Config("hive.concurrent-small-file-read-parallelism")
+    public HiveClientConfig setConcurrentSmallFileReadParallelism(int concurrentSmallFileReadParallelism)
+    {
+        this.concurrentSmallFileReadParallelism = concurrentSmallFileReadParallelism;
+        return this;
+    }
+
+    public long getConcurrentSmallFileReadFileCountThreshold()
+    {
+        return concurrentSmallFileReadFileCountThreshold;
+    }
+
+    @Config("hive.concurrent-small-file-read-file-count")
+    public HiveClientConfig setConcurrentSmallFileReadFileCountThreshold(long concurrentSmallFileReadFileCountThreshold)
+    {
+        this.concurrentSmallFileReadFileCountThreshold = concurrentSmallFileReadFileCountThreshold;
+        return this;
+    }
+
+    public long getConcurrentSmallFileReadFileSizeThreshold()
+    {
+        return concurrentSmallFileReadFileSizeThreshold;
+    }
+
+    @Config("hive.concurrent-small-file-read-file-size")
+    public HiveClientConfig setConcurrentSmallFileReadFileSizeThreshold(long concurrentSmallFileReadFileSizeThreshold)
+    {
+        this.concurrentSmallFileReadFileSizeThreshold = concurrentSmallFileReadFileSizeThreshold;
+        return this;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveHandleResolver.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveHandleResolver.java
@@ -48,7 +48,7 @@ public class HiveHandleResolver
     @Override
     public Class<? extends ConnectorSplit> getSplitClass()
     {
-        return HiveSplit.class;
+        return MultipleHiveSplit.class;
     }
 
     @Override

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveNodePartitioningProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveNodePartitioningProvider.java
@@ -85,7 +85,7 @@ public class HiveNodePartitioningProvider
             ConnectorSession session,
             ConnectorPartitioningHandle partitioningHandle)
     {
-        return value -> ((HiveSplit) value).getReadBucketNumber()
+        return value -> ((MultipleHiveSplit) value).getReadBucketNumber()
                 .orElseThrow(() -> new IllegalArgumentException("Bucket number not set in split"));
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
@@ -38,6 +38,7 @@ import static com.facebook.presto.hive.HiveSessionProperties.InsertExistingParti
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_SESSION_PROPERTY;
 import static com.facebook.presto.spi.session.PropertyMetadata.booleanProperty;
 import static com.facebook.presto.spi.session.PropertyMetadata.integerProperty;
+import static com.facebook.presto.spi.session.PropertyMetadata.longProperty;
 import static com.facebook.presto.spi.session.PropertyMetadata.stringProperty;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.String.format;
@@ -125,6 +126,10 @@ public final class HiveSessionProperties
     public static final String CACHE_ENABLED = "cache_enabled";
     public static final String ENABLE_LOOSE_MEMORY_BASED_ACCOUNTING = "enable_loose_memory_based_accounting";
     public static final String MATERIALIZED_VIEW_MISSING_PARTITIONS_THRESHOLD = "materialized_view_missing_partitions_threshold";
+    public static final String CONCURRENT_SMALL_FILE_READ_ENABLED = "concurrent_small_file_read_enabled";
+    public static final String CONCURRENT_SMALL_FILE_READ_PARALLELISM = "concurrent_small_file_read_parallelism";
+    public static final String CONCURRENT_SMALL_FILE_READ_FILE_COUNT_THRESHOLD = "concurrent_small_file_read_file_count_threshold";
+    public static final String CONCURRENT_SMALL_FILE_READ_FILE_SIZE_THRESHOLD = "concurrent_small_file_read_file_size_threshold";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -593,7 +598,25 @@ public final class HiveSessionProperties
                         MATERIALIZED_VIEW_MISSING_PARTITIONS_THRESHOLD,
                         "Materialized views with missing partitions more than this threshold falls back to the base tables at read time",
                         hiveClientConfig.getMaterializedViewMissingPartitionsThreshold(),
-                        true));
+                        true),
+                booleanProperty(
+                        CONCURRENT_SMALL_FILE_READ_ENABLED,
+                        "Enable concurrent reading files in a driver",
+                        hiveClientConfig.isConcurrentSmallFileReadEnabled(),
+                        false),
+                integerProperty(
+                        CONCURRENT_SMALL_FILE_READ_PARALLELISM,
+                        "Parallelism to read files in a driver",
+                        hiveClientConfig.getConcurrentSmallFileReadParallelism(),
+                        false),
+                longProperty(CONCURRENT_SMALL_FILE_READ_FILE_COUNT_THRESHOLD,
+                        "file count thrshold to enable concurrent reading files in a driver",
+                        hiveClientConfig.getConcurrentSmallFileReadFileCountThreshold(),
+                        false),
+                longProperty(CONCURRENT_SMALL_FILE_READ_FILE_SIZE_THRESHOLD,
+                        "avg file count threshold to enable concurrent reading files in a driver",
+                        hiveClientConfig.getConcurrentSmallFileReadFileSizeThreshold(),
+                        false));
     }
 
     public List<PropertyMetadata<?>> getSessionProperties()
@@ -1037,5 +1060,25 @@ public final class HiveSessionProperties
     public static int getMaterializedViewMissingPartitionsThreshold(ConnectorSession session)
     {
         return session.getProperty(MATERIALIZED_VIEW_MISSING_PARTITIONS_THRESHOLD, Integer.class);
+    }
+
+    public static boolean isConcurrentSmallFileReadEnabled(ConnectorSession session)
+    {
+        return session.getProperty(CONCURRENT_SMALL_FILE_READ_ENABLED, Boolean.class);
+    }
+
+    public static int getConcurrentSmallFileReadParallelism(ConnectorSession session)
+    {
+        return session.getProperty(CONCURRENT_SMALL_FILE_READ_PARALLELISM, Integer.class);
+    }
+
+    public static long getConcurrentSmallFileReadFileCountThreshold(ConnectorSession session)
+    {
+        return session.getProperty(CONCURRENT_SMALL_FILE_READ_FILE_COUNT_THRESHOLD, Long.class);
+    }
+
+    public static long getConcurrentSmallFileReadFileSizeThreshold(ConnectorSession session)
+    {
+        return session.getProperty(CONCURRENT_SMALL_FILE_READ_FILE_SIZE_THRESHOLD, Long.class);
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplit.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplit.java
@@ -15,7 +15,6 @@ package com.facebook.presto.hive;
 
 import com.facebook.presto.hive.metastore.Storage;
 import com.facebook.presto.spi.ColumnHandle;
-import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
@@ -40,7 +39,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 public class HiveSplit
-        implements ConnectorSplit
 {
     private final String path;
     private final long start;
@@ -204,7 +202,6 @@ public class HiveSplit
         return addresses;
     }
 
-    @Override
     public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
     {
         if (sortedCandidates == null || sortedCandidates.isEmpty()) {
@@ -254,7 +251,6 @@ public class HiveSplit
     }
 
     @JsonProperty
-    @Override
     public NodeSelectionStrategy getNodeSelectionStrategy()
     {
         return nodeSelectionStrategy;
@@ -296,7 +292,6 @@ public class HiveSplit
         return redundantColumnDomains;
     }
 
-    @Override
     public Object getInfo()
     {
         return ImmutableMap.builder()
@@ -315,7 +310,6 @@ public class HiveSplit
                 .build();
     }
 
-    @Override
     public Object getSplitIdentifier()
     {
         return ImmutableMap.builder()
@@ -325,7 +319,6 @@ public class HiveSplit
                 .build();
     }
 
-    @Override
     public OptionalLong getSplitSizeInBytes()
     {
         return OptionalLong.of(getLength());

--- a/presto-hive/src/main/java/com/facebook/presto/hive/MultipleHiveSplit.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/MultipleHiveSplit.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.spi.ConnectorSplit;
+import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.List;
+import java.util.OptionalInt;
+import java.util.OptionalLong;
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.spi.schedule.NodeSelectionStrategy.NO_PREFERENCE;
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+public class MultipleHiveSplit
+        implements ConnectorSplit
+{
+    private final List<HiveSplit> hiveSplits;
+
+    @JsonCreator
+    public MultipleHiveSplit(@JsonProperty("hiveSplits") List<HiveSplit> hiveSplits)
+    {
+        requireNonNull(hiveSplits, "hiveSplits is null");
+        this.hiveSplits = ImmutableList.copyOf(hiveSplits);
+    }
+
+    @JsonProperty
+    public List<HiveSplit> getHiveSplits()
+    {
+        return hiveSplits;
+    }
+
+    @Override
+    public NodeSelectionStrategy getNodeSelectionStrategy()
+    {
+        if (hiveSplits.size() == 1) {
+            return hiveSplits.get(0).getNodeSelectionStrategy();
+        }
+        return NO_PREFERENCE;
+    }
+
+    @Override
+    public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+    {
+        if (hiveSplits.size() == 1) {
+            return hiveSplits.get(0).getPreferredNodes(sortedCandidates);
+        }
+        return sortedCandidates;
+    }
+
+    @Override
+    public Object getInfo()
+    {
+        if (hiveSplits.size() == 1) {
+            return hiveSplits.get(0).getInfo();
+        }
+        return hiveSplits.stream().map(HiveSplit::getInfo).collect(Collectors.toList());
+    }
+
+    @Override
+    public OptionalLong getSplitSizeInBytes()
+    {
+        return OptionalLong.of(
+                hiveSplits.stream()
+                        .map(HiveSplit::getSplitSizeInBytes)
+                        .filter(OptionalLong::isPresent)
+                        .mapToLong(OptionalLong::getAsLong)
+                        .sum());
+    }
+
+    @Override
+    public Object getSplitIdentifier()
+    {
+        if (hiveSplits.size() == 1) {
+            return hiveSplits.get(0).getSplitIdentifier();
+        }
+        return ImmutableMap.builder()
+                .put("path", hiveSplits.stream().map(HiveSplit::getPath).collect(Collectors.toList()))
+                .put("start", hiveSplits.stream().map(HiveSplit::getStart).collect(Collectors.toList()))
+                .put("length", hiveSplits.stream().map(HiveSplit::getLength).collect(Collectors.toList()))
+                .build();
+    }
+
+    public OptionalInt getReadBucketNumber()
+    {
+        checkArgument(hiveSplits.size() == 1);
+        return hiveSplits.get(0).getReadBucketNumber();
+    }
+
+    public CacheQuotaRequirement getCacheQuotaRequirement()
+    {
+        checkArgument(hiveSplits.size() == 1);
+        return hiveSplits.get(0).getCacheQuotaRequirement();
+    }
+
+    public long getLength()
+    {
+        return hiveSplits.stream().mapToLong(HiveSplit::getLength).sum();
+    }
+
+    public int getPartitionDataColumnCount()
+    {
+        checkArgument(hiveSplits.size() == 1);
+        return hiveSplits.get(0).getPartitionDataColumnCount();
+    }
+
+    public String getPath()
+    {
+        checkArgument(hiveSplits.size() == 1);
+        return hiveSplits.get(0).getPath();
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -2310,7 +2310,7 @@ public abstract class AbstractTestHiveClient
 
                 long rowNumber = 0;
                 long completedBytes = 0;
-                try (ConnectorPageSource pageSource = pageSourceProvider.createPageSource(transaction.getTransactionHandle(), session, hiveSplit, layoutHandle, columnHandles, NON_CACHEABLE)) {
+                try (ConnectorPageSource pageSource = pageSourceProvider.createPageSource(transaction.getTransactionHandle(), session, new MultipleHiveSplit(ImmutableList.of(hiveSplit)), layoutHandle, columnHandles, NON_CACHEABLE)) {
                     MaterializedResult result = materializeSourceDataStream(session, pageSource, getTypes(columnHandles));
 
                     assertPageSourceType(pageSource, fileType);
@@ -2401,7 +2401,7 @@ public abstract class AbstractTestHiveClient
                 int dummyPartition = Integer.parseInt(partitionKeys.get(2).getValue().orElse(null));
 
                 long rowNumber = 0;
-                try (ConnectorPageSource pageSource = pageSourceProvider.createPageSource(transaction.getTransactionHandle(), session, hiveSplit, layoutHandle, columnHandles, NON_CACHEABLE)) {
+                try (ConnectorPageSource pageSource = pageSourceProvider.createPageSource(transaction.getTransactionHandle(), session, new MultipleHiveSplit(ImmutableList.of(hiveSplit)), layoutHandle, columnHandles, NON_CACHEABLE)) {
                     assertPageSourceType(pageSource, fileType);
                     MaterializedResult result = materializeSourceDataStream(session, pageSource, getTypes(columnHandles));
                     for (MaterializedRow row : result) {
@@ -4782,7 +4782,7 @@ public abstract class AbstractTestHiveClient
 
             List<ColumnHandle> columnHandles = ImmutableList.copyOf(metadata.getColumnHandles(session, tableHandle).values());
 
-            ConnectorPageSource pageSource = pageSourceProvider.createPageSource(transaction.getTransactionHandle(), session, hiveSplit, layoutHandle, columnHandles, NON_CACHEABLE);
+            ConnectorPageSource pageSource = pageSourceProvider.createPageSource(transaction.getTransactionHandle(), session, new MultipleHiveSplit(ImmutableList.of(hiveSplit)), layoutHandle, columnHandles, NON_CACHEABLE);
             assertGetRecords(hiveStorageFormat, tableMetadata, hiveSplit, pageSource, columnHandles);
         }
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestDynamicPruning.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestDynamicPruning.java
@@ -178,7 +178,7 @@ public class TestDynamicPruning
                         Optional.empty(),
                         false)));
         HivePageSourceProvider provider = new HivePageSourceProvider(config, createTestHdfsEnvironment(config, metastoreClientConfig), getDefaultHiveRecordCursorProvider(config, metastoreClientConfig), getDefaultHiveBatchPageSourceFactories(config, metastoreClientConfig), getDefaultHiveSelectivePageSourceFactories(config, metastoreClientConfig), FUNCTION_AND_TYPE_MANAGER, ROW_EXPRESSION_SERVICE);
-        return provider.createPageSource(transaction, getSession(config), split, tableHandle.getLayout().get(), ImmutableList.copyOf(getColumnHandles()), splitContext);
+        return provider.createPageSource(transaction, getSession(config), new MultipleHiveSplit(ImmutableList.of(split)), tableHandle.getLayout().get(), ImmutableList.copyOf(getColumnHandles()), splitContext);
     }
 
     private static TupleDomain<ColumnHandle> getToSkipTupleDomain()

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
@@ -155,7 +155,11 @@ public class TestHiveClientConfig
                 .setOptimizedPartitionUpdateSerializationEnabled(false)
                 .setPartitionLeaseDuration(new Duration(0, TimeUnit.SECONDS))
                 .setMaterializedViewMissingPartitionsThreshold(100)
-                .setLooseMemoryAccountingEnabled(false));
+                .setLooseMemoryAccountingEnabled(false)
+                .setConcurrentSmallFileReadEnabled(false)
+                .setConcurrentSmallFileReadParallelism(5)
+                .setConcurrentSmallFileReadFileCountThreshold(10000)
+                .setConcurrentSmallFileReadFileSizeThreshold(1048576));
     }
 
     @Test
@@ -272,6 +276,10 @@ public class TestHiveClientConfig
                 .put("hive.partition-lease-duration", "4h")
                 .put("hive.loose-memory-accounting-enabled", "true")
                 .put("hive.materialized-view-missing-partitions-threshold", "50")
+                .put("hive.concurrent-small-file-read-enabled", "true")
+                .put("hive.concurrent-small-file-read-parallelism", "10")
+                .put("hive.concurrent-small-file-read-file-count", "100000")
+                .put("hive.concurrent-small-file-read-file-size", "1024")
                 .build();
 
         HiveClientConfig expected = new HiveClientConfig()
@@ -384,7 +392,11 @@ public class TestHiveClientConfig
                 .setOptimizedPartitionUpdateSerializationEnabled(true)
                 .setPartitionLeaseDuration(new Duration(4, TimeUnit.HOURS))
                 .setMaterializedViewMissingPartitionsThreshold(50)
-                .setLooseMemoryAccountingEnabled(true);
+                .setLooseMemoryAccountingEnabled(true)
+                .setConcurrentSmallFileReadEnabled(true)
+                .setConcurrentSmallFileReadParallelism(10)
+                .setConcurrentSmallFileReadFileCountThreshold(100000)
+                .setConcurrentSmallFileReadFileSizeThreshold(1024);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSink.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSink.java
@@ -280,7 +280,7 @@ public class TestHivePageSink
                         Optional.empty(),
                         false)));
         HivePageSourceProvider provider = new HivePageSourceProvider(config, createTestHdfsEnvironment(config, metastoreClientConfig), getDefaultHiveRecordCursorProvider(config, metastoreClientConfig), getDefaultHiveBatchPageSourceFactories(config, metastoreClientConfig), getDefaultHiveSelectivePageSourceFactories(config, metastoreClientConfig), FUNCTION_AND_TYPE_MANAGER, ROW_EXPRESSION_SERVICE);
-        return provider.createPageSource(transaction, getSession(config), split, tableHandle.getLayout().get(), ImmutableList.copyOf(getColumnHandles()), NON_CACHEABLE);
+        return provider.createPageSource(transaction, getSession(config), new MultipleHiveSplit(ImmutableList.of(split)), tableHandle.getLayout().get(), ImmutableList.copyOf(getColumnHandles()), NON_CACHEABLE);
     }
 
     private static ConnectorPageSink createPageSink(HiveTransactionHandle transaction, HiveClientConfig config, MetastoreClientConfig metastoreClientConfig, ExtendedHiveMetastore metastore, Path outputPath, HiveWriterStats stats)

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitSource.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitSource.java
@@ -115,10 +115,10 @@ public class TestHiveSplitSource
         long halfOfSize = fileSize.toBytes() / 2;
         hiveSplitSource.addToQueue(new TestSplit(1, OptionalInt.empty(), fileSize));
 
-        HiveSplit first = (HiveSplit) getSplits(hiveSplitSource, 1).get(0);
+        MultipleHiveSplit first = (MultipleHiveSplit) getSplits(hiveSplitSource, 1).get(0);
         assertEquals(first.getLength(), halfOfSize);
 
-        HiveSplit second = (HiveSplit) getSplits(hiveSplitSource, 1).get(0);
+        MultipleHiveSplit second = (MultipleHiveSplit) getSplits(hiveSplitSource, 1).get(0);
         assertEquals(second.getLength(), fileSize.toBytes() - halfOfSize);
     }
 
@@ -144,7 +144,7 @@ public class TestHiveSplitSource
             assertEquals(hiveSplitSource.getBufferedInternalSplitCount(), i + 1);
         }
 
-        HiveSplit hiveSplit = (HiveSplit) getSplits(hiveSplitSource, 1).get(0);
+        MultipleHiveSplit hiveSplit = (MultipleHiveSplit) getSplits(hiveSplitSource, 1).get(0);
         CacheQuotaRequirement cacheQuotaRequirement = new CacheQuotaRequirement(TABLE, DEFAULT_QUOTA_SIZE);
         assertEquals(hiveSplit.getCacheQuotaRequirement().getQuota(), cacheQuotaRequirement.getQuota());
         assertEquals(hiveSplit.getCacheQuotaRequirement().getCacheQuotaScope(), cacheQuotaRequirement.getCacheQuotaScope());
@@ -168,7 +168,7 @@ public class TestHiveSplitSource
             assertEquals(hiveSplitSource.getBufferedInternalSplitCount(), i + 1);
         }
 
-        hiveSplit = (HiveSplit) getSplits(hiveSplitSource, OptionalInt.of(2), 1).get(0);
+        hiveSplit = (MultipleHiveSplit) getSplits(hiveSplitSource, OptionalInt.of(2), 1).get(0);
         cacheQuotaRequirement = new CacheQuotaRequirement(PARTITION, Optional.empty());
         assertEquals(hiveSplit.getCacheQuotaRequirement().getQuota(), cacheQuotaRequirement.getQuota());
         assertEquals(hiveSplit.getCacheQuotaRequirement().getCacheQuotaScope(), cacheQuotaRequirement.getCacheQuotaScope());
@@ -277,7 +277,7 @@ public class TestHiveSplitSource
 
             // wait for thread to get the split
             ConnectorSplit split = splits.get(10, SECONDS);
-            assertEquals(((HiveSplit) split).getPartitionDataColumnCount(), 33);
+            assertEquals(((MultipleHiveSplit) split).getPartitionDataColumnCount(), 33);
         }
         finally {
             // make sure the thread exits
@@ -398,7 +398,7 @@ public class TestHiveSplitSource
 
             connectorSplits = getSplits(hiveSplitSource, OptionalInt.of(0), 10);
             for (int i = 0; i < 10; i++) {
-                assertEquals(((HiveSplit) connectorSplits.get(i)).getPartitionDataColumnCount(), i);
+                assertEquals(((MultipleHiveSplit) connectorSplits.get(i)).getPartitionDataColumnCount(), i);
             }
             assertTrue(hiveSplitSource.isFinished());
         }


### PR DESCRIPTION
Combine small splits to one mutiple-split until it's size meets the maxSplitBytes(e.g. 64MB). Then read these small splits at the same time.

## Description of Changes
Introduce `MultipleHiveSplit` to combine small HiveSplits and the corresponding `ConcurrentMultipleHivePageSource` to create PageSource for `MultipleHiveSplit`. 
Combine small splits(size < 1MB) to one `MultipleHiveSplit` until the size meets `maxSplitBytes` in `HiveSplitSource`.
