### PR TITLE
[Abandoned] Optimize DistinctLimit for small limit values

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -226,6 +226,7 @@ public final class SystemSessionProperties
     public static final String KEY_BASED_SAMPLING_FUNCTION = "key_based_sampling_function";
     public static final String HASH_BASED_DISTINCT_LIMIT_ENABLED = "hash_based_distinct_limit_enabled";
     public static final String HASH_BASED_DISTINCT_LIMIT_THRESHOLD = "hash_based_distinct_limit_threshold";
+    public static final String FAST_LIMIT_THRESHOLD = "fast_limit_threshold";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -1229,6 +1230,11 @@ public final class SystemSessionProperties
                         HASH_BASED_DISTINCT_LIMIT_ENABLED,
                         "Hash based distinct limit enabled",
                         featuresConfig.isHashBasedDistinctLimitEnabled(),
+                        false),
+                integerProperty(
+                        FAST_LIMIT_THRESHOLD,
+                        "Threshold for fast limiting operations for small limits",
+                        featuresConfig.getFastLimitThreshold(),
                         false));
     }
 
@@ -1275,6 +1281,11 @@ public final class SystemSessionProperties
     public static int getHashBasedDistinctLimitThreshold(Session session)
     {
         return session.getSystemProperty(HASH_BASED_DISTINCT_LIMIT_THRESHOLD, Integer.class);
+    }
+
+    public static int getFastLimitThreshold(Session session)
+    {
+        return session.getSystemProperty(FAST_LIMIT_THRESHOLD, Integer.class);
     }
 
     public List<PropertyMetadata<?>> getSessionProperties()

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -88,7 +88,7 @@ public class FeaturesConfig
     private int maxReorderedJoins = 9;
     private boolean redistributeWrites = true;
     private boolean scaleWriters;
-    private DataSize writerMinSize = new DataSize(32, DataSize.Unit.MEGABYTE);
+    private DataSize writerMinSize = new DataSize(32, MEGABYTE);
     private boolean optimizedScaleWriterProducerBuffer;
     private boolean optimizeMetadataQueries;
     private boolean optimizeMetadataQueriesIgnoreStats;
@@ -132,7 +132,7 @@ public class FeaturesConfig
     private boolean orderByAggregationSpillEnabled = true;
     private boolean windowSpillEnabled = true;
     private boolean orderBySpillEnabled = true;
-    private DataSize aggregationOperatorUnspillMemoryLimit = new DataSize(4, DataSize.Unit.MEGABYTE);
+    private DataSize aggregationOperatorUnspillMemoryLimit = new DataSize(4, MEGABYTE);
     private List<Path> spillerSpillPaths = ImmutableList.of();
     private int spillerThreads = 4;
     private double spillMaxUsedSpaceThreshold = 0.9;
@@ -213,6 +213,7 @@ public class FeaturesConfig
     private boolean verboseRuntimeStatsEnabled;
     private boolean hashBasedDistinctLimitEnabled;
     private int hashBasedDistinctLimitThreshold = 10000;
+    private int fastLimitThreshold = 10000;
 
     private boolean streamingForPartialAggregationEnabled;
 
@@ -1956,6 +1957,19 @@ public class FeaturesConfig
     public int getHashBasedDistinctLimitThreshold()
     {
         return hashBasedDistinctLimitThreshold;
+    }
+
+    public int getFastLimitThreshold()
+    {
+        return fastLimitThreshold;
+    }
+
+    @Config("fast-limit-threshold")
+    @ConfigDescription("Threshold for fast limiting operations")
+    public FeaturesConfig setFastLimitThreshold(int fastLimitThreshold)
+    {
+        this.fastLimitThreshold = fastLimitThreshold;
+        return this;
     }
 
     public boolean isStreamingForPartialAggregationEnabled()

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -188,6 +188,7 @@ public class TestFeaturesConfig
                 .setAggregationIfToFilterRewriteStrategy(AggregationIfToFilterRewriteStrategy.DISABLED)
                 .setHashBasedDistinctLimitEnabled(false)
                 .setHashBasedDistinctLimitThreshold(10000)
+                .setFastLimitThreshold(10000)
                 .setStreamingForPartialAggregationEnabled(false));
     }
 
@@ -327,6 +328,7 @@ public class TestFeaturesConfig
                 .put("optimizer.aggregation-if-to-filter-rewrite-strategy", "filter_with_if")
                 .put("hash-based-distinct-limit-enabled", "true")
                 .put("hash-based-distinct-limit-threshold", "500")
+                .put("fast-limit-threshold", "500")
                 .put("streaming-for-partial-aggregation-enabled", "true")
                 .build();
 
@@ -464,6 +466,7 @@ public class TestFeaturesConfig
                 .setAggregationIfToFilterRewriteStrategy(AggregationIfToFilterRewriteStrategy.FILTER_WITH_IF)
                 .setHashBasedDistinctLimitEnabled(true)
                 .setHashBasedDistinctLimitThreshold(500)
+                .setFastLimitThreshold(500)
                 .setStreamingForPartialAggregationEnabled(true);
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
We now introduce a notion of "fast limits" for small values of limit (default threshold 10k). As a first optimization, we disable hash generation optimization for simple distinct limit operations so that the exchange won't block and the user will start seeings results as soon as the first value is seen and/or the number of distinct values is less than the limit. This helps in interactive querying use cases.


#17328 

Test plan - N/A

Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines. Don't forget to follow our [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution) for any code copied from other projects.


Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== RELEASE NOTES ==

General Changes
* Simple queries like `SELECT DISTINCT c1, c2.. FROM T WHERE .,. LIMIT 1000` will now start streaming results as soon as the first value is available
```
