### PR TITLE
Updates CLI to default protocol to HTTPS if port is 443

### DIFF
--- a/presto-cli/src/main/java/com/facebook/presto/cli/ClientOptions.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/ClientOptions.java
@@ -188,7 +188,9 @@ public class ClientOptions
 
         HostAndPort host = HostAndPort.fromString(server);
         try {
-            return new URI("http", null, host.getHost(), host.getPortOrDefault(80), null, null, null);
+            int port = host.getPortOrDefault(80);
+            String scheme = port == 443 ? "https" : "http";
+            return new URI(scheme, null, host.getHost(), port, null, null, null);
         }
         catch (URISyntaxException e) {
             throw new IllegalArgumentException(e);

--- a/presto-cli/src/test/java/com/facebook/presto/cli/TestClientOptions.java
+++ b/presto-cli/src/test/java/com/facebook/presto/cli/TestClientOptions.java
@@ -80,6 +80,33 @@ public class TestClientOptions
         assertEquals(session.getServer().toString(), "https://localhost/foo");
     }
 
+    @Test
+    public void testServer443Port()
+    {
+        ClientOptions options = new ClientOptions();
+        options.server = "test:443";
+        ClientSession session = options.toClientSession();
+        assertEquals(session.getServer().toString(), "https://test:443");
+    }
+
+    @Test
+    public void testServerHttpsHostPort()
+    {
+        ClientOptions options = new ClientOptions();
+        options.server = "https://test:443";
+        ClientSession session = options.toClientSession();
+        assertEquals(session.getServer().toString(), "https://test:443");
+    }
+
+    @Test
+    public void testServerHttpWithPort443()
+    {
+        ClientOptions options = new ClientOptions();
+        options.server = "http://test:443";
+        ClientSession session = options.toClientSession();
+        assertEquals(session.getServer().toString(), "http://test:443");
+    }
+
     @Test(expectedExceptions = IllegalArgumentException.class)
     public void testInvalidServer()
     {


### PR DESCRIPTION
Cherry-pick of https://github.com/trinodb/trino/pull/8806
If a user passes in a port that is 443, but they do not pass in
a protocol, we can assume that the user is using the HTTPS protocol.

Co-authored-by: Andrew DiBiasio <andrew.dibiasio@starburstdata.com>

Test plan - Added tests

```
== RELEASE NOTES ==

General Changes
* Updates CLI to default protocol to HTTPS if port is 443
```

