### PR TITLE
Upgrade Zstd-jni to v1.5.0-4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1677,7 +1677,7 @@
             <dependency>
                 <groupId>com.github.luben</groupId>
                 <artifactId>zstd-jni</artifactId>
-                <version>1.4.9-2</version>
+                <version>1.5.0-4</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
ZSTD 1.5 is much faster than previous versions.
https://github.com/facebook/zstd/releases/tag/v1.5.0
Internally when migrating from a different encoding library to
presto-orc, presto-orc is 2% slower due to ZSTD version differences.

Test plan - 
Existing tests.

```
== NO RELEASE NOTE ==
```
