### PR TITLE
Construct RLE block with proper types for Parquet with missing struct…

### DIFF
--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/reader/ParquetReader.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/reader/ParquetReader.java
@@ -222,7 +222,7 @@ public class ParquetReader
         }
         for (int i = 0; i < fields.size(); i++) {
             if (blocks[i] == null) {
-                blocks[i] = RunLengthEncodedBlock.create(field.getType(), null, columnChunk.getBlock().getPositionCount());
+                blocks[i] = RunLengthEncodedBlock.create(field.getType().getTypeParameters().get(i), null, columnChunk.getBlock().getPositionCount());
             }
         }
         BooleanList structIsNull = StructColumnReader.calculateStructOffsets(field, columnChunk.getDefinitionLevels(), columnChunk.getRepetitionLevels());


### PR DESCRIPTION
Construct RLE block with proper types for Parquet with missing struct fields

Fixes https://github.com/trinodb/trino/issues/9264

Co-authored-by: Łukasz Osipiuk <lukasz@osipiuk.net>

```
== RELEASE NOTES ==

General Changes
* ...
* ...

Hive Changes
* Construct RLE block with proper types for Parquet with missing struct fields
```
