### PR TITLE
Add support to append row number block to OrcSelectiveReader

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcReaderOptions.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcReaderOptions.java
@@ -25,10 +25,24 @@ public class OrcReaderOptions
     private final boolean zstdJniDecompressionEnabled;
     private final boolean mapNullKeysEnabled;
     private final boolean enableTimestampMicroPrecision;
+    // if the option is set to true, OrcSelectiveReader will append a row number block at the end of the page
+    private final boolean appendRowNumber;
 
-    public OrcReaderOptions(DataSize maxMergeDistance, DataSize tinyStripeThreshold, DataSize maxBlockSize, boolean zstdJniDecompressionEnabled)
+    public OrcReaderOptions(DataSize maxMergeDistance,
+            DataSize tinyStripeThreshold,
+            DataSize maxBlockSize,
+            boolean zstdJniDecompressionEnabled)
     {
-        this(maxMergeDistance, tinyStripeThreshold, maxBlockSize, zstdJniDecompressionEnabled, false, false);
+        this(maxMergeDistance, tinyStripeThreshold, maxBlockSize, zstdJniDecompressionEnabled, false, false, false);
+    }
+
+    public OrcReaderOptions(DataSize maxMergeDistance,
+            DataSize tinyStripeThreshold,
+            DataSize maxBlockSize,
+            boolean zstdJniDecompressionEnabled,
+            boolean appendRowNumber)
+    {
+        this(maxMergeDistance, tinyStripeThreshold, maxBlockSize, zstdJniDecompressionEnabled, false, false, appendRowNumber);
     }
 
     public OrcReaderOptions(
@@ -37,7 +51,8 @@ public class OrcReaderOptions
             DataSize maxBlockSize,
             boolean zstdJniDecompressionEnabled,
             boolean mapNullKeysEnabled,
-            boolean enableTimestampMicroPrecision)
+            boolean enableTimestampMicroPrecision,
+            boolean appendRowNumber)
     {
         this.maxMergeDistance = requireNonNull(maxMergeDistance, "maxMergeDistance is null");
         this.maxBlockSize = requireNonNull(maxBlockSize, "maxBlockSize is null");
@@ -45,6 +60,7 @@ public class OrcReaderOptions
         this.zstdJniDecompressionEnabled = zstdJniDecompressionEnabled;
         this.mapNullKeysEnabled = mapNullKeysEnabled;
         this.enableTimestampMicroPrecision = enableTimestampMicroPrecision;
+        this.appendRowNumber = appendRowNumber;
     }
 
     public DataSize getMaxMergeDistance()
@@ -75,5 +91,10 @@ public class OrcReaderOptions
     public boolean enableTimestampMicroPrecision()
     {
         return enableTimestampMicroPrecision;
+    }
+
+    public boolean appendRowNumber()
+    {
+        return appendRowNumber;
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcRecordReaderOptions.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcRecordReaderOptions.java
@@ -24,10 +24,11 @@ public class OrcRecordReaderOptions
     private final DataSize maxBlockSize;
     private final boolean mapNullKeysEnabled;
     private final boolean enableTimestampMicroPrecision;
+    private final boolean appendRowNumber;
 
     public OrcRecordReaderOptions(OrcReaderOptions options)
     {
-        this(options.getMaxMergeDistance(), options.getTinyStripeThreshold(), options.getMaxBlockSize(), options.mapNullKeysEnabled(), options.enableTimestampMicroPrecision());
+        this(options.getMaxMergeDistance(), options.getTinyStripeThreshold(), options.getMaxBlockSize(), options.mapNullKeysEnabled(), options.enableTimestampMicroPrecision(), options.appendRowNumber());
     }
 
     public OrcRecordReaderOptions(
@@ -35,13 +36,15 @@ public class OrcRecordReaderOptions
             DataSize tinyStripeThreshold,
             DataSize maxBlockSize,
             boolean mapNullKeysEnabled,
-            boolean enableTimestampMicroPrecision)
+            boolean enableTimestampMicroPrecision,
+            boolean appendRowNumber)
     {
         this.maxMergeDistance = requireNonNull(maxMergeDistance, "maxMergeDistance is null");
         this.maxBlockSize = requireNonNull(maxBlockSize, "maxBlockSize is null");
         this.tinyStripeThreshold = requireNonNull(tinyStripeThreshold, "tinyStripeThreshold is null");
         this.mapNullKeysEnabled = mapNullKeysEnabled;
         this.enableTimestampMicroPrecision = enableTimestampMicroPrecision;
+        this.appendRowNumber = appendRowNumber;
     }
 
     public DataSize getMaxMergeDistance()
@@ -67,5 +70,10 @@ public class OrcRecordReaderOptions
     public boolean enableTimestampMicroPrecision()
     {
         return enableTimestampMicroPrecision;
+    }
+
+    public boolean appendRowNumber()
+    {
+        return appendRowNumber;
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcSelectiveRecordReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcSelectiveRecordReader.java
@@ -20,6 +20,7 @@ import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockLease;
 import com.facebook.presto.common.block.LazyBlock;
 import com.facebook.presto.common.block.LazyBlockLoader;
+import com.facebook.presto.common.block.LongArrayBlock;
 import com.facebook.presto.common.block.RunLengthEncodedBlock;
 import com.facebook.presto.common.predicate.FilterFunction;
 import com.facebook.presto.common.predicate.TupleDomainFilter;
@@ -148,6 +149,9 @@ public class OrcSelectiveRecordReader
 
     private int readPositions;
 
+    // true if row number needs to be added, false otherwise
+    private final boolean appendRowNumber;
+
     public OrcSelectiveRecordReader(
             Map<Integer, Type> includedColumns,                 // key: hiveColumnIndex
             List<Integer> outputColumns,                        // elements are hive column indices
@@ -260,6 +264,7 @@ public class OrcSelectiveRecordReader
 
         requireNonNull(constantValues, "constantValues is null");
         this.constantValues = new Object[this.hiveColumnIndices.length];
+        this.appendRowNumber = options.appendRowNumber();
         for (int columnIndex : includedColumns.keySet()) {
             if (!isColumnPresent(columnIndex)) {
                 // Any filter not true of null on a missing column
@@ -631,7 +636,6 @@ public class OrcSelectiveRecordReader
         if (batchSize < 0) {
             return null;
         }
-
         readPositions += batchSize;
         initializePositions(batchSize);
 
@@ -716,7 +720,7 @@ public class OrcSelectiveRecordReader
             }
         }
 
-        Block[] blocks = new Block[outputColumns.size()];
+        Block[] blocks = new Block[ appendRowNumber ? outputColumns.size() + 1 : outputColumns.size()];
         for (int i = 0; i < outputColumns.size(); i++) {
             int columnIndex = outputColumns.get(i);
             if (constantValues[columnIndex] != null) {
@@ -737,10 +741,11 @@ public class OrcSelectiveRecordReader
             }
         }
 
+        if (appendRowNumber) {
+            blocks[outputColumns.size()] = createRowNumbersBlock(positionsToRead, positionCount, this.getFilePosition());
+        }
         Page page = new Page(positionCount, blocks);
-
         validateWritePageChecksum(page);
-
         return page;
     }
 
@@ -880,6 +885,15 @@ public class OrcSelectiveRecordReader
         for (int i = 0; i < positionCount; i++) {
             outputPositions[i] = i;
         }
+    }
+
+    private static Block createRowNumbersBlock(int[] positionsToRead, int positionCount, long startRowNumber)
+    {
+        long[] rowNumbers = new long[positionCount];
+        for (int i = 0; i < positionCount; i++) {
+            rowNumbers[i] = positionsToRead[i] + startRowNumber;
+        }
+        return new LongArrayBlock(positionCount, Optional.empty(), rowNumbers);
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriteValidation.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriteValidation.java
@@ -490,7 +490,8 @@ public class OrcWriteValidation
         public void addPage(Page page)
         {
             requireNonNull(page, "page is null");
-            checkArgument(page.getChannelCount() == columnHashes.size(), "invalid page");
+            // When append row number is set to true, the page will have an additional block appended at the end
+            checkArgument(page.getChannelCount() >= columnHashes.size(), "invalid page");
 
             for (int channel = 0; channel < columnHashes.size(); channel++) {
                 Type type = types.get(channel);

--- a/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
@@ -899,7 +899,8 @@ public class OrcTester
                 includedColumns,
                 outputColumns,
                 false,
-                new TestingHiveOrcAggregatedMemoryContext())) {
+                new TestingHiveOrcAggregatedMemoryContext(),
+                false)) {
             assertEquals(recordReader.getReaderPosition(), 0);
             assertEquals(recordReader.getFilePosition(), 0);
             assertFileContentsPresto(types, recordReader, expectedValues, outputColumns);
@@ -1440,7 +1441,17 @@ public class OrcTester
     static OrcBatchRecordReader createCustomOrcRecordReader(TempFile tempFile, OrcEncoding orcEncoding, OrcPredicate predicate, List<Type> types, int initialBatchSize, boolean cacheable, boolean mapNullKeysEnabled)
             throws IOException
     {
-        return createCustomOrcRecordReader(tempFile, orcEncoding, predicate, types, initialBatchSize, new StorageOrcFileTailSource(), new StorageStripeMetadataSource(), cacheable, ImmutableMap.of(), mapNullKeysEnabled);
+        return createCustomOrcRecordReader(
+                tempFile,
+                orcEncoding,
+                predicate,
+                types,
+                initialBatchSize,
+                new StorageOrcFileTailSource(),
+                new StorageStripeMetadataSource(),
+                cacheable,
+                ImmutableMap.of(),
+                mapNullKeysEnabled);
     }
 
     static OrcBatchRecordReader createCustomOrcRecordReader(
@@ -1469,6 +1480,7 @@ public class OrcTester
                         MAX_BLOCK_SIZE,
                         false,
                         mapNullKeysEnabled,
+                        false,
                         false),
                 cacheable,
                 new DwrfEncryptionProvider(new UnsupportedEncryptionLibrary(), new TestingEncryptionLibrary()),
@@ -1504,6 +1516,7 @@ public class OrcTester
                         MAX_BLOCK_SIZE,
                         false,
                         mapNullKeysEnabled,
+                        false,
                         false),
                 false,
                 new DwrfEncryptionProvider(new UnsupportedEncryptionLibrary(), new TestingEncryptionLibrary()),
@@ -1636,7 +1649,8 @@ public class OrcTester
             OrcPredicate predicate,
             Type type,
             int initialBatchSize,
-            boolean mapNullKeysEnabled)
+            boolean mapNullKeysEnabled,
+            boolean appendRowNumber)
             throws IOException
     {
         return createCustomOrcSelectiveRecordReader(
@@ -1654,7 +1668,8 @@ public class OrcTester
                 ImmutableMap.of(0, type),
                 ImmutableList.of(0),
                 mapNullKeysEnabled,
-                new TestingHiveOrcAggregatedMemoryContext());
+                new TestingHiveOrcAggregatedMemoryContext(),
+                appendRowNumber);
     }
 
     public static OrcSelectiveRecordReader createCustomOrcSelectiveRecordReader(
@@ -1672,7 +1687,8 @@ public class OrcTester
             Map<Integer, Type> includedColumns,
             List<Integer> outputColumns,
             boolean mapNullKeysEnabled,
-            OrcAggregatedMemoryContext systemMemoryUsage)
+            OrcAggregatedMemoryContext systemMemoryUsage,
+            boolean appendRowNumber)
             throws IOException
     {
         OrcDataSource orcDataSource = new FileOrcDataSource(file, new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), new DataSize(1, MEGABYTE), true);
@@ -1688,7 +1704,8 @@ public class OrcTester
                         MAX_BLOCK_SIZE,
                         false,
                         mapNullKeysEnabled,
-                        false),
+                        false,
+                        appendRowNumber),
                 false,
                 new DwrfEncryptionProvider(new UnsupportedEncryptionLibrary(), new TestingEncryptionLibrary()),
                 DwrfKeyProvider.of(intermediateEncryptionKeys),

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestDecryption.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestDecryption.java
@@ -493,6 +493,7 @@ public class TestDecryption
                         MAX_BLOCK_SIZE,
                         false,
                         false,
+                        false,
                         false),
                 false,
                 new DwrfEncryptionProvider(new UnsupportedEncryptionLibrary(), new TestingPlainKeyEncryptionLibrary()),

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestDictionaryColumnWriter.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestDictionaryColumnWriter.java
@@ -847,7 +847,8 @@ public class TestDictionaryColumnWriter
                     OrcPredicate.TRUE,
                     type,
                     INITIAL_BATCH_SIZE,
-                    true)) {
+                    true,
+                    false)) {
                 while (index < values.size()) {
                     Page page = reader.getNextPage();
                     if (page == null) {

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcMapNullKey.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcMapNullKey.java
@@ -100,7 +100,8 @@ public class TestOrcMapNullKey
                     OrcPredicate.TRUE,
                     mapType,
                     INITIAL_BATCH_SIZE,
-                    mapNullKeysEnabled)) {
+                    mapNullKeysEnabled,
+                    false)) {
                 assertEquals(readMap(reader.getNextPage().getBlock(0).getLoadedBlock(), 0), expectedToRead);
 
                 assertNull(reader.getNextPage());

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcReaderPositions.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcReaderPositions.java
@@ -13,12 +13,18 @@
  */
 package com.facebook.presto.orc;
 
+import com.facebook.presto.common.Page;
 import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.function.SqlFunctionProperties;
+import com.facebook.presto.common.predicate.FilterFunction;
+import com.facebook.presto.common.relation.Predicate;
 import com.facebook.presto.orc.cache.StorageOrcFileTailSource;
 import com.facebook.presto.orc.metadata.CompressionKind;
 import com.facebook.presto.orc.metadata.Footer;
 import com.facebook.presto.orc.metadata.statistics.IntegerStatistics;
+import com.facebook.presto.spi.ConnectorSession;
+import com.facebook.presto.testing.TestingConnectorSession;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
@@ -43,7 +49,10 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.LongStream;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
@@ -56,6 +65,7 @@ import static com.facebook.presto.orc.OrcReader.MAX_BATCH_SIZE;
 import static com.facebook.presto.orc.OrcTester.Format.ORC_12;
 import static com.facebook.presto.orc.OrcTester.MAX_BLOCK_SIZE;
 import static com.facebook.presto.orc.OrcTester.createCustomOrcRecordReader;
+import static com.facebook.presto.orc.OrcTester.createCustomOrcSelectiveRecordReader;
 import static com.facebook.presto.orc.OrcTester.createOrcRecordWriter;
 import static com.facebook.presto.orc.OrcTester.createSettableStructObjectInspector;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
@@ -63,6 +73,7 @@ import static java.lang.Math.min;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.hadoop.hive.ql.io.orc.CompressionKind.SNAPPY;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
 public class TestOrcReaderPositions
@@ -137,11 +148,157 @@ public class TestOrcReaderPositions
     }
 
     @Test
+    public void testCompleteFileWithAppendRowNumber()
+            throws Exception
+    {
+        try (TempFile tempFile = new TempFile()) {
+            // create single stripe file with multiple row groups
+            int rowCount = 142_000;
+            createSequentialFile(tempFile.getFile(), rowCount);
+            List<Long> expectedValues = new ArrayList<>();
+            expectedValues.addAll(LongStream.range(0, 142_000).collect(ArrayList::new, List::add, List::addAll));
+            OrcSelectiveRecordReader reader = createCustomOrcSelectiveRecordReader(tempFile, ORC, OrcPredicate.TRUE, BIGINT, MAX_BATCH_SIZE, false, true);
+            verifyAppendNumber(expectedValues, reader);
+        }
+    }
+
+    @Test
+    public void testCompleteFileWithAppendRowNumberWithValidation()
+            throws Exception
+    {
+        try (TempFile tempFile = new TempFile()) {
+            // create single stripe file with multiple row groups
+            int rowCount = 142_000;
+            createSequentialFile(tempFile.getFile(), rowCount);
+            List<Long> expectedValues = new ArrayList<>();
+            expectedValues.addAll(LongStream.range(0, 142_000).collect(ArrayList::new, List::add, List::addAll));
+            OrcSelectiveRecordReader reader = createCustomOrcSelectiveRecordReader(tempFile, ORC, OrcPredicate.TRUE, BIGINT, MAX_BATCH_SIZE, false, true);
+            verifyAppendNumber(expectedValues, reader);
+        }
+    }
+
+    @Test
+    public void testFilterFunctionWithAppendRowNumber()
+            throws Exception
+    {
+        try (TempFile tempFile = new TempFile()) {
+            int rowCount = 100;
+            createSequentialFile(tempFile.getFile(), rowCount);
+            List<Long> expectedValues = LongStream.range(0, 100).boxed().filter(input -> input % 2 != 0)
+                    .collect(ArrayList::new, List::add, List::addAll);
+
+            ConnectorSession session = new TestingConnectorSession(ImmutableList.of());
+            FilterFunction filter = new FilterFunction(session.getSqlFunctionProperties(), true, new IsOddPredicate());
+            OrcSelectiveRecordReader reader = createCustomOrcSelectiveRecordReader(tempFile.getFile(),
+                    ORC,
+                    OrcPredicate.TRUE,
+                    ImmutableList.of(BIGINT),
+                    MAX_BATCH_SIZE,
+                    ImmutableMap.of(),
+                    ImmutableList.of(filter),
+                    ImmutableMap.of(0, 0),
+                    ImmutableMap.of(),
+                    ImmutableMap.of(),
+                    ImmutableMap.of(),
+                    ImmutableMap.of(0, BIGINT),
+                    ImmutableList.of(0),
+                    false,
+                    new TestingHiveOrcAggregatedMemoryContext(),
+                    true);
+            verifyAppendNumber(expectedValues, reader);
+        }
+    }
+
+    @Test
+    public void testRowGroupSkippingWithAppendRowNumber()
+            throws Exception
+    {
+        try (TempFile tempFile = new TempFile()) {
+            // create single stripe file with multiple row groups
+            int rowCount = 142_000;
+            createSequentialFile(tempFile.getFile(), rowCount);
+            // test reading two row groups from middle of file
+            OrcPredicate predicate = (numberOfRows, statisticsByColumnIndex) -> {
+                if (numberOfRows == rowCount) {
+                    return true;
+                }
+                IntegerStatistics stats = statisticsByColumnIndex.get(0).getIntegerStatistics();
+                return (stats.getMin() == 50_000) || (stats.getMin() == 70_000);
+            };
+            List<Long> expectedValues = new ArrayList<>();
+            expectedValues.addAll(LongStream.range(50_000, 60_000).collect(ArrayList::new, List::add, List::addAll));
+            expectedValues.addAll(LongStream.range(70_000, 80_000).collect(ArrayList::new, List::add, List::addAll));
+            OrcSelectiveRecordReader reader = createCustomOrcSelectiveRecordReader(tempFile, ORC, predicate, BIGINT, MAX_BATCH_SIZE, false, true);
+            verifyAppendNumber(expectedValues, reader);
+        }
+    }
+
+    @Test
+    public void testStripeSkippingWithAppendNumber()
+            throws Exception
+    {
+        try (TempFile tempFile = new TempFile()) {
+            createMultiStripeFile(tempFile.getFile());
+            // EVery stripe has 20 rows and there are total of 5 stripes
+            // test reading second and fourth stripes
+            OrcPredicate predicate = (numberOfRows, statisticsByColumnIndex) -> {
+                if (numberOfRows == 100) {
+                    return true;
+                }
+                IntegerStatistics stats = statisticsByColumnIndex.get(0).getIntegerStatistics();
+                return ((stats.getMin() == 60) && (stats.getMax() == 117)) ||
+                        ((stats.getMin() == 180) && (stats.getMax() == 237));
+            };
+
+            List<Long> expectedValues = new ArrayList<>();
+            expectedValues.addAll(LongStream.range(20, 40).collect(ArrayList::new, List::add, List::addAll));
+            expectedValues.addAll(LongStream.range(60, 80).collect(ArrayList::new, List::add, List::addAll));
+
+            List<Long> actualValues = new ArrayList<>();
+            OrcSelectiveRecordReader reader = createCustomOrcSelectiveRecordReader(tempFile, ORC, predicate, BIGINT, MAX_BATCH_SIZE, false, true);
+            assertNotNull(reader);
+            Page returnPage;
+            while (true) {
+                returnPage = reader.getNextPage();
+                if (returnPage == null) {
+                    break;
+                }
+                Block rowNumberBlock = returnPage.getBlock(1);
+                for (int i = 0; i < returnPage.getPositionCount(); i++) {
+                    actualValues.add(rowNumberBlock.getLong(i));
+                }
+            }
+            assertEquals(actualValues, expectedValues);
+        }
+    }
+
+    private void verifyAppendNumber(List<Long> expectedValues, OrcSelectiveRecordReader reader)
+            throws IOException
+    {
+        assertNotNull(reader);
+        assertNotNull(expectedValues);
+        List<Long> actualValues = new ArrayList<>();
+        while (true) {
+            Page returnPage = reader.getNextPage();
+            if (returnPage == null) {
+                break;
+            }
+            Block dataBlock = returnPage.getBlock(0);
+            Block rowNumberBlock = returnPage.getBlock(1);
+            for (int i = 0; i < returnPage.getPositionCount(); i++) {
+                actualValues.add(dataBlock.getLong(i));
+                assertEquals(dataBlock.getLong(i), rowNumberBlock.getLong(i));
+            }
+        }
+        assertEquals(actualValues, expectedValues);
+    }
+
+    @Test
     public void testRowGroupSkipping()
             throws Exception
     {
         try (TempFile tempFile = new TempFile()) {
-            // create single strip file with multiple row groups
+            // create single stripe file with multiple row groups
             int rowCount = 142_000;
             createSequentialFile(tempFile.getFile(), rowCount);
 
@@ -517,5 +674,22 @@ public class TestOrcReaderPositions
         }
 
         writer.close(false);
+    }
+
+    private static class IsOddPredicate
+            implements Predicate
+    {
+        @Override
+        public int[] getInputChannels()
+        {
+            return new int[] {0};
+        }
+
+        @Override
+        public boolean evaluate(SqlFunctionProperties properties, Page page, int position)
+        {
+            long number = page.getBlock(0).getLong(position);
+            return (number & 1) == 1;
+        }
     }
 }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcSelectiveStreamReaders.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcSelectiveStreamReaders.java
@@ -105,7 +105,8 @@ public class TestOrcSelectiveStreamReaders
                         includedColumns,
                         outputColumns,
                         false,
-                        systemMemoryUsage)) {
+                        systemMemoryUsage,
+                        false)) {
                     assertEquals(recordReader.getReaderPosition(), 0);
                     assertEquals(recordReader.getFilePosition(), 0);
 

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestSelectiveOrcReader.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestSelectiveOrcReader.java
@@ -978,7 +978,8 @@ public class TestSelectiveOrcReader
                 includedColumns,
                 outputColumns,
                 false,
-                systemMemoryUsage)) {
+                systemMemoryUsage,
+                false)) {
             assertEquals(recordReader.getReaderPosition(), 0);
             assertEquals(recordReader.getFilePosition(), 0);
 
@@ -1040,7 +1041,8 @@ public class TestSelectiveOrcReader
                 includedColumns,
                 outputColumns,
                 false,
-                new TestingHiveOrcAggregatedMemoryContext())) {
+                new TestingHiveOrcAggregatedMemoryContext(),
+                false)) {
             assertEquals(recordReader.getReaderPosition(), 0);
             assertEquals(recordReader.getFilePosition(), 0);
 
@@ -1095,7 +1097,7 @@ public class TestSelectiveOrcReader
         System.out.println(System.currentTimeMillis() - start);
         writeOrcColumnsPresto(tempFile.getFile(), DWRF, NONE, Optional.empty(), types, ImmutableList.of(values), new OrcWriterStats());
 
-        try (OrcSelectiveRecordReader recordReader = createCustomOrcSelectiveRecordReader(tempFile, OrcEncoding.DWRF, OrcPredicate.TRUE, type, MAX_BATCH_SIZE, false)) {
+        try (OrcSelectiveRecordReader recordReader = createCustomOrcSelectiveRecordReader(tempFile, OrcEncoding.DWRF, OrcPredicate.TRUE, type, MAX_BATCH_SIZE, false, false)) {
             assertEquals(recordReader.getFileRowCount(), rowCount);
             assertEquals(recordReader.getReaderRowCount(), rowCount);
             assertEquals(recordReader.getFilePosition(), 0);
@@ -1162,7 +1164,8 @@ public class TestSelectiveOrcReader
                 includedColumns,
                 outputColumns,
                 false,
-                systemMemoryUsage)) {
+                systemMemoryUsage,
+                false)) {
             Page page = recordReader.getNextPage();
             assertEquals(page.getPositionCount(), 1);
 


### PR DESCRIPTION
Support optional row numbers in OrcSelectiveReader. If appendRowNumber 
flag is set to true, every page returned by the reader will contain an additional 
block in the end that stores the row numbers. If a file has n rows, row
 numbers range from [0 to n-1]

**Test plan** 
Added unit tests to verify output row numbers when complete file is read,  
when stripes are skipped , when row groups are skipped and when filter 
function is applied

```
== NO RELEASE NOTE ==
```
