### PR TITLE
Clarify TRY function documentation

### DIFF
--- a/presto-docs/src/main/sphinx/functions/conditional.rst
+++ b/presto-docs/src/main/sphinx/functions/conditional.rst
@@ -103,7 +103,7 @@ used in conjunction with the ``COALESCE`` function.
 The following errors are handled by ``TRY``:
 
 * Division by zero
-* Invalid cast or function argument
+* Invalid cast argument or invalid function argument
 * Numeric value out of range
 
 Examples


### PR DESCRIPTION
#16913 brought up an ambiguity in try function documentation. Update the documentation to reflect the logic.

```
== NO RELEASE NOTE ==
```
