### PR TITLE
Reduce overheads related to DictionaryBlock#getSizeInBytes()

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/block/AbstractArrayBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/AbstractArrayBlock.java
@@ -17,6 +17,8 @@ import io.airlift.slice.SliceOutput;
 
 import javax.annotation.Nullable;
 
+import java.util.OptionalInt;
+
 import static com.facebook.presto.common.block.ArrayBlock.createArrayBlockInternal;
 import static com.facebook.presto.common.block.BlockUtil.appendNullToIsNullArray;
 import static com.facebook.presto.common.block.BlockUtil.appendNullToOffsetsArray;
@@ -25,6 +27,8 @@ import static com.facebook.presto.common.block.BlockUtil.checkValidPositions;
 import static com.facebook.presto.common.block.BlockUtil.checkValidRegion;
 import static com.facebook.presto.common.block.BlockUtil.compactArray;
 import static com.facebook.presto.common.block.BlockUtil.compactOffsets;
+import static com.facebook.presto.common.block.BlockUtil.countAndMarkSelectedPositionsFromOffsets;
+import static com.facebook.presto.common.block.BlockUtil.countSelectedPositionsFromOffsets;
 import static com.facebook.presto.common.block.BlockUtil.internalPositionInRange;
 import static com.facebook.presto.common.block.MapBlockBuilder.verify;
 
@@ -112,6 +116,12 @@ public abstract class AbstractArrayBlock
     }
 
     @Override
+    public OptionalInt fixedSizeInBytesPerPosition()
+    {
+        return OptionalInt.empty(); // size per position is variable based on the number of entries in each array
+    }
+
+    @Override
     public long getRegionSizeInBytes(int position, int length)
     {
         int positionCount = getPositionCount();
@@ -144,26 +154,40 @@ public abstract class AbstractArrayBlock
         int valueStart = getOffset(position);
         int valueEnd = getOffset(position + length);
 
-        return getRawElementBlock().getApproximateRegionLogicalSizeInBytes(valueStart, valueEnd - valueStart) + (Integer.BYTES + Byte.BYTES) * length;
+        return getRawElementBlock().getApproximateRegionLogicalSizeInBytes(valueStart, valueEnd - valueStart) + ((Integer.BYTES + Byte.BYTES) * (long) length);
     }
 
     @Override
-    public long getPositionsSizeInBytes(boolean[] positions)
+    public final long getPositionsSizeInBytes(boolean[] positions, int selectedArrayPositions)
     {
-        checkValidPositions(positions, getPositionCount());
-        boolean[] used = new boolean[getRawElementBlock().getPositionCount()];
-        int usedPositionCount = 0;
-        for (int i = 0; i < positions.length; ++i) {
-            if (positions[i]) {
-                usedPositionCount++;
-                int valueStart = getOffsets()[getOffsetBase() + i];
-                int valueEnd = getOffsets()[getOffsetBase() + i + 1];
-                for (int j = valueStart; j < valueEnd; ++j) {
-                    used[j] = true;
-                }
-            }
+        int positionCount = getPositionCount();
+        checkValidPositions(positions, positionCount);
+        if (selectedArrayPositions == 0) {
+            return 0;
         }
-        return getRawElementBlock().getPositionsSizeInBytes(used) + ((Integer.BYTES + Byte.BYTES) * (long) usedPositionCount);
+        if (selectedArrayPositions == positionCount) {
+            return getSizeInBytes();
+        }
+
+        Block rawElementBlock = getRawElementBlock();
+        OptionalInt fixedPerElementSizeInBytes = rawElementBlock.fixedSizeInBytesPerPosition();
+        int[] offsets = getOffsets();
+        int offsetBase = getOffsetBase();
+        long elementsSizeInBytes;
+
+        if (fixedPerElementSizeInBytes.isPresent()) {
+            elementsSizeInBytes = fixedPerElementSizeInBytes.getAsInt() * (long) countSelectedPositionsFromOffsets(positions, offsets, offsetBase);
+        }
+        else if (rawElementBlock instanceof RunLengthEncodedBlock) {
+            // RLE blocks don't have fixed size per position, but accept null for the positions array
+            elementsSizeInBytes = rawElementBlock.getPositionsSizeInBytes(null, countSelectedPositionsFromOffsets(positions, offsets, offsetBase));
+        }
+        else {
+            boolean[] selectedElements = new boolean[rawElementBlock.getPositionCount()];
+            int selectedElementCount = countAndMarkSelectedPositionsFromOffsets(positions, offsets, offsetBase, selectedElements);
+            elementsSizeInBytes = rawElementBlock.getPositionsSizeInBytes(selectedElements, selectedElementCount);
+        }
+        return elementsSizeInBytes + ((Integer.BYTES + Byte.BYTES) * (long) selectedArrayPositions);
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/block/AbstractMapBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/AbstractMapBlock.java
@@ -22,6 +22,7 @@ import javax.annotation.Nullable;
 import java.lang.invoke.MethodHandle;
 import java.util.Arrays;
 import java.util.Optional;
+import java.util.OptionalInt;
 
 import static com.facebook.presto.common.block.BlockUtil.appendNullToIsNullArray;
 import static com.facebook.presto.common.block.BlockUtil.appendNullToOffsetsArray;
@@ -30,6 +31,8 @@ import static com.facebook.presto.common.block.BlockUtil.checkValidPositions;
 import static com.facebook.presto.common.block.BlockUtil.checkValidRegion;
 import static com.facebook.presto.common.block.BlockUtil.compactArray;
 import static com.facebook.presto.common.block.BlockUtil.compactOffsets;
+import static com.facebook.presto.common.block.BlockUtil.countAndMarkSelectedPositionsFromOffsets;
+import static com.facebook.presto.common.block.BlockUtil.countSelectedPositionsFromOffsets;
 import static com.facebook.presto.common.block.BlockUtil.internalPositionInRange;
 import static com.facebook.presto.common.block.MapBlock.createMapBlockInternal;
 import static com.facebook.presto.common.block.MapBlockBuilder.buildHashTable;
@@ -156,6 +159,26 @@ public abstract class AbstractMapBlock
     }
 
     @Override
+    public OptionalInt fixedSizeInBytesPerPosition()
+    {
+        return OptionalInt.empty(); // size per row is variable on the number of entries in each row
+    }
+
+    private OptionalInt keyAndValueFixedSizeInBytesPerRow()
+    {
+        OptionalInt keyFixedSizePerRow = getRawKeyBlock().fixedSizeInBytesPerPosition();
+        if (!keyFixedSizePerRow.isPresent()) {
+            return OptionalInt.empty();
+        }
+        OptionalInt valueFixedSizePerRow = getRawValueBlock().fixedSizeInBytesPerPosition();
+        if (!valueFixedSizePerRow.isPresent()) {
+            return OptionalInt.empty();
+        }
+
+        return OptionalInt.of(keyFixedSizePerRow.getAsInt() + valueFixedSizePerRow.getAsInt());
+    }
+
+    @Override
     public long getRegionSizeInBytes(int position, int length)
     {
         int positionCount = getPositionCount();
@@ -213,33 +236,41 @@ public abstract class AbstractMapBlock
     }
 
     @Override
-    public long getPositionsSizeInBytes(boolean[] positions)
+    public final long getPositionsSizeInBytes(boolean[] positions, int selectedMapPositions)
     {
-        // We can use either the getRegionSizeInBytes or getPositionsSizeInBytes
-        // from the underlying raw blocks to implement this function. We chose
-        // getPositionsSizeInBytes with the assumption that constructing a
-        // positions array is cheaper than calling getRegionSizeInBytes for each
-        // used position.
         int positionCount = getPositionCount();
         checkValidPositions(positions, positionCount);
-        boolean[] entryPositions = new boolean[getRawKeyBlock().getPositionCount()];
-        int usedEntryCount = 0;
-        int usedPositionCount = 0;
-        for (int i = 0; i < positions.length; ++i) {
-            if (positions[i]) {
-                usedPositionCount++;
-                int entriesStart = getOffsets()[getOffsetBase() + i];
-                int entriesEnd = getOffsets()[getOffsetBase() + i + 1];
-                for (int j = entriesStart; j < entriesEnd; j++) {
-                    entryPositions[j] = true;
-                }
-                usedEntryCount += (entriesEnd - entriesStart);
-            }
+        if (selectedMapPositions == 0) {
+            return 0;
         }
-        return getRawKeyBlock().getPositionsSizeInBytes(entryPositions) +
-                getRawValueBlock().getPositionsSizeInBytes(entryPositions) +
-                (Integer.BYTES + Byte.BYTES) * (long) usedPositionCount +
-                Integer.BYTES * HASH_MULTIPLIER * (long) usedEntryCount;
+        if (selectedMapPositions == positionCount) {
+            return getSizeInBytes();
+        }
+        int[] offsets = getOffsets();
+        int offsetBase = getOffsetBase();
+        OptionalInt fixedKeyAndValueSizePerRow = keyAndValueFixedSizeInBytesPerRow();
+
+        int selectedEntryCount;
+        long keyAndValuesSizeInBytes;
+        if (fixedKeyAndValueSizePerRow.isPresent()) {
+            // no new positions array need be created, we can just count the number of elements
+            selectedEntryCount = countSelectedPositionsFromOffsets(positions, offsets, offsetBase);
+            keyAndValuesSizeInBytes = fixedKeyAndValueSizePerRow.getAsInt() * (long) selectedEntryCount;
+        }
+        else {
+            // We can use either the getRegionSizeInBytes or getPositionsSizeInBytes
+            // from the underlying raw blocks to implement this function. We chose
+            // getPositionsSizeInBytes with the assumption that constructing a
+            // positions array is cheaper than calling getRegionSizeInBytes for each
+            // used position.
+            boolean[] entryPositions = new boolean[getRawKeyBlock().getPositionCount()];
+            selectedEntryCount = countAndMarkSelectedPositionsFromOffsets(positions, offsets, offsetBase, entryPositions);
+            keyAndValuesSizeInBytes = getRawKeyBlock().getPositionsSizeInBytes(entryPositions, selectedEntryCount) +
+                    getRawValueBlock().getPositionsSizeInBytes(entryPositions, selectedEntryCount);
+        }
+        return keyAndValuesSizeInBytes +
+                (Integer.BYTES + Byte.BYTES) * (long) selectedMapPositions +
+                Integer.BYTES * HASH_MULTIPLIER * (long) selectedEntryCount;
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/block/AbstractRowBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/AbstractRowBlock.java
@@ -17,6 +17,8 @@ import io.airlift.slice.SliceOutput;
 
 import javax.annotation.Nullable;
 
+import java.util.OptionalInt;
+
 import static com.facebook.presto.common.block.BlockUtil.appendNullToIsNullArray;
 import static com.facebook.presto.common.block.BlockUtil.appendNullToOffsetsArray;
 import static com.facebook.presto.common.block.BlockUtil.arraySame;
@@ -125,6 +127,36 @@ public abstract class AbstractRowBlock
     }
 
     @Override
+    public final OptionalInt fixedSizeInBytesPerPosition()
+    {
+        OptionalInt fieldSize = fixedSizeInBytesForAllFieldsPerPosition();
+        if (fieldSize.isPresent()) {
+            // must include the row block overhead in addition to the per position size in bytes
+            return OptionalInt.of(fieldSize.getAsInt() + (Integer.BYTES + Byte.BYTES)); // offsets + rowIsNull
+        }
+        return OptionalInt.empty();
+    }
+
+    /**
+     * Returns the combined {@link Block#fixedSizeInBytesPerPosition()} value for all fields, assuming all
+     * are fixed size. If any field is not fixed size, then no value will be returned. This does <i>not</i>
+     * include the size-per-position overhead associated with the {@link AbstractRowBlock} itself, only of
+     * the constituent field members.
+     */
+    private OptionalInt fixedSizeInBytesForAllFieldsPerPosition()
+    {
+        int fixedSizePerRow = 0;
+        for (Block field : getRawFieldBlocks()) {
+            OptionalInt fieldFixedSize = field.fixedSizeInBytesPerPosition();
+            if (!fieldFixedSize.isPresent()) {
+                return OptionalInt.empty(); // found a block without a single per-position size
+            }
+            fixedSizePerRow += fieldFixedSize.getAsInt();
+        }
+        return OptionalInt.of(fixedSizePerRow);
+    }
+
+    @Override
     public long getRegionSizeInBytes(int position, int length)
     {
         int positionCount = getPositionCount();
@@ -167,7 +199,7 @@ public abstract class AbstractRowBlock
         int startFieldBlockOffset = getFieldBlockOffset(position);
         int fieldBlockLength = getFieldBlockOffset(position + length) - startFieldBlockOffset;
 
-        long approximateLogicalSizeInBytes = (Integer.BYTES + Byte.BYTES) * length; // offsets and rowIsNull
+        long approximateLogicalSizeInBytes = (Integer.BYTES + Byte.BYTES) * (long) length; // offsets and rowIsNull
         for (int i = 0; i < numFields; i++) {
             approximateLogicalSizeInBytes += getRawFieldBlocks()[i].getApproximateRegionLogicalSizeInBytes(startFieldBlockOffset, fieldBlockLength);
         }
@@ -176,27 +208,77 @@ public abstract class AbstractRowBlock
     }
 
     @Override
-    public long getPositionsSizeInBytes(boolean[] positions)
+    public final long getPositionsSizeInBytes(boolean[] positions, int selectedRowPositions)
     {
-        checkValidPositions(positions, getPositionCount());
+        int positionCount = getPositionCount();
+        checkValidPositions(positions, positionCount);
 
-        int usedPositionCount = 0;
-        boolean[] fieldPositions = new boolean[getRawFieldBlocks()[0].getPositionCount()];
-        for (int i = 0; i < positions.length; i++) {
-            if (positions[i]) {
-                usedPositionCount++;
-                int startFieldBlockOffset = getFieldBlockOffset(i);
-                int endFieldBlockOffset = getFieldBlockOffset(i + 1);
-                for (int j = startFieldBlockOffset; j < endFieldBlockOffset; j++) {
-                    fieldPositions[j] = true;
+        if (selectedRowPositions == positionCount) {
+            return getSizeInBytes();
+        }
+
+        OptionalInt fixedSizePerFieldPosition = fixedSizeInBytesForAllFieldsPerPosition();
+        if (fixedSizePerFieldPosition.isPresent()) {
+            // All field blocks are fixed size per position, no specific position mapping is necessary
+            int selectedFieldPositionCount = selectedRowPositions;
+            boolean[] rowIsNull = getRowIsNull();
+            if (rowIsNull != null) {
+                // Some positions in usedPositions may be null which must be removed from the selectedFieldPositionCount
+                int offsetBase = getOffsetBase();
+                for (int i = 0; i < positions.length; i++) {
+                    if (positions[i] && rowIsNull[i + offsetBase]) {
+                        selectedFieldPositionCount--; // selected row is null, don't include it in the selected field positions
+                    }
+                }
+                if (selectedFieldPositionCount < 0) {
+                    throw new IllegalStateException("Invalid field position selection after nulls removed: " + selectedFieldPositionCount);
+                }
+            }
+            return ((Integer.BYTES + Byte.BYTES) * (long) selectedRowPositions) + (fixedSizePerFieldPosition.getAsInt() * (long) selectedFieldPositionCount);
+        }
+
+        return getSpecificPositionsSizeInBytes(positions, selectedRowPositions);
+    }
+
+    private long getSpecificPositionsSizeInBytes(boolean[] positions, int selectedRowPositions)
+    {
+        int positionCount = getPositionCount();
+        int offsetBase = getOffsetBase();
+        boolean[] rowIsNull = getRowIsNull();
+        // No fixed width size per row, specific positions used must be tracked
+        int totalFieldPositions = getRawFieldBlocks()[0].getPositionCount();
+        boolean[] fieldPositions;
+        int selectedFieldPositionCount;
+        if (rowIsNull == null) {
+            // No nulls, so the same number of positions are used
+            selectedFieldPositionCount = selectedRowPositions;
+            if (offsetBase == 0 && positionCount == totalFieldPositions) {
+                // No need to adapt the positions array at all, reuse it directly
+                fieldPositions = positions;
+            }
+            else {
+                // no nulls present, so we can just shift the positions array into alignment with the elements block with other positions unused
+                fieldPositions = new boolean[totalFieldPositions];
+                System.arraycopy(positions, 0, fieldPositions, offsetBase, positions.length);
+            }
+        }
+        else {
+            fieldPositions = new boolean[totalFieldPositions];
+            selectedFieldPositionCount = 0;
+            for (int i = 0; i < positions.length; i++) {
+                if (positions[i] && !rowIsNull[offsetBase + i]) {
+                    selectedFieldPositionCount++;
+                    fieldPositions[getFieldBlockOffset(i)] = true;
                 }
             }
         }
-        long sizeInBytes = 0;
+
+        Block[] rawFieldBlocks = getRawFieldBlocks();
+        long sizeInBytes = ((Integer.BYTES + Byte.BYTES) * (long) selectedRowPositions); // offsets + rowIsNull
         for (int j = 0; j < numFields; j++) {
-            sizeInBytes += getRawFieldBlocks()[j].getPositionsSizeInBytes(fieldPositions);
+            sizeInBytes += rawFieldBlocks[j].getPositionsSizeInBytes(fieldPositions, selectedFieldPositionCount);
         }
-        return sizeInBytes + (Integer.BYTES + Byte.BYTES) * (long) usedPositionCount;
+        return sizeInBytes;
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/block/AbstractSingleArrayBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/AbstractSingleArrayBlock.java
@@ -196,7 +196,7 @@ public abstract class AbstractSingleArrayBlock
     }
 
     @Override
-    public long getPositionsSizeInBytes(boolean[] positions)
+    public long getPositionsSizeInBytes(boolean[] positions, int usedPositionCount)
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-common/src/main/java/com/facebook/presto/common/block/AbstractSingleMapBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/AbstractSingleMapBlock.java
@@ -232,7 +232,7 @@ public abstract class AbstractSingleMapBlock
     }
 
     @Override
-    public long getPositionsSizeInBytes(boolean[] positions)
+    public long getPositionsSizeInBytes(boolean[] positions, int usedPositionCount)
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-common/src/main/java/com/facebook/presto/common/block/AbstractSingleRowBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/AbstractSingleRowBlock.java
@@ -177,7 +177,7 @@ public abstract class AbstractSingleRowBlock
     }
 
     @Override
-    public long getPositionsSizeInBytes(boolean[] positions)
+    public long getPositionsSizeInBytes(boolean[] positions, int usedPositionCount)
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-common/src/main/java/com/facebook/presto/common/block/Block.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/Block.java
@@ -16,6 +16,7 @@ package com.facebook.presto.common.block;
 import io.airlift.slice.Slice;
 import io.airlift.slice.SliceOutput;
 
+import java.util.OptionalInt;
 import java.util.function.BiConsumer;
 
 import static com.facebook.presto.common.block.BlockUtil.checkArrayRange;
@@ -229,11 +230,21 @@ public interface Block
     }
 
     /**
-     * Returns the size of of all positions marked true in the positions array.
+     * Returns the number of bytes (in terms of {@link Block#getSizeInBytes()}) required per position
+     * that this block contains, assuming that the number of bytes required is a known static quantity
+     * and not dependent on any particular specific position. This allows for some complex block wrappings
+     * to potentially avoid having to call {@link Block#getPositionsSizeInBytes(boolean[], int)}  which
+     * would require computing the specific positions selected
+     * @return The size in bytes, per position, if this block type does not require specific position information to compute its size
+     */
+    OptionalInt fixedSizeInBytesPerPosition();
+
+    /**
+     * Returns the size of all positions marked true in the positions array.
      * This is equivalent to multiple calls of {@code block.getRegionSizeInBytes(position, length)}
      * where you mark all positions for the regions first.
      */
-    long getPositionsSizeInBytes(boolean[] positions);
+    long getPositionsSizeInBytes(boolean[] positions, int usedPositionCount);
 
     /**
      * Returns the retained size of this block in memory, including over-allocations.

--- a/presto-common/src/main/java/com/facebook/presto/common/block/BlockUtil.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/BlockUtil.java
@@ -196,12 +196,28 @@ public final class BlockUtil
         return Arrays.copyOfRange(array, index, index + length);
     }
 
-    static int countUsedPositions(boolean[] positions)
+    static int countSelectedPositionsFromOffsets(boolean[] positions, int[] offsets, int offsetBase)
     {
+        checkArrayRange(offsets, offsetBase, positions.length);
         int used = 0;
-        for (boolean position : positions) {
-            if (position) {
-                used++;
+        for (int i = 0; i < positions.length; i++) {
+            int offsetStart = offsets[offsetBase + i];
+            int offsetEnd = offsets[offsetBase + i + 1];
+            used += ((positions[i] ? 1 : 0) * (offsetEnd - offsetStart));
+        }
+        return used;
+    }
+
+    static int countAndMarkSelectedPositionsFromOffsets(boolean[] positions, int[] offsets, int offsetBase, boolean[] elementPositions)
+    {
+        checkArrayRange(offsets, offsetBase, positions.length);
+        int used = 0;
+        for (int i = 0; i < positions.length; i++) {
+            int offsetStart = offsets[offsetBase + i];
+            int offsetEnd = offsets[offsetBase + i + 1];
+            if (positions[i]) {
+                used += (offsetEnd - offsetStart);
+                Arrays.fill(elementPositions, offsetStart, offsetEnd, true);
             }
         }
         return used;

--- a/presto-common/src/main/java/com/facebook/presto/common/block/ByteArrayBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/ByteArrayBlock.java
@@ -19,6 +19,7 @@ import org.openjdk.jol.info.ClassLayout;
 import javax.annotation.Nullable;
 
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.function.BiConsumer;
 
 import static com.facebook.presto.common.array.Arrays.ExpansionFactor.SMALL;
@@ -28,7 +29,6 @@ import static com.facebook.presto.common.block.BlockUtil.appendNullToIsNullArray
 import static com.facebook.presto.common.block.BlockUtil.checkArrayRange;
 import static com.facebook.presto.common.block.BlockUtil.checkValidRegion;
 import static com.facebook.presto.common.block.BlockUtil.compactArray;
-import static com.facebook.presto.common.block.BlockUtil.countUsedPositions;
 import static com.facebook.presto.common.block.BlockUtil.internalPositionInRange;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.String.format;
@@ -37,6 +37,7 @@ public class ByteArrayBlock
         implements Block
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(ByteArrayBlock.class).instanceSize();
+    public static final int SIZE_IN_BYTES_PER_POSITION = Byte.BYTES + Byte.BYTES;
 
     private final int arrayOffset;
     private final int positionCount;
@@ -44,7 +45,6 @@ public class ByteArrayBlock
     private final boolean[] valueIsNull;
     private final byte[] values;
 
-    private final long sizeInBytes;
     private final long retainedSizeInBytes;
 
     public ByteArrayBlock(int positionCount, Optional<boolean[]> valueIsNull, byte[] values)
@@ -73,26 +73,31 @@ public class ByteArrayBlock
         }
         this.valueIsNull = valueIsNull;
 
-        sizeInBytes = (Byte.BYTES + Byte.BYTES) * (long) positionCount;
         retainedSizeInBytes = (INSTANCE_SIZE + sizeOf(valueIsNull) + sizeOf(values));
     }
 
     @Override
     public long getSizeInBytes()
     {
-        return sizeInBytes;
+        return SIZE_IN_BYTES_PER_POSITION * (long) positionCount;
     }
 
     @Override
     public long getRegionSizeInBytes(int position, int length)
     {
-        return (Byte.BYTES + Byte.BYTES) * (long) length;
+        return SIZE_IN_BYTES_PER_POSITION * (long) length;
     }
 
     @Override
-    public long getPositionsSizeInBytes(boolean[] positions)
+    public OptionalInt fixedSizeInBytesPerPosition()
     {
-        return (Byte.BYTES + Byte.BYTES) * (long) countUsedPositions(positions);
+        return OptionalInt.of(SIZE_IN_BYTES_PER_POSITION);
+    }
+
+    @Override
+    public long getPositionsSizeInBytes(boolean[] usedPositions, int usedPositionCount)
+    {
+        return SIZE_IN_BYTES_PER_POSITION * (long) usedPositionCount;
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/block/ByteArrayBlockBuilder.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/ByteArrayBlockBuilder.java
@@ -20,12 +20,12 @@ import org.openjdk.jol.info.ClassLayout;
 import javax.annotation.Nullable;
 
 import java.util.Arrays;
+import java.util.OptionalInt;
 import java.util.function.BiConsumer;
 
 import static com.facebook.presto.common.block.BlockUtil.calculateBlockResetSize;
 import static com.facebook.presto.common.block.BlockUtil.checkArrayRange;
 import static com.facebook.presto.common.block.BlockUtil.checkValidRegion;
-import static com.facebook.presto.common.block.BlockUtil.countUsedPositions;
 import static com.facebook.presto.common.block.BlockUtil.internalPositionInRange;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.Math.max;
@@ -148,19 +148,25 @@ public class ByteArrayBlockBuilder
     @Override
     public long getSizeInBytes()
     {
-        return (Byte.BYTES + Byte.BYTES) * (long) positionCount;
+        return ByteArrayBlock.SIZE_IN_BYTES_PER_POSITION * (long) positionCount;
     }
 
     @Override
     public long getRegionSizeInBytes(int position, int length)
     {
-        return (Byte.BYTES + Byte.BYTES) * (long) length;
+        return ByteArrayBlock.SIZE_IN_BYTES_PER_POSITION * (long) length;
     }
 
     @Override
-    public long getPositionsSizeInBytes(boolean[] positions)
+    public OptionalInt fixedSizeInBytesPerPosition()
     {
-        return (Byte.BYTES + Byte.BYTES) * (long) countUsedPositions(positions);
+        return OptionalInt.of(ByteArrayBlock.SIZE_IN_BYTES_PER_POSITION);
+    }
+
+    @Override
+    public long getPositionsSizeInBytes(boolean[] usedPositions, int usedPositionCount)
+    {
+        return ByteArrayBlock.SIZE_IN_BYTES_PER_POSITION * (long) usedPositionCount;
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/block/DictionaryBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/DictionaryBlock.java
@@ -97,7 +97,7 @@ public class DictionaryBlock
         this.retainedSizeInBytes = INSTANCE_SIZE + dictionary.getRetainedSizeInBytes() + sizeOf(ids);
 
         if (dictionaryIsCompacted) {
-            this.sizeInBytes = this.retainedSizeInBytes;
+            this.sizeInBytes = dictionary.getSizeInBytes() + (Integer.BYTES * (long) positionCount);
             this.uniqueIds = dictionary.getPositionCount();
         }
     }

--- a/presto-common/src/main/java/com/facebook/presto/common/block/DictionaryBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/DictionaryBlock.java
@@ -21,13 +21,13 @@ import org.openjdk.jol.info.ClassLayout;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.OptionalInt;
 import java.util.function.BiConsumer;
 
 import static com.facebook.presto.common.block.BlockUtil.checkArrayRange;
 import static com.facebook.presto.common.block.BlockUtil.checkValidPosition;
 import static com.facebook.presto.common.block.BlockUtil.checkValidPositions;
 import static com.facebook.presto.common.block.BlockUtil.checkValidRegion;
-import static com.facebook.presto.common.block.BlockUtil.countUsedPositions;
 import static com.facebook.presto.common.block.BlockUtil.internalPositionInRange;
 import static com.facebook.presto.common.block.DictionaryId.randomDictionaryId;
 import static io.airlift.slice.SizeOf.sizeOf;
@@ -219,19 +219,32 @@ public class DictionaryBlock
         return sizeInBytes;
     }
 
-    private void calculateCompactSize()
+    @Override
+    public OptionalInt fixedSizeInBytesPerPosition()
     {
-        int uniqueIds = 0;
-        boolean[] used = new boolean[dictionary.getPositionCount()];
-        for (int i = 0; i < positionCount; i++) {
-            int position = getId(i);
-            if (!used[position]) {
-                uniqueIds++;
-                used[position] = true;
+        if (uniqueIds == positionCount) {
+            // Each position is unique, so the per-position fixed size of the dictionary plus the dictionary id overhead
+            // is our fixed size per position
+            OptionalInt dictionarySizePerPosition = dictionary.fixedSizeInBytesPerPosition();
+            if (dictionarySizePerPosition.isPresent()) {
+                // Add overhead from the dictionary index
+                return OptionalInt.of(dictionarySizePerPosition.getAsInt() + Integer.BYTES);
             }
         }
-        this.sizeInBytes = dictionary.getPositionsSizeInBytes(used) + (Integer.BYTES * (long) positionCount);
-        this.uniqueIds = uniqueIds;
+        return OptionalInt.empty();
+    }
+
+    private void calculateCompactSize()
+    {
+        int usedIds = 0;
+        boolean[] used = new boolean[dictionary.getPositionCount()];
+        for (int i = idsOffset; i < idsOffset + positionCount; i++) {
+            int id = ids[i];
+            usedIds += used[id] ? 0 : 1;
+            used[id] = true;
+        }
+        this.uniqueIds = usedIds;
+        this.sizeInBytes = dictionary.getPositionsSizeInBytes(used, usedIds) + (Integer.BYTES * (long) positionCount);
     }
 
     @Override
@@ -249,11 +262,19 @@ public class DictionaryBlock
             return getSizeInBytes();
         }
 
-        boolean[] used = new boolean[dictionary.getPositionCount()];
-        for (int i = positionOffset; i < positionOffset + length; i++) {
-            used[getId(i)] = true;
+        OptionalInt fixedSizePerPosition = fixedSizeInBytesPerPosition();
+        if (fixedSizePerPosition.isPresent()) {
+            return fixedSizePerPosition.getAsInt() * (long) length;
         }
-        return dictionary.getPositionsSizeInBytes(used) + Integer.BYTES * (long) length;
+
+        int usedIds = 0;
+        boolean[] used = new boolean[dictionary.getPositionCount()];
+        for (int i = idsOffset + positionOffset; i < idsOffset + positionOffset + length; i++) {
+            int id = ids[i];
+            usedIds += used[id] ? 0 : 1;
+            used[id] = true;
+        }
+        return dictionary.getPositionsSizeInBytes(used, usedIds) + (Integer.BYTES * (long) length);
     }
 
     @Override
@@ -300,17 +321,30 @@ public class DictionaryBlock
     }
 
     @Override
-    public long getPositionsSizeInBytes(boolean[] positions)
+    public long getPositionsSizeInBytes(boolean[] positions, int usedPositionCount)
     {
         checkValidPositions(positions, positionCount);
+        if (usedPositionCount == 0) {
+            return 0;
+        }
+        if (usedPositionCount == positionCount) {
+            return getSizeInBytes();
+        }
+        OptionalInt fixedSizePerPosition = fixedSizeInBytesPerPosition();
+        if (fixedSizePerPosition.isPresent()) {
+            return fixedSizePerPosition.getAsInt() * (long) usedPositionCount;
+        }
 
+        int usedIds = 0;
         boolean[] used = new boolean[dictionary.getPositionCount()];
         for (int i = 0; i < positions.length; i++) {
             if (positions[i]) {
-                used[getId(i)] = true;
+                int id = ids[idsOffset + i];
+                usedIds += used[id] ? 0 : 1;
+                used[id] = true;
             }
         }
-        return dictionary.getPositionsSizeInBytes(used) + (Integer.BYTES * (long) countUsedPositions(positions));
+        return dictionary.getPositionsSizeInBytes(used, usedIds) + (Integer.BYTES * (long) usedPositionCount);
     }
 
     @Override
@@ -456,6 +490,9 @@ public class DictionaryBlock
 
     public boolean isCompact()
     {
+        if (dictionary.getPositionCount() > positionCount) {
+            return false;
+        }
         if (uniqueIds < 0) {
             calculateCompactSize();
         }

--- a/presto-common/src/main/java/com/facebook/presto/common/block/DictionaryBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/DictionaryBlock.java
@@ -236,15 +236,15 @@ public class DictionaryBlock
 
     private void calculateCompactSize()
     {
-        int usedIds = 0;
+        int uniqueIds = 0;
         boolean[] used = new boolean[dictionary.getPositionCount()];
         for (int i = idsOffset; i < idsOffset + positionCount; i++) {
             int id = ids[i];
-            usedIds += used[id] ? 0 : 1;
+            uniqueIds += used[id] ? 0 : 1;
             used[id] = true;
         }
-        this.uniqueIds = usedIds;
-        this.sizeInBytes = dictionary.getPositionsSizeInBytes(used, usedIds) + (Integer.BYTES * (long) positionCount);
+        this.uniqueIds = uniqueIds;
+        this.sizeInBytes = getSizeInBytesForSelectedPositions(used, uniqueIds, positionCount);
     }
 
     @Override
@@ -267,14 +267,14 @@ public class DictionaryBlock
             return fixedSizePerPosition.getAsInt() * (long) length;
         }
 
-        int usedIds = 0;
+        int uniqueIds = 0;
         boolean[] used = new boolean[dictionary.getPositionCount()];
         for (int i = idsOffset + positionOffset; i < idsOffset + positionOffset + length; i++) {
             int id = ids[i];
-            usedIds += used[id] ? 0 : 1;
+            uniqueIds += used[id] ? 0 : 1;
             used[id] = true;
         }
-        return dictionary.getPositionsSizeInBytes(used, usedIds) + (Integer.BYTES * (long) length);
+        return getSizeInBytesForSelectedPositions(used, uniqueIds, length);
     }
 
     @Override
@@ -335,16 +335,27 @@ public class DictionaryBlock
             return fixedSizePerPosition.getAsInt() * (long) usedPositionCount;
         }
 
-        int usedIds = 0;
+        int uniqueIds = 0;
         boolean[] used = new boolean[dictionary.getPositionCount()];
         for (int i = 0; i < positions.length; i++) {
+            int id = ids[idsOffset + i];
             if (positions[i]) {
-                int id = ids[idsOffset + i];
-                usedIds += used[id] ? 0 : 1;
+                uniqueIds += used[id] ? 0 : 1;
                 used[id] = true;
             }
         }
-        return dictionary.getPositionsSizeInBytes(used, usedIds) + (Integer.BYTES * (long) usedPositionCount);
+        return getSizeInBytesForSelectedPositions(used, uniqueIds, usedPositionCount);
+    }
+
+    private long getSizeInBytesForSelectedPositions(boolean[] usedIds, int uniqueIds, int selectedPositions)
+    {
+        long dictionarySize = dictionary.getPositionsSizeInBytes(usedIds, uniqueIds);
+        if (uniqueIds == dictionary.getPositionCount() && this.uniqueIds == -1) {
+            // All positions in the dictionary are referenced, store the uniqueId count and sizeInBytes
+            this.uniqueIds = uniqueIds;
+            this.sizeInBytes = dictionarySize + (Integer.BYTES * (long) positionCount);
+        }
+        return dictionarySize + (Integer.BYTES * (long) selectedPositions);
     }
 
     @Override
@@ -428,21 +439,26 @@ public class DictionaryBlock
         checkArrayRange(positions, offset, length);
 
         int[] newIds = new int[length];
-        boolean isCompact = isCompact() && length >= dictionary.getPositionCount();
-        boolean[] seen = null;
-        if (isCompact) {
-            seen = new boolean[dictionary.getPositionCount()];
-        }
+        boolean isCompact = length >= dictionary.getPositionCount() && isCompact();
+        boolean[] usedIds = isCompact ? new boolean[dictionary.getPositionCount()] : null;
+        int uniqueIds = 0;
         for (int i = 0; i < length; i++) {
-            newIds[i] = getId(positions[offset + i]);
-            if (isCompact) {
-                seen[newIds[i]] = true;
+            int id = getId(positions[offset + i]);
+            newIds[i] = id;
+            if (usedIds != null) {
+                uniqueIds += usedIds[id] ? 0 : 1;
+                usedIds[id] = true;
             }
         }
-        for (int i = 0; i < dictionary.getPositionCount() && isCompact; i++) {
-            isCompact &= seen[i];
+        // All positions must have been referenced in order to be compact
+        isCompact &= (usedIds != null && usedIds.length == uniqueIds);
+        DictionaryBlock result = new DictionaryBlock(newIds.length, dictionary, newIds, isCompact, dictionarySourceId);
+        if (usedIds != null && !isCompact) {
+            // resulting dictionary is not compact, but we know the number of unique ids and which positions are used
+            result.uniqueIds = uniqueIds;
+            result.sizeInBytes = dictionary.getPositionsSizeInBytes(usedIds, uniqueIds) + (Integer.BYTES * (long) length);
         }
-        return new DictionaryBlock(newIds.length, getDictionary(), newIds, isCompact, getDictionarySourceId());
+        return result;
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/block/DictionaryBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/DictionaryBlock.java
@@ -402,7 +402,11 @@ public class DictionaryBlock
             }
             newIds[i] = oldIndexToNewIndex.get(oldIndex);
         }
-        return new DictionaryBlock(dictionary.copyPositions(positionsToCopy.elements(), 0, positionsToCopy.size()), newIds);
+        return new DictionaryBlock(
+                length,
+                dictionary.copyPositions(positionsToCopy.elements(), 0, positionsToCopy.size()),
+                newIds,
+                true); // new dictionary is compact
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/block/Int128ArrayBlockBuilder.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/Int128ArrayBlockBuilder.java
@@ -22,13 +22,13 @@ import org.openjdk.jol.info.ClassLayout;
 import javax.annotation.Nullable;
 
 import java.util.Arrays;
+import java.util.OptionalInt;
 import java.util.function.BiConsumer;
 
 import static com.facebook.presto.common.block.BlockUtil.calculateBlockResetSize;
 import static com.facebook.presto.common.block.BlockUtil.checkArrayRange;
 import static com.facebook.presto.common.block.BlockUtil.checkValidRegion;
 import static com.facebook.presto.common.block.BlockUtil.compactArray;
-import static com.facebook.presto.common.block.BlockUtil.countUsedPositions;
 import static com.facebook.presto.common.block.BlockUtil.getNum128Integers;
 import static com.facebook.presto.common.block.BlockUtil.internalPositionInRange;
 import static com.facebook.presto.common.block.Int128ArrayBlock.INT128_BYTES;
@@ -166,19 +166,25 @@ public class Int128ArrayBlockBuilder
     @Override
     public long getSizeInBytes()
     {
-        return (INT128_BYTES + Byte.BYTES) * (long) positionCount;
+        return Int128ArrayBlock.SIZE_IN_BYTES_PER_POSITION * (long) positionCount;
+    }
+
+    @Override
+    public OptionalInt fixedSizeInBytesPerPosition()
+    {
+        return OptionalInt.of(Int128ArrayBlock.SIZE_IN_BYTES_PER_POSITION);
     }
 
     @Override
     public long getRegionSizeInBytes(int position, int length)
     {
-        return (INT128_BYTES + Byte.BYTES) * (long) length;
+        return Int128ArrayBlock.SIZE_IN_BYTES_PER_POSITION * (long) length;
     }
 
     @Override
-    public long getPositionsSizeInBytes(boolean[] positions)
+    public long getPositionsSizeInBytes(boolean[] usedPositions, int usedPositionCount)
     {
-        return (INT128_BYTES + Byte.BYTES) * (long) countUsedPositions(positions);
+        return Int128ArrayBlock.SIZE_IN_BYTES_PER_POSITION * (long) usedPositionCount;
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/block/IntArrayBlockBuilder.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/IntArrayBlockBuilder.java
@@ -20,12 +20,12 @@ import org.openjdk.jol.info.ClassLayout;
 import javax.annotation.Nullable;
 
 import java.util.Arrays;
+import java.util.OptionalInt;
 import java.util.function.BiConsumer;
 
 import static com.facebook.presto.common.block.BlockUtil.calculateBlockResetSize;
 import static com.facebook.presto.common.block.BlockUtil.checkArrayRange;
 import static com.facebook.presto.common.block.BlockUtil.checkValidRegion;
-import static com.facebook.presto.common.block.BlockUtil.countUsedPositions;
 import static com.facebook.presto.common.block.BlockUtil.internalPositionInRange;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.Math.max;
@@ -148,19 +148,25 @@ public class IntArrayBlockBuilder
     @Override
     public long getSizeInBytes()
     {
-        return (Integer.BYTES + Byte.BYTES) * (long) positionCount;
+        return IntArrayBlock.SIZE_IN_BYTES_PER_POSITION * (long) positionCount;
+    }
+
+    @Override
+    public OptionalInt fixedSizeInBytesPerPosition()
+    {
+        return OptionalInt.of(IntArrayBlock.SIZE_IN_BYTES_PER_POSITION);
     }
 
     @Override
     public long getRegionSizeInBytes(int position, int length)
     {
-        return (Integer.BYTES + Byte.BYTES) * (long) length;
+        return IntArrayBlock.SIZE_IN_BYTES_PER_POSITION * (long) length;
     }
 
     @Override
-    public long getPositionsSizeInBytes(boolean[] positions)
+    public long getPositionsSizeInBytes(boolean[] usedPositions, int usedPositionCount)
     {
-        return (Integer.BYTES + Byte.BYTES) * (long) countUsedPositions(positions);
+        return IntArrayBlock.SIZE_IN_BYTES_PER_POSITION * (long) usedPositionCount;
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/block/LazyBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/LazyBlock.java
@@ -17,6 +17,7 @@ import io.airlift.slice.Slice;
 import io.airlift.slice.SliceOutput;
 import org.openjdk.jol.info.ClassLayout;
 
+import java.util.OptionalInt;
 import java.util.function.BiConsumer;
 
 import static java.util.Objects.requireNonNull;
@@ -186,6 +187,13 @@ public class LazyBlock
     }
 
     @Override
+    public OptionalInt fixedSizeInBytesPerPosition()
+    {
+        assureLoaded();
+        return block.fixedSizeInBytesPerPosition();
+    }
+
+    @Override
     public long getRegionSizeInBytes(int position, int length)
     {
         assureLoaded();
@@ -193,10 +201,10 @@ public class LazyBlock
     }
 
     @Override
-    public long getPositionsSizeInBytes(boolean[] positions)
+    public long getPositionsSizeInBytes(boolean[] positions, int usedPositionCount)
     {
         assureLoaded();
-        return block.getPositionsSizeInBytes(positions);
+        return block.getPositionsSizeInBytes(positions, usedPositionCount);
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/block/LongArrayBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/LongArrayBlock.java
@@ -19,6 +19,7 @@ import org.openjdk.jol.info.ClassLayout;
 import javax.annotation.Nullable;
 
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.function.BiConsumer;
 
 import static com.facebook.presto.common.array.Arrays.ExpansionFactor.SMALL;
@@ -28,7 +29,6 @@ import static com.facebook.presto.common.block.BlockUtil.appendNullToIsNullArray
 import static com.facebook.presto.common.block.BlockUtil.checkArrayRange;
 import static com.facebook.presto.common.block.BlockUtil.checkValidRegion;
 import static com.facebook.presto.common.block.BlockUtil.compactArray;
-import static com.facebook.presto.common.block.BlockUtil.countUsedPositions;
 import static com.facebook.presto.common.block.BlockUtil.internalPositionInRange;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.Math.toIntExact;
@@ -38,6 +38,7 @@ public class LongArrayBlock
         implements Block
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(LongArrayBlock.class).instanceSize();
+    public static final int SIZE_IN_BYTES_PER_POSITION = Long.BYTES + Byte.BYTES;
 
     private final int arrayOffset;
     private final int positionCount;
@@ -45,7 +46,6 @@ public class LongArrayBlock
     private final boolean[] valueIsNull;
     private final long[] values;
 
-    private final long sizeInBytes;
     private final long retainedSizeInBytes;
 
     public LongArrayBlock(int positionCount, Optional<boolean[]> valueIsNull, long[] values)
@@ -74,26 +74,31 @@ public class LongArrayBlock
         }
         this.valueIsNull = valueIsNull;
 
-        sizeInBytes = (Long.BYTES + Byte.BYTES) * (long) positionCount;
         retainedSizeInBytes = INSTANCE_SIZE + sizeOf(valueIsNull) + sizeOf(values);
     }
 
     @Override
     public long getSizeInBytes()
     {
-        return sizeInBytes;
+        return SIZE_IN_BYTES_PER_POSITION * (long) positionCount;
+    }
+
+    @Override
+    public OptionalInt fixedSizeInBytesPerPosition()
+    {
+        return OptionalInt.of(SIZE_IN_BYTES_PER_POSITION);
     }
 
     @Override
     public long getRegionSizeInBytes(int position, int length)
     {
-        return (Long.BYTES + Byte.BYTES) * (long) length;
+        return SIZE_IN_BYTES_PER_POSITION * (long) length;
     }
 
     @Override
-    public long getPositionsSizeInBytes(boolean[] positions)
+    public long getPositionsSizeInBytes(boolean[] usedPositions, int usedPositionCount)
     {
-        return (Long.BYTES + Byte.BYTES) * (long) countUsedPositions(positions);
+        return SIZE_IN_BYTES_PER_POSITION * (long) usedPositionCount;
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/block/LongArrayBlockBuilder.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/LongArrayBlockBuilder.java
@@ -20,12 +20,12 @@ import org.openjdk.jol.info.ClassLayout;
 import javax.annotation.Nullable;
 
 import java.util.Arrays;
+import java.util.OptionalInt;
 import java.util.function.BiConsumer;
 
 import static com.facebook.presto.common.block.BlockUtil.calculateBlockResetSize;
 import static com.facebook.presto.common.block.BlockUtil.checkArrayRange;
 import static com.facebook.presto.common.block.BlockUtil.checkValidRegion;
-import static com.facebook.presto.common.block.BlockUtil.countUsedPositions;
 import static com.facebook.presto.common.block.BlockUtil.internalPositionInRange;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.Math.max;
@@ -148,19 +148,25 @@ public class LongArrayBlockBuilder
     @Override
     public long getSizeInBytes()
     {
-        return (Long.BYTES + Byte.BYTES) * (long) positionCount;
+        return LongArrayBlock.SIZE_IN_BYTES_PER_POSITION * (long) positionCount;
+    }
+
+    @Override
+    public OptionalInt fixedSizeInBytesPerPosition()
+    {
+        return OptionalInt.of(LongArrayBlock.SIZE_IN_BYTES_PER_POSITION);
     }
 
     @Override
     public long getRegionSizeInBytes(int position, int length)
     {
-        return (Long.BYTES + Byte.BYTES) * (long) length;
+        return LongArrayBlock.SIZE_IN_BYTES_PER_POSITION * (long) length;
     }
 
     @Override
-    public long getPositionsSizeInBytes(boolean[] positions)
+    public long getPositionsSizeInBytes(boolean[] usedPositions, int usedPositionCount)
     {
-        return (Long.BYTES + Byte.BYTES) * (long) countUsedPositions(positions);
+        return LongArrayBlock.SIZE_IN_BYTES_PER_POSITION * (long) usedPositionCount;
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/block/RunLengthEncodedBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/RunLengthEncodedBlock.java
@@ -19,6 +19,9 @@ import io.airlift.slice.Slice;
 import io.airlift.slice.SliceOutput;
 import org.openjdk.jol.info.ClassLayout;
 
+import javax.annotation.Nullable;
+
+import java.util.OptionalInt;
 import java.util.function.BiConsumer;
 
 import static com.facebook.presto.common.block.BlockUtil.checkArrayRange;
@@ -81,6 +84,12 @@ public class RunLengthEncodedBlock
     public long getSizeInBytes()
     {
         return value.getSizeInBytes();
+    }
+
+    @Override
+    public OptionalInt fixedSizeInBytesPerPosition()
+    {
+        return OptionalInt.empty(); // size does not increase with each row
     }
 
     @Override
@@ -160,7 +169,7 @@ public class RunLengthEncodedBlock
     }
 
     @Override
-    public long getPositionsSizeInBytes(boolean[] positions)
+    public long getPositionsSizeInBytes(@Nullable boolean[] positions, int usedPositionCount)
     {
         return value.getSizeInBytes();
     }

--- a/presto-common/src/main/java/com/facebook/presto/common/block/ShortArrayBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/ShortArrayBlock.java
@@ -19,6 +19,7 @@ import org.openjdk.jol.info.ClassLayout;
 import javax.annotation.Nullable;
 
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.function.BiConsumer;
 
 import static com.facebook.presto.common.array.Arrays.ensureCapacity;
@@ -26,7 +27,6 @@ import static com.facebook.presto.common.block.BlockUtil.appendNullToIsNullArray
 import static com.facebook.presto.common.block.BlockUtil.checkArrayRange;
 import static com.facebook.presto.common.block.BlockUtil.checkValidRegion;
 import static com.facebook.presto.common.block.BlockUtil.compactArray;
-import static com.facebook.presto.common.block.BlockUtil.countUsedPositions;
 import static com.facebook.presto.common.block.BlockUtil.internalPositionInRange;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.String.format;
@@ -35,6 +35,7 @@ public class ShortArrayBlock
         implements Block
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(ShortArrayBlock.class).instanceSize();
+    public static final int SIZE_IN_BYTES_PER_POSITION = Short.BYTES + Byte.BYTES;
 
     private final int arrayOffset;
     private final int positionCount;
@@ -42,7 +43,6 @@ public class ShortArrayBlock
     private final boolean[] valueIsNull;
     private final short[] values;
 
-    private final long sizeInBytes;
     private final long retainedSizeInBytes;
 
     public ShortArrayBlock(int positionCount, Optional<boolean[]> valueIsNull, short[] values)
@@ -71,26 +71,31 @@ public class ShortArrayBlock
         }
         this.valueIsNull = valueIsNull;
 
-        sizeInBytes = (Short.BYTES + Byte.BYTES) * (long) positionCount;
         retainedSizeInBytes = INSTANCE_SIZE + sizeOf(valueIsNull) + sizeOf(values);
     }
 
     @Override
     public long getSizeInBytes()
     {
-        return sizeInBytes;
+        return SIZE_IN_BYTES_PER_POSITION * (long) positionCount;
+    }
+
+    @Override
+    public OptionalInt fixedSizeInBytesPerPosition()
+    {
+        return OptionalInt.of(SIZE_IN_BYTES_PER_POSITION);
     }
 
     @Override
     public long getRegionSizeInBytes(int position, int length)
     {
-        return (Short.BYTES + Byte.BYTES) * (long) length;
+        return SIZE_IN_BYTES_PER_POSITION * (long) length;
     }
 
     @Override
-    public long getPositionsSizeInBytes(boolean[] positions)
+    public long getPositionsSizeInBytes(boolean[] usedPositions, int usedPositionCount)
     {
-        return (Short.BYTES + Byte.BYTES) * (long) countUsedPositions(positions);
+        return SIZE_IN_BYTES_PER_POSITION * (long) usedPositionCount;
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/block/ShortArrayBlockBuilder.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/ShortArrayBlockBuilder.java
@@ -20,12 +20,12 @@ import org.openjdk.jol.info.ClassLayout;
 import javax.annotation.Nullable;
 
 import java.util.Arrays;
+import java.util.OptionalInt;
 import java.util.function.BiConsumer;
 
 import static com.facebook.presto.common.block.BlockUtil.calculateBlockResetSize;
 import static com.facebook.presto.common.block.BlockUtil.checkArrayRange;
 import static com.facebook.presto.common.block.BlockUtil.checkValidRegion;
-import static com.facebook.presto.common.block.BlockUtil.countUsedPositions;
 import static com.facebook.presto.common.block.BlockUtil.internalPositionInRange;
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.Math.max;
@@ -148,19 +148,25 @@ public class ShortArrayBlockBuilder
     @Override
     public long getSizeInBytes()
     {
-        return (Short.BYTES + Byte.BYTES) * (long) positionCount;
+        return ShortArrayBlock.SIZE_IN_BYTES_PER_POSITION * (long) positionCount;
+    }
+
+    @Override
+    public OptionalInt fixedSizeInBytesPerPosition()
+    {
+        return OptionalInt.of(ShortArrayBlock.SIZE_IN_BYTES_PER_POSITION);
     }
 
     @Override
     public long getRegionSizeInBytes(int position, int length)
     {
-        return (Short.BYTES + Byte.BYTES) * (long) length;
+        return ShortArrayBlock.SIZE_IN_BYTES_PER_POSITION * (long) length;
     }
 
     @Override
-    public long getPositionsSizeInBytes(boolean[] positions)
+    public long getPositionsSizeInBytes(boolean[] usedPositions, int usedPositionCount)
     {
-        return (Short.BYTES + Byte.BYTES) * (long) countUsedPositions(positions);
+        return ShortArrayBlock.SIZE_IN_BYTES_PER_POSITION * (long) usedPositionCount;
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/block/SingleArrayBlockWriter.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/SingleArrayBlockWriter.java
@@ -17,6 +17,7 @@ import io.airlift.slice.Slice;
 import io.airlift.slice.SliceInput;
 import org.openjdk.jol.info.ClassLayout;
 
+import java.util.OptionalInt;
 import java.util.function.BiConsumer;
 
 import static java.lang.String.format;
@@ -50,6 +51,12 @@ public class SingleArrayBlockWriter
             return size;
         }
         return size - blockBuilder.getRegionSizeInBytes(0, start);
+    }
+
+    @Override
+    public OptionalInt fixedSizeInBytesPerPosition()
+    {
+        return OptionalInt.empty();
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/block/SingleMapBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/SingleMapBlock.java
@@ -22,6 +22,7 @@ import org.openjdk.jol.info.ClassLayout;
 import javax.annotation.Nullable;
 
 import java.lang.invoke.MethodHandle;
+import java.util.OptionalInt;
 import java.util.function.BiConsumer;
 
 import static com.facebook.presto.common.block.AbstractMapBlock.HASH_MULTIPLIER;
@@ -59,6 +60,12 @@ public class SingleMapBlock
         return mapBlock.getRawKeyBlock().getRegionSizeInBytes(offset / 2, positionCount / 2) +
                 mapBlock.getRawValueBlock().getRegionSizeInBytes(offset / 2, positionCount / 2) +
                 sizeOfIntArray(positionCount / 2 * HASH_MULTIPLIER);
+    }
+
+    @Override
+    public OptionalInt fixedSizeInBytesPerPosition()
+    {
+        return OptionalInt.empty();
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/block/SingleMapBlockWriter.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/SingleMapBlockWriter.java
@@ -17,6 +17,7 @@ import io.airlift.slice.Slice;
 import io.airlift.slice.SliceInput;
 import org.openjdk.jol.info.ClassLayout;
 
+import java.util.OptionalInt;
 import java.util.function.BiConsumer;
 
 import static java.lang.String.format;
@@ -69,6 +70,12 @@ public class SingleMapBlockWriter
 
         int numPositions = offset / 2;
         return size - (keyBlockBuilder.getRegionSizeInBytes(0, numPositions) + valueBlockBuilder.getRegionSizeInBytes(0, numPositions));
+    }
+
+    @Override
+    public OptionalInt fixedSizeInBytesPerPosition()
+    {
+        return OptionalInt.empty();
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/block/SingleRowBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/SingleRowBlock.java
@@ -16,6 +16,7 @@ package com.facebook.presto.common.block;
 
 import org.openjdk.jol.info.ClassLayout;
 
+import java.util.OptionalInt;
 import java.util.function.BiConsumer;
 
 import static com.facebook.presto.common.block.BlockUtil.ensureBlocksAreLoaded;
@@ -59,6 +60,12 @@ public class SingleRowBlock
             sizeInBytes += getRawFieldBlock(i).getRegionSizeInBytes(rowIndex, 1);
         }
         return sizeInBytes;
+    }
+
+    @Override
+    public OptionalInt fixedSizeInBytesPerPosition()
+    {
+        return OptionalInt.empty();
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/block/SingleRowBlockWriter.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/SingleRowBlockWriter.java
@@ -17,6 +17,7 @@ import io.airlift.slice.Slice;
 import io.airlift.slice.SliceInput;
 import org.openjdk.jol.info.ClassLayout;
 
+import java.util.OptionalInt;
 import java.util.function.BiConsumer;
 
 import static java.lang.String.format;
@@ -80,6 +81,12 @@ public class SingleRowBlockWriter
             size += (builder.getSizeInBytes() - builder.getRegionSizeInBytes(0, rowIndex));
         }
         return size;
+    }
+
+    @Override
+    public OptionalInt fixedSizeInBytesPerPosition()
+    {
+        return OptionalInt.empty();
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/block/VariableWidthBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/VariableWidthBlock.java
@@ -22,11 +22,13 @@ import org.openjdk.jol.info.ClassLayout;
 import javax.annotation.Nullable;
 
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.function.BiConsumer;
 
 import static com.facebook.presto.common.block.BlockUtil.appendNullToIsNullArray;
 import static com.facebook.presto.common.block.BlockUtil.appendNullToOffsetsArray;
 import static com.facebook.presto.common.block.BlockUtil.checkArrayRange;
+import static com.facebook.presto.common.block.BlockUtil.checkValidPositions;
 import static com.facebook.presto.common.block.BlockUtil.checkValidRegion;
 import static com.facebook.presto.common.block.BlockUtil.compactArray;
 import static com.facebook.presto.common.block.BlockUtil.compactOffsets;
@@ -123,23 +125,34 @@ public class VariableWidthBlock
     }
 
     @Override
+    public OptionalInt fixedSizeInBytesPerPosition()
+    {
+        return OptionalInt.empty(); // size is variable based on the per element length
+    }
+
+    @Override
     public long getRegionSizeInBytes(int position, int length)
     {
         return offsets[arrayOffset + position + length] - offsets[arrayOffset + position] + ((Integer.BYTES + Byte.BYTES) * (long) length);
     }
 
     @Override
-    public long getPositionsSizeInBytes(boolean[] positions)
+    public long getPositionsSizeInBytes(boolean[] positions, int usedPositionCount)
     {
-        long sizeInBytes = 0;
-        int usedPositionCount = 0;
+        checkValidPositions(positions, positionCount);
+        if (usedPositionCount == 0) {
+            return 0;
+        }
+        if (usedPositionCount == positionCount) {
+            return getSizeInBytes();
+        }
+        int sizeInBytes = 0;
         for (int i = 0; i < positions.length; ++i) {
             if (positions[i]) {
-                usedPositionCount++;
-                sizeInBytes += offsets[arrayOffset + i + 1] - offsets[arrayOffset + i];
+                sizeInBytes += (offsets[arrayOffset + i + 1] - offsets[arrayOffset + i]);
             }
         }
-        return sizeInBytes + (Integer.BYTES + Byte.BYTES) * (long) usedPositionCount;
+        return sizeInBytes + ((Integer.BYTES + Byte.BYTES) * (long) usedPositionCount);
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/block/VariableWidthBlockBuilder.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/VariableWidthBlockBuilder.java
@@ -26,6 +26,7 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Arrays;
+import java.util.OptionalInt;
 import java.util.function.BiConsumer;
 
 import static com.facebook.presto.common.block.BlockUtil.MAX_ARRAY_SIZE;
@@ -115,6 +116,12 @@ public class VariableWidthBlockBuilder
     }
 
     @Override
+    public OptionalInt fixedSizeInBytesPerPosition()
+    {
+        return OptionalInt.empty(); // size is variable based on the per element length
+    }
+
+    @Override
     public long getRegionSizeInBytes(int positionOffset, int length)
     {
         int positionCount = getPositionCount();
@@ -124,18 +131,23 @@ public class VariableWidthBlockBuilder
     }
 
     @Override
-    public long getPositionsSizeInBytes(boolean[] positions)
+    public long getPositionsSizeInBytes(boolean[] positions, int usedPositionCount)
     {
-        checkValidPositions(positions, getPositionCount());
-        long sizeInBytes = 0;
-        int usedPositionCount = 0;
+        int positionCount = getPositionCount();
+        checkValidPositions(positions, positionCount);
+        if (usedPositionCount == 0) {
+            return 0;
+        }
+        if (usedPositionCount == positionCount) {
+            return getSizeInBytes();
+        }
+        int sizeInBytes = 0;
         for (int i = 0; i < positions.length; ++i) {
             if (positions[i]) {
-                usedPositionCount++;
-                sizeInBytes += getOffset(i + 1) - getOffset(i);
+                sizeInBytes += offsets[i + 1] - offsets[i];
             }
         }
-        return sizeInBytes + (Integer.BYTES + Byte.BYTES) * (long) usedPositionCount;
+        return sizeInBytes + ((Integer.BYTES + Byte.BYTES) * (long) usedPositionCount);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/GroupByIdBlock.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/GroupByIdBlock.java
@@ -19,6 +19,7 @@ import io.airlift.slice.Slice;
 import io.airlift.slice.SliceOutput;
 import org.openjdk.jol.info.ClassLayout;
 
+import java.util.OptionalInt;
 import java.util.function.BiConsumer;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
@@ -63,9 +64,9 @@ public class GroupByIdBlock
     }
 
     @Override
-    public long getPositionsSizeInBytes(boolean[] positions)
+    public long getPositionsSizeInBytes(boolean[] positions, int usedPositionCount)
     {
-        return block.getPositionsSizeInBytes(positions);
+        return block.getPositionsSizeInBytes(positions, usedPositionCount);
     }
 
     @Override
@@ -198,6 +199,12 @@ public class GroupByIdBlock
     public long getSizeInBytes()
     {
         return block.getSizeInBytes();
+    }
+
+    @Override
+    public OptionalInt fixedSizeInBytesPerPosition()
+    {
+        return block.fixedSizeInBytesPerPosition();
     }
 
     @Override

--- a/presto-main/src/test/java/com/facebook/presto/block/BenchmarkBlocks.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/BenchmarkBlocks.java
@@ -62,6 +62,11 @@ public class BenchmarkBlocks
         return copyPositions(data.dataBlock, data.positions, data.positionCount);
     }
 
+    private Block copyPositions(Block block, int[] positions, int positionCount)
+    {
+        return block.copyPositions(positions, 0, positionCount);
+    }
+
     @Test
     public static void verifyCopyPositions()
             throws Exception
@@ -73,9 +78,32 @@ public class BenchmarkBlocks
         benchmarkSelectiveStreamReaders.copyPositions(data.dataBlock, data.positions, data.positionCount);
     }
 
-    private Block copyPositions(Block block, int[] positions, int positionCount)
+    @Benchmark
+    public long benchmarkGetPositionsSizeInBytes(BenchmarkData data)
     {
-        return block.copyPositions(positions, 0, positionCount);
+        return data.dataBlock.getPositionsSizeInBytes(data.usedPositions, data.positionCount);
+    }
+
+    @Test
+    public static void verifyGetPositionsSizeInBytes()
+    {
+        BenchmarkData data = new BenchmarkData();
+        data.setup();
+        new BenchmarkBlocks().benchmarkGetPositionsSizeInBytes(data);
+    }
+
+    @Benchmark
+    public long benchmarkGetPositionsThenGetSizeInBytes(BenchmarkData data)
+    {
+        return data.dataBlock.getPositions(data.positions, 0, data.positionCount).getSizeInBytes();
+    }
+
+    @Test
+    public static void verifyGetPositionsThenGetSizeInBytes()
+    {
+        BenchmarkData data = new BenchmarkData();
+        data.setup();
+        new BenchmarkBlocks().benchmarkGetPositionsThenGetSizeInBytes(data);
     }
 
     @State(Scope.Thread)
@@ -133,6 +161,7 @@ public class BenchmarkBlocks
         private Type type;
         private Block dataBlock;
         private int[] positions;
+        private boolean[] usedPositions;
 
         @Setup
         public void setup()
@@ -151,6 +180,10 @@ public class BenchmarkBlocks
             }
             positions = Ints.toArray(set);
             Arrays.sort(positions);
+            usedPositions = new boolean[dataBlock.getPositionCount()];
+            for (int position : positions) {
+                usedPositions[position] = true;
+            }
         }
 
         private List<Encoding> createWrappings()

--- a/presto-main/src/test/java/com/facebook/presto/block/TestDictionaryBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestDictionaryBlock.java
@@ -17,12 +17,15 @@ import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockBuilder;
 import com.facebook.presto.common.block.DictionaryBlock;
 import com.facebook.presto.common.block.DictionaryId;
+import com.facebook.presto.common.block.IntArrayBlock;
 import com.facebook.presto.common.block.VariableWidthBlockBuilder;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
 import org.testng.annotations.Test;
 
 import java.util.Arrays;
+import java.util.Optional;
+import java.util.stream.IntStream;
 
 import static com.facebook.presto.block.BlockAssertions.createRLEBlock;
 import static com.facebook.presto.block.BlockAssertions.createRandomDictionaryBlock;
@@ -344,6 +347,91 @@ public class TestDictionaryBlock
         DictionaryBlock dictionaryBlock = createDictionaryBlock(expectedValues, dictionaryPositionCount);
         for (int position = 0; position < dictionaryPositionCount; position++) {
             assertEquals(dictionaryBlock.getEstimatedDataSizeForStats(position), expectedValues[position % positionCount].length());
+        }
+    }
+
+    @Test
+    public void testDictionarySizeMethods()
+    {
+        // fixed width block
+        Block fixedWidthBlock = new IntArrayBlock(100, Optional.empty(), IntStream.range(0, 100).toArray());
+        assertDictionarySizeMethods(fixedWidthBlock);
+        // variable width block
+        Block variableWidthBlock = createSlicesBlock(createExpectedValues(fixedWidthBlock.getPositionCount()));
+        assertDictionarySizeMethods(variableWidthBlock);
+
+        // sparse dictionary block from getPositions
+        assertDictionarySizeMethods(fixedWidthBlock.getPositions(IntStream.range(0, 50).toArray(), 0, 50));
+        assertDictionarySizeMethods(variableWidthBlock.getPositions(IntStream.range(0, 50).toArray(), 0, 50));
+
+        // nested sparse dictionary block via constructor
+        assertDictionarySizeMethods(new DictionaryBlock(fixedWidthBlock, IntStream.range(0, 50).toArray()));
+        assertDictionarySizeMethods(new DictionaryBlock(variableWidthBlock, IntStream.range(0, 50).toArray()));
+        // compact dictionary block via getPositions
+        int[] positions = createCompactRepeatingIdsRange(fixedWidthBlock.getPositionCount());
+        assertDictionarySizeMethods(fixedWidthBlock.getPositions(positions, 0, positions.length));
+        assertDictionarySizeMethods(variableWidthBlock.getPositions(positions, 0, positions.length));
+        // nested compact dictionary block via constructor
+        assertDictionarySizeMethods(new DictionaryBlock(fixedWidthBlock, createCompactRepeatingIdsRange(fixedWidthBlock.getPositionCount())));
+        assertDictionarySizeMethods(new DictionaryBlock(variableWidthBlock, createCompactRepeatingIdsRange(variableWidthBlock.getPositionCount())));
+    }
+
+    private static int[] createCompactRepeatingIdsRange(int positions)
+    {
+        int[] ids = new int[positions * 2];
+        for (int i = 0; i < ids.length; i++) {
+            ids[i] = i % positions;
+        }
+        return ids;
+    }
+
+    private static void assertDictionarySizeMethods(Block block)
+    {
+        int positions = block.getPositionCount();
+
+        int[] allIds = IntStream.range(0, positions).toArray();
+        assertEquals(new DictionaryBlock(block, allIds).getSizeInBytes(), block.getSizeInBytes() + (Integer.BYTES * (long) positions));
+
+        if (positions > 0) {
+            int firstHalfLength = positions / 2;
+            int secondHalfLength = positions - firstHalfLength;
+            int[] firstHalfIds = IntStream.range(0, firstHalfLength).toArray();
+            int[] secondHalfIds = IntStream.range(firstHalfLength, positions).toArray();
+
+            // No positions getPositionSizeInBytes
+            boolean[] selectedPositions = new boolean[positions];
+            assertEquals(new DictionaryBlock(block, allIds).getPositionsSizeInBytes(selectedPositions, 0), 0);
+            // Single position getPositionSizeInBytes
+            selectedPositions[0] = true;
+            assertEquals(
+                    new DictionaryBlock(block, allIds).getPositionsSizeInBytes(selectedPositions, 1),
+                    block.getPositionsSizeInBytes(selectedPositions, 1) + Integer.BYTES);
+            // Single position getSizeInBytes
+            assertEquals(
+                    new DictionaryBlock(block, new int[]{0}).getSizeInBytes(),
+                    block.getPositionsSizeInBytes(selectedPositions, 1) + Integer.BYTES);
+
+            // All positions getPositionSizeInBytes
+            Arrays.fill(selectedPositions, true);
+            assertEquals(
+                    new DictionaryBlock(block, allIds).getPositionsSizeInBytes(selectedPositions, positions),
+                    block.getSizeInBytes() + (Integer.BYTES * (long) positions));
+
+            // Half selected getSizeInBytes
+            assertEquals(
+                    new DictionaryBlock(block, firstHalfIds).getSizeInBytes(),
+                    block.getRegionSizeInBytes(0, firstHalfLength) + (Integer.BYTES * (long) firstHalfLength));
+            assertEquals(
+                    new DictionaryBlock(block, secondHalfIds).getSizeInBytes(),
+                    block.getRegionSizeInBytes(firstHalfLength, secondHalfLength) + (Integer.BYTES * (long) secondHalfLength));
+
+            // Half selected getRegionSizeInBytes
+            assertEquals(
+                    new DictionaryBlock(block, allIds).getRegionSizeInBytes(0, firstHalfLength),
+                    block.getRegionSizeInBytes(0, firstHalfLength) + (Integer.BYTES * (long) firstHalfLength));
+            assertEquals(
+                    new DictionaryBlock(block, allIds).getRegionSizeInBytes(firstHalfLength, secondHalfLength),
+                    block.getRegionSizeInBytes(firstHalfLength, secondHalfLength) + (Integer.BYTES * (long) secondHalfLength));
         }
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestRowExpressionFormatter.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestRowExpressionFormatter.java
@@ -169,7 +169,7 @@ public class TestRowExpressionFormatter
 
         // block
         constantExpression = constant(new LongArrayBlockBuilder(null, 4).writeLong(1L).writeLong(2).build(), new ArrayType(BIGINT));
-        assertEquals(format(constantExpression), "[Block: position count: 2; size: 96 bytes]");
+        assertEquals(format(constantExpression), "[Block: position count: 2; size: 88 bytes]");
     }
 
     @Test

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/SegmentedSliceBlockBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/SegmentedSliceBlockBuilder.java
@@ -25,6 +25,7 @@ import io.airlift.slice.XxHash64;
 import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Arrays;
+import java.util.OptionalInt;
 import java.util.function.BiConsumer;
 
 import static com.facebook.presto.orc.writer.SegmentedSliceBlockBuilder.Segments.INITIAL_SEGMENTS;
@@ -148,13 +149,19 @@ public class SegmentedSliceBlockBuilder
     }
 
     @Override
+    public OptionalInt fixedSizeInBytesPerPosition()
+    {
+        return OptionalInt.empty(); // size is variable based on the per element length
+    }
+
+    @Override
     public long getRegionSizeInBytes(int position, int length)
     {
         throw new UnsupportedOperationException("getRegionSizeInBytes is not supported by SegmentedSliceBlockBuilder");
     }
 
     @Override
-    public long getPositionsSizeInBytes(boolean[] positions)
+    public long getPositionsSizeInBytes(boolean[] positions, int usedPositionCount)
     {
         throw new UnsupportedOperationException("getPositionsSizeInBytes is not supported by SegmentedSliceBlockBuilder");
     }


### PR DESCRIPTION
Comparable changes to https://github.com/trinodb/trino/pull/10970

Reduces the overhead of calculating `DictionaryBlock#getSizeInBytes()` through the following changes:
- Adds a new argument `selectedPositionCount` to `Block#getPositionsSizeInBytes(boolean[] positions, int selectedPositionCount)`. Callers of the previous `getPositionsSizeInBytes(boolean[] positions)` method were trivially modifiable to count how many positions were selected when constructing the array argument and passing the count along with the array allows blocks with a constant size per position to skip re-counting the number of `true` values in the positions array- sometimes repeatedly, in the case of `RowBlock`.
- Adds a new method `Block#fixedSizeInBytesPerPosition()` that allows blocks to describe whether their `getSizeInBytes()` can be calculated directly from the position count, ie: all positions have a known constant size and the `boolean[] usedPositions` array need not be created
- Eagerly populates the unique id count and size in bytes for the result of `DictionaryBlock#getPositions` when the result is not compact, but the used positions map and unique ids count has already been computed
- Ensures that the result of `DictionaryBlock#copyPositions` is reported as compact. Previously the resulting `DictionaryBlock` was not marked compact even though it is, resulting in unnecessary extra work to re-check whether the dictionary is compact on the next call to `getSizeInBytes()`


```
== NO RELEASE NOTE ==
```
