### PR TITLE
Add a hive session property to enable per query cache metrics

### DIFF
--- a/presto-cache/src/test/java/com/facebook/presto/cache/alluxio/TestAlluxioCachingFileSystem.java
+++ b/presto-cache/src/test/java/com/facebook/presto/cache/alluxio/TestAlluxioCachingFileSystem.java
@@ -496,7 +496,7 @@ public class TestAlluxioCachingFileSystem
     private int readFully(AlluxioCachingFileSystem fileSystem, CacheQuota quota, long position, byte[] buffer, int offset, int length)
             throws Exception
     {
-        try (FSDataInputStream stream = fileSystem.openFile(new Path(testFilePath), new HiveFileContext(true, quota, Optional.empty(), Optional.of((long) DATA_LENGTH), 0))) {
+        try (FSDataInputStream stream = fileSystem.openFile(new Path(testFilePath), new HiveFileContext(true, quota, Optional.empty(), Optional.of((long) DATA_LENGTH), 0, false))) {
             return stream.read(position, buffer, offset, length);
         }
     }

--- a/presto-hive-common/src/main/java/com/facebook/presto/hive/HiveFileContext.java
+++ b/presto-hive-common/src/main/java/com/facebook/presto/hive/HiveFileContext.java
@@ -22,23 +22,25 @@ import static java.util.Objects.requireNonNull;
 
 public class HiveFileContext
 {
-    public static final HiveFileContext DEFAULT_HIVE_FILE_CONTEXT = new HiveFileContext(true, NO_CACHE_CONSTRAINTS, Optional.empty(), Optional.empty(), 0);
+    public static final HiveFileContext DEFAULT_HIVE_FILE_CONTEXT = new HiveFileContext(true, NO_CACHE_CONSTRAINTS, Optional.empty(), Optional.empty(), 0, false);
 
     private final boolean cacheable;
     private final CacheQuota cacheQuota;
     private final Optional<ExtraHiveFileInfo<?>> extraFileInfo;
     private final Optional<Long> fileSize;
     private final long modificationTime;
+    private final boolean verboseRuntimeStatsEnabled;
 
     private final RuntimeStats stats = new RuntimeStats();
 
-    public HiveFileContext(boolean cacheable, CacheQuota cacheQuota, Optional<ExtraHiveFileInfo<?>> extraFileInfo, Optional<Long> fileSize, long modificationTime)
+    public HiveFileContext(boolean cacheable, CacheQuota cacheQuota, Optional<ExtraHiveFileInfo<?>> extraFileInfo, Optional<Long> fileSize, long modificationTime, boolean verboseRuntimeStatsEnabled)
     {
         this.cacheable = cacheable;
         this.cacheQuota = requireNonNull(cacheQuota, "cacheQuota is null");
         this.extraFileInfo = requireNonNull(extraFileInfo, "extraFileInfo is null");
         this.fileSize = requireNonNull(fileSize, "fileSize is null");
         this.modificationTime = modificationTime;
+        this.verboseRuntimeStatsEnabled = verboseRuntimeStatsEnabled;
     }
 
     /**
@@ -79,7 +81,9 @@ public class HiveFileContext
 
     public void incrementCounter(String name, long value)
     {
-        stats.addMetricValue(name, value);
+        if (verboseRuntimeStatsEnabled) {
+            stats.addMetricValue(name, value);
+        }
     }
 
     public RuntimeStats getStats()

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -197,6 +197,8 @@ public class HiveClientConfig
     private boolean enableLooseMemoryAccounting;
     private int materializedViewMissingPartitionsThreshold = 100;
 
+    private boolean verboseRuntimeStatsEnabled;
+
     public int getMaxInitialSplits()
     {
         return maxInitialSplits;
@@ -1628,6 +1630,19 @@ public class HiveClientConfig
     public boolean isOptimizedPartitionUpdateSerializationEnabled()
     {
         return optimizedPartitionUpdateSerializationEnabled;
+    }
+
+    @Config("hive.verbose-runtime-stats-enabled")
+    @ConfigDescription("Enable tracking all runtime stats. Note that this may affect query performance")
+    public HiveClientConfig setVerboseRuntimeStatsEnabled(boolean verboseRuntimeStatsEnabled)
+    {
+        this.verboseRuntimeStatsEnabled = verboseRuntimeStatsEnabled;
+        return this;
+    }
+
+    public boolean isVerboseRuntimeStatsEnabled()
+    {
+        return verboseRuntimeStatsEnabled;
     }
 
     @Config("hive.partition-lease-duration")

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSourceProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSourceProvider.java
@@ -207,7 +207,13 @@ public class HivePageSourceProvider
                 hiveSplit.getTableToPartitionMapping(),
                 hiveSplit.getBucketConversion(),
                 hiveSplit.isS3SelectPushdownEnabled(),
-                new HiveFileContext(splitContext.isCacheable(), cacheQuota, hiveSplit.getExtraFileInfo().map(BinaryExtraHiveFileInfo::new), Optional.of(hiveSplit.getFileSize()), hiveSplit.getFileModifiedTime()),
+                new HiveFileContext(
+                        splitContext.isCacheable(),
+                        cacheQuota,
+                        hiveSplit.getExtraFileInfo().map(BinaryExtraHiveFileInfo::new),
+                        Optional.of(hiveSplit.getFileSize()),
+                        hiveSplit.getFileModifiedTime(),
+                        HiveSessionProperties.isVerboseRuntimeStatsEnabled(session)),
                 hiveLayout.getRemainingPredicate(),
                 hiveLayout.isPushdownFilterEnabled(),
                 rowExpressionService,
@@ -318,7 +324,13 @@ public class HivePageSourceProvider
                             handle -> new Subfield(((HiveColumnHandle) handle).getName())).intersect(layout.getDomainPredicate())).orElse(layout.getDomainPredicate()),
                     optimizedRemainingPredicate,
                     hiveStorageTimeZone,
-                    new HiveFileContext(splitContext.isCacheable(), cacheQuota, split.getExtraFileInfo().map(BinaryExtraHiveFileInfo::new), Optional.of(split.getFileSize()), split.getFileModifiedTime()),
+                    new HiveFileContext(
+                            splitContext.isCacheable(),
+                            cacheQuota,
+                            split.getExtraFileInfo().map(BinaryExtraHiveFileInfo::new),
+                            Optional.of(split.getFileSize()),
+                            split.getFileModifiedTime(),
+                            HiveSessionProperties.isVerboseRuntimeStatsEnabled(session)),
                     encryptionInformation);
             if (pageSource.isPresent()) {
                 return Optional.of(pageSource.get());

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
@@ -126,6 +126,7 @@ public final class HiveSessionProperties
     public static final String CACHE_ENABLED = "cache_enabled";
     public static final String ENABLE_LOOSE_MEMORY_BASED_ACCOUNTING = "enable_loose_memory_based_accounting";
     public static final String MATERIALIZED_VIEW_MISSING_PARTITIONS_THRESHOLD = "materialized_view_missing_partitions_threshold";
+    public static final String VERBOSE_RUNTIME_STATS_ENABLED = "verbose_runtime_stats_enabled";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -586,6 +587,11 @@ public final class HiveSessionProperties
                         cacheConfig.isCachingEnabled(),
                         false),
                 booleanProperty(
+                        VERBOSE_RUNTIME_STATS_ENABLED,
+                        "Enable tracking all runtime stats. Note that this may affect query performance.",
+                        hiveClientConfig.isVerboseRuntimeStatsEnabled(),
+                        false),
+                booleanProperty(
                         ENABLE_LOOSE_MEMORY_BASED_ACCOUNTING,
                         "Enable loose memory accounting to avoid OOMing existing queries",
                         hiveClientConfig.isLooseMemoryAccountingEnabled(),
@@ -1043,5 +1049,10 @@ public final class HiveSessionProperties
     public static int getMaterializedViewMissingPartitionsThreshold(ConnectorSession session)
     {
         return session.getProperty(MATERIALIZED_VIEW_MISSING_PARTITIONS_THRESHOLD, Integer.class);
+    }
+
+    public static boolean isVerboseRuntimeStatsEnabled(ConnectorSession session)
+    {
+        return session.getProperty(VERBOSE_RUNTIME_STATS_ENABLED, Boolean.class);
     }
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
@@ -153,6 +153,7 @@ public class TestHiveClientConfig
                 .setManifestVerificationEnabled(false)
                 .setUndoMetastoreOperationsEnabled(true)
                 .setOptimizedPartitionUpdateSerializationEnabled(false)
+                .setVerboseRuntimeStatsEnabled(false)
                 .setPartitionLeaseDuration(new Duration(0, TimeUnit.SECONDS))
                 .setMaterializedViewMissingPartitionsThreshold(100)
                 .setLooseMemoryAccountingEnabled(false));
@@ -271,6 +272,7 @@ public class TestHiveClientConfig
                 .put("hive.experimental-optimized-partition-update-serialization-enabled", "true")
                 .put("hive.partition-lease-duration", "4h")
                 .put("hive.loose-memory-accounting-enabled", "true")
+                .put("hive.verbose-runtime-stats-enabled", "true")
                 .put("hive.materialized-view-missing-partitions-threshold", "50")
                 .build();
 
@@ -382,6 +384,7 @@ public class TestHiveClientConfig
                 .setManifestVerificationEnabled(true)
                 .setUndoMetastoreOperationsEnabled(false)
                 .setOptimizedPartitionUpdateSerializationEnabled(true)
+                .setVerboseRuntimeStatsEnabled(true)
                 .setPartitionLeaseDuration(new Duration(4, TimeUnit.HOURS))
                 .setMaterializedViewMissingPartitionsThreshold(50)
                 .setLooseMemoryAccountingEnabled(true);


### PR DESCRIPTION
The current solution collects the metric per read which may introduce non-trivial overhead. Adding this session property to disable the per query cache metric collection by default. 

Will look into optimizing it in the following commits.

```
== NO RELEASE NOTE ==
```
