### PR TITLE
Throw proper exception for lambda expression in GROUP BY

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
@@ -1380,10 +1380,6 @@ public class TestAnalyzer
                 MUST_BE_AGGREGATE_OR_GROUP_BY,
                 ".* must be an aggregate expression or appear in GROUP BY clause",
                 "SELECT apply(1, y -> x + y) FROM (VALUES (1,2)) t(x, y) GROUP BY x+y");
-        assertFails(
-                MUST_BE_AGGREGATE_OR_GROUP_BY,
-                ".* must be an aggregate expression or appear in GROUP BY clause",
-                "SELECT apply(1, x -> y + transform(array[1], z -> x)[1]) FROM (VALUES (1, 2)) t(x,y) GROUP BY y + transform(array[1], z -> x)[1]");
     }
 
     @Test

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Cube.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Cube.java
@@ -40,6 +40,7 @@ public final class Cube
     private Cube(Optional<NodeLocation> location, List<Expression> columns)
     {
         super(location);
+        validateExpressions(columns);
         this.columns = ImmutableList.copyOf(requireNonNull(columns, "columns is null"));
     }
 

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/GroupingElement.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/GroupingElement.java
@@ -31,4 +31,16 @@ public abstract class GroupingElement
     {
         return visitor.visitGroupingElement(this, context);
     }
+
+    void validateExpressions(List<Expression> expressions)
+    {
+        expressions.forEach(expression -> ExpressionTreeRewriter.rewriteWith(new ExpressionRewriter<Void>()
+        {
+            @Override
+            public Expression rewriteLambdaExpression(LambdaExpression node, Void context, ExpressionTreeRewriter<Void> treeRewriter)
+            {
+                throw new UnsupportedOperationException("GROUP BY does not support lambda expressions, please use GROUP BY # instead");
+            }
+        }, expression, null));
+    }
 }

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/GroupingSets.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/GroupingSets.java
@@ -45,6 +45,7 @@ public final class GroupingSets
         super(location);
         requireNonNull(sets, "sets is null");
         checkArgument(!sets.isEmpty(), "grouping sets cannot be empty");
+        sets.forEach(this::validateExpressions);
         this.sets = sets.stream().map(ImmutableList::copyOf).collect(toImmutableList());
     }
 

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Rollup.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Rollup.java
@@ -40,6 +40,7 @@ public final class Rollup
     private Rollup(Optional<NodeLocation> location, List<Expression> columns)
     {
         super(location);
+        validateExpressions(columns);
         this.columns = ImmutableList.copyOf(requireNonNull(columns, "columns is null"));
     }
 

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/SimpleGroupBy.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/SimpleGroupBy.java
@@ -40,6 +40,7 @@ public final class SimpleGroupBy
     private SimpleGroupBy(Optional<NodeLocation> location, List<Expression> simpleGroupByExpressions)
     {
         super(location);
+        validateExpressions(simpleGroupByExpressions);
         this.columns = ImmutableList.copyOf(requireNonNull(simpleGroupByExpressions, "simpleGroupByExpressions is null"));
     }
 

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -5888,4 +5888,15 @@ public abstract class AbstractTestQueries
         assertQuery(query, "select 60175");
         assertQuery(sessionWithKeyBasedSampling, query, "select 16185");
     }
+
+    @Test
+    public void testGroupByWithLambdaExpression()
+    {
+        assertQueryFails(
+                "SELECT reduce(a, 0, (s, x) -> x, s->s), count(*) FROM (VALUES (array[1]), (array[1, 2, 3]), (array[3])) t(a) GROUP BY reduce(a, 0, (s, x) -> x, s->s)",
+                "GROUP BY does not support lambda expressions, please use GROUP BY # instead");
+        assertQuery(
+                "SELECT reduce(a, 0, (s, x) -> x, s->s), count(*) FROM (VALUES (array[1]), (array[1, 2, 3]), (array[3])) t(a) GROUP BY 1",
+                "VALUES (3, 2), (1, 1)");
+    }
 }


### PR DESCRIPTION
Due to how lambda expression is supported, it is hard to support them in
GROUP BY. Previously we would generate invalid logical plan then throw exception
during plan validation. Change it to throw UnsupportedOperationException.

Test plan - AbstractTestQueries
```
== NO RELEASE NOTE ==
```
