### PR TITLE
Pinot connector: Fixing extra grpc metadata config

### DIFF
--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotSegmentStreamingPageSource.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotSegmentStreamingPageSource.java
@@ -139,7 +139,7 @@ public class PinotSegmentStreamingPageSource
                 .setSegments(split.getSegments())
                 .setEnableStreaming(true)
                 .setBrokerId("presto-coordinator-grpc")
-                .addExtraMetadata(pinotConfig.getExtraHttpHeaders())
+                .addExtraMetadata(pinotConfig.getExtraGrpcMetadata())
                 .setSql(sql);
         if (pinotConfig.isUseProxyGrpcEndpoint()) {
             grpcRequestBuilder.setHostName(grpcHost).setPort(grpcPort);


### PR DESCRIPTION
I was using a wrong config.

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```
