### PR TITLE
Fix the empty UI details page of some error queries

### DIFF
--- a/presto-main/src/main/resources/webapp/src/components/QueryDetail.jsx
+++ b/presto-main/src/main/resources/webapp/src/components/QueryDetail.jsx
@@ -1053,6 +1053,7 @@ export class QueryDetail extends React.Component {
 
     renderRuntimeStats() {
         const query = this.state.query;
+        if (query.queryStats.runtimeStats === undefined) return null;
         if (Object.values(query.queryStats.runtimeStats).length == 0) return null;
         return (
             <div className="row">


### PR DESCRIPTION
When the query has a USER ERROR such as a syntax error, the field runtimeStats is still empty, which will cause UI parsing error. The UI page of this type of query is empty and it is inconvenient to view other information on the page (such as exception stack)

== NO RELEASE NOTE ==