### PR TITLE
Fix Presto verifier corrupted jar error

### DIFF
--- a/presto-docs/src/main/sphinx/admin/verifier.rst
+++ b/presto-docs/src/main/sphinx/admin/verifier.rst
@@ -48,12 +48,11 @@ Next, create a ``config.properties`` file:
     test.application-name=verifier-test
     test-id=1
 
-Download :maven_download:`verifier` and rename it to ``verifier``. To run the Verifier:
+Download :maven_download:`verifier` and rename it to ``verifier.jar``. To run the Verifier:
 
 .. code-block:: none
 
-    chmod +x verifier
-    ./verifier verify config.properties
+    java -Xmx1G -jar verifier.jar verify config.properties
 
 
 Verifier Procedures

--- a/presto-verifier/pom.xml
+++ b/presto-verifier/pom.xml
@@ -313,23 +313,6 @@
             </plugin>
 
             <plugin>
-                <groupId>org.skife.maven</groupId>
-                <artifactId>really-executable-jar-maven-plugin</artifactId>
-                <configuration>
-                    <flags>-Xmx1G</flags>
-                    <classifier>executable</classifier>
-                </configuration>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>really-executable-jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>


### PR DESCRIPTION
Presto verifier from version 0.249 started failing with the error
"Error: Invalid or corrupt jarfile ./verifier"

The jar now contains more than 65535 file and the trick to create an
executable shell file, does not work, due to zip file max limit of 65535
files.

Do not try to create an executable shell file, but provide the users
instructions on how to download the jar and use java to execute it.

Fixes https://github.com/prestodb/presto/issues/16877

Test plan - 

The instructions on the html file worked on my macbook.


```
== RELEASE NOTES ==

Verifier Changes
* Fix verifier executable jar corruption
```
