### PR TITLE
Support Large dictionary on write

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
@@ -317,14 +317,18 @@ public class OrcWriter
             }
         }
         this.columnWriters = columnWriters.build();
-        this.dictionaryMaxMemoryBytes = toIntExact(
-                requireNonNull(options.getDictionaryMaxMemory(), "dictionaryMaxMemory is null").toBytes());
+        this.dictionaryMaxMemoryBytes = toIntExact(options.getDictionaryMaxMemory().toBytes());
+        int dictionaryMemoryAlmostFullRangeBytes = toIntExact(options.getDictionaryMemoryAlmostFullRange().toBytes());
+        int dictionaryUsefulCheckColumnSizeBytes = toIntExact(options.getDictionaryUsefulCheckColumnSize().toBytes());
         this.dictionaryCompressionOptimizer = new DictionaryCompressionOptimizer(
                 dictionaryColumnWriters.build(),
                 stripeMinBytes,
                 stripeMaxBytes,
                 stripeMaxRowCount,
-                dictionaryMaxMemoryBytes);
+                dictionaryMaxMemoryBytes,
+                dictionaryMemoryAlmostFullRangeBytes,
+                dictionaryUsefulCheckColumnSizeBytes,
+                options.getDictionaryUsefulCheckPerChunkFrequency());
 
         for (Entry<String, String> entry : this.userMetadata.entrySet()) {
             recordValidation(validation -> validation.addMetadataProperty(entry.getKey(), utf8Slice(entry.getValue())));

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriterOptions.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriterOptions.java
@@ -35,6 +35,9 @@ public class OrcWriterOptions
     public static final int DEFAULT_STRIPE_MAX_ROW_COUNT = 10_000_000;
     public static final int DEFAULT_ROW_GROUP_MAX_ROW_COUNT = 10_000;
     public static final DataSize DEFAULT_DICTIONARY_MAX_MEMORY = new DataSize(16, MEGABYTE);
+    public static final DataSize DEFAULT_DICTIONARY_MEMORY_ALMOST_FULL_RANGE = new DataSize(4, MEGABYTE);
+    public static final int DEFAULT_DICTIONARY_USEFUL_CHECK_PER_CHUNK_FREQUENCY = Integer.MAX_VALUE;
+    public static final DataSize DEFAULT_DICTIONARY_USEFUL_CHECK_COLUMN_SIZE = new DataSize(6, MEGABYTE);
     public static final DataSize DEFAULT_MAX_STRING_STATISTICS_LIMIT = new DataSize(64, BYTE);
     public static final DataSize DEFAULT_MAX_COMPRESSION_BUFFER_SIZE = new DataSize(256, KILOBYTE);
     public static final DataSize DEFAULT_DWRF_STRIPE_CACHE_MAX_SIZE = new DataSize(8, MEGABYTE);
@@ -46,6 +49,9 @@ public class OrcWriterOptions
     private final int stripeMaxRowCount;
     private final int rowGroupMaxRowCount;
     private final DataSize dictionaryMaxMemory;
+    private final DataSize dictionaryMemoryAlmostFullRange;
+    private final int dictionaryUsefulCheckPerChunkFrequency;
+    private final DataSize dictionaryUsefulCheckColumnSize;
     private final DataSize maxStringStatisticsLimit;
     private final DataSize maxCompressionBufferSize;
     private final OptionalInt compressionLevel;
@@ -66,6 +72,9 @@ public class OrcWriterOptions
             int stripeMaxRowCount,
             int rowGroupMaxRowCount,
             DataSize dictionaryMaxMemory,
+            DataSize dictionaryMemoryAlmostFullRange,
+            int dictionaryUsefulCheckPerChunkFrequency,
+            DataSize dictionaryUsefulCheckColumnSize,
             DataSize maxStringStatisticsLimit,
             DataSize maxCompressionBufferSize,
             OptionalInt compressionLevel,
@@ -81,6 +90,8 @@ public class OrcWriterOptions
         checkArgument(stripeMaxRowCount >= 1, "stripeMaxRowCount must be at least 1");
         checkArgument(rowGroupMaxRowCount >= 1, "rowGroupMaxRowCount must be at least 1");
         requireNonNull(dictionaryMaxMemory, "dictionaryMaxMemory is null");
+        requireNonNull(dictionaryMemoryAlmostFullRange, "dictionaryMemoryAlmostFullRange is null");
+        requireNonNull(dictionaryUsefulCheckColumnSize, "dictionaryUsefulCheckColumnSize is null");
         requireNonNull(maxStringStatisticsLimit, "maxStringStatisticsLimit is null");
         requireNonNull(maxCompressionBufferSize, "maxCompressionBufferSize is null");
         requireNonNull(compressionLevel, "compressionLevel is null");
@@ -92,6 +103,9 @@ public class OrcWriterOptions
         this.stripeMaxRowCount = stripeMaxRowCount;
         this.rowGroupMaxRowCount = rowGroupMaxRowCount;
         this.dictionaryMaxMemory = dictionaryMaxMemory;
+        this.dictionaryMemoryAlmostFullRange = dictionaryMemoryAlmostFullRange;
+        this.dictionaryUsefulCheckPerChunkFrequency = dictionaryUsefulCheckPerChunkFrequency;
+        this.dictionaryUsefulCheckColumnSize = dictionaryUsefulCheckColumnSize;
         this.maxStringStatisticsLimit = maxStringStatisticsLimit;
         this.maxCompressionBufferSize = maxCompressionBufferSize;
         this.compressionLevel = compressionLevel;
@@ -126,6 +140,21 @@ public class OrcWriterOptions
     public DataSize getDictionaryMaxMemory()
     {
         return dictionaryMaxMemory;
+    }
+
+    public DataSize getDictionaryMemoryAlmostFullRange()
+    {
+        return dictionaryMemoryAlmostFullRange;
+    }
+
+    public int getDictionaryUsefulCheckPerChunkFrequency()
+    {
+        return dictionaryUsefulCheckPerChunkFrequency;
+    }
+
+    public DataSize getDictionaryUsefulCheckColumnSize()
+    {
+        return dictionaryUsefulCheckColumnSize;
     }
 
     public DataSize getMaxStringStatisticsLimit()
@@ -182,6 +211,9 @@ public class OrcWriterOptions
                 .add("stripeMaxRowCount", stripeMaxRowCount)
                 .add("rowGroupMaxRowCount", rowGroupMaxRowCount)
                 .add("dictionaryMaxMemory", dictionaryMaxMemory)
+                .add("dictionaryMemoryAlmostFullRange", dictionaryMemoryAlmostFullRange)
+                .add("dictionaryUsefulCheckPerChunkFrequency", dictionaryUsefulCheckPerChunkFrequency)
+                .add("dictionaryUsefulCheckColumnSize", dictionaryUsefulCheckColumnSize)
                 .add("maxStringStatisticsLimit", maxStringStatisticsLimit)
                 .add("maxCompressionBufferSize", maxCompressionBufferSize)
                 .add("compressionLevel", compressionLevel)
@@ -206,6 +238,9 @@ public class OrcWriterOptions
         private int stripeMaxRowCount = DEFAULT_STRIPE_MAX_ROW_COUNT;
         private int rowGroupMaxRowCount = DEFAULT_ROW_GROUP_MAX_ROW_COUNT;
         private DataSize dictionaryMaxMemory = DEFAULT_DICTIONARY_MAX_MEMORY;
+        private DataSize dictionaryMemoryAlmostFullRange = DEFAULT_DICTIONARY_MEMORY_ALMOST_FULL_RANGE;
+        private int dictionaryUsefulCheckPerChunkFrequency = DEFAULT_DICTIONARY_USEFUL_CHECK_PER_CHUNK_FREQUENCY;
+        private DataSize dictionaryUsefulCheckColumnSize = DEFAULT_DICTIONARY_USEFUL_CHECK_COLUMN_SIZE;
         private DataSize maxStringStatisticsLimit = DEFAULT_MAX_STRING_STATISTICS_LIMIT;
         private DataSize maxCompressionBufferSize = DEFAULT_MAX_COMPRESSION_BUFFER_SIZE;
         private OptionalInt compressionLevel = OptionalInt.empty();
@@ -247,6 +282,25 @@ public class OrcWriterOptions
         public Builder withDictionaryMaxMemory(DataSize dictionaryMaxMemory)
         {
             this.dictionaryMaxMemory = requireNonNull(dictionaryMaxMemory, "dictionaryMaxMemory is null");
+            return this;
+        }
+
+        public Builder withDictionaryMemoryAlmostFullRange(DataSize dictionaryMemoryAlmostFullRange)
+        {
+            this.dictionaryMemoryAlmostFullRange = requireNonNull(dictionaryMemoryAlmostFullRange, "dictionaryMemoryAlmostFullRange is null");
+            return this;
+        }
+
+        public Builder withDictionaryUsefulCheckPerChunkFrequency(int dictionaryUsefulCheckPerChunkFrequency)
+        {
+            checkArgument(dictionaryUsefulCheckPerChunkFrequency >= 0, "dictionaryUsefulCheckPerChunkFrequency is negative");
+            this.dictionaryUsefulCheckPerChunkFrequency = dictionaryUsefulCheckPerChunkFrequency;
+            return this;
+        }
+
+        public Builder withDictionaryUsefulCheckColumnSize(DataSize dictionaryUsefulCheckColumnSize)
+        {
+            this.dictionaryUsefulCheckColumnSize = requireNonNull(dictionaryUsefulCheckColumnSize, "dictionaryUsefulCheckColumnSize is null");
             return this;
         }
 
@@ -332,6 +386,9 @@ public class OrcWriterOptions
                     stripeMaxRowCount,
                     rowGroupMaxRowCount,
                     dictionaryMaxMemory,
+                    dictionaryMemoryAlmostFullRange,
+                    dictionaryUsefulCheckPerChunkFrequency,
+                    dictionaryUsefulCheckColumnSize,
                     maxStringStatisticsLimit,
                     maxCompressionBufferSize,
                     compressionLevel,

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcWriterOptions.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcWriterOptions.java
@@ -61,6 +61,10 @@ public class TestOrcWriterOptions
         int stripeMaxRowCount = 1_100_000;
         int rowGroupMaxRowCount = 15_000;
         DataSize dictionaryMaxMemory = new DataSize(13_000, KILOBYTE);
+        DataSize dictionaryMemoryRange = new DataSize(1_000, KILOBYTE);
+        int dictionaryUsefulCheckPerChunkFrequency = 9_999;
+        DataSize dictionaryUsefulCheckIncrement = new DataSize(500, KILOBYTE);
+        DataSize dictionaryUsefulCheckColumnSize = new DataSize(1, MEGABYTE);
         DataSize stringMaxStatisticsLimit = new DataSize(128, BYTE);
         DataSize maxCompressionBufferSize = new DataSize(512, KILOBYTE);
         OptionalInt compressionLevel = OptionalInt.of(5);
@@ -75,6 +79,9 @@ public class TestOrcWriterOptions
                 .withStripeMaxRowCount(stripeMaxRowCount)
                 .withRowGroupMaxRowCount(rowGroupMaxRowCount)
                 .withDictionaryMaxMemory(dictionaryMaxMemory)
+                .withDictionaryMemoryAlmostFullRange(dictionaryMemoryRange)
+                .withDictionaryUsefulCheckPerChunkFrequency(dictionaryUsefulCheckPerChunkFrequency)
+                .withDictionaryUsefulCheckColumnSize(dictionaryUsefulCheckColumnSize)
                 .withMaxStringStatisticsLimit(stringMaxStatisticsLimit)
                 .withMaxCompressionBufferSize(maxCompressionBufferSize)
                 .withCompressionLevel(compressionLevel)
@@ -90,6 +97,9 @@ public class TestOrcWriterOptions
         assertEquals(stripeMaxRowCount, options.getStripeMaxRowCount());
         assertEquals(rowGroupMaxRowCount, options.getRowGroupMaxRowCount());
         assertEquals(dictionaryMaxMemory, options.getDictionaryMaxMemory());
+        assertEquals(dictionaryMemoryRange, options.getDictionaryMemoryAlmostFullRange());
+        assertEquals(dictionaryUsefulCheckPerChunkFrequency, options.getDictionaryUsefulCheckPerChunkFrequency());
+        assertEquals(dictionaryUsefulCheckColumnSize, options.getDictionaryUsefulCheckColumnSize());
         assertEquals(stringMaxStatisticsLimit, options.getMaxStringStatisticsLimit());
         assertEquals(maxCompressionBufferSize, options.getMaxCompressionBufferSize());
         assertEquals(compressionLevel, options.getCompressionLevel());
@@ -108,6 +118,9 @@ public class TestOrcWriterOptions
         int stripeMaxRowCount = 1_100_000;
         int rowGroupMaxRowCount = 15_000;
         DataSize dictionaryMaxMemory = new DataSize(13_000, KILOBYTE);
+        DataSize dictionaryMemoryRange = new DataSize(1_000, KILOBYTE);
+        int dictionaryUsefulCheckPerChunkFrequency = 9_999;
+        DataSize dictionaryUsefulCheckColumnSize = new DataSize(1, MEGABYTE);
         DataSize stringMaxStatisticsLimit = new DataSize(128, BYTE);
         DataSize maxCompressionBufferSize = new DataSize(512, KILOBYTE);
         DataSize dwrfStripeCacheMaxSize = new DataSize(4, MEGABYTE);
@@ -124,6 +137,9 @@ public class TestOrcWriterOptions
                 .withStripeMaxRowCount(stripeMaxRowCount)
                 .withRowGroupMaxRowCount(rowGroupMaxRowCount)
                 .withDictionaryMaxMemory(dictionaryMaxMemory)
+                .withDictionaryMemoryAlmostFullRange(dictionaryMemoryRange)
+                .withDictionaryUsefulCheckPerChunkFrequency(dictionaryUsefulCheckPerChunkFrequency)
+                .withDictionaryUsefulCheckColumnSize(dictionaryUsefulCheckColumnSize)
                 .withMaxStringStatisticsLimit(stringMaxStatisticsLimit)
                 .withMaxCompressionBufferSize(maxCompressionBufferSize)
                 .withCompressionLevel(compressionLevel)
@@ -136,12 +152,12 @@ public class TestOrcWriterOptions
                 .withPreserveDirectEncodingStripeCount(preserveDirectEncodingStripeCount)
                 .build();
 
-        String expectedString = "OrcWriterOptions{stripeMinSize=13MB, stripeMaxSize=27MB, stripeMaxRowCount=1100000, "
-                + "rowGroupMaxRowCount=15000, dictionaryMaxMemory=13000kB, maxStringStatisticsLimit=128B, "
-                + "maxCompressionBufferSize=512kB, compressionLevel=OptionalInt[5], streamLayout=ByColumnSize{}, "
-                + "integerDictionaryEncodingEnabled=false, stringDictionarySortingEnabled=true, "
-                + "dwrfWriterOptions=Optional[DwrfStripeCacheOptions{stripeCacheMode=INDEX_AND_FOOTER, stripeCacheMaxSize=4MB}], "
-                + "ignoreDictionaryRowGroupSizes=false, preserveDirectEncodingStripeCount=0}";
+        String expectedString = "OrcWriterOptions{stripeMinSize=13MB, stripeMaxSize=27MB, stripeMaxRowCount=1100000, rowGroupMaxRowCount=15000, " +
+                "dictionaryMaxMemory=13000kB, dictionaryMemoryAlmostFullRange=1000kB, dictionaryUsefulCheckPerChunkFrequency=9999, " +
+                "dictionaryUsefulCheckColumnSize=1MB, maxStringStatisticsLimit=128B, maxCompressionBufferSize=512kB, " +
+                "compressionLevel=OptionalInt[5], streamLayout=ByColumnSize{}, integerDictionaryEncodingEnabled=false, " +
+                "stringDictionarySortingEnabled=true, dwrfWriterOptions=Optional[DwrfStripeCacheOptions{stripeCacheMode=INDEX_AND_FOOTER, stripeCacheMaxSize=4MB}], " +
+                "ignoreDictionaryRowGroupSizes=false, preserveDirectEncodingStripeCount=0}";
         assertEquals(expectedString, writerOptions.toString());
     }
 }


### PR DESCRIPTION
This change enables ORC writer to work with large dictionaries (>40 MB).

DictionaryCompressionOptimizer, before this change optimized dictionary
only when the dictionary is almost full. When using long dictionaries
(with overhead of 3X) due to overallocation and maintaining index
this caused the writers to OOM.  

This change introduces 3 configs to control the dictionary growth.
1. Enable dictionary usefulness check, when the column dictionary is bigger 
than a configured size ( 4MB).
2. How often the dictionary column size should be checked for usefulness.
Default to INT_MAX so this behavior is disabled by default.
3. Let the users of the OrcWriter configure the almost full range size.
Defaults to 4MB to maintain backward compatibility.

This change also optimizes the DictionaryCompressionOptimizer to use
Lists instead of sets for faster iteration.

Test plan - 
Added new tests.
Run the validation service for 12 hours.

```
== NO RELEASE NOTE ==
```
