### PR TITLE
Introduce memory-revoking-target concept in PoS revoking logic

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkConfig.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkConfig.java
@@ -40,6 +40,7 @@ public class PrestoSparkConfig
     private boolean smileSerializationEnabled = true;
     private int splitAssignmentBatchSize = 1_000_000;
     private double memoryRevokingThreshold;
+    private double memoryRevokingTarget;
 
     public boolean isSparkPartitionCountAutoTuneEnabled()
     {
@@ -207,6 +208,21 @@ public class PrestoSparkConfig
     public PrestoSparkConfig setMemoryRevokingThreshold(double memoryRevokingThreshold)
     {
         this.memoryRevokingThreshold = memoryRevokingThreshold;
+        return this;
+    }
+
+    @DecimalMin("0.0")
+    @DecimalMax("1.0")
+    public double getMemoryRevokingTarget()
+    {
+        return memoryRevokingTarget;
+    }
+
+    @Config("spark.memory-revoking-target")
+    @ConfigDescription("When revoking memory, try to revoke so much that memory pool is filled below target at the end")
+    public PrestoSparkConfig setMemoryRevokingTarget(double memoryRevokingTarget)
+    {
+        this.memoryRevokingTarget = memoryRevokingTarget;
         return this;
     }
 }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkSessionProperties.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkSessionProperties.java
@@ -40,6 +40,7 @@ public class PrestoSparkSessionProperties
     public static final String SPARK_BROADCAST_JOIN_MAX_MEMORY_OVERRIDE = "spark_broadcast_join_max_memory_override";
     public static final String SPARK_SPLIT_ASSIGNMENT_BATCH_SIZE = "spark_split_assignment_batch_size";
     public static final String SPARK_MEMORY_REVOKING_THRESHOLD = "spark_memory_revoking_threshold";
+    public static final String SPARK_MEMORY_REVOKING_TARGET = "spark_memory_revoking_target";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -101,6 +102,11 @@ public class PrestoSparkSessionProperties
                         SPARK_MEMORY_REVOKING_THRESHOLD,
                         "Revoke memory when memory pool is filled over threshold",
                         prestoSparkConfig.getMemoryRevokingThreshold(),
+                        false),
+                doubleProperty(
+                        SPARK_MEMORY_REVOKING_TARGET,
+                        "When revoking memory, try to revoke so much that memory pool is filled below target at the end",
+                        prestoSparkConfig.getMemoryRevokingTarget(),
                         false));
     }
 
@@ -162,5 +168,10 @@ public class PrestoSparkSessionProperties
     public static double getMemoryRevokingThreshold(Session session)
     {
         return session.getSystemProperty(SPARK_MEMORY_REVOKING_THRESHOLD, Double.class);
+    }
+
+    public static double getMemoryRevokingTarget(Session session)
+    {
+        return session.getSystemProperty(SPARK_MEMORY_REVOKING_TARGET, Double.class);
     }
 }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkTaskExecutorFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkTaskExecutorFactory.java
@@ -22,6 +22,7 @@ import com.facebook.presto.common.block.BlockEncodingManager;
 import com.facebook.presto.common.io.DataOutput;
 import com.facebook.presto.event.SplitMonitor;
 import com.facebook.presto.execution.ExecutionFailureInfo;
+import com.facebook.presto.execution.MemoryRevokingSchedulerUtils;
 import com.facebook.presto.execution.ScheduledSplit;
 import com.facebook.presto.execution.StageExecutionId;
 import com.facebook.presto.execution.StageId;
@@ -116,6 +117,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.zip.CRC32;
 
 import static com.facebook.presto.ExceededMemoryLimitException.exceededLocalTotalMemoryLimit;
@@ -131,6 +133,7 @@ import static com.facebook.presto.execution.TaskState.FAILED;
 import static com.facebook.presto.execution.TaskStatus.STARTING_VERSION;
 import static com.facebook.presto.execution.buffer.BufferState.FINISHED;
 import static com.facebook.presto.metadata.MetadataUpdates.DEFAULT_METADATA_UPDATES;
+import static com.facebook.presto.spark.PrestoSparkSessionProperties.getMemoryRevokingTarget;
 import static com.facebook.presto.spark.PrestoSparkSessionProperties.getMemoryRevokingThreshold;
 import static com.facebook.presto.spark.PrestoSparkSessionProperties.getShuffleOutputTargetAverageRowSize;
 import static com.facebook.presto.spark.PrestoSparkSessionProperties.getSparkBroadcastJoinMaxMemoryOverride;
@@ -426,6 +429,11 @@ public class PrestoSparkTaskExecutorFactory
                 false);
 
         final double memoryRevokingThreshold = getMemoryRevokingThreshold(session);
+        final double memoryRevokingTarget = getMemoryRevokingTarget(session);
+        checkArgument(
+                memoryRevokingTarget <= memoryRevokingThreshold,
+                "memoryRevokingTarget should be less than or equal memoryRevokingThreshold, but got %s and %s respectively",
+                memoryRevokingTarget, memoryRevokingThreshold);
         if (isSpillEnabled(session)) {
             memoryPool.addListener((pool, queryId, totalMemoryReservationBytes) -> {
                 if (totalMemoryReservationBytes > queryContext.getPeakNodeTotalMemory()) {
@@ -435,19 +443,23 @@ public class PrestoSparkTaskExecutorFactory
                 if (totalMemoryReservationBytes > pool.getMaxBytes() * memoryRevokingThreshold && memoryRevokeRequestInProgress.compareAndSet(false, true)) {
                     memoryRevocationExecutor.execute(() -> {
                         try {
-                            taskContext.accept(new VoidTraversingQueryContextVisitor<Void>()
+                            AtomicLong remainingBytesToRevoke = new AtomicLong(totalMemoryReservationBytes - (long) (memoryRevokingTarget * pool.getMaxBytes()));
+                            remainingBytesToRevoke.addAndGet(-MemoryRevokingSchedulerUtils.getMemoryAlreadyBeingRevoked(ImmutableList.of(taskContext), remainingBytesToRevoke.get()));
+                            taskContext.accept(new VoidTraversingQueryContextVisitor<AtomicLong>()
                             {
                                 @Override
-                                public Void visitOperatorContext(OperatorContext operatorContext, Void nothing)
+                                public Void visitOperatorContext(OperatorContext operatorContext, AtomicLong remainingBytesToRevoke)
                                 {
-                                    operatorContext.requestMemoryRevoking();
-                                    // If revoke was requested, set memoryRevokePending to true
-                                    if (operatorContext.isMemoryRevokingRequested()) {
-                                        memoryRevokePending.set(true);
+                                    if (remainingBytesToRevoke.get() > 0) {
+                                        long revokedBytes = operatorContext.requestMemoryRevoking();
+                                        if (revokedBytes > 0) {
+                                            memoryRevokePending.set(true);
+                                            remainingBytesToRevoke.addAndGet(-revokedBytes);
+                                        }
                                     }
                                     return null;
                                 }
-                            }, null);
+                            }, remainingBytesToRevoke);
                             memoryRevokeRequestInProgress.set(false);
                         }
                         catch (Exception e) {

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkConfig.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkConfig.java
@@ -44,7 +44,8 @@ public class TestPrestoSparkConfig
                 .setSparkBroadcastJoinMaxMemoryOverride(null)
                 .setSmileSerializationEnabled(true)
                 .setSplitAssignmentBatchSize(1_000_000)
-                .setMemoryRevokingThreshold(0));
+                .setMemoryRevokingThreshold(0)
+                .setMemoryRevokingTarget(0));
     }
 
     @Test
@@ -64,6 +65,7 @@ public class TestPrestoSparkConfig
                 .put("spark.smile-serialization-enabled", "false")
                 .put("spark.split-assignment-batch-size", "420")
                 .put("spark.memory-revoking-threshold", "0.5")
+                .put("spark.memory-revoking-target", "0.5")
                 .build();
         PrestoSparkConfig expected = new PrestoSparkConfig()
                 .setSparkPartitionCountAutoTuneEnabled(false)
@@ -78,7 +80,8 @@ public class TestPrestoSparkConfig
                 .setSparkBroadcastJoinMaxMemoryOverride(new DataSize(1, GIGABYTE))
                 .setSmileSerializationEnabled(false)
                 .setSplitAssignmentBatchSize(420)
-                .setMemoryRevokingThreshold(0.5);
+                .setMemoryRevokingThreshold(0.5)
+                .setMemoryRevokingTarget(0.5);
         assertFullMapping(properties, expected);
     }
 }


### PR DESCRIPTION
Currently, when revoking is triggered, everything is spilled to
disk. This is a bit aggresive since we can keep some data in
memory itself and only dump a portion to disk so that enough
memory is released for the query to continue. This PR introduces
a memory-revoking-target config which can be used to specifiy
how much data should be spilled on revoke.

Test plan 
- Tested ~200 production spilling queries with revoking target set to 0.5 and we see around 20-25% reduction in spilled bytes. 

```
== RELEASE NOTES ==

General Changes
* Add a new configuration property ``spark.memory-revoking-target`` to specify the percent to which memory pool should be occupied after revoke is completed.  This can be overridden by ``spark_memory_revoking_target`` session property
```