### PR TITLE
Local temp storage should be configurable

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/spiller/NodeSpillConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/spiller/NodeSpillConfig.java
@@ -106,7 +106,7 @@ public class NodeSpillConfig
         this.tempStorageBufferSize = tempStorageBufferSize;
         return this;
     }
-    
+
     @NotNull
     public String getLocalTempStorePath()
     {

--- a/presto-main/src/main/java/com/facebook/presto/spiller/NodeSpillConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/spiller/NodeSpillConfig.java
@@ -18,6 +18,8 @@ import io.airlift.units.DataSize;
 
 import javax.validation.constraints.NotNull;
 
+import java.nio.file.Paths;
+
 public class NodeSpillConfig
 {
     private DataSize maxSpillPerNode = new DataSize(100, DataSize.Unit.GIGABYTE);
@@ -27,6 +29,7 @@ public class NodeSpillConfig
 
     private boolean spillCompressionEnabled;
     private boolean spillEncryptionEnabled;
+    private String localTempStorePath;
 
     @NotNull
     public DataSize getMaxSpillPerNode()
@@ -101,6 +104,22 @@ public class NodeSpillConfig
     public NodeSpillConfig setTempStorageBufferSize(DataSize tempStorageBufferSize)
     {
         this.tempStorageBufferSize = tempStorageBufferSize;
+        return this;
+    }
+    
+    @NotNull
+    public String getLocalTempStorePath()
+    {
+        if (null == localTempStorePath) {
+            localTempStorePath = Paths.get(System.getProperty("java.io.tmpdir"), "presto", "temp_storage").toAbsolutePath().toString();
+        }
+        return localTempStorePath;
+    }
+
+    @Config("local.temp-storage.path")
+    public NodeSpillConfig setLocalTempStorePath(String localTempStorePath)
+    {
+        this.localTempStorePath = localTempStorePath;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/storage/TempStorageManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/storage/TempStorageManager.java
@@ -61,7 +61,7 @@ public class TempStorageManager
     private final String localTempStorePath;
 
     @Inject
-    public TempStorageManager(InternalNodeManager internalNodeManager, NodeInfo nodeInfo, NodeSpillConfig nodeSpillConfig))
+    public TempStorageManager(InternalNodeManager internalNodeManager, NodeInfo nodeInfo, NodeSpillConfig nodeSpillConfig)
     {
         this(new ConnectorAwareNodeManager(
                 requireNonNull(internalNodeManager, "internalNodeManager is null"),

--- a/presto-main/src/test/java/com/facebook/presto/spiller/TestNodeSpillConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/spiller/TestNodeSpillConfig.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableMap;
 import io.airlift.units.DataSize;
 import org.testng.annotations.Test;
 
+import java.nio.file.Paths;
 import java.util.Map;
 
 import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertFullMapping;

--- a/presto-main/src/test/java/com/facebook/presto/spiller/TestNodeSpillConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/spiller/TestNodeSpillConfig.java
@@ -37,7 +37,9 @@ public class TestNodeSpillConfig
                 .setQueryMaxSpillPerNode(new DataSize(100, GIGABYTE))
                 .setSpillCompressionEnabled(false)
                 .setSpillEncryptionEnabled(false)
-                .setTempStorageBufferSize(new DataSize(4, KILOBYTE)));
+                .setTempStorageBufferSize(new DataSize(4, KILOBYTE))
+                .setLocalTempStorePath(Paths.get(System.getProperty("java.io.tmpdir"),
+                        "presto", "temp_storage").toAbsolutePath().toString()));
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/spiller/TestNodeSpillConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/spiller/TestNodeSpillConfig.java
@@ -50,6 +50,7 @@ public class TestNodeSpillConfig
                 .put("experimental.spill-compression-enabled", "true")
                 .put("experimental.spill-encryption-enabled", "true")
                 .put("experimental.temp-storage-buffer-size", "24MB")
+                .put("local.temp-storage.path", "/tmp/presto/local_temp_storage")
                 .build();
 
         NodeSpillConfig expected = new NodeSpillConfig()
@@ -58,7 +59,8 @@ public class TestNodeSpillConfig
                 .setQueryMaxSpillPerNode(new DataSize(15, MEGABYTE))
                 .setSpillCompressionEnabled(true)
                 .setSpillEncryptionEnabled(true)
-                .setTempStorageBufferSize(new DataSize(24, MEGABYTE));
+                .setTempStorageBufferSize(new DataSize(24, MEGABYTE))
+                .setLocalTempStorePath("/tmp/presto/local_temp_storage");
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
when starting Presto, I meet a problem : Caused by: java.nio.file.AccessDeniedException: /tmp/presto/tmp_storage. I see the code, the path does not support configuration。So i think the local temp storage should be configurable。https://github.com/prestodb/presto/issues/16984
![image](https://user-images.githubusercontent.com/9431947/141460462-823664c1-1506-41b7-97a5-ea6f59bf6648.png)


```
== RELEASE NOTES ==

General Changes
* Local temp storage can be configurable through "local.temp-storage.path"
* ...
```

