### PR TITLE
Throw proper error code when timezone is invalid during from_unixtime execution.

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestDateTimeFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestDateTimeFunctions.java
@@ -93,4 +93,11 @@ public class TestDateTimeFunctions
             localAssertion.assertFunctionString("NOW()", TIMESTAMP_WITH_TIME_ZONE, "2017-03-01 14:30:00.000 " + DATE_TIME_ZONE.getID());
         }
     }
+
+    @Test
+    public void testNotSupportedTimeZone()
+    {
+        String sql = "FROM_UNIXTIME(a.column1, 'yyyy-mm-dd') FROM (VALUES (1)) a (column1)";
+        assertNotSupported(sql, "Time zone not supported: yyyy-mm-dd");
+    }
 }


### PR DESCRIPTION
During `from_unixtime` execution, if an invalid timezone is passed as parameter, we should throw NOT_SUPPORTED error code. Currently this exception is not handled, which eventually throws GENERIC_INTERNAL_ERROR. 
