### PR TITLE
[Pinot Connector] Adding configs to allow using https for Pinot REST API

### DIFF
--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotClusterInfoFetcher.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotClusterInfoFetcher.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.pinot;
 
 import com.facebook.airlift.http.client.HttpClient;
+import com.facebook.airlift.http.client.HttpUriBuilder;
 import com.facebook.airlift.http.client.Request;
 import com.facebook.airlift.http.client.StaticBodyGenerator;
 import com.facebook.airlift.http.client.StringResponseHandler;
@@ -29,6 +30,7 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.net.HostAndPort;
 import com.google.common.net.HttpHeaders;
 import org.apache.pinot.spi.data.Schema;
 
@@ -63,6 +65,9 @@ import static org.apache.pinot.spi.utils.builder.TableNameBuilder.extractRawTabl
 public class PinotClusterInfoFetcher
 {
     private static final Logger log = Logger.get(PinotClusterInfoFetcher.class);
+    private static final String HTTPS_SCHEME = "https";
+    private static final String HTTP_SCHEME = "http";
+
     private static final String APPLICATION_JSON = "application/json";
     private static final Pattern BROKER_PATTERN = Pattern.compile("Broker_(.*)_(\\d+)");
 
@@ -193,24 +198,42 @@ public class PinotClusterInfoFetcher
 
     private String sendHttpGetToController(String path)
     {
+        final URI controllerPathUri = HttpUriBuilder
+                .uriBuilder()
+                .scheme(pinotConfig.isUseHttpsForController() ? HTTPS_SCHEME : HTTP_SCHEME)
+                .hostAndPort(HostAndPort.fromString(getControllerUrl()))
+                .appendPath(path)
+                .build();
         return doHttpActionWithHeaders(
-                Request.builder().prepareGet().setUri(URI.create(String.format("http://%s/%s", getControllerUrl(), path))),
+                Request.builder().prepareGet().setUri(controllerPathUri),
                 Optional.empty(),
                 Optional.ofNullable(pinotConfig.getControllerRestService()));
     }
 
     private String sendHttpGetToBroker(String table, String path)
     {
+        final URI brokerPathUri = HttpUriBuilder
+                .uriBuilder()
+                .scheme(pinotConfig.isUseHttpsForBroker() ? HTTPS_SCHEME : HTTP_SCHEME)
+                .hostAndPort(HostAndPort.fromString(getBrokerHost(table)))
+                .appendPath(path)
+                .build();
         return doHttpActionWithHeaders(
-                Request.builder().prepareGet().setUri(URI.create(String.format("http://%s/%s", getBrokerHost(table), path))),
+                Request.builder().prepareGet().setUri(brokerPathUri),
                 Optional.empty(),
                 Optional.empty());
     }
 
     private String sendHttpGetToRestProxy(String path)
     {
+        final URI proxyPathUri = HttpUriBuilder
+                .uriBuilder()
+                .scheme(pinotConfig.isUseHttpsForProxy() ? HTTPS_SCHEME : HTTP_SCHEME)
+                .hostAndPort(HostAndPort.fromString(pinotConfig.getRestProxyUrl()))
+                .appendPath(path)
+                .build();
         return doHttpActionWithHeaders(
-                Request.builder().prepareGet().setUri(URI.create(String.format("http://%s/%s", pinotConfig.getRestProxyUrl(), path))),
+                Request.builder().prepareGet().setUri(proxyPathUri),
                 Optional.empty(),
                 Optional.empty());
     }

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotConfig.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotConfig.java
@@ -104,6 +104,9 @@ public class PinotConfig
     private String proxyGrpcHost;
     private int proxyGrpcPort = DEFAULT_PROXY_GRPC_PORT;
     private boolean useProxyForBrokerRequest;
+    private boolean useHttpsForController;
+    private boolean useHttpsForBroker;
+    private boolean useHttpsForProxy;
 
     @NotNull
     public Map<String, String> getExtraHttpHeaders()
@@ -571,6 +574,42 @@ public class PinotConfig
     public PinotConfig setProxyGrpcPort(int proxyGrpcPort)
     {
         this.proxyGrpcPort = proxyGrpcPort;
+        return this;
+    }
+
+    public boolean isUseHttpsForController()
+    {
+        return this.useHttpsForController;
+    }
+
+    @Config("pinot.use-https-for-controller")
+    public PinotConfig setUseHttpsForController(boolean useHttpsForController)
+    {
+        this.useHttpsForController = useHttpsForController;
+        return this;
+    }
+
+    public boolean isUseHttpsForBroker()
+    {
+        return this.useHttpsForBroker;
+    }
+
+    @Config("pinot.use-https-for-broker")
+    public PinotConfig setUseHttpsForBroker(boolean useHttpsForBroker)
+    {
+        this.useHttpsForBroker = useHttpsForBroker;
+        return this;
+    }
+
+    public boolean isUseHttpsForProxy()
+    {
+        return this.useHttpsForProxy;
+    }
+
+    @Config("pinot.use-https-for-proxy")
+    public PinotConfig setUseHttpsForProxy(boolean useHttpsForProxy)
+    {
+        this.useHttpsForProxy = useHttpsForProxy;
         return this;
     }
 }

--- a/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotConfig.java
+++ b/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotConfig.java
@@ -55,6 +55,9 @@ public class TestPinotConfig
                         .setProxyGrpcPort(PinotConfig.DEFAULT_PROXY_GRPC_PORT)
                         .setUseProxyForBrokerRequest(false)
                         .setUseProxyGrpcEndpoint(false)
+                        .setUseHttpsForController(false)
+                        .setUseHttpsForBroker(false)
+                        .setUseHttpsForProxy(false)
                         .setNumSegmentsPerSplit(1)
                         .setFetchRetryCount(2)
                         .setMarkDataFetchExceptionsAsRetriable(true)
@@ -109,6 +112,9 @@ public class TestPinotConfig
                 .put("pinot.forbid-segment-queries", "true")
                 .put("pinot.use-streaming-for-segment-queries", "true")
                 .put("pinot.streaming-server-grpc-max-inbound-message-bytes", "65536")
+                .put("pinot.use-https-for-controller", "true")
+                .put("pinot.use-https-for-broker", "true")
+                .put("pinot.use-https-for-proxy", "true")
                 .build();
 
         PinotConfig expected = new PinotConfig()
@@ -149,7 +155,10 @@ public class TestPinotConfig
                 .setForbidSegmentQueries(true)
                 .setUseStreamingForSegmentQueries(true)
                 .setStreamingServerGrpcMaxInboundMessageBytes(65536)
-                .setUseDateTrunc(true);
+                .setUseDateTrunc(true)
+                .setUseHttpsForController(true)
+                .setUseHttpsForBroker(true)
+                .setUseHttpsForProxy(true);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
```
== RELEASE NOTES ==

Pinot Changes
* Adding configs ``pinot.use-https-for-controller/broker/proxy`` to allow using https for Pinot REST APIs
```
