### PR TITLE
Remove iceberg supported testing placeholders

### DIFF
--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergDistributed.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergDistributed.java
@@ -46,37 +46,13 @@ public class TestIcebergDistributed
         return false;
     }
 
-    public void testJoinWithLessThanOnDatesInJoinClause()
-    {
-    }
-
     @Override
     public void testRenameTable()
     {
     }
 
     @Override
-    public void testAddColumn()
-    {
-    }
-
-    @Override
     public void testRenameColumn()
-    {
-    }
-
-    @Override
-    public void testDropColumn()
-    {
-    }
-
-    @Override
-    public void testInsert()
-    {
-    }
-
-    @Override
-    public void testCreateTable()
     {
     }
 
@@ -112,11 +88,6 @@ public class TestIcebergDistributed
 
     @Override
     public void testDescribeOutputNamedAndUnnamed()
-    {
-    }
-
-    @Override
-    public void testWrittenStats()
     {
     }
 }


### PR DESCRIPTION
There are some tests we have supported in the presto-iceberg connector. But previously we override them with empty placeholders. This PR removes these placeholders to run the tests.

Test plan - Unit tests

```
== NO RELEASE NOTE ==
```
