### PR TITLE
Change to pass TracerProvider instead of Tracer to HttpRequestSession…

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/protocol/QueuedStatementResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/protocol/QueuedStatementResource.java
@@ -183,7 +183,7 @@ public class QueuedStatementResource
         SessionContext sessionContext = new HttpRequestSessionContext(
                 servletRequest,
                 sqlParserOptions,
-                tracerProvider.getNewTracer(),
+                tracerProvider,
                 Optional.of(sessionPropertyManager));
         Query query = new Query(statement, sessionContext, dispatchManager, queryResultsProvider, 0);
         queries.put(query.getQueryId(), query);

--- a/presto-main/src/main/java/com/facebook/presto/tracing/NoopTracerProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/tracing/NoopTracerProvider.java
@@ -21,8 +21,8 @@ import com.google.inject.Inject;
 public class NoopTracerProvider
         implements TracerProvider
 {
+    public static final NoopTracerProvider NOOP_TRACER_PROVIDER = new NoopTracerProvider();
     public static final NoopTracer NOOP_TRACER = new NoopTracer();
-
     @Inject
     public NoopTracerProvider() {}
 


### PR DESCRIPTION
If we pass in Tracer, then no matter if we enable tracer for this query, the trace has already started (.getNewTracer()). We need to just start the trace when needed.

```
== NO RELEASE NOTE ==
```
