### PR TITLE
Fix infinite recursion in ExpressionTreeUtils

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionTreeUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionTreeUtils.java
@@ -199,13 +199,13 @@ public final class ExpressionTreeUtils
 
         // ROW an MAP are special so we explicitly do that here.
         if (tempExpression instanceof Row) {
-            return !(((Row) tempExpression).getItems().stream().filter(x -> !isConstant(expression)).findAny().isPresent());
+            return (((Row) tempExpression).getItems().stream().allMatch(ExpressionTreeUtils::isConstant));
         }
 
         if (tempExpression instanceof FunctionCall) {
             // Hack to just allow map constructor
             if (((FunctionCall) tempExpression).getName().getSuffix().equalsIgnoreCase("map")) {
-                return !((FunctionCall) tempExpression).getArguments().stream().filter(x -> !isConstant(expression)).findAny().isPresent();
+                return ((FunctionCall) tempExpression).getArguments().stream().allMatch(ExpressionTreeUtils::isConstant);
             }
         }
 

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -799,6 +799,8 @@ public abstract class AbstractTestQueries
                         "FROM (VALUES (1, ARRAY['a']), (1, ARRAY['b']), (1, ARRAY['c']), (2, ARRAY['d']), (2, ARRAY['e']), (3, ARRAY['f'])) AS t(x, y) " +
                         "GROUP BY x",
                 "VALUES (1, 'abcx'), (2, 'dex'), (3, 'fx')");
+
+        assertQuery("SELECT REDUCE_AGG((x,y), (0,0), (x, y)->(x[1],y[1]), (x,y)->(x[1],y[1]))[1] from (select 1 x, 2 y)", "select 0");
     }
 
     @Test


### PR DESCRIPTION
Fixed a code bug that's infinite recursion while processing row and map constructors.


Test plan - Added test


```
== NO RELEASE NOTE ==
```
