### PR TITLE
Enhance explain output for JDBC table scans to show filter predicates

### DIFF
--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcMetadata.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcMetadata.java
@@ -85,7 +85,7 @@ public class JdbcMetadata
     public List<ConnectorTableLayoutResult> getTableLayouts(ConnectorSession session, ConnectorTableHandle table, Constraint<ColumnHandle> constraint, Optional<Set<ColumnHandle>> desiredColumns)
     {
         JdbcTableHandle tableHandle = (JdbcTableHandle) table;
-        ConnectorTableLayout layout = new ConnectorTableLayout(new JdbcTableLayoutHandle(tableHandle, constraint.getSummary(), Optional.empty()));
+        ConnectorTableLayout layout = new ConnectorTableLayout(new JdbcTableLayoutHandle(session.getSqlFunctionProperties(), tableHandle, constraint.getSummary(), Optional.empty()));
         return ImmutableList.of(new ConnectorTableLayoutResult(layout, constraint.getSummary()));
     }
 

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcTableLayoutHandle.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcTableLayoutHandle.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.plugin.jdbc;
 
+import com.facebook.presto.common.function.SqlFunctionProperties;
 import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.plugin.jdbc.optimization.JdbcExpression;
 import com.facebook.presto.spi.ColumnHandle;
@@ -23,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
 import java.util.Optional;
 
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
 public class JdbcTableLayoutHandle
@@ -31,16 +33,34 @@ public class JdbcTableLayoutHandle
     private final JdbcTableHandle table;
     private final TupleDomain<ColumnHandle> tupleDomain;
     private final Optional<JdbcExpression> additionalPredicate;
+    private final String layoutString;
+
+    public JdbcTableLayoutHandle(
+            SqlFunctionProperties properties,
+            JdbcTableHandle table,
+            TupleDomain<ColumnHandle> domain,
+            Optional<JdbcExpression> additionalPredicate)
+    {
+        this(table,
+                domain,
+                additionalPredicate,
+                toStringHelper("")
+                        .add("domains", domain.transform((columnHandle) -> ((JdbcColumnHandle) columnHandle).getColumnName()).toString(properties))
+                        .add("additionalPredicate", additionalPredicate.map(JdbcExpression::getExpression).orElse("{}"))
+                        .toString());
+    }
 
     @JsonCreator
     public JdbcTableLayoutHandle(
             @JsonProperty("table") JdbcTableHandle table,
             @JsonProperty("tupleDomain") TupleDomain<ColumnHandle> domain,
-            @JsonProperty("additionalPredicate") Optional<JdbcExpression> additionalPredicate)
+            @JsonProperty("additionalPredicate") Optional<JdbcExpression> additionalPredicate,
+            @JsonProperty("layoutString") String layoutString)
     {
         this.table = requireNonNull(table, "table is null");
         this.tupleDomain = requireNonNull(domain, "tupleDomain is null");
         this.additionalPredicate = additionalPredicate;
+        this.layoutString = requireNonNull(layoutString, "layoutString is null");
     }
 
     @JsonProperty
@@ -59,6 +79,12 @@ public class JdbcTableLayoutHandle
     public TupleDomain<ColumnHandle> getTupleDomain()
     {
         return tupleDomain;
+    }
+
+    @JsonProperty
+    public String getLayoutString()
+    {
+        return layoutString;
     }
 
     @Override
@@ -85,6 +111,6 @@ public class JdbcTableLayoutHandle
     @Override
     public String toString()
     {
-        return table.toString();
+        return layoutString;
     }
 }

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/optimization/JdbcComputePushdown.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/optimization/JdbcComputePushdown.java
@@ -139,6 +139,7 @@ public class JdbcComputePushdown
 
             JdbcTableLayoutHandle oldTableLayoutHandle = (JdbcTableLayoutHandle) oldTableHandle.getLayout().get();
             JdbcTableLayoutHandle newTableLayoutHandle = new JdbcTableLayoutHandle(
+                    session.getSqlFunctionProperties(),
                     oldConnectorTable,
                     oldTableLayoutHandle.getTupleDomain(),
                     jdbcExpression.getTranslated());

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcRecordSetProvider.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestJdbcRecordSetProvider.java
@@ -181,7 +181,7 @@ public class TestJdbcRecordSetProvider
 
     private RecordCursor getCursor(JdbcTableHandle jdbcTableHandle, List<JdbcColumnHandle> columns, TupleDomain<ColumnHandle> domain)
     {
-        JdbcTableLayoutHandle layoutHandle = new JdbcTableLayoutHandle(jdbcTableHandle, domain, Optional.empty());
+        JdbcTableLayoutHandle layoutHandle = new JdbcTableLayoutHandle(SESSION.getSqlFunctionProperties(), jdbcTableHandle, domain, Optional.empty());
         ConnectorSplitSource splits = jdbcClient.getSplits(IDENTITY, layoutHandle);
         JdbcSplit split = (JdbcSplit) getOnlyElement(getFutureValue(splits.getNextBatch(NOT_PARTITIONED, 1000)).getSplits());
 

--- a/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestingDatabase.java
+++ b/presto-base-jdbc/src/test/java/com/facebook/presto/plugin/jdbc/TestingDatabase.java
@@ -101,7 +101,7 @@ final class TestingDatabase
     {
         JdbcIdentity identity = JdbcIdentity.from(session);
         JdbcTableHandle jdbcTableHandle = jdbcClient.getTableHandle(identity, new SchemaTableName(schemaName, tableName));
-        JdbcTableLayoutHandle jdbcLayoutHandle = new JdbcTableLayoutHandle(jdbcTableHandle, TupleDomain.all(), Optional.empty());
+        JdbcTableLayoutHandle jdbcLayoutHandle = new JdbcTableLayoutHandle(session.getSqlFunctionProperties(), jdbcTableHandle, TupleDomain.all(), Optional.empty());
         ConnectorSplitSource splits = jdbcClient.getSplits(identity, jdbcLayoutHandle);
         return (JdbcSplit) getOnlyElement(getFutureValue(splits.getNextBatch(NOT_PARTITIONED, 1000)).getSplits());
     }


### PR DESCRIPTION
Fixes https://github.com/prestodb/presto/issues/16873

Test plan - Tested manually. Explain for Jdbc table scans shows the pushed down filter predicates.

Example explain for ScanFilter is below for query "explain select * from postgresql.public.t1 where j = 2 and cast(i as varchar) like '%2'"

ScanFilter[table = TableHandle {connectorId='postgresql', connectorHandle='postgresql:public.t1:null:public:t1', layout='Optional[**public.t1{domains='{j=[ [[""2""]] ]}', additionalPredicate='{}'}]'**}, filterPredicate = ((j) = (INTEGER'2')) AND (CAST(i AS varchar) LIKE VARCHAR'%2')] => [i:integer, j:integer]
                Estimates: {rows: ? (?), cpu: ?, memory: 0.00, network: 0.00}/{rows: ? (?), cpu: ?, memory: 0.00, network: 0.00}
                **LAYOUT: public.t1{domains='{j=[ [[""2""]] ]}', additionalPredicate='{}'}**
                j := JdbcColumnHandle{connectorId=postgresql, columnName=j, jdbcTypeHandle=JdbcTypeHandle{jdbcType=4, columnSize=10, decimalDigits=0}, columnType=integer, nullable=true, comment=Optional.empty}
                i := JdbcColumnHandle{connectorId=postgresql, columnName=i, jdbcTypeHandle=JdbcTypeHandle{jdbcType=4, columnSize=10, decimalDigits=0}, columnType=integer, nullable=true, comment=Optional.empty}

```
== NO RELEASE NOTE ==
```
