### PR TITLE
Add more RuntimeStats to help performance tuning

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/RuntimeMetricName.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/RuntimeMetricName.java
@@ -37,4 +37,10 @@ public class RuntimeMetricName
     public static final String LOGICAL_PLANNER_TIME_NANOS = "logicalPlannerTimeNanos";
     public static final String FRAGMENT_PLAN_TIME_NANOS = "fragmentPlanTimeNanos";
     public static final String GET_LAYOUT_TIME_NANOS = "getLayoutTimeNanos";
+    // Time between task creation and start.
+    public static final String TASK_QUEUED_TIME_NANOS = "taskQueuedTimeNanos";
+    // Total operation time of a task on a worker. TASK_ELAPSED_TIME_NANOS - TASK_SCHEDULED_TIME_NANOS is the time when the task is doing nothing, e.g. it might be waiting for splits/inputs.
+    public static final String TASK_SCHEDULED_TIME_NANOS = "taskScheduledTimeNanos";
+    // Blocked time for the operators due to waiting for inputs.
+    public static final String TASK_BLOCKED_TIME_NANOS = "taskBlockedTimeNanos";
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/RuntimeStats.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/RuntimeStats.java
@@ -84,6 +84,14 @@ public class RuntimeStats
         metrics.computeIfAbsent(name, RuntimeMetric::new).addValue(value);
     }
 
+    public void addMetricValueIgnoreZero(String name, long value)
+    {
+        if (value == 0) {
+            return;
+        }
+        addMetricValue(name, value);
+    }
+
     /**
      * Merges {@code metric} into this object with name {@code name}.
      */
@@ -119,7 +127,7 @@ public class RuntimeStats
     {
         long startTime = System.nanoTime();
         V result = supplier.get();
-        addMetricValue(tag, System.nanoTime() - startTime);
+        addMetricValueIgnoreZero(tag, System.nanoTime() - startTime);
         return result;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/StageExecutionInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/StageExecutionInfo.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import static com.facebook.presto.common.RuntimeMetricName.GET_SPLITS_TIME_NANOS;
 import static com.facebook.presto.execution.StageExecutionState.FINISHED;
 import static io.airlift.units.DataSize.succinctBytes;
 import static io.airlift.units.Duration.succinctDuration;
@@ -108,6 +109,7 @@ public class StageExecutionInfo
 
         Map<String, OperatorStats> operatorToStats = new HashMap<>();
         RuntimeStats mergedRuntimeStats = new RuntimeStats();
+        mergedRuntimeStats.addMetricValueIgnoreZero(GET_SPLITS_TIME_NANOS, (long) getSplitDistribution.getTotal());
         for (TaskInfo taskInfo : taskInfos) {
             TaskState taskState = taskInfo.getTaskStatus().getState();
             if (taskState.isDone()) {
@@ -175,6 +177,9 @@ public class StageExecutionInfo
             mergedRuntimeStats.mergeWith(taskStats.getRuntimeStats());
             mergedRuntimeStats.addMetricValue(RuntimeMetricName.DRIVER_COUNT_PER_TASK, taskStats.getTotalDrivers());
             mergedRuntimeStats.addMetricValue(RuntimeMetricName.TASK_ELAPSED_TIME_NANOS, taskStats.getElapsedTimeInNanos());
+            mergedRuntimeStats.addMetricValueIgnoreZero(RuntimeMetricName.TASK_QUEUED_TIME_NANOS, taskStats.getQueuedTimeInNanos());
+            mergedRuntimeStats.addMetricValue(RuntimeMetricName.TASK_SCHEDULED_TIME_NANOS, taskStats.getTotalScheduledTimeInNanos());
+            mergedRuntimeStats.addMetricValueIgnoreZero(RuntimeMetricName.TASK_BLOCKED_TIME_NANOS, taskStats.getTotalBlockedTimeInNanos());
         }
 
         StageExecutionStats stageExecutionStats = new StageExecutionStats(

--- a/presto-main/src/main/java/com/facebook/presto/split/SplitManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/split/SplitManager.java
@@ -36,7 +36,6 @@ import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
-import static com.facebook.presto.common.RuntimeMetricName.GET_SPLITS_TIME_NANOS;
 import static com.facebook.presto.execution.scheduler.NodeSchedulerConfig.NetworkTopologyType.LEGACY;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
@@ -97,7 +96,6 @@ public class SplitManager
         if (minScheduleSplitBatchSize > 1) {
             splitSource = new BufferingSplitSource(splitSource, minScheduleSplitBatchSize);
         }
-        session.getRuntimeStats().addMetricValue(GET_SPLITS_TIME_NANOS, System.nanoTime() - startTime);
         return splitSource;
     }
 


### PR DESCRIPTION
Add the following RuntimeStats counters:
`taskQueuedTimeNanos`: Time between a task creation and start. A large
 value indicates that a particular worker is overloaded.

`taskScheduledTimeNanos`: Total operation time of a task on a worker.
TASK_ELAPSED_TIME_NANOS - taskScheduledTimeNanos is the time duration
during which the task is doing nothing, e.g. it might be waiting for
splits/inputs.

`taskBlockedTimeNanos`: Blocked time for the operators due to waiting
for inputs.

Also fixed the getSplitsTimeNanos. GetSplits is done asynchronously.
Previous method didn't record the actual time.

```
== NO RELEASE NOTE ==
```
