### PR TITLE
Fix batch read in SliceDirectSelectiveStreamReader

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDirectSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/SliceDirectSelectiveStreamReader.java
@@ -420,8 +420,7 @@ public class SliceDirectSelectiveStreamReader
         int filteredPositionCount = 0;
         if (positionsIndex > 0) {
             if (dataStream == null) {
-                // The length check has passed and there is no need to run testBytes because there is no data
-                filteredPositionCount = positionsIndex;
+                filteredPositionCount = testEmptyStrings(outputPositions, positionsIndex);
             }
             else {
                 int totalPositionCount = outputPositions[positionsIndex - 1] + 1;
@@ -468,6 +467,31 @@ public class SliceDirectSelectiveStreamReader
         }
 
         return positionsIndex;
+    }
+
+    private int testEmptyStrings(int[] positions, int positionCount)
+    {
+        if (nonDeterministicFilter) {
+            int positionsIndex = 0;
+            for (int i = 0; i < positionCount; i++) {
+                int position = positions[i];
+
+                if (filter.testBytes("".getBytes(), 0, 0)) {
+                    positions[positionsIndex++] = position;
+                }
+                else {
+                    i += filter.getSucceedingPositionsToFail();
+                    positionsIndex -= filter.getPrecedingPositionsToFail();
+                }
+            }
+            return positionsIndex;
+        }
+
+        if (filter.testBytes("".getBytes(), 0, 0)) {
+            return positionCount;
+        }
+
+        return 0;
     }
 
     private int testBytes(int[] positions, int positionCount)

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestSelectiveOrcReader.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestSelectiveOrcReader.java
@@ -843,6 +843,8 @@ public class TestSelectiveOrcReader
 
         // dataStream is null and lengths are 0
         tester.testRoundTrip(VARCHAR, newArrayList("", null), toSubfieldFilters(stringNotEquals(true, "")));
+
+        tester.testRoundTrip(VARCHAR, newArrayList("", ""), toSubfieldFilters(stringLessThan(true, "")));
     }
 
     @Test
@@ -1235,6 +1237,11 @@ public class TestSelectiveOrcReader
     private static TupleDomainFilter stringBetween(boolean nullAllowed, String upper, String lower)
     {
         return BytesRange.of(lower.getBytes(), false, upper.getBytes(), false, nullAllowed);
+    }
+
+    private static TupleDomainFilter stringLessThan(boolean nullAllowed, String upper)
+    {
+        return BytesRange.of(null, true, upper.getBytes(), true, nullAllowed);
     }
 
     private static TupleDomainFilter stringEquals(boolean nullAllowed, String value)


### PR DESCRIPTION
Fix batch read in SliceDirectSelectiveStreamReader for the case when all
strings are empty.

```
== NO RELEASE NOTE ==
```
