### PR TITLE
Allow using HTTPS for grpc proxy requests

### DIFF
--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotConfig.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotConfig.java
@@ -108,6 +108,7 @@ public class PinotConfig
     private boolean useHttpsForController;
     private boolean useHttpsForBroker;
     private boolean useHttpsForProxy;
+    private boolean useHttpsForGrpcProxy;
     private Map<String, String> extraGrpcMetadata = ImmutableMap.of();
     private String overrideDistinctCountFunction = PINOT_DISTINCT_COUNT_FUNCTION_NAME;
 
@@ -591,6 +592,18 @@ public class PinotConfig
     {
         this.proxyGrpcPort = proxyGrpcPort;
         return this;
+    }
+
+    @Config("pinot.use-https-for-grpc-proxy")
+    public PinotConfig setUseHttpsForGrpcProxy(boolean useHttpsForGrpcProxy)
+    {
+        this.useHttpsForGrpcProxy = useHttpsForGrpcProxy;
+        return this;
+    }
+
+    public boolean isUseHttpsForGrpcProxy()
+    {
+        return this.useHttpsForGrpcProxy;
     }
 
     public boolean isUseHttpsForController()

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotPageSourceProvider.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotPageSourceProvider.java
@@ -60,7 +60,7 @@ public class PinotPageSourceProvider
                 pinotConfig.getMaxConnectionsPerServer()));
         this.pinotStreamingQueryClient = new PinotStreamingQueryClient(new PinotStreamingQueryClient.Config(
                 pinotConfig.getStreamingServerGrpcMaxInboundMessageBytes(),
-                pinotConfig.isUseHttpsForGrpcProxy()));
+                !pinotConfig.isUseHttpsForGrpcProxy()));
         this.clusterInfoFetcher = requireNonNull(clusterInfoFetcher, "cluster info fetcher is null");
         this.objectMapper = requireNonNull(objectMapper, "object mapper is null");
     }

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotPageSourceProvider.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotPageSourceProvider.java
@@ -60,7 +60,7 @@ public class PinotPageSourceProvider
                 pinotConfig.getMaxConnectionsPerServer()));
         this.pinotStreamingQueryClient = new PinotStreamingQueryClient(new PinotStreamingQueryClient.Config(
                 pinotConfig.getStreamingServerGrpcMaxInboundMessageBytes(),
-                true));
+                pinotConfig.isUseHttpsForGrpcProxy()));
         this.clusterInfoFetcher = requireNonNull(clusterInfoFetcher, "cluster info fetcher is null");
         this.objectMapper = requireNonNull(objectMapper, "object mapper is null");
     }

--- a/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotConfig.java
+++ b/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotConfig.java
@@ -60,6 +60,7 @@ public class TestPinotConfig
                         .setUseHttpsForController(false)
                         .setUseHttpsForBroker(false)
                         .setUseHttpsForProxy(false)
+                        .setUseHttpsForGrpcProxy(false)
                         .setNumSegmentsPerSplit(1)
                         .setFetchRetryCount(2)
                         .setMarkDataFetchExceptionsAsRetriable(true)
@@ -118,6 +119,7 @@ public class TestPinotConfig
                 .put("pinot.use-https-for-controller", "true")
                 .put("pinot.use-https-for-broker", "true")
                 .put("pinot.use-https-for-proxy", "true")
+                .put("pinot.use-https-for-grpc-proxy", "true")
                 .put("pinot.override-distinct-count-function", "distinctCountBitmap")
                 .build();
 
@@ -164,7 +166,8 @@ public class TestPinotConfig
                 .setUseDateTrunc(true)
                 .setUseHttpsForController(true)
                 .setUseHttpsForBroker(true)
-                .setUseHttpsForProxy(true);
+                .setUseHttpsForProxy(true)
+                .setUseHttpsForGrpcProxy(true);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
Test plan - (Please fill in how you tested your changes)
Unit tests for configuration, tested with a pinot cluster

```
== RELEASE NOTES ==

Pinot Connector Changes
* Allow using HTTPS for gRPC proxy requests to servers with configuration property pinot.use-https-for-grpc-proxy
```
