### PR TITLE
Add distinct type support

### DIFF
--- a/presto-client/src/main/java/com/facebook/presto/client/ClientTypeSignatureParameter.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/ClientTypeSignatureParameter.java
@@ -15,6 +15,7 @@ package com.facebook.presto.client;
 
 import com.facebook.airlift.json.JsonObjectMapperProvider;
 import com.facebook.presto.common.type.BigintEnumType.LongEnumMap;
+import com.facebook.presto.common.type.DistinctTypeInfo;
 import com.facebook.presto.common.type.NamedTypeSignature;
 import com.facebook.presto.common.type.ParameterKind;
 import com.facebook.presto.common.type.TypeSignatureParameter;
@@ -60,6 +61,9 @@ public class ClientTypeSignatureParameter
                 break;
             case VARCHAR_ENUM:
                 value = typeParameterSignature.getVarcharEnumMap();
+                break;
+            case DISTINCT_TYPE:
+                value = typeParameterSignature.getDistinctTypeInfo();
                 break;
             default:
                 throw new UnsupportedOperationException(format("Unknown kind [%s]", kind));
@@ -166,6 +170,9 @@ public class ClientTypeSignatureParameter
                     break;
                 case VARCHAR_ENUM:
                     value = MAPPER.readValue(jsonValue, VarcharEnumMap.class);
+                    break;
+                case DISTINCT_TYPE:
+                    value = MAPPER.readValue(jsonValue, DistinctTypeInfo.class);
                     break;
                 default:
                     throw new UnsupportedOperationException(format("Unsupported kind [%s]", kind));

--- a/presto-common/src/main/java/com/facebook/presto/common/type/DistinctType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/DistinctType.java
@@ -1,0 +1,360 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.type;
+
+import com.facebook.presto.common.QualifiedObjectName;
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.block.BlockBuilderStatus;
+import com.facebook.presto.common.block.UncheckedBlock;
+import com.facebook.presto.common.function.SqlFunctionProperties;
+import io.airlift.slice.Slice;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+
+import static java.util.Objects.requireNonNull;
+
+public class DistinctType
+        implements Type
+{
+    private final QualifiedObjectName name;
+    // Distinct type definition specifies whether it is orderable or not, even if baseType is orderable.
+    private final boolean isOrderable;
+    private final Type baseType;
+
+    private final Optional<QualifiedObjectName> parentTypeName;
+    private Optional<DistinctType> lazilyLoadedParentType;
+    private Function<QualifiedObjectName, DistinctType> distinctTypeLoader;
+
+    public DistinctType(QualifiedObjectName name, Type baseType, boolean isOrderable, List<Optional<QualifiedObjectName>> ancestors, Function<QualifiedObjectName, DistinctType> distinctTypeLoader)
+    {
+        this(name, baseType, isOrderable, new ArrayDeque<>(ancestors), distinctTypeLoader);
+    }
+
+    private DistinctType(QualifiedObjectName name, Type baseType, boolean isOrderable, ArrayDeque<Optional<QualifiedObjectName>> ancestors, Function<QualifiedObjectName, DistinctType> distinctTypeLoader)
+    {
+        this.name = requireNonNull(name, "name is null");
+        this.distinctTypeLoader = requireNonNull(distinctTypeLoader, "distinctTypeLoader is null");
+        this.baseType = requireNonNull(baseType, "baseType is null");
+        this.isOrderable = isOrderable;
+        this.parentTypeName = ancestors.getFirst();
+        ancestors.pollFirst();
+        if (parentTypeName.isPresent()) {
+            this.lazilyLoadedParentType = ancestors.isEmpty() ? null : Optional.of(new DistinctType(name, baseType, isOrderable, ancestors, distinctTypeLoader));
+        }
+        else {
+            this.lazilyLoadedParentType = Optional.empty();
+        }
+    }
+
+    public QualifiedObjectName getName()
+    {
+        return name;
+    }
+
+    public Type getBaseType()
+    {
+        return baseType;
+    }
+
+    public Optional<DistinctType> getParentTypeLoadIfNeeded()
+    {
+        assureLoaded();
+        return lazilyLoadedParentType;
+    }
+
+    public Optional<DistinctType> getParentTypeIfAvailable()
+    {
+        return lazilyLoadedParentType == null ? Optional.empty() : lazilyLoadedParentType;
+    }
+
+    public Optional<QualifiedObjectName> getParentTypeName()
+    {
+        return parentTypeName;
+    }
+
+    public static boolean hasAncestorRelationship(DistinctType firstType, DistinctType secondType)
+    {
+        Optional<DistinctType> lowestCommonSuperType = getLowestCommonSuperType(firstType, secondType);
+        return lowestCommonSuperType.isPresent() && (lowestCommonSuperType.get().equals(firstType) || lowestCommonSuperType.get().equals(secondType));
+    }
+
+    // Computes the lowest common ancestor of 2 distinct types in the type tree.
+    // Visits as few types as possible, in order to avoid network calls to fetch the types.
+    public static Optional<DistinctType> getLowestCommonSuperType(DistinctType firstType, DistinctType secondType)
+    {
+        if (firstType.getBaseType() != secondType.getBaseType()) {
+            return Optional.empty();
+        }
+
+        HashMap<QualifiedObjectName, DistinctType> seenTypes = new HashMap<>();
+        Optional<DistinctType> firstAncestor = Optional.of(firstType);
+        Optional<DistinctType> secondAncestor = Optional.of(secondType);
+
+        seenTypes.put(firstAncestor.get().getName(), firstAncestor.get());
+        while (firstAncestor.get().getParentTypeIfAvailable().isPresent()) {
+            firstAncestor = firstAncestor.get().getParentTypeIfAvailable();
+            seenTypes.put(firstAncestor.get().getName(), firstAncestor.get());
+        }
+
+        if (seenTypes.containsKey(secondAncestor.get().getName())) {
+            return secondAncestor;
+        }
+        seenTypes.put(secondAncestor.get().getName(), secondAncestor.get());
+
+        while (secondAncestor.get().getParentTypeIfAvailable().isPresent()) {
+            secondAncestor = secondAncestor.get().getParentTypeIfAvailable();
+            if (seenTypes.containsKey(secondAncestor.get().getName())) {
+                return secondAncestor;
+            }
+            seenTypes.put(secondAncestor.get().getName(), secondAncestor.get());
+        }
+
+        while (firstAncestor.isPresent() || secondAncestor.isPresent()) {
+            if (firstAncestor.isPresent() && firstAncestor.get().getParentTypeName().isPresent()) {
+                if (seenTypes.containsKey(firstAncestor.get().getParentTypeName().get())) {
+                    return Optional.of(seenTypes.get(firstAncestor.get().getParentTypeName().get()));
+                }
+                firstAncestor = firstAncestor.get().getParentTypeLoadIfNeeded();
+                seenTypes.put(firstAncestor.get().getName(), firstAncestor.get());
+            }
+
+            if (secondAncestor.isPresent() && secondAncestor.get().getParentTypeName().isPresent()) {
+                if (seenTypes.containsKey(secondAncestor.get().getParentTypeName().get())) {
+                    return Optional.of(seenTypes.get(secondAncestor.get().getParentTypeName().get()));
+                }
+                secondAncestor = secondAncestor.get().getParentTypeLoadIfNeeded();
+                seenTypes.put(secondAncestor.get().getName(), secondAncestor.get());
+            }
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+
+        DistinctType other = (DistinctType) obj;
+
+        return Objects.equals(this.name, other.name);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(name);
+    }
+
+    @Override
+    public TypeSignature getTypeSignature()
+    {
+        List<Optional<QualifiedObjectName>> ancestors = new ArrayList<>();
+        DistinctType type = this;
+        while (type != null) {
+            Optional<QualifiedObjectName> parentTypeName = type.getParentTypeName();
+            ancestors.add(parentTypeName);
+            type = getParentTypeIfAvailable().orElse(null);
+        }
+        return new TypeSignature(new DistinctTypeInfo(name, baseType.getTypeSignature(), ancestors, isOrderable));
+    }
+
+    @Override
+    public String getDisplayName()
+    {
+        return name.toString();
+    }
+
+    @Override
+    public boolean isComparable()
+    {
+        return baseType.isComparable();
+    }
+
+    @Override
+    public boolean isOrderable()
+    {
+        return isOrderable;
+    }
+
+    @Override
+    public Class<?> getJavaType()
+    {
+        return baseType.getJavaType();
+    }
+
+    @Override
+    public List<Type> getTypeParameters()
+    {
+        return baseType.getTypeParameters();
+    }
+
+    @Override
+    public BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries, int expectedBytesPerEntry)
+    {
+        return baseType.createBlockBuilder(blockBuilderStatus, expectedEntries, expectedBytesPerEntry);
+    }
+
+    @Override
+    public BlockBuilder createBlockBuilder(BlockBuilderStatus blockBuilderStatus, int expectedEntries)
+    {
+        return baseType.createBlockBuilder(blockBuilderStatus, expectedEntries);
+    }
+
+    @Override
+    public Object getObjectValue(SqlFunctionProperties properties, Block block, int position)
+    {
+        return baseType.getObjectValue(properties, block, position);
+    }
+
+    @Override
+    public boolean getBoolean(Block block, int position)
+    {
+        return baseType.getBoolean(block, position);
+    }
+
+    @Override
+    public boolean getBooleanUnchecked(UncheckedBlock block, int internalPosition)
+    {
+        return baseType.getBooleanUnchecked(block, internalPosition);
+    }
+
+    @Override
+    public long getLong(Block block, int position)
+    {
+        return baseType.getLong(block, position);
+    }
+
+    @Override
+    public long getLongUnchecked(UncheckedBlock block, int internalPosition)
+    {
+        return baseType.getLongUnchecked(block, internalPosition);
+    }
+
+    @Override
+    public double getDouble(Block block, int position)
+    {
+        return baseType.getDouble(block, position);
+    }
+
+    @Override
+    public double getDoubleUnchecked(UncheckedBlock block, int internalPosition)
+    {
+        return baseType.getDoubleUnchecked(block, internalPosition);
+    }
+
+    @Override
+    public Slice getSlice(Block block, int position)
+    {
+        return baseType.getSlice(block, position);
+    }
+
+    @Override
+    public Slice getSliceUnchecked(Block block, int internalPosition)
+    {
+        return baseType.getSliceUnchecked(block, internalPosition);
+    }
+
+    @Override
+    public Object getObject(Block block, int position)
+    {
+        return baseType.getObject(block, position);
+    }
+
+    @Override
+    public Block getBlockUnchecked(Block block, int internalPosition)
+    {
+        return baseType.getBlockUnchecked(block, internalPosition);
+    }
+
+    @Override
+    public void writeBoolean(BlockBuilder blockBuilder, boolean value)
+    {
+        baseType.writeBoolean(blockBuilder, value);
+    }
+
+    @Override
+    public void writeLong(BlockBuilder blockBuilder, long value)
+    {
+        baseType.writeLong(blockBuilder, value);
+    }
+
+    @Override
+    public void writeDouble(BlockBuilder blockBuilder, double value)
+    {
+        baseType.writeDouble(blockBuilder, value);
+    }
+
+    @Override
+    public void writeSlice(BlockBuilder blockBuilder, Slice value)
+    {
+        baseType.writeSlice(blockBuilder, value);
+    }
+
+    @Override
+    public void writeSlice(BlockBuilder blockBuilder, Slice value, int offset, int length)
+    {
+        baseType.writeSlice(blockBuilder, value, offset, length);
+    }
+
+    @Override
+    public void writeObject(BlockBuilder blockBuilder, Object value)
+    {
+        baseType.writeObject(blockBuilder, value);
+    }
+
+    @Override
+    public void appendTo(Block block, int position, BlockBuilder blockBuilder)
+    {
+        baseType.appendTo(block, position, blockBuilder);
+    }
+
+    @Override
+    public boolean equalTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
+    {
+        return baseType.equalTo(leftBlock, leftPosition, rightBlock, rightPosition);
+    }
+
+    @Override
+    public long hash(Block block, int position)
+    {
+        return baseType.hash(block, position);
+    }
+
+    @Override
+    public int compareTo(Block leftBlock, int leftPosition, Block rightBlock, int rightPosition)
+    {
+        return baseType.compareTo(leftBlock, leftPosition, rightBlock, rightPosition);
+    }
+
+    private void assureLoaded()
+    {
+        if (lazilyLoadedParentType != null) {
+            return;
+        }
+        lazilyLoadedParentType = Optional.of(distinctTypeLoader.apply(parentTypeName.get()));
+        distinctTypeLoader = null;
+    }
+}

--- a/presto-common/src/main/java/com/facebook/presto/common/type/DistinctTypeInfo.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/DistinctTypeInfo.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.type;
+
+import com.facebook.presto.common.QualifiedObjectName;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import static java.lang.String.format;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.unmodifiableList;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
+
+public class DistinctTypeInfo
+{
+    private final QualifiedObjectName name;
+    private final TypeSignature baseType;
+    private final List<Optional<QualifiedObjectName>> ancestors;
+    private final boolean isOrderable;
+
+    @JsonCreator
+    public DistinctTypeInfo(
+            @JsonProperty("name") QualifiedObjectName name,
+            @JsonProperty("baseType") TypeSignature baseType,
+            @JsonProperty("parents") List<Optional<QualifiedObjectName>> ancestors,
+            @JsonProperty("isOrderable") boolean isOrderable)
+    {
+        this.name = requireNonNull(name, "name is null");
+        this.baseType = requireNonNull(baseType, "baseType is null");
+        this.ancestors = unmodifiableList(requireNonNull(ancestors, "ancestors is null"));
+        this.isOrderable = isOrderable;
+    }
+
+    public DistinctTypeInfo(QualifiedObjectName name, TypeSignature baseType, Optional<QualifiedObjectName> parent, boolean isOrderable)
+    {
+        this(name, baseType, singletonList(parent), isOrderable);
+    }
+
+    @JsonProperty
+    public QualifiedObjectName getName()
+    {
+        return name;
+    }
+
+    @JsonProperty
+    public TypeSignature getBaseType()
+    {
+        return baseType;
+    }
+
+    @JsonProperty
+    public List<Optional<QualifiedObjectName>> getAncestors()
+    {
+        return ancestors;
+    }
+
+    public Optional<QualifiedObjectName> getParent()
+    {
+        return ancestors.get(0);
+    }
+
+    @JsonProperty
+    public boolean isOrderable()
+    {
+        return isOrderable;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        DistinctTypeInfo other = (DistinctTypeInfo) o;
+
+        return Objects.equals(name, other.name);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(name);
+    }
+
+    @Override
+    public String toString()
+    {
+        return format("%s{%s, %s, %s}", name, baseType, isOrderable, ancestors.stream().map(name -> name.isPresent() ? name.get() : "null").collect(toList()));
+    }
+}

--- a/presto-common/src/main/java/com/facebook/presto/common/type/ParameterKind.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/ParameterKind.java
@@ -25,7 +25,8 @@ public enum ParameterKind
     LONG(Optional.of("LONG_LITERAL")),
     VARIABLE(Optional.empty()),
     LONG_ENUM(Optional.of("LONG_ENUM")),
-    VARCHAR_ENUM(Optional.of("VARCHAR_ENUM"));
+    VARCHAR_ENUM(Optional.of("VARCHAR_ENUM")),
+    DISTINCT_TYPE(Optional.of("DISTINCT_TYPE"));
 
     // TODO: drop special serialization code as soon as all clients
     //       migrate to version which can deserialize new format.

--- a/presto-common/src/main/java/com/facebook/presto/common/type/StandardTypes.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/StandardTypes.java
@@ -53,9 +53,12 @@ public final class StandardTypes
     public static final String BING_TILE = "BingTile";
     public static final String BIGINT_ENUM = "BigintEnum";
     public static final String VARCHAR_ENUM = "VarcharEnum";
+    public static final String DISTINCT_TYPE = "DistinctType";
     public static final String UUID = "uuid";
 
     private StandardTypes() {}
+
+    public static final Set<String> USER_DEFINED_TYPES = unmodifiableSet(new HashSet<>(asList(BIGINT_ENUM, VARCHAR_ENUM, DISTINCT_TYPE)));
 
     public static final Set<String> PARAMETRIC_TYPES = unmodifiableSet(new HashSet<>(asList(
             VARCHAR,
@@ -67,5 +70,6 @@ public final class StandardTypes
             QDIGEST,
             TDIGEST,
             BIGINT_ENUM,
-            VARCHAR_ENUM)));
+            VARCHAR_ENUM,
+            DISTINCT_TYPE)));
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/type/TypeParameter.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TypeParameter.java
@@ -61,6 +61,11 @@ public class TypeParameter
         return new TypeParameter(ParameterKind.VARCHAR_ENUM, enumMap);
     }
 
+    public static TypeParameter of(DistinctTypeInfo distinctTypeInfo)
+    {
+        return new TypeParameter(ParameterKind.DISTINCT_TYPE, distinctTypeInfo);
+    }
+
     public static TypeParameter of(TypeSignatureParameter parameter, TypeManager typeManager)
     {
         switch (parameter.getKind()) {
@@ -82,6 +87,8 @@ public class TypeParameter
                 return of(parameter.getLongEnumMap());
             case VARCHAR_ENUM:
                 return of(parameter.getVarcharEnumMap());
+            case DISTINCT_TYPE:
+                return of(parameter.getDistinctTypeInfo());
             default:
                 throw new UnsupportedOperationException(format("Unsupported parameter [%s]", parameter));
         }

--- a/presto-common/src/main/java/com/facebook/presto/common/type/TypeSignatureBase.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TypeSignatureBase.java
@@ -18,6 +18,7 @@ import com.facebook.presto.common.QualifiedObjectName;
 import java.util.Objects;
 import java.util.Optional;
 
+import static com.facebook.presto.common.type.StandardTypes.DISTINCT_TYPE;
 import static java.lang.String.format;
 import static java.util.Locale.ENGLISH;
 
@@ -46,6 +47,11 @@ public class TypeSignatureBase
     public static TypeSignatureBase of(UserDefinedType userDefinedType)
     {
         return new TypeSignatureBase(userDefinedType.getUserDefinedTypeName(), userDefinedType.getPhysicalTypeSignature().getTypeSignatureBase().getStandardTypeBase());
+    }
+
+    public static TypeSignatureBase of(DistinctTypeInfo distinctTypeInfo)
+    {
+        return new TypeSignatureBase(distinctTypeInfo.getName(), DISTINCT_TYPE);
     }
 
     private TypeSignatureBase(String standardTypeBase)

--- a/presto-common/src/main/java/com/facebook/presto/common/type/TypeSignatureParameter.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TypeSignatureParameter.java
@@ -57,6 +57,11 @@ public class TypeSignatureParameter
         return new TypeSignatureParameter(ParameterKind.VARCHAR_ENUM, enumMap);
     }
 
+    public static TypeSignatureParameter of(DistinctTypeInfo distinctTypeInfo)
+    {
+        return new TypeSignatureParameter(ParameterKind.DISTINCT_TYPE, distinctTypeInfo);
+    }
+
     private TypeSignatureParameter(ParameterKind kind, Object value)
     {
         this.kind = requireNonNull(kind, "kind is null");
@@ -104,6 +109,11 @@ public class TypeSignatureParameter
         return kind == ParameterKind.VARCHAR_ENUM;
     }
 
+    public boolean isDistinctType()
+    {
+        return kind == ParameterKind.DISTINCT_TYPE;
+    }
+
     private <A> A getValue(ParameterKind expectedParameterKind, Class<A> target)
     {
         if (kind != expectedParameterKind) {
@@ -142,6 +152,11 @@ public class TypeSignatureParameter
         return getValue(ParameterKind.VARCHAR_ENUM, VarcharEnumMap.class);
     }
 
+    public DistinctTypeInfo getDistinctTypeInfo()
+    {
+        return getValue(ParameterKind.DISTINCT_TYPE, DistinctTypeInfo.class);
+    }
+
     public Optional<TypeSignature> getTypeSignatureOrNamedTypeSignature()
     {
         switch (kind) {
@@ -164,6 +179,7 @@ public class TypeSignatureParameter
             case LONG:
             case LONG_ENUM:
             case VARCHAR_ENUM:
+            case DISTINCT_TYPE:
                 return false;
             case VARIABLE:
                 return true;

--- a/presto-common/src/main/java/com/facebook/presto/common/type/UserDefinedType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/UserDefinedType.java
@@ -17,6 +17,7 @@ import com.facebook.presto.common.QualifiedObjectName;
 
 import static java.util.Objects.requireNonNull;
 
+// This either represents an enum type, or a distinct type.
 public class UserDefinedType
 {
     private final QualifiedObjectName name;
@@ -36,5 +37,10 @@ public class UserDefinedType
     public TypeSignature getPhysicalTypeSignature()
     {
         return representation;
+    }
+
+    public boolean isDistinctType()
+    {
+        return representation.isDistinctType();
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlQueryExecution.java
@@ -798,7 +798,7 @@ public class SqlQueryExecution
                     stateMachine,
                     slug,
                     retryCount,
-                    metadata,
+                    metadata.createQueryAwareMetadata(stateMachine.getQueryId()),
                     accessControl,
                     sqlParser,
                     splitManager,

--- a/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
@@ -203,6 +203,7 @@ import com.facebook.presto.type.DateOperators;
 import com.facebook.presto.type.DateTimeOperators;
 import com.facebook.presto.type.DecimalOperators;
 import com.facebook.presto.type.DecimalParametricType;
+import com.facebook.presto.type.DistinctTypeCasts;
 import com.facebook.presto.type.DoubleOperators;
 import com.facebook.presto.type.EnumCasts;
 import com.facebook.presto.type.HyperLogLogOperators;
@@ -326,6 +327,7 @@ import static com.facebook.presto.operator.scalar.ArrayTransformFunction.ARRAY_T
 import static com.facebook.presto.operator.scalar.CastFromUnknownOperator.CAST_FROM_UNKNOWN;
 import static com.facebook.presto.operator.scalar.ConcatFunction.VARBINARY_CONCAT;
 import static com.facebook.presto.operator.scalar.ConcatFunction.VARCHAR_CONCAT;
+import static com.facebook.presto.operator.scalar.DistinctTypeEqualOperator.DISTINCT_TYPE_EQUAL_OPERATOR;
 import static com.facebook.presto.operator.scalar.ElementToArrayConcatFunction.ELEMENT_TO_ARRAY_CONCAT_FUNCTION;
 import static com.facebook.presto.operator.scalar.Greatest.GREATEST;
 import static com.facebook.presto.operator.scalar.IdentityCast.IDENTITY_CAST;
@@ -848,6 +850,8 @@ public class BuiltInTypeAndFunctionNamespaceManager
                 .scalars(EnumCasts.class)
                 .scalars(LongEnumOperators.class)
                 .scalars(VarcharEnumOperators.class)
+                .codegenScalars(DistinctTypeCasts.class)
+                .functions(DISTINCT_TYPE_EQUAL_OPERATOR)
                 .codegenScalars(MapFilterFunction.class);
 
         switch (featuresConfig.getRegexLibrary()) {

--- a/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/Metadata.java
@@ -73,6 +73,8 @@ public interface Metadata
 
     List<String> listSchemaNames(Session session, String catalogName);
 
+    Metadata createQueryAwareMetadata(QueryId queryId);
+
     /**
      * Returns a table handle for the specified table name.
      */

--- a/presto-main/src/main/java/com/facebook/presto/metadata/QueryAwareFunctionAndTypeManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/QueryAwareFunctionAndTypeManager.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.metadata;
+
+import com.facebook.presto.common.QualifiedObjectName;
+import com.facebook.presto.common.type.DistinctType;
+import com.facebook.presto.common.type.DistinctTypeInfo;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.TypeSignature;
+import com.facebook.presto.common.type.TypeWithName;
+import com.facebook.presto.common.type.UserDefinedType;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+@ThreadSafe
+public class QueryAwareFunctionAndTypeManager
+        extends FunctionAndTypeManager
+{
+    // Cache user defined types queried for a particular query. So a query sees a consistent view of them.
+    private final ConcurrentHashMap<QualifiedObjectName, UserDefinedType> userDefinedTypes = new ConcurrentHashMap<>();
+
+    public QueryAwareFunctionAndTypeManager(FunctionAndTypeManager functionAndTypeManager)
+    {
+        super(functionAndTypeManager);
+    }
+
+    private void cacheType(Type type)
+    {
+        if (type instanceof DistinctType) {
+            DistinctType distinctType = (DistinctType) type;
+            while (distinctType != null) {
+                userDefinedTypes.putIfAbsent(
+                        distinctType.getName(),
+                        new UserDefinedType(
+                                distinctType.getName(),
+                                new TypeSignature(
+                                        new DistinctTypeInfo(
+                                                distinctType.getName(),
+                                                distinctType.getBaseType().getTypeSignature(),
+                                                distinctType.getParentTypeName(),
+                                                distinctType.isOrderable()))));
+                distinctType = distinctType.getParentTypeIfAvailable().orElse(null);
+            }
+        }
+        else if (type instanceof TypeWithName) {
+            TypeWithName typeWithName = (TypeWithName) type;
+            userDefinedTypes.putIfAbsent(typeWithName.getName(), new UserDefinedType(typeWithName.getName(), typeWithName.getType().getTypeSignature()));
+        }
+    }
+
+    @Override
+    public Type getType(TypeSignature signature)
+    {
+        if (signature.getTypeSignatureBase().hasStandardType()) {
+            Type returnType = super.getType(signature);
+            cacheType(returnType);
+            return returnType;
+        }
+
+        UserDefinedType cachedUserDefinedType = userDefinedTypes.get(signature.getTypeSignatureBase().getTypeName());
+
+        if (cachedUserDefinedType != null) {
+            return super.getType(cachedUserDefinedType);
+        }
+
+        Type returnType = super.getType(signature);
+        cacheType(returnType);
+        return returnType;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/DistinctTypeEqualOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/DistinctTypeEqualOperator.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.common.type.DistinctType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.metadata.BoundVariables;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.metadata.SqlOperator;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.function.FunctionHandle;
+import com.google.common.collect.ImmutableList;
+
+import java.util.Optional;
+
+import static com.facebook.presto.common.function.OperatorType.EQUAL;
+import static com.facebook.presto.common.type.DistinctType.getLowestCommonSuperType;
+import static com.facebook.presto.common.type.StandardTypes.BOOLEAN;
+import static com.facebook.presto.common.type.StandardTypes.DISTINCT_TYPE;
+import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementationChoice.ArgumentProperty.valueTypeArgumentProperty;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementationChoice.NullConvention.RETURN_NULL_ON_NULL;
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_ARGUMENTS;
+import static com.facebook.presto.spi.function.Signature.withVariadicBound;
+import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
+import static java.lang.String.format;
+
+public class DistinctTypeEqualOperator
+        extends SqlOperator
+{
+    public static final DistinctTypeEqualOperator DISTINCT_TYPE_EQUAL_OPERATOR = new DistinctTypeEqualOperator();
+
+    private DistinctTypeEqualOperator()
+    {
+        super(EQUAL,
+                ImmutableList.of(withVariadicBound("T1", DISTINCT_TYPE), withVariadicBound("T2", DISTINCT_TYPE)),
+                ImmutableList.of(),
+                parseTypeSignature(BOOLEAN),
+                ImmutableList.of(parseTypeSignature("T1"), parseTypeSignature("T2")));
+    }
+
+    @Override
+    public BuiltInScalarFunctionImplementation specialize(BoundVariables boundVariables, int arity, FunctionAndTypeManager functionAndTypeManager)
+    {
+        DistinctType leftType = (DistinctType) boundVariables.getTypeVariable("T1");
+        DistinctType rightType = (DistinctType) boundVariables.getTypeVariable("T2");
+
+        Optional<DistinctType> commonSuperType = getLowestCommonSuperType(leftType, rightType);
+        boolean canCompare = commonSuperType.isPresent() && (commonSuperType.get().equals(leftType) || commonSuperType.get().equals(rightType));
+
+        if (!canCompare) {
+            throw new PrestoException(INVALID_ARGUMENTS, format("Cannot compare %s and %s for equality", leftType.getName(), rightType.getName()));
+        }
+
+        Type baseType = leftType.getBaseType();
+        FunctionHandle functionHandle = functionAndTypeManager.resolveOperator(EQUAL, fromTypes(baseType, baseType));
+
+        return new BuiltInScalarFunctionImplementation(
+                true,
+                ImmutableList.of(valueTypeArgumentProperty(RETURN_NULL_ON_NULL), valueTypeArgumentProperty(RETURN_NULL_ON_NULL)),
+                functionAndTypeManager.getJavaScalarFunctionImplementation(functionHandle).getMethodHandle(),
+                Optional.empty());
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ScalarHeader.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ScalarHeader.java
@@ -15,6 +15,7 @@ package com.facebook.presto.operator.scalar;
 
 import com.facebook.presto.spi.function.SqlFunctionVisibility;
 
+import java.util.Map;
 import java.util.Optional;
 
 public class ScalarHeader
@@ -23,13 +24,15 @@ public class ScalarHeader
     private final SqlFunctionVisibility visibility;
     private final boolean deterministic;
     private final boolean calledOnNullInput;
+    private final Map<String, String> typeNameConstraints;
 
-    public ScalarHeader(Optional<String> description, SqlFunctionVisibility visibility, boolean deterministic, boolean calledOnNullInput)
+    public ScalarHeader(Optional<String> description, SqlFunctionVisibility visibility, boolean deterministic, boolean calledOnNullInput, Map<String, String> typeNameConstraints)
     {
         this.description = description;
         this.visibility = visibility;
         this.deterministic = deterministic;
         this.calledOnNullInput = calledOnNullInput;
+        this.typeNameConstraints = typeNameConstraints;
     }
 
     public Optional<String> getDescription()
@@ -50,5 +53,10 @@ public class ScalarHeader
     public boolean isCalledOnNullInput()
     {
         return calledOnNullInput;
+    }
+
+    public Map<String, String> getTypeNameConstraints()
+    {
+        return typeNameConstraints;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/annotations/ScalarFromAnnotationsParser.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/annotations/ScalarFromAnnotationsParser.java
@@ -19,6 +19,7 @@ import com.facebook.presto.operator.annotations.FunctionsParserHelper;
 import com.facebook.presto.operator.scalar.ParametricScalar;
 import com.facebook.presto.operator.scalar.annotations.ParametricScalarImplementation.SpecializedSignature;
 import com.facebook.presto.spi.function.CodegenScalarFunction;
+import com.facebook.presto.spi.function.CodegenScalarOperator;
 import com.facebook.presto.spi.function.ScalarFunction;
 import com.facebook.presto.spi.function.ScalarOperator;
 import com.facebook.presto.spi.function.Signature;
@@ -89,7 +90,7 @@ public final class ScalarFromAnnotationsParser
         for (Method method : FunctionsParserHelper.findPublicMethods(
                 annotated,
                 ImmutableSet.of(SqlType.class, ScalarFunction.class, ScalarOperator.class),
-                ImmutableSet.of(SqlInvokedScalarFunction.class, CodegenScalarFunction.class))) {
+                ImmutableSet.of(SqlInvokedScalarFunction.class, CodegenScalarFunction.class, CodegenScalarOperator.class))) {
             checkCondition((method.getAnnotation(ScalarFunction.class) != null) || (method.getAnnotation(ScalarOperator.class) != null),
                     FUNCTION_IMPLEMENTATION_ERROR, "Method [%s] annotated with @SqlType is missing @ScalarFunction or @ScalarOperator", method);
             for (ScalarImplementationHeader header : ScalarImplementationHeader.fromAnnotatedElement(method)) {

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/annotations/SqlInvokedScalarFromAnnotationsParser.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/annotations/SqlInvokedScalarFromAnnotationsParser.java
@@ -17,6 +17,7 @@ import com.facebook.presto.common.QualifiedObjectName;
 import com.facebook.presto.common.type.TypeSignature;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.function.CodegenScalarFunction;
+import com.facebook.presto.spi.function.CodegenScalarOperator;
 import com.facebook.presto.spi.function.Description;
 import com.facebook.presto.spi.function.Parameter;
 import com.facebook.presto.spi.function.RoutineCharacteristics;
@@ -101,10 +102,11 @@ public final class SqlInvokedScalarFromAnnotationsParser
 
     private static List<Method> findScalarsInFunctionSetClass(Class<?> clazz)
     {
+        // It isn't clean to exclude several annotations like codegenscalaroperator here. We should refactor this
         Set<Method> methods = findPublicStaticMethods(
                 clazz,
                 ImmutableSet.of(SqlInvokedScalarFunction.class, SqlType.class, SqlParameter.class, SqlParameters.class, Description.class),
-                ImmutableSet.of(ScalarFunction.class, ScalarOperator.class, CodegenScalarFunction.class));
+                ImmutableSet.of(ScalarFunction.class, ScalarOperator.class, CodegenScalarFunction.class, CodegenScalarOperator.class));
         for (Method method : methods) {
             checkCondition(
                     method.isAnnotationPresent(SqlInvokedScalarFunction.class) && method.isAnnotationPresent(SqlType.class),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/RowExpressionInterpreter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/RowExpressionInterpreter.java
@@ -270,6 +270,7 @@ public class RowExpressionInterpreter
 
             Object value;
             FunctionImplementationType implementationType = functionMetadata.getImplementationType();
+//            FunctionImplementationType implementationType = JAVA;
             if (implementationType.isExternal()) {
                 // do not interpret remote functions on coordinator
                 return call(node.getDisplayName(), functionHandle, node.getType(), toRowExpressions(argumentValues, node.getArguments()));

--- a/presto-main/src/main/java/com/facebook/presto/type/DistinctTypeCasts.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/DistinctTypeCasts.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.type;
+
+import com.facebook.presto.common.type.DistinctType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.function.CodegenScalarOperator;
+import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.function.TypeParameter;
+
+import java.lang.invoke.MethodHandle;
+
+import static com.facebook.presto.common.function.OperatorType.CAST;
+import static com.facebook.presto.common.type.DistinctType.hasAncestorRelationship;
+import static com.facebook.presto.common.type.StandardTypes.DISTINCT_TYPE;
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
+import static java.lang.String.format;
+import static java.lang.invoke.MethodHandles.identity;
+
+public class DistinctTypeCasts
+{
+    private DistinctTypeCasts() {}
+
+    @CodegenScalarOperator(CAST)
+    @TypeParameter("T2")
+    @TypeParameter(value = "T1", boundedBy = DISTINCT_TYPE)
+    @SqlType("T2")
+    public static MethodHandle castFromDistinct(@SqlType("T1") Type fromType, @TypeParameter("T2") Type toType)
+    {
+        return cast(fromType, toType);
+    }
+
+    @CodegenScalarOperator(CAST)
+    @TypeParameter("T1")
+    @TypeParameter(value = "T2", boundedBy = DISTINCT_TYPE)
+    @SqlType("T2")
+    public static MethodHandle castToDistinct(@SqlType("T1") Type fromType, @TypeParameter("T2") Type toType)
+    {
+        return cast(fromType, toType);
+    }
+
+    private static void checkCanCast(Type fromType, Type toType)
+    {
+        if (fromType instanceof DistinctType && toType instanceof DistinctType) {
+            DistinctType fromDistinctType = (DistinctType) fromType;
+            DistinctType toDistinctType = (DistinctType) toType;
+
+            if (!hasAncestorRelationship(fromDistinctType, toDistinctType)) {
+                throw new PrestoException(INVALID_CAST_ARGUMENT, format("Cannot cast %s to %s", fromDistinctType.getName(), toDistinctType.getName()));
+            }
+        }
+        else if (fromType instanceof DistinctType) {
+            DistinctType fromDistinctType = (DistinctType) fromType;
+            if (!fromDistinctType.getBaseType().equals(toType)) {
+                throw new PrestoException(INVALID_CAST_ARGUMENT, format("Cannot cast %s to %s", fromDistinctType.getName(), toType));
+            }
+        }
+        else if (toType instanceof DistinctType) {
+            DistinctType toDistinctType = (DistinctType) toType;
+            if (!toDistinctType.getBaseType().equals(fromType)) {
+                throw new PrestoException(INVALID_CAST_ARGUMENT, format("Cannot cast %s to %s", fromType, toDistinctType.getName()));
+            }
+        }
+    }
+
+    private static MethodHandle cast(Type fromType, Type toType)
+    {
+        checkCanCast(fromType, toType);
+        return identity(fromType.getJavaType());
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/metadata/AbstractMockMetadata.java
+++ b/presto-main/src/test/java/com/facebook/presto/metadata/AbstractMockMetadata.java
@@ -61,6 +61,12 @@ public abstract class AbstractMockMetadata
     }
 
     @Override
+    public Metadata createQueryAwareMetadata(QueryId queryId)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public void verifyComparableOrderableContract()
     {
         throw new UnsupportedOperationException();

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/CodegenScalarOperator.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/CodegenScalarOperator.java
@@ -13,23 +13,17 @@
  */
 package com.facebook.presto.spi.function;
 
-import java.lang.annotation.Repeatable;
+import com.facebook.presto.common.function.OperatorType;
+
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
-import static java.lang.annotation.ElementType.CONSTRUCTOR;
 import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 @Retention(RUNTIME)
-@Target({PARAMETER, METHOD, CONSTRUCTOR})
-@Repeatable(TypeParameters.class)
-public @interface TypeParameter
+@Target(METHOD)
+public @interface CodegenScalarOperator
 {
-    String value();
-
-    String boundedBy() default "";
-
-    String typeName() default "";
+    OperatorType value();
 }

--- a/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
@@ -38,6 +38,7 @@ import com.facebook.presto.spi.Plugin;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.WarningCollector;
 import com.facebook.presto.spi.eventlistener.EventListener;
+import com.facebook.presto.spi.function.SqlFunction;
 import com.facebook.presto.split.PageSourceManager;
 import com.facebook.presto.split.SplitManager;
 import com.facebook.presto.sql.parser.SqlParserOptions;
@@ -270,6 +271,11 @@ public class DistributedQueryRunner
             MILLISECONDS.sleep(10);
             availableCoordinaors = getResourceManager().get().getNodeManager().getCoordinators().size();
         }
+    }
+
+    public void registerBuiltInFunctions(List<? extends SqlFunction> functions)
+    {
+        this.servers.forEach(server -> server.getMetadata().registerBuiltInFunctions(functions));
     }
 
     private NodeState getCoordinatorInfoState(int coordinator)

--- a/presto-tests/src/main/java/com/facebook/presto/tests/TestingPrestoClient.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/TestingPrestoClient.java
@@ -21,6 +21,7 @@ import com.facebook.presto.client.QueryStatusInfo;
 import com.facebook.presto.common.type.ArrayType;
 import com.facebook.presto.common.type.BigintEnumType;
 import com.facebook.presto.common.type.DecimalType;
+import com.facebook.presto.common.type.DistinctType;
 import com.facebook.presto.common.type.JsonType;
 import com.facebook.presto.common.type.MapType;
 import com.facebook.presto.common.type.RowType;
@@ -269,6 +270,9 @@ public class TestingPrestoClient
         }
         else if (type instanceof TypeWithName) {
             return convertToRowValue(((TypeWithName) type).getType(), value);
+        }
+        else if (type instanceof DistinctType) {
+            return convertToRowValue(((DistinctType) type).getBaseType(), value);
         }
         else if (type.getTypeSignature().getBase().equals("ObjectId")) {
             return value;

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestDistinctTypes.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestDistinctTypes.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.common.QualifiedObjectName;
+import com.facebook.presto.common.type.DistinctTypeInfo;
+import com.facebook.presto.common.type.TypeSignature;
+import com.facebook.presto.common.type.UserDefinedType;
+import com.facebook.presto.spi.function.ScalarFunction;
+import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.function.TypeParameter;
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.testing.MaterializedRow;
+import com.facebook.presto.testing.QueryRunner;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.intellij.lang.annotations.Language;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static com.facebook.presto.common.type.StandardTypes.BOOLEAN;
+import static com.facebook.presto.common.type.StandardTypes.DISTINCT_TYPE;
+import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.metadata.FunctionExtractor.extractFunctions;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static java.util.Collections.singletonList;
+import static org.testng.Assert.assertEquals;
+
+@Test(singleThreaded = true)
+public class TestDistinctTypes
+        extends AbstractTestQueryFramework
+{
+    private static final UserDefinedType USER_ID = new UserDefinedType(
+            QualifiedObjectName.valueOf("test.dt.user_id"),
+            new TypeSignature(
+                    new DistinctTypeInfo(
+                            QualifiedObjectName.valueOf("test.dt.user_id"),
+                            parseTypeSignature("integer"),
+                            Optional.empty(),
+                            true)));
+
+    private static final UserDefinedType ADMIN_ID = new UserDefinedType(
+            QualifiedObjectName.valueOf("test.dt.admin_id"),
+            new TypeSignature(
+                    new DistinctTypeInfo(
+                            QualifiedObjectName.valueOf("test.dt.admin_id"),
+                            parseTypeSignature("integer"),
+                            Optional.of(QualifiedObjectName.valueOf("test.dt.user_id")),
+                            true)));
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        try {
+            Session session = testSessionBuilder().build();
+            DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(session)
+                    .setNodeCount(2)
+                    .setCoordinatorProperties(ImmutableMap.of("node-scheduler.include-coordinator", "false"))
+                    .build();
+            queryRunner.enableTestFunctionNamespaces(ImmutableList.of("test"), ImmutableMap.of());
+            queryRunner.getMetadata().getFunctionAndTypeManager().addUserDefinedType(USER_ID);
+            queryRunner.getMetadata().getFunctionAndTypeManager().addUserDefinedType(ADMIN_ID);
+            queryRunner.registerBuiltInFunctions(extractFunctions(TestDistinctTypes.class));
+
+            return queryRunner;
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void assertQueryResultUnordered(@Language("SQL") String query, List<List<Object>> expectedRows)
+    {
+        MaterializedResult rows = computeActual(query);
+        assertEquals(
+                ImmutableSet.copyOf(rows.getMaterializedRows()),
+                expectedRows.stream().map(row -> new MaterializedRow(1, row)).collect(Collectors.toSet()));
+    }
+
+    private void assertSingleValue(@Language("SQL") String query, Object expectedResult)
+    {
+        assertQueryResultUnordered(query, singletonList(singletonList(expectedResult)));
+    }
+
+    @Test
+    public void testDistinctCasts()
+    {
+        // Using values ensures that queries are run on workers
+        assertSingleValue("SELECT CAST(x as test.dt.user_id) = CAST(1 as test.dt.admin_id) FROM (VALUES 1) t(x)", true);
+        assertSingleValue("SELECT CAST(1 as test.dt.user_id) = CAST(x as test.dt.admin_id) FROM (VALUES 2) t(x)", false);
+
+        assertSingleValue("SELECT CAST(x AS test.dt.user_id) = CAST(x as test.dt.user_id) FROM (VALUES 1) t(x)", true);
+        assertSingleValue("SELECT CAST(CAST(x AS test.dt.user_id) AS integer) FROM (VALUES 1) t(x)", 1);
+
+        assertQueryFails("SELECT CAST(CAST(1 AS test.dt.user_id) AS varchar)", "Cannot cast test.dt.user_id to varchar");
+        assertQueryFails("SELECT CAST(CAST(1 AS BIGINT) AS test.dt.user_id)", "Cannot cast bigint to test.dt.user_id");
+
+        assertSingleValue("SELECT cast(array[cast(x as test.dt.admin_id)] as array(test.dt.user_id)) FROM (VALUES 1) t(x)", singletonList(1));
+        assertSingleValue("SELECT array[cast(x as test.dt.admin_id)] = array[cast(1 as test.dt.user_id)] FROM (VALUES 1) t(x)", true);
+
+        assertSingleValue("SELECT good_user(cast(x as test.dt.user_id)) FROM (VALUES 1) t(x)", true);
+        assertSingleValue("SELECT good_user(cast(x as test.dt.admin_id)) FROM (VALUES 1) t(x)", true);
+        assertQueryFails("SELECT good_admin(cast(1 as test.dt.user_id))", ".*Unable to find matching typeName.*");
+    }
+
+    @ScalarFunction("good_user")
+    @TypeParameter(value = "T", boundedBy = DISTINCT_TYPE, typeName = "test.dt.user_id")
+    @SqlType(BOOLEAN)
+    public static boolean goodUser(@SqlType("T") long value)
+    {
+        return value == 1;
+    }
+
+    @ScalarFunction("good_admin")
+    @TypeParameter(value = "T", boundedBy = DISTINCT_TYPE, typeName = "test.dt.admin_id")
+    @SqlType(BOOLEAN)
+    public static boolean goodAdmin(@SqlType("T") long value)
+    {
+        return value == 1;
+    }
+}


### PR DESCRIPTION
Add some distinct type support, need initial comments on overall design

* Use QueryAwareFunctionAndTypeManager to make sure all user defined types within a query are consistent
* CAST working among distinct/base types
* Able to call user defined functions with coercion
* Added equal operator for distinct types - other operators should be similar. 
* Added example of a user defined function using distinct type in tests. 
* We need more tests
* Connector support pending

```
== NO RELEASE NOTE ==
```
