### PR TITLE
Pass credentials in SqlFunctionProperties

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/function/SqlFunctionProperties.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/function/SqlFunctionProperties.java
@@ -16,8 +16,11 @@ package com.facebook.presto.common.function;
 import com.facebook.presto.common.type.TimeZoneKey;
 
 import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 
+import static java.util.Collections.emptyMap;
+import static java.util.Collections.unmodifiableMap;
 import static java.util.Objects.requireNonNull;
 
 public class SqlFunctionProperties
@@ -31,6 +34,7 @@ public class SqlFunctionProperties
     private final long sessionStartTime;
     private final Locale sessionLocale;
     private final String sessionUser;
+    private final Map<String, String> extraCredentials;
 
     private SqlFunctionProperties(
             boolean parseDecimalLiteralAsDouble,
@@ -41,7 +45,8 @@ public class SqlFunctionProperties
             boolean legacyMapSubscript,
             long sessionStartTime,
             Locale sessionLocale,
-            String sessionUser)
+            String sessionUser,
+            Map<String, String> extraCredentials)
     {
         this.parseDecimalLiteralAsDouble = parseDecimalLiteralAsDouble;
         this.legacyRowFieldOrdinalAccessEnabled = legacyRowFieldOrdinalAccessEnabled;
@@ -52,6 +57,7 @@ public class SqlFunctionProperties
         this.sessionStartTime = sessionStartTime;
         this.sessionLocale = requireNonNull(sessionLocale, "sessionLocale is null");
         this.sessionUser = requireNonNull(sessionUser, "sessionUser is null");
+        this.extraCredentials = requireNonNull(extraCredentials, "extraCredentials is null");
     }
 
     public boolean isParseDecimalLiteralAsDouble()
@@ -100,6 +106,11 @@ public class SqlFunctionProperties
         return sessionUser;
     }
 
+    public Map<String, String> getExtraCredentials()
+    {
+        return extraCredentials;
+    }
+
     @Override
     public boolean equals(Object o)
     {
@@ -114,13 +125,17 @@ public class SqlFunctionProperties
                 Objects.equals(legacyRowFieldOrdinalAccessEnabled, that.legacyRowFieldOrdinalAccessEnabled) &&
                 Objects.equals(timeZoneKey, that.timeZoneKey) &&
                 Objects.equals(legacyTimestamp, that.legacyTimestamp) &&
-                Objects.equals(legacyMapSubscript, that.legacyMapSubscript);
+                Objects.equals(legacyMapSubscript, that.legacyMapSubscript) &&
+                Objects.equals(sessionStartTime, that.sessionStartTime) &&
+                Objects.equals(sessionLocale, that.sessionLocale) &&
+                Objects.equals(sessionUser, that.sessionUser) &&
+                Objects.equals(extraCredentials, that.extraCredentials);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(parseDecimalLiteralAsDouble, legacyRowFieldOrdinalAccessEnabled, timeZoneKey, legacyTimestamp, legacyMapSubscript);
+        return Objects.hash(parseDecimalLiteralAsDouble, legacyRowFieldOrdinalAccessEnabled, timeZoneKey, legacyTimestamp, legacyMapSubscript, sessionStartTime, sessionLocale, sessionUser, extraCredentials);
     }
 
     public static Builder builder()
@@ -139,6 +154,7 @@ public class SqlFunctionProperties
         private long sessionStartTime;
         private Locale sessionLocale;
         private String sessionUser;
+        private Map<String, String> extraCredentials = emptyMap();
 
         private Builder() {}
 
@@ -196,9 +212,15 @@ public class SqlFunctionProperties
             return this;
         }
 
+        public Builder setExtraCredentials(Map<String, String> extraCredentials)
+        {
+            this.extraCredentials = unmodifiableMap(extraCredentials);
+            return this;
+        }
+
         public SqlFunctionProperties build()
         {
-            return new SqlFunctionProperties(parseDecimalLiteralAsDouble, legacyRowFieldOrdinalAccessEnabled, legacyTypeCoercionWarningEnabled, timeZoneKey, legacyTimestamp, legacyMapSubscript, sessionStartTime, sessionLocale, sessionUser);
+            return new SqlFunctionProperties(parseDecimalLiteralAsDouble, legacyRowFieldOrdinalAccessEnabled, legacyTypeCoercionWarningEnabled, timeZoneKey, legacyTimestamp, legacyMapSubscript, sessionStartTime, sessionLocale, sessionUser, extraCredentials);
         }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/Session.java
+++ b/presto-main/src/main/java/com/facebook/presto/Session.java
@@ -475,6 +475,7 @@ public final class Session
                 .setSessionStartTime(getStartTime())
                 .setSessionLocale(getLocale())
                 .setSessionUser(getUser())
+                .setExtraCredentials(identity.getExtraCredentials())
                 .build();
     }
 


### PR DESCRIPTION
Add extraCredentials to SqlFunctionProperties. UDFs can use this information to access security credentials for the user

```
== NO RELEASE NOTE ==
```
