### PR TITLE
Add TPCDS schema to HiveQueryRunner

### DIFF
--- a/presto-hive/pom.xml
+++ b/presto-hive/pom.xml
@@ -396,6 +396,12 @@
             <artifactId>jmh-generator-annprocess</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-tpcds</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/presto-hive/src/test/java/com/facebook/presto/hive/HiveQueryRunner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/HiveQueryRunner.java
@@ -16,7 +16,6 @@ package com.facebook.presto.hive;
 import com.facebook.airlift.log.Logger;
 import com.facebook.airlift.log.Logging;
 import com.facebook.presto.Session;
-import com.facebook.presto.common.QualifiedObjectName;
 import com.facebook.presto.execution.QueryManagerConfig.ExchangeMaterializationStrategy;
 import com.facebook.presto.hive.TestHiveEventListenerPlugin.TestingHiveEventListenerPlugin;
 import com.facebook.presto.hive.authentication.NoHdfsAuthentication;
@@ -26,20 +25,20 @@ import com.facebook.presto.hive.metastore.file.FileHiveMetastore;
 import com.facebook.presto.spi.security.Identity;
 import com.facebook.presto.spi.security.PrincipalType;
 import com.facebook.presto.spi.security.SelectedRole;
-import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.DistributedQueryRunner;
 import com.facebook.presto.tpch.TpchPlugin;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import io.airlift.tpch.TpchTable;
-import org.intellij.lang.annotations.Language;
 import org.joda.time.DateTimeZone;
 
 import java.io.File;
 import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiFunction;
@@ -53,12 +52,8 @@ import static com.facebook.presto.SystemSessionProperties.HASH_PARTITION_COUNT;
 import static com.facebook.presto.SystemSessionProperties.PARTITIONING_PROVIDER_CATALOG;
 import static com.facebook.presto.spi.security.SelectedRole.Type.ROLE;
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
-import static com.facebook.presto.tests.QueryAssertions.copyTpchTables;
+import static com.facebook.presto.tests.QueryAssertions.copyTables;
 import static com.facebook.presto.tpch.TpchMetadata.TINY_SCHEMA_NAME;
-import static io.airlift.units.Duration.nanosSince;
-import static java.lang.String.format;
-import static java.util.Locale.ENGLISH;
-import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.testng.Assert.assertEquals;
 
 public final class HiveQueryRunner
@@ -76,6 +71,8 @@ public final class HiveQueryRunner
     public static final MetastoreContext METASTORE_CONTEXT = new MetastoreContext("test_user", "test_queryId", Optional.empty(), Optional.empty(), Optional.empty(), false, HiveColumnConverterProvider.DEFAULT_COLUMN_CONVERTER_PROVIDER);
     private static final String TEMPORARY_TABLE_SCHEMA = "__temporary_tables__";
     private static final DateTimeZone TIME_ZONE = DateTimeZone.forID("America/Bahia_Banderas");
+
+    private static List<String> tpchTables;
 
     public static DistributedQueryRunner createQueryRunner(TpchTable<?>... tables)
             throws Exception
@@ -187,14 +184,15 @@ public final class HiveQueryRunner
             queryRunner.createCatalog(HIVE_CATALOG, HIVE_CATALOG, hiveProperties);
             queryRunner.createCatalog(HIVE_BUCKETED_CATALOG, HIVE_CATALOG, hiveBucketedProperties);
 
+            setupTpchTables(tables);
             if (!metastore.getDatabase(METASTORE_CONTEXT, TPCH_SCHEMA).isPresent()) {
                 metastore.createDatabase(METASTORE_CONTEXT, createDatabaseMetastoreObject(TPCH_SCHEMA));
-                copyTpchTables(queryRunner, "tpch", TINY_SCHEMA_NAME, createSession(Optional.empty()), tables);
+                copyTables(queryRunner, "tpch", TINY_SCHEMA_NAME, createSession(Optional.empty()), tpchTables, true, false);
             }
 
             if (!metastore.getDatabase(METASTORE_CONTEXT, TPCH_BUCKETED_SCHEMA).isPresent()) {
                 metastore.createDatabase(METASTORE_CONTEXT, createDatabaseMetastoreObject(TPCH_BUCKETED_SCHEMA));
-                copyTpchTablesBucketed(queryRunner, "tpch", TINY_SCHEMA_NAME, createBucketedSession(Optional.empty()), tables);
+                copyTables(queryRunner, "tpch", TINY_SCHEMA_NAME, createBucketedSession(Optional.empty()), tpchTables, true, true);
             }
 
             if (!metastore.getDatabase(METASTORE_CONTEXT, TEMPORARY_TABLE_SCHEMA).isPresent()) {
@@ -207,6 +205,13 @@ public final class HiveQueryRunner
             queryRunner.close();
             throw e;
         }
+    }
+
+    private static void setupTpchTables(Iterable<TpchTable<?>> tables)
+    {
+        ImmutableList.Builder<String> tpchtableNames = ImmutableList.builder();
+        tables.forEach(table -> tpchtableNames.add(table.getTableName().toLowerCase(Locale.ENGLISH)));
+        tpchTables = tpchtableNames.build();
     }
 
     public static DistributedQueryRunner createMaterializingQueryRunner(Iterable<TpchTable<?>> tables)
@@ -316,50 +321,6 @@ public final class HiveQueryRunner
                 .setCatalog(HIVE_CATALOG)
                 .setSchema(TPCH_SCHEMA)
                 .build();
-    }
-
-    public static void copyTpchTablesBucketed(
-            QueryRunner queryRunner,
-            String sourceCatalog,
-            String sourceSchema,
-            Session session,
-            Iterable<TpchTable<?>> tables)
-    {
-        log.info("Loading data from %s.%s...", sourceCatalog, sourceSchema);
-        long startTime = System.nanoTime();
-        for (TpchTable<?> table : tables) {
-            copyTableBucketed(queryRunner, new QualifiedObjectName(sourceCatalog, sourceSchema, table.getTableName().toLowerCase(ENGLISH)), session);
-        }
-        log.info("Loading from %s.%s complete in %s", sourceCatalog, sourceSchema, nanosSince(startTime).toString(SECONDS));
-    }
-
-    private static void copyTableBucketed(QueryRunner queryRunner, QualifiedObjectName table, Session session)
-    {
-        long start = System.nanoTime();
-        log.info("Running import for %s", table.getObjectName());
-        @Language("SQL") String sql;
-        switch (table.getObjectName()) {
-            case "part":
-            case "partsupp":
-            case "supplier":
-            case "nation":
-            case "region":
-                sql = format("CREATE TABLE %s AS SELECT * FROM %s", table.getObjectName(), table);
-                break;
-            case "lineitem":
-                sql = format("CREATE TABLE %s WITH (bucketed_by=array['orderkey'], bucket_count=11) AS SELECT * FROM %s", table.getObjectName(), table);
-                break;
-            case "customer":
-                sql = format("CREATE TABLE %s WITH (bucketed_by=array['custkey'], bucket_count=11) AS SELECT * FROM %s", table.getObjectName(), table);
-                break;
-            case "orders":
-                sql = format("CREATE TABLE %s WITH (bucketed_by=array['custkey'], bucket_count=11) AS SELECT * FROM %s", table.getObjectName(), table);
-                break;
-            default:
-                throw new UnsupportedOperationException();
-        }
-        long rows = (Long) queryRunner.execute(session, sql).getMaterializedRows().get(0).getField(0);
-        log.info("Imported %s rows for %s in %s", rows, table.getObjectName(), nanosSince(start).convertToMostSuccinctTimeUnit());
     }
 
     public static void main(String[] args)

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveLogicalPlanner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveLogicalPlanner.java
@@ -163,6 +163,7 @@ import static java.util.stream.Collectors.joining;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
+@Test(singleThreaded = true)
 public class TestHiveLogicalPlanner
         extends AbstractTestQueryFramework
 {

--- a/presto-tests/src/main/java/com/facebook/presto/tests/QueryAssertions.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/QueryAssertions.java
@@ -42,7 +42,6 @@ import static com.google.common.base.Strings.nullToEmpty;
 import static com.google.common.util.concurrent.Uninterruptibles.sleepUninterruptibly;
 import static io.airlift.units.Duration.nanosSince;
 import static java.lang.String.format;
-import static java.util.Locale.ENGLISH;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.testng.Assert.assertEquals;
@@ -332,37 +331,91 @@ public final class QueryAssertions
             Session session,
             Iterable<TpchTable<?>> tables)
     {
-        copyTpchTables(queryRunner, sourceCatalog, sourceSchema, session, tables, false);
+        copyTables(
+                queryRunner,
+                sourceCatalog,
+                sourceSchema,
+                session,
+                Iterables.transform(tables, table -> table.getTableName()),
+                false,
+                false);
     }
 
-    public static void copyTpchTables(
+    public static void copyTables(
             QueryRunner queryRunner,
             String sourceCatalog,
             String sourceSchema,
             Session session,
-            Iterable<TpchTable<?>> tables,
-            boolean ifNotExists)
+            Iterable<String> tables,
+            boolean ifNotExists,
+            boolean bucketed)
     {
         log.info("Loading data from %s.%s...", sourceCatalog, sourceSchema);
         long startTime = System.nanoTime();
-        for (TpchTable<?> table : tables) {
-            copyTable(queryRunner, sourceCatalog, sourceSchema, table.getTableName().toLowerCase(ENGLISH), session, ifNotExists);
+        for (String table : tables) {
+            copyTable(queryRunner, sourceCatalog, sourceSchema, session, table, ifNotExists, bucketed);
         }
         log.info("Loading from %s.%s complete in %s", sourceCatalog, sourceSchema, nanosSince(startTime).toString(SECONDS));
     }
 
-    private static void copyTable(QueryRunner queryRunner, String sourceCatalog, String sourceSchema, String sourceTable, Session session, boolean ifNotExists)
+    public static void copyTable(
+            QueryRunner queryRunner,
+            String sourceCatalog,
+            String sourceSchema,
+            Session session,
+            String sourceTable,
+            boolean ifNotExists,
+            boolean bucketed)
     {
         QualifiedObjectName table = new QualifiedObjectName(sourceCatalog, sourceSchema, sourceTable);
-        copyTable(queryRunner, table, session, ifNotExists);
-    }
 
-    private static void copyTable(QueryRunner queryRunner, QualifiedObjectName table, Session session, boolean ifNotExists)
-    {
         long start = System.nanoTime();
         log.info("Running import for %s", table.getObjectName());
-        @Language("SQL") String sql = format("CREATE TABLE %s %s AS SELECT * FROM %s", ifNotExists ? "IF NOT EXISTS" : "", table.getObjectName(), table);
+
+        @Language("SQL") String sql = getCopyTableSql(sourceCatalog, table, ifNotExists, bucketed);
         long rows = (Long) queryRunner.execute(session, sql).getMaterializedRows().get(0).getField(0);
+
         log.info("Imported %s rows for %s in %s", rows, table.getObjectName(), nanosSince(start).convertToMostSuccinctTimeUnit());
+    }
+
+    private static String getCopyTableSql(String sourceCatalog, QualifiedObjectName table, boolean ifNotExists, boolean bucketed)
+    {
+        if (!bucketed) {
+            return format("CREATE TABLE %s %s AS SELECT * FROM %s", ifNotExists ? "IF NOT EXISTS" : "", table.getObjectName(), table);
+        }
+        else {
+            switch (sourceCatalog) {
+                case "tpch":
+                    return getTpchCopyTableSqlBucketed(table);
+                default:
+                    throw new UnsupportedOperationException();
+            }
+        }
+    }
+
+    private static String getTpchCopyTableSqlBucketed(QualifiedObjectName table)
+    {
+        @Language("SQL") String sql;
+        switch (table.getObjectName()) {
+            case "part":
+            case "partsupp":
+            case "supplier":
+            case "nation":
+            case "region":
+                sql = format("CREATE TABLE %s AS SELECT * FROM %s", table.getObjectName(), table);
+                break;
+            case "lineitem":
+                sql = format("CREATE TABLE %s WITH (bucketed_by=array['orderkey'], bucket_count=11) AS SELECT * FROM %s", table.getObjectName(), table);
+                break;
+            case "customer":
+                sql = format("CREATE TABLE %s WITH (bucketed_by=array['custkey'], bucket_count=11) AS SELECT * FROM %s", table.getObjectName(), table);
+                break;
+            case "orders":
+                sql = format("CREATE TABLE %s WITH (bucketed_by=array['custkey'], bucket_count=11) AS SELECT * FROM %s", table.getObjectName(), table);
+                break;
+            default:
+                throw new UnsupportedOperationException();
+        }
+        return sql;
     }
 }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/QueryAssertions.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/QueryAssertions.java
@@ -387,6 +387,8 @@ public final class QueryAssertions
             switch (sourceCatalog) {
                 case "tpch":
                     return getTpchCopyTableSqlBucketed(table);
+                case "tpcds":
+                    return getTpcdsCopyTableSqlBucketed(table);
                 default:
                     throw new UnsupportedOperationException();
             }
@@ -416,6 +418,57 @@ public final class QueryAssertions
             default:
                 throw new UnsupportedOperationException();
         }
+        return sql;
+    }
+
+    private static String getTpcdsCopyTableSqlBucketed(QualifiedObjectName table)
+    {
+        @Language("SQL") String sql;
+        switch (table.getObjectName()) {
+            case "call_center":
+            case "catalog_page":
+            case "customer":
+            case "customer_address":
+            case "customer_demographics":
+            case "date_dim":
+            case "household_demographics":
+            case "income_band":
+            case "item":
+            case "promotion":
+            case "reason":
+            case "ship_mode":
+            case "store":
+            case "time_dim":
+            case "warehouse":
+            case "web_page":
+            case "web_site":
+                sql = format("CREATE TABLE %s AS SELECT * FROM %s", table.getObjectName(), table);
+                break;
+            case "inventory":
+                sql = format("CREATE TABLE %s WITH (bucketed_by=array['inv_date_sk'], bucket_count=11) AS SELECT * FROM %s", table.getObjectName(), table);
+                break;
+            case "store_returns":
+                sql = format("CREATE TABLE %s WITH (bucketed_by=array['sr_returned_date_sk'], bucket_count=11) AS SELECT * FROM %s", table.getObjectName(), table);
+                break;
+            case "store_sales":
+                sql = format("CREATE TABLE %s WITH (bucketed_by=array['ss_sold_date_sk'], bucket_count=11) AS SELECT * FROM %s", table.getObjectName(), table);
+                break;
+            case "web_returns":
+                sql = format("CREATE TABLE %s WITH (bucketed_by=array['wr_returned_date_sk'], bucket_count=11) AS SELECT * FROM %s", table.getObjectName(), table);
+                break;
+            case "web_sales":
+                sql = format("CREATE TABLE %s WITH (bucketed_by=array['ws_sold_date_sk'], bucket_count=11) AS SELECT * FROM %s", table.getObjectName(), table);
+                break;
+            case "catalog_returns":
+                sql = format("CREATE TABLE %s WITH (bucketed_by=array['cr_returned_date_sk'], bucket_count=11) AS SELECT * FROM %s", table.getObjectName(), table);
+                break;
+            case "catalog_sales":
+                sql = format("CREATE TABLE %s WITH (bucketed_by=array['cs_sold_date_sk'], bucket_count=11) AS SELECT * FROM %s", table.getObjectName(), table);
+                break;
+            default:
+                throw new UnsupportedOperationException();
+        }
+
         return sql;
     }
 }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/tpcds/TpcdsTableName.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/tpcds/TpcdsTableName.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests.tpcds;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.Locale;
+
+public enum TpcdsTableName
+{
+    CALL_CENTER,
+    CATALOG_PAGE,
+    CATALOG_RETURNS,
+    CATALOG_SALES,
+    CUSTOMER,
+    CUSTOMER_ADDRESS,
+    CUSTOMER_DEMOGRAPHICS,
+    DATE_DIM,
+    HOUSEHOLD_DEMOGRAPHICS,
+    INCOME_BAND,
+    INVENTORY,
+    ITEM,
+    PROMOTION,
+    REASON,
+    SHIP_MODE,
+    STORE,
+    STORE_RETURNS,
+    STORE_SALES,
+    TIME_DIM,
+    WAREHOUSE,
+    WEB_PAGE,
+    WEB_RETURNS,
+    WEB_SALES,
+    WEB_SITE;
+
+    public String getTableName()
+    {
+        return this.name().toLowerCase(Locale.ROOT);
+    }
+
+    public static List<TpcdsTableName> getBaseTables()
+    {
+        return ImmutableList.copyOf(values());
+    }
+}


### PR DESCRIPTION
```
== RELEASE NOTES ==

Hive Changes
* Add TPCDS schema support for HiveQueryRunner

```

Now when presto is launched by hiveQueryRunner, we can test tpcds and tpcds_bucketed schemas in TINY scale.

```
$ ./presto --server localhost:8080 --user user --session query_max_execution_time=1h --client-request-timeout=1h --session iterative_optimizer_timeout=1h --catalog hive
presto> show schemas;
        Schema
----------------------
 __temporary_tables__
 information_schema
 tpcds
 tpcds1f
 tpcds_bucketed
 tpch
 tpch10g
 tpch_bucketed
(8 rows)

Query 20211207_185626_00081_ccpde, FINISHED, 4 nodes
Splits: 22 total, 22 done (100.00%)
0:00 [8 rows, 128B] [175 rows/s, 2.74KB/s]

presto> use tpcds;
USE
presto:tpcds> show tables;
         Table
------------------------
 call_center
 catalog_page
 catalog_returns
 catalog_sales
 customer
 customer_address
 customer_demographics
 date_dim
 household_demographics
 income_band
 inventory
 item
 promotion
 reason
 ship_mode
 store
 store_returns
 store_sales
 time_dim
 warehouse
 web_page
 web_returns
 web_sales
 web_site
(24 rows)

Query 20211207_185631_00083_ccpde, FINISHED, 4 nodes
Splits: 22 total, 22 done (100.00%)
0:00 [24 rows, 616B] [480 rows/s, 12KB/s]

presto:tpcds> use tpcds_bucketed;
USE
presto:tpcds_bucketed> show tables;
         Table
------------------------
 call_center
 catalog_page
 catalog_returns
 catalog_sales
 customer
 customer_address
 customer_demographics
 date_dim
 household_demographics
 income_band
 inventory
 item
 promotion
 reason
 ship_mode
 store
 store_returns
 store_sales
 time_dim
 warehouse
 web_page
 web_returns
 web_sales
 web_site
(24 rows)

Query 20211207_185637_00087_ccpde, FINISHED, 4 nodes
Splits: 22 total, 22 done (100.00%)
0:00 [24 rows, 832B] [514 rows/s, 17.4KB/s]

presto:tpcds_bucketed>
```
