### PR TITLE
Fixing Tpch Query Runner

### DIFF
--- a/presto-tests/src/test/java/com/facebook/presto/memory/TestMemoryManager.java
+++ b/presto-tests/src/test/java/com/facebook/presto/memory/TestMemoryManager.java
@@ -454,7 +454,7 @@ public class TestMemoryManager
         try (DistributedQueryRunner queryRunner = createQueryRunner(properties, ImmutableMap.of(), properties, 2)) {
             // Reserve all the memory
             QueryId fakeQueryId = new QueryId("fake");
-            for (TestingPrestoServer server : queryRunner.getServers()) {
+            for (TestingPrestoServer server : queryRunner.getCoordinatorWorkers()) {
                 for (MemoryPool pool : server.getLocalMemoryManager().getPools()) {
                     assertTrue(pool.tryReserve(fakeQueryId, "test", pool.getMaxBytes()));
                 }
@@ -513,7 +513,7 @@ public class TestMemoryManager
             }
 
             // Release the memory in the reserved pool
-            for (TestingPrestoServer server : queryRunner.getServers()) {
+            for (TestingPrestoServer server : queryRunner.getCoordinatorWorkers()) {
                 Optional<MemoryPool> reserved = server.getLocalMemoryManager().getReservedPool();
                 assertTrue(reserved.isPresent());
                 // Free up the entire pool
@@ -534,7 +534,7 @@ public class TestMemoryManager
                     .forEach(info -> assertEquals(info.getState(), FINISHED));
 
             // Make sure we didn't leak any memory on the workers
-            for (TestingPrestoServer worker : queryRunner.getServers()) {
+            for (TestingPrestoServer worker : queryRunner.getCoordinatorWorkers()) {
                 Optional<MemoryPool> reserved = worker.getLocalMemoryManager().getReservedPool();
                 assertTrue(reserved.isPresent());
                 assertEquals(reserved.get().getMaxBytes(), reserved.get().getFreeBytes());

--- a/presto-tests/src/test/java/com/facebook/presto/server/TestServerInfoResource.java
+++ b/presto-tests/src/test/java/com/facebook/presto/server/TestServerInfoResource.java
@@ -33,6 +33,7 @@ import static com.facebook.airlift.json.JsonCodec.jsonCodec;
 import static com.facebook.airlift.testing.Closeables.closeQuietly;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_USER;
 import static com.facebook.presto.tests.tpch.TpchQueryRunner.createQueryRunner;
+import static com.facebook.presto.tests.tpch.TpchQueryRunner.createQueryRunnerWithNoClusterReadyCheck;
 import static org.testng.Assert.assertEquals;
 
 public class TestServerInfoResource
@@ -73,11 +74,11 @@ public class TestServerInfoResource
         closeQuietly(server);
     }
 
-    @Test
+    @Test(timeOut = 30_000)
     public void testGetServerStateWithoutRequiredResourceManagers()
             throws Exception
     {
-        DistributedQueryRunner queryRunner = createQueryRunner(
+        DistributedQueryRunner queryRunner = createQueryRunnerWithNoClusterReadyCheck(
                 ImmutableMap.of(),
                 ImmutableMap.of("cluster.required-resource-managers-active", "2", "cluster.required-coordinators-active", "1"),
                 ImmutableMap.of("query.client.timeout", "10s"), 2);
@@ -93,11 +94,11 @@ public class TestServerInfoResource
         closeQuietly(server);
     }
 
-    @Test
+    @Test(timeOut = 30_000)
     public void testGetServerStateWithoutRequiredCoordinators()
             throws Exception
     {
-        DistributedQueryRunner queryRunner = createQueryRunner(
+        DistributedQueryRunner queryRunner = createQueryRunnerWithNoClusterReadyCheck(
                 ImmutableMap.of(),
                 ImmutableMap.of("cluster.required-resource-managers-active", "1", "cluster.required-coordinators-active", "3"),
                 ImmutableMap.of("query.client.timeout", "10s"), 2);

--- a/presto-tests/src/test/java/com/facebook/presto/tests/tpch/TpchQueryRunner.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/tpch/TpchQueryRunner.java
@@ -35,23 +35,41 @@ public final class TpchQueryRunner
     public static DistributedQueryRunner createQueryRunner(Map<String, String> extraProperties, int coordinatorCount)
             throws Exception
     {
-        return TpchQueryRunnerBuilder.builder()
+        DistributedQueryRunner queryRunner = TpchQueryRunnerBuilder.builder()
                 .setExtraProperties(extraProperties)
                 .setResourceManagerEnabled(true)
                 .setCoordinatorCount(coordinatorCount)
                 .build();
+        queryRunner.waitForClusterToGetReady();
+        return queryRunner;
     }
 
     public static DistributedQueryRunner createQueryRunner(Map<String, String> resourceManagerProperties, Map<String, String> coordinatorProperties, Map<String, String> extraProperties, int coordinatorCount)
             throws Exception
     {
-        return TpchQueryRunnerBuilder.builder()
+        return createQueryRunner(resourceManagerProperties, coordinatorProperties, extraProperties, coordinatorCount, false);
+    }
+
+    public static DistributedQueryRunner createQueryRunnerWithNoClusterReadyCheck(Map<String, String> resourceManagerProperties, Map<String, String> coordinatorProperties, Map<String, String> extraProperties, int coordinatorCount)
+            throws Exception
+    {
+        return createQueryRunner(resourceManagerProperties, coordinatorProperties, extraProperties, coordinatorCount, true);
+    }
+
+    public static DistributedQueryRunner createQueryRunner(Map<String, String> resourceManagerProperties, Map<String, String> coordinatorProperties, Map<String, String> extraProperties, int coordinatorCount, boolean skipClusterReadyCheck)
+            throws Exception
+    {
+        DistributedQueryRunner queryRunner = TpchQueryRunnerBuilder.builder()
                 .setResourceManagerProperties(resourceManagerProperties)
                 .setCoordinatorProperties(coordinatorProperties)
                 .setExtraProperties(extraProperties)
                 .setResourceManagerEnabled(true)
                 .setCoordinatorCount(coordinatorCount)
                 .build();
+        if (!skipClusterReadyCheck) {
+            queryRunner.waitForClusterToGetReady();
+        }
+        return queryRunner;
     }
 
     public static void main(String[] args)


### PR DESCRIPTION
- In Disaggregated coordinator setup, we want tests to wait for the cluster to be up and ready before allowing queries to run.
Sometimes it takes a while for one of the server to be up and causes query to timeout as they won't start executing and the test timeout reaches.
Adding the waitForClusterToGetReady method to some of the missing places to avoid this to happen for tests.
- Also changing order of RM creation given coordinator refreshAndStartQueries loop ends up eating lot of CPU and delaying RM to start.
- Fixing TestMemoryManager#testClusterPoolsMultiCoordinator which start failling due to change in RM order as we were trying to reserve/free memory on RM as well.
- Fixing TestServerInfoResource#createQueryRunnerWithNoClusterReadyCheck and testGetServerStateWithoutRequiredCoordinators which stucks in waiting for cluster to be ready due to the /v1/info/state check.

Test plan - unit test

```
== NO RELEASE NOTE ==
```
