### PR TITLE
Improve the error message for IO related errors

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriterFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriterFactory.java
@@ -246,7 +246,7 @@ public class OrcFileWriterFactory
                     dwrfWriterEncryption));
         }
         catch (IOException e) {
-            throw new PrestoException(HIVE_WRITER_OPEN_ERROR, "Error creating " + orcEncoding + " file", e);
+            throw new PrestoException(HIVE_WRITER_OPEN_ERROR, "Error creating " + orcEncoding + " file. " + e.getMessage(), e);
         }
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/HdfsOrcDataSource.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/HdfsOrcDataSource.java
@@ -69,12 +69,12 @@ public class HdfsOrcDataSource
             throw e;
         }
         catch (Exception e) {
-            String message = format("Error reading from %s at position %s", this, position);
+            String message = format("Error reading from %s at position %s. ", this, position);
             if (e.getClass().getSimpleName().equals("BlockMissingException")) {
                 throw new PrestoException(HIVE_MISSING_DATA, message, e);
             }
             if (e instanceof IOException) {
-                throw new PrestoException(HIVE_FILESYSTEM_ERROR, message, e);
+                throw new PrestoException(HIVE_FILESYSTEM_ERROR, message + e.getMessage(), e);
             }
             throw new PrestoException(HIVE_UNKNOWN_ERROR, message, e);
         }


### PR DESCRIPTION
This PR  improves the error message for presto failures related to storage errors.

```
== NO RELEASE NOTE ==
```
