### PR TITLE
Improve memory accounting for broadcast table

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
@@ -153,6 +153,7 @@ import static com.facebook.presto.SystemSessionProperties.getHashPartitionCount;
 import static com.facebook.presto.SystemSessionProperties.getQueryMaxBroadcastMemory;
 import static com.facebook.presto.SystemSessionProperties.getQueryMaxExecutionTime;
 import static com.facebook.presto.SystemSessionProperties.getQueryMaxRunTime;
+import static com.facebook.presto.SystemSessionProperties.getQueryMaxTotalMemoryPerNode;
 import static com.facebook.presto.SystemSessionProperties.getWarningHandlingLevel;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.execution.QueryState.FAILED;
@@ -1166,6 +1167,7 @@ public class PrestoSparkQueryExecutionFactory
                         broadcastDependency = new PrestoSparkStorageBasedBroadcastDependency(
                                 childRdd,
                                 maxBroadcastMemory,
+                                getQueryMaxTotalMemoryPerNode(session),
                                 queryCompletionDeadline,
                                 tempStorage,
                                 tempDataOperationContext,

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkBroadcastTableCacheManager.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkBroadcastTableCacheManager.java
@@ -60,7 +60,7 @@ public class PrestoSparkBroadcastTableCacheManager
 
     public synchronized long getBroadcastTableSizeInBytes(StageId stageId, PlanNodeId planNodeId)
     {
-        return broadcastTableToSizeMap.get(new BroadcastTableCacheKey(stageId, planNodeId));
+        return broadcastTableToSizeMap.getOrDefault(new BroadcastTableCacheKey(stageId, planNodeId), 0L);
     }
 
     private static class BroadcastTableCacheKey

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkPageInput.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkPageInput.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.spark.execution;
 
 import com.facebook.presto.common.Page;
+import com.facebook.presto.operator.UpdateMemory;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
@@ -25,5 +26,5 @@ import javax.annotation.concurrent.ThreadSafe;
 public interface PrestoSparkPageInput
 {
     @Nullable
-    Page getNextPage();
+    Page getNextPage(UpdateMemory updateMemory);
 }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkSerializedPageInput.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkSerializedPageInput.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.spark.execution;
 
 import com.facebook.presto.common.Page;
+import com.facebook.presto.operator.UpdateMemory;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkSerializedPage;
 import com.facebook.presto.spi.page.PagesSerde;
 
@@ -41,7 +42,7 @@ public class PrestoSparkSerializedPageInput
     }
 
     @Override
-    public Page getNextPage()
+    public Page getNextPage(UpdateMemory updateMemory)
     {
         PrestoSparkSerializedPage prestoSparkSerializedPage = null;
         synchronized (this) {

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkShufflePageInput.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkShufflePageInput.java
@@ -17,6 +17,7 @@ import com.facebook.presto.common.Page;
 import com.facebook.presto.common.PageBuilder;
 import com.facebook.presto.common.block.BlockBuilder;
 import com.facebook.presto.common.type.Type;
+import com.facebook.presto.operator.UpdateMemory;
 import com.facebook.presto.spark.classloader_interface.MutablePartitionId;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkMutableRow;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkShuffleStats;
@@ -68,7 +69,7 @@ public class PrestoSparkShufflePageInput
     }
 
     @Override
-    public Page getNextPage()
+    public Page getNextPage(UpdateMemory updateMemory)
     {
         SliceOutput output = new DynamicSliceOutput(types.isEmpty() ? 0 : BUFFER_SIZE);
         int rowCount = 0;


### PR DESCRIPTION
Storage based broadcast join uses distributed storage for storing
broadcast table. Before broadcasting the data, driver will perform
a size check to ensure that the table size is under threshold. If
the table size is beyond threshold size, driver fails the query with
exceeded broadcast memory limit. This threshold can be overriden
using `spark_broadcast_join_max_memory_override` property and users
can override it to insanely high value. This would prevent the query
from failing in driver memory check but it will eventually fail on
executor with JVM OOMs.

This PR add two checks to prevent this kind of OOMs:
1. The first check is added in driver where threshold bytes is computed
using threshold = min(spark_broadcast_join_max_memory_override,
query_max_memory_per_node). This will max out the threshold to max
available memory and fail the query on driver if size goes beyond
`query_max_memory_per_node`

2. When hashtable is created on executors, entire data is read from
storage and stored in a list<page>. This data is then deserailized
which further inceased memory usage. While loading this data, memory
usage is not updated which means that if the table is huge, we will
keep loading the data until JVM OOMs. A memory callback is added in
this logic where after loading data from each file, a callback will
be made to update the memory usage so far. With this, EXECEEDED_MEMORY_LIMIT
error is thrown as soon as memory usage in executor goes beyond
`query_max_memory_per_node` while loading HT in memory

Test plan -
* Added a unit test.
* Tested two production queries that were failing with JVM OOM and both started failing with EXCEEDED_MEMORY_LIMIT (one at driver memory check and other at executor memory check)