### PR TITLE
Adding tracing instrumentations in codesites

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/HiveQueryRunner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/HiveQueryRunner.java
@@ -133,6 +133,8 @@ public final class HiveQueryRunner
         Map<String, String> systemProperties = ImmutableMap.<String, String>builder()
                 .put("task.writer-count", "2")
                 .put("task.partitioned-writer-count", "4")
+                .put("tracing.tracer-type", "simple")
+                .put("tracing.enable-distributed-tracing", "simple")
                 .putAll(extraProperties)
                 .build();
 

--- a/presto-main/src/main/java/com/facebook/presto/dispatcher/LocalDispatchQueryFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/dispatcher/LocalDispatchQueryFactory.java
@@ -29,6 +29,8 @@ import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.resourceGroups.QueryType;
 import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
 import com.facebook.presto.sql.tree.Statement;
+import com.facebook.presto.tracing.NoopTracerProvider;
+import com.facebook.presto.tracing.QueryStateTracingListener;
 import com.facebook.presto.transaction.TransactionManager;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
@@ -112,6 +114,7 @@ public class LocalDispatchQueryFactory
                 metadata,
                 warningCollector);
 
+        stateMachine.addStateChangeListener(new QueryStateTracingListener(stateMachine.getSession().getTracer().orElse(NoopTracerProvider.NOOP_TRACER)));
         queryMonitor.queryCreatedEvent(stateMachine.getBasicQueryInfo(Optional.empty()));
 
         ListenableFuture<QueryExecution> queryExecutionFuture = executor.submit(() -> {

--- a/presto-main/src/main/java/com/facebook/presto/server/protocol/Query.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/protocol/Query.java
@@ -39,6 +39,7 @@ import com.facebook.presto.spi.function.SqlInvokedFunction;
 import com.facebook.presto.spi.page.PagesSerde;
 import com.facebook.presto.spi.page.SerializedPage;
 import com.facebook.presto.spi.security.SelectedRole;
+import com.facebook.presto.spi.tracing.Tracer;
 import com.facebook.presto.transaction.TransactionId;
 import com.facebook.presto.transaction.TransactionInfo;
 import com.facebook.presto.transaction.TransactionManager;
@@ -178,7 +179,7 @@ class Query
 
         result.queryManager.addOutputInfoListener(result.getQueryId(), result::setQueryOutputInfo);
 
-        result.queryManager.addStateChangeListener(result.getQueryId(), state -> {
+        result.queryManager.addStateChangeListener(result.getQueryId(), (state) -> {
             if (state.isDone()) {
                 QueryInfo queryInfo = queryManager.getFullQueryInfo(result.getQueryId());
                 result.closeExchangeClientIfNecessary(queryInfo);
@@ -242,6 +243,13 @@ class Query
     public boolean isSlugValid(String slug)
     {
         return this.slug.equals(slug);
+    }
+
+    public Tracer getTracer()
+    {
+        Optional<Tracer> tracer = session.getTracer();
+        checkArgument(tracer.isPresent(), "tracer is not present");
+        return tracer.get();
     }
 
     public synchronized Optional<String> getSetCatalog()

--- a/presto-main/src/main/java/com/facebook/presto/server/protocol/QueuedStatementResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/protocol/QueuedStatementResource.java
@@ -22,12 +22,14 @@ import com.facebook.presto.dispatcher.DispatchInfo;
 import com.facebook.presto.dispatcher.DispatchManager;
 import com.facebook.presto.execution.ExecutionFailureInfo;
 import com.facebook.presto.execution.QueryState;
+import com.facebook.presto.metadata.SessionPropertyManager;
 import com.facebook.presto.server.HttpRequestSessionContext;
 import com.facebook.presto.server.ServerConfig;
 import com.facebook.presto.server.SessionContext;
 import com.facebook.presto.spi.ErrorCode;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.spi.tracing.TracerProvider;
 import com.facebook.presto.sql.parser.SqlParserOptions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -118,6 +120,8 @@ public class QueuedStatementResource
     private final boolean compressionEnabled;
 
     private final SqlParserOptions sqlParserOptions;
+    private final TracerProvider tracerProvider;
+    private final SessionPropertyManager sessionPropertyManager;     // We may need some system default session property values at early query stage even before session is created.
 
     @Inject
     public QueuedStatementResource(
@@ -125,7 +129,9 @@ public class QueuedStatementResource
             DispatchExecutor executor,
             LocalQueryProvider queryResultsProvider,
             SqlParserOptions sqlParserOptions,
-            ServerConfig serverConfig)
+            ServerConfig serverConfig,
+            TracerProvider tracerProvider,
+            SessionPropertyManager sessionPropertyManager)
     {
         this.dispatchManager = requireNonNull(dispatchManager, "dispatchManager is null");
         this.queryResultsProvider = queryResultsProvider;
@@ -134,6 +140,8 @@ public class QueuedStatementResource
 
         this.responseExecutor = requireNonNull(executor, "responseExecutor is null").getExecutor();
         this.timeoutExecutor = requireNonNull(executor, "timeoutExecutor is null").getScheduledExecutor();
+        this.tracerProvider = requireNonNull(tracerProvider, "tracerProvider is null");
+        this.sessionPropertyManager = sessionPropertyManager;
 
         queryPurger.scheduleWithFixedDelay(
                 () -> {
@@ -170,7 +178,13 @@ public class QueuedStatementResource
             throw badRequest(BAD_REQUEST, "SQL statement is empty");
         }
 
-        SessionContext sessionContext = new HttpRequestSessionContext(servletRequest, sqlParserOptions);
+        // TODO: For future cases we may want to start tracing from client. Then continuation of tracing
+        //       will be needed instead of creating a new trace here.
+        SessionContext sessionContext = new HttpRequestSessionContext(
+                servletRequest,
+                sqlParserOptions,
+                tracerProvider.getNewTracer(),
+                Optional.of(sessionPropertyManager));
         Query query = new Query(statement, sessionContext, dispatchManager, queryResultsProvider, 0);
         queries.put(query.getQueryId(), query);
 

--- a/presto-main/src/main/java/com/facebook/presto/tracing/QueryStateTracingListener.java
+++ b/presto-main/src/main/java/com/facebook/presto/tracing/QueryStateTracingListener.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tracing;
+
+import com.facebook.presto.execution.QueryState;
+import com.facebook.presto.execution.StateMachine;
+import com.facebook.presto.spi.tracing.Tracer;
+
+import static java.util.Objects.requireNonNull;
+
+public class QueryStateTracingListener
+        implements StateMachine.StateChangeListener<QueryState>
+{
+    private QueryState previousState;
+    private final Tracer tracer;
+
+    public QueryStateTracingListener(Tracer tracer)
+    {
+        this.tracer = requireNonNull(tracer, "tracer is null");
+    }
+
+    @Override
+    public synchronized void stateChanged(QueryState newState)
+    {
+        if (previousState == null) {
+            // Initial state condition
+            tracer.startBlock(newState.toString(), "");
+            previousState = newState;
+            return;
+        }
+
+        tracer.endBlock(previousState.toString(), "");
+        if (newState.isDone()) {
+            // Last state
+            previousState = newState;
+            tracer.endTrace("Query finished with state " + newState);
+            return;
+        }
+
+        tracer.startBlock(newState.toString(), "");
+        previousState = newState;
+    }
+}

--- a/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/TestQueuesDb.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/TestQueuesDb.java
@@ -151,6 +151,7 @@ public class TestQueuesDb
     public void testTwoQueriesAtSameTime()
             throws Exception
     {
+        dao.updateResourceGroup(5, "dashboard-${USER}", "1MB", 2, 1, 1, null, null, null, null, null, null, null, null, 3L, TEST_ENVIRONMENT);
         QueryId firstDashboardQuery = createQuery(queryRunner, dashboardSession(), LONG_LASTING_QUERY);
         QueryId secondDashboardQuery = createQuery(queryRunner, dashboardSession(), LONG_LASTING_QUERY);
         waitForQueryState(queryRunner, firstDashboardQuery, RUNNING);


### PR DESCRIPTION
Hooking up tracing logic with code sites. Tracing started on query post if both system and user enables the tracing.
```
== NO RELEASE NOTE ==
```
