### PR TITLE
Delegate to SimpleNodeSelector in SimpleTtlNodeSelector when the node scheduling strategy is not supported

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/nodeSelection/SimpleTtlNodeSelector.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/nodeSelection/SimpleTtlNodeSelector.java
@@ -163,6 +163,12 @@ public class SimpleTtlNodeSelector
     @Override
     public SplitPlacementResult computeAssignments(Set<Split> splits, List<RemoteTask> existingTasks)
     {
+        boolean isNodeSelectionStrategyNoPreference = splits.stream().allMatch(split -> split.getNodeSelectionStrategy() == NodeSelectionStrategy.NO_PREFERENCE);
+        // Current NodeSelectionStrategy support is limited to NO_PREFERENCE
+        if (!isNodeSelectionStrategyNoPreference) {
+            return simpleNodeSelector.computeAssignments(splits, existingTasks);
+        }
+
         ImmutableMultimap.Builder<InternalNode, Split> assignment = ImmutableMultimap.builder();
         NodeMap nodeMap = this.nodeMap.get().get();
         NodeAssignmentStats assignmentStats = new NodeAssignmentStats(nodeTaskMap, nodeMap, existingTasks);


### PR DESCRIPTION
SimpleTtlNodeSelector does not support other `NodeSchedulingStrategy`s like `HARD_AFFINITY`, so delegating the split assignments to SimpleNodeSelector in such a scenario.

```
== NO RELEASE NOTE ==
```
