### PR TITLE
Use scheme for querying brokers as specified in the PinotConfig

### DIFF
--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotBrokerPageSourceBase.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotBrokerPageSourceBase.java
@@ -64,6 +64,8 @@ import static java.util.Objects.requireNonNull;
 public abstract class PinotBrokerPageSourceBase
         implements ConnectorPageSource
 {
+    private static final String HTTPS_SCHEME = "https";
+    private static final String HTTP_SCHEME = "http";
     private static final String PINOT_INFINITY = "∞";
     private static final String PINOT_POSITIVE_INFINITY = "+" + PINOT_INFINITY;
     private static final String PINOT_NEGATIVE_INFINITY = "-" + PINOT_INFINITY;
@@ -247,9 +249,9 @@ public abstract class PinotBrokerPageSourceBase
             JsonNode result = rows.get(rowNumber);
             if (result == null || result.size() < blockBuilders.size()) {
                 throw new PinotException(
-                    PINOT_UNEXPECTED_RESPONSE,
-                    Optional.of(query),
-                    String.format("Expected row of %d columns", blockBuilders.size()));
+                        PINOT_UNEXPECTED_RESPONSE,
+                        Optional.of(query),
+                        String.format("Expected row of %d columns", blockBuilders.size()));
             }
             for (int columnNumber = 0; columnNumber < blockBuilders.size(); columnNumber++) {
                 setValue(types.get(columnNumber), blockBuilders.get(columnNumber), result.get(columnNumber));
@@ -264,9 +266,9 @@ public abstract class PinotBrokerPageSourceBase
 
         if (numServersQueried == null || numServersResponded == null || numServersQueried.asInt() > numServersResponded.asInt()) {
             throw new PinotException(
-                PINOT_INSUFFICIENT_SERVER_RESPONSE,
-                Optional.of(pql),
-                String.format("Only %s out of %s servers responded for query %s", numServersResponded.asInt(), numServersQueried.asInt(), pql));
+                    PINOT_INSUFFICIENT_SERVER_RESPONSE,
+                    Optional.of(pql),
+                    String.format("Only %s out of %s servers responded for query %s", numServersResponded.asInt(), numServersQueried.asInt(), pql));
         }
 
         JsonNode exceptions = jsonBody.get("exceptions");
@@ -274,9 +276,9 @@ public abstract class PinotBrokerPageSourceBase
             // Pinot is known to return exceptions with benign errorcodes like 200
             // so we treat any exception as an error
             throw new PinotException(
-                PINOT_EXCEPTION,
-                Optional.of(pql),
-                String.format("Query %s encountered exception %s", pql, exceptions.get(0)));
+                    PINOT_EXCEPTION,
+                    Optional.of(pql),
+                    String.format("Query %s encountered exception %s", pql, exceptions.get(0)));
         }
     }
 
@@ -311,19 +313,19 @@ public abstract class PinotBrokerPageSourceBase
             List<Type> types)
     {
         return doWithRetries(PinotSessionProperties.getPinotRetryCount(session), (retryNumber) -> {
-            String queryHost;
+            URI queryUri;
             Optional<String> rpcService;
             if (pinotConfig.getRestProxyUrl() != null) {
-                queryHost = pinotConfig.getRestProxyUrl();
+                queryUri = URI.create(String.format(getQueryUrlTemplate(), pinotConfig.isUseHttpsForProxy() ? HTTPS_SCHEME : HTTP_SCHEME, pinotConfig.getRestProxyUrl()));
                 rpcService = Optional.ofNullable(pinotConfig.getRestProxyServiceForQuery());
             }
             else {
-                queryHost = clusterInfoFetcher.getBrokerHost(pinotQuery.getTable());
+                queryUri = URI.create(String.format(getQueryUrlTemplate(), pinotConfig.isUseHttpsForBroker() ? HTTPS_SCHEME : HTTP_SCHEME, clusterInfoFetcher.getBrokerHost(pinotQuery.getTable())));
                 rpcService = Optional.empty();
             }
             Request.Builder builder = Request.Builder
                     .preparePost()
-                    .setUri(URI.create(String.format(getQueryUrlTemplate(), queryHost)));
+                    .setUri(queryUri);
             String body = clusterInfoFetcher.doHttpActionWithHeaders(builder, Optional.of(getRequestPayload(pinotQuery)), rpcService);
             return populateFromQueryResults(pinotQuery, blockBuilders, types, body);
         });

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotBrokerPageSourcePql.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotBrokerPageSourcePql.java
@@ -40,7 +40,7 @@ public class PinotBrokerPageSourcePql
         extends PinotBrokerPageSourceBase
 {
     private static final String REQUEST_PAYLOAD_KEY = "pql";
-    private static final String QUERY_URL_TEMPLATE = "http://%s/query";
+    private static final String QUERY_URL_TEMPLATE = "%s://%s/query";
 
     private final GeneratedPinotQuery brokerPql;
     private final List<PinotColumnHandle> expectedHandles;

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotBrokerPageSourceSql.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotBrokerPageSourceSql.java
@@ -35,7 +35,7 @@ public class PinotBrokerPageSourceSql
         extends PinotBrokerPageSourceBase
 {
     private static final String REQUEST_PAYLOAD_KEY = "sql";
-    private static final String QUERY_URL_TEMPLATE = "http://%s/query/sql";
+    private static final String QUERY_URL_TEMPLATE = "%s://%s/query/sql";
 
     private final GeneratedPinotQuery brokerSql;
     private final List<PinotColumnHandle> expectedHandles;


### PR DESCRIPTION
Test plan - (Please fill in how you tested your changes)
These changes have been tested in a Pinot Cluster. 

```
== RELEASE NOTES ==
Pinot Changes
* Ensure pinot connector respects the https scheme property when executing a broker query
```
