### PR TITLE
Create MongoDB index for _schema collection only if absent

### DIFF
--- a/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoSession.java
+++ b/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoSession.java
@@ -360,7 +360,9 @@ public class MongoSession
                 Document metadata = new Document(TABLE_NAME_KEY, tableName);
                 metadata.append(FIELDS_KEY, guessTableFields(schemaTableName));
 
-                schema.createIndex(new Document(TABLE_NAME_KEY, 1), new IndexOptions().unique(true));
+                if (!indexExists(schema)) {
+                    schema.createIndex(new Document(TABLE_NAME_KEY, 1), new IndexOptions().unique(true));
+                }
                 schema.insertOne(metadata);
 
                 return metadata;
@@ -378,6 +380,12 @@ public class MongoSession
             }
         }
         return false;
+    }
+
+    private boolean indexExists(MongoCollection<Document> schemaCollection)
+    {
+        return MongoIndex.parse(schemaCollection.listIndexes()).stream()
+                .anyMatch(index -> index.getKeys().size() == 1 && TABLE_NAME_KEY.equals(index.getKeys().get(0).getName()));
     }
 
     private Set<String> getTableMetadataNames(String schemaName)
@@ -416,7 +424,9 @@ public class MongoSession
         metadata.append(FIELDS_KEY, fields);
 
         MongoCollection<Document> schema = db.getCollection(schemaCollection);
-        schema.createIndex(new Document(TABLE_NAME_KEY, 1), new IndexOptions().unique(true));
+        if (!indexExists(schema)) {
+            schema.createIndex(new Document(TABLE_NAME_KEY, 1), new IndexOptions().unique(true));
+        }
         schema.insertOne(metadata);
     }
 


### PR DESCRIPTION
Cherry-pick of https://github.com/trinodb/trino/pull/8321

The change checks if the index on the meta data collection already
exists on tableName. If so, it will not try to create the index
again for every new collection in MongoDB.

Co-authored-by: academy-codex <academycodex@gmail.com>

```
== RELEASE NOTES ==

General Changes
* Create MongoDB index for _schema collection only if absent
```
