### PR TITLE
[Bugfixing] [Pinot Connector] Mismatched columns between ProjectNode and AggregationNode output

### DIFF
--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotBrokerPageSourceSql.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotBrokerPageSourceSql.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.pinot;
 
+import com.facebook.presto.common.PageBuilder;
 import com.facebook.presto.common.block.BlockBuilder;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.pinot.query.PinotQueryGenerator.GeneratedPinotQuery;
@@ -22,6 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -37,16 +39,19 @@ public class PinotBrokerPageSourceSql
     private static final String QUERY_URL_TEMPLATE = "http://%s/query/sql";
 
     private final GeneratedPinotQuery brokerSql;
+    private final List<PinotColumnHandle> expectedHandles;
 
     public PinotBrokerPageSourceSql(
             PinotConfig pinotConfig,
             ConnectorSession session,
             GeneratedPinotQuery brokerSql,
             List<PinotColumnHandle> columnHandles,
+            List<PinotColumnHandle> expectedHandles,
             PinotClusterInfoFetcher clusterInfoFetcher,
             ObjectMapper objectMapper)
     {
         super(pinotConfig, session, columnHandles, clusterInfoFetcher, objectMapper);
+        this.expectedHandles = requireNonNull(expectedHandles, "expected handles is null");
         this.brokerSql = requireNonNull(brokerSql, "broker is null");
     }
 
@@ -127,10 +132,41 @@ public class PinotBrokerPageSourceSql
     public BlockAndTypeBuilder buildBlockAndTypeBuilder(List<PinotColumnHandle> columnHandles,
             GeneratedPinotQuery brokerSql)
     {
-        // SQL broker page source returns the columns in the order requested by Presto.
-        List<Type> columnTypes = columnHandles.stream()
+        // When we created the SQL, we came up with some column handles
+        // however other optimizers post-pushdown can come in and prune/re-order the required column handles
+        // so we need to map from the column handles the PQL corresponds to, to the actual column handles
+        // needed in the scan.
+
+        List<Type> expectedTypes = columnHandles.stream()
                 .map(PinotColumnHandle::getDataType)
                 .collect(Collectors.toList());
-        return new BlockAndTypeBuilder(columnTypes);
+        PageBuilder pageBuilder = new PageBuilder(expectedTypes);
+
+        // The expectedColumnHandles are the handles corresponding to the generated SQL
+        // However, the engine could end up requesting only a permutation/subset of those handles
+        // during the actual scan
+
+        // Map the handles from planning time to the handles asked in the scan
+        // so that we know which columns to discard.
+        int[] handleMapping = new int[expectedHandles.size()];
+        for (int i = 0; i < handleMapping.length; ++i) {
+            handleMapping[i] = columnHandles.indexOf(expectedHandles.get(i));
+        }
+
+        ArrayList<BlockBuilder> columnBlockBuilders = new ArrayList<>();
+        ArrayList<Type> columnTypes = new ArrayList<>();
+
+        for (int expectedColumnIndex : brokerSql.getExpectedColumnIndices()) {
+            // columnIndex is the index of this column in the current scan
+            // It is obtained from the mapping and can be -ve, which means that the
+            // expectedColumnIndex'th column returned by Pinot can be discarded.
+            int columnIndex = -1;
+            if (expectedColumnIndex >= 0) {
+                columnIndex = handleMapping[expectedColumnIndex];
+            }
+            columnBlockBuilders.add(columnIndex >= 0 ? pageBuilder.getBlockBuilder(columnIndex) : null);
+            columnTypes.add(columnIndex >= 0 ? expectedTypes.get(columnIndex) : null);
+        }
+        return new BlockAndTypeBuilder(pageBuilder, columnBlockBuilders, columnTypes);
     }
 }

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotPageSourceProvider.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotPageSourceProvider.java
@@ -108,6 +108,7 @@ public class PinotPageSourceProvider
                             session,
                             pinotSplit.getBrokerPinotQuery().get(),
                             handles,
+                            pinotSplit.getExpectedColumnHandles(),
                             clusterInfoFetcher,
                             objectMapper);
                     case PQL:

--- a/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotBrokerPageSourceSql.java
+++ b/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotBrokerPageSourceSql.java
@@ -178,6 +178,7 @@ public class TestPinotBrokerPageSourceSql
                                 false))),
                 generatedPinotQuery,
                 ImmutableList.of(),
+                ImmutableList.of(),
                 new MockPinotClusterInfoFetcher(pinotConfig),
                 objectMapper);
         assertEquals(pageSource.getRequestPayload(generatedPinotQuery), "{\"sql\":\"SELECT * FROM myTable\"}");
@@ -215,6 +216,7 @@ public class TestPinotBrokerPageSourceSql
                 pinotConfig,
                 new TestingConnectorSession(ImmutableList.of()),
                 generatedSql,
+                actualHandles,
                 actualHandles,
                 new MockPinotClusterInfoFetcher(pinotConfig),
                 objectMapper);


### PR DESCRIPTION
Fixing the issue that ProjectNode asked columns are different from what AggregationNode has pushed down.

Use expectedColumnHandler to make the mapping for BlockBuilder.

For query: `SELECT 'a' as a, count(*) FROM t GROUP BY a;`

The columnHandler from ProjectPlan is just `count`, but generated pinot query is `SELECT a, count(*) from t GROUP BY a` with 2 columns.

So it causes the expected column handle mismatch issue.

Test plan - (Please fill in how you tested your changes)
Unit test and local setup verification

== RELEASE NOTES ==

Pinot Changes
* Fix query crash when Pinot query returns mismatched schema.