### PR TITLE
Reduce dictionary memory usage in OrcWriters

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriterConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriterConfig.java
@@ -15,8 +15,8 @@ package com.facebook.presto.hive;
 
 import com.facebook.airlift.configuration.Config;
 import com.facebook.presto.orc.OrcWriterOptions;
-import com.facebook.presto.orc.StreamLayout;
 import com.facebook.presto.orc.metadata.DwrfStripeCacheMode;
+import com.facebook.presto.orc.writer.StreamLayoutFactory;
 import io.airlift.units.DataSize;
 
 import javax.validation.constraints.NotNull;
@@ -55,7 +55,7 @@ public class OrcFileWriterConfig
                 .withDictionaryMaxMemory(dictionaryMaxMemory)
                 .withMaxStringStatisticsLimit(stringStatisticsLimit)
                 .withMaxCompressionBufferSize(maxCompressionBufferSize)
-                .withStreamLayout(getStreamLayout(streamLayoutType))
+                .withStreamLayoutFactory(getStreamLayoutFactory(streamLayoutType))
                 .withDwrfStripeCacheEnabled(isDwrfStripeCacheEnabled)
                 .withDwrfStripeCacheMaxSize(dwrfStripeCacheMaxSize)
                 .withDwrfStripeCacheMode(dwrfStripeCacheMode);
@@ -201,13 +201,13 @@ public class OrcFileWriterConfig
         return this;
     }
 
-    private static StreamLayout getStreamLayout(StreamLayoutType type)
+    private static StreamLayoutFactory getStreamLayoutFactory(StreamLayoutType type)
     {
         switch (type) {
             case BY_COLUMN_SIZE:
-                return new StreamLayout.ByColumnSize();
+                return new StreamLayoutFactory.ColumnSizeLayoutFactory();
             case BY_STREAM_SIZE:
-                return new StreamLayout.ByStreamSize();
+                return new StreamLayoutFactory.StreamSizeLayoutFactory();
             default:
                 throw new RuntimeException("Unrecognized type " + type);
         }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestOrcFileWriterConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestOrcFileWriterConfig.java
@@ -15,9 +15,9 @@ package com.facebook.presto.hive;
 
 import com.facebook.presto.hive.OrcFileWriterConfig.StreamLayoutType;
 import com.facebook.presto.orc.OrcWriterOptions;
-import com.facebook.presto.orc.StreamLayout.ByColumnSize;
-import com.facebook.presto.orc.StreamLayout.ByStreamSize;
 import com.facebook.presto.orc.metadata.DwrfStripeCacheMode;
+import com.facebook.presto.orc.writer.StreamLayoutFactory.ColumnSizeLayoutFactory;
+import com.facebook.presto.orc.writer.StreamLayoutFactory.StreamSizeLayoutFactory;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.units.DataSize;
 import org.testng.annotations.Test;
@@ -150,7 +150,7 @@ public class TestOrcFileWriterConfig
         assertEquals(dictionaryMaxMemory, options.getDictionaryMaxMemory());
         assertEquals(stringStatisticsLimit, options.getMaxStringStatisticsLimit());
         assertEquals(maxCompressionBufferSize, options.getMaxCompressionBufferSize());
-        assertTrue(options.getStreamLayout() instanceof ByStreamSize);
+        assertTrue(options.getStreamLayoutFactory() instanceof StreamSizeLayoutFactory);
         assertEquals(Optional.empty(), options.getDwrfStripeCacheOptions());
     }
 
@@ -161,10 +161,10 @@ public class TestOrcFileWriterConfig
 
         config.setStreamLayoutType(BY_STREAM_SIZE);
         OrcWriterOptions options = config.toOrcWriterOptionsBuilder().build();
-        assertTrue(options.getStreamLayout() instanceof ByStreamSize);
+        assertTrue(options.getStreamLayoutFactory() instanceof StreamSizeLayoutFactory);
 
         config.setStreamLayoutType(BY_COLUMN_SIZE);
         options = config.toOrcWriterOptionsBuilder().build();
-        assertTrue(options.getStreamLayout() instanceof ByColumnSize);
+        assertTrue(options.getStreamLayoutFactory() instanceof ColumnSizeLayoutFactory);
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/ColumnWriterOptions.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/ColumnWriterOptions.java
@@ -34,6 +34,7 @@ public class ColumnWriterOptions
     private final DataSize stringStatisticsLimit;
     private final boolean integerDictionaryEncodingEnabled;
     private final boolean stringDictionarySortingEnabled;
+    private final boolean stringDictionaryEncodingEnabled;
     private final boolean ignoreDictionaryRowGroupSizes;
     private final int preserveDirectEncodingStripeCount;
     private final CompressionBufferPool compressionBufferPool;
@@ -45,6 +46,7 @@ public class ColumnWriterOptions
             DataSize stringStatisticsLimit,
             boolean integerDictionaryEncodingEnabled,
             boolean stringDictionarySortingEnabled,
+            boolean stringDictionaryEncodingEnabled,
             boolean ignoreDictionaryRowGroupSizes,
             int preserveDirectEncodingStripeCount,
             CompressionBufferPool compressionBufferPool)
@@ -56,6 +58,7 @@ public class ColumnWriterOptions
         this.stringStatisticsLimit = requireNonNull(stringStatisticsLimit, "stringStatisticsLimit is null");
         this.integerDictionaryEncodingEnabled = integerDictionaryEncodingEnabled;
         this.stringDictionarySortingEnabled = stringDictionarySortingEnabled;
+        this.stringDictionaryEncodingEnabled = stringDictionaryEncodingEnabled;
         this.ignoreDictionaryRowGroupSizes = ignoreDictionaryRowGroupSizes;
         this.preserveDirectEncodingStripeCount = preserveDirectEncodingStripeCount;
         this.compressionBufferPool = requireNonNull(compressionBufferPool, "compressionBufferPool is null");
@@ -76,9 +79,9 @@ public class ColumnWriterOptions
         return compressionMaxBufferSize;
     }
 
-    public DataSize getStringStatisticsLimit()
+    public int getStringStatisticsLimit()
     {
-        return stringStatisticsLimit;
+        return toIntExact(stringStatisticsLimit.toBytes());
     }
 
     public boolean isIntegerDictionaryEncodingEnabled()
@@ -89,6 +92,11 @@ public class ColumnWriterOptions
     public boolean isStringDictionarySortingEnabled()
     {
         return stringDictionarySortingEnabled;
+    }
+
+    public boolean isStringDictionaryEncodingEnabled()
+    {
+        return stringDictionaryEncodingEnabled;
     }
 
     public boolean isIgnoreDictionaryRowGroupSizes()
@@ -119,6 +127,7 @@ public class ColumnWriterOptions
         private DataSize stringStatisticsLimit = DEFAULT_MAX_STRING_STATISTICS_LIMIT;
         private boolean integerDictionaryEncodingEnabled;
         private boolean stringDictionarySortingEnabled = true;
+        private boolean stringDictionaryEncodingEnabled = true;
         private boolean ignoreDictionaryRowGroupSizes;
         private int preserveDirectEncodingStripeCount = DEFAULT_PRESERVE_DIRECT_ENCODING_STRIPE_COUNT;
         private CompressionBufferPool compressionBufferPool = new LastUsedCompressionBufferPool();
@@ -161,6 +170,12 @@ public class ColumnWriterOptions
             return this;
         }
 
+        public Builder setStringDictionaryEncodingEnabled(boolean stringDictionaryEncodingEnabled)
+        {
+            this.stringDictionaryEncodingEnabled = stringDictionaryEncodingEnabled;
+            return this;
+        }
+
         public Builder setIgnoreDictionaryRowGroupSizes(boolean ignoreDictionaryRowGroupSizes)
         {
             this.ignoreDictionaryRowGroupSizes = ignoreDictionaryRowGroupSizes;
@@ -188,6 +203,7 @@ public class ColumnWriterOptions
                     stringStatisticsLimit,
                     integerDictionaryEncodingEnabled,
                     stringDictionarySortingEnabled,
+                    stringDictionaryEncodingEnabled,
                     ignoreDictionaryRowGroupSizes,
                     preserveDirectEncodingStripeCount,
                     compressionBufferPool);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/ColumnWriterOptions.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/ColumnWriterOptions.java
@@ -14,6 +14,8 @@
 package com.facebook.presto.orc;
 
 import com.facebook.presto.orc.metadata.CompressionKind;
+import com.facebook.presto.orc.writer.CompressionBufferPool;
+import com.facebook.presto.orc.writer.CompressionBufferPool.LastUsedCompressionBufferPool;
 import io.airlift.units.DataSize;
 
 import java.util.OptionalInt;
@@ -34,6 +36,7 @@ public class ColumnWriterOptions
     private final boolean stringDictionarySortingEnabled;
     private final boolean ignoreDictionaryRowGroupSizes;
     private final int preserveDirectEncodingStripeCount;
+    private final CompressionBufferPool compressionBufferPool;
 
     public ColumnWriterOptions(
             CompressionKind compressionKind,
@@ -43,7 +46,8 @@ public class ColumnWriterOptions
             boolean integerDictionaryEncodingEnabled,
             boolean stringDictionarySortingEnabled,
             boolean ignoreDictionaryRowGroupSizes,
-            int preserveDirectEncodingStripeCount)
+            int preserveDirectEncodingStripeCount,
+            CompressionBufferPool compressionBufferPool)
     {
         this.compressionKind = requireNonNull(compressionKind, "compressionKind is null");
         this.compressionLevel = requireNonNull(compressionLevel, "compressionLevel is null");
@@ -54,6 +58,7 @@ public class ColumnWriterOptions
         this.stringDictionarySortingEnabled = stringDictionarySortingEnabled;
         this.ignoreDictionaryRowGroupSizes = ignoreDictionaryRowGroupSizes;
         this.preserveDirectEncodingStripeCount = preserveDirectEncodingStripeCount;
+        this.compressionBufferPool = requireNonNull(compressionBufferPool, "compressionBufferPool is null");
     }
 
     public CompressionKind getCompressionKind()
@@ -96,6 +101,11 @@ public class ColumnWriterOptions
         return preserveDirectEncodingStripeCount;
     }
 
+    public CompressionBufferPool getCompressionBufferPool()
+    {
+        return compressionBufferPool;
+    }
+
     public static Builder builder()
     {
         return new Builder();
@@ -111,6 +121,7 @@ public class ColumnWriterOptions
         private boolean stringDictionarySortingEnabled = true;
         private boolean ignoreDictionaryRowGroupSizes;
         private int preserveDirectEncodingStripeCount = DEFAULT_PRESERVE_DIRECT_ENCODING_STRIPE_COUNT;
+        private CompressionBufferPool compressionBufferPool = new LastUsedCompressionBufferPool();
 
         private Builder() {}
 
@@ -162,6 +173,12 @@ public class ColumnWriterOptions
             return this;
         }
 
+        public Builder setCompressionBufferPool(CompressionBufferPool compressionBufferPool)
+        {
+            this.compressionBufferPool = requireNonNull(compressionBufferPool, "compressionBufferPool is null");
+            return this;
+        }
+
         public ColumnWriterOptions build()
         {
             return new ColumnWriterOptions(
@@ -172,7 +189,8 @@ public class ColumnWriterOptions
                     integerDictionaryEncodingEnabled,
                     stringDictionarySortingEnabled,
                     ignoreDictionaryRowGroupSizes,
-                    preserveDirectEncodingStripeCount);
+                    preserveDirectEncodingStripeCount,
+                    compressionBufferPool);
         }
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
@@ -218,6 +218,7 @@ public class OrcWriter
                 .setStringStatisticsLimit(options.getMaxStringStatisticsLimit())
                 .setIntegerDictionaryEncodingEnabled(options.isIntegerDictionaryEncodingEnabled())
                 .setStringDictionarySortingEnabled(options.isStringDictionarySortingEnabled())
+                .setStringDictionaryEncodingEnabled(options.isStringDictionaryEncodingEnabled())
                 .setIgnoreDictionaryRowGroupSizes(options.isIgnoreDictionaryRowGroupSizes())
                 .setPreserveDirectEncodingStripeCount(options.getPreserveDirectEncodingStripeCount())
                 .setCompressionBufferPool(compressionBufferPool)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
@@ -42,6 +42,7 @@ import com.facebook.presto.orc.writer.ColumnWriter;
 import com.facebook.presto.orc.writer.CompressionBufferPool;
 import com.facebook.presto.orc.writer.CompressionBufferPool.LastUsedCompressionBufferPool;
 import com.facebook.presto.orc.writer.DictionaryColumnWriter;
+import com.facebook.presto.orc.writer.StreamLayout;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableList;
@@ -231,7 +232,7 @@ public class OrcWriter
         this.stripeMaxRowCount = options.getStripeMaxRowCount();
         this.rowGroupMaxRowCount = options.getRowGroupMaxRowCount();
         recordValidation(validation -> validation.setRowGroupMaxRowCount(rowGroupMaxRowCount));
-        this.streamLayout = requireNonNull(options.getStreamLayout(), "streamLayout is null");
+        this.streamLayout = requireNonNull(options.getStreamLayoutFactory().create(), "streamLayout is null");
 
         this.userMetadata = ImmutableMap.<String, String>builder()
                 .putAll(requireNonNull(userMetadata, "userMetadata is null"))

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriterOptions.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriterOptions.java
@@ -59,6 +59,7 @@ public class OrcWriterOptions
     private final StreamLayoutFactory streamLayoutFactory;
     private final boolean integerDictionaryEncodingEnabled;
     private final boolean stringDictionarySortingEnabled;
+    private final boolean stringDictionaryEncodingEnabled;
     // TODO: Originally the dictionary row group sizes were not included in memory accounting due
     //  to a bug. Fixing the bug causes certain queries to OOM. When enabled this flag maintains the
     //  previous behavior so previously working queries will not OOM. The OOMs caused due to the
@@ -82,6 +83,7 @@ public class OrcWriterOptions
             StreamLayoutFactory streamLayoutFactory,
             boolean integerDictionaryEncodingEnabled,
             boolean stringDictionarySortingEnabled,
+            boolean stringDictionaryEncodingEnabled,
             Optional<DwrfStripeCacheOptions> dwrfWriterOptions,
             boolean ignoreDictionaryRowGroupSizes,
             int preserveDirectEncodingStripeCount)
@@ -113,6 +115,7 @@ public class OrcWriterOptions
         this.streamLayoutFactory = streamLayoutFactory;
         this.integerDictionaryEncodingEnabled = integerDictionaryEncodingEnabled;
         this.stringDictionarySortingEnabled = stringDictionarySortingEnabled;
+        this.stringDictionaryEncodingEnabled = stringDictionaryEncodingEnabled;
         this.dwrfWriterOptions = dwrfWriterOptions;
         this.ignoreDictionaryRowGroupSizes = ignoreDictionaryRowGroupSizes;
         this.preserveDirectEncodingStripeCount = preserveDirectEncodingStripeCount;
@@ -188,6 +191,11 @@ public class OrcWriterOptions
         return stringDictionarySortingEnabled;
     }
 
+    public boolean isStringDictionaryEncodingEnabled()
+    {
+        return stringDictionaryEncodingEnabled;
+    }
+
     public Optional<DwrfStripeCacheOptions> getDwrfStripeCacheOptions()
     {
         return dwrfWriterOptions;
@@ -221,6 +229,7 @@ public class OrcWriterOptions
                 .add("streamLayoutFactory", streamLayoutFactory)
                 .add("integerDictionaryEncodingEnabled", integerDictionaryEncodingEnabled)
                 .add("stringDictionarySortingEnabled", stringDictionarySortingEnabled)
+                .add("stringDictionaryEncodingEnabled", stringDictionaryEncodingEnabled)
                 .add("dwrfWriterOptions", dwrfWriterOptions)
                 .add("ignoreDictionaryRowGroupSizes", ignoreDictionaryRowGroupSizes)
                 .add("preserveDirectEncodingStripeCount", preserveDirectEncodingStripeCount)
@@ -253,6 +262,7 @@ public class OrcWriterOptions
         private StreamLayoutFactory streamLayoutFactory = new ColumnSizeLayoutFactory();
         private boolean integerDictionaryEncodingEnabled;
         private boolean stringDictionarySortingEnabled = true;
+        private boolean stringDictionaryEncodingEnabled = true;
         private boolean dwrfStripeCacheEnabled;
         private DwrfStripeCacheMode dwrfStripeCacheMode = DEFAULT_DWRF_STRIPE_CACHE_MODE;
         private DataSize dwrfStripeCacheMaxSize = DEFAULT_DWRF_STRIPE_CACHE_MAX_SIZE;
@@ -346,6 +356,12 @@ public class OrcWriterOptions
             return this;
         }
 
+        public Builder withStringDictionaryEncodingEnabled(boolean stringDictionaryEncodingEnabled)
+        {
+            this.stringDictionaryEncodingEnabled = stringDictionaryEncodingEnabled;
+            return this;
+        }
+
         public Builder withDwrfStripeCacheEnabled(boolean dwrfStripeCacheEnabled)
         {
             this.dwrfStripeCacheEnabled = dwrfStripeCacheEnabled;
@@ -401,6 +417,7 @@ public class OrcWriterOptions
                     streamLayoutFactory,
                     integerDictionaryEncodingEnabled,
                     stringDictionarySortingEnabled,
+                    stringDictionaryEncodingEnabled,
                     dwrfWriterOptions,
                     ignoreDictionaryRowGroupSizes,
                     preserveDirectEncodingStripeCount);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriterOptions.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriterOptions.java
@@ -226,6 +226,11 @@ public class OrcWriterOptions
                 .toString();
     }
 
+    public static OrcWriterOptions getDefaultOrcWriterOptions()
+    {
+        return OrcWriterOptions.builder().build();
+    }
+
     public static Builder builder()
     {
         return new Builder();

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriterOptions.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriterOptions.java
@@ -13,8 +13,9 @@
  */
 package com.facebook.presto.orc;
 
-import com.facebook.presto.orc.StreamLayout.ByColumnSize;
 import com.facebook.presto.orc.metadata.DwrfStripeCacheMode;
+import com.facebook.presto.orc.writer.StreamLayoutFactory;
+import com.facebook.presto.orc.writer.StreamLayoutFactory.ColumnSizeLayoutFactory;
 import io.airlift.units.DataSize;
 
 import java.util.Optional;
@@ -55,7 +56,7 @@ public class OrcWriterOptions
     private final DataSize maxStringStatisticsLimit;
     private final DataSize maxCompressionBufferSize;
     private final OptionalInt compressionLevel;
-    private final StreamLayout streamLayout;
+    private final StreamLayoutFactory streamLayoutFactory;
     private final boolean integerDictionaryEncodingEnabled;
     private final boolean stringDictionarySortingEnabled;
     // TODO: Originally the dictionary row group sizes were not included in memory accounting due
@@ -78,7 +79,7 @@ public class OrcWriterOptions
             DataSize maxStringStatisticsLimit,
             DataSize maxCompressionBufferSize,
             OptionalInt compressionLevel,
-            StreamLayout streamLayout,
+            StreamLayoutFactory streamLayoutFactory,
             boolean integerDictionaryEncodingEnabled,
             boolean stringDictionarySortingEnabled,
             Optional<DwrfStripeCacheOptions> dwrfWriterOptions,
@@ -95,7 +96,7 @@ public class OrcWriterOptions
         requireNonNull(maxStringStatisticsLimit, "maxStringStatisticsLimit is null");
         requireNonNull(maxCompressionBufferSize, "maxCompressionBufferSize is null");
         requireNonNull(compressionLevel, "compressionLevel is null");
-        requireNonNull(streamLayout, "streamLayout is null");
+        requireNonNull(streamLayoutFactory, "streamLayoutFactory is null");
         requireNonNull(dwrfWriterOptions, "dwrfWriterOptions is null");
 
         this.stripeMinSize = stripeMinSize;
@@ -109,7 +110,7 @@ public class OrcWriterOptions
         this.maxStringStatisticsLimit = maxStringStatisticsLimit;
         this.maxCompressionBufferSize = maxCompressionBufferSize;
         this.compressionLevel = compressionLevel;
-        this.streamLayout = streamLayout;
+        this.streamLayoutFactory = streamLayoutFactory;
         this.integerDictionaryEncodingEnabled = integerDictionaryEncodingEnabled;
         this.stringDictionarySortingEnabled = stringDictionarySortingEnabled;
         this.dwrfWriterOptions = dwrfWriterOptions;
@@ -172,9 +173,9 @@ public class OrcWriterOptions
         return compressionLevel;
     }
 
-    public StreamLayout getStreamLayout()
+    public StreamLayoutFactory getStreamLayoutFactory()
     {
-        return streamLayout;
+        return streamLayoutFactory;
     }
 
     public boolean isIntegerDictionaryEncodingEnabled()
@@ -217,7 +218,7 @@ public class OrcWriterOptions
                 .add("maxStringStatisticsLimit", maxStringStatisticsLimit)
                 .add("maxCompressionBufferSize", maxCompressionBufferSize)
                 .add("compressionLevel", compressionLevel)
-                .add("streamLayout", streamLayout)
+                .add("streamLayoutFactory", streamLayoutFactory)
                 .add("integerDictionaryEncodingEnabled", integerDictionaryEncodingEnabled)
                 .add("stringDictionarySortingEnabled", stringDictionarySortingEnabled)
                 .add("dwrfWriterOptions", dwrfWriterOptions)
@@ -249,7 +250,7 @@ public class OrcWriterOptions
         private DataSize maxStringStatisticsLimit = DEFAULT_MAX_STRING_STATISTICS_LIMIT;
         private DataSize maxCompressionBufferSize = DEFAULT_MAX_COMPRESSION_BUFFER_SIZE;
         private OptionalInt compressionLevel = OptionalInt.empty();
-        private StreamLayout streamLayout = new ByColumnSize();
+        private StreamLayoutFactory streamLayoutFactory = new ColumnSizeLayoutFactory();
         private boolean integerDictionaryEncodingEnabled;
         private boolean stringDictionarySortingEnabled = true;
         private boolean dwrfStripeCacheEnabled;
@@ -327,9 +328,9 @@ public class OrcWriterOptions
             return this;
         }
 
-        public Builder withStreamLayout(StreamLayout streamLayout)
+        public Builder withStreamLayoutFactory(StreamLayoutFactory streamLayoutFactory)
         {
-            this.streamLayout = requireNonNull(streamLayout, "streamLayout is null");
+            this.streamLayoutFactory = requireNonNull(streamLayoutFactory, "streamLayoutFactory is null");
             return this;
         }
 
@@ -397,7 +398,7 @@ public class OrcWriterOptions
                     maxStringStatisticsLimit,
                     maxCompressionBufferSize,
                     compressionLevel,
-                    streamLayout,
+                    streamLayoutFactory,
                     integerDictionaryEncodingEnabled,
                     stringDictionarySortingEnabled,
                     dwrfWriterOptions,

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/CompressionBufferPool.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/CompressionBufferPool.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.writer;
+
+import org.openjdk.jol.info.ClassLayout;
+
+import javax.annotation.concurrent.NotThreadSafe;
+
+import static io.airlift.slice.SizeOf.sizeOf;
+import static java.util.Objects.requireNonNull;
+
+public interface CompressionBufferPool
+{
+    byte[] checkOut(int length);
+
+    void checkIn(byte[] buffer);
+
+    long getRetainedBytes();
+
+    @NotThreadSafe
+    class LastUsedCompressionBufferPool
+            implements CompressionBufferPool
+    {
+        private static final int INSTANCE_SIZE = ClassLayout.parseClass(LastUsedCompressionBufferPool.class).instanceSize();
+        private byte[] lastUsed;
+
+        @Override
+        public byte[] checkOut(int length)
+        {
+            if (lastUsed == null || lastUsed.length < length) {
+                lastUsed = null;
+                return new byte[length];
+            }
+            byte[] returnValue = lastUsed;
+            lastUsed = null;
+            return returnValue;
+        }
+
+        @Override
+        public void checkIn(byte[] buffer)
+        {
+            lastUsed = requireNonNull(buffer, "buffer is null");
+        }
+
+        @Override
+        public long getRetainedBytes()
+        {
+            return INSTANCE_SIZE + sizeOf(lastUsed);
+        }
+    }
+}

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/SliceDictionaryColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/SliceDictionaryColumnWriter.java
@@ -74,7 +74,7 @@ public class SliceDictionaryColumnWriter
         super(column, type, columnWriterOptions, dwrfEncryptor, orcEncoding, metadataWriter);
         this.dictionaryDataStream = new ByteArrayOutputStream(columnWriterOptions, dwrfEncryptor, Stream.StreamKind.DICTIONARY_DATA);
         this.dictionaryLengthStream = createLengthOutputStream(columnWriterOptions, dwrfEncryptor, orcEncoding);
-        this.stringStatisticsLimitInBytes = toIntExact(columnWriterOptions.getStringStatisticsLimit().toBytes());
+        this.stringStatisticsLimitInBytes = columnWriterOptions.getStringStatisticsLimit();
         this.statisticsBuilder = newStringStatisticsBuilder();
         this.sortDictionaryKeys = columnWriterOptions.isStringDictionarySortingEnabled();
         checkState(sortDictionaryKeys || orcEncoding == DWRF, "Disabling sort is only supported in DWRF format");

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/StreamLayout.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/StreamLayout.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.orc;
+package com.facebook.presto.orc.writer;
 
 import com.facebook.presto.orc.metadata.Stream;
 import com.facebook.presto.orc.stream.StreamDataOutput;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/StreamLayoutFactory.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/StreamLayoutFactory.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.writer;
+
+public interface StreamLayoutFactory
+{
+    StreamLayout create();
+
+    class ColumnSizeLayoutFactory
+            implements StreamLayoutFactory
+    {
+        @Override
+        public StreamLayout create()
+        {
+            return new StreamLayout.ByColumnSize();
+        }
+
+        @Override
+        public String toString()
+        {
+            return "ColumnSizeLayoutFactory{}";
+        }
+    }
+
+    class StreamSizeLayoutFactory
+            implements StreamLayoutFactory
+    {
+        @Override
+        public StreamLayout create()
+        {
+            return new StreamLayout.ByStreamSize();
+        }
+
+        @Override
+        public String toString()
+        {
+            return "StreamSizeLayoutFactory{}";
+        }
+    }
+}

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcWriterOptions.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcWriterOptions.java
@@ -42,6 +42,7 @@ public class TestOrcWriterOptions
                     .withDwrfStripeCacheMaxSize(DWRF_STRIPE_CACHE_MAX_SIZE)
                     .build();
 
+            assertEquals(options.getDwrfStripeCacheOptions().isPresent(), value);
             if (value) {
                 DwrfStripeCacheOptions dwrfStripeCacheOptions = options.getDwrfStripeCacheOptions().get();
                 assertEquals(dwrfStripeCacheOptions.getStripeCacheMode(), DWRF_STRIPE_CACHE_MODE);
@@ -63,7 +64,6 @@ public class TestOrcWriterOptions
         DataSize dictionaryMaxMemory = new DataSize(13_000, KILOBYTE);
         DataSize dictionaryMemoryRange = new DataSize(1_000, KILOBYTE);
         int dictionaryUsefulCheckPerChunkFrequency = 9_999;
-        DataSize dictionaryUsefulCheckIncrement = new DataSize(500, KILOBYTE);
         DataSize dictionaryUsefulCheckColumnSize = new DataSize(1, MEGABYTE);
         DataSize stringMaxStatisticsLimit = new DataSize(128, BYTE);
         DataSize maxCompressionBufferSize = new DataSize(512, KILOBYTE);

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcWriterOptions.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcWriterOptions.java
@@ -14,6 +14,8 @@
 package com.facebook.presto.orc;
 
 import com.facebook.presto.orc.metadata.DwrfStripeCacheMode;
+import com.facebook.presto.orc.writer.StreamLayoutFactory;
+import com.facebook.presto.orc.writer.StreamLayoutFactory.ColumnSizeLayoutFactory;
 import com.google.common.collect.ImmutableList;
 import io.airlift.units.DataSize;
 import org.testng.annotations.Test;
@@ -68,7 +70,7 @@ public class TestOrcWriterOptions
         DataSize stringMaxStatisticsLimit = new DataSize(128, BYTE);
         DataSize maxCompressionBufferSize = new DataSize(512, KILOBYTE);
         OptionalInt compressionLevel = OptionalInt.of(5);
-        StreamLayout streamLayout = new StreamLayout.ByColumnSize();
+        StreamLayoutFactory streamLayoutFactory = new StreamLayoutFactory.StreamSizeLayoutFactory();
         boolean integerDictionaryEncodingEnabled = true;
         boolean stringDictionarySortingEnabled = false;
         int preserveDirectEncodingStripeCount = 10;
@@ -85,7 +87,7 @@ public class TestOrcWriterOptions
                 .withMaxStringStatisticsLimit(stringMaxStatisticsLimit)
                 .withMaxCompressionBufferSize(maxCompressionBufferSize)
                 .withCompressionLevel(compressionLevel)
-                .withStreamLayout(streamLayout)
+                .withStreamLayoutFactory(streamLayoutFactory)
                 .withIntegerDictionaryEncodingEnabled(integerDictionaryEncodingEnabled)
                 .withStringDictionarySortingEnabled(stringDictionarySortingEnabled)
                 .withPreserveDirectEncodingStripeCount(preserveDirectEncodingStripeCount);
@@ -103,7 +105,7 @@ public class TestOrcWriterOptions
         assertEquals(stringMaxStatisticsLimit, options.getMaxStringStatisticsLimit());
         assertEquals(maxCompressionBufferSize, options.getMaxCompressionBufferSize());
         assertEquals(compressionLevel, options.getCompressionLevel());
-        assertEquals(streamLayout, options.getStreamLayout());
+        assertEquals(streamLayoutFactory, options.getStreamLayoutFactory());
         assertEquals(integerDictionaryEncodingEnabled, options.isIntegerDictionaryEncodingEnabled());
         assertEquals(stringDictionarySortingEnabled, options.isStringDictionarySortingEnabled());
         assertEquals(Optional.empty(), options.getDwrfStripeCacheOptions());
@@ -126,7 +128,7 @@ public class TestOrcWriterOptions
         DataSize dwrfStripeCacheMaxSize = new DataSize(4, MEGABYTE);
         DwrfStripeCacheMode dwrfStripeCacheMode = DwrfStripeCacheMode.INDEX_AND_FOOTER;
         OptionalInt compressionLevel = OptionalInt.of(5);
-        StreamLayout streamLayout = new StreamLayout.ByColumnSize();
+        StreamLayoutFactory streamLayoutFactory = new ColumnSizeLayoutFactory();
         boolean integerDictionaryEncodingEnabled = false;
         boolean stringDictionarySortingEnabled = true;
         int preserveDirectEncodingStripeCount = 0;
@@ -143,7 +145,7 @@ public class TestOrcWriterOptions
                 .withMaxStringStatisticsLimit(stringMaxStatisticsLimit)
                 .withMaxCompressionBufferSize(maxCompressionBufferSize)
                 .withCompressionLevel(compressionLevel)
-                .withStreamLayout(streamLayout)
+                .withStreamLayoutFactory(streamLayoutFactory)
                 .withIntegerDictionaryEncodingEnabled(integerDictionaryEncodingEnabled)
                 .withStringDictionarySortingEnabled(stringDictionarySortingEnabled)
                 .withDwrfStripeCacheEnabled(true)
@@ -155,7 +157,7 @@ public class TestOrcWriterOptions
         String expectedString = "OrcWriterOptions{stripeMinSize=13MB, stripeMaxSize=27MB, stripeMaxRowCount=1100000, rowGroupMaxRowCount=15000, " +
                 "dictionaryMaxMemory=13000kB, dictionaryMemoryAlmostFullRange=1000kB, dictionaryUsefulCheckPerChunkFrequency=9999, " +
                 "dictionaryUsefulCheckColumnSize=1MB, maxStringStatisticsLimit=128B, maxCompressionBufferSize=512kB, " +
-                "compressionLevel=OptionalInt[5], streamLayout=ByColumnSize{}, integerDictionaryEncodingEnabled=false, " +
+                "compressionLevel=OptionalInt[5], streamLayoutFactory=ColumnSizeLayoutFactory{}, integerDictionaryEncodingEnabled=false, " +
                 "stringDictionarySortingEnabled=true, dwrfWriterOptions=Optional[DwrfStripeCacheOptions{stripeCacheMode=INDEX_AND_FOOTER, stripeCacheMaxSize=4MB}], " +
                 "ignoreDictionaryRowGroupSizes=false, preserveDirectEncodingStripeCount=0}";
         assertEquals(expectedString, writerOptions.toString());

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcWriterOptions.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcWriterOptions.java
@@ -73,6 +73,7 @@ public class TestOrcWriterOptions
         StreamLayoutFactory streamLayoutFactory = new StreamLayoutFactory.StreamSizeLayoutFactory();
         boolean integerDictionaryEncodingEnabled = true;
         boolean stringDictionarySortingEnabled = false;
+        boolean stringDictionaryEncodingEnabled = false;
         int preserveDirectEncodingStripeCount = 10;
 
         OrcWriterOptions.Builder builder = OrcWriterOptions.builder()
@@ -90,6 +91,7 @@ public class TestOrcWriterOptions
                 .withStreamLayoutFactory(streamLayoutFactory)
                 .withIntegerDictionaryEncodingEnabled(integerDictionaryEncodingEnabled)
                 .withStringDictionarySortingEnabled(stringDictionarySortingEnabled)
+                .withStringDictionaryEncodingEnabled(stringDictionaryEncodingEnabled)
                 .withPreserveDirectEncodingStripeCount(preserveDirectEncodingStripeCount);
 
         OrcWriterOptions options = builder.build();
@@ -108,6 +110,7 @@ public class TestOrcWriterOptions
         assertEquals(streamLayoutFactory, options.getStreamLayoutFactory());
         assertEquals(integerDictionaryEncodingEnabled, options.isIntegerDictionaryEncodingEnabled());
         assertEquals(stringDictionarySortingEnabled, options.isStringDictionarySortingEnabled());
+        assertEquals(stringDictionaryEncodingEnabled, options.isStringDictionaryEncodingEnabled());
         assertEquals(Optional.empty(), options.getDwrfStripeCacheOptions());
         assertEquals(preserveDirectEncodingStripeCount, options.getPreserveDirectEncodingStripeCount());
     }
@@ -158,7 +161,8 @@ public class TestOrcWriterOptions
                 "dictionaryMaxMemory=13000kB, dictionaryMemoryAlmostFullRange=1000kB, dictionaryUsefulCheckPerChunkFrequency=9999, " +
                 "dictionaryUsefulCheckColumnSize=1MB, maxStringStatisticsLimit=128B, maxCompressionBufferSize=512kB, " +
                 "compressionLevel=OptionalInt[5], streamLayoutFactory=ColumnSizeLayoutFactory{}, integerDictionaryEncodingEnabled=false, " +
-                "stringDictionarySortingEnabled=true, dwrfWriterOptions=Optional[DwrfStripeCacheOptions{stripeCacheMode=INDEX_AND_FOOTER, stripeCacheMaxSize=4MB}], " +
+                "stringDictionarySortingEnabled=true, stringDictionaryEncodingEnabled=true, " +
+                "dwrfWriterOptions=Optional[DwrfStripeCacheOptions{stripeCacheMode=INDEX_AND_FOOTER, stripeCacheMaxSize=4MB}], " +
                 "ignoreDictionaryRowGroupSizes=false, preserveDirectEncodingStripeCount=0}";
         assertEquals(expectedString, writerOptions.toString());
     }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestStreamLayout.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestStreamLayout.java
@@ -13,11 +13,11 @@
  */
 package com.facebook.presto.orc;
 
-import com.facebook.presto.orc.StreamLayout.ByColumnSize;
-import com.facebook.presto.orc.StreamLayout.ByStreamSize;
 import com.facebook.presto.orc.metadata.Stream;
 import com.facebook.presto.orc.metadata.Stream.StreamKind;
 import com.facebook.presto.orc.stream.StreamDataOutput;
+import com.facebook.presto.orc.writer.StreamLayout.ByColumnSize;
+import com.facebook.presto.orc.writer.StreamLayout.ByStreamSize;
 import io.airlift.slice.Slices;
 import org.testng.annotations.Test;
 

--- a/presto-orc/src/test/java/com/facebook/presto/orc/writer/TestCompressionBufferPool.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/writer/TestCompressionBufferPool.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.writer;
+
+import com.facebook.presto.orc.writer.CompressionBufferPool.LastUsedCompressionBufferPool;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNotSame;
+import static org.testng.Assert.assertSame;
+
+public class TestCompressionBufferPool
+{
+    @Test
+    public void testBufferReuse()
+    {
+        CompressionBufferPool bufferPool = new LastUsedCompressionBufferPool();
+        byte[] buffer1 = bufferPool.checkOut(0);
+        verifyBuffer(buffer1, 0);
+        bufferPool.checkIn(buffer1);
+
+        byte[] buffer2 = bufferPool.checkOut(0);
+        assertSame(buffer1, buffer2);
+        // Do not checkIn buffer2, but ask for another buffer
+
+        byte[] buffer3 = bufferPool.checkOut(0);
+        assertNotSame(buffer1, buffer3);
+        verifyBuffer(buffer3, 0);
+
+        bufferPool.checkIn(buffer3);
+    }
+
+    @Test
+    public void testLargeBuffer()
+    {
+        CompressionBufferPool bufferPool = new LastUsedCompressionBufferPool();
+        byte[] buffer1 = bufferPool.checkOut(1000);
+        verifyBuffer(buffer1, 1000);
+        bufferPool.checkIn(buffer1);
+
+        byte[] buffer2 = bufferPool.checkOut(500);
+        assertSame(buffer1, buffer2);
+        bufferPool.checkIn(buffer2);
+
+        byte[] buffer3 = bufferPool.checkOut(2000);
+        verifyBuffer(buffer3, 2000);
+    }
+
+    private void verifyBuffer(byte[] buffer, int expectedLength)
+    {
+        assertNotNull(buffer);
+        assertEquals(buffer.length, expectedLength);
+    }
+}

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcFileRewriter.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcFileRewriter.java
@@ -57,7 +57,7 @@ import static com.facebook.presto.orc.OrcEncoding.ORC;
 import static com.facebook.presto.orc.OrcPredicate.TRUE;
 import static com.facebook.presto.orc.OrcReader.INITIAL_BATCH_SIZE;
 import static com.facebook.presto.orc.OrcWriteValidation.OrcWriteValidationMode.HASHED;
-import static com.facebook.presto.raptor.storage.OrcFileWriter.DEFAULT_OPTION;
+import static com.facebook.presto.orc.OrcWriterOptions.getDefaultOrcWriterOptions;
 import static com.facebook.presto.raptor.storage.OrcStorageManager.DEFAULT_STORAGE_TIMEZONE;
 import static com.facebook.presto.raptor.storage.OrcStorageManager.HUGE_MAX_READ_BLOCK_SIZE;
 import static com.facebook.presto.raptor.util.Closer.closer;
@@ -195,7 +195,7 @@ public final class OrcFileRewriter
                                     compression,
                                     Optional.empty(),
                                     NO_ENCRYPTION,
-                                    DEFAULT_OPTION,
+                                    getDefaultOrcWriterOptions(),
                                     userMetadata,
                                     DEFAULT_STORAGE_TIMEZONE,
                                     validate,

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcFileWriter.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/OrcFileWriter.java
@@ -21,7 +21,6 @@ import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.common.type.TypeSignature;
 import com.facebook.presto.orc.OrcWriter;
-import com.facebook.presto.orc.OrcWriterOptions;
 import com.facebook.presto.orc.WriterStats;
 import com.facebook.presto.orc.metadata.CompressionKind;
 import com.facebook.presto.spi.PrestoException;
@@ -40,6 +39,7 @@ import static com.facebook.airlift.json.JsonCodec.jsonCodec;
 import static com.facebook.presto.orc.DwrfEncryptionProvider.NO_ENCRYPTION;
 import static com.facebook.presto.orc.OrcEncoding.ORC;
 import static com.facebook.presto.orc.OrcWriteValidation.OrcWriteValidationMode.HASHED;
+import static com.facebook.presto.orc.OrcWriterOptions.getDefaultOrcWriterOptions;
 import static com.facebook.presto.raptor.RaptorErrorCode.RAPTOR_WRITER_DATA_ERROR;
 import static com.facebook.presto.raptor.storage.OrcStorageManager.DEFAULT_STORAGE_TIMEZONE;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
@@ -50,7 +50,6 @@ import static java.util.Objects.requireNonNull;
 public class OrcFileWriter
         implements FileWriter
 {
-    public static final OrcWriterOptions DEFAULT_OPTION = OrcWriterOptions.builder().build();
     private static final JsonCodec<OrcFileMetadata> METADATA_CODEC = jsonCodec(OrcFileMetadata.class);
 
     private final OrcWriter orcWriter;
@@ -102,7 +101,7 @@ public class OrcFileWriter
                     requireNonNull(compression, "compression is null"),
                     Optional.empty(),
                     NO_ENCRYPTION,
-                    DEFAULT_OPTION,
+                    getDefaultOrcWriterOptions(),
                     userMetadata,
                     DEFAULT_STORAGE_TIMEZONE,
                     validate,


### PR DESCRIPTION
This PR contains 3 changes.

1. Reuse the compression buffer across streams. This reduces the
compression buffer usages on wide tables by 100's of MB.
2. Refactor the OrcWriterOptions to provide factory instead of
actual implementation. While introducing CompressionBufferPool
I introduced bugs, so refactored the code to provide factories.
3. Option to disable String dictionary encoding. There are tables
with 4000+ String columns and String dictionary encoding simply
could not handle that case.

Test plan 
Added new tests for CompressionBufferPool
Existing tests for the writer.

```
== NO RELEASE NOTE ==
```
