### PR TITLE
Reduce OperatorStats allocation rate

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/DriverContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/DriverContext.java
@@ -143,9 +143,10 @@ public class DriverContext
 
     public void startProcessTimer()
     {
-        if (startNanos.compareAndSet(0, System.nanoTime())) {
-            pipelineContext.start();
+        // Must update startNanos first so that the value is valid once executionStartTime is not null
+        if (executionStartTime.get() == null && startNanos.compareAndSet(0, System.nanoTime())) {
             executionStartTime.set(DateTime.now());
+            pipelineContext.start();
         }
     }
 
@@ -174,8 +175,9 @@ public class DriverContext
             // already finished
             return;
         }
-        executionEndTime.set(DateTime.now());
+        // Must update endNanos first, so that the value is valid after executionEndTime is not null
         endNanos.set(System.nanoTime());
+        executionEndTime.set(DateTime.now());
 
         pipelineContext.driverFinished(this);
     }
@@ -323,6 +325,14 @@ public class DriverContext
             totalBlockedTime += blockedMonitor.getBlockedTime();
         }
 
+        // startNanos is always valid once executionStartTime is not null
+        DateTime executionStartTime = this.executionStartTime.get();
+        Duration queuedTime = new Duration(nanosBetween(createNanos, executionStartTime == null ? System.nanoTime() : startNanos.get()), NANOSECONDS);
+
+        // endNanos is always valid once executionStartTime is not null
+        DateTime executionEndTime = this.executionEndTime.get();
+        Duration elapsedTime = new Duration(nanosBetween(createNanos, executionEndTime == null ? System.nanoTime() : endNanos.get()), NANOSECONDS);
+
         List<OperatorStats> operators = ImmutableList.copyOf(transform(operatorContexts, OperatorContext::getOperatorStats));
         OperatorStats inputOperator = getFirst(operators, null);
         DataSize rawInputDataSize;
@@ -356,23 +366,8 @@ public class DriverContext
             outputPositions = 0;
         }
 
-        long startNanos = this.startNanos.get();
-        if (startNanos < createNanos) {
-            startNanos = System.nanoTime();
-        }
-        Duration queuedTime = new Duration(startNanos - createNanos, NANOSECONDS);
-
-        long endNanos = this.endNanos.get();
-        Duration elapsedTime;
-        if (endNanos >= startNanos) {
-            elapsedTime = new Duration(endNanos - createNanos, NANOSECONDS);
-        }
-        else {
-            elapsedTime = new Duration(0, NANOSECONDS);
-        }
-
-        long physicalWrittenDataSize = 0;
         ImmutableSet.Builder<BlockedReason> builder = ImmutableSet.builder();
+        long physicalWrittenDataSize = 0;
         for (OperatorStats operator : operators) {
             physicalWrittenDataSize += operator.getPhysicalWrittenDataSize().toBytes();
             if (operator.getBlockedReason().isPresent()) {
@@ -384,8 +379,8 @@ public class DriverContext
         return new DriverStats(
                 lifespan,
                 createdTime,
-                executionStartTime.get(),
-                executionEndTime.get(),
+                executionStartTime,
+                executionEndTime,
                 queuedTime.convertToMostSuccinctTimeUnit(),
                 elapsedTime.convertToMostSuccinctTimeUnit(),
                 succinctBytes(driverMemoryContext.getUserMemory()),

--- a/presto-main/src/main/java/com/facebook/presto/operator/DriverContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/DriverContext.java
@@ -356,11 +356,6 @@ public class DriverContext
             outputPositions = 0;
         }
 
-        long physicalWrittenDataSize = operators.stream()
-                .map(OperatorStats::getPhysicalWrittenDataSize)
-                .mapToLong(DataSize::toBytes)
-                .sum();
-
         long startNanos = this.startNanos.get();
         if (startNanos < createNanos) {
             startNanos = System.nanoTime();
@@ -376,9 +371,10 @@ public class DriverContext
             elapsedTime = new Duration(0, NANOSECONDS);
         }
 
+        long physicalWrittenDataSize = 0;
         ImmutableSet.Builder<BlockedReason> builder = ImmutableSet.builder();
-
         for (OperatorStats operator : operators) {
+            physicalWrittenDataSize += operator.getPhysicalWrittenDataSize().toBytes();
             if (operator.getBlockedReason().isPresent()) {
                 builder.add(operator.getBlockedReason().get());
             }

--- a/presto-main/src/main/java/com/facebook/presto/operator/OperatorStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/OperatorStats.java
@@ -435,9 +435,9 @@ public class OperatorStats
         return info;
     }
 
-    public OperatorStats add(OperatorStats... operators)
+    public OperatorStats add(OperatorStats operatorStats)
     {
-        return add(ImmutableList.copyOf(operators));
+        return add(ImmutableList.of(operatorStats));
     }
 
     public OperatorStats add(Iterable<OperatorStats> operators)

--- a/presto-main/src/main/java/com/facebook/presto/operator/OperatorStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/OperatorStats.java
@@ -84,6 +84,7 @@ public class OperatorStats
 
     private final Optional<BlockedReason> blockedReason;
 
+    @Nullable
     private final OperatorInfo info;
 
     private final RuntimeStats runtimeStats;
@@ -137,6 +138,7 @@ public class OperatorStats
 
             @JsonProperty("blockedReason") Optional<BlockedReason> blockedReason,
 
+            @Nullable
             @JsonProperty("info") OperatorInfo info,
             @JsonProperty("runtimeStats") RuntimeStats runtimeStats)
     {
@@ -607,6 +609,10 @@ public class OperatorStats
 
     public OperatorStats summarize()
     {
+        if (info == null || info.isFinal()) {
+            return this;
+        }
+        OperatorInfo info = null;
         return new OperatorStats(
                 stageId,
                 stageExecutionId,
@@ -645,7 +651,7 @@ public class OperatorStats
                 peakTotalMemoryReservation,
                 spilledDataSize,
                 blockedReason,
-                (info != null && info.isFinal()) ? info : null,
+                info,
                 runtimeStats);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/PipelineContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PipelineContext.java
@@ -32,11 +32,9 @@ import org.joda.time.DateTime;
 
 import javax.annotation.concurrent.ThreadSafe;
 
-import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -48,8 +46,6 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.collect.ImmutableSet.toImmutableSet;
-import static com.google.common.collect.Iterables.transform;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.stream.Collectors.toList;
@@ -336,8 +332,7 @@ public class PipelineContext
         int completedDrivers = this.completedDrivers.get();
         List<DriverContext> driverContexts = ImmutableList.copyOf(this.drivers);
         int totalSplits = this.totalSplits.get();
-        PipelineStatus pipelineStatus = getPipelineStatus(driverContexts.iterator(), totalSplits, completedDrivers, partitioned);
-
+        PipelineStatusBuilder pipelineStatusBuilder = new PipelineStatusBuilder(totalSplits, completedDrivers, partitioned);
         int totalDrivers = completedDrivers + driverContexts.size();
 
         Distribution queuedTime = new Distribution(this.queuedTime);
@@ -360,12 +355,23 @@ public class PipelineContext
 
         long physicalWrittenDataSize = this.physicalWrittenDataSize.get();
 
-        List<DriverStats> drivers = new ArrayList<>();
+        ImmutableSet.Builder<BlockedReason> blockedReasons = ImmutableSet.builder();
+        boolean hasUnfinishedDrivers = false;
+        boolean unfinishedDriversFullyBlocked = true;
 
+        TreeMap<Integer, OperatorStats> operatorSummaries = new TreeMap<>(this.operatorSummaries);
         ListMultimap<Integer, OperatorStats> runningOperators = ArrayListMultimap.create();
+        ImmutableList.Builder<DriverStats> drivers = ImmutableList.builderWithExpectedSize(driverContexts.size());
         for (DriverContext driverContext : driverContexts) {
             DriverStats driverStats = driverContext.getDriverStats();
             drivers.add(driverStats);
+            pipelineStatusBuilder.accumulate(driverStats);
+            if (driverStats.getStartTime() != null && driverStats.getEndTime() == null) {
+                // driver has started running, but not yet completed
+                hasUnfinishedDrivers = true;
+                unfinishedDriversFullyBlocked &= driverStats.isFullyBlocked();
+                blockedReasons.addAll(driverStats.getBlockedReasons());
+            }
 
             queuedTime.add(driverStats.getQueuedTime().roundTo(NANOSECONDS));
             elapsedTime.add(driverStats.getElapsedTime().roundTo(NANOSECONDS));
@@ -376,9 +382,8 @@ public class PipelineContext
 
             totalAllocation += driverStats.getTotalAllocation().toBytes();
 
-            List<OperatorStats> operators = ImmutableList.copyOf(transform(driverContext.getOperatorContexts(), OperatorContext::getOperatorStats));
-            for (OperatorStats operator : operators) {
-                runningOperators.put(operator.getOperatorId(), operator);
+            for (OperatorStats operatorStats : driverStats.getOperatorStats()) {
+                runningOperators.put(operatorStats.getOperatorId(), operatorStats);
             }
 
             rawInputDataSize += driverStats.getRawInputDataSize().toBytes();
@@ -394,7 +399,6 @@ public class PipelineContext
         }
 
         // merge the running operator stats into the operator summary
-        TreeMap<Integer, OperatorStats> operatorSummaries = new TreeMap<>(this.operatorSummaries);
         for (Integer operatorId : runningOperators.keySet()) {
             List<OperatorStats> runningStats = runningOperators.get(operatorId);
             if (runningStats.isEmpty()) {
@@ -414,14 +418,8 @@ public class PipelineContext
             operatorSummaries.put(operatorId, combined);
         }
 
-        Set<DriverStats> runningDriverStats = drivers.stream()
-                .filter(driver -> driver.getEndTime() == null && driver.getStartTime() != null)
-                .collect(toImmutableSet());
-        ImmutableSet<BlockedReason> blockedReasons = runningDriverStats.stream()
-                .flatMap(driver -> driver.getBlockedReasons().stream())
-                .collect(toImmutableSet());
-
-        boolean fullyBlocked = !runningDriverStats.isEmpty() && runningDriverStats.stream().allMatch(DriverStats::isFullyBlocked);
+        PipelineStatus pipelineStatus = pipelineStatusBuilder.build();
+        boolean fullyBlocked = hasUnfinishedDrivers && unfinishedDriversFullyBlocked;
 
         return new PipelineStats(
                 pipelineId,
@@ -452,7 +450,7 @@ public class PipelineContext
                 totalCpuTime,
                 totalBlockedTime,
                 fullyBlocked,
-                blockedReasons,
+                blockedReasons.build(),
 
                 totalAllocation,
 
@@ -468,7 +466,7 @@ public class PipelineContext
                 physicalWrittenDataSize,
 
                 ImmutableList.copyOf(operatorSummaries.values()),
-                drivers);
+                drivers.build());
     }
 
     public <C, R> R accept(QueryContextVisitor<C, R> visitor, C context)
@@ -491,8 +489,27 @@ public class PipelineContext
 
     private static PipelineStatus getPipelineStatus(Iterator<DriverContext> driverContextsIterator, int totalSplits, int completedDrivers, boolean partitioned)
     {
-        int runningDrivers = 0;
-        int blockedDrivers = 0;
+        PipelineStatusBuilder builder = new PipelineStatusBuilder(totalSplits, completedDrivers, partitioned);
+        while (driverContextsIterator.hasNext()) {
+            builder.accumulate(driverContextsIterator.next());
+        }
+        return builder.build();
+    }
+
+    /**
+     * Allows building a {@link PipelineStatus} either from a series of {@link DriverContext} instances or
+     * {@link DriverStats} instances. In {@link PipelineContext#getPipelineStats()} where {@link DriverStats}
+     * instances are already created as a state snapshot of {@link DriverContext}, using those instead of
+     * re-checking the fields on {@link DriverContext} is cheaper since it avoids extra volatile reads and
+     * reduces the opportunities to read inconsistent values
+     */
+    private static final class PipelineStatusBuilder
+    {
+        private final int totalSplits;
+        private final int completedDrivers;
+        private final boolean partitioned;
+        private int runningDrivers;
+        private int blockedDrivers;
         // When a split for a partitioned pipeline is delivered to a worker,
         // conceptually, the worker would have an additional driver.
         // The queuedDrivers field in PipelineStatus is supposed to represent this.
@@ -500,9 +517,17 @@ public class PipelineContext
         //
         // physically queued drivers: actual number of instantiated drivers whose execution hasn't started
         // conceptually queued drivers: includes assigned splits that haven't been turned into a driver
-        int physicallyQueuedDrivers = 0;
-        while (driverContextsIterator.hasNext()) {
-            DriverContext driverContext = driverContextsIterator.next();
+        private int physicallyQueuedDrivers;
+
+        private PipelineStatusBuilder(int totalSplits, int completedDrivers, boolean partitioned)
+        {
+            this.totalSplits = totalSplits;
+            this.partitioned = partitioned;
+            this.completedDrivers = completedDrivers;
+        }
+
+        public void accumulate(DriverContext driverContext)
+        {
             if (!driverContext.isExecutionStarted()) {
                 physicallyQueuedDrivers++;
             }
@@ -514,18 +539,34 @@ public class PipelineContext
             }
         }
 
-        int queuedDrivers;
-        if (partitioned) {
-            queuedDrivers = totalSplits - runningDrivers - blockedDrivers - completedDrivers;
-            if (queuedDrivers < 0) {
-                // It is possible to observe negative here because inputs to the above expression was not taken in a snapshot.
-                queuedDrivers = 0;
+        public void accumulate(DriverStats driverStats)
+        {
+            if (driverStats.getStartTime() == null) {
+                // driver has not started running
+                physicallyQueuedDrivers++;
+            }
+            else if (driverStats.isFullyBlocked()) {
+                blockedDrivers++;
+            }
+            else {
+                runningDrivers++;
             }
         }
-        else {
-            queuedDrivers = physicallyQueuedDrivers;
-        }
 
-        return new PipelineStatus(queuedDrivers, runningDrivers, blockedDrivers, partitioned ? queuedDrivers : 0, partitioned ? runningDrivers : 0);
+        public PipelineStatus build()
+        {
+            int queuedDrivers;
+            if (partitioned) {
+                queuedDrivers = totalSplits - runningDrivers - blockedDrivers - completedDrivers;
+                if (queuedDrivers < 0) {
+                    // It is possible to observe negative here because inputs to passed into the constructor are not taken in a snapshot
+                    queuedDrivers = 0;
+                }
+            }
+            else {
+                queuedDrivers = physicallyQueuedDrivers;
+            }
+            return new PipelineStatus(queuedDrivers, runningDrivers, blockedDrivers, partitioned ? queuedDrivers : 0, partitioned ? runningDrivers : 0);
+        }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/PipelineStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PipelineStats.java
@@ -25,7 +25,6 @@ import javax.annotation.concurrent.Immutable;
 
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
@@ -419,9 +418,17 @@ public class PipelineStats
                 outputDataSizeInBytes,
                 outputPositions,
                 physicalWrittenDataSizeInBytes,
-                operatorSummaries.stream()
-                        .map(OperatorStats::summarize)
-                        .collect(Collectors.toList()),
+                summarizeOperatorStats(operatorSummaries),
                 ImmutableList.of());
+    }
+
+    private static List<OperatorStats> summarizeOperatorStats(List<OperatorStats> operatorSummaries)
+    {
+        // Use an exact size ImmutableList builder to avoid a redundant copy in the PipelineStats constructor
+        ImmutableList.Builder<OperatorStats> results = ImmutableList.builderWithExpectedSize(operatorSummaries.size());
+        for (OperatorStats operatorStats : operatorSummaries) {
+            results.add(operatorStats.summarize());
+        }
+        return results.build();
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/TaskStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TaskStats.java
@@ -24,7 +24,6 @@ import javax.annotation.Nullable;
 
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
@@ -570,9 +569,17 @@ public class TaskStats
                 physicalWrittenDataSizeInBytes,
                 fullGcCount,
                 fullGcTimeInMillis,
-                pipelines.stream()
-                        .map(PipelineStats::summarize)
-                        .collect(Collectors.toList()),
+                summarizePipelineStats(pipelines),
                 runtimeStats);
+    }
+
+    private static List<PipelineStats> summarizePipelineStats(List<PipelineStats> pipelines)
+    {
+        // Use an exact size ImmutableList builder to avoid a redundant copy in the TaskStats constructor
+        ImmutableList.Builder<PipelineStats> results = ImmutableList.builderWithExpectedSize(pipelines.size());
+        for (PipelineStats pipeline : pipelines) {
+            results.add(pipeline.summarize());
+        }
+        return results.build();
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestOperatorStats.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestOperatorStats.java
@@ -18,6 +18,7 @@ import com.facebook.presto.common.RuntimeMetric;
 import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.operator.repartition.PartitionedOutputInfo;
 import com.facebook.presto.spi.plan.PlanNodeId;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.units.DataSize;
 import io.airlift.units.Duration;
@@ -203,7 +204,7 @@ public class TestOperatorStats
     @Test
     public void testAdd()
     {
-        OperatorStats actual = EXPECTED.add(EXPECTED, EXPECTED);
+        OperatorStats actual = EXPECTED.add(ImmutableList.of(EXPECTED, EXPECTED));
 
         assertEquals(actual.getStageId(), 0);
         assertEquals(actual.getStageExecutionId(), 10);
@@ -252,7 +253,7 @@ public class TestOperatorStats
     @Test
     public void testAddMergeable()
     {
-        OperatorStats actual = MERGEABLE.add(MERGEABLE, MERGEABLE);
+        OperatorStats actual = MERGEABLE.add(ImmutableList.of(MERGEABLE, MERGEABLE));
 
         assertEquals(actual.getStageId(), 0);
         assertEquals(actual.getStageExecutionId(), 10);


### PR DESCRIPTION
Avoids unnecessary allocations associated with OperatorStats by:
- Avoiding new instance creation in `OperatorStats#summarize()` when possible
- Modifies PipelineContext to merge running and completed OperatorStats directly instead of performing incremental pairwise merges
- Avoids redundant OperatorStats creation, DriverContext traversals, volatile reads, and intermediate collections in `PipelineContext#getPipelineStats`
- Creates known sized ImmutableList instances instead of creating `ArrayList` instances via streams when the result is immediately passed to a constructor that will call `ImmutableList#copyOf`

```
== NO RELEASE NOTE ==
```
