### PR TITLE
Fix NullPointerException when handling BIND in RowExpressionInterpreter

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/RowExpressionInterpreter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/RowExpressionInterpreter.java
@@ -609,7 +609,7 @@ public class RowExpressionInterpreter
                     List<Object> values = node.getArguments()
                             .stream()
                             .map(value -> value.accept(this, context))
-                            .collect(toImmutableList());
+                            .collect(toList());
                     if (hasUnresolvedValue(values)) {
                         return new SpecialFormExpression(
                                 BIND,

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -2902,6 +2902,9 @@ public abstract class AbstractTestQueries
         assertQuery("SELECT TRY(2/0)", "SELECT null");
         assertQuery("SELECT COALESCE(TRY(2/0), 0)", "SELECT 0");
         assertQuery("SELECT TRY(ABS(-2))", "SELECT 2");
+
+        // test try with null
+        assertQuery("SELECT TRY(1 / x) FROM (SELECT NULL as x)", "SELECT NULL");
     }
 
     @Test


### PR DESCRIPTION
When using BIND, it may happen that parameters get evaluated to null, simple because there is `SELECT null AS x` somewhere. We should handle nulls and use them as method args

```
== NO RELEASE NOTE ==
```
