### PR TITLE
Support Left outer join in Materialized View

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMaterializedViewUtils.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMaterializedViewUtils.java
@@ -34,6 +34,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -60,8 +61,8 @@ public class HiveMaterializedViewUtils
     }
 
     /**
-     * Validate the partition columns of a materialized view to ensure 1) a materialized view is partitioned; and 2) it has at least one partition
-     * directly mapped to all base tables.
+     * Validate the partition columns of a materialized view to ensure 1) a materialized view is partitioned; 2) it has at least one partition
+     * directly mapped to all base tables and 3) Outer join conditions have common partitions that are partitions in the view as well
      * <p>
      * A column is directly mapped to a base table column if it is derived directly or transitively from the base table column,
      * by only selecting a column or an aliased column without any function or operator applied.
@@ -78,8 +79,8 @@ public class HiveMaterializedViewUtils
     {
         SchemaTableName viewName = new SchemaTableName(viewTable.getDatabaseName(), viewTable.getTableName());
 
-        Map<String, Map<SchemaTableName, String>> viewToBaseColumnMap = viewDefinition.getColumnMappingsAsMap();
-        if (viewToBaseColumnMap.isEmpty()) {
+        Map<String, Map<SchemaTableName, String>> viewToBaseDirectColumnMap = viewDefinition.getDirectColumnMappingsAsMap();
+        if (viewToBaseDirectColumnMap.isEmpty()) {
             throw new PrestoException(
                     NOT_SUPPORTED,
                     format("Materialized view %s must have at least one column directly defined by a base table column.", viewName));
@@ -90,30 +91,45 @@ public class HiveMaterializedViewUtils
             throw new PrestoException(NOT_SUPPORTED, "Unpartitioned materialized view is not supported.");
         }
 
-        viewDefinition.getBaseTables().stream()
+        List<Table> baseTables = viewDefinition.getBaseTables().stream()
                 .map(baseTableName -> metastore.getTable(metastoreContext, baseTableName.getSchemaName(), baseTableName.getTableName())
                         .orElseThrow(() -> new TableNotFoundException(baseTableName)))
-                .forEach(table -> {
-                    if (!isCommonPartitionFound(table, viewPartitions, viewToBaseColumnMap)) {
-                        throw new PrestoException(
-                                NOT_SUPPORTED,
-                                format("Materialized view %s must have at least partition to base table partition mapping for all base tables.", viewName));
-                    }
-                });
+                .collect(toImmutableList());
+
+        Map<Table, List<Column>> baseTablePartitions = baseTables.stream()
+                .collect(toImmutableMap(
+                        table -> table,
+                        Table::getPartitionColumns));
+
+        for (Table baseTable : baseTablePartitions.keySet()) {
+            SchemaTableName schemaBaseTable = new SchemaTableName(baseTable.getDatabaseName(), baseTable.getTableName());
+            if (!isCommonPartitionFound(schemaBaseTable, baseTablePartitions.get(baseTable), viewPartitions, viewToBaseDirectColumnMap)) {
+                throw new PrestoException(
+                        NOT_SUPPORTED,
+                        format("Materialized view %s must have at least one partition column that exists in %s as well", viewName, baseTable.getTableName()));
+            }
+            if (viewDefinition.getBaseTablesOnOuterJoinSide().contains(schemaBaseTable) && viewToBaseTableOnOuterJoinSideIndirectMappedPartitions(viewDefinition, baseTable).get().isEmpty()) {
+                throw new PrestoException(
+                        NOT_SUPPORTED,
+                        format("Outer join conditions in Materialized view %s must have at least one common partition equality constraint", viewName));
+            }
+        }
     }
 
     private static boolean isCommonPartitionFound(
-            Table baseTable,
+            SchemaTableName baseTable,
+            List<Column> baseTablePartitions,
             List<Column> viewPartitions,
             Map<String, Map<SchemaTableName, String>> viewToBaseColumnMap)
     {
-        SchemaTableName baseTableName = new SchemaTableName(baseTable.getDatabaseName(), baseTable.getTableName());
         for (Column viewPartition : viewPartitions) {
-            String viewPartitionMapToBaseTablePartition = viewToBaseColumnMap
-                    .getOrDefault(viewPartition.getName(), emptyMap())
-                    .getOrDefault(baseTableName, "");
-            if (baseTable.getPartitionColumns().stream().anyMatch(baseTablePartition -> baseTablePartition.getName().equals(viewPartitionMapToBaseTablePartition))) {
-                return true;
+            for (Column basePartition : baseTablePartitions) {
+                if (viewToBaseColumnMap
+                        .getOrDefault(viewPartition.getName(), emptyMap())
+                        .getOrDefault(baseTable, "")
+                        .equals(basePartition.getName())) {
+                    return true;
+                }
             }
         }
         return false;
@@ -170,66 +186,142 @@ public class HiveMaterializedViewUtils
                 .collect(toImmutableList()));
     }
 
-    public static MaterializedDataPredicates differenceDataPredicates(
-            MaterializedDataPredicates leftPredicatesInfo,
-            MaterializedDataPredicates rightPredicatesInfo,
-            Map<String, String> rightToLeftPredicatesKeyMap)
+    // Every table on outer join side, must have a partition which is in EQ clause and present in Materialized View as well.
+    // For a given base table, this function computes partition columns of Materialized View which are not directly mapped to base table,
+    // and are directly mapped to some other base table which is not on outer join side.
+    // For example:
+    // Materialized View: SELECT t1_a as t1.a, t2_a as t2.a FROM t1 LEFT JOIN t2 ON t1.a = t2.a, partitioned by [t1_a, t2_a]
+    // baseTable: t2, partitioned by [a]
+    // Output: t1_a -> t2.a
+    public static Optional<Map<String, String>> viewToBaseTableOnOuterJoinSideIndirectMappedPartitions(
+            ConnectorMaterializedViewDefinition viewDefinition,
+            Table baseTable)
     {
-        if (rightToLeftPredicatesKeyMap.isEmpty()) {
-            return EMPTY_MATERIALIZED_VIEW_DATA_PREDICATES;
+        SchemaTableName schemaBaseTable = new SchemaTableName(baseTable.getDatabaseName(), baseTable.getTableName());
+        if (!viewDefinition.getBaseTablesOnOuterJoinSide().contains(schemaBaseTable)) {
+            return Optional.empty();
         }
-        if (rightPredicatesInfo.isEmpty()) {
-            return leftPredicatesInfo;
-        }
+        Map<String, String> viewToBaseIndirectMappedColumns = new HashMap<>();
 
-        Set<String> leftMappedCommonKeys = new HashSet<>();
-        Set<String> rightMappedCommonKeys = new HashSet<>();
-        for (String rightKey : rightPredicatesInfo.getColumnNames()) {
-            String leftKey = rightToLeftPredicatesKeyMap.get(rightKey);
-            if (leftKey != null && leftPredicatesInfo.getColumnNames().contains(leftKey)) {
-                leftMappedCommonKeys.add(leftKey);
-                rightMappedCommonKeys.add(rightKey);
+        Map<String, Map<SchemaTableName, String>> columnMappings = viewDefinition.getColumnMappingsAsMap();
+        Map<String, Map<SchemaTableName, String>> directColumnMappings = viewDefinition.getDirectColumnMappingsAsMap();
+
+        for (String viewPartition : viewDefinition.getValidRefreshColumns().orElse(ImmutableList.of())) {
+            String baseTablePartition = columnMappings.get(viewPartition).get(schemaBaseTable);
+            // Check if it is a base table partition column
+            if (baseTable.getPartitionColumns().stream().noneMatch(col -> col.getName().equals(baseTablePartition))) {
+                continue;
+            }
+            // Check if view partition column directly maps to some partition column of other base table which is not on outer join side
+            // For e.g. in case of left outer join, we want to find partition which maps to left table
+            if (directColumnMappings.get(viewPartition).keySet().stream().allMatch(e -> !e.equals(schemaBaseTable)) &&
+                    directColumnMappings.get(viewPartition).keySet().stream().allMatch(t -> !viewDefinition.getBaseTablesOnOuterJoinSide().contains(t))) {
+                viewToBaseIndirectMappedColumns.put(viewPartition, baseTablePartition);
             }
         }
-        if (leftMappedCommonKeys.isEmpty()) {
+        return Optional.of(viewToBaseIndirectMappedColumns);
+    }
+
+    public static MaterializedDataPredicates differenceDataPredicates(
+            MaterializedDataPredicates baseTablePredicatesInfo,
+            MaterializedDataPredicates viewPredicatesInfo,
+            Map<String, String> viewToBaseTablePredicatesKeyMap)
+    {
+        return differenceDataPredicates(baseTablePredicatesInfo, viewPredicatesInfo, viewToBaseTablePredicatesKeyMap, ImmutableMap.of());
+    }
+
+  /**
+   * From given base table partitions, removes all partitions that are already used to compute
+   * related view partitions, only returning partitions that are not reflected in Materialized View.
+   * We assume that given materialized view partitions are still fresh,
+   * and in sync with base table partitions, i.e. related Materialized View partitions are already invalidated
+   * when new base table partitions land.
+   * @param baseTablePredicatesInfo Partitions info for base table
+   * @param viewPredicatesInfo Partitions info for view
+   * @param viewToBaseTablePredicatesKeyMap Partitions mapping from view to base table. Only includes direct mapping, i.e. excludes mapping from outer joins EQ clauses.
+   * @param viewToBaseTableIndirectMap Extra partitions mapping from view to base table, computed from viewToBaseTableOnOuterJoinSideIndirectMappedPartitions()
+   * @return Base Table partitions that have not been used to refresh view.
+   */
+    public static MaterializedDataPredicates differenceDataPredicates(
+            MaterializedDataPredicates baseTablePredicatesInfo,
+            MaterializedDataPredicates viewPredicatesInfo,
+            Map<String, String> viewToBaseTablePredicatesKeyMap,
+            Map<String, String> viewToBaseTableIndirectMap)
+    {
+        if (viewToBaseTablePredicatesKeyMap.isEmpty()) {
+            return EMPTY_MATERIALIZED_VIEW_DATA_PREDICATES;
+        }
+        if (viewPredicatesInfo.isEmpty()) {
+            return baseTablePredicatesInfo;
+        }
+
+        Set<String> baseTableMappedCommonKeys = new HashSet<>();
+        Set<String> viewMappedCommonKeys = new HashSet<>();
+        for (String rightKey : viewPredicatesInfo.getColumnNames()) {
+            String leftKey = viewToBaseTablePredicatesKeyMap.get(rightKey);
+            if (leftKey != null && baseTablePredicatesInfo.getColumnNames().contains(leftKey)) {
+                baseTableMappedCommonKeys.add(leftKey);
+                viewMappedCommonKeys.add(rightKey);
+            }
+        }
+
+        if (baseTableMappedCommonKeys.isEmpty()) {
             return EMPTY_MATERIALIZED_VIEW_DATA_PREDICATES;
         }
 
         // Intentionally used linkedHashMap so that equal guarantees are kept even if underlying implementation is changed.
-        Set<LinkedHashMap<String, NullableValue>> rightPredicatesMappedToLeftCommonKeys = new HashSet<>();
-        for (TupleDomain<String> rightPredicate : rightPredicatesInfo.getPredicateDisjuncts()) {
-            LinkedHashMap<String, NullableValue> rightPredicateKeyValue = getLinkedHashMap(
+        Set<LinkedHashMap<String, NullableValue>> viewPredicatesMappedToBaseTableCommonKeys = new HashSet<>();
+        for (TupleDomain<String> rightPredicate : viewPredicatesInfo.getPredicateDisjuncts()) {
+            LinkedHashMap<String, NullableValue> viewPredicateKeyValue = getLinkedHashMap(
                     extractFixedValues(rightPredicate).orElseThrow(() -> new IllegalStateException("rightPredicateKeyValue is not present!")));
 
-            LinkedHashMap<String, NullableValue> rightPredicateMappedToLeftCommonKeys = getLinkedHashMap(
-                    rightPredicateKeyValue.keySet().stream()
-                            .filter(rightMappedCommonKeys::contains)
+            LinkedHashMap<String, NullableValue> viewPredicateMappedToBaseTableCommonKeys = getLinkedHashMap(
+                    viewPredicateKeyValue.keySet().stream()
+                            .filter(viewMappedCommonKeys::contains)
                             .collect(toLinkedMap(
-                                    rightToLeftPredicatesKeyMap::get,
-                                    rightPredicateKeyValue::get)));
+                                    viewToBaseTablePredicatesKeyMap::get,
+                                    viewPredicateKeyValue::get)));
 
-            rightPredicatesMappedToLeftCommonKeys.add(rightPredicateMappedToLeftCommonKeys);
+            viewToBaseTableIndirectMap.entrySet().forEach(
+                    e -> viewPredicateMappedToBaseTableCommonKeys.put(e.getValue(), viewPredicateKeyValue.get(e.getKey())));
+
+            viewPredicatesMappedToBaseTableCommonKeys.add(viewPredicateMappedToBaseTableCommonKeys);
         }
 
-        ImmutableList.Builder<TupleDomain<String>> leftMinusRight = ImmutableList.builder();
+        ImmutableList.Builder<TupleDomain<String>> difference = ImmutableList.builder();
 
-        for (TupleDomain<String> leftPredicate : leftPredicatesInfo.getPredicateDisjuncts()) {
-            LinkedHashMap<String, NullableValue> leftPredicateKeyValue = getLinkedHashMap(
+        for (TupleDomain<String> leftPredicate : baseTablePredicatesInfo.getPredicateDisjuncts()) {
+            LinkedHashMap<String, NullableValue> baseTablePredicateKeyValue = getLinkedHashMap(
                     extractFixedValues(leftPredicate).orElseThrow(() -> new IllegalStateException("leftPredicateKeyValue is not present!")));
 
-            LinkedHashMap<String, NullableValue> leftPredicateMappedToLeftCommonKeys = getLinkedHashMap(
-                    leftPredicateKeyValue.keySet().stream()
-                            .filter(leftMappedCommonKeys::contains)
+            LinkedHashMap<String, NullableValue> baseTablePredicateMappedToBaseTableCommonKeys = getLinkedHashMap(
+                    baseTablePredicateKeyValue.keySet().stream()
+                            .filter(baseTableMappedCommonKeys::contains)
                             .collect(Collectors.toMap(
                                     columnName -> columnName,
-                                    leftPredicateKeyValue::get)));
+                                    baseTablePredicateKeyValue::get)));
 
-            if (!rightPredicatesMappedToLeftCommonKeys.contains(leftPredicateMappedToLeftCommonKeys)) {
-                leftMinusRight.add(leftPredicate);
+            if (!viewPredicatesMappedToBaseTableCommonKeys.contains(baseTablePredicateMappedToBaseTableCommonKeys)) {
+                difference.add(leftPredicate);
+            }
+            else if (!viewToBaseTableIndirectMap.isEmpty()) {
+                // If base table is part of an outer join, its columns can be null. So check if an equivalent partition exists for view with null values
+                LinkedHashMap<String, NullableValue> baseTablePredicateMappedToBaseTableAllKeys = getLinkedHashMap(
+                        baseTablePredicateKeyValue.keySet().stream()
+                                .filter(baseTableMappedCommonKeys::contains)
+                                .collect(Collectors.toMap(
+                                        columnName -> columnName,
+                                        columnName -> NullableValue.asNull(baseTablePredicateKeyValue.get(columnName).getType()))));
+
+                viewToBaseTableIndirectMap.entrySet().forEach(e -> baseTablePredicateMappedToBaseTableAllKeys.put(e.getValue(), baseTablePredicateKeyValue.get(e.getValue())));
+
+                if (!viewPredicatesMappedToBaseTableCommonKeys.contains(baseTablePredicateMappedToBaseTableCommonKeys)) {
+                    difference.add(leftPredicate);
+                }
             }
         }
 
-        return new MaterializedDataPredicates(leftMinusRight.build(), leftPredicatesInfo.getColumnNames());
+        return new MaterializedDataPredicates(difference.build(), baseTablePredicatesInfo.getColumnNames());
     }
 
     public static MaterializedDataPredicates getEmptyMaterializedViewDataPredicates()

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveLogicalPlanner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveLogicalPlanner.java
@@ -140,6 +140,7 @@ import static com.facebook.presto.sql.planner.plan.ExchangeNode.Scope.LOCAL;
 import static com.facebook.presto.sql.planner.plan.ExchangeNode.Scope.REMOTE_STREAMING;
 import static com.facebook.presto.sql.planner.plan.ExchangeNode.Type.GATHER;
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.INNER;
+import static com.facebook.presto.sql.planner.plan.JoinNode.Type.LEFT;
 import static com.facebook.presto.testing.TestingAccessControlManager.TestingPrivilegeType.INSERT_TABLE;
 import static com.facebook.presto.testing.TestingAccessControlManager.TestingPrivilegeType.SELECT_COLUMN;
 import static com.facebook.presto.testing.TestingAccessControlManager.privilege;
@@ -1635,15 +1636,19 @@ public class TestHiveLogicalPlanner
     public void testMaterializedViewForIntersect()
     {
         QueryRunner queryRunner = getQueryRunner();
-        String table = "test_customer_intersect";
+        String table1 = "test_customer_intersect1";
+        String table2 = "test_customer_intersect2";
         String view = "test_customer_view_intersect";
         try {
             computeActual(format("CREATE TABLE %s WITH (partitioned_by = ARRAY['nationkey']) " +
-                    "AS SELECT custkey, name, address, nationkey FROM customer", table));
+                    "AS SELECT custkey, name, address, nationkey FROM customer", table1));
+
+            computeActual(format("CREATE TABLE %s WITH (partitioned_by = ARRAY['nationkey']) " +
+                    "AS SELECT custkey, name, address, nationkey FROM customer", table2));
 
             String baseQuery = format(
                     "SELECT name, custkey, nationkey FROM ( SELECT name, custkey, nationkey FROM %s WHERE custkey < 1000 INTERSECT " +
-                            "SELECT name, custkey, nationkey FROM %s WHERE custkey <= 900 )", table, table);
+                            "SELECT name, custkey, nationkey FROM %s WHERE custkey <= 900 )", table1, table2);
 
             assertUpdate(format("CREATE MATERIALIZED VIEW %s WITH (partitioned_by = ARRAY['nationkey']) " +
                     "AS %s", view, baseQuery));
@@ -1660,18 +1665,19 @@ public class TestHiveLogicalPlanner
             assertPlan(getSession(), viewQuery, anyTree(
                     anyTree(
                             anyTree(
-                                    filter("custkey < BIGINT'1000'", PlanMatchPattern.constrainedTableScan(table,
+                                    filter("custkey < BIGINT'1000'", PlanMatchPattern.constrainedTableScan(table1,
                                     ImmutableMap.of("nationkey", multipleValues(BIGINT, ImmutableList.of(10L, 11L, 12L, 13L, 14L, 15L, 16L, 17L, 18L, 19L, 20L, 21L, 22L, 23L, 24L))),
                                     ImmutableMap.of("custkey", "custkey")))),
                             anyTree(
-                                    filter("custkey_21 <= BIGINT'900'", PlanMatchPattern.constrainedTableScan(table,
+                                    filter("custkey_21 <= BIGINT'900'", PlanMatchPattern.constrainedTableScan(table2,
                                     ImmutableMap.of("nationkey", multipleValues(BIGINT, ImmutableList.of(10L, 11L, 12L, 13L, 14L, 15L, 16L, 17L, 18L, 19L, 20L, 21L, 22L, 23L, 24L))),
                                     ImmutableMap.of("custkey_21", "custkey"))))),
                     PlanMatchPattern.constrainedTableScan(view, ImmutableMap.of())));
         }
         finally {
             queryRunner.execute("DROP MATERIALIZED VIEW IF EXISTS " + view);
-            queryRunner.execute("DROP TABLE IF EXISTS " + table);
+            queryRunner.execute("DROP TABLE IF EXISTS " + table1);
+            queryRunner.execute("DROP TABLE IF EXISTS " + table2);
         }
     }
 
@@ -1679,15 +1685,19 @@ public class TestHiveLogicalPlanner
     public void testMaterializedViewForUnionAll()
     {
         QueryRunner queryRunner = getQueryRunner();
-        String table = "test_customer_union";
+        String table1 = "test_customer_union1";
+        String table2 = "test_customer_union2";
         String view = "test_customer_view_union";
         try {
             computeActual(format("CREATE TABLE %s WITH (partitioned_by = ARRAY['nationkey']) " +
-                    "AS SELECT custkey, name, address, nationkey FROM customer", table));
+                    "AS SELECT custkey, name, address, nationkey FROM customer", table1));
+
+            computeActual(format("CREATE TABLE %s WITH (partitioned_by = ARRAY['nationkey']) " +
+                    "AS SELECT custkey, name, address, nationkey FROM customer", table2));
 
             String baseQuery = format(
                     "SELECT name, custkey, nationkey FROM ( SELECT name, custkey, nationkey FROM %s WHERE custkey < 1000 UNION ALL " +
-                            "SELECT name, custkey, nationkey FROM %s WHERE custkey >= 1000 )", table, table);
+                            "SELECT name, custkey, nationkey FROM %s WHERE custkey >= 1000 )", table1, table2);
 
             assertUpdate(format("CREATE MATERIALIZED VIEW %s WITH (partitioned_by = ARRAY['nationkey']) " +
                     "AS %s", view, baseQuery));
@@ -1702,17 +1712,18 @@ public class TestHiveLogicalPlanner
             assertEquals(viewTable, baseTable);
 
             assertPlan(getSession(), viewQuery, anyTree(
-                    filter("custkey < BIGINT'1000'", PlanMatchPattern.constrainedTableScan(table,
+                    filter("custkey < BIGINT'1000'", PlanMatchPattern.constrainedTableScan(table1,
                                     ImmutableMap.of("nationkey", multipleValues(BIGINT, ImmutableList.of(10L, 11L, 12L, 13L, 14L, 15L, 16L, 17L, 18L, 19L, 20L, 21L, 22L, 23L, 24L))),
                                     ImmutableMap.of("custkey", "custkey"))),
-                    filter("custkey_21 >= BIGINT'1000'", PlanMatchPattern.constrainedTableScan(table,
+                    filter("custkey_21 >= BIGINT'1000'", PlanMatchPattern.constrainedTableScan(table2,
                             ImmutableMap.of("nationkey", multipleValues(BIGINT, ImmutableList.of(10L, 11L, 12L, 13L, 14L, 15L, 16L, 17L, 18L, 19L, 20L, 21L, 22L, 23L, 24L))),
                             ImmutableMap.of("custkey_21", "custkey"))),
                     PlanMatchPattern.constrainedTableScan(view, ImmutableMap.of())));
         }
         finally {
             queryRunner.execute("DROP MATERIALIZED VIEW IF EXISTS " + view);
-            queryRunner.execute("DROP TABLE IF EXISTS " + table);
+            queryRunner.execute("DROP TABLE IF EXISTS " + table1);
+            queryRunner.execute("DROP TABLE IF EXISTS " + table2);
         }
     }
 
@@ -1761,15 +1772,19 @@ public class TestHiveLogicalPlanner
     public void testMaterializedViewForExcept()
     {
         QueryRunner queryRunner = getQueryRunner();
-        String table = "test_customer_except";
+        String table1 = "test_customer_except1";
+        String table2 = "test_customer_except2";
         String view = "test_customer_view_except";
         try {
             computeActual(format("CREATE TABLE %s WITH (partitioned_by = ARRAY['nationkey']) " +
-                    "AS SELECT custkey, name, address, nationkey FROM customer", table));
+                    "AS SELECT custkey, name, address, nationkey FROM customer", table1));
+
+            computeActual(format("CREATE TABLE %s WITH (partitioned_by = ARRAY['nationkey']) " +
+                    "AS SELECT custkey, name, address, nationkey FROM customer", table2));
 
             String baseQuery = format(
                     "SELECT name, custkey, nationkey FROM %s WHERE custkey < 1000 EXCEPT " +
-                            "SELECT name, custkey, nationkey FROM %s WHERE custkey > 900", table, table);
+                            "SELECT name, custkey, nationkey FROM %s WHERE custkey > 900", table1, table2);
 
             assertUpdate(format("CREATE MATERIALIZED VIEW %s WITH (partitioned_by = ARRAY['nationkey']) " +
                     "AS %s", view, baseQuery));
@@ -1786,18 +1801,19 @@ public class TestHiveLogicalPlanner
             assertPlan(getSession(), viewQuery, anyTree(
                     anyTree(
                             anyTree(
-                                    filter("custkey < BIGINT'1000'", PlanMatchPattern.constrainedTableScan(table,
+                                    filter("custkey < BIGINT'1000'", PlanMatchPattern.constrainedTableScan(table1,
                                     ImmutableMap.of("nationkey", multipleValues(BIGINT, ImmutableList.of(10L, 11L, 12L, 13L, 14L, 15L, 16L, 17L, 18L, 19L, 20L, 21L, 22L, 23L, 24L))),
                                     ImmutableMap.of("custkey", "custkey")))),
                             anyTree(
-                                    filter("custkey_21 > BIGINT'900'", PlanMatchPattern.constrainedTableScan(table,
+                                    filter("custkey_21 > BIGINT'900'", PlanMatchPattern.constrainedTableScan(table2,
                                     ImmutableMap.of("nationkey", multipleValues(BIGINT, ImmutableList.of(10L, 11L, 12L, 13L, 14L, 15L, 16L, 17L, 18L, 19L, 20L, 21L, 22L, 23L, 24L))),
                                     ImmutableMap.of("custkey_21", "custkey"))))),
                     PlanMatchPattern.constrainedTableScan(view, ImmutableMap.of())));
         }
         finally {
             queryRunner.execute("DROP MATERIALIZED VIEW IF EXISTS " + view);
-            queryRunner.execute("DROP TABLE IF EXISTS " + table);
+            queryRunner.execute("DROP TABLE IF EXISTS " + table1);
+            queryRunner.execute("DROP TABLE IF EXISTS " + table2);
         }
     }
 
@@ -2463,6 +2479,83 @@ public class TestHiveLogicalPlanner
     }
 
     @Test
+    public void testMaterializedViewInvalidLeftOuterJoin()
+    {
+        QueryRunner queryRunner = getQueryRunner();
+        String view = "view_invalid_left_outer_join";
+        String table1 = "t1_invalid_left_outer_join";
+        String table2 = "t2_invalid_left_outer_join";
+
+        try {
+            queryRunner.execute(format("CREATE TABLE %s WITH (partitioned_by = ARRAY['ds']) AS SELECT 1 as a, '2020-01-01' as ds", table1));
+            queryRunner.execute(format("CREATE TABLE %s WITH (partitioned_by = ARRAY['ds']) AS SELECT 1 as a, '2020-01-01' as ds", table2));
+
+            assertQueryFails(format("CREATE MATERIALIZED VIEW %s WITH (partitioned_by = ARRAY['t1_ds', 't2_ds']) " +
+                            "AS SELECT t1.a as t1_a, t2.a as t2_a, t1.ds as t1_ds, t2.ds as t2_ds FROM %s t1 LEFT JOIN %s t2 ON t1.a = t2.a", view, table1, table2),
+                    ".*must have at least one common partition equality constraint.*");
+
+            assertQueryFails(format("CREATE MATERIALIZED VIEW %s WITH (partitioned_by = ARRAY['t2_ds']) " +
+                            "AS SELECT t1.a as t1_a, t2.a as t2_a, t2.ds as t2_ds FROM %s t1 LEFT JOIN %s t2 ON t1.ds = t2.ds", view, table1, table2),
+                    ".*must have at least one partition column that exists in.*");
+        }
+        finally {
+            queryRunner.execute("DROP MATERIALIZED VIEW IF EXISTS " + view);
+            queryRunner.execute("DROP TABLE IF EXISTS " + table1);
+            queryRunner.execute("DROP TABLE IF EXISTS " + table2);
+        }
+    }
+
+    @Test
+    public void testMaterializedViewForLeftOuterJoin()
+    {
+        QueryRunner queryRunner = getQueryRunner();
+        String table1 = "orders_key_partitioned_left_outer_join";
+        String table2 = "orders_price_partitioned_left_outer_join";
+        String view = "orders_view_left_outer_join";
+        try {
+            queryRunner.execute(format("CREATE TABLE %s WITH (partitioned_by = ARRAY['ds']) AS " +
+                    "SELECT orderkey, '2019-01-01' as ds FROM orders WHERE orderkey < 1500 " +
+                    "UNION ALL " +
+                    "SELECT orderkey, '2019-01-02' as ds FROM orders WHERE orderkey > 1500 and orderkey < 2000", table1));
+
+            queryRunner.execute(format("CREATE TABLE %s WITH (partitioned_by = ARRAY['ds']) AS " +
+                    "SELECT orderkey, totalprice, '2019-01-01' as ds FROM orders WHERE orderkey < 1000 " +
+                    "UNION ALL " +
+                    "SELECT orderkey, totalprice, '2019-01-02' as ds FROM orders WHERE orderkey > 1000 and orderkey < 2000", table2));
+
+            assertUpdate(format("CREATE MATERIALIZED VIEW %s WITH (partitioned_by = ARRAY['t1_ds', 't2_ds']) AS " +
+                    "SELECT t1.orderkey as view_orderkey, t2.totalprice as view_totalprice, t1.ds as t1_ds, t2.ds as t2_ds " +
+                    "FROM %s t1 left join %s t2 ON (t1.ds=t2.ds AND t1.orderkey = t2.orderkey)", view, table1, table2));
+
+            assertTrue(queryRunner.tableExists(getSession(), view));
+
+            assertUpdate(format("REFRESH MATERIALIZED VIEW %s WHERE t1_ds='2019-01-01'", view), 375);
+
+            String viewQuery = format("SELECT view_orderkey, view_totalprice, t1_ds FROM %s WHERE view_orderkey <  10000 ORDER BY view_orderkey", view);
+            String baseQuery = format("SELECT t1.orderkey as view_orderkey, t2.totalprice as view_totalprice, t1.ds " +
+                    "FROM %s t1 left join  %s t2 ON (t1.ds=t2.ds AND t1.orderkey = t2.orderkey) " +
+                    "WHERE t1.orderkey < 10000 ORDER BY t1.orderkey", table1, table2);
+            MaterializedResult viewTable = computeActual(viewQuery);
+            MaterializedResult baseTable = computeActual(baseQuery);
+            assertEquals(viewTable, baseTable);
+
+            assertPlan(getSession(), viewQuery, anyTree(
+                    join(LEFT, ImmutableList.of(equiJoinClause("ds", "ds_8"), equiJoinClause("orderkey", "orderkey_7")),
+                            anyTree(filter("orderkey < BIGINT'10000'", PlanMatchPattern.constrainedTableScan(table1,
+                                    ImmutableMap.of(
+                                            "ds", singleValue(createVarcharType(10), utf8Slice("2019-01-02"))),
+                                    ImmutableMap.of("orderkey", "orderkey", "ds", "ds")))),
+                            anyTree(PlanMatchPattern.constrainedTableScan(table2, ImmutableMap.of("ds", singleValue(createVarcharType(10), utf8Slice("2019-01-02"))), ImmutableMap.of("orderkey_7", "orderkey", "ds_8", "ds")))),
+                    filter("view_orderkey < BIGINT'10000'", PlanMatchPattern.constrainedTableScan(view, ImmutableMap.of(), ImmutableMap.of("view_orderkey", "view_orderkey")))));
+        }
+        finally {
+            queryRunner.execute("DROP MATERIALIZED VIEW IF EXISTS " + view);
+            queryRunner.execute("DROP TABLE IF EXISTS " + table1);
+            queryRunner.execute("DROP TABLE IF EXISTS " + table2);
+        }
+    }
+
+    @Test
     public void testMaterializedViewFullOuterJoin()
     {
         QueryRunner queryRunner = getQueryRunner();
@@ -2484,12 +2577,31 @@ public class TestHiveLogicalPlanner
                             "AS SELECT t1.orderkey as view_orderkey, t2.totalprice as view_totalprice, " +
                             "t1.ds as ds, t1.orderpriority as view_orderpriority, t2.orderstatus as view_orderstatus " +
                             " FROM %s t1 full outer join %s t2 ON t1.ds=t2.ds", view, table1, table2),
-                    ".*Only inner join and cross join unnested are supported for materialized view.*");
+                    ".*Only inner join, left join and cross join unnested are supported for materialized view.*");
         }
         finally {
             queryRunner.execute("DROP MATERIALIZED VIEW IF EXISTS " + view);
             queryRunner.execute("DROP TABLE IF EXISTS " + table1);
             queryRunner.execute("DROP TABLE IF EXISTS " + table2);
+        }
+    }
+
+    @Test
+    public void testMaterializedViewSameTableTwice()
+    {
+        QueryRunner queryRunner = getQueryRunner();
+        String table = "same_table";
+        String view = "same_table_twice";
+
+        try {
+            queryRunner.execute(format("CREATE TABLE %s WITH (partitioned_by = ARRAY['ds']) AS SELECT 1 as a, '2020-01-01' as ds", table));
+
+            assertQueryFails(format("CREATE MATERIALIZED VIEW %s WITH (partitioned_by = ARRAY['ds']) " +
+                    "AS SELECT t1.a, t1.ds FROM %s t1 UNION ALL SELECT t2.a, t2.ds FROM %s t2", view, table, table), ".*Materialized View definition does not support multiple instances of same table*");
+        }
+        finally {
+            queryRunner.execute("DROP MATERIALIZED VIEW IF EXISTS " + view);
+            queryRunner.execute("DROP TABLE IF EXISTS " + table);
         }
     }
 
@@ -2518,7 +2630,7 @@ public class TestHiveLogicalPlanner
                     ".*Subqueries are not supported for materialized view.*");
 
             assertUpdate(format("CREATE MATERIALIZED VIEW %s WITH (partitioned_by = ARRAY['ds']) " +
-                            "AS SELECT t1.a, t1.ds FROM %s t1 join (select t2.ds AS t2_ds, t2.a from %s t2 where t2.a <= 420) ON t1.ds = t2_ds", view3, table1, table2));
+                    "AS SELECT t1.a, t1.ds FROM %s t1 join (select t2.ds AS t2_ds, t2.a from %s t2 where t2.a <= 420) ON t1.ds = t2_ds", view3, table1, table2));
         }
         finally {
             queryRunner.execute("DROP MATERIALIZED VIEW IF EXISTS " + view1);
@@ -2551,7 +2663,7 @@ public class TestHiveLogicalPlanner
 
             assertQueryFails(format("CREATE MATERIALIZED VIEW %s WITH (partitioned_by = ARRAY['ds']) " +
                             "AS SELECT t1.ds FROM %s t1, LATERAL(SELECT t2.ds, t2.orderstatus AS view_orderstatus, t1.orderpriority AS view_orderpriority FROM %s t2 WHERE t1.ds = t2.ds)", view, table1, table2),
-                    ".*Only inner join and cross join unnested are supported for materialized view.*");
+                    ".*Only inner join, left join and cross join unnested are supported for materialized view.*");
         }
         finally {
             queryRunner.execute("DROP MATERIALIZED VIEW IF EXISTS " + view);

--- a/presto-main/src/main/java/com/facebook/presto/sql/MaterializedViewUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/MaterializedViewUtils.java
@@ -22,90 +22,37 @@ import com.facebook.presto.metadata.SessionPropertyManager;
 import com.facebook.presto.spi.MaterializedViewStatus;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.security.Identity;
-import com.facebook.presto.sql.analyzer.Analysis;
-import com.facebook.presto.sql.analyzer.MaterializedViewColumnMappingExtractor;
 import com.facebook.presto.sql.planner.LiteralEncoder;
 import com.facebook.presto.sql.tree.BooleanLiteral;
 import com.facebook.presto.sql.tree.ComparisonExpression;
-import com.facebook.presto.sql.tree.CreateMaterializedView;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.Identifier;
 import com.facebook.presto.sql.tree.IsNullPredicate;
 import com.facebook.presto.sql.tree.LogicalBinaryExpression;
-import com.facebook.presto.sql.tree.Node;
-import com.facebook.presto.sql.tree.Query;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.Stack;
 
 import static com.facebook.presto.common.predicate.TupleDomain.extractFixedValues;
-import static com.facebook.presto.metadata.MetadataUtil.toSchemaTableName;
-import static com.facebook.presto.spi.ConnectorMaterializedViewDefinition.TableColumn;
 import static com.facebook.presto.sql.tree.BooleanLiteral.FALSE_LITERAL;
 import static com.facebook.presto.sql.tree.ComparisonExpression.Operator.EQUAL;
 import static com.facebook.presto.sql.tree.LogicalBinaryExpression.Operator.AND;
 import static com.facebook.presto.sql.tree.LogicalBinaryExpression.Operator.OR;
-import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 
 public class MaterializedViewUtils
 {
     private MaterializedViewUtils() {}
-
-    /**
-     * Compute the 1-to-N column mapping from a materialized view to its base tables.
-     * <p>
-     * From {@code analysis}, we could derive only one base table column that one materialized view column maps to.
-     * In case of 1 materialized view defined on N base tables via join, union, etc, this method helps compute
-     * all the N base table columns that one materialized view column maps to.
-     * It calls on {@link MaterializedViewColumnMappingExtractor} to get all base table columns mapped by join, union, etc,
-     * and then uses them to expand the 1-to-1 column mapping derived from {@code analysis} to the 1-to-N column mapping.
-     * <p>
-     * For example, given SELECT column_a AS column_x FROM table_a JOIN table_b ON (table_a.column_a = table_b.column_b),
-     * the 1-to-1 column mapping from {@code analysis} is column_x -> table_a.column_a. Mapped base table columns are
-     * [table_a.column_a, table_b.column_b]. Then it will return a 1-to-N column mapping column_x -> {table_a -> column_a, table_b -> column_b}.
-     */
-    public static Map<String, Map<SchemaTableName, String>> computeMaterializedViewToBaseTableColumnMappings(Analysis analysis)
-    {
-        checkState(
-                analysis.getStatement() instanceof CreateMaterializedView,
-                "Only support the computation of column mappings when analyzing CreateMaterializedView");
-
-        ImmutableMap.Builder<String, Map<SchemaTableName, String>> fullColumnMappings = ImmutableMap.builder();
-
-        Query viewQuery = ((CreateMaterializedView) analysis.getStatement()).getQuery();
-        Map<String, TableColumn> originalColumnMappings = getOriginalColumnsFromAnalysis(viewQuery, analysis);
-
-        List<List<TableColumn>> mappedBaseColumns = MaterializedViewColumnMappingExtractor.extractMappedBaseColumns(analysis);
-
-        for (Map.Entry<String, TableColumn> columnMapping : originalColumnMappings.entrySet()) {
-            String viewColumn = columnMapping.getKey();
-            TableColumn originalBaseColumn = columnMapping.getValue();
-
-            Map<SchemaTableName, String> fullBaseColumns = new HashMap<>();
-
-            mappedBaseColumns.forEach(mappedBaseColumnPair -> {
-                if (originalBaseColumn.equals(mappedBaseColumnPair.get(0))) {
-                    fullBaseColumns.put(mappedBaseColumnPair.get(1).getTableName(), mappedBaseColumnPair.get(1).getColumnName());
-                }
-                else if (originalBaseColumn.equals(mappedBaseColumnPair.get(1))) {
-                    fullBaseColumns.put(mappedBaseColumnPair.get(0).getTableName(), mappedBaseColumnPair.get(0).getColumnName());
-                }
-            });
-
-            fullBaseColumns.put(originalBaseColumn.getTableName(), originalBaseColumn.getColumnName());
-
-            fullColumnMappings.put(viewColumn, ImmutableMap.copyOf(fullBaseColumns));
-        }
-
-        return fullColumnMappings.build();
-    }
 
     public static Session buildOwnerSession(Session session, Optional<String> owner, SessionPropertyManager sessionPropertyManager, String catalog, String schema)
     {
@@ -185,12 +132,25 @@ public class MaterializedViewUtils
         return baseTables.stream().collect(toImmutableMap(table -> table, table -> BooleanLiteral.FALSE_LITERAL));
     }
 
-    private static Map<String, TableColumn> getOriginalColumnsFromAnalysis(Node viewQuery, Analysis analysis)
+    // Returns transitive closure of a graph by performing depth first search from each node
+    public static <T> Map<T, Set<T>> transitiveClosure(Map<T, Set<T>> graph)
     {
-        return analysis.getOutputDescriptor(viewQuery).getVisibleFields().stream()
-                .filter(field -> field.getOriginTable().isPresent() && field.getOriginColumnName().isPresent())
-                .collect(toImmutableMap(
-                        field -> field.getName().get(),
-                        field -> new TableColumn(toSchemaTableName(field.getOriginTable().get()), field.getOriginColumnName().get())));
+        ImmutableMap.Builder<T, Set<T>> closure = ImmutableMap.builder();
+        for (T node : graph.keySet()) {
+            // Do depth first search for each node to find its connected component
+            Set<T> visited = new HashSet<>();
+            Stack<T> stack = new Stack<>();
+            stack.push(node);
+            while (!stack.empty()) {
+                T current = stack.pop();
+                if (visited.contains(current)) {
+                    continue;
+                }
+                visited.add(current);
+                graph.getOrDefault(current, ImmutableSet.of()).forEach(neighbor -> stack.push(neighbor));
+            }
+            closure.put(node, visited);
+        }
+        return closure.build();
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewColumnMappingExtractor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewColumnMappingExtractor.java
@@ -13,56 +13,123 @@
  */
 package com.facebook.presto.sql.analyzer;
 
+import com.facebook.presto.Session;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.sql.tree.ComparisonExpression;
 import com.facebook.presto.sql.tree.CreateMaterializedView;
 import com.facebook.presto.sql.tree.Query;
 import com.facebook.presto.sql.tree.SetOperation;
-import com.google.common.collect.ImmutableList;
+import com.facebook.presto.sql.tree.Table;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
+import static com.facebook.presto.metadata.MetadataUtil.createQualifiedObjectName;
 import static com.facebook.presto.metadata.MetadataUtil.toSchemaTableName;
 import static com.facebook.presto.spi.ConnectorMaterializedViewDefinition.TableColumn;
+import static com.facebook.presto.sql.MaterializedViewUtils.transitiveClosure;
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.NOT_SUPPORTED;
+import static com.facebook.presto.sql.tree.Join.Type.INNER;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static java.util.Objects.requireNonNull;
 
 public class MaterializedViewColumnMappingExtractor
         extends MaterializedViewPlanValidator
 {
     private final Analysis analysis;
-
-    private ImmutableList.Builder<List<TableColumn>> mappedBaseColumns;
-
-    private MaterializedViewColumnMappingExtractor(Analysis analysis)
-    {
-        this.analysis = requireNonNull(analysis, "analysis is null");
-
-        this.mappedBaseColumns = ImmutableList.builder();
-    }
+    private final Session session;
 
     /**
-     * Call MaterializedViewColumnMappingExtractor to traverse the materialized view query,
-     * and return possible pairs of the base table columns that are mapped by join criteria,
-     * union, intersect, etc.
+     * We create a undirected graph where each node corresponds to a base table column.
+     * Edges represent mapping by JOIN criteria, UNION, INTERSECT etc.
      * <p>
      * For example, given SELECT column_a AS column_x FROM table_a JOIN table_b ON (table_a.column_a = table_b.column_b),
-     * one possible pair of mapped base table columns is (table_a.column_a, table_b.column_b).
+     * (table_a.column_a, table_b.column_b) is an edge in the graph.
+     * </p>
      */
-    public static List<List<TableColumn>> extractMappedBaseColumns(Analysis analysis)
+    private Map<TableColumn, Set<TableColumn>> mappedBaseColumns;
+
+    /**
+     * Similar to `mappedBaseColumns`, but ignores EQ clauses from outer joins.
+     * <p>
+     * For example, given SELECT column_a FROM table_a LEFT JOIN table_b ON (table_a.column_a = table_b.column_b),
+     * produces no mappings.
+     * </p>
+     */
+    private Map<TableColumn, Set<TableColumn>> directMappedBaseColumns;
+
+    /**
+     * We create a list of tables where all columns can possibly become null,
+     * rather than being 1-1 mapped to MV outputs. This implies that these tables
+     * are on the outer side of a join.
+     * <p>
+     * For example, A LEFT JOIN (B LEFT JOIN C) has [B, C] as base tables
+     * on the outer join side
+     * </p>
+     */
+    private List<SchemaTableName> baseTablesOnOuterJoinSide;
+
+    public MaterializedViewColumnMappingExtractor(Analysis analysis, Session session)
     {
+        this.analysis = requireNonNull(analysis, "analysis is null");
+        this.session = requireNonNull(session, "session is null");
+        this.mappedBaseColumns = new HashMap<>();
+        this.directMappedBaseColumns = new HashMap<>();
+        this.baseTablesOnOuterJoinSide = new ArrayList<>();
+
         checkState(
                 analysis.getStatement() instanceof CreateMaterializedView,
                 "Only support extracting of mapped columns from create materialized view query");
 
-        MaterializedViewColumnMappingExtractor extractor = new MaterializedViewColumnMappingExtractor(analysis);
         Query viewQuery = ((CreateMaterializedView) analysis.getStatement()).getQuery();
-        extractor.process(viewQuery, new MaterializedViewPlanValidatorContext());
+        process(viewQuery, new MaterializedViewPlanValidatorContext());
+        this.mappedBaseColumns = transitiveClosure(mappedBaseColumns);
+        this.directMappedBaseColumns = transitiveClosure(directMappedBaseColumns);
+    }
 
-        return extractor.getMappedBaseColumns();
+    /**
+     * Compute the 1-to-N column mapping from a materialized view to its base tables.
+     * <p>
+     * From {@code analysis}, we could derive only one base table column that one materialized view column maps to.
+     * In case of 1 materialized view defined on N base tables via join, union, etc, this method helps compute
+     * all the N base table columns that one materialized view column maps to.
+     * <p>
+     * For example, given SELECT column_a AS column_x FROM table_a JOIN table_b ON (table_a.column_a = table_b.column_b),
+     * the 1-to-1 column mapping from {@code analysis} is column_x -> table_a.column_a. Mapped base table columns are
+     * [table_a.column_a, table_b.column_b]. Then it will return a 1-to-N column mapping column_x -> {table_a -> column_a, table_b -> column_b}.
+     */
+    public Map<String, Map<SchemaTableName, String>> getMaterializedViewColumnMappings()
+    {
+        return getColumnMappings(analysis, mappedBaseColumns);
+    }
+
+    /**
+     * Similar to getMaterializedViewColumnMappings, but only includes direct column mappings. It excludes columns mappings
+     * derived from outer join EQ clauses.
+     * <p>
+     * For example, given SELECT t1_a as t1.a, t2_a as t2.a FROM t1 LEFT JOIN t2 ON t1.a = t2.a
+     * Column mappings are:
+     * t1_a -> {t1 -> t1.a}
+     * t2_a -> {t2 -> t2.a}
+     */
+    public Map<String, Map<SchemaTableName, String>> getMaterializedViewDirectColumnMappings()
+    {
+        return getColumnMappings(analysis, directMappedBaseColumns);
+    }
+
+    public List<SchemaTableName> getBaseTablesOnOuterJoinSide()
+    {
+        return Collections.unmodifiableList(baseTablesOnOuterJoinSide);
     }
 
     @Override
@@ -77,15 +144,29 @@ public class MaterializedViewColumnMappingExtractor
         int numRelations = outputDescriptorList.size();
         int numFields = outputDescriptorList.get(0).getVisibleFieldCount();
         for (int fieldIndex = 0; fieldIndex < numFields; fieldIndex++) {
-            for (int firstRelationIndex = 0; firstRelationIndex < numRelations; firstRelationIndex++) {
+            for (int firstRelationIndex = 1; firstRelationIndex < numRelations; firstRelationIndex++) {
                 Optional<TableColumn> firstBaseColumn = tryGetOriginalTableColumn(outputDescriptorList.get(firstRelationIndex).getFieldByIndex(fieldIndex));
-                for (int secondRelationIndex = firstRelationIndex + 1; secondRelationIndex < numRelations; secondRelationIndex++) {
-                    Optional<TableColumn> secondBaseColumn = tryGetOriginalTableColumn(outputDescriptorList.get(secondRelationIndex).getFieldByIndex(fieldIndex));
-                    if (firstBaseColumn.isPresent() && secondBaseColumn.isPresent() && !firstBaseColumn.get().equals(secondBaseColumn.get())) {
-                        mappedBaseColumns.add(ImmutableList.of(firstBaseColumn.get(), secondBaseColumn.get()));
-                    }
+                Optional<TableColumn> secondBaseColumn = tryGetOriginalTableColumn(outputDescriptorList.get(firstRelationIndex - 1).getFieldByIndex(fieldIndex));
+                if (firstBaseColumn.isPresent() && secondBaseColumn.isPresent()) {
+                    mappedBaseColumns.computeIfAbsent(firstBaseColumn.get(), k -> new HashSet<>()).add(secondBaseColumn.get());
+                    mappedBaseColumns.computeIfAbsent(secondBaseColumn.get(), k -> new HashSet<>()).add(firstBaseColumn.get());
+
+                    directMappedBaseColumns.computeIfAbsent(firstBaseColumn.get(), k -> new HashSet<>()).add(secondBaseColumn.get());
+                    directMappedBaseColumns.computeIfAbsent(secondBaseColumn.get(), k -> new HashSet<>()).add(firstBaseColumn.get());
                 }
             }
+        }
+
+        return null;
+    }
+
+    @Override
+    protected Void visitTable(Table node, MaterializedViewPlanValidatorContext context)
+    {
+        super.visitTable(node, context);
+
+        if (context.isWithinOuterJoin()) {
+            baseTablesOnOuterJoinSide.add(toSchemaTableName(createQualifiedObjectName(session, node, node.getName())));
         }
 
         return null;
@@ -99,6 +180,8 @@ public class MaterializedViewColumnMappingExtractor
         if (!context.isWithinJoinOn()) {
             return null;
         }
+
+        // We assume only EQ comparisons, which is verified by MaterializedViewPlanValidator
 
         Field left = analysis.getScope(context.getTopJoinNode()).tryResolveField(node.getLeft())
                 .orElseThrow(() -> new SemanticException(
@@ -115,11 +198,53 @@ public class MaterializedViewColumnMappingExtractor
 
         Optional<TableColumn> leftBaseColumn = tryGetOriginalTableColumn(left);
         Optional<TableColumn> rightBaseColumn = tryGetOriginalTableColumn(right);
-        if (leftBaseColumn.isPresent() && rightBaseColumn.isPresent() && !leftBaseColumn.get().equals(rightBaseColumn.get())) {
-            mappedBaseColumns.add(ImmutableList.of(leftBaseColumn.get(), rightBaseColumn.get()));
+        if (leftBaseColumn.isPresent() && rightBaseColumn.isPresent()) {
+            mappedBaseColumns.computeIfAbsent(leftBaseColumn.get(), k -> new HashSet<>()).add(rightBaseColumn.get());
+            mappedBaseColumns.computeIfAbsent(rightBaseColumn.get(), k -> new HashSet<>()).add(leftBaseColumn.get());
+
+            if (context.getTopJoinNode().getType().equals(INNER)) {
+                directMappedBaseColumns.computeIfAbsent(leftBaseColumn.get(), k -> new HashSet<>()).add(rightBaseColumn.get());
+                directMappedBaseColumns.computeIfAbsent(rightBaseColumn.get(), k -> new HashSet<>()).add(leftBaseColumn.get());
+            }
         }
 
         return null;
+    }
+
+    private static Map<String, TableColumn> getOriginalColumnsFromAnalysis(Analysis analysis)
+    {
+        Query viewQuery = ((CreateMaterializedView) analysis.getStatement()).getQuery();
+
+        return analysis.getOutputDescriptor(viewQuery).getVisibleFields().stream()
+                .filter(field -> field.getOriginTable().isPresent() && field.getOriginColumnName().isPresent())
+                .collect(toImmutableMap(
+                        field -> field.getName().get(),
+                        field -> new TableColumn(toSchemaTableName(field.getOriginTable().get()), field.getOriginColumnName().get(), true)));
+    }
+
+    private static Map<String, Map<SchemaTableName, String>> getColumnMappings(Analysis analysis, Map<TableColumn, Set<TableColumn>> columnMappings)
+    {
+        checkState(
+                analysis.getStatement() instanceof CreateMaterializedView,
+                "Only support the computation of column mappings when analyzing CreateMaterializedView");
+
+        ImmutableMap.Builder<String, Map<SchemaTableName, String>> fullColumnMappings = ImmutableMap.builder();
+
+        Map<String, TableColumn> originalColumnMappings = getOriginalColumnsFromAnalysis(analysis);
+
+        for (Map.Entry<String, TableColumn> columnMapping : originalColumnMappings.entrySet()) {
+            String viewColumn = columnMapping.getKey();
+            TableColumn originalBaseColumn = columnMapping.getValue();
+
+            Map<SchemaTableName, String> fullBaseColumns =
+                    columnMappings.getOrDefault(originalBaseColumn, ImmutableSet.of(originalBaseColumn))
+                            .stream()
+                            .collect(toImmutableMap(e -> e.getTableName(), e -> e.getColumnName()));
+
+            fullColumnMappings.put(viewColumn, fullBaseColumns);
+        }
+
+        return fullColumnMappings.build();
     }
 
     private static Optional<TableColumn> tryGetOriginalTableColumn(Field field)
@@ -127,13 +252,8 @@ public class MaterializedViewColumnMappingExtractor
         if (field.getOriginTable().isPresent() && field.getOriginColumnName().isPresent()) {
             SchemaTableName table = toSchemaTableName(field.getOriginTable().get());
             String column = field.getOriginColumnName().get();
-            return Optional.of(new TableColumn(table, column));
+            return Optional.of(new TableColumn(table, column, true));
         }
         return Optional.empty();
-    }
-
-    private List<List<TableColumn>> getMappedBaseColumns()
-    {
-        return mappedBaseColumns.build();
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewPlanValidator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewPlanValidator.java
@@ -22,11 +22,15 @@ import com.facebook.presto.sql.tree.JoinOn;
 import com.facebook.presto.sql.tree.LogicalBinaryExpression;
 import com.facebook.presto.sql.tree.Query;
 import com.facebook.presto.sql.tree.SubqueryExpression;
+import com.facebook.presto.sql.tree.Table;
 import com.facebook.presto.sql.tree.Unnest;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 
 import static com.facebook.presto.sql.analyzer.SemanticErrorCode.NOT_SUPPORTED;
 
@@ -43,6 +47,20 @@ public class MaterializedViewPlanValidator
     }
 
     @Override
+    protected Void visitTable(Table node, MaterializedViewPlanValidatorContext context)
+    {
+        // Materialized View Definition does not support have multiple instances of same table. We have this assumption throughout our codebase as we use it
+        // for keys in several maps. For e.g. Partition mapping logic would need to be rewritten by considering partitions from each instance
+        // of base table separately. We will need to use (table name + node location) as an identifier in all such places. For now, we just
+        // forbid it.
+        if (!context.addTable(node)) {
+            throw new SemanticException(NOT_SUPPORTED, node, "Materialized View definition does not support multiple instances of same table");
+        }
+
+        return super.visitTable(node, context);
+    }
+
+    @Override
     protected Void visitJoin(Join node, MaterializedViewPlanValidatorContext context)
     {
         context.pushJoinNode(node);
@@ -51,13 +69,14 @@ public class MaterializedViewPlanValidator
             throw new SemanticException(NOT_SUPPORTED, node, "More than one join in materialized view is not supported yet.");
         }
 
+        JoinCriteria joinCriteria;
         switch (node.getType()) {
             case INNER:
                 if (!node.getCriteria().isPresent()) {
                     throw new SemanticException(NOT_SUPPORTED, node, "Inner join with no criteria is not supported for materialized view.");
                 }
 
-                JoinCriteria joinCriteria = node.getCriteria().get();
+                joinCriteria = node.getCriteria().get();
                 if (!(joinCriteria instanceof JoinOn)) {
                     throw new SemanticException(NOT_SUPPORTED, node, "Only join-on is supported for materialized view.");
                 }
@@ -83,8 +102,33 @@ public class MaterializedViewPlanValidator
 
                 break;
 
+            case LEFT:
+                if (!node.getCriteria().isPresent()) {
+                    throw new SemanticException(NOT_SUPPORTED, node, "Outer join with no criteria is not supported for materialized view.");
+                }
+
+                joinCriteria = node.getCriteria().get();
+                if (!(joinCriteria instanceof JoinOn)) {
+                    throw new SemanticException(NOT_SUPPORTED, node, "Only join-on is supported for materialized view.");
+                }
+
+                process(node.getLeft(), context);
+
+                boolean wasWithinOuterJoin = context.isWithinOuterJoin();
+                context.setWithinOuterJoin(true);
+                process(node.getRight(), context);
+                // withinOuterJoin denotes if we are within an outer side of a join. Because it can be nested, replace it with its older value.
+                // So we set it to false, only when we leave the topmost outer join.
+                context.setWithinOuterJoin(wasWithinOuterJoin);
+
+                context.setWithinJoinOn(true);
+                process(((JoinOn) joinCriteria).getExpression(), context);
+                context.setWithinJoinOn(false);
+
+                break;
+
             default:
-                throw new SemanticException(NOT_SUPPORTED, node, "Only inner join and cross join unnested are supported for materialized view.");
+                throw new SemanticException(NOT_SUPPORTED, node, "Only inner join, left join and cross join unnested are supported for materialized view.");
         }
 
         context.popJoinNode();
@@ -125,11 +169,15 @@ public class MaterializedViewPlanValidator
     {
         private boolean isWithinJoinOn;
         private final LinkedList<Join> joinNodeStack;
+        private boolean isWithinOuterJoin;
+        private final HashSet<Table> tables;
 
         public MaterializedViewPlanValidatorContext()
         {
             isWithinJoinOn = false;
             joinNodeStack = new LinkedList<>();
+            isWithinOuterJoin = false;
+            tables = new HashSet<>();
         }
 
         public boolean isWithinJoinOn()
@@ -140,6 +188,16 @@ public class MaterializedViewPlanValidator
         public void setWithinJoinOn(boolean withinJoinOn)
         {
             isWithinJoinOn = withinJoinOn;
+        }
+
+        public boolean isWithinOuterJoin()
+        {
+            return isWithinOuterJoin;
+        }
+
+        public void setWithinOuterJoin(boolean withinOuterJoin)
+        {
+            isWithinOuterJoin = withinOuterJoin;
         }
 
         public void pushJoinNode(Join join)
@@ -160,6 +218,16 @@ public class MaterializedViewPlanValidator
         public List<Join> getJoinNodes()
         {
             return ImmutableList.copyOf(joinNodeStack);
+        }
+
+        public boolean addTable(Table table)
+        {
+            return tables.add(table);
+        }
+
+        public Set<Table> getTables()
+        {
+            return ImmutableSet.copyOf(tables);
         }
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorMaterializedViewDefinition.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorMaterializedViewDefinition.java
@@ -35,6 +35,7 @@ public final class ConnectorMaterializedViewDefinition
     private final List<SchemaTableName> baseTables;
     private final Optional<String> owner;
     private final List<ColumnMapping> columnMappings;
+    private final List<SchemaTableName> baseTablesOnOuterJoinSide;
     private final Optional<List<String>> validRefreshColumns;
 
     @JsonCreator
@@ -45,6 +46,7 @@ public final class ConnectorMaterializedViewDefinition
             @JsonProperty("baseTables") List<SchemaTableName> baseTables,
             @JsonProperty("owner") Optional<String> owner,
             @JsonProperty("columnMapping") List<ColumnMapping> columnMappings,
+            @JsonProperty("baseTablesOnOuterJoinSide") List<SchemaTableName> baseTablesOnOuterJoinSide,
             @JsonProperty("validRefreshColumns") Optional<List<String>> validRefreshColumns)
     {
         this.originalSql = requireNonNull(originalSql, "originalSql is null");
@@ -53,6 +55,7 @@ public final class ConnectorMaterializedViewDefinition
         this.baseTables = unmodifiableList(new ArrayList<>(requireNonNull(baseTables, "baseTables is null")));
         this.owner = requireNonNull(owner, "owner is null");
         this.columnMappings = unmodifiableList(new ArrayList<>(requireNonNull(columnMappings, "columnMappings is null")));
+        this.baseTablesOnOuterJoinSide = unmodifiableList(new ArrayList<>(requireNonNull(baseTablesOnOuterJoinSide, "baseTablesOnOuterJoinSide is null")));
         this.validRefreshColumns = requireNonNull(validRefreshColumns, "validRefreshColumns is null").map(columns -> unmodifiableList(new ArrayList<>(columns)));
     }
 
@@ -64,6 +67,8 @@ public final class ConnectorMaterializedViewDefinition
             List<SchemaTableName> baseTables,
             Optional<String> owner,
             Map<String, Map<SchemaTableName, String>> originalColumnMapping,
+            Map<String, Map<SchemaTableName, String>> nonNullColumnMappings,
+            List<SchemaTableName> baseTablesOnOuterJoinSide,
             Optional<List<String>> validRefreshColumns)
     {
         this(
@@ -72,7 +77,11 @@ public final class ConnectorMaterializedViewDefinition
                 table,
                 baseTables,
                 owner,
-                convertFromMapToColumnMappings(requireNonNull(originalColumnMapping, "originalColumnMapping is null"), new SchemaTableName(schema, table)),
+                convertFromMapToColumnMappings(
+                        requireNonNull(originalColumnMapping, "originalColumnMapping is null"),
+                        requireNonNull(nonNullColumnMappings, "nonNullColumnMappings is null"),
+                        new SchemaTableName(schema, table)),
+                baseTablesOnOuterJoinSide,
                 validRefreshColumns);
     }
 
@@ -113,6 +122,12 @@ public final class ConnectorMaterializedViewDefinition
     }
 
     @JsonProperty
+    public List<SchemaTableName> getBaseTablesOnOuterJoinSide()
+    {
+        return baseTablesOnOuterJoinSide;
+    }
+
+    @JsonProperty
     public Optional<List<String>> getValidRefreshColumns()
     {
         return validRefreshColumns;
@@ -128,6 +143,7 @@ public final class ConnectorMaterializedViewDefinition
         sb.append(",baseTables=").append(baseTables);
         sb.append(",owner=").append(owner.orElse(null));
         sb.append(",columnMappings=").append(columnMappings);
+        sb.append(",baseTablesOnOuterJoinSide=").append(baseTablesOnOuterJoinSide);
         sb.append(",validRefreshColumns=").append(validRefreshColumns.orElse(null));
         sb.append("}");
         return sb.toString();
@@ -143,16 +159,28 @@ public final class ConnectorMaterializedViewDefinition
     }
 
     @JsonIgnore
-    private static List<ColumnMapping> convertFromMapToColumnMappings(Map<String, Map<SchemaTableName, String>> originalColumnMappings, SchemaTableName sourceTable)
+    public Map<String, Map<SchemaTableName, String>> getDirectColumnMappingsAsMap()
+    {
+        return columnMappings.stream()
+                .collect(toMap(
+                        mapping -> mapping.getViewColumn().getColumnName(),
+                        mapping -> mapping.getBaseTableColumns().stream().filter(col -> col.isDirectMapped().orElse(true)).collect(toMap(TableColumn::getTableName, TableColumn::getColumnName))));
+    }
+
+    @JsonIgnore
+    private static List<ColumnMapping> convertFromMapToColumnMappings(Map<String, Map<SchemaTableName, String>> originalColumnMappings, Map<String, Map<SchemaTableName, String>> directColumnMappings, SchemaTableName sourceTable)
     {
         List<ColumnMapping> columnMappingList = new ArrayList<>();
 
         for (String sourceColumn : originalColumnMappings.keySet()) {
-            TableColumn viewColumn = new TableColumn(sourceTable, sourceColumn);
+            TableColumn viewColumn = new TableColumn(sourceTable, sourceColumn, true);
+            Map<SchemaTableName, String> directMappings = directColumnMappings.get(sourceColumn);
 
             List<TableColumn> baseTableColumns = new ArrayList<>();
             for (SchemaTableName baseTable : originalColumnMappings.get(sourceColumn).keySet()) {
-                baseTableColumns.add(new TableColumn(baseTable, originalColumnMappings.get(sourceColumn).get(baseTable)));
+                String column = originalColumnMappings.get(sourceColumn).get(baseTable);
+                boolean isDirectMapped = directMappings != null && (directMappings.containsKey(baseTable) && directMappings.get(baseTable) == column);
+                baseTableColumns.add(new TableColumn(baseTable, column, isDirectMapped));
             }
 
             columnMappingList.add(new ColumnMapping(viewColumn, unmodifiableList(baseTableColumns)));
@@ -202,14 +230,32 @@ public final class ConnectorMaterializedViewDefinition
     {
         private final SchemaTableName tableName;
         private final String columnName;
+        // This signifies whether the mapping is direct or not.
+        // Mapping is always direct in inner join case. In the outer join case, only the mapping from a column to its source column in the join input table is direct.
+        // For e.g. in case of SELECT t1_a as t1.a, t2_a as t2.a FROM t1 LEFT JOIN t2 ON t1.a = t2.a
+        // t1_a -> t1.a is direct mapped
+        // t1_a -> t2.a is NOT direct mapped(as t1,t2 are in outer join)
+        // t2_a -> t2.a is direct mapped(value can become null but column mapping is not altered)
+        // t2_a -> t1.a is NOT direct mapped(as t1,t2 are in outer join)
+        private final Optional<Boolean> isDirectMapped;
 
         @JsonCreator
         public TableColumn(
                 @JsonProperty("tableName") SchemaTableName tableName,
-                @JsonProperty("columnName") String columnName)
+                @JsonProperty("columnName") String columnName,
+                @JsonProperty("isDirectMapped") Optional<Boolean> isDirectMapped)
         {
             this.tableName = requireNonNull(tableName, "tableName is null");
             this.columnName = requireNonNull(columnName, "columnName is null");
+            this.isDirectMapped = requireNonNull(isDirectMapped, "isDirectMapped is null");
+        }
+
+        public TableColumn(
+                SchemaTableName tableName,
+                String columnName,
+                boolean isDirectMapped)
+        {
+            this(tableName, columnName, Optional.of(isDirectMapped));
         }
 
         @JsonProperty
@@ -222,6 +268,12 @@ public final class ConnectorMaterializedViewDefinition
         public String getColumnName()
         {
             return columnName;
+        }
+
+        @JsonProperty
+        public Optional<Boolean> isDirectMapped()
+        {
+            return isDirectMapped;
         }
 
         @Override
@@ -242,13 +294,14 @@ public final class ConnectorMaterializedViewDefinition
 
             TableColumn that = (TableColumn) o;
             return Objects.equals(this.columnName, that.columnName) &&
-                    Objects.equals(this.tableName, that.tableName);
+                    Objects.equals(this.tableName, that.tableName) &&
+                    Objects.equals(this.isDirectMapped, that.isDirectMapped);
         }
 
         @Override
         public String toString()
         {
-            return tableName + ":" + columnName;
+            return tableName + ":" + columnName + (isDirectMapped.orElse(true) ? "" : "isDirectMapped:false");
         }
     }
 }


### PR DESCRIPTION
Test plan - Added tests

This PR allows creating left outer joins as MV. Here are some comments on overall changes:

1) Rewrite materialized view column mapping extractor. Earlier version does not work well on queries using mix of unions/joins. Added new approach which computes transitive closure to get all column mappings between view and base table.

2) We extend column mappings to include a "nullable" field. This signifies that a column may not be mapped completely to view table, but can also become null(as in outer joins).

3) Our column mapping logic(before and after this PR) does not work when same table is present multiple times. So, we now forbid it.

3) For t1 left join t2, we require MV to have 2 partitions, t1.ds and t2.ds. Only t1.ds is sufficient for left joins, but this implementation makes it simpler to extend this for full outer joins. In future, we can treat one sided joins as a special case and allow having only t1.ds as a partition. 

```
== NO RELEASE NOTE ==
```
