### PR TITLE
Rename array_dupes function to array_duplicates

### DIFF
--- a/presto-docs/src/main/sphinx/functions/array.rst
+++ b/presto-docs/src/main/sphinx/functions/array.rst
@@ -44,7 +44,7 @@ Array Functions
 
     Remove duplicate values from the array ``x``.
 
-.. function:: array_dupes(array(T)) -> array(bigint/varchar)
+.. function:: array_duplicates(array(T)) -> array(bigint/varchar)
 
     Returns a set of elements that occur more than once in ``array``.
 
@@ -64,7 +64,7 @@ Array Functions
     Returns a map: keys are the unique elements in the ``array``, values are how many times the key appears.
     Ignores null elements. Empty array returns empty map.
 
-.. function:: array_has_dupes(array(T)) -> boolean
+.. function:: array_has_duplicates(array(T)) -> boolean
 
     Returns a boolean: whether ``array`` has any elements that occur more than once.
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/sql/ArraySqlFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/sql/ArraySqlFunctions.java
@@ -79,43 +79,43 @@ public class ArraySqlFunctions
                 "m -> m)";
     }
 
-    @SqlInvokedScalarFunction(value = "array_dupes", deterministic = true, calledOnNullInput = false)
+    @SqlInvokedScalarFunction(value = "array_duplicates", alias = {"array_dupes"}, deterministic = true, calledOnNullInput = false)
     @Description("Returns set of elements that have duplicates")
     @SqlParameter(name = "input", type = "array(varchar)")
     @SqlType("array(varchar)")
-    public static String arrayDupesVarchar()
+    public static String arrayDuplicatesVarchar()
     {
         return "RETURN CONCAT(" +
                 "CAST(IF (cardinality(filter(input, x -> x is NULL)) > 1, ARRAY[NULL], ARRAY[]) AS ARRAY(VARCHAR))," +
                 "map_keys(map_filter(array_frequency(input), (k, v) -> v > 1)))";
     }
 
-    @SqlInvokedScalarFunction(value = "array_dupes", deterministic = true, calledOnNullInput = false)
+    @SqlInvokedScalarFunction(value = "array_duplicates", alias = {"array_dupes"}, deterministic = true, calledOnNullInput = false)
     @Description("Returns set of elements that have duplicates")
     @SqlParameter(name = "input", type = "array(bigint)")
     @SqlType("array(bigint)")
-    public static String arrayDupesBigint()
+    public static String arrayDuplicatesBigint()
     {
         return "RETURN CONCAT(" +
                 "CAST(IF (cardinality(filter(input, x -> x is NULL)) > 1, ARRAY[NULL], ARRAY[]) AS ARRAY(BIGINT))," +
                 "map_keys(map_filter(array_frequency(input), (k, v) -> v > 1)))";
     }
 
-    @SqlInvokedScalarFunction(value = "array_has_dupes", deterministic = true, calledOnNullInput = false)
+    @SqlInvokedScalarFunction(value = "array_has_duplicates", alias = {"array_has_dupes"}, deterministic = true, calledOnNullInput = false)
     @Description("Returns whether array has any duplicate element")
     @SqlParameter(name = "input", type = "array(varchar)")
     @SqlType("boolean")
-    public static String arrayHasDupesVarchar()
+    public static String arrayHasDuplicatesVarchar()
     {
-        return "RETURN cardinality(array_dupes(input)) > 0";
+        return "RETURN cardinality(array_duplicates(input)) > 0";
     }
 
-    @SqlInvokedScalarFunction(value = "array_has_dupes", deterministic = true, calledOnNullInput = false)
+    @SqlInvokedScalarFunction(value = "array_has_duplicates", alias = {"array_has_dupes"}, deterministic = true, calledOnNullInput = false)
     @Description("Returns whether array has any duplicate element")
     @SqlParameter(name = "input", type = "array(bigint)")
     @SqlType("boolean")
-    public static String arrayHasDupesBigint()
+    public static String arrayHasDuplicatesBigint()
     {
-        return "RETURN cardinality(array_dupes(input)) > 0";
+        return "RETURN cardinality(array_duplicates(input)) > 0";
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/sql/TestArraySqlFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/sql/TestArraySqlFunctions.java
@@ -128,38 +128,44 @@ public class TestArraySqlFunctions
     }
 
     @Test
-    public void testArrayHasDupes()
+    public void testArrayHasDuplicates()
     {
-        assertFunction("array_has_dupes(cast(null as array(varchar)))", BOOLEAN, null);
-        assertFunction("array_has_dupes(cast(array[] as array(varchar)))", BOOLEAN, false);
+        assertFunction("array_has_duplicates(cast(null as array(varchar)))", BOOLEAN, null);
+        assertFunction("array_has_duplicates(cast(array[] as array(varchar)))", BOOLEAN, false);
 
+        assertFunction("array_has_duplicates(array[varchar 'a', varchar 'b', varchar 'a'])", BOOLEAN, true);
+        assertFunction("array_has_duplicates(array[varchar 'a', varchar 'b'])", BOOLEAN, false);
+        assertFunction("array_has_duplicates(array[varchar 'a', varchar 'a'])", BOOLEAN, true);
+
+        assertFunction("array_has_duplicates(array[1, 2, 1])", BOOLEAN, true);
+        assertFunction("array_has_duplicates(array[1, 2])", BOOLEAN, false);
+        assertFunction("array_has_duplicates(array[1, 1, 1])", BOOLEAN, true);
+
+        assertFunction("array_has_duplicates(array[0, null])", BOOLEAN, false);
+        assertFunction("array_has_duplicates(array[0, null, null])", BOOLEAN, true);
+
+        // Test legacy name.
         assertFunction("array_has_dupes(array[varchar 'a', varchar 'b', varchar 'a'])", BOOLEAN, true);
-        assertFunction("array_has_dupes(array[varchar 'a', varchar 'b'])", BOOLEAN, false);
-        assertFunction("array_has_dupes(array[varchar 'a', varchar 'a'])", BOOLEAN, true);
-
-        assertFunction("array_has_dupes(array[1, 2, 1])", BOOLEAN, true);
-        assertFunction("array_has_dupes(array[1, 2])", BOOLEAN, false);
-        assertFunction("array_has_dupes(array[1, 1, 1])", BOOLEAN, true);
-
-        assertFunction("array_has_dupes(array[0, null])", BOOLEAN, false);
-        assertFunction("array_has_dupes(array[0, null, null])", BOOLEAN, true);
     }
 
     @Test
-    public void testArrayDupes()
+    public void testArrayDuplicates()
     {
-        assertFunction("array_dupes(cast(null as array(varchar)))", new ArrayType(VARCHAR), null);
-        assertFunction("array_dupes(cast(array[] as array(varchar)))", new ArrayType(VARCHAR), ImmutableList.of());
+        assertFunction("array_duplicates(cast(null as array(varchar)))", new ArrayType(VARCHAR), null);
+        assertFunction("array_duplicates(cast(array[] as array(varchar)))", new ArrayType(VARCHAR), ImmutableList.of());
 
-        assertFunction("array_dupes(array[varchar 'a', varchar 'b', varchar 'a'])", new ArrayType(VARCHAR), ImmutableList.of("a"));
-        assertFunction("array_dupes(array[varchar 'a', varchar 'b'])", new ArrayType(VARCHAR), ImmutableList.of());
-        assertFunction("array_dupes(array[varchar 'a', varchar 'a'])", new ArrayType(VARCHAR), ImmutableList.of("a"));
+        assertFunction("array_duplicates(array[varchar 'a', varchar 'b', varchar 'a'])", new ArrayType(VARCHAR), ImmutableList.of("a"));
+        assertFunction("array_duplicates(array[varchar 'a', varchar 'b'])", new ArrayType(VARCHAR), ImmutableList.of());
+        assertFunction("array_duplicates(array[varchar 'a', varchar 'a'])", new ArrayType(VARCHAR), ImmutableList.of("a"));
 
+        assertFunction("array_duplicates(array[1, 2, 1])", new ArrayType(BIGINT), ImmutableList.of(1L));
+        assertFunction("array_duplicates(array[1, 2])", new ArrayType(BIGINT), ImmutableList.of());
+        assertFunction("array_duplicates(array[1, 1, 1])", new ArrayType(BIGINT), ImmutableList.of(1L));
+
+        assertFunction("array_duplicates(array[0, null])", new ArrayType(BIGINT), ImmutableList.of());
+        assertFunction("array_duplicates(array[0, null, null])", new ArrayType(BIGINT), Collections.singletonList(null));
+
+        // Test legacy name.
         assertFunction("array_dupes(array[1, 2, 1])", new ArrayType(BIGINT), ImmutableList.of(1L));
-        assertFunction("array_dupes(array[1, 2])", new ArrayType(BIGINT), ImmutableList.of());
-        assertFunction("array_dupes(array[1, 1, 1])", new ArrayType(BIGINT), ImmutableList.of(1L));
-
-        assertFunction("array_dupes(array[0, null])", new ArrayType(BIGINT), ImmutableList.of());
-        assertFunction("array_dupes(array[0, null, null])", new ArrayType(BIGINT), Collections.singletonList(null));
     }
 }


### PR DESCRIPTION
Also, rename array_has_dupes function to array_has_duplicates.

The new names are consistent with the rest of the Presto functions.

Kept the old names as aliases, but removed these from the documentation
to discourage usage.

```
== RELEASE NOTES ==

General Changes
* Rename array_dupes and array_has_dupes functions to :func:`array_duplicates` and :func:`array_has_duplicates`.