### PR TITLE
Add 'is_velox_aggr_types' session property and use it.

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -225,6 +225,7 @@ public final class SystemSessionProperties
     public static final String KEY_BASED_SAMPLING_FUNCTION = "key_based_sampling_function";
     public static final String HASH_BASED_DISTINCT_LIMIT_ENABLED = "hash_based_distinct_limit_enabled";
     public static final String HASH_BASED_DISTINCT_LIMIT_THRESHOLD = "hash_based_distinct_limit_threshold";
+    public static final String IS_VELOX_AGGR_TYPES = "is_velox_aggr_types";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -1223,6 +1224,11 @@ public final class SystemSessionProperties
                         HASH_BASED_DISTINCT_LIMIT_ENABLED,
                         "Hash based distinct limit enabled",
                         featuresConfig.isHashBasedDistinctLimitEnabled(),
+                        false),
+                booleanProperty(
+                        IS_VELOX_AGGR_TYPES,
+                        "Use Velox aggregation types",
+                        featuresConfig.isVeloxAggrTypes(),
                         false));
     }
 
@@ -1269,6 +1275,11 @@ public final class SystemSessionProperties
     public static int getHashBasedDistinctLimitThreshold(Session session)
     {
         return session.getSystemProperty(HASH_BASED_DISTINCT_LIMIT_THRESHOLD, Integer.class);
+    }
+
+    public static boolean isVeloxAggrTypes(Session session)
+    {
+        return session.getSystemProperty(IS_VELOX_AGGR_TYPES, Boolean.class);
     }
 
     public List<PropertyMetadata<?>> getSessionProperties()

--- a/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
@@ -301,7 +301,7 @@ import static com.facebook.presto.operator.aggregation.MinNAggregationFunction.M
 import static com.facebook.presto.operator.aggregation.QuantileDigestAggregationFunction.QDIGEST_AGG;
 import static com.facebook.presto.operator.aggregation.QuantileDigestAggregationFunction.QDIGEST_AGG_WITH_WEIGHT;
 import static com.facebook.presto.operator.aggregation.QuantileDigestAggregationFunction.QDIGEST_AGG_WITH_WEIGHT_AND_ERROR;
-import static com.facebook.presto.operator.aggregation.RealAverageAggregation.REAL_AVERAGE_AGGREGATION;
+import static com.facebook.presto.operator.aggregation.RealAverageAggregation.getRealAverageAggregation;
 import static com.facebook.presto.operator.aggregation.TDigestAggregationFunction.TDIGEST_AGG;
 import static com.facebook.presto.operator.aggregation.TDigestAggregationFunction.TDIGEST_AGG_WITH_WEIGHT;
 import static com.facebook.presto.operator.aggregation.TDigestAggregationFunction.TDIGEST_AGG_WITH_WEIGHT_AND_COMPRESSION;
@@ -611,7 +611,7 @@ public class BuiltInTypeAndFunctionNamespaceManager
                 .aggregates(IntervalDayToSecondSumAggregation.class)
                 .aggregates(IntervalYearToMonthSumAggregation.class)
                 .aggregates(AverageAggregations.class)
-                .function(REAL_AVERAGE_AGGREGATION)
+                .function(getRealAverageAggregation(featuresConfig.isVeloxAggrTypes()))
                 .aggregates(IntervalDayToSecondAverageAggregation.class)
                 .aggregates(IntervalYearToMonthAverageAggregation.class)
                 .aggregates(DifferentialEntropyAggregation.class)

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -101,6 +101,7 @@ public class FeaturesConfig
     private boolean exchangeCompressionEnabled;
     private boolean exchangeChecksumEnabled;
     private boolean legacyArrayAgg;
+    private boolean veloxAggrTypes;
     private boolean reduceAggForComplexTypesEnabled = true;
     private boolean legacyLogFunction;
     private boolean groupByUsesEqualTo;
@@ -393,6 +394,18 @@ public class FeaturesConfig
     public boolean isLegacyArrayAgg()
     {
         return legacyArrayAgg;
+    }
+
+    @Config("velox-aggr-types")
+    public FeaturesConfig setVeloxAggrTypes(boolean veloxAggrTypes)
+    {
+        this.veloxAggrTypes = veloxAggrTypes;
+        return this;
+    }
+
+    public boolean isVeloxAggrTypes()
+    {
+        return veloxAggrTypes;
     }
 
     @Config("deprecated.legacy-log-function")


### PR DESCRIPTION
Test plan - I ran the local mac setup with c++ worker. Existing tests.

Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines. Don't forget to follow our [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution) for any code copied from other projects.

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

The whole change is an attempt to modify intermediate and final aggregation types for few aggregations, so they work with C++ worker (based on Velox).
Multiple problems, such as redundant columns, different order and different types were encountered so far.

General Changes
* Add 'is_velox_aggr_types' session property.
* Add "velox-aggr-types" in FeatureConfig.
* Use the new session property in PushPartialAggregationThroughExchange to alter intermediate aggregation type for "min/max_by" and "avg" aggregations.
* Use the new "velox-aggr-types" to create RealAverageAggregation with DOUBLE Final Type, instead of REAL, in case the property is true. Note, that this only works as intended if the initial session property is et to true, since RealAverageAggregation is being created once at the start. I'm looking for ways to alter Final Aggregation Type in the Plan "on the fly", if that's possible, similar to the way we deal with intermediate types. The only problem is that final type is much more complex, as the coordinator deals with it, not just workers.

Hive Changes
* ...
* ...
```

== NO RELEASE NOTE ==
