### PR TITLE
[Pinot Connector] Adding Pinot session config `pinot.topn_large`

### DIFF
--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotSessionProperties.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotSessionProperties.java
@@ -43,7 +43,8 @@ public class PinotSessionProperties
     public static final String PUSHDOWN_TOPN_BROKER_QUERIES = "pushdown_topn_broker_queries";
     public static final String FORBID_SEGMENT_QUERIES = "forbid_segment_queries";
     public static final String NUM_SEGMENTS_PER_SPLIT = "num_segments_per_split";
-    public static final String LIMIT_LARGER_FOR_SEGMENT = "limit_larger_for_segment";
+    public static final String TOPN_LARGE = "topn_large";
+    public static final String LIMIT_LARGE_FOR_SEGMENT = "limit_larger_for_segment";
     public static final String OVERRIDE_DISTINCT_COUNT_FUNCTION = "override_distinct_count_function";
 
     private final List<PropertyMetadata<?>> sessionProperties;
@@ -104,9 +105,14 @@ public class PinotSessionProperties
         return session.getProperty(PUSHDOWN_TOPN_BROKER_QUERIES, Boolean.class);
     }
 
+    public static int getTopNLarge(ConnectorSession session)
+    {
+        return session.getProperty(TOPN_LARGE, Integer.class);
+    }
+
     public static int getLimitLargerForSegment(ConnectorSession session)
     {
-        return session.getProperty(LIMIT_LARGER_FOR_SEGMENT, Integer.class);
+        return session.getProperty(LIMIT_LARGE_FOR_SEGMENT, Integer.class);
     }
 
     public static String getOverrideDistinctCountFunction(ConnectorSession session)
@@ -149,12 +155,17 @@ public class PinotSessionProperties
                         pinotConfig.getNonAggregateLimitForBrokerQueries(),
                         false),
                 integerProperty(
-                        LIMIT_LARGER_FOR_SEGMENT,
+                        LIMIT_LARGE_FOR_SEGMENT,
                         "Server query selection limit for large segment",
                         pinotConfig.getLimitLargeForSegment(),
                         false),
+                integerProperty(
+                        TOPN_LARGE,
+                        "Broker query group by limit",
+                        pinotConfig.getTopNLarge(),
+                        false),
                 stringProperty(
-                    OVERRIDE_DISTINCT_COUNT_FUNCTION,
+                        OVERRIDE_DISTINCT_COUNT_FUNCTION,
                         "Override distinct count function to another function name",
                         pinotConfig.getOverrideDistinctCountFunction(),
                         false),

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/query/PinotQueryGeneratorContext.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/query/PinotQueryGeneratorContext.java
@@ -375,7 +375,7 @@ public class PinotQueryGeneratorContext
                 }
             }
             else {
-                queryLimit = pinotConfig.getTopNLarge();
+                queryLimit = PinotSessionProperties.getTopNLarge(session);
             }
         }
         String limitClause = "";
@@ -461,7 +461,7 @@ public class PinotQueryGeneratorContext
                 queryLimit = limit.getAsInt();
             }
             else {
-                queryLimit = pinotConfig.getTopNLarge();
+                queryLimit = PinotSessionProperties.getTopNLarge(session);
             }
         }
         String limitClause = "";

--- a/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotSplitManager.java
+++ b/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotSplitManager.java
@@ -16,6 +16,7 @@ package com.facebook.presto.pinot;
 import com.facebook.presto.pinot.query.PinotQueryGenerator;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ConnectorSplitSource;
+import com.facebook.presto.spi.plan.AggregationNode;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.sql.analyzer.FeaturesConfig;
 import com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder;
@@ -111,6 +112,44 @@ public class TestPinotSplitManager
     }
 
     @Test
+    public void testBrokerTopNLarge()
+    {
+        testBrokerTopNLarge(realtimeOnlyTable, 1000, 5000, true);
+        testBrokerTopNLarge(realtimeOnlyTable, 1000, 5000, false);
+    }
+
+    private void testBrokerTopNLarge(PinotTableHandle table, int sessionTopNLarge, int configTopNLarge, boolean useSql)
+    {
+        String topNLimitKeyword = useSql ? "LIMIT " : "TOP ";
+        PinotConfig pinotConfig = new PinotConfig().setUsePinotSqlForBrokerQueries(useSql).setTopNLarge(configTopNLarge);
+        SessionHolder sessionHolder = new SessionHolder(pinotConfig);
+        ConnectorSession session = createSessionWithTopNLarge(sessionTopNLarge, pinotConfig);
+        PlanBuilder planBuilder = createPlanBuilder(sessionHolder);
+        PlanNode tableScanNode =
+                tableScan(planBuilder, table, regionId, city, fare, secondsSinceEpoch);
+        AggregationNode aggregationNode = planBuilder.aggregation(
+                aggregationNodeBuilder -> aggregationNodeBuilder
+                        .source(tableScanNode)
+                        .singleGroupingSet(variable("city"), variable("regionid"))
+                        .addAggregation(planBuilder.variable("sum_fare"), getRowExpression("sum(fare)", sessionHolder))
+                        .addAggregation(planBuilder.variable("count_regionid"), getRowExpression("count(regionid)", sessionHolder)));
+
+        PinotQueryGenerator.PinotQueryGeneratorResult pinotQueryGeneratorResult = new PinotQueryGenerator(pinotConfig, functionAndTypeManager, functionAndTypeManager, standardFunctionResolution).generate(aggregationNode, session).get();
+        String[] limits = pinotQueryGeneratorResult.getGeneratedPinotQuery().getQuery().split(topNLimitKeyword);
+        assertEquals(Integer.parseInt(limits[1]), sessionTopNLarge);
+
+        aggregationNode = planBuilder.aggregation(
+                aggregationNodeBuilder -> aggregationNodeBuilder
+                        .source(tableScanNode)
+                        .singleGroupingSet(variable("city"), variable("regionid"))
+                        .addAggregation(planBuilder.variable("sum_fare"), getRowExpression("sum(fare)", sessionHolder))
+                        .addAggregation(planBuilder.variable("count_regionid"), getRowExpression("count(regionid)", sessionHolder)));
+        pinotQueryGeneratorResult = new PinotQueryGenerator(pinotConfig, functionAndTypeManager, functionAndTypeManager, standardFunctionResolution).generate(aggregationNode, sessionHolder.getConnectorSession()).get();
+        limits = pinotQueryGeneratorResult.getGeneratedPinotQuery().getQuery().split(topNLimitKeyword);
+        assertEquals(Integer.parseInt(limits[1]), configTopNLarge);
+    }
+
+    @Test
     public void testSplitsBroker()
     {
         PinotQueryGenerator.GeneratedPinotQuery generatedPql = new PinotQueryGenerator.GeneratedPinotQuery(realtimeOnlyTable.getTableName(), String.format("SELECT %s, COUNT(1) FROM %s GROUP BY %s TOP %d", city.getColumnName(), realtimeOnlyTable.getTableName(), city.getColumnName(), pinotConfig.getTopNLarge()), PinotQueryGenerator.PinotQueryFormat.PQL, ImmutableList.of(0, 1), 1, false, true);
@@ -198,8 +237,28 @@ public class TestPinotSplitManager
                 System.currentTimeMillis(),
                 new PinotSessionProperties(pinotConfig).getSessionProperties(),
                 ImmutableMap.of(
-                        PinotSessionProperties.LIMIT_LARGER_FOR_SEGMENT,
+                        PinotSessionProperties.LIMIT_LARGE_FOR_SEGMENT,
                         limitLarge),
+                new FeaturesConfig().isLegacyTimestamp(),
+                Optional.empty(),
+                ImmutableSet.of(),
+                Optional.empty(),
+                ImmutableMap.of());
+    }
+
+    public static ConnectorSession createSessionWithTopNLarge(int topNLarge, PinotConfig pinotConfig)
+    {
+        return new TestingConnectorSession(
+                "user",
+                Optional.of("test"),
+                Optional.empty(),
+                UTC_KEY,
+                ENGLISH,
+                System.currentTimeMillis(),
+                new PinotSessionProperties(pinotConfig).getSessionProperties(),
+                ImmutableMap.of(
+                        PinotSessionProperties.TOPN_LARGE,
+                        topNLarge),
                 new FeaturesConfig().isLegacyTimestamp(),
                 Optional.empty(),
                 ImmutableSet.of(),


### PR DESCRIPTION
Adding Pinot session config `pinot.topn_large` to override the default topN value.

Test plan - (Please fill in how you tested your changes)
Unit test


```
== RELEASE NOTES ==

Pinot Changes
* Adding Pinot session config `pinot.topn_large` to override the default topN value.
```
