### PR TITLE
Reduce dictionary memory requirements

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/DictionaryCompressionOptimizer.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/DictionaryCompressionOptimizer.java
@@ -81,7 +81,7 @@ public class DictionaryCompressionOptimizer
     // But nulls are stored in the rowGroupIndexes and the null memory is unaccounted for and causes OOMs.
     // This constant defines how many nulls in a dictionary column to be counted as 1 byte.
     // Setting this to 1 means, 1 null will be counted as 1 dictionary byte and might abandon some dictionary
-    // prematurely. Setting to 8 means, 8 nulls will count as 1 bit, but most likely will result in OOM.
+    // prematurely. Setting to 8 means, 8 nulls will count as 1 byte, but most likely will result in OOM.
     // For the few files that were having issues, 4 worked the best, so starting this value with 4.
     static final int NUMBER_OF_NULLS_FOR_DICTIONARY_BYTE = 4;
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStream.java
@@ -17,10 +17,12 @@ import com.facebook.presto.orc.ColumnWriterOptions;
 import com.facebook.presto.orc.DwrfDataEncryptor;
 import com.facebook.presto.orc.OrcEncoding;
 import com.facebook.presto.orc.checkpoint.LongStreamCheckpoint;
+import com.facebook.presto.orc.metadata.Stream.StreamKind;
 
 import java.util.Optional;
 
 import static com.facebook.presto.orc.OrcEncoding.DWRF;
+import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.LENGTH;
 
 public interface LongOutputStream
@@ -28,11 +30,25 @@ public interface LongOutputStream
 {
     static LongOutputStream createLengthOutputStream(ColumnWriterOptions columnWriterOptions, Optional<DwrfDataEncryptor> dwrfEncryptor, OrcEncoding orcEncoding)
     {
+        return createLongOutputStream(columnWriterOptions, dwrfEncryptor, orcEncoding, LENGTH);
+    }
+
+    static LongOutputStream createDataOutputStream(ColumnWriterOptions columnWriterOptions, Optional<DwrfDataEncryptor> dwrfEncryptor, OrcEncoding orcEncoding)
+    {
+        return createLongOutputStream(columnWriterOptions, dwrfEncryptor, orcEncoding, DATA);
+    }
+
+    static LongOutputStream createLongOutputStream(
+            ColumnWriterOptions columnWriterOptions,
+            Optional<DwrfDataEncryptor> dwrfEncryptor,
+            OrcEncoding orcEncoding,
+            StreamKind streamKind)
+    {
         if (orcEncoding == DWRF) {
-            return new LongOutputStreamV1(columnWriterOptions, dwrfEncryptor, false, LENGTH);
+            return new LongOutputStreamV1(columnWriterOptions, dwrfEncryptor, false, streamKind);
         }
         else {
-            return new LongOutputStreamV2(columnWriterOptions, false, LENGTH);
+            return new LongOutputStreamV2(columnWriterOptions, false, streamKind);
         }
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/LongDictionaryColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/LongDictionaryColumnWriter.java
@@ -47,10 +47,11 @@ public class LongDictionaryColumnWriter
 {
     private static final long INSTANCE_SIZE = ClassLayout.parseClass(LongDictionaryColumnWriter.class).instanceSize();
     private static final int NULL_INDEX = -1;
+    private static final int EXPECTED_ENTRIES = 10_000;
 
-    private final LongOutputStream dictionaryDataStream;
     private final int typeSize;
 
+    private LongOutputStream dictionaryDataStream;
     private LongDictionaryBuilder dictionary;
     private IntegerStatisticsBuilder statisticsBuilder;
     private ColumnEncoding columnEncoding;
@@ -69,9 +70,10 @@ public class LongDictionaryColumnWriter
         super(column, type, columnWriterOptions, dwrfEncryptor, orcEncoding, metadataWriter);
         checkArgument(orcEncoding == DWRF, "Long dictionary encoding is only supported in DWRF");
         checkArgument(type instanceof FixedWidthType, "Not a fixed width type");
-        this.dictionaryDataStream = new LongOutputStreamDwrf(columnWriterOptions, dwrfEncryptor, true, DICTIONARY_DATA);
-        this.dictionary = new LongDictionaryBuilder(10_000);
         this.typeSize = ((FixedWidthType) type).getFixedSize();
+
+        this.dictionaryDataStream = new LongOutputStreamDwrf(columnWriterOptions, dwrfEncryptor, true, DICTIONARY_DATA);
+        this.dictionary = new LongDictionaryBuilder(EXPECTED_ENTRIES);
         this.statisticsBuilder = new IntegerStatisticsBuilder();
     }
 
@@ -336,8 +338,8 @@ public class LongDictionaryColumnWriter
     protected void resetDictionary()
     {
         columnEncoding = null;
-        dictionary = new LongDictionaryBuilder(10_000);
-        dictionaryDataStream.reset();
+        dictionary = new LongDictionaryBuilder(EXPECTED_ENTRIES);
+        dictionaryDataStream = new LongOutputStreamDwrf(columnWriterOptions, dwrfEncryptor, true, DICTIONARY_DATA);
         statisticsBuilder = new IntegerStatisticsBuilder();
         directValues = null;
         directNulls = null;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/SliceDictionaryBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/SliceDictionaryBuilder.java
@@ -24,8 +24,6 @@ import static it.unimi.dsi.fastutil.HashCommon.arraySize;
 import static java.lang.Math.min;
 import static java.util.Objects.requireNonNull;
 
-// TODO this class is not memory efficient.  We can bypass all of the Presto type and block code
-// since we are only interested in a hash of byte arrays.
 public class SliceDictionaryBuilder
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(SliceDictionaryBuilder.class).instanceSize();
@@ -91,12 +89,6 @@ public class SliceDictionaryBuilder
     public int getRawSliceOffset(int position)
     {
         return segmentedSliceBuilder.getPositionOffset(position);
-    }
-
-    public void clear()
-    {
-        slicePositionByHash.fill(EMPTY_SLOT);
-        segmentedSliceBuilder.reset();
     }
 
     public int getEntryCount()

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestDictionaryCompressionOptimizer.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestDictionaryCompressionOptimizer.java
@@ -740,7 +740,7 @@ public class TestDictionaryCompressionOptimizer
             int dictionaryEntries = getDictionaryEntries();
             int bytesPerValue = estimateIndexBytesPerValue(dictionaryEntries);
             return (dictionaryEntries * bytesPerEntry) + (getNonNullValueCount() * bytesPerValue)
-                    + getNullValueCount() / NUMBER_OF_NULLS_PER_BYTE;
+                    + (getNullValueCount() / NUMBER_OF_NULLS_PER_BYTE);
         }
 
         @Override

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestDictionaryCompressionOptimizer.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestDictionaryCompressionOptimizer.java
@@ -27,7 +27,9 @@ import java.util.stream.Collectors;
 
 import static com.facebook.airlift.testing.Assertions.assertGreaterThanOrEqual;
 import static com.facebook.airlift.testing.Assertions.assertLessThan;
+import static com.facebook.presto.orc.DictionaryCompressionOptimizer.NUMBER_OF_NULLS_FOR_DICTIONARY_BYTE;
 import static com.facebook.presto.orc.DictionaryCompressionOptimizer.estimateIndexBytesPerValue;
+import static com.facebook.presto.orc.writer.DictionaryColumnWriter.NUMBER_OF_NULLS_PER_BYTE;
 import static com.google.common.base.Preconditions.checkArgument;
 import static java.lang.Math.min;
 import static java.lang.Math.toIntExact;
@@ -526,6 +528,31 @@ public class TestDictionaryCompressionOptimizer
         }
     }
 
+    @Test
+    public void testAllNullsColumnConvertToDirect()
+    {
+        double nullsRate = 1.0;
+        TestDictionaryColumn column = new TestDictionaryColumn(10, 1, OptionalInt.empty(), 1, nullsRate);
+
+        int stripeMaxBytes = megabytes(100);
+        int dictionaryMaxMemoryBytes = megabytes(16);
+        int dictionaryAlmostFullMemoryBytes = dictionaryMaxMemoryBytes - DICTIONARY_ALMOST_FULL_MEMORY_RANGE;
+        DataSimulator simulator = new DataSimulator(stripeMaxBytes / 2, stripeMaxBytes, Integer.MAX_VALUE, dictionaryMaxMemoryBytes, 0, column);
+
+        assertFalse(simulator.isDictionaryMemoryFull());
+        assertFalse(column.isDirectEncoded());
+        assertEquals(simulator.getRowCount(), 0);
+        assertEquals(simulator.getBufferedBytes(), 0);
+
+        simulator.advanceToNextStateChange();
+        int minDictionaryConversionRow = dictionaryAlmostFullMemoryBytes * NUMBER_OF_NULLS_FOR_DICTIONARY_BYTE;
+        int maxDictionaryConversationRow = minDictionaryConversionRow + 1024 + 1;
+
+        assertLessThan(simulator.getRowCount(), maxDictionaryConversationRow);
+        assertGreaterThanOrEqual(simulator.getRowCount(), minDictionaryConversionRow);
+        assertTrue(column.isDirectEncoded());
+    }
+
     private static int megabytes(int size)
     {
         return toIntExact(new DataSize(size, Unit.MEGABYTE).toBytes());
@@ -701,7 +728,7 @@ public class TestDictionaryCompressionOptimizer
 
         public void advanceTo(int rowCount)
         {
-            assertTrue(rowCount >= this.rowCount);
+            assertTrue(rowCount >= this.rowCount, "rowCount: " + rowCount);
             this.rowCount = rowCount;
         }
 
@@ -712,7 +739,8 @@ public class TestDictionaryCompressionOptimizer
             }
             int dictionaryEntries = getDictionaryEntries();
             int bytesPerValue = estimateIndexBytesPerValue(dictionaryEntries);
-            return (dictionaryEntries * bytesPerEntry) + (getNonNullValueCount() * bytesPerValue);
+            return (dictionaryEntries * bytesPerEntry) + (getNonNullValueCount() * bytesPerValue)
+                    + getNullValueCount() / NUMBER_OF_NULLS_PER_BYTE;
         }
 
         @Override
@@ -725,6 +753,12 @@ public class TestDictionaryCompressionOptimizer
         public long getNonNullValueCount()
         {
             return (long) (getValueCount() * (1 - nullRate));
+        }
+
+        @Override
+        public long getNullValueCount()
+        {
+            return (long) (getValueCount() * nullRate);
         }
 
         @Override
@@ -756,7 +790,9 @@ public class TestDictionaryCompressionOptimizer
         public OptionalInt tryConvertToDirect(int maxDirectBytes)
         {
             assertFalse(direct);
-            long directBytes = (long) (rowCount * valuesPerRow * bytesPerEntry);
+            long nonNullBytes = getNonNullValueCount() * bytesPerEntry;
+            long nullBytes = getNullValueCount() / NUMBER_OF_NULLS_PER_BYTE;
+            long directBytes = nonNullBytes + nullBytes;
             if (directBytes <= maxDirectBytes) {
                 direct = true;
                 return OptionalInt.of(toIntExact(directBytes));


### PR DESCRIPTION
This PR contains 2 changes.

1. When Orc file has lot of nulls, dictionary compression optimizer does not
account for nulls and can allocate few GB memory erroneously. The change
accounts for null and fixed the cases where it regressed.
2. Dictionary writer does not free up the stream memory and builds dictionary
this doubles requirement for the dictionary writer. Now the Streams are freed
up after the flush to reduce this need.

Test plan
Added new tests to validate
Existing tests.
Ran it on validation service.

```
== NO RELEASE NOTE ==
```
