### PR TITLE
Support Caching module for iceberg connector

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergModule.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergModule.java
@@ -15,12 +15,9 @@ package com.facebook.presto.iceberg;
 
 import com.facebook.presto.cache.CacheConfig;
 import com.facebook.presto.cache.CacheFactory;
-import com.facebook.presto.cache.CacheManager;
 import com.facebook.presto.cache.CacheStats;
 import com.facebook.presto.cache.ForCachingFileSystem;
-import com.facebook.presto.cache.NoOpCacheManager;
 import com.facebook.presto.cache.filemerge.FileMergeCacheConfig;
-import com.facebook.presto.cache.filemerge.FileMergeCacheManager;
 import com.facebook.presto.hive.CacheStatsMBean;
 import com.facebook.presto.hive.DynamicConfigurationProvider;
 import com.facebook.presto.hive.FileFormatDataSourceStats;
@@ -83,11 +80,9 @@ import java.util.concurrent.ExecutorService;
 import static com.facebook.airlift.concurrent.Threads.daemonThreadsNamed;
 import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
 import static com.facebook.airlift.json.JsonCodecBinder.jsonCodecBinder;
-import static com.facebook.presto.cache.CacheType.FILE_MERGE;
 import static com.google.inject.multibindings.Multibinder.newSetBinder;
 import static java.lang.Math.toIntExact;
 import static java.util.concurrent.Executors.newFixedThreadPool;
-import static java.util.concurrent.Executors.newScheduledThreadPool;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.weakref.jmx.ObjectNames.generatedNameOf;
 import static org.weakref.jmx.guice.ExportBinder.newExporter;
@@ -170,22 +165,6 @@ public class IcebergModule
         return newFixedThreadPool(
                 metastoreClientConfig.getMaxMetastoreRefreshThreads(),
                 daemonThreadsNamed("hive-metastore-iceberg-%s"));
-    }
-
-    @Singleton
-    @Provides
-    public CacheManager createCacheManager(CacheConfig cacheConfig, FileMergeCacheConfig fileMergeCacheConfig, CacheStats cacheStats)
-    {
-        if (cacheConfig.isCachingEnabled() && cacheConfig.getCacheType() == FILE_MERGE) {
-            return new FileMergeCacheManager(
-                    cacheConfig,
-                    fileMergeCacheConfig,
-                    cacheStats,
-                    newScheduledThreadPool(5, daemonThreadsNamed("iceberg-cache-flusher-%s")),
-                    newScheduledThreadPool(1, daemonThreadsNamed("iceberg-cache-remover-%s")),
-                    newScheduledThreadPool(1, daemonThreadsNamed("hive-cache-size-calculator-%s")));
-        }
-        return new NoOpCacheManager();
     }
 
     @Singleton

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSessionProperties.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSessionProperties.java
@@ -21,6 +21,7 @@ import com.facebook.presto.hive.ParquetFileWriterConfig;
 import com.facebook.presto.orc.OrcWriteValidation;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.facebook.presto.spi.session.PropertyMetadata;
 import com.google.common.collect.ImmutableList;
 import io.airlift.units.DataSize;
@@ -70,6 +71,7 @@ public final class IcebergSessionProperties
     private static final String ORC_OPTIMIZED_WRITER_MAX_DICTIONARY_MEMORY = "orc_optimized_writer_max_dictionary_memory";
     private static final String ORC_COMPRESSION_CODEC = "orc_compression_codec";
     private static final String CACHE_ENABLED = "cache_enabled";
+    private static final String NODE_SELECTION_STRATEGY = "node_selection_strategy";
     private final List<PropertyMetadata<?>> sessionProperties;
 
     @Inject
@@ -231,6 +233,15 @@ public final class IcebergSessionProperties
                         false,
                         value -> HiveCompressionCodec.valueOf(((String) value).toUpperCase()),
                         HiveCompressionCodec::name),
+                new PropertyMetadata<>(
+                        NODE_SELECTION_STRATEGY,
+                        "Node affinity selection strategy",
+                        VARCHAR,
+                        NodeSelectionStrategy.class,
+                        hiveClientConfig.getNodeSelectionStrategy(),
+                        false,
+                        value -> NodeSelectionStrategy.valueOf((String) value),
+                        NodeSelectionStrategy::toString),
                 booleanProperty(
                         CACHE_ENABLED,
                         "Enable cache for Iceberg",
@@ -381,5 +392,10 @@ public final class IcebergSessionProperties
     public static boolean isCacheEnabled(ConnectorSession session)
     {
         return session.getProperty(CACHE_ENABLED, Boolean.class);
+    }
+
+    public static NodeSelectionStrategy getNodeSelectionStrategy(ConnectorSession session)
+    {
+        return session.getProperty(NODE_SELECTION_STRATEGY, NodeSelectionStrategy.class);
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSplitManager.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSplitManager.java
@@ -83,7 +83,7 @@ public class IcebergSplitManager
 
         // TODO Use residual. Right now there is no way to propagate residual to presto but at least we can
         //      propagate it at split level so the parquet pushdown can leverage it.
-        IcebergSplitSource splitSource = new IcebergSplitSource(tableScan.planTasks());
+        IcebergSplitSource splitSource = new IcebergSplitSource(session, tableScan.planTasks());
         return splitSource;
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/InternalIcebergConnectorFactory.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/InternalIcebergConnectorFactory.java
@@ -17,6 +17,7 @@ import com.facebook.airlift.bootstrap.Bootstrap;
 import com.facebook.airlift.bootstrap.LifeCycleManager;
 import com.facebook.airlift.event.client.EventModule;
 import com.facebook.airlift.json.JsonModule;
+import com.facebook.presto.cache.CachingModule;
 import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.hive.NodeVersion;
 import com.facebook.presto.hive.authentication.HiveAuthenticationModule;
@@ -65,6 +66,7 @@ public final class InternalIcebergConnectorFactory
                     new HiveS3Module(catalogName),
                     new HiveAuthenticationModule(),
                     new HiveMetastoreModule(catalogName, metastore),
+                    new CachingModule(),
                     binder -> {
                         binder.bind(NodeVersion.class).toInstance(new NodeVersion(context.getNodeManager().getCurrentNode().getVersion()));
                         binder.bind(NodeManager.class).toInstance(context.getNodeManager());


### PR DESCRIPTION
Fix #16925

Test plan - (Please fill in how you tested your changes)

Using iceberg catalog to create an iceberg table with the following iceberg.properties.

```
connector.name=iceberg
hive.metastore.uri=thrift://localhost:9083
cache.enabled=true
cache.type=ALLUXIO
cache.base-directory=file:///tmp/alluxio
cache.alluxio.max-cache-size=1GB
hive.node-selection-strategy=SOFT_AFFINITY
hive.config.resources=/softwares/hadoop-2.8.5/etc/hadoop/core-site.xml
```

The presto cannot start successful without this PR.

```
== RELEASE NOTES ==

Iceberg Changes
* Support Caching module for iceberg connector.
```
