### PR TITLE
Prohibit LIMIT clause in materialized views

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveLogicalPlanner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveLogicalPlanner.java
@@ -2506,6 +2506,26 @@ public class TestHiveLogicalPlanner
     }
 
     @Test
+    public void testMaterializedViewWithLimit()
+    {
+        QueryRunner queryRunner = getQueryRunner();
+        String view = "view_with_limit";
+        String table = "t1_with_limit";
+
+        try {
+            queryRunner.execute(format("CREATE TABLE %s WITH (partitioned_by = ARRAY['ds']) AS SELECT 1 as a, '2020-01-01' as ds", table));
+
+            assertQueryFails(format("CREATE MATERIALIZED VIEW %s WITH (partitioned_by = ARRAY['ds']) " +
+                            "AS SELECT a, ds FROM %s t1 LIMIT 10000", view, table),
+                    ".*LIMIT clause in materialized view is not supported.*");
+        }
+        finally {
+            queryRunner.execute("DROP MATERIALIZED VIEW IF EXISTS " + view);
+            queryRunner.execute("DROP TABLE IF EXISTS " + table);
+        }
+    }
+
+    @Test
     public void testMaterializedViewForLeftOuterJoin()
     {
         QueryRunner queryRunner = getQueryRunner();

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewPlanValidator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewPlanValidator.java
@@ -21,6 +21,7 @@ import com.facebook.presto.sql.tree.JoinCriteria;
 import com.facebook.presto.sql.tree.JoinOn;
 import com.facebook.presto.sql.tree.LogicalBinaryExpression;
 import com.facebook.presto.sql.tree.Query;
+import com.facebook.presto.sql.tree.QuerySpecification;
 import com.facebook.presto.sql.tree.SubqueryExpression;
 import com.facebook.presto.sql.tree.Table;
 import com.facebook.presto.sql.tree.Unnest;
@@ -58,6 +59,24 @@ public class MaterializedViewPlanValidator
         }
 
         return super.visitTable(node, context);
+    }
+
+    @Override
+    protected Void visitQuery(Query node, MaterializedViewPlanValidatorContext context)
+    {
+        if (node.getLimit().isPresent()) {
+            throw new SemanticException(NOT_SUPPORTED, node, "LIMIT clause in materialized view is not supported.");
+        }
+        return super.visitQuery(node, context);
+    }
+
+    @Override
+    protected Void visitQuerySpecification(QuerySpecification node, MaterializedViewPlanValidatorContext context)
+    {
+        if (node.getLimit().isPresent()) {
+            throw new SemanticException(NOT_SUPPORTED, node, "LIMIT clause in materialized view is not supported.");
+        }
+        return super.visitQuerySpecification(node, context);
     }
 
     @Override


### PR DESCRIPTION
LIMIT clauses can create confusion in materialized view queries as limits as refreshing multiple partitions at once can lead to inconsistencies. Lets prohibit them altogether.

Example MV: SELECT a, ds from table limit 10000;

What users usually mean is they want 10000 elements per ds, but

REFRESH MV where ds = today
and
REFRESH MV where ds >= yesterday

will have different number of rows for ds=today

```
== NO RELEASE NOTE ==
```
