### PR TITLE
Add support for deleting files when table is dropped in ThriftHiveMetastore

### DIFF
--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/MetastoreClientConfig.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/MetastoreClientConfig.java
@@ -51,6 +51,7 @@ public class MetastoreClientConfig
     private double partitionCacheValidationPercentage;
     private int partitionCacheColumnCountLimit = 500;
     private HiveMetastoreAuthenticationType hiveMetastoreAuthenticationType = HiveMetastoreAuthenticationType.NONE;
+    private boolean deleteFilesOnTableDrop;
 
     public HostAndPort getMetastoreSocksProxy()
     {
@@ -287,6 +288,19 @@ public class MetastoreClientConfig
     public MetastoreClientConfig setHiveMetastoreAuthenticationType(HiveMetastoreAuthenticationType hiveMetastoreAuthenticationType)
     {
         this.hiveMetastoreAuthenticationType = hiveMetastoreAuthenticationType;
+        return this;
+    }
+
+    public boolean isDeleteFilesOnTableDrop()
+    {
+        return deleteFilesOnTableDrop;
+    }
+
+    @Config("hive.metastore.thrift.delete-files-on-table-drop")
+    @ConfigDescription("Delete files on dropping table in case the metastore fails to do so")
+    public MetastoreClientConfig setDeleteFilesOnTableDrop(boolean deleteFilesOnTableDrop)
+    {
+        this.deleteFilesOnTableDrop = deleteFilesOnTableDrop;
         return this;
     }
 }

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/MetastoreUtil.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/MetastoreUtil.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.hive.metastore;
 
+import com.facebook.airlift.log.Logger;
 import com.facebook.presto.common.Page;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.predicate.Domain;
@@ -100,6 +101,7 @@ import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.common.type.Varchars.isVarcharType;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_FILESYSTEM_ERROR;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_INVALID_PARTITION_VALUE;
+import static com.facebook.presto.hive.metastore.PrestoTableType.MANAGED_TABLE;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.spi.statistics.ColumnStatisticType.MAX_VALUE;
 import static com.facebook.presto.spi.statistics.ColumnStatisticType.MAX_VALUE_SIZE_IN_BYTES;
@@ -136,6 +138,8 @@ import static org.joda.time.DateTimeZone.UTC;
 
 public class MetastoreUtil
 {
+    private static final Logger log = Logger.get(MetastoreUtil.class);
+
     public static final String METASTORE_HEADERS = "metastore_headers";
     public static final String PRESTO_OFFLINE = "presto_offline";
     public static final String AVRO_SCHEMA_URL_KEY = "avro.schema.url";
@@ -946,6 +950,22 @@ public class MetastoreUtil
         }
         catch (Exception e) {
             return false;
+        }
+    }
+
+    public static boolean isManagedTable(String tableType)
+    {
+        return tableType.equals(MANAGED_TABLE.name());
+    }
+
+    public static void deleteDirectoryRecursively(HdfsContext context, HdfsEnvironment hdfsEnvironment, Path path, boolean recursive)
+    {
+        try {
+            hdfsEnvironment.getFileSystem(context, path).delete(path, recursive);
+        }
+        catch (IOException | RuntimeException e) {
+            // don't fail if unable to delete path
+            log.warn(e, "Failed to delete path: " + path.toString());
         }
     }
 }

--- a/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/TestMetastoreClientConfig.java
+++ b/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/TestMetastoreClientConfig.java
@@ -48,7 +48,8 @@ public class TestMetastoreClientConfig
                 .setMetastoreImpersonationEnabled(false)
                 .setPartitionCacheValidationPercentage(0)
                 .setPartitionCacheColumnCountLimit(500)
-                .setHiveMetastoreAuthenticationType(HiveMetastoreAuthenticationType.NONE));
+                .setHiveMetastoreAuthenticationType(HiveMetastoreAuthenticationType.NONE)
+                .setDeleteFilesOnTableDrop(false));
     }
 
     @Test
@@ -73,6 +74,7 @@ public class TestMetastoreClientConfig
                 .put("hive.partition-cache-validation-percentage", "60.0")
                 .put("hive.partition-cache-column-count-limit", "50")
                 .put("hive.metastore.authentication.type", "KERBEROS")
+                .put("hive.metastore.thrift.delete-files-on-table-drop", "true")
                 .build();
 
         MetastoreClientConfig expected = new MetastoreClientConfig()
@@ -93,7 +95,8 @@ public class TestMetastoreClientConfig
                 .setMetastoreImpersonationEnabled(true)
                 .setPartitionCacheValidationPercentage(60.0)
                 .setPartitionCacheColumnCountLimit(50)
-                .setHiveMetastoreAuthenticationType(HiveMetastoreAuthenticationType.KERBEROS);
+                .setHiveMetastoreAuthenticationType(HiveMetastoreAuthenticationType.KERBEROS)
+                .setDeleteFilesOnTableDrop(true);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -923,8 +923,10 @@ public abstract class AbstractTestHiveClient
         }
 
         HiveCluster hiveCluster = new TestingHiveCluster(metastoreClientConfig, host, port);
+        HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(new HdfsConfigurationInitializer(hiveClientConfig, metastoreClientConfig), ImmutableSet.of());
+        hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, metastoreClientConfig, new NoHdfsAuthentication());
         ExtendedHiveMetastore metastore = new CachingHiveMetastore(
-                new BridgingHiveMetastore(new ThriftHiveMetastore(hiveCluster, metastoreClientConfig), new HivePartitionMutator()),
+                new BridgingHiveMetastore(new ThriftHiveMetastore(hiveCluster, metastoreClientConfig, hdfsEnvironment), new HivePartitionMutator()),
                 executor,
                 false,
                 Duration.valueOf("1m"),

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystem.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystem.java
@@ -187,7 +187,7 @@ public abstract class AbstractTestHiveFileSystem
         hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, metastoreClientConfig, new NoHdfsAuthentication());
         ColumnConverterProvider columnConverterProvider = HiveColumnConverterProvider.DEFAULT_COLUMN_CONVERTER_PROVIDER;
         metastoreClient = new TestingHiveMetastore(
-                new BridgingHiveMetastore(new ThriftHiveMetastore(hiveCluster, metastoreClientConfig), new HivePartitionMutator()),
+                new BridgingHiveMetastore(new ThriftHiveMetastore(hiveCluster, metastoreClientConfig, hdfsEnvironment), new HivePartitionMutator()),
                 executor,
                 metastoreClientConfig,
                 getBasePath(),

--- a/presto-hive/src/test/java/com/facebook/presto/hive/MockHiveMetastore.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/MockHiveMetastore.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_METASTORE_ERROR;
+import static com.facebook.presto.hive.HiveTestUtils.HDFS_ENVIRONMENT;
 import static com.facebook.presto.hive.metastore.TestCachingHiveMetastore.MockHiveCluster;
 import static java.util.Objects.requireNonNull;
 
@@ -35,7 +36,7 @@ public class MockHiveMetastore
 
     public MockHiveMetastore(MockHiveCluster mockHiveCluster)
     {
-        super(mockHiveCluster, new MetastoreClientConfig());
+        super(mockHiveCluster, new MetastoreClientConfig(), HDFS_ENVIRONMENT);
         this.clientProvider = requireNonNull(mockHiveCluster, "mockHiveCluster is null");
     }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestingSemiTransactionalHiveMetastore.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestingSemiTransactionalHiveMetastore.java
@@ -80,7 +80,7 @@ public class TestingSemiTransactionalHiveMetastore
         HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, metastoreClientConfig, new NoHdfsAuthentication());
         HiveCluster hiveCluster = new TestingHiveCluster(metastoreClientConfig, HOST, PORT);
         ColumnConverterProvider columnConverterProvider = HiveColumnConverterProvider.DEFAULT_COLUMN_CONVERTER_PROVIDER;
-        ExtendedHiveMetastore delegate = new BridgingHiveMetastore(new ThriftHiveMetastore(hiveCluster, metastoreClientConfig), new HivePartitionMutator());
+        ExtendedHiveMetastore delegate = new BridgingHiveMetastore(new ThriftHiveMetastore(hiveCluster, metastoreClientConfig, hdfsEnvironment), new HivePartitionMutator());
         ExecutorService executor = newCachedThreadPool(daemonThreadsNamed("hive-%s"));
         ListeningExecutorService renameExecutor = listeningDecorator(executor);
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/metastore/TestCachingHiveMetastore.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/metastore/TestCachingHiveMetastore.java
@@ -38,6 +38,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
 import static com.facebook.airlift.concurrent.Threads.daemonThreadsNamed;
+import static com.facebook.presto.hive.HiveTestUtils.HDFS_ENVIRONMENT;
 import static com.facebook.presto.hive.metastore.NoopMetastoreCacheStats.NOOP_METASTORE_CACHE_STATS;
 import static com.facebook.presto.hive.metastore.Partition.Builder;
 import static com.facebook.presto.hive.metastore.thrift.MockHiveMetastoreClient.BAD_DATABASE;
@@ -74,7 +75,7 @@ public class TestCachingHiveMetastore
         MockHiveCluster mockHiveCluster = new MockHiveCluster(mockClient);
         ListeningExecutorService executor = listeningDecorator(newCachedThreadPool(daemonThreadsNamed("test-%s")));
         MetastoreClientConfig metastoreClientConfig = new MetastoreClientConfig();
-        ThriftHiveMetastore thriftHiveMetastore = new ThriftHiveMetastore(mockHiveCluster, metastoreClientConfig);
+        ThriftHiveMetastore thriftHiveMetastore = new ThriftHiveMetastore(mockHiveCluster, metastoreClientConfig, HDFS_ENVIRONMENT);
         PartitionMutator hivePartitionMutator = new HivePartitionMutator();
         metastore = new CachingHiveMetastore(
                 new BridgingHiveMetastore(thriftHiveMetastore, hivePartitionMutator),

--- a/presto-hive/src/test/java/com/facebook/presto/hive/s3/S3HiveQueryRunner.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/s3/S3HiveQueryRunner.java
@@ -27,6 +27,8 @@ import com.google.common.net.HostAndPort;
 import java.util.Map;
 import java.util.Optional;
 
+import static com.facebook.presto.hive.HiveTestUtils.HDFS_ENVIRONMENT;
+
 public final class S3HiveQueryRunner
 {
     private S3HiveQueryRunner() {}
@@ -56,7 +58,8 @@ public final class S3HiveQueryRunner
                                         new MetastoreClientConfig(),
                                         hiveEndpoint.getHost(),
                                         hiveEndpoint.getPort()),
-                                new MetastoreClientConfig()),
+                                new MetastoreClientConfig(),
+                                HDFS_ENVIRONMENT),
                         new HivePartitionMutator())));
     }
 }


### PR DESCRIPTION
Fixes #15308 

The metastore is expected to delete files when a managed table is
dropped, but for some reason this doesn't always happen for S3, so
we can work around it by having Presto do the deletion.

```
== RELEASE NOTES ==

Hive Changes
* Add metastore config property ``hive.metastore.thrift.delete-files-on-table-drop`` to delete files on drop table (:pr:`17369`)
```
