### PR TITLE
Fixing TestServerInfoResource

### DIFF
--- a/presto-tests/src/test/java/com/facebook/presto/server/TestServerInfoResource.java
+++ b/presto-tests/src/test/java/com/facebook/presto/server/TestServerInfoResource.java
@@ -21,7 +21,9 @@ import com.facebook.presto.spi.NodeState;
 import com.facebook.presto.tests.DistributedQueryRunner;
 import com.google.common.collect.ImmutableMap;
 import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeGroups;
 import org.testng.annotations.Test;
 
 import java.net.URI;
@@ -36,9 +38,11 @@ import static com.facebook.presto.tests.tpch.TpchQueryRunner.createQueryRunner;
 import static com.facebook.presto.tests.tpch.TpchQueryRunner.createQueryRunnerWithNoClusterReadyCheck;
 import static org.testng.Assert.assertEquals;
 
+@Test(singleThreaded = true)
 public class TestServerInfoResource
 {
     private HttpClient client;
+    private DistributedQueryRunner queryRunner;
 
     @BeforeClass
     public void setup()
@@ -54,14 +58,27 @@ public class TestServerInfoResource
         client = null;
     }
 
-    @Test
-    public void testGetServerStateWithRequiredResourceManagerCoordinators()
+    @AfterMethod
+    public void serverTearDown()
+    {
+        for (TestingPrestoServer server : queryRunner.getServers()) {
+            closeQuietly(server);
+        }
+    }
+
+    @BeforeGroups("createQueryRunner")
+    public void createQueryRunnerSetup()
             throws Exception
     {
-        DistributedQueryRunner queryRunner = createQueryRunner(
+        queryRunner = createQueryRunner(
                 ImmutableMap.of(),
                 ImmutableMap.of("cluster.required-resource-managers-active", "1", "cluster.required-coordinators-active", "1"),
                 ImmutableMap.of("query.client.timeout", "10s"), 2);
+    }
+
+    @Test(timeOut = 30_000, groups = {"createQueryRunner"})
+    public void testGetServerStateWithRequiredResourceManagerCoordinators()
+    {
         TestingPrestoServer server = queryRunner.getCoordinator(0);
         URI uri = uriBuilderFrom(server.getBaseUrl().resolve("/v1/info/state")).build();
         Request request = prepareGet()
@@ -70,18 +87,21 @@ public class TestServerInfoResource
                 .build();
         NodeState state = client.execute(request, createJsonResponseHandler(jsonCodec(NodeState.class)));
         assertEquals(state, NodeState.ACTIVE);
-
-        closeQuietly(server);
     }
 
-    @Test(timeOut = 30_000)
-    public void testGetServerStateWithoutRequiredResourceManagers()
+    @BeforeGroups("getServerStateWithoutRequiredResourceManagers")
+    public void createQueryRunnerWithNoClusterReadyCheckSetup()
             throws Exception
     {
-        DistributedQueryRunner queryRunner = createQueryRunnerWithNoClusterReadyCheck(
+        queryRunner = createQueryRunnerWithNoClusterReadyCheck(
                 ImmutableMap.of(),
                 ImmutableMap.of("cluster.required-resource-managers-active", "2", "cluster.required-coordinators-active", "1"),
                 ImmutableMap.of("query.client.timeout", "10s"), 2);
+    }
+
+    @Test(timeOut = 30_000, groups = {"getServerStateWithoutRequiredResourceManagers"})
+    public void testGetServerStateWithoutRequiredResourceManagers()
+    {
         TestingPrestoServer server = queryRunner.getCoordinator(0);
         URI uri = uriBuilderFrom(server.getBaseUrl().resolve("/v1/info/state")).build();
         Request request = prepareGet()
@@ -90,18 +110,21 @@ public class TestServerInfoResource
                 .build();
         NodeState state = client.execute(request, createJsonResponseHandler(jsonCodec(NodeState.class)));
         assertEquals(state, NodeState.INACTIVE);
-
-        closeQuietly(server);
     }
 
-    @Test(timeOut = 30_000)
-    public void testGetServerStateWithoutRequiredCoordinators()
+    @BeforeGroups("getServerStateWithoutRequiredCoordinators")
+    public void getServerStateWithoutRequiredCoordinatorsSetup()
             throws Exception
     {
-        DistributedQueryRunner queryRunner = createQueryRunnerWithNoClusterReadyCheck(
+        queryRunner = createQueryRunnerWithNoClusterReadyCheck(
                 ImmutableMap.of(),
                 ImmutableMap.of("cluster.required-resource-managers-active", "1", "cluster.required-coordinators-active", "3"),
                 ImmutableMap.of("query.client.timeout", "10s"), 2);
+    }
+
+    @Test(timeOut = 30_000, groups = {"getServerStateWithoutRequiredCoordinators"})
+    public void testGetServerStateWithoutRequiredCoordinators()
+    {
         TestingPrestoServer server = queryRunner.getCoordinator(0);
         URI uri = uriBuilderFrom(server.getBaseUrl().resolve("/v1/info/state")).build();
         Request request = prepareGet()
@@ -110,7 +133,5 @@ public class TestServerInfoResource
                 .build();
         NodeState state = client.execute(request, createJsonResponseHandler(jsonCodec(NodeState.class)));
         assertEquals(state, NodeState.INACTIVE);
-
-        closeQuietly(server);
     }
 }


### PR DESCRIPTION
Due to the DistributedQueryRunner creation within the test, it may end up taking longer than the timeout for the tests to finish. This leads to failures.
With the change, moving the DistributedQueryRunner creation outside of the method so the timeout will be actually accounted towards running the tests only
and not for the server startup.

Test plan - unit test

```
== NO RELEASE NOTE ==
```
