### PR TITLE
Reduce memory used by primitive flat map value blocks

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapFlatSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapFlatSelectiveStreamReader.java
@@ -23,6 +23,7 @@ import com.facebook.presto.common.block.RunLengthEncodedBlock;
 import com.facebook.presto.common.block.VariableWidthBlockBuilder;
 import com.facebook.presto.common.predicate.TupleDomainFilter;
 import com.facebook.presto.common.type.BigintType;
+import com.facebook.presto.common.type.FixedWidthType;
 import com.facebook.presto.common.type.IntegerType;
 import com.facebook.presto.common.type.MapType;
 import com.facebook.presto.common.type.SmallintType;
@@ -477,7 +478,13 @@ public class MapFlatSelectiveStreamReader
         int count = 0;
 
         Type valueType = outputType.getValueType();
-        BlockBuilder valueBlockBuilder = valueType.createBlockBuilder(null, offset);
+        BlockBuilder valueBlockBuilder;
+        if (valueType instanceof FixedWidthType) {
+            valueBlockBuilder = ((FixedWidthType) valueType).createFixedSizeBlockBuilder(offset);
+        }
+        else {
+            valueBlockBuilder = valueType.createBlockBuilder(null, offset);
+        }
 
         int[] valueBlockPositions = new int[keyCount];
 


### PR DESCRIPTION
Flat map stream reader calculates exact number of values and then passes it to `valueType.createBlockBuilder` as `expectedEntries` to create a block builder for values. However `createBlockBuilder` can adjust down received `expectedEntries` which has two negative side effects:
 
1) The initially created buffer is too small and will have to go through several growth phases (new array + array copy) before it reaches its final state.
2) The final size of the buffer is larger than really needed which leads to wasted memory.

This change makes value type create a block builder of exact size by utilizing FixedWidthType interface. The FixedWidthType interface is implemented by all primitive types. This change reduces memory usage only for primitive values.

## Measuring Impact
To measure impact of this change I created 2 files with flat maps. Both files have 100K rows and use typical 224MB stripes.  A map entry can be null with a chance of 25%. Every row has a random number of map keys in a range from [0 up to 5K].

The benchmark reads a file and calculates total retained size of all pages, plus calculates AVG/MAX/P50/P90 statistics of retained size for individual pages. As you can see below all numbers went down showing the reduced memory footprint after this change.

## Benchmark Results
**map<int,float>, file size 684M**
```
Before:
Total retained size for file 1: 1,668,417,824
Avg	7,478,461
P50	7,056,319
P90	9,066,987
Max	9,418,462

After:
Total retained size for file 1: 1,505,305,008
Avg	6,741,628
P50	7,011,927
P90	7,494,319
Max	8,197,154
```

**map<long, double>, file size 1.4G**
```
Before:
Total retained size for file 1: 2,759,229,156
Avg	10,013,795
P50	10,815,542
P90	11,064,808
Max	11,385,373

After:
Total retained size for file 1: 2,270,356,300
Avg	8,233,720
P50	8,474,190
P90	9,221,656
Max	10,183,101
```

I also tested this change on the muddler files used in my previous commit:
```
Before:
Total retained size for 1: 737,351,653
Total retained size for 2: 736,093,119
Total retained size for 3: 726,476,460
Total retained size for 4: 734,947,405
		
After my previous commit:
Total retained size for 1: 643,228,633
Total retained size for 2: 642,122,942
Total retained size for 3: 634,552,769
Total retained size for 4: 641,224,415

After my  previous + this commit:
Total retained size for 1: 605,337,081
Total retained size for 2: 604,171,894
Total retained size for 3: 605,459,329
Total retained size for 4: 604,395,591
```

Test plan:
- existing tests

```
== NO RELEASE NOTE ==
```