### PR TITLE
Fix bug in listTableColumns

### DIFF
--- a/presto-base-jdbc/pom.xml
+++ b/presto-base-jdbc/pom.xml
@@ -106,6 +106,13 @@
         </dependency>
 
         <!-- for testing -->
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-testng-services</artifactId>

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcMetadata.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcMetadata.java
@@ -134,7 +134,7 @@ public class JdbcMetadata
             tables = ImmutableList.of(new SchemaTableName(prefix.getSchemaName(), prefix.getTableName()));
         }
         else {
-            tables = listTables(session, prefix.getSchemaName());
+            tables = listTables(session, Optional.of(prefix.getSchemaName()));
         }
         for (SchemaTableName tableName : tables) {
             try {


### PR DESCRIPTION
This commit fixes the bug where we fetch columns for a given schema that contains multiple tables

Refactoring done as a part of an old [PR](https://github.com/prestodb/presto/pull/13087/files#diff-4b88cc155f0dee89e6ed0a96085abfe79308bf316ce5d460f67b94a90620586aR110) forgot to update the call site. The default implementation for `listTables(ConnectorSession session, String schemaNameOrNull)` returns an emptyList.

Test plan - Added new unit tests that cover the method call.


```
== NO RELEASE NOTE ==
```
