### PR TITLE
Logging for last_data_commit_time/last_access_time

### DIFF
--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/AccumuloConnector.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/AccumuloConnector.java
@@ -20,6 +20,7 @@ import com.facebook.presto.accumulo.conf.AccumuloTableProperties;
 import com.facebook.presto.accumulo.io.AccumuloPageSinkProvider;
 import com.facebook.presto.accumulo.io.AccumuloRecordSetProvider;
 import com.facebook.presto.spi.connector.Connector;
+import com.facebook.presto.spi.connector.ConnectorCommitResult;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.connector.ConnectorPageSinkProvider;
 import com.facebook.presto.spi.connector.ConnectorRecordSetProvider;
@@ -31,6 +32,7 @@ import com.facebook.presto.spi.transaction.IsolationLevel;
 import javax.inject.Inject;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -94,9 +96,13 @@ public class AccumuloConnector
     }
 
     @Override
-    public void commit(ConnectorTransactionHandle transactionHandle)
+    public Optional<ConnectorCommitResult> commit(ConnectorTransactionHandle transactionHandle)
     {
-        checkArgument(transactions.remove(transactionHandle) != null, "no such transaction: %s", transactionHandle);
+        checkArgument(
+                transactions.remove(transactionHandle) != null,
+                "no such transaction: %s",
+                transactionHandle);
+        return Optional.empty();
     }
 
     @Override

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcConnector.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcConnector.java
@@ -19,6 +19,7 @@ import com.facebook.presto.plugin.jdbc.optimization.JdbcPlanOptimizerProvider;
 import com.facebook.presto.spi.connector.Connector;
 import com.facebook.presto.spi.connector.ConnectorAccessControl;
 import com.facebook.presto.spi.connector.ConnectorCapabilities;
+import com.facebook.presto.spi.connector.ConnectorCommitResult;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.connector.ConnectorPageSinkProvider;
 import com.facebook.presto.spi.connector.ConnectorPlanOptimizerProvider;
@@ -128,9 +129,10 @@ public class JdbcConnector
     }
 
     @Override
-    public void commit(ConnectorTransactionHandle transaction)
+    public Optional<ConnectorCommitResult> commit(ConnectorTransactionHandle transaction)
     {
         checkArgument(transactions.remove(transaction) != null, "no such transaction: %s", transaction);
+        return Optional.empty();
     }
 
     @Override

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/CachingHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/CachingHiveMetastore.java
@@ -507,10 +507,10 @@ public class CachingHiveMetastore
     }
 
     @Override
-    public void createTable(MetastoreContext metastoreContext, Table table, PrincipalPrivileges principalPrivileges)
+    public MetastoreOperationStats createTable(MetastoreContext metastoreContext, Table table, PrincipalPrivileges principalPrivileges)
     {
         try {
-            delegate.createTable(metastoreContext, table, principalPrivileges);
+            return delegate.createTable(metastoreContext, table, principalPrivileges);
         }
         finally {
             invalidateTable(table.getDatabaseName(), table.getTableName());
@@ -529,10 +529,10 @@ public class CachingHiveMetastore
     }
 
     @Override
-    public void replaceTable(MetastoreContext metastoreContext, String databaseName, String tableName, Table newTable, PrincipalPrivileges principalPrivileges)
+    public MetastoreOperationStats replaceTable(MetastoreContext metastoreContext, String databaseName, String tableName, Table newTable, PrincipalPrivileges principalPrivileges)
     {
         try {
-            delegate.replaceTable(metastoreContext, databaseName, tableName, newTable, principalPrivileges);
+            return delegate.replaceTable(metastoreContext, databaseName, tableName, newTable, principalPrivileges);
         }
         finally {
             invalidateTable(databaseName, tableName);
@@ -541,10 +541,10 @@ public class CachingHiveMetastore
     }
 
     @Override
-    public void renameTable(MetastoreContext metastoreContext, String databaseName, String tableName, String newDatabaseName, String newTableName)
+    public MetastoreOperationStats renameTable(MetastoreContext metastoreContext, String databaseName, String tableName, String newDatabaseName, String newTableName)
     {
         try {
-            delegate.renameTable(metastoreContext, databaseName, tableName, newDatabaseName, newTableName);
+            return delegate.renameTable(metastoreContext, databaseName, tableName, newDatabaseName, newTableName);
         }
         finally {
             invalidateTable(databaseName, tableName);
@@ -553,10 +553,10 @@ public class CachingHiveMetastore
     }
 
     @Override
-    public void addColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String columnName, HiveType columnType, String columnComment)
+    public MetastoreOperationStats addColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String columnName, HiveType columnType, String columnComment)
     {
         try {
-            delegate.addColumn(metastoreContext, databaseName, tableName, columnName, columnType, columnComment);
+            return delegate.addColumn(metastoreContext, databaseName, tableName, columnName, columnType, columnComment);
         }
         finally {
             invalidateTable(databaseName, tableName);
@@ -564,10 +564,10 @@ public class CachingHiveMetastore
     }
 
     @Override
-    public void renameColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String oldColumnName, String newColumnName)
+    public MetastoreOperationStats renameColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String oldColumnName, String newColumnName)
     {
         try {
-            delegate.renameColumn(metastoreContext, databaseName, tableName, oldColumnName, newColumnName);
+            return delegate.renameColumn(metastoreContext, databaseName, tableName, oldColumnName, newColumnName);
         }
         finally {
             invalidateTable(databaseName, tableName);
@@ -575,10 +575,10 @@ public class CachingHiveMetastore
     }
 
     @Override
-    public void dropColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String columnName)
+    public MetastoreOperationStats dropColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String columnName)
     {
         try {
-            delegate.dropColumn(metastoreContext, databaseName, tableName, columnName);
+            return delegate.dropColumn(metastoreContext, databaseName, tableName, columnName);
         }
         finally {
             invalidateTable(databaseName, tableName);
@@ -782,10 +782,10 @@ public class CachingHiveMetastore
     }
 
     @Override
-    public void addPartitions(MetastoreContext metastoreContext, String databaseName, String tableName, List<PartitionWithStatistics> partitions)
+    public MetastoreOperationStats addPartitions(MetastoreContext metastoreContext, String databaseName, String tableName, List<PartitionWithStatistics> partitions)
     {
         try {
-            delegate.addPartitions(metastoreContext, databaseName, tableName, partitions);
+            return delegate.addPartitions(metastoreContext, databaseName, tableName, partitions);
         }
         finally {
             // todo do we need to invalidate all partitions?
@@ -805,10 +805,10 @@ public class CachingHiveMetastore
     }
 
     @Override
-    public void alterPartition(MetastoreContext metastoreContext, String databaseName, String tableName, PartitionWithStatistics partition)
+    public MetastoreOperationStats alterPartition(MetastoreContext metastoreContext, String databaseName, String tableName, PartitionWithStatistics partition)
     {
         try {
-            delegate.alterPartition(metastoreContext, databaseName, tableName, partition);
+            return delegate.alterPartition(metastoreContext, databaseName, tableName, partition);
         }
         finally {
             invalidatePartitionCache(databaseName, tableName);

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/ExtendedHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/ExtendedHiveMetastore.java
@@ -55,7 +55,7 @@ public interface ExtendedHiveMetastore
 
     void renameDatabase(MetastoreContext metastoreContext, String databaseName, String newDatabaseName);
 
-    void createTable(MetastoreContext metastoreContext, Table table, PrincipalPrivileges principalPrivileges);
+    MetastoreOperationStats createTable(MetastoreContext metastoreContext, Table table, PrincipalPrivileges principalPrivileges);
 
     void dropTable(MetastoreContext metastoreContext, String databaseName, String tableName, boolean deleteData);
 
@@ -64,15 +64,15 @@ public interface ExtendedHiveMetastore
      * alter one field of a table object previously acquired from getTable is
      * probably not what you want.
      */
-    void replaceTable(MetastoreContext metastoreContext, String databaseName, String tableName, Table newTable, PrincipalPrivileges principalPrivileges);
+    MetastoreOperationStats replaceTable(MetastoreContext metastoreContext, String databaseName, String tableName, Table newTable, PrincipalPrivileges principalPrivileges);
 
-    void renameTable(MetastoreContext metastoreContext, String databaseName, String tableName, String newDatabaseName, String newTableName);
+    MetastoreOperationStats renameTable(MetastoreContext metastoreContext, String databaseName, String tableName, String newDatabaseName, String newTableName);
 
-    void addColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String columnName, HiveType columnType, String columnComment);
+    MetastoreOperationStats addColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String columnName, HiveType columnType, String columnComment);
 
-    void renameColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String oldColumnName, String newColumnName);
+    MetastoreOperationStats renameColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String oldColumnName, String newColumnName);
 
-    void dropColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String columnName);
+    MetastoreOperationStats dropColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String columnName);
 
     Optional<Partition> getPartition(MetastoreContext metastoreContext, String databaseName, String tableName, List<String> partitionValues);
 
@@ -92,11 +92,11 @@ public interface ExtendedHiveMetastore
 
     Map<String, Optional<Partition>> getPartitionsByNames(MetastoreContext metastoreContext, String databaseName, String tableName, List<String> partitionNames);
 
-    void addPartitions(MetastoreContext metastoreContext, String databaseName, String tableName, List<PartitionWithStatistics> partitions);
+    MetastoreOperationStats addPartitions(MetastoreContext metastoreContext, String databaseName, String tableName, List<PartitionWithStatistics> partitions);
 
     void dropPartition(MetastoreContext metastoreContext, String databaseName, String tableName, List<String> parts, boolean deleteData);
 
-    void alterPartition(MetastoreContext metastoreContext, String databaseName, String tableName, PartitionWithStatistics partition);
+    MetastoreOperationStats alterPartition(MetastoreContext metastoreContext, String databaseName, String tableName, PartitionWithStatistics partition);
 
     void createRole(MetastoreContext metastoreContext, String role, String grantor);
 

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/MetastoreOperationStats.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/MetastoreOperationStats.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.metastore;
+
+import org.joda.time.DateTime;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+public class MetastoreOperationStats
+{
+    private final MetastoreOperationType operationType;
+    private final List<DateTime> lastDataCommitTimes;
+    private static final int DUMMY_MILLISECONDS = -1000;
+
+    public MetastoreOperationStats()
+    {
+        operationType = MetastoreOperationType.OTHERS;
+        lastDataCommitTimes = Arrays.asList(new DateTime(DUMMY_MILLISECONDS));
+    }
+
+    public MetastoreOperationStats(MetastoreOperationType operationType, List<DateTime> lastDataCommitTimes)
+    {
+        this.operationType = requireNonNull(operationType, "operationType is null");
+        this.lastDataCommitTimes = requireNonNull(lastDataCommitTimes, "lastDataCommitTimes is null");
+    }
+
+    public List<DateTime> getLastDataCommitTimes()
+    {
+        return lastDataCommitTimes;
+    }
+
+    public MetastoreOperationType getOperationType()
+    {
+        return operationType;
+    }
+}

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/MetastoreOperationType.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/MetastoreOperationType.java
@@ -11,18 +11,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.hive;
+package com.facebook.presto.hive.metastore;
 
-import com.facebook.presto.hive.metastore.SemiTransactionalHiveMetastore;
-import com.facebook.presto.spi.connector.ConnectorCommitResult;
-import com.facebook.presto.spi.connector.ConnectorMetadata;
-
-public interface TransactionalMetadata
-        extends ConnectorMetadata
+public enum MetastoreOperationType
 {
-    ConnectorCommitResult commit();
-
-    void rollback();
-
-    SemiTransactionalHiveMetastore getMetastore();
+    ADD_PARTITION,
+    ALTER_TABLES,
+    ALTER_PARTITIONS,
+    APPEND_PARTITION,
+    APPEND_PARTITION_BY_NAME,
+    CREATE_TABLE,
+    GET_PARTITION,
+    GET_PARTITION_BY_NAME,
+    GET_TABLE,
+    OTHERS
 }

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/Partition.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/Partition.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import org.joda.time.DateTime;
 
 import javax.annotation.concurrent.Immutable;
 
@@ -44,6 +45,7 @@ public class Partition
     private final boolean eligibleToIgnore;
     private final boolean sealedPartition;
     private final int createTime;
+    private final DateTime lastAccessTime;
 
     @JsonCreator
     public Partition(
@@ -56,7 +58,8 @@ public class Partition
             @JsonProperty("partitionVersion") Optional<Long> partitionVersion,
             @JsonProperty("eligibleToIgnore") boolean eligibleToIgnore,
             @JsonProperty("sealedPartition") boolean sealedPartition,
-            @JsonProperty("createTime") int createTime)
+            @JsonProperty("createTime") int createTime,
+            @JsonProperty("lastAccessTime") DateTime lastAccessTime)
     {
         this.databaseName = requireNonNull(databaseName, "databaseName is null");
         this.tableName = requireNonNull(tableName, "tableName is null");
@@ -68,6 +71,7 @@ public class Partition
         this.eligibleToIgnore = eligibleToIgnore;
         this.sealedPartition = sealedPartition;
         this.createTime = createTime;
+        this.lastAccessTime = lastAccessTime;
     }
 
     @JsonProperty
@@ -136,6 +140,12 @@ public class Partition
         return createTime;
     }
 
+    @JsonProperty
+    public DateTime getLastAccessTime()
+    {
+        return lastAccessTime;
+    }
+
     @Override
     public String toString()
     {
@@ -166,13 +176,25 @@ public class Partition
                 Objects.equals(partitionVersion, partition.partitionVersion) &&
                 Objects.equals(eligibleToIgnore, partition.eligibleToIgnore) &&
                 Objects.equals(sealedPartition, partition.sealedPartition) &&
-                Objects.equals(createTime, partition.getCreateTime());
+                Objects.equals(createTime, partition.getCreateTime()) &&
+                Objects.equals(lastAccessTime, partition.lastAccessTime);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(databaseName, tableName, values, storage, columns, parameters, partitionVersion, eligibleToIgnore, sealedPartition, createTime);
+        return Objects.hash(
+                databaseName,
+                tableName,
+                values,
+                storage,
+                columns,
+                parameters,
+                partitionVersion,
+                eligibleToIgnore,
+                sealedPartition,
+                createTime,
+                lastAccessTime);
     }
 
     public static Builder builder()
@@ -197,6 +219,7 @@ public class Partition
         private boolean isEligibleToIgnore;
         private boolean isSealedPartition = true;
         private int createTime;
+        private DateTime lastAccessTime = new DateTime(-1000);
 
         private Builder()
         {
@@ -214,6 +237,7 @@ public class Partition
             this.partitionVersion = partition.getPartitionVersion();
             this.isEligibleToIgnore = partition.isEligibleToIgnore();
             this.createTime = partition.getCreateTime();
+            this.lastAccessTime = partition.getLastAccessTime();
         }
 
         public Builder setDatabaseName(String databaseName)
@@ -281,9 +305,26 @@ public class Partition
             return this;
         }
 
+        public Builder setLastAccessTime(int lastAccessTime)
+        {
+            this.lastAccessTime = new DateTime(lastAccessTime * 1000);
+            return this;
+        }
+
         public Partition build()
         {
-            return new Partition(databaseName, tableName, values, storageBuilder.build(), columns, parameters, partitionVersion, isEligibleToIgnore, isSealedPartition, createTime);
+            return new Partition(
+                    databaseName,
+                    tableName,
+                    values,
+                    storageBuilder.build(),
+                    columns,
+                    parameters,
+                    partitionVersion,
+                    isEligibleToIgnore,
+                    isSealedPartition,
+                    createTime,
+                    lastAccessTime);
         }
     }
 }

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/RecordingHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/RecordingHiveMetastore.java
@@ -278,10 +278,10 @@ public class RecordingHiveMetastore
     }
 
     @Override
-    public void createTable(MetastoreContext metastoreContext, Table table, PrincipalPrivileges principalPrivileges)
+    public MetastoreOperationStats createTable(MetastoreContext metastoreContext, Table table, PrincipalPrivileges principalPrivileges)
     {
         verifyRecordingMode();
-        delegate.createTable(metastoreContext, table, principalPrivileges);
+        return delegate.createTable(metastoreContext, table, principalPrivileges);
     }
 
     @Override
@@ -292,38 +292,38 @@ public class RecordingHiveMetastore
     }
 
     @Override
-    public void replaceTable(MetastoreContext metastoreContext, String databaseName, String tableName, Table newTable, PrincipalPrivileges principalPrivileges)
+    public MetastoreOperationStats replaceTable(MetastoreContext metastoreContext, String databaseName, String tableName, Table newTable, PrincipalPrivileges principalPrivileges)
     {
         verifyRecordingMode();
-        delegate.replaceTable(metastoreContext, databaseName, tableName, newTable, principalPrivileges);
+        return delegate.replaceTable(metastoreContext, databaseName, tableName, newTable, principalPrivileges);
     }
 
     @Override
-    public void renameTable(MetastoreContext metastoreContext, String databaseName, String tableName, String newDatabaseName, String newTableName)
+    public MetastoreOperationStats renameTable(MetastoreContext metastoreContext, String databaseName, String tableName, String newDatabaseName, String newTableName)
     {
         verifyRecordingMode();
-        delegate.renameTable(metastoreContext, databaseName, tableName, newDatabaseName, newTableName);
+        return delegate.renameTable(metastoreContext, databaseName, tableName, newDatabaseName, newTableName);
     }
 
     @Override
-    public void addColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String columnName, HiveType columnType, String columnComment)
+    public MetastoreOperationStats addColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String columnName, HiveType columnType, String columnComment)
     {
         verifyRecordingMode();
-        delegate.addColumn(metastoreContext, databaseName, tableName, columnName, columnType, columnComment);
+        return delegate.addColumn(metastoreContext, databaseName, tableName, columnName, columnType, columnComment);
     }
 
     @Override
-    public void renameColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String oldColumnName, String newColumnName)
+    public MetastoreOperationStats renameColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String oldColumnName, String newColumnName)
     {
         verifyRecordingMode();
-        delegate.renameColumn(metastoreContext, databaseName, tableName, oldColumnName, newColumnName);
+        return delegate.renameColumn(metastoreContext, databaseName, tableName, oldColumnName, newColumnName);
     }
 
     @Override
-    public void dropColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String columnName)
+    public MetastoreOperationStats dropColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String columnName)
     {
         verifyRecordingMode();
-        delegate.dropColumn(metastoreContext, databaseName, tableName, columnName);
+        return delegate.dropColumn(metastoreContext, databaseName, tableName, columnName);
     }
 
     @Override
@@ -377,10 +377,10 @@ public class RecordingHiveMetastore
     }
 
     @Override
-    public void addPartitions(MetastoreContext metastoreContext, String databaseName, String tableName, List<PartitionWithStatistics> partitions)
+    public MetastoreOperationStats addPartitions(MetastoreContext metastoreContext, String databaseName, String tableName, List<PartitionWithStatistics> partitions)
     {
         verifyRecordingMode();
-        delegate.addPartitions(metastoreContext, databaseName, tableName, partitions);
+        return delegate.addPartitions(metastoreContext, databaseName, tableName, partitions);
     }
 
     @Override
@@ -391,10 +391,10 @@ public class RecordingHiveMetastore
     }
 
     @Override
-    public void alterPartition(MetastoreContext metastoreContext, String databaseName, String tableName, PartitionWithStatistics partition)
+    public MetastoreOperationStats alterPartition(MetastoreContext metastoreContext, String databaseName, String tableName, PartitionWithStatistics partition)
     {
         verifyRecordingMode();
-        delegate.alterPartition(metastoreContext, databaseName, tableName, partition);
+        return delegate.alterPartition(metastoreContext, databaseName, tableName, partition);
     }
 
     @Override

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/Table.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/Table.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import org.joda.time.DateTime;
 
 import javax.annotation.concurrent.Immutable;
 
@@ -47,6 +48,7 @@ public class Table
     private final Map<String, String> parameters;
     private final Optional<String> viewOriginalText;
     private final Optional<String> viewExpandedText;
+    private final Optional<DateTime> lastAccessTime;
 
     @JsonCreator
     public Table(
@@ -59,7 +61,8 @@ public class Table
             @JsonProperty("partitionColumns") List<Column> partitionColumns,
             @JsonProperty("parameters") Map<String, String> parameters,
             @JsonProperty("viewOriginalText") Optional<String> viewOriginalText,
-            @JsonProperty("viewExpandedText") Optional<String> viewExpandedText)
+            @JsonProperty("viewExpandedText") Optional<String> viewExpandedText,
+            @JsonProperty("lastAccessTime") Optional<DateTime> lastAccessTime)
     {
         this.databaseName = requireNonNull(databaseName, "databaseName is null");
         this.tableName = requireNonNull(tableName, "tableName is null");
@@ -71,6 +74,13 @@ public class Table
         this.parameters = ImmutableMap.copyOf(requireNonNull(parameters, "parameters is null"));
         this.viewOriginalText = requireNonNull(viewOriginalText, "viewOriginalText is null");
         this.viewExpandedText = requireNonNull(viewExpandedText, "viewExpandedText is null");
+        this.lastAccessTime = requireNonNull(lastAccessTime, "lastCommitDataTime is null");
+    }
+
+    @JsonProperty
+    public Optional<DateTime> getLastAccessTime()
+    {
+        return lastAccessTime;
     }
 
     @JsonProperty
@@ -170,6 +180,7 @@ public class Table
                 .add("parameters", parameters)
                 .add("viewOriginalText", viewOriginalText)
                 .add("viewExpandedText", viewExpandedText)
+                .add("lastAccessTime", lastAccessTime)
                 .toString();
     }
 
@@ -193,7 +204,8 @@ public class Table
                 Objects.equals(storage, table.storage) &&
                 Objects.equals(parameters, table.parameters) &&
                 Objects.equals(viewOriginalText, table.viewOriginalText) &&
-                Objects.equals(viewExpandedText, table.viewExpandedText);
+                Objects.equals(viewExpandedText, table.viewExpandedText) &&
+                Objects.equals(lastAccessTime, table.lastAccessTime);
     }
 
     @Override
@@ -209,7 +221,8 @@ public class Table
                 storage,
                 parameters,
                 viewOriginalText,
-                viewExpandedText);
+                viewExpandedText,
+                lastAccessTime);
     }
 
     public static class Builder
@@ -224,6 +237,7 @@ public class Table
         private Map<String, String> parameters = new LinkedHashMap<>();
         private Optional<String> viewOriginalText = Optional.empty();
         private Optional<String> viewExpandedText = Optional.empty();
+        private Optional<DateTime> lastAccessTime = Optional.empty();
 
         private Builder()
         {
@@ -242,6 +256,7 @@ public class Table
             parameters = new LinkedHashMap<>(table.parameters);
             viewOriginalText = table.viewOriginalText;
             viewExpandedText = table.viewExpandedText;
+            lastAccessTime = table.lastAccessTime;
         }
 
         public Builder setDatabaseName(String databaseName)
@@ -315,6 +330,14 @@ public class Table
             return this;
         }
 
+        public Builder setLastAccessTime(Optional<Integer> lastAccessTime)
+        {
+            if (lastAccessTime.isPresent()) {
+                this.lastAccessTime = Optional.of(new DateTime(lastAccessTime.get() * 1000));
+            }
+            return this;
+        }
+
         public Builder withStorage(Consumer<Storage.Builder> consumer)
         {
             consumer.accept(storageBuilder);
@@ -333,7 +356,8 @@ public class Table
                     partitionColumns,
                     parameters,
                     viewOriginalText,
-                    viewExpandedText);
+                    viewExpandedText,
+                    lastAccessTime);
         }
     }
 }

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/alluxio/AlluxioHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/alluxio/AlluxioHiveMetastore.java
@@ -28,6 +28,7 @@ import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
 import com.facebook.presto.hive.metastore.HiveColumnStatistics;
 import com.facebook.presto.hive.metastore.HivePrivilegeInfo;
 import com.facebook.presto.hive.metastore.MetastoreContext;
+import com.facebook.presto.hive.metastore.MetastoreOperationStats;
 import com.facebook.presto.hive.metastore.MetastoreUtil;
 import com.facebook.presto.hive.metastore.Partition;
 import com.facebook.presto.hive.metastore.PartitionNameWithVersion;
@@ -235,7 +236,7 @@ public class AlluxioHiveMetastore
     }
 
     @Override
-    public void createTable(MetastoreContext metastoreContext, Table table, PrincipalPrivileges principalPrivileges)
+    public MetastoreOperationStats createTable(MetastoreContext metastoreContext, Table table, PrincipalPrivileges principalPrivileges)
     {
         throw new UnsupportedOperationException("createTable is not supported in AlluxioHiveMetastore");
     }
@@ -247,31 +248,31 @@ public class AlluxioHiveMetastore
     }
 
     @Override
-    public void replaceTable(MetastoreContext metastoreContext, String databaseName, String tableName, Table newTable, PrincipalPrivileges principalPrivileges)
+    public MetastoreOperationStats replaceTable(MetastoreContext metastoreContext, String databaseName, String tableName, Table newTable, PrincipalPrivileges principalPrivileges)
     {
         throw new UnsupportedOperationException("replaceTable is not supported in AlluxioHiveMetastore");
     }
 
     @Override
-    public void renameTable(MetastoreContext metastoreContext, String databaseName, String tableName, String newDatabaseName, String newTableName)
+    public MetastoreOperationStats renameTable(MetastoreContext metastoreContext, String databaseName, String tableName, String newDatabaseName, String newTableName)
     {
         throw new UnsupportedOperationException("renameTable is not supported in AlluxioHiveMetastore");
     }
 
     @Override
-    public void addColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String columnName, HiveType columnType, String columnComment)
+    public MetastoreOperationStats addColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String columnName, HiveType columnType, String columnComment)
     {
         throw new UnsupportedOperationException("addColumn is not supported in AlluxioHiveMetastore");
     }
 
     @Override
-    public void renameColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String oldColumnName, String newColumnName)
+    public MetastoreOperationStats renameColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String oldColumnName, String newColumnName)
     {
         throw new UnsupportedOperationException("renameColumn is not supported in AlluxioHiveMetastore");
     }
 
     @Override
-    public void dropColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String columnName)
+    public MetastoreOperationStats dropColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String columnName)
     {
         throw new UnsupportedOperationException("dropColumn is not supported in AlluxioHiveMetastore");
     }
@@ -373,7 +374,7 @@ public class AlluxioHiveMetastore
     }
 
     @Override
-    public void addPartitions(MetastoreContext metastoreContext, String databaseName, String tableName, List<PartitionWithStatistics> partitions)
+    public MetastoreOperationStats addPartitions(MetastoreContext metastoreContext, String databaseName, String tableName, List<PartitionWithStatistics> partitions)
     {
         throw new UnsupportedOperationException("addPartitions is not supported in AlluxioHiveMetastore");
     }
@@ -385,7 +386,7 @@ public class AlluxioHiveMetastore
     }
 
     @Override
-    public void alterPartition(MetastoreContext metastoreContext, String databaseName, String tableName, PartitionWithStatistics partition)
+    public MetastoreOperationStats alterPartition(MetastoreContext metastoreContext, String databaseName, String tableName, PartitionWithStatistics partition)
     {
         throw new UnsupportedOperationException("alterPartition is not supported in AlluxioHiveMetastore");
     }

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/file/PartitionMetadata.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/file/PartitionMetadata.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import org.joda.time.DateTime;
 
 import java.util.Arrays;
 import java.util.List;
@@ -198,6 +199,7 @@ public class PartitionMetadata
                 Optional.empty(),
                 eligibleToIgnore,
                 sealedPartition,
-                0);
+                0,
+                new DateTime(-1000));
     }
 }

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/file/TableMetadata.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/file/TableMetadata.java
@@ -294,6 +294,7 @@ public class TableMetadata
                 partitionColumns,
                 parameters,
                 viewOriginalText,
-                viewExpandedText);
+                viewExpandedText,
+                Optional.empty());
     }
 }

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/BridgingHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/BridgingHiveMetastore.java
@@ -22,6 +22,7 @@ import com.facebook.presto.hive.metastore.Database;
 import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
 import com.facebook.presto.hive.metastore.HivePrivilegeInfo;
 import com.facebook.presto.hive.metastore.MetastoreContext;
+import com.facebook.presto.hive.metastore.MetastoreOperationStats;
 import com.facebook.presto.hive.metastore.MetastoreUtil;
 import com.facebook.presto.hive.metastore.Partition;
 import com.facebook.presto.hive.metastore.PartitionNameWithVersion;
@@ -168,10 +169,10 @@ public class BridgingHiveMetastore
     }
 
     @Override
-    public void createTable(MetastoreContext metastoreContext, Table table, PrincipalPrivileges principalPrivileges)
+    public MetastoreOperationStats createTable(MetastoreContext metastoreContext, Table table, PrincipalPrivileges principalPrivileges)
     {
         checkArgument(!table.getTableType().equals(TEMPORARY_TABLE), "temporary tables must never be stored in the metastore");
-        delegate.createTable(metastoreContext, toMetastoreApiTable(table, principalPrivileges, metastoreContext.getColumnConverter()));
+        return delegate.createTable(metastoreContext, toMetastoreApiTable(table, principalPrivileges, metastoreContext.getColumnConverter()));
     }
 
     @Override
@@ -181,14 +182,14 @@ public class BridgingHiveMetastore
     }
 
     @Override
-    public void replaceTable(MetastoreContext metastoreContext, String databaseName, String tableName, Table newTable, PrincipalPrivileges principalPrivileges)
+    public MetastoreOperationStats replaceTable(MetastoreContext metastoreContext, String databaseName, String tableName, Table newTable, PrincipalPrivileges principalPrivileges)
     {
         checkArgument(!newTable.getTableType().equals(TEMPORARY_TABLE), "temporary tables must never be stored in the metastore");
-        alterTable(metastoreContext, databaseName, tableName, toMetastoreApiTable(newTable, principalPrivileges, metastoreContext.getColumnConverter()));
+        return alterTable(metastoreContext, databaseName, tableName, toMetastoreApiTable(newTable, principalPrivileges, metastoreContext.getColumnConverter()));
     }
 
     @Override
-    public void renameTable(MetastoreContext metastoreContext, String databaseName, String tableName, String newDatabaseName, String newTableName)
+    public MetastoreOperationStats renameTable(MetastoreContext metastoreContext, String databaseName, String tableName, String newDatabaseName, String newTableName)
     {
         Optional<org.apache.hadoop.hive.metastore.api.Table> source = delegate.getTable(metastoreContext, databaseName, tableName);
         if (!source.isPresent()) {
@@ -197,11 +198,11 @@ public class BridgingHiveMetastore
         org.apache.hadoop.hive.metastore.api.Table table = source.get();
         table.setDbName(newDatabaseName);
         table.setTableName(newTableName);
-        alterTable(metastoreContext, databaseName, tableName, table);
+        return alterTable(metastoreContext, databaseName, tableName, table);
     }
 
     @Override
-    public void addColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String columnName, HiveType columnType, String columnComment)
+    public MetastoreOperationStats addColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String columnName, HiveType columnType, String columnComment)
     {
         Optional<org.apache.hadoop.hive.metastore.api.Table> source = delegate.getTable(metastoreContext, databaseName, tableName);
         if (!source.isPresent()) {
@@ -210,11 +211,11 @@ public class BridgingHiveMetastore
         org.apache.hadoop.hive.metastore.api.Table table = source.get();
         Column column = new Column(columnName, columnType, Optional.ofNullable(columnComment), Optional.empty());
         table.getSd().getCols().add(metastoreContext.getColumnConverter().fromColumn(column));
-        alterTable(metastoreContext, databaseName, tableName, table);
+        return alterTable(metastoreContext, databaseName, tableName, table);
     }
 
     @Override
-    public void renameColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String oldColumnName, String newColumnName)
+    public MetastoreOperationStats renameColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String oldColumnName, String newColumnName)
     {
         Optional<org.apache.hadoop.hive.metastore.api.Table> source = delegate.getTable(metastoreContext, databaseName, tableName);
         if (!source.isPresent()) {
@@ -231,22 +232,22 @@ public class BridgingHiveMetastore
                 fieldSchema.setName(newColumnName);
             }
         }
-        alterTable(metastoreContext, databaseName, tableName, table);
+        return alterTable(metastoreContext, databaseName, tableName, table);
     }
 
     @Override
-    public void dropColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String columnName)
+    public MetastoreOperationStats dropColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String columnName)
     {
         verifyCanDropColumn(this, metastoreContext, databaseName, tableName, columnName);
         org.apache.hadoop.hive.metastore.api.Table table = delegate.getTable(metastoreContext, databaseName, tableName)
                 .orElseThrow(() -> new TableNotFoundException(new SchemaTableName(databaseName, tableName)));
         table.getSd().getCols().removeIf(fieldSchema -> fieldSchema.getName().equals(columnName));
-        alterTable(metastoreContext, databaseName, tableName, table);
+        return alterTable(metastoreContext, databaseName, tableName, table);
     }
 
-    private void alterTable(MetastoreContext metastoreContext, String databaseName, String tableName, org.apache.hadoop.hive.metastore.api.Table table)
+    private MetastoreOperationStats alterTable(MetastoreContext metastoreContext, String databaseName, String tableName, org.apache.hadoop.hive.metastore.api.Table table)
     {
-        delegate.alterTable(metastoreContext, databaseName, tableName, table);
+        return delegate.alterTable(metastoreContext, databaseName, tableName, table);
     }
 
     @Override
@@ -302,9 +303,9 @@ public class BridgingHiveMetastore
     }
 
     @Override
-    public void addPartitions(MetastoreContext metastoreContext, String databaseName, String tableName, List<PartitionWithStatistics> partitions)
+    public MetastoreOperationStats addPartitions(MetastoreContext metastoreContext, String databaseName, String tableName, List<PartitionWithStatistics> partitions)
     {
-        delegate.addPartitions(metastoreContext, databaseName, tableName, partitions);
+        return delegate.addPartitions(metastoreContext, databaseName, tableName, partitions);
     }
 
     @Override
@@ -314,9 +315,9 @@ public class BridgingHiveMetastore
     }
 
     @Override
-    public void alterPartition(MetastoreContext metastoreContext, String databaseName, String tableName, PartitionWithStatistics partition)
+    public MetastoreOperationStats alterPartition(MetastoreContext metastoreContext, String databaseName, String tableName, PartitionWithStatistics partition)
     {
-        delegate.alterPartition(metastoreContext, databaseName, tableName, partition);
+        return delegate.alterPartition(metastoreContext, databaseName, tableName, partition);
     }
 
     @Override

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/HiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/HiveMetastore.java
@@ -18,6 +18,7 @@ import com.facebook.presto.common.type.Type;
 import com.facebook.presto.hive.metastore.Column;
 import com.facebook.presto.hive.metastore.HivePrivilegeInfo;
 import com.facebook.presto.hive.metastore.MetastoreContext;
+import com.facebook.presto.hive.metastore.MetastoreOperationStats;
 import com.facebook.presto.hive.metastore.PartitionNameWithVersion;
 import com.facebook.presto.hive.metastore.PartitionStatistics;
 import com.facebook.presto.hive.metastore.PartitionWithStatistics;
@@ -49,11 +50,11 @@ public interface HiveMetastore
 
     void alterDatabase(MetastoreContext metastoreContext, String databaseName, Database database);
 
-    void createTable(MetastoreContext metastoreContext, Table table);
+    MetastoreOperationStats createTable(MetastoreContext metastoreContext, Table table);
 
     void dropTable(MetastoreContext metastoreContext, String databaseName, String tableName, boolean deleteData);
 
-    void alterTable(MetastoreContext metastoreContext, String databaseName, String tableName, Table table);
+    MetastoreOperationStats alterTable(MetastoreContext metastoreContext, String databaseName, String tableName, Table table);
 
     List<String> getAllDatabases(MetastoreContext metastoreContext);
 
@@ -63,11 +64,19 @@ public interface HiveMetastore
 
     Optional<Database> getDatabase(MetastoreContext metastoreContext, String databaseName);
 
-    void addPartitions(MetastoreContext metastoreContext, String databaseName, String tableName, List<PartitionWithStatistics> partitions);
+    MetastoreOperationStats addPartitions(
+            MetastoreContext metastoreContext,
+            String databaseName,
+            String tableName,
+            List<PartitionWithStatistics> partitions);
 
     void dropPartition(MetastoreContext metastoreContext, String databaseName, String tableName, List<String> parts, boolean deleteData);
 
-    void alterPartition(MetastoreContext metastoreContext, String databaseName, String tableName, PartitionWithStatistics partition);
+    MetastoreOperationStats alterPartition(
+            MetastoreContext metastoreContext,
+            String databaseName,
+            String tableName,
+            PartitionWithStatistics partition);
 
     Optional<List<String>> getPartitionNames(MetastoreContext metastoreContext, String databaseName, String tableName);
 
@@ -80,11 +89,22 @@ public interface HiveMetastore
         throw new UnsupportedOperationException();
     }
 
-    Optional<Partition> getPartition(MetastoreContext metastoreContext, String databaseName, String tableName, List<String> partitionValues);
+    Optional<Partition> getPartition(
+            MetastoreContext metastoreContext,
+            String databaseName,
+            String tableName,
+            List<String> partitionValues);
 
-    List<Partition> getPartitionsByNames(MetastoreContext metastoreContext, String databaseName, String tableName, List<String> partitionNames);
+    List<Partition> getPartitionsByNames(
+            MetastoreContext metastoreContext,
+            String databaseName,
+            String tableName,
+            List<String> partitionNames);
 
-    Optional<Table> getTable(MetastoreContext metastoreContext, String databaseName, String tableName);
+    Optional<Table> getTable(
+            MetastoreContext metastoreContext,
+            String databaseName,
+            String tableName);
 
     Set<ColumnStatisticType> getSupportedColumnStatistics(MetastoreContext metastoreContext, Type type);
 

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftMetastoreUtil.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftMetastoreUtil.java
@@ -439,7 +439,8 @@ public final class ThriftMetastoreUtil
                         .collect(toList()))
                 .setParameters(table.getParameters() == null ? ImmutableMap.of() : table.getParameters())
                 .setViewOriginalText(Optional.ofNullable(emptyToNull(table.getViewOriginalText())))
-                .setViewExpandedText(Optional.ofNullable(emptyToNull(table.getViewExpandedText())));
+                .setViewExpandedText(Optional.ofNullable(emptyToNull(table.getViewExpandedText())))
+                .setLastAccessTime(Optional.ofNullable(table.getLastAccessTime()));
 
         fromMetastoreApiStorageDescriptor(storageDescriptor, tableBuilder.getStorageBuilder(), table.getTableName());
 
@@ -493,7 +494,8 @@ public final class ThriftMetastoreUtil
                         .map(fieldSchema -> columnConverter.toColumn(fieldSchema))
                         .collect(toList()))
                 .setParameters(partition.getParameters())
-                .setCreateTime(partition.getCreateTime());
+                .setCreateTime(partition.getCreateTime())
+                .setLastAccessTime(partition.getLastAccessTime());
 
         // mutate apache partition to Presto partition
         partitionMutator.mutate(partitionBuilder, partition);

--- a/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/TestRecordingHiveMetastore.java
+++ b/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/TestRecordingHiveMetastore.java
@@ -89,7 +89,8 @@ public class TestRecordingHiveMetastore
             ImmutableList.of(TABLE_COLUMN),
             ImmutableMap.of("param", "value3"),
             Optional.of("original_text"),
-            Optional.of("expanded_text"));
+            Optional.of("expanded_text"),
+            Optional.empty());
     private static final Partition PARTITION = new Partition(
             "database",
             "table",
@@ -100,7 +101,8 @@ public class TestRecordingHiveMetastore
             Optional.empty(),
             false,
             true,
-            0);
+            0,
+            null);
     private static final PartitionStatistics PARTITION_STATISTICS = new PartitionStatistics(
             new HiveBasicStatistics(10, 11, 10000, 10001),
             ImmutableMap.of("column", new HiveColumnStatistics(

--- a/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/UnimplementedHiveMetastore.java
+++ b/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/UnimplementedHiveMetastore.java
@@ -109,7 +109,7 @@ public class UnimplementedHiveMetastore
     }
 
     @Override
-    public void createTable(MetastoreContext metastoreContext, Table table, PrincipalPrivileges principalPrivileges)
+    public MetastoreOperationStats createTable(MetastoreContext metastoreContext, Table table, PrincipalPrivileges principalPrivileges)
     {
         throw new UnsupportedOperationException();
     }
@@ -121,31 +121,31 @@ public class UnimplementedHiveMetastore
     }
 
     @Override
-    public void replaceTable(MetastoreContext metastoreContext, String databaseName, String tableName, Table newTable, PrincipalPrivileges principalPrivileges)
+    public MetastoreOperationStats replaceTable(MetastoreContext metastoreContext, String databaseName, String tableName, Table newTable, PrincipalPrivileges principalPrivileges)
     {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void renameTable(MetastoreContext metastoreContext, String databaseName, String tableName, String newDatabaseName, String newTableName)
+    public MetastoreOperationStats renameTable(MetastoreContext metastoreContext, String databaseName, String tableName, String newDatabaseName, String newTableName)
     {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void addColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String columnName, HiveType columnType, String columnComment)
+    public MetastoreOperationStats addColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String columnName, HiveType columnType, String columnComment)
     {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void renameColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String oldColumnName, String newColumnName)
+    public MetastoreOperationStats renameColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String oldColumnName, String newColumnName)
     {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void dropColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String columnName)
+    public MetastoreOperationStats dropColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String columnName)
     {
         throw new UnsupportedOperationException();
     }
@@ -189,7 +189,7 @@ public class UnimplementedHiveMetastore
     }
 
     @Override
-    public void addPartitions(MetastoreContext metastoreContext, String databaseName, String tableName, List<PartitionWithStatistics> partitions)
+    public MetastoreOperationStats addPartitions(MetastoreContext metastoreContext, String databaseName, String tableName, List<PartitionWithStatistics> partitions)
     {
         throw new UnsupportedOperationException();
     }
@@ -201,7 +201,7 @@ public class UnimplementedHiveMetastore
     }
 
     @Override
-    public void alterPartition(MetastoreContext metastoreContext, String databaseName, String tableName, PartitionWithStatistics partition)
+    public MetastoreOperationStats alterPartition(MetastoreContext metastoreContext, String databaseName, String tableName, PartitionWithStatistics partition)
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveConnector.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveConnector.java
@@ -20,6 +20,7 @@ import com.facebook.presto.spi.classloader.ThreadContextClassLoader;
 import com.facebook.presto.spi.connector.Connector;
 import com.facebook.presto.spi.connector.ConnectorAccessControl;
 import com.facebook.presto.spi.connector.ConnectorCapabilities;
+import com.facebook.presto.spi.connector.ConnectorCommitResult;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.connector.ConnectorMetadataUpdaterProvider;
 import com.facebook.presto.spi.connector.ConnectorNodePartitioningProvider;
@@ -36,6 +37,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
 
@@ -213,12 +215,13 @@ public class HiveConnector
     }
 
     @Override
-    public void commit(ConnectorTransactionHandle transaction)
+    public Optional<ConnectorCommitResult> commit(ConnectorTransactionHandle transaction)
     {
+        log.error("Hive connector is used");
         TransactionalMetadata metadata = transactionManager.remove(transaction);
         checkArgument(metadata != null, "no such transaction: %s", transaction);
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            metadata.commit();
+            return Optional.ofNullable(metadata.commit());
         }
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveInputInfo.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveInputInfo.java
@@ -13,25 +13,30 @@
  */
 package com.facebook.presto.hive;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
 
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 public class HiveInputInfo
 {
     private final List<String> partitionIds;
     // Code that serialize HiveInputInfo into log would often need the ability to limit the length of log entries.
     // This boolean field allows such code to mark the log entry as length limited.
     private final boolean truncated;
+    public final List<Integer> lastAccessTimes;
 
     @JsonCreator
     public HiveInputInfo(
             @JsonProperty("partitionIds") List<String> partitionIds,
-            @JsonProperty("truncated") boolean truncated)
+            @JsonProperty("truncated") boolean truncated,
+            @JsonProperty("truncated") List<Integer> lastAccessTimes)
     {
         this.partitionIds = partitionIds;
         this.truncated = truncated;
+        this.lastAccessTimes = lastAccessTimes;
     }
 
     @JsonProperty
@@ -44,5 +49,11 @@ public class HiveInputInfo
     public boolean isTruncated()
     {
         return truncated;
+    }
+
+    @JsonProperty
+    public List<Integer> getLastAccessTimes()
+    {
+        return lastAccessTimes;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -74,6 +74,7 @@ import com.facebook.presto.spi.SystemTable;
 import com.facebook.presto.spi.TableLayoutFilterCoverage;
 import com.facebook.presto.spi.TableNotFoundException;
 import com.facebook.presto.spi.ViewNotFoundException;
+import com.facebook.presto.spi.connector.ConnectorCommitResult;
 import com.facebook.presto.spi.connector.ConnectorOutputMetadata;
 import com.facebook.presto.spi.connector.ConnectorPartitioningHandle;
 import com.facebook.presto.spi.connector.ConnectorPartitioningMetadata;
@@ -366,6 +367,9 @@ public class HiveMetadata
     private static final String ORC_BLOOM_FILTER_FPP_KEY = "orc.bloom.filter.fpp";
 
     private static final String PRESTO_TEMPORARY_TABLE_NAME_PREFIX = "__presto_temporary_table_";
+
+    private static final int MAX_NUM_OF_FETCHED_PARTITIONS = 15000;
+    private static final String DUMMY_PARTITION_NAME = "<UNPARTITIONED>";
 
     // Comma is not a reserved keyword with or without quote
     // See https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL#LanguageManualDDL-Keywords,Non-reservedKeywordsandReservedKeywords
@@ -730,18 +734,74 @@ public class HiveMetadata
     }
 
     @Override
-    public Optional<Object> getInfo(ConnectorTableLayoutHandle layoutHandle)
+    public Optional<Object> getInfo(ConnectorSession session, ConnectorTableLayoutHandle layoutHandle)
     {
         HiveTableLayoutHandle tableLayoutHandle = (HiveTableLayoutHandle) layoutHandle;
-        if (tableLayoutHandle.getPartitions().isPresent()) {
-            return Optional.of(new HiveInputInfo(
-                    tableLayoutHandle.getPartitions().get().stream()
-                            .map(HivePartition::getPartitionId)
-                            .collect(toList()),
-                    false));
+        if (!tableLayoutHandle.getPartitions().isPresent()
+                || 0 == tableLayoutHandle.getPartitions().get().size()) {
+            return Optional.empty();
         }
 
-        return Optional.empty();
+        MetastoreContext metastoreContext = new MetastoreContext(
+                session.getIdentity(),
+                session.getQueryId(),
+                session.getClientInfo(),
+                session.getSource(),
+                getMetastoreHeaders(session),
+                isUserDefinedTypeEncodingEnabled(session),
+                columnConverterProvider);
+
+        if (isUnpartitionedTable(tableLayoutHandle)) {
+            Optional<Table> table = metastore.getTable(
+                    metastoreContext,
+                    tableLayoutHandle.getSchemaTableName().getSchemaName(),
+                    tableLayoutHandle.getSchemaTableName().getTableName());
+
+            Integer lastAccessTime = -1;
+            if (table.isPresent() && table.get().getLastAccessTime().isPresent()) {
+                lastAccessTime = (int) table.get().getLastAccessTime().get().getMillis() / 1000;
+            }
+            return Optional.of(new HiveInputInfo(
+                    ImmutableList.of(DUMMY_PARTITION_NAME),
+                    false,
+                    ImmutableList.of(lastAccessTime)));
+        }
+
+        List<String> partitionNames = tableLayoutHandle
+                .getPartitions().get().stream()
+                .map(HivePartition::getPartitionId)
+                .limit(MAX_NUM_OF_FETCHED_PARTITIONS)
+                .collect(toList());
+
+        Map<String, Optional<Partition>> partitions = metastore.getPartitionsByNames(
+                metastoreContext,
+                tableLayoutHandle.getSchemaTableName().getSchemaName(),
+                tableLayoutHandle.getSchemaTableName().getTableName(),
+                partitionNames);
+
+        List<Integer> lastAccessTimes = partitionNames.stream()
+                .map(partitionName -> partitions.get(partitionName))
+                .map(partition -> {
+                    if (partition.isPresent()) {
+                        return (int) partition.get().getLastAccessTime().getMillis() / 1000;
+                    }
+                    else {
+                        return -1;
+                    }
+                })
+                .collect(toList());
+
+        return Optional.of(new HiveInputInfo(partitionNames, false, lastAccessTimes));
+    }
+
+    private boolean isUnpartitionedTable(HiveTableLayoutHandle tableLayoutHandle)
+    {
+        List<HivePartition> partitions = tableLayoutHandle.getPartitions().get();
+        if (1 == partitions.size()
+                && 0 == partitions.get(0).getPartitionId().compareTo(DUMMY_PARTITION_NAME)) {
+            return true;
+        }
+        return false;
     }
 
     @Override
@@ -3671,9 +3731,9 @@ public class HiveMetadata
     }
 
     @Override
-    public void commit()
+    public ConnectorCommitResult commit()
     {
-        metastore.commit();
+        return metastore.commit();
     }
 
     @Override

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystem.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystem.java
@@ -26,6 +26,7 @@ import com.facebook.presto.hive.metastore.Database;
 import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
 import com.facebook.presto.hive.metastore.HivePartitionMutator;
 import com.facebook.presto.hive.metastore.MetastoreContext;
+import com.facebook.presto.hive.metastore.MetastoreOperationStats;
 import com.facebook.presto.hive.metastore.PrincipalPrivileges;
 import com.facebook.presto.hive.metastore.Table;
 import com.facebook.presto.hive.metastore.thrift.BridgingHiveMetastore;
@@ -513,12 +514,13 @@ public abstract class AbstractTestHiveFileSystem
         }
 
         @Override
-        public void createTable(MetastoreContext metastoreContext, Table table, PrincipalPrivileges privileges)
+        public MetastoreOperationStats createTable(MetastoreContext metastoreContext, Table table, PrincipalPrivileges privileges)
         {
             // hack to work around the metastore not being configured for S3 or other FS
             Table.Builder tableBuilder = Table.builder(table);
             tableBuilder.getStorageBuilder().setLocation("/");
             super.createTable(metastoreContext, tableBuilder.build(), privileges);
+            return new MetastoreOperationStats();
         }
 
         @Override

--- a/presto-hive/src/test/java/com/facebook/presto/hive/BenchmarkConcurrentHashMap.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/BenchmarkConcurrentHashMap.java
@@ -13,16 +13,6 @@
  */
 package com.facebook.presto.hive;
 
-import com.facebook.presto.hive.metastore.SemiTransactionalHiveMetastore;
-import com.facebook.presto.spi.connector.ConnectorCommitResult;
-import com.facebook.presto.spi.connector.ConnectorMetadata;
-
-public interface TransactionalMetadata
-        extends ConnectorMetadata
+public class BenchmarkConcurrentHashMap
 {
-    ConnectorCommitResult commit();
-
-    void rollback();
-
-    SemiTransactionalHiveMetastore getMetastore();
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestAbstractDwrfEncryptionInformationSource.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestAbstractDwrfEncryptionInformationSource.java
@@ -69,6 +69,7 @@ public class TestAbstractDwrfEncryptionInformationSource
                 isPartitioned ? ImmutableList.of(new Column("ds", HIVE_STRING, Optional.empty(), Optional.empty())) : ImmutableList.of(),
                 tableEncryptionProperties.map(DwrfTableEncryptionProperties::toHiveProperties).orElse(ImmutableMap.of()),
                 Optional.empty(),
+                Optional.empty(),
                 Optional.empty());
     }
 
@@ -109,8 +110,30 @@ public class TestAbstractDwrfEncryptionInformationSource
                                 ImmutableList.of(new Subfield("col_struct.a"), new Subfield("col_struct.b.b2")),
                                 Optional.empty()))),
                 ImmutableMap.of(
-                        "ds=2020-01-01", new Partition("dbName", "tableName", ImmutableList.of("2020-01-01"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty(), false, true, 0),
-                        "ds=2020-01-02", new Partition("dbName", "tableName", ImmutableList.of("2020-01-02"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty(), false, true, 0)));
+                        "ds=2020-01-01", new Partition(
+                                "dbName",
+                                "tableName",
+                                ImmutableList.of("2020-01-01"),
+                                table.getStorage(),
+                                table.getDataColumns(),
+                                ImmutableMap.of(),
+                                Optional.empty(),
+                                false,
+                                true,
+                                0,
+                                null),
+                        "ds=2020-01-02", new Partition(
+                                "dbName",
+                                "tableName",
+                                ImmutableList.of("2020-01-02"),
+                                table.getStorage(),
+                                table.getDataColumns(),
+                                ImmutableMap.of(),
+                                Optional.empty(),
+                                false,
+                                true,
+                                0,
+                                null)));
 
         assertTrue(encryptionInformation.isPresent());
         assertEquals(
@@ -129,8 +152,30 @@ public class TestAbstractDwrfEncryptionInformationSource
                 table,
                 Optional.of(ImmutableSet.of()),
                 ImmutableMap.of(
-                        "ds=2020-01-01", new Partition("dbName", "tableName", ImmutableList.of("2020-01-01"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty(), false, true, 0),
-                        "ds=2020-01-02", new Partition("dbName", "tableName", ImmutableList.of("2020-01-02"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty(), false, true, 0)));
+                        "ds=2020-01-01", new Partition(
+                                "dbName",
+                                "tableName",
+                                ImmutableList.of("2020-01-01"),
+                                table.getStorage(),
+                                table.getDataColumns(),
+                                ImmutableMap.of(),
+                                Optional.empty(),
+                                false,
+                                true,
+                                0,
+                                null),
+                        "ds=2020-01-02", new Partition(
+                                "dbName",
+                                "tableName",
+                                ImmutableList.of("2020-01-02"),
+                                table.getStorage(),
+                                table.getDataColumns(),
+                                ImmutableMap.of(),
+                                Optional.empty(),
+                                false,
+                                true,
+                                0,
+                                null)));
 
         assertTrue(encryptionInformation.isPresent());
         assertEquals(
@@ -161,8 +206,30 @@ public class TestAbstractDwrfEncryptionInformationSource
                                 ImmutableList.of(new Subfield("col_struct.a"), new Subfield("col_struct.b.b2")),
                                 Optional.empty()))),
                 ImmutableMap.of(
-                        "ds=2020-01-01", new Partition("dbName", "tableName", ImmutableList.of("2020-01-01"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty(), false, true, 0),
-                        "ds=2020-01-02", new Partition("dbName", "tableName", ImmutableList.of("2020-01-02"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty(), false, true, 0)));
+                        "ds=2020-01-01", new Partition(
+                                "dbName",
+                                "tableName",
+                                ImmutableList.of("2020-01-01"),
+                                table.getStorage(),
+                                table.getDataColumns(),
+                                ImmutableMap.of(),
+                                Optional.empty(),
+                                false,
+                                true,
+                                0,
+                                null),
+                        "ds=2020-01-02", new Partition(
+                                "dbName",
+                                "tableName",
+                                ImmutableList.of("2020-01-02"),
+                                table.getStorage(),
+                                table.getDataColumns(),
+                                ImmutableMap.of(),
+                                Optional.empty(),
+                                false,
+                                true,
+                                0,
+                                null)));
 
         Map<String, byte[]> expectedFieldToKeyData = ImmutableMap.of("col_bigint", "key2".getBytes(), "col_struct.a", "key2".getBytes(), "col_struct.b.b2", "key1".getBytes());
         assertTrue(encryptionInformation.isPresent());

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveEncryptionInformationProvider.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveEncryptionInformationProvider.java
@@ -52,6 +52,7 @@ public class TestHiveEncryptionInformationProvider
             ImmutableList.of(),
             ImmutableMap.of(),
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
 
     @Test

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMaterializedViewUtils.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMaterializedViewUtils.java
@@ -634,6 +634,7 @@ public class TestHiveMaterializedViewUtils
                 partitionColumns,
                 ImmutableMap.of(),
                 Optional.empty(),
+                Optional.empty(),
                 Optional.empty());
     }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMetadata.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMetadata.java
@@ -104,6 +104,7 @@ public class TestHiveMetadata
                 ImmutableList.of(partitionColumn),
                 ImmutableMap.of(),
                 Optional.empty(),
+                Optional.empty(),
                 Optional.empty());
 
         ColumnMetadata actual = HiveMetadata.columnMetadataGetter(mockTable, mockTypeManager, new HiveColumnConverter()).apply(hiveColumnHandle1);

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePartitionManager.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePartitionManager.java
@@ -78,6 +78,7 @@ public class TestHivePartitionManager
             ImmutableList.of(PARTITION_COLUMN),
             ImmutableMap.of(),
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
 
     private static final List<String> PARTITIONS = ImmutableList.of("ds=2019-07-23", "ds=2019-08-23");

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitManager.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitManager.java
@@ -150,6 +150,7 @@ public class TestHiveSplitManager
             ImmutableList.of(new Column("ds", HIVE_STRING, Optional.empty(), Optional.empty())),
             ImmutableMap.of(),
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
 
     private ListeningExecutorService executor;
@@ -472,7 +473,8 @@ public class TestHiveSplitManager
                         Optional.empty(),
                         false,
                         true,
-                        0),
+                        0,
+                        null),
                 PARTITION_NAME,
                 partitionStatistics);
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestingSemiTransactionalHiveMetastore.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestingSemiTransactionalHiveMetastore.java
@@ -36,6 +36,7 @@ import com.facebook.presto.hive.metastore.thrift.TestingHiveCluster;
 import com.facebook.presto.hive.metastore.thrift.ThriftHiveMetastore;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.connector.ConnectorCommitResult;
 import com.facebook.presto.spi.security.PrestoPrincipal;
 import com.facebook.presto.spi.security.RoleGrant;
 import com.facebook.presto.spi.statistics.ColumnStatisticType;
@@ -339,7 +340,7 @@ public class TestingSemiTransactionalHiveMetastore
     }
 
     @Override
-    public synchronized void commit()
+    public synchronized ConnectorCommitResult commit()
     {
         throw new UnsupportedOperationException("method not implemented");
     }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergConnector.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergConnector.java
@@ -22,6 +22,7 @@ import com.facebook.presto.spi.classloader.ThreadContextClassLoader;
 import com.facebook.presto.spi.connector.Connector;
 import com.facebook.presto.spi.connector.ConnectorAccessControl;
 import com.facebook.presto.spi.connector.ConnectorCapabilities;
+import com.facebook.presto.spi.connector.ConnectorCommitResult;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.connector.ConnectorNodePartitioningProvider;
 import com.facebook.presto.spi.connector.ConnectorPageSinkProvider;
@@ -37,6 +38,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import static com.facebook.presto.spi.connector.ConnectorCapabilities.NOT_NULL_COLUMN_CONSTRAINT;
@@ -186,9 +188,10 @@ public class IcebergConnector
     }
 
     @Override
-    public void commit(ConnectorTransactionHandle transaction)
+    public Optional<ConnectorCommitResult> commit(ConnectorTransactionHandle transaction)
     {
         transactionManager.remove(transaction);
+        return Optional.empty();
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/event/QueryMonitor.java
+++ b/presto-main/src/main/java/com/facebook/presto/event/QueryMonitor.java
@@ -411,7 +411,8 @@ public class QueryMonitor
                             queryInfo.getOutput().get().getSchema(),
                             queryInfo.getOutput().get().getTable(),
                             tableFinishInfo.map(TableFinishInfo::getSerializedConnectorOutputMetadata),
-                            tableFinishInfo.map(TableFinishInfo::isJsonLengthLimitExceeded)));
+                            tableFinishInfo.map(TableFinishInfo::isJsonLengthLimitExceeded),
+                            queryInfo.getOutput().get().getLastDataCommitTimes()));
         }
         return new QueryIOMetadata(inputs.build(), output);
     }

--- a/presto-main/src/main/java/com/facebook/presto/execution/Output.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/Output.java
@@ -16,9 +16,11 @@ package com.facebook.presto.execution;
 import com.facebook.presto.spi.ConnectorId;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.joda.time.DateTime;
 
 import javax.annotation.concurrent.Immutable;
 
+import java.util.List;
 import java.util.Objects;
 
 import static java.util.Objects.requireNonNull;
@@ -29,16 +31,20 @@ public final class Output
     private final ConnectorId connectorId;
     private final String schema;
     private final String table;
+    private List<DateTime> lastDataCommitTimes;
 
     @JsonCreator
     public Output(
             @JsonProperty("connectorId") ConnectorId connectorId,
             @JsonProperty("schema") String schema,
-            @JsonProperty("table") String table)
+            @JsonProperty("table") String table,
+            @JsonProperty("lastDataCommitTimes") List<DateTime> lastDataCommitTimes)
     {
         this.connectorId = requireNonNull(connectorId, "connectorId is null");
         this.schema = requireNonNull(schema, "schema is null");
         this.table = requireNonNull(table, "table is null");
+        this.lastDataCommitTimes = requireNonNull(
+                lastDataCommitTimes, "lastDataCommitTimes is null");
     }
 
     @JsonProperty
@@ -59,6 +65,19 @@ public final class Output
         return table;
     }
 
+    @JsonProperty
+    public List<DateTime> getLastDataCommitTimes()
+    {
+        return lastDataCommitTimes;
+    }
+
+    @JsonProperty
+    public void setLastDataCommitTimes(List<DateTime> lastDataCommitTimes)
+    {
+        requireNonNull(lastDataCommitTimes, "lastDataCommitTimes is null");
+        this.lastDataCommitTimes = lastDataCommitTimes;
+    }
+
     @Override
     public boolean equals(Object o)
     {
@@ -71,12 +90,13 @@ public final class Output
         Output output = (Output) o;
         return Objects.equals(connectorId, output.connectorId) &&
                 Objects.equals(schema, output.schema) &&
-                Objects.equals(table, output.table);
+                Objects.equals(table, output.table) &&
+                Objects.equals(lastDataCommitTimes, output.lastDataCommitTimes);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(connectorId, schema, table);
+        return Objects.hash(connectorId, schema, table, lastDataCommitTimes);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryManagerStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryManagerStats.java
@@ -68,7 +68,8 @@ public class QueryManagerStats
         submittedQueries.update(1);
         queuedQueries.incrementAndGet();
         managedQueryExecution.addStateChangeListener(new StatisticsListener());
-        managedQueryExecution.addFinalQueryInfoListener(finalQueryInfo -> queryFinished(new BasicQueryInfo(finalQueryInfo)));
+        managedQueryExecution.addFinalQueryInfoListener(
+                finalQueryInfo -> queryFinished(new BasicQueryInfo(finalQueryInfo)));
     }
 
     private void queryStarted()

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/TableWriteInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/TableWriteInfo.java
@@ -86,7 +86,13 @@ public class TableWriteInfo
             WriterTarget target = tableFinishNode.get().getTarget().orElseThrow(() -> new VerifyException("target is absent"));
             if (target instanceof TableWriterNode.CreateName) {
                 TableWriterNode.CreateName create = (TableWriterNode.CreateName) target;
-                return Optional.of(new ExecutionWriterTarget.CreateHandle(metadata.beginCreateTable(session, create.getConnectorId().getCatalogName(), create.getTableMetadata(), create.getLayout()), create.getSchemaTableName()));
+                return Optional.of(new ExecutionWriterTarget.CreateHandle(
+                        metadata.beginCreateTable(
+                                session,
+                                create.getConnectorId().getCatalogName(),
+                                create.getTableMetadata(),
+                                create.getLayout()),
+                        create.getSchemaTableName()));
             }
             if (target instanceof TableWriterNode.InsertReference) {
                 TableWriterNode.InsertReference insert = (TableWriterNode.InsertReference) target;

--- a/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
@@ -487,7 +487,7 @@ public class MetadataManager
     {
         ConnectorId connectorId = handle.getConnectorId();
         ConnectorMetadata metadata = getMetadata(session, connectorId);
-        return handle.getLayout().flatMap(tableLayout -> metadata.getInfo(tableLayout));
+        return handle.getLayout().flatMap(tableLayout -> metadata.getInfo(session.toConnectorSession(), tableLayout));
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/InputExtractor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/InputExtractor.java
@@ -69,7 +69,13 @@ public class InputExtractor
     {
         SchemaTableName schemaTable = table.getTable();
         Optional<Object> inputMetadata = metadata.getInfo(session, tableHandle);
-        return new Input(table.getConnectorId(), schemaTable.getSchemaName(), schemaTable.getTableName(), inputMetadata, ImmutableList.copyOf(columns), statistics);
+        return new Input(
+                table.getConnectorId(),
+                schemaTable.getSchemaName(),
+                schemaTable.getTableName(),
+                inputMetadata,
+                ImmutableList.copyOf(columns),
+                statistics);
     }
 
     private class Visitor

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/OutputExtractor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/OutputExtractor.java
@@ -21,6 +21,7 @@ import com.facebook.presto.sql.planner.plan.InternalPlanVisitor;
 import com.facebook.presto.sql.planner.plan.TableWriterNode;
 import com.google.common.base.VerifyException;
 
+import java.util.Collections;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkState;
@@ -39,7 +40,8 @@ public class OutputExtractor
         return Optional.of(new Output(
                 visitor.getConnectorId(),
                 visitor.getSchemaTableName().getSchemaName(),
-                visitor.getSchemaTableName().getTableName()));
+                visitor.getSchemaTableName().getTableName(),
+                Collections.emptyList()));
     }
 
     private class Visitor

--- a/presto-main/src/main/java/com/facebook/presto/transaction/InMemoryTransactionManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/transaction/InMemoryTransactionManager.java
@@ -22,6 +22,7 @@ import com.facebook.presto.metadata.CatalogMetadata;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.connector.Connector;
+import com.facebook.presto.spi.connector.ConnectorCommitResult;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.facebook.presto.spi.function.FunctionNamespaceManager;
@@ -532,7 +533,9 @@ public class InMemoryTransactionManager
                     return immediateFuture(null);
                 }
                 // Transaction already aborted
-                return immediateFailedFuture(new PrestoException(TRANSACTION_ALREADY_ABORTED, "Current transaction has already been aborted"));
+                return immediateFailedFuture(new PrestoException(
+                        TRANSACTION_ALREADY_ABORTED,
+                        "Current transaction has already been aborted"));
             }
 
             ListenableFuture<?> functionNamespaceFuture = Futures.allAsList(functionNamespaceTransactions.values().stream()
@@ -566,11 +569,19 @@ public class InMemoryTransactionManager
 
             ConnectorTransactionMetadata writeConnector = connectorIdToMetadata.get(writeConnectorId);
             Supplier<ListenableFuture> commitFunctionNamespaceTransactions = () -> functionNamespaceFuture;
-            ListenableFuture<?> commitFuture = Futures.transformAsync(finishingExecutor.submit(writeConnector::commit), ignored -> commitFunctionNamespaceTransactions.get(), directExecutor());
-            ListenableFuture<?> readOnlyCommitFuture = Futures.transformAsync(commitFuture, ignored -> commitReadOnlyConnectors.get(), directExecutor());
-            addExceptionCallback(readOnlyCommitFuture, this::abortInternal);
+            ListenableFuture<?> readOnlyCommitFuture = Futures.transformAsync(
+                    commitFunctionNamespaceTransactions.get(), ignored -> commitReadOnlyConnectors.get(), directExecutor());
+            ListenableFuture<?> writeCommitFuture = Futures.transformAsync(
+                    readOnlyCommitFuture, ignored -> finishingExecutor.submit(writeConnector::commit), directExecutor());
+            addExceptionCallback(writeCommitFuture, this::abortInternal);
 
-            return nonCancellationPropagating(readOnlyCommitFuture);
+            return nonCancellationPropagating(writeCommitFuture);
+        }
+
+        public ConnectorCommitResult addConnectorId(ConnectorCommitResult result, ConnectorId id)
+        {
+            result.setConnectorId(id);
+            return result;
         }
 
         public synchronized ListenableFuture<?> asyncAbort()
@@ -671,11 +682,13 @@ public class InMemoryTransactionManager
                 return transactionHandle;
             }
 
-            public void commit()
+            public Optional<ConnectorCommitResult> commit()
             {
                 if (finished.compareAndSet(false, true)) {
-                    connector.commit(transactionHandle);
+                    return connector.commit(transactionHandle);
                 }
+
+                return Optional.empty();
             }
 
             public void abort()

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestOutput.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestOutput.java
@@ -17,6 +17,8 @@ import com.facebook.airlift.json.JsonCodec;
 import com.facebook.presto.spi.ConnectorId;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
+
 import static org.testng.Assert.assertEquals;
 
 public class TestOutput
@@ -26,7 +28,11 @@ public class TestOutput
     @Test
     public void testRoundTrip()
     {
-        Output expected = new Output(new ConnectorId("connectorId"), "schema", "table");
+        Output expected = new Output(
+                new ConnectorId("connectorId"),
+                "schema",
+                "table",
+                Collections.emptyList());
 
         String json = codec.toJson(expected);
         Output actual = codec.fromJson(json);

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestQueryStateMachine.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestQueryStateMachine.java
@@ -82,7 +82,12 @@ public class TestQueryStateMachine
     private static final String QUERY = "sql";
     private static final URI LOCATION = URI.create("fake://fake-query");
     private static final SQLException FAILED_CAUSE = new SQLException("FAILED");
-    private static final List<Input> INPUTS = ImmutableList.of(new Input(new ConnectorId("connector"), "schema", "table", Optional.empty(), ImmutableList.of(new Column("a", "varchar")), Optional.empty()));
+    private static final List<Input> INPUTS = ImmutableList.of(new Input(
+            new ConnectorId("connector"),
+            "schema",
+            "table", Optional.empty(),
+            ImmutableList.of(new Column("a", "varchar")),
+            Optional.empty()));
     private static final Optional<Output> OUTPUT = Optional.empty();
     private static final List<String> OUTPUT_FIELD_NAMES = ImmutableList.of("a", "b", "c");
     private static final List<Type> OUTPUT_FIELD_TYPES = ImmutableList.of(BIGINT, BIGINT, BIGINT);

--- a/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoConnector.java
+++ b/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoConnector.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.mongodb;
 
 import com.facebook.presto.spi.connector.Connector;
+import com.facebook.presto.spi.connector.ConnectorCommitResult;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.connector.ConnectorPageSinkProvider;
 import com.facebook.presto.spi.connector.ConnectorPageSourceProvider;
@@ -23,6 +24,7 @@ import com.facebook.presto.spi.transaction.IsolationLevel;
 
 import javax.inject.Inject;
 
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -78,9 +80,10 @@ public class MongoConnector
     }
 
     @Override
-    public void commit(ConnectorTransactionHandle transaction)
+    public Optional<ConnectorCommitResult> commit(ConnectorTransactionHandle transaction)
     {
         checkArgument(transactions.remove(transaction) != null, "no such transaction: %s", transaction);
+        return Optional.empty();
     }
 
     @Override

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorConnector.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorConnector.java
@@ -21,6 +21,7 @@ import com.facebook.presto.spi.NodeManager;
 import com.facebook.presto.spi.SystemTable;
 import com.facebook.presto.spi.connector.Connector;
 import com.facebook.presto.spi.connector.ConnectorAccessControl;
+import com.facebook.presto.spi.connector.ConnectorCommitResult;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.connector.ConnectorNodePartitioningProvider;
 import com.facebook.presto.spi.connector.ConnectorPageSinkProvider;
@@ -39,6 +40,7 @@ import javax.annotation.concurrent.GuardedBy;
 import javax.inject.Inject;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -136,10 +138,12 @@ public class RaptorConnector
     }
 
     @Override
-    public void commit(ConnectorTransactionHandle transaction)
+    public Optional<ConnectorCommitResult> commit(ConnectorTransactionHandle transaction)
     {
         checkArgument(transactions.remove(transaction) != null, "no such transaction: %s", transaction);
         finishDelete(((RaptorTransactionHandle) transaction).getUuid());
+
+        return Optional.empty();
     }
 
     @Override

--- a/presto-spi/pom.xml
+++ b/presto-spi/pom.xml
@@ -53,6 +53,12 @@
             <artifactId>jol-core</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- for testing -->
         <dependency>
             <groupId>com.facebook.presto</groupId>

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/Connector.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/Connector.java
@@ -19,6 +19,7 @@ import com.facebook.presto.spi.session.PropertyMetadata;
 import com.facebook.presto.spi.transaction.IsolationLevel;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import static java.util.Collections.emptyList;
@@ -160,8 +161,9 @@ public interface Connector
      * Commit the transaction. Will be called at most once and will not be called if
      * {@link #rollback(ConnectorTransactionHandle)} is called.
      */
-    default void commit(ConnectorTransactionHandle transactionHandle)
+    default Optional<ConnectorCommitResult> commit(ConnectorTransactionHandle transactionHandle)
     {
+        return Optional.empty();
     }
 
     /**

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorCommitResult.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorCommitResult.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.connector;
+
+import com.facebook.presto.spi.ConnectorId;
+import org.joda.time.DateTime;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class ConnectorCommitResult
+{
+    private final Map<String, List<DateTime>> inputLastDataCommitTimes = new HashMap<>();
+    private final Map<String, List<DateTime>> outputLastDataCommitTimes = new HashMap<>();
+    private ConnectorId connectorId = new ConnectorId("Unknown");
+
+    public void setConnectorId(ConnectorId id)
+    {
+        connectorId = id;
+    }
+
+    public ConnectorId getConnectorId()
+    {
+        return connectorId;
+    }
+
+    public void addInputLastDataCommitTimes(String key, List<DateTime> value)
+    {
+        if (!inputLastDataCommitTimes.containsKey(key)) {
+            inputLastDataCommitTimes.put(key, new ArrayList<>());
+        }
+        inputLastDataCommitTimes.get(key).addAll(value);
+    }
+
+    public void addOutputLastDataCommitTimes(String key, List<DateTime> value)
+    {
+        if (!outputLastDataCommitTimes.containsKey(key)) {
+            outputLastDataCommitTimes.put(key, new ArrayList<DateTime>());
+        }
+        outputLastDataCommitTimes.get(key).addAll(value);
+    }
+
+    public List<DateTime> getInputLastDataCommitTimes(String key)
+    {
+        return inputLastDataCommitTimes.get(key);
+    }
+
+    public List<DateTime> getOutputLastDataCommitTimes(String key)
+    {
+        return outputLastDataCommitTimes.get(key);
+    }
+
+    public boolean containInput(String key)
+    {
+        return inputLastDataCommitTimes.containsKey(key);
+    }
+
+    public boolean containOutput(String key)
+    {
+        return outputLastDataCommitTimes.containsKey(key);
+    }
+
+    public Set<String> getInputKeys()
+    {
+        return inputLastDataCommitTimes.keySet();
+    }
+
+    public Set<String> getOutputKeys()
+    {
+        return outputLastDataCommitTimes.keySet();
+    }
+
+    public void removeInput(String key)
+    {
+        inputLastDataCommitTimes.remove(key);
+    }
+
+    public void removeOutput(String key)
+    {
+        outputLastDataCommitTimes.remove(key);
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
@@ -206,7 +206,7 @@ public interface ConnectorMetadata
      *
      * @throws RuntimeException if table handle is no longer valid
      */
-    default Optional<Object> getInfo(ConnectorTableLayoutHandle layoutHandle)
+    default Optional<Object> getInfo(ConnectorSession session, ConnectorTableLayoutHandle layoutHandle)
     {
         return Optional.empty();
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -246,10 +246,10 @@ public class ClassLoaderSafeConnectorMetadata
     }
 
     @Override
-    public Optional<Object> getInfo(ConnectorTableLayoutHandle table)
+    public Optional<Object> getInfo(ConnectorSession session, ConnectorTableLayoutHandle table)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getInfo(table);
+            return delegate.getInfo(session, table);
         }
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/QueryInputMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/QueryInputMetadata.java
@@ -30,7 +30,13 @@ public class QueryInputMetadata
     private final Optional<Object> connectorInfo;
     private final Optional<TableStatistics> statistics;
 
-    public QueryInputMetadata(String catalogName, String schema, String table, List<String> columns, Optional<Object> connectorInfo, Optional<TableStatistics> statistics)
+    public QueryInputMetadata(
+            String catalogName,
+            String schema,
+            String table,
+            List<String> columns,
+            Optional<Object> connectorInfo,
+            Optional<TableStatistics> statistics)
     {
         this.catalogName = requireNonNull(catalogName, "catalogName is null");
         this.schema = requireNonNull(schema, "schema is null");

--- a/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/QueryOutputMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/QueryOutputMetadata.java
@@ -14,7 +14,9 @@
 package com.facebook.presto.spi.eventlistener;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.joda.time.DateTime;
 
+import java.util.List;
 import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
@@ -28,13 +30,25 @@ public class QueryOutputMetadata
     private final Optional<String> connectorOutputMetadata;
     private final Optional<Boolean> jsonLengthLimitExceeded;
 
-    public QueryOutputMetadata(String catalogName, String schema, String table, Optional<String> connectorOutputMetadata, Optional<Boolean> jsonLengthLimitExceeded)
+    private final List<DateTime> lastDataCommitTimes;
+
+    public QueryOutputMetadata(
+            String catalogName,
+            String schema,
+            String table,
+            Optional<String> connectorOutputMetadata,
+            Optional<Boolean> jsonLengthLimitExceeded,
+            List<DateTime> lastDataCommitTimes)
     {
         this.catalogName = requireNonNull(catalogName, "catalogName is null");
         this.schema = requireNonNull(schema, "schema is null");
         this.table = requireNonNull(table, "table is null");
-        this.connectorOutputMetadata = requireNonNull(connectorOutputMetadata, "connectorOutputMetadata is null");
-        this.jsonLengthLimitExceeded = requireNonNull(jsonLengthLimitExceeded, "jsonLengthLimitExceeded is null");
+        this.connectorOutputMetadata = requireNonNull(
+                connectorOutputMetadata, "connectorOutputMetadata is null");
+        this.jsonLengthLimitExceeded = requireNonNull(
+                jsonLengthLimitExceeded, "jsonLengthLimitExceeded is null");
+        this.lastDataCommitTimes = requireNonNull(
+                lastDataCommitTimes, "lastDataCommitTimes is null");
     }
 
     @JsonProperty
@@ -65,5 +79,11 @@ public class QueryOutputMetadata
     public Optional<Boolean> getJsonLengthLimitExceeded()
     {
         return jsonLengthLimitExceeded;
+    }
+
+    @JsonProperty
+    public List<DateTime> getLastDataCommitTimes()
+    {
+        return lastDataCommitTimes;
     }
 }


### PR DESCRIPTION
Log last_data_commit _time or last_access_time

This change modifies a few components in order to log 
the timestamp for last data commit time and last access time for a table.

TESTS:
1. Locally ran PrismQueryRunner.
2. Passed unit tests.
3. Ran e2e test.

Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines. Don't forget to follow our [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution) for any code copied from other projects.

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== RELEASE NOTES ==

General Changes
* ...
* ...

Hive Changes
* ...
* ...
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```
