### PR TITLE
Fix documentation for tdigest_agg

### DIFF
--- a/presto-docs/src/main/sphinx/functions/tdigest.rst
+++ b/presto-docs/src/main/sphinx/functions/tdigest.rst
@@ -67,12 +67,14 @@ Functions
     Returns the ``tdigest`` which is composed of  all input values of ``x`` using
     the per-item weight ``w``.
 
-.. function:: tdigest_agg(x, w, accuracy) -> tdigest<double>
+.. function:: tdigest_agg(x, w, compression) -> tdigest<double>
 
     Returns the ``tdigest`` which is composed of  all input values of ``x`` using
-    the per-item weight ``w`` and maximum error of ``accuracy``. ``accuracy``
-    must be a value greater than zero and less than one, and it must be constant
-    for all input rows.
+    the per-item weight ``w`` and compression factor ``compression``. ``compression``
+    must be a value greater than zero, and it must be constant for all input rows.
+
+    Compression factor of 500 is a good starting point that typically yields good
+    accuracy and performance.
 
 .. function:: destructure_tdigest(tdigest<double>) -> row<centroid_means array<double>, centroid_weights array<integer>, compression double, min double, max double, sum double, count bigint>
 


### PR DESCRIPTION
The documentation incorrectly specified that the function takes 'accuracy'
argument when in fact the argument is 'compression factor'.

```
== NO RELEASE NOTE ==
```
