### PR TITLE
Add release notes for 0.269

### DIFF
--- a/presto-docs/src/main/sphinx/release.rst
+++ b/presto-docs/src/main/sphinx/release.rst
@@ -5,6 +5,7 @@ Release Notes
 .. toctree::
     :maxdepth: 1
 
+    release/release-0.269
     release/release-0.268
     release/release-0.267
     release/release-0.266

--- a/presto-docs/src/main/sphinx/release/release-0.269.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.269.rst
@@ -1,0 +1,32 @@
+=============
+Release 0.269
+=============
+
+**Details**
+===========
+
+General Changes
+_______________
+* Add :func:`uuid` to return a unique identifier.
+
+Presto on Spark Changes
+_______________________
+* Add configuration property ``spark.memory-revoking-target`` and session property ``spark_memory_revoking_target`` to specify the occupancy percent of memory pool after revoke is completed.
+
+Accumulo Connector Changes
+__________________________
+* Replace :func:`uuid` from being connector specific to a standard function. In the process the return type has been changed from ``VARCHAR`` to ``UUID`` and existing use cases might need to perform a cast - ``CAST(UUID() AS VARCHAR)``.
+
+Delta Lake Connector Changes
+_____________________________
+* Add :doc:`/connector/deltalake` for reading Delta Lake tables (https://delta.io/) natively in Presto.
+
+Iceberg Connector Changes
+_________________________
+* Add Iceberg table predicate pushdown to reduce the number of files scanned.
+
+
+**Credits**
+===========
+
+Ajay George, Andrii Rosa, Arjun Gupta, Arunachalam Thirupathi, Basil Crow, Beinan Wang, Costin V Cozianu, James Sun, Pranjal Shankhdhar, Sagar Sumit, Swapnil Tailor, Timothy Meehan, Venki Korukanti, Xiang Fu, Ying Su, Zhenxiao Luo, ericyuliu, sambekar15, singcha, v-jizhang


### PR DESCRIPTION
# Missing Release Notes

# Extracted Release Notes
- #16843 (Author: Venki Korukanti): Delta lake connector - Reader
  - New connector for reading [Delta Lake tables](https://delta.io/) natively in Presto.
- #16964 (Author: Beinan Wang): Support iceberg table filter pushdown
  - Add Iceberg table predicate pushdown to reduce the number of files scanned.
- #17167 (Author: Arjun Gupta): Introduce memory-revoking-target concept in PoS revoking logic
  - Add a new configuration property ``spark.memory-revoking-target`` to specify the percent to which memory pool should be occupied after revoke is completed.  This can be overridden by ``spark_memory_revoking_target`` session property.
- #17174 (Author: v-jizhang): Add JDBC URL parameter for MySQL
  - Add JDBC URL parameter doc for MySQL.
  - ...
- #17189 (Author: Xiang Fu): [Pinot Connector] Adding Pinot session config `pinot.topn_large`
  - Adding Pinot session property `pinot.topn_large` to override the default topN value.
- #17202 (Author: ericyuliu): make UUID() a standard function
  - Add :func:`uuid` to return a unique identifier.
  - Replace :func:`uuid` from being connector specific to a standard function. In the process the return type has been changed from ``VARCHAR`` to ``UUID`` and existing use cases might need to perform a cast - ``CAST(UUID() AS VARCHAR)``.

# All Commits
- 669a5ddcb76b3dd04feb19fc0675e97da339c058 make UUID() a standard function (ericyuliu)
- 3ea2ac2312c8466c33fc926e19950f449f3b79f5 Use segmented arrays for row group indexes (Arunachalam Thirupathi)
- f24ffa7bc6e1cf4364081a03d8f26f3472b9766b Refactor DictionaryRowGroup to top level class (Arunachalam Thirupathi)
- f7f03f3601df11d87ab3aa2f86dd6257510e7233 Reduce dictionary row group size (Arunachalam Thirupathi)
- a1fc5110d816205c4ab129aa3b0e40374f83dc0e Reduce Slice Dictionary Memory usage (Arunachalam Thirupathi)
- 5424a61b29d582bf161913276c53f118fbbf287a Adjust buffered bytes calculation in ORC dictionary (Arunachalam Thirupathi)
- d2053572d141a0e8b8c640c9ce007432109d422e Fix the TimeZone test failures (Arunachalam Thirupathi)
- e54c446546c781ce7456fd5ad7ba5a1159ddb8e3 Wrap the Delta connector classes in classloader safe classes (Venki Korukanti)
- 2dca5c6ee9f31efade53edd65728768565697c30 adding session config for topn-large (Xiang Fu)
- b5513ea602c5c43147e8a293a99f4b947a636bdd Adding pinot configs to docs (Xiang Fu)
- b0238046732314f1d54c1f2eec30f33ca0a88ee7 Add presto query id to SparkContext config (singcha)
- b2b2a2c5e90d861e4f32f79686ee61770e6deb02 Fix the average row size calculation in the ORC reader (Arunachalam Thirupathi)
- 5f9d59ef6bf4531c0115d1345c5abdd21d1ec59f TLS example should show port 8443 (v-jizhang)
- 376552cf07e7728544c0178b8310cb2a91084086 Enable filter pushdown for parquet (Ying Su)
- 4a5a4452a45cc39ec4f9e6b68865eae6d6b58798 Introduce parquet_pushdown_filter_enabled session property (Ying Su)
- 352b461c7fdab9cf3b66aa404e14b064f570596d Add JDBC URL parameter for MySQL (v-jizhang)
- d179ac5e8ab351d545b41c2463fcdb85761d61bd Introduce memory-revoking-target concept in PoS revoking logic (Arjun Gupta)
- 07b1cc64a88c038d8c2f03195fb75ac430f92b15 Fix compilation error in IcebergPlanOptimizer (Zhenxiao Luo)
- dd83cece9fef39192d1972b8611de045de6cc83c Add bytecode util to write primitive values with implicit casts (Pranjal Shankhdhar)
- 77a39a829834a432526ba078f975193148f5c376 Use RoundingMode in preference to the legacy method (Ajay George)
- f3fc08268d41e7afb0079a71b31fc62e7284362e Use putAll instead of iterate and put (Ajay George)
- 99748b79827022e9633103ee8948cd48b466a241 Support iceberg table filter pushdown (Beinan Wang)
- 8ac456f6b0e51fa118e5c711b29536716dd54fb0 Provide ddl support (sambekar15)
- 37bd73aaeebd2f05437dcd43889b5cdb947f1ee5 Use diamond operator where possible (Basil Crow)
- b91e66cb37e0168ce6bce9bdfde98429dbcc68a9 Fixing flaky distrubuted queue test (Swapnil Tailor)
- 1954589483373b949b51e3f73dd47c5686db2265 Revert "Improve listing performance of Hudi tables" (Costin V Cozianu)
- 34c9c44ef4816a6b6505d7b6e502c50623374465 Refactor Delta lake connector tests to remove the flakiness (Venki Korukanti)
- 07bad172ea595a34aaf4341f6e799c4a8b3629cd Add Delta Lake connector docs (Venki Korukanti)
- bc31bb19db6e2214ea608996656cdb802d7c278e Support nested column project and filter pushdown in Delta reader (Venki Korukanti)
- a886809fcfb58e3c02c353c9e06ae20726aa3c6a Refactor Hive Parquet dereference pushdown optimizer rule (Venki Korukanti)
- 47e8536290f4b0f25f2f96b96cff65029b1d24ec Support filter pushdown and partition pruning (Venki Korukanti)
- eaf7f82c6ab64d657ca914f87a4662a726eed25d Support reading partitioned Delta tables (Venki Korukanti)
- 51b7675267f3646005de3e2df67042cd565fcf5b Initial Delta connector with basic integration tests (Venki Korukanti)
- cf2d314d3fc31b281a5103be9d0cd4e833c56839 Add test Delta tables (Venki Korukanti)
- 4a1a6c3f140a0261b84e548a984500767719ea74 Expose nested BlockBuilders for nested types (Arunachalam Thirupathi)
- 070c9954e342f83d6854586c2cd08db9eaf6de3b Improve listing performance of Hudi tables (Sagar Sumit)