### PR TITLE
Add ORC writer flush policy

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriterConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriterConfig.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.hive;
 
 import com.facebook.airlift.configuration.Config;
+import com.facebook.presto.orc.DefaultOrcWriterFlushPolicy;
 import com.facebook.presto.orc.OrcWriterOptions;
 import com.facebook.presto.orc.metadata.DwrfStripeCacheMode;
 import com.facebook.presto.orc.writer.StreamLayoutFactory;
@@ -32,9 +33,9 @@ public class OrcFileWriterConfig
         BY_COLUMN_SIZE,
     }
 
-    private DataSize stripeMinSize = OrcWriterOptions.DEFAULT_STRIPE_MIN_SIZE;
-    private DataSize stripeMaxSize = OrcWriterOptions.DEFAULT_STRIPE_MAX_SIZE;
-    private int stripeMaxRowCount = OrcWriterOptions.DEFAULT_STRIPE_MAX_ROW_COUNT;
+    private DataSize stripeMinSize = DefaultOrcWriterFlushPolicy.DEFAULT_STRIPE_MIN_SIZE;
+    private DataSize stripeMaxSize = DefaultOrcWriterFlushPolicy.DEFAULT_STRIPE_MAX_SIZE;
+    private int stripeMaxRowCount = DefaultOrcWriterFlushPolicy.DEFAULT_STRIPE_MAX_ROW_COUNT;
     private int rowGroupMaxRowCount = OrcWriterOptions.DEFAULT_ROW_GROUP_MAX_ROW_COUNT;
     private DataSize dictionaryMaxMemory = OrcWriterOptions.DEFAULT_DICTIONARY_MAX_MEMORY;
     private DataSize stringStatisticsLimit = OrcWriterOptions.DEFAULT_MAX_STRING_STATISTICS_LIMIT;
@@ -46,11 +47,15 @@ public class OrcFileWriterConfig
 
     public OrcWriterOptions.Builder toOrcWriterOptionsBuilder()
     {
-        // Give separate copy to callers for isolation.
-        return OrcWriterOptions.builder()
+        DefaultOrcWriterFlushPolicy flushPolicy = DefaultOrcWriterFlushPolicy.builder()
                 .withStripeMinSize(stripeMinSize)
                 .withStripeMaxSize(stripeMaxSize)
                 .withStripeMaxRowCount(stripeMaxRowCount)
+                .build();
+
+        // Give separate copy to callers for isolation.
+        return OrcWriterOptions.builder()
+                .withFlushPolicy(flushPolicy)
                 .withRowGroupMaxRowCount(rowGroupMaxRowCount)
                 .withDictionaryMaxMemory(dictionaryMaxMemory)
                 .withMaxStringStatisticsLimit(stringStatisticsLimit)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriterFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriterFactory.java
@@ -20,6 +20,7 @@ import com.facebook.presto.hive.datasink.DataSinkFactory;
 import com.facebook.presto.hive.metastore.MetastoreUtil;
 import com.facebook.presto.hive.metastore.StorageFormat;
 import com.facebook.presto.hive.orc.HdfsOrcDataSource;
+import com.facebook.presto.orc.DefaultOrcWriterFlushPolicy;
 import com.facebook.presto.orc.DwrfEncryptionProvider;
 import com.facebook.presto.orc.DwrfWriterEncryption;
 import com.facebook.presto.orc.OrcDataSource;
@@ -224,9 +225,11 @@ public class OrcFileWriterFactory
                     compression,
                     orcFileWriterConfig
                             .toOrcWriterOptionsBuilder()
-                            .withStripeMinSize(getOrcOptimizedWriterMinStripeSize(session))
-                            .withStripeMaxSize(getOrcOptimizedWriterMaxStripeSize(session))
-                            .withStripeMaxRowCount(getOrcOptimizedWriterMaxStripeRows(session))
+                            .withFlushPolicy(DefaultOrcWriterFlushPolicy.builder()
+                                    .withStripeMinSize(getOrcOptimizedWriterMinStripeSize(session))
+                                    .withStripeMaxSize(getOrcOptimizedWriterMaxStripeSize(session))
+                                    .withStripeMaxRowCount(getOrcOptimizedWriterMaxStripeRows(session))
+                                    .build())
                             .withDictionaryMaxMemory(getOrcOptimizedWriterMaxDictionaryMemory(session))
                             .withMaxStringStatisticsLimit(getOrcStringStatisticsLimit(session))
                             .withIgnoreDictionaryRowGroupSizes(isExecutionBasedMemoryAccountingEnabled(session))

--- a/presto-hive/src/main/java/com/facebook/presto/hive/util/TempFileWriter.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/util/TempFileWriter.java
@@ -17,6 +17,7 @@ import com.facebook.presto.common.NotSupportedException;
 import com.facebook.presto.common.Page;
 import com.facebook.presto.common.io.DataSink;
 import com.facebook.presto.common.type.Type;
+import com.facebook.presto.orc.DefaultOrcWriterFlushPolicy;
 import com.facebook.presto.orc.OrcWriteValidation.OrcWriteValidationMode;
 import com.facebook.presto.orc.OrcWriter;
 import com.facebook.presto.orc.OrcWriterOptions;
@@ -90,7 +91,9 @@ public class TempFileWriter
                     NO_ENCRYPTION,
                     OrcWriterOptions.builder()
                             .withMaxStringStatisticsLimit(new DataSize(0, BYTE))
-                            .withStripeMinSize(new DataSize(64, MEGABYTE))
+                            .withFlushPolicy(DefaultOrcWriterFlushPolicy.builder()
+                                    .withStripeMinSize(new DataSize(64, MEGABYTE))
+                                    .build())
                             .withDictionaryMaxMemory(new DataSize(1, MEGABYTE))
                             .build(),
                     ImmutableMap.of(),

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestOrcFileWriterConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestOrcFileWriterConfig.java
@@ -36,6 +36,7 @@ import static com.facebook.presto.orc.metadata.DwrfStripeCacheMode.INDEX_AND_FOO
 import static io.airlift.units.DataSize.Unit.BYTE;
 import static io.airlift.units.DataSize.Unit.KILOBYTE;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static java.lang.Math.toIntExact;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotSame;
@@ -143,9 +144,9 @@ public class TestOrcFileWriterConfig
         assertNotSame(config.toOrcWriterOptionsBuilder(), config.toOrcWriterOptionsBuilder());
         OrcWriterOptions options = config.toOrcWriterOptionsBuilder().build();
 
-        assertEquals(stripeMinSize, options.getStripeMinSize());
-        assertEquals(stripeMaxSize, options.getStripeMaxSize());
-        assertEquals(stripeMaxRowCount, options.getStripeMaxRowCount());
+        assertEquals(toIntExact(stripeMinSize.toBytes()), options.getFlushPolicy().getStripeMinBytes());
+        assertEquals(toIntExact(stripeMaxSize.toBytes()), options.getFlushPolicy().getStripeMaxBytes());
+        assertEquals(stripeMaxRowCount, options.getFlushPolicy().getStripeMaxRowCount());
         assertEquals(rowGroupMaxRowCount, options.getRowGroupMaxRowCount());
         assertEquals(dictionaryMaxMemory, options.getDictionaryMaxMemory());
         assertEquals(stringStatisticsLimit, options.getMaxStringStatisticsLimit());

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergFileWriterFactory.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergFileWriterFactory.java
@@ -25,6 +25,7 @@ import com.facebook.presto.hive.HiveSessionProperties;
 import com.facebook.presto.hive.NodeVersion;
 import com.facebook.presto.hive.OrcFileWriterConfig;
 import com.facebook.presto.hive.orc.HdfsOrcDataSource;
+import com.facebook.presto.orc.DefaultOrcWriterFlushPolicy;
 import com.facebook.presto.orc.DwrfEncryptionProvider;
 import com.facebook.presto.orc.OrcDataSource;
 import com.facebook.presto.orc.OrcDataSourceId;
@@ -215,9 +216,11 @@ public class IcebergFileWriterFactory
                     getCompressionCodec(session).getOrcCompressionKind(),
                     orcFileWriterConfig
                             .toOrcWriterOptionsBuilder()
-                            .withStripeMinSize(HiveSessionProperties.getOrcOptimizedWriterMinStripeSize(session))
-                            .withStripeMaxSize(HiveSessionProperties.getOrcOptimizedWriterMaxStripeSize(session))
-                            .withStripeMaxRowCount(HiveSessionProperties.getOrcOptimizedWriterMaxStripeRows(session))
+                            .withFlushPolicy(DefaultOrcWriterFlushPolicy.builder()
+                                    .withStripeMinSize(HiveSessionProperties.getOrcOptimizedWriterMinStripeSize(session))
+                                    .withStripeMaxSize(HiveSessionProperties.getOrcOptimizedWriterMaxStripeSize(session))
+                                    .withStripeMaxRowCount(HiveSessionProperties.getOrcOptimizedWriterMaxStripeRows(session))
+                                    .build())
                             .withDictionaryMaxMemory(HiveSessionProperties.getOrcOptimizedWriterMaxDictionaryMemory(session))
                             .withMaxStringStatisticsLimit(HiveSessionProperties.getOrcStringStatisticsLimit(session))
                             .build(),

--- a/presto-orc/src/main/java/com/facebook/presto/orc/DefaultOrcWriterFlushPolicy.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/DefaultOrcWriterFlushPolicy.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc;
+
+import com.facebook.presto.common.Page;
+import io.airlift.units.DataSize;
+
+import java.util.Optional;
+
+import static com.facebook.presto.orc.FlushReason.DICTIONARY_FULL;
+import static com.facebook.presto.orc.FlushReason.MAX_BYTES;
+import static com.facebook.presto.orc.FlushReason.MAX_ROWS;
+import static com.google.common.base.MoreObjects.toStringHelper;
+import static com.google.common.base.Preconditions.checkArgument;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static java.lang.Math.max;
+import static java.lang.Math.toIntExact;
+import static java.util.Objects.requireNonNull;
+
+public class DefaultOrcWriterFlushPolicy
+        implements OrcWriterFlushPolicy
+{
+    public static final DataSize DEFAULT_STRIPE_MIN_SIZE = new DataSize(32, MEGABYTE);
+    public static final DataSize DEFAULT_STRIPE_MAX_SIZE = new DataSize(64, MEGABYTE);
+    public static final int DEFAULT_STRIPE_MAX_ROW_COUNT = 10_000_000;
+
+    private final int stripeMaxRowCount;
+    private final int stripeMinBytes;
+    private final int stripeMaxBytes;
+
+    private DefaultOrcWriterFlushPolicy(int stripeMaxRowCount, int stripeMinBytes, int stripeMaxBytes)
+    {
+        this.stripeMaxRowCount = stripeMaxRowCount;
+        this.stripeMinBytes = stripeMinBytes;
+        this.stripeMaxBytes = stripeMaxBytes;
+    }
+
+    @Override
+    public Optional<FlushReason> shouldFlushStripe(int stripeRowCount, int bufferedBytes, boolean dictionaryIsFull)
+    {
+        if (stripeRowCount == stripeMaxRowCount) {
+            return Optional.of(MAX_ROWS);
+        }
+        else if (bufferedBytes > stripeMaxBytes) {
+            return Optional.of(MAX_BYTES);
+        }
+        else if (dictionaryIsFull) {
+            return Optional.of(DICTIONARY_FULL);
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public int getMaxChunkRowCount(Page page)
+    {
+        // avoid chunks with huge logical size
+        int chunkMaxLogicalBytes = max(1, stripeMaxBytes / 2);
+        double averageLogicalSizePerRow = (double) page.getApproximateLogicalSizeInBytes() / page.getPositionCount();
+        return max(1, (int) (chunkMaxLogicalBytes / max(1, averageLogicalSizePerRow)));
+    }
+
+    @Override
+    public int getStripeMinBytes()
+    {
+        return stripeMinBytes;
+    }
+
+    @Override
+    public int getStripeMaxBytes()
+    {
+        return stripeMaxBytes;
+    }
+
+    @Override
+    public int getStripeMaxRowCount()
+    {
+        return stripeMaxRowCount;
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("stripeMaxRowCount", stripeMaxRowCount)
+                .add("stripeMinBytes", stripeMinBytes)
+                .add("stripeMaxBytes", stripeMaxBytes)
+                .toString();
+    }
+
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    public static class Builder
+    {
+        private int stripeMaxRowCount = DEFAULT_STRIPE_MAX_ROW_COUNT;
+        private DataSize stripeMinSize = DEFAULT_STRIPE_MIN_SIZE;
+        private DataSize stripeMaxSize = DEFAULT_STRIPE_MAX_SIZE;
+
+        private Builder() {}
+
+        public Builder withStripeMaxRowCount(int stripeMaxRowCount)
+        {
+            checkArgument(stripeMaxRowCount >= 1, "stripeMaxRowCount must be at least 1");
+            this.stripeMaxRowCount = stripeMaxRowCount;
+            return this;
+        }
+
+        public Builder withStripeMinSize(DataSize stripeMinSize)
+        {
+            this.stripeMinSize = requireNonNull(stripeMinSize, "stripeMinSize is null");
+            return this;
+        }
+
+        public Builder withStripeMaxSize(DataSize stripeMaxSize)
+        {
+            this.stripeMaxSize = requireNonNull(stripeMaxSize, "stripeMaxSize is null");
+            return this;
+        }
+
+        public DefaultOrcWriterFlushPolicy build()
+        {
+            checkArgument(stripeMaxSize.compareTo(stripeMinSize) >= 0, "stripeMaxSize must be greater than stripeMinSize");
+            return new DefaultOrcWriterFlushPolicy(
+                    stripeMaxRowCount,
+                    toIntExact(stripeMinSize.toBytes()),
+                    toIntExact(stripeMaxSize.toBytes()));
+        }
+    }
+}

--- a/presto-orc/src/main/java/com/facebook/presto/orc/FlushReason.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/FlushReason.java
@@ -13,17 +13,20 @@
  */
 package com.facebook.presto.orc;
 
-import com.facebook.presto.orc.metadata.StripeInformation;
-
-public interface WriterStats
+public enum FlushReason
 {
-    void recordStripeWritten(
-            int stripeMinBytes,
-            int stripeMaxBytes,
-            int dictionaryMaxMemoryBytes,
-            FlushReason flushReason,
-            int dictionaryBytes,
-            StripeInformation stripeInformation);
+    /** Stripe accumulated enough rows. */
+    MAX_ROWS,
 
-    void updateSizeInBytes(long deltaInBytes);
+    /** tripe binary size reached size limit. */
+    MAX_BYTES,
+
+    /** Dictionary binary size reached size limit. */
+    DICTIONARY_FULL,
+
+    /** Writer is closing the file. */
+    CLOSED,
+
+    /** Unspecified reason, can be used by custom flush policies. */
+    OTHER
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
@@ -19,7 +19,6 @@ import com.facebook.presto.common.io.DataSink;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.orc.OrcWriteValidation.OrcWriteValidationBuilder;
 import com.facebook.presto.orc.OrcWriteValidation.OrcWriteValidationMode;
-import com.facebook.presto.orc.WriterStats.FlushReason;
 import com.facebook.presto.orc.metadata.ColumnEncoding;
 import com.facebook.presto.orc.metadata.CompressedMetadataWriter;
 import com.facebook.presto.orc.metadata.CompressionKind;
@@ -75,12 +74,9 @@ import java.util.stream.IntStream;
 import static com.facebook.presto.common.io.DataOutput.createDataOutput;
 import static com.facebook.presto.orc.DwrfEncryptionInfo.UNENCRYPTED;
 import static com.facebook.presto.orc.DwrfEncryptionInfo.createNodeToGroupMap;
+import static com.facebook.presto.orc.FlushReason.CLOSED;
 import static com.facebook.presto.orc.OrcEncoding.DWRF;
 import static com.facebook.presto.orc.OrcReader.validateFile;
-import static com.facebook.presto.orc.WriterStats.FlushReason.CLOSED;
-import static com.facebook.presto.orc.WriterStats.FlushReason.DICTIONARY_FULL;
-import static com.facebook.presto.orc.WriterStats.FlushReason.MAX_BYTES;
-import static com.facebook.presto.orc.WriterStats.FlushReason.MAX_ROWS;
 import static com.facebook.presto.orc.metadata.ColumnEncoding.ColumnEncodingKind.DIRECT;
 import static com.facebook.presto.orc.metadata.DwrfMetadataWriter.toFileStatistics;
 import static com.facebook.presto.orc.metadata.DwrfMetadataWriter.toStripeEncryptionGroup;
@@ -94,7 +90,6 @@ import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static io.airlift.slice.Slices.utf8Slice;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static java.lang.Integer.min;
-import static java.lang.Math.max;
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
@@ -106,21 +101,17 @@ public class OrcWriter
 
     static final String PRESTO_ORC_WRITER_VERSION_METADATA_KEY = "presto.writer.version";
     static final String PRESTO_ORC_WRITER_VERSION;
-    private final WriterStats stats;
-
     static {
         String version = OrcWriter.class.getPackage().getImplementationVersion();
         PRESTO_ORC_WRITER_VERSION = version == null ? "UNKNOWN" : version;
     }
 
+    private final WriterStats stats;
+    private final OrcWriterFlushPolicy flushPolicy;
     private final DataSink dataSink;
     private final List<Type> types;
     private final OrcEncoding orcEncoding;
     private final ColumnWriterOptions columnWriterOptions;
-    private final int stripeMinBytes;
-    private final int stripeMaxBytes;
-    private final int chunkMaxLogicalBytes;
-    private final int stripeMaxRowCount;
     private final int rowGroupMaxRowCount;
     private final StreamLayout streamLayout;
     private final Map<String, String> userMetadata;
@@ -226,11 +217,7 @@ public class OrcWriter
         recordValidation(validation -> validation.setCompression(compressionKind));
 
         requireNonNull(options, "options is null");
-        checkArgument(options.getStripeMaxSize().compareTo(options.getStripeMinSize()) >= 0, "stripeMaxSize must be greater than stripeMinSize");
-        this.stripeMinBytes = toIntExact(requireNonNull(options.getStripeMinSize(), "stripeMinSize is null").toBytes());
-        this.stripeMaxBytes = toIntExact(requireNonNull(options.getStripeMaxSize(), "stripeMaxSize is null").toBytes());
-        this.chunkMaxLogicalBytes = max(1, stripeMaxBytes / 2);
-        this.stripeMaxRowCount = options.getStripeMaxRowCount();
+        this.flushPolicy = requireNonNull(options.getFlushPolicy(), "flushPolicy is null");
         this.rowGroupMaxRowCount = options.getRowGroupMaxRowCount();
         recordValidation(validation -> validation.setRowGroupMaxRowCount(rowGroupMaxRowCount));
         this.streamLayout = requireNonNull(options.getStreamLayoutFactory().create(), "streamLayout is null");
@@ -329,9 +316,9 @@ public class OrcWriter
         int dictionaryUsefulCheckColumnSizeBytes = toIntExact(options.getDictionaryUsefulCheckColumnSize().toBytes());
         this.dictionaryCompressionOptimizer = new DictionaryCompressionOptimizer(
                 dictionaryColumnWriters.build(),
-                stripeMinBytes,
-                stripeMaxBytes,
-                stripeMaxRowCount,
+                flushPolicy.getStripeMinBytes(),
+                flushPolicy.getStripeMaxBytes(),
+                flushPolicy.getStripeMaxRowCount(),
                 dictionaryMaxMemoryBytes,
                 dictionaryMemoryAlmostFullRangeBytes,
                 dictionaryUsefulCheckColumnSizeBytes,
@@ -397,13 +384,11 @@ public class OrcWriter
             validationBuilder.addPage(page);
         }
 
-        // avoid chunk with huge logical size
-        double averageLogicalSizePerRow = (double) page.getApproximateLogicalSizeInBytes() / page.getPositionCount();
-        int maxChunkRowCount = max(1, (int) (chunkMaxLogicalBytes / max(1, averageLogicalSizePerRow)));
+        int maxChunkRowCount = flushPolicy.getMaxChunkRowCount(page);
 
         while (page != null) {
             // logical size and row group boundaries
-            int chunkRows = min(maxChunkRowCount, min(rowGroupMaxRowCount - rowGroupRowCount, stripeMaxRowCount - stripeRowCount));
+            int chunkRows = min(maxChunkRowCount, min(rowGroupMaxRowCount - rowGroupRowCount, flushPolicy.getStripeMaxRowCount() - stripeRowCount));
 
             // align page to max size per chunk
             chunkRows = min(page.getPositionCount(), chunkRows);
@@ -454,16 +439,11 @@ public class OrcWriter
 
         // flush stripe if necessary
         bufferedBytes = toIntExact(columnWriters.stream().mapToLong(ColumnWriter::getBufferedBytes).sum());
-        if (stripeRowCount == stripeMaxRowCount) {
-            flushStripe(MAX_ROWS);
+        boolean dictionaryIsFull = dictionaryCompressionOptimizer.isFull(bufferedBytes);
+        Optional<FlushReason> flushReason = flushPolicy.shouldFlushStripe(stripeRowCount, bufferedBytes, dictionaryIsFull);
+        if (flushReason.isPresent()) {
+            flushStripe(flushReason.get());
         }
-        else if (bufferedBytes > stripeMaxBytes) {
-            flushStripe(MAX_BYTES);
-        }
-        else if (dictionaryCompressionOptimizer.isFull(bufferedBytes)) {
-            flushStripe(DICTIONARY_FULL);
-        }
-
         columnWritersRetainedBytes = columnWriters.stream().mapToLong(ColumnWriter::getRetainedBytes).sum();
     }
 
@@ -637,7 +617,13 @@ public class OrcWriter
         closedStripesRetainedBytes += closedStripe.getRetainedSizeInBytes();
 
         recordValidation(validation -> validation.addStripe(stripeInformation.getNumberOfRows()));
-        stats.recordStripeWritten(stripeMinBytes, stripeMaxBytes, dictionaryMaxMemoryBytes, flushReason, dictionaryCompressionOptimizer.getDictionaryMemoryBytes(), stripeInformation);
+        stats.recordStripeWritten(
+                flushPolicy.getStripeMinBytes(),
+                flushPolicy.getStripeMaxBytes(),
+                dictionaryMaxMemoryBytes,
+                flushReason,
+                dictionaryCompressionOptimizer.getDictionaryMemoryBytes(),
+                stripeInformation);
 
         return outputData;
     }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriterFlushPolicy.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriterFlushPolicy.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc;
+
+import com.facebook.presto.common.Page;
+
+import java.util.Optional;
+
+public interface OrcWriterFlushPolicy
+{
+    /**
+     * Return a non-empty response with a flush reason if the stripe should be flushed.
+     * Return an empty response if current stripe should not be flushed yet.
+     */
+    Optional<FlushReason> shouldFlushStripe(
+            int stripeRowCount,
+            int bufferedBytes,
+            boolean dictionaryIsFull);
+
+    /**
+     * Calculate how often to check whether the stripe should be flushed or not.
+     * It's called once per Page.
+     */
+    int getMaxChunkRowCount(Page page);
+
+    int getStripeMinBytes();
+
+    int getStripeMaxBytes();
+
+    int getStripeMaxRowCount();
+}

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriterStats.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriterStats.java
@@ -19,10 +19,10 @@ import org.weakref.jmx.Nested;
 
 import java.util.concurrent.atomic.AtomicLong;
 
-import static com.facebook.presto.orc.WriterStats.FlushReason.CLOSED;
-import static com.facebook.presto.orc.WriterStats.FlushReason.DICTIONARY_FULL;
-import static com.facebook.presto.orc.WriterStats.FlushReason.MAX_BYTES;
-import static com.facebook.presto.orc.WriterStats.FlushReason.MAX_ROWS;
+import static com.facebook.presto.orc.FlushReason.CLOSED;
+import static com.facebook.presto.orc.FlushReason.DICTIONARY_FULL;
+import static com.facebook.presto.orc.FlushReason.MAX_BYTES;
+import static com.facebook.presto.orc.FlushReason.MAX_ROWS;
 import static com.google.common.base.MoreObjects.toStringHelper;
 
 public class OrcWriterStats

--- a/presto-orc/src/test/java/com/facebook/presto/orc/AbstractTestDwrfStripeCaching.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/AbstractTestDwrfStripeCaching.java
@@ -184,7 +184,7 @@ public abstract class AbstractTestDwrfStripeCaching
             Type type = INTEGER;
             List<Type> types = ImmutableList.of(type, type, type);
             OrcWriterOptions writerOptions = OrcWriterOptions.builder()
-                    .withStripeMaxRowCount(100)
+                    .withFlushPolicy(DefaultOrcWriterFlushPolicy.builder().withStripeMaxRowCount(100).build())
                     .withDwrfStripeCacheEnabled(cacheEnabled)
                     .withDwrfStripeCacheMode(cacheMode)
                     .withDwrfStripeCacheMaxSize(cacheMaxSize)

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestDefaultOrcWriterFlushPolicy.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestDefaultOrcWriterFlushPolicy.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc;
+
+import io.airlift.units.DataSize;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static com.facebook.presto.orc.FlushReason.DICTIONARY_FULL;
+import static com.facebook.presto.orc.FlushReason.MAX_BYTES;
+import static com.facebook.presto.orc.FlushReason.MAX_ROWS;
+import static io.airlift.units.DataSize.Unit.BYTE;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestDefaultOrcWriterFlushPolicy
+{
+    @Test
+    public void testFlushMaxStripeRowCount()
+    {
+        DefaultOrcWriterFlushPolicy flushPolicy = DefaultOrcWriterFlushPolicy.builder()
+                .withStripeMaxRowCount(10)
+                .build();
+
+        assertEquals(flushPolicy.getStripeMaxRowCount(), 10);
+
+        Optional<FlushReason> actual = flushPolicy.shouldFlushStripe(5, 0, false);
+        assertFalse(actual.isPresent());
+
+        actual = flushPolicy.shouldFlushStripe(10, 0, false);
+        assertTrue(actual.isPresent());
+        assertEquals(actual.get(), MAX_ROWS);
+
+        actual = flushPolicy.shouldFlushStripe(20, 0, false);
+        assertFalse(actual.isPresent());
+    }
+
+    @Test
+    public void testFlushMaxStripeSize()
+    {
+        DefaultOrcWriterFlushPolicy flushPolicy = DefaultOrcWriterFlushPolicy.builder()
+                .withStripeMinSize(new DataSize(50, BYTE))
+                .withStripeMaxSize(new DataSize(100, BYTE))
+                .build();
+
+        assertEquals(flushPolicy.getStripeMinBytes(), 50);
+        assertEquals(flushPolicy.getStripeMaxBytes(), 100);
+
+        Optional<FlushReason> actual = flushPolicy.shouldFlushStripe(1, 90, false);
+        assertFalse(actual.isPresent());
+
+        actual = flushPolicy.shouldFlushStripe(1, 100, false);
+        assertFalse(actual.isPresent());
+
+        actual = flushPolicy.shouldFlushStripe(1, 200, false);
+        assertTrue(actual.isPresent());
+        assertEquals(actual.get(), MAX_BYTES);
+    }
+
+    @Test
+    public void testFlushDictionaryFull()
+    {
+        DefaultOrcWriterFlushPolicy flushPolicy = DefaultOrcWriterFlushPolicy.builder().build();
+
+        Optional<FlushReason> actual = flushPolicy.shouldFlushStripe(1, 1, false);
+        assertFalse(actual.isPresent());
+
+        actual = flushPolicy.shouldFlushStripe(1, 1, true);
+        assertTrue(actual.isPresent());
+        assertEquals(actual.get(), DICTIONARY_FULL);
+    }
+}

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestDictionaryColumnWriter.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestDictionaryColumnWriter.java
@@ -186,7 +186,7 @@ public class TestDictionaryColumnWriter
             DirectConversionTester directConversionTester = new DirectConversionTester();
             OrcWriterOptions writerOptions = OrcWriterOptions.builder()
                     .withRowGroupMaxRowCount(14_876)
-                    .withStripeMaxRowCount(STRIPE_MAX_ROWS)
+                    .withFlushPolicy(DefaultOrcWriterFlushPolicy.builder().withStripeMaxRowCount(STRIPE_MAX_ROWS).build())
                     .build();
             testDictionary(VARCHAR, input.getEncoding(), writerOptions, directConversionTester, values);
         }
@@ -248,7 +248,7 @@ public class TestDictionaryColumnWriter
         }
         int preserveDirectEncodingStripeCount = 2;
         OrcWriterOptions.Builder orcWriterOptionsBuilder = OrcWriterOptions.builder()
-                .withStripeMaxRowCount(STRIPE_MAX_ROWS)
+                .withFlushPolicy(DefaultOrcWriterFlushPolicy.builder().withStripeMaxRowCount(STRIPE_MAX_ROWS).build())
                 .withIntegerDictionaryEncodingEnabled(true)
                 .withPreserveDirectEncodingStripeCount(preserveDirectEncodingStripeCount);
 
@@ -312,7 +312,7 @@ public class TestDictionaryColumnWriter
         long totalRows = values.size();
         for (StringDictionaryInput input : StringDictionaryInput.values()) {
             OrcWriterOptions orcWriterOptions = OrcWriterOptions.builder()
-                    .withStripeMaxRowCount(STRIPE_MAX_ROWS)
+                    .withFlushPolicy(DefaultOrcWriterFlushPolicy.builder().withStripeMaxRowCount(STRIPE_MAX_ROWS).build())
                     .withStringDictionaryEncodingEnabled(false)
                     .withStringDictionarySortingEnabled(input.isSortStringDictionaryKeys())
                     .build();
@@ -381,7 +381,7 @@ public class TestDictionaryColumnWriter
         List<Integer> values = generateRandomIntegers(90_000);
         DirectConversionTester directConversionTester = new DirectConversionTester();
         OrcWriterOptions writerOptions = OrcWriterOptions.builder()
-                .withStripeMaxRowCount(STRIPE_MAX_ROWS)
+                .withFlushPolicy(DefaultOrcWriterFlushPolicy.builder().withStripeMaxRowCount(STRIPE_MAX_ROWS).build())
                 .withIntegerDictionaryEncodingEnabled(true)
                 .withRowGroupMaxRowCount(14_998)
                 .build();
@@ -448,7 +448,7 @@ public class TestDictionaryColumnWriter
         List<Long> values = generateRandomLongs(80_000);
         DirectConversionTester directConversionTester = new DirectConversionTester();
         OrcWriterOptions writerOptions = OrcWriterOptions.builder()
-                .withStripeMaxRowCount(STRIPE_MAX_ROWS)
+                .withFlushPolicy(DefaultOrcWriterFlushPolicy.builder().withStripeMaxRowCount(STRIPE_MAX_ROWS).build())
                 .withIntegerDictionaryEncodingEnabled(true)
                 .withRowGroupMaxRowCount(14_998)
                 .build();
@@ -600,7 +600,7 @@ public class TestDictionaryColumnWriter
         DirectConversionTester tester = new DirectConversionTester();
         int preserveDirectEncodingStripeCount = 2;
         OrcWriterOptions orcWriterOptions = OrcWriterOptions.builder()
-                .withStripeMaxRowCount(STRIPE_MAX_ROWS)
+                .withFlushPolicy(DefaultOrcWriterFlushPolicy.builder().withStripeMaxRowCount(STRIPE_MAX_ROWS).build())
                 .withIntegerDictionaryEncodingEnabled(true)
                 .withPreserveDirectEncodingStripeCount(preserveDirectEncodingStripeCount)
                 .build();
@@ -775,7 +775,7 @@ public class TestDictionaryColumnWriter
             throws IOException
     {
         OrcWriterOptions orcWriterOptions = OrcWriterOptions.builder()
-                .withStripeMaxRowCount(STRIPE_MAX_ROWS)
+                .withFlushPolicy(DefaultOrcWriterFlushPolicy.builder().withStripeMaxRowCount(STRIPE_MAX_ROWS).build())
                 .withIntegerDictionaryEncodingEnabled(enableIntDictionary)
                 .withStringDictionarySortingEnabled(sortStringDictionaryKeys)
                 .build();

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcWriter.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcWriter.java
@@ -122,9 +122,11 @@ public class TestOrcWriter
             throws IOException
     {
         OrcWriterOptions orcWriterOptions = OrcWriterOptions.builder()
-                .withStripeMinSize(new DataSize(0, MEGABYTE))
-                .withStripeMaxSize(new DataSize(32, MEGABYTE))
-                .withStripeMaxRowCount(ORC_STRIPE_SIZE)
+                .withFlushPolicy(DefaultOrcWriterFlushPolicy.builder()
+                        .withStripeMinSize(new DataSize(0, MEGABYTE))
+                        .withStripeMaxSize(new DataSize(32, MEGABYTE))
+                        .withStripeMaxRowCount(ORC_STRIPE_SIZE)
+                        .build())
                 .withRowGroupMaxRowCount(ORC_ROW_GROUP_SIZE)
                 .withDictionaryMaxMemory(new DataSize(32, MEGABYTE))
                 .withCompressionLevel(level)
@@ -195,9 +197,11 @@ public class TestOrcWriter
                 Optional.empty(),
                 NO_ENCRYPTION,
                 OrcWriterOptions.builder()
-                        .withStripeMinSize(new DataSize(0, MEGABYTE))
-                        .withStripeMaxSize(new DataSize(32, MEGABYTE))
-                        .withStripeMaxRowCount(10)
+                        .withFlushPolicy(DefaultOrcWriterFlushPolicy.builder()
+                                .withStripeMinSize(new DataSize(0, MEGABYTE))
+                                .withStripeMaxSize(new DataSize(32, MEGABYTE))
+                                .withStripeMaxRowCount(10)
+                                .build())
                         .withRowGroupMaxRowCount(ORC_ROW_GROUP_SIZE)
                         .withDictionaryMaxMemory(new DataSize(32, MEGABYTE))
                         .build(),

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcWriterOptions.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcWriterOptions.java
@@ -27,6 +27,7 @@ import static com.facebook.presto.orc.metadata.DwrfStripeCacheMode.INDEX_AND_FOO
 import static io.airlift.units.DataSize.Unit.BYTE;
 import static io.airlift.units.DataSize.Unit.KILOBYTE;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static java.lang.Math.toIntExact;
 import static org.testng.Assert.assertEquals;
 
 public class TestOrcWriterOptions
@@ -77,9 +78,11 @@ public class TestOrcWriterOptions
         int preserveDirectEncodingStripeCount = 10;
 
         OrcWriterOptions.Builder builder = OrcWriterOptions.builder()
-                .withStripeMinSize(stripeMinSize)
-                .withStripeMaxSize(stripeMaxSize)
-                .withStripeMaxRowCount(stripeMaxRowCount)
+                .withFlushPolicy(DefaultOrcWriterFlushPolicy.builder()
+                        .withStripeMinSize(stripeMinSize)
+                        .withStripeMaxSize(stripeMaxSize)
+                        .withStripeMaxRowCount(stripeMaxRowCount)
+                        .build())
                 .withRowGroupMaxRowCount(rowGroupMaxRowCount)
                 .withDictionaryMaxMemory(dictionaryMaxMemory)
                 .withDictionaryMemoryAlmostFullRange(dictionaryMemoryRange)
@@ -96,9 +99,9 @@ public class TestOrcWriterOptions
 
         OrcWriterOptions options = builder.build();
 
-        assertEquals(stripeMinSize, options.getStripeMinSize());
-        assertEquals(stripeMaxSize, options.getStripeMaxSize());
-        assertEquals(stripeMaxRowCount, options.getStripeMaxRowCount());
+        assertEquals(toIntExact(stripeMinSize.toBytes()), options.getFlushPolicy().getStripeMinBytes());
+        assertEquals(toIntExact(stripeMaxSize.toBytes()), options.getFlushPolicy().getStripeMaxBytes());
+        assertEquals(stripeMaxRowCount, options.getFlushPolicy().getStripeMaxRowCount());
         assertEquals(rowGroupMaxRowCount, options.getRowGroupMaxRowCount());
         assertEquals(dictionaryMaxMemory, options.getDictionaryMaxMemory());
         assertEquals(dictionaryMemoryRange, options.getDictionaryMemoryAlmostFullRange());
@@ -137,9 +140,11 @@ public class TestOrcWriterOptions
         int preserveDirectEncodingStripeCount = 0;
 
         OrcWriterOptions writerOptions = OrcWriterOptions.builder()
-                .withStripeMinSize(stripeMinSize)
-                .withStripeMaxSize(stripeMaxSize)
-                .withStripeMaxRowCount(stripeMaxRowCount)
+                .withFlushPolicy(DefaultOrcWriterFlushPolicy.builder()
+                        .withStripeMinSize(stripeMinSize)
+                        .withStripeMaxSize(stripeMaxSize)
+                        .withStripeMaxRowCount(stripeMaxRowCount)
+                        .build())
                 .withRowGroupMaxRowCount(rowGroupMaxRowCount)
                 .withDictionaryMaxMemory(dictionaryMaxMemory)
                 .withDictionaryMemoryAlmostFullRange(dictionaryMemoryRange)
@@ -157,7 +162,8 @@ public class TestOrcWriterOptions
                 .withPreserveDirectEncodingStripeCount(preserveDirectEncodingStripeCount)
                 .build();
 
-        String expectedString = "OrcWriterOptions{stripeMinSize=13MB, stripeMaxSize=27MB, stripeMaxRowCount=1100000, rowGroupMaxRowCount=15000, " +
+        String expectedString = "OrcWriterOptions{flushPolicy=DefaultOrcWriterFlushPolicy{stripeMaxRowCount=1100000, " +
+                "stripeMinBytes=13631488, stripeMaxBytes=28311552}, rowGroupMaxRowCount=15000, " +
                 "dictionaryMaxMemory=13000kB, dictionaryMemoryAlmostFullRange=1000kB, dictionaryUsefulCheckPerChunkFrequency=9999, " +
                 "dictionaryUsefulCheckColumnSize=1MB, maxStringStatisticsLimit=128B, maxCompressionBufferSize=512kB, " +
                 "compressionLevel=OptionalInt[5], streamLayoutFactory=ColumnSizeLayoutFactory{}, integerDictionaryEncodingEnabled=false, " +

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestStructBatchStreamReader.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestStructBatchStreamReader.java
@@ -231,9 +231,11 @@ public class TestStructBatchStreamReader
                 Optional.empty(),
                 NO_ENCRYPTION,
                 OrcWriterOptions.builder()
-                        .withStripeMinSize(new DataSize(0, MEGABYTE))
-                        .withStripeMaxSize(new DataSize(32, MEGABYTE))
-                        .withStripeMaxRowCount(ORC_STRIPE_SIZE)
+                        .withFlushPolicy(DefaultOrcWriterFlushPolicy.builder()
+                                .withStripeMinSize(new DataSize(0, MEGABYTE))
+                                .withStripeMaxSize(new DataSize(32, MEGABYTE))
+                                .withStripeMaxRowCount(ORC_STRIPE_SIZE)
+                                .build())
                         .withRowGroupMaxRowCount(ORC_ROW_GROUP_SIZE)
                         .withDictionaryMaxMemory(new DataSize(32, MEGABYTE))
                         .build(),

--- a/presto-orc/src/test/java/com/facebook/presto/orc/writer/TestWriterBlockRawSize.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/writer/TestWriterBlockRawSize.java
@@ -23,6 +23,7 @@ import com.facebook.presto.common.type.RowType;
 import com.facebook.presto.common.type.TimestampType;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.orc.ColumnWriterOptions;
+import com.facebook.presto.orc.DefaultOrcWriterFlushPolicy;
 import com.facebook.presto.orc.DwrfEncryptionInfo;
 import com.facebook.presto.orc.FileOrcDataSource;
 import com.facebook.presto.orc.OrcEncoding;
@@ -304,7 +305,7 @@ public class TestWriterBlockRawSize
 
         OrcWriterOptions writerOptions = OrcWriterOptions.builder()
                 .withRowGroupMaxRowCount(block.getPositionCount() * numBlocksPerRowGroup)
-                .withStripeMaxRowCount(block.getPositionCount() * numBlocksPerStripe)
+                .withFlushPolicy(DefaultOrcWriterFlushPolicy.builder().withStripeMaxRowCount(block.getPositionCount() * numBlocksPerStripe).build())
                 .build();
 
         for (OrcEncoding encoding : OrcEncoding.values()) {


### PR DESCRIPTION
Extract current flush policy into a separate object behind an interface to be able to customize flush policy.

Flush policy should be implemented as a new OrcWriterFlushPolicy interface. Existing logic is extracted into DefaultOrcWriterFlushPolicy. The default implementation is exactly the same as the replaced logic. OrcWriterFlushPolicy passed to the OrcWriter as a part of OrcWriterOptions. 

Unfortunately due to tight coupling with the Dictionary Optimizer it's almost impossible to neatly encapsulate flush decision without exposing stripe min/max size and max stripe row count, so I let it be in the flush policy interface.

Test plan:
* added new unit tests
* ran existing unit tests
* completed verifier run with id 75500
   * `Progress: 9527 succeeded, 451 skipped, 0 resolved, 0 failed, 100.00% done` 

```
== NO RELEASE NOTE ==
```
