### PR TITLE
Add release notes for 0.264

### DIFF
--- a/presto-docs/src/main/sphinx/release.rst
+++ b/presto-docs/src/main/sphinx/release.rst
@@ -5,6 +5,7 @@ Release Notes
 .. toctree::
     :maxdepth: 1
 
+    release/release-0.264
     release/release-0.263.1
     release/release-0.263
     release/release-0.262

--- a/presto-docs/src/main/sphinx/release/release-0.264.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.264.rst
@@ -1,0 +1,30 @@
+=============
+Release 0.264
+=============
+
+**Highlights**
+==============
+* Add support in Iceberg connector for a native mode that can be used without a Hive installation, to run queries against Iceberg native catalogs
+
+**Details**
+===========
+
+General Changes
+_______________
+* Add :func:`murmur3_x64_128` UDF that computes a hash equivalent to MurmurHash3_x64_128 (Murmur3F) in C++.
+* Add a new configuration property ``experimental.dedup-based-distinct-aggregation-spill-enabled`` to enable deduplication of input data before spilling for distinct aggregates. This can be overridden by ``dedup_based_distinct_aggregation_spill_enabled`` session property.
+* Add configuration properties ``simple-ttl-node-selector.use-default-execution-time-estimate-as-fallback`` and ``simple-ttl-node-selector.default-execution-time-estimate``. The former configures ``SimpleTtlNodeSelector`` to use a default execution time estimate when there is no corresponding user-provided estimate. The latter configures the value of the default execution time estimate.
+* Add support for running task count ``runningTasks`` at the cluster level via ``v1/cluster`` endpoint.
+
+Hive Changes
+____________
+* Add session property ``hive.metastore_headers`` to allow the users to set headers that will be used in metastore operations.
+
+Iceberg Changes
+____________
+* Add support in Iceberg connector for a native mode that can be used without a Hive installation, to run queries against Iceberg  native catalogs.
+
+**Credits**
+===========
+
+Arjun Gupta, Arunachalam Thirupathi, Basar Hamdi Onat, Beinan, Ge Gao, Hanumath Rao Maduri, Hitarth Trivedi, Jack Ye, James Petty, James Sun, Maria Basmanova, Neerad Somanchi, Pranjal Shankhdhar, Reetika Agrawal, Rongrong Zhong, Shrinidhi Joshi, Sreeni Viswanadha, Swapnil Tailor, Tim Meehan, Zac Wen, Zhan Yuan, abhiseksaikia, linzebing, tanjialiang, zhaoyulong


### PR DESCRIPTION
# Missing Release Notes
## Ge Gao
- [x] https://github.com/prestodb/presto/pull/16838 ACL enforcement for refresh materialized view (Merged by: James Sun)

## Jack Ye
- [x] https://github.com/prestodb/presto/pull/16612 Refactor Iceberg connector to support Iceberg native catalogs (Merged by: Beinan)

## Pranjal Shankhdhar
- [x] https://github.com/prestodb/presto/pull/16808 Add Except support for Materialized view (Merged by: James Sun)

## Reetika Agrawal
- [x] https://github.com/prestodb/presto/pull/16841 Add presto-function-namespace-manager to plugin (Merged by: Rongrong Zhong)

## Tim Meehan
- [x] 2121dbda7bd59eb2ea00f906a95e4898577b635a Fix flaky tests to unblock development on main

# Extracted Release Notes
- #16663 (Author: Hitarth Trivedi): Added runningTasks to BasicQueryStats
  - Add support for running task count ``runningTasks`` at the cluster level via ``v1/cluster`` endpoint.
- #16717 (Author: Basar Hamdi Onat): Add metastore header field to Metastore Context
  - Add session property ``hive.metastore_headers`` to allow the users to set headers that will be used in metastore operations.
- #16795 (Author: Arjun Gupta): Dedup input data before buffering in distinct aggregates
  - Add a new configuration property ``experimental.dedup-based-distinct-aggregation-spill-enabled`` to enable deduplication of input data before spilling for distinct aggregates. This can be overridden by ``dedup_based_distinct_aggregation_spill_enabled`` session property.
- #16799 (Author: Shrinidhi Joshi): Add murmur3_x64_128 UDF
  - Add :func:`murmur3_x64_128` UDF that computes a hash equivalent to MurmurHash3_x64_128 (Murmur3F) in C++.
- #16831 (Author: Rongrong Zhong): Fix IpAddressType.compareTo
  - Fix an issue where queries ORDER BY IPADDRESS would give wrong results.
- #16837 (Author: Neerad Somanchi): Use a default execution time estimate in SimpleTtlNodeSelector
  - Add configuration properties ``simple-ttl-node-selector.use-default-execution-time-estimate-as-fallback`` and ``simple-ttl-node-selector.default-execution-time-estimate``. The former configures ``SimpleTtlNodeSelector`` to use a default execution time estimate when there is no corresponding user-provided estimate. The latter configures the value of the default execution time estimate.

# All Commits
- 2121dbda7bd59eb2ea00f906a95e4898577b635a Fix flaky tests to unblock development on main (Tim Meehan)
- ef19add4ae534ef820b992f474cf4c14e2d899af Use Type specific Column Statistics (Arunachalam Thirupathi)
- e5c7d90b71b5f29d7112699239ffb0f9965578d6 Add Type specific ColumnStatistics (Arunachalam Thirupathi)
- e286c95b717d8786e2e9f14348f9405beb1eed0e Add presto-function-namespace-manager to plugin (Reetika Agrawal)
- e68cbd634f76ee2aa25b656e8e8e1ad002ce8604 Implement more query clauses for Materialized View (Pranjal Shankhdhar)
- ad122d3167d6109da0d793deada833d70eccbc2a Add a hive session property to enable per query cache metrics (Zhan Yuan)
- d31fbfd550f0f5b7eefbde05854e3a2a643b4ef3 Use a default exectution time estimate in SimpleTtlNodeSelector (Neerad Somanchi)
- e7433188e04d254e20847e42e950f24ea1585c2c Expose more counters for coordinator in RuntimeStats (Zhan Yuan)
- 343b039da3fc4f078cf82ef0a97091ca4f5bf99a Dedup input data before buffering in distinct aggregates (Arjun Gupta)
- 11521c72ac44e28e145b4b26c12b15cad9dc84c5 Add support to add codegen scalar functions (Pranjal Shankhdhar)
- 7c6e521fb864c8927e4a2600dc79deefb00c0c88 Refactor: Move CallSiteBinder stuff to presto-bytecode (Pranjal Shankhdhar)
- 1b138371a701e00534629053858e520bc642d854 Avoid rewrite if the materialized view is unavailable (Zac Wen)
- 466b0f83bf3c80f51014426ab9ced5138eb2d227 Add metastore header field to Metastore Context (Basar Hamdi Onat)
- adcc9fbbc72b62ee0cf25bfd358abfdc51dfffdc Fix flaky TestDistributedClusterStatsResource and TestQueues (abhiseksaikia)
- daba7801a27da6315b6ae00d2b41128dacdf98c7 Enabling flaky tests by disabling Failure detector in RM (Swapnil Tailor)
- 6f1423832518dc2b01fffe77b3edc26e5022a7c2 Add specific constructor behavior for positionCount only pages (James Petty)
- efb56c47bd0b25da878782577c4197f993a961b8 Add special handling for row count only in MergingPageOutput (James Petty)
- 07cb30ca297f4098e83fd244758d9c2e8463c42c Add PageProcessor fast path for unfiltered row count projections (James Petty)
- 497edbee589440ce37c69c306169075182b1620e Include orderByChannel in InputChannels list for Ordering accumulator (Arjun Gupta)
- 35840e82b0cabbe2b7e28110ea2ba61ca70bf67b Encapsulate ColumnStatistics type statistics (Arunachalam Thirupathi)
- 5861762dbff35b3426b9790a37b5e79e2699f94f Use Factory method for ColumnStatistics (Arunachalam Thirupathi)
- c0d6788a4b5b7d6d48e9253d87e297fe8006ecdc ACL enforcement for refresh materialized view (Ge Gao)
- 1d25867f503f65c7e2c80c34be7ef2adfb88e3f6 Avoid redundant string.format in verify (zhaoyulong)
- 673da3591f5623423be880b2eae3025247b158ab Fix incorrect createTime initialize when altering partition (zhaoyulong)
- 5045a8cd4658fa7ce5a08746c51f5756c697ca44 Expose per-query FRC hit rate (Hanumath Rao Maduri)
- 59ae6bb3e15104ce0188596046e8346b2f608463 Enable key-based sampling for DistinctLimit operator (Sreeni Viswanadha)
- 60eb3d1c9496fcc012fb9d8f51f4dcb7fcab8d63 Add runningTasks to BasicQueryStats and added cluster level aggregated runningTasks to v1/cluster (Hitarth Trivedi)
- 245f31ab6bb8369bf661268cdccd9b71ecdd73d1 Allow except in materialized view queries (Pranjal Shankhdhar)
- 1e056d54fd8c3db7696af63c2f8ac7aa92248dd8 Revert "Add support to write codegen scalar functions" (Tim Meehan)
- ea6a265efd4268e7cefa503ee2cd3f0d671cd759 Revert "Refactor SqlTypeBytecodeExpression" (Tim Meehan)
- 237ae5dcc335c6a229f3d51f5a1f4ad53ea08fe4 Fix IpAddressType.compareTo (Rongrong Zhong)
- b92550b01f29b59d21beb17567f34fb521bd316d Refactor Iceberg connector to support Iceberg native catalogs (Jack Ye)
- 5cb040b3ec053105b3506a897cd3d4f97c5825e5 Handle Identifiers within different nodes (Zac Wen)
- cee66ad4691bf36ee4dd53f10d3e7a03baa57b6f Change System.currentTimeMillis() to System.nanoTime() in SimpleTracer (tanjialiang)
- 0eb3cbb54884f37dda62abaff53d9c13a64570a8 Fix the incorrect ResourceWaitingTime (zhaoyulong)
- ac46fbbdc4a6261c27a6c1d55ef1138723c66f46 Add murmur3_x64_128 function (Shrinidhi Joshi)
- ad656e9c39cf9b1692de9740f837462e18529681 Add testing tracing infra for tracing instrumentation correctness check (tanjialiang)
- 6d91e5f03f30219ab31c47b17e822803f42d1518 Add config based tracer provider selection (tanjialiang)
- ad2dcc993a59a29795b7aef77d79914b482a09c1 Add updateMaxCombinedBytesPerRow for OrcBlockLoader (linzebing)
- da45be897913985d290f91957eabd2e091c2f319 Fix bug in sampling join sequence (Sreeni Viswanadha)
- 30b4e6942f494d34530918e0b4383f63752123cc Handle materialized view missing too many partitions (Shrinidhi Joshi)