### PR TITLE
Optimize Single Type Writer Constructors

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/block/SingleArrayBlockWriter.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/SingleArrayBlockWriter.java
@@ -28,14 +28,12 @@ public class SingleArrayBlockWriter
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(SingleArrayBlockWriter.class).instanceSize();
 
     private final BlockBuilder blockBuilder;
-    private final long initialBlockBuilderSize;
     private int positionsWritten;
 
     public SingleArrayBlockWriter(BlockBuilder blockBuilder, int start)
     {
         super(start);
         this.blockBuilder = blockBuilder;
-        this.initialBlockBuilderSize = blockBuilder.getSizeInBytes();
     }
 
     @Override
@@ -47,7 +45,11 @@ public class SingleArrayBlockWriter
     @Override
     public long getSizeInBytes()
     {
-        return blockBuilder.getSizeInBytes() - initialBlockBuilderSize;
+        long size = blockBuilder.getSizeInBytes();
+        if (start == 0) {
+            return size;
+        }
+        return size - blockBuilder.getRegionSizeInBytes(0, start);
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/block/SingleMapBlockWriter.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/SingleMapBlockWriter.java
@@ -30,7 +30,6 @@ public class SingleMapBlockWriter
     private final int offset;
     private final BlockBuilder keyBlockBuilder;
     private final BlockBuilder valueBlockBuilder;
-    private final long initialBlockBuilderSize;
     private int positionsWritten;
 
     private boolean writeToValueNext;
@@ -40,7 +39,6 @@ public class SingleMapBlockWriter
         this.offset = start;
         this.keyBlockBuilder = keyBlockBuilder;
         this.valueBlockBuilder = valueBlockBuilder;
-        this.initialBlockBuilderSize = keyBlockBuilder.getSizeInBytes() + valueBlockBuilder.getSizeInBytes();
     }
 
     @Override
@@ -64,7 +62,13 @@ public class SingleMapBlockWriter
     @Override
     public long getSizeInBytes()
     {
-        return keyBlockBuilder.getSizeInBytes() + valueBlockBuilder.getSizeInBytes() - initialBlockBuilderSize;
+        long size = keyBlockBuilder.getSizeInBytes() + valueBlockBuilder.getSizeInBytes();
+        if (offset == 0) {
+            return size;
+        }
+
+        int numPositions = offset / 2;
+        return size - (keyBlockBuilder.getRegionSizeInBytes(0, numPositions) + valueBlockBuilder.getRegionSizeInBytes(0, numPositions));
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/block/SingleRowBlockWriter.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/SingleRowBlockWriter.java
@@ -28,9 +28,8 @@ public class SingleRowBlockWriter
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(SingleRowBlockWriter.class).instanceSize();
 
     private final BlockBuilder[] fieldBlockBuilders;
-    private final long initialBlockBuilderSize;
-    private int positionsWritten;
 
+    private boolean isEntryOpen;
     private int currentFieldIndexToWrite;
     private boolean fieldBlockBuilderReturned;
 
@@ -38,11 +37,6 @@ public class SingleRowBlockWriter
     {
         super(rowIndex);
         this.fieldBlockBuilders = fieldBlockBuilders;
-        long initialBlockBuilderSize = 0;
-        for (BlockBuilder fieldBlockBuilder : fieldBlockBuilders) {
-            initialBlockBuilderSize += fieldBlockBuilder.getSizeInBytes();
-        }
-        this.initialBlockBuilderSize = initialBlockBuilderSize;
     }
 
     /**
@@ -72,11 +66,20 @@ public class SingleRowBlockWriter
     @Override
     public long getSizeInBytes()
     {
-        long currentBlockBuilderSize = 0;
-        for (BlockBuilder fieldBlockBuilder : fieldBlockBuilders) {
-            currentBlockBuilderSize += fieldBlockBuilder.getSizeInBytes();
+        long size = 0;
+        if (rowIndex == 0) {
+            for (BlockBuilder blockBuilder : fieldBlockBuilders) {
+                size += blockBuilder.getSizeInBytes();
+            }
+            return size;
         }
-        return currentBlockBuilderSize - initialBlockBuilderSize;
+
+        int endIndex = currentFieldIndexToWrite + (isEntryOpen ? 1 : 0);
+        for (int i = 0; i < endIndex; i++) {
+            BlockBuilder builder = fieldBlockBuilders[i];
+            size += (builder.getSizeInBytes() - builder.getRegionSizeInBytes(0, rowIndex));
+        }
+        return size;
     }
 
     @Override
@@ -160,6 +163,7 @@ public class SingleRowBlockWriter
     public BlockBuilder beginBlockEntry()
     {
         checkFieldIndexToWrite();
+        isEntryOpen = true;
         return fieldBlockBuilders[currentFieldIndexToWrite].beginBlockEntry();
     }
 
@@ -198,8 +202,8 @@ public class SingleRowBlockWriter
 
     private void entryAdded()
     {
+        isEntryOpen = false;
         currentFieldIndexToWrite++;
-        positionsWritten++;
     }
 
     @Override
@@ -208,7 +212,7 @@ public class SingleRowBlockWriter
         if (fieldBlockBuilderReturned) {
             throw new IllegalStateException("field block builder has been returned");
         }
-        return positionsWritten;
+        return currentFieldIndexToWrite;
     }
 
     @Override

--- a/presto-common/src/test/java/com/facebook/presto/common/block/TestSingleArrayBlockWriter.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/block/TestSingleArrayBlockWriter.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.block;
+
+import com.facebook.presto.common.type.MapType;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static io.airlift.slice.Slices.utf8Slice;
+import static org.testng.Assert.assertEquals;
+
+public class TestSingleArrayBlockWriter
+{
+    private static final int ARRAY_POSITIONS = 100;
+
+    @Test
+    public void testSizeInBytes()
+    {
+        MapType mapType = new MapType(
+                BIGINT,
+                VARCHAR,
+                MethodHandleUtil.methodHandle(TestSingleArrayBlockWriter.class, "throwUnsupportedOperation"),
+                MethodHandleUtil.methodHandle(TestSingleArrayBlockWriter.class, "throwUnsupportedOperation"));
+
+        ArrayBlockBuilder arrayBlockBuilder = new ArrayBlockBuilder(mapType, null, ARRAY_POSITIONS);
+
+        for (int i = 0; i < ARRAY_POSITIONS; i++) {
+            SingleArrayBlockWriter singleArrayBlockWriter = arrayBlockBuilder.beginBlockEntry();
+            int expectedSize = 0;
+            for (int j = 0; j < 10; j++) {
+                assertEquals(singleArrayBlockWriter.getSizeInBytes(), expectedSize, "For Index: " + i);
+
+                // Write Map<Bigint, Varchar>
+                BlockBuilder innerMapWriter = singleArrayBlockWriter.beginBlockEntry();
+                // Opening entry, does not account for size.
+                assertEquals(singleArrayBlockWriter.getSizeInBytes(), expectedSize, "For Index: " + i);
+
+                // Each entry is of 28 bytes, with 6 byte value.
+                BIGINT.writeLong(innerMapWriter, i * 2);
+                VARCHAR.writeSlice(innerMapWriter, utf8Slice("Value1"));
+                expectedSize += 28;
+                assertEquals(singleArrayBlockWriter.getSizeInBytes(), expectedSize, "For Index: " + i);
+
+                // Another entry with 28 bytes.
+                BIGINT.writeLong(innerMapWriter, i * 2 + 1);
+                VARCHAR.writeSlice(innerMapWriter, utf8Slice("Value2"));
+                expectedSize += 28;
+                assertEquals(singleArrayBlockWriter.getSizeInBytes(), expectedSize, "For Index: " + i);
+
+                // closing the entry increases by 5 (offset + null)
+                singleArrayBlockWriter.closeEntry();
+                expectedSize += 5;
+                assertEquals(singleArrayBlockWriter.getSizeInBytes(), expectedSize, "For Index: " + i);
+            }
+
+            singleArrayBlockWriter.appendNull();
+            expectedSize += 5;
+            assertEquals(singleArrayBlockWriter.getSizeInBytes(), expectedSize, "For Index: " + i);
+
+            arrayBlockBuilder.closeEntry();
+            assertEquals(singleArrayBlockWriter.getSizeInBytes(), expectedSize, "For Index: " + i);
+        }
+    }
+
+    @Test
+    public void testSizeInBytesForNulls()
+    {
+        MapType mapType = new MapType(
+                BIGINT,
+                VARCHAR,
+                MethodHandleUtil.methodHandle(TestSingleArrayBlockWriter.class, "throwUnsupportedOperation"),
+                MethodHandleUtil.methodHandle(TestSingleArrayBlockWriter.class, "throwUnsupportedOperation"));
+
+        ArrayBlockBuilder arrayBlockBuilder = new ArrayBlockBuilder(mapType, null, ARRAY_POSITIONS);
+
+        for (int i = 0; i < ARRAY_POSITIONS; i++) {
+            SingleArrayBlockWriter singleArrayBlockWriter = arrayBlockBuilder.beginBlockEntry();
+            int expectedSize = 0;
+            for (int j = 0; j < 10; j++) {
+                assertEquals(singleArrayBlockWriter.getSizeInBytes(), expectedSize, "For Index: " + i);
+
+                singleArrayBlockWriter.appendNull();
+                expectedSize += 5;
+                assertEquals(singleArrayBlockWriter.getSizeInBytes(), expectedSize, "For Index: " + i);
+            }
+
+            arrayBlockBuilder.closeEntry();
+            assertEquals(singleArrayBlockWriter.getSizeInBytes(), expectedSize, "For Index: " + i);
+        }
+    }
+
+    public static void throwUnsupportedOperation()
+    {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/presto-common/src/test/java/com/facebook/presto/common/block/TestSingleMapBlockWriter.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/block/TestSingleMapBlockWriter.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.block;
+
+import com.facebook.presto.common.type.MapType;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static io.airlift.slice.Slices.utf8Slice;
+import static org.testng.Assert.assertEquals;
+
+public class TestSingleMapBlockWriter
+{
+    private static final int MAP_POSITIONS = 100;
+
+    @Test
+    public void testSizeInBytes()
+    {
+        MapType innerMapType = new MapType(
+                BIGINT,
+                VARCHAR,
+                MethodHandleUtil.methodHandle(TestSingleMapBlockWriter.class, "throwUnsupportedOperation"),
+                MethodHandleUtil.methodHandle(TestSingleMapBlockWriter.class, "throwUnsupportedOperation"));
+
+        MapType mapType = new MapType(
+                BIGINT,
+                innerMapType,
+                MethodHandleUtil.methodHandle(TestSingleMapBlockWriter.class, "throwUnsupportedOperation"),
+                MethodHandleUtil.methodHandle(TestSingleMapBlockWriter.class, "throwUnsupportedOperation"));
+
+        MapBlockBuilder mapBlockBuilder = (MapBlockBuilder) mapType.createBlockBuilder(null, MAP_POSITIONS);
+
+        for (int i = 0; i < MAP_POSITIONS; i++) {
+            SingleMapBlockWriter singleMapBlockWriter = mapBlockBuilder.beginBlockEntry();
+            int expectedSize = 0;
+            for (int j = 0; j < 10; j++) {
+                assertEquals(singleMapBlockWriter.getSizeInBytes(), expectedSize, "For Index: " + i);
+
+                // Write Map's Key (long + isNull)
+                BIGINT.writeLong(singleMapBlockWriter, j);
+                expectedSize += 9;
+                assertEquals(singleMapBlockWriter.getSizeInBytes(), expectedSize, "For Index: " + i);
+
+                // Write Map<Bigint, Varchar>
+                BlockBuilder innerMapWriter = singleMapBlockWriter.beginBlockEntry();
+                // Opening entry, does not account for size.
+                assertEquals(singleMapBlockWriter.getSizeInBytes(), expectedSize, "For Index: " + i);
+
+                // Each entry is of 28 bytes, with 6 byte value.
+                BIGINT.writeLong(innerMapWriter, i * 2);
+                VARCHAR.writeSlice(innerMapWriter, utf8Slice("Value1"));
+                expectedSize += 28;
+                assertEquals(singleMapBlockWriter.getSizeInBytes(), expectedSize, "For Index: " + i);
+
+                // Another entry with 28 bytes.
+                BIGINT.writeLong(innerMapWriter, i * 2 + 1);
+                VARCHAR.writeSlice(innerMapWriter, utf8Slice("Value2"));
+                expectedSize += 28;
+                assertEquals(singleMapBlockWriter.getSizeInBytes(), expectedSize, "For Index: " + i);
+
+                // closing the entry increases by 5 (offset + null)
+                singleMapBlockWriter.closeEntry();
+                expectedSize += 5;
+                assertEquals(singleMapBlockWriter.getSizeInBytes(), expectedSize, "For Index: " + i);
+            }
+            mapBlockBuilder.closeEntry();
+            assertEquals(singleMapBlockWriter.getSizeInBytes(), expectedSize, "For Index: " + i);
+
+            // Introduce some null elements in Map and the size should still work.
+            mapBlockBuilder.appendNull();
+        }
+    }
+
+    @Test
+    public void testSizeInBytesForNulls()
+    {
+        MapType innerMapType = new MapType(
+                BIGINT,
+                VARCHAR,
+                MethodHandleUtil.methodHandle(TestSingleMapBlockWriter.class, "throwUnsupportedOperation"),
+                MethodHandleUtil.methodHandle(TestSingleMapBlockWriter.class, "throwUnsupportedOperation"));
+
+        MapType mapType = new MapType(
+                BIGINT,
+                innerMapType,
+                MethodHandleUtil.methodHandle(TestSingleMapBlockWriter.class, "throwUnsupportedOperation"),
+                MethodHandleUtil.methodHandle(TestSingleMapBlockWriter.class, "throwUnsupportedOperation"));
+
+        MapBlockBuilder mapBlockBuilder = (MapBlockBuilder) mapType.createBlockBuilder(null, MAP_POSITIONS);
+
+        for (int i = 0; i < MAP_POSITIONS; i++) {
+            SingleMapBlockWriter singleMapBlockWriter = mapBlockBuilder.beginBlockEntry();
+            int expectedSize = 0;
+            for (int j = 0; j < 10; j++) {
+                assertEquals(singleMapBlockWriter.getSizeInBytes(), expectedSize, "For Index: " + i);
+
+                // Write Map's Key (long + isNull)
+                BIGINT.writeLong(singleMapBlockWriter, j);
+                expectedSize += 9;
+                assertEquals(singleMapBlockWriter.getSizeInBytes(), expectedSize, "For Index: " + i);
+
+                // Write Map<Bigint, Varchar>
+                BlockBuilder innerMapWriter = singleMapBlockWriter.beginBlockEntry();
+                // Opening entry, does not account for size.
+                assertEquals(singleMapBlockWriter.getSizeInBytes(), expectedSize, "For Index: " + i);
+
+                // Each entry is of 22 bytes, with 6 byte value.
+                BIGINT.writeLong(innerMapWriter, i * 2);
+                innerMapWriter.appendNull();
+                expectedSize += 22;
+                assertEquals(singleMapBlockWriter.getSizeInBytes(), expectedSize, "For Index: " + i);
+
+                // Another entry with 22 bytes.
+                BIGINT.writeLong(innerMapWriter, i * 2 + 1);
+                innerMapWriter.appendNull();
+                expectedSize += 22;
+                assertEquals(singleMapBlockWriter.getSizeInBytes(), expectedSize, "For Index: " + i);
+
+                // closing the entry increases by 5 (offset + null)
+                singleMapBlockWriter.closeEntry();
+                expectedSize += 5;
+                assertEquals(singleMapBlockWriter.getSizeInBytes(), expectedSize, "For Index: " + i);
+            }
+            mapBlockBuilder.closeEntry();
+            assertEquals(singleMapBlockWriter.getSizeInBytes(), expectedSize, "For Index: " + i);
+        }
+    }
+
+    public static void throwUnsupportedOperation()
+    {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/presto-common/src/test/java/com/facebook/presto/common/block/TestSingleRowBlockWriter.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/block/TestSingleRowBlockWriter.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.block;
+
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.MapType;
+import com.facebook.presto.common.type.RowType;
+import com.facebook.presto.common.type.Type;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.common.type.RealType.REAL;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static io.airlift.slice.Slices.utf8Slice;
+import static org.testng.Assert.assertEquals;
+
+public class TestSingleRowBlockWriter
+{
+    @Test
+    public void testSizeInBytes()
+    {
+        MapType mapType = new MapType(
+                BIGINT,
+                VARCHAR,
+                MethodHandleUtil.methodHandle(TestSingleRowBlockWriter.class, "throwUnsupportedOperation"),
+                MethodHandleUtil.methodHandle(TestSingleRowBlockWriter.class, "throwUnsupportedOperation"));
+
+        ArrayType arrayType = new ArrayType(DOUBLE);
+
+        RowType.Field rowField = new RowType.Field(Optional.of("my_struct"), INTEGER);
+        RowType rowType = RowType.from(ImmutableList.of(rowField));
+
+        List<Type> fieldTypes = ImmutableList.of(REAL, mapType, arrayType, rowType);
+
+        RowBlockBuilder rowBlockBuilder = new RowBlockBuilder(fieldTypes, null, 1);
+
+        for (int i = 0; i < 100; i++) {
+            SingleRowBlockWriter singleRowBlockWriter = rowBlockBuilder.beginBlockEntry();
+            int expectedSize = 0;
+            assertEquals(singleRowBlockWriter.getSizeInBytes(), expectedSize, "For Index: " + i);
+
+            // Write real (4byte value + 1 byte for null)
+            REAL.writeLong(singleRowBlockWriter, i);
+            expectedSize += 5;
+            assertEquals(singleRowBlockWriter.getSizeInBytes(), expectedSize, "For Index: " + i);
+
+            // Write Map<Bigint, Varchar>
+            BlockBuilder mapWriter = singleRowBlockWriter.beginBlockEntry();
+            // Opening entry, does not account for size.
+            assertEquals(singleRowBlockWriter.getSizeInBytes(), expectedSize, "For Index: " + i);
+
+            // Each entry is of 28 bytes, with 6 byte value.
+            BIGINT.writeLong(mapWriter, i * 2);
+            VARCHAR.writeSlice(mapWriter, utf8Slice("Value1"));
+            expectedSize += 28;
+            assertEquals(singleRowBlockWriter.getSizeInBytes(), expectedSize, "For Index: " + i);
+
+            // Another entry with 28 bytes.
+            BIGINT.writeLong(mapWriter, i * 2 + 1);
+            VARCHAR.writeSlice(mapWriter, utf8Slice("Value2"));
+            expectedSize += 28;
+            assertEquals(singleRowBlockWriter.getSizeInBytes(), expectedSize, "For Index: " + i);
+
+            // closing the entry increases by 5 (offset + null)
+            singleRowBlockWriter.closeEntry();
+            expectedSize += 5;
+            assertEquals(singleRowBlockWriter.getSizeInBytes(), expectedSize, "For Index: " + i);
+
+            // Write array entry.
+            BlockBuilder arrayWriter = singleRowBlockWriter.beginBlockEntry();
+            assertEquals(singleRowBlockWriter.getSizeInBytes(), expectedSize, "For Index: " + i);
+
+            // Each entry is 9 bytes ( 8 bytes for double , 1 byte for null)
+            DOUBLE.writeDouble(arrayWriter, i * 3);
+            expectedSize += 9;
+            assertEquals(singleRowBlockWriter.getSizeInBytes(), expectedSize, "For Index: " + i);
+            DOUBLE.writeDouble(arrayWriter, i * 3 + 1);
+            expectedSize += 9;
+            assertEquals(singleRowBlockWriter.getSizeInBytes(), expectedSize, "For Index: " + i);
+            singleRowBlockWriter.closeEntry();
+            // closing the entry increases by 5 (offset + null)
+            expectedSize += 5;
+            assertEquals(singleRowBlockWriter.getSizeInBytes(), expectedSize, "For Index: " + i);
+
+            // Write row type.
+            BlockBuilder rowWriter = singleRowBlockWriter.beginBlockEntry();
+            assertEquals(singleRowBlockWriter.getSizeInBytes(), expectedSize, "For Index: " + i);
+
+            rowWriter.appendNull();
+            expectedSize += 5;
+            assertEquals(singleRowBlockWriter.getSizeInBytes(), expectedSize, "For Index: " + i);
+
+            singleRowBlockWriter.closeEntry();
+            expectedSize += 5;
+            assertEquals(singleRowBlockWriter.getSizeInBytes(), expectedSize, "For Index: " + i);
+
+            rowBlockBuilder.closeEntry();
+            assertEquals(singleRowBlockWriter.getSizeInBytes(), expectedSize, "For Index: " + i);
+
+            rowBlockBuilder.appendNull();
+        }
+    }
+
+    @Test
+    public void testSizeInBytesForNulls()
+    {
+        MapType mapType = new MapType(
+                BIGINT,
+                VARCHAR,
+                MethodHandleUtil.methodHandle(TestSingleRowBlockWriter.class, "throwUnsupportedOperation"),
+                MethodHandleUtil.methodHandle(TestSingleRowBlockWriter.class, "throwUnsupportedOperation"));
+
+        ArrayType arrayType = new ArrayType(DOUBLE);
+
+        RowType.Field rowField = new RowType.Field(Optional.of("my_struct"), INTEGER);
+        RowType rowType = RowType.from(ImmutableList.of(rowField));
+
+        List<Type> fieldTypes = ImmutableList.of(REAL, mapType, arrayType, rowType);
+
+        RowBlockBuilder rowBlockBuilder = new RowBlockBuilder(fieldTypes, null, 1);
+
+        for (int i = 0; i < 100; i++) {
+            SingleRowBlockWriter singleRowBlockWriter = rowBlockBuilder.beginBlockEntry();
+            int expectedSize = 0;
+            assertEquals(singleRowBlockWriter.getSizeInBytes(), expectedSize);
+
+            // Write real (4byte value + 1 byte for null)
+            singleRowBlockWriter.appendNull();
+            expectedSize += 5;
+            assertEquals(singleRowBlockWriter.getSizeInBytes(), expectedSize, "For Index: " + i);
+
+            // Write Map<Bigint, Varchar>
+            singleRowBlockWriter.appendNull();
+            expectedSize += 5;
+            assertEquals(singleRowBlockWriter.getSizeInBytes(), expectedSize, "For Index: " + i);
+
+            // Write array entry.
+            singleRowBlockWriter.appendNull();
+            expectedSize += 5;
+            assertEquals(singleRowBlockWriter.getSizeInBytes(), expectedSize, "For Index: " + i);
+
+            // Write row type.
+            singleRowBlockWriter.appendNull();
+            expectedSize += 5;
+            assertEquals(singleRowBlockWriter.getSizeInBytes(), expectedSize, "For Index: " + i);
+
+            rowBlockBuilder.closeEntry();
+            assertEquals(singleRowBlockWriter.getSizeInBytes(), expectedSize, "For Index: " + i);
+
+            rowBlockBuilder.appendNull();
+        }
+    }
+
+    public static void throwUnsupportedOperation()
+    {
+        throw new UnsupportedOperationException();
+    }
+}


### PR DESCRIPTION
SingleArrayBlockWriter, SingleMapBlockWriter and SingleRowBlockWriter in
the constructor, computes the initial size. Later if getSizeInBytes is
called, it can compute the size of the object by getting the current
size and subtracting the initial size. 

But single type writers are short lived objects and never used for 
getSizeInBytes. BlockBuilder inherits Block interface, that forces to 
implement this interface. So this is mostly unused API, but required
to be implemented. On some of the deeply nested structs, this size
calculation takes 2% of total run time. This change calculates it 
lazily when required.

Test plan - 
Added new tests ensured the tests passed, then changed the code.

```
== NO RELEASE NOTE ==
```
