### PR TITLE
Upgrade to alluxio 2.7.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <dep.nexus-staging-plugin.version>1.6.8</dep.nexus-staging-plugin.version>
         <dep.asm.version>9.0</dep.asm.version>
         <dep.gcs.version>1.9.17</dep.gcs.version>
-        <dep.alluxio.version>2.6.1</dep.alluxio.version>
+        <dep.alluxio.version>2.7.0</dep.alluxio.version>
         <dep.kafka.version>2.3.1</dep.kafka.version>
         <dep.druid.version>0.19.0</dep.druid.version>
         <dep.jaxb.version>2.3.1</dep.jaxb.version>


### PR DESCRIPTION
Upgrade alluxio to 2.7.0, we fixed the LRU bug in 2.7.0 which would improve the cache hit rate, especially in small cache size

```
== NO RELEASE NOTE ==
```
