### PR TITLE
Enhancements for AGG IF to FILTER rewrite

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/RuntimeMetricName.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/RuntimeMetricName.java
@@ -37,6 +37,7 @@ public class RuntimeMetricName
     public static final String LOGICAL_PLANNER_TIME_NANOS = "logicalPlannerTimeNanos";
     public static final String FRAGMENT_PLAN_TIME_NANOS = "fragmentPlanTimeNanos";
     public static final String GET_LAYOUT_TIME_NANOS = "getLayoutTimeNanos";
+    public static final String REWRITE_AGGREGATION_IF_TO_FILTER_APPLIED = "rewriteAggregationIfToFilterApplied";
     // Time between task creation and start.
     public static final String TASK_QUEUED_TIME_NANOS = "taskQueuedTimeNanos";
     // Total operation time of a task on a worker. TASK_ELAPSED_TIME_NANOS - TASK_SCHEDULED_TIME_NANOS is the time when the task is doing nothing, e.g. it might be waiting for splits/inputs.

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -290,6 +290,7 @@ public class FeaturesConfig
     {
         DISABLED,
         FILTER_WITH_IF, // Rewrites AGG(IF(condition, expr)) to AGG(IF(condition, expr)) FILTER (WHERE condition).
+        UNWRAP_IF_SAFE, // Rewrites AGG(IF(condition, expr)) to AGG(expr) FILTER (WHERE condition) if it is safe to do so.
         UNWRAP_IF // Rewrites AGG(IF(condition, expr)) to AGG(expr) FILTER (WHERE condition).
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RewriteAggregationIfToFilter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/RewriteAggregationIfToFilter.java
@@ -48,6 +48,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.facebook.presto.SystemSessionProperties.getAggregationIfToFilterRewriteStrategy;
+import static com.facebook.presto.common.RuntimeMetricName.REWRITE_AGGREGATION_IF_TO_FILTER_APPLIED;
 import static com.facebook.presto.expressions.LogicalRowExpressions.TRUE_CONSTANT;
 import static com.facebook.presto.expressions.LogicalRowExpressions.or;
 import static com.facebook.presto.matching.Capture.newCapture;
@@ -126,6 +127,7 @@ public class RewriteAggregationIfToFilter
             return Result.empty();
         }
 
+        context.getSession().getRuntimeStats().addMetricValue(REWRITE_AGGREGATION_IF_TO_FILTER_APPLIED, 1);
         // Get the corresponding assignments in the input project.
         // The aggregationReferences only has the aggregations to rewrite, thus the sourceAssignments only has IF/CAST(IF) expressions with NULL false results.
         // Multiple aggregations may reference the same input. We use a map to dedup them based on the VariableReferenceExpression, so that we only do the rewrite once per input

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestRewriteAggregationIfToFilter.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestRewriteAggregationIfToFilter.java
@@ -17,15 +17,18 @@ package com.facebook.presto.sql.planner.iterative.rule;
 import com.facebook.presto.common.type.ArrayType;
 import com.facebook.presto.common.type.BooleanType;
 import com.facebook.presto.spi.plan.AggregationNode;
+import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.planner.Symbol;
 import com.facebook.presto.sql.planner.assertions.ExpressionMatcher;
 import com.facebook.presto.sql.planner.iterative.rule.test.BaseRuleTest;
+import com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.Test;
 
 import java.util.Optional;
+import java.util.function.Function;
 
 import static com.facebook.presto.SystemSessionProperties.AGGREGATION_IF_TO_FILTER_REWRITE_STRATEGY;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
@@ -107,184 +110,201 @@ public class TestRewriteAggregationIfToFilter
     @Test
     public void testFireCount()
     {
-        tester().assertThat(new RewriteAggregationIfToFilter(getFunctionManager()))
-                .setSystemProperty(AGGREGATION_IF_TO_FILTER_REWRITE_STRATEGY, "filter_with_if")
-                .on(p -> {
-                    VariableReferenceExpression a = p.variable("a");
-                    VariableReferenceExpression ds = p.variable("ds", VARCHAR);
-                    return p.aggregation(ap -> ap.globalGrouping().step(AggregationNode.Step.FINAL)
-                            .addAggregation(p.variable("expr"), p.rowExpression("count(a)"))
-                            .source(p.project(
-                                    assignment(a, p.rowExpression("IF(ds > '2021-07-01', 1)")),
-                                    p.values(ds))));
-                })
-                .matches(
-                        aggregation(
-                                globalAggregation(),
-                                ImmutableMap.of(Optional.of("expr"), functionCall("count", ImmutableList.of("a"))),
-                                ImmutableMap.of(new Symbol("expr"), new Symbol("greater_than")),
-                                Optional.empty(),
-                                AggregationNode.Step.FINAL,
-                                filter(
-                                        "greater_than",
-                                        project(ImmutableMap.of(
-                                                "a", expression("IF(ds > '2021-07-01', 1)"),
-                                                "greater_than", expression("ds > '2021-07-01'")),
-                                                values("ds")))));
+        for (String strategy : new String[] {"unwrap_if_safe", "unwrap_if"}) {
+            tester().assertThat(new RewriteAggregationIfToFilter(getFunctionManager()))
+                    .setSystemProperty(AGGREGATION_IF_TO_FILTER_REWRITE_STRATEGY, strategy)
+                    .on(p -> {
+                        VariableReferenceExpression a = p.variable("a");
+                        VariableReferenceExpression ds = p.variable("ds", VARCHAR);
+                        return p.aggregation(ap -> ap.globalGrouping().step(AggregationNode.Step.FINAL)
+                                .addAggregation(p.variable("expr"), p.rowExpression("count(a)"))
+                                .source(p.project(
+                                        assignment(a, p.rowExpression("IF(ds > '2021-07-01', 1)")),
+                                        p.values(ds))));
+                    })
+                    .matches(
+                            aggregation(
+                                    globalAggregation(),
+                                    ImmutableMap.of(Optional.of("expr"), functionCall("count", ImmutableList.of("expr_0"))),
+                                    ImmutableMap.of(new Symbol("expr"), new Symbol("greater_than")),
+                                    Optional.empty(),
+                                    AggregationNode.Step.FINAL,
+                                    filter(
+                                            "greater_than",
+                                            project(ImmutableMap.of(
+                                                            "a", expression("IF(ds > '2021-07-01', 1)"),
+                                                            "greater_than", expression("ds > '2021-07-01'"),
+                                                            "expr_0", expression("1")),
+                                                    values("ds")))));
+        }
     }
 
     @Test
     public void testUnwrapIf()
     {
-        tester().assertThat(new RewriteAggregationIfToFilter(getFunctionManager()))
-                .setSystemProperty(AGGREGATION_IF_TO_FILTER_REWRITE_STRATEGY, "unwrap_if")
-                .on(p -> {
-                    VariableReferenceExpression a = p.variable("a");
-                    VariableReferenceExpression ds = p.variable("ds", VARCHAR);
-                    return p.aggregation(ap -> ap.globalGrouping().step(AggregationNode.Step.FINAL)
-                            .addAggregation(p.variable("expr"), p.rowExpression("count(a)"))
-                            .source(p.project(
-                                    assignment(a, p.rowExpression("IF(ds > '2021-07-01', 1)")),
-                                    p.values(ds))));
-                })
-                .matches(
-                        aggregation(
-                                globalAggregation(),
-                                ImmutableMap.of(Optional.of("expr"), functionCall("count", ImmutableList.of("expr0"))),
-                                ImmutableMap.of(new Symbol("expr"), new Symbol("greater_than")),
-                                Optional.empty(),
-                                AggregationNode.Step.FINAL,
-                                filter(
-                                        "greater_than",
-                                        project(ImmutableMap.of(
-                                                "a", expression("IF(ds > '2021-07-01', 1)"),
-                                                "greater_than", expression("ds > '2021-07-01'"),
-                                                "expr0", expression("1")),
-                                                values("ds")))));
+        for (String strategy : new String[] {"unwrap_if_safe", "unwrap_if"}) {
+            tester().assertThat(new RewriteAggregationIfToFilter(getFunctionManager()))
+                    .setSystemProperty(AGGREGATION_IF_TO_FILTER_REWRITE_STRATEGY, strategy)
+                    .on(p -> {
+                        VariableReferenceExpression a = p.variable("a");
+                        VariableReferenceExpression ds = p.variable("ds", VARCHAR);
+                        return p.aggregation(ap -> ap.globalGrouping().step(AggregationNode.Step.FINAL)
+                                .addAggregation(p.variable("expr"), p.rowExpression("count(a)"))
+                                .source(p.project(
+                                        assignment(a, p.rowExpression("IF(ds > '2021-07-01', 1)")),
+                                        p.values(ds))));
+                    })
+                    .matches(
+                            aggregation(
+                                    globalAggregation(),
+                                    ImmutableMap.of(Optional.of("expr"), functionCall("count", ImmutableList.of("expr0"))),
+                                    ImmutableMap.of(new Symbol("expr"), new Symbol("greater_than")),
+                                    Optional.empty(),
+                                    AggregationNode.Step.FINAL,
+                                    filter(
+                                            "greater_than",
+                                            project(ImmutableMap.of(
+                                                            "a", expression("IF(ds > '2021-07-01', 1)"),
+                                                            "greater_than", expression("ds > '2021-07-01'"),
+                                                            "expr0", expression("1")),
+                                                    values("ds")))));
+        }
     }
 
     @Test
     public void testFireMin()
     {
-        tester().assertThat(new RewriteAggregationIfToFilter(getFunctionManager()))
-                .setSystemProperty(AGGREGATION_IF_TO_FILTER_REWRITE_STRATEGY, "filter_with_if")
-                .on(p -> {
-                    VariableReferenceExpression a = p.variable("a");
-                    VariableReferenceExpression ds = p.variable("ds", VARCHAR);
-                    VariableReferenceExpression column0 = p.variable("column0", BIGINT);
-                    return p.aggregation(ap -> ap.globalGrouping().step(AggregationNode.Step.FINAL)
-                            .addAggregation(p.variable("expr0"), p.rowExpression("MIN(a)"))
-                            .source(p.project(
-                                    assignment(a, p.rowExpression("IF(ds > '2021-06-01', column0)")),
-                                    p.values(ds, column0))));
-                })
-                .matches(
-                        aggregation(
-                                globalAggregation(),
-                                ImmutableMap.of(Optional.of("expr0"), functionCall("min", ImmutableList.of("a"))),
-                                ImmutableMap.of(new Symbol("expr0"), new Symbol("greater_than")),
-                                Optional.empty(),
-                                AggregationNode.Step.FINAL,
-                                filter(
-                                        "greater_than",
-                                        project(new ImmutableMap.Builder<String, ExpressionMatcher>()
-                                                        .put("a", expression("IF(ds > '2021-06-01', column0)"))
-                                                        .put("greater_than", expression("ds > '2021-06-01'"))
-                                                        .build(),
-                                                values("ds", "column0")))));
+        for (String strategy : new String[] {"unwrap_if_safe", "unwrap_if"}) {
+            tester().assertThat(new RewriteAggregationIfToFilter(getFunctionManager()))
+                    .setSystemProperty(AGGREGATION_IF_TO_FILTER_REWRITE_STRATEGY, strategy)
+                    .on(p -> {
+                        VariableReferenceExpression a = p.variable("a");
+                        VariableReferenceExpression ds = p.variable("ds", VARCHAR);
+                        VariableReferenceExpression column0 = p.variable("column0", BIGINT);
+                        return p.aggregation(ap -> ap.globalGrouping().step(AggregationNode.Step.FINAL)
+                                .addAggregation(p.variable("expr0"), p.rowExpression("MIN(a)"))
+                                .source(p.project(
+                                        assignment(a, p.rowExpression("IF(ds > '2021-06-01', column0)")),
+                                        p.values(ds, column0))));
+                    })
+                    .matches(
+                            aggregation(
+                                    globalAggregation(),
+                                    ImmutableMap.of(Optional.of("expr0"), functionCall("min", ImmutableList.of("column0_0"))),
+                                    ImmutableMap.of(new Symbol("expr0"), new Symbol("greater_than")),
+                                    Optional.empty(),
+                                    AggregationNode.Step.FINAL,
+                                    filter(
+                                            "greater_than",
+                                            project(new ImmutableMap.Builder<String, ExpressionMatcher>()
+                                                            .put("a", expression("IF(ds > '2021-06-01', column0)"))
+                                                            .put("greater_than", expression("ds > '2021-06-01'"))
+                                                            .put("column0_0", expression("column0"))
+                                                            .build(),
+                                                    values("ds", "column0")))));
+        }
     }
 
     @Test
     public void testFireMax()
     {
-        tester().assertThat(new RewriteAggregationIfToFilter(getFunctionManager()))
-                .setSystemProperty(AGGREGATION_IF_TO_FILTER_REWRITE_STRATEGY, "filter_with_if")
-                .on(p -> {
-                    VariableReferenceExpression a = p.variable("a");
-                    VariableReferenceExpression ds = p.variable("ds", VARCHAR);
-                    VariableReferenceExpression column0 = p.variable("column0", BIGINT);
-                    return p.aggregation(ap -> ap.globalGrouping().step(AggregationNode.Step.FINAL)
-                            .addAggregation(p.variable("expr0"), p.rowExpression("MAX(a)"))
-                            .source(p.project(
-                                    assignment(a, p.rowExpression("IF(ds > '2021-06-01', column0)")),
-                                    p.values(ds, column0))));
-                })
-                .matches(
-                        aggregation(
-                                globalAggregation(),
-                                ImmutableMap.of(Optional.of("expr0"), functionCall("max", ImmutableList.of("a"))),
-                                ImmutableMap.of(new Symbol("expr0"), new Symbol("greater_than")),
-                                Optional.empty(),
-                                AggregationNode.Step.FINAL,
-                                filter(
-                                        "greater_than",
-                                        project(new ImmutableMap.Builder<String, ExpressionMatcher>()
-                                                        .put("a", expression("IF(ds > '2021-06-01', column0)"))
-                                                        .put("greater_than", expression("ds > '2021-06-01'"))
-                                                        .build(),
-                                                values("ds", "column0")))));
+        for (String strategy : new String[] {"unwrap_if_safe", "unwrap_if"}) {
+            tester().assertThat(new RewriteAggregationIfToFilter(getFunctionManager()))
+                    .setSystemProperty(AGGREGATION_IF_TO_FILTER_REWRITE_STRATEGY, strategy)
+                    .on(p -> {
+                        VariableReferenceExpression a = p.variable("a");
+                        VariableReferenceExpression ds = p.variable("ds", VARCHAR);
+                        VariableReferenceExpression column0 = p.variable("column0", BIGINT);
+                        return p.aggregation(ap -> ap.globalGrouping().step(AggregationNode.Step.FINAL)
+                                .addAggregation(p.variable("expr0"), p.rowExpression("MAX(a)"))
+                                .source(p.project(
+                                        assignment(a, p.rowExpression("IF(ds > '2021-06-01', column0)")),
+                                        p.values(ds, column0))));
+                    })
+                    .matches(
+                            aggregation(
+                                    globalAggregation(),
+                                    ImmutableMap.of(Optional.of("expr0"), functionCall("max", ImmutableList.of("column0_0"))),
+                                    ImmutableMap.of(new Symbol("expr0"), new Symbol("greater_than")),
+                                    Optional.empty(),
+                                    AggregationNode.Step.FINAL,
+                                    filter(
+                                            "greater_than",
+                                            project(new ImmutableMap.Builder<String, ExpressionMatcher>()
+                                                            .put("a", expression("IF(ds > '2021-06-01', column0)"))
+                                                            .put("greater_than", expression("ds > '2021-06-01'"))
+                                                            .put("column0_0", expression("column0"))
+                                                            .build(),
+                                                    values("ds", "column0")))));
+        }
     }
 
     @Test
     public void testFireArbitrary()
     {
-        tester().assertThat(new RewriteAggregationIfToFilter(getFunctionManager()))
-                .setSystemProperty(AGGREGATION_IF_TO_FILTER_REWRITE_STRATEGY, "filter_with_if")
-                .on(p -> {
-                    VariableReferenceExpression a = p.variable("a");
-                    VariableReferenceExpression ds = p.variable("ds", VARCHAR);
-                    VariableReferenceExpression column0 = p.variable("column0", BIGINT);
-                    return p.aggregation(ap -> ap.globalGrouping().step(AggregationNode.Step.FINAL)
-                            .addAggregation(p.variable("expr0"), p.rowExpression("ARBITRARY(a)"))
-                            .source(p.project(
-                                    assignment(a, p.rowExpression("IF(ds > '2021-06-01', column0)")),
-                                    p.values(ds, column0))));
-                })
-                .matches(
-                        aggregation(
-                                globalAggregation(),
-                                ImmutableMap.of(Optional.of("expr0"), functionCall("arbitrary", ImmutableList.of("a"))),
-                                ImmutableMap.of(new Symbol("expr0"), new Symbol("greater_than")),
-                                Optional.empty(),
-                                AggregationNode.Step.FINAL,
-                                filter(
-                                        "greater_than",
-                                        project(new ImmutableMap.Builder<String, ExpressionMatcher>()
-                                                        .put("a", expression("IF(ds > '2021-06-01', column0)"))
-                                                        .put("greater_than", expression("ds > '2021-06-01'"))
-                                                        .build(),
-                                                values("ds", "column0")))));
+        for (String strategy : new String[] {"unwrap_if_safe", "unwrap_if"}) {
+            tester().assertThat(new RewriteAggregationIfToFilter(getFunctionManager()))
+                    .setSystemProperty(AGGREGATION_IF_TO_FILTER_REWRITE_STRATEGY, strategy)
+                    .on(p -> {
+                        VariableReferenceExpression a = p.variable("a");
+                        VariableReferenceExpression ds = p.variable("ds", VARCHAR);
+                        VariableReferenceExpression column0 = p.variable("column0", BIGINT);
+                        return p.aggregation(ap -> ap.globalGrouping().step(AggregationNode.Step.FINAL)
+                                .addAggregation(p.variable("expr0"), p.rowExpression("ARBITRARY(a)"))
+                                .source(p.project(
+                                        assignment(a, p.rowExpression("IF(ds > '2021-06-01', column0)")),
+                                        p.values(ds, column0))));
+                    })
+                    .matches(
+                            aggregation(
+                                    globalAggregation(),
+                                    ImmutableMap.of(Optional.of("expr0"), functionCall("arbitrary", ImmutableList.of("column0_0"))),
+                                    ImmutableMap.of(new Symbol("expr0"), new Symbol("greater_than")),
+                                    Optional.empty(),
+                                    AggregationNode.Step.FINAL,
+                                    filter(
+                                            "greater_than",
+                                            project(new ImmutableMap.Builder<String, ExpressionMatcher>()
+                                                            .put("a", expression("IF(ds > '2021-06-01', column0)"))
+                                                            .put("greater_than", expression("ds > '2021-06-01'"))
+                                                            .put("column0_0", expression("column0"))
+                                                            .build(),
+                                                    values("ds", "column0")))));
+        }
     }
 
     @Test
     public void testFireSum()
     {
-        tester().assertThat(new RewriteAggregationIfToFilter(getFunctionManager()))
-                .setSystemProperty(AGGREGATION_IF_TO_FILTER_REWRITE_STRATEGY, "filter_with_if")
-                .on(p -> {
-                    VariableReferenceExpression a = p.variable("a");
-                    VariableReferenceExpression ds = p.variable("ds", VARCHAR);
-                    VariableReferenceExpression column0 = p.variable("column0", BIGINT);
-                    return p.aggregation(ap -> ap.globalGrouping().step(AggregationNode.Step.FINAL)
-                            .addAggregation(p.variable("expr0"), p.rowExpression("SUM(a)"))
-                            .source(p.project(
-                                    assignment(a, p.rowExpression("IF(ds > '2021-06-01', column0)")),
-                                    p.values(ds, column0))));
-                })
-                .matches(
-                        aggregation(
-                                globalAggregation(),
-                                ImmutableMap.of(Optional.of("expr0"), functionCall("sum", ImmutableList.of("a"))),
-                                ImmutableMap.of(new Symbol("expr0"), new Symbol("greater_than")),
-                                Optional.empty(),
-                                AggregationNode.Step.FINAL,
-                                filter(
-                                        "greater_than",
-                                        project(new ImmutableMap.Builder<String, ExpressionMatcher>()
-                                                        .put("a", expression("IF(ds > '2021-06-01', column0)"))
-                                                        .put("greater_than", expression("ds > '2021-06-01'"))
-                                                        .build(),
-                                                values("ds", "column0")))));
+        for (String strategy : new String[] {"unwrap_if_safe", "unwrap_if"}) {
+            tester().assertThat(new RewriteAggregationIfToFilter(getFunctionManager()))
+                    .setSystemProperty(AGGREGATION_IF_TO_FILTER_REWRITE_STRATEGY, strategy)
+                    .on(p -> {
+                        VariableReferenceExpression a = p.variable("a");
+                        VariableReferenceExpression ds = p.variable("ds", VARCHAR);
+                        VariableReferenceExpression column0 = p.variable("column0", BIGINT);
+                        return p.aggregation(ap -> ap.globalGrouping().step(AggregationNode.Step.FINAL)
+                                .addAggregation(p.variable("expr0"), p.rowExpression("SUM(a)"))
+                                .source(p.project(
+                                        assignment(a, p.rowExpression("IF(ds > '2021-06-01', column0)")),
+                                        p.values(ds, column0))));
+                    })
+                    .matches(
+                            aggregation(
+                                    globalAggregation(),
+                                    ImmutableMap.of(Optional.of("expr0"), functionCall("sum", ImmutableList.of("column0_0"))),
+                                    ImmutableMap.of(new Symbol("expr0"), new Symbol("greater_than")),
+                                    Optional.empty(),
+                                    AggregationNode.Step.FINAL,
+                                    filter(
+                                            "greater_than",
+                                            project(new ImmutableMap.Builder<String, ExpressionMatcher>()
+                                                            .put("a", expression("IF(ds > '2021-06-01', column0)"))
+                                                            .put("greater_than", expression("ds > '2021-06-01'"))
+                                                            .put("column0_0", expression("column0"))
+                                                            .build(),
+                                                    values("ds", "column0")))));
+        }
     }
 
     @Test
@@ -324,120 +344,130 @@ public class TestRewriteAggregationIfToFilter
     @Test
     public void testFireTwoAggregations()
     {
-        tester().assertThat(new RewriteAggregationIfToFilter(getFunctionManager()))
-                .setSystemProperty(AGGREGATION_IF_TO_FILTER_REWRITE_STRATEGY, "filter_with_if")
-                .on(p -> {
-                    VariableReferenceExpression a = p.variable("a");
-                    VariableReferenceExpression b = p.variable("b");
-                    VariableReferenceExpression ds = p.variable("ds", VARCHAR);
-                    return p.aggregation(ap -> ap.globalGrouping().step(AggregationNode.Step.FINAL)
-                            .addAggregation(p.variable("expr0"), p.rowExpression("count(a)"))
-                            .addAggregation(p.variable("expr1"), p.rowExpression("count(b)"))
-                            .source(p.project(
-                                    assignment(
-                                            a, p.rowExpression("IF(ds > '2021-07-01', 1)"),
-                                            b, p.rowExpression("IF(ds > '2021-06-01', 2)")),
-                                    p.values(ds))));
-                })
-                .matches(
-                        aggregation(
-                                globalAggregation(),
-                                ImmutableMap.of(
-                                        Optional.of("expr0"), functionCall("count", ImmutableList.of("a")),
-                                        Optional.of("expr1"), functionCall("count", ImmutableList.of("b"))),
-                                ImmutableMap.of(
-                                        new Symbol("expr0"), new Symbol("greater_than"),
-                                        new Symbol("expr1"), new Symbol("greater_than_0")),
-                                Optional.empty(),
-                                AggregationNode.Step.FINAL,
-                                filter(
-                                        "greater_than or greater_than_0",
-                                        project(new ImmutableMap.Builder<String, ExpressionMatcher>()
-                                                        .put("a", expression("IF(ds > '2021-07-01', 1)"))
-                                                        .put("b", expression("IF(ds > '2021-06-01', 2)"))
-                                                        .put("greater_than", expression("ds > '2021-07-01'"))
-                                                        .put("greater_than_0", expression("ds > '2021-06-01'"))
-                                                        .build(),
-                                                values("ds")))));
+        for (String strategy : new String[] {"unwrap_if_safe", "unwrap_if"}) {
+            tester().assertThat(new RewriteAggregationIfToFilter(getFunctionManager()))
+                    .setSystemProperty(AGGREGATION_IF_TO_FILTER_REWRITE_STRATEGY, strategy)
+                    .on(p -> {
+                        VariableReferenceExpression a = p.variable("a");
+                        VariableReferenceExpression b = p.variable("b");
+                        VariableReferenceExpression ds = p.variable("ds", VARCHAR);
+                        return p.aggregation(ap -> ap.globalGrouping().step(AggregationNode.Step.FINAL)
+                                .addAggregation(p.variable("expr0"), p.rowExpression("count(a)"))
+                                .addAggregation(p.variable("expr1"), p.rowExpression("count(b)"))
+                                .source(p.project(
+                                        assignment(
+                                                a, p.rowExpression("IF(ds > '2021-07-01', 1)"),
+                                                b, p.rowExpression("IF(ds > '2021-06-01', 2)")),
+                                        p.values(ds))));
+                    })
+                    .matches(
+                            aggregation(
+                                    globalAggregation(),
+                                    ImmutableMap.of(
+                                            Optional.of("expr0"), functionCall("count", ImmutableList.of("expr")),
+                                            Optional.of("expr1"), functionCall("count", ImmutableList.of("expr_1"))),
+                                    ImmutableMap.of(
+                                            new Symbol("expr0"), new Symbol("greater_than"),
+                                            new Symbol("expr1"), new Symbol("greater_than_0")),
+                                    Optional.empty(),
+                                    AggregationNode.Step.FINAL,
+                                    filter(
+                                            "greater_than or greater_than_0",
+                                            project(new ImmutableMap.Builder<String, ExpressionMatcher>()
+                                                            .put("a", expression("IF(ds > '2021-07-01', 1)"))
+                                                            .put("b", expression("IF(ds > '2021-06-01', 2)"))
+                                                            .put("greater_than", expression("ds > '2021-07-01'"))
+                                                            .put("expr", expression("1"))
+                                                            .put("greater_than_0", expression("ds > '2021-06-01'"))
+                                                            .put("expr_1", expression("2"))
+                                                            .build(),
+                                                    values("ds")))));
+        }
     }
 
     @Test
     public void testFireTwoAggregationsWithSharedInput()
     {
-        tester().assertThat(new RewriteAggregationIfToFilter(getFunctionManager()))
-                .setSystemProperty(AGGREGATION_IF_TO_FILTER_REWRITE_STRATEGY, "filter_with_if")
-                .on(p -> {
-                    VariableReferenceExpression a = p.variable("a");
-                    VariableReferenceExpression ds = p.variable("ds", VARCHAR);
-                    VariableReferenceExpression column0 = p.variable("column0", BIGINT);
-                    return p.aggregation(ap -> ap.globalGrouping().step(AggregationNode.Step.FINAL)
-                            .addAggregation(p.variable("expr0"), p.rowExpression("MIN(a)"))
-                            .addAggregation(p.variable("expr1"), p.rowExpression("MAX(a)"))
-                            .source(p.project(
-                                    assignment(a, p.rowExpression("IF(ds > '2021-06-01', column0)")),
-                                    p.values(ds, column0))));
-                })
-                .matches(
-                        aggregation(
-                                globalAggregation(),
-                                ImmutableMap.of(
-                                        Optional.of("expr0"), functionCall("min", ImmutableList.of("a")),
-                                        Optional.of("expr1"), functionCall("max", ImmutableList.of("a"))),
-                                ImmutableMap.of(
-                                        new Symbol("expr0"), new Symbol("greater_than"),
-                                        new Symbol("expr1"), new Symbol("greater_than")),
-                                Optional.empty(),
-                                AggregationNode.Step.FINAL,
-                                filter(
-                                        "greater_than",
-                                        project(new ImmutableMap.Builder<String, ExpressionMatcher>()
-                                                        .put("a", expression("IF(ds > '2021-06-01', column0)"))
-                                                        .put("greater_than", expression("ds > '2021-06-01'"))
-                                                        .build(),
-                                                values("ds", "column0")))));
+        for (String strategy : new String[] {"unwrap_if_safe", "unwrap_if"}) {
+            tester().assertThat(new RewriteAggregationIfToFilter(getFunctionManager()))
+                    .setSystemProperty(AGGREGATION_IF_TO_FILTER_REWRITE_STRATEGY, strategy)
+                    .on(p -> {
+                        VariableReferenceExpression a = p.variable("a");
+                        VariableReferenceExpression ds = p.variable("ds", VARCHAR);
+                        VariableReferenceExpression column0 = p.variable("column0", BIGINT);
+                        return p.aggregation(ap -> ap.globalGrouping().step(AggregationNode.Step.FINAL)
+                                .addAggregation(p.variable("expr0"), p.rowExpression("MIN(a)"))
+                                .addAggregation(p.variable("expr1"), p.rowExpression("MAX(a)"))
+                                .source(p.project(
+                                        assignment(a, p.rowExpression("IF(ds > '2021-06-01', column0)")),
+                                        p.values(ds, column0))));
+                    })
+                    .matches(
+                            aggregation(
+                                    globalAggregation(),
+                                    ImmutableMap.of(
+                                            Optional.of("expr0"), functionCall("min", ImmutableList.of("column0_0")),
+                                            Optional.of("expr1"), functionCall("max", ImmutableList.of("column0_0"))),
+                                    ImmutableMap.of(
+                                            new Symbol("expr0"), new Symbol("greater_than"),
+                                            new Symbol("expr1"), new Symbol("greater_than")),
+                                    Optional.empty(),
+                                    AggregationNode.Step.FINAL,
+                                    filter(
+                                            "greater_than",
+                                            project(new ImmutableMap.Builder<String, ExpressionMatcher>()
+                                                            .put("a", expression("IF(ds > '2021-06-01', column0)"))
+                                                            .put("greater_than", expression("ds > '2021-06-01'"))
+                                                            .put("column0_0", expression("column0"))
+                                                            .build(),
+                                                    values("ds", "column0")))));
+        }
     }
 
     @Test
     public void testFireForOneOfTwoAggregations()
     {
-        tester().assertThat(new RewriteAggregationIfToFilter(getFunctionManager()))
-                .setSystemProperty(AGGREGATION_IF_TO_FILTER_REWRITE_STRATEGY, "filter_with_if")
-                .on(p -> {
-                    VariableReferenceExpression a = p.variable("a");
-                    VariableReferenceExpression b = p.variable("b");
-                    VariableReferenceExpression ds = p.variable("ds", VARCHAR);
-                    return p.aggregation(ap -> ap.globalGrouping().step(AggregationNode.Step.FINAL)
-                            .addAggregation(p.variable("expr0"), p.rowExpression("count(a)"))
-                            .addAggregation(p.variable("expr1"), p.rowExpression("count(b)"))
-                            .source(p.project(
-                                    assignment(
-                                            a, p.rowExpression("IF(ds > '2021-07-01', 1)"),
-                                            b, p.rowExpression("ds")),
-                                    p.values(ds))));
-                })
-                .matches(
-                        aggregation(
-                                globalAggregation(),
-                                ImmutableMap.of(
-                                        Optional.of("expr0"), functionCall("count", ImmutableList.of("a")),
-                                        Optional.of("expr1"), functionCall("count", ImmutableList.of("b"))),
-                                ImmutableMap.of(new Symbol("expr0"), new Symbol("greater_than")),
-                                Optional.empty(),
-                                AggregationNode.Step.FINAL,
-                                filter(
-                                        "true",
-                                        project(new ImmutableMap.Builder<String, ExpressionMatcher>()
-                                                        .put("a", expression("IF(ds > '2021-07-01', 1)"))
-                                                        .put("b", expression("ds"))
-                                                        .put("greater_than", expression("ds > '2021-07-01'"))
-                                                        .build(),
-                                                values("ds")))));
+        for (String strategy : new String[] {"unwrap_if_safe", "unwrap_if"}) {
+            tester().assertThat(new RewriteAggregationIfToFilter(getFunctionManager()))
+                    .setSystemProperty(AGGREGATION_IF_TO_FILTER_REWRITE_STRATEGY, strategy)
+                    .on(p -> {
+                        VariableReferenceExpression a = p.variable("a");
+                        VariableReferenceExpression b = p.variable("b");
+                        VariableReferenceExpression ds = p.variable("ds", VARCHAR);
+                        return p.aggregation(ap -> ap.globalGrouping().step(AggregationNode.Step.FINAL)
+                                .addAggregation(p.variable("expr0"), p.rowExpression("count(a)"))
+                                .addAggregation(p.variable("expr1"), p.rowExpression("count(b)"))
+                                .source(p.project(
+                                        assignment(
+                                                a, p.rowExpression("IF(ds > '2021-07-01', 1)"),
+                                                b, p.rowExpression("ds")),
+                                        p.values(ds))));
+                    })
+                    .matches(
+                            aggregation(
+                                    globalAggregation(),
+                                    ImmutableMap.of(
+                                            Optional.of("expr0"), functionCall("count", ImmutableList.of("expr")),
+                                            Optional.of("expr1"), functionCall("count", ImmutableList.of("b"))),
+                                    ImmutableMap.of(new Symbol("expr0"), new Symbol("greater_than")),
+                                    Optional.empty(),
+                                    AggregationNode.Step.FINAL,
+                                    filter(
+                                            "true",
+                                            project(new ImmutableMap.Builder<String, ExpressionMatcher>()
+                                                            .put("a", expression("IF(ds > '2021-07-01', 1)"))
+                                                            .put("b", expression("ds"))
+                                                            .put("greater_than", expression("ds > '2021-07-01'"))
+                                                            .put("expr", expression("1"))
+                                                            .build(),
+                                                    values("ds")))));
+        }
     }
 
     @Test
     public void testArrayOffset()
     {
-        for (String strategy : new String[] {"filter_with_if", "unwrap_if"}) {
+        for (String strategy : new String[] {"filter_with_if", "unwrap_if_safe", "unwrap_if"}) {
             tester().assertThat(new RewriteAggregationIfToFilter(getFunctionManager()))
                     .setSystemProperty(AGGREGATION_IF_TO_FILTER_REWRITE_STRATEGY, strategy)
                     .on(p -> {
@@ -469,7 +499,7 @@ public class TestRewriteAggregationIfToFilter
     @Test
     public void testDivide()
     {
-        for (String strategy : new String[] {"filter_with_if", "unwrap_if"}) {
+        for (String strategy : new String[] {"filter_with_if", "unwrap_if_safe", "unwrap_if"}) {
             tester().assertThat(new RewriteAggregationIfToFilter(getFunctionManager()))
                     .setSystemProperty(AGGREGATION_IF_TO_FILTER_REWRITE_STRATEGY, strategy)
                     .on(p -> {
@@ -567,5 +597,79 @@ public class TestRewriteAggregationIfToFilter
                                                         .put("greater_than", expression("b > 0"))
                                                         .build(),
                                                 values("a", "b")))));
+    }
+
+    @Test
+    public void testRewriteStrategies()
+    {
+        Function<PlanBuilder, PlanNode> planProvider = p -> {
+            VariableReferenceExpression a = p.variable("a");
+            VariableReferenceExpression column0 = p.variable("column0", BIGINT);
+            return p.aggregation(ap -> ap.globalGrouping().step(AggregationNode.Step.FINAL)
+                    .addAggregation(p.variable("expr0"), p.rowExpression("SUM(a)"))
+                    .source(p.project(
+                            assignment(a, p.rowExpression("IF(column0 > 1, column0)")),
+                            p.values(column0))));
+        };
+
+        tester().assertThat(new RewriteAggregationIfToFilter(getFunctionManager()))
+                .setSystemProperty(AGGREGATION_IF_TO_FILTER_REWRITE_STRATEGY, "disabled")
+                .on(planProvider)
+                .doesNotFire();
+
+        tester().assertThat(new RewriteAggregationIfToFilter(getFunctionManager()))
+                .setSystemProperty(AGGREGATION_IF_TO_FILTER_REWRITE_STRATEGY, "filter_with_if")
+                .on(planProvider)
+                .matches(
+                        aggregation(
+                                globalAggregation(),
+                                ImmutableMap.of(Optional.of("expr0"), functionCall("sum", ImmutableList.of("a"))),
+                                ImmutableMap.of(new Symbol("expr0"), new Symbol("greater_than")),
+                                Optional.empty(),
+                                AggregationNode.Step.FINAL,
+                                filter(
+                                        "greater_than",
+                                        project(new ImmutableMap.Builder<String, ExpressionMatcher>()
+                                                        .put("a", expression("IF(column0 > 1, column0)"))
+                                                        .put("greater_than", expression("column0 > 1"))
+                                                        .build(),
+                                                values("column0")))));
+
+        tester().assertThat(new RewriteAggregationIfToFilter(getFunctionManager()))
+                .setSystemProperty(AGGREGATION_IF_TO_FILTER_REWRITE_STRATEGY, "unwrap_if_safe")
+                .on(planProvider)
+                .matches(
+                        aggregation(
+                                globalAggregation(),
+                                ImmutableMap.of(Optional.of("expr0"), functionCall("sum", ImmutableList.of("a"))),
+                                ImmutableMap.of(new Symbol("expr0"), new Symbol("greater_than")),
+                                Optional.empty(),
+                                AggregationNode.Step.FINAL,
+                                filter(
+                                        "greater_than",
+                                        project(new ImmutableMap.Builder<String, ExpressionMatcher>()
+                                                        .put("a", expression("IF(column0 > 1, column0)"))
+                                                        .put("greater_than", expression("column0 > 1"))
+                                                        .build(),
+                                                values("column0")))));
+
+        tester().assertThat(new RewriteAggregationIfToFilter(getFunctionManager()))
+                .setSystemProperty(AGGREGATION_IF_TO_FILTER_REWRITE_STRATEGY, "unwrap_if")
+                .on(planProvider)
+                .matches(
+                        aggregation(
+                                globalAggregation(),
+                                ImmutableMap.of(Optional.of("expr0"), functionCall("sum", ImmutableList.of("column0_0"))),
+                                ImmutableMap.of(new Symbol("expr0"), new Symbol("greater_than")),
+                                Optional.empty(),
+                                AggregationNode.Step.FINAL,
+                                filter(
+                                        "greater_than",
+                                        project(new ImmutableMap.Builder<String, ExpressionMatcher>()
+                                                        .put("a", expression("IF(column0 > 1, column0)"))
+                                                        .put("greater_than", expression("column0 > 1"))
+                                                        .put("column0_0", expression("column0"))
+                                                        .build(),
+                                                values("column0")))));
     }
 }


### PR DESCRIPTION
This PR has the following 3 commits in order:
1. `Add a new rewrite strategy UNWRAP_IF_SAFE`
   - A safe version of `UNWRAP_IF`. In this mode, we only unwrap IF for cases which we are sure its 100% safe to do it.
   - Update the corresponding testing to adopt this change.
2. `Add support for AGG(CAST(IF(expr, x))`
   - Improve the rule to handle this case when CAST() is present by rewriting AGG(CAST(IF(expr, x)) to AGG(CAST(x)) FILTER (WHERE expr).
   - Add a new unit test for CAST().
3. `Add a new stats for AGG(IF()) rewrite`
   - The new stats would be present in `RuntimeStats` if any node has been changed by the rewrite rule.

```
== NO RELEASE NOTE ==
```
