### PR TITLE
Create TaskStatus before stats when reporting taskInfo to coordinator

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlTask.java
@@ -374,11 +374,12 @@ public class SqlTask
 
     private TaskInfo createTaskInfo(TaskHolder taskHolder)
     {
+        // create task status first to prevent potentially seeing incomplete stats for a done task state
+        TaskStatus taskStatus = createTaskStatus(taskHolder);
         TaskStats taskStats = getTaskStats(taskHolder);
         Set<PlanNodeId> noMoreSplits = getNoMoreSplits(taskHolder);
         MetadataUpdates metadataRequests = getMetadataUpdateRequests(taskHolder);
 
-        TaskStatus taskStatus = createTaskStatus(taskHolder);
         return new TaskInfo(
                 taskStateMachine.getTaskId(),
                 taskStatus,


### PR DESCRIPTION
Cherry-pick of https://github.com/trinodb/trino/pull/9913

Co-authored-by: Anton Tanasenko <atg.sleepless@gmail.com>

```
== RELEASE NOTES ==

General Changes
* Create TaskStatus before stats when reporting taskInfo to coordinator

```
