### PR TITLE
[Pinot] bugfixing: query failure and column ordering when doing Pinot SQL pushdown

### DIFF
--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotBrokerPageSourceSql.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotBrokerPageSourceSql.java
@@ -119,12 +119,7 @@ public class PinotBrokerPageSourceSql
             setRows(sql, blockBuilders, types, rows);
             return rows.size();
         }
-        else {
-            throw new PinotException(
-                    PINOT_UNEXPECTED_RESPONSE,
-                    Optional.of(sql),
-                    "Expected resultTable to be present");
-        }
+        return 0;
     }
 
     @VisibleForTesting

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotPlanOptimizer.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotPlanOptimizer.java
@@ -163,7 +163,7 @@ public class PinotPlanOptimizer
             PinotTableHandle pinotTableHandle = getPinotTableHandle(tableScanNode).orElseThrow(() -> new PinotException(PINOT_UNCLASSIFIED_ERROR, Optional.empty(), "Expected to find a pinot table handle"));
             PinotQueryGeneratorContext context = pinotQuery.get().getContext();
             TableHandle oldTableHandle = tableScanNode.getTable();
-            LinkedHashMap<VariableReferenceExpression, PinotColumnHandle> assignments = context.getAssignments();
+            LinkedHashMap<VariableReferenceExpression, PinotColumnHandle> assignments = context.getAssignments(pinotQuery.get().getGeneratedPinotQuery().getFormat() == PinotQueryGenerator.PinotQueryFormat.SQL);
             boolean isQueryShort = pinotQuery.get().getGeneratedPinotQuery().isQueryShort();
             TableHandle newTableHandle = new TableHandle(
                     oldTableHandle.getConnectorId(),

--- a/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotSplitManager.java
+++ b/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotSplitManager.java
@@ -63,7 +63,7 @@ public class TestPinotSplitManager
         PlanBuilder planBuilder = createPlanBuilder(sessionHolder);
         PlanNode plan = tableScan(planBuilder, table, regionId, city, fare, secondsSinceEpoch);
         PinotQueryGenerator.PinotQueryGeneratorResult pinotQueryGeneratorResult = new PinotQueryGenerator(pinotConfig, functionAndTypeManager, functionAndTypeManager, standardFunctionResolution).generate(plan, sessionHolder.getConnectorSession()).get();
-        List<PinotColumnHandle> expectedHandles = ImmutableList.copyOf(pinotQueryGeneratorResult.getContext().getAssignments().values());
+        List<PinotColumnHandle> expectedHandles = ImmutableList.copyOf(pinotQueryGeneratorResult.getContext().getAssignments(pinotQueryGeneratorResult.getGeneratedPinotQuery().getFormat() == PinotQueryGenerator.PinotQueryFormat.SQL).values());
         PinotQueryGenerator.GeneratedPinotQuery generatedPql = pinotQueryGeneratorResult.getGeneratedPinotQuery();
         PinotTableHandle pinotTableHandle = new PinotTableHandle(table.getConnectorId(), table.getSchemaName(), table.getTableName(), Optional.of(false), Optional.of(expectedHandles), Optional.of(generatedPql));
         List<PinotSplit> splits = getSplitsHelper(pinotTableHandle, segmentsPerSplit, false);
@@ -78,7 +78,7 @@ public class TestPinotSplitManager
         PlanBuilder planBuilder = createPlanBuilder(sessionHolder);
         PlanNode plan = filter(planBuilder, tableScan(planBuilder, table, regionId, city, fare, secondsSinceEpoch), getRowExpression("city = 'Boston'", sessionHolder));
         PinotQueryGenerator.PinotQueryGeneratorResult pinotQueryGeneratorResult = new PinotQueryGenerator(pinotConfig, functionAndTypeManager, functionAndTypeManager, standardFunctionResolution).generate(plan, sessionHolder.getConnectorSession()).get();
-        List<PinotColumnHandle> expectedHandles = ImmutableList.copyOf(pinotQueryGeneratorResult.getContext().getAssignments().values());
+        List<PinotColumnHandle> expectedHandles = ImmutableList.copyOf(pinotQueryGeneratorResult.getContext().getAssignments(pinotQueryGeneratorResult.getGeneratedPinotQuery().getFormat() == PinotQueryGenerator.PinotQueryFormat.SQL).values());
         PinotQueryGenerator.GeneratedPinotQuery generatedPql = pinotQueryGeneratorResult.getGeneratedPinotQuery();
         PinotTableHandle pinotTableHandle = new PinotTableHandle(table.getConnectorId(), table.getSchemaName(), table.getTableName(), Optional.of(false), Optional.of(expectedHandles), Optional.of(generatedPql));
         List<PinotSplit> splits = getSplitsHelper(pinotTableHandle, segmentsPerSplit, false);


### PR DESCRIPTION
* Fixing the query failure issue when Pinot returns empty result.
Current presto will fail a query if the underlying pinot table is empty.

* Fixing the column ordering for Pinot SQL pushdown
For aggregation group by pushdown:
PQL always expect groupby columns comes first then aggregations
SQL only rely on the outputs ordering.

For query: `SELECT a, round(sum(b)/count(distinct(c)),2) AS d FROM t GROUP BY a;`.
It may generate a ProjectPlan with output: `sum, count, a` or `a, sum, count`,
but generated pinot query is always `SELECT a, sum(b), distinctCount(c) from t GROUP BY a`.
So it causes the expected column handle mismatch issue.

```
== RELEASE NOTES ==

Pinot Changes
* Fix query crash when Pinot returns empty result.
* Fix query crash when Pinot aggregation query returns mismatched schema.
```
