### PR TITLE
Add session property for DWRF Stripe Cache Writer

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -193,7 +193,6 @@ public class HiveClientConfig
 
     private Duration partitionLeaseDuration = new Duration(0, TimeUnit.SECONDS);
 
-    private boolean executionBasedMemoryAccounting;
     private boolean enableLooseMemoryAccounting;
     private int materializedViewMissingPartitionsThreshold = 100;
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
@@ -127,6 +127,8 @@ public final class HiveSessionProperties
     public static final String ENABLE_LOOSE_MEMORY_BASED_ACCOUNTING = "enable_loose_memory_based_accounting";
     public static final String MATERIALIZED_VIEW_MISSING_PARTITIONS_THRESHOLD = "materialized_view_missing_partitions_threshold";
     public static final String VERBOSE_RUNTIME_STATS_ENABLED = "verbose_runtime_stats_enabled";
+    private static final String DWRF_WRITER_STRIPE_CACHE_ENABLED = "dwrf_writer_stripe_cache_enabled";
+    private static final String DWRF_WRITER_STRIPE_CACHE_SIZE = "dwrf_writer_stripe_cache_size";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -605,6 +607,16 @@ public final class HiveSessionProperties
                         METASTORE_HEADERS,
                         "The headers that will be sent in the calls to Metastore",
                         null,
+                        false),
+                booleanProperty(
+                        DWRF_WRITER_STRIPE_CACHE_ENABLED,
+                        "Write stripe cache for the DWRF files.",
+                        orcFileWriterConfig.isDwrfStripeCacheEnabled(),
+                        false),
+                dataSizeSessionProperty(
+                        DWRF_WRITER_STRIPE_CACHE_SIZE,
+                        "Maximum size of DWRF stripe cache to be held in memory",
+                        orcFileWriterConfig.getDwrfStripeCacheMaxSize(),
                         false));
     }
 
@@ -1054,5 +1066,15 @@ public final class HiveSessionProperties
     public static boolean isVerboseRuntimeStatsEnabled(ConnectorSession session)
     {
         return session.getProperty(VERBOSE_RUNTIME_STATS_ENABLED, Boolean.class);
+    }
+
+    public static boolean isDwrfWriterStripeCacheEnabled(ConnectorSession session)
+    {
+        return session.getProperty(DWRF_WRITER_STRIPE_CACHE_ENABLED, Boolean.class);
+    }
+
+    public static DataSize getDwrfWriterStripeCacheeMaxSize(ConnectorSession session)
+    {
+        return session.getProperty(DWRF_WRITER_STRIPE_CACHE_SIZE, DataSize.class);
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriterConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriterConfig.java
@@ -163,7 +163,7 @@ public class OrcFileWriterConfig
         return this;
     }
 
-    public boolean getDwrfStripeCacheEnabled()
+    public boolean isDwrfStripeCacheEnabled()
     {
         return isDwrfStripeCacheEnabled;
     }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriterFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriterFactory.java
@@ -59,6 +59,7 @@ import java.util.stream.IntStream;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_UNSUPPORTED_FORMAT;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_WRITER_OPEN_ERROR;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_WRITE_VALIDATION_FAILED;
+import static com.facebook.presto.hive.HiveSessionProperties.getDwrfWriterStripeCacheeMaxSize;
 import static com.facebook.presto.hive.HiveSessionProperties.getOrcMaxBufferSize;
 import static com.facebook.presto.hive.HiveSessionProperties.getOrcMaxMergeDistance;
 import static com.facebook.presto.hive.HiveSessionProperties.getOrcOptimizedWriterMaxDictionaryMemory;
@@ -68,6 +69,7 @@ import static com.facebook.presto.hive.HiveSessionProperties.getOrcOptimizedWrit
 import static com.facebook.presto.hive.HiveSessionProperties.getOrcOptimizedWriterValidateMode;
 import static com.facebook.presto.hive.HiveSessionProperties.getOrcStreamBufferSize;
 import static com.facebook.presto.hive.HiveSessionProperties.getOrcStringStatisticsLimit;
+import static com.facebook.presto.hive.HiveSessionProperties.isDwrfWriterStripeCacheEnabled;
 import static com.facebook.presto.hive.HiveSessionProperties.isExecutionBasedMemoryAccountingEnabled;
 import static com.facebook.presto.hive.HiveType.toHiveTypes;
 import static com.facebook.presto.orc.OrcEncoding.DWRF;
@@ -228,6 +230,8 @@ public class OrcFileWriterFactory
                             .withDictionaryMaxMemory(getOrcOptimizedWriterMaxDictionaryMemory(session))
                             .withMaxStringStatisticsLimit(getOrcStringStatisticsLimit(session))
                             .withIgnoreDictionaryRowGroupSizes(isExecutionBasedMemoryAccountingEnabled(session))
+                            .withDwrfStripeCacheEnabled(isDwrfWriterStripeCacheEnabled(session))
+                            .withDwrfStripeCacheMaxSize(getDwrfWriterStripeCacheeMaxSize(session))
                             .build(),
                     fileInputColumnIndexes,
                     ImmutableMap.<String, String>builder()

--- a/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriterFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriterFactory.java
@@ -227,7 +227,7 @@ public class OrcFileWriterFactory
                             .withStripeMaxRowCount(getOrcOptimizedWriterMaxStripeRows(session))
                             .withDictionaryMaxMemory(getOrcOptimizedWriterMaxDictionaryMemory(session))
                             .withMaxStringStatisticsLimit(getOrcStringStatisticsLimit(session))
-                            .setIgnoreDictionaryRowGroupSizes(isExecutionBasedMemoryAccountingEnabled(session))
+                            .withIgnoreDictionaryRowGroupSizes(isExecutionBasedMemoryAccountingEnabled(session))
                             .build(),
                     fileInputColumnIndexes,
                     ImmutableMap.<String, String>builder()

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestOrcFileWriterConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestOrcFileWriterConfig.java
@@ -136,7 +136,7 @@ public class TestOrcFileWriterConfig
         assertEquals(stringStatisticsLimit, config.getStringStatisticsLimit());
         assertEquals(maxCompressionBufferSize, config.getMaxCompressionBufferSize());
         assertEquals(streamLayoutType, config.getStreamLayoutType());
-        assertFalse(config.getDwrfStripeCacheEnabled());
+        assertFalse(config.isDwrfStripeCacheEnabled());
         assertEquals(dwrfStripeCacheMaxSize, config.getDwrfStripeCacheMaxSize());
         assertEquals(dwrfStripeCacheMode, config.getDwrfStripeCacheMode());
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriterOptions.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriterOptions.java
@@ -304,7 +304,7 @@ public class OrcWriterOptions
             return this;
         }
 
-        public Builder setIgnoreDictionaryRowGroupSizes(boolean ignoreDictionaryRowGroupSizes)
+        public Builder withIgnoreDictionaryRowGroupSizes(boolean ignoreDictionaryRowGroupSizes)
         {
             this.ignoreDictionaryRowGroupSizes = ignoreDictionaryRowGroupSizes;
             return this;


### PR DESCRIPTION
Dwrf stripe cache writer is controlled by worker property. Introduce a
session property to provide more control if only some queries are
impacted.

Test plan 
Existing tests.

```
== NO RELEASE NOTE ==
```
