### PR TITLE
Fix build failures caused by new method in HiveMetastore interface

### DIFF
--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/HiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/HiveMetastore.java
@@ -114,9 +114,15 @@ public interface HiveMetastore
 
     Set<HivePrivilegeInfo> listTablePrivileges(MetastoreContext metastoreContext, String databaseName, String tableName, PrestoPrincipal principal);
 
-    long lock(MetastoreContext metastoreContext, String databaseName, String tableName);
+    default long lock(MetastoreContext metastoreContext, String databaseName, String tableName)
+    {
+        throw new UnsupportedOperationException();
+    }
 
-    void unlock(MetastoreContext metastoreContext, long lockId);
+    default void unlock(MetastoreContext metastoreContext, long lockId)
+    {
+        throw new UnsupportedOperationException();
+    }
 
     default void setPartitionLeases(MetastoreContext metastoreContext, String databaseName, String tableName, Map<String, String> partitionNameToLocation, Duration leaseDuration)
     {

--- a/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/thrift/InMemoryHiveMetastore.java
+++ b/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/thrift/InMemoryHiveMetastore.java
@@ -507,18 +507,6 @@ public class InMemoryHiveMetastore
         throw new UnsupportedOperationException();
     }
 
-    @Override
-    public long lock(MetastoreContext metastoreContext, String databaseName, String tableName)
-    {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void unlock(MetastoreContext metastoreContext, long lockId)
-    {
-        throw new UnsupportedOperationException();
-    }
-
     private Partition getPartitionFromInMemoryMap(MetastoreContext metastoreContext, PartitionName name)
     {
         com.facebook.presto.hive.metastore.Partition partition = partitions.get(name);


### PR DESCRIPTION
Fix the build failure in FB caused by this PR. https://github.com/prestodb/presto/pull/16983

```
== NO RELEASE NOTE ==
```
