### PR TITLE
Handle RowTypes without field names.

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveDistributedQueries.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveDistributedQueries.java
@@ -75,5 +75,10 @@ public class TestHiveDistributedQueries
         assertEquals(getOnlyElement(result.getOnlyColumnAsSet()), getExplainPlan(query, LOGICAL));
     }
 
+    @Test
+    public void testEmptyRowFieldNames() {
+        assertQuery("SELECT zip(array[1,2,3], array[10, 20])", "SELECT array[row(1, 10), row(2, 20), row(3, null)]");
+    }
+
     // Hive specific tests should normally go in TestHiveIntegrationSmokeTest
 }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/TestingPrestoClient.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/TestingPrestoClient.java
@@ -38,6 +38,7 @@ import com.facebook.presto.type.SqlIntervalDayTime;
 import com.facebook.presto.type.SqlIntervalYearMonth;
 import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Streams;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -49,6 +50,7 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -248,11 +250,10 @@ public class TestingPrestoClient
                             e -> convertToRowValue(((MapType) type).getValueType(), e.getValue())));
         }
         else if (type instanceof RowType) {
-            Map<String, Object> data = (Map<String, Object>) value;
+            LinkedHashMap<String, Object> data = (LinkedHashMap<String, Object>) value;
             RowType rowType = (RowType) type;
-
-            return rowType.getFields().stream()
-                    .map(field -> convertToRowValue(field.getType(), data.get(field.getName().get())))
+            return Streams.zip(data.entrySet().stream(), rowType.getFields().stream(),
+                    (entry, field) -> convertToRowValue(field.getType(), entry.getValue()))
                     .collect(toList());
         }
         else if (type instanceof DecimalType) {


### PR DESCRIPTION
Currently TestingPrestoClient always assumes nested rowTypes will have names. This need not be the case always. This fix uses the fact that returned values are ordered and uses that in place of looking up by fieldname.

Test plan - Tested this manually with velox query: 
``` 
SELECT zip(quantities, map_values(quantity_by_linenumber)) FROM orders_ex
```

and also added a unit test.

```
== NO RELEASE NOTE ==
```
