### PR TITLE
Add different tracing mode to current tracing system

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -212,7 +212,7 @@ public final class SystemSessionProperties
     public static final String RESOURCE_AWARE_SCHEDULING_STRATEGY = "resource_aware_scheduling_strategy";
     public static final String HEAP_DUMP_ON_EXCEEDED_MEMORY_LIMIT_ENABLED = "heap_dump_on_exceeded_memory_limit_enabled";
     public static final String EXCEEDED_MEMORY_LIMIT_HEAP_DUMP_FILE_DIRECTORY = "exceeded_memory_limit_heap_dump_file_directory";
-    public static final String ENABLE_DISTRIBUTED_TRACING = "enable_distributed_tracing";
+    public static final String DISTRIBUTED_TRACING_MODE = "distributed_tracing_mode";
     public static final String VERBOSE_RUNTIME_STATS_ENABLED = "verbose_runtime_stats_enabled";
 
     //TODO: Prestissimo related session properties that are temporarily put here. They will be relocated in the future
@@ -1124,10 +1124,10 @@ public final class SystemSessionProperties
                         "Enable query optimization with materialized view",
                         featuresConfig.isQueryOptimizationWithMaterializedViewEnabled(),
                         true),
-                booleanProperty(
-                        ENABLE_DISTRIBUTED_TRACING,
-                        "Enable distributed tracing of the query",
-                        tracingConfig.getEnableDistributedTracing(),
+                stringProperty(
+                        DISTRIBUTED_TRACING_MODE,
+                        "Mode for distributed tracing. NO_TRACE, ALWAYS_TRACE, or SAMPLE_BASED",
+                        tracingConfig.getDistributedTracingMode().name(),
                         false),
                 booleanProperty(
                         VERBOSE_RUNTIME_STATS_ENABLED,

--- a/presto-main/src/main/java/com/facebook/presto/tracing/TracingConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/tracing/TracingConfig.java
@@ -14,6 +14,9 @@
 package com.facebook.presto.tracing;
 
 import com.facebook.airlift.configuration.Config;
+import com.facebook.presto.spi.PrestoException;
+
+import static com.facebook.presto.spi.StandardErrorCode.DISTRIBUTED_TRACING_ERROR;
 
 public class TracingConfig
 {
@@ -23,7 +26,15 @@ public class TracingConfig
         public static final String SIMPLE = "simple";
     }
 
+    public enum DistributedTracingMode
+    {
+        NO_TRACE,
+        ALWAYS_TRACE,
+        SAMPLE_BASED
+    }
+
     private String tracerType = TracerType.NOOP;
+    private DistributedTracingMode tracingMode = DistributedTracingMode.NO_TRACE;
     private boolean enableDistributedTracing;
 
     public String getTracerType()
@@ -47,6 +58,23 @@ public class TracingConfig
     public TracingConfig setEnableDistributedTracing(boolean enableDistributedTracing)
     {
         this.enableDistributedTracing = enableDistributedTracing;
+        return this;
+    }
+
+    public DistributedTracingMode getDistributedTracingMode()
+    {
+        return tracingMode;
+    }
+
+    @Config("tracing.distributed-tracing-mode")
+    public TracingConfig setDistributedTracingMode(String tracingMode)
+    {
+        if (tracingMode.equalsIgnoreCase(DistributedTracingMode.SAMPLE_BASED.name())) {
+            throw new PrestoException(
+                    DISTRIBUTED_TRACING_ERROR,
+                    "SAMPLE_BASED Tracing Mode is currently not supported.");
+        }
+        this.tracingMode = DistributedTracingMode.valueOf(tracingMode.toUpperCase());
         return this;
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/tracing/TestTracingConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/tracing/TestTracingConfig.java
@@ -29,7 +29,8 @@ public class TestTracingConfig
     {
         assertRecordedDefaults(ConfigAssertions.recordDefaults(TracingConfig.class)
                 .setTracerType("noop")
-                .setEnableDistributedTracing(false));
+                .setEnableDistributedTracing(false)
+                .setDistributedTracingMode(TracingConfig.DistributedTracingMode.NO_TRACE.name()));
     }
 
     @Test
@@ -38,11 +39,13 @@ public class TestTracingConfig
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("tracing.tracer-type", "simple")
                 .put("tracing.enable-distributed-tracing", "true")
+                .put("tracing.distributed-tracing-mode", "always_trace")
                 .build();
 
         TracingConfig expected = new TracingConfig()
                 .setTracerType("simple")
-                .setEnableDistributedTracing(true);
+                .setEnableDistributedTracing(true)
+                .setDistributedTracingMode(TracingConfig.DistributedTracingMode.ALWAYS_TRACE.name());
         assertFullMapping(properties, expected);
     }
 }


### PR DESCRIPTION
Summary:
Tracing mode is roughly categorized to 3 modes:
1. adhoc tracing mode - for debugging purpose. The sample rate should be 100%. This mode should be triggered manually only.
2. sample based tracing mode - for aggregation purpose. This mode all queries on the cluster are subject to be traced based on the sample rate. Normally for aggregation analysis.
3. no trace mode - this mode tracing is not triggered.

Test plan:
- Additional unit test is added to test the new config property.
- Different session properties of tracing mode are provided to queries running in the cluster with this new binary. Expected tracing behavior was observed.

```
== NO RELEASE NOTE ==
```
