### PR TITLE
Change ORC default layout to column size

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriterConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriterConfig.java
@@ -21,7 +21,7 @@ import io.airlift.units.DataSize;
 
 import javax.validation.constraints.NotNull;
 
-import static com.facebook.presto.hive.OrcFileWriterConfig.StreamLayoutType.BY_STREAM_SIZE;
+import static com.facebook.presto.hive.OrcFileWriterConfig.StreamLayoutType.BY_COLUMN_SIZE;
 
 @SuppressWarnings("unused")
 public class OrcFileWriterConfig
@@ -39,7 +39,7 @@ public class OrcFileWriterConfig
     private DataSize dictionaryMaxMemory = OrcWriterOptions.DEFAULT_DICTIONARY_MAX_MEMORY;
     private DataSize stringStatisticsLimit = OrcWriterOptions.DEFAULT_MAX_STRING_STATISTICS_LIMIT;
     private DataSize maxCompressionBufferSize = OrcWriterOptions.DEFAULT_MAX_COMPRESSION_BUFFER_SIZE;
-    private StreamLayoutType streamLayoutType = BY_STREAM_SIZE;
+    private StreamLayoutType streamLayoutType = BY_COLUMN_SIZE;
     private boolean isDwrfStripeCacheEnabled;
     private DataSize dwrfStripeCacheMaxSize = OrcWriterOptions.DEFAULT_DWRF_STRIPE_CACHE_MAX_SIZE;
     private DwrfStripeCacheMode dwrfStripeCacheMode = OrcWriterOptions.DEFAULT_DWRF_STRIPE_CACHE_MODE;

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestOrcFileWriterConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestOrcFileWriterConfig.java
@@ -54,7 +54,7 @@ public class TestOrcFileWriterConfig
                 .setDictionaryMaxMemory(new DataSize(16, MEGABYTE))
                 .setStringStatisticsLimit(new DataSize(64, BYTE))
                 .setMaxCompressionBufferSize(new DataSize(256, KILOBYTE))
-                .setStreamLayoutType(BY_STREAM_SIZE)
+                .setStreamLayoutType(BY_COLUMN_SIZE)
                 .setDwrfStripeCacheEnabled(false)
                 .setDwrfStripeCacheMaxSize(new DataSize(8, MEGABYTE))
                 .setDwrfStripeCacheMode(INDEX_AND_FOOTER));
@@ -71,7 +71,7 @@ public class TestOrcFileWriterConfig
                 .put("hive.orc.writer.dictionary-max-memory", "13MB")
                 .put("hive.orc.writer.string-statistics-limit", "17MB")
                 .put("hive.orc.writer.max-compression-buffer-size", "19MB")
-                .put("hive.orc.writer.stream-layout-type", "BY_COLUMN_SIZE")
+                .put("hive.orc.writer.stream-layout-type", "BY_STREAM_SIZE")
                 .put("hive.orc.writer.dwrf-stripe-cache-enabled", "true")
                 .put("hive.orc.writer.dwrf-stripe-cache-max-size", "10MB")
                 .put("hive.orc.writer.dwrf-stripe-cache-mode", "FOOTER")
@@ -85,7 +85,7 @@ public class TestOrcFileWriterConfig
                 .setDictionaryMaxMemory(new DataSize(13, MEGABYTE))
                 .setStringStatisticsLimit(new DataSize(17, MEGABYTE))
                 .setMaxCompressionBufferSize(new DataSize(19, MEGABYTE))
-                .setStreamLayoutType(BY_COLUMN_SIZE)
+                .setStreamLayoutType(BY_STREAM_SIZE)
                 .setDwrfStripeCacheEnabled(true)
                 .setDwrfStripeCacheMaxSize(new DataSize(10, MEGABYTE))
                 .setDwrfStripeCacheMode(FOOTER);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriterOptions.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriterOptions.java
@@ -13,7 +13,7 @@
  */
 package com.facebook.presto.orc;
 
-import com.facebook.presto.orc.StreamLayout.ByStreamSize;
+import com.facebook.presto.orc.StreamLayout.ByColumnSize;
 import com.facebook.presto.orc.metadata.DwrfStripeCacheMode;
 import io.airlift.units.DataSize;
 
@@ -244,7 +244,7 @@ public class OrcWriterOptions
         private DataSize maxStringStatisticsLimit = DEFAULT_MAX_STRING_STATISTICS_LIMIT;
         private DataSize maxCompressionBufferSize = DEFAULT_MAX_COMPRESSION_BUFFER_SIZE;
         private OptionalInt compressionLevel = OptionalInt.empty();
-        private StreamLayout streamLayout = new ByStreamSize();
+        private StreamLayout streamLayout = new ByColumnSize();
         private boolean integerDictionaryEncodingEnabled;
         private boolean stringDictionarySortingEnabled = true;
         private boolean dwrfStripeCacheEnabled;


### PR DESCRIPTION
Before this change, default ORC layout was to sort the streams by size.
Either all columns for a node are read or none is read. So grouping
all streams of a column together reduces the IO. This change switches
the default to column size.

Test plan - 
Existing tests. This change was enabled in validation cluster and working
for long time now.

```
== RELEASE NOTES ==

General Changes
* Switch the default value of config `hive.orc.writer.stream-layout-type` to `BY_COLUMN_SIZE` to improve IO efficiency.

```
