### PR TITLE
Fix build failures by remove junit deps in presto-parquet module

### DIFF
--- a/presto-parquet/pom.xml
+++ b/presto-parquet/pom.xml
@@ -187,13 +187,6 @@
             <artifactId>jmh-generator-annprocess</artifactId>
             <scope>test</scope>
         </dependency>
-
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.1</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/presto-parquet/src/test/java/com/facebook/presto/parquet/reader/TestColumnIndexBuilder.java
+++ b/presto-parquet/src/test/java/com/facebook/presto/parquet/reader/TestColumnIndexBuilder.java
@@ -26,7 +26,7 @@ import org.apache.parquet.internal.column.columnindex.ColumnIndexBuilder;
 import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Types;
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
@@ -60,15 +60,12 @@ import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.DOUBLE;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.FLOAT;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-// import static org.hamcrest.CoreMatchers.instanceOf;
-// import static org.junit.Assert.assertThat;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+import static org.testng.internal.junit.ArrayAsserts.assertArrayEquals;
 
 public class TestColumnIndexBuilder
 {
@@ -1464,7 +1461,7 @@ public class TestColumnIndexBuilder
             Binary expectedValue = expectedValues[i];
             ByteBuffer value = values.get(i);
             if (expectedValue == null) {
-                assertFalse("The byte buffer should be empty for null pages", value.hasRemaining());
+                assertFalse(value.hasRemaining(), "The byte buffer should be empty for null pages");
             }
             else {
                 assertArrayEquals("Invalid value for page " + i, expectedValue.getBytesUnsafe(), value.array());
@@ -1479,11 +1476,11 @@ public class TestColumnIndexBuilder
             Boolean expectedValue = expectedValues[i];
             ByteBuffer value = values.get(i);
             if (expectedValue == null) {
-                assertFalse("The byte buffer should be empty for null pages", value.hasRemaining());
+                assertFalse(value.hasRemaining(), "The byte buffer should be empty for null pages");
             }
             else {
-                assertEquals("The byte buffer should be 1 byte long for boolean", 1, value.remaining());
-                assertEquals("Invalid value for page " + i, expectedValue.booleanValue(), value.get(0) != 0);
+                assertEquals(1, value.remaining(), "The byte buffer should be 1 byte long for boolean");
+                assertEquals(expectedValue.booleanValue(), value.get(0) != 0, "Invalid value for page " + i);
             }
         }
     }
@@ -1495,11 +1492,11 @@ public class TestColumnIndexBuilder
             Double expectedValue = expectedValues[i];
             ByteBuffer value = values.get(i);
             if (expectedValue == null) {
-                assertFalse("The byte buffer should be empty for null pages", value.hasRemaining());
+                assertFalse(value.hasRemaining(), "The byte buffer should be empty for null pages");
             }
             else {
-                assertEquals("The byte buffer should be 8 bytes long for double", 8, value.remaining());
-                assertTrue("Invalid value for page " + i, Double.compare(expectedValue.doubleValue(), value.getDouble(0)) == 0);
+                assertEquals(8, value.remaining(), "The byte buffer should be 8 bytes long for double");
+                assertTrue(Double.compare(expectedValue.doubleValue(), value.getDouble(0)) == 0, "Invalid value for page " + i);
             }
         }
     }
@@ -1511,11 +1508,11 @@ public class TestColumnIndexBuilder
             Float expectedValue = expectedValues[i];
             ByteBuffer value = values.get(i);
             if (expectedValue == null) {
-                assertFalse("The byte buffer should be empty for null pages", value.hasRemaining());
+                assertFalse(value.hasRemaining(), "The byte buffer should be empty for null pages");
             }
             else {
-                assertEquals("The byte buffer should be 4 bytes long for double", 4, value.remaining());
-                assertTrue("Invalid value for page " + i, Float.compare(expectedValue.floatValue(), value.getFloat(0)) == 0);
+                assertEquals(4, value.remaining(), "The byte buffer should be 4 bytes long for double");
+                assertTrue(Float.compare(expectedValue.floatValue(), value.getFloat(0)) == 0, "Invalid value for page " + i);
             }
         }
     }
@@ -1527,11 +1524,11 @@ public class TestColumnIndexBuilder
             Integer expectedValue = expectedValues[i];
             ByteBuffer value = values.get(i);
             if (expectedValue == null) {
-                assertFalse("The byte buffer should be empty for null pages", value.hasRemaining());
+                assertFalse(value.hasRemaining(), "The byte buffer should be empty for null pages");
             }
             else {
-                assertEquals("The byte buffer should be 4 bytes long for int32", 4, value.remaining());
-                assertEquals("Invalid value for page " + i, expectedValue.intValue(), value.getInt(0));
+                assertEquals(4, value.remaining(), "The byte buffer should be 4 bytes long for int32");
+                assertEquals(expectedValue.intValue(), value.getInt(0), "Invalid value for page " + i);
             }
         }
     }
@@ -1543,11 +1540,11 @@ public class TestColumnIndexBuilder
             Long expectedValue = expectedValues[i];
             ByteBuffer value = values.get(i);
             if (expectedValue == null) {
-                assertFalse("The byte buffer should be empty for null pages", value.hasRemaining());
+                assertFalse(value.hasRemaining(), "The byte buffer should be empty for null pages");
             }
             else {
-                assertEquals("The byte buffer should be 8 bytes long for int64", 8, value.remaining());
-                assertEquals("Invalid value for page " + i, expectedValue.intValue(), value.getLong(0));
+                assertEquals(8, value.remaining(), "The byte buffer should be 8 bytes long for int64");
+                assertEquals(expectedValue.intValue(), value.getLong(0), "Invalid value for page " + i);
             }
         }
     }
@@ -1557,7 +1554,7 @@ public class TestColumnIndexBuilder
         List<Long> nullCounts = columnIndex.getNullCounts();
         assertEquals(expectedNullCounts.length, nullCounts.size());
         for (int i = 0; i < expectedNullCounts.length; ++i) {
-            assertEquals("Invalid null count at page " + i, expectedNullCounts[i], nullCounts.get(i).longValue());
+            assertEquals(expectedNullCounts[i], nullCounts.get(i).longValue(), "Invalid null count at page " + i);
         }
     }
 
@@ -1566,7 +1563,7 @@ public class TestColumnIndexBuilder
         List<Boolean> nullPages = columnIndex.getNullPages();
         assertEquals(expectedNullPages.length, nullPages.size());
         for (int i = 0; i < expectedNullPages.length; ++i) {
-            assertEquals("Invalid null pages at page " + i, expectedNullPages[i], nullPages.get(i).booleanValue());
+            assertEquals(expectedNullPages[i], nullPages.get(i).booleanValue(), "Invalid null pages at page " + i);
         }
     }
 
@@ -1630,8 +1627,7 @@ public class TestColumnIndexBuilder
         IntList actualList = new IntArrayList();
         actualIt.forEachRemaining((int value) -> actualList.add(value));
         int[] actualValues = actualList.toIntArray();
-        assertArrayEquals(
-                "ExpectedValues: " + Arrays.toString(expectedValues) + " ActualValues: " + Arrays.toString(actualValues),
+        assertArrayEquals("ExpectedValues: " + Arrays.toString(expectedValues) + " ActualValues: " + Arrays.toString(actualValues),
                 expectedValues, actualValues);
     }
 }

--- a/presto-parquet/src/test/java/com/facebook/presto/parquet/reader/TestColumnIndexFilter.java
+++ b/presto-parquet/src/test/java/com/facebook/presto/parquet/reader/TestColumnIndexFilter.java
@@ -29,7 +29,7 @@ import org.apache.parquet.internal.filter2.columnindex.ColumnIndexFilter;
 import org.apache.parquet.internal.filter2.columnindex.ColumnIndexStore;
 import org.apache.parquet.internal.filter2.columnindex.RowRanges;
 import org.apache.parquet.schema.PrimitiveType;
-import org.junit.Test;
+import org.testng.annotations.Test;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -66,7 +66,7 @@ import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.DOUBLE;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
 import static org.apache.parquet.schema.Types.optional;
-import static org.junit.Assert.assertArrayEquals;
+import static org.testng.internal.junit.ArrayAsserts.assertArrayEquals;
 
 /**
  * Unit tests of {@link ColumnIndexFilter}


### PR DESCRIPTION
Using testng instead of junit to fix the error below in FB's build

[ERROR] Failed to execute goal on project presto-parquet: Could not resolve dependencies for project com.facebook.presto:presto-parquet:jar:0.272-SNAPSHOT: Failed to collect dependencies at junit:junit:jar:4.13.1: Failed to read artifact descriptor for junit:junit:jar:4.13.1: Could not transfer artifact junit:junit:pom:4.13.1 from/to nexus (https://maven.thefacebook.com/nexus/content/groups/public): Transfer failed for https://maven.thefacebook.com/nexus/content/groups/public/junit/junit/4.13.1/junit-4.13.1.pom: No route to host (Host unreachable) -> [Help 1]

```
== NO RELEASE NOTE ==
```
