### PR TITLE
Do not hold on to mutable config object

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/cost/TaskCountEstimator.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/TaskCountEstimator.java
@@ -34,9 +34,10 @@ public class TaskCountEstimator
     {
         requireNonNull(nodeSchedulerConfig, "nodeSchedulerConfig is null");
         requireNonNull(nodeManager, "nodeManager is null");
+        boolean schedulerIncludeCoordinator = nodeSchedulerConfig.isIncludeCoordinator();
         this.numberOfNodes = () -> {
             Set<InternalNode> activeNodes = nodeManager.getAllNodes().getActiveNodes();
-            if (nodeSchedulerConfig.isIncludeCoordinator()) {
+            if (schedulerIncludeCoordinator) {
                 return activeNodes.size();
             }
             return toIntExact(activeNodes.stream()


### PR DESCRIPTION
Cherry-pick of https://github.com/trinodb/trino/pull/10382
A lambda expression should not hold a mutable object.
Co-authored-by: Piotr Findeisen <piotr.findeisen@gmail.com>

```
== RELEASE NOTES ==

General Changes
* Do not hold on to mutable config object
```