### PR TITLE
Fix typo and remove non existence system memory pool in jmx doc

### DIFF
--- a/presto-docs/src/main/sphinx/connector/jmx.rst
+++ b/presto-docs/src/main/sphinx/connector/jmx.rst
@@ -31,17 +31,27 @@ To enable periodical dumps, define the following properties:
     jmx.max-entries=86400
 
 ``dump-tables`` is a comma separated list of Managed Beans (MBean). It specifies
-which MBeans will be sampled and stored in memory every ``dump-period``.
-History will have limited size of ``max-entries`` of entries. Both ``dump-period``
-and ``max-entries`` have default values of ``10s`` and ``86400`` accordingly.
+which MBeans are sampled and stored in memory every ``dump-period``. You can
+configure the maximum number of history entries with ``max-entries`` and it
+defaults to ``86400``. The time between dumps can be configured using
+``dump-period`` and it defaults to ``10s``.
 
-Commas in MBean names should be escaped in the following manner:
+Commas in MBean names must be escaped using double backslashes (``\\``) in the
+following manner:
+
+.. code-block:: text
+
+    connector.name=jmx
+    jmx.dump-tables=com.facebook.presto.memory:name=general\\,type=memorypool,com.facebook.presto.memory:name=reserved\\,type=memorypool
+
+Double backslashes are required because a single backslash (``\``) is used to
+split the value across multiple lines in the following manner:
 
 .. code-block:: none
 
     connector.name=jmx
     jmx.dump-tables=com.facebook.presto.memory:name=general\\,type=memorypool,\
-       com.facebook.presto.memory:name=reserved\\,type=memorypool
+        com.facebook.presto.memory:name=reserved\\,type=memorypool
 
 Querying JMX
 ------------

--- a/presto-docs/src/main/sphinx/connector/jmx.rst
+++ b/presto-docs/src/main/sphinx/connector/jmx.rst
@@ -40,9 +40,8 @@ Commas in MBean names should be escaped in the following manner:
 .. code-block:: none
 
     connector.name=jmx
-    jmx.dump-tables=com.facebook.presto.memory:type=memorypool\\,name=general,\
-       com.facebook.presto.memory:type=memorypool\\,name=system,\
-       com.facebook.presto.memory:type=memorypool\\,name=reserved
+    jmx.dump-tables=com.facebook.presto.memory:name=general\\,type=memorypool,\
+       com.facebook.presto.memory:name=reserved\\,type=memorypool
 
 Querying JMX
 ------------


### PR DESCRIPTION
Cherry-pick of https://github.com/trinodb/trino/pull/1110 and https://github.com/trinodb/trino/pull/8367

```
== NO RELEASE NOTE ==
```
