### PR TITLE
Upgrade Joda version to 2.10.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <dep.drift.version>1.33</dep.drift.version>
         <!-- Changing joda version changes tzdata which must match deployed JVM tzdata
              Do not change this without also making sure it matches -->
-        <dep.joda.version>2.10.8</dep.joda.version>
+        <dep.joda.version>2.10.13</dep.joda.version>
         <dep.tempto.version>1.51</dep.tempto.version>
         <dep.testng.version>6.10</dep.testng.version>
         <dep.assertj-core.version>3.8.0</dep.assertj-core.version>

--- a/presto-common/src/main/resources/com/facebook/presto/common/type/zone-index.properties
+++ b/presto-common/src/main/resources/com/facebook/presto/common/type/zone-index.properties
@@ -2237,3 +2237,4 @@
 2228 Europe/Saratov
 2229 Asia/Qostanay
 2230 America/Nuuk
+2231 Pacific/Kanton

--- a/presto-common/src/test/java/com/facebook/presto/common/type/TestTimeZoneKey.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/type/TestTimeZoneKey.java
@@ -216,7 +216,7 @@ public class TestTimeZoneKey
             hasher.putString(timeZoneKey.getId(), StandardCharsets.UTF_8);
         }
         // Zone file should not (normally) be changed, so let's make this more difficult
-        assertEquals(hasher.hash().asLong(), 6334606028834602490L, "zone-index.properties file contents changed!");
+        assertEquals(hasher.hash().asLong(), -2665680993684804317L, "zone-index.properties file contents changed!");
     }
 
     public void assertTimeZoneNotSupported(String zoneId)

--- a/presto-main/src/test/java/com/facebook/presto/util/TestTimeZoneUtils.java
+++ b/presto-main/src/test/java/com/facebook/presto/util/TestTimeZoneUtils.java
@@ -67,12 +67,15 @@ public class TestTimeZoneUtils
                 continue;
             }
 
-            if (zoneId.equals("Pacific/Kanton")) {
-                // TODO: remove Once Joda version supports this Timezone.
-                // JDK supported this timezone, but not Joda and was resulting in the test failure.
-                // https://www.joda.org/joda-time/timezones.html
+            if (zoneId.equals("Pacific/Enderbury")) {
+                // Pacific/Enderbury is mapped to Pacific/Kanton
+                // Pacific/Kanton is only available in newer JDKs. This will pass
+                // in the CI machines, but all developers need to upgrade to newer JDK
+                // for the tests to pass.
                 continue;
             }
+
+            System.out.println("Processing timeZone " + zoneId);
 
             DateTimeZone dateTimeZone = DateTimeZone.forID(zoneId);
             DateTimeZone indexedZone = getDateTimeZone(TimeZoneKey.getTimeZoneKey(zoneId));


### PR DESCRIPTION
In newer timezone database, pacific/Enderbury is mapped to Pacific/Kanton
Pacific/Kanton is not supported by older version of JDK. So instead of
forcing all developers to use newer JDK in their development platform
I am adding a workaround to disable the tests.

Note: If any of the presto production use cases, have time zones saved
in pacific/Enderbury, they need to upgrade their version of JDK used
for presto to work correctly as well.

Test plan - 
Existing tests.

```
== NO RELEASE NOTE ==
```
