### PR TITLE
Store tracing id for later exposure

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/event/QueryMonitor.java
+++ b/presto-main/src/main/java/com/facebook/presto/event/QueryMonitor.java
@@ -134,7 +134,8 @@ public class QueryMonitor
                                 Optional.empty(),
                                 Optional.empty(),
                                 Optional.empty(),
-                                ImmutableList.of())));
+                                ImmutableList.of(),
+                                queryInfo.getSession().getTraceToken())));
     }
 
     public void queryImmediateFailureEvent(BasicQueryInfo queryInfo, ExecutionFailureInfo failure)
@@ -149,7 +150,8 @@ public class QueryMonitor
                         Optional.empty(),
                         Optional.empty(),
                         Optional.empty(),
-                        ImmutableList.of()),
+                        ImmutableList.of(),
+                        queryInfo.getSession().getTraceToken()),
                 new QueryStatistics(
                         ofMillis(0),
                         ofMillis(0),
@@ -241,7 +243,8 @@ public class QueryMonitor
                 queryInfo.getOutputStage().flatMap(stage -> stageInfoCodec.toJsonWithLengthLimit(stage, maxJsonLimit)),
                 queryInfo.getRuntimeOptimizedStages().orElse(ImmutableList.of()).stream()
                         .map(stageId -> String.valueOf(stageId.getId()))
-                        .collect(toImmutableList()));
+                        .collect(toImmutableList()),
+                queryInfo.getSession().getTraceToken());
     }
 
     private List<OperatorStatistics> createOperatorStatistics(QueryInfo queryInfo)

--- a/presto-main/src/main/java/com/facebook/presto/tracing/SimpleTracer.java
+++ b/presto-main/src/main/java/com/facebook/presto/tracing/SimpleTracer.java
@@ -83,6 +83,12 @@ public class SimpleTracer
         pointList.add(new SimpleTracerPoint(annotation));
     }
 
+    @Override
+    public String getTracerId()
+    {
+        return "simple_dummy_id";
+    }
+
     public String toString()
     {
         return toStringHelper(this)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/QueryMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/QueryMetadata.java
@@ -25,6 +25,7 @@ public class QueryMetadata
 {
     private final String queryId;
     private final Optional<String> transactionId;
+    private final Optional<String> tracingId;
 
     private final String query;
     private final String queryState;
@@ -48,7 +49,8 @@ public class QueryMetadata
             Optional<String> plan,
             Optional<String> jsonPlan,
             Optional<String> payload,
-            List<String> runtimeOptimizedStages)
+            List<String> runtimeOptimizedStages,
+            Optional<String> tracingId)
     {
         this.queryId = requireNonNull(queryId, "queryId is null");
         this.transactionId = requireNonNull(transactionId, "transactionId is null");
@@ -59,6 +61,7 @@ public class QueryMetadata
         this.jsonPlan = requireNonNull(jsonPlan, "jsonPlan is null");
         this.payload = requireNonNull(payload, "payload is null");
         this.runtimeOptimizedStages = requireNonNull(runtimeOptimizedStages, "runtimeOptimizedStages is null");
+        this.tracingId = requireNonNull(tracingId, "tracingId is null");
     }
 
     @JsonProperty
@@ -113,5 +116,11 @@ public class QueryMetadata
     public List<String> getRuntimeOptimizedStages()
     {
         return runtimeOptimizedStages;
+    }
+
+    @JsonProperty
+    public Optional<String> getTracingId()
+    {
+        return tracingId;
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/tracing/NoopTracer.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/tracing/NoopTracer.java
@@ -40,4 +40,10 @@ public class NoopTracer
     public void endTrace(String annotation)
     {
     }
+
+    @Override
+    public String getTracerId()
+    {
+        return "noop_dummy_id";
+    }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/tracing/Tracer.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/tracing/Tracer.java
@@ -47,4 +47,6 @@ public interface Tracer
      * @param annotation message associated with the end point of the trace
      */
     void endTrace(String annotation);
+
+    String getTracerId();
 }


### PR DESCRIPTION
Store tracing id so that we can expose it in result structure later.
```
== NO RELEASE NOTE ==
```
