### PR TITLE
upgrading the parquet/avro version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <dep.testng.version>6.10</dep.testng.version>
         <dep.assertj-core.version>3.8.0</dep.assertj-core.version>
         <dep.logback.version>1.2.3</dep.logback.version>
-        <dep.parquet.version>1.11.0</dep.parquet.version>
+        <dep.parquet.version>1.11.1</dep.parquet.version>
         <dep.nexus-staging-plugin.version>1.6.8</dep.nexus-staging-plugin.version>
         <dep.asm.version>9.0</dep.asm.version>
         <dep.gcs.version>1.9.17</dep.gcs.version>
@@ -623,7 +623,7 @@
             <dependency>
                 <groupId>com.facebook.presto.hive</groupId>
                 <artifactId>hive-apache</artifactId>
-                <version>3.0.0-3</version>
+                <version>3.0.0-7</version>
             </dependency>
 
             <dependency>

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveFileFormats.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveFileFormats.java
@@ -736,7 +736,7 @@ public class TestHiveFileFormats
                 .isFailingForPageSource(new ParquetPageSourceFactory(FUNCTION_AND_TYPE_MANAGER, FUNCTION_RESOLUTION, HDFS_ENVIRONMENT, STATS, METADATA_READER), expectedErrorCode, expectedMessageMapLongLong);
 
         String expectedMessageMapLongMapDouble = "The column column_name of table schema.table is declared as type map<bigint,bigint>, but the Parquet file ((.*?)) declares the column as type optional group column_name \\(MAP\\) \\{\n"
-                + "  repeated group map \\(MAP_KEY_VALUE\\) \\{\n"
+                + "  repeated group key_value \\(MAP_KEY_VALUE\\) \\{\n"
                 + "    required double key;\n"
                 + "    optional double value;\n"
                 + "  \\}\n"
@@ -877,8 +877,8 @@ public class TestHiveFileFormats
 
         HiveErrorCode expectedErrorCode = HIVE_PARTITION_SCHEMA_MISMATCH;
         String expectedMessageRowLongNest = "The column column_name of table schema.table is declared as type map<string,struct<s_double:int,s_int:int>>, but the Parquet file ((.*?)) declares the column as type optional group column_name \\(MAP\\) \\{\n" +
-                "  repeated group map \\(MAP_KEY_VALUE\\) \\{\n" +
-                "    required binary key \\(UTF8\\);\n" +
+                "  repeated group key_value \\(MAP_KEY_VALUE\\) \\{\n" +
+                "    required binary key \\(STRING\\);\n" +
                 "    optional group value \\{\n" +
                 "      optional int32 s_int;\n" +
                 "      optional double s_double;\n" +

--- a/presto-iceberg/pom.xml
+++ b/presto-iceberg/pom.xml
@@ -50,6 +50,10 @@
                     <artifactId>parquet-format</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>org.apache.yetus</groupId>
+                    <artifactId>audience-annotations</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-api</artifactId>
                 </exclusion>

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/ParquetSchemaConverter.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/ParquetSchemaConverter.java
@@ -149,7 +149,7 @@ public class ParquetSchemaConverter
 
     private org.apache.parquet.schema.Type getMapType(MapType type, String name, List<String> parent)
     {
-        parent = ImmutableList.<String>builder().addAll(parent).add(name).add("map").build();
+        parent = ImmutableList.<String>builder().addAll(parent).add(name).add("key_value").build();
         Type keyType = type.getKeyType();
         Type valueType = type.getValueType();
         return Types.map(OPTIONAL)


### PR DESCRIPTION
* parquet version upgraded from 1.10.1 (coming via [presto-hive-apache 3.0.0-3](https://github.com/prestodb/presto-hive-apache/blob/3.0.0-3/pom.xml)) to 1.11.1 (coming via [presto-hive-apache 3.0.0-7](https://github.com/prestodb/presto-hive-apache/blob/3.0.0-7/pom.xml))
* avro version upgraded from 1.8.2 (coming via [presto-hive-apache 3.0.0-3](https://github.com/prestodb/presto-hive-apache/blob/3.0.0-3/pom.xml)) to 1.9.2 (coming via [presto-hive-apache 3.0.0-7](https://github.com/prestodb/presto-hive-apache/blob/3.0.0-7/pom.xml))

Test plan -
Existing tests

```
== RELEASE NOTES ==

General Changes
* parquet version upgraded from 1.10.1 (coming via presto-hive-apache 3.0.0-3) to 1.11.1 (coming via presto-hive-apache 3.0.0-7)
* avro version upgraded from 1.8.2 (coming via presto-hive-apache 3.0.0-3) to 1.9.2 (coming via presto-hive-apache 3.0.0-7)

```
