### PR TITLE
Add a quicker, hash-based version of distinct limit

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -220,6 +220,8 @@ public final class SystemSessionProperties
     public static final String KEY_BASED_SAMPLING_ENABLED = "key_based_sampling_enabled";
     public static final String KEY_BASED_SAMPLING_PERCENTAGE = "key_based_sampling_percentage";
     public static final String KEY_BASED_SAMPLING_FUNCTION = "key_based_sampling_function";
+    public static final String HASH_BASED_DISTINCT_LIMIT_ENABLED = "hash_based_distinct_limit_enabled";
+    public static final String HASH_BASED_DISTINCT_LIMIT_THRESHOLD = "hash_based_distinct_limit_threshold";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -1187,6 +1189,18 @@ public final class SystemSessionProperties
                         KEY_BASED_SAMPLING_FUNCTION,
                         "Sampling function for key based sampling",
                         "key_sampling_percent",
+                        false),
+                integerProperty(
+                        HASH_BASED_DISTINCT_LIMIT_THRESHOLD,
+                        "Threshold for doing hash based distinct",
+                        // 10k is a decent-sized limit that guarantees almost no collisions if the # distinct < 10k according to:
+                        //   https://stackoverflow.com/questions/22029012/probability-of-64bit-hash-code-collisions
+                        featuresConfig.getHashBasedDistinctLimitThreshold(),
+                        false),
+                booleanProperty(
+                        HASH_BASED_DISTINCT_LIMIT_ENABLED,
+                        "Hash based distinct limit enabled",
+                        featuresConfig.isHashBasedDistinctLimitEnabled(),
                         false));
     }
 
@@ -1223,6 +1237,16 @@ public final class SystemSessionProperties
     public static String getKeyBasedSamplingFunction(Session session)
     {
         return session.getSystemProperty(KEY_BASED_SAMPLING_FUNCTION, String.class);
+    }
+
+    public static boolean isHashBasedDistinctLimitEnabled(Session session)
+    {
+        return session.getSystemProperty(HASH_BASED_DISTINCT_LIMIT_ENABLED, Boolean.class);
+    }
+
+    public static int getHashBasedDistinctLimitThreshold(Session session)
+    {
+        return session.getSystemProperty(HASH_BASED_DISTINCT_LIMIT_THRESHOLD, Integer.class);
     }
 
     public List<PropertyMetadata<?>> getSessionProperties()

--- a/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
@@ -335,6 +335,7 @@ import static com.facebook.presto.operator.scalar.JsonStringToRowCast.JSON_STRIN
 import static com.facebook.presto.operator.scalar.JsonToArrayCast.JSON_TO_ARRAY;
 import static com.facebook.presto.operator.scalar.JsonToMapCast.JSON_TO_MAP;
 import static com.facebook.presto.operator.scalar.JsonToRowCast.JSON_TO_ROW;
+import static com.facebook.presto.operator.scalar.KDistinct.K_DISTINCT;
 import static com.facebook.presto.operator.scalar.Least.LEAST;
 import static com.facebook.presto.operator.scalar.MapConcatFunction.MAP_CONCAT_FUNCTION;
 import static com.facebook.presto.operator.scalar.MapConstructor.MAP_CONSTRUCTOR;
@@ -825,6 +826,7 @@ public class BuiltInTypeAndFunctionNamespaceManager
                 .functions(MAP_TRANSFORM_KEY_FUNCTION, MAP_TRANSFORM_VALUE_FUNCTION)
                 .function(TRY_CAST)
                 .function(APPROXIMATE_MOST_FREQUENT)
+                .function(K_DISTINCT)
                 .aggregate(MergeSetDigestAggregation.class)
                 .aggregate(BuildSetDigestAggregation.class)
                 .scalars(SetDigestFunctions.class)

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/KDistinct.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/KDistinct.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.annotation.UsedByGeneratedCode;
+import com.facebook.presto.common.QualifiedObjectName;
+import com.facebook.presto.metadata.BoundVariables;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.metadata.SqlScalarFunction;
+import com.facebook.presto.spi.function.FunctionKind;
+import com.facebook.presto.spi.function.Signature;
+import com.facebook.presto.spi.function.SqlFunctionVisibility;
+import com.facebook.presto.sql.gen.lambda.BinaryFunctionInterface;
+import com.google.common.collect.ImmutableList;
+import it.unimi.dsi.fastutil.longs.LongArraySet;
+
+import java.lang.invoke.MethodHandle;
+import java.util.Optional;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.metadata.BuiltInTypeAndFunctionNamespaceManager.DEFAULT_NAMESPACE;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementationChoice.ArgumentProperty.functionTypeArgumentProperty;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementationChoice.ArgumentProperty.valueTypeArgumentProperty;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementationChoice.NullConvention.RETURN_NULL_ON_NULL;
+import static com.facebook.presto.spi.function.SqlFunctionVisibility.HIDDEN;
+import static com.facebook.presto.util.Reflection.methodHandle;
+
+public final class KDistinct
+        extends SqlScalarFunction
+{
+    public static final KDistinct K_DISTINCT = new KDistinct();
+    private static final MethodHandle STATE_FACTORY = methodHandle(KDistinct.class, "createState");
+
+    private KDistinct()
+    {
+        super(new Signature(
+                QualifiedObjectName.valueOf(DEFAULT_NAMESPACE, "k_distinct"),
+                FunctionKind.SCALAR,
+                ImmutableList.of(),
+                ImmutableList.of(),
+                BOOLEAN.getTypeSignature(),
+                ImmutableList.of(BIGINT.getTypeSignature(), BIGINT.getTypeSignature()),
+                false));
+    }
+
+    @Override
+    public SqlFunctionVisibility getVisibility()
+    {
+        return HIDDEN;
+    }
+
+    @Override
+    public boolean isDeterministic()
+    {
+        return false;
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "Returns true for the first K distinct hash values updating the state if it's not already in";
+    }
+
+    @Override
+    public BuiltInScalarFunctionImplementation specialize(BoundVariables boundVariables, int arity, FunctionAndTypeManager functionAndTypeManager)
+    {
+        return new BuiltInScalarFunctionImplementation(
+                false,
+                ImmutableList.of(
+                        valueTypeArgumentProperty(RETURN_NULL_ON_NULL),
+                        functionTypeArgumentProperty(BinaryFunctionInterface.class)),
+                methodHandle(KDistinct.class, "addKey", Object.class, long.class, long.class),
+                Optional.of(methodHandle(KDistinct.class, "createState")));
+    }
+
+    @UsedByGeneratedCode
+    public static boolean addKey(Object state, long hash, long k)
+    {
+        State currentState = (State) state;
+        if (currentState.longArraySet != null) {
+            if (currentState.longArraySet.size() == k) {
+                return false;
+            }
+        }
+        else {
+            currentState.longArraySet = new LongArraySet(new long[(int) k]);
+        }
+
+        return currentState.longArraySet.add(hash);
+    }
+
+    @UsedByGeneratedCode
+    public static Object createState()
+    {
+        return new State();
+    }
+
+    private static class State
+    {
+        public LongArraySet longArraySet;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -210,6 +210,8 @@ public class FeaturesConfig
     private boolean queryOptimizationWithMaterializedViewEnabled;
     private AggregationIfToFilterRewriteStrategy aggregationIfToFilterRewriteStrategy = AggregationIfToFilterRewriteStrategy.DISABLED;
     private boolean verboseRuntimeStatsEnabled;
+    private boolean hashBasedDistinctLimitEnabled;
+    private int hashBasedDistinctLimitThreshold = 10000;
 
     public enum PartitioningPrecisionStrategy
     {
@@ -1886,5 +1888,31 @@ public class FeaturesConfig
     {
         this.aggregationIfToFilterRewriteStrategy = strategy;
         return this;
+    }
+
+    public boolean isHashBasedDistinctLimitEnabled()
+    {
+        return hashBasedDistinctLimitEnabled;
+    }
+
+    @Config("hash-based-distinct-limit-enabled")
+    @ConfigDescription("Enable fast hash-based distinct limit")
+    public FeaturesConfig setHashBasedDistinctLimitEnabled(boolean hashBasedDistinctLimitEnabled)
+    {
+        this.hashBasedDistinctLimitEnabled = hashBasedDistinctLimitEnabled;
+        return this;
+    }
+
+    @Config("hash-based-distinct-limit-threshold")
+    @ConfigDescription("Threshold for fast hash-based distinct limit")
+    public FeaturesConfig setHashBasedDistinctLimitThreshold(int hashBasedDistinctLimitThreshold)
+    {
+        this.hashBasedDistinctLimitThreshold = hashBasedDistinctLimitThreshold;
+        return this;
+    }
+
+    public int getHashBasedDistinctLimitThreshold()
+    {
+        return hashBasedDistinctLimitThreshold;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -118,6 +118,7 @@ import com.facebook.presto.sql.planner.optimizations.AddExchanges;
 import com.facebook.presto.sql.planner.optimizations.AddLocalExchanges;
 import com.facebook.presto.sql.planner.optimizations.ApplyConnectorOptimization;
 import com.facebook.presto.sql.planner.optimizations.CheckSubqueryNodesAreRewritten;
+import com.facebook.presto.sql.planner.optimizations.HashBasedPartialDistinctLimit;
 import com.facebook.presto.sql.planner.optimizations.HashGenerationOptimizer;
 import com.facebook.presto.sql.planner.optimizations.ImplementIntersectAndExceptAsUnion;
 import com.facebook.presto.sql.planner.optimizations.IndexJoinOptimizer;
@@ -623,6 +624,10 @@ public class PlanOptimizers
 
         // Precomputed hashes - this assumes that partitioning will not change
         builder.add(new HashGenerationOptimizer(metadata.getFunctionAndTypeManager()));
+
+        // Add some opportunistic optimizations for queries with limit to utilize precomputed hash from the previous step
+        builder.add(new HashBasedPartialDistinctLimit(metadata.getFunctionAndTypeManager()));
+
         builder.add(new MetadataDeleteOptimizer(metadata));
 
         // TODO: consider adding a formal final plan sanitization optimizer that prepares the plan for transmission/execution/logging

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HashBasedPartialDistinctLimit.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HashBasedPartialDistinctLimit.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.plan.DistinctLimitNode;
+import com.facebook.presto.spi.plan.FilterNode;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.PlanVariableAllocator;
+import com.facebook.presto.sql.planner.TypeProvider;
+import com.facebook.presto.sql.planner.plan.SimplePlanRewriter;
+
+import static com.facebook.presto.SystemSessionProperties.getHashBasedDistinctLimitThreshold;
+import static com.facebook.presto.SystemSessionProperties.isHashBasedDistinctLimitEnabled;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.sql.planner.plan.SimplePlanRewriter.rewriteWith;
+import static com.facebook.presto.sql.relational.Expressions.call;
+import static com.facebook.presto.sql.relational.Expressions.constant;
+
+public class HashBasedPartialDistinctLimit
+        implements PlanOptimizer
+{
+    private final FunctionAndTypeManager functionAndTypeManager;
+
+    public HashBasedPartialDistinctLimit(FunctionAndTypeManager functionAndTypeManager)
+    {
+        this.functionAndTypeManager = functionAndTypeManager;
+    }
+
+    @Override
+    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, PlanVariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    {
+        if (isHashBasedDistinctLimitEnabled(session)) {
+            return rewriteWith(new Rewriter(session, idAllocator, variableAllocator, functionAndTypeManager), plan, null);
+        }
+
+        return plan;
+    }
+
+    private static class Rewriter
+            extends SimplePlanRewriter<Void>
+    {
+        private final Session session;
+        private final PlanNodeIdAllocator idAllocator;
+        private final PlanVariableAllocator variableAllocator;
+        private final FunctionAndTypeManager functionAndTypeManager;
+
+        private Rewriter(Session session, PlanNodeIdAllocator idAllocator, PlanVariableAllocator variableAllocator, FunctionAndTypeManager functionAndTypeManager)
+        {
+            this.session = session;
+            this.idAllocator = idAllocator;
+            this.variableAllocator = variableAllocator;
+            this.functionAndTypeManager = functionAndTypeManager;
+        }
+
+        @Override
+        public PlanNode visitDistinctLimit(DistinctLimitNode node, RewriteContext<Void> context)
+        {
+            if (node.isPartial() && node.getLimit() <= getHashBasedDistinctLimitThreshold(session)) {
+                VariableReferenceExpression hashVariable;
+
+                if (node.getHashVariable().isPresent()) {
+                    hashVariable = node.getHashVariable().get();
+                }
+                else if (node.getDistinctVariables().size() == 1 && node.getDistinctVariables().get(0).getType() == BIGINT) {
+                    // see if this is a distinct on single long variable for which we don't optimize hash
+                    hashVariable = node.getDistinctVariables().get(0);
+                }
+                else {
+                    return node;
+                }
+
+                return new FilterNode(
+                        node.getSourceLocation(),
+                        idAllocator.getNextId(),
+                        node.getSource(),
+                        call(functionAndTypeManager, "k_distinct", BIGINT, hashVariable, constant(node.getLimit(), BIGINT)));
+            }
+
+            return context.defaultRewrite(node);
+        }
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -182,7 +182,9 @@ public class TestFeaturesConfig
                 .setMaterializedViewDataConsistencyEnabled(true)
                 .setQueryOptimizationWithMaterializedViewEnabled(false)
                 .setVerboseRuntimeStatsEnabled(false)
-                .setAggregationIfToFilterRewriteStrategy(AggregationIfToFilterRewriteStrategy.DISABLED));
+                .setAggregationIfToFilterRewriteStrategy(AggregationIfToFilterRewriteStrategy.DISABLED)
+                .setHashBasedDistinctLimitEnabled(false)
+                .setHashBasedDistinctLimitThreshold(10000));
     }
 
     @Test
@@ -316,6 +318,8 @@ public class TestFeaturesConfig
                 .put("query-optimization-with-materialized-view-enabled", "true")
                 .put("verbose-runtime-stats-enabled", "true")
                 .put("optimizer.aggregation-if-to-filter-rewrite-strategy", "filter_with_if")
+                .put("hash-based-distinct-limit-enabled", "true")
+                .put("hash-based-distinct-limit-threshold", "500")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -446,7 +450,9 @@ public class TestFeaturesConfig
                 .setMaterializedViewDataConsistencyEnabled(false)
                 .setQueryOptimizationWithMaterializedViewEnabled(true)
                 .setVerboseRuntimeStatsEnabled(true)
-                .setAggregationIfToFilterRewriteStrategy(AggregationIfToFilterRewriteStrategy.FILTER_WITH_IF);
+                .setAggregationIfToFilterRewriteStrategy(AggregationIfToFilterRewriteStrategy.FILTER_WITH_IF)
+                .setHashBasedDistinctLimitEnabled(true)
+                .setHashBasedDistinctLimitThreshold(500);
         assertFullMapping(properties, expected);
     }
 


### PR DESCRIPTION
Added a quicker version of partial distinct limit based on hashes for reducing latency. This eliminates the DistinctLimitPartial node type and instead uses a filter using a stateful filter function that just keeps the N distinct hashes and filters out everything after it reaches the limit or if a hash is already seen.

It maybe slightly inaccurate when there are hash collisions but for adhoc quick data exploration this will be good as the user doesn't have to wait hours to see the values.

Fixes #17196 

Test plan - Tests already exist

```
== RELEASE NOTES ==

General Changes
* We now have a faster version of distinct limit N queries for N <= 10000 that uses distinct hashes for quicker results to handle common situations where there are a few dozen distinct values in large datasets. This feature can be enabled by session param: hash_based_distinct_limit_enabled and the limit (default 1000) can be adjusted using: hash_based_distinct_limit_threashold.
```

