### PR TITLE
Add schema access requirement to JDBC driver doc

### DIFF
--- a/presto-docs/src/main/sphinx/installation/jdbc.rst
+++ b/presto-docs/src/main/sphinx/installation/jdbc.rst
@@ -15,6 +15,15 @@ The driver is also available from Maven Central:
         <version>\ |version|\ </version>
     </dependency>
 
+Requirements
+------------
+
+The Presto JDBC driver has the following requirements:
+
+* Java version 8 or higher.
+* All users that connect to Presto with the JDBC driver must be granted access to
+  query tables in the ``system.jdbc`` schema.
+
 Connecting
 ----------
 


### PR DESCRIPTION
Cherry-pick of https://github.com/trinodb/trino/pull/9780
From the original PR: "The JDBC driver requires access to the
system.jdbc schema. Since this applies to any users or client
applications using the driver, we ought to add the requirement
for all users to be granted access to this schema."

Co-authored-by: Joe Lodin <joe.lodin@starburstdata.com>

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```
