### PR TITLE
Optimize creation of OrcDecompressor.OutputBuffer in OrcInputStream

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/OrcInputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/OrcInputStream.java
@@ -67,6 +67,7 @@ public final class OrcInputStream
     private int currentCompressedBlockOffset;
 
     private byte[] buffer;
+    private OrcDecompressor.OutputBuffer bufferAdapter;
     private int position;
     private int length;
     private int uncompressedOffset;
@@ -107,6 +108,7 @@ public final class OrcInputStream
             this.compressedSliceInput = sliceInput;
             this.buffer = new byte[0];
             this.compressedSliceInputRetainedSizeInBytes = sliceInputRetainedSizeInBytes;
+            this.bufferAdapter = createDecompressorOutputBufferAdapter();
         }
 
         memoryUsage.setBytes(getRetainedSizeInBytes());
@@ -491,25 +493,7 @@ public final class OrcInputStream
                 readCompressed = compressedBuffer.length;
             }
 
-            OrcDecompressor.OutputBuffer output = new OrcDecompressor.OutputBuffer()
-            {
-                @Override
-                public byte[] initialize(int size)
-                {
-                    buffer = ensureCapacity(buffer, size);
-                    return buffer;
-                }
-
-                @Override
-                public byte[] grow(int size)
-                {
-                    if (size > buffer.length) {
-                        buffer = Arrays.copyOfRange(buffer, 0, size);
-                    }
-                    return buffer;
-                }
-            };
-            length = decompressor.get().decompress(compressedBuffer, 0, readCompressed, output);
+            length = decompressor.get().decompress(compressedBuffer, 0, readCompressed, bufferAdapter);
             position = 0;
         }
         uncompressedOffset = position;
@@ -543,5 +527,27 @@ public final class OrcInputStream
                 .add("decompressor", decompressor.map(Object::toString).orElse("none"))
                 .add("decryptor", dwrfDecryptor.map(Object::toString).orElse("none"))
                 .toString();
+    }
+
+    private OrcDecompressor.OutputBuffer createDecompressorOutputBufferAdapter()
+    {
+        return new OrcDecompressor.OutputBuffer()
+        {
+            @Override
+            public byte[] initialize(int size)
+            {
+                buffer = ensureCapacity(buffer, size);
+                return buffer;
+            }
+
+            @Override
+            public byte[] grow(int size)
+            {
+                if (size > buffer.length) {
+                    buffer = Arrays.copyOfRange(buffer, 0, size);
+                }
+                return buffer;
+            }
+        };
     }
 }


### PR DESCRIPTION
Slightly reduce GC pressure by reusing OrcDecompressor.OutputBuffer instead of creating it
in every OrcInputStream.advance() call.

Test plan:
- existing tests

```
== NO RELEASE NOTE ==
```
