### PR TITLE
Skip synthetic members to enable code coverage

### DIFF
--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/AccumuloConnector.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/AccumuloConnector.java
@@ -20,6 +20,7 @@ import com.facebook.presto.accumulo.conf.AccumuloTableProperties;
 import com.facebook.presto.accumulo.io.AccumuloPageSinkProvider;
 import com.facebook.presto.accumulo.io.AccumuloRecordSetProvider;
 import com.facebook.presto.spi.connector.Connector;
+import com.facebook.presto.spi.connector.ConnectorCommitHandle;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.connector.ConnectorPageSinkProvider;
 import com.facebook.presto.spi.connector.ConnectorRecordSetProvider;
@@ -34,6 +35,7 @@ import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+import static com.facebook.presto.spi.connector.EmptyConnectorCommitHandle.INSTANCE;
 import static com.facebook.presto.spi.transaction.IsolationLevel.READ_UNCOMMITTED;
 import static com.facebook.presto.spi.transaction.IsolationLevel.checkConnectorSupports;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -94,9 +96,10 @@ public class AccumuloConnector
     }
 
     @Override
-    public void commit(ConnectorTransactionHandle transactionHandle)
+    public ConnectorCommitHandle commit(ConnectorTransactionHandle transactionHandle)
     {
         checkArgument(transactions.remove(transactionHandle) != null, "no such transaction: %s", transactionHandle);
+        return INSTANCE;
     }
 
     @Override

--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcConnector.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcConnector.java
@@ -19,6 +19,7 @@ import com.facebook.presto.plugin.jdbc.optimization.JdbcPlanOptimizerProvider;
 import com.facebook.presto.spi.connector.Connector;
 import com.facebook.presto.spi.connector.ConnectorAccessControl;
 import com.facebook.presto.spi.connector.ConnectorCapabilities;
+import com.facebook.presto.spi.connector.ConnectorCommitHandle;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.connector.ConnectorPageSinkProvider;
 import com.facebook.presto.spi.connector.ConnectorPlanOptimizerProvider;
@@ -41,6 +42,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 import static com.facebook.presto.spi.connector.ConnectorCapabilities.NOT_NULL_COLUMN_CONSTRAINT;
+import static com.facebook.presto.spi.connector.EmptyConnectorCommitHandle.INSTANCE;
 import static com.facebook.presto.spi.transaction.IsolationLevel.READ_COMMITTED;
 import static com.facebook.presto.spi.transaction.IsolationLevel.checkConnectorSupports;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -128,9 +130,10 @@ public class JdbcConnector
     }
 
     @Override
-    public void commit(ConnectorTransactionHandle transaction)
+    public ConnectorCommitHandle commit(ConnectorTransactionHandle transaction)
     {
         checkArgument(transactions.remove(transaction) != null, "no such transaction: %s", transaction);
+        return INSTANCE;
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/block/BlockBuilderStatus.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/BlockBuilderStatus.java
@@ -74,7 +74,8 @@ public class BlockBuilderStatus
 
         int size = ClassLayout.parseClass(clazz).instanceSize();
         for (Field field : clazz.getDeclaredFields()) {
-            if (!field.getType().isPrimitive()) {
+            // The !field.isSynthetic() condition is specifically for jacoco which adds synthetic members $jacocoData and $jacocoInit() to classes.
+            if (!field.getType().isPrimitive() && !field.isSynthetic()) {
                 size += deepInstanceSize(field.getType());
             }
         }

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/CachingHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/CachingHiveMetastore.java
@@ -507,10 +507,10 @@ public class CachingHiveMetastore
     }
 
     @Override
-    public void createTable(MetastoreContext metastoreContext, Table table, PrincipalPrivileges principalPrivileges)
+    public MetastoreOperationStats createTable(MetastoreContext metastoreContext, Table table, PrincipalPrivileges principalPrivileges)
     {
         try {
-            delegate.createTable(metastoreContext, table, principalPrivileges);
+            return delegate.createTable(metastoreContext, table, principalPrivileges);
         }
         finally {
             invalidateTable(table.getDatabaseName(), table.getTableName());
@@ -529,10 +529,10 @@ public class CachingHiveMetastore
     }
 
     @Override
-    public void replaceTable(MetastoreContext metastoreContext, String databaseName, String tableName, Table newTable, PrincipalPrivileges principalPrivileges)
+    public MetastoreOperationStats replaceTable(MetastoreContext metastoreContext, String databaseName, String tableName, Table newTable, PrincipalPrivileges principalPrivileges)
     {
         try {
-            delegate.replaceTable(metastoreContext, databaseName, tableName, newTable, principalPrivileges);
+            return delegate.replaceTable(metastoreContext, databaseName, tableName, newTable, principalPrivileges);
         }
         finally {
             invalidateTable(databaseName, tableName);
@@ -541,10 +541,10 @@ public class CachingHiveMetastore
     }
 
     @Override
-    public void renameTable(MetastoreContext metastoreContext, String databaseName, String tableName, String newDatabaseName, String newTableName)
+    public MetastoreOperationStats renameTable(MetastoreContext metastoreContext, String databaseName, String tableName, String newDatabaseName, String newTableName)
     {
         try {
-            delegate.renameTable(metastoreContext, databaseName, tableName, newDatabaseName, newTableName);
+            return delegate.renameTable(metastoreContext, databaseName, tableName, newDatabaseName, newTableName);
         }
         finally {
             invalidateTable(databaseName, tableName);
@@ -553,10 +553,10 @@ public class CachingHiveMetastore
     }
 
     @Override
-    public void addColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String columnName, HiveType columnType, String columnComment)
+    public MetastoreOperationStats addColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String columnName, HiveType columnType, String columnComment)
     {
         try {
-            delegate.addColumn(metastoreContext, databaseName, tableName, columnName, columnType, columnComment);
+            return delegate.addColumn(metastoreContext, databaseName, tableName, columnName, columnType, columnComment);
         }
         finally {
             invalidateTable(databaseName, tableName);
@@ -564,10 +564,10 @@ public class CachingHiveMetastore
     }
 
     @Override
-    public void renameColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String oldColumnName, String newColumnName)
+    public MetastoreOperationStats renameColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String oldColumnName, String newColumnName)
     {
         try {
-            delegate.renameColumn(metastoreContext, databaseName, tableName, oldColumnName, newColumnName);
+            return delegate.renameColumn(metastoreContext, databaseName, tableName, oldColumnName, newColumnName);
         }
         finally {
             invalidateTable(databaseName, tableName);
@@ -575,10 +575,10 @@ public class CachingHiveMetastore
     }
 
     @Override
-    public void dropColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String columnName)
+    public MetastoreOperationStats dropColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String columnName)
     {
         try {
-            delegate.dropColumn(metastoreContext, databaseName, tableName, columnName);
+            return delegate.dropColumn(metastoreContext, databaseName, tableName, columnName);
         }
         finally {
             invalidateTable(databaseName, tableName);
@@ -782,10 +782,10 @@ public class CachingHiveMetastore
     }
 
     @Override
-    public void addPartitions(MetastoreContext metastoreContext, String databaseName, String tableName, List<PartitionWithStatistics> partitions)
+    public MetastoreOperationStats addPartitions(MetastoreContext metastoreContext, String databaseName, String tableName, List<PartitionWithStatistics> partitions)
     {
         try {
-            delegate.addPartitions(metastoreContext, databaseName, tableName, partitions);
+            return delegate.addPartitions(metastoreContext, databaseName, tableName, partitions);
         }
         finally {
             // todo do we need to invalidate all partitions?
@@ -805,10 +805,10 @@ public class CachingHiveMetastore
     }
 
     @Override
-    public void alterPartition(MetastoreContext metastoreContext, String databaseName, String tableName, PartitionWithStatistics partition)
+    public MetastoreOperationStats alterPartition(MetastoreContext metastoreContext, String databaseName, String tableName, PartitionWithStatistics partition)
     {
         try {
-            delegate.alterPartition(metastoreContext, databaseName, tableName, partition);
+            return delegate.alterPartition(metastoreContext, databaseName, tableName, partition);
         }
         finally {
             invalidatePartitionCache(databaseName, tableName);

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/CustomDateTimeDeserializer.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/CustomDateTimeDeserializer.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.metastore;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import org.joda.time.DateTime;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+
+import java.io.IOException;
+
+public class CustomDateTimeDeserializer
+        extends JsonDeserializer<DateTime>
+{
+    private static DateTimeFormatter formatter =
+            DateTimeFormat.forPattern("yyyy-MM-dd HH:mm");
+
+    @Override
+    public DateTime deserialize(JsonParser parser, DeserializationContext context)
+            throws IOException, JsonProcessingException
+    {
+        String dateTime = parser.getText();
+        return formatter.parseDateTime(dateTime);
+    }
+}

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/CustomDateTimeSerializer.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/CustomDateTimeSerializer.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.metastore;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import org.joda.time.DateTime;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+
+import java.io.IOException;
+
+public class CustomDateTimeSerializer
+        extends JsonSerializer<DateTime>
+{
+    private static DateTimeFormatter formatter =
+            DateTimeFormat.forPattern("yyyy-MM-dd HH:mm");
+
+    @Override
+    public void serialize(DateTime value, JsonGenerator generator, SerializerProvider provider)
+            throws IOException
+    {
+        generator.writeString(formatter.print(value));
+    }
+}

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/ExtendedHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/ExtendedHiveMetastore.java
@@ -56,7 +56,7 @@ public interface ExtendedHiveMetastore
 
     void renameDatabase(MetastoreContext metastoreContext, String databaseName, String newDatabaseName);
 
-    void createTable(MetastoreContext metastoreContext, Table table, PrincipalPrivileges principalPrivileges);
+    MetastoreOperationStats createTable(MetastoreContext metastoreContext, Table table, PrincipalPrivileges principalPrivileges);
 
     void dropTable(MetastoreContext metastoreContext, String databaseName, String tableName, boolean deleteData);
 
@@ -65,15 +65,15 @@ public interface ExtendedHiveMetastore
      * alter one field of a table object previously acquired from getTable is
      * probably not what you want.
      */
-    void replaceTable(MetastoreContext metastoreContext, String databaseName, String tableName, Table newTable, PrincipalPrivileges principalPrivileges);
+    MetastoreOperationStats replaceTable(MetastoreContext metastoreContext, String databaseName, String tableName, Table newTable, PrincipalPrivileges principalPrivileges);
 
-    void renameTable(MetastoreContext metastoreContext, String databaseName, String tableName, String newDatabaseName, String newTableName);
+    MetastoreOperationStats renameTable(MetastoreContext metastoreContext, String databaseName, String tableName, String newDatabaseName, String newTableName);
 
-    void addColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String columnName, HiveType columnType, String columnComment);
+    MetastoreOperationStats addColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String columnName, HiveType columnType, String columnComment);
 
-    void renameColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String oldColumnName, String newColumnName);
+    MetastoreOperationStats renameColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String oldColumnName, String newColumnName);
 
-    void dropColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String columnName);
+    MetastoreOperationStats dropColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String columnName);
 
     Optional<Partition> getPartition(MetastoreContext metastoreContext, String databaseName, String tableName, List<String> partitionValues);
 
@@ -93,11 +93,11 @@ public interface ExtendedHiveMetastore
 
     Map<String, Optional<Partition>> getPartitionsByNames(MetastoreContext metastoreContext, String databaseName, String tableName, List<String> partitionNames);
 
-    void addPartitions(MetastoreContext metastoreContext, String databaseName, String tableName, List<PartitionWithStatistics> partitions);
+    MetastoreOperationStats addPartitions(MetastoreContext metastoreContext, String databaseName, String tableName, List<PartitionWithStatistics> partitions);
 
     void dropPartition(MetastoreContext metastoreContext, String databaseName, String tableName, List<String> parts, boolean deleteData);
 
-    void alterPartition(MetastoreContext metastoreContext, String databaseName, String tableName, PartitionWithStatistics partition);
+    MetastoreOperationStats alterPartition(MetastoreContext metastoreContext, String databaseName, String tableName, PartitionWithStatistics partition);
 
     void createRole(MetastoreContext metastoreContext, String role, String grantor);
 

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/HiveCommitHandle.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/HiveCommitHandle.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.metastore;
+
+import com.facebook.presto.spi.ConnectorId;
+import com.facebook.presto.spi.connector.ConnectorCommitHandle;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.joda.time.DateTime;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.Objects.requireNonNull;
+
+public class HiveCommitHandle
+        implements ConnectorCommitHandle
+{
+    private Map<String, List<DateTime>> outputLastDataCommitTimes;
+    private ConnectorId connectorId;
+
+    @JsonCreator
+    public HiveCommitHandle(
+            @JsonProperty("connectorId") ConnectorId connectorId,
+            @JsonProperty("outputLastDataCommitTimes") Map<String, List<DateTime>> outputLastDataCommitTimes)
+    {
+        this.connectorId = requireNonNull(connectorId);
+        this.outputLastDataCommitTimes = requireNonNull(outputLastDataCommitTimes);
+    }
+
+    public ConnectorId getConnectorId()
+    {
+        return connectorId;
+    }
+
+    public void addOutputLastDataCommitTimes(String key, List<DateTime> value)
+    {
+        if (!outputLastDataCommitTimes.containsKey(key)) {
+            outputLastDataCommitTimes.put(key, new ArrayList<DateTime>());
+        }
+        outputLastDataCommitTimes.get(key).addAll(value);
+    }
+
+    @JsonProperty
+    public List<DateTime> getOutputLastDataCommitTimes(String key)
+    {
+        return outputLastDataCommitTimes.get(key);
+    }
+
+    public boolean containOutput(String key)
+    {
+        return outputLastDataCommitTimes.containsKey(key);
+    }
+
+    public Set<String> getOutputKeys()
+    {
+        return outputLastDataCommitTimes.keySet();
+    }
+
+    public void removeOutput(String key)
+    {
+        outputLastDataCommitTimes.remove(key);
+    }
+}

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/MetastoreOperationStats.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/MetastoreOperationStats.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.metastore;
+
+import org.joda.time.DateTime;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static java.util.Objects.requireNonNull;
+
+public class MetastoreOperationStats
+{
+    private final MetastoreOperationType operationType;
+    private final List<DateTime> lastDataCommitTimes;
+    private static final int DUMMY_MILLISECONDS = 0;
+
+    public static final MetastoreOperationStats EMPTY_STATS = new MetastoreOperationStats();
+
+    public MetastoreOperationStats()
+    {
+        operationType = MetastoreOperationType.OTHERS;
+        lastDataCommitTimes = Arrays.asList(new DateTime(DUMMY_MILLISECONDS));
+    }
+
+    public MetastoreOperationStats(MetastoreOperationType operationType, List<DateTime> lastDataCommitTimes)
+    {
+        this.operationType = requireNonNull(operationType, "operationType is null");
+        this.lastDataCommitTimes = requireNonNull(lastDataCommitTimes, "lastDataCommitTimes is null");
+    }
+
+    public List<DateTime> getLastDataCommitTimes()
+    {
+        return lastDataCommitTimes;
+    }
+
+    public MetastoreOperationType getOperationType()
+    {
+        return operationType;
+    }
+}

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/MetastoreOperationType.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/MetastoreOperationType.java
@@ -11,18 +11,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.hive;
+package com.facebook.presto.hive.metastore;
 
-import com.facebook.presto.hive.metastore.SemiTransactionalHiveMetastore;
-import com.facebook.presto.spi.connector.ConnectorCommitHandle;
-import com.facebook.presto.spi.connector.ConnectorMetadata;
-
-public interface TransactionalMetadata
-        extends ConnectorMetadata
+public enum MetastoreOperationType
 {
-    ConnectorCommitHandle commit();
-
-    void rollback();
-
-    SemiTransactionalHiveMetastore getMetastore();
+    ADD_PARTITION,
+    ALTER_TABLES,
+    ALTER_PARTITIONS,
+    APPEND_PARTITION,
+    APPEND_PARTITION_BY_NAME,
+    CREATE_TABLE,
+    GET_PARTITION,
+    GET_PARTITION_BY_NAME,
+    GET_TABLE,
+    OTHERS
 }

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/Partition.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/Partition.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import org.joda.time.DateTime;
 
 import javax.annotation.concurrent.Immutable;
 
@@ -44,6 +45,7 @@ public class Partition
     private final boolean eligibleToIgnore;
     private final boolean sealedPartition;
     private final int createTime;
+    private final DateTime lastAccessTime;
 
     @JsonCreator
     public Partition(
@@ -56,7 +58,8 @@ public class Partition
             @JsonProperty("partitionVersion") Optional<Long> partitionVersion,
             @JsonProperty("eligibleToIgnore") boolean eligibleToIgnore,
             @JsonProperty("sealedPartition") boolean sealedPartition,
-            @JsonProperty("createTime") int createTime)
+            @JsonProperty("createTime") int createTime,
+            @JsonProperty("lastAccessTime") DateTime lastAccessTime)
     {
         this.databaseName = requireNonNull(databaseName, "databaseName is null");
         this.tableName = requireNonNull(tableName, "tableName is null");
@@ -68,6 +71,7 @@ public class Partition
         this.eligibleToIgnore = eligibleToIgnore;
         this.sealedPartition = sealedPartition;
         this.createTime = createTime;
+        this.lastAccessTime = lastAccessTime;
     }
 
     @JsonProperty
@@ -136,6 +140,12 @@ public class Partition
         return createTime;
     }
 
+    @JsonProperty
+    public DateTime getLastAccessTime()
+    {
+        return lastAccessTime;
+    }
+
     @Override
     public String toString()
     {
@@ -166,13 +176,25 @@ public class Partition
                 Objects.equals(partitionVersion, partition.partitionVersion) &&
                 Objects.equals(eligibleToIgnore, partition.eligibleToIgnore) &&
                 Objects.equals(sealedPartition, partition.sealedPartition) &&
-                Objects.equals(createTime, partition.getCreateTime());
+                Objects.equals(createTime, partition.getCreateTime()) &&
+                Objects.equals(lastAccessTime, partition.lastAccessTime);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(databaseName, tableName, values, storage, columns, parameters, partitionVersion, eligibleToIgnore, sealedPartition, createTime);
+        return Objects.hash(
+                databaseName,
+                tableName,
+                values,
+                storage,
+                columns,
+                parameters,
+                partitionVersion,
+                eligibleToIgnore,
+                sealedPartition,
+                createTime,
+                lastAccessTime);
     }
 
     public static Builder builder()
@@ -197,6 +219,7 @@ public class Partition
         private boolean isEligibleToIgnore;
         private boolean isSealedPartition = true;
         private int createTime;
+        private DateTime lastAccessTime = new DateTime(0);
 
         private Builder()
         {
@@ -214,6 +237,7 @@ public class Partition
             this.partitionVersion = partition.getPartitionVersion();
             this.isEligibleToIgnore = partition.isEligibleToIgnore();
             this.createTime = partition.getCreateTime();
+            this.lastAccessTime = partition.getLastAccessTime();
         }
 
         public Builder setDatabaseName(String databaseName)
@@ -281,9 +305,26 @@ public class Partition
             return this;
         }
 
+        public Builder setLastAccessTime(int lastAccessTime)
+        {
+            this.lastAccessTime = new DateTime(lastAccessTime * 1000);
+            return this;
+        }
+
         public Partition build()
         {
-            return new Partition(databaseName, tableName, values, storageBuilder.build(), columns, parameters, partitionVersion, isEligibleToIgnore, isSealedPartition, createTime);
+            return new Partition(
+                    databaseName,
+                    tableName,
+                    values,
+                    storageBuilder.build(),
+                    columns,
+                    parameters,
+                    partitionVersion,
+                    isEligibleToIgnore,
+                    isSealedPartition,
+                    createTime,
+                    lastAccessTime);
         }
     }
 }

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/RecordingHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/RecordingHiveMetastore.java
@@ -278,10 +278,10 @@ public class RecordingHiveMetastore
     }
 
     @Override
-    public void createTable(MetastoreContext metastoreContext, Table table, PrincipalPrivileges principalPrivileges)
+    public MetastoreOperationStats createTable(MetastoreContext metastoreContext, Table table, PrincipalPrivileges principalPrivileges)
     {
         verifyRecordingMode();
-        delegate.createTable(metastoreContext, table, principalPrivileges);
+        return delegate.createTable(metastoreContext, table, principalPrivileges);
     }
 
     @Override
@@ -292,38 +292,38 @@ public class RecordingHiveMetastore
     }
 
     @Override
-    public void replaceTable(MetastoreContext metastoreContext, String databaseName, String tableName, Table newTable, PrincipalPrivileges principalPrivileges)
+    public MetastoreOperationStats replaceTable(MetastoreContext metastoreContext, String databaseName, String tableName, Table newTable, PrincipalPrivileges principalPrivileges)
     {
         verifyRecordingMode();
-        delegate.replaceTable(metastoreContext, databaseName, tableName, newTable, principalPrivileges);
+        return delegate.replaceTable(metastoreContext, databaseName, tableName, newTable, principalPrivileges);
     }
 
     @Override
-    public void renameTable(MetastoreContext metastoreContext, String databaseName, String tableName, String newDatabaseName, String newTableName)
+    public MetastoreOperationStats renameTable(MetastoreContext metastoreContext, String databaseName, String tableName, String newDatabaseName, String newTableName)
     {
         verifyRecordingMode();
-        delegate.renameTable(metastoreContext, databaseName, tableName, newDatabaseName, newTableName);
+        return delegate.renameTable(metastoreContext, databaseName, tableName, newDatabaseName, newTableName);
     }
 
     @Override
-    public void addColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String columnName, HiveType columnType, String columnComment)
+    public MetastoreOperationStats addColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String columnName, HiveType columnType, String columnComment)
     {
         verifyRecordingMode();
-        delegate.addColumn(metastoreContext, databaseName, tableName, columnName, columnType, columnComment);
+        return delegate.addColumn(metastoreContext, databaseName, tableName, columnName, columnType, columnComment);
     }
 
     @Override
-    public void renameColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String oldColumnName, String newColumnName)
+    public MetastoreOperationStats renameColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String oldColumnName, String newColumnName)
     {
         verifyRecordingMode();
-        delegate.renameColumn(metastoreContext, databaseName, tableName, oldColumnName, newColumnName);
+        return delegate.renameColumn(metastoreContext, databaseName, tableName, oldColumnName, newColumnName);
     }
 
     @Override
-    public void dropColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String columnName)
+    public MetastoreOperationStats dropColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String columnName)
     {
         verifyRecordingMode();
-        delegate.dropColumn(metastoreContext, databaseName, tableName, columnName);
+        return delegate.dropColumn(metastoreContext, databaseName, tableName, columnName);
     }
 
     @Override
@@ -377,10 +377,10 @@ public class RecordingHiveMetastore
     }
 
     @Override
-    public void addPartitions(MetastoreContext metastoreContext, String databaseName, String tableName, List<PartitionWithStatistics> partitions)
+    public MetastoreOperationStats addPartitions(MetastoreContext metastoreContext, String databaseName, String tableName, List<PartitionWithStatistics> partitions)
     {
         verifyRecordingMode();
-        delegate.addPartitions(metastoreContext, databaseName, tableName, partitions);
+        return delegate.addPartitions(metastoreContext, databaseName, tableName, partitions);
     }
 
     @Override
@@ -391,10 +391,10 @@ public class RecordingHiveMetastore
     }
 
     @Override
-    public void alterPartition(MetastoreContext metastoreContext, String databaseName, String tableName, PartitionWithStatistics partition)
+    public MetastoreOperationStats alterPartition(MetastoreContext metastoreContext, String databaseName, String tableName, PartitionWithStatistics partition)
     {
         verifyRecordingMode();
-        delegate.alterPartition(metastoreContext, databaseName, tableName, partition);
+        return delegate.alterPartition(metastoreContext, databaseName, tableName, partition);
     }
 
     @Override

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/SemiTransactionalHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/SemiTransactionalHiveMetastore.java
@@ -24,12 +24,14 @@ import com.facebook.presto.hive.HiveType;
 import com.facebook.presto.hive.LocationHandle.WriteMode;
 import com.facebook.presto.hive.PartitionNotFoundException;
 import com.facebook.presto.hive.TableAlreadyExistsException;
+import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.ErrorCodeSupplier;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.StandardErrorCode;
 import com.facebook.presto.spi.TableNotFoundException;
+import com.facebook.presto.spi.connector.ConnectorCommitHandle;
 import com.facebook.presto.spi.security.PrestoPrincipal;
 import com.facebook.presto.spi.security.PrincipalType;
 import com.facebook.presto.spi.security.RoleGrant;
@@ -47,6 +49,7 @@ import io.airlift.units.Duration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.joda.time.DateTime;
 
 import javax.annotation.concurrent.GuardedBy;
 
@@ -93,6 +96,7 @@ import static com.facebook.presto.spi.ErrorType.USER_ERROR;
 import static com.facebook.presto.spi.StandardErrorCode.ALREADY_EXISTS;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.facebook.presto.spi.StandardErrorCode.TRANSACTION_CONFLICT;
+import static com.facebook.presto.spi.connector.EmptyConnectorCommitHandle.INSTANCE;
 import static com.facebook.presto.spi.security.PrincipalType.USER;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -294,6 +298,7 @@ public class SemiTransactionalHiveMetastore
         if (!table.isPresent()) {
             return new HivePageSinkMetadata(schemaTableName, Optional.empty(), ImmutableMap.of());
         }
+
         Map<List<String>, Action<PartitionAndMore>> partitionActionMap = partitionActions.get(schemaTableName);
         Map<List<String>, Optional<Partition>> modifiedPartitionMap;
         if (partitionActionMap == null) {
@@ -323,36 +328,53 @@ public class SemiTransactionalHiveMetastore
 
     public synchronized void createDatabase(MetastoreContext metastoreContext, Database database)
     {
-        setExclusive((delegate, hdfsEnvironment) -> delegate.createDatabase(metastoreContext, database));
+        setExclusive((delegate, hdfsEnvironment) -> {
+            delegate.createDatabase(metastoreContext, database);
+            return INSTANCE;
+        });
     }
 
     public synchronized void dropDatabase(MetastoreContext metastoreContext, String schemaName)
     {
-        setExclusive((delegate, hdfsEnvironment) -> delegate.dropDatabase(metastoreContext, schemaName));
+        setExclusive((delegate, hdfsEnvironment) -> {
+            delegate.dropDatabase(metastoreContext, schemaName);
+            return INSTANCE;
+        });
     }
 
     public synchronized void renameDatabase(MetastoreContext metastoreContext, String source, String target)
     {
-        setExclusive((delegate, hdfsEnvironment) -> delegate.renameDatabase(metastoreContext, source, target));
+        setExclusive((delegate, hdfsEnvironment) -> {
+            delegate.renameDatabase(metastoreContext, source, target);
+            return INSTANCE;
+        });
     }
 
     // TODO: Allow updating statistics for 2 tables in the same transaction
     public synchronized void setTableStatistics(MetastoreContext metastoreContext, Table table, PartitionStatistics tableStatistics)
     {
-        setExclusive((delegate, hdfsEnvironment) -> delegate.updateTableStatistics(metastoreContext, table.getDatabaseName(), table.getTableName(), statistics -> updatePartitionStatistics(statistics, tableStatistics)));
+        setExclusive((delegate, hdfsEnvironment) -> {
+            delegate.updateTableStatistics(
+                    metastoreContext, table.getDatabaseName(),
+                    table.getTableName(),
+                    statistics -> updatePartitionStatistics(statistics, tableStatistics));
+            return INSTANCE;
+        });
     }
 
     // TODO: Allow updating statistics for 2 tables in the same transaction
     public synchronized void setPartitionStatistics(MetastoreContext metastoreContext, Table table, Map<List<String>, PartitionStatistics> partitionStatisticsMap)
     {
-        setExclusive((delegate, hdfsEnvironment) ->
-                partitionStatisticsMap.forEach((partitionValues, newPartitionStats) ->
-                        delegate.updatePartitionStatistics(
-                                metastoreContext,
-                                table.getDatabaseName(),
-                                table.getTableName(),
-                                getPartitionName(table, partitionValues),
-                                oldPartitionStats -> updatePartitionStatistics(oldPartitionStats, newPartitionStats))));
+        setExclusive((delegate, hdfsEnvironment) -> {
+            partitionStatisticsMap.forEach((partitionValues, newPartitionStats) ->
+                    delegate.updatePartitionStatistics(
+                            metastoreContext,
+                            table.getDatabaseName(),
+                            table.getTableName(),
+                            getPartitionName(table, partitionValues),
+                            oldPartitionStats -> updatePartitionStatistics(oldPartitionStats, newPartitionStats)));
+            return INSTANCE;
+        });
     }
 
     // For HiveBasicStatistics, we only overwrite the original statistics if the new one is not empty.
@@ -433,27 +455,49 @@ public class SemiTransactionalHiveMetastore
 
     public synchronized void replaceView(MetastoreContext metastoreContext, String databaseName, String tableName, Table table, PrincipalPrivileges principalPrivileges)
     {
-        setExclusive((delegate, hdfsEnvironment) -> delegate.replaceTable(metastoreContext, databaseName, tableName, table, principalPrivileges));
+        setExclusive((delegate, hdfsEnvironment) -> {
+            MetastoreOperationStats operationStats = delegate.replaceTable(metastoreContext, databaseName, tableName, table, principalPrivileges);
+            return getCommitResult(databaseName + "." + tableName, operationStats);
+        });
     }
 
     public synchronized void renameTable(MetastoreContext metastoreContext, String databaseName, String tableName, String newDatabaseName, String newTableName)
     {
-        setExclusive((delegate, hdfsEnvironment) -> delegate.renameTable(metastoreContext, databaseName, tableName, newDatabaseName, newTableName));
+        setExclusive((delegate, hdfsEnvironment) -> {
+            MetastoreOperationStats operationStats = delegate.renameTable(metastoreContext, databaseName, tableName, newDatabaseName, newTableName);
+            return getCommitResult(databaseName + "." + tableName, operationStats);
+        });
     }
 
     public synchronized void addColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String columnName, HiveType columnType, String columnComment)
     {
-        setExclusive((delegate, hdfsEnvironment) -> delegate.addColumn(metastoreContext, databaseName, tableName, columnName, columnType, columnComment));
+        setExclusive((delegate, hdfsEnvironment) -> {
+            MetastoreOperationStats operationStats = delegate.addColumn(metastoreContext, databaseName, tableName, columnName, columnType, columnComment);
+            return getCommitResult(databaseName + "." + tableName, operationStats);
+        });
     }
 
     public synchronized void renameColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String oldColumnName, String newColumnName)
     {
-        setExclusive((delegate, hdfsEnvironment) -> delegate.renameColumn(metastoreContext, databaseName, tableName, oldColumnName, newColumnName));
+        setExclusive((delegate, hdfsEnvironment) -> {
+            MetastoreOperationStats operationStats = delegate.renameColumn(metastoreContext, databaseName, tableName, oldColumnName, newColumnName);
+            return getCommitResult(databaseName + "." + tableName, operationStats);
+        });
     }
 
     public synchronized void dropColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String columnName)
     {
-        setExclusive((delegate, hdfsEnvironment) -> delegate.dropColumn(metastoreContext, databaseName, tableName, columnName));
+        setExclusive((delegate, hdfsEnvironment) -> {
+            MetastoreOperationStats operationStats = delegate.dropColumn(metastoreContext, databaseName, tableName, columnName);
+            return getCommitResult(databaseName + "." + tableName, operationStats);
+        });
+    }
+
+    private ConnectorCommitHandle getCommitResult(String resultKey, MetastoreOperationStats operationStats)
+    {
+        Map<String, List<DateTime>> lastDataCommitTimes = new HashMap<>();
+        lastDataCommitTimes.put(resultKey, operationStats.getLastDataCommitTimes());
+        return new HiveCommitHandle(new ConnectorId("Hive"), lastDataCommitTimes);
     }
 
     public synchronized void finishInsertIntoExistingTable(
@@ -539,6 +583,7 @@ public class SemiTransactionalHiveMetastore
                         schemaTableName,
                         recursiveDeleteResult.getNotDeletedEligibleItems()));
             }
+            return INSTANCE;
         });
     }
 
@@ -858,12 +903,18 @@ public class SemiTransactionalHiveMetastore
 
     public synchronized void createRole(MetastoreContext metastoreContext, String role, String grantor)
     {
-        setExclusive((delegate, hdfsEnvironment) -> delegate.createRole(metastoreContext, role, grantor));
+        setExclusive((delegate, hdfsEnvironment) -> {
+            delegate.createRole(metastoreContext, role, grantor);
+            return INSTANCE;
+        });
     }
 
     public synchronized void dropRole(MetastoreContext metastoreContext, String role)
     {
-        setExclusive((delegate, hdfsEnvironment) -> delegate.dropRole(metastoreContext, role));
+        setExclusive((delegate, hdfsEnvironment) -> {
+            delegate.dropRole(metastoreContext, role);
+            return INSTANCE;
+        });
     }
 
     public synchronized Set<String> listRoles(MetastoreContext metastoreContext)
@@ -874,12 +925,18 @@ public class SemiTransactionalHiveMetastore
 
     public synchronized void grantRoles(MetastoreContext metastoreContext, Set<String> roles, Set<PrestoPrincipal> grantees, boolean withAdminOption, PrestoPrincipal grantor)
     {
-        setExclusive((delegate, hdfsEnvironment) -> delegate.grantRoles(metastoreContext, roles, grantees, withAdminOption, grantor));
+        setExclusive((delegate, hdfsEnvironment) -> {
+            delegate.grantRoles(metastoreContext, roles, grantees, withAdminOption, grantor);
+            return INSTANCE;
+        });
     }
 
     public synchronized void revokeRoles(MetastoreContext metastoreContext, Set<String> roles, Set<PrestoPrincipal> grantees, boolean adminOptionFor, PrestoPrincipal grantor)
     {
-        setExclusive((delegate, hdfsEnvironment) -> delegate.revokeRoles(metastoreContext, roles, grantees, adminOptionFor, grantor));
+        setExclusive((delegate, hdfsEnvironment) -> {
+            delegate.revokeRoles(metastoreContext, roles, grantees, adminOptionFor, grantor);
+            return INSTANCE;
+        });
     }
 
     public synchronized Set<RoleGrant> listRoleGrants(MetastoreContext metastoreContext, PrestoPrincipal principal)
@@ -922,12 +979,18 @@ public class SemiTransactionalHiveMetastore
 
     public synchronized void grantTablePrivileges(MetastoreContext metastoreContext, String databaseName, String tableName, PrestoPrincipal grantee, Set<HivePrivilegeInfo> privileges)
     {
-        setExclusive((delegate, hdfsEnvironment) -> delegate.grantTablePrivileges(metastoreContext, databaseName, tableName, grantee, privileges));
+        setExclusive((delegate, hdfsEnvironment) -> {
+            delegate.grantTablePrivileges(metastoreContext, databaseName, tableName, grantee, privileges);
+            return INSTANCE;
+        });
     }
 
     public synchronized void revokeTablePrivileges(MetastoreContext metastoreContext, String databaseName, String tableName, PrestoPrincipal grantee, Set<HivePrivilegeInfo> privileges)
     {
-        setExclusive((delegate, hdfsEnvironment) -> delegate.revokeTablePrivileges(metastoreContext, databaseName, tableName, grantee, privileges));
+        setExclusive((delegate, hdfsEnvironment) -> {
+            delegate.revokeTablePrivileges(metastoreContext, databaseName, tableName, grantee, privileges);
+            return INSTANCE;
+        });
     }
 
     public synchronized void declareIntentionToWrite(
@@ -949,22 +1012,22 @@ public class SemiTransactionalHiveMetastore
         declaredIntentionsToWrite.add(new DeclaredIntentionToWrite(writeMode, context, metastoreContext, stagingPathRoot, tempPathRoot, context.getSession().get().getQueryId(), schemaTableName, temporaryTable));
     }
 
-    public synchronized void commit()
+    public synchronized ConnectorCommitHandle commit()
     {
         try {
             switch (state) {
                 case EMPTY:
-                    break;
+                    return INSTANCE;
                 case SHARED_OPERATION_BUFFERED:
-                    commitShared();
-                    break;
+                    return commitShared();
                 case EXCLUSIVE_OPERATION_BUFFERED:
                     requireNonNull(bufferedExclusiveOperation, "bufferedExclusiveOperation is null");
-                    bufferedExclusiveOperation.execute(delegate, hdfsEnvironment);
-                    break;
+                    return bufferedExclusiveOperation.execute(delegate, hdfsEnvironment);
                 case FINISHED:
+                    log.error("FINISHED");
                     throw new IllegalStateException("Tried to commit buffered metastore operations after transaction has been committed/aborted");
                 default:
+                    log.error("default");
                     throw new IllegalStateException("Unknown state");
             }
         }
@@ -995,7 +1058,7 @@ public class SemiTransactionalHiveMetastore
     }
 
     @GuardedBy("this")
-    private void commitShared()
+    private ConnectorCommitHandle commitShared()
     {
         checkHoldsLock();
 
@@ -1119,6 +1182,8 @@ public class SemiTransactionalHiveMetastore
 
             // The program control flow will go to finally next. And cleanup will run because
             // moveForwardInFinally has been set to false.
+
+            return committer.getCommitHandle();
         }
         finally {
             // In this method, all operations are best-effort clean up operations.
@@ -1605,6 +1670,59 @@ public class SemiTransactionalHiveMetastore
                 PrestoException prestoException = new PrestoException(errorCode, message.toString());
                 suppressedExceptions.forEach(prestoException::addSuppressed);
                 throw prestoException;
+            }
+        }
+
+        public ConnectorCommitHandle getCommitHandle()
+        {
+            HiveCommitHandle commitHandle = new HiveCommitHandle(new ConnectorId("Hive"), new HashMap<>());
+            appendTableCreationResults(commitHandle);
+            appendPartitionCreationResults(commitHandle);
+            appendPartitionAlterationResults(commitHandle);
+            return commitHandle;
+        }
+
+        private void appendTableCreationResults(HiveCommitHandle commitHandle)
+        {
+            for (CreateTableOperation operation : addTableOperations) {
+                if (operation.getOperationStats() == null) {
+                    continue;
+                }
+                commitHandle.addOutputLastDataCommitTimes(
+                        operation.getOperationKey(),
+                        operation.getOperationStats().getLastDataCommitTimes());
+            }
+        }
+
+        private void appendPartitionCreationResults(HiveCommitHandle commitHandle)
+        {
+            for (SchemaTableName schemaTableName : partitionAdders.keySet()) {
+                // For CTAS queries, the commit result may already contain table creation result.
+                if (commitHandle.containOutput(schemaTableName.toString())) {
+                    commitHandle.removeOutput(schemaTableName.toString());
+                }
+
+                PartitionAdder partitionAdder = partitionAdders.get(schemaTableName);
+                if (partitionAdder.getOperationStats() == null) {
+                    continue;
+                }
+
+                for (MetastoreOperationStats operationStats : partitionAdder.getOperationStats()) {
+                    commitHandle.addOutputLastDataCommitTimes(
+                            schemaTableName.toString(), operationStats.getLastDataCommitTimes());
+                }
+            }
+        }
+
+        private void appendPartitionAlterationResults(HiveCommitHandle commitHandle)
+        {
+            for (AlterPartitionOperation operation : alterPartitionOperations) {
+                if (operation.getOperationStats() == null) {
+                    continue;
+                }
+                commitHandle.addOutputLastDataCommitTimes(
+                        operation.getOperationKey(),
+                        operation.getOperationStats().getLastDataCommitTimes());
             }
         }
     }
@@ -2509,6 +2627,7 @@ public class SemiTransactionalHiveMetastore
         private final boolean ignoreExisting;
         private final String queryId;
         private final MetastoreContext metastoreContext;
+        private MetastoreOperationStats operationStats;
 
         public CreateTableOperation(MetastoreContext metastoreContext, Table newTable, PrincipalPrivileges privileges, boolean ignoreExisting)
         {
@@ -2518,6 +2637,7 @@ public class SemiTransactionalHiveMetastore
             this.privileges = requireNonNull(privileges, "privileges is null");
             this.ignoreExisting = ignoreExisting;
             this.queryId = getPrestoQueryId(newTable).orElseThrow(() -> new IllegalArgumentException("Query id is not present"));
+            this.operationStats = null;
         }
 
         public String getDescription()
@@ -2525,11 +2645,22 @@ public class SemiTransactionalHiveMetastore
             return format("add table %s.%s", newTable.getDatabaseName(), newTable.getTableName());
         }
 
+        public MetastoreOperationStats getOperationStats()
+        {
+            return operationStats;
+        }
+
+        public String getOperationKey()
+        {
+            return newTable.getDatabaseName() + "." + newTable.getTableName();
+        }
+
         public void run(ExtendedHiveMetastore metastore)
         {
             boolean done = false;
             try {
-                metastore.createTable(metastoreContext, newTable, privileges);
+                operationStats = metastore.createTable(
+                        metastoreContext, newTable, privileges);
                 done = true;
             }
             catch (RuntimeException e) {
@@ -2595,6 +2726,7 @@ public class SemiTransactionalHiveMetastore
                 return;
             }
             metastore.dropTable(metastoreContext, newTable.getDatabaseName(), newTable.getTableName(), false);
+            operationStats = null;
         }
     }
 
@@ -2604,15 +2736,28 @@ public class SemiTransactionalHiveMetastore
         private final PartitionWithStatistics oldPartition;
         private boolean undo;
         private final MetastoreContext metastoreContext;
+        private MetastoreOperationStats operationStats;
 
         public AlterPartitionOperation(MetastoreContext metastoreContext, PartitionWithStatistics newPartition, PartitionWithStatistics oldPartition)
         {
             this.newPartition = requireNonNull(newPartition, "newPartition is null");
             this.oldPartition = requireNonNull(oldPartition, "oldPartition is null");
             this.metastoreContext = requireNonNull(metastoreContext, "metastoreContext is null");
+            this.operationStats = null;
             checkArgument(newPartition.getPartition().getDatabaseName().equals(oldPartition.getPartition().getDatabaseName()));
             checkArgument(newPartition.getPartition().getTableName().equals(oldPartition.getPartition().getTableName()));
             checkArgument(newPartition.getPartition().getValues().equals(oldPartition.getPartition().getValues()));
+        }
+
+        public MetastoreOperationStats getOperationStats()
+        {
+            return operationStats;
+        }
+
+        public String getOperationKey()
+        {
+            Partition partition = newPartition.getPartition();
+            return partition.getDatabaseName() + "." + partition.getTableName();
         }
 
         public String getDescription()
@@ -2627,7 +2772,11 @@ public class SemiTransactionalHiveMetastore
         public void run(ExtendedHiveMetastore metastore)
         {
             undo = true;
-            metastore.alterPartition(metastoreContext, newPartition.getPartition().getDatabaseName(), newPartition.getPartition().getTableName(), newPartition);
+            operationStats = metastore.alterPartition(
+                    metastoreContext,
+                    newPartition.getPartition().getDatabaseName(),
+                    newPartition.getPartition().getTableName(),
+                    newPartition);
         }
 
         public void undo(ExtendedHiveMetastore metastore)
@@ -2636,6 +2785,7 @@ public class SemiTransactionalHiveMetastore
                 return;
             }
             metastore.alterPartition(metastoreContext, oldPartition.getPartition().getDatabaseName(), oldPartition.getPartition().getTableName(), oldPartition);
+            operationStats = null;
         }
     }
 
@@ -2710,6 +2860,7 @@ public class SemiTransactionalHiveMetastore
         private final List<PartitionWithStatistics> partitions;
         private final MetastoreContext metastoreContext;
         private List<List<String>> createdPartitionValues = new ArrayList<>();
+        private List<MetastoreOperationStats> operationStats;
 
         public PartitionAdder(MetastoreContext metastoreContext, String schemaName, String tableName, ExtendedHiveMetastore metastore, int batchSize)
         {
@@ -2719,6 +2870,12 @@ public class SemiTransactionalHiveMetastore
             this.metastore = metastore;
             this.batchSize = batchSize;
             this.partitions = new ArrayList<>(batchSize);
+            this.operationStats = new ArrayList<>();
+        }
+
+        public List<MetastoreOperationStats> getOperationStats()
+        {
+            return operationStats;
         }
 
         public String getSchemaName()
@@ -2742,7 +2899,7 @@ public class SemiTransactionalHiveMetastore
             List<List<PartitionWithStatistics>> batchedPartitions = Lists.partition(partitions, batchSize);
             for (List<PartitionWithStatistics> batch : batchedPartitions) {
                 try {
-                    metastore.addPartitions(metastoreContext, schemaName, tableName, batch);
+                    operationStats.add(metastore.addPartitions(metastoreContext, schemaName, tableName, batch));
                     for (PartitionWithStatistics partition : batch) {
                         createdPartitionValues.add(partition.getPartition().getValues());
                     }
@@ -2800,6 +2957,7 @@ public class SemiTransactionalHiveMetastore
                     partitionsFailedToRollback.add(createdPartitionValue);
                 }
             }
+            operationStats = ImmutableList.of();
             createdPartitionValues = partitionsFailedToRollback;
             return partitionsFailedToRollback;
         }
@@ -2829,6 +2987,6 @@ public class SemiTransactionalHiveMetastore
 
     private interface ExclusiveOperation
     {
-        void execute(ExtendedHiveMetastore delegate, HdfsEnvironment hdfsEnvironment);
+        ConnectorCommitHandle execute(ExtendedHiveMetastore delegate, HdfsEnvironment hdfsEnvironment);
     }
 }

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/Table.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/Table.java
@@ -17,8 +17,11 @@ import com.facebook.presto.spi.SchemaTableName;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import org.joda.time.DateTime;
 
 import javax.annotation.concurrent.Immutable;
 
@@ -48,6 +51,10 @@ public class Table
     private final Optional<String> viewOriginalText;
     private final Optional<String> viewExpandedText;
 
+    @JsonSerialize(using = CustomDateTimeSerializer.class)
+    @JsonDeserialize(using = CustomDateTimeDeserializer.class)
+    private final Optional<DateTime> lastAccessTime;
+
     @JsonCreator
     public Table(
             @JsonProperty("databaseName") String databaseName,
@@ -59,7 +66,8 @@ public class Table
             @JsonProperty("partitionColumns") List<Column> partitionColumns,
             @JsonProperty("parameters") Map<String, String> parameters,
             @JsonProperty("viewOriginalText") Optional<String> viewOriginalText,
-            @JsonProperty("viewExpandedText") Optional<String> viewExpandedText)
+            @JsonProperty("viewExpandedText") Optional<String> viewExpandedText,
+            @JsonProperty("lastAccessTime") Optional<DateTime> lastAccessTime)
     {
         this.databaseName = requireNonNull(databaseName, "databaseName is null");
         this.tableName = requireNonNull(tableName, "tableName is null");
@@ -71,6 +79,7 @@ public class Table
         this.parameters = ImmutableMap.copyOf(requireNonNull(parameters, "parameters is null"));
         this.viewOriginalText = requireNonNull(viewOriginalText, "viewOriginalText is null");
         this.viewExpandedText = requireNonNull(viewExpandedText, "viewExpandedText is null");
+        this.lastAccessTime = requireNonNull(lastAccessTime, "lastCommitDataTime is null");
     }
 
     @JsonProperty
@@ -146,6 +155,12 @@ public class Table
         return viewExpandedText;
     }
 
+    @JsonProperty
+    public Optional<DateTime> getLastAccessTime()
+    {
+        return lastAccessTime;
+    }
+
     public static Builder builder()
     {
         return new Builder();
@@ -170,6 +185,7 @@ public class Table
                 .add("parameters", parameters)
                 .add("viewOriginalText", viewOriginalText)
                 .add("viewExpandedText", viewExpandedText)
+                .add("lastAccessTime", lastAccessTime)
                 .toString();
     }
 
@@ -193,7 +209,8 @@ public class Table
                 Objects.equals(storage, table.storage) &&
                 Objects.equals(parameters, table.parameters) &&
                 Objects.equals(viewOriginalText, table.viewOriginalText) &&
-                Objects.equals(viewExpandedText, table.viewExpandedText);
+                Objects.equals(viewExpandedText, table.viewExpandedText) &&
+                Objects.equals(lastAccessTime, table.lastAccessTime);
     }
 
     @Override
@@ -209,7 +226,8 @@ public class Table
                 storage,
                 parameters,
                 viewOriginalText,
-                viewExpandedText);
+                viewExpandedText,
+                lastAccessTime);
     }
 
     public static class Builder
@@ -224,6 +242,7 @@ public class Table
         private Map<String, String> parameters = new LinkedHashMap<>();
         private Optional<String> viewOriginalText = Optional.empty();
         private Optional<String> viewExpandedText = Optional.empty();
+        private Optional<DateTime> lastAccessTime = Optional.empty();
 
         private Builder()
         {
@@ -242,6 +261,7 @@ public class Table
             parameters = new LinkedHashMap<>(table.parameters);
             viewOriginalText = table.viewOriginalText;
             viewExpandedText = table.viewExpandedText;
+            lastAccessTime = table.lastAccessTime;
         }
 
         public Builder setDatabaseName(String databaseName)
@@ -315,6 +335,14 @@ public class Table
             return this;
         }
 
+        public Builder setLastAccessTime(Optional<Integer> lastAccessTime)
+        {
+            if (lastAccessTime.isPresent()) {
+                this.lastAccessTime = Optional.of(new DateTime(lastAccessTime.get() * 1000));
+            }
+            return this;
+        }
+
         public Builder withStorage(Consumer<Storage.Builder> consumer)
         {
             consumer.accept(storageBuilder);
@@ -333,7 +361,8 @@ public class Table
                     partitionColumns,
                     parameters,
                     viewOriginalText,
-                    viewExpandedText);
+                    viewExpandedText,
+                    lastAccessTime);
         }
     }
 }

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/alluxio/AlluxioHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/alluxio/AlluxioHiveMetastore.java
@@ -28,6 +28,7 @@ import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
 import com.facebook.presto.hive.metastore.HiveColumnStatistics;
 import com.facebook.presto.hive.metastore.HivePrivilegeInfo;
 import com.facebook.presto.hive.metastore.MetastoreContext;
+import com.facebook.presto.hive.metastore.MetastoreOperationStats;
 import com.facebook.presto.hive.metastore.MetastoreUtil;
 import com.facebook.presto.hive.metastore.Partition;
 import com.facebook.presto.hive.metastore.PartitionNameWithVersion;
@@ -235,7 +236,7 @@ public class AlluxioHiveMetastore
     }
 
     @Override
-    public void createTable(MetastoreContext metastoreContext, Table table, PrincipalPrivileges principalPrivileges)
+    public MetastoreOperationStats createTable(MetastoreContext metastoreContext, Table table, PrincipalPrivileges principalPrivileges)
     {
         throw new UnsupportedOperationException("createTable is not supported in AlluxioHiveMetastore");
     }
@@ -247,31 +248,31 @@ public class AlluxioHiveMetastore
     }
 
     @Override
-    public void replaceTable(MetastoreContext metastoreContext, String databaseName, String tableName, Table newTable, PrincipalPrivileges principalPrivileges)
+    public MetastoreOperationStats replaceTable(MetastoreContext metastoreContext, String databaseName, String tableName, Table newTable, PrincipalPrivileges principalPrivileges)
     {
         throw new UnsupportedOperationException("replaceTable is not supported in AlluxioHiveMetastore");
     }
 
     @Override
-    public void renameTable(MetastoreContext metastoreContext, String databaseName, String tableName, String newDatabaseName, String newTableName)
+    public MetastoreOperationStats renameTable(MetastoreContext metastoreContext, String databaseName, String tableName, String newDatabaseName, String newTableName)
     {
         throw new UnsupportedOperationException("renameTable is not supported in AlluxioHiveMetastore");
     }
 
     @Override
-    public void addColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String columnName, HiveType columnType, String columnComment)
+    public MetastoreOperationStats addColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String columnName, HiveType columnType, String columnComment)
     {
         throw new UnsupportedOperationException("addColumn is not supported in AlluxioHiveMetastore");
     }
 
     @Override
-    public void renameColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String oldColumnName, String newColumnName)
+    public MetastoreOperationStats renameColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String oldColumnName, String newColumnName)
     {
         throw new UnsupportedOperationException("renameColumn is not supported in AlluxioHiveMetastore");
     }
 
     @Override
-    public void dropColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String columnName)
+    public MetastoreOperationStats dropColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String columnName)
     {
         throw new UnsupportedOperationException("dropColumn is not supported in AlluxioHiveMetastore");
     }
@@ -373,7 +374,7 @@ public class AlluxioHiveMetastore
     }
 
     @Override
-    public void addPartitions(MetastoreContext metastoreContext, String databaseName, String tableName, List<PartitionWithStatistics> partitions)
+    public MetastoreOperationStats addPartitions(MetastoreContext metastoreContext, String databaseName, String tableName, List<PartitionWithStatistics> partitions)
     {
         throw new UnsupportedOperationException("addPartitions is not supported in AlluxioHiveMetastore");
     }
@@ -385,7 +386,7 @@ public class AlluxioHiveMetastore
     }
 
     @Override
-    public void alterPartition(MetastoreContext metastoreContext, String databaseName, String tableName, PartitionWithStatistics partition)
+    public MetastoreOperationStats alterPartition(MetastoreContext metastoreContext, String databaseName, String tableName, PartitionWithStatistics partition)
     {
         throw new UnsupportedOperationException("alterPartition is not supported in AlluxioHiveMetastore");
     }

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/file/FileHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/file/FileHiveMetastore.java
@@ -30,6 +30,7 @@ import com.facebook.presto.hive.metastore.HiveColumnStatistics;
 import com.facebook.presto.hive.metastore.HivePrivilegeInfo;
 import com.facebook.presto.hive.metastore.HiveTableName;
 import com.facebook.presto.hive.metastore.MetastoreContext;
+import com.facebook.presto.hive.metastore.MetastoreOperationStats;
 import com.facebook.presto.hive.metastore.MetastoreUtil;
 import com.facebook.presto.hive.metastore.Partition;
 import com.facebook.presto.hive.metastore.PartitionNameWithVersion;
@@ -85,6 +86,7 @@ import static com.facebook.presto.hive.HiveErrorCode.HIVE_METASTORE_ERROR;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_PARTITION_DROPPED_DURING_QUERY;
 import static com.facebook.presto.hive.metastore.HivePrivilegeInfo.HivePrivilege.OWNERSHIP;
 import static com.facebook.presto.hive.metastore.HiveTableName.hiveTableName;
+import static com.facebook.presto.hive.metastore.MetastoreOperationStats.EMPTY_STATS;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.convertPredicateToParts;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.extractPartitionValues;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.getHiveBasicStatistics;
@@ -236,7 +238,7 @@ public class FileHiveMetastore
     }
 
     @Override
-    public synchronized void createTable(MetastoreContext metastoreContext, Table table, PrincipalPrivileges principalPrivileges)
+    public synchronized MetastoreOperationStats createTable(MetastoreContext metastoreContext, Table table, PrincipalPrivileges principalPrivileges)
     {
         checkArgument(!table.getTableType().equals(TEMPORARY_TABLE), "temporary tables must never be committed to the metastore");
 
@@ -286,6 +288,8 @@ public class FileHiveMetastore
         for (Entry<String, Collection<HivePrivilegeInfo>> entry : principalPrivileges.getRolePrivileges().asMap().entrySet()) {
             setTablePrivileges(metastoreContext, new PrestoPrincipal(ROLE, entry.getKey()), table.getDatabaseName(), table.getTableName(), entry.getValue());
         }
+
+        return EMPTY_STATS;
     }
 
     @Override
@@ -442,7 +446,7 @@ public class FileHiveMetastore
     }
 
     @Override
-    public synchronized void replaceTable(MetastoreContext metastoreContext, String databaseName, String tableName, Table newTable, PrincipalPrivileges principalPrivileges)
+    public synchronized MetastoreOperationStats replaceTable(MetastoreContext metastoreContext, String databaseName, String tableName, Table newTable, PrincipalPrivileges principalPrivileges)
     {
         checkArgument(!newTable.getTableType().equals(TEMPORARY_TABLE), "temporary tables must never be stored in the metastore");
 
@@ -466,10 +470,12 @@ public class FileHiveMetastore
         for (Entry<String, Collection<HivePrivilegeInfo>> entry : principalPrivileges.getRolePrivileges().asMap().entrySet()) {
             setTablePrivileges(metastoreContext, new PrestoPrincipal(ROLE, entry.getKey()), table.getDatabaseName(), table.getTableName(), entry.getValue());
         }
+
+        return EMPTY_STATS;
     }
 
     @Override
-    public synchronized void renameTable(MetastoreContext metastoreContext, String databaseName, String tableName, String newDatabaseName, String newTableName)
+    public synchronized MetastoreOperationStats renameTable(MetastoreContext metastoreContext, String databaseName, String tableName, String newDatabaseName, String newTableName)
     {
         requireNonNull(databaseName, "databaseName is null");
         requireNonNull(tableName, "tableName is null");
@@ -493,6 +499,8 @@ public class FileHiveMetastore
         catch (IOException e) {
             throw new PrestoException(HIVE_METASTORE_ERROR, e);
         }
+
+        return EMPTY_STATS;
     }
 
     private static boolean isIcebergTable(Map<String, String> parameters)
@@ -501,7 +509,7 @@ public class FileHiveMetastore
     }
 
     @Override
-    public synchronized void addColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String columnName, HiveType columnType, String columnComment)
+    public synchronized MetastoreOperationStats addColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String columnName, HiveType columnType, String columnComment)
     {
         alterTable(databaseName, tableName, oldTable -> {
             if (oldTable.getColumn(columnName).isPresent()) {
@@ -513,10 +521,12 @@ public class FileHiveMetastore
                     .add(new Column(columnName, columnType, Optional.ofNullable(columnComment), Optional.empty()))
                     .build());
         });
+
+        return EMPTY_STATS;
     }
 
     @Override
-    public synchronized void renameColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String oldColumnName, String newColumnName)
+    public synchronized MetastoreOperationStats renameColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String oldColumnName, String newColumnName)
     {
         alterTable(databaseName, tableName, oldTable -> {
             if (oldTable.getColumn(newColumnName).isPresent()) {
@@ -544,10 +554,12 @@ public class FileHiveMetastore
 
             return oldTable.withDataColumns(newDataColumns.build());
         });
+
+        return EMPTY_STATS;
     }
 
     @Override
-    public synchronized void dropColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String columnName)
+    public synchronized MetastoreOperationStats dropColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String columnName)
     {
         alterTable(databaseName, tableName, oldTable -> {
             verifyCanDropColumn(this, metastoreContext, databaseName, tableName, columnName);
@@ -565,6 +577,8 @@ public class FileHiveMetastore
 
             return oldTable.withDataColumns(newDataColumns.build());
         });
+
+        return EMPTY_STATS;
     }
 
     private void alterTable(String databaseName, String tableName, Function<TableMetadata, TableMetadata> alterFunction)
@@ -585,7 +599,7 @@ public class FileHiveMetastore
     }
 
     @Override
-    public synchronized void addPartitions(MetastoreContext metastoreContext, String databaseName, String tableName, List<PartitionWithStatistics> partitions)
+    public synchronized MetastoreOperationStats addPartitions(MetastoreContext metastoreContext, String databaseName, String tableName, List<PartitionWithStatistics> partitions)
     {
         requireNonNull(databaseName, "databaseName is null");
         requireNonNull(tableName, "tableName is null");
@@ -620,6 +634,7 @@ public class FileHiveMetastore
                         throw new PrestoException(HIVE_METASTORE_ERROR, "Could not write partition schema", e);
                     }
                 }
+                return EMPTY_STATS;
             }
             catch (Throwable e) {
                 for (Path createdFile : createdFiles) {
@@ -689,7 +704,7 @@ public class FileHiveMetastore
     }
 
     @Override
-    public synchronized void alterPartition(MetastoreContext metastoreContext, String databaseName, String tableName, PartitionWithStatistics partitionWithStatistics)
+    public synchronized MetastoreOperationStats alterPartition(MetastoreContext metastoreContext, String databaseName, String tableName, PartitionWithStatistics partitionWithStatistics)
     {
         Table table = getRequiredTable(metastoreContext, databaseName, tableName);
 
@@ -698,6 +713,8 @@ public class FileHiveMetastore
 
         Path partitionMetadataDirectory = getPartitionMetadataDirectory(table, partition.getValues());
         writeSchemaFile("partition", partitionMetadataDirectory, partitionCodec, new PartitionMetadata(table, partitionWithStatistics), true);
+
+        return EMPTY_STATS;
     }
 
     @Override

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/file/PartitionMetadata.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/file/PartitionMetadata.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import org.joda.time.DateTime;
 
 import java.util.Arrays;
 import java.util.List;
@@ -198,6 +199,7 @@ public class PartitionMetadata
                 Optional.empty(),
                 eligibleToIgnore,
                 sealedPartition,
-                0);
+                0,
+                new DateTime(0));
     }
 }

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/file/TableMetadata.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/file/TableMetadata.java
@@ -294,6 +294,7 @@ public class TableMetadata
                 partitionColumns,
                 parameters,
                 viewOriginalText,
-                viewExpandedText);
+                viewExpandedText,
+                Optional.empty());
     }
 }

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/glue/GlueHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/glue/GlueHiveMetastore.java
@@ -72,6 +72,7 @@ import com.facebook.presto.hive.metastore.Database;
 import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
 import com.facebook.presto.hive.metastore.HivePrivilegeInfo;
 import com.facebook.presto.hive.metastore.MetastoreContext;
+import com.facebook.presto.hive.metastore.MetastoreOperationStats;
 import com.facebook.presto.hive.metastore.MetastoreUtil;
 import com.facebook.presto.hive.metastore.Partition;
 import com.facebook.presto.hive.metastore.PartitionNameWithVersion;
@@ -119,6 +120,7 @@ import java.util.function.Function;
 
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_METASTORE_ERROR;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_PARTITION_DROPPED_DURING_QUERY;
+import static com.facebook.presto.hive.metastore.MetastoreOperationStats.EMPTY_STATS;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.convertPredicateToParts;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.createDirectory;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.getHiveBasicStatistics;
@@ -497,7 +499,7 @@ public class GlueHiveMetastore
     }
 
     @Override
-    public void createTable(MetastoreContext metastoreContext, Table table, PrincipalPrivileges principalPrivileges)
+    public MetastoreOperationStats createTable(MetastoreContext metastoreContext, Table table, PrincipalPrivileges principalPrivileges)
     {
         try {
             TableInput input = GlueInputConverter.convertTable(table);
@@ -515,6 +517,8 @@ public class GlueHiveMetastore
         catch (AmazonServiceException e) {
             throw new PrestoException(HIVE_METASTORE_ERROR, e);
         }
+
+        return EMPTY_STATS;
     }
 
     @Override
@@ -555,7 +559,7 @@ public class GlueHiveMetastore
     }
 
     @Override
-    public void replaceTable(MetastoreContext metastoreContext, String databaseName, String tableName, Table newTable, PrincipalPrivileges principalPrivileges)
+    public MetastoreOperationStats replaceTable(MetastoreContext metastoreContext, String databaseName, String tableName, Table newTable, PrincipalPrivileges principalPrivileges)
     {
         try {
             TableInput newTableInput = GlueInputConverter.convertTable(newTable);
@@ -563,6 +567,8 @@ public class GlueHiveMetastore
                     .withCatalogId(catalogId)
                     .withDatabaseName(databaseName)
                     .withTableInput(newTableInput)));
+
+            return EMPTY_STATS;
         }
         catch (EntityNotFoundException e) {
             throw new TableNotFoundException(new SchemaTableName(databaseName, tableName));
@@ -573,13 +579,13 @@ public class GlueHiveMetastore
     }
 
     @Override
-    public void renameTable(MetastoreContext metastoreContext, String databaseName, String tableName, String newDatabaseName, String newTableName)
+    public MetastoreOperationStats renameTable(MetastoreContext metastoreContext, String databaseName, String tableName, String newDatabaseName, String newTableName)
     {
         throw new PrestoException(NOT_SUPPORTED, "Table rename is not yet supported by Glue service");
     }
 
     @Override
-    public void addColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String columnName, HiveType columnType, String columnComment)
+    public MetastoreOperationStats addColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String columnName, HiveType columnType, String columnComment)
     {
         com.amazonaws.services.glue.model.Table table = getGlueTableOrElseThrow(databaseName, tableName);
         ImmutableList.Builder<com.amazonaws.services.glue.model.Column> newDataColumns = ImmutableList.builder();
@@ -587,10 +593,11 @@ public class GlueHiveMetastore
         newDataColumns.add(convertColumn(new Column(columnName, columnType, Optional.ofNullable(columnComment), Optional.empty())));
         table.getStorageDescriptor().setColumns(newDataColumns.build());
         replaceGlueTable(databaseName, tableName, table);
+        return EMPTY_STATS;
     }
 
     @Override
-    public void renameColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String oldColumnName, String newColumnName)
+    public MetastoreOperationStats renameColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String oldColumnName, String newColumnName)
     {
         com.amazonaws.services.glue.model.Table table = getGlueTableOrElseThrow(databaseName, tableName);
         if (table.getPartitionKeys() != null && table.getPartitionKeys().stream().anyMatch(c -> c.getName().equals(oldColumnName))) {
@@ -610,10 +617,11 @@ public class GlueHiveMetastore
         }
         table.getStorageDescriptor().setColumns(newDataColumns.build());
         replaceGlueTable(databaseName, tableName, table);
+        return EMPTY_STATS;
     }
 
     @Override
-    public void dropColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String columnName)
+    public MetastoreOperationStats dropColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String columnName)
     {
         verifyCanDropColumn(this, metastoreContext, databaseName, tableName, columnName);
         com.amazonaws.services.glue.model.Table table = getGlueTableOrElseThrow(databaseName, tableName);
@@ -636,6 +644,8 @@ public class GlueHiveMetastore
 
         table.getStorageDescriptor().setColumns(newDataColumns.build());
         replaceGlueTable(databaseName, tableName, table);
+
+        return EMPTY_STATS;
     }
 
     private void replaceGlueTable(String databaseName, String tableName, com.amazonaws.services.glue.model.Table newTable)
@@ -849,7 +859,7 @@ public class GlueHiveMetastore
     }
 
     @Override
-    public void addPartitions(MetastoreContext metastoreContext, String databaseName, String tableName, List<PartitionWithStatistics> partitions)
+    public MetastoreOperationStats addPartitions(MetastoreContext metastoreContext, String databaseName, String tableName, List<PartitionWithStatistics> partitions)
     {
         try {
             List<Future<BatchCreatePartitionResult>> futures = new ArrayList<>();
@@ -867,6 +877,8 @@ public class GlueHiveMetastore
                 BatchCreatePartitionResult result = future.get();
                 propagatePartitionErrorToPrestoException(databaseName, tableName, result.getErrors());
             }
+
+            return EMPTY_STATS;
         }
         catch (AmazonServiceException | InterruptedException | ExecutionException e) {
             if (e instanceof InterruptedException) {
@@ -918,7 +930,7 @@ public class GlueHiveMetastore
     }
 
     @Override
-    public void alterPartition(MetastoreContext metastoreContext, String databaseName, String tableName, PartitionWithStatistics partition)
+    public MetastoreOperationStats alterPartition(MetastoreContext metastoreContext, String databaseName, String tableName, PartitionWithStatistics partition)
     {
         try {
             PartitionInput newPartition = GlueInputConverter.convertPartition(partition);
@@ -928,6 +940,8 @@ public class GlueHiveMetastore
                     .withTableName(tableName)
                     .withPartitionInput(newPartition)
                     .withPartitionValueList(partition.getPartition().getValues())));
+
+            return EMPTY_STATS;
         }
         catch (EntityNotFoundException e) {
             throw new PartitionNotFoundException(new SchemaTableName(databaseName, tableName), partition.getPartition().getValues());

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/BridgingHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/BridgingHiveMetastore.java
@@ -22,6 +22,7 @@ import com.facebook.presto.hive.metastore.Database;
 import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
 import com.facebook.presto.hive.metastore.HivePrivilegeInfo;
 import com.facebook.presto.hive.metastore.MetastoreContext;
+import com.facebook.presto.hive.metastore.MetastoreOperationStats;
 import com.facebook.presto.hive.metastore.MetastoreUtil;
 import com.facebook.presto.hive.metastore.Partition;
 import com.facebook.presto.hive.metastore.PartitionNameWithVersion;
@@ -168,10 +169,10 @@ public class BridgingHiveMetastore
     }
 
     @Override
-    public void createTable(MetastoreContext metastoreContext, Table table, PrincipalPrivileges principalPrivileges)
+    public MetastoreOperationStats createTable(MetastoreContext metastoreContext, Table table, PrincipalPrivileges principalPrivileges)
     {
         checkArgument(!table.getTableType().equals(TEMPORARY_TABLE), "temporary tables must never be stored in the metastore");
-        delegate.createTable(metastoreContext, toMetastoreApiTable(table, principalPrivileges, metastoreContext.getColumnConverter()));
+        return delegate.createTable(metastoreContext, toMetastoreApiTable(table, principalPrivileges, metastoreContext.getColumnConverter()));
     }
 
     @Override
@@ -181,14 +182,14 @@ public class BridgingHiveMetastore
     }
 
     @Override
-    public void replaceTable(MetastoreContext metastoreContext, String databaseName, String tableName, Table newTable, PrincipalPrivileges principalPrivileges)
+    public MetastoreOperationStats replaceTable(MetastoreContext metastoreContext, String databaseName, String tableName, Table newTable, PrincipalPrivileges principalPrivileges)
     {
         checkArgument(!newTable.getTableType().equals(TEMPORARY_TABLE), "temporary tables must never be stored in the metastore");
-        alterTable(metastoreContext, databaseName, tableName, toMetastoreApiTable(newTable, principalPrivileges, metastoreContext.getColumnConverter()));
+        return alterTable(metastoreContext, databaseName, tableName, toMetastoreApiTable(newTable, principalPrivileges, metastoreContext.getColumnConverter()));
     }
 
     @Override
-    public void renameTable(MetastoreContext metastoreContext, String databaseName, String tableName, String newDatabaseName, String newTableName)
+    public MetastoreOperationStats renameTable(MetastoreContext metastoreContext, String databaseName, String tableName, String newDatabaseName, String newTableName)
     {
         Optional<org.apache.hadoop.hive.metastore.api.Table> source = delegate.getTable(metastoreContext, databaseName, tableName);
         if (!source.isPresent()) {
@@ -197,11 +198,11 @@ public class BridgingHiveMetastore
         org.apache.hadoop.hive.metastore.api.Table table = source.get();
         table.setDbName(newDatabaseName);
         table.setTableName(newTableName);
-        alterTable(metastoreContext, databaseName, tableName, table);
+        return alterTable(metastoreContext, databaseName, tableName, table);
     }
 
     @Override
-    public void addColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String columnName, HiveType columnType, String columnComment)
+    public MetastoreOperationStats addColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String columnName, HiveType columnType, String columnComment)
     {
         Optional<org.apache.hadoop.hive.metastore.api.Table> source = delegate.getTable(metastoreContext, databaseName, tableName);
         if (!source.isPresent()) {
@@ -210,11 +211,11 @@ public class BridgingHiveMetastore
         org.apache.hadoop.hive.metastore.api.Table table = source.get();
         Column column = new Column(columnName, columnType, Optional.ofNullable(columnComment), Optional.empty());
         table.getSd().getCols().add(metastoreContext.getColumnConverter().fromColumn(column));
-        alterTable(metastoreContext, databaseName, tableName, table);
+        return alterTable(metastoreContext, databaseName, tableName, table);
     }
 
     @Override
-    public void renameColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String oldColumnName, String newColumnName)
+    public MetastoreOperationStats renameColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String oldColumnName, String newColumnName)
     {
         Optional<org.apache.hadoop.hive.metastore.api.Table> source = delegate.getTable(metastoreContext, databaseName, tableName);
         if (!source.isPresent()) {
@@ -231,22 +232,22 @@ public class BridgingHiveMetastore
                 fieldSchema.setName(newColumnName);
             }
         }
-        alterTable(metastoreContext, databaseName, tableName, table);
+        return alterTable(metastoreContext, databaseName, tableName, table);
     }
 
     @Override
-    public void dropColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String columnName)
+    public MetastoreOperationStats dropColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String columnName)
     {
         verifyCanDropColumn(this, metastoreContext, databaseName, tableName, columnName);
         org.apache.hadoop.hive.metastore.api.Table table = delegate.getTable(metastoreContext, databaseName, tableName)
                 .orElseThrow(() -> new TableNotFoundException(new SchemaTableName(databaseName, tableName)));
         table.getSd().getCols().removeIf(fieldSchema -> fieldSchema.getName().equals(columnName));
-        alterTable(metastoreContext, databaseName, tableName, table);
+        return alterTable(metastoreContext, databaseName, tableName, table);
     }
 
-    private void alterTable(MetastoreContext metastoreContext, String databaseName, String tableName, org.apache.hadoop.hive.metastore.api.Table table)
+    private MetastoreOperationStats alterTable(MetastoreContext metastoreContext, String databaseName, String tableName, org.apache.hadoop.hive.metastore.api.Table table)
     {
-        delegate.alterTable(metastoreContext, databaseName, tableName, table);
+        return delegate.alterTable(metastoreContext, databaseName, tableName, table);
     }
 
     @Override
@@ -302,9 +303,9 @@ public class BridgingHiveMetastore
     }
 
     @Override
-    public void addPartitions(MetastoreContext metastoreContext, String databaseName, String tableName, List<PartitionWithStatistics> partitions)
+    public MetastoreOperationStats addPartitions(MetastoreContext metastoreContext, String databaseName, String tableName, List<PartitionWithStatistics> partitions)
     {
-        delegate.addPartitions(metastoreContext, databaseName, tableName, partitions);
+        return delegate.addPartitions(metastoreContext, databaseName, tableName, partitions);
     }
 
     @Override
@@ -314,9 +315,9 @@ public class BridgingHiveMetastore
     }
 
     @Override
-    public void alterPartition(MetastoreContext metastoreContext, String databaseName, String tableName, PartitionWithStatistics partition)
+    public MetastoreOperationStats alterPartition(MetastoreContext metastoreContext, String databaseName, String tableName, PartitionWithStatistics partition)
     {
-        delegate.alterPartition(metastoreContext, databaseName, tableName, partition);
+        return delegate.alterPartition(metastoreContext, databaseName, tableName, partition);
     }
 
     @Override

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/HiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/HiveMetastore.java
@@ -18,6 +18,7 @@ import com.facebook.presto.common.type.Type;
 import com.facebook.presto.hive.metastore.Column;
 import com.facebook.presto.hive.metastore.HivePrivilegeInfo;
 import com.facebook.presto.hive.metastore.MetastoreContext;
+import com.facebook.presto.hive.metastore.MetastoreOperationStats;
 import com.facebook.presto.hive.metastore.PartitionNameWithVersion;
 import com.facebook.presto.hive.metastore.PartitionStatistics;
 import com.facebook.presto.hive.metastore.PartitionWithStatistics;
@@ -49,11 +50,11 @@ public interface HiveMetastore
 
     void alterDatabase(MetastoreContext metastoreContext, String databaseName, Database database);
 
-    void createTable(MetastoreContext metastoreContext, Table table);
+    MetastoreOperationStats createTable(MetastoreContext metastoreContext, Table table);
 
     void dropTable(MetastoreContext metastoreContext, String databaseName, String tableName, boolean deleteData);
 
-    void alterTable(MetastoreContext metastoreContext, String databaseName, String tableName, Table table);
+    MetastoreOperationStats alterTable(MetastoreContext metastoreContext, String databaseName, String tableName, Table table);
 
     List<String> getAllDatabases(MetastoreContext metastoreContext);
 
@@ -63,11 +64,19 @@ public interface HiveMetastore
 
     Optional<Database> getDatabase(MetastoreContext metastoreContext, String databaseName);
 
-    void addPartitions(MetastoreContext metastoreContext, String databaseName, String tableName, List<PartitionWithStatistics> partitions);
+    MetastoreOperationStats addPartitions(
+            MetastoreContext metastoreContext,
+            String databaseName,
+            String tableName,
+            List<PartitionWithStatistics> partitions);
 
     void dropPartition(MetastoreContext metastoreContext, String databaseName, String tableName, List<String> parts, boolean deleteData);
 
-    void alterPartition(MetastoreContext metastoreContext, String databaseName, String tableName, PartitionWithStatistics partition);
+    MetastoreOperationStats alterPartition(
+            MetastoreContext metastoreContext,
+            String databaseName,
+            String tableName,
+            PartitionWithStatistics partition);
 
     Optional<List<String>> getPartitionNames(MetastoreContext metastoreContext, String databaseName, String tableName);
 
@@ -80,11 +89,22 @@ public interface HiveMetastore
         throw new UnsupportedOperationException();
     }
 
-    Optional<Partition> getPartition(MetastoreContext metastoreContext, String databaseName, String tableName, List<String> partitionValues);
+    Optional<Partition> getPartition(
+            MetastoreContext metastoreContext,
+            String databaseName,
+            String tableName,
+            List<String> partitionValues);
 
-    List<Partition> getPartitionsByNames(MetastoreContext metastoreContext, String databaseName, String tableName, List<String> partitionNames);
+    List<Partition> getPartitionsByNames(
+            MetastoreContext metastoreContext,
+            String databaseName,
+            String tableName,
+            List<String> partitionNames);
 
-    Optional<Table> getTable(MetastoreContext metastoreContext, String databaseName, String tableName);
+    Optional<Table> getTable(
+            MetastoreContext metastoreContext,
+            String databaseName,
+            String tableName);
 
     Set<ColumnStatisticType> getSupportedColumnStatistics(MetastoreContext metastoreContext, Type type);
 

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftHiveMetastore.java
@@ -30,6 +30,7 @@ import com.facebook.presto.hive.metastore.Column;
 import com.facebook.presto.hive.metastore.HiveColumnStatistics;
 import com.facebook.presto.hive.metastore.HivePrivilegeInfo;
 import com.facebook.presto.hive.metastore.MetastoreContext;
+import com.facebook.presto.hive.metastore.MetastoreOperationStats;
 import com.facebook.presto.hive.metastore.PartitionStatistics;
 import com.facebook.presto.hive.metastore.PartitionWithStatistics;
 import com.facebook.presto.spi.PrestoException;
@@ -101,6 +102,7 @@ import static com.facebook.presto.hive.HiveBasicStatistics.createEmptyStatistics
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_METASTORE_ERROR;
 import static com.facebook.presto.hive.metastore.HivePrivilegeInfo.HivePrivilege;
 import static com.facebook.presto.hive.metastore.HivePrivilegeInfo.HivePrivilege.OWNERSHIP;
+import static com.facebook.presto.hive.metastore.MetastoreOperationStats.EMPTY_STATS;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.PRESTO_VIEW_FLAG;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.convertPredicateToParts;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.getHiveBasicStatistics;
@@ -843,7 +845,7 @@ public class ThriftHiveMetastore
     }
 
     @Override
-    public void createTable(MetastoreContext metastoreContext, Table table)
+    public MetastoreOperationStats createTable(MetastoreContext metastoreContext, Table table)
     {
         try {
             retry()
@@ -854,6 +856,8 @@ public class ThriftHiveMetastore
                                 client.createTable(table);
                                 return null;
                             })));
+
+            return EMPTY_STATS;
         }
         catch (AlreadyExistsException e) {
             throw new TableAlreadyExistsException(new SchemaTableName(table.getDbName(), table.getTableName()));
@@ -894,7 +898,7 @@ public class ThriftHiveMetastore
     }
 
     @Override
-    public void alterTable(MetastoreContext metastoreContext, String databaseName, String tableName, Table table)
+    public MetastoreOperationStats alterTable(MetastoreContext metastoreContext, String databaseName, String tableName, Table table)
     {
         try {
             retry()
@@ -909,6 +913,7 @@ public class ThriftHiveMetastore
                                 client.alterTable(databaseName, tableName, table);
                                 return null;
                             })));
+            return EMPTY_STATS;
         }
         catch (NoSuchObjectException e) {
             throw new TableNotFoundException(new SchemaTableName(databaseName, tableName));
@@ -971,7 +976,8 @@ public class ThriftHiveMetastore
     }
 
     @Override
-    public void addPartitions(MetastoreContext metastoreContext, String databaseName, String tableName, List<PartitionWithStatistics> partitionsWithStatistics)
+    public MetastoreOperationStats addPartitions(
+            MetastoreContext metastoreContext, String databaseName, String tableName, List<PartitionWithStatistics> partitionsWithStatistics)
     {
         List<Partition> partitions = partitionsWithStatistics.stream()
                 .map(part -> ThriftMetastoreUtil.toMetastoreApiPartition(part, metastoreContext.getColumnConverter()))
@@ -980,6 +986,7 @@ public class ThriftHiveMetastore
         for (PartitionWithStatistics partitionWithStatistics : partitionsWithStatistics) {
             storePartitionColumnStatistics(metastoreContext, databaseName, tableName, partitionWithStatistics.getPartitionName(), partitionWithStatistics);
         }
+        return EMPTY_STATS;
     }
 
     private void addPartitionsWithoutStatistics(MetastoreContext metastoreContext, String databaseName, String tableName, List<Partition> partitions)
@@ -1064,11 +1071,13 @@ public class ThriftHiveMetastore
     }
 
     @Override
-    public void alterPartition(MetastoreContext metastoreContext, String databaseName, String tableName, PartitionWithStatistics partitionWithStatistics)
+    public MetastoreOperationStats alterPartition(MetastoreContext metastoreContext, String databaseName, String tableName, PartitionWithStatistics partitionWithStatistics)
     {
         alterPartitionWithoutStatistics(metastoreContext, databaseName, tableName, toMetastoreApiPartition(partitionWithStatistics, metastoreContext.getColumnConverter()));
         storePartitionColumnStatistics(metastoreContext, databaseName, tableName, partitionWithStatistics.getPartitionName(), partitionWithStatistics);
         dropExtraColumnStatisticsAfterAlterPartition(metastoreContext, databaseName, tableName, partitionWithStatistics);
+
+        return EMPTY_STATS;
     }
 
     private void alterPartitionWithoutStatistics(MetastoreContext metastoreContext, String databaseName, String tableName, Partition partition)

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftMetastoreUtil.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftMetastoreUtil.java
@@ -439,7 +439,8 @@ public final class ThriftMetastoreUtil
                         .collect(toList()))
                 .setParameters(table.getParameters() == null ? ImmutableMap.of() : table.getParameters())
                 .setViewOriginalText(Optional.ofNullable(emptyToNull(table.getViewOriginalText())))
-                .setViewExpandedText(Optional.ofNullable(emptyToNull(table.getViewExpandedText())));
+                .setViewExpandedText(Optional.ofNullable(emptyToNull(table.getViewExpandedText())))
+                .setLastAccessTime(Optional.ofNullable(table.getLastAccessTime()));
 
         fromMetastoreApiStorageDescriptor(storageDescriptor, tableBuilder.getStorageBuilder(), table.getTableName());
 
@@ -493,7 +494,8 @@ public final class ThriftMetastoreUtil
                         .map(fieldSchema -> columnConverter.toColumn(fieldSchema))
                         .collect(toList()))
                 .setParameters(partition.getParameters())
-                .setCreateTime(partition.getCreateTime());
+                .setCreateTime(partition.getCreateTime())
+                .setLastAccessTime(partition.getLastAccessTime());
 
         // mutate apache partition to Presto partition
         partitionMutator.mutate(partitionBuilder, partition);

--- a/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/TestRecordingHiveMetastore.java
+++ b/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/TestRecordingHiveMetastore.java
@@ -89,7 +89,8 @@ public class TestRecordingHiveMetastore
             ImmutableList.of(TABLE_COLUMN),
             ImmutableMap.of("param", "value3"),
             Optional.of("original_text"),
-            Optional.of("expanded_text"));
+            Optional.of("expanded_text"),
+            Optional.empty());
     private static final Partition PARTITION = new Partition(
             "database",
             "table",
@@ -100,7 +101,8 @@ public class TestRecordingHiveMetastore
             Optional.empty(),
             false,
             true,
-            0);
+            0,
+            null);
     private static final PartitionStatistics PARTITION_STATISTICS = new PartitionStatistics(
             new HiveBasicStatistics(10, 11, 10000, 10001),
             ImmutableMap.of("column", new HiveColumnStatistics(

--- a/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/UnimplementedHiveMetastore.java
+++ b/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/UnimplementedHiveMetastore.java
@@ -109,7 +109,7 @@ public class UnimplementedHiveMetastore
     }
 
     @Override
-    public void createTable(MetastoreContext metastoreContext, Table table, PrincipalPrivileges principalPrivileges)
+    public MetastoreOperationStats createTable(MetastoreContext metastoreContext, Table table, PrincipalPrivileges principalPrivileges)
     {
         throw new UnsupportedOperationException();
     }
@@ -121,31 +121,31 @@ public class UnimplementedHiveMetastore
     }
 
     @Override
-    public void replaceTable(MetastoreContext metastoreContext, String databaseName, String tableName, Table newTable, PrincipalPrivileges principalPrivileges)
+    public MetastoreOperationStats replaceTable(MetastoreContext metastoreContext, String databaseName, String tableName, Table newTable, PrincipalPrivileges principalPrivileges)
     {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void renameTable(MetastoreContext metastoreContext, String databaseName, String tableName, String newDatabaseName, String newTableName)
+    public MetastoreOperationStats renameTable(MetastoreContext metastoreContext, String databaseName, String tableName, String newDatabaseName, String newTableName)
     {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void addColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String columnName, HiveType columnType, String columnComment)
+    public MetastoreOperationStats addColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String columnName, HiveType columnType, String columnComment)
     {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void renameColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String oldColumnName, String newColumnName)
+    public MetastoreOperationStats renameColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String oldColumnName, String newColumnName)
     {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public void dropColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String columnName)
+    public MetastoreOperationStats dropColumn(MetastoreContext metastoreContext, String databaseName, String tableName, String columnName)
     {
         throw new UnsupportedOperationException();
     }
@@ -189,7 +189,7 @@ public class UnimplementedHiveMetastore
     }
 
     @Override
-    public void addPartitions(MetastoreContext metastoreContext, String databaseName, String tableName, List<PartitionWithStatistics> partitions)
+    public MetastoreOperationStats addPartitions(MetastoreContext metastoreContext, String databaseName, String tableName, List<PartitionWithStatistics> partitions)
     {
         throw new UnsupportedOperationException();
     }
@@ -201,7 +201,7 @@ public class UnimplementedHiveMetastore
     }
 
     @Override
-    public void alterPartition(MetastoreContext metastoreContext, String databaseName, String tableName, PartitionWithStatistics partition)
+    public MetastoreOperationStats alterPartition(MetastoreContext metastoreContext, String databaseName, String tableName, PartitionWithStatistics partition)
     {
         throw new UnsupportedOperationException();
     }

--- a/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/thrift/InMemoryHiveMetastore.java
+++ b/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/thrift/InMemoryHiveMetastore.java
@@ -20,6 +20,7 @@ import com.facebook.presto.hive.TableAlreadyExistsException;
 import com.facebook.presto.hive.metastore.Column;
 import com.facebook.presto.hive.metastore.HivePrivilegeInfo;
 import com.facebook.presto.hive.metastore.MetastoreContext;
+import com.facebook.presto.hive.metastore.MetastoreOperationStats;
 import com.facebook.presto.hive.metastore.MetastoreUtil;
 import com.facebook.presto.hive.metastore.PartitionStatistics;
 import com.facebook.presto.hive.metastore.PartitionWithStatistics;
@@ -57,6 +58,7 @@ import java.util.Set;
 import java.util.function.Function;
 
 import static com.facebook.presto.hive.HiveBasicStatistics.createEmptyStatistics;
+import static com.facebook.presto.hive.metastore.MetastoreOperationStats.EMPTY_STATS;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.convertPredicateToParts;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.toPartitionValues;
 import static com.facebook.presto.hive.metastore.thrift.ThriftMetastoreUtil.toMetastoreApiPartition;
@@ -170,7 +172,7 @@ public class InMemoryHiveMetastore
     }
 
     @Override
-    public synchronized void createTable(MetastoreContext metastoreContext, Table table)
+    public synchronized MetastoreOperationStats createTable(MetastoreContext metastoreContext, Table table)
     {
         TableType tableType = TableType.valueOf(table.getTableType());
         checkArgument(EnumSet.of(MANAGED_TABLE, EXTERNAL_TABLE, VIRTUAL_VIEW).contains(tableType), "Invalid table type: %s", tableType);
@@ -201,6 +203,8 @@ public class InMemoryHiveMetastore
         if (privileges != null) {
             throw new UnsupportedOperationException();
         }
+
+        return EMPTY_STATS;
     }
 
     @Override
@@ -251,7 +255,7 @@ public class InMemoryHiveMetastore
     }
 
     @Override
-    public synchronized void alterTable(MetastoreContext metastoreContext, String databaseName, String tableName, Table newTable)
+    public synchronized MetastoreOperationStats alterTable(MetastoreContext metastoreContext, String databaseName, String tableName, Table newTable)
     {
         SchemaTableName oldName = new SchemaTableName(databaseName, tableName);
         SchemaTableName newName = new SchemaTableName(newTable.getDbName(), newTable.getTableName());
@@ -261,7 +265,7 @@ public class InMemoryHiveMetastore
             if (relations.replace(oldName, newTable) == null) {
                 throw new TableNotFoundException(oldName);
             }
-            return;
+            return EMPTY_STATS;
         }
 
         // remove old table definition and add the new one
@@ -274,6 +278,8 @@ public class InMemoryHiveMetastore
             throw new TableAlreadyExistsException(newName);
         }
         relations.remove(oldName);
+
+        return EMPTY_STATS;
     }
 
     @Override
@@ -307,13 +313,15 @@ public class InMemoryHiveMetastore
     }
 
     @Override
-    public synchronized void addPartitions(MetastoreContext metastoreContext, String databaseName, String tableName, List<PartitionWithStatistics> partitionsWithStatistics)
+    public synchronized MetastoreOperationStats addPartitions(MetastoreContext metastoreContext, String databaseName, String tableName, List<PartitionWithStatistics> partitionsWithStatistics)
     {
         for (PartitionWithStatistics partitionWithStatistics : partitionsWithStatistics) {
             PartitionName partitionKey = PartitionName.partition(databaseName, tableName, partitionWithStatistics.getPartitionName());
             partitions.put(partitionKey, partitionWithStatistics.getPartition());
             partitionColumnStatistics.put(partitionKey, partitionWithStatistics.getStatistics());
         }
+
+        return EMPTY_STATS;
     }
 
     @Override
@@ -324,11 +332,13 @@ public class InMemoryHiveMetastore
     }
 
     @Override
-    public synchronized void alterPartition(MetastoreContext metastoreContext, String databaseName, String tableName, PartitionWithStatistics partitionWithStatistics)
+    public synchronized MetastoreOperationStats alterPartition(MetastoreContext metastoreContext, String databaseName, String tableName, PartitionWithStatistics partitionWithStatistics)
     {
         PartitionName partitionKey = PartitionName.partition(databaseName, tableName, partitionWithStatistics.getPartitionName());
         partitions.put(partitionKey, partitionWithStatistics.getPartition());
         partitionColumnStatistics.put(partitionKey, partitionWithStatistics.getStatistics());
+
+        return EMPTY_STATS;
     }
 
     @Override

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveConnector.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveConnector.java
@@ -20,6 +20,7 @@ import com.facebook.presto.spi.classloader.ThreadContextClassLoader;
 import com.facebook.presto.spi.connector.Connector;
 import com.facebook.presto.spi.connector.ConnectorAccessControl;
 import com.facebook.presto.spi.connector.ConnectorCapabilities;
+import com.facebook.presto.spi.connector.ConnectorCommitHandle;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.connector.ConnectorMetadataUpdaterProvider;
 import com.facebook.presto.spi.connector.ConnectorNodePartitioningProvider;
@@ -213,12 +214,12 @@ public class HiveConnector
     }
 
     @Override
-    public void commit(ConnectorTransactionHandle transaction)
+    public ConnectorCommitHandle commit(ConnectorTransactionHandle transaction)
     {
         TransactionalMetadata metadata = transactionManager.remove(transaction);
         checkArgument(metadata != null, "no such transaction: %s", transaction);
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            metadata.commit();
+            return metadata.commit();
         }
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveInputInfo.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveInputInfo.java
@@ -13,25 +13,30 @@
  */
 package com.facebook.presto.hive;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
 
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 public class HiveInputInfo
 {
     private final List<String> partitionIds;
     // Code that serialize HiveInputInfo into log would often need the ability to limit the length of log entries.
     // This boolean field allows such code to mark the log entry as length limited.
     private final boolean truncated;
+    public final List<Integer> lastAccessTimes;
 
     @JsonCreator
     public HiveInputInfo(
             @JsonProperty("partitionIds") List<String> partitionIds,
-            @JsonProperty("truncated") boolean truncated)
+            @JsonProperty("truncated") boolean truncated,
+            @JsonProperty("truncated") List<Integer> lastAccessTimes)
     {
         this.partitionIds = partitionIds;
         this.truncated = truncated;
+        this.lastAccessTimes = lastAccessTimes;
     }
 
     @JsonProperty
@@ -44,5 +49,11 @@ public class HiveInputInfo
     public boolean isTruncated()
     {
         return truncated;
+    }
+
+    @JsonProperty
+    public List<Integer> getLastAccessTimes()
+    {
+        return lastAccessTimes;
     }
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystem.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystem.java
@@ -26,6 +26,7 @@ import com.facebook.presto.hive.metastore.Database;
 import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
 import com.facebook.presto.hive.metastore.HivePartitionMutator;
 import com.facebook.presto.hive.metastore.MetastoreContext;
+import com.facebook.presto.hive.metastore.MetastoreOperationStats;
 import com.facebook.presto.hive.metastore.PrincipalPrivileges;
 import com.facebook.presto.hive.metastore.Table;
 import com.facebook.presto.hive.metastore.thrift.BridgingHiveMetastore;
@@ -105,6 +106,7 @@ import static com.facebook.presto.hive.HiveTestUtils.getDefaultHiveRecordCursorP
 import static com.facebook.presto.hive.HiveTestUtils.getDefaultHiveSelectivePageSourceFactories;
 import static com.facebook.presto.hive.HiveTestUtils.getDefaultOrcFileWriterFactory;
 import static com.facebook.presto.hive.HiveTestUtils.getTypes;
+import static com.facebook.presto.hive.metastore.MetastoreOperationStats.EMPTY_STATS;
 import static com.facebook.presto.spi.SplitContext.NON_CACHEABLE;
 import static com.facebook.presto.spi.connector.ConnectorSplitManager.SplitSchedulingStrategy.UNGROUPED_SCHEDULING;
 import static com.facebook.presto.testing.MaterializedResult.materializeSourceDataStream;
@@ -513,12 +515,13 @@ public abstract class AbstractTestHiveFileSystem
         }
 
         @Override
-        public void createTable(MetastoreContext metastoreContext, Table table, PrincipalPrivileges privileges)
+        public MetastoreOperationStats createTable(MetastoreContext metastoreContext, Table table, PrincipalPrivileges privileges)
         {
             // hack to work around the metastore not being configured for S3 or other FS
             Table.Builder tableBuilder = Table.builder(table);
             tableBuilder.getStorageBuilder().setLocation("/");
             super.createTable(metastoreContext, tableBuilder.build(), privileges);
+            return EMPTY_STATS;
         }
 
         @Override

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestAbstractDwrfEncryptionInformationSource.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestAbstractDwrfEncryptionInformationSource.java
@@ -69,6 +69,7 @@ public class TestAbstractDwrfEncryptionInformationSource
                 isPartitioned ? ImmutableList.of(new Column("ds", HIVE_STRING, Optional.empty(), Optional.empty())) : ImmutableList.of(),
                 tableEncryptionProperties.map(DwrfTableEncryptionProperties::toHiveProperties).orElse(ImmutableMap.of()),
                 Optional.empty(),
+                Optional.empty(),
                 Optional.empty());
     }
 
@@ -109,8 +110,30 @@ public class TestAbstractDwrfEncryptionInformationSource
                                 ImmutableList.of(new Subfield("col_struct.a"), new Subfield("col_struct.b.b2")),
                                 Optional.empty()))),
                 ImmutableMap.of(
-                        "ds=2020-01-01", new Partition("dbName", "tableName", ImmutableList.of("2020-01-01"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty(), false, true, 0),
-                        "ds=2020-01-02", new Partition("dbName", "tableName", ImmutableList.of("2020-01-02"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty(), false, true, 0)));
+                        "ds=2020-01-01", new Partition(
+                                "dbName",
+                                "tableName",
+                                ImmutableList.of("2020-01-01"),
+                                table.getStorage(),
+                                table.getDataColumns(),
+                                ImmutableMap.of(),
+                                Optional.empty(),
+                                false,
+                                true,
+                                0,
+                                null),
+                        "ds=2020-01-02", new Partition(
+                                "dbName",
+                                "tableName",
+                                ImmutableList.of("2020-01-02"),
+                                table.getStorage(),
+                                table.getDataColumns(),
+                                ImmutableMap.of(),
+                                Optional.empty(),
+                                false,
+                                true,
+                                0,
+                                null)));
 
         assertTrue(encryptionInformation.isPresent());
         assertEquals(
@@ -129,8 +152,30 @@ public class TestAbstractDwrfEncryptionInformationSource
                 table,
                 Optional.of(ImmutableSet.of()),
                 ImmutableMap.of(
-                        "ds=2020-01-01", new Partition("dbName", "tableName", ImmutableList.of("2020-01-01"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty(), false, true, 0),
-                        "ds=2020-01-02", new Partition("dbName", "tableName", ImmutableList.of("2020-01-02"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty(), false, true, 0)));
+                        "ds=2020-01-01", new Partition(
+                                "dbName",
+                                "tableName",
+                                ImmutableList.of("2020-01-01"),
+                                table.getStorage(),
+                                table.getDataColumns(),
+                                ImmutableMap.of(),
+                                Optional.empty(),
+                                false,
+                                true,
+                                0,
+                                null),
+                        "ds=2020-01-02", new Partition(
+                                "dbName",
+                                "tableName",
+                                ImmutableList.of("2020-01-02"),
+                                table.getStorage(),
+                                table.getDataColumns(),
+                                ImmutableMap.of(),
+                                Optional.empty(),
+                                false,
+                                true,
+                                0,
+                                null)));
 
         assertTrue(encryptionInformation.isPresent());
         assertEquals(
@@ -161,8 +206,30 @@ public class TestAbstractDwrfEncryptionInformationSource
                                 ImmutableList.of(new Subfield("col_struct.a"), new Subfield("col_struct.b.b2")),
                                 Optional.empty()))),
                 ImmutableMap.of(
-                        "ds=2020-01-01", new Partition("dbName", "tableName", ImmutableList.of("2020-01-01"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty(), false, true, 0),
-                        "ds=2020-01-02", new Partition("dbName", "tableName", ImmutableList.of("2020-01-02"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty(), false, true, 0)));
+                        "ds=2020-01-01", new Partition(
+                                "dbName",
+                                "tableName",
+                                ImmutableList.of("2020-01-01"),
+                                table.getStorage(),
+                                table.getDataColumns(),
+                                ImmutableMap.of(),
+                                Optional.empty(),
+                                false,
+                                true,
+                                0,
+                                null),
+                        "ds=2020-01-02", new Partition(
+                                "dbName",
+                                "tableName",
+                                ImmutableList.of("2020-01-02"),
+                                table.getStorage(),
+                                table.getDataColumns(),
+                                ImmutableMap.of(),
+                                Optional.empty(),
+                                false,
+                                true,
+                                0,
+                                null)));
 
         Map<String, byte[]> expectedFieldToKeyData = ImmutableMap.of("col_bigint", "key2".getBytes(), "col_struct.a", "key2".getBytes(), "col_struct.b.b2", "key1".getBytes());
         assertTrue(encryptionInformation.isPresent());

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveEncryptionInformationProvider.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveEncryptionInformationProvider.java
@@ -52,6 +52,7 @@ public class TestHiveEncryptionInformationProvider
             ImmutableList.of(),
             ImmutableMap.of(),
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
 
     @Test

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMaterializedViewUtils.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMaterializedViewUtils.java
@@ -634,6 +634,7 @@ public class TestHiveMaterializedViewUtils
                 partitionColumns,
                 ImmutableMap.of(),
                 Optional.empty(),
+                Optional.empty(),
                 Optional.empty());
     }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMetadata.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMetadata.java
@@ -104,6 +104,7 @@ public class TestHiveMetadata
                 ImmutableList.of(partitionColumn),
                 ImmutableMap.of(),
                 Optional.empty(),
+                Optional.empty(),
                 Optional.empty());
 
         ColumnMetadata actual = HiveMetadata.columnMetadataGetter(mockTable, mockTypeManager, new HiveColumnConverter()).apply(hiveColumnHandle1);

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePartitionManager.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePartitionManager.java
@@ -78,6 +78,7 @@ public class TestHivePartitionManager
             ImmutableList.of(PARTITION_COLUMN),
             ImmutableMap.of(),
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
 
     private static final List<String> PARTITIONS = ImmutableList.of("ds=2019-07-23", "ds=2019-08-23");

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitManager.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitManager.java
@@ -150,6 +150,7 @@ public class TestHiveSplitManager
             ImmutableList.of(new Column("ds", HIVE_STRING, Optional.empty(), Optional.empty())),
             ImmutableMap.of(),
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
 
     private ListeningExecutorService executor;
@@ -472,7 +473,8 @@ public class TestHiveSplitManager
                         Optional.empty(),
                         false,
                         true,
-                        0),
+                        0,
+                        null),
                 PARTITION_NAME,
                 partitionStatistics);
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestingSemiTransactionalHiveMetastore.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestingSemiTransactionalHiveMetastore.java
@@ -36,6 +36,7 @@ import com.facebook.presto.hive.metastore.thrift.TestingHiveCluster;
 import com.facebook.presto.hive.metastore.thrift.ThriftHiveMetastore;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.connector.ConnectorCommitHandle;
 import com.facebook.presto.spi.security.PrestoPrincipal;
 import com.facebook.presto.spi.security.RoleGrant;
 import com.facebook.presto.spi.statistics.ColumnStatisticType;
@@ -339,7 +340,7 @@ public class TestingSemiTransactionalHiveMetastore
     }
 
     @Override
-    public synchronized void commit()
+    public synchronized ConnectorCommitHandle commit()
     {
         throw new UnsupportedOperationException("method not implemented");
     }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergConnector.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergConnector.java
@@ -22,6 +22,7 @@ import com.facebook.presto.spi.classloader.ThreadContextClassLoader;
 import com.facebook.presto.spi.connector.Connector;
 import com.facebook.presto.spi.connector.ConnectorAccessControl;
 import com.facebook.presto.spi.connector.ConnectorCapabilities;
+import com.facebook.presto.spi.connector.ConnectorCommitHandle;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.connector.ConnectorNodePartitioningProvider;
 import com.facebook.presto.spi.connector.ConnectorPageSinkProvider;
@@ -40,6 +41,7 @@ import java.util.List;
 import java.util.Set;
 
 import static com.facebook.presto.spi.connector.ConnectorCapabilities.NOT_NULL_COLUMN_CONSTRAINT;
+import static com.facebook.presto.spi.connector.EmptyConnectorCommitHandle.INSTANCE;
 import static com.facebook.presto.spi.transaction.IsolationLevel.SERIALIZABLE;
 import static com.facebook.presto.spi.transaction.IsolationLevel.checkConnectorSupports;
 import static com.google.common.collect.Sets.immutableEnumSet;
@@ -186,9 +188,10 @@ public class IcebergConnector
     }
 
     @Override
-    public void commit(ConnectorTransactionHandle transaction)
+    public ConnectorCommitHandle commit(ConnectorTransactionHandle transaction)
     {
         transactionManager.remove(transaction);
+        return INSTANCE;
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/event/QueryMonitor.java
+++ b/presto-main/src/main/java/com/facebook/presto/event/QueryMonitor.java
@@ -414,7 +414,8 @@ public class QueryMonitor
                             queryInfo.getOutput().get().getSchema(),
                             queryInfo.getOutput().get().getTable(),
                             tableFinishInfo.map(TableFinishInfo::getSerializedConnectorOutputMetadata),
-                            tableFinishInfo.map(TableFinishInfo::isJsonLengthLimitExceeded)));
+                            tableFinishInfo.map(TableFinishInfo::isJsonLengthLimitExceeded),
+                            queryInfo.getOutput().get().getLastDataCommitTimes()));
         }
         return new QueryIOMetadata(inputs.build(), output);
     }

--- a/presto-main/src/main/java/com/facebook/presto/execution/Output.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/Output.java
@@ -16,9 +16,11 @@ package com.facebook.presto.execution;
 import com.facebook.presto.spi.ConnectorId;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.joda.time.DateTime;
 
 import javax.annotation.concurrent.Immutable;
 
+import java.util.List;
 import java.util.Objects;
 
 import static java.util.Objects.requireNonNull;
@@ -29,16 +31,20 @@ public final class Output
     private final ConnectorId connectorId;
     private final String schema;
     private final String table;
+    private Object lastDataCommitTimes;
 
     @JsonCreator
     public Output(
             @JsonProperty("connectorId") ConnectorId connectorId,
             @JsonProperty("schema") String schema,
-            @JsonProperty("table") String table)
+            @JsonProperty("table") String table,
+            @JsonProperty("lastDataCommitTimes") Object lastDataCommitTimes)
     {
         this.connectorId = requireNonNull(connectorId, "connectorId is null");
         this.schema = requireNonNull(schema, "schema is null");
         this.table = requireNonNull(table, "table is null");
+        this.lastDataCommitTimes = requireNonNull(
+                lastDataCommitTimes, "lastDataCommitTimes is null");
     }
 
     @JsonProperty
@@ -59,6 +65,19 @@ public final class Output
         return table;
     }
 
+    @JsonProperty
+    public Object getLastDataCommitTimes()
+    {
+        return lastDataCommitTimes;
+    }
+
+    @JsonProperty
+    public void setLastDataCommitTimes(Object lastDataCommitTimes)
+    {
+        requireNonNull(lastDataCommitTimes, "lastDataCommitTimes is null");
+        this.lastDataCommitTimes = lastDataCommitTimes;
+    }
+
     @Override
     public boolean equals(Object o)
     {
@@ -71,12 +90,13 @@ public final class Output
         Output output = (Output) o;
         return Objects.equals(connectorId, output.connectorId) &&
                 Objects.equals(schema, output.schema) &&
-                Objects.equals(table, output.table);
+                Objects.equals(table, output.table) &&
+                Objects.equals(lastDataCommitTimes, output.lastDataCommitTimes);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(connectorId, schema, table);
+        return Objects.hash(connectorId, schema, table, lastDataCommitTimes);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryManagerStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryManagerStats.java
@@ -68,7 +68,8 @@ public class QueryManagerStats
         submittedQueries.update(1);
         queuedQueries.incrementAndGet();
         managedQueryExecution.addStateChangeListener(new StatisticsListener());
-        managedQueryExecution.addFinalQueryInfoListener(finalQueryInfo -> queryFinished(new BasicQueryInfo(finalQueryInfo)));
+        managedQueryExecution.addFinalQueryInfoListener(
+                finalQueryInfo -> queryFinished(new BasicQueryInfo(finalQueryInfo)));
     }
 
     private void queryStarted()

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
@@ -27,6 +27,7 @@ import com.facebook.presto.spi.ErrorCode;
 import com.facebook.presto.spi.PrestoException;
 import com.facebook.presto.spi.QueryId;
 import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.connector.ConnectorCommitHandle;
 import com.facebook.presto.spi.function.SqlFunctionId;
 import com.facebook.presto.spi.function.SqlInvokedFunction;
 import com.facebook.presto.spi.resourceGroups.QueryType;
@@ -51,6 +52,7 @@ import javax.annotation.concurrent.ThreadSafe;
 
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -146,6 +148,9 @@ public class QueryStateMachine
 
     private final AtomicReference<Set<Input>> inputs = new AtomicReference<>(ImmutableSet.of());
     private final AtomicReference<Optional<Output>> output = new AtomicReference<>(Optional.empty());
+
+    private final AtomicReference<ConnectorCommitHandle> commitHandle = new AtomicReference<>();
+
     private final StateMachine<Optional<QueryInfo>> finalQueryInfo;
     private final AtomicReference<Optional<String>> expandedQuery = new AtomicReference<>(Optional.empty());
 
@@ -525,6 +530,39 @@ public class QueryStateMachine
         this.output.set(output);
     }
 
+    public void SetConnectorCommitResult(ConnectorCommitHandle commitHandle)
+    {
+        requireNonNull(commitHandle, "commitHandle is null");
+        this.commitHandle.set(commitHandle);
+    }
+
+    private void supplyOutputLastDataCommitTimes()
+    {
+        if (output.get().isPresent()) {
+            String resultKey = output.get().get().getSchema() + "." + output.get().get().getTable();
+            if (commitHandle.get().containOutput(resultKey)) {
+                output.get().get().setLastDataCommitTimes(
+                        commitHandle.get().getOutputLastDataCommitTimes(resultKey));
+                commitHandle.get().removeOutput(resultKey);
+            }
+            else {
+                output.get().get().setLastDataCommitTimes(Collections.emptyList());
+            }
+        }
+        else {
+            // There should be at most ONE element in the output based on current setting.
+            for (String resultKey : commitHandle.get().getOutputKeys()) {
+                String[] keys = resultKey.split("\\.");
+                Output outputManual = new Output(
+                        commitHandle.get().getConnectorId(),
+                        keys[0],
+                        keys[1],
+                        commitHandle.get().getOutputLastDataCommitTimes(resultKey));
+                this.output.set(Optional.of(outputManual));
+            }
+        }
+    }
+
     public Map<String, String> getSetSessionProperties()
     {
         return setSessionProperties;
@@ -715,6 +753,7 @@ public class QueryStateMachine
 
         Optional<TransactionInfo> transaction = session.getTransactionId()
                 .flatMap(transactionManager::getOptionalTransactionInfo);
+
         if (transaction.isPresent() && transaction.get().isAutoCommitContext()) {
             ListenableFuture<?> commitFuture = transactionManager.asyncCommit(transaction.get().getTransactionId());
             Futures.addCallback(commitFuture, new FutureCallback<Object>()
@@ -722,7 +761,15 @@ public class QueryStateMachine
                 @Override
                 public void onSuccess(@Nullable Object result)
                 {
-                    transitionToFinished();
+                    if (result instanceof Optional) {
+                        Optional<?> realResult = (Optional<?>) result;
+                        if (realResult.isPresent()) {
+                            transitionToFinished(realResult.get());
+                        }
+                    }
+                    else {
+                        transitionToFinished(null);
+                    }
                 }
 
                 @Override
@@ -733,13 +780,19 @@ public class QueryStateMachine
             }, directExecutor());
         }
         else {
-            transitionToFinished();
+            transitionToFinished(null);
         }
         return true;
     }
 
-    private void transitionToFinished()
+    public void transitionToFinished(Object result)
     {
+        if (result instanceof ConnectorCommitHandle) {
+            ConnectorCommitHandle connectorCommitHandle = (ConnectorCommitHandle) result;
+            commitHandle.set(connectorCommitHandle);
+            supplyOutputLastDataCommitTimes();
+        }
+
         cleanupQueryQuietly();
         queryStateTimer.endQuery();
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/TableWriteInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/TableWriteInfo.java
@@ -86,7 +86,13 @@ public class TableWriteInfo
             WriterTarget target = tableFinishNode.get().getTarget().orElseThrow(() -> new VerifyException("target is absent"));
             if (target instanceof TableWriterNode.CreateName) {
                 TableWriterNode.CreateName create = (TableWriterNode.CreateName) target;
-                return Optional.of(new ExecutionWriterTarget.CreateHandle(metadata.beginCreateTable(session, create.getConnectorId().getCatalogName(), create.getTableMetadata(), create.getLayout()), create.getSchemaTableName()));
+                return Optional.of(new ExecutionWriterTarget.CreateHandle(
+                        metadata.beginCreateTable(
+                                session,
+                                create.getConnectorId().getCatalogName(),
+                                create.getTableMetadata(),
+                                create.getLayout()),
+                        create.getSchemaTableName()));
             }
             if (target instanceof TableWriterNode.InsertReference) {
                 TableWriterNode.InsertReference insert = (TableWriterNode.InsertReference) target;

--- a/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
@@ -487,7 +487,7 @@ public class MetadataManager
     {
         ConnectorId connectorId = handle.getConnectorId();
         ConnectorMetadata metadata = getMetadata(session, connectorId);
-        return handle.getLayout().flatMap(tableLayout -> metadata.getInfo(tableLayout));
+        return handle.getLayout().flatMap(tableLayout -> metadata.getInfo(session.toConnectorSession(), tableLayout));
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/InputExtractor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/InputExtractor.java
@@ -69,7 +69,13 @@ public class InputExtractor
     {
         SchemaTableName schemaTable = table.getTable();
         Optional<Object> inputMetadata = metadata.getInfo(session, tableHandle);
-        return new Input(table.getConnectorId(), schemaTable.getSchemaName(), schemaTable.getTableName(), inputMetadata, ImmutableList.copyOf(columns), statistics);
+        return new Input(
+                table.getConnectorId(),
+                schemaTable.getSchemaName(),
+                schemaTable.getTableName(),
+                inputMetadata,
+                ImmutableList.copyOf(columns),
+                statistics);
     }
 
     private class Visitor

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/OutputExtractor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/OutputExtractor.java
@@ -21,6 +21,7 @@ import com.facebook.presto.sql.planner.plan.InternalPlanVisitor;
 import com.facebook.presto.sql.planner.plan.TableWriterNode;
 import com.google.common.base.VerifyException;
 
+import java.util.Collections;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkState;
@@ -39,7 +40,8 @@ public class OutputExtractor
         return Optional.of(new Output(
                 visitor.getConnectorId(),
                 visitor.getSchemaTableName().getSchemaName(),
-                visitor.getSchemaTableName().getTableName()));
+                visitor.getSchemaTableName().getTableName(),
+                Collections.emptyList()));
     }
 
     private class Visitor

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestOutput.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestOutput.java
@@ -17,6 +17,8 @@ import com.facebook.airlift.json.JsonCodec;
 import com.facebook.presto.spi.ConnectorId;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
+
 import static org.testng.Assert.assertEquals;
 
 public class TestOutput
@@ -26,7 +28,11 @@ public class TestOutput
     @Test
     public void testRoundTrip()
     {
-        Output expected = new Output(new ConnectorId("connectorId"), "schema", "table");
+        Output expected = new Output(
+                new ConnectorId("connectorId"),
+                "schema",
+                "table",
+                Collections.emptyList());
 
         String json = codec.toJson(expected);
         Output actual = codec.fromJson(json);

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestQueryStateMachine.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestQueryStateMachine.java
@@ -82,7 +82,12 @@ public class TestQueryStateMachine
     private static final String QUERY = "sql";
     private static final URI LOCATION = URI.create("fake://fake-query");
     private static final SQLException FAILED_CAUSE = new SQLException("FAILED");
-    private static final List<Input> INPUTS = ImmutableList.of(new Input(new ConnectorId("connector"), "schema", "table", Optional.empty(), ImmutableList.of(new Column("a", "varchar")), Optional.empty()));
+    private static final List<Input> INPUTS = ImmutableList.of(new Input(
+            new ConnectorId("connector"),
+            "schema",
+            "table", Optional.empty(),
+            ImmutableList.of(new Column("a", "varchar")),
+            Optional.empty()));
     private static final Optional<Output> OUTPUT = Optional.empty();
     private static final List<String> OUTPUT_FIELD_NAMES = ImmutableList.of("a", "b", "c");
     private static final List<Type> OUTPUT_FIELD_TYPES = ImmutableList.of(BIGINT, BIGINT, BIGINT);

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestCanonicalPlanGenerator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestCanonicalPlanGenerator.java
@@ -230,21 +230,25 @@ public class TestCanonicalPlanGenerator
     {
         assertEquals(
                 Arrays.stream(PartitioningScheme.class.getDeclaredFields())
+                        .filter(f -> !f.isSynthetic())
                         .map(Field::getName)
                         .collect(toImmutableSet()),
                 ImmutableSet.of("partitioning", "outputLayout", "hashColumn", "replicateNullsAndAny", "bucketToPartition"));
         assertEquals(
                 Arrays.stream(Partitioning.class.getDeclaredFields())
+                        .filter(f -> !f.isSynthetic())
                         .map(Field::getName)
                         .collect(toImmutableSet()),
                 ImmutableSet.of("handle", "arguments"));
         assertEquals(
                 Arrays.stream(PartitioningHandle.class.getDeclaredFields())
+                        .filter(f -> !f.isSynthetic())
                         .map(Field::getName)
                         .collect(toImmutableSet()),
                 ImmutableSet.of("connectorId", "transactionHandle", "connectorHandle"));
         assertEquals(
                 Arrays.stream(CanonicalPartitioningScheme.class.getDeclaredFields())
+                        .filter(f -> !f.isSynthetic())
                         .map(Field::getName)
                         .collect(toImmutableSet()),
                 ImmutableSet.of("connectorId", "connectorHandle", "arguments", "outputLayout"));
@@ -255,22 +259,26 @@ public class TestCanonicalPlanGenerator
     {
         assertEquals(
                 Arrays.stream(TableScanNode.class.getDeclaredFields())
+                        .filter(f -> !f.isSynthetic())
                         .map(Field::getName)
                         .collect(toImmutableSet()),
                 ImmutableSet.of("table", "assignments", "outputVariables", "currentConstraint", "enforcedConstraint"));
         assertEquals(
                 Arrays.stream(CanonicalTableScanNode.class.getDeclaredFields())
+                        .filter(f -> !f.isSynthetic())
                         .map(Field::getName)
                         .collect(toImmutableSet()),
                 ImmutableSet.of("table", "assignments", "outputVariables"));
 
         assertEquals(
                 Arrays.stream(TableHandle.class.getDeclaredFields())
+                        .filter(f -> !f.isSynthetic())
                         .map(Field::getName)
                         .collect(toImmutableSet()),
                 ImmutableSet.of("connectorId", "connectorHandle", "transaction", "layout", "dynamicFilter"));
         assertEquals(
                 Arrays.stream(CanonicalTableHandle.class.getDeclaredFields())
+                        .filter(f -> !f.isSynthetic())
                         .map(Field::getName)
                         .collect(toImmutableSet()),
                 ImmutableSet.of("connectorId", "tableHandle", "layoutIdentifier", "layoutHandle"));

--- a/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoConnector.java
+++ b/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoConnector.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.mongodb;
 
 import com.facebook.presto.spi.connector.Connector;
+import com.facebook.presto.spi.connector.ConnectorCommitHandle;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.connector.ConnectorPageSinkProvider;
 import com.facebook.presto.spi.connector.ConnectorPageSourceProvider;
@@ -26,6 +27,7 @@ import javax.inject.Inject;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+import static com.facebook.presto.spi.connector.EmptyConnectorCommitHandle.INSTANCE;
 import static com.facebook.presto.spi.transaction.IsolationLevel.READ_UNCOMMITTED;
 import static com.facebook.presto.spi.transaction.IsolationLevel.checkConnectorSupports;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -78,9 +80,10 @@ public class MongoConnector
     }
 
     @Override
-    public void commit(ConnectorTransactionHandle transaction)
+    public ConnectorCommitHandle commit(ConnectorTransactionHandle transaction)
     {
         checkArgument(transactions.remove(transaction) != null, "no such transaction: %s", transaction);
+        return INSTANCE;
     }
 
     @Override

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorConnector.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorConnector.java
@@ -21,6 +21,7 @@ import com.facebook.presto.spi.NodeManager;
 import com.facebook.presto.spi.SystemTable;
 import com.facebook.presto.spi.connector.Connector;
 import com.facebook.presto.spi.connector.ConnectorAccessControl;
+import com.facebook.presto.spi.connector.ConnectorCommitHandle;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
 import com.facebook.presto.spi.connector.ConnectorNodePartitioningProvider;
 import com.facebook.presto.spi.connector.ConnectorPageSinkProvider;
@@ -47,6 +48,7 @@ import java.util.concurrent.ScheduledExecutorService;
 
 import static com.facebook.airlift.concurrent.Threads.daemonThreadsNamed;
 import static com.facebook.presto.raptor.util.DatabaseUtil.onDemandDao;
+import static com.facebook.presto.spi.connector.EmptyConnectorCommitHandle.INSTANCE;
 import static com.facebook.presto.spi.transaction.IsolationLevel.READ_COMMITTED;
 import static com.facebook.presto.spi.transaction.IsolationLevel.checkConnectorSupports;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -136,10 +138,11 @@ public class RaptorConnector
     }
 
     @Override
-    public void commit(ConnectorTransactionHandle transaction)
+    public ConnectorCommitHandle commit(ConnectorTransactionHandle transaction)
     {
         checkArgument(transactions.remove(transaction) != null, "no such transaction: %s", transaction);
         finishDelete(((RaptorTransactionHandle) transaction).getUuid());
+        return INSTANCE;
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/Connector.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/Connector.java
@@ -21,6 +21,7 @@ import com.facebook.presto.spi.transaction.IsolationLevel;
 import java.util.List;
 import java.util.Set;
 
+import static com.facebook.presto.spi.connector.EmptyConnectorCommitHandle.INSTANCE;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptySet;
 
@@ -160,8 +161,9 @@ public interface Connector
      * Commit the transaction. Will be called at most once and will not be called if
      * {@link #rollback(ConnectorTransactionHandle)} is called.
      */
-    default void commit(ConnectorTransactionHandle transactionHandle)
+    default ConnectorCommitHandle commit(ConnectorTransactionHandle transactionHandle)
     {
+        return INSTANCE;
     }
 
     /**

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorCommitHandle.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorCommitHandle.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.spi.connector;
+
+import com.facebook.presto.spi.ConnectorId;
+
+import java.util.List;
+import java.util.Set;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySet;
+
+public interface ConnectorCommitHandle
+{
+    default Object getOutputLastDataCommitTimes(String outputKey)
+    {
+        return emptyList();
+    }
+
+    default boolean containOutput(String outputKey)
+    {
+        return false;
+    }
+
+    default void removeOutput(String outputKey)
+    {
+    }
+
+    default Set<String> getOutputKeys()
+    {
+        return emptySet();
+    }
+
+    default ConnectorId getConnectorId()
+    {
+        return new ConnectorId("Unknown");
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
@@ -206,7 +206,7 @@ public interface ConnectorMetadata
      *
      * @throws RuntimeException if table handle is no longer valid
      */
-    default Optional<Object> getInfo(ConnectorTableLayoutHandle layoutHandle)
+    default Optional<Object> getInfo(ConnectorSession session, ConnectorTableLayoutHandle layoutHandle)
     {
         return Optional.empty();
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/EmptyConnectorCommitHandle.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/EmptyConnectorCommitHandle.java
@@ -11,18 +11,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.hive;
+package com.facebook.presto.spi.connector;
 
-import com.facebook.presto.hive.metastore.SemiTransactionalHiveMetastore;
-import com.facebook.presto.spi.connector.ConnectorCommitHandle;
-import com.facebook.presto.spi.connector.ConnectorMetadata;
-
-public interface TransactionalMetadata
-        extends ConnectorMetadata
+public enum EmptyConnectorCommitHandle
+        implements ConnectorCommitHandle
 {
-    ConnectorCommitHandle commit();
-
-    void rollback();
-
-    SemiTransactionalHiveMetastore getMetastore();
+    INSTANCE;
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -246,10 +246,10 @@ public class ClassLoaderSafeConnectorMetadata
     }
 
     @Override
-    public Optional<Object> getInfo(ConnectorTableLayoutHandle table)
+    public Optional<Object> getInfo(ConnectorSession session, ConnectorTableLayoutHandle table)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getInfo(table);
+            return delegate.getInfo(session, table);
         }
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/QueryInputMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/QueryInputMetadata.java
@@ -30,7 +30,13 @@ public class QueryInputMetadata
     private final Optional<Object> connectorInfo;
     private final Optional<TableStatistics> statistics;
 
-    public QueryInputMetadata(String catalogName, String schema, String table, List<String> columns, Optional<Object> connectorInfo, Optional<TableStatistics> statistics)
+    public QueryInputMetadata(
+            String catalogName,
+            String schema,
+            String table,
+            List<String> columns,
+            Optional<Object> connectorInfo,
+            Optional<TableStatistics> statistics)
     {
         this.catalogName = requireNonNull(catalogName, "catalogName is null");
         this.schema = requireNonNull(schema, "schema is null");

--- a/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/QueryOutputMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/QueryOutputMetadata.java
@@ -15,6 +15,7 @@ package com.facebook.presto.spi.eventlistener;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.List;
 import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
@@ -28,13 +29,25 @@ public class QueryOutputMetadata
     private final Optional<String> connectorOutputMetadata;
     private final Optional<Boolean> jsonLengthLimitExceeded;
 
-    public QueryOutputMetadata(String catalogName, String schema, String table, Optional<String> connectorOutputMetadata, Optional<Boolean> jsonLengthLimitExceeded)
+    private final Object lastDataCommitTimes;
+
+    public QueryOutputMetadata(
+            String catalogName,
+            String schema,
+            String table,
+            Optional<String> connectorOutputMetadata,
+            Optional<Boolean> jsonLengthLimitExceeded,
+            Object lastDataCommitTimes)
     {
         this.catalogName = requireNonNull(catalogName, "catalogName is null");
         this.schema = requireNonNull(schema, "schema is null");
         this.table = requireNonNull(table, "table is null");
-        this.connectorOutputMetadata = requireNonNull(connectorOutputMetadata, "connectorOutputMetadata is null");
-        this.jsonLengthLimitExceeded = requireNonNull(jsonLengthLimitExceeded, "jsonLengthLimitExceeded is null");
+        this.connectorOutputMetadata = requireNonNull(
+                connectorOutputMetadata, "connectorOutputMetadata is null");
+        this.jsonLengthLimitExceeded = requireNonNull(
+                jsonLengthLimitExceeded, "jsonLengthLimitExceeded is null");
+        this.lastDataCommitTimes = requireNonNull(
+                lastDataCommitTimes, "lastDataCommitTimes is null");
     }
 
     @JsonProperty
@@ -65,5 +78,11 @@ public class QueryOutputMetadata
     public Optional<Boolean> getJsonLengthLimitExceeded()
     {
         return jsonLengthLimitExceeded;
+    }
+
+    @JsonProperty
+    public Object getLastDataCommitTimes()
+    {
+        return lastDataCommitTimes;
     }
 }


### PR DESCRIPTION
Code coverage will add synthetic members to classes that has been
causing issues for getting tests to run with code coverage
enabled. Skipping or ignoring these members is the fix.

Test plan - (Please fill in how you tested your changes)

Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines. Don't forget to follow our [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution) for any code copied from other projects.

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== RELEASE NOTES ==

General Changes
* ...
* ...

Hive Changes
* ...
* ...
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```
