### PR TITLE
Fix typo in Cassandra doc

### DIFF
--- a/presto-docs/src/main/sphinx/connector/cassandra.rst
+++ b/presto-docs/src/main/sphinx/connector/cassandra.rst
@@ -77,7 +77,7 @@ Property Name                                      Description
         If authorization is enabled, ``cassandra.username`` must have enough permissions to perform ``SELECT`` queries on
         the ``system.size_estimates`` table.
 
-.. _Cassandra consistency: http://www.datastax.com/documentation/cassandra/2.0/cassandra/dml/dml_config_consistency_c.html
+.. _Cassandra consistency: https://docs.datastax.com/en/cassandra-oss/2.2/cassandra/dml/dmlConfigConsistency.html
 
 The following advanced configuration properties are available:
 
@@ -163,7 +163,7 @@ The ``users`` table is an example Cassandra table from the Cassandra
 `Getting Started`_ guide. It can be created along with the ``mykeyspace``
 keyspace using Cassandra's cqlsh (CQL interactive terminal):
 
-.. _Getting Started: https://wiki.apache.org/cassandra/GettingStarted
+.. _Getting Started: https://cassandra.apache.org/doc/latest/cassandra/getting_started/index.html
 
 .. code-block:: none
 

--- a/presto-docs/src/main/sphinx/connector/cassandra.rst
+++ b/presto-docs/src/main/sphinx/connector/cassandra.rst
@@ -207,7 +207,7 @@ BLOB              VARBINARY
 BOOLEAN           BOOLEAN
 DECIMAL           DOUBLE
 DOUBLE            DOUBLE
-FLOAT             DOUBLE
+FLOAT             REAL
 INET              VARCHAR(45)
 INT               INTEGER
 LIST<?>           VARCHAR

--- a/presto-docs/src/main/sphinx/connector/cassandra.rst
+++ b/presto-docs/src/main/sphinx/connector/cassandra.rst
@@ -217,7 +217,7 @@ TEXT              VARCHAR
 TIMESTAMP         TIMESTAMP
 TIMEUUID          VARCHAR
 VARCHAR           VARCHAR
-VARIANT           VARCHAR
+VARINT            VARCHAR
 SMALLINT          INTEGER
 TINYINT           INTEGER
 DATE              DATE


### PR DESCRIPTION
Cherry-pick of https://github.com/trinodb/trino/pull/11025
Fix typo in cassandra doc, VARINT is incorrectly written as VARIANT.

We can find the correct name in the
[Cassandra doc](https://cassandra.apache.org/doc/trunk/cassandra/cql/types.html#native-types).

```
native_type::= ASCII | BIGINT | BLOB | BOOLEAN | COUNTER | DATE
| DECIMAL | DOUBLE | DURATION | FLOAT | INET | INT |
SMALLINT | TEXT | TIME | TIMESTAMP | TIMEUUID | TINYINT |
UUID | VARCHAR | VARINT
```

Co-authored-by: tangjiangling <surpass.simple@gmail.com>


```
== NO RELEASE NOTE ==
```
