### PR TITLE
Fix long dictionary raw bytes estimate

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/DictionaryCompressionOptimizer.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/DictionaryCompressionOptimizer.java
@@ -324,7 +324,7 @@ public class DictionaryCompressionOptimizer
 
         for (DictionaryColumnManager column : allWriters) {
             if (!column.isDirectEncoded()) {
-                uncompressedBytes += column.getRawBytes();
+                uncompressedBytes += column.getRawBytesEstimate();
                 compressedBytes += column.getDictionaryBytes();
             }
         }
@@ -361,7 +361,7 @@ public class DictionaryCompressionOptimizer
 
         for (DictionaryColumnManager column : allWriters) {
             if (!column.isDirectEncoded()) {
-                totalDictionaryRawBytes += column.getRawBytes();
+                totalDictionaryRawBytes += column.getRawBytesEstimate();
                 totalDictionaryBytes += column.getDictionaryBytes();
                 totalDictionaryIndexBytes += column.getIndexBytes();
 
@@ -377,7 +377,7 @@ public class DictionaryCompressionOptimizer
         for (int index = 0; index < directConversionCandidates.size(); index++) {
             DictionaryColumnManager column = directConversionCandidates.get(index);
             // determine the size of the currently written stripe if we were convert this column to direct
-            long currentRawBytes = totalNonDictionaryBytes + column.getRawBytes();
+            long currentRawBytes = totalNonDictionaryBytes + column.getRawBytesEstimate();
             long currentDictionaryBytes = totalDictionaryBytes - column.getDictionaryBytes();
             long currentIndexBytes = totalDictionaryIndexBytes - column.getIndexBytes();
             long currentTotalBytes = currentRawBytes + currentDictionaryBytes + currentIndexBytes;
@@ -435,7 +435,7 @@ public class DictionaryCompressionOptimizer
 
         long getNullValueCount();
 
-        long getRawBytes();
+        long getRawBytesEstimate();
 
         int getDictionaryEntries();
 
@@ -495,16 +495,16 @@ public class DictionaryCompressionOptimizer
             }
         }
 
-        public long getRawBytes()
+        public long getRawBytesEstimate()
         {
             checkState(!isDirectEncoded());
-            return dictionaryColumn.getRawBytes();
+            return dictionaryColumn.getRawBytesEstimate();
         }
 
         public double getRawBytesPerRow()
         {
             checkState(!isDirectEncoded());
-            return 1.0 * getRawBytes() / rowCount;
+            return 1.0 * getRawBytesEstimate() / rowCount;
         }
 
         public int getDictionaryBytes()
@@ -549,7 +549,7 @@ public class DictionaryCompressionOptimizer
             if (bufferedBytes == 0) {
                 return 0;
             }
-            return 1.0 * getRawBytes() / bufferedBytes;
+            return 1.0 * getRawBytesEstimate() / bufferedBytes;
         }
 
         public long getBufferedBytes()

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/IntegerStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/IntegerStatisticsBuilder.java
@@ -46,6 +46,11 @@ public class IntegerStatisticsBuilder
         }
     }
 
+    public long getMaximum()
+    {
+        return maximum;
+    }
+
     private void addIntegerStatistics(long valueCount, IntegerStatistics value)
     {
         requireNonNull(value, "value is null");

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestDictionaryColumnWriter.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestDictionaryColumnWriter.java
@@ -69,6 +69,7 @@ public class TestDictionaryColumnWriter
     private static final int COLUMN_ID = 1;
     private static final int BATCH_ROWS = 1_000;
     private static final int STRIPE_MAX_ROWS = 15_000;
+    private static final int INTEGER_VALUES_DICTIONARY_BASE = 1_000_000_000;
     private static final Random RANDOM = new Random();
 
     private static int megabytes(int size)
@@ -198,7 +199,7 @@ public class TestDictionaryColumnWriter
         ImmutableList.Builder<String> builder = ImmutableList.builder();
         for (int i = 0; i < 60_000; i++) {
             // Make a 7 letter String, by using million as base to force dictionary encoding.
-            builder.add(Integer.toString((i % 1000) + 1_000_000));
+            builder.add(Integer.toString((i % 1000) + INTEGER_VALUES_DICTIONARY_BASE));
         }
         for (StringDictionaryInput input : StringDictionaryInput.values()) {
             DirectConversionTester directConversionTester = new DirectConversionTester();
@@ -214,7 +215,7 @@ public class TestDictionaryColumnWriter
     {
         ImmutableList.Builder<String> builder = ImmutableList.builder();
         for (int i = 0; i < 60_000; i++) {
-            builder.add(Integer.toString((i % 2000) + 1_000_000));
+            builder.add(Integer.toString((i % 2000) + INTEGER_VALUES_DICTIONARY_BASE));
         }
         List<String> values = builder.build();
 
@@ -488,7 +489,7 @@ public class TestDictionaryColumnWriter
         builder.addAll(baseList);
         int repeatInterval = 1500;
         for (int i = baseList.size(); i < 45_000; i++) {
-            builder.add(i % repeatInterval);
+            builder.add(INTEGER_VALUES_DICTIONARY_BASE + i % repeatInterval);
         }
         List<Integer> values = builder.build();
 
@@ -531,7 +532,7 @@ public class TestDictionaryColumnWriter
         builder.addAll(baseList);
         int repeatInterval = 1500;
         for (int i = baseList.size(); i < 60_000; i++) {
-            builder.add(i % repeatInterval);
+            builder.add(INTEGER_VALUES_DICTIONARY_BASE + i % repeatInterval);
         }
         List<Integer> values = builder.build();
         List<StripeFooter> stripeFooters = testIntegerDictionary(directConversionTester, values);
@@ -572,7 +573,7 @@ public class TestDictionaryColumnWriter
         builder.addAll(baseList);
         int repeatInterval = 1500;
         for (long i = baseList.size(); i < 50_000; i++) {
-            builder.add(i % repeatInterval);
+            builder.add(INTEGER_VALUES_DICTIONARY_BASE + i % repeatInterval);
         }
 
         List<Long> values = builder.build();
@@ -581,7 +582,7 @@ public class TestDictionaryColumnWriter
         verifyDwrfDirectEncoding(stripeFooters, 0);
         verifyDwrfDirectEncoding(stripeFooters, 1);
         verifyDictionaryEncoding(stripeFooters, DWRF, 2, repeatInterval);
-        verifyDictionaryEncoding(stripeFooters, DWRF, 3, repeatInterval);
+        verifyDwrfDirectEncoding(stripeFooters, 3);
     }
 
     @Test
@@ -594,7 +595,7 @@ public class TestDictionaryColumnWriter
         }
         int repeatInterval = 1500;
         for (long i = 0; i < 100_000; i++) {
-            builder.add(i % repeatInterval);
+            builder.add(INTEGER_VALUES_DICTIONARY_BASE + i % repeatInterval);
         }
         DirectConversionTester tester = new DirectConversionTester();
         int preserveDirectEncodingStripeCount = 2;

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestDictionaryCompressionOptimizer.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestDictionaryCompressionOptimizer.java
@@ -762,7 +762,7 @@ public class TestDictionaryCompressionOptimizer
         }
 
         @Override
-        public long getRawBytes()
+        public long getRawBytesEstimate()
         {
             return (long) bytesPerEntry * getNonNullValueCount();
         }


### PR DESCRIPTION
In Long dictionary encoding unique values are storeed in dictionary
and indexes in data stream. This encoding is beneficial when
the values are large numbers. Long dictionary encoding considered
all values as 8 bytes for raw bytes calculation and this resulted in
small values using dictionary encoding.

Consider a stream that has only unique values from 1 to 10. Long
Dictionary encoding is not beneficial for these values. If the stream
has 10 unique numbers, but all of them are large numbers then long
dictionary encoding will be beneficial. This PR changes how raw bytes
estimate is calculated for the long dictionary.

Test plan
Existing tests are updated to reflect the raw bytes.

```
== NO RELEASE NOTE ==
```
