### PR TITLE
Fix hive split loader to catch Error throwable

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/BackgroundHiveSplitLoader.java
@@ -120,7 +120,7 @@ public class BackgroundHiveSplitLoader
                 try {
                     future = loadSplits();
                 }
-                catch (Exception e) {
+                catch (Throwable e) {
                     if (e instanceof IOException) {
                         e = new PrestoException(HIVE_FILESYSTEM_ERROR, e);
                     }


### PR DESCRIPTION
`BackgroundHiveSplitLoader` only catches `Exception` during split loading. When an Error is throwed, the loader thread will dead without any callback to `HiveSplitSource`, which makes the query scheduler keep waiting for the split source till query timeout.

Test plan - 1) Added unit tests.

```
== RELEASE NOTES ==

Hive Changes
* Fix hive split loader to catch Error throwable
```
