### PR TITLE
Refactor null handling in ORC Dictionary writers

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriteValidation.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriteValidation.java
@@ -356,7 +356,8 @@ public class OrcWriteValidation
         requireNonNull(expectedColumnStatistics, "expectedColumnStatistics is null");
 
         if (actualColumnStatistics.getNumberOfValues() != expectedColumnStatistics.getNumberOfValues()) {
-            throw new OrcCorruptionException(orcDataSourceId, "Write validation failed: unexpected number of values in %s statistics", name);
+            String failureMessage = format("Actual Values %s does not match expected values %s", actualColumnStatistics, expectedColumnStatistics);
+            throw new OrcCorruptionException(orcDataSourceId, "Write validation failed: %s in %s statistics", failureMessage, name);
         }
 
         if (!Objects.equals(actualColumnStatistics.getBooleanStatistics(), expectedColumnStatistics.getBooleanStatistics())) {

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/SliceDirectColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/SliceDirectColumnWriter.java
@@ -64,11 +64,11 @@ public class SliceDirectColumnWriter
     private final ColumnEncoding columnEncoding;
     private final LongOutputStream lengthStream;
     private final ByteArrayOutputStream dataStream;
-    private final PresentOutputStream presentStream;
     private final CompressedMetadataWriter metadataWriter;
 
     private final List<ColumnStatistics> rowGroupColumnStatistics = new ArrayList<>();
     private long columnStatisticsRetainedSizeInBytes;
+    private PresentOutputStream presentStream;
 
     private final Supplier<SliceColumnStatisticsBuilder> statisticsBuilderSupplier;
     private SliceColumnStatisticsBuilder statisticsBuilder;
@@ -111,8 +111,20 @@ public class SliceDirectColumnWriter
     {
         checkState(!closed);
         presentStream.recordCheckpoint();
+        beginDataRowGroup();
+    }
+
+    void beginDataRowGroup()
+    {
         lengthStream.recordCheckpoint();
         dataStream.recordCheckpoint();
+    }
+
+    void updatePresentStream(PresentOutputStream updatedPresentStream)
+    {
+        requireNonNull(updatedPresentStream, "updatedPresentStream is null");
+        checkState(presentStream.getBufferedBytes() == 0, "Present stream has some content");
+        presentStream = updatedPresentStream;
     }
 
     @Override


### PR DESCRIPTION
Before this change, nulls are tracked in dictionary indexes as negative
indexes. When they are converted to direct encoding or during stripe
flush they are written to PresentOutputStreams. In the final streams
nulls are represented using bit fields but in memory they are represented
as byte, short or int depending on the dictionary size.

Representing them as index had 8,16 or 32(byte, short or int) times overhead.
This caused the writers to OOM as dictionary buffered bytes count only
1/8th of a byte for nulls. The present stream has the same representation
whether it is direct or dictionary encoded data. This change now tracks the
Present stream in dictionary directly and when converting to direct, the
present stream responsibility is transferred to the direct writer.

Test plan -
Existing tests
Modified existing tests to pass in null for direct conversion.

```
== NO RELEASE NOTE ==
```
