### PR TITLE
improve fragment cache hit ratio

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -205,6 +205,7 @@ public class HiveClientConfig
 
     private boolean userDefinedTypeEncodingEnabled;
 
+    @Min(0)
     public int getMaxInitialSplits()
     {
         return maxInitialSplits;

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
@@ -134,6 +134,7 @@ public final class HiveSessionProperties
     public static final String SIZE_BASED_SPLIT_WEIGHTS_ENABLED = "size_based_split_weights_enabled";
     public static final String MINIMUM_ASSIGNED_SPLIT_WEIGHT = "minimum_assigned_split_weight";
     private static final String USE_RECORD_PAGE_SOURCE_FOR_CUSTOM_SPLIT = "use_record_page_source_for_custom_split";
+    public static final String MAX_INITIAL_SPLITS = "max_initial_splits";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -657,7 +658,12 @@ public final class HiveSessionProperties
                         USE_RECORD_PAGE_SOURCE_FOR_CUSTOM_SPLIT,
                         "Use record page source for custom split",
                         hiveClientConfig.isUseRecordPageSourceForCustomSplit(),
-                        false));
+                        false),
+                integerProperty(
+                        MAX_INITIAL_SPLITS,
+                        "Hive max initial split count",
+                        hiveClientConfig.getMaxInitialSplits(),
+                        true));
     }
 
     public List<PropertyMetadata<?>> getSessionProperties()
@@ -1136,5 +1142,10 @@ public final class HiveSessionProperties
     public static boolean isUseRecordPageSourceForCustomSplit(ConnectorSession session)
     {
         return session.getProperty(USE_RECORD_PAGE_SOURCE_FOR_CUSTOM_SPLIT, Boolean.class);
+    }
+
+    public static int getHiveMaxInitialSplitSize(ConnectorSession session)
+    {
+        return session.getProperty(MAX_INITIAL_SPLITS, Integer.class);
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitManager.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplitManager.java
@@ -87,6 +87,7 @@ import static com.facebook.presto.hive.HiveErrorCode.HIVE_PARTITION_DROPPED_DURI
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_PARTITION_SCHEMA_MISMATCH;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_TRANSACTION_NOT_FOUND;
 import static com.facebook.presto.hive.HivePartition.UNPARTITIONED_ID;
+import static com.facebook.presto.hive.HiveSessionProperties.getHiveMaxInitialSplitSize;
 import static com.facebook.presto.hive.HiveSessionProperties.getLeaseDuration;
 import static com.facebook.presto.hive.HiveSessionProperties.isOfflineDataDebugModeEnabled;
 import static com.facebook.presto.hive.HiveSessionProperties.isPartitionStatisticsBasedOptimizationEnabled;
@@ -138,7 +139,6 @@ public class HiveSplitManager
     private final DataSize maxOutstandingSplitsSize;
     private final int minPartitionBatchSize;
     private final int maxPartitionBatchSize;
-    private final int maxInitialSplits;
     private final int splitLoaderConcurrency;
     private final boolean recursiveDfsWalkerEnabled;
     private final CounterStat highMemorySplitSourceCounter;
@@ -169,7 +169,6 @@ public class HiveSplitManager
                 hiveClientConfig.getMaxOutstandingSplitsSize(),
                 hiveClientConfig.getMinPartitionBatchSize(),
                 hiveClientConfig.getMaxPartitionBatchSize(),
-                hiveClientConfig.getMaxInitialSplits(),
                 hiveClientConfig.getSplitLoaderConcurrency(),
                 hiveClientConfig.getRecursiveDirWalkerEnabled(),
                 cacheQuotaRequirementProvider,
@@ -188,7 +187,6 @@ public class HiveSplitManager
             DataSize maxOutstandingSplitsSize,
             int minPartitionBatchSize,
             int maxPartitionBatchSize,
-            int maxInitialSplits,
             int splitLoaderConcurrency,
             boolean recursiveDfsWalkerEnabled,
             CacheQuotaRequirementProvider cacheQuotaRequirementProvider,
@@ -206,7 +204,6 @@ public class HiveSplitManager
         this.maxOutstandingSplitsSize = maxOutstandingSplitsSize;
         this.minPartitionBatchSize = minPartitionBatchSize;
         this.maxPartitionBatchSize = maxPartitionBatchSize;
-        this.maxInitialSplits = maxInitialSplits;
         this.splitLoaderConcurrency = splitLoaderConcurrency;
         this.recursiveDfsWalkerEnabled = recursiveDfsWalkerEnabled;
         this.cacheQuotaRequirementProvider = requireNonNull(cacheQuotaRequirementProvider, "cacheQuotaRequirementProvider is null");
@@ -305,7 +302,7 @@ public class HiveSplitManager
                         table.getDatabaseName(),
                         table.getTableName(),
                         cacheQuotaRequirement,
-                        maxInitialSplits,
+                        getHiveMaxInitialSplitSize(session),
                         maxOutstandingSplits,
                         maxOutstandingSplitsSize,
                         hiveSplitLoader,
@@ -318,7 +315,7 @@ public class HiveSplitManager
                         table.getDatabaseName(),
                         table.getTableName(),
                         cacheQuotaRequirement,
-                        maxInitialSplits,
+                        getHiveMaxInitialSplitSize(session),
                         maxOutstandingSplits,
                         maxOutstandingSplitsSize,
                         hiveSplitLoader,
@@ -331,7 +328,7 @@ public class HiveSplitManager
                         table.getDatabaseName(),
                         table.getTableName(),
                         cacheQuotaRequirement,
-                        maxInitialSplits,
+                        getHiveMaxInitialSplitSize(session),
                         maxOutstandingSplitsSize,
                         hiveSplitLoader,
                         executor,

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -993,7 +993,6 @@ public abstract class AbstractTestHiveClient
                 hiveClientConfig.getMaxOutstandingSplitsSize(),
                 hiveClientConfig.getMinPartitionBatchSize(),
                 hiveClientConfig.getMaxPartitionBatchSize(),
-                hiveClientConfig.getMaxInitialSplits(),
                 hiveClientConfig.getSplitLoaderConcurrency(),
                 false,
                 new ConfigBasedCacheQuotaRequirementProvider(cacheConfig),

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystem.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystem.java
@@ -227,7 +227,6 @@ public abstract class AbstractTestHiveFileSystem
                 config.getMaxOutstandingSplitsSize(),
                 config.getMinPartitionBatchSize(),
                 config.getMaxPartitionBatchSize(),
-                config.getMaxInitialSplits(),
                 config.getSplitLoaderConcurrency(),
                 config.getRecursiveDirWalkerEnabled(),
                 new ConfigBasedCacheQuotaRequirementProvider(cacheConfig),

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitManager.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitManager.java
@@ -526,7 +526,6 @@ public class TestHiveSplitManager
                 hiveClientConfig.getMaxOutstandingSplitsSize(),
                 hiveClientConfig.getMinPartitionBatchSize(),
                 hiveClientConfig.getMaxPartitionBatchSize(),
-                hiveClientConfig.getMaxInitialSplits(),
                 hiveClientConfig.getSplitLoaderConcurrency(),
                 false,
                 new ConfigBasedCacheQuotaRequirementProvider(new CacheConfig()),


### PR DESCRIPTION
When using fragment cache to read hive table, we find the fragment cache hit ratio is usually less than 90%. For same sql ,before the fragment cache hit ratio become to 100%, we need execute dozens of times. 

### Description
The fragment cache key is generated based on the split information. But for same sql, split generation isn't idempotent.  Because split's generation is performed on parallel processing, and splits have two type: initial splits, other splits, which have different split's size. We can't guarantee split's start&end value is fixed, this will lead to many splits can't be hit.

### Solution
we support set max initial split number in session, so that we can set max_initial_splits to 0, when using fragment cache

Test plan - (Please fill in how you tested your changes)
For sql like this:

`select count(*) from table1 group by id`

we can guarantee cache hit ratio to 100%, when we execute sql secondly.
```
== NO RELEASE NOTE ==