### PR TITLE
Support iceberg connector concurrent insertion

### DIFF
--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/CachingHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/CachingHiveMetastore.java
@@ -941,6 +941,19 @@ public class CachingHiveMetastore
         delegate.setPartitionLeases(metastoreContext, databaseName, tableName, partitionNameToLocation, leaseDuration);
     }
 
+    @Override
+    public long lock(MetastoreContext metastoreContext, String databaseName, String tableName)
+    {
+        tableCache.invalidate(getCachingKey(metastoreContext, hiveTableName(databaseName, tableName)));
+        return delegate.lock(metastoreContext, databaseName, tableName);
+    }
+
+    @Override
+    public void unlock(MetastoreContext metastoreContext, long lockId)
+    {
+        delegate.unlock(metastoreContext, lockId);
+    }
+
     public Set<HivePrivilegeInfo> loadTablePrivileges(KeyAndContext<UserTableKey> loadTablePrivilegesKey)
     {
         return delegate.listTablePrivileges(loadTablePrivilegesKey.getContext(), loadTablePrivilegesKey.getKey().getDatabase(), loadTablePrivilegesKey.getKey().getTable(), loadTablePrivilegesKey.getKey().getPrincipal());

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/ExtendedHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/ExtendedHiveMetastore.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.hive.metastore;
 
+import com.facebook.presto.common.NotSupportedException;
 import com.facebook.presto.common.predicate.Domain;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.hive.HiveType;
@@ -117,4 +118,14 @@ public interface ExtendedHiveMetastore
     Set<HivePrivilegeInfo> listTablePrivileges(MetastoreContext metastoreContext, String databaseName, String tableName, PrestoPrincipal principal);
 
     void setPartitionLeases(MetastoreContext metastoreContext, String databaseName, String tableName, Map<String, String> partitionNameToLocation, Duration leaseDuration);
+
+    default long lock(MetastoreContext metastoreContext, String databaseName, String tableName)
+    {
+        throw new NotSupportedException("Lock is not supported by default");
+    }
+
+    default void unlock(MetastoreContext metastoreContext, long lockId)
+    {
+        throw new NotSupportedException("Unlock is not supported by default");
+    }
 }

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/BridgingHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/BridgingHiveMetastore.java
@@ -378,4 +378,16 @@ public class BridgingHiveMetastore
     {
         delegate.setPartitionLeases(metastoreContext, databaseName, tableName, partitionNameToLocation, leaseDuration);
     }
+
+    @Override
+    public long lock(MetastoreContext metastoreContext, String databaseName, String tableName)
+    {
+        return delegate.lock(metastoreContext, databaseName, tableName);
+    }
+
+    @Override
+    public void unlock(MetastoreContext metastoreContext, long lockId)
+    {
+        delegate.unlock(metastoreContext, lockId);
+    }
 }

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/HiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/HiveMetastore.java
@@ -114,6 +114,10 @@ public interface HiveMetastore
 
     Set<HivePrivilegeInfo> listTablePrivileges(MetastoreContext metastoreContext, String databaseName, String tableName, PrestoPrincipal principal);
 
+    long lock(MetastoreContext metastoreContext, String databaseName, String tableName);
+
+    void unlock(MetastoreContext metastoreContext, long lockId);
+
     default void setPartitionLeases(MetastoreContext metastoreContext, String databaseName, String tableName, Map<String, String> partitionNameToLocation, Duration leaseDuration)
     {
         throw new UnsupportedOperationException();

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/HiveMetastoreClient.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/HiveMetastoreClient.java
@@ -13,17 +13,21 @@
  */
 package com.facebook.presto.hive.metastore.thrift;
 
+import org.apache.hadoop.hive.metastore.api.CheckLockRequest;
 import org.apache.hadoop.hive.metastore.api.ColumnStatisticsObj;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.HiveObjectPrivilege;
 import org.apache.hadoop.hive.metastore.api.HiveObjectRef;
+import org.apache.hadoop.hive.metastore.api.LockRequest;
+import org.apache.hadoop.hive.metastore.api.LockResponse;
 import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.PrincipalType;
 import org.apache.hadoop.hive.metastore.api.PrivilegeBag;
 import org.apache.hadoop.hive.metastore.api.Role;
 import org.apache.hadoop.hive.metastore.api.RolePrincipalGrant;
 import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.hadoop.hive.metastore.api.UnlockRequest;
 import org.apache.thrift.TException;
 
 import java.io.Closeable;
@@ -145,5 +149,14 @@ public interface HiveMetastoreClient
             throws TException;
 
     void setUGI(String userName)
+            throws TException;
+
+    LockResponse checkLock(CheckLockRequest request)
+            throws TException;
+
+    LockResponse lock(LockRequest request)
+            throws TException;
+
+    void unlock(UnlockRequest request)
             throws TException;
 }

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftHiveMetastoreClient.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftHiveMetastoreClient.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.hive.metastore.thrift;
 
 import com.google.common.collect.ImmutableList;
+import org.apache.hadoop.hive.metastore.api.CheckLockRequest;
 import org.apache.hadoop.hive.metastore.api.ColumnStatistics;
 import org.apache.hadoop.hive.metastore.api.ColumnStatisticsDesc;
 import org.apache.hadoop.hive.metastore.api.ColumnStatisticsObj;
@@ -26,6 +27,8 @@ import org.apache.hadoop.hive.metastore.api.GrantRevokeRoleResponse;
 import org.apache.hadoop.hive.metastore.api.GrantRevokeType;
 import org.apache.hadoop.hive.metastore.api.HiveObjectPrivilege;
 import org.apache.hadoop.hive.metastore.api.HiveObjectRef;
+import org.apache.hadoop.hive.metastore.api.LockRequest;
+import org.apache.hadoop.hive.metastore.api.LockResponse;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.PartitionsStatsRequest;
@@ -36,6 +39,7 @@ import org.apache.hadoop.hive.metastore.api.RolePrincipalGrant;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.metastore.api.TableStatsRequest;
 import org.apache.hadoop.hive.metastore.api.ThriftHiveMetastore;
+import org.apache.hadoop.hive.metastore.api.UnlockRequest;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.protocol.TProtocol;
@@ -399,5 +403,26 @@ public class ThriftHiveMetastoreClient
             throws TException
     {
         client.set_ugi(userName, new ArrayList<>());
+    }
+
+    @Override
+    public LockResponse checkLock(CheckLockRequest request)
+            throws TException
+    {
+        return client.check_lock(request);
+    }
+
+    @Override
+    public LockResponse lock(LockRequest request)
+            throws TException
+    {
+        return client.lock(request);
+    }
+
+    @Override
+    public void unlock(UnlockRequest request)
+            throws TException
+    {
+        client.unlock(request);
     }
 }

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftHiveMetastoreStats.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftHiveMetastoreStats.java
@@ -50,6 +50,8 @@ public class ThriftHiveMetastoreStats
     private final HiveMetastoreApiStats listRoleGrants = new HiveMetastoreApiStats();
     private final HiveMetastoreApiStats createRole = new HiveMetastoreApiStats();
     private final HiveMetastoreApiStats dropRole = new HiveMetastoreApiStats();
+    private final HiveMetastoreApiStats lock = new HiveMetastoreApiStats();
+    private final HiveMetastoreApiStats unlock = new HiveMetastoreApiStats();
 
     @Managed
     @Nested
@@ -273,5 +275,19 @@ public class ThriftHiveMetastoreStats
     public HiveMetastoreApiStats getDropRole()
     {
         return dropRole;
+    }
+
+    @Managed
+    @Nested
+    public HiveMetastoreApiStats getLock()
+    {
+        return lock;
+    }
+
+    @Managed
+    @Nested
+    public HiveMetastoreApiStats getUnlock()
+    {
+        return unlock;
     }
 }

--- a/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/thrift/InMemoryHiveMetastore.java
+++ b/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/thrift/InMemoryHiveMetastore.java
@@ -507,6 +507,18 @@ public class InMemoryHiveMetastore
         throw new UnsupportedOperationException();
     }
 
+    @Override
+    public long lock(MetastoreContext metastoreContext, String databaseName, String tableName)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void unlock(MetastoreContext metastoreContext, long lockId)
+    {
+        throw new UnsupportedOperationException();
+    }
+
     private Partition getPartitionFromInMemoryMap(MetastoreContext metastoreContext, PartitionName name)
     {
         com.facebook.presto.hive.metastore.Partition partition = partitions.get(name);

--- a/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/thrift/MockHiveMetastoreClient.java
+++ b/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/thrift/MockHiveMetastoreClient.java
@@ -24,11 +24,14 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import org.apache.hadoop.hive.metastore.TableType;
 import org.apache.hadoop.hive.metastore.Warehouse;
+import org.apache.hadoop.hive.metastore.api.CheckLockRequest;
 import org.apache.hadoop.hive.metastore.api.ColumnStatisticsObj;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.HiveObjectPrivilege;
 import org.apache.hadoop.hive.metastore.api.HiveObjectRef;
+import org.apache.hadoop.hive.metastore.api.LockRequest;
+import org.apache.hadoop.hive.metastore.api.LockResponse;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
 import org.apache.hadoop.hive.metastore.api.Partition;
@@ -39,6 +42,7 @@ import org.apache.hadoop.hive.metastore.api.RolePrincipalGrant;
 import org.apache.hadoop.hive.metastore.api.SerDeInfo;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.hadoop.hive.metastore.api.UnlockRequest;
 import org.apache.thrift.TException;
 
 import java.util.List;
@@ -415,5 +419,23 @@ public class MockHiveMetastoreClient
     public void setUGI(String userName)
     {
         // No-op
+    }
+
+    @Override
+    public LockResponse checkLock(CheckLockRequest request)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public LockResponse lock(LockRequest request)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void unlock(UnlockRequest request)
+    {
+        throw new UnsupportedOperationException();
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/HiveTableOperations.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/HiveTableOperations.java
@@ -29,6 +29,9 @@ import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.TableNotFoundException;
 import com.facebook.presto.spi.security.PrestoPrincipal;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableMultimap;
 import org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe;
 import org.apache.hadoop.mapred.FileInputFormat;
@@ -53,7 +56,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantLock;
 
 import static com.facebook.presto.hive.HiveMetadata.TABLE_COMMENT;
 import static com.facebook.presto.hive.metastore.HivePrivilegeInfo.HivePrivilege.DELETE;
@@ -103,6 +108,8 @@ public class HiveTableOperations
     private String currentMetadataLocation;
     private boolean shouldRefresh = true;
     private int version = -1;
+
+    private static LoadingCache<String, ReentrantLock> commitLockCache;
 
     public HiveTableOperations(
             ExtendedHiveMetastore metastore,
@@ -156,6 +163,24 @@ public class HiveTableOperations
         this.tableName = requireNonNull(table, "table is null");
         this.owner = requireNonNull(owner, "owner is null");
         this.location = requireNonNull(location, "location is null");
+        //TODO: duration from config
+        initTableLevelLockCache(TimeUnit.MINUTES.toMillis(10));
+    }
+
+    private static synchronized void initTableLevelLockCache(long evictionTimeout)
+    {
+        if (commitLockCache == null) {
+            commitLockCache = CacheBuilder.newBuilder()
+                .expireAfterAccess(evictionTimeout, TimeUnit.MILLISECONDS)
+                .build(
+                    new CacheLoader<String, ReentrantLock>() {
+                        @Override
+                        public ReentrantLock load(String fullName)
+                        {
+                            return new ReentrantLock();
+                        }
+                    });
+        }
     }
 
     @Override
@@ -208,72 +233,88 @@ public class HiveTableOperations
 
         String newMetadataLocation = writeNewMetadata(metadata, version + 1);
 
-        // TODO: use metastore locking
-
         Table table;
+        // getting a process-level lock per table to avoid concurrent commit attempts to the same table from the same
+        // JVM process, which would result in unnecessary and costly HMS lock acquisition requests
+        Optional<Long> lockId = Optional.empty();
+        ReentrantLock tableLevelMutex = commitLockCache.getUnchecked(database + "." + tableName);
+        tableLevelMutex.lock();
         try {
-            if (base == null) {
-                String tableComment = metadata.properties().get(TABLE_COMMENT);
-                Map<String, String> parameters = new HashMap<>();
-                parameters.put("EXTERNAL", "TRUE");
-                parameters.put(TABLE_TYPE_PROP, ICEBERG_TABLE_TYPE_VALUE);
-                parameters.put(METADATA_LOCATION, newMetadataLocation);
-                if (tableComment != null) {
-                    parameters.put(TABLE_COMMENT, tableComment);
-                }
-                Table.Builder builder = Table.builder()
-                        .setDatabaseName(database)
-                        .setTableName(tableName)
-                        .setOwner(owner.orElseThrow(() -> new IllegalStateException("Owner not set")))
-                        .setTableType(PrestoTableType.EXTERNAL_TABLE)
-                        .setDataColumns(toHiveColumns(metadata.schema().columns()))
-                        .withStorage(storage -> storage.setLocation(metadata.location()))
-                        .withStorage(storage -> storage.setStorageFormat(STORAGE_FORMAT))
-                        .setParameters(parameters);
-                table = builder.build();
-            }
-            else {
-                Table currentTable = getTable();
-                checkState(currentMetadataLocation != null, "No current metadata location for existing table");
-                String metadataLocation = currentTable.getParameters().get(METADATA_LOCATION);
-                if (!currentMetadataLocation.equals(metadataLocation)) {
-                    throw new CommitFailedException("Metadata location [%s] is not same as table metadata location [%s] for %s", currentMetadataLocation, metadataLocation, getSchemaTableName());
-                }
-                table = Table.builder(currentTable)
-                        .setDataColumns(toHiveColumns(metadata.schema().columns()))
-                        .withStorage(storage -> storage.setLocation(metadata.location()))
-                        .setParameter(METADATA_LOCATION, newMetadataLocation)
-                        .setParameter(PREVIOUS_METADATA_LOCATION, currentMetadataLocation)
-                        .build();
-            }
-        }
-        catch (RuntimeException e) {
             try {
-                io().deleteFile(newMetadataLocation);
+                lockId = Optional.of(metastore.lock(metastoreContext, database, tableName));
+                if (base == null) {
+                    String tableComment = metadata.properties().get(TABLE_COMMENT);
+                    Map<String, String> parameters = new HashMap<>();
+                    parameters.put("EXTERNAL", "TRUE");
+                    parameters.put(TABLE_TYPE_PROP, ICEBERG_TABLE_TYPE_VALUE);
+                    parameters.put(METADATA_LOCATION, newMetadataLocation);
+                    if (tableComment != null) {
+                        parameters.put(TABLE_COMMENT, tableComment);
+                    }
+                    Table.Builder builder = Table.builder()
+                            .setDatabaseName(database)
+                            .setTableName(tableName)
+                            .setOwner(owner.orElseThrow(() -> new IllegalStateException("Owner not set")))
+                            .setTableType(PrestoTableType.EXTERNAL_TABLE)
+                            .setDataColumns(toHiveColumns(metadata.schema().columns()))
+                            .withStorage(storage -> storage.setLocation(metadata.location()))
+                            .withStorage(storage -> storage.setStorageFormat(STORAGE_FORMAT))
+                            .setParameters(parameters);
+                    table = builder.build();
+                }
+                else {
+                    Table currentTable = getTable();
+                    checkState(currentMetadataLocation != null, "No current metadata location for existing table");
+                    String metadataLocation = currentTable.getParameters().get(METADATA_LOCATION);
+                    if (!currentMetadataLocation.equals(metadataLocation)) {
+                        throw new CommitFailedException("Metadata location [%s] is not same as table metadata location [%s] for %s", currentMetadataLocation, metadataLocation, getSchemaTableName());
+                    }
+                    table = Table.builder(currentTable)
+                            .setDataColumns(toHiveColumns(metadata.schema().columns()))
+                            .withStorage(storage -> storage.setLocation(metadata.location()))
+                            .setParameter(METADATA_LOCATION, newMetadataLocation)
+                            .setParameter(PREVIOUS_METADATA_LOCATION, currentMetadataLocation)
+                            .build();
+                }
             }
-            catch (RuntimeException exception) {
-                e.addSuppressed(exception);
+            catch (RuntimeException e) {
+                try {
+                    io().deleteFile(newMetadataLocation);
+                }
+                catch (RuntimeException exception) {
+                    e.addSuppressed(exception);
+                }
+                throw e;
             }
-            throw e;
-        }
 
-        PrestoPrincipal owner = new PrestoPrincipal(USER, table.getOwner());
-        PrincipalPrivileges privileges = new PrincipalPrivileges(
-                ImmutableMultimap.<String, HivePrivilegeInfo>builder()
+            PrestoPrincipal owner = new PrestoPrincipal(USER, table.getOwner());
+            PrincipalPrivileges privileges = new PrincipalPrivileges(
+                    ImmutableMultimap.<String, HivePrivilegeInfo>builder()
                         .put(table.getOwner(), new HivePrivilegeInfo(SELECT, true, owner, owner))
                         .put(table.getOwner(), new HivePrivilegeInfo(INSERT, true, owner, owner))
                         .put(table.getOwner(), new HivePrivilegeInfo(UPDATE, true, owner, owner))
                         .put(table.getOwner(), new HivePrivilegeInfo(DELETE, true, owner, owner))
                         .build(),
-                ImmutableMultimap.of());
-        if (base == null) {
-            metastore.createTable(metastoreContext, table, privileges);
+                    ImmutableMultimap.of());
+            if (base == null) {
+                metastore.createTable(metastoreContext, table, privileges);
+            }
+            else {
+                metastore.replaceTable(metastoreContext, database, tableName, table, privileges);
+            }
         }
-        else {
-            metastore.replaceTable(metastoreContext, database, tableName, table, privileges);
+        finally {
+            shouldRefresh = true;
+            try {
+                lockId.ifPresent(id -> metastore.unlock(metastoreContext, id));
+            }
+            catch (Exception e) {
+                log.error(e, "Failed to unlock: %s", lockId.orElse(null));
+            }
+            finally {
+                tableLevelMutex.unlock();
+            }
         }
-
-        shouldRefresh = true;
     }
 
     @Override

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergSmoke.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergSmoke.java
@@ -23,9 +23,17 @@ import org.apache.iceberg.FileFormat;
 import org.intellij.lang.annotations.Language;
 import org.testng.annotations.Test;
 
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiConsumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.iceberg.IcebergQueryRunner.createIcebergQueryRunner;
@@ -37,6 +45,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 public class TestIcebergSmoke
         extends AbstractTestIntegrationSmokeTest
@@ -422,6 +431,51 @@ public class TestIcebergSmoke
     public void testInsertIntoNotNullColumn()
     {
         // TODO: To support non-null column. (NOT_NULL_COLUMN_CONSTRAINT)
+    }
+
+    @Test
+    public void testConcurrentInsert()
+    {
+        final Session session = getSession();
+        assertUpdate(session, "CREATE TABLE test_concurrent_insert (col0 INTEGER, col1 VARCHAR) WITH (format = 'ORC')");
+
+        int concurrency = 5;
+        final String[] strings = {"one", "two", "three", "four", "five"};
+        final CountDownLatch countDownLatch = new CountDownLatch(concurrency);
+        AtomicInteger value = new AtomicInteger(0);
+        Set<Throwable> errors = new CopyOnWriteArraySet<>();
+        List<Thread> threads = Stream.generate(() -> new Thread(() -> {
+            int i = value.getAndIncrement();
+            try {
+                getQueryRunner().execute(session, format("INSERT INTO test_concurrent_insert VALUES(%s, '%s')", i + 1, strings[i]));
+            }
+            catch (Throwable throwable) {
+                errors.add(throwable);
+            }
+            finally {
+                countDownLatch.countDown();
+            }
+        })).limit(concurrency).collect(Collectors.toList());
+
+        threads.forEach(Thread::start);
+
+        try {
+            final int seconds = 10;
+            if (!countDownLatch.await(seconds, TimeUnit.SECONDS)) {
+                fail(format("Failed to insert in %s seconds", seconds));
+            }
+            if (!errors.isEmpty()) {
+                fail(format("Failed to insert concurrently: %s", errors.stream().map(Throwable::getMessage).collect(Collectors.joining(" & "))));
+            }
+            assertQuery(session, "SELECT count(*) FROM test_concurrent_insert", "SELECT " + concurrency);
+            assertQuery(session, "SELECT * FROM test_concurrent_insert", "VALUES(1, 'one'), (2, 'two'), (3, 'three'), (4, 'four'), (5, 'five')");
+        }
+        catch (InterruptedException e) {
+            fail("Interrupted when await insertion", e);
+        }
+        finally {
+            dropTable(session, "test_concurrent_insert");
+        }
     }
 
     @Test


### PR DESCRIPTION
Before this pr, if multiple clients insert into same table concurrently, the insertion can be exexuted successfully but some insertion will lost. Because the snapshot replacement required a metastore lock to make sure the isolation. Also the native `HiveTableOperations` in iceberg implements the lock guard.

```
== RELEASE NOTES ==

Iceberg Changes
* Support concurrent insertion from the same presto cluster or mutiple presto clusters which sharing the same metastore

```
