### PR TITLE
Handle the scalar subqueries for unnest

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -1110,6 +1110,12 @@ class StatementAnalyzer
             ImmutableList.Builder<Field> outputFields = ImmutableList.builder();
             for (Expression expression : node.getExpressions()) {
                 ExpressionAnalysis expressionAnalysis = analyzeExpression(expression, createScope(scope));
+                if (!expressionAnalysis.getScalarSubqueries().isEmpty()) {
+                    throw new SemanticException(
+                            NOT_SUPPORTED,
+                            node,
+                            "Scalar subqueries in UNNEST are not supported");
+                }
                 Type expressionType = expressionAnalysis.getType(expression);
                 if (expressionType instanceof ArrayType) {
                     Type elementType = ((ArrayType) expressionType).getElementType();

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
@@ -1598,6 +1598,18 @@ public class TestAnalyzer
     }
 
     @Test
+    public void testUnnestInnerScalarAlias()
+    {
+        analyze("SELECT * FROM (SELECT array[1,2] a) a CROSS JOIN UNNEST(a) AS T(x)");
+    }
+
+    @Test(expectedExceptions = SemanticException.class, expectedExceptionsMessageRegExp = "line 1:37: Scalar subqueries in UNNEST are not supported")
+    public void testUnnestInnerScalar()
+    {
+        analyze("SELECT * FROM (SELECT 1) CROSS JOIN UNNEST((SELECT array[1])) AS T(x)");
+    }
+
+    @Test
     public void testJoinLateral()
     {
         analyze("SELECT * FROM (VALUES array[2, 2]) a(x) CROSS JOIN LATERAL(VALUES x)");


### PR DESCRIPTION
The query fails at planning stage due to illegal state:
```
presto:sf1> select * from (select 1) cross join unnest((select array[1])) AS T(x);
Query 20220223_215553_00017_e3qbq failed: Unexpected subquery expression in logical plan: (SELECT ARRAY[1]

)
java.lang.IllegalStateException: Unexpected subquery expression in logical plan: (SELECT ARRAY[1]

)

```
The fix is to detect nested scalar query at the query analysis stage.
The result will look like:

```
Query 20220224_222704_00016_suqrw failed: line 1:37: Scalar subqueries in UNNEST are not yet supported
com.facebook.presto.sql.analyzer.SemanticException: line 1:37: Scalar subqueries in UNNEST are not yet supported
```

```
== NO RELEASE NOTE ==
```
