### PR TITLE
Remove iceberg.catalog.uri from iceberg connector configs

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergConfig.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergConfig.java
@@ -35,7 +35,6 @@ public class IcebergConfig
     private HiveCompressionCodec compressionCodec = GZIP;
     private CatalogType catalogType = HIVE;
     private String catalogWarehouse;
-    private String catalogUri;
     private int catalogCacheSize = 10;
     private List<String> hadoopConfigResources = ImmutableList.of();
 
@@ -89,19 +88,6 @@ public class IcebergConfig
     public IcebergConfig setCatalogWarehouse(String catalogWarehouse)
     {
         this.catalogWarehouse = catalogWarehouse;
-        return this;
-    }
-
-    public String getCatalogUri()
-    {
-        return catalogUri;
-    }
-
-    @Config("iceberg.catalog.uri")
-    @ConfigDescription("Iceberg catalog connection URI")
-    public IcebergConfig setCatalogUri(String catalogUri)
-    {
-        this.catalogUri = catalogUri;
         return this;
     }
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergResourceFactory.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergResourceFactory.java
@@ -36,7 +36,6 @@ import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.google.common.base.Throwables.throwIfInstanceOf;
 import static com.google.common.base.Throwables.throwIfUnchecked;
 import static java.util.Objects.requireNonNull;
-import static org.apache.iceberg.CatalogProperties.URI;
 import static org.apache.iceberg.CatalogProperties.WAREHOUSE_LOCATION;
 
 /**
@@ -49,7 +48,6 @@ public class IcebergResourceFactory
     private final String catalogName;
     private final CatalogType catalogType;
     private final String catalogWarehouse;
-    private final String catalogUri;
     private final List<String> hadoopConfigResources;
 
     @Inject
@@ -59,7 +57,6 @@ public class IcebergResourceFactory
         requireNonNull(config, "config is null");
         this.catalogType = config.getCatalogType();
         this.catalogWarehouse = config.getCatalogWarehouse();
-        this.catalogUri = config.getCatalogUri();
         this.hadoopConfigResources = config.getHadoopConfigResources();
         catalogCache = CacheBuilder.newBuilder()
                 .maximumSize(config.getCatalogCacheSize())
@@ -136,9 +133,6 @@ public class IcebergResourceFactory
         Map<String, String> properties = new HashMap<>();
         if (catalogWarehouse != null) {
             properties.put(WAREHOUSE_LOCATION, catalogWarehouse);
-        }
-        if (catalogUri != null) {
-            properties.put(URI, catalogUri);
         }
         return properties;
     }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergConfig.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergConfig.java
@@ -38,7 +38,6 @@ public class TestIcebergConfig
                 .setCompressionCodec(GZIP)
                 .setCatalogType(HIVE)
                 .setCatalogWarehouse(null)
-                .setCatalogUri(null)
                 .setCatalogCacheSize(10)
                 .setHadoopConfigResources(null));
     }
@@ -51,7 +50,6 @@ public class TestIcebergConfig
                 .put("iceberg.compression-codec", "NONE")
                 .put("iceberg.catalog.type", "HADOOP")
                 .put("iceberg.catalog.warehouse", "path")
-                .put("iceberg.catalog.uri", "uri")
                 .put("iceberg.catalog.cached-catalog-num", "6")
                 .put("iceberg.hadoop.config.resources", "/etc/hadoop/conf/core-site.xml")
                 .build();
@@ -61,7 +59,6 @@ public class TestIcebergConfig
                 .setCompressionCodec(NONE)
                 .setCatalogType(HADOOP)
                 .setCatalogWarehouse("path")
-                .setCatalogUri("uri")
                 .setCatalogCacheSize(6)
                 .setHadoopConfigResources("/etc/hadoop/conf/core-site.xml");
 


### PR DESCRIPTION
The `iceberg.catalog.uri` config is the same as the `hive.metastore.uri` config, so we can safely remove the redundant config.

In Iceberg, the `uri` is only used for the Hive catalog, as indicated in some tutorials such as the SparkCatalog (https://iceberg.apache.org/javadoc/0.9.1/org/apache/iceberg/spark/SparkCatalog.html). Because in Presto, we have already used `hive.metastore.uri` to connect to the Hive metastore, these two configs are the same.

Test plan - Unit test and integration test

```
== RELEASE NOTES ==

Iceberg Changes
* Remove the iceberg.catalog.uri config. Use hive.metastore.uri instead.
```
