### PR TITLE
Create table DDL propagates Column typeMetadata

### DIFF
--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/ColumnConverter.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/ColumnConverter.java
@@ -35,4 +35,11 @@ public interface ColumnConverter
      * Generates a new TypeSignature using {@param hiveType} and extra {@param typeMetadata}
      */
     TypeSignature getTypeSignature(HiveType hiveType, Optional<String> typeMetadata);
+
+    /**
+     * Issue #17249: clean up
+     * Generates serialized typeMetadata using {@param hiveType} and @param typeSignature
+     * Empty if there is no typeMetadata
+     */
+    Optional<String> getTypeMetadata(HiveType hiveType, TypeSignature typeSignature);
 }

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/HiveColumnConverter.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/HiveColumnConverter.java
@@ -44,4 +44,10 @@ public class HiveColumnConverter
     {
         return hiveType.getTypeSignature();
     }
+
+    @Override
+    public Optional<String> getTypeMetadata(HiveType hiveType, TypeSignature typeSignature)
+    {
+        return Optional.empty();
+    }
 }

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/MetastoreUtil.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/MetastoreUtil.java
@@ -24,6 +24,7 @@ import com.facebook.presto.common.type.DateType;
 import com.facebook.presto.common.type.DecimalType;
 import com.facebook.presto.common.type.Decimals;
 import com.facebook.presto.common.type.DoubleType;
+import com.facebook.presto.common.type.EnumType;
 import com.facebook.presto.common.type.IntegerType;
 import com.facebook.presto.common.type.MapType;
 import com.facebook.presto.common.type.RealType;
@@ -33,6 +34,7 @@ import com.facebook.presto.common.type.StandardTypes;
 import com.facebook.presto.common.type.TimestampType;
 import com.facebook.presto.common.type.TinyintType;
 import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.TypeWithName;
 import com.facebook.presto.common.type.VarbinaryType;
 import com.facebook.presto.common.type.VarcharType;
 import com.facebook.presto.hive.HdfsContext;
@@ -864,6 +866,13 @@ public class MetastoreUtil
         if (type instanceof ArrayType || type instanceof RowType || type instanceof MapType) {
             return ImmutableSet.of(NUMBER_OF_NON_NULL_VALUES, TOTAL_SIZE_IN_BYTES);
         }
+        if (type instanceof TypeWithName) {
+            return getSupportedColumnStatistics(((TypeWithName) type).getType());
+        }
+        if (type instanceof EnumType) {
+            return getSupportedColumnStatistics(((EnumType) type).getValueType());
+        }
+
         // Throwing here to make sure this method is updated when a new type is added in Hive connector
         throw new IllegalArgumentException("Unsupported type: " + type);
     }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveTypeTranslator.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveTypeTranslator.java
@@ -15,9 +15,11 @@ package com.facebook.presto.hive;
 
 import com.facebook.presto.common.type.CharType;
 import com.facebook.presto.common.type.DecimalType;
+import com.facebook.presto.common.type.EnumType;
 import com.facebook.presto.common.type.NamedTypeSignature;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeSignatureParameter;
+import com.facebook.presto.common.type.TypeWithName;
 import com.facebook.presto.common.type.VarcharType;
 import com.facebook.presto.spi.PrestoException;
 import com.google.common.collect.ImmutableList;
@@ -102,6 +104,9 @@ public class HiveTypeTranslator
                         type, HiveVarchar.MAX_VARCHAR_LENGTH));
             }
         }
+        if (type instanceof EnumType<?>) {
+            return translate(((EnumType<?>) type).getValueType());
+        }
         if (type instanceof CharType) {
             CharType charType = (CharType) type;
             int charLength = charType.getLength();
@@ -110,6 +115,9 @@ public class HiveTypeTranslator
             }
             throw new PrestoException(NOT_SUPPORTED, format("Unsupported Hive type: %s. Supported CHAR types: CHAR(<=%d).",
                     type, HiveChar.MAX_CHAR_LENGTH));
+        }
+        if (type instanceof TypeWithName) {
+            return translate(((TypeWithName) type).getType());
         }
         if (VARBINARY.equals(type)) {
             return HIVE_BINARY.getTypeInfo();

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMetadata.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMetadata.java
@@ -209,6 +209,12 @@ public class TestHiveMetadata
         }
 
         @Override
+        public Optional<String> getTypeMetadata(HiveType hiveType, TypeSignature typeSignature)
+        {
+            throw new NotImplementedException();
+        }
+
+        @Override
         public TypeSignature getTypeSignature(HiveType hiveType, Optional<String> typeMetadata)
         {
             if (typeMetadata == null) {


### PR DESCRIPTION
Introduce a new interface method `getTypeMetadata`  to `ColumnConverter` which is the inverse of `getTypeSignature` and tunnel it throughout `HiveMetadata` 

```
== NO RELEASE NOTE ==
```
