### PR TITLE
Propagate exception when reading metadata fails

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/HiveTableOperations.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/HiveTableOperations.java
@@ -341,7 +341,6 @@ public class HiveTableOperations
         Tasks.foreach(newLocation)
                 .retry(20)
                 .exponentialBackoff(100, 5000, 600000, 4.0)
-                .suppressFailureWhenFinished()
                 .run(metadataLocation -> newMetadata.set(
                         TableMetadataParser.read(this, io().newInputFile(metadataLocation))));
 


### PR DESCRIPTION
Cherry-pick of https://github.com/trinodb/trino/pull/8951

Quote rom the original PR:
"`.suppressFailureWhenFinished()` causes the `run` method return `false`
on failure, instead of throwing. This behavior was not desirable here,
leading to NPE when trying to access the result."

Fixes https://github.com/trinodb/trino/issues/8873

Co-authored-by: Piotr Findeisen <piotr.findeisen@gmail.com>


```
== RELEASE NOTES ==

General Changes
* Propagate exception when reading metadata fails
* 
```