### PR TITLE
Support creating iceberg v2 table

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadata.java
@@ -77,6 +77,7 @@ import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_INVALID_SNAPS
 import static com.facebook.presto.iceberg.IcebergTableProperties.FILE_FORMAT_PROPERTY;
 import static com.facebook.presto.iceberg.IcebergTableProperties.PARTITIONING_PROPERTY;
 import static com.facebook.presto.iceberg.IcebergTableProperties.getFileFormat;
+import static com.facebook.presto.iceberg.IcebergTableProperties.getFormatVersion;
 import static com.facebook.presto.iceberg.IcebergTableProperties.getPartitioning;
 import static com.facebook.presto.iceberg.IcebergUtil.getColumns;
 import static com.facebook.presto.iceberg.IcebergUtil.getFileFormat;
@@ -100,6 +101,7 @@ import static java.util.function.Function.identity;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 import static org.apache.iceberg.TableProperties.DEFAULT_FILE_FORMAT;
+import static org.apache.iceberg.TableProperties.FORMAT_VERSION;
 
 public class IcebergNativeMetadata
         implements ConnectorMetadata
@@ -323,11 +325,15 @@ public class IcebergNativeMetadata
 
         PartitionSpec partitionSpec = parsePartitionFields(schema, getPartitioning(tableMetadata.getProperties()));
 
-        ImmutableMap.Builder<String, String> propertiesBuilder = ImmutableMap.builderWithExpectedSize(2);
+        ImmutableMap.Builder<String, String> propertiesBuilder = ImmutableMap.builder();
         FileFormat fileFormat = getFileFormat(tableMetadata.getProperties());
         propertiesBuilder.put(DEFAULT_FILE_FORMAT, fileFormat.toString());
         if (tableMetadata.getComment().isPresent()) {
             propertiesBuilder.put(TABLE_COMMENT, tableMetadata.getComment().get());
+        }
+        String formatVersion = getFormatVersion(tableMetadata.getProperties());
+        if (formatVersion != null) {
+            propertiesBuilder.put(FORMAT_VERSION, formatVersion);
         }
 
         try {

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergTableProperties.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergTableProperties.java
@@ -35,6 +35,7 @@ public class IcebergTableProperties
     public static final String FILE_FORMAT_PROPERTY = "format";
     public static final String PARTITIONING_PROPERTY = "partitioning";
     public static final String LOCATION_PROPERTY = "location";
+    public static final String FORMAT_VERSION = "format_version";
 
     private final List<PropertyMetadata<?>> tableProperties;
 
@@ -67,6 +68,11 @@ public class IcebergTableProperties
                         "File system location URI for the table",
                         null,
                         false))
+                .add(stringProperty(
+                        FORMAT_VERSION,
+                        "Format version for the table",
+                        null,
+                        false))
                 .build();
     }
 
@@ -90,5 +96,10 @@ public class IcebergTableProperties
     public static String getTableLocation(Map<String, Object> tableProperties)
     {
         return (String) tableProperties.get(LOCATION_PROPERTY);
+    }
+
+    public static String getFormatVersion(Map<String, Object> tableProperties)
+    {
+        return (String) tableProperties.get(FORMAT_VERSION);
     }
 }


### PR DESCRIPTION
Make iceberg connector able to create v2 table in sql statement.

eg. creating a table in prestoi
```
create table test4 (id bigint, data varchar) with (format_version="2");
```

We could check the metadata as below
```
cat /tmp/iceberg/test/test4/metadata/v1.metadata.json
{
  "format-version" : 2,
  "table-uuid" : "3492eb33-e415-42dd-a08b-8a8fb182bb81",
  "location" : "/tmp/iceberg/test/test4",
...
```

I will post another PR to update the document because our doc really has a lot to catch up on.

```
== RELEASE NOTES ==

Iceberg Changes
* Support iceberg table with version1 and version2
```