### PR TITLE
Increasing timeout for TestMemoryManager#testQueryMemoryPerNodeLimit to avoid it's flakiness

### DIFF
--- a/presto-tests/src/test/java/com/facebook/presto/memory/TestMemoryManager.java
+++ b/presto-tests/src/test/java/com/facebook/presto/memory/TestMemoryManager.java
@@ -585,7 +585,7 @@ public class TestMemoryManager
         }
     }
 
-    @Test(timeOut = 60_000, expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = ".*Query exceeded per-node user memory limit of 1kB.*")
+    @Test(timeOut = 120_000, expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = ".*Query exceeded per-node user memory limit of 1kB.*")
     public void testQueryMemoryPerNodeLimit()
             throws Exception
     {


### PR DESCRIPTION
Due to Major GC happening in jenkins, sometimes the test end up running longer than 1 minute and fails.
Increasing timeout to avoid the flakiness due to GCs

Test plan - unit test

```
== NO RELEASE NOTE ==
```
