### PR TITLE
Fixing number of running queries

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/resourcemanager/AggregatedResourceGroupInfoBuilder.java
+++ b/presto-main/src/main/java/com/facebook/presto/resourcemanager/AggregatedResourceGroupInfoBuilder.java
@@ -50,6 +50,7 @@ public class AggregatedResourceGroupInfoBuilder
     private int maxQueuedQueries;
     private long memoryUsageBytes;
     private int numQueuedQueries;
+    private int numRunningQueries;
 
     private void init(ResourceGroupInfo resourceGroupInfo)
     {
@@ -63,6 +64,7 @@ public class AggregatedResourceGroupInfoBuilder
         this.maxQueuedQueries = resourceGroupInfo.getMaxQueuedQueries();
         this.memoryUsageBytes = resourceGroupInfo.getMemoryUsage().toBytes();
         this.numQueuedQueries = resourceGroupInfo.getNumQueuedQueries();
+        this.numRunningQueries = resourceGroupInfo.getNumRunningQueries();
         this.subGroupsMap = new HashMap<>();
         this.runningQueriesBuilder = ImmutableList.builder();
         addRunningQueries(resourceGroupInfo.getRunningQueries());
@@ -77,6 +79,7 @@ public class AggregatedResourceGroupInfoBuilder
         }
         checkState(resourceGroupInfo != null && this.id.equals(resourceGroupInfo.getId()));
         this.numQueuedQueries = addExact(this.numQueuedQueries, resourceGroupInfo.getNumQueuedQueries());
+        this.numRunningQueries = addExact(this.numRunningQueries, resourceGroupInfo.getNumRunningQueries());
         if (resourceGroupStatePreference.get(resourceGroupInfo.getState()) < resourceGroupStatePreference.get(this.state)) {
             this.state = resourceGroupInfo.getState();
         }
@@ -124,7 +127,7 @@ public class AggregatedResourceGroupInfoBuilder
                 maxQueuedQueries,
                 DataSize.succinctBytes(memoryUsageBytes),
                 numQueuedQueries,
-                runningQueries.size(),
+                numRunningQueries,
                 0,
                 subGroupsMap.values().stream().map(AggregatedResourceGroupInfoBuilder::build).collect(toImmutableList()),
                 runningQueries);


### PR DESCRIPTION
We don't surface list of running and queued queries at each node level, instead we surface it at the root level. Because of this, the current change that relies on existence of queries in each node level is failing to calculate the total number of running queries at individual node level. As part of this PR, we have fixed this. 

Test plan - verified by deploying to a test cluster with disaggregated coordinator setup

```
== NO RELEASE NOTE ==
```


