### PR TITLE
Document query.max-cpu-time property

### DIFF
--- a/presto-docs/src/main/sphinx/admin/properties.rst
+++ b/presto-docs/src/main/sphinx/admin/properties.rst
@@ -53,6 +53,15 @@ General Properties
 Memory Management Properties
 ----------------------------
 
+``query.max-cpu-time``
+^^^^^^^^^^^^^^^^^^^^^^
+
+* **Type:** ``duration``
+* **Default value:** ``1_000_000_000d``
+
+This is the max amount of CPU time that a query can use across the entire
+cluster. Queries that exceed this limit are killed.
+
 ``query.max-memory-per-node``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Cherry-pick of https://github.com/trinodb/trino/pull/10969
A documentation of the query.max-cpu-time property

Co-authored-by: Jessica <jessica.twitty-shuler@starburstdata.com>

```
== NO RELEASE NOTE ==
```
