### PR TITLE
Hive insert overwrite when using S3 storage

### DIFF
--- a/.github/workflows/hive-tests.yml
+++ b/.github/workflows/hive-tests.yml
@@ -56,3 +56,29 @@ jobs:
           if [ "${HIVE_AWS_ACCESS_KEY_ID}" != "" ]; then
               ./mvnw test ${MAVEN_TEST} -pl :presto-hive -P test-hive-glue
           fi
+
+  hive-dockerized-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - name: Cache local Maven repository
+        id: cache-maven
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-2-
+      - name: Populate maven cache
+        if: steps.cache-maven.outputs.cache-hit != 'true'
+        run: ./mvnw de.qaware.maven:go-offline-maven-plugin:resolve-dependencies
+      - name: Install Hive Module
+        run: |
+          export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
+          ./mvnw install ${MAVEN_FAST_INSTALL} -am -pl :presto-hive
+      - name: Run Hive Dockerized Tests
+        run: ./mvnw test ${MAVEN_TEST} -pl :presto-hive -P test-hive-insert-overwrite

--- a/presto-hive/pom.xml
+++ b/presto-hive/pom.xml
@@ -471,6 +471,8 @@
                                 <exclude>**/TestHivePushdownIntegrationSmokeTest.java</exclude>
                                 <exclude>**/TestHivePushdownDistributedQueries.java</exclude>
                                 <exclude>**/TestParquetDistributedQueries.java</exclude>
+                                <exclude>**/TestHive2InsertOverwrite.java</exclude>
+                                <exclude>**/TestHive3InsertOverwrite.java</exclude>
                             </excludes>
                         </configuration>
                     </plugin>
@@ -601,6 +603,23 @@
                         <configuration>
                             <includes>
                                 <include>**/TestParquetDistributedQueries.java</include>
+                            </includes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>test-hive-insert-overwrite</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <includes>
+                                <include>**/TestHive2InsertOverwrite.java</include>
+                                <include>**/TestHive3InsertOverwrite.java</include>
                             </includes>
                         </configuration>
                     </plugin>

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -40,9 +40,16 @@ import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 
 import static com.facebook.presto.hive.BucketFunctionType.HIVE_COMPATIBLE;
+import static com.facebook.presto.hive.HiveClientConfig.InsertExistingPartitionsBehavior.APPEND;
+import static com.facebook.presto.hive.HiveClientConfig.InsertExistingPartitionsBehavior.ERROR;
+import static com.facebook.presto.hive.HiveClientConfig.InsertExistingPartitionsBehavior.OVERWRITE;
+import static com.facebook.presto.hive.HiveSessionProperties.INSERT_EXISTING_PARTITIONS_BEHAVIOR;
 import static com.facebook.presto.hive.HiveStorageFormat.ORC;
 import static com.facebook.presto.spi.schedule.NodeSelectionStrategy.NO_PREFERENCE;
+import static com.google.common.base.Preconditions.checkArgument;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static java.lang.String.format;
+import static java.util.Locale.ENGLISH;
 
 @DefunctConfig({
         "hive.file-system-cache-ttl",
@@ -93,6 +100,7 @@ public class HiveClientConfig
     private boolean createEmptyBucketFiles = true;
     private boolean insertOverwriteImmutablePartitions;
     private boolean failFastOnInsertIntoImmutablePartitionsEnabled = true;
+    private InsertExistingPartitionsBehavior insertExistingPartitionsBehavior;
     private int maxPartitionsPerWriter = 100;
     private int maxOpenSortFiles = 50;
     private int writeValidationThreads = 16;
@@ -591,16 +599,53 @@ public class HiveClientConfig
         return this;
     }
 
+    @Deprecated
     public boolean isInsertOverwriteImmutablePartitionEnabled()
     {
         return insertOverwriteImmutablePartitions;
     }
 
+    @Deprecated
     @Config("hive.insert-overwrite-immutable-partitions-enabled")
     @ConfigDescription("When enabled, insertion query will overwrite existing partitions when partitions are immutable. This config only takes effect with hive.immutable-partitions set to true")
     public HiveClientConfig setInsertOverwriteImmutablePartitionEnabled(boolean insertOverwriteImmutablePartitions)
     {
         this.insertOverwriteImmutablePartitions = insertOverwriteImmutablePartitions;
+        return this;
+    }
+
+    public enum InsertExistingPartitionsBehavior
+    {
+        ERROR,
+        APPEND,
+        OVERWRITE,
+        /**/;
+
+        public static InsertExistingPartitionsBehavior valueOf(String value, boolean immutablePartition)
+        {
+            InsertExistingPartitionsBehavior enumValue = valueOf(value.toUpperCase(ENGLISH));
+            if (immutablePartition) {
+                checkArgument(enumValue != APPEND, format("Presto is configured to treat Hive partitions as immutable. %s is not allowed to be set to %s", INSERT_EXISTING_PARTITIONS_BEHAVIOR, APPEND));
+            }
+
+            return enumValue;
+        }
+    }
+
+    public InsertExistingPartitionsBehavior getInsertExistingPartitionsBehavior()
+    {
+        if (insertExistingPartitionsBehavior != null) {
+            return insertExistingPartitionsBehavior;
+        }
+
+        return immutablePartitions ? (isInsertOverwriteImmutablePartitionEnabled() ? OVERWRITE : ERROR) : APPEND;
+    }
+
+    @Config("hive.insert-existing-partitions-behavior")
+    @ConfigDescription("Default value for insert existing partitions behavior")
+    public HiveClientConfig setInsertExistingPartitionsBehavior(InsertExistingPartitionsBehavior insertExistingPartitionsBehavior)
+    {
+        this.insertExistingPartitionsBehavior = insertExistingPartitionsBehavior;
         return this;
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriteUtils.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriteUtils.java
@@ -422,6 +422,13 @@ public final class HiveWriteUtils
         }
     }
 
+    public static boolean isFileCreatedByQuery(String fileName, String queryId)
+    {
+        // For normal files, the queryId is at the beginning of the file name.
+        // For bucketed files, the queryId is at the end of the file name.
+        return fileName.startsWith(queryId) || fileName.endsWith(queryId);
+    }
+
     public static Path createTemporaryPath(ConnectorSession session, HdfsContext context, HdfsEnvironment hdfsEnvironment, Path targetPath)
     {
         // use a per-user temporary directory to avoid permission problems

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriterFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriterFactory.java
@@ -18,7 +18,7 @@ import com.facebook.presto.common.Page;
 import com.facebook.presto.common.block.SortOrder;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeManager;
-import com.facebook.presto.hive.HiveSessionProperties.InsertExistingPartitionsBehavior;
+import com.facebook.presto.hive.HiveClientConfig.InsertExistingPartitionsBehavior;
 import com.facebook.presto.hive.LocationService.WriteInfo;
 import com.facebook.presto.hive.PartitionUpdate.UpdateMode;
 import com.facebook.presto.hive.metastore.Column;
@@ -546,7 +546,6 @@ public class HiveWriterFactory
         // * No partition writable check is required.
         // * Table schema and storage format is used for the new partition (instead of existing partition schema and storage format).
         WriteInfo writeInfo = locationService.getPartitionWriteInfo(locationHandle, Optional.empty(), partitionName);
-        checkState(writeInfo.getWriteMode() != DIRECT_TO_TARGET_EXISTING_DIRECTORY, "Overwriting existing partition doesn't support DIRECT_TO_TARGET_EXISTING_DIRECTORY write mode");
         return new WriterParameters(
                 UpdateMode.OVERWRITE,
                 getHiveSchema(table),

--- a/presto-hive/src/test/java/com/facebook/presto/hive/BaseTestHiveInsertOverwrite.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/BaseTestHiveInsertOverwrite.java
@@ -1,0 +1,193 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.hive.containers.HiveMinIODataLake;
+import com.facebook.presto.hive.s3.S3HiveQueryRunner;
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.facebook.airlift.testing.Closeables.closeAllRuntimeException;
+import static com.facebook.presto.tests.sql.TestTable.randomTableSuffix;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.joining;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public abstract class BaseTestHiveInsertOverwrite
+        extends AbstractTestQueryFramework
+{
+    private static final String HIVE_TEST_SCHEMA = "hive_insert_overwrite";
+
+    private String bucketName;
+    private HiveMinIODataLake dockerizedS3DataLake;
+
+    private final String hiveHadoopImage;
+
+    public BaseTestHiveInsertOverwrite(String hiveHadoopImage)
+    {
+        this.hiveHadoopImage = requireNonNull(hiveHadoopImage, "hiveHadoopImage is null");
+    }
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        this.bucketName = "test-hive-insert-overwrite-" + randomTableSuffix();
+        this.dockerizedS3DataLake = new HiveMinIODataLake(bucketName, ImmutableMap.of(), hiveHadoopImage);
+        this.dockerizedS3DataLake.start();
+        return S3HiveQueryRunner.create(
+                this.dockerizedS3DataLake.getHiveHadoop().getHiveMetastoreEndpoint(),
+                this.dockerizedS3DataLake.getMinio().getMinioApiEndpoint(),
+                HiveMinIODataLake.ACCESS_KEY,
+                HiveMinIODataLake.SECRET_KEY,
+                ImmutableMap.<String, String>builder()
+                        // This is required when using MinIO which requires path style access
+                        .put("hive.s3.path-style-access", "true")
+                        .put("hive.insert-existing-partitions-behavior", "OVERWRITE")
+                        .put("hive.non-managed-table-writes-enabled", "true")
+                        .build());
+    }
+
+    @BeforeClass
+    public void setUp()
+    {
+        computeActual(format(
+                "CREATE SCHEMA hive.%1$s WITH (location='s3a://%2$s/%1$s')",
+                HIVE_TEST_SCHEMA,
+                bucketName));
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void close()
+            throws Exception
+    {
+        closeAllRuntimeException(dockerizedS3DataLake);
+    }
+
+    @Test
+    public void testInsertOverwritePartitionedTable()
+    {
+        String testTable = getTestTableName();
+        computeActual(getCreateTableStatement(
+                testTable,
+                "partitioned_by=ARRAY['regionkey']"));
+        copyTpchNationToTable(testTable);
+        assertOverwritePartition(testTable);
+    }
+
+    @Test
+    public void testInsertOverwritePartitionedAndBucketedTable()
+    {
+        String testTable = getTestTableName();
+        computeActual(getCreateTableStatement(
+                testTable,
+                "partitioned_by=ARRAY['regionkey']",
+                "bucketed_by = ARRAY['nationkey']",
+                "bucket_count = 3"));
+        copyTpchNationToTable(testTable);
+        assertOverwritePartition(testTable);
+    }
+
+    @Test
+    public void testInsertOverwritePartitionedAndBucketedExternalTable()
+    {
+        String testTable = getTestTableName();
+        // Store table data in data lake bucket
+        computeActual(getCreateTableStatement(
+                testTable,
+                "partitioned_by=ARRAY['regionkey']",
+                "bucketed_by = ARRAY['nationkey']",
+                "bucket_count = 3"));
+        copyTpchNationToTable(testTable);
+
+        String tableName = testTable.substring(testTable.lastIndexOf('.') + 1);
+        // Map this table as external table
+        String externalTableName = testTable + "_ext";
+        computeActual(getCreateTableStatement(
+                externalTableName,
+                "partitioned_by=ARRAY['regionkey']",
+                "bucketed_by = ARRAY['nationkey']",
+                "bucket_count = 3",
+                format("external_location = 's3a://%s/%s/%s/'", this.bucketName, HIVE_TEST_SCHEMA, tableName)));
+        copyTpchNationToTable(testTable);
+        assertOverwritePartition(externalTableName);
+    }
+
+    protected void assertOverwritePartition(String testTable)
+    {
+        computeActual(format(
+                "INSERT INTO %s VALUES " +
+                        "('POLAND', 'Test Data', 25, 5), " +
+                        "('CZECH', 'Test Data', 26, 5)",
+                testTable));
+
+        String oldPartitionPath = getPartitionPath(testTable);
+        assertQuery(format("SELECT count(*) FROM %s WHERE regionkey = 5", testTable), "SELECT 2");
+
+        computeActual(format("INSERT INTO %s values('POLAND', 'Overwrite', 25, 5)", testTable));
+
+        String newPartitionPath = getPartitionPath(testTable);
+        assertQuery(format("SELECT count(*) FROM %s WHERE regionkey = 5", testTable), "SELECT 1");
+
+        assertEquals(oldPartitionPath, newPartitionPath);
+        computeActual(format("DROP TABLE %s", testTable));
+    }
+
+    private String getPartitionPath(String testTable)
+    {
+        MaterializedResult result = computeActual(format("SELECT \"$PATH\" from %s where regionkey = 5", testTable));
+        assertTrue(result.getMaterializedRows().size() > 0);
+        String path = result.getMaterializedRows().get(0).getField(0).toString();
+        return path.substring(0, path.lastIndexOf("/"));
+    }
+
+    protected String getTestTableName()
+    {
+        return format("hive.%s.%s", HIVE_TEST_SCHEMA, "nation_" + randomTableSuffix());
+    }
+
+    protected String getCreateTableStatement(String tableName, String... propertiesEntries)
+    {
+        return getCreateTableStatement(tableName, Arrays.asList(propertiesEntries));
+    }
+
+    protected String getCreateTableStatement(String tableName, List<String> propertiesEntries)
+    {
+        return format(
+                "CREATE TABLE %s (" +
+                        "    name varchar(25), " +
+                        "    comment varchar(152),  " +
+                        "    nationkey bigint, " +
+                        "    regionkey bigint) " +
+                        (propertiesEntries.size() < 1 ? "" : propertiesEntries
+                                .stream()
+                                .collect(joining(",", "WITH (", ")"))),
+                tableName);
+    }
+
+    protected void copyTpchNationToTable(String testTable)
+    {
+        computeActual(format("INSERT INTO " + testTable + " SELECT name, comment, nationkey, regionkey FROM tpch.tiny.nation"));
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHive2InsertOverwrite.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHive2InsertOverwrite.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import static com.facebook.presto.hive.containers.HiveHadoopContainer.DEFAULT_IMAGE;
+
+public class TestHive2InsertOverwrite
+        extends BaseTestHiveInsertOverwrite
+{
+    public TestHive2InsertOverwrite()
+    {
+        super(DEFAULT_IMAGE);
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHive3InsertOverwrite.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHive3InsertOverwrite.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import static com.facebook.presto.hive.containers.HiveHadoopContainer.HIVE3_IMAGE;
+
+public class TestHive3InsertOverwrite
+        extends BaseTestHiveInsertOverwrite
+{
+    public TestHive3InsertOverwrite()
+    {
+        super(HIVE3_IMAGE);
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
@@ -33,6 +33,7 @@ import java.util.concurrent.TimeUnit;
 
 import static com.facebook.presto.hive.BucketFunctionType.HIVE_COMPATIBLE;
 import static com.facebook.presto.hive.BucketFunctionType.PRESTO_NATIVE;
+import static com.facebook.presto.hive.HiveClientConfig.InsertExistingPartitionsBehavior.APPEND;
 import static com.facebook.presto.hive.HiveCompressionCodec.NONE;
 import static com.facebook.presto.hive.HiveCompressionCodec.SNAPPY;
 import static com.facebook.presto.hive.HiveStorageFormat.DWRF;
@@ -76,6 +77,7 @@ public class TestHiveClientConfig
                 .setOrcCompressionCodec(HiveCompressionCodec.GZIP)
                 .setRespectTableFormat(true)
                 .setImmutablePartitions(false)
+                .setInsertExistingPartitionsBehavior(APPEND)
                 .setCreateEmptyBucketFiles(true)
                 .setInsertOverwriteImmutablePartitionEnabled(false)
                 .setFailFastOnInsertIntoImmutablePartitionsEnabled(true)
@@ -198,6 +200,7 @@ public class TestHiveClientConfig
                 .put("hive.orc-compression-codec", "ZSTD")
                 .put("hive.respect-table-format", "false")
                 .put("hive.immutable-partitions", "true")
+                .put("hive.insert-existing-partitions-behavior", "OVERWRITE")
                 .put("hive.create-empty-bucket-files", "false")
                 .put("hive.insert-overwrite-immutable-partitions-enabled", "true")
                 .put("hive.fail-fast-on-insert-into-immutable-partitions-enabled", "false")

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveIntegrationSmokeTest.java
@@ -19,7 +19,7 @@ import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeSignature;
 import com.facebook.presto.cost.StatsAndCosts;
 import com.facebook.presto.execution.QueryInfo;
-import com.facebook.presto.hive.HiveSessionProperties.InsertExistingPartitionsBehavior;
+import com.facebook.presto.hive.HiveClientConfig.InsertExistingPartitionsBehavior;
 import com.facebook.presto.metadata.InsertTableHandle;
 import com.facebook.presto.metadata.Metadata;
 import com.facebook.presto.metadata.TableLayout;

--- a/presto-hive/src/test/java/com/facebook/presto/hive/containers/HiveHadoopContainer.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/containers/HiveHadoopContainer.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.hive.containers;
 
+import com.facebook.airlift.log.Logger;
 import com.facebook.presto.testing.containers.BaseTestContainer;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.net.HostAndPort;
@@ -22,9 +23,13 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import static java.lang.String.format;
+
 public class HiveHadoopContainer
         extends BaseTestContainer
 {
+    private static final Logger log = Logger.get(HiveHadoopContainer.class);
+
     private static final String IMAGE_VERSION = "10";
     public static final String DEFAULT_IMAGE = "prestodb/hdp2.6-hive:" + IMAGE_VERSION;
     public static final String HIVE3_IMAGE = "prestodb/hive3.1-hive:" + IMAGE_VERSION;
@@ -57,6 +62,17 @@ public class HiveHadoopContainer
                 envVars,
                 network,
                 startupRetryLimit);
+    }
+
+    @Override
+    protected void startContainer()
+    {
+        super.startContainer();
+        log.info(format(
+                "HiveHadoop container started with address for HiveServer: http://%s, HiveMetastore: http://%s and SocksProxy: http://%s",
+                getHiveServerEndpoint().toString(),
+                getHiveMetastoreEndpoint().toString(),
+                getMappedHdfsSocksProxy().toString()));
     }
 
     public HostAndPort getMappedHdfsSocksProxy()

--- a/presto-hive/src/test/java/com/facebook/presto/hive/s3/S3HiveQueryRunner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/s3/S3HiveQueryRunner.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.s3;
+
+import com.facebook.presto.hive.HiveQueryRunner;
+import com.facebook.presto.hive.MetastoreClientConfig;
+import com.facebook.presto.hive.metastore.HivePartitionMutator;
+import com.facebook.presto.hive.metastore.thrift.BridgingHiveMetastore;
+import com.facebook.presto.hive.metastore.thrift.TestingHiveCluster;
+import com.facebook.presto.hive.metastore.thrift.ThriftHiveMetastore;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.net.HostAndPort;
+
+import java.util.Map;
+import java.util.Optional;
+
+public final class S3HiveQueryRunner
+{
+    private S3HiveQueryRunner() {}
+
+    public static DistributedQueryRunner create(
+            HostAndPort hiveEndpoint,
+            HostAndPort s3Endpoint,
+            String s3AccessKey,
+            String s3SecretKey,
+            Map<String, String> additionalHiveProperties)
+            throws Exception
+    {
+        return HiveQueryRunner.createQueryRunner(ImmutableList.of(), ImmutableList.of(), ImmutableMap.of(),
+                ImmutableMap.of(), "sql-standard",
+                ImmutableMap.<String, String>builder()
+                        .put("hive.s3.endpoint", "http://" + s3Endpoint)
+                        .put("hive.s3.aws-access-key", s3AccessKey)
+                        .put("hive.s3.aws-secret-key", s3SecretKey)
+                        .putAll(additionalHiveProperties)
+                        .build(),
+                Optional.of(1),
+                Optional.empty(),
+                Optional.empty(),
+                Optional.of(new BridgingHiveMetastore(
+                        new ThriftHiveMetastore(
+                                new TestingHiveCluster(
+                                        new MetastoreClientConfig(),
+                                        hiveEndpoint.getHost(),
+                                        hiveEndpoint.getPort()),
+                                new MetastoreClientConfig()),
+                        new HivePartitionMutator())));
+    }
+}

--- a/presto-hive/src/test/resources/hive_s3_insert_overwrite/hadoop-core-site.xml
+++ b/presto-hive/src/test/resources/hive_s3_insert_overwrite/hadoop-core-site.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<configuration>
+    <property>
+        <name>fs.defaultFS</name>
+        <value>hdfs://hadoop-master:9000</value>
+    </property>
+    <property>
+        <name>fs.s3a.endpoint</name>
+        <value>http://minio:4566</value>
+    </property>
+    <property>
+        <name>fs.s3a.access.key</name>
+        <value>accesskey</value>
+    </property>
+    <property>
+        <name>fs.s3a.secret.key</name>
+        <value>secretkey</value>
+    </property>
+    <property>
+        <name>fs.s3a.path.style.access</name>
+        <value>true</value>
+    </property>
+</configuration>

--- a/presto-hive/src/test/resources/hive_s3_insert_overwrite/hive-site.xml
+++ b/presto-hive/src/test/resources/hive_s3_insert_overwrite/hive-site.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<configuration>
+
+    <property>
+        <name>hive.metastore.uris</name>
+        <value>thrift://localhost:9083</value>
+    </property>
+
+    <property>
+        <name>javax.jdo.option.ConnectionURL</name>
+        <value>jdbc:mysql://localhost:3306/metastore?useSSL=false</value>
+    </property>
+
+    <property>
+        <name>javax.jdo.option.ConnectionDriverName</name>
+        <value>com.mysql.cj.jdbc.Driver</value>
+    </property>
+
+    <property>
+        <name>javax.jdo.option.ConnectionUserName</name>
+        <value>root</value>
+    </property>
+
+    <property>
+        <name>javax.jdo.option.ConnectionPassword</name>
+        <value>root</value>
+    </property>
+
+    <property>
+        <name>hive.metastore.connect.retries</name>
+        <value>15</value>
+    </property>
+
+    <property>
+        <name>hive.metastore.disallow.incompatible.col.type.changes</name>
+        <value>false</value>
+    </property>
+
+    <property>
+        <!-- https://community.hortonworks.com/content/supportkb/247055/errorjavalangunsupportedoperationexception-storage.html -->
+        <name>metastore.storage.schema.reader.impl</name>
+        <value>org.apache.hadoop.hive.metastore.SerDeStorageSchemaReader</value>
+    </property>
+
+    <property>
+        <name>hive.support.concurrency</name>
+        <value>true</value>
+    </property>
+
+    <property>
+        <name>hive.txn.manager</name>
+        <value>org.apache.hadoop.hive.ql.lockmgr.DbTxnManager</value>
+    </property>
+
+    <property>
+        <name>hive.compactor.initiator.on</name>
+        <value>true</value>
+    </property>
+
+    <property>
+        <name>hive.compactor.worker.threads</name>
+        <value>1</value>
+    </property>
+
+    <property>
+        <name>hive.users.in.admin.role</name>
+        <value>hdfs,hive</value>
+    </property>
+
+</configuration>

--- a/presto-tests/src/main/java/com/facebook/presto/tests/sql/TestTable.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/sql/TestTable.java
@@ -13,11 +13,20 @@
  */
 package com.facebook.presto.tests.sql;
 
+import java.security.SecureRandom;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.lang.Character.MAX_RADIX;
+import static java.lang.Math.abs;
+import static java.lang.Math.min;
 
 public class TestTable
         implements AutoCloseable
 {
+    private static final SecureRandom random = new SecureRandom();
+    // The suffix needs to be long enough to "prevent" collisions in practice. The length of 5 was proven not to be long enough
+    private static final int RANDOM_SUFFIX_LENGTH = 10;
+
     private final SqlExecutor sqlExecutor;
     private final String name;
 
@@ -39,5 +48,11 @@ public class TestTable
     public void close()
     {
         sqlExecutor.execute("DROP TABLE " + name);
+    }
+
+    public static String randomTableSuffix()
+    {
+        String randomSuffix = Long.toString(abs(random.nextLong()), MAX_RADIX);
+        return randomSuffix.substring(0, min(RANDOM_SUFFIX_LENGTH, randomSuffix.length()));
     }
 }


### PR DESCRIPTION
Cherry-pick of https://github.com/trinodb/trino/pull/9234

Co-authored-by: Arkadiusz Czajkowski <arek@starburstdata.com>

This PR fixes insert overwrite operation on S3 backing storage when below property is set

- hive.insert-existing-partitions-behavior=OVERWRITE

Applied fix writes to partition target directory directly. After successfully writing new files coordinator deletes all files within partition whose name prefix or suffix didn't match current query ID

Test plan - Test containers for HMS and MinIO allowing to test and debug S3 related issue easily from IDE
based on above local dockerized S3 data lake

```
== RELEASE NOTES ==

Hive Changes
*  A new hive config property hive.insert-existing-partitions-behavior
*  Support for overwriting existing partitions for S3 backed Hive tables when the hive config property "hive.insert-existing-partitions-behavior" is set to 'OVERWRITE'.
*  Deprecate the config property hive.insert-overwrite-immutable-partitions-enabled
```
