### PR TITLE
Remove minAverageValueSize field from ColumnStatistics

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriteValidation.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriteValidation.java
@@ -604,7 +604,7 @@ public class OrcWriteValidation
             ImmutableList.Builder<ColumnStatistics> statisticsBuilders = ImmutableList.builder();
             // if there are no rows, there will be no stats
             if (rowCount > 0) {
-                statisticsBuilders.add(new ColumnStatistics(rowCount, 0, null));
+                statisticsBuilders.add(new ColumnStatistics(rowCount, null));
                 columnStatisticsValidations.forEach(validation -> validation.build(statisticsBuilders));
             }
             return statisticsBuilders.build();
@@ -762,7 +762,7 @@ public class OrcWriteValidation
         @Override
         public ColumnStatistics buildColumnStatistics()
         {
-            return new ColumnStatistics(rowCount, 0, null);
+            return new ColumnStatistics(rowCount, null);
         }
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
@@ -597,7 +597,7 @@ public class OrcWriter
 
         // the 0th column is a struct column for the whole row
         columnEncodings.put(0, new ColumnEncoding(DIRECT, 0));
-        columnStatistics.put(0, new ColumnStatistics((long) stripeRowCount, 0, null));
+        columnStatistics.put(0, new ColumnStatistics((long) stripeRowCount, null));
 
         Map<Integer, ColumnEncoding> unencryptedColumnEncodings = columnEncodings.entrySet().stream()
                 .filter(entry -> !dwrfEncryptionInfo.getGroupByNodeId(entry.getKey()).isPresent())
@@ -776,7 +776,6 @@ public class OrcWriter
             nodeAndSubNodeStats.computeIfAbsent(group, x -> new ArrayList<>()).add(columnStatistics);
             unencryptedStats.add(new ColumnStatistics(
                     columnStatistics.getNumberOfValues(),
-                    columnStatistics.getMinAverageValueSizeInBytes(),
                     null));
             for (Integer fieldIndex : orcTypes.get(index).getFieldTypeIndexes()) {
                 addStatsRecursive(allStats, fieldIndex, nodeAndSubNodeStats, unencryptedStats, encryptedStats);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfMetadataReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfMetadataReader.java
@@ -72,12 +72,7 @@ import static com.facebook.presto.orc.metadata.OrcMetadataReader.maxStringTrunca
 import static com.facebook.presto.orc.metadata.OrcMetadataReader.minStringTruncateToValidRange;
 import static com.facebook.presto.orc.metadata.PostScript.HiveWriterVersion.ORC_HIVE_8732;
 import static com.facebook.presto.orc.metadata.PostScript.HiveWriterVersion.ORIGINAL;
-import static com.facebook.presto.orc.metadata.statistics.BinaryStatistics.BINARY_VALUE_BYTES_OVERHEAD;
-import static com.facebook.presto.orc.metadata.statistics.BooleanStatistics.BOOLEAN_VALUE_BYTES;
 import static com.facebook.presto.orc.metadata.statistics.ColumnStatistics.createColumnStatistics;
-import static com.facebook.presto.orc.metadata.statistics.DoubleStatistics.DOUBLE_VALUE_BYTES;
-import static com.facebook.presto.orc.metadata.statistics.IntegerStatistics.INTEGER_VALUE_BYTES;
-import static com.facebook.presto.orc.metadata.statistics.StringStatistics.STRING_VALUE_BYTES_OVERHEAD;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.lang.Math.toIntExact;
@@ -477,36 +472,8 @@ public class DwrfMetadataReader
 
     private static ColumnStatistics toColumnStatistics(HiveWriterVersion hiveWriterVersion, DwrfProto.ColumnStatistics statistics, boolean isRowGroup)
     {
-        long minAverageValueBytes;
-        if (statistics.hasBucketStatistics()) {
-            minAverageValueBytes = BOOLEAN_VALUE_BYTES;
-        }
-        else if (statistics.hasIntStatistics()) {
-            minAverageValueBytes = INTEGER_VALUE_BYTES;
-        }
-        else if (statistics.hasDoubleStatistics()) {
-            minAverageValueBytes = DOUBLE_VALUE_BYTES;
-        }
-        else if (statistics.hasStringStatistics()) {
-            minAverageValueBytes = STRING_VALUE_BYTES_OVERHEAD;
-            if (statistics.hasNumberOfValues() && statistics.getNumberOfValues() > 0) {
-                minAverageValueBytes += statistics.getStringStatistics().getSum() / statistics.getNumberOfValues();
-            }
-        }
-        else if (statistics.hasBinaryStatistics()) {
-            // offset and value length
-            minAverageValueBytes = BINARY_VALUE_BYTES_OVERHEAD;
-            if (statistics.hasNumberOfValues() && statistics.getNumberOfValues() > 0) {
-                minAverageValueBytes += statistics.getBinaryStatistics().getSum() / statistics.getNumberOfValues();
-            }
-        }
-        else {
-            minAverageValueBytes = 0;
-        }
-
         return createColumnStatistics(
                 statistics.getNumberOfValues(),
-                minAverageValueBytes,
                 statistics.hasBucketStatistics() ? toBooleanStatistics(statistics.getBucketStatistics()) : null,
                 statistics.hasIntStatistics() ? toIntegerStatistics(statistics.getIntStatistics()) : null,
                 statistics.hasDoubleStatistics() ? toDoubleStatistics(statistics.getDoubleStatistics()) : null,

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/BinaryColumnStatistics.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/BinaryColumnStatistics.java
@@ -18,6 +18,7 @@ import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Objects;
 
+import static com.facebook.presto.orc.metadata.statistics.BinaryStatistics.BINARY_VALUE_BYTES_OVERHEAD;
 import static java.util.Objects.requireNonNull;
 
 public class BinaryColumnStatistics
@@ -29,11 +30,10 @@ public class BinaryColumnStatistics
 
     public BinaryColumnStatistics(
             Long numberOfValues,
-            long minAverageValueSizeInBytes,
             HiveBloomFilter bloomFilter,
             BinaryStatistics binaryStatistics)
     {
-        super(numberOfValues, minAverageValueSizeInBytes, bloomFilter);
+        super(numberOfValues, bloomFilter);
         requireNonNull(binaryStatistics, "binaryStatistics is null");
         this.binaryStatistics = binaryStatistics;
     }
@@ -45,11 +45,17 @@ public class BinaryColumnStatistics
     }
 
     @Override
+    public long getMinAverageValueSizeInBytes()
+    {
+        long numberOfValues = getNumberOfValues();
+        return BINARY_VALUE_BYTES_OVERHEAD + (numberOfValues > 0 ? binaryStatistics.getSum() / numberOfValues : 0);
+    }
+
+    @Override
     public ColumnStatistics withBloomFilter(HiveBloomFilter bloomFilter)
     {
         return new BinaryColumnStatistics(
                 getNumberOfValues(),
-                getMinAverageValueSizeInBytes(),
                 bloomFilter,
                 binaryStatistics);
     }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/BinaryStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/BinaryStatisticsBuilder.java
@@ -18,7 +18,6 @@ import io.airlift.slice.Slice;
 import java.util.List;
 import java.util.Optional;
 
-import static com.facebook.presto.orc.metadata.statistics.BinaryStatistics.BINARY_VALUE_BYTES_OVERHEAD;
 import static com.google.common.base.Verify.verify;
 import static java.util.Objects.requireNonNull;
 
@@ -58,10 +57,9 @@ public class BinaryStatisticsBuilder
         Optional<BinaryStatistics> binaryStatistics = buildBinaryStatistics();
         if (binaryStatistics.isPresent()) {
             verify(nonNullValueCount > 0);
-            long minAverageSizeBytes = BINARY_VALUE_BYTES_OVERHEAD + sum / nonNullValueCount;
-            return new BinaryColumnStatistics(nonNullValueCount, minAverageSizeBytes, null, binaryStatistics.get());
+            return new BinaryColumnStatistics(nonNullValueCount, null, binaryStatistics.get());
         }
-        return new ColumnStatistics(nonNullValueCount, 0, null);
+        return new ColumnStatistics(nonNullValueCount, null);
     }
 
     public static Optional<BinaryStatistics> mergeBinaryStatistics(List<ColumnStatistics> stats)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/BooleanColumnStatistics.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/BooleanColumnStatistics.java
@@ -18,6 +18,7 @@ import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Objects;
 
+import static com.facebook.presto.orc.metadata.statistics.BooleanStatistics.BOOLEAN_VALUE_BYTES;
 import static java.util.Objects.requireNonNull;
 
 public class BooleanColumnStatistics
@@ -29,11 +30,10 @@ public class BooleanColumnStatistics
 
     public BooleanColumnStatistics(
             Long numberOfValues,
-            long minAverageValueSizeInBytes,
             HiveBloomFilter bloomFilter,
             BooleanStatistics booleanStatistics)
     {
-        super(numberOfValues, minAverageValueSizeInBytes, bloomFilter);
+        super(numberOfValues, bloomFilter);
         requireNonNull(booleanStatistics, "booleanStatistics is null");
         this.booleanStatistics = booleanStatistics;
     }
@@ -45,11 +45,16 @@ public class BooleanColumnStatistics
     }
 
     @Override
+    public long getMinAverageValueSizeInBytes()
+    {
+        return BOOLEAN_VALUE_BYTES;
+    }
+
+    @Override
     public ColumnStatistics withBloomFilter(HiveBloomFilter bloomFilter)
     {
         return new BooleanColumnStatistics(
                 getNumberOfValues(),
-                getMinAverageValueSizeInBytes(),
                 bloomFilter,
                 booleanStatistics);
     }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/BooleanStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/BooleanStatisticsBuilder.java
@@ -19,7 +19,6 @@ import com.facebook.presto.common.type.Type;
 import java.util.List;
 import java.util.Optional;
 
-import static com.facebook.presto.orc.metadata.statistics.BooleanStatistics.BOOLEAN_VALUE_BYTES;
 import static java.util.Objects.requireNonNull;
 
 public class BooleanStatisticsBuilder
@@ -67,9 +66,9 @@ public class BooleanStatisticsBuilder
     {
         Optional<BooleanStatistics> booleanStatistics = buildBooleanStatistics();
         if (booleanStatistics.isPresent()) {
-            return new BooleanColumnStatistics(nonNullValueCount, BOOLEAN_VALUE_BYTES, null, booleanStatistics.get());
+            return new BooleanColumnStatistics(nonNullValueCount, null, booleanStatistics.get());
         }
-        return new ColumnStatistics(nonNullValueCount, 0, null);
+        return new ColumnStatistics(nonNullValueCount, null);
     }
 
     public static Optional<BooleanStatistics> mergeBooleanStatistics(List<ColumnStatistics> stats)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/DateColumnStatistics.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/DateColumnStatistics.java
@@ -18,6 +18,7 @@ import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Objects;
 
+import static com.facebook.presto.orc.metadata.statistics.DateStatistics.DATE_VALUE_BYTES;
 import static java.util.Objects.requireNonNull;
 
 public class DateColumnStatistics
@@ -29,11 +30,10 @@ public class DateColumnStatistics
 
     public DateColumnStatistics(
             Long numberOfValues,
-            long minAverageValueSizeInBytes,
             HiveBloomFilter bloomFilter,
             DateStatistics dateStatistics)
     {
-        super(numberOfValues, minAverageValueSizeInBytes, bloomFilter);
+        super(numberOfValues, bloomFilter);
         requireNonNull(dateStatistics, "dateStatistics is null");
         this.dateStatistics = dateStatistics;
     }
@@ -45,11 +45,16 @@ public class DateColumnStatistics
     }
 
     @Override
+    public long getMinAverageValueSizeInBytes()
+    {
+        return DATE_VALUE_BYTES;
+    }
+
+    @Override
     public ColumnStatistics withBloomFilter(HiveBloomFilter bloomFilter)
     {
         return new DateColumnStatistics(
                 getNumberOfValues(),
-                getMinAverageValueSizeInBytes(),
                 bloomFilter,
                 dateStatistics);
     }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/DateStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/DateStatisticsBuilder.java
@@ -16,7 +16,6 @@ package com.facebook.presto.orc.metadata.statistics;
 import java.util.List;
 import java.util.Optional;
 
-import static com.facebook.presto.orc.metadata.statistics.DateStatistics.DATE_VALUE_BYTES;
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
@@ -61,9 +60,9 @@ public class DateStatisticsBuilder
     {
         Optional<DateStatistics> dateStatistics = buildDateStatistics();
         if (dateStatistics.isPresent()) {
-            return new DateColumnStatistics(nonNullValueCount, DATE_VALUE_BYTES, null, dateStatistics.get());
+            return new DateColumnStatistics(nonNullValueCount, null, dateStatistics.get());
         }
-        return new ColumnStatistics(nonNullValueCount, 0, null);
+        return new ColumnStatistics(nonNullValueCount, null);
     }
 
     public static Optional<DateStatistics> mergeDateStatistics(List<ColumnStatistics> stats)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/DecimalColumnStatistics.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/DecimalColumnStatistics.java
@@ -29,11 +29,10 @@ public class DecimalColumnStatistics
 
     public DecimalColumnStatistics(
             Long numberOfValues,
-            long minAverageValueSizeInBytes,
             HiveBloomFilter bloomFilter,
             DecimalStatistics decimalStatistics)
     {
-        super(numberOfValues, minAverageValueSizeInBytes, bloomFilter);
+        super(numberOfValues, bloomFilter);
         requireNonNull(decimalStatistics, "decimalStatistics is null");
         this.decimalStatistics = decimalStatistics;
     }
@@ -45,11 +44,16 @@ public class DecimalColumnStatistics
     }
 
     @Override
+    public long getMinAverageValueSizeInBytes()
+    {
+        return decimalStatistics.getMinAverageValueSizeInBytes();
+    }
+
+    @Override
     public ColumnStatistics withBloomFilter(HiveBloomFilter bloomFilter)
     {
         return new DecimalColumnStatistics(
                 getNumberOfValues(),
-                getMinAverageValueSizeInBytes(),
                 bloomFilter,
                 decimalStatistics);
     }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/DecimalStatistics.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/DecimalStatistics.java
@@ -39,6 +39,7 @@ public class DecimalStatistics
     private final BigDecimal minimum;
     private final BigDecimal maximum;
     private final long retainedSizeInBytes;
+    private final long decimalSizeInBytes;
 
     @SuppressWarnings("NumberEquality")
     public DecimalStatistics(BigDecimal minimum, BigDecimal maximum, long decimalSizeInBytes)
@@ -55,6 +56,7 @@ public class DecimalStatistics
             retainedSizeInBytes += BIG_DECIMAL_INSTANCE_SIZE + decimalSizeInBytes;
         }
         this.retainedSizeInBytes = retainedSizeInBytes + INSTANCE_SIZE;
+        this.decimalSizeInBytes = decimalSizeInBytes;
     }
 
     @Override
@@ -73,6 +75,16 @@ public class DecimalStatistics
     public long getRetainedSizeInBytes()
     {
         return retainedSizeInBytes;
+    }
+
+    public long getDecimalSizeInBytes()
+    {
+        return decimalSizeInBytes;
+    }
+
+    public long getMinAverageValueSizeInBytes()
+    {
+        return DECIMAL_VALUE_BYTES_OVERHEAD + decimalSizeInBytes;
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/DoubleColumnStatistics.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/DoubleColumnStatistics.java
@@ -18,6 +18,7 @@ import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Objects;
 
+import static com.facebook.presto.orc.metadata.statistics.DoubleStatistics.DOUBLE_VALUE_BYTES;
 import static java.util.Objects.requireNonNull;
 
 public class DoubleColumnStatistics
@@ -29,11 +30,10 @@ public class DoubleColumnStatistics
 
     public DoubleColumnStatistics(
             Long numberOfValues,
-            long minAverageValueSizeInBytes,
             HiveBloomFilter bloomFilter,
             DoubleStatistics doubleStatistics)
     {
-        super(numberOfValues, minAverageValueSizeInBytes, bloomFilter);
+        super(numberOfValues, bloomFilter);
         requireNonNull(doubleStatistics, "doubleStatistics is null");
         this.doubleStatistics = doubleStatistics;
     }
@@ -45,11 +45,16 @@ public class DoubleColumnStatistics
     }
 
     @Override
+    public long getMinAverageValueSizeInBytes()
+    {
+        return DOUBLE_VALUE_BYTES;
+    }
+
+    @Override
     public ColumnStatistics withBloomFilter(HiveBloomFilter bloomFilter)
     {
         return new DoubleColumnStatistics(
                 getNumberOfValues(),
-                getMinAverageValueSizeInBytes(),
                 bloomFilter,
                 doubleStatistics);
     }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/DoubleStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/DoubleStatisticsBuilder.java
@@ -20,7 +20,6 @@ import com.facebook.presto.common.type.Type;
 import java.util.List;
 import java.util.Optional;
 
-import static com.facebook.presto.orc.metadata.statistics.DoubleStatistics.DOUBLE_VALUE_BYTES;
 import static java.util.Objects.requireNonNull;
 
 public class DoubleStatisticsBuilder
@@ -85,9 +84,9 @@ public class DoubleStatisticsBuilder
     {
         Optional<DoubleStatistics> doubleStatistics = buildDoubleStatistics();
         if (doubleStatistics.isPresent()) {
-            return new DoubleColumnStatistics(nonNullValueCount, DOUBLE_VALUE_BYTES, null, doubleStatistics.get());
+            return new DoubleColumnStatistics(nonNullValueCount, null, doubleStatistics.get());
         }
-        return new ColumnStatistics(nonNullValueCount, 0, null);
+        return new ColumnStatistics(nonNullValueCount, null);
     }
 
     public static Optional<DoubleStatistics> mergeDoubleStatistics(List<ColumnStatistics> stats)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/IntegerColumnStatistics.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/IntegerColumnStatistics.java
@@ -18,6 +18,7 @@ import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Objects;
 
+import static com.facebook.presto.orc.metadata.statistics.IntegerStatistics.INTEGER_VALUE_BYTES;
 import static java.util.Objects.requireNonNull;
 
 public class IntegerColumnStatistics
@@ -29,11 +30,10 @@ public class IntegerColumnStatistics
 
     public IntegerColumnStatistics(
             Long numberOfValues,
-            long minAverageValueSizeInBytes,
             HiveBloomFilter bloomFilter,
             IntegerStatistics integerStatistics)
     {
-        super(numberOfValues, minAverageValueSizeInBytes, bloomFilter);
+        super(numberOfValues, bloomFilter);
         requireNonNull(integerStatistics, "integerStatistics is null");
         this.integerStatistics = integerStatistics;
     }
@@ -45,11 +45,16 @@ public class IntegerColumnStatistics
     }
 
     @Override
+    public long getMinAverageValueSizeInBytes()
+    {
+        return INTEGER_VALUE_BYTES;
+    }
+
+    @Override
     public ColumnStatistics withBloomFilter(HiveBloomFilter bloomFilter)
     {
         return new IntegerColumnStatistics(
                 getNumberOfValues(),
-                getMinAverageValueSizeInBytes(),
                 bloomFilter,
                 integerStatistics);
     }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/IntegerStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/IntegerStatisticsBuilder.java
@@ -16,7 +16,6 @@ package com.facebook.presto.orc.metadata.statistics;
 import java.util.List;
 import java.util.Optional;
 
-import static com.facebook.presto.orc.metadata.statistics.IntegerStatistics.INTEGER_VALUE_BYTES;
 import static java.lang.Math.addExact;
 import static java.util.Objects.requireNonNull;
 
@@ -86,9 +85,9 @@ public class IntegerStatisticsBuilder
     {
         Optional<IntegerStatistics> integerStatistics = buildIntegerStatistics();
         if (integerStatistics.isPresent()) {
-            return new IntegerColumnStatistics(nonNullValueCount, INTEGER_VALUE_BYTES, null, integerStatistics.get());
+            return new IntegerColumnStatistics(nonNullValueCount, null, integerStatistics.get());
         }
-        return new ColumnStatistics(nonNullValueCount, 0, null);
+        return new ColumnStatistics(nonNullValueCount, null);
     }
 
     public static Optional<IntegerStatistics> mergeIntegerStatistics(List<ColumnStatistics> stats)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/LongDecimalStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/LongDecimalStatisticsBuilder.java
@@ -23,8 +23,8 @@ import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
 
-import static com.facebook.presto.orc.metadata.statistics.DecimalStatistics.DECIMAL_VALUE_BYTES_OVERHEAD;
 import static com.google.common.base.Preconditions.checkState;
+import static java.lang.Math.max;
 import static java.util.Objects.requireNonNull;
 
 public class LongDecimalStatisticsBuilder
@@ -81,28 +81,29 @@ public class LongDecimalStatisticsBuilder
         }
     }
 
-    private Optional<DecimalStatistics> buildDecimalStatistics()
+    private Optional<DecimalStatistics> buildDecimalStatistics(long decimalSizeInBytes)
     {
         if (nonNullValueCount == 0) {
             return Optional.empty();
         }
         checkState(minimum != null && maximum != null);
-        return Optional.of(new DecimalStatistics(minimum, maximum, LONG_DECIMAL_VALUE_BYTES));
+        return Optional.of(new DecimalStatistics(minimum, maximum, decimalSizeInBytes));
     }
 
     @Override
     public ColumnStatistics buildColumnStatistics()
     {
-        Optional<DecimalStatistics> decimalStatistics = buildDecimalStatistics();
+        Optional<DecimalStatistics> decimalStatistics = buildDecimalStatistics(LONG_DECIMAL_VALUE_BYTES);
         if (decimalStatistics.isPresent()) {
-            return new DecimalColumnStatistics(nonNullValueCount, DECIMAL_VALUE_BYTES_OVERHEAD + LONG_DECIMAL_VALUE_BYTES, null, decimalStatistics.get());
+            return new DecimalColumnStatistics(nonNullValueCount, null, decimalStatistics.get());
         }
-        return new ColumnStatistics(nonNullValueCount, 0, null);
+        return new ColumnStatistics(nonNullValueCount, null);
     }
 
     public static Optional<DecimalStatistics> mergeDecimalStatistics(List<ColumnStatistics> stats)
     {
         LongDecimalStatisticsBuilder decimalStatisticsBuilder = new LongDecimalStatisticsBuilder();
+        long decimalSizeInBytes = 0;
         for (ColumnStatistics columnStatistics : stats) {
             DecimalStatistics partialStatistics = columnStatistics.getDecimalStatistics();
             if (columnStatistics.getNumberOfValues() > 0) {
@@ -111,8 +112,9 @@ public class LongDecimalStatisticsBuilder
                     return Optional.empty();
                 }
                 decimalStatisticsBuilder.addDecimalStatistics(columnStatistics.getNumberOfValues(), partialStatistics);
+                decimalSizeInBytes = max(decimalSizeInBytes, partialStatistics.getDecimalSizeInBytes());
             }
         }
-        return decimalStatisticsBuilder.buildDecimalStatistics();
+        return decimalStatisticsBuilder.buildDecimalStatistics(decimalSizeInBytes);
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/ShortDecimalStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/ShortDecimalStatisticsBuilder.java
@@ -17,8 +17,6 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Optional;
 
-import static com.facebook.presto.orc.metadata.statistics.DecimalStatistics.DECIMAL_VALUE_BYTES_OVERHEAD;
-
 public class ShortDecimalStatisticsBuilder
         implements LongValueStatisticsBuilder
 {
@@ -60,8 +58,8 @@ public class ShortDecimalStatisticsBuilder
     {
         Optional<DecimalStatistics> decimalStatistics = buildDecimalStatistics();
         if (decimalStatistics.isPresent()) {
-            return new DecimalColumnStatistics(nonNullValueCount, DECIMAL_VALUE_BYTES_OVERHEAD + SHORT_DECIMAL_VALUE_BYTES, null, decimalStatistics.get());
+            return new DecimalColumnStatistics(nonNullValueCount, null, decimalStatistics.get());
         }
-        return new ColumnStatistics(nonNullValueCount, 0, null);
+        return new ColumnStatistics(nonNullValueCount, null);
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/StringColumnStatistics.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/StringColumnStatistics.java
@@ -18,6 +18,7 @@ import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Objects;
 
+import static com.facebook.presto.orc.metadata.statistics.StringStatistics.STRING_VALUE_BYTES_OVERHEAD;
 import static java.util.Objects.requireNonNull;
 
 public class StringColumnStatistics
@@ -29,11 +30,10 @@ public class StringColumnStatistics
 
     public StringColumnStatistics(
             Long numberOfValues,
-            long minAverageValueSizeInBytes,
             HiveBloomFilter bloomFilter,
             StringStatistics stringStatistics)
     {
-        super(numberOfValues, minAverageValueSizeInBytes, bloomFilter);
+        super(numberOfValues, bloomFilter);
         requireNonNull(stringStatistics, "stringStatistics is null");
         this.stringStatistics = stringStatistics;
     }
@@ -45,11 +45,17 @@ public class StringColumnStatistics
     }
 
     @Override
+    public long getMinAverageValueSizeInBytes()
+    {
+        long numberOfValues = getNumberOfValues();
+        return STRING_VALUE_BYTES_OVERHEAD + (numberOfValues > 0 ? stringStatistics.getSum() / numberOfValues : 0);
+    }
+
+    @Override
     public ColumnStatistics withBloomFilter(HiveBloomFilter bloomFilter)
     {
         return new StringColumnStatistics(
                 getNumberOfValues(),
-                getMinAverageValueSizeInBytes(),
                 bloomFilter,
                 stringStatistics);
     }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/StringStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/StringStatisticsBuilder.java
@@ -19,7 +19,6 @@ import io.airlift.slice.Slices;
 import java.util.List;
 import java.util.Optional;
 
-import static com.facebook.presto.orc.metadata.statistics.StringStatistics.STRING_VALUE_BYTES_OVERHEAD;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
@@ -127,10 +126,9 @@ public class StringStatisticsBuilder
         Optional<StringStatistics> stringStatistics = buildStringStatistics();
         if (stringStatistics.isPresent()) {
             verify(nonNullValueCount > 0);
-            long minAverageSizeBytes = STRING_VALUE_BYTES_OVERHEAD + sum / nonNullValueCount;
-            return new StringColumnStatistics(nonNullValueCount, minAverageSizeBytes, null, stringStatistics.get());
+            return new StringColumnStatistics(nonNullValueCount, null, stringStatistics.get());
         }
-        return new ColumnStatistics(nonNullValueCount, 0, null);
+        return new ColumnStatistics(nonNullValueCount, null);
     }
 
     public static Optional<StringStatistics> mergeStringStatistics(List<ColumnStatistics> stats)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/ByteColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/ByteColumnWriter.java
@@ -119,7 +119,7 @@ public class ByteColumnWriter
     public Map<Integer, ColumnStatistics> finishRowGroup()
     {
         checkState(!closed);
-        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, 0, null);
+        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, null);
         rowGroupColumnStatistics.add(statistics);
         columnStatisticsRetainedSizeInBytes += statistics.getRetainedSizeInBytes();
         nonNullValueCount = 0;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/ListColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/ListColumnWriter.java
@@ -148,7 +148,7 @@ public class ListColumnWriter
     {
         checkState(!closed);
 
-        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, 0, null);
+        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, null);
         rowGroupColumnStatistics.add(statistics);
         columnStatisticsRetainedSizeInBytes += statistics.getRetainedSizeInBytes();
         nonNullValueCount = 0;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/MapColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/MapColumnWriter.java
@@ -155,7 +155,7 @@ public class MapColumnWriter
     {
         checkState(!closed);
 
-        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, 0, null);
+        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, null);
         rowGroupColumnStatistics.add(statistics);
         columnStatisticsRetainedSizeInBytes += statistics.getRetainedSizeInBytes();
         nonNullValueCount = 0;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/StructColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/StructColumnWriter.java
@@ -145,7 +145,7 @@ public class StructColumnWriter
     public Map<Integer, ColumnStatistics> finishRowGroup()
     {
         checkState(!closed);
-        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, 0, null);
+        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, null);
         rowGroupColumnStatistics.add(statistics);
         columnStatisticsRetainedSizeInBytes += statistics.getRetainedSizeInBytes();
         nonNullValueCount = 0;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/TimestampColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/TimestampColumnWriter.java
@@ -176,7 +176,7 @@ public class TimestampColumnWriter
     public Map<Integer, ColumnStatistics> finishRowGroup()
     {
         checkState(!closed);
-        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, 0, null);
+        ColumnStatistics statistics = new ColumnStatistics((long) nonNullValueCount, null);
         rowGroupColumnStatistics.add(statistics);
         columnStatisticsRetainedSizeInBytes += statistics.getRetainedSizeInBytes();
         nonNullValueCount = 0;

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcBloomFilters.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcBloomFilters.java
@@ -286,19 +286,16 @@ public class TestOrcBloomFilters
 
         Map<Integer, ColumnStatistics> matchingStatisticsByColumnIndex = ImmutableMap.of(0, new IntegerColumnStatistics(
                 null,
-                0,
                 toHiveBloomFilter(orcBloomFilter),
                 new IntegerStatistics(10L, 2000L, null)));
 
         Map<Integer, ColumnStatistics> nonMatchingStatisticsByColumnIndex = ImmutableMap.of(0, new IntegerColumnStatistics(
                 null,
-                0,
                 toHiveBloomFilter(emptyOrcBloomFilter),
                 new IntegerStatistics(10L, 2000L, null)));
 
         Map<Integer, ColumnStatistics> withoutBloomFilterStatisticsByColumnIndex = ImmutableMap.of(0, new IntegerColumnStatistics(
                 null,
-                0,
                 null,
                 new IntegerStatistics(10L, 2000L, null)));
 

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestTupleDomainOrcPredicate.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestTupleDomainOrcPredicate.java
@@ -93,9 +93,9 @@ public class TestTupleDomainOrcPredicate
         BooleanStatistics booleanStatistics = null;
         if (trueValueCount != null) {
             booleanStatistics = new BooleanStatistics(trueValueCount);
-            return new BooleanColumnStatistics(numberOfValues, 2L, null, booleanStatistics);
+            return new BooleanColumnStatistics(numberOfValues, null, booleanStatistics);
         }
-        return new ColumnStatistics(numberOfValues, 2L, null);
+        return new ColumnStatistics(numberOfValues, null);
     }
 
     @Test
@@ -124,7 +124,7 @@ public class TestTupleDomainOrcPredicate
 
     private static IntegerColumnStatistics integerColumnStats(Long numberOfValues, Long minimum, Long maximum)
     {
-        return new IntegerColumnStatistics(numberOfValues, 9L, null, new IntegerStatistics(minimum, maximum, null));
+        return new IntegerColumnStatistics(numberOfValues, null, new IntegerStatistics(minimum, maximum, null));
     }
 
     @Test
@@ -153,7 +153,7 @@ public class TestTupleDomainOrcPredicate
 
     private static DoubleColumnStatistics doubleColumnStats(Long numberOfValues, Double minimum, Double maximum)
     {
-        return new DoubleColumnStatistics(numberOfValues, 9L, null, new DoubleStatistics(minimum, maximum));
+        return new DoubleColumnStatistics(numberOfValues, null, new DoubleStatistics(minimum, maximum));
     }
 
     @Test
@@ -243,7 +243,7 @@ public class TestTupleDomainOrcPredicate
         Slice minimumSlice = minimum == null ? null : utf8Slice(minimum);
         Slice maximumSlice = maximum == null ? null : utf8Slice(maximum);
         // sum and minAverageValueSizeInBytes are not used in this test; they could be arbitrary numbers
-        return new StringColumnStatistics(numberOfValues, 10L, null, new StringStatistics(minimumSlice, maximumSlice, 100L));
+        return new StringColumnStatistics(numberOfValues, null, new StringStatistics(minimumSlice, maximumSlice, 100L));
     }
 
     @Test
@@ -272,7 +272,7 @@ public class TestTupleDomainOrcPredicate
 
     private static ColumnStatistics dateColumnStats(Long numberOfValues, Integer minimum, Integer maximum)
     {
-        return new DateColumnStatistics(numberOfValues, 5L, null, new DateStatistics(minimum, maximum));
+        return new DateColumnStatistics(numberOfValues, null, new DateStatistics(minimum, maximum));
     }
 
     @Test
@@ -328,7 +328,7 @@ public class TestTupleDomainOrcPredicate
     {
         BigDecimal minimumDecimal = minimum == null ? null : new BigDecimal(minimum);
         BigDecimal maximumDecimal = maximum == null ? null : new BigDecimal(maximum);
-        return new DecimalColumnStatistics(numberOfValues, 9L, null, new DecimalStatistics(minimumDecimal, maximumDecimal, SHORT_DECIMAL_VALUE_BYTES));
+        return new DecimalColumnStatistics(numberOfValues, null, new DecimalStatistics(minimumDecimal, maximumDecimal, SHORT_DECIMAL_VALUE_BYTES));
     }
 
     @Test
@@ -350,7 +350,7 @@ public class TestTupleDomainOrcPredicate
     private static ColumnStatistics binaryColumnStats(Long numberOfValues)
     {
         // sum and minAverageValueSizeInBytes are not used in this test; they could be arbitrary numbers
-        return new BinaryColumnStatistics(numberOfValues, 10L, null, new BinaryStatistics(100L));
+        return new BinaryColumnStatistics(numberOfValues, null, new BinaryStatistics(100L));
     }
 
     private static Long shortDecimal(String value)

--- a/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/AbstractStatisticsBuilderTest.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/AbstractStatisticsBuilderTest.java
@@ -171,7 +171,7 @@ public abstract class AbstractStatisticsBuilderTest<B extends StatisticsBuilder,
     static List<ColumnStatistics> insertEmptyColumnStatisticsAt(List<ColumnStatistics> statisticsList, int index, long numberOfValues)
     {
         List<ColumnStatistics> newStatisticsList = new ArrayList<>(statisticsList);
-        newStatisticsList.add(index, new ColumnStatistics(numberOfValues, 0, null));
+        newStatisticsList.add(index, new ColumnStatistics(numberOfValues, null));
         return newStatisticsList;
     }
 

--- a/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestStringStatisticsBuilder.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestStringStatisticsBuilder.java
@@ -323,11 +323,10 @@ public class TestStringStatisticsBuilder
     private static ColumnStatistics stringColumnStatistics(Slice minimum, Slice maximum)
     {
         if (minimum == null && maximum == null) {
-            return new ColumnStatistics(100L, 100, null);
+            return new ColumnStatistics(100L, null);
         }
         return new StringColumnStatistics(
                 100L,
-                100,
                 null,
                 new StringStatistics(minimum, maximum, 100));
     }


### PR DESCRIPTION
ColumnStatistics minAverageValueSizeInBytes can be computed when
required. This is only used in readStripe to estimate the row size.
This is used only once, so no caching is required. This saves 8 bytes
per ColumnStatistics instance and simplifies the size calculation code.

This change will modify the behavior of minAverageValueSizeInBytes
for String and Binary column types. For these types  sizes are computed
per row group (which could truncate) and they are summed and then
divided again. With this change they are accumulated and then divided
in the end, so they will be slightly larger (but better in my opinion).

Consider the String statistics with 2 row groups (ignore overhead bytes)
First row group: 5 values with 19 bytes
Second row group : 1 values with 11 bytes.

Previously it would compute
First row group : 3 bytes
second row group: 11 bytes

After merge it would produce: (5 * 3) + (1 * 11) = 26 bytes.
Merged row group stats : 26/6 = 4 bytes.

With the new code it would produce: (19 + 11)/6 = 5 bytes.

This is a very minor behavior change and should not impact anything.

Test plan - (Please fill in how you tested your changes)
Existing tests.

```
== NO RELEASE NOTE ==
```
