### PR TITLE
Support basic timestamp in the iceberg connector

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/ExpressionConverter.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/ExpressionConverter.java
@@ -27,6 +27,8 @@ import com.facebook.presto.common.type.IntegerType;
 import com.facebook.presto.common.type.MapType;
 import com.facebook.presto.common.type.RealType;
 import com.facebook.presto.common.type.RowType;
+import com.facebook.presto.common.type.TimeType;
+import com.facebook.presto.common.type.TimestampType;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.VarbinaryType;
 import com.facebook.presto.common.type.VarcharType;
@@ -47,6 +49,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.Float.intBitsToFloat;
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.apache.iceberg.expressions.Expressions.alwaysFalse;
 import static org.apache.iceberg.expressions.Expressions.alwaysTrue;
 import static org.apache.iceberg.expressions.Expressions.and;
@@ -177,6 +180,10 @@ public final class ExpressionConverter
         // TODO: Remove this conversion once we move to next iceberg version
         if (type instanceof DateType) {
             return toIntExact(((Long) marker.getValue()));
+        }
+
+        if (type instanceof TimestampType || type instanceof TimeType) {
+            return MILLISECONDS.toMicros((Long) marker.getValue());
         }
 
         if (type instanceof VarcharType) {

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSource.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSource.java
@@ -42,6 +42,8 @@ import static com.facebook.presto.common.type.Decimals.isShortDecimal;
 import static com.facebook.presto.common.type.DoubleType.DOUBLE;
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static com.facebook.presto.common.type.RealType.REAL;
+import static com.facebook.presto.common.type.TimeType.TIME;
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_BAD_DATA;
 import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_INVALID_PARTITION_VALUE;
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
@@ -208,7 +210,7 @@ public class IcebergPageSource
             if (type.equals(DOUBLE)) {
                 return parseDouble(valueString);
             }
-            if (type.equals(DATE)) {
+            if (type.equals(DATE) || type.equals(TIME) || type.equals(TIMESTAMP)) {
                 return parseLong(valueString);
             }
             if (type instanceof VarcharType) {

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/TypeConverter.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/TypeConverter.java
@@ -60,7 +60,6 @@ import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static com.facebook.presto.common.type.RealType.REAL;
 import static com.facebook.presto.common.type.SmallintType.SMALLINT;
 import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
-import static com.facebook.presto.common.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static com.facebook.presto.common.type.TinyintType.TINYINT;
 import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.hive.HiveType.HIVE_BINARY;
@@ -116,6 +115,10 @@ public final class TypeConverter
                 return RealType.REAL;
             case INTEGER:
                 return IntegerType.INTEGER;
+            case TIME:
+                return TimeType.TIME;
+            case TIMESTAMP:
+                return TimestampType.TIMESTAMP;
             case STRING:
                 return VarcharType.createUnboundedVarcharType();
             case LIST:
@@ -175,13 +178,13 @@ public final class TypeConverter
             return fromMap((MapType) type);
         }
         if (type instanceof TimeType) {
-            throw new PrestoException(NOT_SUPPORTED, format("Time not supported for Iceberg."));
+            return Types.TimeType.get();
         }
         if (type instanceof TimestampType) {
-            throw new PrestoException(NOT_SUPPORTED, format("Timestamp not supported for Iceberg."));
+            return Types.TimestampType.withoutZone();
         }
         if (type instanceof TimestampWithTimeZoneType) {
-            throw new PrestoException(NOT_SUPPORTED, format("Timestamp with timezone not supported for Iceberg."));
+            return Types.TimestampType.withZone();
         }
         throw new PrestoException(NOT_SUPPORTED, "Type not supported for Iceberg: " + type.getDisplayName());
     }
@@ -266,10 +269,6 @@ public final class TypeConverter
             return HIVE_DATE.getTypeInfo();
         }
         if (TIMESTAMP.equals(type)) {
-            return HIVE_TIMESTAMP.getTypeInfo();
-        }
-        if (TIMESTAMP_WITH_TIME_ZONE.equals(type)) {
-            // Hive does not have TIMESTAMP_WITH_TIME_ZONE, this is just a work around for iceberg.
             return HIVE_TIMESTAMP.getTypeInfo();
         }
         if (type instanceof DecimalType) {

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergSmoke.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergSmoke.java
@@ -53,7 +53,10 @@ public class TestIcebergSmoke
     @Test
     public void testTimestamp()
     {
-        // TODO
+        assertUpdate("CREATE TABLE test_timestamp (x timestamp)");
+        assertUpdate("INSERT INTO test_timestamp VALUES (timestamp '2017-05-01 10:12:34')", 1);
+        assertQuery("SELECT * FROM test_timestamp", "SELECT CAST('2017-05-01 10:12:34' AS TIMESTAMP)");
+        dropTable(getSession(), "test_timestamp");
     }
 
     @Test


### PR DESCRIPTION
Cherry-pick iceberg timestamp support from https://github.com/trinodb/trino/commit/e82c2d5301396ca16248eb6931bec11bf1352470

Co-Authored-By: Parth Brahmbhatt <pbrahmbhatt@netflix.com>

Test plan - Unit test

```
== RELEASE NOTES ==

Iceberg Changes
* Support basic timestamp in the iceberg connector.
```
