### PR TITLE
Making resource group service cache configurable

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/resourcemanager/ResourceManagerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/resourcemanager/ResourceManagerConfig.java
@@ -37,6 +37,7 @@ public class ResourceManagerConfig
     private int resourceManagerExecutorThreads = 1000;
     private Duration proxyAsyncTimeout = new Duration(60, SECONDS);
     private Duration memoryPoolFetchInterval = new Duration(1, SECONDS);
+    private boolean resourceGroupServiceCacheEnabled;
     private Duration resourceGroupServiceCacheExpireInterval = new Duration(10, SECONDS);
     private Duration resourceGroupServiceCacheRefreshInterval = new Duration(1, SECONDS);
 
@@ -198,6 +199,19 @@ public class ResourceManagerConfig
         return this;
     }
 
+    public boolean getResourceGroupServiceCacheEnabled()
+    {
+        return resourceGroupServiceCacheEnabled;
+    }
+
+    @Config("resource-manager.resource-group-service-cache-enabled")
+    public ResourceManagerConfig setResourceGroupServiceCacheEnabled(Boolean resourceGroupServiceCacheEnabled)
+    {
+        this.resourceGroupServiceCacheEnabled = resourceGroupServiceCacheEnabled;
+        return this;
+    }
+
+    @MinDuration("1ms")
     public Duration getResourceGroupServiceCacheExpireInterval()
     {
         return resourceGroupServiceCacheExpireInterval;

--- a/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerConfig.java
@@ -44,6 +44,7 @@ public class TestResourceManagerConfig
                 .setQueryHeartbeatInterval(new Duration(1, SECONDS))
                 .setProxyAsyncTimeout(new Duration(60, SECONDS))
                 .setMemoryPoolFetchInterval(new Duration(1, SECONDS))
+                .setResourceGroupServiceCacheEnabled(false)
                 .setResourceGroupServiceCacheExpireInterval(new Duration(10, SECONDS))
                 .setResourceGroupServiceCacheRefreshInterval(new Duration(1, SECONDS)));
     }
@@ -64,6 +65,7 @@ public class TestResourceManagerConfig
                 .put("resource-manager.query-heartbeat-interval", "75m")
                 .put("resource-manager.proxy-async-timeout", "345m")
                 .put("resource-manager.memory-pool-fetch-interval", "6m")
+                .put("resource-manager.resource-group-service-cache-enabled", "true")
                 .put("resource-manager.resource-group-service-cache-expire-interval", "1m")
                 .put("resource-manager.resource-group-service-cache-refresh-interval", "10m")
                 .build();
@@ -81,6 +83,7 @@ public class TestResourceManagerConfig
                 .setQueryHeartbeatInterval(new Duration(75, MINUTES))
                 .setProxyAsyncTimeout(new Duration(345, MINUTES))
                 .setMemoryPoolFetchInterval(new Duration(6, MINUTES))
+                .setResourceGroupServiceCacheEnabled(true)
                 .setResourceGroupServiceCacheExpireInterval(new Duration(1, MINUTES))
                 .setResourceGroupServiceCacheRefreshInterval(new Duration(10, MINUTES));
 

--- a/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/TestDistributedQueuesDb.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/TestDistributedQueuesDb.java
@@ -59,8 +59,6 @@ public class TestDistributedQueuesDb
         coordinatorProperties.put("resource-manager.query-heartbeat-interval", "10ms");
         coordinatorProperties.put("resource-group-runtimeinfo-refresh-interval", "100ms");
         coordinatorProperties.put("concurrency-threshold-to-enable-resource-group-refresh", "0");
-        coordinatorProperties.put("resource-manager.resource-group-service-cache-expire-interval", "1s");
-        coordinatorProperties.put("resource-manager.resource-group-service-cache-refresh-interval", "10ms");
 
         queryRunner = createQueryRunner(dbConfigUrl, dao, coordinatorProperties.build(), 2);
     }


### PR DESCRIPTION
Due to resource group service cache, coordinator end up getting stale cluster resource group info.
This leads to run more than allowed queries in a cluster for disagg coordinator setup.
Making this cache configurable allow us to disable it to avoid such scenario.

Test plan - unit test and verifier run


```
== RELEASE NOTES ==

General Changes
* Making resource group service cache configurable

