### PR TITLE
Fix pinot queries with reserved keywords

### DIFF
--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/query/PinotFilterExpressionConverter.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/query/PinotFilterExpressionConverter.java
@@ -126,7 +126,7 @@ public class PinotFilterExpressionConverter
         Optional<String> left = handleTimeValueCast(context, arguments.get(1), arguments.get(0));
         Optional<String> right = handleTimeValueCast(context, arguments.get(0), arguments.get(1));
         if (left.isPresent() && right.isPresent()) {
-            return Optional.of(derived(format("(%s %s %s)", left.get(), operator, right.get())));
+            return Optional.of(derived(format("(\"%s\" %s %s)", left.get(), operator, right.get())));
         }
         return Optional.empty();
     }


### PR DESCRIPTION
If we have a datetime/timestamp column named after a reserved pinot keyword, the query was crashing (i.e. a column named 'timestamp')

```
== NO RELEASE NOTE ==
```
