### PR TITLE
Throw proper error code when timezone is invalid from packDateTimeWit…

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/DateTimeFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/DateTimeFunctions.java
@@ -119,7 +119,15 @@ public final class DateTimeFunctions
             // of TIME WITH TIME ZONE
             millis -= valueToSessionTimeZoneOffsetDiff(properties.getSessionStartTime(), getDateTimeZone(properties.getTimeZoneKey()));
         }
-        return packDateTimeWithZone(millis, properties.getTimeZoneKey());
+        try {
+            return packDateTimeWithZone(millis, properties.getTimeZoneKey());
+        }
+        catch (NotSupportedException | TimeZoneNotSupportedException e) {
+            throw new PrestoException(NOT_SUPPORTED, e.getMessage(), e);
+        }
+        catch (IllegalArgumentException e) {
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, e.getMessage(), e);
+        }
     }
 
     @Description("current time without time zone")
@@ -147,7 +155,15 @@ public final class DateTimeFunctions
     @SqlType(StandardTypes.TIMESTAMP_WITH_TIME_ZONE)
     public static long currentTimestamp(SqlFunctionProperties properties)
     {
-        return packDateTimeWithZone(properties.getSessionStartTime(), properties.getTimeZoneKey());
+        try {
+            return packDateTimeWithZone(properties.getSessionStartTime(), properties.getTimeZoneKey());
+        }
+        catch (NotSupportedException | TimeZoneNotSupportedException e) {
+            throw new PrestoException(NOT_SUPPORTED, e.getMessage(), e);
+        }
+        catch (IllegalArgumentException e) {
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, e.getMessage(), e);
+        }
     }
 
     @Description("current timestamp without time zone")
@@ -183,7 +199,16 @@ public final class DateTimeFunctions
         catch (IllegalArgumentException e) {
             throw new PrestoException(INVALID_FUNCTION_ARGUMENT, e.getMessage(), e);
         }
-        return packDateTimeWithZone(Math.round(unixTime * 1000), timeZoneKey);
+
+        try {
+            return packDateTimeWithZone(Math.round(unixTime * 1000), timeZoneKey);
+        }
+        catch (NotSupportedException | TimeZoneNotSupportedException e) {
+            throw new PrestoException(NOT_SUPPORTED, e.getMessage(), e);
+        }
+        catch (IllegalArgumentException e) {
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, e.getMessage(), e);
+        }
     }
 
     @ScalarFunction("from_unixtime")
@@ -268,7 +293,15 @@ public final class DateTimeFunctions
         DateTimeFormatter formatter = ISODateTimeFormat.dateTimeParser()
                 .withChronology(getChronology(properties.getTimeZoneKey()))
                 .withOffsetParsed();
-        return packDateTimeWithZone(parseDateTimeHelper(formatter, iso8601DateTime.toStringUtf8()));
+        try {
+            return packDateTimeWithZone(parseDateTimeHelper(formatter, iso8601DateTime.toStringUtf8()));
+        }
+        catch (NotSupportedException | TimeZoneNotSupportedException e) {
+            throw new PrestoException(NOT_SUPPORTED, e.getMessage(), e);
+        }
+        catch (IllegalArgumentException e) {
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, e.getMessage(), e);
+        }
     }
 
     @ScalarFunction("from_iso8601_date")
@@ -304,7 +337,15 @@ public final class DateTimeFunctions
     @SqlType(StandardTypes.TIMESTAMP_WITH_TIME_ZONE)
     public static long timestampAtTimeZone(@SqlType(StandardTypes.TIMESTAMP_WITH_TIME_ZONE) long timestampWithTimeZone, @SqlType("varchar(x)") Slice zoneId)
     {
-        return packDateTimeWithZone(unpackMillisUtc(timestampWithTimeZone), zoneId.toStringUtf8());
+        try {
+            return packDateTimeWithZone(unpackMillisUtc(timestampWithTimeZone), zoneId.toStringUtf8());
+        }
+        catch (NotSupportedException | TimeZoneNotSupportedException e) {
+            throw new PrestoException(NOT_SUPPORTED, e.getMessage(), e);
+        }
+        catch (IllegalArgumentException e) {
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, e.getMessage(), e);
+        }
     }
 
     @ScalarFunction(value = "at_timezone", visibility = HIDDEN)
@@ -313,7 +354,15 @@ public final class DateTimeFunctions
     {
         checkCondition((zoneOffset % 60_000L) == 0L, INVALID_FUNCTION_ARGUMENT, "Invalid time zone offset interval: interval contains seconds");
         long zoneOffsetMinutes = zoneOffset / 60_000L;
-        return packDateTimeWithZone(unpackMillisUtc(timestampWithTimeZone), getTimeZoneKeyForOffset(zoneOffsetMinutes));
+        try {
+            return packDateTimeWithZone(unpackMillisUtc(timestampWithTimeZone), getTimeZoneKeyForOffset(zoneOffsetMinutes));
+        }
+        catch (NotSupportedException | TimeZoneNotSupportedException e) {
+            throw new PrestoException(NOT_SUPPORTED, e.getMessage(), e);
+        }
+        catch (IllegalArgumentException e) {
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, e.getMessage(), e);
+        }
     }
 
     @Description("truncate to the specified precision in the session timezone")
@@ -580,6 +629,9 @@ public final class DateTimeFunctions
                             .withOffsetParsed()
                             .withLocale(properties.getSessionLocale()),
                     datetime.toStringUtf8()));
+        }
+        catch (NotSupportedException | TimeZoneNotSupportedException e) {
+            throw new PrestoException(NOT_SUPPORTED, e.getMessage(), e);
         }
         catch (IllegalArgumentException e) {
             throw new PrestoException(INVALID_FUNCTION_ARGUMENT, e);
@@ -1384,7 +1436,15 @@ public final class DateTimeFunctions
             localMillis += TimeUnit.DAYS.toMillis(1);
         }
 
-        return packDateTimeWithZone(millis, timeZoneKey);
+        try {
+            return packDateTimeWithZone(millis, timeZoneKey);
+        }
+        catch (NotSupportedException | TimeZoneNotSupportedException e) {
+            throw new PrestoException(NOT_SUPPORTED, e.getMessage(), e);
+        }
+        catch (IllegalArgumentException e) {
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, e.getMessage(), e);
+        }
     }
 
     // HACK WARNING!

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestDateTimeFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestDateTimeFunctions.java
@@ -99,5 +99,8 @@ public class TestDateTimeFunctions
     {
         String sql = "FROM_UNIXTIME(a.column1, 'yyyy-mm-dd') FROM (VALUES (1)) a (column1)";
         assertNotSupported(sql, "Time zone not supported: yyyy-mm-dd");
+
+        sql = "FROM_UNIXTIME(a.column1) AT TIME ZONE 'PDT','yyyy-MM-dd HH:mm:ss' FROM (VALUES (1)) a (column1)";
+        assertNotSupported(sql, "Time zone not supported: PDT");
     }
 }


### PR DESCRIPTION
During packDateTimeWithZone execution, if an invalid timezone is passed as parameter, we should throw NOT_SUPPORTED error code. Currently this exception is not handled, which eventually throws GENERIC_INTERNAL_ERROR. Previously we handled such cases here: https://github.com/prestodb/presto/pull/17241 however it a few more places need to have try catch and throw proper exception.