### PR TITLE
Documentation syntax fixes

### DIFF
--- a/presto-docs/src/main/sphinx/connector.rst
+++ b/presto-docs/src/main/sphinx/connector.rst
@@ -14,7 +14,6 @@ from different data sources.
     connector/cassandra
     connector/druid
     connector/elasticsearch
-    connector/gsheets
     connector/hive
     connector/hive-security
     connector/iceberg

--- a/presto-docs/src/main/sphinx/connector/druid.rst
+++ b/presto-docs/src/main/sphinx/connector/druid.rst
@@ -32,17 +32,17 @@ Configuration Properties
 
 The following configuration properties are available:
 
-=================================================== ============================================================
+===================================================  ============================================================
 Property Name                                        Description
-=================================================== ============================================================
+===================================================  ============================================================
 ``druid.coordinator-url``                            Druid coordinator url.
 ``druid.broker-url``                                 Druid broker url.
 ``druid.schema-name``                                Druid schema name.
 ``druid.compute-pushdown-enabled``                   Whether to pushdown all query processing to Druid.
-``druid.case-insensitive-name-matching``             Match dataset and table names case-insensitively
+``druid.case-insensitive-name-matching``             Match dataset and table names case-insensitively.
 ``druid.case-insensitive-name-matching.cache-ttl``   Duration for which remote dataset and table names will be
                                                      cached. Set to ``0ms`` to disable the cache
-==================================================== ============================================================
+===================================================  ============================================================
 
 ``druid.coordinator-url``
 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -69,14 +69,14 @@ Whether to pushdown all query processing to Druid.
 the default is ``false``.
 
 ``druid.case-insensitive-name-matching``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Match dataset and table names case-insensitively.
 
 The default is ``false``.
 
 ``druid.case-insensitive-name-matching.cache-ttl``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Duration for which remote dataset and table names will be cached. Set to ``0ms`` to disable the cache.
 

--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -184,9 +184,10 @@ Property Name                                      Description                  
 
 ``hive.s3select-pushdown.enabled``                 Enable query pushdown to AWS S3 Select service.              ``false``
 
-``hive.s3select-pushdown.max-connections``         Maximum number of simultaneously open connections to S3 for  500
+``hive.s3select-pushdown.max-connections``         Maximum number of simultaneously open connections to S3 for    500
                                                    S3SelectPushdown.
-``hive.metastore.load-balancing-enabled``       Enable load balancing between multiple Metastore instances
+
+``hive.metastore.load-balancing-enabled``          Enable load balancing between multiple Metastore instances
 ================================================== ============================================================ ============
 
 Metastore Configuration Properties
@@ -732,7 +733,7 @@ Procedures
     not conforming to this convention are ignored, unless the argument is set to ``false``.
 
 Extra Hidden Columns
-----------
+--------------------
 
 The Hive connector exposes extra hidden metadata columns in Hive tables. You can query these
 columns as a part of SQL query like any other columns of the table.

--- a/presto-docs/src/main/sphinx/security/built-in-system-access-control.rst
+++ b/presto-docs/src/main/sphinx/security/built-in-system-access-control.rst
@@ -156,6 +156,7 @@ users as owners of ``default`` schema and prevent user ``guest`` from ownership
 of any schema, you can use the following rules:
 
 .. code-block:: json
+
     {
       "catalogs": [
         {


### PR DESCRIPTION
These changes include documentation fixes. 

For example, currently https://prestodb.io/docs/current/security/built-in-system-access-control.html#schema-rules in _built-in-system-access-control.rst _ is not coming completely, rules section is missing here:

![image](https://user-images.githubusercontent.com/7887476/144798434-2e5355f2-ff5d-402a-a2a7-cec0a120be11.png)



