### PR TITLE
Add a configuration property for total FRC cache size

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/FileFragmentResultCacheConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/FileFragmentResultCacheConfig.java
@@ -38,6 +38,7 @@ public class FileFragmentResultCacheConfig
     private Duration cacheTtl = new Duration(2, DAYS);
     private DataSize maxInFlightSize = new DataSize(1, GIGABYTE);
     private DataSize maxSinglePagesSize = new DataSize(500, MEGABYTE);
+    private DataSize maxCacheSize = new DataSize(100, GIGABYTE);
 
     public boolean isCachingEnabled()
     {
@@ -131,6 +132,20 @@ public class FileFragmentResultCacheConfig
     public FileFragmentResultCacheConfig setMaxSinglePagesSize(DataSize maxSinglePagesSize)
     {
         this.maxSinglePagesSize = maxSinglePagesSize;
+        return this;
+    }
+
+    @MinDataSize("0B")
+    public DataSize getMaxCacheSize()
+    {
+        return maxCacheSize;
+    }
+
+    @Config("fragment-result-cache.max-cache-size")
+    @ConfigDescription("Maximum on-disk size of this fragment result cache")
+    public FileFragmentResultCacheConfig setMaxCacheSize(DataSize maxCacheSize)
+    {
+        this.maxCacheSize = maxCacheSize;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/FileFragmentResultCacheManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/FileFragmentResultCacheManager.java
@@ -65,14 +65,18 @@ public class FileFragmentResultCacheManager
     private static final Logger log = Logger.get(FileFragmentResultCacheManager.class);
 
     private final Path baseDirectory;
+    // Max size for the in-memory buffer.
     private final long maxInFlightBytes;
+    // Size limit for every single page.
     private final long maxSinglePagesBytes;
+    // Max on-disk size for this fragment result cache.
+    private final long maxCacheBytes;
     private final PagesSerdeFactory pagesSerdeFactory;
     private final FragmentCacheStats fragmentCacheStats;
     private final ExecutorService flushExecutor;
     private final ExecutorService removalExecutor;
 
-    private final Cache<CacheKey, Path> cache;
+    private final Cache<CacheKey, CacheEntry> cache;
 
     // TODO: Decouple CacheKey by encoding PlanNode and SplitIdentifier separately so we don't have to keep too many objects in memory
     @Inject
@@ -89,6 +93,7 @@ public class FileFragmentResultCacheManager
         this.baseDirectory = Paths.get(cacheConfig.getBaseDirectory());
         this.maxInFlightBytes = cacheConfig.getMaxInFlightSize().toBytes();
         this.maxSinglePagesBytes = cacheConfig.getMaxSinglePagesSize().toBytes();
+        this.maxCacheBytes = cacheConfig.getMaxCacheSize().toBytes();
         // pagesSerde is not thread safe
         this.pagesSerdeFactory = new PagesSerdeFactory(blockEncodingSerde, cacheConfig.isBlockEncodingCompressionEnabled());
         this.fragmentCacheStats = requireNonNull(fragmentCacheStats, "fragmentCacheStats is null");
@@ -132,7 +137,11 @@ public class FileFragmentResultCacheManager
     {
         CacheKey key = new CacheKey(serializedPlan, split.getSplitIdentifier());
         long resultSize = getPagesSize(result);
-        if (fragmentCacheStats.getInFlightBytes() + resultSize > maxInFlightBytes || cache.getIfPresent(key) != null || resultSize > maxSinglePagesBytes) {
+        if (fragmentCacheStats.getInFlightBytes() + resultSize > maxInFlightBytes ||
+                cache.getIfPresent(key) != null ||
+                resultSize > maxSinglePagesBytes ||
+                // Here we use the logical size resultSize as an estimate for admission control.
+                fragmentCacheStats.getCacheSizeInBytes() + resultSize > maxCacheBytes) {
             return immediateFuture(null);
         }
 
@@ -150,13 +159,14 @@ public class FileFragmentResultCacheManager
 
     private void cachePages(CacheKey key, Path path, List<Page> pages, long resultSize)
     {
-        // TODO: To support both memory and disk limit, we should check cache size before putting to cache and use written bytes as weight for cache
         try {
             Files.createFile(path);
             try (SliceOutput output = new OutputStreamSliceOutput(newOutputStream(path, APPEND))) {
                 writePages(pagesSerdeFactory.createPagesSerde(), output, pages.iterator());
-                cache.put(key, path);
+                long resultPhysicalBytes = output.size();
+                cache.put(key, new CacheEntry(path, resultPhysicalBytes));
                 fragmentCacheStats.incrementCacheEntries();
+                fragmentCacheStats.addCacheSizeInBytes(resultPhysicalBytes);
             }
             catch (UncheckedIOException | IOException e) {
                 log.warn(e, "%s encountered an error while writing to path %s", Thread.currentThread().getName(), path);
@@ -189,20 +199,20 @@ public class FileFragmentResultCacheManager
     public Optional<Iterator<Page>> get(String serializedPlan, Split split)
     {
         CacheKey key = new CacheKey(serializedPlan, split.getSplitIdentifier());
-        Path path = cache.getIfPresent(key);
-        if (path == null) {
+        CacheEntry cacheEntry = cache.getIfPresent(key);
+        if (cacheEntry == null) {
             fragmentCacheStats.incrementCacheMiss();
             return Optional.empty();
         }
 
         try {
-            InputStream inputStream = newInputStream(path);
+            InputStream inputStream = newInputStream(cacheEntry.getPath());
             Iterator<Page> result = readPages(pagesSerdeFactory.createPagesSerde(), new InputStreamSliceInput(inputStream));
             fragmentCacheStats.incrementCacheHit();
             return Optional.of(closeWhenExhausted(result, inputStream));
         }
         catch (UncheckedIOException | IOException e) {
-            log.error(e, "read path %s error", path);
+            log.error(e, "read path %s error", cacheEntry.getPath());
             // there might be a chance the file has been deleted. We would return cache miss in this case.
             fragmentCacheStats.incrementCacheMiss();
             return Optional.empty();
@@ -281,15 +291,39 @@ public class FileFragmentResultCacheManager
         }
     }
 
+    private static class CacheEntry
+    {
+        private final Path path;
+        private final long resultBytes;
+
+        public Path getPath()
+        {
+            return path;
+        }
+
+        public long getResultBytes()
+        {
+            return resultBytes;
+        }
+
+        public CacheEntry(Path path, long resultBytes)
+        {
+            this.path = requireNonNull(path, "path is null");
+            this.resultBytes = resultBytes;
+        }
+    }
+
     private class CacheRemovalListener
-            implements RemovalListener<CacheKey, Path>
+            implements RemovalListener<CacheKey, CacheEntry>
     {
         @Override
-        public void onRemoval(RemovalNotification<CacheKey, Path> notification)
+        public void onRemoval(RemovalNotification<CacheKey, CacheEntry> notification)
         {
-            removalExecutor.submit(() -> tryDeleteFile(notification.getValue()));
+            CacheEntry cacheEntry = notification.getValue();
+            removalExecutor.submit(() -> tryDeleteFile(cacheEntry.getPath()));
             fragmentCacheStats.incrementCacheRemoval();
             fragmentCacheStats.decrementCacheEntries();
+            fragmentCacheStats.addCacheSizeInBytes(-cacheEntry.getResultBytes());
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/FragmentCacheStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/FragmentCacheStats.java
@@ -25,6 +25,9 @@ public class FragmentCacheStats
     private final AtomicLong cacheRemoval = new AtomicLong();
     private final AtomicLong cacheEntries = new AtomicLong();
 
+    // Total on-disk size in bytes.
+    private final AtomicLong cacheSizeInBytes = new AtomicLong();
+
     public void incrementCacheHit()
     {
         hit.getAndIncrement();
@@ -38,6 +41,11 @@ public class FragmentCacheStats
     public void addInFlightBytes(long bytes)
     {
         inFlightBytes.addAndGet(bytes);
+    }
+
+    public void addCacheSizeInBytes(long bytes)
+    {
+        cacheSizeInBytes.addAndGet(bytes);
     }
 
     public void incrementCacheRemoval()
@@ -83,5 +91,11 @@ public class FragmentCacheStats
     public long getCacheEntries()
     {
         return cacheEntries.get();
+    }
+
+    @Managed
+    public long getCacheSizeInBytes()
+    {
+        return cacheSizeInBytes.get();
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestFileFragmentResultCacheConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestFileFragmentResultCacheConfig.java
@@ -40,7 +40,8 @@ public class TestFileFragmentResultCacheConfig
                 .setMaxCachedEntries(10_000)
                 .setCacheTtl(new Duration(2, DAYS))
                 .setMaxInFlightSize(new DataSize(1, GIGABYTE))
-                .setMaxSinglePagesSize(new DataSize(500, MEGABYTE)));
+                .setMaxSinglePagesSize(new DataSize(500, MEGABYTE))
+                .setMaxCacheSize(new DataSize(100, GIGABYTE)));
     }
 
     @Test
@@ -55,6 +56,7 @@ public class TestFileFragmentResultCacheConfig
                 .put("fragment-result-cache.cache-ttl", "1d")
                 .put("fragment-result-cache.max-in-flight-size", "2GB")
                 .put("fragment-result-cache.max-single-pages-size", "200MB")
+                .put("fragment-result-cache.max-cache-size", "200GB")
                 .build();
 
         FileFragmentResultCacheConfig expected = new FileFragmentResultCacheConfig()
@@ -64,7 +66,8 @@ public class TestFileFragmentResultCacheConfig
                 .setMaxCachedEntries(100000)
                 .setCacheTtl(new Duration(1, DAYS))
                 .setMaxInFlightSize(new DataSize(2, GIGABYTE))
-                .setMaxSinglePagesSize(new DataSize(200, MEGABYTE));
+                .setMaxSinglePagesSize(new DataSize(200, MEGABYTE))
+                .setMaxCacheSize(new DataSize(200, GIGABYTE));
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
Store the on-disk size in the FRC cache entry so that we can update the
total cache size when the cache entry is evicted.

Add a configuration property for total FRC cache size

Test plan 
Added unit tests.

```
== RELEASE NOTES ==

General Changes
* Add a configuration property fragment-result-cache.max-cache-size to control the total on-disk size of fragment result cache. The default value is 100G.

```

