### PR TITLE
Reduce memory consumed by flat map value block

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapFlatSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapFlatSelectiveStreamReader.java
@@ -502,7 +502,11 @@ public class MapFlatSelectiveStreamReader
             }
         }
 
-        return outputType.createBlockFromKeyValue(outputPositionCount, Optional.ofNullable(includeNulls ? nulls : null), offsets, new DictionaryBlock(keyBlock, keyIds), valueBlockBuilder);
+        return outputType.createBlockFromKeyValue(outputPositionCount,
+                Optional.ofNullable(includeNulls ? nulls : null),
+                offsets,
+                new DictionaryBlock(keyBlock, keyIds),
+                valueBlockBuilder.build());
     }
 
     private static RunLengthEncodedBlock createNullBlock(Type type, int positionCount)


### PR DESCRIPTION
MapFlatSelectiveStreamReader was using block builder as a flat map value block. 
The problem here is that block builder would be carrying `nulls` array even if they
were not present. In this change I made value block builder construct the block, 
which would create a block without the `nulls` array if map values do not have nulls.
For cases where values have nulls we won't get any improvements.

Measuring:
I used real files from muddler table to see impact of this change. The test was reading 
flat map columns from 4 different files with around 11k rows each, and getting total 
retained size of all pages produced by a reader for a given file. As you can see below
the value for "after" is lower than "before". Page stats contains average, P50 and P90
page sizes.

Before:
Total retained size for file 1: 737,351,653
Pages stats for file 1:
Avg	11,606,859
P50	11,869,948
P90	11,993,972

Total retained size for file 2: 736,093,119
Pages stats for file 2:
Avg	11,586,791
P50	11,878,952
P90	11,993,374

Total retained size for file 3: 726,476,460
Pages stats for file 3:
Avg	11,072,512
P50	11,972,149
P90	12,078,522

Total retained size for file 4: 734,947,405
Pages stats for file 4:
Avg	11,567,334
P50	11,992,222
P90	12,125,308


After:
Total retained size for file 1: 643,228,633
Pages stats for file 1:
Avg	10,125,293
P50	10,354,469
P90	10,462,926

Total retained size for file 2: 642,122,942
Pages stats for file 2:
Avg	10,107,649
P50	10,360,654
P90	10,466,821

Total retained size for file 3: 634,552,769
Pages stats for file 3:
Avg	9,671,775
P50	10,445,832
P90	10,542,446

Total retained size for file 4: 641,224,415
Pages stats for file 4:
Avg	10,092,291
P50	10,462,820
P90	10,579,976

Test plan:
- existing tests

```
== NO RELEASE NOTE ==
```
