### PR TITLE
Add release notes for 0.268

### DIFF
--- a/presto-docs/src/main/sphinx/release.rst
+++ b/presto-docs/src/main/sphinx/release.rst
@@ -5,6 +5,7 @@ Release Notes
 .. toctree::
     :maxdepth: 1
 
+    release/release-0.268
     release/release-0.267
     release/release-0.266
     release/release-0.265

--- a/presto-docs/src/main/sphinx/release/release-0.268.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.268.rst
@@ -1,0 +1,30 @@
+=============
+Release 0.268
+=============
+
+**Details**
+===========
+
+General Changes
+_______________
+* Add support to use consistent hashing as a hash strategy when affinity scheduling is used. This feature can be turned on by setting ``node-scheduler.node-selection-hash-strategy`` to ``CONSISTENT``. A separate configuration ``node-scheduler.consistent-hashing-min-virtual-node-count`` specifies the minimal number of virtual nodes in the consistent hashing ring.
+
+Hive Changes
+____________
+* Add support for in-memory orc stripe row group index caching. This feature is disabled by default. To enable, set ``orc.row-group-index-cache-enabled`` to ``true``. The cache size can be configured with ``orc.row-group-index-cache-size``, and cache TTL can be configured with ``orc.row-group-index-cache-ttl-since-last-access``.
+* Support Hive scalar function.
+
+Iceberg Changes
+_______________
+* Add support for in-memory orc stripe row group index caching. This feature is disabled by default. To enable, set ``orc.row-group-index-cache-enabled`` to ``true``. The cache size can be configured with ``orc.row-group-index-cache-size``, and cache TTL can be configured with ``orc.row-group-index-cache-ttl-since-last-access``.
+
+Pinot Changes
+_____________
+* Adding config `pinot.extra-grpc-metadata` to allow customized gRPC request metadata.
+* Adding config `pinot.override-distinct-count-function` and session config `override_distinct_count_function` to override ``distinctCount`` function name.
+* Adding configs ``pinot.use-https-for-controller/broker/proxy`` to allow using https for Pinot REST APIs.
+
+**Credits**
+===========
+
+Ajay George, Alex Ryckman Mellnik, Arunachalam Thirupathi, Beinan Wang, Chen, Jack Ye, James Sun, Neerad Somanchi, Pranjal Shankhdhar, Reetika Agrawal, Rongrong Zhong, SOURAV PAL, Sagar Sumit, Sreeni Viswanadha, Swapnil Tailor, Thejas Viswanathan, Timothy Meehan, Xiang Fu, Ying Su, Zac, Zhan Yuan, Zhenxiao Luo, mengdilin, tanjialiang, zhaoyulong


### PR DESCRIPTION
# Missing Release Notes

## SOURAV PAL
- [x] https://github.com/prestodb/presto/pull/17095 Fix long overflow caused by ttl comparison (Merged by: Timothy Meehan)

# Extracted Release Notes
- #16737 (Author: zhaoyulong): Support hive scalar function
  - Support Hive scalar function.
- #17099 (Author: Xiang Fu): [Pinot Connector] Adding configs to allow using https for Pinot REST API
  - Adding configs ``pinot.use-https-for-controller/broker/proxy`` to allow using https for Pinot REST APIs.
- #17106 (Author: Rongrong Zhong): Row group index caching
  - Add support for in-memory orc stripe row group index caching. This feature is disabled by default. To enable, set ``orc.row-group-index-cache-enabled`` to ``true``. The cache size can be configured with ``orc.row-group-index-cache-size``, and cache TTL can be configured with ``orc.row-group-index-cache-ttl-since-last-access``.
  - Add support for in-memory orc stripe row group index caching. This feature is disabled by default. To enable, set ``orc.row-group-index-cache-enabled`` to ``true``. The cache size can be configured with ``orc.row-group-index-cache-size``, and cache TTL can be configured with ``orc.row-group-index-cache-ttl-since-last-access``.
- #17113 (Author: Xiang Fu): [Pinot Connector] Support adding extra grpc metadata from PinotConfig
  - Adding config `pinot.extra-grpc-metadata` to allow customized gRPC request metadata.
- #17115 (Author: Rongrong Zhong): Support consistent hashing in soft affinity node selection strategy
  - Add support to use consistent hashing as a hash strategy when affinity scheduling is used. This feature can be turned on by setting ``node-scheduler.node-selection-hash-strategy`` to ``CONSISTENT``. A separate configuration ``node-scheduler.consistent-hashing-min-virtual-node-count`` specifies the minimal number of virtual nodes in the consistent hashing ring.
- #17133 (Author: Xiang Fu): [Pinot Connector] Adding config to override distinctCount function name
  - Adding config `pinot.override-distinct-count-function` and session config `override_distinct_count_function` to override ``distinctCount`` function name.

# All Commits
- 1d71890dd2d61254ea56ad48a557ca283db07d1e Pass file size to Iceberg commit task (Jack Ye)
- a3b756967ea97c4cb783da868e4a132b8e4d4277 fixing the distinctCount function name override bug (Xiang Fu)
- 434d03e4f770ab716a7ba06e6a95e6d9529045f7 Adding config to override distinctCount function name (Xiang Fu)
- 123c2ab8487aa962344601895d98af6fec22ddb3 Add ConsistentHashingNodeProvider (Rongrong Zhong)
- 9e46a70a4be0e9b2a6ffc55a7f341947299f5e27 Add NodeProvider interface and ModularHashingNodeProvider (Rongrong Zhong)
- 9b0712a76f3bac729c2396d5e4912f54ec46f514 Fix a typo in DriverContext (Chen)
- 033e7fd7402e99bc4029a2d45cf25e666df1ceda Optimize putIfAbsent in Dictionary Buillders (Arunachalam Thirupathi)
- e54a3e0c8ea23f9b06484e50130dad2ffaccfda8 Add shadow cache configs (Beinan Wang)
- 09a9141e6788682f2d3551c9ade1a3ccc01c7b62 Tie construction of ColumnConverter to MetastoreContext (mengdilin)
- 1be922445e31326eece64ca9b8d8da3f215bc557 Line numbers in operator nodes. (Sreeni Viswanadha)
- 313c2d98cf6a80f273b3565150b8218b037913f8 Caching orc row group index (Rongrong Zhong)
- c882b649568da4939f7efa4413c04112ebb4f717 Initialize RowGroupIndex only once (Rongrong Zhong)
- 9c8eee9366ab6a66cb0549cd6247cf73ad75e245 Document TDigest functions and type (Alex Ryckman Mellnik)
- c0e987f860bdc1d79bb215a9339fed435603b296 Support adding extra grpc metadata from PinotConfig (Xiang Fu)
- 5290e4f170ba74cf2533bbcc5280b7a67024679e Delegate to SimpleNodeSelector in SimpleTtlNodeSelector when NodeSchedulingStrategy is not NO_PREFERENCE (Neerad Somanchi)
- 30f68dcde2fd7763506659befa491bd42bf37bd5 Adding configs to allow using https for pinot REST API (Xiang Fu)
- 6af495cb192279ae6de56bbce50c26d6f217d26b Add different tracing mode to current tracing system (tanjialiang)
- 204d3fa50ac1c3d499f094505cab36a7314edaf9 Introduce HiveFunctionNamespaceManager to load Hive FunctionNamespace (zhaoyulong)
- 723c7d4c510e413c7d15254e19a53c3e8247b2e3 Introduce HiveScalarFunctionImplementation and HiveScalarFunctionInvoker (zhaoyulong)
- d3bac7db353d8d3e94b4da2253b8861a365ed521 Add Encoder / Decoder for type transformation between Presto and Hive (zhaoyulong)
- f042688071ef918c9598508ba60e767c80a47b6f Add HiveFunctionNamespacePlugin (zhaoyulong)
- 9db30730379ff1dbf8e2ee71b8246f0d6b819057 Fix NPE when reading an empty Iceberg table without snapshot ID (Jack Ye)
- 10c4acf483656badbcbf06fe89a4b11c6d6b4354 Fix NullPointerException in SimpleTtlNodeSelector (Neerad Somanchi)
- 8319b30616d084383d6cdcc8f86de758b2e2c740 Documentation syntax fixes (Reetika Agrawal)
- fb0a014ccdc30dbfe020fdf8c517b5d9398cdb67 Fix long overflow caused by ttl comparison (SOURAV PAL)
- 5f0a71afde5c9dd033061ecd16c76f0984e8e408 Add a new stats for AGG(IF()) rewrite (Zac)
- cd7911e9147266c9c9ee859f84ec7f1f707610b6 Add support for AGG(CAST(IF(expr, x)) (Zac)
- 66419cc42d802c160fd12f9ec17b117300986c09 Add a new rewrite strategy UNWRAP_IF_SAFE (Zac)
- 4c63d15a8c4cae52cd521d497d89110bcece403f Support Left outer join in Materialized View (Pranjal Shankhdhar)
- a7b4031688dc0f4875d8b9b084daded8eb66d447 Move TupleDomainFilter to presto-common (Ying Su)
- b39102105f91d618b08bb835e8b671dc8af9ec4b Move ByteArrayUtils to presto-common (Ying Su)
- 51d90e34fd3647c6a25a51d7aabd7506043721e5 Move FilterFunction to presto-common (Ying Su)
- 25fb9fa535b9a061498c1debe3433ee48444806a Refactor Utils class in presto-common (Ying)
- a1e19c6b74d69f0ce15412ae7b519fc0bedc2005 Added support for limit (Thejas Viswanathan)
- 5cbfe6beb8f6e443d85bd6aa83f804342089fe41 Disabling flaky test (Swapnil Tailor)
- 53259831296fc0bd7fd210e9d62770c6340b3e02 Fix bug in listTableColumns (Ajay George)
- 56c5255c77e8c709d8d736726a0d454b8cf1953b Add more RuntimeStats to help performance tuning (Zhan Yuan)
- 3d2d556c75226d7533a65bbf7083931cc4f9825c Add typeMetadata to Column (mengdilin)
- 3ba60179f891eb9cdd9bc46d1eaf2144b726c76a Diable the flaky test in google sheet connector (Beinan Wang)
- 97d5e9f0f0afa7cd3f1a50605a1e907fe71654bc Make Hudi bootstrap table use custom split. (Sagar Sumit)