### PR TITLE
Coalesce small files in Hive connector 

### DIFF
--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/AccumuloMetadata.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/AccumuloMetadata.java
@@ -214,8 +214,9 @@ public class AccumuloMetadata
     }
 
     @Override
-    public Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session, ConnectorInsertTableHandle insertHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
+    public Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session, ConnectorInsertTableHandle insertHandle, Collection<Slice> fragments, Collection<Slice> deprecatedFragments, Collection<ComputedStatistics> computedStatistics)
     {
+        checkArgument(deprecatedFragments.isEmpty(), "deprecated fragments are unsupported");
         clearRollback();
         return Optional.empty();
     }

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcMetadata.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcMetadata.java
@@ -46,6 +46,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import static com.facebook.presto.spi.StandardErrorCode.PERMISSION_DENIED;
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
@@ -214,8 +215,9 @@ public class JdbcMetadata
     }
 
     @Override
-    public Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session, ConnectorInsertTableHandle tableHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
+    public Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session, ConnectorInsertTableHandle tableHandle, Collection<Slice> fragments, Collection<Slice> deprecatedFragments, Collection<ComputedStatistics> computedStatistics)
     {
+        checkArgument(deprecatedFragments.isEmpty(), "deprecatedFragments are unsupported");
         JdbcOutputTableHandle jdbcInsertHandle = (JdbcOutputTableHandle) tableHandle;
         jdbcClient.finishInsertTable(JdbcIdentity.from(session), jdbcInsertHandle);
         return Optional.empty();

--- a/presto-blackhole/src/main/java/com/facebook/presto/plugin/blackhole/BlackHoleMetadata.java
+++ b/presto-blackhole/src/main/java/com/facebook/presto/plugin/blackhole/BlackHoleMetadata.java
@@ -54,6 +54,7 @@ import static com.facebook.presto.plugin.blackhole.BlackHoleConnector.ROWS_PER_P
 import static com.facebook.presto.plugin.blackhole.BlackHoleConnector.SPLIT_COUNT_PROPERTY;
 import static com.facebook.presto.spi.StandardErrorCode.ALREADY_EXISTS;
 import static com.facebook.presto.spi.StandardErrorCode.INVALID_TABLE_PROPERTY;
+import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.String.format;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
@@ -237,8 +238,9 @@ public class BlackHoleMetadata
     }
 
     @Override
-    public Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session, ConnectorInsertTableHandle insertHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
+    public Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session, ConnectorInsertTableHandle insertHandle, Collection<Slice> fragments, Collection<Slice> deprecatedFragments, Collection<ComputedStatistics> computedStatistics)
     {
+        checkArgument(deprecatedFragments.isEmpty(), "deprecatedFragments are unsupported");
         return Optional.empty();
     }
 

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraMetadata.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraMetadata.java
@@ -348,8 +348,9 @@ public class CassandraMetadata
     }
 
     @Override
-    public Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session, ConnectorInsertTableHandle insertHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
+    public Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session, ConnectorInsertTableHandle insertHandle, Collection<Slice> fragments, Collection<Slice> deprecatedFragments, Collection<ComputedStatistics> computedStatistics)
     {
+        checkArgument(deprecatedFragments.isEmpty(), "deprecated fragments are unsupported");
         return Optional.empty();
     }
 }

--- a/presto-docs/src/main/sphinx/admin/properties.rst
+++ b/presto-docs/src/main/sphinx/admin/properties.rst
@@ -53,6 +53,16 @@ General Properties
     redistributing all the data across the network. This can also be specified
     on a per-query basis using the ``redistribute_writes`` session property.
 
+``small-fragment-coalescing-scan-parallelism``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    * **Type:** ``data size``
+    * **Default value:** ``32``
+
+    This property controls the number of concurrent scan threads used to coalesce small
+    fragments produced when writing out tables. This can also be specified on a per-query
+    basis using the ``small_fragment_coalescing_scan_parallelism`` session property.
+
 .. _tuning-memory:
 
 Memory Management Properties

--- a/presto-docs/src/main/sphinx/connector/hive.rst
+++ b/presto-docs/src/main/sphinx/connector/hive.rst
@@ -192,6 +192,9 @@ Property Name                                      Description                  
                                                    S3SelectPushdown.
 
 ``hive.metastore.load-balancing-enabled``          Enable load balancing between multiple Metastore instances
+
+``hive.small-file-coalescing-threshold``           Data size threshold below which small files will be merged   ``0B``
+                                                   together to produce larger files. Set to 0 to disable.
 ================================================== ============================================================ ============
 
 Metastore Configuration Properties

--- a/presto-druid/src/main/java/com/facebook/presto/druid/DruidMetadata.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/DruidMetadata.java
@@ -48,6 +48,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static java.util.Objects.requireNonNull;
@@ -168,8 +169,9 @@ public class DruidMetadata
     }
 
     @Override
-    public Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session, ConnectorInsertTableHandle insertHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
+    public Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session, ConnectorInsertTableHandle insertHandle, Collection<Slice> fragments, Collection<Slice> deprecatedFragments, Collection<ComputedStatistics> computedStatistics)
     {
+        checkArgument(deprecatedFragments.isEmpty(), "deprecated fragments are unsupported");
         return Optional.empty();
     }
 

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/MetastoreUtil.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/MetastoreUtil.java
@@ -74,6 +74,7 @@ import javax.annotation.Nullable;
 
 import java.io.IOException;
 import java.math.BigInteger;
+import java.nio.file.NoSuchFileException;
 import java.sql.Date;
 import java.sql.Timestamp;
 import java.util.ArrayList;
@@ -486,6 +487,19 @@ public class MetastoreUtil
         }
     }
 
+    public static boolean deleteFile(FileSystem fileSystem, Path path)
+    {
+        try {
+            return fileSystem.delete(path, false);
+        }
+        catch (NoSuchFileException e) {
+            return false;
+        }
+        catch (IOException e) {
+            throw new PrestoException(HIVE_FILESYSTEM_ERROR, getDeleteErrorMessage(path), e);
+        }
+    }
+
     public static Map<String, String> toPartitionNamesAndValues(String partitionName)
     {
         ImmutableMap.Builder<String, String> resultBuilder = ImmutableMap.builder();
@@ -757,6 +771,11 @@ public class MetastoreUtil
     private static String getRenameErrorMessage(Path source, Path target)
     {
         return format("Error moving data files from %s to final location %s", source, target);
+    }
+
+    private static String getDeleteErrorMessage(Path path)
+    {
+        return format("Error deleting data file %s", path);
     }
 
     public static List<String> convertPredicateToParts(Map<Column, Domain> partitionPredicates)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/CreateEmptyPartitionProcedure.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/CreateEmptyPartitionProcedure.java
@@ -147,6 +147,7 @@ public class CreateEmptyPartitionProcedure
                 session,
                 hiveInsertTableHandle,
                 ImmutableList.of(Slices.wrappedBuffer(serializedPartitionUpdate)),
+                ImmutableList.of(),
                 ImmutableList.of());
         hiveMetadata.commit();
     }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/ForFileUpdate.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/ForFileUpdate.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import javax.inject.Qualifier;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target({FIELD, PARAMETER, METHOD})
+@Qualifier
+public @interface ForFileUpdate
+{
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -218,6 +218,8 @@ public class HiveClientConfig
     private boolean columnIndexFilterEnabled;
     private boolean fileSplittable = true;
 
+    private DataSize smallFileCoalescingThreshold = DataSize.succinctDataSize(0, MEGABYTE);
+
     @Min(0)
     public int getMaxInitialSplits()
     {
@@ -1845,5 +1847,18 @@ public class HiveClientConfig
     public boolean isHudiMetadataEnabled()
     {
         return this.hudiMetadataEnabled;
+    }
+
+    @Config("hive.small-file-coalescing-threshold")
+    @ConfigDescription("Coalesce together files smaller than this. Default is 0 bytes (disabled).")
+    public HiveClientConfig setSmallFileCoalescingThreshold(DataSize smallFileCoalescingThreshold)
+    {
+        this.smallFileCoalescingThreshold = smallFileCoalescingThreshold;
+        return this;
+    }
+
+    public DataSize getSmallFileCoalescingThreshold()
+    {
+        return smallFileCoalescingThreshold;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientModule.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientModule.java
@@ -152,6 +152,7 @@ public class HiveClientModule
         binder.bind(HiveMetadataFactory.class).in(Scopes.SINGLETON);
         binder.bind(new TypeLiteral<Supplier<TransactionalMetadata>>() {}).to(HiveMetadataFactory.class).in(Scopes.SINGLETON);
         binder.bind(StagingFileCommitter.class).to(HiveStagingFileCommitter.class).in(Scopes.SINGLETON);
+        binder.bind(SmallFragmentCoalescingPlanner.class).to(HiveSmallFragmentCoalescingPlanner.class).in(Scopes.SINGLETON);
         binder.bind(ZeroRowFileCreator.class).to(HiveZeroRowFileCreator.class).in(Scopes.SINGLETON);
         binder.bind(PartitionObjectBuilder.class).to(HivePartitionObjectBuilder.class).in(Scopes.SINGLETON);
         binder.bind(HiveTransactionManager.class).in(Scopes.SINGLETON);
@@ -245,15 +246,15 @@ public class HiveClientModule
         return newCachedThreadPool(daemonThreadsNamed("hive-metadata-updater-" + hiveClientId + "-%s"));
     }
 
-    @ForFileRename
+    @ForFileUpdate
     @Singleton
     @Provides
-    public ListeningExecutorService createFileRanemeExecutor(HiveConnectorId hiveClientId, HiveClientConfig hiveClientConfig)
+    public ListeningExecutorService createFileUpdateExecutor(HiveConnectorId hiveClientId, HiveClientConfig hiveClientConfig)
     {
         return listeningDecorator(
                 new ExecutorServiceAdapter(
                         new BoundedExecutor(
-                                newCachedThreadPool(daemonThreadsNamed("hive-rename-" + hiveClientId + "-%s")),
+                                newCachedThreadPool(daemonThreadsNamed("hive-update-" + hiveClientId + "-%s")),
                                 hiveClientConfig.getMaxConcurrentFileRenames())));
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSink.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSink.java
@@ -447,7 +447,7 @@ public class HivePageSink
     private void updateFileInfo(List<Slice> partitionUpdatesWithRenamedFileNames, SettableFuture<?> renamingFuture, PartitionUpdate partitionUpdate, String fileName, FileWriteInfo fileWriteInfo, int writerIndex)
     {
         // Update the file info in partitionUpdate with new filename
-        FileWriteInfo fileInfoWithRenamedFileName = new FileWriteInfo(fileName, fileName, fileWriteInfo.getFileSize());
+        FileWriteInfo fileInfoWithRenamedFileName = new FileWriteInfo(fileName, fileName, fileWriteInfo.getFileWriteStatistics());
         PartitionUpdate partitionUpdateWithRenamedFileName = new PartitionUpdate(partitionUpdate.getName(),
                 partitionUpdate.getUpdateMode(),
                 partitionUpdate.getWritePath(),

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePartialAggregationPushdown.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePartialAggregationPushdown.java
@@ -263,7 +263,8 @@ public class HivePartialAggregationPushdown
                     oldTableLayoutHandle.isPushdownFilterEnabled(),
                     oldTableLayoutHandle.getLayoutString(),
                     oldTableLayoutHandle.getRequestedColumns(),
-                    true);
+                    true,
+                    Optional.empty());
 
             TableHandle newTableHandle = new TableHandle(
                     oldTableHandle.getConnectorId(),

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePartitionManager.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePartitionManager.java
@@ -420,6 +420,6 @@ public class HivePartitionManager
             builder.put(column, parsedValue);
         }
         Map<ColumnHandle, NullableValue> values = builder.build();
-        return new HivePartition(tableName, partitionName, values);
+        return new HivePartition(tableName, partitionName, values, Optional.empty());
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePartitionObjectBuilder.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePartitionObjectBuilder.java
@@ -27,13 +27,13 @@ import static com.facebook.presto.hive.HiveSessionProperties.getNewPartitionUser
 public class HivePartitionObjectBuilder
         implements PartitionObjectBuilder
 {
-    @Override
     public Partition buildPartitionObject(
             ConnectorSession session,
             Table table,
             PartitionUpdate partitionUpdate,
             String prestoVersion,
-            Map<String, String> extraParameters)
+            Map<String, String> extraParameters,
+            boolean uncommitted)
     {
         ImmutableMap.Builder extraParametersBuilder = ImmutableMap.builder()
                 .put(HiveMetadata.PRESTO_VERSION_NAME, prestoVersion)
@@ -53,7 +53,7 @@ public class HivePartitionObjectBuilder
                         .setStorageFormat(HiveSessionProperties.isRespectTableFormat(session) ?
                                 table.getStorage().getStorageFormat() :
                                 StorageFormat.fromHiveStorageFormat(HiveSessionProperties.getHiveStorageFormat(session)))
-                        .setLocation(partitionUpdate.getTargetPath().toString())
+                        .setLocation(uncommitted ? partitionUpdate.getWritePath().toString() : partitionUpdate.getTargetPath().toString())
                         .setBucketProperty(table.getStorage().getBucketProperty())
                         .setSerdeParameters(table.getStorage().getSerdeParameters())
                         .setParameters(table.getStorage().getParameters()))

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
@@ -139,6 +139,7 @@ public final class HiveSessionProperties
     public static final String MAX_INITIAL_SPLITS = "max_initial_splits";
     public static final String FILE_SPLITTABLE = "file_splittable";
     private static final String HUDI_METADATA_ENABLED = "hudi_metadata_enabled";
+    public static final String SMALL_FILE_COALESCING_THRESHOLD = "small_file_coalescing_threshold";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -670,6 +671,11 @@ public final class HiveSessionProperties
                         HUDI_METADATA_ENABLED,
                         "For Hudi tables prefer to fetch the list of file names, sizes and other metadata from the internal metadata table rather than storage",
                         hiveClientConfig.isHudiMetadataEnabled(),
+                        false),
+                dataSizeSessionProperty(
+                        SMALL_FILE_COALESCING_THRESHOLD,
+                        "Coalesce together files smaller than this. 0 bytes disables coalescing.",
+                        hiveClientConfig.getSmallFileCoalescingThreshold(),
                         false));
     }
 
@@ -1169,5 +1175,10 @@ public final class HiveSessionProperties
     public static boolean isHudiMetadataEnabled(ConnectorSession session)
     {
         return session.getProperty(HUDI_METADATA_ENABLED, Boolean.class);
+    }
+
+    public static DataSize getSmallFileCoalescingThreshold(ConnectorSession session)
+    {
+        return session.getProperty(SMALL_FILE_COALESCING_THRESHOLD, DataSize.class);
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSmallFragmentCoalescingPlanner.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSmallFragmentCoalescingPlanner.java
@@ -1,0 +1,235 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.airlift.json.JsonCodec;
+import com.facebook.airlift.json.smile.SmileCodec;
+import com.facebook.presto.common.Subfield;
+import com.facebook.presto.common.predicate.Domain;
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.hive.PartitionUpdate.FileWriteInfo;
+import com.facebook.presto.hive.metastore.Partition;
+import com.facebook.presto.hive.metastore.Table;
+import com.facebook.presto.spi.ColumnHandle;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ConnectorSmallFragmentCoalescingPlan;
+import com.facebook.presto.spi.ConnectorSmallFragmentCoalescingPlan.SubPlan;
+import com.facebook.presto.spi.ConnectorTableLayoutHandle;
+import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import io.airlift.slice.Slice;
+import org.joda.time.DateTimeZone;
+
+import javax.inject.Inject;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import static com.facebook.presto.common.predicate.Domain.multipleValues;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.expressions.LogicalRowExpressions.TRUE_CONSTANT;
+import static com.facebook.presto.hive.HiveSessionProperties.isOptimizedPartitionUpdateSerializationEnabled;
+import static com.facebook.presto.hive.HiveUtil.getPartitionKeyColumnHandles;
+import static com.facebook.presto.hive.HiveUtil.serializeZstdCompressed;
+import static com.facebook.presto.hive.LocationHandle.TableType.TEMPORARY;
+import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.base.Predicates.alwaysTrue;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.airlift.slice.Slices.utf8Slice;
+import static io.airlift.slice.Slices.wrappedBuffer;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Stream.concat;
+
+/**
+ * A helper to produce a plan for coalescing small fragments in a narrow set of cases.
+ *
+ * Works with partition and unpartitioned tables that aren't bucketed or using numbered file names.
+ */
+public class HiveSmallFragmentCoalescingPlanner
+        implements SmallFragmentCoalescingPlanner
+{
+    private final JsonCodec<PartitionUpdate> partitionUpdateCodec;
+    private final SmileCodec<PartitionUpdate> partitionUpdateSmileCodec;
+    private final DateTimeZone timeZone;
+    private final TypeManager typeManager;
+    private final PartitionObjectBuilder partitionObjectBuilder;
+    private final String prestoVersion;
+
+    @Inject
+    public HiveSmallFragmentCoalescingPlanner(
+            JsonCodec<PartitionUpdate> partitionUpdateCodec,
+            SmileCodec<PartitionUpdate> partitionUpdateSmileCodec,
+            HiveClientConfig clientConfig,
+            TypeManager typeManager,
+            PartitionObjectBuilder partitionObjectBuilder,
+            NodeVersion nodeVersion)
+    {
+        this.partitionUpdateCodec = requireNonNull(partitionUpdateCodec, "partitionUpdateCodec is null");
+        this.partitionUpdateSmileCodec = requireNonNull(partitionUpdateSmileCodec, "partitionSmileUpdateCodec is null");
+        this.timeZone = requireNonNull(clientConfig.getDateTimeZone(), "timeZone is null");
+        this.typeManager = requireNonNull(typeManager, "typeManager is null");
+        this.partitionObjectBuilder = requireNonNull(partitionObjectBuilder, "partitionObjectBuilder is null");
+        this.prestoVersion = requireNonNull(nodeVersion, "nodeVersion is null").toString();
+    }
+
+    @Override
+    public ConnectorSmallFragmentCoalescingPlan createSmallFragmentCoalescingPlan(
+            ConnectorSession session,
+            HiveWritableTableHandle hiveWritableTableHandle,
+            List<PartitionUpdate> partitionUpdates,
+            Collection<Slice> fragments)
+    {
+        long sizeLimit = HiveSessionProperties.getSmallFileCoalescingThreshold(session).toBytes();
+        // Checks to make sure this is supported are done here at the public entry point for the planner
+        if (hiveWritableTableHandle.getBucketProperty().isPresent()
+                || hiveWritableTableHandle.getLocationHandle().getTableType() == TEMPORARY
+                || partitionUpdates.stream().anyMatch(PartitionUpdate::containsNumberedFileNames)
+                // Some HiveFileWriters won't generate the statistics page
+                || partitionUpdates.stream().anyMatch(HiveSmallFragmentCoalescingPlanner::partitionUpdateMissingStatistics)) {
+            return ConnectorSmallFragmentCoalescingPlan.noOpPlan(fragments);
+        }
+        boolean optimizedPartitionUpdateSerializationEnabled = isOptimizedPartitionUpdateSerializationEnabled(session);
+
+        List<Slice> retainedFragments = concat(
+                // Retain files with no size or that are too big to coalesce
+                partitionUpdates.stream()
+                        // Need this filter to avoid including the PartitionUpdate row count twice
+                        .filter(update -> update.getFileWriteInfos().size() > 1)
+                        .map(update -> buildFragment(update, optimizedPartitionUpdateSerializationEnabled, info -> !info.getFileWriteStatistics().isPresent() || info.getFileWriteStatistics().get().getFileSize() > sizeLimit)),
+                // Retain files from partition updates for partitions with only one file
+                partitionUpdates.stream()
+                        .filter(update -> update.getFileWriteInfos().size() <= 1)
+                        .map(update -> buildFragment(update, optimizedPartitionUpdateSerializationEnabled, alwaysTrue()))
+                ).collect(toList());
+        List<Slice> deprecatedFragments = partitionUpdates.stream()
+                .filter(update -> update.getFileWriteInfos().size() > 1)
+                .map(update -> buildFragment(update, optimizedPartitionUpdateSerializationEnabled, info -> info.getFileWriteStatistics().isPresent() && info.getFileWriteStatistics().get().getFileSize() <= sizeLimit))
+                .collect(toImmutableList());
+        Stream<SubPlan> subPlans = partitionUpdates.stream()
+                .filter(update -> hasCoalescableFiles(update, sizeLimit))
+                .map(partitionUpdate -> coalescePartitionFiles(session, hiveWritableTableHandle, partitionUpdate, sizeLimit));
+        return new ConnectorSmallFragmentCoalescingPlan(retainedFragments, deprecatedFragments, subPlans);
+    }
+
+    private Slice buildFragment(
+            PartitionUpdate update,
+            boolean optimizedPartitionUpdateSerializationEnabled,
+            Predicate<FileWriteInfo> predicate)
+    {
+        List<FileWriteInfo> fileWriteInfos = update.getFileWriteInfos().stream().filter(predicate).collect(toImmutableList());
+        PartitionUpdate replacementUpdate = update.withFileWriteInfos(fileWriteInfos);
+        if (optimizedPartitionUpdateSerializationEnabled) {
+            return wrappedBuffer(serializeZstdCompressed(partitionUpdateSmileCodec, replacementUpdate));
+        }
+        else {
+            return wrappedBuffer(partitionUpdateCodec.toBytes(replacementUpdate));
+        }
+    }
+
+    private SubPlan coalescePartitionFiles(
+            ConnectorSession session,
+            HiveWritableTableHandle writableTableHandle,
+            PartitionUpdate partitionUpdate,
+            long sizeLimit)
+    {
+        ConnectorTableLayoutHandle tableLayout = createConnectorTableLayoutHandle(session, writableTableHandle, partitionUpdate, sizeLimit);
+
+        List<ColumnHandle> columnHandles = ImmutableList.copyOf(writableTableHandle.getInputColumns());
+        HiveTableHandle tableHandle = new HiveTableHandle(writableTableHandle.getSchemaName(), writableTableHandle.getTableName());
+        SubPlan subPlan = new SubPlan(tableLayout, columnHandles, tableHandle);
+        return subPlan;
+    }
+
+    private ConnectorTableLayoutHandle createConnectorTableLayoutHandle(ConnectorSession session, HiveWritableTableHandle tableHandle, PartitionUpdate update, long sizeLimit)
+    {
+        Table table = tableHandle.getPageSinkMetadata().getTable().get();
+        table = Table.builder(table).withStorage(storage -> storage.setLocation(update.getWritePath().toString())).build();
+        HiveColumnHandle pathColumnHandle = HiveColumnHandle.pathColumnHandle();
+        List<Slice> smallFilePaths = update.getFileWriteInfos().stream()
+                .filter(info -> info.getFileWriteStatistics().isPresent() && info.getFileWriteStatistics().get().getFileSize() <= sizeLimit)
+                .map(info -> utf8Slice(update.getWritePath().toString() + "/" + info.getTargetFileName())).collect(toList());
+        Domain pathsDomain = multipleValues(VARCHAR, smallFilePaths);
+        TupleDomain pathsTupleDomain = TupleDomain.withColumnDomains(ImmutableMap.of(new Subfield(pathColumnHandle.getName()), pathsDomain));
+        List<HiveColumnHandle> partitionColumnHandles = getPartitionKeyColumnHandles(table);
+        List<Type> partitionColumnTypes = partitionColumnHandles.stream().map(HiveColumnHandle::getTypeSignature).map(typeManager::getType).collect(toList());
+
+        Map<String, String> partitionEncryptionParameters = ImmutableMap.of();
+        if (tableHandle.getEncryptionInformation().isPresent()) {
+            EncryptionInformation encryptionInformation = tableHandle.getEncryptionInformation().get();
+            if (encryptionInformation.getDwrfEncryptionMetadata().isPresent()) {
+                DwrfEncryptionMetadata dwrfEncryptionMetadata = encryptionInformation.getDwrfEncryptionMetadata().get();
+                if (table.getPartitionColumns().isEmpty()) {
+                    checkState(table.getParameters().entrySet().containsAll(dwrfEncryptionMetadata.getExtraMetadata().entrySet()), "Encryption parameters should be present");
+                }
+                else {
+                    partitionEncryptionParameters = ImmutableMap.copyOf(dwrfEncryptionMetadata.getExtraMetadata());
+                }
+            }
+        }
+
+        HivePartition partition;
+        if (!update.getName().isEmpty()) {
+            HivePartition hivePartition = HivePartitionManager.parsePartition(tableHandle.getSchemaTableName(), update.getName(), partitionColumnHandles, partitionColumnTypes, timeZone);
+            Partition metastorePartition = partitionObjectBuilder.buildUncommittedPartitionObject(
+                    session,
+                    table,
+                    update,
+                    prestoVersion,
+                    partitionEncryptionParameters);
+            partition = hivePartition.withMetastorePartition(metastorePartition);
+        }
+        else {
+            partition = new HivePartition(tableHandle.getSchemaTableName());
+        }
+
+        HiveTableLayoutHandle handle = new HiveTableLayoutHandle(tableHandle.getSchemaTableName(),
+                update.getWritePath().toString(),
+                partitionColumnHandles,
+                table.getDataColumns(),
+                table.getParameters(),
+                ImmutableList.of(partition),
+                pathsTupleDomain,
+                TRUE_CONSTANT,
+                ImmutableMap.of(pathColumnHandle.getName(), pathColumnHandle),
+                TupleDomain.all(),
+                Optional.empty(),
+                Optional.empty(),
+                false,
+                "Layout for small file coalescing",
+                Optional.empty(),
+                false,
+                Optional.of(table));
+        return handle;
+    }
+
+    private static boolean hasCoalescableFiles(PartitionUpdate update, long sizeLimit)
+    {
+        return update.getFileWriteInfos().stream().filter(info -> info.getFileWriteStatistics().isPresent() && info.getFileWriteStatistics().get().getFileSize() <= sizeLimit).count() > 1;
+    }
+
+    private static boolean partitionUpdateMissingStatistics(PartitionUpdate update)
+    {
+        return update.getFileWriteInfos().stream()
+                .map(FileWriteInfo::getFileWriteStatistics)
+                .anyMatch(Predicates.not(Optional::isPresent));
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveStagingFileCommitter.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveStagingFileCommitter.java
@@ -37,15 +37,15 @@ public class HiveStagingFileCommitter
         implements StagingFileCommitter
 {
     private final HdfsEnvironment hdfsEnvironment;
-    private final ListeningExecutorService fileRenameExecutor;
+    private final ListeningExecutorService fileUpdateExecutor;
 
     @Inject
     public HiveStagingFileCommitter(
             HdfsEnvironment hdfsEnvironment,
-            @ForFileRename ListeningExecutorService fileRenameExecutor)
+            @ForFileUpdate ListeningExecutorService fileUpdateExecutor)
     {
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
-        this.fileRenameExecutor = requireNonNull(fileRenameExecutor, "fileRenameExecutor is null");
+        this.fileUpdateExecutor = requireNonNull(fileUpdateExecutor, "fileUpdateExecutor is null");
     }
 
     @Override
@@ -67,7 +67,7 @@ public class HiveStagingFileCommitter
                 checkState(!fileWriteInfo.getWriteFileName().equals(fileWriteInfo.getTargetFileName()));
                 Path source = new Path(path, fileWriteInfo.getWriteFileName());
                 Path target = new Path(path, fileWriteInfo.getTargetFileName());
-                commitFutures.add(fileRenameExecutor.submit(() -> {
+                commitFutures.add(fileUpdateExecutor.submit(() -> {
                     renameFile(fileSystem, source, target);
                     return null;
                 }));

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveTableLayoutHandle.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveTableLayoutHandle.java
@@ -18,6 +18,7 @@ import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.common.predicate.TupleDomain.ColumnDomain;
 import com.facebook.presto.hive.HiveBucketing.HiveBucketFilter;
 import com.facebook.presto.hive.metastore.Column;
+import com.facebook.presto.hive.metastore.Table;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.ConnectorTableLayoutHandle;
@@ -58,6 +59,7 @@ public final class HiveTableLayoutHandle
     private final String layoutString;
     private final Optional<Set<HiveColumnHandle>> requestedColumns;
     private final boolean partialAggregationsPushedDown;
+    private final Optional<Table> metastoreTable;
 
     // coordinator-only properties
     @Nullable
@@ -97,6 +99,7 @@ public final class HiveTableLayoutHandle
         this.layoutString = requireNonNull(layoutString, "layoutString is null");
         this.requestedColumns = requireNonNull(requestedColumns, "requestedColumns is null");
         this.partialAggregationsPushedDown = partialAggregationsPushedDown;
+        this.metastoreTable = Optional.empty();
     }
 
     public HiveTableLayoutHandle(
@@ -115,7 +118,8 @@ public final class HiveTableLayoutHandle
             boolean pushdownFilterEnabled,
             String layoutString,
             Optional<Set<HiveColumnHandle>> requestedColumns,
-            boolean partialAggregationsPushedDown)
+            boolean partialAggregationsPushedDown,
+            Optional<Table> metastoreTable)
     {
         this.schemaTableName = requireNonNull(schemaTableName, "table is null");
         this.tablePath = requireNonNull(tablePath, "tablePath is null");
@@ -133,6 +137,7 @@ public final class HiveTableLayoutHandle
         this.layoutString = requireNonNull(layoutString, "layoutString is null");
         this.requestedColumns = requireNonNull(requestedColumns, "requestedColumns is null");
         this.partialAggregationsPushedDown = partialAggregationsPushedDown;
+        this.metastoreTable = requireNonNull(metastoreTable, "metastoreTable is null");
     }
 
     @JsonProperty
@@ -269,5 +274,10 @@ public final class HiveTableLayoutHandle
                 .put("remainingPredicate", remainingPredicate)
                 .put("bucketFilter", bucketFilter)
                 .build();
+    }
+
+    public Optional<Table> getMetastoreTable()
+    {
+        return metastoreTable;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriterFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriterFactory.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.hive;
 
 import com.facebook.airlift.event.client.EventClient;
+import com.facebook.airlift.log.Logger;
 import com.facebook.presto.common.Page;
 import com.facebook.presto.common.block.SortOrder;
 import com.facebook.presto.common.type.Type;
@@ -103,6 +104,7 @@ import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.META_
 
 public class HiveWriterFactory
 {
+    private static final Logger LOGGER = Logger.get(HiveSmallFragmentCoalescingPlanner.class);
     private static final int MAX_BUCKET_COUNT = 100_000;
     private static final int BUCKET_NUMBER_PADDING = Integer.toString(MAX_BUCKET_COUNT - 1).length();
     private static final Iterable<Pattern> BUCKET_PATTERNS = ImmutableList.of(
@@ -365,6 +367,8 @@ public class HiveWriterFactory
         }
 
         Path path = new Path(writerParameters.getWriteInfo().getWritePath(), writeFileName);
+
+        LOGGER.info("HiveWriterFactory path to write " + path);
 
         HiveFileWriter hiveFileWriter = null;
         for (HiveFileWriterFactory fileWriterFactory : fileWriterFactories) {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriter.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriter.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.hive;
 
+import com.facebook.airlift.log.Logger;
 import com.facebook.presto.common.NotSupportedException;
 import com.facebook.presto.common.Page;
 import com.facebook.presto.common.block.Block;
@@ -56,6 +57,7 @@ import static java.util.Objects.requireNonNull;
 public class OrcFileWriter
         implements HiveFileWriter
 {
+    private static final Logger log = Logger.get(OrcFileWriterFactory.class);
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(OrcFileWriter.class).instanceSize();
     private static final ThreadMXBean THREAD_MX_BEAN = ManagementFactory.getThreadMXBean();
 
@@ -203,6 +205,7 @@ public class OrcFileWriter
     @Override
     public Optional<Page> commit()
     {
+//        log.info("Committing writer");
         try {
             orcWriter.close();
         }
@@ -235,6 +238,7 @@ public class OrcFileWriter
     @Override
     public void rollback()
     {
+//        log.info("Rolling back writer");
         try {
             try {
                 orcWriter.close();

--- a/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriterFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriterFactory.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.hive;
 
+import com.facebook.airlift.log.Logger;
 import com.facebook.presto.common.io.DataSink;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeManager;
@@ -89,6 +90,8 @@ import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.META_
 public class OrcFileWriterFactory
         implements HiveFileWriterFactory
 {
+    private static final Logger log = Logger.get(OrcFileWriterFactory.class);
+
     private final DateTimeZone hiveStorageTimeZone;
     private final HdfsEnvironment hdfsEnvironment;
     private final DataSinkFactory dataSinkFactory;
@@ -158,6 +161,7 @@ public class OrcFileWriterFactory
             ConnectorSession session,
             Optional<EncryptionInformation> encryptionInformation)
     {
+//        log.info("OrcFileWriterFactory creating file " + path.toString());
         if (!HiveSessionProperties.isOrcOptimizedWriterEnabled(session)) {
             return Optional.empty();
         }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/PartitionObjectBuilder.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/PartitionObjectBuilder.java
@@ -21,10 +21,31 @@ import java.util.Map;
 
 public interface PartitionObjectBuilder
 {
+    default Partition buildPartitionObject(
+            ConnectorSession session,
+            Table table,
+            PartitionUpdate partitionUpdate,
+            String prestoVersion,
+            Map<String, String> extraParameters)
+    {
+        return buildPartitionObject(session, table, partitionUpdate, prestoVersion, extraParameters, false);
+    }
+
+    default Partition buildUncommittedPartitionObject(
+            ConnectorSession session,
+            Table table,
+            PartitionUpdate partitionUpdate,
+            String prestoVersion,
+            Map<String, String> extraParameters)
+    {
+        return buildPartitionObject(session, table, partitionUpdate, prestoVersion, extraParameters, true);
+    }
+
     Partition buildPartitionObject(
             ConnectorSession session,
             Table table,
             PartitionUpdate partitionUpdate,
             String prestoVersion,
-            Map<String, String> extraParameters);
+            Map<String, String> extraParameters,
+            boolean uncommitted);
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/SmallFragmentCoalescingPlanner.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/SmallFragmentCoalescingPlanner.java
@@ -13,19 +13,18 @@
  */
 package com.facebook.presto.hive;
 
-import javax.inject.Qualifier;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ConnectorSmallFragmentCoalescingPlan;
+import io.airlift.slice.Slice;
 
-import java.lang.annotation.Retention;
-import java.lang.annotation.Target;
+import java.util.Collection;
+import java.util.List;
 
-import static java.lang.annotation.ElementType.FIELD;
-import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.ElementType.PARAMETER;
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
-
-@Retention(RUNTIME)
-@Target({FIELD, PARAMETER, METHOD})
-@Qualifier
-public @interface ForFileRename
+public interface SmallFragmentCoalescingPlanner
 {
+    ConnectorSmallFragmentCoalescingPlan createSmallFragmentCoalescingPlan(
+            ConnectorSession session,
+            HiveWritableTableHandle tableHandle,
+            List<PartitionUpdate> partitionUpdates,
+            Collection<Slice> fragments);
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/rule/HiveAddRequestedColumnsToLayout.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/rule/HiveAddRequestedColumnsToLayout.java
@@ -90,7 +90,8 @@ public class HiveAddRequestedColumnsToLayout
                     Optional.of(tableScan.getOutputVariables().stream()
                             .map(output -> (HiveColumnHandle) tableScan.getAssignments().get(output))
                             .collect(toImmutableSet())),
-                    hiveLayout.isPartialAggregationsPushedDown());
+                    hiveLayout.isPartialAggregationsPushedDown(),
+                    Optional.empty());
 
             return new TableScanNode(
                     tableScan.getSourceLocation(),

--- a/presto-hive/src/main/java/com/facebook/presto/hive/rule/HiveFilterPushdown.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/rule/HiveFilterPushdown.java
@@ -294,7 +294,8 @@ public class HiveFilterPushdown
                                         remainingExpression,
                                         domainPredicate),
                                 currentLayoutHandle.map(layout -> ((HiveTableLayoutHandle) layout).getRequestedColumns()).orElse(Optional.empty()),
-                                false)),
+                                false,
+                                Optional.empty())),
                 dynamicFilterExpression);
     }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystem.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystem.java
@@ -216,7 +216,14 @@ public abstract class AbstractTestHiveFileSystem
                 new HiveEncryptionInformationProvider(ImmutableList.of()),
                 new HivePartitionStats(),
                 new HiveFileRenamer(),
-                columnConverterProvider);
+                columnConverterProvider,
+                new HiveSmallFragmentCoalescingPlanner(
+                        HiveTestUtils.PARTITION_UPDATE_CODEC,
+                        HiveTestUtils.PARTITION_UPDATE_SMILE_CODEC,
+                        config,
+                        FUNCTION_AND_TYPE_MANAGER,
+                        new HivePartitionObjectBuilder(),
+                        new NodeVersion("test_version")));
         transactionManager = new HiveTransactionManager();
         splitManager = new HiveSplitManager(
                 transactionManager,

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
@@ -40,6 +40,7 @@ import static com.facebook.presto.hive.HiveStorageFormat.DWRF;
 import static com.facebook.presto.hive.HiveStorageFormat.ORC;
 import static com.facebook.presto.hive.TestHiveUtil.nonDefaultTimeZone;
 import static com.facebook.presto.spi.schedule.NodeSelectionStrategy.HARD_AFFINITY;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
 
 public class TestHiveClientConfig
 {
@@ -48,19 +49,19 @@ public class TestHiveClientConfig
     {
         ConfigAssertions.assertRecordedDefaults(ConfigAssertions.recordDefaults(HiveClientConfig.class)
                 .setTimeZone(TimeZone.getDefault().getID())
-                .setMaxSplitSize(new DataSize(64, Unit.MEGABYTE))
+                .setMaxSplitSize(new DataSize(64, MEGABYTE))
                 .setMaxPartitionsPerScan(100_000)
                 .setMaxOutstandingSplits(1_000)
-                .setMaxOutstandingSplitsSize(new DataSize(256, Unit.MEGABYTE))
+                .setMaxOutstandingSplitsSize(new DataSize(256, MEGABYTE))
                 .setMaxSplitIteratorThreads(1_000)
                 .setAllowCorruptWritesForTesting(false)
                 .setMinPartitionBatchSize(10)
                 .setMaxPartitionBatchSize(100)
                 .setMaxInitialSplits(200)
-                .setMaxInitialSplitSize(new DataSize(32, Unit.MEGABYTE))
+                .setMaxInitialSplitSize(new DataSize(32, MEGABYTE))
                 .setSplitLoaderConcurrency(4)
                 .setDomainCompactionThreshold(100)
-                .setWriterSortBufferSize(new DataSize(64, Unit.MEGABYTE))
+                .setWriterSortBufferSize(new DataSize(64, MEGABYTE))
                 .setNodeSelectionStrategy(NodeSelectionStrategy.valueOf("NO_PREFERENCE"))
                 .setMaxConcurrentFileRenames(20)
                 .setMaxConcurrentZeroRowFileCreations(20)
@@ -85,18 +86,18 @@ public class TestHiveClientConfig
                 .setMaxPartitionsPerWriter(100)
                 .setMaxOpenSortFiles(50)
                 .setWriteValidationThreads(16)
-                .setTextMaxLineLength(new DataSize(100, Unit.MEGABYTE))
+                .setTextMaxLineLength(new DataSize(100, MEGABYTE))
                 .setUseParquetColumnNames(false)
-                .setParquetMaxReadBlockSize(new DataSize(16, Unit.MEGABYTE))
+                .setParquetMaxReadBlockSize(new DataSize(16, MEGABYTE))
                 .setUseOrcColumnNames(false)
                 .setAssumeCanonicalPartitionKeys(false)
                 .setOrcBloomFiltersEnabled(false)
                 .setOrcDefaultBloomFilterFpp(0.05)
-                .setOrcMaxMergeDistance(new DataSize(1, Unit.MEGABYTE))
-                .setOrcMaxBufferSize(new DataSize(8, Unit.MEGABYTE))
-                .setOrcStreamBufferSize(new DataSize(8, Unit.MEGABYTE))
-                .setOrcTinyStripeThreshold(new DataSize(8, Unit.MEGABYTE))
-                .setOrcMaxReadBlockSize(new DataSize(16, Unit.MEGABYTE))
+                .setOrcMaxMergeDistance(new DataSize(1, MEGABYTE))
+                .setOrcMaxBufferSize(new DataSize(8, MEGABYTE))
+                .setOrcStreamBufferSize(new DataSize(8, MEGABYTE))
+                .setOrcTinyStripeThreshold(new DataSize(8, MEGABYTE))
+                .setOrcMaxReadBlockSize(new DataSize(16, MEGABYTE))
                 .setOrcLazyReadSmallRanges(true)
                 .setRcfileOptimizedWriterEnabled(true)
                 .setRcfileWriterValidate(false)
@@ -142,7 +143,7 @@ public class TestHiveClientConfig
                 .setFileStatusCacheExpireAfterWrite(new Duration(0, TimeUnit.SECONDS))
                 .setFileStatusCacheMaxSize(0)
                 .setFileStatusCacheTables("")
-                .setPageFileStripeMaxSize(new DataSize(24, Unit.MEGABYTE))
+                .setPageFileStripeMaxSize(new DataSize(24, MEGABYTE))
                 .setParquetBatchReaderVerificationEnabled(false)
                 .setParquetBatchReadOptimizationEnabled(false)
                 .setBucketFunctionTypeForExchange(HIVE_COMPATIBLE)
@@ -166,7 +167,8 @@ public class TestHiveClientConfig
                 .setUserDefinedTypeEncodingEnabled(false)
                 .setUseRecordPageSourceForCustomSplit(true)
                 .setFileSplittable(true)
-                .setHudiMetadataEnabled(false));
+                .setHudiMetadataEnabled(false)
+                .setSmallFileCoalescingThreshold(new DataSize(0, MEGABYTE)));
     }
 
     @Test
@@ -293,23 +295,24 @@ public class TestHiveClientConfig
                 .put("hive.use-record-page-source-for-custom-split", "false")
                 .put("hive.file-splittable", "false")
                 .put("hive.hudi-metadata-enabled", "true")
+                .put("hive.small-file-coalescing-threshold", "2MB")
                 .build();
 
         HiveClientConfig expected = new HiveClientConfig()
                 .setTimeZone(TimeZone.getTimeZone(ZoneId.of(nonDefaultTimeZone().getID())).getID())
-                .setMaxSplitSize(new DataSize(256, Unit.MEGABYTE))
+                .setMaxSplitSize(new DataSize(256, MEGABYTE))
                 .setMaxPartitionsPerScan(123)
                 .setMaxOutstandingSplits(10)
-                .setMaxOutstandingSplitsSize(new DataSize(32, Unit.MEGABYTE))
+                .setMaxOutstandingSplitsSize(new DataSize(32, MEGABYTE))
                 .setMaxSplitIteratorThreads(10)
                 .setAllowCorruptWritesForTesting(true)
                 .setMinPartitionBatchSize(1)
                 .setMaxPartitionBatchSize(1000)
                 .setMaxInitialSplits(10)
-                .setMaxInitialSplitSize(new DataSize(16, Unit.MEGABYTE))
+                .setMaxInitialSplitSize(new DataSize(16, MEGABYTE))
                 .setSplitLoaderConcurrency(1)
                 .setDomainCompactionThreshold(42)
-                .setWriterSortBufferSize(new DataSize(13, Unit.MEGABYTE))
+                .setWriterSortBufferSize(new DataSize(13, MEGABYTE))
                 .setNodeSelectionStrategy(HARD_AFFINITY)
                 .setMaxConcurrentFileRenames(100)
                 .setMaxConcurrentZeroRowFileCreations(100)
@@ -332,7 +335,7 @@ public class TestHiveClientConfig
                 .setWriteValidationThreads(11)
                 .setDomainSocketPath("/foo")
                 .setS3FileSystemType(S3FileSystemType.EMRFS)
-                .setTextMaxLineLength(new DataSize(13, Unit.MEGABYTE))
+                .setTextMaxLineLength(new DataSize(13, MEGABYTE))
                 .setUseParquetColumnNames(true)
                 .setParquetMaxReadBlockSize(new DataSize(66, Unit.KILOBYTE))
                 .setUseOrcColumnNames(true)
@@ -414,7 +417,8 @@ public class TestHiveClientConfig
                 .setUserDefinedTypeEncodingEnabled(true)
                 .setUseRecordPageSourceForCustomSplit(false)
                 .setFileSplittable(false)
-                .setHudiMetadataEnabled(true);
+                .setHudiMetadataEnabled(true)
+                .setSmallFileCoalescingThreshold(new DataSize(2, MEGABYTE));
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -5511,7 +5511,7 @@ public class TestHiveIntegrationSmokeTest
                     InsertTableHandle insertTableHandle = metadata.beginInsert(transactionSession, handle.get());
                     HiveInsertTableHandle hiveInsertTableHandle = (HiveInsertTableHandle) insertTableHandle.getConnectorHandle();
 
-                    metadata.finishInsert(transactionSession, insertTableHandle, ImmutableList.of(), ImmutableList.of());
+                    metadata.finishInsert(transactionSession, insertTableHandle, ImmutableList.of(), ImmutableList.of(), ImmutableList.of());
                     return hiveInsertTableHandle;
                 });
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveManifestUtils.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveManifestUtils.java
@@ -40,6 +40,7 @@ import static com.facebook.presto.hive.HiveManifestUtils.decompressFileNames;
 import static com.facebook.presto.hive.HiveManifestUtils.decompressFileSizes;
 import static com.facebook.presto.hive.HiveManifestUtils.getFileSize;
 import static com.facebook.presto.hive.PartitionUpdate.FileWriteInfo;
+import static com.facebook.presto.hive.PartitionUpdate.FileWriteStatistics;
 import static com.facebook.presto.hive.PartitionUpdate.UpdateMode.NEW;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static io.airlift.slice.Slices.utf8Slice;
@@ -77,7 +78,7 @@ public class TestHiveManifestUtils
     @Test
     public void testCreatePartitionManifest()
     {
-        PartitionUpdate partitionUpdate = new PartitionUpdate("testPartition", NEW, "/testDir", "/testDir", ImmutableList.of(new FileWriteInfo("testFileName", "testFileName", Optional.of(FILE_SIZE))), 100, 1024, 1024, false);
+        PartitionUpdate partitionUpdate = new PartitionUpdate("testPartition", NEW, "/testDir", "/testDir", ImmutableList.of(new FileWriteInfo("testFileName", "testFileName", Optional.of(new FileWriteStatistics(100, 1024, FILE_SIZE)))), 100, 1024, 1024, false);
         Optional<Page> manifestPage = createPartitionManifest(partitionUpdate);
         assertTrue(manifestPage.isPresent());
         assertEquals(manifestPage.get().getChannelCount(), 2);

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMetadata.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMetadata.java
@@ -124,7 +124,8 @@ public class TestHiveMetadata
             partitions.add(new HivePartition(
                     new SchemaTableName("test", "test"),
                     Integer.toString(i),
-                    ImmutableMap.of(TEST_COLUMN_HANDLE, NullableValue.of(VarcharType.VARCHAR, Slices.utf8Slice(Integer.toString(i))))));
+                    ImmutableMap.of(TEST_COLUMN_HANDLE, NullableValue.of(VarcharType.VARCHAR, Slices.utf8Slice(Integer.toString(i)))),
+                    Optional.empty()));
         }
 
         createPredicate(ImmutableList.of(TEST_COLUMN_HANDLE), partitions.build());
@@ -139,7 +140,8 @@ public class TestHiveMetadata
             partitions.add(new HivePartition(
                     new SchemaTableName("test", "test"),
                     Integer.toString(i),
-                    ImmutableMap.of(TEST_COLUMN_HANDLE, NullableValue.asNull(VarcharType.VARCHAR))));
+                    ImmutableMap.of(TEST_COLUMN_HANDLE, NullableValue.asNull(VarcharType.VARCHAR)),
+                    Optional.empty()));
         }
 
         createPredicate(ImmutableList.of(TEST_COLUMN_HANDLE), partitions.build());
@@ -154,13 +156,15 @@ public class TestHiveMetadata
             partitions.add(new HivePartition(
                     new SchemaTableName("test", "test"),
                     Integer.toString(i),
-                    ImmutableMap.of(TEST_COLUMN_HANDLE, NullableValue.of(VarcharType.VARCHAR, Slices.utf8Slice(Integer.toString(i))))));
+                    ImmutableMap.of(TEST_COLUMN_HANDLE, NullableValue.of(VarcharType.VARCHAR, Slices.utf8Slice(Integer.toString(i)))),
+                    Optional.empty()));
         }
 
         partitions.add(new HivePartition(
                 new SchemaTableName("test", "test"),
                 "null",
-                ImmutableMap.of(TEST_COLUMN_HANDLE, NullableValue.asNull(VarcharType.VARCHAR))));
+                ImmutableMap.of(TEST_COLUMN_HANDLE, NullableValue.asNull(VarcharType.VARCHAR)),
+                Optional.empty()));
 
         createPredicate(ImmutableList.of(TEST_COLUMN_HANDLE), partitions.build());
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMetadataFileFormatEncryptionSettings.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMetadataFileFormatEncryptionSettings.java
@@ -140,7 +140,14 @@ public class TestHiveMetadataFileFormatEncryptionSettings
                 new HiveEncryptionInformationProvider(ImmutableList.of(new TestDwrfEncryptionInformationSource())),
                 new HivePartitionStats(),
                 new HiveFileRenamer(),
-                HiveColumnConverterProvider.DEFAULT_COLUMN_CONVERTER_PROVIDER);
+                HiveColumnConverterProvider.DEFAULT_COLUMN_CONVERTER_PROVIDER,
+                new HiveSmallFragmentCoalescingPlanner(
+                        HiveTestUtils.PARTITION_UPDATE_CODEC,
+                        HiveTestUtils.PARTITION_UPDATE_SMILE_CODEC,
+                        HIVE_CLIENT_CONFIG,
+                        FUNCTION_AND_TYPE_MANAGER,
+                        new HivePartitionObjectBuilder(),
+                        new NodeVersion(TEST_SERVER_VERSION)));
 
         metastore.createDatabase(METASTORE_CONTEXT, Database.builder()
                 .setDatabaseName(TEST_DB_NAME)
@@ -461,6 +468,7 @@ public class TestHiveMetadataFileFormatEncryptionSettings
                     SESSION,
                     insertTableHandle,
                     partitionUpdates.stream().map(update -> Slices.utf8Slice(PARTITION_CODEC.toJson(update))).collect(toImmutableList()),
+                    ImmutableList.of(),
                     ImmutableList.of());
             createHiveMetadata.commit();
 
@@ -478,6 +486,7 @@ public class TestHiveMetadataFileFormatEncryptionSettings
                     SESSION,
                     insertTableHandle,
                     partitionUpdates.stream().map(update -> Slices.utf8Slice(PARTITION_CODEC.toJson(update))).collect(toImmutableList()),
+                    ImmutableList.of(),
                     ImmutableList.of());
             overrideHiveMetadata.commit();
 
@@ -576,6 +585,7 @@ public class TestHiveMetadataFileFormatEncryptionSettings
                     SESSION,
                     insertTableHandle,
                     partitionUpdates.stream().map(update -> Slices.utf8Slice(PARTITION_CODEC.toJson(update))).collect(toImmutableList()),
+                    ImmutableList.of(),
                     ImmutableList.of());
             createHiveMetadata.commit();
 
@@ -588,6 +598,7 @@ public class TestHiveMetadataFileFormatEncryptionSettings
                     SESSION,
                     insertTableHandle,
                     partitionUpdates.stream().map(update -> Slices.utf8Slice(PARTITION_CODEC.toJson(update))).collect(toImmutableList()),
+                    ImmutableList.of(),
                     ImmutableList.of());
         }
         finally {

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveRecoverableExecution.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveRecoverableExecution.java
@@ -38,6 +38,7 @@ import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.concurrent.TimeoutException;
 
+import static com.facebook.presto.Session.SessionBuilder;
 import static com.facebook.presto.SystemSessionProperties.COLOCATED_JOIN;
 import static com.facebook.presto.SystemSessionProperties.CONCURRENT_LIFESPANS_PER_NODE;
 import static com.facebook.presto.SystemSessionProperties.EXCHANGE_MATERIALIZATION_STRATEGY;
@@ -441,9 +442,16 @@ public class TestHiveRecoverableExecution
                 ImmutableMap.of(),
                 ImmutableMap.of());
 
-        return testSessionBuilder()
+        return setRecoverableSessionProperties(testSessionBuilder(), writerConcurrency, optimizedPartitionUpdateSerializationEnabled)
                 .setIdentity(identity)
-                .setSystemProperty(COLOCATED_JOIN, "true")
+                .setCatalog(HIVE_CATALOG)
+                .setSchema(TPCH_BUCKETED_SCHEMA)
+                .build();
+    }
+
+    public static Session.SessionBuilder setRecoverableSessionProperties(SessionBuilder builder, int writerConcurrency, boolean optimizedPartitionUpdateSerializationEnabled)
+    {
+        return builder.setSystemProperty(COLOCATED_JOIN, "true")
                 .setSystemProperty(GROUPED_EXECUTION, "true")
                 .setSystemProperty(CONCURRENT_LIFESPANS_PER_NODE, "1")
                 .setSystemProperty(RECOVERABLE_GROUPED_EXECUTION, "true")
@@ -456,9 +464,6 @@ public class TestHiveRecoverableExecution
                 .setSystemProperty(HASH_PARTITION_COUNT, "11")
                 .setSystemProperty(MAX_STAGE_RETRIES, "4")
                 .setCatalogSessionProperty(HIVE_CATALOG, VIRTUAL_BUCKET_COUNT, "16")
-                .setCatalogSessionProperty(HIVE_CATALOG, OPTIMIZED_PARTITION_UPDATE_SERIALIZATION_ENABLED, optimizedPartitionUpdateSerializationEnabled + "")
-                .setCatalog(HIVE_CATALOG)
-                .setSchema(TPCH_BUCKETED_SCHEMA)
-                .build();
+                .setCatalogSessionProperty(HIVE_CATALOG, OPTIMIZED_PARTITION_UPDATE_SERIALIZATION_ENABLED, optimizedPartitionUpdateSerializationEnabled + "");
     }
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitManager.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitManager.java
@@ -512,7 +512,14 @@ public class TestHiveSplitManager
                 new HiveEncryptionInformationProvider(ImmutableList.of()),
                 new HivePartitionStats(),
                 new HiveFileRenamer(),
-                HiveColumnConverterProvider.DEFAULT_COLUMN_CONVERTER_PROVIDER);
+                HiveColumnConverterProvider.DEFAULT_COLUMN_CONVERTER_PROVIDER,
+                new HiveSmallFragmentCoalescingPlanner(
+                        HiveTestUtils.PARTITION_UPDATE_CODEC,
+                        HiveTestUtils.PARTITION_UPDATE_SMILE_CODEC,
+                        hiveClientConfig,
+                        FUNCTION_AND_TYPE_MANAGER,
+                        new HivePartitionObjectBuilder(),
+                        new NodeVersion(TEST_SERVER_VERSION)));
 
         HiveSplitManager splitManager = new HiveSplitManager(
                 new TestingHiveTransactionManager(metadataFactory),
@@ -543,7 +550,8 @@ public class TestHiveSplitManager
                 new HivePartition(
                         new SchemaTableName("test_schema", "test_table"),
                         PARTITION_NAME,
-                        ImmutableMap.of(partitionColumn, NullableValue.of(createUnboundedVarcharType(), utf8Slice(PARTITION_VALUE)))));
+                        ImmutableMap.of(partitionColumn, NullableValue.of(createUnboundedVarcharType(), utf8Slice(PARTITION_VALUE))),
+                        Optional.empty()));
         TupleDomain<Subfield> domainPredicate = queryTupleDomain
                 .transform(HiveColumnHandle.class::cast)
                 .transform(column -> new Subfield(column.getName(), ImmutableList.of()));
@@ -569,7 +577,8 @@ public class TestHiveSplitManager
                         false,
                         "layout",
                         Optional.empty(),
-                        false),
+                        false,
+                        Optional.empty()),
                 SPLIT_SCHEDULING_CONTEXT);
         List<Set<ColumnHandle>> actualRedundantColumnDomains = splitSource.getNextBatch(NOT_PARTITIONED, 100).get().getSplits().stream()
                 .map(HiveSplit.class::cast)

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestingSemiTransactionalHiveMetastore.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestingSemiTransactionalHiveMetastore.java
@@ -66,9 +66,9 @@ public class TestingSemiTransactionalHiveMetastore
 
     private List<String> partitionNames;
 
-    private TestingSemiTransactionalHiveMetastore(HdfsEnvironment hdfsEnvironment, ExtendedHiveMetastore delegate, ListeningExecutorService renameExecutor, boolean skipDeletionForAlter, boolean skipTargetCleanupOnRollback, boolean undoMetastoreOperationsEnabled, ColumnConverterProvider columnConverterProvider)
+    private TestingSemiTransactionalHiveMetastore(HdfsEnvironment hdfsEnvironment, ExtendedHiveMetastore delegate, ListeningExecutorService updateExecutor, boolean skipDeletionForAlter, boolean skipTargetCleanupOnRollback, boolean undoMetastoreOperationsEnabled, ColumnConverterProvider columnConverterProvider)
     {
-        super(hdfsEnvironment, delegate, renameExecutor, skipDeletionForAlter, skipTargetCleanupOnRollback, undoMetastoreOperationsEnabled, columnConverterProvider);
+        super(hdfsEnvironment, delegate, updateExecutor, skipDeletionForAlter, skipTargetCleanupOnRollback, undoMetastoreOperationsEnabled, columnConverterProvider);
     }
 
     public static TestingSemiTransactionalHiveMetastore create()
@@ -82,9 +82,9 @@ public class TestingSemiTransactionalHiveMetastore
         ColumnConverterProvider columnConverterProvider = HiveColumnConverterProvider.DEFAULT_COLUMN_CONVERTER_PROVIDER;
         ExtendedHiveMetastore delegate = new BridgingHiveMetastore(new ThriftHiveMetastore(hiveCluster, metastoreClientConfig), new HivePartitionMutator());
         ExecutorService executor = newCachedThreadPool(daemonThreadsNamed("hive-%s"));
-        ListeningExecutorService renameExecutor = listeningDecorator(executor);
+        ListeningExecutorService updateExecutor = listeningDecorator(executor);
 
-        return new TestingSemiTransactionalHiveMetastore(hdfsEnvironment, delegate, renameExecutor, false, false, true, columnConverterProvider);
+        return new TestingSemiTransactionalHiveMetastore(hdfsEnvironment, delegate, updateExecutor, false, false, true, columnConverterProvider);
     }
 
     public void addTable(String database, String tableName, Table table, List<String> partitions)

--- a/presto-hive/src/test/java/com/facebook/presto/hive/statistics/BenchmarkGetPartitionsSample.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/statistics/BenchmarkGetPartitionsSample.java
@@ -33,6 +33,7 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 import org.openjdk.jmh.runner.options.VerboseMode;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static com.facebook.presto.hive.statistics.MetastoreHiveStatisticsProvider.getPartitionsSample;
@@ -65,7 +66,12 @@ public class BenchmarkGetPartitionsSample
             ImmutableList.Builder<HivePartition> partitions = ImmutableList.builder();
             SchemaTableName table = new SchemaTableName("schema", "table");
             for (int i = 0; i < TOTAL_SIZE; i++) {
-                partitions.add(new HivePartition(table, "partition_" + i, ImmutableMap.of()));
+                partitions.add(
+                        new HivePartition(
+                                table,
+                                "partition_" + i,
+                                ImmutableMap.of(),
+                                Optional.empty()));
             }
             this.partitions = partitions.build();
         }

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaMetadata.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaMetadata.java
@@ -49,6 +49,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.facebook.presto.kafka.KafkaHandleResolver.convertColumnHandle;
 import static com.facebook.presto.kafka.KafkaHandleResolver.convertTableHandle;
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
@@ -287,8 +288,9 @@ public class KafkaMetadata
     }
 
     @Override
-    public Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session, ConnectorInsertTableHandle insertHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
+    public Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session, ConnectorInsertTableHandle insertHandle, Collection<Slice> fragments, Collection<Slice> deprecatedFragments, Collection<ComputedStatistics> computedStatistics)
     {
+        checkArgument(deprecatedFragments.isEmpty(), "deprecated fragments are unsupported");
         // TODO: support transactional inserts
         return Optional.empty();
     }

--- a/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduMetadata.java
+++ b/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduMetadata.java
@@ -54,6 +54,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
 
@@ -295,8 +296,10 @@ public class KuduMetadata
     public Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session,
             ConnectorInsertTableHandle insertHandle,
             Collection<Slice> fragments,
+            Collection<Slice> deprecatedFragments,
             Collection<ComputedStatistics> computedStatistics)
     {
+        checkArgument(deprecatedFragments.isEmpty(), "deprecated fragments are unsupported");
         return Optional.empty();
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -222,6 +222,7 @@ public final class SystemSessionProperties
     public static final String MAX_STAGE_COUNT_FOR_EAGER_SCHEDULING = "max_stage_count_for_eager_scheduling";
     public static final String HYPERLOGLOG_STANDARD_ERROR_WARNING_THRESHOLD = "hyperloglog_standard_error_warning_threshold";
     public static final String PREFER_MERGE_JOIN = "prefer_merge_join";
+    public static final String SMALL_FRAGMENT_COALESCING_SCAN_PARALLELISM = "small_fragment_coalescing_scan_parallelism";
 
     //TODO: Prestissimo related session properties that are temporarily put here. They will be relocated in the future
     public static final String PRESTISSIMO_SIMPLIFIED_EXPRESSION_EVALUATION_ENABLED = "simplified_expression_evaluation_enabled";
@@ -1260,6 +1261,11 @@ public final class SystemSessionProperties
                         ROUND_ROBIN_SHUFFLE_BEFORE_PARTIAL_DISTINCT_LIMIT,
                         "Add a local roundrobin shuffle before partial distinct limit",
                         featuresConfig.isRoundRobinShuffleBeforePartialDistinctLimit(),
+                        false),
+                integerProperty(
+                        SMALL_FRAGMENT_COALESCING_SCAN_PARALLELISM,
+                        "Per query number of threads reading small fragments when coalescing",
+                        featuresConfig.getSmallFragmentCoalescingScanParallelism(),
                         false));
     }
 
@@ -2119,5 +2125,10 @@ public final class SystemSessionProperties
     public static boolean isRoundRobinShuffleBeforePartialDistinctLimit(Session session)
     {
         return session.getSystemProperty(ROUND_ROBIN_SHUFFLE_BEFORE_PARTIAL_DISTINCT_LIMIT, Boolean.class);
+    }
+
+    public static int getSmallFragmentCoalescingScanParallelism(Session session)
+    {
+        return session.getSystemProperty(SMALL_FRAGMENT_COALESCING_SCAN_PARALLELISM, Integer.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/metadata/InsertTableHandle.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/InsertTableHandle.java
@@ -84,4 +84,9 @@ public final class InsertTableHandle
     {
         return connectorId + ":" + connectorHandle;
     }
+
+    public InsertTableHandle with(ConnectorInsertTableHandle handle)
+    {
+        return new InsertTableHandle(connectorId, transactionHandle, handle);
+    }
 }

--- a/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
@@ -26,6 +26,7 @@ import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.ConnectorMaterializedViewDefinition;
 import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ConnectorSmallFragmentCoalescingPlan;
 import com.facebook.presto.spi.ConnectorTableMetadata;
 import com.facebook.presto.spi.Constraint;
 import com.facebook.presto.spi.MaterializedViewStatus;
@@ -297,7 +298,7 @@ public interface Metadata
     /**
      * Finish insert query
      */
-    Optional<ConnectorOutputMetadata> finishInsert(Session session, InsertTableHandle tableHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics);
+    Optional<ConnectorOutputMetadata> finishInsert(Session session, InsertTableHandle tableHandle, Collection<Slice> fragments, Collection<Slice> deprecatedFragments, Collection<ComputedStatistics> computedStatistics);
 
     /**
      * Get the row ID column handle used with UpdatablePageSource.
@@ -521,4 +522,6 @@ public interface Metadata
     {
         return NOT_APPLICABLE;
     }
+
+    ConnectorSmallFragmentCoalescingPlan createSmallFragmentCoalescingPlan(Session session, InsertTableHandle insertTableHandle, Collection<Slice> fragments);
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -224,6 +224,8 @@ public class FeaturesConfig
 
     private double hyperloglogStandardErrorWarningThreshold = 0.004;
 
+    private int smallFragmentCoalescingScanParallelism = 32;
+
     public enum PartitioningPrecisionStrategy
     {
         // Let Presto decide when to repartition
@@ -2054,6 +2056,19 @@ public class FeaturesConfig
     public FeaturesConfig setRoundRobinShuffleBeforePartialDistinctLimit(boolean roundRobinShuffleBeforePartialDistinctLimit)
     {
         this.roundRobinShuffleBeforePartialDistinctLimit = roundRobinShuffleBeforePartialDistinctLimit;
+        return this;
+    }
+
+    public int getSmallFragmentCoalescingScanParallelism()
+    {
+        return smallFragmentCoalescingScanParallelism;
+    }
+
+    @Config("small-fragment-coalescing-scan-parallelism")
+    @ConfigDescription("Per query number of threads reading small fragments when coalescing. Default is 32.")
+    public FeaturesConfig setSmallFragmentCoalescingScanParallelism(int smallFragmentCoalescingScanParallelism)
+    {
+        this.smallFragmentCoalescingScanParallelism = smallFragmentCoalescingScanParallelism;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/SmallFragmentCoalescer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/SmallFragmentCoalescer.java
@@ -1,0 +1,212 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.SystemSessionProperties;
+import com.facebook.presto.common.Page;
+import com.facebook.presto.execution.Lifespan;
+import com.facebook.presto.execution.scheduler.ExecutionWriterTarget;
+import com.facebook.presto.metadata.ConnectorMetadataUpdaterManager;
+import com.facebook.presto.metadata.InsertTableHandle;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.metadata.Split;
+import com.facebook.presto.spi.ConnectorPageSink;
+import com.facebook.presto.spi.ConnectorPageSource;
+import com.facebook.presto.spi.ConnectorSmallFragmentCoalescingPlan;
+import com.facebook.presto.spi.PageSinkContext;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.TableHandle;
+import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.split.PageSinkManager;
+import com.facebook.presto.split.PageSourceProvider;
+import com.facebook.presto.split.SplitManager;
+import com.facebook.presto.split.SplitSource;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import com.sun.management.ThreadMXBean;
+import io.airlift.slice.Slice;
+
+import java.lang.management.ManagementFactory;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static com.facebook.airlift.concurrent.MoreFutures.getFutureValue;
+import static com.facebook.presto.spi.connector.ConnectorSplitManager.SplitSchedulingStrategy.UNGROUPED_SCHEDULING;
+import static com.facebook.presto.spi.connector.NotPartitionedPartitionHandle.NOT_PARTITIONED;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Stream.concat;
+
+public class SmallFragmentCoalescer
+{
+    private static final ThreadMXBean THREAD_MX_BEAN = (ThreadMXBean) ManagementFactory.getThreadMXBean();
+
+    private final Session session;
+    private final Metadata metadata;
+    private final ExecutionWriterTarget target;
+    private final PageSourceProvider pageSourceProvider;
+    private final PageSinkManager pageSinkManager;
+    private final ConnectorMetadataUpdaterManager metadataUpdaterManager;
+    private final SplitManager splitManager;
+
+    private final AtomicLong cpuNanosecondsConsumed = new AtomicLong();
+
+    @VisibleForTesting
+    public SmallFragmentCoalescer()
+    {
+        this.session = null;
+        this.metadata = null;
+        this.target = null;
+        this.pageSinkManager = null;
+        this.pageSourceProvider = null;
+        this.metadataUpdaterManager = null;
+        this.splitManager = null;
+    }
+
+    public SmallFragmentCoalescer(
+            Session session,
+            Metadata metadata,
+            ExecutionWriterTarget target,
+            PageSourceProvider pageSourceProvider,
+            PageSinkManager pageSinkManager,
+            ConnectorMetadataUpdaterManager metadataUpdaterManager,
+            SplitManager splitManager)
+    {
+        this.session = requireNonNull(session, "session is null");
+        this.metadata = requireNonNull(metadata, "metadata is null");
+        this.target = requireNonNull(target, "target is null");
+        this.pageSourceProvider = requireNonNull(pageSourceProvider, "pageSourceProvider is null");
+        this.pageSinkManager = requireNonNull(pageSinkManager, "pageSinkManager is null");
+        this.metadataUpdaterManager = requireNonNull(metadataUpdaterManager, "metadataUpdaterManager is null");
+        this.splitManager = requireNonNull(splitManager, "splitManager is null");
+    }
+
+    public SmallFragmentCoalescingResult coalesceSmallFragments(Collection<Slice> fragments)
+    {
+        requireNonNull(fragments, "fragments is null");
+        if (target instanceof ExecutionWriterTarget.InsertHandle) {
+            InsertTableHandle handle = ((ExecutionWriterTarget.InsertHandle) target).getHandle();
+            ConnectorSmallFragmentCoalescingPlan plan = metadata.createSmallFragmentCoalescingPlan(session, handle, fragments);
+            List<ConnectorSmallFragmentCoalescingPlan.SubPlan> plans = plan.getSubPlans().collect(Collectors.toList());
+            ThreadFactory threadFactory = new ThreadFactoryBuilder()
+                    .setNameFormat(session.getQueryId().getId() + " fragment coalescing page producer")
+                    .setDaemon(true)
+                    .build();
+            int pageProducingParallelism = SystemSessionProperties.getSmallFragmentCoalescingScanParallelism(session);
+            ListeningExecutorService pageProducerExecutor = MoreExecutors.listeningDecorator(Executors.newFixedThreadPool(pageProducingParallelism, threadFactory));
+            try {
+                Collection<Slice> resultFragments = concat(
+                        plans.stream().flatMap(subPlan -> executeCoalescingSubPlan(session, handle, subPlan, pageProducerExecutor)),
+                        plan.getRetainedFragments().stream())
+                        .collect(toImmutableList());
+                return new SmallFragmentCoalescingResult(resultFragments, plan.getDeprecatedFragments(), cpuNanosecondsConsumed.get());
+            }
+            finally {
+                pageProducerExecutor.shutdownNow();
+            }
+        }
+        else {
+            return new SmallFragmentCoalescingResult(ImmutableSet.copyOf(fragments), ImmutableSet.of(), 1);
+        }
+    }
+
+    private Stream<Slice> executeCoalescingSubPlan(Session session, InsertTableHandle insertTableHandle, ConnectorSmallFragmentCoalescingPlan.SubPlan subPlan, ListeningExecutorService pageProducerExecutor)
+    {
+        PageSinkContext.Builder pageSinkContextBuilder = PageSinkContext.builder().setCommitRequired(false);
+        metadataUpdaterManager.getMetadataUpdater(insertTableHandle.getConnectorId()).ifPresent(pageSinkContextBuilder::setConnectorMetadataUpdater);
+        ConnectorPageSink pageSink = pageSinkManager.createPageSink(session, insertTableHandle, pageSinkContextBuilder.build());
+        TableHandle tableHandle = new TableHandle(insertTableHandle.getConnectorId(), subPlan.getConnectorTableHandle(), insertTableHandle.getTransactionHandle(), Optional.of(subPlan.getTableLayoutHandle()));
+        BlockingQueue<Page> pages = new LinkedBlockingQueue<>(32);
+        ListenableFuture<List<Long>> pageProducersFuture = createSmallFragmentPageProducers(pages, session, tableHandle, subPlan, pageProducerExecutor);
+        try {
+            while (!pageProducersFuture.isDone() || !pages.isEmpty()) {
+                Page p = pages.poll(1, TimeUnit.SECONDS);
+                if (p == null) {
+                    continue;
+                }
+                pageSink.appendPage(p);
+            }
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+        cpuNanosecondsConsumed.addAndGet(getFutureValue(pageProducersFuture).stream().reduce(Long::sum).orElse(0L));
+        Stream<Slice> fragments = getFutureValue(pageSink.finish()).stream();
+        return fragments;
+    }
+
+    private ListenableFuture<List<Long>> createSmallFragmentPageProducers(BlockingQueue<Page> pages, Session session, TableHandle tableHandle, ConnectorSmallFragmentCoalescingPlan.SubPlan subPlan, ListeningExecutorService es)
+    {
+        List<ListenableFuture<Long>> producerFutures = new ArrayList<>();
+        try (SplitSource splitSource = splitManager.getSplits(session, tableHandle, UNGROUPED_SCHEDULING, WarningCollector.NOOP)) {
+            while (!splitSource.isFinished()) {
+                SplitSource.SplitBatch splitBatch = getFutureValue(splitSource.getNextBatch(NOT_PARTITIONED, Lifespan.taskWide(), 1000), PrestoException.class);
+                for (Split split : splitBatch.getSplits()) {
+                    ListenableFuture<Long> producerFuture = es.submit(() -> {
+                        long startThreadCpuTime = THREAD_MX_BEAN.getCurrentThreadCpuTime();
+                        try (ConnectorPageSource source = pageSourceProvider.createPageSource(session, split, tableHandle, subPlan.getColumns())) {
+                            while (!source.isFinished()) {
+                                Page page = source.getNextPage();
+                                if (page == null) {
+                                    continue;
+                                }
+                                try {
+                                    pages.put(page.getLoadedPage());
+                                }
+                                catch (InterruptedException e) {
+                                    break;
+                                }
+                            }
+                        }
+                        return THREAD_MX_BEAN.getCurrentThreadCpuTime() - startThreadCpuTime;
+                    });
+                    producerFutures.add(producerFuture);
+                }
+            }
+        }
+        return Futures.allAsList(producerFutures);
+    }
+
+    public static class SmallFragmentCoalescingResult
+    {
+        public final Collection<Slice> fragments;
+        // Replaced and need to be deleted
+        public final Collection<Slice> deprecatedFragments;
+        public final long cpuNanosecondsConsumed;
+
+        public SmallFragmentCoalescingResult(Collection<Slice> fragments, Collection<Slice> deprecatedFragments, long cpuNanosecondsConsumed)
+        {
+            this.fragments = requireNonNull(fragments, "fragments is null");
+            this.deprecatedFragments = requireNonNull(deprecatedFragments, "deprecatedFragments is null");
+            this.cpuNanosecondsConsumed = cpuNanosecondsConsumed;
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/LocalQueryRunner.java
@@ -847,7 +847,8 @@ public class LocalQueryRunner
                 new RowExpressionDeterminismEvaluator(metadata),
                 new NoOpFragmentResultCacheManager(),
                 new ObjectMapper(),
-                standaloneSpillerFactory);
+                standaloneSpillerFactory,
+                splitManager);
 
         // plan query
         StageExecutionDescriptor stageExecutionDescriptor = subplan.getFragment().getStageExecutionDescriptor();

--- a/presto-main/src/main/java/com/facebook/presto/testing/TestingMetadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/TestingMetadata.java
@@ -254,7 +254,7 @@ public class TestingMetadata
     }
 
     @Override
-    public Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session, ConnectorInsertTableHandle insertHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
+    public Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session, ConnectorInsertTableHandle insertHandle, Collection<Slice> fragments, Collection<Slice> deprecatedFragments, Collection<ComputedStatistics> computedStatistics)
     {
         return Optional.empty();
     }

--- a/presto-main/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TaskTestUtils.java
@@ -52,6 +52,7 @@ import com.facebook.presto.spi.resourceGroups.ResourceGroupId;
 import com.facebook.presto.spiller.GenericSpillerFactory;
 import com.facebook.presto.split.PageSinkManager;
 import com.facebook.presto.split.PageSourceManager;
+import com.facebook.presto.split.SplitManager;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.gen.ExpressionCompiler;
 import com.facebook.presto.sql.gen.JoinCompiler;
@@ -189,7 +190,8 @@ public final class TaskTestUtils
                 new ObjectMapper(),
                 (session) -> {
                     throw new UnsupportedOperationException();
-                });
+                },
+                new SplitManager(metadata, new QueryManagerConfig(), new NodeSchedulerConfig()));
     }
 
     public static TaskInfo updateTask(SqlTask sqlTask, List<TaskSource> taskSources, OutputBuffers outputBuffers)

--- a/presto-main/src/test/java/com/facebook/presto/metadata/AbstractMockMetadata.java
+++ b/presto-main/src/test/java/com/facebook/presto/metadata/AbstractMockMetadata.java
@@ -25,6 +25,7 @@ import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.ConnectorMaterializedViewDefinition;
+import com.facebook.presto.spi.ConnectorSmallFragmentCoalescingPlan;
 import com.facebook.presto.spi.ConnectorTableMetadata;
 import com.facebook.presto.spi.Constraint;
 import com.facebook.presto.spi.MaterializedViewStatus;
@@ -337,7 +338,7 @@ public abstract class AbstractMockMetadata
     }
 
     @Override
-    public Optional<ConnectorOutputMetadata> finishInsert(Session session, InsertTableHandle tableHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
+    public Optional<ConnectorOutputMetadata> finishInsert(Session session, InsertTableHandle tableHandle, Collection<Slice> fragments, Collection<Slice> deprecatedFragments, Collection<ComputedStatistics> computedStatistics)
     {
         throw new UnsupportedOperationException();
     }
@@ -608,6 +609,12 @@ public abstract class AbstractMockMetadata
 
     @Override
     public Set<ConnectorCapabilities> getConnectorCapabilities(Session session, ConnectorId catalogName)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ConnectorSmallFragmentCoalescingPlan createSmallFragmentCoalescingPlan(Session session, InsertTableHandle tableHandle, Collection<Slice> fragments)
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -194,7 +194,8 @@ public class TestFeaturesConfig
                 .setMaxStageCountForEagerScheduling(25)
                 .setHyperloglogStandardErrorWarningThreshold(0.004)
                 .setPreferMergeJoin(false)
-                .setRoundRobinShuffleBeforePartialDistinctLimit(false));
+                .setRoundRobinShuffleBeforePartialDistinctLimit(false)
+                .setSmallFragmentCoalescingScanParallelism(32));
     }
 
     @Test
@@ -340,6 +341,7 @@ public class TestFeaturesConfig
                 .put("hyperloglog-standard-error-warning-threshold", "0.02")
                 .put("optimizer.prefer-merge-join", "true")
                 .put("optimizer.round-robin-shuffle-before-partial-distinct-limit", "true")
+                .put("small-fragment-coalescing-scan-parallelism", "7")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -482,7 +484,8 @@ public class TestFeaturesConfig
                 .setMaxStageCountForEagerScheduling(123)
                 .setHyperloglogStandardErrorWarningThreshold(0.02)
                 .setPreferMergeJoin(true)
-                .setRoundRobinShuffleBeforePartialDistinctLimit(true);
+                .setRoundRobinShuffleBeforePartialDistinctLimit(true)
+                .setSmallFragmentCoalescingScanParallelism(7);
         assertFullMapping(properties, expected);
     }
 

--- a/presto-memory/src/main/java/com/facebook/presto/plugin/memory/MemoryMetadata.java
+++ b/presto-memory/src/main/java/com/facebook/presto/plugin/memory/MemoryMetadata.java
@@ -265,8 +265,9 @@ public class MemoryMetadata
     }
 
     @Override
-    public synchronized Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session, ConnectorInsertTableHandle insertHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
+    public synchronized Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session, ConnectorInsertTableHandle insertHandle, Collection<Slice> fragments, Collection<Slice> deprecatedFragments, Collection<ComputedStatistics> computedStatistics)
     {
+        checkArgument(deprecatedFragments.isEmpty(), "deprecated fragments are unsupported");
         requireNonNull(insertHandle, "insertHandle is null");
         MemoryInsertTableHandle memoryInsertHandle = (MemoryInsertTableHandle) insertHandle;
 

--- a/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoMetadata.java
+++ b/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoMetadata.java
@@ -48,6 +48,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
@@ -248,8 +249,9 @@ public class MongoMetadata
     }
 
     @Override
-    public Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session, ConnectorInsertTableHandle insertHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
+    public Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session, ConnectorInsertTableHandle insertHandle, Collection<Slice> fragments, Collection<Slice> deprecatedFragments, Collection<ComputedStatistics> computedStatistics)
     {
+        checkArgument(deprecatedFragments.isEmpty(), "deprecated fragments are unsupported");
         return Optional.empty();
     }
 

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorMetadata.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorMetadata.java
@@ -784,8 +784,9 @@ public class RaptorMetadata
     }
 
     @Override
-    public Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session, ConnectorInsertTableHandle insertHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
+    public Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session, ConnectorInsertTableHandle insertHandle, Collection<Slice> fragments, Collection<Slice> deprecatedFragments, Collection<ComputedStatistics> computedStatistics)
     {
+        checkArgument(deprecatedFragments.isEmpty(), "deprecated fragments are unsupported");
         RaptorInsertTableHandle handle = (RaptorInsertTableHandle) insertHandle;
         long transactionId = handle.getTransactionId();
         long tableId = handle.getTableId();

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/metadata/TestRaptorMetadata.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/metadata/TestRaptorMetadata.java
@@ -756,7 +756,7 @@ public class TestRaptorMetadata
         assertNull(transactionSuccessful(transactionId));
 
         // commit insert
-        metadata.finishInsert(SESSION, insertHandle, ImmutableList.of(), ImmutableList.of());
+        metadata.finishInsert(SESSION, insertHandle, ImmutableList.of(), ImmutableList.of(), ImmutableList.of());
         assertTrue(transactionExists(transactionId));
         assertTrue(transactionSuccessful(transactionId));
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorSmallFragmentCoalescingPlan.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorSmallFragmentCoalescingPlan.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi;
+
+import io.airlift.slice.Slice;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.unmodifiableList;
+import static java.util.Objects.requireNonNull;
+
+public class ConnectorSmallFragmentCoalescingPlan
+{
+    private final Collection<Slice> retainedFragments;
+    private final Collection<Slice> deprecatedFragments;
+    private final Stream<SubPlan> subPlans;
+
+    public ConnectorSmallFragmentCoalescingPlan(Collection<Slice> retainedFragments, Collection<Slice> deprecatedFragments, Stream<SubPlan> subPlans)
+    {
+        this.retainedFragments = requireNonNull(retainedFragments, "retainedFragments is null");
+        this.deprecatedFragments = requireNonNull(deprecatedFragments, "deprecatedFragments is null");
+        this.subPlans = requireNonNull(subPlans, "tableLayoutHandle is null");
+    }
+
+    public Collection<Slice> getRetainedFragments()
+    {
+        return retainedFragments;
+    }
+
+    public Collection<Slice> getDeprecatedFragments()
+    {
+        return deprecatedFragments;
+    }
+
+    public Stream<SubPlan> getSubPlans()
+    {
+        return subPlans;
+    }
+
+    public static ConnectorSmallFragmentCoalescingPlan noOpPlan(Collection<Slice> fragments)
+    {
+        return new ConnectorSmallFragmentCoalescingPlan(unmodifiableList(new ArrayList<>(fragments)), emptyList(), Stream.empty());
+    }
+
+    public static class SubPlan
+    {
+        private final ConnectorTableLayoutHandle tableLayoutHandle;
+        private final List<ColumnHandle> columns;
+        private final ConnectorTableHandle connectorTableHandle;
+
+        public SubPlan(ConnectorTableLayoutHandle tableLayoutHandle, List<ColumnHandle> columns, ConnectorTableHandle connectorTableHandle)
+        {
+            this.tableLayoutHandle = requireNonNull(tableLayoutHandle, "tableLayoutHandle is null");
+            this.columns = requireNonNull(columns, "columns is null");
+            this.connectorTableHandle = requireNonNull(connectorTableHandle, "connectorTableHandle is null");
+        }
+
+        public ConnectorTableLayoutHandle getTableLayoutHandle()
+        {
+            return tableLayoutHandle;
+        }
+
+        public ConnectorTableHandle getConnectorTableHandle()
+        {
+            return connectorTableHandle;
+        }
+
+        public List<ColumnHandle> getColumns()
+        {
+            return columns;
+        }
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
@@ -24,6 +24,7 @@ import com.facebook.presto.spi.ConnectorNewTableLayout;
 import com.facebook.presto.spi.ConnectorOutputTableHandle;
 import com.facebook.presto.spi.ConnectorResolvedIndex;
 import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ConnectorSmallFragmentCoalescingPlan;
 import com.facebook.presto.spi.ConnectorTableHandle;
 import com.facebook.presto.spi.ConnectorTableLayout;
 import com.facebook.presto.spi.ConnectorTableLayoutHandle;
@@ -499,7 +500,7 @@ public interface ConnectorMetadata
     /**
      * Finish insert query
      */
-    default Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session, ConnectorInsertTableHandle insertHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
+    default Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session, ConnectorInsertTableHandle insertHandle, Collection<Slice> fragments, Collection<Slice> deprecatedFragments, Collection<ComputedStatistics> computedStatistics)
     {
         throw new PrestoException(GENERIC_INTERNAL_ERROR, "ConnectorMetadata beginInsert() is implemented without finishInsert()");
     }
@@ -786,5 +787,10 @@ public interface ConnectorMetadata
     default TableLayoutFilterCoverage getTableLayoutFilterCoverage(ConnectorTableLayoutHandle tableHandle, Set<String> relevantPartitionColumns)
     {
         return NOT_APPLICABLE;
+    }
+
+    default ConnectorSmallFragmentCoalescingPlan createSmallFragmentCoalescingPlan(ConnectorSession connectorSession, ConnectorInsertTableHandle connectorHandle, Collection<Slice> fragments)
+    {
+        return ConnectorSmallFragmentCoalescingPlan.noOpPlan(fragments);
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -24,6 +24,7 @@ import com.facebook.presto.spi.ConnectorNewTableLayout;
 import com.facebook.presto.spi.ConnectorOutputTableHandle;
 import com.facebook.presto.spi.ConnectorResolvedIndex;
 import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.spi.ConnectorSmallFragmentCoalescingPlan;
 import com.facebook.presto.spi.ConnectorTableHandle;
 import com.facebook.presto.spi.ConnectorTableLayout;
 import com.facebook.presto.spi.ConnectorTableLayoutHandle;
@@ -446,10 +447,10 @@ public class ClassLoaderSafeConnectorMetadata
     }
 
     @Override
-    public Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session, ConnectorInsertTableHandle insertHandle, Collection<Slice> fragments, Collection<ComputedStatistics> computedStatistics)
+    public Optional<ConnectorOutputMetadata> finishInsert(ConnectorSession session, ConnectorInsertTableHandle insertHandle, Collection<Slice> fragments, Collection<Slice> deprecatedFragments, Collection<ComputedStatistics> computedStatistics)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.finishInsert(session, insertHandle, fragments, computedStatistics);
+            return delegate.finishInsert(session, insertHandle, fragments, deprecatedFragments, computedStatistics);
         }
     }
 
@@ -714,6 +715,14 @@ public class ClassLoaderSafeConnectorMetadata
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
             return delegate.getTableLayoutFilterCoverage(tableHandle, relevantPartitionColumns);
+        }
+    }
+
+    @Override
+    public ConnectorSmallFragmentCoalescingPlan createSmallFragmentCoalescingPlan(ConnectorSession connectorSession, ConnectorInsertTableHandle connectorHandle, Collection<Slice> fragments)
+    {
+        try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
+            return delegate.createSmallFragmentCoalescingPlan(connectorSession, connectorHandle, fragments);
         }
     }
 }


### PR DESCRIPTION
Presto can generate very large numbers of small files when used with materialized exchange or Presto on Spark where very large hash partition counts are supported along with multiple open files per task.

This PR adds support to the connector API for requesting that a connector provide a plan for how to coalesce these small fragments. Currently only the Hive connector has support for this.

It takes ~90 seconds to coalesce 16k 600kb files into a single file. The fewer empty files there are the faster it goes since anything over the threshold doesn't need to be interacted with. 1/3rd of this is time spent deleting files and the other 2/3rd is time spent doing the actual coalescing.

Depends on https://github.com/facebookexternal/presto-facebook/pull/1773

```
== RELEASE NOTES ==

Hive Connector Changes
* Add support for small file coalescing which is disabled by default, but can be enabled using the hive configuration property `hive.small-file-coalescing-threshold` or session property `small_file_coalescing_threshold` which controls the minimum `DataSize` an output file must be for it not to be coalesced. The configuration property `small-fragment-coalescing-scan-parallelism` can be used to control the number of scan threads used to coalesce small files.
```