### PR TITLE
Fix Long Dictionary getDictionaryBytes method

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/LongDictionaryColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/LongDictionaryColumnWriter.java
@@ -84,7 +84,11 @@ public class LongDictionaryColumnWriter
     @Override
     public int getDictionaryBytes()
     {
-        return dictionary.size() * typeSize;
+        // This method measures the dictionary size required for the reader to decode.
+        // The reader uses long[] array to hold the contents of the dictionary.
+        // @See com.facebook.presto.orc.reader.LongDictionarySelectiveStreamReader.dictionary
+        // So always multiply by the Long.BYTES size instead of typeSize.
+        return dictionary.size() * Long.BYTES;
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/SliceDictionaryBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/SliceDictionaryBuilder.java
@@ -132,7 +132,7 @@ public class SliceDictionaryBuilder
                 // Doesn't have this element
                 return hashPosition;
             }
-            else if (segmentedSliceBuilder.equals(slicePosition, block, position, length)) {
+            if (segmentedSliceBuilder.equals(slicePosition, block, position, length)) {
                 // Already has this element
                 return hashPosition;
             }


### PR DESCRIPTION
This PR contains 2 changes.

1. Apply the same change that was suggested on LongDictionaryBuilder
to keep both the classes consistent
2. Calculate getDictionaryBytes correctly in LongDictionaryBuilder.
LongDictionaryBuilder is currently disabled in Presto, so this change
does not impact the Presto use cases, unless enabled via config.

Test plan - 
Existing tests.

```
== NO RELEASE NOTE ==
```
