### PR TITLE
Add support for planning segmented aggregation

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -2539,6 +2539,7 @@ public class LocalExecutionPlanner
                         false,
                         false,
                         false,
+                        ImmutableList.of(),
                         new DataSize(0, BYTE),
                         context,
                         STATS_START_CHANNEL,
@@ -2644,6 +2645,7 @@ public class LocalExecutionPlanner
                         false,
                         false,
                         false,
+                        ImmutableList.of(),
                         new DataSize(0, BYTE),
                         context,
                         STATS_START_CHANNEL,
@@ -2698,6 +2700,7 @@ public class LocalExecutionPlanner
                         false,
                         false,
                         false,
+                        ImmutableList.of(),
                         new DataSize(0, BYTE),
                         context,
                         0,
@@ -3073,6 +3076,7 @@ public class LocalExecutionPlanner
                     distinctAggregationSpillEnabled,
                     orderByAggregationSpillEnabled,
                     node.isStreamable(),
+                    node.getPreGroupedVariables(),
                     unspillMemoryLimit,
                     context,
                     0,
@@ -3097,6 +3101,7 @@ public class LocalExecutionPlanner
                 boolean distinctSpillEnabled,
                 boolean orderBySpillEnabled,
                 boolean isStreamable,
+                List<VariableReferenceExpression> preGroupbyVariables,
                 DataSize unspillMemoryLimit,
                 LocalExecutionPlanContext context,
                 int startOutputChannel,
@@ -3143,7 +3148,7 @@ public class LocalExecutionPlanner
                     .map(entry -> source.getTypes().get(entry))
                     .collect(toImmutableList());
 
-            if (isStreamable) {
+            if (isStreamable && preGroupbyVariables.size() == groupbyVariables.size()) {
                 return new StreamingAggregationOperatorFactory(
                         context.getNextOperatorId(),
                         planNodeId,

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddLocalExchanges.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/AddLocalExchanges.java
@@ -325,6 +325,16 @@ public class AddLocalExchanges
                 // !isPresent() indicates the property was satisfied completely
                 preGroupedSymbols = groupingKeys;
             }
+            else {
+                // Enable segmented aggregation if the input is pre-grouped by GroupBy key prefix.
+                for (int i = 1; i < groupingKeys.size(); ++i) {
+                    List<VariableReferenceExpression> groupingKeyPrefix = groupingKeys.subList(0, i);
+                    if (!LocalProperties.match(child.getProperties().getLocalProperties(), LocalProperties.grouped(groupingKeyPrefix)).get(0).isPresent()) {
+                        // !isPresent() indicates the property was satisfied completely
+                        preGroupedSymbols = groupingKeyPrefix;
+                    }
+                }
+            }
 
             AggregationNode result = new AggregationNode(
                     node.getSourceLocation(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
@@ -594,7 +594,10 @@ public class PlanPrinter
             if (node.getStep() != AggregationNode.Step.SINGLE) {
                 type = format("(%s)", node.getStep().toString());
             }
-            if (node.isStreamable()) {
+            if (node.isSegmentedAggregation()) {
+                type = format("%s(SEGMENTED)", type);
+            }
+            else if (node.isStreamable()) {
                 type = format("%s(STREAMING)", type);
             }
             String key = "";

--- a/presto-spi/src/main/java/com/facebook/presto/spi/plan/AggregationNode.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/plan/AggregationNode.java
@@ -213,6 +213,11 @@ public final class AggregationNode
         return !preGroupedVariables.isEmpty() && groupingSets.getGroupingSetCount() == 1 && groupingSets.getGlobalGroupingSets().isEmpty();
     }
 
+    public boolean isSegmentedAggregation()
+    {
+        return isStreamable() && preGroupedVariables.size() < groupingSets.getGroupingKeys().size();
+    }
+
     @Override
     public boolean equals(Object o)
     {


### PR DESCRIPTION
If the input of the aggregation is already pre-grouped by the prefix of
the GroupBy columns, we can flush the hash table whenever we see a new
pre-grouped key.

The execution side change is currently only available in the cpp stack.
This commit adds the planning side support to set the pre-grouped keys
in the AggregationNode plan node so that cpp stack can enable the
feature at execution time. The java stack will fallback to the
hash-based aggregation in this case.
