### PR TITLE
DO NOT COMMIT, FOR TEST

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/block/SingleArrayBlockWriter.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/SingleArrayBlockWriter.java
@@ -47,7 +47,7 @@ public class SingleArrayBlockWriter
     @Override
     public long getSizeInBytes()
     {
-        return blockBuilder.getSizeInBytes() - initialBlockBuilderSize;
+        throw new UnsupportedOperationException("ArrayBlockWriter: Test to see the impact");
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/block/SingleMapBlockWriter.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/SingleMapBlockWriter.java
@@ -64,7 +64,7 @@ public class SingleMapBlockWriter
     @Override
     public long getSizeInBytes()
     {
-        return keyBlockBuilder.getSizeInBytes() + valueBlockBuilder.getSizeInBytes() - initialBlockBuilderSize;
+        throw new UnsupportedOperationException("MapBlockWriter: Test to see the impact");
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/block/SingleRowBlockWriter.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/SingleRowBlockWriter.java
@@ -72,11 +72,7 @@ public class SingleRowBlockWriter
     @Override
     public long getSizeInBytes()
     {
-        long currentBlockBuilderSize = 0;
-        for (BlockBuilder fieldBlockBuilder : fieldBlockBuilders) {
-            currentBlockBuilderSize += fieldBlockBuilder.getSizeInBytes();
-        }
-        return currentBlockBuilderSize - initialBlockBuilderSize;
+        throw new UnsupportedOperationException("RowBlockWriter: Test to see the impact");
     }
 
     @Override


### PR DESCRIPTION
Code inspection shows single Type writer, getSizeInBytes is not used
this PR is to verify if any unit test fails because of this change.

Test plan - (Please fill in how you tested your changes)

Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines. Don't forget to follow our [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution) for any code copied from other projects.

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== RELEASE NOTES ==

General Changes
* ...
* ...

Hive Changes
* ...
* ...
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```
