### PR TITLE
Add skip checksum feature for verifier 

### DIFF
--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DataVerification.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DataVerification.java
@@ -86,8 +86,8 @@ public class DataVerification
             QueryObjectBundle test,
             Optional<QueryResult<Void>> controlQueryResult,
             Optional<QueryResult<Void>> testQueryResult,
-            ChecksumQueryContext controlContext,
-            ChecksumQueryContext testContext)
+            ChecksumQueryContext controlChecksumQueryContext,
+            ChecksumQueryContext testChecksumQueryContext)
     {
         List<Column> controlColumns = getColumns(getHelperAction(), typeManager, control.getObjectName());
         List<Column> testColumns = getColumns(getHelperAction(), typeManager, test.getObjectName());
@@ -95,15 +95,15 @@ public class DataVerification
         Query controlChecksumQuery = checksumValidator.generateChecksumQuery(control.getObjectName(), controlColumns);
         Query testChecksumQuery = checksumValidator.generateChecksumQuery(test.getObjectName(), testColumns);
 
-        controlContext.setChecksumQuery(formatSql(controlChecksumQuery));
-        testContext.setChecksumQuery(formatSql(testChecksumQuery));
+        controlChecksumQueryContext.setChecksumQuery(formatSql(controlChecksumQuery));
+        testChecksumQueryContext.setChecksumQuery(formatSql(testChecksumQuery));
 
         QueryResult<ChecksumResult> controlChecksum = callAndConsume(
                 () -> getHelperAction().execute(controlChecksumQuery, CONTROL_CHECKSUM, ChecksumResult::fromResultSet),
-                stats -> stats.getQueryStats().map(QueryStats::getQueryId).ifPresent(controlContext::setChecksumQueryId));
+                stats -> stats.getQueryStats().map(QueryStats::getQueryId).ifPresent(controlChecksumQueryContext::setChecksumQueryId));
         QueryResult<ChecksumResult> testChecksum = callAndConsume(
                 () -> getHelperAction().execute(testChecksumQuery, TEST_CHECKSUM, ChecksumResult::fromResultSet),
-                stats -> stats.getQueryStats().map(QueryStats::getQueryId).ifPresent(testContext::setChecksumQueryId));
+                stats -> stats.getQueryStats().map(QueryStats::getQueryId).ifPresent(testChecksumQueryContext::setChecksumQueryId));
 
         return match(checksumValidator, controlColumns, testColumns, getOnlyElement(controlChecksum.getResults()), getOnlyElement(testChecksum.getResults()));
     }

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DdlVerification.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DdlVerification.java
@@ -66,21 +66,21 @@ public abstract class DdlVerification<S extends Statement>
             QueryObjectBundle test,
             Optional<QueryResult<Void>> controlQueryResult,
             Optional<QueryResult<Void>> testQueryResult,
-            ChecksumQueryContext controlContext,
-            ChecksumQueryContext testContext)
+            ChecksumQueryContext controlChecksumQueryContext,
+            ChecksumQueryContext testChecksumQueryContext)
     {
         Statement controlChecksumQuery = getChecksumQuery(control);
         Statement testChecksumQuery = getChecksumQuery(test);
 
-        controlContext.setChecksumQuery(formatSql(controlChecksumQuery));
-        testContext.setChecksumQuery(formatSql(testChecksumQuery));
+        controlChecksumQueryContext.setChecksumQuery(formatSql(controlChecksumQuery));
+        testChecksumQueryContext.setChecksumQuery(formatSql(testChecksumQuery));
 
         String controlChecksum = getOnlyElement(callAndConsume(
                 () -> getHelperAction().execute(controlChecksumQuery, CONTROL_CHECKSUM, checksumConverter),
-                stats -> stats.getQueryStats().map(QueryStats::getQueryId).ifPresent(controlContext::setChecksumQueryId)).getResults());
+                stats -> stats.getQueryStats().map(QueryStats::getQueryId).ifPresent(controlChecksumQueryContext::setChecksumQueryId)).getResults());
         String testChecksum = getOnlyElement(callAndConsume(
                 () -> getHelperAction().execute(testChecksumQuery, TEST_CHECKSUM, checksumConverter),
-                stats -> stats.getQueryStats().map(QueryStats::getQueryId).ifPresent(testContext::setChecksumQueryId)).getResults());
+                stats -> stats.getQueryStats().map(QueryStats::getQueryId).ifPresent(testChecksumQueryContext::setChecksumQueryId)).getResults());
 
         S controlObject;
         S testObject;

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/ExplainVerification.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/ExplainVerification.java
@@ -73,8 +73,8 @@ public class ExplainVerification
             QueryBundle test,
             Optional<QueryResult<String>> controlQueryResult,
             Optional<QueryResult<String>> testQueryResult,
-            ChecksumQueryContext controlContext,
-            ChecksumQueryContext testContext)
+            ChecksumQueryContext controlChecksumQueryContext,
+            ChecksumQueryContext testChecksumQueryContext)
     {
         checkArgument(controlQueryResult.isPresent(), "control query plan is missing");
         checkArgument(testQueryResult.isPresent(), "test query plan is missing");

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerifierConfig.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerifierConfig.java
@@ -51,6 +51,7 @@ public class VerifierConfig
     private boolean setupOnMainClusters = true;
     private boolean teardownOnMainClusters = true;
     private boolean skipControl;
+    private boolean skipChecksum;
 
     private boolean explain;
 
@@ -303,6 +304,19 @@ public class VerifierConfig
     {
         this.skipControl = skipControl;
         return this;
+    }
+
+    @ConfigDescription("Skip checksum, only run control and test queries.")
+    @Config("skip-checksum")
+    public VerifierConfig setSkipChecksum(boolean skipChecksum)
+    {
+        this.skipChecksum = skipChecksum;
+        return this;
+    }
+
+    public boolean isSkipChecksum()
+    {
+        return skipChecksum;
     }
 
     public boolean isExplain()

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestVerifierConfig.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestVerifierConfig.java
@@ -46,6 +46,7 @@ public class TestVerifierConfig
                 .setSetupOnMainClusters(true)
                 .setTeardownOnMainClusters(true)
                 .setSkipControl(false)
+                .setSkipChecksum(false)
                 .setExplain(false));
     }
 
@@ -71,6 +72,7 @@ public class TestVerifierConfig
                 .put("setup-on-main-clusters", "false")
                 .put("teardown-on-main-clusters", "false")
                 .put("skip-control", "true")
+                .put("skip-checksum", "true")
                 .put("explain", "true")
                 .build();
         VerifierConfig expected = new VerifierConfig()
@@ -92,6 +94,7 @@ public class TestVerifierConfig
                 .setSetupOnMainClusters(false)
                 .setTeardownOnMainClusters(false)
                 .setSkipControl(true)
+                .setSkipChecksum(true)
                 .setExplain(true);
 
         assertFullMapping(properties, expected);


### PR DESCRIPTION
For certain verifier suites such as the ones to test memory regression
we are not interested in testing correctness and therefore
running the checksum queries is not needed since the intent
is to verify if the query ran successfully on the test cluster.

Test plan - Ran PrestoFacebookVerifier with and without the config enabled.


```
== RELEASE NOTES ==

Verifier Changes
* Add support to skip running checksum queries. This can be enabled by the configuration property ``skip-checksum``.

```


