### PR TITLE
Fix NPE when reading an empty Iceberg table without snapshot ID

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergMetadata.java
@@ -427,6 +427,11 @@ public class IcebergMetadata
     @Override
     public Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session, ConnectorInsertTableHandle insertHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
     {
+        if (fragments.isEmpty()) {
+            transaction.commitTransaction();
+            return Optional.empty();
+        }
+
         IcebergWritableTableHandle table = (IcebergWritableTableHandle) insertHandle;
         org.apache.iceberg.Table icebergTable = transaction.table();
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergNativeMetadata.java
@@ -51,6 +51,7 @@ import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.PartitionSpecParser;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SchemaParser;
+import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.Transaction;
 import org.apache.iceberg.catalog.SupportsNamespaces;
@@ -152,16 +153,24 @@ public class IcebergNativeMetadata
             // return null to throw
             return null;
         }
-        if (name.getSnapshotId().isPresent() && table.snapshot(name.getSnapshotId().get()) == null) {
-            throw new PrestoException(ICEBERG_INVALID_SNAPSHOT_ID, format("Invalid snapshot [%s] for table: %s", name.getSnapshotId().get(), table));
-        }
 
         return new IcebergTableHandle(
                 tableName.getSchemaName(),
                 name.getTableName(),
                 name.getTableType(),
-                Optional.of(name.getSnapshotId().orElse(table.currentSnapshot().snapshotId())),
+                resolveSnapshotId(name, table),
                 TupleDomain.all());
+    }
+
+    private Optional<Long> resolveSnapshotId(IcebergTableName name, Table table)
+    {
+        if (name.getSnapshotId().isPresent()) {
+            if (table.snapshot(name.getSnapshotId().get()) == null) {
+                throw new PrestoException(ICEBERG_INVALID_SNAPSHOT_ID, format("Invalid snapshot [%s] for table: %s", name.getSnapshotId().get(), table));
+            }
+            return name.getSnapshotId();
+        }
+        return Optional.ofNullable(table.currentSnapshot()).map(Snapshot::snapshotId);
     }
 
     @Override
@@ -196,7 +205,7 @@ public class IcebergNativeMetadata
         }
 
         SchemaTableName systemTableName = new SchemaTableName(tableName.getSchemaName(), name.getTableNameWithType());
-        Optional<Long> snapshotId = Optional.of(name.getSnapshotId().orElse(table.currentSnapshot().snapshotId()));
+        Optional<Long> snapshotId = resolveSnapshotId(name, table);
         switch (name.getTableType()) {
             case HISTORY:
                 if (name.getSnapshotId().isPresent()) {
@@ -384,6 +393,11 @@ public class IcebergNativeMetadata
     @Override
     public Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session, ConnectorInsertTableHandle insertHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
     {
+        if (fragments.isEmpty()) {
+            transaction.commitTransaction();
+            return Optional.empty();
+        }
+
         IcebergWritableTableHandle table = (IcebergWritableTableHandle) insertHandle;
         org.apache.iceberg.Table icebergTable = transaction.table();
 

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergSmoke.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergSmoke.java
@@ -36,6 +36,7 @@ import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 public class TestIcebergSmoke
         extends AbstractTestIntegrationSmokeTest
@@ -388,20 +389,22 @@ public class TestIcebergSmoke
     {
         Session session = getSession();
         MaterializedResult result = computeActual("SHOW SCHEMAS FROM system");
-        assertUpdate(session, "CREATE TABLE test_rollback (col0 INTEGER, col1 BIGINT)");
+        assertUpdate(session, "CREATE TABLE test_rollback AS SELECT * FROM (VALUES (123, CAST(321 AS BIGINT))) AS t (col0, col1)", 1);
         long afterCreateTableId = getLatestSnapshotId();
 
         assertUpdate(session, "INSERT INTO test_rollback (col0, col1) VALUES (123, CAST(987 AS BIGINT))", 1);
         long afterFirstInsertId = getLatestSnapshotId();
 
         assertUpdate(session, "INSERT INTO test_rollback (col0, col1) VALUES (456, CAST(654 AS BIGINT))", 1);
-        assertQuery(session, "SELECT * FROM test_rollback ORDER BY col0", "VALUES (123, CAST(987 AS BIGINT)), (456, CAST(654 AS BIGINT))");
+        assertQuery(session, "SELECT * FROM test_rollback ORDER BY col0",
+                "VALUES (123, CAST(987 AS BIGINT)), (456, CAST(654 AS BIGINT)), (123, CAST(321 AS BIGINT))");
 
         assertUpdate(format("CALL system.rollback_to_snapshot('tpch', 'test_rollback', %s)", afterFirstInsertId));
-        assertQuery(session, "SELECT * FROM test_rollback ORDER BY col0", "VALUES (123, CAST(987 AS BIGINT))");
+        assertQuery(session, "SELECT * FROM test_rollback ORDER BY col0",
+                "VALUES (123, CAST(987 AS BIGINT)), (123, CAST(321 AS BIGINT))");
 
         assertUpdate(format("CALL system.rollback_to_snapshot('tpch', 'test_rollback', %s)", afterCreateTableId));
-        assertEquals((long) computeActual(session, "SELECT COUNT(*) FROM test_rollback").getOnlyValue(), 0);
+        assertEquals((long) computeActual(session, "SELECT COUNT(*) FROM test_rollback").getOnlyValue(), 1);
 
         dropTable(session, "test_rollback");
     }
@@ -677,5 +680,16 @@ public class TestIcebergSmoke
 
         dropTable(session, "test_nested_table");
         dropTable(session, "test_nested_table2");
+    }
+
+    @Test
+    public void testReadEmptyTable()
+    {
+        assertUpdate("CREATE TABLE test_read_empty (a bigint, b double, c varchar)");
+        assertTrue(getQueryRunner().tableExists(getSession(), "test_read_empty"));
+        assertQuery("SELECT * FROM test_read_empty", "SELECT * FROM region WHERE name='not_exist'");
+
+        assertUpdate("DROP TABLE test_read_empty");
+        assertFalse(getQueryRunner().tableExists(getSession(), "test_create_original"));
     }
 }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergSystemTables.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergSystemTables.java
@@ -119,7 +119,7 @@ public class TestIcebergSystemTables
                         "('is_current_ancestor', 'boolean', '', '')");
 
         // Test the number of history entries
-        assertQuery("SELECT count(*) FROM test_schema.\"test_table$history\"", "VALUES 3");
+        assertQuery("SELECT count(*) FROM test_schema.\"test_table$history\"", "VALUES 2");
     }
 
     @Test
@@ -133,8 +133,8 @@ public class TestIcebergSystemTables
                         "('manifest_list', 'varchar', '', '')," +
                         "('summary', 'map(varchar, varchar)', '', '')");
 
-        assertQuery("SELECT operation FROM test_schema.\"test_table$snapshots\"", "VALUES 'append', 'append', 'append'");
-        assertQuery("SELECT summary['total-records'] FROM test_schema.\"test_table$snapshots\"", "VALUES '0', '3', '6'");
+        assertQuery("SELECT operation FROM test_schema.\"test_table$snapshots\"", "VALUES 'append', 'append'");
+        assertQuery("SELECT summary['total-records'] FROM test_schema.\"test_table$snapshots\"", "VALUES '3', '6'");
     }
 
     @Test


### PR DESCRIPTION
Test plan - added test `testReadEmptyTable`, fixed related test failures


```
== NO RELEASE NOTE ==
```
