### PR TITLE
Pushdown `is null` to Pinot

### DIFF
--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/query/PinotFilterExpressionConverter.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/query/PinotFilterExpressionConverter.java
@@ -383,8 +383,6 @@ public class PinotFilterExpressionConverter
             case NULL_IF:
             case SWITCH:
             case WHEN:
-            case IS_NULL:
-                return handleIsNull(specialForm, true, context);
             case COALESCE:
             case DEREFERENCE:
             case ROW_CONSTRUCTOR:
@@ -399,6 +397,8 @@ public class PinotFilterExpressionConverter
                         specialForm.getArguments().get(0).accept(this, context).getDefinition(),
                         specialForm.getForm().toString(),
                         specialForm.getArguments().get(1).accept(this, context).getDefinition()));
+            case IS_NULL:
+                return handleIsNull(specialForm, true, context);
             default:
                 throw new PinotException(PINOT_UNSUPPORTED_EXPRESSION, Optional.empty(), "Unexpected special form: " + specialForm);
         }

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/query/PinotFilterExpressionConverter.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/query/PinotFilterExpressionConverter.java
@@ -90,6 +90,16 @@ public class PinotFilterExpressionConverter
                         .collect(Collectors.joining(", "))));
     }
 
+    private PinotExpression handleIsNull(
+            SpecialFormExpression specialForm,
+            boolean isWhitelist,
+            Function<VariableReferenceExpression, Selection> context)
+    {
+        return derived(format("(%s %s)",
+                specialForm.getArguments().get(0).accept(this, context).getDefinition(),
+                isWhitelist ? "IS NULL" : "IS NOT NULL"));
+    }
+
     private PinotExpression handleLogicalBinary(
             String operator,
             CallExpression call,
@@ -371,6 +381,7 @@ public class PinotFilterExpressionConverter
             case SWITCH:
             case WHEN:
             case IS_NULL:
+                return handleIsNull(specialForm, true, context);
             case COALESCE:
             case DEREFERENCE:
             case ROW_CONSTRUCTOR:

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/query/PinotFilterExpressionConverter.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/query/PinotFilterExpressionConverter.java
@@ -258,6 +258,9 @@ public class PinotFilterExpressionConverter
                 if (specialFormExpression.getForm() == SpecialFormExpression.Form.IN) {
                     return handleIn(specialFormExpression, false, context);
                 }
+                if (specialFormExpression.getForm() == SpecialFormExpression.Form.IS_NULL) {
+                    return handleIsNull(specialFormExpression, false, context);
+                }
             }
         }
 

--- a/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/query/TestPinotExpressionConverters.java
+++ b/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/query/TestPinotExpressionConverters.java
@@ -153,6 +153,8 @@ public class TestPinotExpressionConverters
         testFilter("city not in ('San Jose', 'Campbell', 'Union City')", "(city NOT IN ('San Jose', 'Campbell', 'Union City'))", sessionHolder);
         testFilterUnsupported("secondssinceepoch + 1 in (234, 24324)", sessionHolder);
         testFilterUnsupported("NOT (secondssinceepoch = 2323)", sessionHolder);
+        testFilter("city is null", "(city IS NULL)", sessionHolder);
+        testFilter("city is not null", "(city IS NOT NULL)", sessionHolder);
 
         // combinations
         testFilter("totalfare between 20 and 30 AND regionid > 20 OR city = 'Campbell'",


### PR DESCRIPTION
Fixes apache/pinot#7586:
1. `IS NOT NULL` queries fail currently, with error `NOT operator is supported only on top of IN operator...`. This PR adds support to run `IS NOT NULL` queries on Pinot data from Presto.
2. Both `IS NULL` and `IS NOT NULL` is not pushed down to Pinot. This PR adds support this support.

Test plan - 
1. Ran `EXPLAIN SELECT playerName FROM default.baseballstats WHERE playerName IS NULL`. Output:
```
- Output[playerName] => [playername:varchar]
        Estimates: {rows: ? (?), cpu: ?, memory: 0.00, network: ?}
        playerName := playername
    - RemoteStreamingExchange[GATHER] => [playername:varchar]
            Estimates: {rows: ? (?), cpu: ?, memory: 0.00, network: ?}
        - TableScan[TableHandle {connectorId='pinot', connectorHandle='PinotTableHandle{connectorId=pinot, schemaName=default, tableName=baseballStats, isQueryShort=Optional[false], expectedColumnHandles=Optional[[PinotColumnHandle{columnName=playerName, dataType=varchar, type=REGULAR}]], pinotQuery=Optional[GeneratedPinotQuery{query=SELECT playerName FROM baseballStats__TABLE_NAME_SUFFIX_TEMPLATE__ WHERE (playerName IS NULL)__TIME_BOUNDARY_FILTER_TEMPLATE__ LIMIT 2147483647, format=SQL, table=baseballStats, expectedColumnIndices=[], groupByClauses=0, haveFilter=true, isQueryShort=false}]}', layout='Optional[PinotTableHandle{connectorId=pinot, schemaName=default, tableName=baseballStats, isQueryShort=Optional[false], expectedColumnHandles=Optional[[PinotColumnHandle{columnName=playerName, dataType=varchar, type=REGULAR}]], pinotQuery=Optional[GeneratedPinotQuery{query=SELECT playerName FROM baseballStats__TABLE_NAME_SUFFIX_TEMPLATE__ WHERE (playerName IS NULL)__TIME_BOUNDARY_FILTER_TEMPLATE__ LIMIT 2147483647, format=SQL, table=baseballStats, expectedColumnIndices=[], groupByClauses=0, haveFilter=true, isQueryShort=false}]}]'}] => [playername:varchar]
                Estimates: {rows: ? (?), cpu: ?, memory: 0.00, network: 0.00}
                playername := PinotColumnHandle{columnName=playerName, dataType=varchar, type=REGULAR}
```

2. Ran `EXPLAIN SELECT playerName FROM default.baseballstats WHERE playerName IS NOT NULL`. Output:
```
- Output[playerName] => [playername:varchar]
        Estimates: {rows: ? (?), cpu: ?, memory: 0.00, network: ?}
        playerName := playername
    - RemoteStreamingExchange[GATHER] => [playername:varchar]
            Estimates: {rows: ? (?), cpu: ?, memory: 0.00, network: ?}
        - TableScan[TableHandle {connectorId='pinot', connectorHandle='PinotTableHandle{connectorId=pinot, schemaName=default, tableName=baseballStats, isQueryShort=Optional[false], expectedColumnHandles=Optional[[PinotColumnHandle{columnName=playerName, dataType=varchar, type=REGULAR}]], pinotQuery=Optional[GeneratedPinotQuery{query=SELECT playerName FROM baseballStats__TABLE_NAME_SUFFIX_TEMPLATE__ WHERE (playerName IS NOT NULL)__TIME_BOUNDARY_FILTER_TEMPLATE__ LIMIT 2147483647, format=SQL, table=baseballStats, expectedColumnIndices=[], groupByClauses=0, haveFilter=true, isQueryShort=false}]}', layout='Optional[PinotTableHandle{connectorId=pinot, schemaName=default, tableName=baseballStats, isQueryShort=Optional[false], expectedColumnHandles=Optional[[PinotColumnHandle{columnName=playerName, dataType=varchar, type=REGULAR}]], pinotQuery=Optional[GeneratedPinotQuery{query=SELECT playerName FROM baseballStats__TABLE_NAME_SUFFIX_TEMPLATE__ WHERE (playerName IS NOT NULL)__TIME_BOUNDARY_FILTER_TEMPLATE__ LIMIT 2147483647, format=SQL, table=baseballStats, expectedColumnIndices=[], groupByClauses=0, haveFilter=true, isQueryShort=false}]}]'}] => [playername:varchar]
                Estimates: {rows: ? (?), cpu: ?, memory: 0.00, network: 0.00}
                playername := PinotColumnHandle{columnName=playerName, dataType=varchar, type=REGULAR}
```

```
== RELEASE NOTES ==

Pinot Changes
* Adds support to run `IS NOT NULL` queries on Pinot data from Presto.
* Adds support to pushdown `IS NULL` and `IS NOT NULL` queries to Pinot.
```