### PR TITLE
Upgrade Iceberg to 0.12.0 and upgrade Parquet to 1.12.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <dep.testng.version>6.10</dep.testng.version>
         <dep.assertj-core.version>3.8.0</dep.assertj-core.version>
         <dep.logback.version>1.2.3</dep.logback.version>
-        <dep.parquet.version>1.11.1</dep.parquet.version>
+        <dep.parquet.version>1.12.0</dep.parquet.version>
         <dep.nexus-staging-plugin.version>1.6.8</dep.nexus-staging-plugin.version>
         <dep.asm.version>9.0</dep.asm.version>
         <dep.gcs.version>1.9.17</dep.gcs.version>

--- a/presto-iceberg/pom.xml
+++ b/presto-iceberg/pom.xml
@@ -12,7 +12,7 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <dep.iceberg.version>0.11.1</dep.iceberg.version>
+        <dep.iceberg.version>0.12.0</dep.iceberg.version>
     </properties>
 
     <dependencies>
@@ -241,6 +241,10 @@
                     <groupId>org.apache.iceberg</groupId>
                     <artifactId>iceberg-bundled-guava</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -273,6 +277,10 @@
                     <groupId>org.apache.iceberg</groupId>
                     <artifactId>iceberg-bundled-guava</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -280,6 +288,12 @@
             <groupId>org.apache.iceberg</groupId>
             <artifactId>iceberg-hive-metastore</artifactId>
             <version>${dep.iceberg.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -290,6 +304,10 @@
                 <exclusion>
                     <groupId>org.apache.parquet</groupId>
                     <artifactId>parquet-avro</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
Upgrade Iceberg to 0.12.0 and upgrade Parquet to 1.12.0

```
== RELEASE NOTES ==

Hive Changes
* Upgrade Parquet to 1.12.0

Iceberg Changes
* Upgrade Iceberg to 0.12.0
```


