### PR TITLE
Avoid Slice allocation in SliceWriters

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/block/AbstractSingleArrayBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/AbstractSingleArrayBlock.java
@@ -115,6 +115,13 @@ public abstract class AbstractSingleArrayBlock
     }
 
     @Override
+    public void writeBytesTo(int position, int offset, int length, SliceOutput sliceOutput)
+    {
+        checkReadablePosition(position);
+        getBlock().writeBytesTo(position + start, offset, length, sliceOutput);
+    }
+
+    @Override
     public void writePositionTo(int position, BlockBuilder blockBuilder)
     {
         checkReadablePosition(position);

--- a/presto-common/src/main/java/com/facebook/presto/common/block/AbstractSingleMapBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/AbstractSingleMapBlock.java
@@ -142,6 +142,18 @@ public abstract class AbstractSingleMapBlock
     }
 
     @Override
+    public void writeBytesTo(int position, int offset, int length, SliceOutput sliceOutput)
+    {
+        position = getAbsolutePosition(position);
+        if (position % 2 == 0) {
+            getRawKeyBlock().writeBytesTo(position / 2, offset, length, sliceOutput);
+        }
+        else {
+            getRawValueBlock().writeBytesTo(position / 2, offset, length, sliceOutput);
+        }
+    }
+
+    @Override
     public boolean equals(int position, int offset, Block otherBlock, int otherPosition, int otherOffset, int length)
     {
         position = getAbsolutePosition(position);

--- a/presto-common/src/main/java/com/facebook/presto/common/block/AbstractSingleRowBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/AbstractSingleRowBlock.java
@@ -123,6 +123,13 @@ public abstract class AbstractSingleRowBlock
     }
 
     @Override
+    public void writeBytesTo(int position, int offset, int length, SliceOutput sliceOutput)
+    {
+        checkFieldIndex(position);
+        getRawFieldBlock(position).writeBytesTo(rowIndex, offset, length, sliceOutput);
+    }
+
+    @Override
     public boolean equals(int position, int offset, Block otherBlock, int otherPosition, int otherOffset, int length)
     {
         checkFieldIndex(position);

--- a/presto-common/src/main/java/com/facebook/presto/common/block/AbstractVariableWidthBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/AbstractVariableWidthBlock.java
@@ -131,6 +131,13 @@ public abstract class AbstractVariableWidthBlock
     }
 
     @Override
+    public void writeBytesTo(int position, int offset, int length, SliceOutput sliceOutput)
+    {
+        checkReadablePosition(position);
+        sliceOutput.writeBytes(getRawSlice(position), getPositionOffset(position) + offset, length);
+    }
+
+    @Override
     public void writePositionTo(int position, BlockBuilder blockBuilder)
     {
         writeBytesTo(position, 0, getSliceLength(position), blockBuilder);

--- a/presto-common/src/main/java/com/facebook/presto/common/block/AbstractVariableWidthBlockBuilder.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/AbstractVariableWidthBlockBuilder.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.block;
+
+public abstract class AbstractVariableWidthBlockBuilder
+        extends AbstractVariableWidthBlock
+        implements BlockBuilder
+{
+    public abstract AbstractVariableWidthBlockBuilder writeBytes(byte[] bytes, int offset, int length);
+}

--- a/presto-common/src/main/java/com/facebook/presto/common/block/Block.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/Block.java
@@ -121,6 +121,16 @@ public interface Block
     }
 
     /**
+     * Appends the byte sequences at {@code offset} in the value at {@code position}
+     * to {@code sliceOutput}.
+     * This method must be implemented if @{code getSlice} is implemented.
+     */
+    default void writeBytesTo(int position, int offset, int length, SliceOutput sliceOutput)
+    {
+        throw new UnsupportedOperationException(getClass().getName());
+    }
+
+    /**
      * Appends the value at {@code position} to {@code blockBuilder} and close the entry.
      */
     void writePositionTo(int position, BlockBuilder blockBuilder);

--- a/presto-common/src/main/java/com/facebook/presto/common/block/DictionaryBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/DictionaryBlock.java
@@ -169,6 +169,12 @@ public class DictionaryBlock
     }
 
     @Override
+    public void writeBytesTo(int position, int offset, int length, SliceOutput sliceOutput)
+    {
+        dictionary.writeBytesTo(getId(position), offset, length, sliceOutput);
+    }
+
+    @Override
     public void writePositionTo(int position, BlockBuilder blockBuilder)
     {
         dictionary.writePositionTo(getId(position), blockBuilder);

--- a/presto-common/src/main/java/com/facebook/presto/common/block/LazyBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/LazyBlock.java
@@ -126,6 +126,13 @@ public class LazyBlock
     }
 
     @Override
+    public void writeBytesTo(int position, int offset, int length, SliceOutput sliceOutput)
+    {
+        assureLoaded();
+        block.writeBytesTo(position, offset, length, sliceOutput);
+    }
+
+    @Override
     public void writePositionTo(int position, BlockBuilder blockBuilder)
     {
         assureLoaded();

--- a/presto-common/src/main/java/com/facebook/presto/common/block/RunLengthEncodedBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/RunLengthEncodedBlock.java
@@ -250,6 +250,13 @@ public class RunLengthEncodedBlock
     }
 
     @Override
+    public void writeBytesTo(int position, int offset, int length, SliceOutput sliceOutput)
+    {
+        checkReadablePosition(position);
+        value.writeBytesTo(0, offset, length, sliceOutput);
+    }
+
+    @Override
     public void writePositionTo(int position, BlockBuilder blockBuilder)
     {
         checkReadablePosition(position);

--- a/presto-common/src/main/java/com/facebook/presto/common/block/VariableWidthBlockBuilder.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/VariableWidthBlockBuilder.java
@@ -48,8 +48,7 @@ import static java.lang.Math.min;
 import static java.lang.String.format;
 
 public class VariableWidthBlockBuilder
-        extends AbstractVariableWidthBlock
-        implements BlockBuilder
+        extends AbstractVariableWidthBlockBuilder
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(VariableWidthBlockBuilder.class).instanceSize();
 
@@ -232,6 +231,17 @@ public class VariableWidthBlockBuilder
 
     @Override
     public BlockBuilder writeBytes(Slice source, int sourceIndex, int length)
+    {
+        if (!initialized) {
+            initializeCapacity();
+        }
+        sliceOutput.writeBytes(source, sourceIndex, length);
+        currentEntrySize += length;
+        return this;
+    }
+
+    @Override
+    public AbstractVariableWidthBlockBuilder writeBytes(byte[] source, int sourceIndex, int length)
     {
         if (!initialized) {
             initializeCapacity();

--- a/presto-common/src/main/java/com/facebook/presto/common/type/AbstractVarcharType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/AbstractVarcharType.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.common.type;
 
+import com.facebook.presto.common.block.AbstractVariableWidthBlockBuilder;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockBuilder;
 import com.facebook.presto.common.function.SqlFunctionProperties;
@@ -144,6 +145,16 @@ public class AbstractVarcharType
     public void writeSlice(BlockBuilder blockBuilder, Slice value, int offset, int length)
     {
         blockBuilder.writeBytes(value, offset, length).closeEntry();
+    }
+
+    /**
+     * writeBytes directly to blockBuilder, without creating a short-lived Slice wrapper.
+     * This is used by external systems to interface with Presto. It is currently used
+     * by DWRF file writer, from converting row representation to columnar String representation.
+     */
+    public void writeBytes(AbstractVariableWidthBlockBuilder blockBuilder, byte[] bytes, int offset, int length)
+    {
+        blockBuilder.writeBytes(bytes, offset, length).closeEntry();
     }
 
     @Override

--- a/presto-common/src/test/java/com/facebook/presto/common/block/TestVariableWidthBlockBuilder.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/block/TestVariableWidthBlockBuilder.java
@@ -18,10 +18,16 @@ import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import org.testng.annotations.Test;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static io.airlift.slice.SizeOf.SIZE_OF_INT;
 import static io.airlift.slice.SizeOf.sizeOf;
+import static io.airlift.slice.Slices.utf8Slice;
 import static java.lang.Math.ceil;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.openjdk.jol.info.ClassLayout.parseClass;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -57,6 +63,34 @@ public class TestVariableWidthBlockBuilder
         long actualArrayBytes = sizeOf(new int[(int) ceil(resetSkew * (entries + 1))]) + sizeOf(new boolean[(int) ceil(resetSkew * entries)]);
         long actualSliceBytes = SLICE_INSTANCE_SIZE + sizeOf(new byte[(int) ceil(resetSkew * entries)]);
         assertEquals(blockBuilder.getRetainedSizeInBytes(), BLOCK_BUILDER_INSTANCE_SIZE + actualSliceBytes + actualArrayBytes);
+    }
+
+    @Test
+    public void testWriteBytes()
+    {
+        int entries = 100;
+        String inputChars = "abcdefghijklmnopqrstuvwwxyz01234566789!@#$%^";
+        VariableWidthBlockBuilder blockBuilder = new VariableWidthBlockBuilder(null, entries, entries);
+        List<String> values = new ArrayList<>();
+        Random rand = new Random(0);
+        byte[] bytes = inputChars.getBytes(UTF_8);
+        assertEquals(bytes.length, inputChars.length());
+        for (int i = 0; i < entries; i++) {
+            int valueLength = rand.nextInt(bytes.length);
+            VARCHAR.writeBytes(blockBuilder, bytes, 0, valueLength);
+            values.add(inputChars.substring(0, valueLength));
+        }
+        verifyBlockValues(blockBuilder, values);
+        verifyBlockValues(blockBuilder.build(), values);
+    }
+
+    private void verifyBlockValues(Block block, List<String> values)
+    {
+        assertEquals(block.getPositionCount(), values.size());
+        for (int i = 0; i < block.getPositionCount(); i++) {
+            Slice slice = VARCHAR.getSlice(block, i);
+            assertEquals(slice, utf8Slice(values.get(i)));
+        }
     }
 
     private void testIsFull(PageBuilderStatus pageBuilderStatus)

--- a/presto-main/src/main/java/com/facebook/presto/operator/GroupByIdBlock.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/GroupByIdBlock.java
@@ -141,6 +141,12 @@ public class GroupByIdBlock
     }
 
     @Override
+    public void writeBytesTo(int position, int offset, int length, SliceOutput sliceOutput)
+    {
+        block.writeBytesTo(position, offset, length, sliceOutput);
+    }
+
+    @Override
     public void writePositionTo(int position, BlockBuilder blockBuilder)
     {
         block.writePositionTo(position, blockBuilder);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/BinaryStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/BinaryStatisticsBuilder.java
@@ -13,7 +13,7 @@
  */
 package com.facebook.presto.orc.metadata.statistics;
 
-import io.airlift.slice.Slice;
+import com.facebook.presto.common.block.Block;
 
 import java.util.List;
 import java.util.Optional;
@@ -28,10 +28,10 @@ public class BinaryStatisticsBuilder
     private long sum;
 
     @Override
-    public void addValue(Slice value, int sourceIndex, int length)
+    public void addValue(Block block, int position)
     {
-        requireNonNull(value, "value is null");
-        sum += length;
+        requireNonNull(block, "block is null");
+        sum += block.getSliceLength(position);
         nonNullValueCount++;
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/SliceColumnStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/SliceColumnStatisticsBuilder.java
@@ -14,8 +14,10 @@
 package com.facebook.presto.orc.metadata.statistics;
 
 import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.type.AbstractVariableWidthType;
 import com.facebook.presto.common.type.Type;
-import io.airlift.slice.Slice;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 public interface SliceColumnStatisticsBuilder
         extends StatisticsBuilder
@@ -23,18 +25,14 @@ public interface SliceColumnStatisticsBuilder
     @Override
     default void addBlock(Type type, Block block)
     {
+        checkArgument(type instanceof AbstractVariableWidthType, "type is not a AbstractVariableWidthType");
+        AbstractVariableWidthType variableWidthType = (AbstractVariableWidthType) type;
         for (int position = 0; position < block.getPositionCount(); position++) {
             if (!block.isNull(position)) {
-                Slice slice = type.getSlice(block, position);
-                addValue(slice, 0, slice.length());
+                addValue(block, position);
             }
         }
     }
 
-    default void addValue(Slice value)
-    {
-        addValue(value, 0, value.length());
-    }
-
-    void addValue(Slice value, int sourceIndex, int length);
+    void addValue(Block block, int position);
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/ByteArrayOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/ByteArrayOutputStream.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.orc.stream;
 
+import com.facebook.presto.common.block.Block;
 import com.facebook.presto.orc.ColumnWriterOptions;
 import com.facebook.presto.orc.DwrfDataEncryptor;
 import com.facebook.presto.orc.OrcOutputBuffer;
@@ -65,6 +66,12 @@ public class ByteArrayOutputStream
     {
         checkState(!closed);
         buffer.writeBytes(slice, sourceIndex, length);
+    }
+
+    public void writeBlockPosition(Block block, int position, int offset, int length)
+    {
+        checkState(!closed);
+        block.writeBytesTo(position, offset, length, buffer);
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/DictionaryColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/DictionaryColumnWriter.java
@@ -65,7 +65,6 @@ public abstract class DictionaryColumnWriter
     private static final int EXPECTED_ROW_GROUP_SEGMENT_SIZE = 10_000;
 
     protected final int column;
-    protected final Type type;
     protected final ColumnWriterOptions columnWriterOptions;
     protected final Optional<DwrfDataEncryptor> dwrfEncryptor;
     protected final OrcEncoding orcEncoding;
@@ -99,7 +98,6 @@ public abstract class DictionaryColumnWriter
     {
         checkArgument(column >= 0, "column is negative");
         this.column = column;
-        this.type = requireNonNull(type, "type is null");
         this.columnWriterOptions = requireNonNull(columnWriterOptions, "columnWriterOptions is null");
         this.dwrfEncryptor = requireNonNull(dwrfEncryptor, "dwrfEncryptor is null");
         this.orcEncoding = requireNonNull(orcEncoding, "orcEncoding is null");

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/LongDictionaryColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/LongDictionaryColumnWriter.java
@@ -45,6 +45,7 @@ public class LongDictionaryColumnWriter
     private static final long INSTANCE_SIZE = ClassLayout.parseClass(LongDictionaryColumnWriter.class).instanceSize();
     private static final int EXPECTED_ENTRIES = 10_000;
 
+    private final FixedWidthType type;
     private final long typeSize;
 
     private LongOutputStream dictionaryDataStream;
@@ -64,7 +65,8 @@ public class LongDictionaryColumnWriter
         super(column, type, columnWriterOptions, dwrfEncryptor, orcEncoding, metadataWriter);
         checkArgument(orcEncoding == DWRF, "Long dictionary encoding is only supported in DWRF");
         checkArgument(type instanceof FixedWidthType, "Not a fixed width type");
-        this.typeSize = ((FixedWidthType) type).getFixedSize();
+        this.type = (FixedWidthType) type;
+        this.typeSize = this.type.getFixedSize();
 
         this.dictionaryDataStream = new LongOutputStreamDwrf(columnWriterOptions, dwrfEncryptor, true, DICTIONARY_DATA);
         this.dictionary = new LongDictionaryBuilder(EXPECTED_ENTRIES);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/SliceDictionaryBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/SliceDictionaryBuilder.java
@@ -15,6 +15,7 @@ package com.facebook.presto.orc.writer;
 
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.orc.array.IntBigArray;
+import com.google.common.annotations.VisibleForTesting;
 import io.airlift.slice.Slice;
 import org.openjdk.jol.info.ClassLayout;
 
@@ -76,17 +77,25 @@ public class SliceDictionaryBuilder
         return segmentedSliceBuilder.getSliceLength(position);
     }
 
-    public Slice getSlice(int position, int length)
+    @VisibleForTesting
+    Slice getSlice(int position, int length)
     {
         return segmentedSliceBuilder.getSlice(position, 0, length);
     }
 
-    public Slice getRawSlice(int position)
+    public Block getBlock()
+    {
+        return segmentedSliceBuilder;
+    }
+
+    @VisibleForTesting
+    Slice getRawSlice(int position)
     {
         return segmentedSliceBuilder.getRawSlice(position);
     }
 
-    public int getRawSliceOffset(int position)
+    @VisibleForTesting
+    int getRawSliceOffset(int position)
     {
         return segmentedSliceBuilder.getPositionOffset(position);
     }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/SliceDictionaryColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/SliceDictionaryColumnWriter.java
@@ -257,7 +257,7 @@ public class SliceDictionaryColumnWriter
     {
         int length = dictionary.getSliceLength(dictionaryIndex);
         dictionaryLengthStream.writeLong(length);
-        dictionaryDataStream.writeSlice(dictionary.getRawSlice(dictionaryIndex), dictionary.getRawSliceOffset(dictionaryIndex), length);
+        dictionaryDataStream.writeBlockPosition(dictionary.getBlock(), dictionaryIndex, 0, length);
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/SliceDirectColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/SliceDirectColumnWriter.java
@@ -159,7 +159,7 @@ public class SliceDirectColumnWriter
     {
         int length = block.getSliceLength(position);
         lengthStream.writeLong(length);
-        dataStream.writeSlice(block.getSlice(position, 0, length));
+        dataStream.writeBlockPosition(block, position, 0, length);
         statisticsBuilder.addValue(block, position);
         return length;
     }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/SliceDirectColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/SliceDirectColumnWriter.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.orc.writer;
 
 import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.type.AbstractVariableWidthType;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.orc.ColumnWriterOptions;
 import com.facebook.presto.orc.DwrfDataEncryptor;
@@ -59,7 +60,6 @@ public class SliceDirectColumnWriter
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(SliceDirectColumnWriter.class).instanceSize();
     private final int column;
-    private final Type type;
     private final boolean compressed;
     private final ColumnEncoding columnEncoding;
     private final LongOutputStream lengthStream;
@@ -85,11 +85,11 @@ public class SliceDirectColumnWriter
             MetadataWriter metadataWriter)
     {
         checkArgument(column >= 0, "column is negative");
+        checkArgument(type instanceof AbstractVariableWidthType, "type is not an AbstractVariableWidthType");
         requireNonNull(columnWriterOptions, "columnWriterOptions is null");
         requireNonNull(dwrfEncryptor, "dwrfEncryptor is null");
         requireNonNull(metadataWriter, "metadataWriter is null");
         this.column = column;
-        this.type = requireNonNull(type, "type is null");
         this.compressed = columnWriterOptions.getCompressionKind() != NONE;
         this.columnEncoding = new ColumnEncoding(orcEncoding == DWRF ? DIRECT : DIRECT_V2, 0);
         this.lengthStream = createLengthOutputStream(columnWriterOptions, dwrfEncryptor, orcEncoding);
@@ -143,9 +143,7 @@ public class SliceDirectColumnWriter
         int nonNullValueCount = 0;
         for (int position = 0; position < block.getPositionCount(); position++) {
             if (!block.isNull(position)) {
-                Slice value = type.getSlice(block, position);
-                elementSize += value.length();
-                writeSlice(value, 0, value.length());
+                elementSize += writeBlockPosition(block, position);
                 nonNullValueCount++;
             }
         }
@@ -157,11 +155,13 @@ public class SliceDirectColumnWriter
         presentStream.writeBoolean(value);
     }
 
-    void writeSlice(Slice slice, int sourceIndex, int length)
+    int writeBlockPosition(Block block, int position)
     {
+        int length = block.getSliceLength(position);
         lengthStream.writeLong(length);
-        dataStream.writeSlice(slice, sourceIndex, length);
-        statisticsBuilder.addValue(slice, sourceIndex, length);
+        dataStream.writeSlice(block.getSlice(position, 0, length));
+        statisticsBuilder.addValue(block, position);
+        return length;
     }
 
     @Override

--- a/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestBinaryStatisticsBuilder.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestBinaryStatisticsBuilder.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.orc.metadata.statistics;
 
+import com.facebook.presto.common.block.VariableWidthBlockBuilder;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
 import org.testng.annotations.Test;
@@ -20,6 +21,7 @@ import org.testng.annotations.Test;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.orc.metadata.statistics.AbstractStatisticsBuilderTest.StatisticsType.NONE;
 import static com.facebook.presto.orc.metadata.statistics.BinaryStatistics.BINARY_VALUE_BYTES_OVERHEAD;
 import static com.facebook.presto.orc.metadata.statistics.ColumnStatistics.mergeColumnStatistics;
@@ -36,7 +38,7 @@ public class TestBinaryStatisticsBuilder
 
     public TestBinaryStatisticsBuilder()
     {
-        super(NONE, BinaryStatisticsBuilder::new, BinaryStatisticsBuilder::addValue);
+        super(NONE, BinaryStatisticsBuilder::new, TestBinaryStatisticsBuilder::addValue);
     }
 
     @Test
@@ -53,19 +55,24 @@ public class TestBinaryStatisticsBuilder
     {
         BinaryStatisticsBuilder binaryStatisticsBuilder = new BinaryStatisticsBuilder();
         for (Slice value : ImmutableList.of(EMPTY_SLICE, FIRST_VALUE, SECOND_VALUE)) {
-            binaryStatisticsBuilder.addValue(value);
+            addValue(binaryStatisticsBuilder, value);
         }
         assertBinaryStatistics(binaryStatisticsBuilder.buildColumnStatistics(), 3, EMPTY_SLICE.length() + FIRST_VALUE.length() + SECOND_VALUE.length());
     }
 
     @Test
-    public void testSliceWithIndexLength()
+    public void testBlockBinaryStatistics()
     {
-        BinaryStatisticsBuilder binaryStatisticsBuilder = new BinaryStatisticsBuilder();
-        Slice slice = utf8Slice("abcdefghijklmnopqrstuvwxyz");
+        String alphabets = "abcdefghijklmnopqrstuvwxyz";
+        VariableWidthBlockBuilder blockBuilder = new VariableWidthBlockBuilder(null, alphabets.length(), alphabets.length());
+        Slice slice = utf8Slice(alphabets);
         for (int i = 0; i < slice.length(); i++) {
-            binaryStatisticsBuilder.addValue(slice, i, 1);
+            VARBINARY.writeSlice(blockBuilder, slice, i, 1);
         }
+        blockBuilder.appendNull();
+
+        BinaryStatisticsBuilder binaryStatisticsBuilder = new BinaryStatisticsBuilder();
+        binaryStatisticsBuilder.addBlock(VARBINARY, blockBuilder);
 
         BinaryStatistics binaryStatistics = binaryStatisticsBuilder.buildColumnStatistics().getBinaryStatistics();
         assertEquals(binaryStatistics.getSum(), slice.length());
@@ -80,15 +87,15 @@ public class TestBinaryStatisticsBuilder
         statisticsList.add(statisticsBuilder.buildColumnStatistics());
         assertMergedBinaryStatistics(statisticsList, 0, 0);
 
-        statisticsBuilder.addValue(EMPTY_SLICE);
+        addValue(statisticsBuilder, EMPTY_SLICE);
         statisticsList.add(statisticsBuilder.buildColumnStatistics());
         assertMergedBinaryStatistics(statisticsList, 1, 0);
 
-        statisticsBuilder.addValue(FIRST_VALUE);
+        addValue(statisticsBuilder, FIRST_VALUE);
         statisticsList.add(statisticsBuilder.buildColumnStatistics());
         assertMergedBinaryStatistics(statisticsList, 3, FIRST_VALUE.length());
 
-        statisticsBuilder.addValue(SECOND_VALUE);
+        addValue(statisticsBuilder, SECOND_VALUE);
         statisticsList.add(statisticsBuilder.buildColumnStatistics());
         assertMergedBinaryStatistics(statisticsList, 6, FIRST_VALUE.length() * 2 + SECOND_VALUE.length());
     }
@@ -121,5 +128,13 @@ public class TestBinaryStatisticsBuilder
             assertNull(columnStatistics.getBinaryStatistics());
             assertEquals(columnStatistics.getNumberOfValues(), 0);
         }
+    }
+
+    public static void addValue(BinaryStatisticsBuilder binaryStatisticsBuilder, Slice slice)
+    {
+        VariableWidthBlockBuilder blockBuilder = new VariableWidthBlockBuilder(null, 1, slice.length());
+        blockBuilder.writeBytes(slice, 0, slice.length()).closeEntry();
+
+        binaryStatisticsBuilder.addBlock(VARBINARY, blockBuilder);
     }
 }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestStringStatisticsBuilder.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestStringStatisticsBuilder.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.orc.metadata.statistics;
 
+import com.facebook.presto.common.block.VariableWidthBlockBuilder;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
@@ -21,6 +22,7 @@ import org.testng.annotations.Test;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.facebook.presto.orc.metadata.statistics.AbstractStatisticsBuilderTest.StatisticsType.STRING;
 import static com.facebook.presto.orc.metadata.statistics.ColumnStatistics.mergeColumnStatistics;
 import static com.facebook.presto.orc.metadata.statistics.StringStatistics.STRING_VALUE_BYTES_OVERHEAD;
@@ -48,7 +50,7 @@ public class TestStringStatisticsBuilder
 
     public TestStringStatisticsBuilder()
     {
-        super(STRING, () -> new StringStatisticsBuilder(Integer.MAX_VALUE), StringStatisticsBuilder::addValue);
+        super(STRING, () -> new StringStatisticsBuilder(Integer.MAX_VALUE), TestStringStatisticsBuilder::addValue);
     }
 
     @Test
@@ -95,7 +97,7 @@ public class TestStringStatisticsBuilder
     {
         StringStatisticsBuilder stringStatisticsBuilder = new StringStatisticsBuilder(Integer.MAX_VALUE);
         for (Slice value : ImmutableList.of(EMPTY_SLICE, LOW_BOTTOM_VALUE, LOW_TOP_VALUE)) {
-            stringStatisticsBuilder.addValue(value);
+            addValue(stringStatisticsBuilder, value);
         }
         assertStringStatistics(stringStatisticsBuilder.buildColumnStatistics(), 3, EMPTY_SLICE.length() + LOW_BOTTOM_VALUE.length() + LOW_TOP_VALUE.length());
     }
@@ -109,15 +111,15 @@ public class TestStringStatisticsBuilder
         statisticsList.add(statisticsBuilder.buildColumnStatistics());
         assertMergedStringStatistics(statisticsList, 0, 0);
 
-        statisticsBuilder.addValue(EMPTY_SLICE);
+        addValue(statisticsBuilder, EMPTY_SLICE);
         statisticsList.add(statisticsBuilder.buildColumnStatistics());
         assertMergedStringStatistics(statisticsList, 1, 0);
 
-        statisticsBuilder.addValue(LOW_BOTTOM_VALUE);
+        addValue(statisticsBuilder, LOW_BOTTOM_VALUE);
         statisticsList.add(statisticsBuilder.buildColumnStatistics());
         assertMergedStringStatistics(statisticsList, 3, LOW_BOTTOM_VALUE.length());
 
-        statisticsBuilder.addValue(LOW_TOP_VALUE);
+        addValue(statisticsBuilder, LOW_TOP_VALUE);
         statisticsList.add(statisticsBuilder.buildColumnStatistics());
         assertMergedStringStatistics(statisticsList, 6, LOW_BOTTOM_VALUE.length() * 2 + LOW_TOP_VALUE.length());
     }
@@ -166,22 +168,22 @@ public class TestStringStatisticsBuilder
         statisticsList.add(statisticsBuilder.buildColumnStatistics());
         assertMergedStringStatistics(statisticsList, 0, 0);
 
-        statisticsBuilder.addValue(LOW_BOTTOM_VALUE);
+        addValue(statisticsBuilder, LOW_BOTTOM_VALUE);
         statisticsList.add(statisticsBuilder.buildColumnStatistics());
         assertMergedStringStatistics(statisticsList, 1, LOW_BOTTOM_VALUE.length());
         assertMinMax(mergeColumnStatistics(statisticsList).getStringStatistics(), LOW_BOTTOM_VALUE, LOW_BOTTOM_VALUE);
 
-        statisticsBuilder.addValue(LOW_TOP_VALUE);
+        addValue(statisticsBuilder, LOW_TOP_VALUE);
         statisticsList.add(statisticsBuilder.buildColumnStatistics());
         assertMergedStringStatistics(statisticsList, 3, LOW_BOTTOM_VALUE.length() * 2 + LOW_TOP_VALUE.length());
         assertMinMax(mergeColumnStatistics(statisticsList).getStringStatistics(), LOW_BOTTOM_VALUE, LOW_TOP_VALUE);
 
-        statisticsBuilder.addValue(HIGH_BOTTOM_VALUE);
+        addValue(statisticsBuilder, HIGH_BOTTOM_VALUE);
         statisticsList.add(statisticsBuilder.buildColumnStatistics());
         assertMergedStringStatistics(statisticsList, 6, LOW_BOTTOM_VALUE.length() * 3 + LOW_TOP_VALUE.length() * 2 + HIGH_BOTTOM_VALUE.length());
         assertMinMax(mergeColumnStatistics(statisticsList).getStringStatistics(), LOW_BOTTOM_VALUE, null);
 
-        statisticsBuilder.addValue(HIGH_BOTTOM_VALUE);
+        addValue(statisticsBuilder, HIGH_BOTTOM_VALUE);
         statisticsList.add(statisticsBuilder.buildColumnStatistics());
         assertMergedStringStatistics(statisticsList, 10, LOW_BOTTOM_VALUE.length() * 4 + LOW_TOP_VALUE.length() * 3 + HIGH_BOTTOM_VALUE.length() * 3);
         assertMinMax(mergeColumnStatistics(statisticsList).getStringStatistics(), LOW_BOTTOM_VALUE, null);
@@ -193,22 +195,22 @@ public class TestStringStatisticsBuilder
         statisticsList.add(statisticsBuilder.buildColumnStatistics());
         assertMergedStringStatistics(statisticsList, 0, 0);
 
-        statisticsBuilder.addValue(MEDIUM_TOP_VALUE);
+        addValue(statisticsBuilder, MEDIUM_TOP_VALUE);
         statisticsList.add(statisticsBuilder.buildColumnStatistics());
         assertMergedStringStatistics(statisticsList, 1, MEDIUM_TOP_VALUE.length());
         assertMinMax(mergeColumnStatistics(statisticsList).getStringStatistics(), MEDIUM_TOP_VALUE, MEDIUM_TOP_VALUE);
 
-        statisticsBuilder.addValue(MEDIUM_BOTTOM_VALUE);
+        addValue(statisticsBuilder, MEDIUM_BOTTOM_VALUE);
         statisticsList.add(statisticsBuilder.buildColumnStatistics());
         assertMergedStringStatistics(statisticsList, 3, MEDIUM_TOP_VALUE.length() * 2 + MEDIUM_BOTTOM_VALUE.length());
         assertMinMax(mergeColumnStatistics(statisticsList).getStringStatistics(), MEDIUM_BOTTOM_VALUE, MEDIUM_TOP_VALUE);
 
-        statisticsBuilder.addValue(LONG_BOTTOM_VALUE);
+        addValue(statisticsBuilder, LONG_BOTTOM_VALUE);
         statisticsList.add(statisticsBuilder.buildColumnStatistics());
         assertMergedStringStatistics(statisticsList, 6, MEDIUM_TOP_VALUE.length() * 3 + MEDIUM_BOTTOM_VALUE.length() * 2 + LONG_BOTTOM_VALUE.length());
         assertMinMax(mergeColumnStatistics(statisticsList).getStringStatistics(), null, MEDIUM_TOP_VALUE);
 
-        statisticsBuilder.addValue(LONG_BOTTOM_VALUE);
+        addValue(statisticsBuilder, LONG_BOTTOM_VALUE);
         statisticsList.add(statisticsBuilder.buildColumnStatistics());
         assertMergedStringStatistics(statisticsList, 10, MEDIUM_TOP_VALUE.length() * 4 + MEDIUM_BOTTOM_VALUE.length() * 3 + LONG_BOTTOM_VALUE.length() * 3);
         assertMinMax(mergeColumnStatistics(statisticsList).getStringStatistics(), null, MEDIUM_TOP_VALUE);
@@ -217,19 +219,19 @@ public class TestStringStatisticsBuilder
         statisticsList = new ArrayList<>();
 
         statisticsBuilder = new StringStatisticsBuilder(7);
-        statisticsBuilder.addValue(MEDIUM_BOTTOM_VALUE);
+        addValue(statisticsBuilder, MEDIUM_BOTTOM_VALUE);
         statisticsList.add(statisticsBuilder.buildColumnStatistics());
         assertMinMax(mergeColumnStatistics(statisticsList).getStringStatistics(), MEDIUM_BOTTOM_VALUE, MEDIUM_BOTTOM_VALUE);
 
-        statisticsBuilder.addValue(LONG_BOTTOM_VALUE);
+        addValue(statisticsBuilder, LONG_BOTTOM_VALUE);
         statisticsList.add(statisticsBuilder.buildColumnStatistics());
         assertMinMax(mergeColumnStatistics(statisticsList).getStringStatistics(), null, MEDIUM_BOTTOM_VALUE);
 
-        statisticsBuilder.addValue(HIGH_TOP_VALUE);
+        addValue(statisticsBuilder, HIGH_TOP_VALUE);
         statisticsList.add(statisticsBuilder.buildColumnStatistics());
         assertMinMax(mergeColumnStatistics(statisticsList).getStringStatistics(), null, null);
 
-        statisticsBuilder.addValue(HIGH_BOTTOM_VALUE);
+        addValue(statisticsBuilder, HIGH_BOTTOM_VALUE);
         statisticsList.add(statisticsBuilder.buildColumnStatistics());
         assertMinMax(mergeColumnStatistics(statisticsList).getStringStatistics(), null, null);
     }
@@ -239,7 +241,7 @@ public class TestStringStatisticsBuilder
     {
         StringStatisticsBuilder statisticsBuilder = new StringStatisticsBuilder(Integer.MAX_VALUE);
         Slice shortSlice = Slices.wrappedBuffer(LONG_BOTTOM_VALUE.getBytes(), 0, 1);
-        statisticsBuilder.addValue(shortSlice);
+        addValue(statisticsBuilder, shortSlice);
         Slice stats = statisticsBuilder.buildColumnStatistics().getStringStatistics().getMax();
 
         // assert we only spend 1 byte for stats
@@ -257,21 +259,26 @@ public class TestStringStatisticsBuilder
     }
 
     @Test
-    public void testSliceWithIndexLength()
+    public void testBlockStringStatistics()
     {
-        StringStatisticsBuilder builder = new StringStatisticsBuilder(10);
-        Slice slice = utf8Slice("abcdefghijklmnopqrstuvwxyz");
+        String alphabets = "abcdefghijklmnopqrstuvwxyz";
+        VariableWidthBlockBuilder blockBuilder = new VariableWidthBlockBuilder(null, alphabets.length(), alphabets.length());
+        Slice slice = utf8Slice(alphabets);
         for (int i = 0; i < slice.length(); i++) {
-            builder.addValue(slice, i, 1);
+            VARCHAR.writeSlice(blockBuilder, slice, i, 1);
         }
+        blockBuilder.appendNull();
 
-        StringStatistics stringStatistics = builder.buildColumnStatistics().getStringStatistics();
+        StringStatisticsBuilder stringStatisticsBuilder = new StringStatisticsBuilder(1000);
+        stringStatisticsBuilder.addBlock(VARCHAR, blockBuilder);
+
+        StringStatistics stringStatistics = stringStatisticsBuilder.buildColumnStatistics().getStringStatistics();
         assertEquals(stringStatistics.getMin(), slice.slice(0, 1));
         assertEquals(stringStatistics.getMax(), slice.slice(slice.length() - 1, 1));
         assertEquals(stringStatistics.getSum(), slice.length());
     }
 
-    private void assertMergedStringStatistics(List<ColumnStatistics> statisticsList, int expectedNumberOfValues, long expectedSum)
+    private void assertMergedStringStatistics(List<ColumnStatistics> statisticsList, int expectedNumberOfValues, int expectedSum)
     {
         assertStringStatistics(mergeColumnStatistics(statisticsList), expectedNumberOfValues, expectedSum);
 
@@ -285,7 +292,7 @@ public class TestStringStatisticsBuilder
         checkArgument(values != null && values.size() > 0);
         StringStatisticsBuilder builder = new StringStatisticsBuilder(limit);
         for (Slice value : values) {
-            builder.addValue(value);
+            addValue(builder, value);
         }
         assertMinMax(builder.buildColumnStatistics().getStringStatistics(), expectedMin, expectedMax);
     }
@@ -295,7 +302,7 @@ public class TestStringStatisticsBuilder
         checkArgument(values != null && values.size() > 0);
         StringStatisticsBuilder builder = new StringStatisticsBuilder(limit);
         for (Slice value : values) {
-            builder.addValue(value);
+            addValue(builder, value);
         }
         assertMinMax(builder.buildColumnStatistics().getStringStatistics(), expectedMin, expectedMax, expectedSum);
     }
@@ -341,5 +348,13 @@ public class TestStringStatisticsBuilder
             assertNull(columnStatistics.getStringStatistics());
             assertEquals(columnStatistics.getNumberOfValues(), 0);
         }
+    }
+
+    public static void addValue(StringStatisticsBuilder stringStatisticsBuilder, Slice slice)
+    {
+        VariableWidthBlockBuilder blockBuilder = new VariableWidthBlockBuilder(null, 1, slice.length());
+        blockBuilder.writeBytes(slice, 0, slice.length()).closeEntry();
+
+        stringStatisticsBuilder.addBlock(VARCHAR, blockBuilder);
     }
 }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/writer/TestSliceDictionaryBuilder.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/writer/TestSliceDictionaryBuilder.java
@@ -11,10 +11,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.orc;
+package com.facebook.presto.orc.writer;
 
 import com.facebook.presto.common.block.VariableWidthBlock;
-import com.facebook.presto.orc.writer.SliceDictionaryBuilder;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import org.testng.annotations.Test;


### PR DESCRIPTION
There are two paths where Slices are allocated in Slice Writers.
1. Statistics Calculation requires Slices to compute min/max/sum. 
The first PR calculates the Statistics directly from block and
position. This avoids the Slice allocation.
2. Writing to OrcOutputBuffer requires Slice.  The second PR
appends the block position directly to the OrcOutputBuffer.

SliceWriters after this change, will not allocate short lived Slices.

Test plan 
Existing tests.
Ran Validation Service and cross reader/writer validation.

```
== NO RELEASE NOTE ==
```
