### PR TITLE
Reduce hadoop configuration construction time

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveHdfsConfiguration.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveHdfsConfiguration.java
@@ -61,8 +61,7 @@ public class HiveHdfsConfiguration
             return hadoopConfiguration.get();
         }
 
-        Configuration config = new Configuration(false);
-        copy(hadoopConfiguration.get(), config);
+        Configuration config = new Configuration(hadoopConfiguration.get());
         for (DynamicConfigurationProvider provider : dynamicProviders) {
             provider.updateConfiguration(config, context, uri);
         }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/cache/HiveCachingHdfsConfiguration.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/cache/HiveCachingHdfsConfiguration.java
@@ -34,7 +34,6 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.function.BiFunction;
 
-import static com.facebook.presto.hive.util.ConfigurationUtils.copy;
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
@@ -80,10 +79,7 @@ public class HiveCachingHdfsConfiguration
             catch (IOException e) {
                 throw new PrestoException(GENERIC_INTERNAL_ERROR, "cannot create caching file system", e);
             }
-        });
-        Configuration defaultConfig = hiveHdfsConfiguration.getConfiguration(context, uri);
-
-        copy(defaultConfig, config);
+        }, hiveHdfsConfiguration.getConfiguration(context, uri));
         return config;
     }
 
@@ -93,9 +89,9 @@ public class HiveCachingHdfsConfiguration
     {
         private final BiFunction<Configuration, URI, FileSystem> factory;
 
-        private CachingJobConf(BiFunction<Configuration, URI, FileSystem> factory)
+        private CachingJobConf(BiFunction<Configuration, URI, FileSystem> factory, Configuration conf)
         {
-            super(false);
+            super(conf);
             this.factory = requireNonNull(factory, "factory is null");
         }
 


### PR DESCRIPTION
For tables with large number of partitions, a huge amount of cpu times are consumed by creating hadoop configuration. Especially the 'hdfs-site.xml' & 'core-site.xml' file is large.

 ### Description
Data: tpcds 1T
Table: store_returns (about 2000 partitions)
Sql: select count(*) from store_returns
Query execution time: about 3-4s
Flame figure：
![image](https://user-images.githubusercontent.com/8530791/151091829-f3d57e38-67b7-4f78-a4f9-a238cfb6af46.png)

when we enable file list cache. we find the function 'ConfigurationUtil.copy' consumed amount of cpu times. 
Because the copy function will traverse old configuration, then set to new configuration, which will lead to map rehash operation and other cpu consumed operation.

### Solution
![image](https://user-images.githubusercontent.com/8530791/151092596-0f5677fd-89b7-4575-8657-b62baa45ab01.png)
Configuration support be constructed from other configuration. so we need't use the ConfigurationUtil.copy function.

by optimize configuration construction flow, the query runtime reduce from 4s to 1s

```
== NO RELEASE NOTE ==
```
