### PR TITLE
Fix a copy/paste typo in error description

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalysis.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalysis.java
@@ -62,7 +62,7 @@ public class ExpressionAnalysis
         this.typeOnlyCoercions = ImmutableSet.copyOf(requireNonNull(typeOnlyCoercions, "typeOnlyCoercions is null"));
         this.columnReferences = ImmutableMap.copyOf(requireNonNull(columnReferences, "columnReferences is null"));
         this.subqueryInPredicates = ImmutableSet.copyOf(requireNonNull(subqueryInPredicates, "subqueryInPredicates is null"));
-        this.scalarSubqueries = ImmutableSet.copyOf(requireNonNull(scalarSubqueries, "subqueryInPredicates is null"));
+        this.scalarSubqueries = ImmutableSet.copyOf(requireNonNull(scalarSubqueries, "scalarSubqueries is null"));
         this.existsSubqueries = ImmutableSet.copyOf(requireNonNull(existsSubqueries, "existsSubqueries is null"));
         this.quantifiedComparisons = ImmutableSet.copyOf(requireNonNull(quantifiedComparisons, "quantifiedComparisons is null"));
         this.lambdaArgumentReferences = ImmutableMap.copyOf(requireNonNull(lambdaArgumentReferences, "lambdaArgumentReferences is null"));


### PR DESCRIPTION
Error message during non-null check of scalarSubqueries in ExpressionAnalysis is misleading -
Use the correct reference.

Test plan - not needed

```
== NO RELEASE NOTE ==
```
