### PR TITLE
Double quote identifier in generated pinot query

### DIFF
--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/query/PinotQueryGeneratorContext.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/query/PinotQueryGeneratorContext.java
@@ -640,8 +640,8 @@ public class PinotQueryGeneratorContext
 
         public Selection(String definition, Origin origin)
         {
-            this.definition = definition;
             this.origin = origin;
+            this.definition = (origin == Origin.TABLE_COLUMN) ? (definition.startsWith("\"") ? definition : String.format("\"%s\"", definition)) : definition;
         }
 
         public String getDefinition()

--- a/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotQueryBase.java
+++ b/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotQueryBase.java
@@ -117,7 +117,7 @@ public class TestPinotQueryBase
                     .put(new VariableReferenceExpression(Optional.empty(), "scores", new ArrayType(DOUBLE)), new PinotQueryGeneratorContext.Selection("scores", TABLE_COLUMN)) // direct column reference
                     .put(new VariableReferenceExpression(Optional.empty(), "fare", DOUBLE), new PinotQueryGeneratorContext.Selection("fare", TABLE_COLUMN)) // direct column reference
                     .put(new VariableReferenceExpression(Optional.empty(), "distinctCountDim", DOUBLE), new PinotQueryGeneratorContext.Selection("distinctCountDim", TABLE_COLUMN)) // direct column reference
-                    .put(new VariableReferenceExpression(Optional.empty(), "totalfare", DOUBLE), new PinotQueryGeneratorContext.Selection("(fare + trip)", DERIVED)) // derived column
+                    .put(new VariableReferenceExpression(Optional.empty(), "totalfare", DOUBLE), new PinotQueryGeneratorContext.Selection("(\"fare\" + \"trip\")", DERIVED)) // derived column
                     .put(new VariableReferenceExpression(Optional.empty(), "count_regionid", BIGINT), new PinotQueryGeneratorContext.Selection("count(regionid)", DERIVED))// derived column
                     .put(new VariableReferenceExpression(Optional.empty(), "sum_fare", BIGINT), new PinotQueryGeneratorContext.Selection("sum(fare)", DERIVED))// derived column
                     .put(new VariableReferenceExpression(Optional.empty(), "array_min_0", DOUBLE), new PinotQueryGeneratorContext.Selection("array_min(scores)", DERIVED)) // derived column

--- a/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/query/TestPinotExpressionConverters.java
+++ b/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/query/TestPinotExpressionConverters.java
@@ -44,29 +44,29 @@ public class TestPinotExpressionConverters
 
     public void testProjectExpressionConverter(SessionHolder sessionHolder)
     {
-        testProject("secondssinceepoch", "secondsSinceEpoch", sessionHolder);
+        testProject("secondssinceepoch", "\"secondsSinceEpoch\"", sessionHolder);
         // functions
         testAggregationProject(
                 "date_trunc('hour', from_unixtime(secondssinceepoch))",
-                "dateTimeConvert(secondsSinceEpoch, '1:SECONDS:EPOCH', '1:MILLISECONDS:EPOCH', '1:HOURS')",
+                "dateTimeConvert(\"secondsSinceEpoch\", '1:SECONDS:EPOCH', '1:MILLISECONDS:EPOCH', '1:HOURS')",
                 sessionHolder);
 
         // arithmetic
-        testAggregationProject("regionid + 1", "ADD(regionId, 1)", sessionHolder);
-        testAggregationProject("regionid - 1", "SUB(regionId, 1)", sessionHolder);
-        testAggregationProject("1 * regionid", "MULT(1, regionId)", sessionHolder);
-        testAggregationProject("1 / regionid", "DIV(1, regionId)", sessionHolder);
+        testAggregationProject("regionid + 1", "ADD(\"regionId\", 1)", sessionHolder);
+        testAggregationProject("regionid - 1", "SUB(\"regionId\", 1)", sessionHolder);
+        testAggregationProject("1 * regionid", "MULT(1, \"regionId\")", sessionHolder);
+        testAggregationProject("1 / regionid", "DIV(1, \"regionId\")", sessionHolder);
 
         // TODO ... this one is failing
-        testAggregationProject("secondssinceepoch + 1559978258.674", "ADD(secondsSinceEpoch, 1559978258.674)", sessionHolder);
+        testAggregationProject("secondssinceepoch + 1559978258.674", "ADD(\"secondsSinceEpoch\", 1559978258.674)", sessionHolder);
 
-        testAggregationProject("secondssinceepoch + 1559978258", "ADD(secondsSinceEpoch, 1559978258)", sessionHolder);
+        testAggregationProject("secondssinceepoch + 1559978258", "ADD(\"secondsSinceEpoch\", 1559978258)", sessionHolder);
 
         testAggregationProjectUnsupported("secondssinceepoch > 0", sessionHolder);
 
         testAggregationProject(
                 "date_trunc('hour', from_unixtime(secondssinceepoch + 2))",
-                "dateTimeConvert(ADD(secondsSinceEpoch, 2), '1:SECONDS:EPOCH', '1:MILLISECONDS:EPOCH', '1:HOURS')",
+                "dateTimeConvert(ADD(\"secondsSinceEpoch\", 2), '1:SECONDS:EPOCH', '1:MILLISECONDS:EPOCH', '1:HOURS')",
                 sessionHolder);
     }
 
@@ -95,7 +95,7 @@ public class TestPinotExpressionConverters
     {
         testAggregationProject(
                 "secondssinceepoch + 1559978258.674",
-                "ADD(secondsSinceEpoch, 1559978258.674)",
+                "ADD(\"secondsSinceEpoch\", 1559978258.674)",
                 sessionHolder);
     }
 
@@ -115,12 +115,12 @@ public class TestPinotExpressionConverters
     {
         testAggregationProject(
                 "date_trunc('hour', from_unixtime(secondssinceepoch + 2))",
-                "dateTrunc(ADD(secondsSinceEpoch, 2),seconds, UTC, hour)",
+                "dateTrunc(ADD(\"secondsSinceEpoch\", 2),seconds, UTC, hour)",
                 sessionHolder);
 
         testAggregationProject(
                 "date_trunc('hour', from_unixtime(secondssinceepoch + 2, 'America/New_York'))",
-                "dateTrunc(ADD(secondsSinceEpoch, 2),seconds, America/New_York, hour)",
+                "dateTrunc(ADD(\"secondsSinceEpoch\", 2),seconds, America/New_York, hour)",
                 sessionHolder);
     }
 
@@ -139,28 +139,28 @@ public class TestPinotExpressionConverters
     public void testFilterExpressionConverter(SessionHolder sessionHolder)
     {
         // Simple comparisons
-        testFilter("regionid = 20", "(regionId = 20)", sessionHolder);
-        testFilter("regionid >= 20", "(regionId >= 20)", sessionHolder);
-        testFilter("city = 'Campbell'", "(city = 'Campbell')", sessionHolder);
+        testFilter("regionid = 20", "(\"regionId\" = 20)", sessionHolder);
+        testFilter("regionid >= 20", "(\"regionId\" >= 20)", sessionHolder);
+        testFilter("city = 'Campbell'", "(\"city\" = 'Campbell')", sessionHolder);
 
         // between
-        testFilter("totalfare between 20 and 30", "((fare + trip) BETWEEN 20 AND 30)", sessionHolder);
+        testFilter("totalfare between 20 and 30", "((\"fare\" + \"trip\") BETWEEN 20 AND 30)", sessionHolder);
 
         // in, not in
-        testFilter("regionid in (20, 30, 40)", "(regionId IN (20, 30, 40))", sessionHolder);
-        testFilter("regionid not in (20, 30, 40)", "(regionId NOT IN (20, 30, 40))", sessionHolder);
-        testFilter("city in ('San Jose', 'Campbell', 'Union City')", "(city IN ('San Jose', 'Campbell', 'Union City'))", sessionHolder);
-        testFilter("city not in ('San Jose', 'Campbell', 'Union City')", "(city NOT IN ('San Jose', 'Campbell', 'Union City'))", sessionHolder);
+        testFilter("regionid in (20, 30, 40)", "(\"regionId\" IN (20, 30, 40))", sessionHolder);
+        testFilter("regionid not in (20, 30, 40)", "(\"regionId\" NOT IN (20, 30, 40))", sessionHolder);
+        testFilter("city in ('San Jose', 'Campbell', 'Union City')", "(\"city\" IN ('San Jose', 'Campbell', 'Union City'))", sessionHolder);
+        testFilter("city not in ('San Jose', 'Campbell', 'Union City')", "(\"city\" NOT IN ('San Jose', 'Campbell', 'Union City'))", sessionHolder);
         testFilterUnsupported("secondssinceepoch + 1 in (234, 24324)", sessionHolder);
         testFilterUnsupported("NOT (secondssinceepoch = 2323)", sessionHolder);
-        testFilter("city is null", "(city IS NULL)", sessionHolder);
-        testFilter("city is not null", "(city IS NOT NULL)", sessionHolder);
+        testFilter("city is null", "(\"city\" IS NULL)", sessionHolder);
+        testFilter("city is not null", "(\"city\" IS NOT NULL)", sessionHolder);
 
         // combinations
         testFilter("totalfare between 20 and 30 AND regionid > 20 OR city = 'Campbell'",
-                "((((fare + trip) BETWEEN 20 AND 30) AND (regionId > 20)) OR (city = 'Campbell'))", sessionHolder);
+                "((((\"fare\" + \"trip\") BETWEEN 20 AND 30) AND (\"regionId\" > 20)) OR (\"city\" = 'Campbell'))", sessionHolder);
 
-        testFilter("secondssinceepoch > 1559978258", "(secondsSinceEpoch > 1559978258)", sessionHolder);
+        testFilter("secondssinceepoch > 1559978258", "(\"secondsSinceEpoch\" > 1559978258)", sessionHolder);
         testFilter("DATE '2019-11-15'", "18215", sessionHolder);
     }
 

--- a/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/query/TestPinotPlanOptimizer.java
+++ b/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/query/TestPinotPlanOptimizer.java
@@ -214,7 +214,7 @@ public class TestPinotPlanOptimizer
         PlanBuilder planBuilder = createPlanBuilder(defaultSessionHolder);
         PlanNode originalPlan = limit(planBuilder, 50L, tableScan(planBuilder, pinotTable, regionId, city, fare, secondsSinceEpoch));
         PlanNode optimized = getOptimizedPlan(planBuilder, originalPlan);
-        assertPlanMatch(optimized, PinotTableScanMatcher.match(pinotTable, Optional.of("SELECT regionId, city, fare, secondsSinceEpoch FROM hybrid LIMIT 50"), Optional.of(false), originalPlan.getOutputVariables(), useSqlSyntax()), typeProvider);
+        assertPlanMatch(optimized, PinotTableScanMatcher.match(pinotTable, Optional.of("SELECT \"regionId\", \"city\", \"fare\", \"secondsSinceEpoch\" FROM hybrid LIMIT 50"), Optional.of(false), originalPlan.getOutputVariables(), useSqlSyntax()), typeProvider);
     }
 
     @Test
@@ -225,7 +225,7 @@ public class TestPinotPlanOptimizer
         FilterNode filter = filter(planBuilder, tableScanNode, getRowExpression("lower(substr(city, 0, 3)) = 'del' AND fare > 100", defaultSessionHolder));
         PlanNode originalPlan = limit(planBuilder, 50L, filter);
         PlanNode optimized = getOptimizedPlan(planBuilder, originalPlan);
-        PlanMatchPattern tableScanMatcher = PinotTableScanMatcher.match(pinotTable, Optional.of("SELECT regionId, city, fare, secondsSinceEpoch FROM hybrid__TABLE_NAME_SUFFIX_TEMPLATE__ WHERE \\(fare > 100\\).*"), Optional.of(true), filter.getOutputVariables(), useSqlSyntax());
+        PlanMatchPattern tableScanMatcher = PinotTableScanMatcher.match(pinotTable, Optional.of("SELECT \"regionId\", \"city\", \"fare\", \"secondsSinceEpoch\" FROM hybrid__TABLE_NAME_SUFFIX_TEMPLATE__ WHERE \\(\"fare\" > 100\\).*"), Optional.of(true), filter.getOutputVariables(), useSqlSyntax());
         assertPlanMatch(optimized, PlanMatchPattern.limit(50L, PlanMatchPattern.filter("lower(substr(city, 0, 3)) = 'del'", tableScanMatcher)), typeProvider);
     }
 
@@ -236,7 +236,7 @@ public class TestPinotPlanOptimizer
         FilterNode filter = filter(planBuilder, tableScan(planBuilder, pinotTable, regionId, city, fare, daysSinceEpoch), getRowExpression("dayssinceepoch < DATE '2014-01-31'", defaultSessionHolder));
         PlanNode originalPlan = limit(planBuilder, 50L, filter);
         PlanNode optimized = getOptimizedPlan(planBuilder, originalPlan);
-        assertPlanMatch(optimized, PinotTableScanMatcher.match(pinotTable, Optional.of("SELECT regionId, city, fare, daysSinceEpoch FROM hybrid WHERE \\(daysSinceEpoch < 16101\\) LIMIT 50"), Optional.of(false), originalPlan.getOutputVariables(), useSqlSyntax()), typeProvider);
+        assertPlanMatch(optimized, PinotTableScanMatcher.match(pinotTable, Optional.of("SELECT \"regionId\", \"city\", \"fare\", \"daysSinceEpoch\" FROM hybrid WHERE \\(\"daysSinceEpoch\" < 16101\\) LIMIT 50"), Optional.of(false), originalPlan.getOutputVariables(), useSqlSyntax()), typeProvider);
     }
 
     @Test
@@ -246,7 +246,7 @@ public class TestPinotPlanOptimizer
         FilterNode filter = filter(planBuilder, tableScan(planBuilder, pinotTable, regionId, city, fare, daysSinceEpoch), getRowExpression("cast(dayssinceepoch as timestamp) < TIMESTAMP '2014-01-31 00:00:00 UTC'", defaultSessionHolder));
         PlanNode originalPlan = limit(planBuilder, 50L, filter);
         PlanNode optimized = getOptimizedPlan(planBuilder, originalPlan);
-        assertPlanMatch(optimized, PinotTableScanMatcher.match(pinotTable, Optional.of("SELECT regionId, city, fare, daysSinceEpoch FROM hybrid WHERE \\(daysSinceEpoch < 16101\\) LIMIT 50"), Optional.of(false), originalPlan.getOutputVariables(), useSqlSyntax()), typeProvider);
+        assertPlanMatch(optimized, PinotTableScanMatcher.match(pinotTable, Optional.of("SELECT \"regionId\", \"city\", \"fare\", \"daysSinceEpoch\" FROM hybrid WHERE \\(\"daysSinceEpoch\" < 16101\\) LIMIT 50"), Optional.of(false), originalPlan.getOutputVariables(), useSqlSyntax()), typeProvider);
     }
 
     @Test
@@ -256,7 +256,7 @@ public class TestPinotPlanOptimizer
         FilterNode filter = filter(planBuilder, tableScan(planBuilder, pinotTable, regionId, city, fare, millisSinceEpoch), getRowExpression("millissinceepoch < TIMESTAMP '2014-01-31 00:00:00 UTC'", defaultSessionHolder));
         PlanNode originalPlan = limit(planBuilder, 50L, filter);
         PlanNode optimized = getOptimizedPlan(planBuilder, originalPlan);
-        assertPlanMatch(optimized, PinotTableScanMatcher.match(pinotTable, Optional.of("SELECT regionId, city, fare, millisSinceEpoch FROM hybrid WHERE \\(millisSinceEpoch < 1391126400000\\) LIMIT 50"), Optional.of(false), originalPlan.getOutputVariables(), useSqlSyntax()), typeProvider);
+        assertPlanMatch(optimized, PinotTableScanMatcher.match(pinotTable, Optional.of("SELECT \"regionId\", \"city\", \"fare\", \"millisSinceEpoch\" FROM hybrid WHERE \\(\"millisSinceEpoch\" < 1391126400000\\) LIMIT 50"), Optional.of(false), originalPlan.getOutputVariables(), useSqlSyntax()), typeProvider);
     }
 
     @Test
@@ -266,7 +266,7 @@ public class TestPinotPlanOptimizer
         FilterNode filter = filter(planBuilder, tableScan(planBuilder, pinotTable, regionId, city, fare, millisSinceEpoch), getRowExpression("cast(millissinceepoch as date) < DATE '2014-01-31'", defaultSessionHolder));
         PlanNode originalPlan = limit(planBuilder, 50L, filter);
         PlanNode optimized = getOptimizedPlan(planBuilder, originalPlan);
-        assertPlanMatch(optimized, PinotTableScanMatcher.match(pinotTable, Optional.of("SELECT regionId, city, fare, millisSinceEpoch FROM hybrid WHERE \\(millisSinceEpoch < 1391126400000\\) LIMIT 50"), Optional.of(false), originalPlan.getOutputVariables(), useSqlSyntax()), typeProvider);
+        assertPlanMatch(optimized, PinotTableScanMatcher.match(pinotTable, Optional.of("SELECT \"regionId\", \"city\", \"fare\", \"millisSinceEpoch\" FROM hybrid WHERE \\(\"millisSinceEpoch\" < 1391126400000\\) LIMIT 50"), Optional.of(false), originalPlan.getOutputVariables(), useSqlSyntax()), typeProvider);
     }
 
     @Test
@@ -276,7 +276,7 @@ public class TestPinotPlanOptimizer
         FilterNode filter = filter(planBuilder, tableScan(planBuilder, pinotTable, regionId, city, fare, daysSinceEpoch), getRowExpression("dayssinceepoch <  TIMESTAMP '2014-01-31 00:00:00 UTC'", defaultSessionHolder));
         PlanNode originalPlan = limit(planBuilder, 50L, filter);
         PlanNode optimized = getOptimizedPlan(planBuilder, originalPlan);
-        assertPlanMatch(optimized, PinotTableScanMatcher.match(pinotTable, Optional.of("SELECT regionId, city, fare, daysSinceEpoch FROM hybrid WHERE \\(dayssinceepoch < 16101\\) LIMIT 50"), Optional.of(false), originalPlan.getOutputVariables(), useSqlSyntax()), typeProvider);
+        assertPlanMatch(optimized, PinotTableScanMatcher.match(pinotTable, Optional.of("SELECT \"regionId\", \"city\", \"fare\", \"daysSinceEpoch\" FROM hybrid WHERE \\(\"dayssinceepoch\" < 16101\\) LIMIT 50"), Optional.of(false), originalPlan.getOutputVariables(), useSqlSyntax()), typeProvider);
     }
 
     @Test
@@ -286,7 +286,7 @@ public class TestPinotPlanOptimizer
         FilterNode filter = filter(planBuilder, tableScan(planBuilder, pinotTable, regionId, city, fare, millisSinceEpoch), getRowExpression("millissinceepoch <  DATE '2014-01-31'", defaultSessionHolder));
         PlanNode originalPlan = limit(planBuilder, 50L, filter);
         PlanNode optimized = getOptimizedPlan(planBuilder, originalPlan);
-        assertPlanMatch(optimized, PinotTableScanMatcher.match(pinotTable, Optional.of("SELECT regionId, city, fare, millisSinceEpoch FROM hybrid WHERE \\(millisSinceEpoch < 1391126400000\\) LIMIT 50"), Optional.of(false), originalPlan.getOutputVariables(), useSqlSyntax()), typeProvider);
+        assertPlanMatch(optimized, PinotTableScanMatcher.match(pinotTable, Optional.of("SELECT \"regionId\", \"city\", \"fare\", \"millisSinceEpoch\" FROM hybrid WHERE \\(\"millisSinceEpoch\" < 1391126400000\\) LIMIT 50"), Optional.of(false), originalPlan.getOutputVariables(), useSqlSyntax()), typeProvider);
     }
 
     @Test
@@ -300,7 +300,7 @@ public class TestPinotPlanOptimizer
 
         PlanNode optimized = getOptimizedPlan(planBuilder, originalPlan);
 
-        PlanMatchPattern tableScanMatcher = PinotTableScanMatcher.match(pinotTable, Optional.of("SELECT regionId, city, fare, secondsSinceEpoch FROM hybrid LIMIT 50"), Optional.of(false), originalPlan.getOutputVariables(), useSqlSyntax());
+        PlanMatchPattern tableScanMatcher = PinotTableScanMatcher.match(pinotTable, Optional.of("SELECT \"regionId\", \"city\", \"fare\", \"secondsSinceEpoch\" FROM hybrid LIMIT 50"), Optional.of(false), originalPlan.getOutputVariables(), useSqlSyntax());
         assertPlanMatch(optimized, aggregation(aggregationsSecond, tableScanMatcher), typeProvider);
     }
 
@@ -338,7 +338,7 @@ public class TestPinotPlanOptimizer
                 optimized,
                 PinotTableScanMatcher.match(
                         pinotTable,
-                        Optional.of(String.format("SELECT %s\\(regionId\\) FROM hybrid", distinctCountFunctionName)),
+                        Optional.of(String.format("SELECT %s\\(\"regionId\"\\) FROM hybrid", distinctCountFunctionName)),
                         Optional.of(false),
                         leftAggregation.getOutputVariables(),
                         useSqlSyntax()),
@@ -354,7 +354,7 @@ public class TestPinotPlanOptimizer
                 optimized,
                 PinotTableScanMatcher.match(
                         pinotTable,
-                        Optional.of(String.format("SELECT %s\\(regionId\\) FROM hybrid", distinctCountFunctionName)),
+                        Optional.of(String.format("SELECT %s\\(\"regionId\"\\) FROM hybrid", distinctCountFunctionName)),
                         Optional.of(false),
                         rightAggregation.getOutputVariables(),
                         useSqlSyntax()),
@@ -372,14 +372,14 @@ public class TestPinotPlanOptimizer
                 optimized,
                 PinotTableScanMatcher.match(
                         pinotTable,
-                        Optional.of("SELECT DISTINCTCOUNTHLL\\(regionId\\) FROM hybrid"),
+                        Optional.of("SELECT DISTINCTCOUNTHLL\\(\"regionId\"\\) FROM hybrid"),
                         Optional.of(false),
                         leftAggregation.getOutputVariables(),
                         useSqlSyntax()),
                 typeProvider);
 
         PlanNode optimizedPlan = getOptimizedPlan(planBuilder, limit(planBuilder, 50L, tableScan(planBuilder, pinotTable, distinctCountDim)));
-        assertPlanMatch(optimizedPlan, PinotTableScanMatcher.match(pinotTable, Optional.of("SELECT distinctCountDim FROM hybrid LIMIT 50"), Optional.of(false), optimizedPlan.getOutputVariables(), useSqlSyntax()), typeProvider);
+        assertPlanMatch(optimizedPlan, PinotTableScanMatcher.match(pinotTable, Optional.of("SELECT \"distinctCountDim\" FROM hybrid LIMIT 50"), Optional.of(false), optimizedPlan.getOutputVariables(), useSqlSyntax()), typeProvider);
     }
 
     @Test
@@ -408,7 +408,7 @@ public class TestPinotPlanOptimizer
                     source,
                     PinotTableScanMatcher.match(
                             pinotTable,
-                            Optional.of("SELECT DISTINCTCOUNT\\(regionId\\) FROM hybrid"),
+                            Optional.of("SELECT DISTINCTCOUNT\\(\"regionId\"\\) FROM hybrid"),
                             Optional.of(false),
                             source.getOutputVariables(),
                             useSqlSyntax()),

--- a/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/query/TestPinotPlanOptimizerSql.java
+++ b/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/query/TestPinotPlanOptimizerSql.java
@@ -54,7 +54,7 @@ public class TestPinotPlanOptimizerSql
                 optimized,
                 PinotTableScanMatcher.match(
                         pinotTable,
-                        Optional.of("SELECT regionId FROM hybrid GROUP BY regionId LIMIT 50"),
+                        Optional.of("SELECT \"regionId\" FROM hybrid GROUP BY \"regionId\" LIMIT 50"),
                         Optional.of(false),
                         originalPlan.getOutputVariables(),
                         useSqlSyntax()),
@@ -73,7 +73,7 @@ public class TestPinotPlanOptimizerSql
                 optimized,
                 PinotTableScanMatcher.match(
                         pinotTable,
-                        Optional.of("SELECT regionId, city FROM hybrid GROUP BY regionId, city LIMIT 50"),
+                        Optional.of("SELECT \"regionId\", \"city\" FROM hybrid GROUP BY \"regionId\", \"city\" LIMIT 50"),
                         Optional.of(false),
                         originalPlan.getOutputVariables(),
                         useSqlSyntax()),

--- a/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/query/TestPinotQueryGeneratorSql.java
+++ b/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/query/TestPinotQueryGeneratorSql.java
@@ -91,7 +91,7 @@ public class TestPinotQueryGeneratorSql
         testPinotQuery(
                 pinotConfig,
                 aggregationNode,
-                ImmutableList.of("SELECT city, regionId, sum(fare), count(regionId) FROM realtimeOnly GROUP BY city, regionId LIMIT 10000", "SELECT city, regionId, count(regionId), sum(fare) FROM realtimeOnly GROUP BY city, regionId LIMIT 10000"),
+                ImmutableList.of("SELECT \"city\", \"regionId\", sum(\"fare\"), count(\"regionId\") FROM realtimeOnly GROUP BY \"city\", \"regionId\" LIMIT 10000", "SELECT \"city\", \"regionId\", count(\"regionId\"), sum(\"fare\") FROM realtimeOnly GROUP BY \"city\", \"regionId\" LIMIT 10000"),
                 defaultSessionHolder,
                 ImmutableMap.of());
 
@@ -106,7 +106,7 @@ public class TestPinotQueryGeneratorSql
         testPinotQuery(
                 pinotConfig,
                 project,
-                "SELECT city, regionId, count(regionId), sum(fare) FROM realtimeOnly GROUP BY city, regionId LIMIT 10000",
+                "SELECT \"city\", \"regionId\", count(\"regionId\"), sum(\"fare\") FROM realtimeOnly GROUP BY \"city\", \"regionId\" LIMIT 10000",
                 defaultSessionHolder,
                 ImmutableMap.of());
 
@@ -120,7 +120,7 @@ public class TestPinotQueryGeneratorSql
         testPinotQuery(
                 pinotConfig,
                 project,
-                "SELECT city, regionId, count(regionId), sum(fare) FROM realtimeOnly GROUP BY city, regionId LIMIT 10000",
+                "SELECT \"city\", \"regionId\", count(\"regionId\"), sum(\"fare\") FROM realtimeOnly GROUP BY \"city\", \"regionId\" LIMIT 10000",
                 defaultSessionHolder,
                 ImmutableMap.of());
 
@@ -134,7 +134,7 @@ public class TestPinotQueryGeneratorSql
         testPinotQuery(
                 pinotConfig,
                 project,
-                "SELECT city, regionId, count(regionId), sum(fare) FROM realtimeOnly GROUP BY city, regionId LIMIT 10000",
+                "SELECT \"city\", \"regionId\", count(\"regionId\"), sum(\"fare\") FROM realtimeOnly GROUP BY \"city\", \"regionId\" LIMIT 10000",
                 defaultSessionHolder,
                 ImmutableMap.of());
 
@@ -147,7 +147,7 @@ public class TestPinotQueryGeneratorSql
         testPinotQuery(
                 pinotConfig,
                 project,
-                "SELECT city, regionId, sum(fare), count(regionId) FROM realtimeOnly GROUP BY city, regionId LIMIT 10000",
+                "SELECT \"city\", \"regionId\", sum(\"fare\"), count(\"regionId\") FROM realtimeOnly GROUP BY \"city\", \"regionId\" LIMIT 10000",
                 defaultSessionHolder,
                 ImmutableMap.of());
     }
@@ -168,7 +168,7 @@ public class TestPinotQueryGeneratorSql
         testPinotQuery(
                 pinotConfig,
                 aggregationNode,
-                "SELECT city, sum(fare) FROM realtimeOnly GROUP BY city LIMIT 10000",
+                "SELECT \"city\", sum(\"fare\") FROM realtimeOnly GROUP BY \"city\" LIMIT 10000",
                 sessionHolder,
                 ImmutableMap.of());
 
@@ -182,7 +182,7 @@ public class TestPinotQueryGeneratorSql
         testPinotQuery(
                 pinotConfig,
                 topN,
-                "SELECT city, sum(fare) FROM realtimeOnly GROUP BY city ORDER BY city DESC LIMIT 50",
+                "SELECT \"city\", sum(\"fare\") FROM realtimeOnly GROUP BY \"city\" ORDER BY \"city\" DESC LIMIT 50",
                 sessionHolder,
                 ImmutableMap.of());
 
@@ -196,7 +196,7 @@ public class TestPinotQueryGeneratorSql
         testPinotQuery(
                 pinotConfig,
                 topN,
-                "SELECT city, sum(fare) FROM realtimeOnly GROUP BY city ORDER BY sum(fare) LIMIT 1000",
+                "SELECT \"city\", sum(\"fare\") FROM realtimeOnly GROUP BY \"city\" ORDER BY sum(\"fare\") LIMIT 1000",
                 sessionHolder,
                 ImmutableMap.of());
 
@@ -210,7 +210,7 @@ public class TestPinotQueryGeneratorSql
         testPinotQuery(
                 pinotConfig,
                 topN,
-                "SELECT city, sum(fare) FROM realtimeOnly GROUP BY city ORDER BY sum(fare) LIMIT 1000",
+                "SELECT \"city\", sum(\"fare\") FROM realtimeOnly GROUP BY \"city\" ORDER BY sum(\"fare\") LIMIT 1000",
                 sessionHolder,
                 ImmutableMap.of());
     }
@@ -237,14 +237,14 @@ public class TestPinotQueryGeneratorSql
         testPinotQuery(
                 pinotConfig,
                 aggregationNode,
-                "SELECT city, sum(fare) FROM realtimeOnly GROUP BY city LIMIT 10000",
+                "SELECT \"city\", sum(\"fare\") FROM realtimeOnly GROUP BY \"city\" LIMIT 10000",
                 sessionHolder,
                 ImmutableMap.of());
 
         testPinotQuery(
                 pinotConfig,
                 topN,
-                "SELECT city, sum(fare) FROM realtimeOnly GROUP BY city ORDER BY sum(fare) LIMIT 1000",
+                "SELECT \"city\", sum(\"fare\") FROM realtimeOnly GROUP BY \"city\" ORDER BY sum(\"fare\") LIMIT 1000",
                 sessionHolder,
                 ImmutableMap.of());
     }
@@ -259,19 +259,19 @@ public class TestPinotQueryGeneratorSql
         testPinotQuery(
                 pinotConfig,
                 topN(planBuilder, 50L, ImmutableList.of("fare"), ImmutableList.of(false), tableScanNode),
-                "SELECT regionId, city, fare FROM realtimeOnly ORDER BY fare DESC LIMIT 50",
+                "SELECT \"regionId\", \"city\", \"fare\" FROM realtimeOnly ORDER BY \"fare\" DESC LIMIT 50",
                 sessionHolder,
                 ImmutableMap.of());
         testPinotQuery(
                 pinotConfig,
                 topN(planBuilder, 50L, ImmutableList.of("fare", "city"), ImmutableList.of(true, false), tableScanNode),
-                "SELECT regionId, city, fare FROM realtimeOnly ORDER BY fare, city DESC LIMIT 50",
+                "SELECT \"regionId\", \"city\", \"fare\" FROM realtimeOnly ORDER BY \"fare\", \"city\" DESC LIMIT 50",
                 sessionHolder,
                 ImmutableMap.of());
         testPinotQuery(
                 pinotConfig,
                 topN(planBuilder, 50L, ImmutableList.of("city", "fare"), ImmutableList.of(false, true), tableScanNode),
-                "SELECT regionId, city, fare FROM realtimeOnly ORDER BY city DESC, fare LIMIT 50",
+                "SELECT \"regionId\", \"city\", \"fare\" FROM realtimeOnly ORDER BY \"city\" DESC, \"fare\" LIMIT 50",
                 sessionHolder,
                 ImmutableMap.of());
 
@@ -279,7 +279,7 @@ public class TestPinotQueryGeneratorSql
         testPinotQuery(
                 pinotConfig,
                 project(planBuilder, topNNode, ImmutableList.of("regionid", "city")),
-                "SELECT regionId, city FROM realtimeOnly ORDER BY fare, city DESC LIMIT 50",
+                "SELECT \"regionId\", \"city\" FROM realtimeOnly ORDER BY \"fare\", \"city\" DESC LIMIT 50",
                 sessionHolder,
                 ImmutableMap.of());
 
@@ -287,13 +287,13 @@ public class TestPinotQueryGeneratorSql
         testPinotQuery(
                 pinotConfig,
                 topN(planBuilder, 500L, ImmutableList.of("fare"), ImmutableList.of(false), tableScanNode),
-                "SELECT fare, city, regionId FROM realtimeOnly ORDER BY fare DESC LIMIT 500",
+                "SELECT \"fare\", \"city\", \"regionId\" FROM realtimeOnly ORDER BY \"fare\" DESC LIMIT 500",
                 sessionHolder,
                 ImmutableMap.of());
         testPinotQuery(
                 pinotConfig,
                 topN(planBuilder, 5000L, ImmutableList.of("fare", "city"), ImmutableList.of(true, false), tableScanNode),
-                "SELECT fare, city, regionId FROM realtimeOnly ORDER BY fare, city DESC LIMIT 5000",
+                "SELECT \"fare\", \"city\", \"regionId\" FROM realtimeOnly ORDER BY \"fare\", \"city\" DESC LIMIT 5000",
                 sessionHolder,
                 ImmutableMap.of());
     }
@@ -308,14 +308,14 @@ public class TestPinotQueryGeneratorSql
         testPinotQuery(
                 pinotConfig,
                 aggregationNode,
-                "SELECT regionId FROM realtimeOnly GROUP BY regionId LIMIT 10000",
+                "SELECT \"regionId\" FROM realtimeOnly GROUP BY \"regionId\" LIMIT 10000",
                 defaultSessionHolder,
                 ImmutableMap.of());
         aggregationNode = planBuilder.aggregation(aggBuilder -> aggBuilder.source(tableScanNode).singleGroupingSet(variable("city"), variable("regionid")));
         testPinotQuery(
                 pinotConfig,
                 aggregationNode,
-                "SELECT city, regionId FROM realtimeOnly GROUP BY city, regionId LIMIT 10000",
+                "SELECT \"city\", \"regionId\" FROM realtimeOnly GROUP BY \"city\", \"regionId\" LIMIT 10000",
                 defaultSessionHolder,
                 ImmutableMap.of());
     }


### PR DESCRIPTION
Always double-quoting identifiers to concur the problem that some column names in pinot are reserved keywords and Pinot query parser throwing exceptions on those scenarios.

Test plan - (Please fill in how you tested your changes)
Unit tests

```
== RELEASE NOTES ==

Pinot Changes
* Always double-quotes identifiers in generated Pinot queries.

```
