### PR TITLE
Add release notes for 0.270

### DIFF
--- a/presto-docs/src/main/sphinx/release.rst
+++ b/presto-docs/src/main/sphinx/release.rst
@@ -5,6 +5,7 @@ Release Notes
 .. toctree::
     :maxdepth: 1
 
+    release/release-0.270
     release/release-0.269
     release/release-0.268
     release/release-0.267

--- a/presto-docs/src/main/sphinx/release/release-0.270.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.270.rst
@@ -1,0 +1,36 @@
+=============
+Release 0.270
+=============
+
+**Details**
+===========
+
+General Changes
+_______________
+* Fix error classification when an invalid timezone is passed as a parameter to :func:`from_unixtime`.
+* Improve performance of ``DISTINCT LIMIT N`` queries for N <= 10000. This can be enabled with the session property ``hash_based_distinct_limit_enabled``
+  or the configuration property ``hash-based-distinct-limit-enabled`` and the limit can be adjusted by using the session property ``hash_based_distinct_limit_threshold``
+  or the configuration property ``hash-based-distinct-limit-threshold``.
+* Add :func:`last_day_of_month` UDF to return the last day of the month.
+* Add dynamic filtering support for right join.
+* Add support for any expression for dynamic filtering probe side.
+* Add new optimizer rule to simplify expressions like ``cardinality(map_keys(m))`` into ``cardinality((m))``. Same for :func:`map_values` function.
+* Add support for the following primitive types to Avro decoder: ``TINYINT``, ``SMALLINT``, ``INTEGER`` and ``REAL``.
+
+Hive Connector Changes
+____________
+* Remove the configuration property ``hive.parquet.fail-on-corrupted-statistics`` and the session property ``parquet_fail_with_corrupted_statistics``.
+
+Iceberg Connector Changes
+_______________
+* Remove the configuration property ``iceberg.native-mode``. Use ``iceberg.catalog.type`` instead.
+
+Pinot Connector Changes
+_____________
+* Add support for Pinot ``TIMESTAMP`` and ``JSON`` types.
+* Add support for Pinot version 0.9.3.
+
+**Credits**
+===========
+
+Amit Dutta, Arunachalam Thirupathi, Beinan, Chunxu Tang, James Petty, James Sun, Nikolay Laptev, Pedro Sereno, Pranjal Shankhdhar, Rongrong Zhong, Sreeni Viswanadha, Timothy Meehan, Xiang Fu, Yang Yang, Zhenxiao Luo, chuxiao, ericyuliu, wangjingdong, zhangyanbing


### PR DESCRIPTION
# Missing Release Notes
## Amit Dutta
- [x] https://github.com/prestodb/presto/pull/17247 Fix spell in ValidateStreamingAggregations. (Merged by: Timothy Meehan)
- [x] https://github.com/prestodb/presto/pull/17241 Throw proper error code when timezone is invalid during from_unixtime execution. (Merged by: Timothy Meehan)

## Nikolay Laptev
- [x] https://github.com/prestodb/presto/pull/17198 A simple sql to sql rewrite for cardinality() (Merged by: James Sun)

## Pedro Sereno
- [x] https://github.com/prestodb/presto/pull/17242 fix deltalake docs sql query render (Merged by: Rongrong Zhong)

# Extracted Release Notes
- #16280 (Author: Yang Yang): Extend avro reader to support more primitive types
  - Extend avro reader to support more primitive types.
- #17015 (Author: Xiang Fu): upgrade pinot lib to support new features introduced in Apache Pinot 0.9.3
  - Upgrade to support Pinot version 0.9.3.
  - Support Pinot `TIMESTAMP` and `JSON` types.
- #17169 (Author: Zhenxiao Luo): Support any expression for dynamic filtering probe side
  - Dynamic filtering support for right join.
  - Support any expression for dynamic filtering probe side.
- #17199 (Author: Sreeni Viswanadha): Add a quicker, hash-based version of distinct limit
  - We now have a faster version of distinct limit N queries for N <= 10000 that uses distinct hashes for quicker results to handle common situations where there are a few dozen distinct values in large datasets. This feature can be enabled by session param: hash_based_distinct_limit_enabled and the limit (default 1000) can be adjusted using: hash_based_distinct_limit_threashold.
- #17217 (Author: Zhenxiao Luo): Parquet predicate improvements
  - DefuncConfig: hive.parquet.fail-on-corrupted-statistics. Always fail on corrupted parquet statistics.
- #17219 (Author: ericyuliu): Add last_day_of_month function
  - Add :func:`last_day_of_month` UDF to return the last day of the month.
- #17233 (Author: Chunxu Tang): Consolidate iceberg native-mode into the catalog type
  - Remove the native-mode iceberg config. Use catalog.type instead.

# All Commits
- c47ed3fddb0e65a27f5d37fb942b43d49274018f Move SqlFunctionExecutor to SPI (James Sun)
- eb5712df1c8feba9416d8aa1f719c4656c57ca17 Reverse the dependency between function manager and grpc (James Sun)
- a9c921f74e7349c8e8399b80ab648045018bc7e4 Abstract SqlFunctionExecutor (James Sun)
- abd40ba4e5b4532c19ffac043adec3ebefd82c2a Fix spell in ValidateStreamingAggregations (Amit Dutta)
- efd857ffa8cbff0e887ebe29cf693483ad71250f upgrade pinot lib to support new features introduced in Apache Pinot 0.9.3 (Xiang Fu)
- 1dbfc9d774a38776503e8cc0541efa11f9f12ddd remove max initial split from hivesplitmanager constructor & improve fragment cache hit ratio (zhangyanbing)
- 1885f643b24d492ec65b0744ff9862cc2a212341 fix deltalake docs sql query render (Pedro Sereno)
- e580d2060e9b0b3a6b22519857e9c23c6685926e Release dictionary memory on Stripe flush (Arunachalam Thirupathi)
- 293772089e48bc18441007dcd8c87c596aa7d69f Account for nulls in DictionaryCompressionOptimizer (Arunachalam Thirupathi)
- b1cdf21863dff6b8424f53fe8b430d9becbbf3fd Exclude guava dependency from io.grpc (James Sun)
- a88fd7c5e95ab6623aa0af85a8f627912227c8b1 Throw proper error code when timezone is invalid. (Amit Dutta)
- 41329cdf883f264ede6e53c7f1d66e1297c5c0b3 Update module versions (Rongrong Zhong)
- 655011c1fdf7042c9534dd27f6bf42abdfe6181d support grpc udf (wangjingdong)
- fac513e7d52fced865c1d0e5d43e425b8e41edcb Add last_day_of_month function (ericyuliu)
- f91d2f6fe770b3d25de504a8539326fda5d8fc41 Consolidate iceberg native-mode into the catalog type (Chunxu Tang)
- 869562e723ed540f4111fc6401947d27a4768ef5 Pass credentials in SqlFunctionProperties (Pranjal Shankhdhar)
- 37e3cc0ece6a6c6f740b669b6bd0fcf9066914d2 Remove iceberg supported testing placeholders (Chunxu Tang)
- 85d6e2670b6d21369d1484fdf57cfa941a3d949f Upgrade log4j to get rid of CVE-2021-44228 (chuxiao)
- 15d790b8d3034df5a137fcb17877ede46f8611bb Disable testOuterJoinWithExpression test (James Sun)
- 1534f870e35e6296fa967a931b97d1aa85095157 Merge dynamic filtering tests (James Sun)
- 8c2757a2184de478b79da4b79ac59dd3f58f50c5 Extend avro reader to support more primitive types (Yang Yang)
- 7c3db271d884aa1523d6a1d6e76562bbc9a5c865 DefuncConfig: hive.parquet.fail-on-corrupted-statistics. Always fail on corrupted parquet statistics (Zhenxiao Luo)
- c205dc69d9ba6a50a47b487695b084e7b872aa30 Speed up construction of parquet predicate from dictionary (Zhenxiao Luo)
- e66670082afcb0a5003a8a4f1c45abf4a683194c Add a quicker, hash-based version of distinct limit (Sreeni Viswanadha)
- 2d0e6631c238f486760de596353707d2ae208979 Add end to end test for dynamic filtering support in right join (Zhenxiao Luo)
- 6aa1f737790703f15ae21c4fe0a6bb8a33b09b9f Support right join for dynamic filter and any expression for probe side (Zhenxiao Luo)
- 56ebb753dbc5e4e248c7f708739baaad76f06051 Simplify PlanVariableAllocator loop (James Petty)
- af84cc8040f744effd217d81c3863b04776ba35e Simplify cardinality on map keys and values functions (Nikolay Laptev)
- 749d43a5248c6a9b832538bd4241016bdc222ba7 Pinot connector: Fixing extra grpc metadata config (Xiang Fu)
- 689a2f19bed4b03892163d48cfb2ab672db8b994 Prohibit LIMIT clause in materialized views (Pranjal Shankhdhar)