### PR TITLE
Fix AbstractArrayBlock#copyPositions with zero elements

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/block/AbstractArrayBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/AbstractArrayBlock.java
@@ -74,8 +74,8 @@ public abstract class AbstractArrayBlock
 
         int totalElements = newOffsets[length];
         if (totalElements == 0) {
-            // No elements selected
-            Block newValues = getRawElementBlock().copyRegion(getOffsetBase(), 0);
+            // No elements selected, copy a zero-length region from the elements block
+            Block newValues = getRawElementBlock().copyRegion(0, 0);
             return createArrayBlockInternal(0, length, newValueIsNull, newOffsets, newValues);
         }
 

--- a/presto-main/src/test/java/com/facebook/presto/block/TestArrayBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestArrayBlock.java
@@ -291,6 +291,7 @@ public class TestArrayBlock
         return size;
     }
 
+    @Test
     public void testCompactBlock()
     {
         Block emptyValueBlock = new ByteArrayBlock(0, Optional.empty(), new byte[0]);

--- a/presto-main/src/test/java/com/facebook/presto/block/TestArrayBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestArrayBlock.java
@@ -17,14 +17,17 @@ import com.facebook.presto.common.block.ArrayBlockBuilder;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockBuilder;
 import com.facebook.presto.common.block.ByteArrayBlock;
+import com.facebook.presto.common.type.ArrayType;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import org.testng.annotations.Test;
 
+import java.util.Arrays;
 import java.util.Optional;
 import java.util.Random;
 import java.util.stream.IntStream;
 
+import static com.facebook.presto.block.BlockAssertions.assertBlockEquals;
 import static com.facebook.presto.block.BlockAssertions.createLongDictionaryBlock;
 import static com.facebook.presto.block.BlockAssertions.createRLEBlock;
 import static com.facebook.presto.block.BlockAssertions.createRandomDictionaryBlock;
@@ -246,6 +249,32 @@ public class TestArrayBlock
         // Array(Dictionary(Array(LongArrayBlock)))
         Block arrayOfDictionaryOfArrayOfLong = fromElementBlock(positionCount, Optional.of(nulls), offsets, createRandomDictionaryBlock(arrayOfDictionaryOfLong, 100, true));
         assertEquals(arrayOfDictionaryOfArrayOfLong.getLogicalSizeInBytes(), 1900);
+    }
+
+    @Test
+    public void testCopyEmptyRawElementPositions()
+    {
+        int positionCount = 100;
+        int[] offsets = new int[positionCount + 1];
+        // Only the first array is non-empty
+        Arrays.fill(offsets, 1, offsets.length, 1);
+
+        // Array(LongArrayBlock(1)) - single element
+        Block elements = fromElementBlock(positionCount, Optional.empty(), offsets, createRandomLongsBlock(1, 0));
+        // Shift the array offsets index
+        Block offsetsShifted = elements.getRegion(50, 50);
+        assertEquals(offsetsShifted.getOffsetBase(), 50);
+        // Copy the first, middle, and last elements via copyPositions
+        Block copiedArray = offsetsShifted.copyPositions(new int[]{0, 25, 49}, 0, 3);
+        assertEquals(copiedArray.getPositionCount(), 3);
+
+        BlockBuilder blockBuilder = new ArrayBlockBuilder(BIGINT, null, 0, 0);
+        long[][] expectedValues = new long[3][];
+        for (int i = 0; i < expectedValues.length; i++) {
+            expectedValues[i] = new long[0]; // empty, but not null
+        }
+        writeValues(expectedValues, blockBuilder);
+        assertBlockEquals(new ArrayType(BIGINT), copiedArray, blockBuilder.build());
     }
 
     private static int getExpectedEstimatedDataSize(long[][] values)


### PR DESCRIPTION
Introduced in https://github.com/prestodb/presto/pull/16797, `AbstractArrayBlock#copyPositions` could potentially fail when no underlying element positions were selected (either because selected array positions were all null, all were empty arrays, or copyPositions itself was passed a length argument of 0). When that occurred, the raw element block would perform a copyRegion with a length of 0 but the starting offset of the _ArrayBlock_ offsets base, which might not be a valid position within the elements block. The fix is to call `copyRegion` on the elements block from position 0 of length 0, which is always valid.

Since the invalid offset argument was only passed when performing empty element copies, the bug only introduced the possibility of unexpected failures under specific conditions and not any potential for incorrect results.

Since the bug was never included in an official release, no release notes are required.
```
== NO RELEASE NOTE ==
```