### PR TITLE
Support consistent hashing in soft affinity node selection strategy

### DIFF
--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/model/AccumuloSplit.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/model/AccumuloSplit.java
@@ -16,6 +16,7 @@ package com.facebook.presto.accumulo.model;
 import com.facebook.presto.accumulo.serializers.AccumuloRowSerializer;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -168,7 +169,7 @@ public class AccumuloSplit
     }
 
     @Override
-    public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+    public List<HostAddress> getPreferredNodes(NodeProvider nodeProvider)
     {
         return addresses;
     }

--- a/presto-atop/src/main/java/com/facebook/presto/atop/AtopSplit.java
+++ b/presto-atop/src/main/java/com/facebook/presto/atop/AtopSplit.java
@@ -15,6 +15,7 @@ package com.facebook.presto.atop;
 
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -85,7 +86,7 @@ public class AtopSplit
     }
 
     @Override
-    public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+    public List<HostAddress> getPreferredNodes(NodeProvider nodeProvider)
     {
         // discard the port number
         return ImmutableList.of(HostAddress.fromString(host.getHostText()));

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcSplit.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcSplit.java
@@ -18,6 +18,7 @@ import com.facebook.presto.plugin.jdbc.optimization.JdbcExpression;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -108,7 +109,7 @@ public class JdbcSplit
     }
 
     @Override
-    public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+    public List<HostAddress> getPreferredNodes(NodeProvider nodeProvider)
     {
         return ImmutableList.of();
     }

--- a/presto-bigquery/src/main/java/com/facebook/presto/plugin/bigquery/BigQuerySplit.java
+++ b/presto-bigquery/src/main/java/com/facebook/presto/plugin/bigquery/BigQuerySplit.java
@@ -16,6 +16,7 @@ package com.facebook.presto.plugin.bigquery;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -95,7 +96,7 @@ public class BigQuerySplit
     }
 
     @Override
-    public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+    public List<HostAddress> getPreferredNodes(NodeProvider nodeProvider)
     {
         return ImmutableList.of();
     }

--- a/presto-blackhole/src/main/java/com/facebook/presto/plugin/blackhole/BlackHoleSplit.java
+++ b/presto-blackhole/src/main/java/com/facebook/presto/plugin/blackhole/BlackHoleSplit.java
@@ -15,6 +15,7 @@ package com.facebook.presto.plugin.blackhole;
 
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -79,7 +80,7 @@ public final class BlackHoleSplit
     }
 
     @Override
-    public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+    public List<HostAddress> getPreferredNodes(NodeProvider nodeProvider)
     {
         return ImmutableList.of();
     }

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraSplit.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraSplit.java
@@ -15,6 +15,7 @@ package com.facebook.presto.cassandra;
 
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -97,7 +98,7 @@ public class CassandraSplit
     }
 
     @Override
-    public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+    public List<HostAddress> getPreferredNodes(NodeProvider nodeProvider)
     {
         return addresses;
     }

--- a/presto-druid/src/main/java/com/facebook/presto/druid/DruidSplit.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/DruidSplit.java
@@ -16,6 +16,7 @@ package com.facebook.presto.druid;
 import com.facebook.presto.druid.metadata.DruidSegmentInfo;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -106,7 +107,7 @@ public class DruidSplit
     }
 
     @Override
-    public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+    public List<HostAddress> getPreferredNodes(NodeProvider nodeProvider)
     {
         return address.map(ImmutableList::of).orElse(ImmutableList.of());
     }

--- a/presto-elasticsearch/src/main/java/com/facebook/presto/elasticsearch/ElasticsearchSplit.java
+++ b/presto-elasticsearch/src/main/java/com/facebook/presto/elasticsearch/ElasticsearchSplit.java
@@ -17,6 +17,7 @@ import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -81,7 +82,7 @@ public class ElasticsearchSplit
     }
 
     @Override
-    public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+    public List<HostAddress> getPreferredNodes(NodeProvider nodeProvider)
     {
         return address.map(host -> ImmutableList.of(HostAddress.fromString(host)))
                 .orElseGet(ImmutableList::of);

--- a/presto-example-http/src/main/java/com/facebook/presto/example/ExampleSplit.java
+++ b/presto-example-http/src/main/java/com/facebook/presto/example/ExampleSplit.java
@@ -15,6 +15,7 @@ package com.facebook.presto.example;
 
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -86,7 +87,7 @@ public class ExampleSplit
     }
 
     @Override
-    public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+    public List<HostAddress> getPreferredNodes(NodeProvider nodeProvider)
     {
         return addresses;
     }

--- a/presto-google-sheets/src/main/java/com/facebook/presto/google/sheets/SheetsSplit.java
+++ b/presto-google-sheets/src/main/java/com/facebook/presto/google/sheets/SheetsSplit.java
@@ -15,6 +15,7 @@ package com.facebook.presto.google.sheets;
 
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -70,7 +71,7 @@ public class SheetsSplit
     }
 
     @Override
-    public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+    public List<HostAddress> getPreferredNodes(NodeProvider nodeProvider)
     {
         return hostAddresses;
     }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplit.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplit.java
@@ -17,7 +17,7 @@ import com.facebook.presto.hive.metastore.Storage;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
-import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.SplitWeight;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -34,7 +34,6 @@ import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.Set;
 
-import static com.facebook.presto.spi.StandardErrorCode.NO_NODES_AVAILABLE;
 import static com.facebook.presto.spi.schedule.NodeSelectionStrategy.SOFT_AFFINITY;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -209,20 +208,10 @@ public class HiveSplit
     }
 
     @Override
-    public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+    public List<HostAddress> getPreferredNodes(NodeProvider nodeProvider)
     {
-        if (sortedCandidates == null || sortedCandidates.isEmpty()) {
-            throw new PrestoException(NO_NODES_AVAILABLE, "sortedCandidates is null or empty for HiveSplit");
-        }
-
         if (getNodeSelectionStrategy() == SOFT_AFFINITY) {
-            // Use + 1 as secondary hash for now, would always get a different position from the first hash.
-            int size = sortedCandidates.size();
-            int mod = path.hashCode() % size;
-            int position = mod < 0 ? mod + size : mod;
-            return ImmutableList.of(
-                    sortedCandidates.get(position),
-                    sortedCandidates.get((position + 1) % size));
+            return nodeProvider.get(path, 2);
         }
         return addresses;
     }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSplit.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSplit.java
@@ -15,7 +15,7 @@ package com.facebook.presto.iceberg;
 
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
-import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -27,7 +27,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import static com.facebook.presto.spi.StandardErrorCode.NO_NODES_AVAILABLE;
 import static com.facebook.presto.spi.schedule.NodeSelectionStrategy.SOFT_AFFINITY;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
@@ -106,20 +105,10 @@ public class IcebergSplit
         return nodeSelectionStrategy;
     }
     @Override
-    public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+    public List<HostAddress> getPreferredNodes(NodeProvider nodeProvider)
     {
-        if (sortedCandidates == null || sortedCandidates.isEmpty()) {
-            throw new PrestoException(NO_NODES_AVAILABLE, "sortedCandidates is null or empty for HiveSplit");
-        }
-
         if (getNodeSelectionStrategy() == SOFT_AFFINITY) {
-            // Use + 1 as secondary hash for now, would always get a different position from the first hash.
-            int size = sortedCandidates.size();
-            int mod = path.hashCode() % size;
-            int position = mod < 0 ? mod + size : mod;
-            return ImmutableList.of(
-                sortedCandidates.get(position),
-                sortedCandidates.get((position + 1) % size));
+            return nodeProvider.get(path, 2);
         }
         return addresses;
     }

--- a/presto-jmx/src/main/java/com/facebook/presto/connector/jmx/JmxSplit.java
+++ b/presto-jmx/src/main/java/com/facebook/presto/connector/jmx/JmxSplit.java
@@ -15,6 +15,7 @@ package com.facebook.presto.connector.jmx;
 
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -59,7 +60,7 @@ public class JmxSplit
     }
 
     @Override
-    public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+    public List<HostAddress> getPreferredNodes(NodeProvider nodeProvider)
     {
         return addresses;
     }

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaSplit.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/KafkaSplit.java
@@ -15,6 +15,7 @@ package com.facebook.presto.kafka;
 
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -137,7 +138,7 @@ public class KafkaSplit
     }
 
     @Override
-    public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+    public List<HostAddress> getPreferredNodes(NodeProvider nodeProvider)
     {
         return ImmutableList.of(leader);
     }

--- a/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduSplit.java
+++ b/presto-kudu/src/main/java/com/facebook/presto/kudu/KuduSplit.java
@@ -15,6 +15,7 @@ package com.facebook.presto.kudu;
 
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -67,7 +68,7 @@ public class KuduSplit
     }
 
     @Override
-    public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+    public List<HostAddress> getPreferredNodes(NodeProvider nodeProvider)
     {
         return ImmutableList.of();
     }

--- a/presto-local-file/src/main/java/com/facebook/presto/localfile/LocalFileSplit.java
+++ b/presto-local-file/src/main/java/com/facebook/presto/localfile/LocalFileSplit.java
@@ -16,6 +16,7 @@ package com.facebook.presto.localfile;
 import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -71,7 +72,7 @@ public class LocalFileSplit
     }
 
     @Override
-    public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+    public List<HostAddress> getPreferredNodes(NodeProvider nodeProvider)
     {
         return ImmutableList.of(address);
     }

--- a/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaSplit.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaSplit.java
@@ -16,6 +16,7 @@ package com.facebook.presto.connector.informationSchema;
 import com.facebook.presto.metadata.QualifiedTablePrefix;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -64,7 +65,7 @@ public class InformationSchemaSplit
     }
 
     @Override
-    public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+    public List<HostAddress> getPreferredNodes(NodeProvider nodeProvider)
     {
         return addresses;
     }

--- a/presto-main/src/main/java/com/facebook/presto/connector/system/SystemSplit.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/system/SystemSplit.java
@@ -18,6 +18,7 @@ import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -78,7 +79,7 @@ public class SystemSplit
     }
 
     @Override
-    public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+    public List<HostAddress> getPreferredNodes(NodeProvider nodeProvider)
     {
         return addresses;
     }

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/ConsistentHashingNodeProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/ConsistentHashingNodeProvider.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.scheduler;
+
+import com.facebook.presto.metadata.InternalNode;
+import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
+import com.google.common.collect.ImmutableList;
+import com.google.common.hash.HashFunction;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+
+import static com.facebook.presto.common.type.encoding.StringUtils.UTF_8;
+import static com.google.common.hash.Hashing.murmur3_32;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class ConsistentHashingNodeProvider
+        implements NodeProvider
+{
+    private static final HashFunction HASH_FUNCTION = murmur3_32();
+    private final NavigableMap<Integer, InternalNode> candidates;
+
+    static ConsistentHashingNodeProvider create(Collection<InternalNode> nodes, int weight)
+    {
+        NavigableMap<Integer, InternalNode> activeNodesByConsistentHashing = new TreeMap<>();
+        for (InternalNode node : nodes) {
+            for (int i = 0; i < weight; i++) {
+                activeNodesByConsistentHashing.put(murmur3_32().hashString(format("%s%d", node.getNodeIdentifier(), i), UTF_8).asInt(), node);
+            }
+        }
+        return new ConsistentHashingNodeProvider(activeNodesByConsistentHashing);
+    }
+
+    public ConsistentHashingNodeProvider(NavigableMap<Integer, InternalNode> candidates)
+    {
+        this.candidates = requireNonNull(candidates, "candidates is null");
+    }
+
+    @Override
+    public List<HostAddress> get(String key, int count)
+    {
+        ImmutableList.Builder<HostAddress> nodes = ImmutableList.builder();
+        for (int i = 0; i < count; i++) {
+            int hashKey = HASH_FUNCTION.hashString(format("%s%d", key, i), UTF_8).asInt();
+            Map.Entry<Integer, InternalNode> entry = candidates.ceilingEntry(hashKey);
+            if (entry != null) {
+                nodes.add(candidates.ceilingEntry(hashKey).getValue().getHostAndPort());
+            }
+            else {
+                nodes.add(candidates.firstEntry().getValue().getHostAndPort());
+            }
+        }
+        return nodes.build();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/ModularHashingNodeProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/ModularHashingNodeProvider.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.scheduler;
+
+import com.facebook.presto.metadata.InternalNode;
+import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
+import com.facebook.presto.spi.PrestoException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.facebook.presto.spi.StandardErrorCode.NO_NODES_AVAILABLE;
+import static java.util.Collections.unmodifiableList;
+
+public class ModularHashingNodeProvider
+        implements NodeProvider
+{
+    private final List<InternalNode> sortedCandidates;
+
+    public ModularHashingNodeProvider(List<InternalNode> sortedCandidates)
+    {
+        if (sortedCandidates == null || sortedCandidates.isEmpty()) {
+            throw new PrestoException(NO_NODES_AVAILABLE, "sortedCandidates is null or empty for ModularHashingNodeProvider");
+        }
+        this.sortedCandidates = sortedCandidates;
+    }
+
+    @Override
+    public List<HostAddress> get(String identifier, int count)
+    {
+        int size = sortedCandidates.size();
+        int mod = identifier.hashCode() % size;
+        int position = mod < 0 ? mod + size : mod;
+        List<HostAddress> chosenCandidates = new ArrayList<>();
+        for (int i = 0; i < count && i < sortedCandidates.size(); i++) {
+            chosenCandidates.add(sortedCandidates.get((position + i) % size).getHostAndPort());
+        }
+        return unmodifiableList(chosenCandidates);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NodeSchedulerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NodeSchedulerConfig.java
@@ -37,6 +37,8 @@ public class NodeSchedulerConfig
     private int maxPendingSplitsPerTask = 10;
     private int maxUnacknowledgedSplitsPerTask = 500;
     private String networkTopology = NetworkTopologyType.LEGACY;
+    private NodeSelectionHashStrategy nodeSelectionHashStrategy = NodeSelectionHashStrategy.MODULAR_HASHING;
+    private int minVirtualNodeCount = 1000;
     private ResourceAwareSchedulingStrategy resourceAwareSchedulingStrategy = ResourceAwareSchedulingStrategy.RANDOM;
 
     @NotNull
@@ -115,6 +117,34 @@ public class NodeSchedulerConfig
     public NodeSchedulerConfig setMaxUnacknowledgedSplitsPerTask(int maxUnacknowledgedSplitsPerTask)
     {
         this.maxUnacknowledgedSplitsPerTask = maxUnacknowledgedSplitsPerTask;
+        return this;
+    }
+
+    public NodeSelectionHashStrategy getNodeSelectionHashStrategy()
+    {
+        return nodeSelectionHashStrategy;
+    }
+
+    @Config("node-scheduler.node-selection-hash-strategy")
+    @ConfigDescription("Hashing strategy used for node selection when scheduling splits to nodes. Options are MODULAR_HASHING, CONSISTENT_HASHING")
+    public NodeSchedulerConfig setNodeSelectionHashStrategy(NodeSelectionHashStrategy nodeSelectionHashStrategy)
+    {
+        this.nodeSelectionHashStrategy = nodeSelectionHashStrategy;
+        return this;
+    }
+
+    public int getMinVirtualNodeCount()
+    {
+        return minVirtualNodeCount;
+    }
+
+    @Config("node-scheduler.consistent-hashing-min-virtual-node-count")
+    @ConfigDescription("When CONSISTENT_HASHING node selection hash strategy is used, the minimum number of virtual node count. Default 1000. " +
+            "The actual virtual node count is guaranteed to be larger than this number. When number is smaller than physical node count, " +
+            "physical node is used, otherwise the smallest multiplier of physical node count that is greater than this value is used.")
+    public NodeSchedulerConfig setMinVirtualNodeCount(int minVirtualNodeCount)
+    {
+        this.minVirtualNodeCount = minVirtualNodeCount;
         return this;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NodeSelectionHashStrategy.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NodeSelectionHashStrategy.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.scheduler;
+
+public enum NodeSelectionHashStrategy
+{
+    MODULAR_HASHING,
+    CONSISTENT_HASHING
+}

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/nodeSelection/SimpleNodeSelector.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/nodeSelection/SimpleNodeSelector.java
@@ -21,10 +21,12 @@ import com.facebook.presto.execution.scheduler.InternalNodeInfo;
 import com.facebook.presto.execution.scheduler.ModularHashingNodeProvider;
 import com.facebook.presto.execution.scheduler.NodeAssignmentStats;
 import com.facebook.presto.execution.scheduler.NodeMap;
+import com.facebook.presto.execution.scheduler.NodeSelectionHashStrategy;
 import com.facebook.presto.execution.scheduler.SplitPlacementResult;
 import com.facebook.presto.metadata.InternalNode;
 import com.facebook.presto.metadata.InternalNodeManager;
 import com.facebook.presto.metadata.Split;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SplitContext;
 import com.facebook.presto.spi.SplitWeight;
@@ -51,6 +53,7 @@ import static com.facebook.presto.execution.scheduler.NodeScheduler.selectDistri
 import static com.facebook.presto.execution.scheduler.NodeScheduler.selectExactNodes;
 import static com.facebook.presto.execution.scheduler.NodeScheduler.selectNodes;
 import static com.facebook.presto.execution.scheduler.NodeScheduler.toWhenHasSplitQueueSpaceFuture;
+import static com.facebook.presto.execution.scheduler.NodeSelectionHashStrategy.MODULAR_HASHING;
 import static com.facebook.presto.metadata.InternalNode.NodeStatus.DEAD;
 import static com.facebook.presto.spi.StandardErrorCode.NODE_SELECTION_NOT_SUPPORTED;
 import static com.facebook.presto.spi.StandardErrorCode.NO_NODES_AVAILABLE;
@@ -77,6 +80,7 @@ public class SimpleNodeSelector
     private final long maxPendingSplitsWeightPerTask;
     private final int maxUnacknowledgedSplitsPerTask;
     private final int maxTasksPerStage;
+    private final NodeSelectionHashStrategy nodeSelectionHashStrategy;
 
     public SimpleNodeSelector(
             InternalNodeManager nodeManager,
@@ -88,7 +92,8 @@ public class SimpleNodeSelector
             long maxSplitsWeightPerNode,
             long maxPendingSplitsWeightPerTask,
             int maxUnacknowledgedSplitsPerTask,
-            int maxTasksPerStage)
+            int maxTasksPerStage,
+            NodeSelectionHashStrategy nodeSelectionHashStrategy)
     {
         this.nodeManager = requireNonNull(nodeManager, "nodeManager is null");
         this.nodeSelectionStats = requireNonNull(nodeSelectionStats, "nodeSelectionStats is null");
@@ -101,6 +106,7 @@ public class SimpleNodeSelector
         this.maxUnacknowledgedSplitsPerTask = maxUnacknowledgedSplitsPerTask;
         checkArgument(maxUnacknowledgedSplitsPerTask > 0, "maxUnacknowledgedSplitsPerTask must be > 0, found: %s", maxUnacknowledgedSplitsPerTask);
         this.maxTasksPerStage = maxTasksPerStage;
+        this.nodeSelectionHashStrategy = requireNonNull(nodeSelectionHashStrategy, "nodeSelectionHashStrategy is null");
     }
 
     @Override
@@ -146,16 +152,22 @@ public class SimpleNodeSelector
         Set<InternalNode> blockedExactNodes = new HashSet<>();
         boolean splitWaitingForAnyNode = false;
 
+        NodeProvider nodeProvider = nodeMap.getActiveNodeProvider(nodeSelectionHashStrategy);
+
         OptionalInt preferredNodeCount = OptionalInt.empty();
         for (Split split : splits) {
             List<InternalNode> candidateNodes;
             switch (split.getNodeSelectionStrategy()) {
                 case HARD_AFFINITY:
-                    candidateNodes = selectExactNodes(nodeMap, split.getPreferredNodes(new ModularHashingNodeProvider(nodeMap.getActiveNodes())), includeCoordinator);
+                    candidateNodes = selectExactNodes(nodeMap, split.getPreferredNodes(nodeProvider), includeCoordinator);
                     preferredNodeCount = OptionalInt.of(candidateNodes.size());
                     break;
                 case SOFT_AFFINITY:
-                    candidateNodes = selectExactNodes(nodeMap, split.getPreferredNodes(new ModularHashingNodeProvider(nodeMap.getAllNodes())), includeCoordinator);
+                    // Using all nodes for soft affinity scheduling with modular hashing because otherwise temporarily down nodes would trigger too much rehashing
+                    if (nodeSelectionHashStrategy == MODULAR_HASHING) {
+                        nodeProvider = new ModularHashingNodeProvider(nodeMap.getAllNodes());
+                    }
+                    candidateNodes = selectExactNodes(nodeMap, split.getPreferredNodes(nodeProvider), includeCoordinator);
                     preferredNodeCount = OptionalInt.of(candidateNodes.size());
                     candidateNodes = ImmutableList.<InternalNode>builder()
                             .addAll(candidateNodes)

--- a/presto-main/src/main/java/com/facebook/presto/metadata/Split.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/Split.java
@@ -17,6 +17,7 @@ import com.facebook.presto.execution.Lifespan;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.SplitContext;
 import com.facebook.presto.spi.SplitWeight;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
@@ -95,9 +96,9 @@ public final class Split
         return connectorSplit.getInfo();
     }
 
-    public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+    public List<HostAddress> getPreferredNodes(NodeProvider nodeProvider)
     {
-        return connectorSplit.getPreferredNodes(sortedCandidates);
+        return connectorSplit.getPreferredNodes(nodeProvider);
     }
 
     public NodeSelectionStrategy getNodeSelectionStrategy()

--- a/presto-main/src/main/java/com/facebook/presto/operator/index/IndexSplit.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/index/IndexSplit.java
@@ -15,6 +15,7 @@ package com.facebook.presto.operator.index;
 
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.RecordSet;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 
@@ -39,7 +40,7 @@ public class IndexSplit
     }
 
     @Override
-    public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+    public List<HostAddress> getPreferredNodes(NodeProvider nodeProvider)
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-main/src/main/java/com/facebook/presto/split/EmptySplit.java
+++ b/presto-main/src/main/java/com/facebook/presto/split/EmptySplit.java
@@ -16,6 +16,7 @@ package com.facebook.presto.split;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -45,7 +46,7 @@ public class EmptySplit
     }
 
     @Override
-    public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+    public List<HostAddress> getPreferredNodes(NodeProvider nodeProvider)
     {
         return ImmutableList.of();
     }

--- a/presto-main/src/main/java/com/facebook/presto/split/RemoteSplit.java
+++ b/presto-main/src/main/java/com/facebook/presto/split/RemoteSplit.java
@@ -17,6 +17,7 @@ import com.facebook.presto.execution.Location;
 import com.facebook.presto.execution.TaskId;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -66,7 +67,7 @@ public class RemoteSplit
     }
 
     @Override
-    public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+    public List<HostAddress> getPreferredNodes(NodeProvider nodeProvider)
     {
         return ImmutableList.of();
     }

--- a/presto-main/src/main/java/com/facebook/presto/testing/TestingSplit.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/TestingSplit.java
@@ -15,6 +15,7 @@ package com.facebook.presto.testing;
 
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -69,7 +70,7 @@ public class TestingSplit
     }
 
     @Override
-    public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+    public List<HostAddress> getPreferredNodes(NodeProvider nodeProvider)
     {
         return addresses;
     }

--- a/presto-main/src/test/java/com/facebook/presto/execution/BenchmarkNodeScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/BenchmarkNodeScheduler.java
@@ -31,6 +31,7 @@ import com.facebook.presto.metadata.Split;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.facebook.presto.testing.TestingSession;
@@ -281,7 +282,7 @@ public class BenchmarkNodeScheduler
         }
 
         @Override
-        public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+        public List<HostAddress> getPreferredNodes(NodeProvider nodeProvider)
         {
             return hosts;
         }

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestNodeSchedulerConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestNodeSchedulerConfig.java
@@ -23,6 +23,8 @@ import java.util.Map;
 import static com.facebook.presto.execution.scheduler.NodeSchedulerConfig.NetworkTopologyType.LEGACY;
 import static com.facebook.presto.execution.scheduler.NodeSchedulerConfig.ResourceAwareSchedulingStrategy.RANDOM;
 import static com.facebook.presto.execution.scheduler.NodeSchedulerConfig.ResourceAwareSchedulingStrategy.TTL;
+import static com.facebook.presto.execution.scheduler.NodeSelectionHashStrategy.CONSISTENT_HASHING;
+import static com.facebook.presto.execution.scheduler.NodeSelectionHashStrategy.MODULAR_HASHING;
 
 public class TestNodeSchedulerConfig
 {
@@ -36,6 +38,8 @@ public class TestNodeSchedulerConfig
                 .setMaxPendingSplitsPerTask(10)
                 .setMaxUnacknowledgedSplitsPerTask(500)
                 .setIncludeCoordinator(true)
+                .setNodeSelectionHashStrategy(MODULAR_HASHING)
+                .setMinVirtualNodeCount(1000)
                 .setResourceAwareSchedulingStrategy(RANDOM));
     }
 
@@ -49,6 +53,8 @@ public class TestNodeSchedulerConfig
                 .put("node-scheduler.max-pending-splits-per-task", "11")
                 .put("node-scheduler.max-unacknowledged-splits-per-task", "501")
                 .put("node-scheduler.max-splits-per-node", "101")
+                .put("node-scheduler.node-selection-hash-strategy", "CONSISTENT_HASHING")
+                .put("node-scheduler.consistent-hashing-min-virtual-node-count", "2000")
                 .put("experimental.resource-aware-scheduling-strategy", "TTL")
                 .build();
 
@@ -59,6 +65,8 @@ public class TestNodeSchedulerConfig
                 .setMaxPendingSplitsPerTask(11)
                 .setMaxUnacknowledgedSplitsPerTask(501)
                 .setMinCandidates(11)
+                .setNodeSelectionHashStrategy(CONSISTENT_HASHING)
+                .setMinVirtualNodeCount(2000)
                 .setResourceAwareSchedulingStrategy(TTL);
 
         ConfigAssertions.assertFullMapping(properties, expected);

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskExecution.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskExecution.java
@@ -44,6 +44,7 @@ import com.facebook.presto.operator.ValuesOperator.ValuesOperatorFactory;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.UpdatablePageSource;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
@@ -1360,7 +1361,7 @@ public class TestSqlTaskExecution
         }
 
         @Override
-        public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+        public List<HostAddress> getPreferredNodes(NodeProvider nodeProvider)
         {
             return ImmutableList.of();
         }

--- a/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestConsistentHashingNodeProvider.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestConsistentHashingNodeProvider.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.scheduler;
+
+import com.facebook.presto.client.NodeVersion;
+import com.facebook.presto.metadata.InternalNode;
+import com.facebook.presto.spi.HostAddress;
+import org.testng.annotations.Test;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.stream.IntStream;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.lang.String.format;
+import static org.testng.Assert.assertTrue;
+
+public class TestConsistentHashingNodeProvider
+{
+    @Test
+    public void testDistribution()
+    {
+        List<InternalNode> nodes = IntStream.range(0, 10).mapToObj(i -> new InternalNode(format("other%d", i), URI.create(format("http://127.0.0.%d:100", i)), NodeVersion.UNKNOWN, false)).collect(toImmutableList());
+        ConsistentHashingNodeProvider nodeProvider = ConsistentHashingNodeProvider.create(nodes, 100);
+        Random random = new Random();
+        Map<HostAddress, Integer> result = new HashMap<>();
+        for (int i = 0; i < 1_000_000; i++) {
+            HostAddress hostAddress = nodeProvider.get(format("split%d", random.nextInt()), 1).get(0);
+            int count = result.getOrDefault(hostAddress, 0);
+            result.put(hostAddress, count + 1);
+        }
+        assertTrue(result.values().stream().allMatch(count -> count >= 80000 && count <= 120000));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/execution/scheduler/group/TestDynamicLifespanScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/scheduler/group/TestDynamicLifespanScheduler.java
@@ -21,6 +21,7 @@ import com.facebook.presto.execution.scheduler.SourceScheduler;
 import com.facebook.presto.metadata.InternalNode;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.connector.ConnectorPartitionHandle;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
@@ -295,7 +296,7 @@ public class TestDynamicLifespanScheduler
         }
 
         @Override
-        public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+        public List<HostAddress> getPreferredNodes(NodeProvider nodeProvider)
         {
             return ImmutableList.of();
         }

--- a/presto-main/src/test/java/com/facebook/presto/memory/TestSystemMemoryBlocking.java
+++ b/presto-main/src/test/java/com/facebook/presto/memory/TestSystemMemoryBlocking.java
@@ -26,6 +26,7 @@ import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.ConnectorTableHandle;
 import com.facebook.presto.spi.FixedPageSource;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
@@ -165,7 +166,7 @@ public class TestSystemMemoryBlocking
         }
 
         @Override
-        public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+        public List<HostAddress> getPreferredNodes(NodeProvider nodeProvider)
         {
             return ImmutableList.of();
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestDriver.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestDriver.java
@@ -28,6 +28,7 @@ import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.FixedPageSource;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.TableHandle;
 import com.facebook.presto.spi.plan.AggregationNode;
@@ -649,7 +650,7 @@ public class TestDriver
         }
 
         @Override
-        public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+        public List<HostAddress> getPreferredNodes(NodeProvider nodeProvider)
         {
             return ImmutableList.of();
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestFileFragmentResultCacheManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestFileFragmentResultCacheManager.java
@@ -19,6 +19,7 @@ import com.facebook.presto.metadata.Split;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.google.common.collect.ImmutableList;
@@ -297,7 +298,7 @@ public class TestFileFragmentResultCacheManager
         }
 
         @Override
-        public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+        public List<HostAddress> getPreferredNodes(NodeProvider nodeProvider)
         {
             return ImmutableList.of();
         }

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/FunctionAssertions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/FunctionAssertions.java
@@ -46,6 +46,7 @@ import com.facebook.presto.spi.ErrorCodeSupplier;
 import com.facebook.presto.spi.FixedPageSource;
 import com.facebook.presto.spi.HostAddress;
 import com.facebook.presto.spi.InMemoryRecordSet;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.RecordPageSource;
 import com.facebook.presto.spi.RecordSet;
@@ -1146,7 +1147,7 @@ public final class FunctionAssertions
         }
 
         @Override
-        public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+        public List<HostAddress> getPreferredNodes(NodeProvider nodeProvider)
         {
             return ImmutableList.of();
         }

--- a/presto-main/src/test/java/com/facebook/presto/split/MockSplitSource.java
+++ b/presto-main/src/test/java/com/facebook/presto/split/MockSplitSource.java
@@ -18,6 +18,7 @@ import com.facebook.presto.metadata.Split;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.connector.ConnectorPartitionHandle;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
@@ -171,7 +172,7 @@ public class MockSplitSource
         }
 
         @Override
-        public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+        public List<HostAddress> getPreferredNodes(NodeProvider nodeProvider)
         {
             return ImmutableList.of();
         }

--- a/presto-memory/src/main/java/com/facebook/presto/plugin/memory/MemorySplit.java
+++ b/presto-memory/src/main/java/com/facebook/presto/plugin/memory/MemorySplit.java
@@ -15,6 +15,7 @@ package com.facebook.presto.plugin.memory;
 
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -92,7 +93,7 @@ public class MemorySplit
     }
 
     @Override
-    public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+    public List<HostAddress> getPreferredNodes(NodeProvider nodeProvider)
     {
         return ImmutableList.of(address);
     }

--- a/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoSplit.java
+++ b/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoSplit.java
@@ -17,6 +17,7 @@ import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -71,7 +72,7 @@ public class MongoSplit
     }
 
     @Override
-    public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+    public List<HostAddress> getPreferredNodes(NodeProvider nodeProvider)
     {
         return addresses;
     }

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotSplit.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotSplit.java
@@ -16,6 +16,7 @@ package com.facebook.presto.pinot;
 import com.facebook.presto.pinot.query.PinotQueryGenerator;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -182,7 +183,7 @@ public class PinotSplit
     }
 
     @Override
-    public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+    public List<HostAddress> getPreferredNodes(NodeProvider nodeProvider)
     {
         return ImmutableList.of();
     }

--- a/presto-prometheus/src/main/java/com/facebook/presto/plugin/prometheus/PrometheusSplit.java
+++ b/presto-prometheus/src/main/java/com/facebook/presto/plugin/prometheus/PrometheusSplit.java
@@ -15,7 +15,7 @@ package com.facebook.presto.plugin.prometheus;
 
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
-import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -24,7 +24,6 @@ import com.google.common.collect.ImmutableList;
 import java.net.URI;
 import java.util.List;
 
-import static com.facebook.presto.spi.StandardErrorCode.NO_NODES_AVAILABLE;
 import static com.facebook.presto.spi.schedule.NodeSelectionStrategy.NO_PREFERENCE;
 import static java.util.Objects.requireNonNull;
 
@@ -65,11 +64,8 @@ public class PrometheusSplit
     }
 
     @Override
-    public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+    public List<HostAddress> getPreferredNodes(NodeProvider nodeProvider)
     {
-        if (sortedCandidates == null || sortedCandidates.isEmpty()) {
-            throw new PrestoException(NO_NODES_AVAILABLE, "sortedCandidates is null or empty for Prometheus Split");
-        }
         return addresses;
     }
 

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorSplit.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorSplit.java
@@ -17,6 +17,7 @@ import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -151,7 +152,7 @@ public class RaptorSplit
     }
 
     @Override
-    public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+    public List<HostAddress> getPreferredNodes(NodeProvider nodeProvider)
     {
         return addresses;
     }

--- a/presto-redis/src/main/java/com/facebook/presto/redis/RedisSplit.java
+++ b/presto-redis/src/main/java/com/facebook/presto/redis/RedisSplit.java
@@ -15,6 +15,7 @@ package com.facebook.presto.redis;
 
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -143,7 +144,7 @@ public final class RedisSplit
     }
 
     @Override
-    public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+    public List<HostAddress> getPreferredNodes(NodeProvider nodeProvider)
     {
         return nodes;
     }

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/planner/TestPrestoSparkSourceDistributionSplitAssigner.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/planner/TestPrestoSparkSourceDistributionSplitAssigner.java
@@ -19,6 +19,7 @@ import com.facebook.presto.metadata.Split;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.connector.ConnectorPartitionHandle;
 import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
 import com.facebook.presto.spi.plan.PlanNodeId;
@@ -367,7 +368,7 @@ public class TestPrestoSparkSourceDistributionSplitAssigner
         }
 
         @Override
-        public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+        public List<HostAddress> getPreferredNodes(NodeProvider nodeProvider)
         {
             throw new UnsupportedOperationException();
         }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorSplit.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorSplit.java
@@ -35,7 +35,7 @@ public interface ConnectorSplit
      * But there is no guarantee that the scheduler will pick them if the provided nodes are busy.
      * 3. Empty list indicates no preference.
      */
-    List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates);
+    List<HostAddress> getPreferredNodes(NodeProvider nodeProvider);
 
     Object getInfo();
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/NodeProvider.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/NodeProvider.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi;
+
+import java.util.List;
+
+public interface NodeProvider
+{
+    /**
+     * @param identifier   an unique identifier used to obtain the nodes
+     * @param count        how many desirable nodes to be returned
+     * @return a list of the chosen nodes by specific hash function
+     */
+    List<HostAddress> get(String identifier, int count);
+}

--- a/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftConnectorSplit.java
+++ b/presto-thrift-connector/src/main/java/com/facebook/presto/connector/thrift/ThriftConnectorSplit.java
@@ -15,6 +15,7 @@ package com.facebook.presto.connector.thrift;
 
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.facebook.presto.thrift.api.connector.PrestoThriftId;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -50,7 +51,7 @@ public class ThriftConnectorSplit
     }
 
     @Override
-    public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+    public List<HostAddress> getPreferredNodes(NodeProvider nodeProvider)
     {
         return addresses;
     }

--- a/presto-tpcds/src/main/java/com/facebook/presto/tpcds/TpcdsSplit.java
+++ b/presto-tpcds/src/main/java/com/facebook/presto/tpcds/TpcdsSplit.java
@@ -15,6 +15,7 @@ package com.facebook.presto.tpcds;
 
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -95,7 +96,7 @@ public class TpcdsSplit
     }
 
     @Override
-    public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+    public List<HostAddress> getPreferredNodes(NodeProvider nodeProvider)
     {
         return addresses;
     }

--- a/presto-tpch/src/main/java/com/facebook/presto/tpch/TpchSplit.java
+++ b/presto-tpch/src/main/java/com/facebook/presto/tpch/TpchSplit.java
@@ -17,6 +17,7 @@ import com.facebook.presto.common.predicate.TupleDomain;
 import com.facebook.presto.spi.ColumnHandle;
 import com.facebook.presto.spi.ConnectorSplit;
 import com.facebook.presto.spi.HostAddress;
+import com.facebook.presto.spi.NodeProvider;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -95,7 +96,7 @@ public class TpchSplit
     }
 
     @Override
-    public List<HostAddress> getPreferredNodes(List<HostAddress> sortedCandidates)
+    public List<HostAddress> getPreferredNodes(NodeProvider nodeProvider)
     {
         return addresses;
     }


### PR DESCRIPTION
```
== RELEASE NOTES ==

General Changes
* Add support to use consistent hashing as a hash strategy when affinity scheduling is used. This feature can be turned on by setting ``node-scheduler.node-selection-hash-strategy`` to ``CONSISTENT``. A separate configuration ``node-scheduler.consistent-hashing-min-virtual-node-count`` specifies the minimal number of virtual nodes in the consistent hashing ring.
```
