### PR TITLE
Fix parquet data page offset calculation in parquet writer

### DIFF
--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/ParquetWriter.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/writer/ParquetWriter.java
@@ -211,7 +211,7 @@ public class ParquetWriter
         List<BufferData> bufferDataList = builder.build();
 
         // update stats
-        long stripeStartOffset = outputStream.size();
+        long stripeStartOffset = outputStream.longSize();
         List<ColumnMetaData> metadatas = bufferDataList.stream()
                 .map(BufferData::getMetaData)
                 .collect(toImmutableList());


### PR DESCRIPTION
Cherry-pick of https://github.com/trinodb/trino/pull/10722

The ParquetWriter::flush method calls int OutputStreamSliceOutput::size()
to get the data page offset which is a long, thus flushing fails trying
to write files larger than ~2 GB with an integer overflow exception.

Co-authored-by: Saulius Valatka <saulius.vl@gmail.com>

```
== RELEASE NOTES ==

General Changes
* Fix parquet data page offset calculation in parquet writer

```
