### PR TITLE
Add expanded query for refresh materialized view

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/event/QueryMonitor.java
+++ b/presto-main/src/main/java/com/facebook/presto/event/QueryMonitor.java
@@ -192,7 +192,8 @@ public class QueryMonitor
                 ofEpochMilli(queryInfo.getQueryStats().getEndTime().getMillis()),
                 ofEpochMilli(queryInfo.getQueryStats().getEndTime().getMillis()),
                 ImmutableList.of(),
-                ImmutableList.of()));
+                ImmutableList.of(),
+                Optional.empty()));
 
         logQueryTimeline(queryInfo);
     }
@@ -221,7 +222,8 @@ public class QueryMonitor
                         ofEpochMilli(queryStats.getExecutionStartTime().getMillis()),
                         ofEpochMilli(queryStats.getEndTime() != null ? queryStats.getEndTime().getMillis() : 0),
                         stageStatisticsBuilder.build(),
-                        createOperatorStatistics(queryInfo)));
+                        createOperatorStatistics(queryInfo),
+                        queryInfo.getExpandedQuery()));
 
         logQueryTimeline(queryInfo);
     }

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryInfo.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.execution;
 
-import com.facebook.presto.Session;
 import com.facebook.presto.SessionRepresentation;
 import com.facebook.presto.spi.ErrorCode;
 import com.facebook.presto.spi.ErrorType;
@@ -41,10 +40,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
-import static com.facebook.presto.execution.QueryState.FAILED;
-import static com.facebook.presto.execution.QueryStats.immediateFailureQueryStats;
 import static com.facebook.presto.execution.StageInfo.getAllStages;
-import static com.facebook.presto.memory.LocalMemoryManager.GENERAL_POOL;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
@@ -59,6 +55,8 @@ public class QueryInfo
     private final URI self;
     private final List<String> fieldNames;
     private final String query;
+    // expand the original query to a more accurate one if the data flow indicated by the original query is too obscure.
+    private final Optional<String> expandedQuery;
     private final QueryStats queryStats;
     private final Optional<String> setCatalog;
     private final Optional<String> setSchema;
@@ -97,6 +95,7 @@ public class QueryInfo
             @JsonProperty("self") URI self,
             @JsonProperty("fieldNames") List<String> fieldNames,
             @JsonProperty("query") String query,
+            @JsonProperty("expandedQuery") Optional<String> expandedQuery,
             @JsonProperty("queryStats") QueryStats queryStats,
             @JsonProperty("setCatalog") Optional<String> setCatalog,
             @JsonProperty("setSchema") Optional<String> setSchema,
@@ -136,6 +135,7 @@ public class QueryInfo
         requireNonNull(deallocatedPreparedStatements, "deallocatedPreparedStatements is null");
         requireNonNull(startedTransactionId, "startedTransactionId is null");
         requireNonNull(query, "query is null");
+        requireNonNull(expandedQuery, "expandedQuery is null");
         requireNonNull(outputStage, "outputStage is null");
         requireNonNull(inputs, "inputs is null");
         requireNonNull(output, "output is null");
@@ -155,6 +155,7 @@ public class QueryInfo
         this.self = self;
         this.fieldNames = ImmutableList.copyOf(fieldNames);
         this.query = query;
+        this.expandedQuery = expandedQuery;
         this.queryStats = queryStats;
         this.setCatalog = setCatalog;
         this.setSchema = setSchema;
@@ -180,45 +181,6 @@ public class QueryInfo
         this.runtimeOptimizedStages = runtimeOptimizedStages;
         this.addedSessionFunctions = ImmutableMap.copyOf(addedSessionFunctions);
         this.removedSessionFunctions = ImmutableSet.copyOf(removedSessionFunctions);
-    }
-
-    public static QueryInfo immediateFailureQueryInfo(Session session, String query, URI self, Optional<ResourceGroupId> resourceGroupId, ExecutionFailureInfo failureCause)
-    {
-        QueryInfo queryInfo = new QueryInfo(
-                session.getQueryId(),
-                session.toSessionRepresentation(),
-                FAILED,
-                GENERAL_POOL,
-                false,
-                self,
-                ImmutableList.of(),
-                query,
-                immediateFailureQueryStats(),
-                Optional.empty(),
-                Optional.empty(),
-                ImmutableMap.of(),
-                ImmutableSet.of(),
-                ImmutableMap.of(),
-                ImmutableMap.of(),
-                ImmutableSet.of(),
-                Optional.empty(),
-                false,
-                null,
-                Optional.empty(),
-                failureCause.getCause(),
-                failureCause.getErrorCode(),
-                ImmutableList.of(),
-                ImmutableSet.of(),
-                Optional.empty(),
-                false,
-                resourceGroupId,
-                Optional.empty(),
-                Optional.empty(),
-                Optional.empty(),
-                ImmutableMap.of(),
-                ImmutableSet.of());
-
-        return queryInfo;
     }
 
     @JsonProperty
@@ -267,6 +229,12 @@ public class QueryInfo
     public String getQuery()
     {
         return query;
+    }
+
+    @JsonProperty
+    public Optional<String> getExpandedQuery()
+    {
+        return expandedQuery;
     }
 
     @JsonProperty

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
@@ -146,6 +146,7 @@ public class QueryStateMachine
     private final AtomicReference<Set<Input>> inputs = new AtomicReference<>(ImmutableSet.of());
     private final AtomicReference<Optional<Output>> output = new AtomicReference<>(Optional.empty());
     private final StateMachine<Optional<QueryInfo>> finalQueryInfo;
+    private final AtomicReference<Optional<String>> expandedQuery = new AtomicReference<>(Optional.empty());
 
     private final Map<SqlFunctionId, SqlInvokedFunction> addedSessionFunctions = new ConcurrentHashMap<>();
     private final Set<SqlFunctionId> removedSessionFunctions = Sets.newConcurrentHashSet();
@@ -437,6 +438,7 @@ public class QueryStateMachine
                 self,
                 outputManager.getQueryOutputInfo().map(QueryOutputInfo::getColumnNames).orElse(ImmutableList.of()),
                 query,
+                expandedQuery.get(),
                 queryStats,
                 Optional.ofNullable(setCatalog.get()),
                 Optional.ofNullable(setSchema.get()),
@@ -626,6 +628,11 @@ public class QueryStateMachine
     public void setUpdateType(String updateType)
     {
         this.updateType.set(updateType);
+    }
+
+    public void setExpandedQuery(Optional<String> expandedQuery)
+    {
+        this.expandedQuery.set(expandedQuery);
     }
 
     public QueryState getQueryState()
@@ -924,6 +931,7 @@ public class QueryStateMachine
                 queryInfo.getSelf(),
                 queryInfo.getFieldNames(),
                 queryInfo.getQuery(),
+                queryInfo.getExpandedQuery(),
                 pruneQueryStats(queryInfo.getQueryStats()),
                 queryInfo.getSetCatalog(),
                 queryInfo.getSetSchema(),

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
@@ -188,6 +188,7 @@ public class SqlQueryExecution
 
             this.analysis = analyzer.analyzeSemantic(preparedQuery.getStatement(), false);
             stateMachine.setUpdateType(analysis.getUpdateType());
+            stateMachine.setExpandedQuery(analysis.getExpandedQuery());
 
             stateMachine.beginColumnAccessPermissionChecking();
             analyzer.checkColumnAccessPermissions(this.analysis);

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
@@ -160,6 +160,8 @@ public class Analysis
 
     private final Map<QualifiedObjectName, String> materializedViews = new LinkedHashMap<>();
 
+    private Optional<String> expandedQuery = Optional.empty();
+
     public Analysis(@Nullable Statement root, List<Expression> parameters, boolean isDescribe)
     {
         requireNonNull(parameters);
@@ -839,6 +841,16 @@ public class Analysis
     public boolean isOrderByRedundant(OrderBy orderBy)
     {
         return redundantOrderBy.contains(NodeRef.of(orderBy));
+    }
+
+    public void setExpandedQuery(String expandedQuery)
+    {
+        this.expandedQuery = Optional.of(expandedQuery);
+    }
+
+    public Optional<String> getExpandedQuery()
+    {
+        return expandedQuery;
     }
 
     @Immutable

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -706,6 +706,11 @@ class StatementAnalyzer
             ConnectorMaterializedViewDefinition view = metadata.getMaterializedView(session, viewName)
                     .orElseThrow(() -> new SemanticException(MISSING_MATERIALIZED_VIEW, node, "Materialized view '%s' does not exist", viewName));
 
+            // the original refresh statement will always be one line
+            analysis.setExpandedQuery(format("-- Expanded Query: %s\nINSERT INTO %s %s",
+                    SqlFormatterUtil.getFormattedSql(node, sqlParser, Optional.empty()),
+                    viewName.getObjectName(),
+                    view.getOriginalSql()));
             accessControl.checkCanInsertIntoTable(session.getRequiredTransactionId(), getOwnerIdentity(view.getOwner(), session), session.getAccessControlContext(), viewName);
 
             // Use AllowAllAccessControl; otherwise Analyzer will check SELECT permission on the materialized view, which is not necessary.

--- a/presto-main/src/test/java/com/facebook/presto/server/TestBasicQueryInfo.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestBasicQueryInfo.java
@@ -53,6 +53,7 @@ public class TestBasicQueryInfo
                         URI.create("1"),
                         ImmutableList.of("2", "3"),
                         "SELECT 4",
+                        Optional.empty(),
                         new QueryStats(
                                 DateTime.parse("1991-09-06T05:00-05:30"),
                                 DateTime.parse("1991-09-06T05:01-05:30"),

--- a/presto-main/src/test/java/com/facebook/presto/server/TestQueryStateInfo.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestQueryStateInfo.java
@@ -103,6 +103,7 @@ public class TestQueryStateInfo
                 URI.create("1"),
                 ImmutableList.of("2", "3"),
                 query,
+                Optional.empty(),
                 new QueryStats(
                         DateTime.parse("1991-09-06T05:00-05:30"),
                         DateTime.parse("1991-09-06T05:01-05:30"),

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
@@ -659,6 +659,7 @@ public class PrestoSparkQueryExecutionFactory
                 URI.create("http://fake.invalid/query/" + session.getQueryId()),
                 planAndMore.map(PlanAndMore::getFieldNames).orElse(ImmutableList.of()),
                 query,
+                Optional.empty(),
                 queryStats,
                 Optional.empty(),
                 Optional.empty(),

--- a/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/QueryCompletedEvent.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/QueryCompletedEvent.java
@@ -38,6 +38,7 @@ public class QueryCompletedEvent
     private final Instant createTime;
     private final Instant executionStartTime;
     private final Instant endTime;
+    private final Optional<String> expandedQuery;
 
     public QueryCompletedEvent(
             QueryMetadata metadata,
@@ -52,7 +53,8 @@ public class QueryCompletedEvent
             Instant executionStartTime,
             Instant endTime,
             List<StageStatistics> stageStatistics,
-            List<OperatorStatistics> operatorStatistics)
+            List<OperatorStatistics> operatorStatistics,
+            Optional<String> expandedQuery)
     {
         this.metadata = requireNonNull(metadata, "metadata is null");
         this.statistics = requireNonNull(statistics, "statistics is null");
@@ -67,6 +69,7 @@ public class QueryCompletedEvent
         this.endTime = requireNonNull(endTime, "endTime is null");
         this.stageStatistics = requireNonNull(stageStatistics, "stageStatistics is null");
         this.operatorStatistics = requireNonNull(operatorStatistics, "operatorStatistics is null");
+        this.expandedQuery = requireNonNull(expandedQuery, "expandedQuery is null");
     }
 
     public QueryMetadata getMetadata()
@@ -132,5 +135,10 @@ public class QueryCompletedEvent
     public List<OperatorStatistics> getOperatorStatistics()
     {
         return operatorStatistics;
+    }
+
+    public Optional<String> getExpandedQuery()
+    {
+        return expandedQuery;
     }
 }


### PR DESCRIPTION
Currently upon query's completion, the corresponding event only contains the original query. In the case of materialized view query, given the fact that if the materialized view is not fully materialized, part of the result would contain data from the base table, from the original itself it would be difficult to build the data lineage.

Therefore, this PR introduces expanded query, which extend the original materialized view related query to a more accurate one for logging.

- For Refresh MV events => change the command to `INSERT INTO mv_name SELECT ... FROM base_table_name` and also keep the original sql as a comment

```
== NO RELEASE NOTE ==
```
