### PR TITLE
Use diamond operator where possible

### DIFF
--- a/presto-common/src/test/java/com/facebook/presto/common/array/TestLong2IntOpenHashMap.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/array/TestLong2IntOpenHashMap.java
@@ -57,7 +57,7 @@ public class TestLong2IntOpenHashMap
 
     private void testAddAndGet(int entries)
     {
-        Map<Long, Integer> map = new HashMap<Long, Integer>();
+        Map<Long, Integer> map = new HashMap<>();
         Long2IntOpenHashMap long2IntOpenHashMap = new Long2IntOpenHashMap();
 
         assertEquals(long2IntOpenHashMap.size(), 0);

--- a/presto-druid/src/main/java/com/facebook/presto/druid/ingestion/DruidPageSink.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/ingestion/DruidPageSink.java
@@ -54,7 +54,7 @@ public class DruidPageSink
         this.tableHandle = requireNonNull(tableHandle, "tableHandle is null");
         this.druidPageWriter = requireNonNull(druidPageWriter, "pageWriter is null");
         this.dataPath = new Path(druidConfig.getIngestionStoragePath(), tableHandle.getTableName() + UUID.randomUUID());
-        this.dataFileList = new ArrayList<String>();
+        this.dataFileList = new ArrayList<>();
     }
 
     @Override

--- a/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestSpatialJoinOperator.java
+++ b/presto-geospatial/src/test/java/com/facebook/presto/plugin/geospatial/TestSpatialJoinOperator.java
@@ -126,7 +126,7 @@ public class TestSpatialJoinOperator
                 Integer.MAX_VALUE,
                 60L,
                 SECONDS,
-                new SynchronousQueue<Runnable>(),
+                new SynchronousQueue<>(),
                 daemonThreadsNamed("test-executor-%s"),
                 new ThreadPoolExecutor.DiscardPolicy());
         scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%s"));

--- a/presto-hive/src/main/java/com/facebook/presto/hive/authentication/KerberosHiveMetastoreAuthentication.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/authentication/KerberosHiveMetastoreAuthentication.java
@@ -82,7 +82,7 @@ public class KerberosHiveMetastoreAuthentication
     private TTransport authenticateWithToken(TTransport rawTransport, String tokenString)
     {
         try {
-            Token<DelegationTokenIdentifier> token = new Token<DelegationTokenIdentifier>();
+            Token<DelegationTokenIdentifier> token = new Token<>();
             token.decodeFromUrlString(tokenString);
 
             TTransport saslTransport = new TSaslClientTransport(

--- a/presto-main/src/main/java/com/facebook/presto/memory/ClusterMemoryManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/ClusterMemoryManager.java
@@ -393,7 +393,7 @@ public class ClusterMemoryManager
         nodes.stream()
                 .filter(node -> node.getPools().get(GENERAL_POOL) != null)
                 .map(node ->
-                        new SimpleEntry<MemoryPoolInfo, Long>(
+                        new SimpleEntry<>(
                                 node.getPools().get(GENERAL_POOL),
                                 node.getPools().get(GENERAL_POOL).getQueryMemoryReservations().values().stream().mapToLong(l -> l).sum()))
                 .sorted(nodeMemoryComparator.reversed())

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/OrCodeGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/OrCodeGenerator.java
@@ -40,7 +40,7 @@ public class OrCodeGenerator
         Preconditions.checkArgument(arguments.size() == 2);
 
         // We flatten the AND here.
-        Deque<RowExpression> stack = new ArrayDeque<RowExpression>();
+        Deque<RowExpression> stack = new ArrayDeque<>();
         stack.push(arguments.get(1));
         stack.push(arguments.get(0));
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/SwitchCodeGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/SwitchCodeGenerator.java
@@ -104,7 +104,7 @@ public class SwitchCodeGenerator
         Variable wasNull = generatorContext.wasNull();
         block.putVariable(wasNull, false);
 
-        Map<RowExpression, LabelNode> resultLabels = new HashMap<RowExpression, LabelNode>();
+        Map<RowExpression, LabelNode> resultLabels = new HashMap<>();
         // We already know the P1 .. Pn are all boolean just call them and search for true (false/null don't matter).
         for (RowExpression clause : whenClauses) {
             checkArgument(clause instanceof SpecialFormExpression && ((SpecialFormExpression) clause).getForm().equals(WHEN));

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/SymbolMapper.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/SymbolMapper.java
@@ -142,7 +142,7 @@ public class SymbolMapper
     {
         // SymbolMapper inlines symbol with multiple level reference (SymbolInliner only inline single level).
         ImmutableList.Builder<VariableReferenceExpression> orderBy = ImmutableList.builder();
-        HashMap<VariableReferenceExpression, SortOrder> orderingMap = new HashMap<VariableReferenceExpression, SortOrder>();
+        HashMap<VariableReferenceExpression, SortOrder> orderingMap = new HashMap<>();
         for (VariableReferenceExpression variable : orderingScheme.getOrderByVariables()) {
             VariableReferenceExpression translated = map(variable);
             // Some variables may become duplicates after canonicalization, so we put them only once.

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
@@ -133,7 +133,7 @@ public class TestHashJoinOperator
                 Integer.MAX_VALUE,
                 60L,
                 SECONDS,
-                new SynchronousQueue<Runnable>(),
+                new SynchronousQueue<>(),
                 daemonThreadsNamed("test-executor-%s"),
                 new ThreadPoolExecutor.DiscardPolicy());
         scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%s"));

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestTDigestFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestTDigestFunctions.java
@@ -206,7 +206,7 @@ public class TestTDigestFunctions
     public void testNormalDistributionHighVarianceQuantileArray()
     {
         TDigest tDigest = createTDigest(STANDARD_COMPRESSION_FACTOR);
-        List<Double> list = new ArrayList<Double>();
+        List<Double> list = new ArrayList<>();
         NormalDistribution normal = new NormalDistribution(0, 1);
 
         for (int i = 0; i < NUMBER_OF_ENTRIES; i++) {
@@ -241,7 +241,7 @@ public class TestTDigestFunctions
     {
         TDigest tDigest1 = createTDigest(STANDARD_COMPRESSION_FACTOR);
         TDigest tDigest2 = createTDigest(STANDARD_COMPRESSION_FACTOR);
-        List<Integer> list = new ArrayList<Integer>();
+        List<Integer> list = new ArrayList<>();
 
         for (int i = 0; i < NUMBER_OF_ENTRIES / 2; i++) {
             tDigest1.add(i);
@@ -263,7 +263,7 @@ public class TestTDigestFunctions
     {
         TDigest tDigest1 = createTDigest(STANDARD_COMPRESSION_FACTOR);
         TDigest tDigest2 = createTDigest(STANDARD_COMPRESSION_FACTOR);
-        List<Integer> list = new ArrayList<Integer>();
+        List<Integer> list = new ArrayList<>();
 
         for (int i = 0; i < NUMBER_OF_ENTRIES / 2; i++) {
             tDigest1.add(i);
@@ -284,7 +284,7 @@ public class TestTDigestFunctions
     public void testAddElementsRandomized()
     {
         TDigest tDigest = createTDigest(STANDARD_COMPRESSION_FACTOR);
-        List<Double> list = new ArrayList<Double>();
+        List<Double> list = new ArrayList<>();
 
         for (int i = 0; i < NUMBER_OF_ENTRIES; i++) {
             double value = Math.random() * NUMBER_OF_ENTRIES;
@@ -303,7 +303,7 @@ public class TestTDigestFunctions
     public void testNormalDistributionLowVariance()
     {
         TDigest tDigest = createTDigest(STANDARD_COMPRESSION_FACTOR);
-        List<Double> list = new ArrayList<Double>();
+        List<Double> list = new ArrayList<>();
         NormalDistribution normal = new NormalDistribution(1000, 1);
 
         for (int i = 0; i < NUMBER_OF_ENTRIES; i++) {
@@ -323,7 +323,7 @@ public class TestTDigestFunctions
     public void testNormalDistributionHighVariance()
     {
         TDigest tDigest = createTDigest(STANDARD_COMPRESSION_FACTOR);
-        List<Double> list = new ArrayList<Double>();
+        List<Double> list = new ArrayList<>();
         NormalDistribution normal = new NormalDistribution(0, 1);
 
         for (int i = 0; i < NUMBER_OF_ENTRIES; i++) {
@@ -511,7 +511,7 @@ public class TestTDigestFunctions
         for (int k = 1; k < trials; k++) {
             TDigest tDigest = createTDigest(STANDARD_COMPRESSION_FACTOR);
             GeometricDistribution geometric = new GeometricDistribution(k * 0.1);
-            List<Integer> list = new ArrayList<Integer>();
+            List<Integer> list = new ArrayList<>();
 
             for (int i = 0; i < NUMBER_OF_ENTRIES; i++) {
                 int sample = geometric.sample();
@@ -534,7 +534,7 @@ public class TestTDigestFunctions
         for (int k = 1; k < trials; k++) {
             TDigest tDigest = createTDigest(STANDARD_COMPRESSION_FACTOR);
             PoissonDistribution poisson = new PoissonDistribution(k * 0.1);
-            List<Integer> list = new ArrayList<Integer>();
+            List<Integer> list = new ArrayList<>();
 
             for (int i = 0; i < NUMBER_OF_ENTRIES; i++) {
                 int sample = poisson.sample();
@@ -583,7 +583,7 @@ public class TestTDigestFunctions
 
         TDigest scaledTdigest = createTDigest(wrappedBuffer(sqlVarbinary.getBytes()));
         List<Double> scaledDigestFrequencies = getFrequencies(scaledTdigest, asList(2.0d, 4.0d, 6.0d, 8.0d));
-        List<Double> scaledUpFrequencies = new ArrayList<Double>();
+        List<Double> scaledUpFrequencies = new ArrayList<>();
         unscaledFrequencies.forEach(frequency -> scaledUpFrequencies.add(frequency * 2));
         assertEquals(scaledDigestFrequencies, scaledUpFrequencies);
 
@@ -597,7 +597,7 @@ public class TestTDigestFunctions
 
         scaledTdigest = createTDigest(wrappedBuffer(sqlVarbinary.getBytes()));
         scaledDigestFrequencies = getFrequencies(scaledTdigest, asList(2.0d, 4.0d, 6.0d, 8.0d));
-        List<Double> scaledDownFrequencies = new ArrayList<Double>();
+        List<Double> scaledDownFrequencies = new ArrayList<>();
         unscaledFrequencies.forEach(frequency -> scaledDownFrequencies.add(frequency * 0.5));
         assertEquals(scaledDigestFrequencies, scaledDownFrequencies);
     }
@@ -672,7 +672,7 @@ public class TestTDigestFunctions
 
     private List<Double> getFrequencies(TDigest tdigest, List<Double> buckets)
     {
-        List<Double> histogram = new ArrayList<Double>();
+        List<Double> histogram = new ArrayList<>();
         for (Double bin : buckets) {
             histogram.add(tdigest.getCdf(bin) * tdigest.getSize());
         }

--- a/presto-main/src/test/java/com/facebook/presto/tdigest/TestTDigest.java
+++ b/presto-main/src/test/java/com/facebook/presto/tdigest/TestTDigest.java
@@ -79,7 +79,7 @@ public class TestTDigest
     {
         TDigest tDigest1 = createTDigest(STANDARD_COMPRESSION_FACTOR);
         TDigest tDigest2 = createTDigest(STANDARD_COMPRESSION_FACTOR);
-        List<Integer> list = new ArrayList<Integer>();
+        List<Integer> list = new ArrayList<>();
 
         for (int i = 0; i < NUMBER_OF_ENTRIES / 2; i++) {
             tDigest1.add(i);
@@ -102,7 +102,7 @@ public class TestTDigest
     {
         TDigest tDigest1 = createTDigest(STANDARD_COMPRESSION_FACTOR);
         TDigest tDigest2 = createTDigest(STANDARD_COMPRESSION_FACTOR);
-        List<Integer> list = new ArrayList<Integer>();
+        List<Integer> list = new ArrayList<>();
 
         for (int i = 0; i < NUMBER_OF_ENTRIES / 2; i++) {
             tDigest1.add(i);
@@ -124,7 +124,7 @@ public class TestTDigest
     public void testAddElementsRandomized()
     {
         TDigest tDigest = createTDigest(STANDARD_COMPRESSION_FACTOR);
-        List<Double> list = new ArrayList<Double>();
+        List<Double> list = new ArrayList<>();
 
         for (int i = 0; i < NUMBER_OF_ENTRIES; i++) {
             double value = Math.random() * NUMBER_OF_ENTRIES;
@@ -145,7 +145,7 @@ public class TestTDigest
     public void testNormalDistributionLowVariance()
     {
         TDigest tDigest = createTDigest(STANDARD_COMPRESSION_FACTOR);
-        List<Double> list = new ArrayList<Double>();
+        List<Double> list = new ArrayList<>();
         NormalDistribution normal = new NormalDistribution(1000, 1);
 
         for (int i = 0; i < NUMBER_OF_ENTRIES; i++) {
@@ -184,7 +184,7 @@ public class TestTDigest
     public void testNormalDistributionHighVariance()
     {
         TDigest tDigest = createTDigest(STANDARD_COMPRESSION_FACTOR);
-        List<Double> list = new ArrayList<Double>();
+        List<Double> list = new ArrayList<>();
         NormalDistribution normal = new NormalDistribution(0, 1);
 
         for (int i = 0; i < NUMBER_OF_ENTRIES; i++) {
@@ -315,7 +315,7 @@ public class TestTDigest
         for (int k = 1; k < trials; k++) {
             TDigest tDigest = createTDigest(STANDARD_COMPRESSION_FACTOR);
             GeometricDistribution geometric = new GeometricDistribution(k * 0.1);
-            List<Integer> list = new ArrayList<Integer>();
+            List<Integer> list = new ArrayList<>();
 
             for (int i = 0; i < NUMBER_OF_ENTRIES; i++) {
                 int sample = geometric.sample();
@@ -340,7 +340,7 @@ public class TestTDigest
         for (int k = 1; k < trials; k++) {
             TDigest tDigest = createTDigest(STANDARD_COMPRESSION_FACTOR);
             PoissonDistribution poisson = new PoissonDistribution(k * 0.1);
-            List<Integer> list = new ArrayList<Integer>();
+            List<Integer> list = new ArrayList<>();
 
             for (int i = 0; i < NUMBER_OF_ENTRIES; i++) {
                 int sample = poisson.sample();

--- a/presto-session-property-managers/src/main/java/com/facebook/presto/session/FileSessionPropertyManager.java
+++ b/presto-session-property-managers/src/main/java/com/facebook/presto/session/FileSessionPropertyManager.java
@@ -85,7 +85,7 @@ public class FileSessionPropertyManager
     {
         // later properties override earlier properties
         Map<String, String> defaultProperties = new HashMap<>();
-        Set<String> overridePropertyNames = new HashSet<String>();
+        Set<String> overridePropertyNames = new HashSet<>();
         for (SessionMatchSpec sessionMatchSpec : sessionMatchSpecs) {
             Map<String, String> newProperties = sessionMatchSpec.match(context);
             defaultProperties.putAll(newProperties);

--- a/presto-tpch/src/main/java/com/facebook/presto/tpch/TpchRecordSetProvider.java
+++ b/presto-tpch/src/main/java/com/facebook/presto/tpch/TpchRecordSetProvider.java
@@ -58,7 +58,7 @@ public class TpchRecordSetProvider
         for (ColumnHandle column : columns) {
             String columnName = ((TpchColumnHandle) column).getColumnName();
             if (columnName.equalsIgnoreCase(TpchMetadata.ROW_NUMBER_COLUMN_NAME)) {
-                builder.add(new RowNumberTpchColumn<E>());
+                builder.add(new RowNumberTpchColumn<>());
             }
             else {
                 builder.add(table.getColumn(columnName));


### PR DESCRIPTION
The diamond operator, introduced in Java 7, adds type inference and reduces verbosity in assignments when using generics. The vast majority of this codebase uses the diamond operator where possible, but a few legacy usages of the earlier style remain. This modernizes the code by adopting the diamond operator where possible, improving legibility through the use of a consistent programming paradigm.

These changes were tested by successfully running `mvn clean package -DskipTests` locally.

```
== NO RELEASE NOTE ==
```