### PR TITLE
Optimize putIfAbsent in Dictionary Buillders

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/LongDictionaryBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/LongDictionaryBuilder.java
@@ -56,29 +56,16 @@ public class LongDictionaryBuilder
 
     public int putIfAbsent(long value)
     {
-        int slicePosition;
-        long hashPosition = getHashPositionOfElement(value);
-        if (elementPositionByHash.get(hashPosition) != EMPTY_SLOT) {
-            slicePosition = elementPositionByHash.get(hashPosition);
-        }
-        else {
-            slicePosition = addNewElement(hashPosition, value);
-        }
-        return slicePosition;
-    }
-
-    private long getHashPositionOfElement(long value)
-    {
         long hashPosition = getHash(value);
         hashPosition = getMaskedHash(hashPosition);
         while (true) {
-            int slicePosition = elementPositionByHash.get(hashPosition);
-            if (slicePosition == EMPTY_SLOT) {
+            int elementPosition = elementPositionByHash.get(hashPosition);
+            if (elementPosition == EMPTY_SLOT) {
                 // Doesn't have this element
-                return hashPosition;
+                return addNewElement(hashPosition, value);
             }
-            if (elements.getLong(slicePosition) == value) {
-                return hashPosition;
+            if (elements.getLong(elementPosition) == value) {
+                return elementPosition;
             }
 
             hashPosition = getMaskedHash(hashPosition + 1);


### PR DESCRIPTION
getHashPositionOfElement is only used by the putIfAbsent. This change
removes the abstraction and some unnecessary lookups. On successful
match, two additional lookups into the hash table is removed. When the
hash position is empty, one additional lookup is removed. Performance
benchmark shows about 15% improvement on the LongDictionary use case.
The SliceDictionary performance improvement is negligible as the String
dictionary is costly to maintain.

Test plan - 
Existing tests

```
== NO RELEASE NOTE ==
```
