### PR TITLE
Bump Alluxio client from 2.7.0 to 2.7.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <dep.nexus-staging-plugin.version>1.6.8</dep.nexus-staging-plugin.version>
         <dep.asm.version>9.0</dep.asm.version>
         <dep.gcs.version>1.9.17</dep.gcs.version>
-        <dep.alluxio.version>2.7.0</dep.alluxio.version>
+        <dep.alluxio.version>2.7.3</dep.alluxio.version>
         <dep.kafka.version>2.3.1</dep.kafka.version>
         <dep.pinot.version>0.9.3</dep.pinot.version>
         <dep.druid.version>0.19.0</dep.druid.version>


### PR DESCRIPTION
For issue [17265](https://github.com/prestodb/presto/issues/17265). They recently picked up a patch to a GSON [vulnerability](https://github.com/google/gson/pull/1991).

Test plan - I used existing tests.


```
== RELEASE NOTES ==

General Changes
* Bumped Alluxio client from `2.7.0` to `2.7.3`

