### PR TITLE
Enforce ACLs for SELECT path for materialized view

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveDistributedQueries.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveDistributedQueries.java
@@ -43,12 +43,6 @@ public class TestHiveDistributedQueries
     }
 
     @Override
-    protected boolean supportsMaterializedViews()
-    {
-        return true;
-    }
-
-    @Override
     protected boolean supportsNotNullColumns()
     {
         return false;

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveLogicalPlanner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveLogicalPlanner.java
@@ -42,6 +42,7 @@ import com.facebook.presto.spi.relation.CallExpression;
 import com.facebook.presto.spi.relation.ConstantExpression;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.spi.security.Identity;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.planner.Plan;
 import com.facebook.presto.sql.planner.assertions.ExpectedValueProvider;
@@ -77,6 +78,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import static com.facebook.presto.SystemSessionProperties.JOIN_REORDERING_STRATEGY;
@@ -137,6 +139,9 @@ import static com.facebook.presto.sql.planner.plan.ExchangeNode.Scope.LOCAL;
 import static com.facebook.presto.sql.planner.plan.ExchangeNode.Scope.REMOTE_STREAMING;
 import static com.facebook.presto.sql.planner.plan.ExchangeNode.Type.GATHER;
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.INNER;
+import static com.facebook.presto.testing.TestingAccessControlManager.TestingPrivilegeType.INSERT_TABLE;
+import static com.facebook.presto.testing.TestingAccessControlManager.TestingPrivilegeType.SELECT_COLUMN;
+import static com.facebook.presto.testing.TestingAccessControlManager.privilege;
 import static com.facebook.presto.testing.assertions.Assert.assertEquals;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -1401,7 +1406,8 @@ public class TestHiveLogicalPlanner
             assertEquals(viewTable, baseTable);
 
             assertPlan(getSession(), viewQuery, anyTree(
-                    filter("orderkey < BIGINT'10000'", PlanMatchPattern.constrainedTableScan(view, ImmutableMap.of(), ImmutableMap.of("orderkey", "orderkey")))));
+                    anyTree(values("orderkey")), // Alias for the filter column
+                    anyTree(filter("orderkey_17 < BIGINT'10000'", PlanMatchPattern.constrainedTableScan(view, ImmutableMap.of(), ImmutableMap.of("orderkey_17", "orderkey"))))));
         }
         finally {
             queryRunner.execute("DROP MATERIALIZED VIEW IF EXISTS " + view);
@@ -2196,9 +2202,10 @@ public class TestHiveLogicalPlanner
             assertEquals(optimizedQueryResult, baseQueryResult);
 
             PlanMatchPattern expectedPattern = anyTree(
-                    filter("orderkey < BIGINT'1000'", PlanMatchPattern.constrainedTableScan(view2,
+                    anyTree(values("orderkey", "orderdate")),
+                    anyTree(filter("orderkey_25 < BIGINT'1000'", PlanMatchPattern.constrainedTableScan(view2,
                             ImmutableMap.of(),
-                            ImmutableMap.of("orderkey", "orderkey"))));
+                            ImmutableMap.of("orderkey_25", "orderkey")))));
 
             assertPlan(queryOptimizationWithMaterializedView, baseQuery, expectedPattern);
             assertPlan(getSession(), viewQuery, expectedPattern);
@@ -2526,6 +2533,143 @@ public class TestHiveLogicalPlanner
         finally {
             queryRunner.execute("DROP MATERIALIZED VIEW IF EXISTS " + view);
             queryRunner.execute("DROP TABLE IF EXISTS " + table);
+        }
+    }
+
+    @Test
+    public void testMaterializedViewQueryAccessControl()
+    {
+        QueryRunner queryRunner = getQueryRunner();
+        Session invokerSession = Session.builder(getSession())
+                .setIdentity(new Identity("test_view_invoker", Optional.empty()))
+                .setCatalog(getSession().getCatalog().get())
+                .setSchema(getSession().getSchema().get())
+                .setSystemProperty(QUERY_OPTIMIZATION_WITH_MATERIALIZED_VIEW_ENABLED, "true")
+                .build();
+        Session ownerSession = getSession();
+
+        queryRunner.execute(
+                ownerSession,
+                "CREATE TABLE test_orders_base WITH (partitioned_by = ARRAY['orderstatus']) " +
+                        "AS SELECT orderkey, custkey, totalprice, orderstatus FROM orders LIMIT 10");
+        queryRunner.execute(
+                ownerSession,
+                "CREATE MATERIALIZED VIEW test_orders_view " +
+                        "WITH (partitioned_by = ARRAY['orderstatus']) " +
+                        "AS SELECT SUM(totalprice) AS totalprice, orderstatus FROM test_orders_base GROUP BY orderstatus");
+        setReferencedMaterializedViews((DistributedQueryRunner) getQueryRunner(), "test_orders_base", ImmutableList.of("test_orders_view"));
+
+        Consumer<String> testQueryWithDeniedPrivilege = query -> {
+            // Verify checking the base table instead of the materialized view for SELECT permission
+            assertAccessDenied(
+                    invokerSession,
+                    query,
+                    "Cannot select from columns \\[.*\\] in table .*test_orders_base.*",
+                    privilege(invokerSession.getUser(), "test_orders_base", SELECT_COLUMN));
+            assertAccessAllowed(
+                    invokerSession,
+                    query,
+                    privilege(invokerSession.getUser(), "test_orders_view", SELECT_COLUMN));
+        };
+
+        try {
+            // Check for both the direct materialized view query and the base table query optimization with materialized view
+            String directMaterializedViewQuery = "SELECT totalprice, orderstatus FROM test_orders_view";
+            String queryWithMaterializedViewOptimization = "SELECT SUM(totalprice) AS totalprice, orderstatus FROM test_orders_base GROUP BY orderstatus";
+
+            // Test when the materialized view is not materialized yet
+            testQueryWithDeniedPrivilege.accept(directMaterializedViewQuery);
+            testQueryWithDeniedPrivilege.accept(queryWithMaterializedViewOptimization);
+
+            // Test when the materialized view is partially materialized
+            queryRunner.execute(ownerSession, "REFRESH MATERIALIZED VIEW test_orders_view WHERE orderstatus = 'F'");
+            testQueryWithDeniedPrivilege.accept(directMaterializedViewQuery);
+            testQueryWithDeniedPrivilege.accept(queryWithMaterializedViewOptimization);
+
+            // Test when the materialized view is fully materialized
+            queryRunner.execute(ownerSession, "REFRESH MATERIALIZED VIEW test_orders_view WHERE orderstatus <> 'F'");
+            testQueryWithDeniedPrivilege.accept(directMaterializedViewQuery);
+            testQueryWithDeniedPrivilege.accept(queryWithMaterializedViewOptimization);
+        }
+        finally {
+            queryRunner.execute(ownerSession, "DROP MATERIALIZED VIEW test_orders_view");
+            queryRunner.execute(ownerSession, "DROP TABLE test_orders_base");
+        }
+    }
+
+    @Test
+    public void testRefreshMaterializedViewAccessControl()
+    {
+        QueryRunner queryRunner = getQueryRunner();
+        Session invokerSession = Session.builder(getSession())
+                .setIdentity(new Identity("test_view_invoker", Optional.empty()))
+                .setCatalog(getSession().getCatalog().get())
+                .setSchema(getSession().getSchema().get())
+                .build();
+        Session ownerSession = getSession();
+
+        queryRunner.execute(
+                ownerSession,
+                "CREATE TABLE test_orders_base WITH (partitioned_by = ARRAY['orderstatus']) " +
+                        "AS SELECT orderkey, custkey, totalprice, orderstatus FROM orders LIMIT 10");
+        queryRunner.execute(
+                ownerSession,
+                "CREATE MATERIALIZED VIEW test_orders_view " +
+                        "WITH (partitioned_by = ARRAY['orderstatus']) " +
+                        "AS SELECT orderkey, totalprice, orderstatus FROM test_orders_base");
+
+        String refreshMaterializedView = "REFRESH MATERIALIZED VIEW test_orders_view WHERE orderstatus = 'F'";
+
+        try {
+            // Verify that refresh checks the owner's permission instead of the invoker's permission on the base table
+            assertAccessDenied(
+                    invokerSession,
+                    refreshMaterializedView,
+                    "Cannot select from columns \\[.*\\] in table .*test_orders_base.*",
+                    privilege(ownerSession.getUser(), "test_orders_base", SELECT_COLUMN));
+            assertAccessAllowed(
+                    invokerSession,
+                    refreshMaterializedView,
+                    privilege(invokerSession.getUser(), "test_orders_base", SELECT_COLUMN));
+
+            // Verify that refresh checks owner's permission instead of the invokers permission on the materialized view.
+            // Verify that refresh requires INSERT_TABLE permission instead of SELECT_COLUMN permission on the materialized view.
+            assertAccessDenied(
+                    invokerSession,
+                    refreshMaterializedView,
+                    "Cannot insert into table .*test_orders_view.*",
+                    privilege(ownerSession.getUser(), "test_orders_view", INSERT_TABLE));
+            assertAccessAllowed(
+                    invokerSession,
+                    refreshMaterializedView,
+                    privilege(invokerSession.getUser(), "test_orders_view", INSERT_TABLE));
+            assertAccessAllowed(
+                    invokerSession,
+                    refreshMaterializedView,
+                    privilege(ownerSession.getUser(), "test_orders_view", SELECT_COLUMN));
+            assertAccessAllowed(
+                    invokerSession,
+                    refreshMaterializedView,
+                    privilege(invokerSession.getUser(), "test_orders_view", SELECT_COLUMN));
+
+            // Verify for the owner invoking refresh
+            assertAccessDenied(
+                    ownerSession,
+                    refreshMaterializedView,
+                    "Cannot select from columns \\[.*\\] in table .*test_orders_base.*",
+                    privilege(ownerSession.getUser(), "test_orders_base", SELECT_COLUMN));
+            assertAccessDenied(
+                    ownerSession,
+                    refreshMaterializedView,
+                    "Cannot insert into table .*test_orders_view.*",
+                    privilege(ownerSession.getUser(), "test_orders_view", INSERT_TABLE));
+            assertAccessAllowed(
+                    ownerSession,
+                    refreshMaterializedView);
+        }
+        finally {
+            queryRunner.execute(ownerSession, "DROP MATERIALIZED VIEW test_orders_view");
+            queryRunner.execute(ownerSession, "DROP TABLE test_orders_base");
         }
     }
 

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
@@ -46,7 +46,6 @@ import static com.facebook.presto.testing.TestingAccessControlManager.TestingPri
 import static com.facebook.presto.testing.TestingAccessControlManager.TestingPrivilegeType.CREATE_VIEW_WITH_SELECT_COLUMNS;
 import static com.facebook.presto.testing.TestingAccessControlManager.TestingPrivilegeType.DROP_COLUMN;
 import static com.facebook.presto.testing.TestingAccessControlManager.TestingPrivilegeType.DROP_TABLE;
-import static com.facebook.presto.testing.TestingAccessControlManager.TestingPrivilegeType.INSERT_TABLE;
 import static com.facebook.presto.testing.TestingAccessControlManager.TestingPrivilegeType.RENAME_COLUMN;
 import static com.facebook.presto.testing.TestingAccessControlManager.TestingPrivilegeType.RENAME_TABLE;
 import static com.facebook.presto.testing.TestingAccessControlManager.TestingPrivilegeType.SELECT_COLUMN;
@@ -76,11 +75,6 @@ public abstract class AbstractTestDistributedQueries
     protected boolean supportsViews()
     {
         return true;
-    }
-
-    protected boolean supportsMaterializedViews()
-    {
-        return false;
     }
 
     protected boolean supportsNotNullColumns()
@@ -1067,80 +1061,6 @@ public abstract class AbstractTestDistributedQueries
         assertAccessAllowed(nestedViewOwnerSession, "DROP VIEW test_nested_view_access");
         assertAccessAllowed(viewOwnerSession, "DROP VIEW test_view_access");
         assertAccessAllowed(viewOwnerSession, "DROP VIEW test_invoker_view_access");
-    }
-
-    @Test
-    public void testRefreshMaterializedViewAccessControl()
-    {
-        skipTestUnless(supportsMaterializedViews());
-
-        Session invokerSession = TestingSession.testSessionBuilder()
-                .setIdentity(new Identity("test_view_invoker", Optional.empty()))
-                .setCatalog(getSession().getCatalog().get())
-                .setSchema(getSession().getSchema().get())
-                .build();
-        Session ownerSession = getSession();
-
-        computeActual(
-                ownerSession,
-                "CREATE TABLE test_orders_base WITH (partitioned_by = ARRAY['orderstatus']) " +
-                        "AS SELECT orderkey, custkey, totalprice, orderstatus FROM orders LIMIT 10");
-        computeActual(
-                ownerSession,
-                "CREATE MATERIALIZED VIEW test_orders_view " +
-                        "WITH (partitioned_by = ARRAY['orderstatus']) " +
-                        "AS SELECT orderkey, totalprice, orderstatus FROM test_orders_base");
-
-        String refreshMaterializedView = "REFRESH MATERIALIZED VIEW test_orders_view WHERE orderstatus = 'F'";
-
-        // Verify that refresh checks the owner's permission instead of the invoker's permission on the base table
-        assertAccessDenied(
-                invokerSession,
-                refreshMaterializedView,
-                "Cannot select from columns \\[.*\\] in table .*test_orders_base.*",
-                privilege(ownerSession.getUser(), "test_orders_base", SELECT_COLUMN));
-        assertAccessAllowed(
-                invokerSession,
-                refreshMaterializedView,
-                privilege(invokerSession.getUser(), "test_orders_base", SELECT_COLUMN));
-
-        // Verify that refresh checks owner's permission instead of the invokers permission on the materialized view.
-        // Verify that refresh requires INSERT_TABLE permission instead of SELECT_COLUMN permission on the materialized view.
-        assertAccessDenied(
-                invokerSession,
-                refreshMaterializedView,
-                "Cannot insert into table .*test_orders_view.*",
-                privilege(ownerSession.getUser(), "test_orders_view", INSERT_TABLE));
-        assertAccessAllowed(
-                invokerSession,
-                refreshMaterializedView,
-                privilege(invokerSession.getUser(), "test_orders_view", INSERT_TABLE));
-        assertAccessAllowed(
-                invokerSession,
-                refreshMaterializedView,
-                privilege(ownerSession.getUser(), "test_orders_view", SELECT_COLUMN));
-        assertAccessAllowed(
-                invokerSession,
-                refreshMaterializedView,
-                privilege(invokerSession.getUser(), "test_orders_view", SELECT_COLUMN));
-
-        // Verify for the owner invoking refresh
-        assertAccessDenied(
-                ownerSession,
-                refreshMaterializedView,
-                "Cannot select from columns \\[.*\\] in table .*test_orders_base.*",
-                privilege(ownerSession.getUser(), "test_orders_base", SELECT_COLUMN));
-        assertAccessDenied(
-                ownerSession,
-                refreshMaterializedView,
-                "Cannot insert into table .*test_orders_view.*",
-                privilege(ownerSession.getUser(), "test_orders_view", INSERT_TABLE));
-        assertAccessAllowed(
-                ownerSession,
-                refreshMaterializedView);
-
-        computeActual(ownerSession, "DROP MATERIALIZED VIEW test_orders_view");
-        computeActual(ownerSession, "DROP TABLE test_orders_base");
     }
 
     @Test


### PR DESCRIPTION
We decided to check invoker's SELECT permission on the base table only but not on the materialized view, on the SELECT path for both directly querying the materialized view and querying the base base with materialized view optimization.

This is for materialized view in invoker mode that we only support right now.

Generally today we add the required AccessControls to Analysis.tableColumnReferences for the base tables and the materialized view, when we traverse the AST of rewritten select query. This change replaces the AccessControl collected for the materialized view with AllowAllAccessControl after the AST traversal is done, in order to not check permission on the materialized view.

So the change mainly includes two parts:
1. Replace the AccessControl for the materialized view with AllowAllAccessControl after the AST traversal is done.
2. For the case that the materialized view is fully materialized, when rewriting the query,
instead of returning
`SELECT * FROM my_mv`
we will return
`SELECT * FROM my_mv
UNION ALL
SELECT * FROM my_base_table WHERE false
`

This is to expose the base table and columns during the AST traversal of the rewritten query. In the case that the materialized view is not materialized or partially materialized, the base table is already exposed today.
```
== NO RELEASE NOTE ==
```