### PR TITLE
[Pinot Connector] Support querying Pinot JSON type

### DIFF
--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotSegmentPageSource.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotSegmentPageSource.java
@@ -494,6 +494,7 @@ public class PinotSegmentPageSource
                 String[] stringArray = currentDataTable.getDataTable().getStringArray(rowIndex, columnIndex);
                 return utf8Slice(Arrays.toString(stringArray));
             case STRING:
+            case JSON:
                 String field = currentDataTable.getDataTable().getString(rowIndex, columnIndex);
                 if (field == null || field.isEmpty()) {
                     return Slices.EMPTY_SLICE;

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/query/PinotQueryGenerator.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/query/PinotQueryGenerator.java
@@ -16,6 +16,7 @@ package com.facebook.presto.pinot.query;
 import com.facebook.airlift.log.Logger;
 import com.facebook.presto.common.type.BigintType;
 import com.facebook.presto.common.type.FixedWidthType;
+import com.facebook.presto.common.type.JsonType;
 import com.facebook.presto.common.type.TypeManager;
 import com.facebook.presto.common.type.VarcharType;
 import com.facebook.presto.pinot.PinotColumnHandle;
@@ -499,7 +500,7 @@ public class PinotQueryGenerator
                     case GROUP_BY: {
                         GroupByColumnNode groupByColumn = (GroupByColumnNode) expression;
                         VariableReferenceExpression groupByInputColumn = getVariableReference(groupByColumn.getInputColumn());
-                        checkState(groupByInputColumn.getType() instanceof FixedWidthType || groupByInputColumn.getType() instanceof VarcharType);
+                        checkState(groupByInputColumn.getType() instanceof FixedWidthType || groupByInputColumn.getType() instanceof VarcharType || groupByInputColumn.getType() instanceof JsonType);
                         variablesInAggregation.add(groupByInputColumn);
                         break;
                     }


### PR DESCRIPTION
Test plan - (Please fill in how you tested your changes)

Local cluster test, based on top of Pinot [JsonIndexQuickStart](https://github.com/apache/pinot/blob/master/pinot-tools/src/main/java/org/apache/pinot/tools/JsonIndexQuickStart.java).

Before:
```
presto:default> SELECT json_extract(repo, '$.name'), count(*) from githubEvents  group by 1;
Query 20220218_051408_00009_tar98 failed: Internal error
```

After
```
presto:default> SELECT json_extract(repo, '$.name'), count(*) from githubEvents group by 1;
                                     _col0                                      | _col1
--------------------------------------------------------------------------------+-------
 "g0tmi1k/exploit-database"                                                     |     2
 "ctfs/write-ups-2014"                                                          |     1
 "miyabishi/waltz_editor"                                                       |     1
 "th174/LegitiFact-source-checker-bot"                                          |     1
 "g0v-data/mirror-minutely"                                                     |    22
 "lukemassa/jclubtakeaways"                                                     |     2
 "treckstar/yolo-octo-hipster"                                                  |     1
...
```


Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== RELEASE NOTES ==

Pinot Changes
* Support querying Pinot JSON type
```

