### PR TITLE
Fix bug in OrcOutputBuffer leading to severe undercompression of large blobs

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcOutputBuffer.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcOutputBuffer.java
@@ -445,7 +445,7 @@ public class OrcOutputBuffer
             return;
         }
 
-        checkArgument(length <= buffer.length, "Write chunk length must be less than compression buffer size");
+        checkArgument(length <= maxBufferSize, "Write chunk length must be less than max compression buffer size");
 
         boolean isCompressed = false;
         byte[] compressionBuffer = null;
@@ -497,7 +497,7 @@ public class OrcOutputBuffer
         }
 
         while (length > 0) {
-            int chunkSize = Integer.min(length, buffer.length);
+            int chunkSize = Integer.min(length, maxBufferSize);
             writeChunkToOutputStream(bytes, bytesOffset, chunkSize);
             length -= chunkSize;
             bytesOffset += chunkSize;


### PR DESCRIPTION
OrcOutputBuffer uses a special direct compression mode for inputs coming in one piece larger than 32KB. OrcOutputBuffer splits such inputs into smaller ready for compression chunks equal to the current size of the compression buffer. And by default the size of compression buffer is just 256 bytes. 

In a severe case, when the buffer size has not been increased since initialization, the input would be split into 256 byte chunks instead of default max 256KB chunks. This led to severe undercompression of such input, I can see that a lot of JSON based columns could benefit from this fix.

I used a random 56MB json file to see how bad it is. Before the fix the compression was quite slow and the size of compressed result was around 24MB, after the fix the size of compressed result dropped from 24MB to 1.2MB.


Test plan:
* added new test case

```
== NO RELEASE NOTE ==
```
