### PR TITLE
Add configuration for Alluxio connector to support zookeeper high availability mode

### DIFF
--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/alluxio/AlluxioHiveMetastoreConfig.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/alluxio/AlluxioHiveMetastoreConfig.java
@@ -22,10 +22,22 @@ import com.facebook.airlift.configuration.ConfigDescription;
 public class AlluxioHiveMetastoreConfig
 {
     private String masterAddress;
+    private boolean zookeeperEnabled;
+    private String zookeeperAddress;
 
     public String getMasterAddress()
     {
         return masterAddress;
+    }
+
+    public boolean isZookeeperEnabled()
+    {
+        return zookeeperEnabled;
+    }
+
+    public String getZookeeperAddress()
+    {
+        return zookeeperAddress;
     }
 
     @Config("hive.metastore.alluxio.master.address")
@@ -33,6 +45,22 @@ public class AlluxioHiveMetastoreConfig
     public AlluxioHiveMetastoreConfig setMasterAddress(String masterAddress)
     {
         this.masterAddress = masterAddress;
+        return this;
+    }
+
+    @Config("hive.metastore.alluxio.zookeeper.enabled")
+    @ConfigDescription("If true, setup master fault tolerant mode using ZooKeeper.")
+    public AlluxioHiveMetastoreConfig setZookeeperEnabled(boolean zookeeperEnabled)
+    {
+        this.zookeeperEnabled = zookeeperEnabled;
+        return this;
+    }
+
+    @Config("hive.metastore.alluxio.zookeeper.address")
+    @ConfigDescription("Address of ZooKeeper.")
+    public AlluxioHiveMetastoreConfig setZookeeperAddress(String zookeeperAddress)
+    {
+        this.zookeeperAddress = zookeeperAddress;
         return this;
     }
 }

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/alluxio/AlluxioMetastoreModule.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/alluxio/AlluxioMetastoreModule.java
@@ -56,11 +56,17 @@ public class AlluxioMetastoreModule
     TableMasterClient provideCatalogMasterClient(AlluxioHiveMetastoreConfig config)
     {
         InstancedConfiguration conf = new InstancedConfiguration(ConfigurationUtils.defaults());
-        String address = config.getMasterAddress();
-        String[] parts = address.split(":", 2);
-        conf.set(PropertyKey.MASTER_HOSTNAME, parts[0]);
-        if (parts.length > 1) {
-            conf.set(PropertyKey.MASTER_RPC_PORT, parts[1]);
+        if (config.isZookeeperEnabled()) {
+            conf.set(PropertyKey.ZOOKEEPER_ENABLED, true);
+            conf.set(PropertyKey.ZOOKEEPER_ADDRESS, config.getZookeeperAddress());
+        }
+        else {
+            String address = config.getMasterAddress();
+            String[] parts = address.split(":", 2);
+            conf.set(PropertyKey.MASTER_HOSTNAME, parts[0]);
+            if (parts.length > 1) {
+                conf.set(PropertyKey.MASTER_RPC_PORT, parts[1]);
+            }
         }
         MasterClientContext context = MasterClientContext.newBuilder(ClientContext.create(conf)).build();
         return new RetryHandlingTableMasterClient(context);

--- a/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/alluxio/TestAlluxioHiveMetastoreConfig.java
+++ b/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/alluxio/TestAlluxioHiveMetastoreConfig.java
@@ -28,7 +28,9 @@ public class TestAlluxioHiveMetastoreConfig
     public void testDefaults()
     {
         assertRecordedDefaults(recordDefaults(AlluxioHiveMetastoreConfig.class)
-                .setMasterAddress(null));
+                .setMasterAddress(null)
+                .setZookeeperEnabled(false)
+                .setZookeeperAddress(null));
     }
 
     @Test
@@ -36,10 +38,14 @@ public class TestAlluxioHiveMetastoreConfig
     {
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("hive.metastore.alluxio.master.address", "localhost:19998")
+                .put("hive.metastore.alluxio.zookeeper.enabled", "true")
+                .put("hive.metastore.alluxio.zookeeper.address", "zK1:218,ZK2:2181,ZK3:2181")
                 .build();
 
         AlluxioHiveMetastoreConfig expected = new AlluxioHiveMetastoreConfig()
-                .setMasterAddress("localhost:19998");
+                .setMasterAddress("localhost:19998")
+                .setZookeeperEnabled(true)
+                .setZookeeperAddress("zK1:218,ZK2:2181,ZK3:2181");
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
The current Alluxio connector configuration only support single master mode. Adding alluxio.zookeeper.enabled and alluxio.zookeeper.address to support zookeeper high availability mode.

```
== NO RELEASE NOTE ==
```
