### PR TITLE
Add release notes for 0.265

### DIFF
--- a/presto-docs/src/main/sphinx/release.rst
+++ b/presto-docs/src/main/sphinx/release.rst
@@ -5,6 +5,7 @@ Release Notes
 .. toctree::
     :maxdepth: 1
 
+    release/release-0.265
     release/release-0.264.1
     release/release-0.264
     release/release-0.263.1

--- a/presto-docs/src/main/sphinx/release/release-0.265.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.265.rst
@@ -1,0 +1,25 @@
+=============
+Release 0.265
+=============
+
+**Details**
+===========
+
+General Changes
+_______________
+* Add a configuration property ``fragment-result-cache.max-cache-size`` to control the total on-disk size of fragment result cache. The default value is 100G.
+* Rename function ``array_dupes`` to :func:`array_duplicates`, and rename function ``array_has_dupes`` to :func:`array_has_duplicates`. Previous names are kept as aliases but will be deprecated in the future.
+
+Verifier Changes
+________________
+* Fix verifier executable jar corruption.
+
+Hive Changes
+____________
+* Improve memory and CPU usage for writing DWRF files.
+* Upgrade Hudi support to 0.9.0.
+
+**Credits**
+===========
+
+Ajay George, Arjun Gupta, Arunachalam Thirupathi, Ge Gao, James Petty, James Sun, Junhyung Song, JySongWithZhangce, Masha Basmanova, Naveen Kumar Mahadevuni, Pranjal Shankhdhar, Rongrong Zhong, Sagar Sumit, Sreeni Viswanadha, Tim Meehan, Will Holen, Ying Su, Zac Wen, Zhan Yuan, abhiseksaikia, beinan


### PR DESCRIPTION
# Missing Release Notes
## Ge Gao
- [x] https://github.com/prestodb/presto/pull/16870 Enforce ACLs for SELECT path for materialized view (Merged by: James Sun)

# Extracted Release Notes
- #16824 (Author: Sreeni Viswanadha): Add source location info to RowExpression
  - Expressions in the plan now have line/column number.
- #16863 (Author: Zhan Yuan): Add a configuration property for total FRC cache size
  - Add a configuration property fragment-result-cache.max-cache-size to control the total on-disk size of fragment result cache. The default value is 100G.
- #16881 (Author: Sagar Sumit): Upgrade to Hudi 0.9.0
  - Upgrade Hudi support to 0.9.0.
- #16891 (Author: Masha Basmanova): Rename array_dupes function to array_duplicates
  - Rename array_dupes and array_has_dupes functions to :func:`array_duplicates` and :func:`array_has_duplicates`.
- #16901 (Author: Arunachalam Thirupathi): Fix Presto verifier corrupted jar error
  - Fix verifier executable jar corruption.
- #16905 (Author: Arunachalam Thirupathi): Reduce Long dictionary memory consumption
  - Improve memory and CPU usage for writing DWRF files.

# All Commits
- 2baf80cca4c5c273815ce700fd1924ea8d6df9d0 Fix LongDictionary getDictionaryBytes (Arunachalam Thirupathi)
- 81bfeabb8d65cd7f17d0bfb6801b490a793e7779 Apply similar change to  SliceDictionaryBuilder (Arunachalam Thirupathi)
- ab03ca8662be5df68e6c557f96ef14975a27069b Add session property for Dwrf Stripe Cache Writer (Arunachalam Thirupathi)
- 4b2e1d614882996f2467dab7ea3016de66203576 Cleanup existing HiveClientConfig and OrcWriterOptions (Arunachalam Thirupathi)
- 9a89eab9b46792a7c22e41fcc9ad56bde18c1e15 Carry Forward Direct Encoding Decision for Stripes (Arunachalam Thirupathi)
- c631ce833f7a8061047820e8acbd84c90ec38ca0 Reduce Long dictionary memory consumption (Arunachalam Thirupathi)
- 97b84b00d0cc3e951fa1b31dcf313206be3cfbed Remove redundant LinkedList from AsyncPageTransportServlet (James Petty)
- 0406fbe02cc6f93c02dc46c964cc9d0ec62b4769 Add source location info to RowExpression (Sreeni Viswanadha)
- e177ed67e3492167a5edb7cda74727bbe4847b8d Add TSC voting information to the README (Tim Meehan)
- 15a3f16b08aa91d8bee31b721cefa9ec619c6695 Add expanded query for refresh materialized view (Zac Wen)
- 0ae3165f57a86c444e53b9dc5135ad7637f09ade Avoid unnecessary allocations in AsyncPageTransportServlet (Will Holen)
- 3a9171c3a7132cd610f91da77a26cf8c5362e7cf Avoid regex in QueryId.* (Will Holen)
- 219b996f6930f9ba333eac66df5f491d32656dd6 Implement approx_most_frequent with memory efficient data structure (abhiseksaikia)
- fe030df71084ed22b6b764b6aed28aaaca131050 Remove unused reference to sphinx-maven-plugin (Arunachalam Thirupathi)
- acb15a3031b47e547a722dfcb39b201e6b5278ff Fix presto-docs build failure (Arunachalam Thirupathi)
- 6f84eccef19f6c9764a2ed7488cbc8b323d05ade Fix NullPointerException when handling BIND in RowExpressionInterpreter (Pranjal Shankhdhar)
- ae391b5bc598513fdcd881ee66e6f9ad7e64cddf Fix TableSubquery processing in LimitWithoutOrderByChecker (Ajay George)
- d97b4870e08d8b49a38f697018293553f37ff4fc Introduce BenchmarkBlocks (Ying Su)
- 9bcafd8fc4424506923c5b4106247bbc483ad177 Support HA mode config for alluxio connector (JySongWithZhangce)
- 690035293e69958fca6894c4e9047cb8a7c83636 Fix Presto verifier corrupted jar error (Arunachalam Thirupathi)
- 247881d621aa26e4823e7a8a113100345ad923a3 Move ensureCapacity methods from BlockUtil to Arrays (Ying Su)
- 3541380ee7f32dc8dd91864dc3b00ab843d7b24c Reorder methods in Arrays by types (Ying Su)
- daf2a9e9d38798cdec1184409376bb7e12c9e218 Remove Arrays class from presto-orc (Ying Su)
- 58a1f796e922c3677cde59f02fd94e9c356d78cc Move presto-array to presto-common (Ying Su)
- 8b4933c405c5bd2dc10dc83dd638610c0f6ace8a Drop presto-array's dependency on fastutils (Ying Su)
- 3b93d528e60983daefe54dc727fa0100d5f5e92f Minor comment error correction (Junhyung Song)
- 0629c8b76ef75ef36abe9e0a51de52a8104820d4 Enforce ACLs on SELECT path for materialized view (Ge Gao)
- eb00a9330a3ec324fae6695f55ad7a5813576c32 Enhance explain output for JDBC table scans to show filter predicates (Naveen Kumar Mahadevuni)
- aff7d0c380c8a7c519ca1befaa6f72274520a42e Remove minAverageValueSize field from ColumnStatistics (Arunachalam Thirupathi)
- 12eee769009ae2edcff5a24a14efd041aeb6be65 Fix bug in parition predicates in materialized view (Pranjal Shankhdhar)
- 1231dcb82fc95af81a6c81009e078cd769ceee88 Fix load mysql jdbc driver failure in function namespace module during server start (beinan)
- 64db52387dbe619999faa8215b33b23cacc8fffb Rename array_dupes function to array_duplicates (Masha Basmanova)
- b33ea692cd2f655e722f61ddfaa9411f29562b1f Fix output column name in materialized view query optimization (Pranjal Shankhdhar)
- b52db2c4c2baa720489ae3908acd9303a41081fc Upgrading Hudi to version 0.9.0 and fix a breaking (Sagar Sumit)
- 78b53baacff9057cb0bd309b29be8b6bac2fd39d Add a configuration property for total FRC cache size (Zhan Yuan)
- 3b3548b32a154d0c047d53df1eee184fd332c713 Document worker REST API (Masha Basmanova)
- e971c526f9892cc928a9213759ff112cbd3cf353 Delete unused incomplete rest.rst (Masha Basmanova)
- fea4e16c921dfcc2e4a76999c559093822aec903 Fix flaky tests to unblock development on main (Tim Meehan)
- f10495514d118875d9826d1144158b45acaec4e1 Fetch maxQuerySpillPerNode value from correct config (Arjun Gupta)
- 4f3dda942313c4953d7c1de6d232821fc98eae15 Remove metrics OrcStripeCount and OrcSkippedStripe (Zhan Yuan)
- 9bdc5108b7f5a032777d0eb0f103742131ae88e3 Add filter check for JDBC pushdown unit tests (James Sun)