### PR TITLE
Disabling flaky test

### DIFF
--- a/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/TestQueuesDb.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/resourceGroups/db/TestQueuesDb.java
@@ -147,7 +147,8 @@ public class TestQueuesDb
         waitForCompleteQueryCount(queryRunner, 1);
     }
 
-    @Test(timeOut = 60_000)
+    //Disabling flaky test
+    @Test(timeOut = 60_000, enabled = false)
     public void testTwoQueriesAtSameTime()
             throws Exception
     {

--- a/presto-tests/src/test/java/com/facebook/presto/resourcemanager/TestDistributedQueryResource.java
+++ b/presto-tests/src/test/java/com/facebook/presto/resourcemanager/TestDistributedQueryResource.java
@@ -173,7 +173,7 @@ public class TestDistributedQueryResource
         }
     }
 
-    @Test
+    @Test(timeOut = 60_000)
     public void testGetAllQueryInfoForLimits()
             throws InterruptedException
     {


### PR DESCRIPTION
It seems the query order is not respected all the time due to the nature of multi threading with Dispatcher logic.
So the first query submitted might end up getting queued and the second one runs if the thread handling second one gets prioritized.
This leads to the failure, needs better investigation to see what should be the right fix here. Disabling till then.

Test plan - unit test

Issue: https://github.com/prestodb/presto/issues/17302

```
== NO RELEASE NOTE ==
```
