### PR TITLE
Add casts for distinct types

### DIFF
--- a/presto-client/src/main/java/com/facebook/presto/client/ClientTypeSignatureParameter.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/ClientTypeSignatureParameter.java
@@ -15,6 +15,7 @@ package com.facebook.presto.client;
 
 import com.facebook.airlift.json.JsonObjectMapperProvider;
 import com.facebook.presto.common.type.BigintEnumType.LongEnumMap;
+import com.facebook.presto.common.type.DistinctTypeInfo;
 import com.facebook.presto.common.type.NamedTypeSignature;
 import com.facebook.presto.common.type.ParameterKind;
 import com.facebook.presto.common.type.TypeSignatureParameter;
@@ -60,6 +61,9 @@ public class ClientTypeSignatureParameter
                 break;
             case VARCHAR_ENUM:
                 value = typeParameterSignature.getVarcharEnumMap();
+                break;
+            case DISTINCT_TYPE:
+                value = typeParameterSignature.getDistinctTypeInfo();
                 break;
             default:
                 throw new UnsupportedOperationException(format("Unknown kind [%s]", kind));
@@ -166,6 +170,9 @@ public class ClientTypeSignatureParameter
                     break;
                 case VARCHAR_ENUM:
                     value = MAPPER.readValue(jsonValue, VarcharEnumMap.class);
+                    break;
+                case DISTINCT_TYPE:
+                    value = MAPPER.readValue(jsonValue, DistinctTypeInfo.class);
                     break;
                 default:
                     throw new UnsupportedOperationException(format("Unsupported kind [%s]", kind));

--- a/presto-common/src/main/java/com/facebook/presto/common/type/AbstractIntType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/AbstractIntType.java
@@ -24,7 +24,7 @@ import io.airlift.slice.Slice;
 import static java.lang.Long.rotateLeft;
 
 public abstract class AbstractIntType
-        extends AbstractType
+        extends AbstractPrimitiveType
         implements FixedWidthType
 {
     protected AbstractIntType(TypeSignature signature)

--- a/presto-common/src/main/java/com/facebook/presto/common/type/AbstractLongType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/AbstractLongType.java
@@ -24,7 +24,7 @@ import io.airlift.slice.Slice;
 import static java.lang.Long.rotateLeft;
 
 public abstract class AbstractLongType
-        extends AbstractType
+        extends AbstractPrimitiveType
         implements FixedWidthType
 {
     public AbstractLongType(TypeSignature signature)

--- a/presto-common/src/main/java/com/facebook/presto/common/type/AbstractPrimitiveType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/AbstractPrimitiveType.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.type;
+
+public abstract class AbstractPrimitiveType
+        extends AbstractType
+{
+    private final TypeSignature signature;
+
+    protected AbstractPrimitiveType(TypeSignature signature, Class<?> javaType)
+    {
+        super(javaType);
+        this.signature = signature;
+    }
+
+    @Override
+    public final TypeSignature getTypeSignature()
+    {
+        return signature;
+    }
+}

--- a/presto-common/src/main/java/com/facebook/presto/common/type/AbstractType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/AbstractType.java
@@ -25,25 +25,11 @@ import java.util.List;
 public abstract class AbstractType
         implements Type
 {
-    private final TypeSignature signature;
     private final Class<?> javaType;
 
-    protected AbstractType(TypeSignature signature, Class<?> javaType)
+    protected AbstractType(Class<?> javaType)
     {
-        this.signature = signature;
         this.javaType = javaType;
-    }
-
-    @Override
-    public final TypeSignature getTypeSignature()
-    {
-        return signature;
-    }
-
-    @Override
-    public String getDisplayName()
-    {
-        return signature.toString();
     }
 
     @Override
@@ -206,6 +192,12 @@ public abstract class AbstractType
     @Override
     public int hashCode()
     {
-        return signature.hashCode();
+        return getTypeSignature().hashCode();
+    }
+
+    @Override
+    public String getDisplayName()
+    {
+        return getTypeSignature().toString();
     }
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/type/AbstractVariableWidthType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/AbstractVariableWidthType.java
@@ -21,7 +21,7 @@ import com.facebook.presto.common.block.VariableWidthBlockBuilder;
 import static java.lang.Math.min;
 
 public abstract class AbstractVariableWidthType
-        extends AbstractType
+        extends AbstractPrimitiveType
         implements VariableWidthType
 {
     private static final int EXPECTED_BYTES_PER_ENTRY = 32;

--- a/presto-common/src/main/java/com/facebook/presto/common/type/ArrayType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/ArrayType.java
@@ -39,13 +39,19 @@ public class ArrayType
 
     public ArrayType(Type elementType)
     {
-        super(new TypeSignature(ARRAY, TypeSignatureParameter.of(elementType.getTypeSignature())), Block.class);
+        super(Block.class);
         this.elementType = requireNonNull(elementType, "elementType is null");
     }
 
     public Type getElementType()
     {
         return elementType;
+    }
+
+    @Override
+    public TypeSignature getTypeSignature()
+    {
+        return new TypeSignature(ARRAY, TypeSignatureParameter.of(elementType.getTypeSignature()));
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/type/BooleanType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/BooleanType.java
@@ -27,7 +27,7 @@ import java.util.Optional;
 import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
 
 public final class BooleanType
-        extends AbstractType
+        extends AbstractPrimitiveType
         implements FixedWidthType
 {
     public static final BooleanType BOOLEAN = new BooleanType();

--- a/presto-common/src/main/java/com/facebook/presto/common/type/DecimalType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/DecimalType.java
@@ -23,7 +23,7 @@ import static com.facebook.presto.common.type.Decimals.MAX_SHORT_PRECISION;
 import static java.util.Collections.unmodifiableList;
 
 public abstract class DecimalType
-        extends AbstractType
+        extends AbstractPrimitiveType
         implements FixedWidthType
 {
     public static final int DEFAULT_SCALE = 0;

--- a/presto-common/src/main/java/com/facebook/presto/common/type/DoubleType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/DoubleType.java
@@ -26,7 +26,7 @@ import static java.lang.Double.doubleToLongBits;
 import static java.lang.Double.longBitsToDouble;
 
 public final class DoubleType
-        extends AbstractType
+        extends AbstractPrimitiveType
         implements FixedWidthType
 {
     public static final DoubleType DOUBLE = new DoubleType();

--- a/presto-common/src/main/java/com/facebook/presto/common/type/KdbTreeType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/KdbTreeType.java
@@ -20,7 +20,7 @@ import com.facebook.presto.common.block.BlockBuilderStatus;
 import com.facebook.presto.common.function.SqlFunctionProperties;
 
 public final class KdbTreeType
-        extends AbstractType
+        extends AbstractPrimitiveType
 {
     public static final KdbTreeType KDB_TREE = new KdbTreeType();
     public static final String NAME = "KdbTree";

--- a/presto-common/src/main/java/com/facebook/presto/common/type/MapType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/MapType.java
@@ -52,10 +52,7 @@ public class MapType
             MethodHandle keyBlockEquals,
             MethodHandle keyBlockHashCode)
     {
-        super(new TypeSignature(StandardTypes.MAP,
-                        TypeSignatureParameter.of(keyType.getTypeSignature()),
-                        TypeSignatureParameter.of(valueType.getTypeSignature())),
-                Block.class);
+        super(Block.class);
         if (!keyType.isComparable()) {
             throw new IllegalArgumentException(format("key type must be comparable, got %s", keyType));
         }
@@ -64,6 +61,15 @@ public class MapType
         requireNonNull(keyBlockHashCode, "keyBlockHashCode is null");
         this.keyBlockHashCode = keyBlockHashCode;
         this.keyBlockEquals = keyBlockEquals;
+    }
+
+    @Override
+    public TypeSignature getTypeSignature()
+    {
+        return new TypeSignature(
+                StandardTypes.MAP,
+                TypeSignatureParameter.of(keyType.getTypeSignature()),
+                TypeSignatureParameter.of(valueType.getTypeSignature()));
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/type/RowType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/RowType.java
@@ -24,10 +24,10 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static com.facebook.presto.common.type.StandardTypes.ROW;
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
 
 /**
  * As defined in ISO/IEC FCD 9075-2 (SQL 2011), section 4.8
@@ -38,28 +38,27 @@ public class RowType
     private final List<Field> fields;
     private final List<Type> fieldTypes;
 
-    private RowType(TypeSignature typeSignature, List<Field> fields)
+    private RowType(List<Field> fields)
     {
-        super(typeSignature, Block.class);
-
+        super(Block.class);
         this.fields = fields;
         this.fieldTypes = fields.stream()
                 .map(Field::getType)
-                .collect(Collectors.toList());
+                .collect(toList());
     }
 
     public static RowType from(List<Field> fields)
     {
-        return new RowType(makeSignature(fields), fields);
+        return new RowType(fields);
     }
 
     public static RowType anonymous(List<Type> types)
     {
         List<Field> fields = types.stream()
                 .map(type -> new Field(Optional.empty(), type))
-                .collect(Collectors.toList());
+                .collect(toList());
 
-        return new RowType(makeSignature(fields), fields);
+        return new RowType(fields);
     }
 
     public static RowType withDefaultFieldNames(List<Type> types)
@@ -68,13 +67,7 @@ public class RowType
         for (int i = 0; i < types.size(); i++) {
             fields.add(new Field(Optional.of("field" + i), types.get(i)));
         }
-        return new RowType(makeSignature(fields), fields);
-    }
-
-    // Only RowParametricType.createType should call this method
-    public static RowType createWithTypeSignature(TypeSignature typeSignature, List<Field> fields)
-    {
-        return new RowType(typeSignature, fields);
+        return new RowType(fields);
     }
 
     public static Field field(String name, Type type)
@@ -95,10 +88,16 @@ public class RowType
         }
 
         List<TypeSignatureParameter> parameters = fields.stream()
-                .map(field -> TypeSignatureParameter.of(new NamedTypeSignature(field.getName().map(name -> new RowFieldName(name, false)), field.getType().getTypeSignature())))
-                .collect(Collectors.toList());
+                .map(field -> TypeSignatureParameter.of(new NamedTypeSignature(field.getName().map(name -> new RowFieldName(name, field.isDelimited())), field.getType().getTypeSignature())))
+                .collect(toList());
 
         return new TypeSignature(ROW, parameters);
+    }
+
+    @Override
+    public TypeSignature getTypeSignature()
+    {
+        return makeSignature(fields);
     }
 
     @Override
@@ -195,11 +194,18 @@ public class RowType
     {
         private final Type type;
         private final Optional<String> name;
+        private final boolean delimited;
 
         public Field(Optional<String> name, Type type)
         {
+            this(name, type, false);
+        }
+
+        public Field(Optional<String> name, Type type, boolean delimited)
+        {
             this.type = requireNonNull(type, "type is null");
             this.name = requireNonNull(name, "name is null");
+            this.delimited = delimited;
         }
 
         public Type getType()
@@ -210,6 +216,11 @@ public class RowType
         public Optional<String> getName()
         {
             return name;
+        }
+
+        public boolean isDelimited()
+        {
+            return delimited;
         }
     }
 

--- a/presto-common/src/main/java/com/facebook/presto/common/type/SmallintType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/SmallintType.java
@@ -27,7 +27,7 @@ import static java.lang.Long.rotateLeft;
 import static java.lang.String.format;
 
 public final class SmallintType
-        extends AbstractType
+        extends AbstractPrimitiveType
         implements FixedWidthType
 {
     public static final SmallintType SMALLINT = new SmallintType();

--- a/presto-common/src/main/java/com/facebook/presto/common/type/TinyintType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TinyintType.java
@@ -27,7 +27,7 @@ import static java.lang.Long.rotateLeft;
 import static java.lang.String.format;
 
 public final class TinyintType
-        extends AbstractType
+        extends AbstractPrimitiveType
         implements FixedWidthType
 {
     public static final TinyintType TINYINT = new TinyintType();

--- a/presto-common/src/main/java/com/facebook/presto/common/type/TypeSignature.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TypeSignature.java
@@ -168,6 +168,12 @@ public class TypeSignature
         return parameters.size() == 1 && parameters.get(0).isDistinctType();
     }
 
+    public DistinctTypeInfo getDistinctTypeInfo()
+    {
+        checkArgument(isDistinctType(), format("%s is not a distinct type", this));
+        return getParameters().get(0).getDistinctTypeInfo();
+    }
+
     @JsonCreator
     public static TypeSignature parseTypeSignature(String signature)
     {

--- a/presto-common/src/main/java/com/facebook/presto/common/type/UnknownType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/UnknownType.java
@@ -21,7 +21,7 @@ import com.facebook.presto.common.block.PageBuilderStatus;
 import com.facebook.presto.common.function.SqlFunctionProperties;
 
 public final class UnknownType
-        extends AbstractType
+        extends AbstractPrimitiveType
         implements FixedWidthType
 {
     public static final UnknownType UNKNOWN = new UnknownType();

--- a/presto-main/src/main/java/com/facebook/presto/cost/StatsUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/StatsUtil.java
@@ -53,7 +53,7 @@ final class StatsUtil
 
         if (convertibleToDoubleWithCast(type)) {
             InterpretedFunctionInvoker functionInvoker = new InterpretedFunctionInvoker(functionAndTypeManager);
-            FunctionHandle cast = functionAndTypeManager.lookupCast(CAST, type.getTypeSignature(), DoubleType.DOUBLE.getTypeSignature());
+            FunctionHandle cast = functionAndTypeManager.lookupCast(CAST, type, DoubleType.DOUBLE);
 
             return OptionalDouble.of((double) functionInvoker.invoke(cast, session.getSqlFunctionProperties(), singletonList(value)));
         }

--- a/presto-main/src/main/java/com/facebook/presto/metadata/FunctionAndTypeManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/FunctionAndTypeManager.java
@@ -500,16 +500,16 @@ public class FunctionAndTypeManager
         return builtInTypeAndFunctionNamespaceManager.getFunctionHandle(Optional.empty(), match.get());
     }
 
-    public FunctionHandle lookupCast(CastType castType, TypeSignature fromType, TypeSignature toType)
+    public FunctionHandle lookupCast(CastType castType, Type fromType, Type toType)
     {
-        Signature signature = new Signature(castType.getCastName(), SCALAR, emptyList(), emptyList(), toType, singletonList(fromType), false);
+        Signature signature = new Signature(castType.getCastName(), SCALAR, emptyList(), emptyList(), toType.getTypeSignature(), singletonList(fromType.getTypeSignature()), false);
 
         try {
             builtInTypeAndFunctionNamespaceManager.getScalarFunctionImplementation(signature);
         }
         catch (PrestoException e) {
             if (castType.isOperatorType() && e.getErrorCode().getCode() == FUNCTION_IMPLEMENTATION_MISSING.toErrorCode().getCode()) {
-                throw new OperatorNotFoundException(toOperatorType(castType), ImmutableList.of(fromType), toType);
+                throw new OperatorNotFoundException(toOperatorType(castType), ImmutableList.of(fromType.getTypeSignature()), toType.getTypeSignature());
             }
             throw e;
         }

--- a/presto-main/src/main/java/com/facebook/presto/metadata/SpecializedFunctionKey.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/SpecializedFunctionKey.java
@@ -13,10 +13,12 @@
  */
 package com.facebook.presto.metadata;
 
+import com.facebook.presto.spi.function.Signature;
 import com.facebook.presto.spi.function.SqlFunction;
 
 import java.util.Objects;
 
+import static com.facebook.presto.metadata.SignatureBinder.applyBoundVariables;
 import static java.util.Objects.requireNonNull;
 
 public class SpecializedFunctionKey
@@ -45,6 +47,11 @@ public class SpecializedFunctionKey
     public int getArity()
     {
         return arity;
+    }
+
+    public Signature getBoundSignature()
+    {
+        return applyBoundVariables(function.getSignature(), boundVariables, arity);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayJoin.java
@@ -20,7 +20,6 @@ import com.facebook.presto.common.block.BlockBuilder;
 import com.facebook.presto.common.function.SqlFunctionProperties;
 import com.facebook.presto.common.type.StandardTypes;
 import com.facebook.presto.common.type.Type;
-import com.facebook.presto.common.type.TypeSignature;
 import com.facebook.presto.common.type.UnknownType;
 import com.facebook.presto.metadata.BoundVariables;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
@@ -63,7 +62,6 @@ public final class ArrayJoin
     public static final ArrayJoin ARRAY_JOIN = new ArrayJoin();
     public static final ArrayJoinWithNullReplacement ARRAY_JOIN_WITH_NULL_REPLACEMENT = new ArrayJoinWithNullReplacement();
 
-    private static final TypeSignature VARCHAR_TYPE_SIGNATURE = VARCHAR.getTypeSignature();
     private static final String FUNCTION_NAME = "array_join";
     private static final String DESCRIPTION = "Concatenates the elements of the given array using a delimiter and an optional string to replace nulls";
 
@@ -217,7 +215,7 @@ public final class ArrayJoin
         }
         else {
             try {
-                MethodHandle cast = functionAndTypeManager.getJavaScalarFunctionImplementation(functionAndTypeManager.lookupCast(CAST, type.getTypeSignature(), VARCHAR_TYPE_SIGNATURE)).getMethodHandle();
+                MethodHandle cast = functionAndTypeManager.getJavaScalarFunctionImplementation(functionAndTypeManager.lookupCast(CAST, type, VARCHAR)).getMethodHandle();
 
                 MethodHandle getter;
                 Class<?> elementType = type.getJavaType();

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayToArrayCast.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayToArrayCast.java
@@ -77,7 +77,7 @@ public class ArrayToArrayCast
         Type fromType = boundVariables.getTypeVariable("F");
         Type toType = boundVariables.getTypeVariable("T");
 
-        FunctionHandle functionHandle = functionAndTypeManager.lookupCast(CastType.CAST, fromType.getTypeSignature(), toType.getTypeSignature());
+        FunctionHandle functionHandle = functionAndTypeManager.lookupCast(CastType.CAST, fromType, toType);
         JavaScalarFunctionImplementation function = functionAndTypeManager.getJavaScalarFunctionImplementation(functionHandle);
         Class<?> castOperatorClass = generateArrayCast(functionAndTypeManager, functionAndTypeManager.getFunctionMetadata(functionHandle), function);
         MethodHandle methodHandle = methodHandle(castOperatorClass, "castArray", SqlFunctionProperties.class, Block.class);

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapSubscriptOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapSubscriptOperator.java
@@ -226,7 +226,7 @@ public class MapSubscriptOperator
 
             FunctionHandle castFunction = null;
             try {
-                castFunction = functionAndTypeManager.lookupCast(CAST, keyType.getTypeSignature(), VARCHAR.getTypeSignature());
+                castFunction = functionAndTypeManager.lookupCast(CAST, keyType, VARCHAR);
             }
             catch (PrestoException ignored) {
             }

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapToMapCast.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MapToMapCast.java
@@ -107,7 +107,7 @@ public final class MapToMapCast
         MethodHandle getter = nativeValueGetter(fromType);
 
         // Adapt cast that takes ([SqlFunctionProperties,] ?) to one that takes (?, SqlFunctionProperties), where ? is the return type of getter.
-        JavaScalarFunctionImplementation castImplementation = functionAndTypeManager.getJavaScalarFunctionImplementation(functionAndTypeManager.lookupCast(CastType.CAST, fromType.getTypeSignature(), toType.getTypeSignature()));
+        JavaScalarFunctionImplementation castImplementation = functionAndTypeManager.getJavaScalarFunctionImplementation(functionAndTypeManager.lookupCast(CastType.CAST, fromType, toType));
         MethodHandle cast = castImplementation.getMethodHandle();
         if (cast.type().parameterArray()[0] != SqlFunctionProperties.class) {
             cast = MethodHandles.dropArguments(cast, 0, SqlFunctionProperties.class);

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowToRowCast.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/RowToRowCast.java
@@ -141,7 +141,7 @@ public class RowToRowCast
 
         // loop through to append member blocks
         for (int i = 0; i < toTypes.size(); i++) {
-            FunctionHandle functionHandle = functionAndTypeManager.lookupCast(CastType.CAST, fromTypes.get(i).getTypeSignature(), toTypes.get(i).getTypeSignature());
+            FunctionHandle functionHandle = functionAndTypeManager.lookupCast(CastType.CAST, fromTypes.get(i), toTypes.get(i));
             JavaScalarFunctionImplementation function = functionAndTypeManager.getJavaScalarFunctionImplementation(functionHandle);
             Type currentFromType = fromTypes.get(i);
             if (currentFromType.equals(UNKNOWN)) {

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/TryCastFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/TryCastFunction.java
@@ -87,7 +87,7 @@ public class TryCastFunction
         MethodHandle tryCastHandle;
 
         // the resulting method needs to return a boxed type
-        FunctionHandle functionHandle = functionAndTypeManager.lookupCast(CAST, fromType.getTypeSignature(), toType.getTypeSignature());
+        FunctionHandle functionHandle = functionAndTypeManager.lookupCast(CAST, fromType, toType);
         ScalarFunctionImplementationChoice implementation = getAllScalarFunctionImplementationChoices(functionAndTypeManager.getJavaScalarFunctionImplementation(functionHandle)).get(0);
         argumentProperties = ImmutableList.of(implementation.getArgumentProperty(0));
         MethodHandle coercion = implementation.getMethodHandle();

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
@@ -781,7 +781,7 @@ public class ExpressionAnalyzer
 
             if (!JSON.equals(type)) {
                 try {
-                    functionAndTypeManager.lookupCast(CAST, VARCHAR.getTypeSignature(), type.getTypeSignature());
+                    functionAndTypeManager.lookupCast(CAST, VARCHAR, type);
                 }
                 catch (IllegalArgumentException e) {
                     throw new SemanticException(TYPE_MISMATCH, node, "No literal form for type %s", type);
@@ -1104,7 +1104,7 @@ public class ExpressionAnalyzer
             Type value = process(node.getExpression(), context);
             if (!value.equals(UNKNOWN) && !node.isTypeOnly()) {
                 try {
-                    functionAndTypeManager.lookupCast(CAST, value.getTypeSignature(), type.getTypeSignature());
+                    functionAndTypeManager.lookupCast(CAST, value, type);
                 }
                 catch (OperatorNotFoundException e) {
                     throw new SemanticException(TYPE_MISMATCH, node, "Cannot cast %s to %s", value, type);

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/NullIfCodeGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/NullIfCodeGenerator.java
@@ -20,7 +20,6 @@ import com.facebook.presto.bytecode.Variable;
 import com.facebook.presto.bytecode.control.IfStatement;
 import com.facebook.presto.bytecode.instruction.LabelNode;
 import com.facebook.presto.common.type.Type;
-import com.facebook.presto.common.type.TypeSignature;
 import com.facebook.presto.metadata.CastType;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
 import com.facebook.presto.spi.function.FunctionHandle;
@@ -73,8 +72,8 @@ public class NullIfCodeGenerator
                 EQUAL.name(),
                 equalsFunction,
                 ImmutableList.of(
-                        cast(generatorContext, firstValue, firstType, equalFunctionMetadata.getArgumentTypes().get(0)),
-                        cast(generatorContext, generatorContext.generate(second, Optional.empty()), secondType, equalFunctionMetadata.getArgumentTypes().get(1))));
+                        cast(generatorContext, firstValue, firstType, functionAndTypeManager.getType(equalFunctionMetadata.getArgumentTypes().get(0))),
+                        cast(generatorContext, generatorContext.generate(second, Optional.empty()), secondType, functionAndTypeManager.getType(equalFunctionMetadata.getArgumentTypes().get(1)))));
 
         BytecodeBlock conditionBlock = new BytecodeBlock()
                 .append(equalsCall)
@@ -100,7 +99,7 @@ public class NullIfCodeGenerator
             BytecodeGeneratorContext generatorContext,
             BytecodeNode argument,
             Type actualType,
-            TypeSignature requiredType)
+            Type requiredType)
     {
         if (actualType.getTypeSignature().equals(requiredType)) {
             return argument;
@@ -108,7 +107,7 @@ public class NullIfCodeGenerator
 
         FunctionHandle functionHandle = generatorContext
                 .getFunctionManager()
-                .lookupCast(CastType.CAST, actualType.getTypeSignature(), requiredType);
+                .lookupCast(CastType.CAST, actualType, requiredType);
 
         // TODO: do we need a full function call? (nullability checks, etc)
         return generatorContext.generateCall(CAST.name(), generatorContext.getFunctionManager().getJavaScalarFunctionImplementation(functionHandle), ImmutableList.of(argument));

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionDomainTranslator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionDomainTranslator.java
@@ -638,7 +638,7 @@ public final class ExpressionDomainTranslator
         private Optional<FunctionHandle> getSaturatedFloorCastOperator(Type fromType, Type toType)
         {
             try {
-                return Optional.of(metadata.getFunctionAndTypeManager().lookupCast(SATURATED_FLOOR_CAST, fromType.getTypeSignature(), toType.getTypeSignature()));
+                return Optional.of(metadata.getFunctionAndTypeManager().lookupCast(SATURATED_FLOOR_CAST, fromType, toType));
             }
             catch (OperatorNotFoundException e) {
                 return Optional.empty();
@@ -647,7 +647,7 @@ public final class ExpressionDomainTranslator
 
         private int compareOriginalValueToCoerced(Type originalValueType, Object originalValue, Type coercedValueType, Object coercedValue)
         {
-            FunctionHandle castToOriginalTypeOperator = metadata.getFunctionAndTypeManager().lookupCast(CAST, coercedValueType.getTypeSignature(), originalValueType.getTypeSignature());
+            FunctionHandle castToOriginalTypeOperator = metadata.getFunctionAndTypeManager().lookupCast(CAST, coercedValueType, originalValueType);
             Object coercedValueInOriginalType = functionInvoker.invoke(castToOriginalTypeOperator, session.getSqlFunctionProperties(), coercedValue);
             Block originalValueBlock = Utils.nativeValueToBlock(originalValueType, originalValue);
             Block coercedValueBlock = Utils.nativeValueToBlock(originalValueType, coercedValueInOriginalType);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
@@ -813,8 +813,8 @@ public class ExpressionInterpreter
             FunctionAndTypeManager functionAndTypeManager = metadata.getFunctionAndTypeManager();
             Type commonType = functionAndTypeManager.getCommonSuperType(firstType, secondType).get();
 
-            FunctionHandle firstCast = functionAndTypeManager.lookupCast(CAST, firstType.getTypeSignature(), commonType.getTypeSignature());
-            FunctionHandle secondCast = functionAndTypeManager.lookupCast(CAST, secondType.getTypeSignature(), commonType.getTypeSignature());
+            FunctionHandle firstCast = functionAndTypeManager.lookupCast(CAST, firstType, commonType);
+            FunctionHandle secondCast = functionAndTypeManager.lookupCast(CAST, secondType, commonType);
 
             // cast(first as <common type>) == cast(second as <common type>)
             boolean equal = Boolean.TRUE.equals(invokeOperator(
@@ -1149,7 +1149,7 @@ public class ExpressionInterpreter
                 return new Cast(toExpression(value, sourceType), node.getType(), node.isSafe(), node.isTypeOnly());
             }
 
-            FunctionHandle operator = metadata.getFunctionAndTypeManager().lookupCast(CAST, sourceType.getTypeSignature(), targetType.getTypeSignature());
+            FunctionHandle operator = metadata.getFunctionAndTypeManager().lookupCast(CAST, sourceType, targetType);
 
             try {
                 Object castedValue = functionInvoker.invoke(operator, session.getSqlFunctionProperties(), ImmutableList.of(value));

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LiteralInterpreter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LiteralInterpreter.java
@@ -256,7 +256,7 @@ public final class LiteralInterpreter
             }
 
             try {
-                FunctionHandle functionHandle = metadata.getFunctionAndTypeManager().lookupCast(CAST, VARCHAR.getTypeSignature(), type.getTypeSignature());
+                FunctionHandle functionHandle = metadata.getFunctionAndTypeManager().lookupCast(CAST, VARCHAR, type);
                 return functionInvoker.invoke(functionHandle, session.getSqlFunctionProperties(), ImmutableList.of(utf8Slice(node.getValue())));
             }
             catch (IllegalArgumentException e) {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/RowExpressionInterpreter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/RowExpressionInterpreter.java
@@ -21,7 +21,6 @@ import com.facebook.presto.common.function.OperatorType;
 import com.facebook.presto.common.type.ArrayType;
 import com.facebook.presto.common.type.FunctionType;
 import com.facebook.presto.common.type.RowType;
-import com.facebook.presto.common.type.StandardTypes;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeSignature;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
@@ -66,7 +65,6 @@ import static com.facebook.presto.common.type.JsonType.JSON;
 import static com.facebook.presto.common.type.StandardTypes.ARRAY;
 import static com.facebook.presto.common.type.StandardTypes.MAP;
 import static com.facebook.presto.common.type.StandardTypes.ROW;
-import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
 import static com.facebook.presto.common.type.TypeUtils.writeNativeValue;
 import static com.facebook.presto.common.type.UnknownType.UNKNOWN;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
@@ -378,8 +376,8 @@ public class RowExpressionInterpreter
                     Type leftType = node.getArguments().get(0).getType();
                     Type rightType = node.getArguments().get(1).getType();
                     Type commonType = metadata.getFunctionAndTypeManager().getCommonSuperType(leftType, rightType).get();
-                    FunctionHandle firstCast = metadata.getFunctionAndTypeManager().lookupCast(CAST, leftType.getTypeSignature(), commonType.getTypeSignature());
-                    FunctionHandle secondCast = metadata.getFunctionAndTypeManager().lookupCast(CAST, rightType.getTypeSignature(), commonType.getTypeSignature());
+                    FunctionHandle firstCast = metadata.getFunctionAndTypeManager().lookupCast(CAST, leftType, commonType);
+                    FunctionHandle secondCast = metadata.getFunctionAndTypeManager().lookupCast(CAST, rightType, commonType);
 
                     // cast(first as <common type>) == cast(second as <common type>)
                     boolean equal = Boolean.TRUE.equals(invokeOperator(
@@ -710,7 +708,7 @@ public class RowExpressionInterpreter
             String failureInfo = JsonCodec.jsonCodec(FailureInfo.class).toJson(Failures.toFailure(exception).toFailureInfo());
             FunctionHandle jsonParse = metadata.getFunctionAndTypeManager().lookupFunction("json_parse", fromTypes(VARCHAR));
             Object json = functionInvoker.invoke(jsonParse, session.getSqlFunctionProperties(), utf8Slice(failureInfo));
-            FunctionHandle cast = metadata.getFunctionAndTypeManager().lookupCast(CAST, UNKNOWN.getTypeSignature(), type.getTypeSignature());
+            FunctionHandle cast = metadata.getFunctionAndTypeManager().lookupCast(CAST, UNKNOWN, type);
             if (exception instanceof PrestoException) {
                 long errorCode = ((PrestoException) exception).getErrorCode().getCode();
                 FunctionHandle failureFunction = metadata.getFunctionAndTypeManager().lookupFunction("fail", fromTypes(INTEGER, JSON));
@@ -818,8 +816,8 @@ public class RowExpressionInterpreter
                                     JSON_TO_ARRAY_CAST.name(),
                                     functionAndTypeManager.lookupCast(
                                             JSON_TO_ARRAY_CAST,
-                                            parseTypeSignature(StandardTypes.VARCHAR),
-                                            returnType),
+                                            VARCHAR,
+                                            functionAndTypeManager.getType(returnType)),
                                     callExpression.getType(),
                                     innerCall.getArguments()));
                         }
@@ -828,8 +826,8 @@ public class RowExpressionInterpreter
                                     JSON_TO_MAP_CAST.name(),
                                     functionAndTypeManager.lookupCast(
                                             JSON_TO_MAP_CAST,
-                                            parseTypeSignature(StandardTypes.VARCHAR),
-                                            returnType),
+                                            VARCHAR,
+                                            functionAndTypeManager.getType(returnType)),
                                     callExpression.getType(),
                                     innerCall.getArguments()));
                         }
@@ -838,8 +836,8 @@ public class RowExpressionInterpreter
                                     JSON_TO_ROW_CAST.name(),
                                     functionAndTypeManager.lookupCast(
                                             JSON_TO_ROW_CAST,
-                                            parseTypeSignature(StandardTypes.VARCHAR),
-                                            returnType),
+                                            VARCHAR,
+                                            functionAndTypeManager.getType(returnType)),
                                     callExpression.getType(),
                                     innerCall.getArguments()));
                         }
@@ -932,11 +930,11 @@ public class RowExpressionInterpreter
                 RowExpression patternExpression = LiteralEncoder.toRowExpression(callExpression.getSourceLocation(), unescapedPattern, patternType);
                 Type superType = commonSuperType.get();
                 if (!valueType.equals(superType)) {
-                    FunctionHandle cast = metadata.getFunctionAndTypeManager().lookupCast(CAST, valueType.getTypeSignature(), superType.getTypeSignature());
+                    FunctionHandle cast = metadata.getFunctionAndTypeManager().lookupCast(CAST, valueType, superType);
                     valueExpression = call(CAST.name(), cast, superType, valueExpression);
                 }
                 if (!patternType.equals(superType)) {
-                    FunctionHandle cast = metadata.getFunctionAndTypeManager().lookupCast(CAST, patternType.getTypeSignature(), superType.getTypeSignature());
+                    FunctionHandle cast = metadata.getFunctionAndTypeManager().lookupCast(CAST, patternType, superType);
                     patternExpression = call(CAST.name(), cast, superType, patternExpression);
                 }
                 FunctionHandle equal = metadata.getFunctionAndTypeManager().resolveOperator(EQUAL, fromTypes(superType, superType));

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ExtractSpatialJoins.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ExtractSpatialJoins.java
@@ -659,7 +659,7 @@ public class ExtractSpatialJoins
             projections.put(outputVariable, outputVariable);
         }
 
-        FunctionHandle castFunctionHandle = functionAndTypeManager.lookupCast(CAST, VARCHAR.getTypeSignature(), KDB_TREE.getTypeSignature());
+        FunctionHandle castFunctionHandle = functionAndTypeManager.lookupCast(CAST, VARCHAR, KDB_TREE);
 
         ImmutableList.Builder partitioningArgumentsBuilder = ImmutableList.builder()
                 .add(new CallExpression(partitionVariable.getSourceLocation(), CAST.name(), castFunctionHandle, KDB_TREE, ImmutableList.of(Expressions.constant(utf8Slice(KdbTreeUtils.toJson(kdbTree)), VARCHAR))))

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/KeyBasedSampler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/KeyBasedSampler.java
@@ -120,7 +120,7 @@ public class KeyBasedSampler
             if (!Varchars.isVarcharType(type)) {
                 arg = call(
                         "CAST",
-                        functionAndTypeManager.lookupCast(CAST, rowExpression.getType().getTypeSignature(), VARCHAR.getTypeSignature()),
+                        functionAndTypeManager.lookupCast(CAST, rowExpression.getType(), VARCHAR),
                         VARCHAR,
                         rowExpression);
             }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
@@ -1301,7 +1301,7 @@ public class PlanPrinter
         }
 
         try {
-            FunctionHandle cast = functionAndTypeManager.lookupCast(CAST, type.getTypeSignature(), VARCHAR.getTypeSignature());
+            FunctionHandle cast = functionAndTypeManager.lookupCast(CAST, type, VARCHAR);
             Slice coerced = (Slice) new InterpretedFunctionInvoker(functionAndTypeManager).invoke(cast, session.getSqlFunctionProperties(), value);
             return "\"" + coerced.toStringUtf8().replace("\"", "\\\"") + "\"";
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/RowExpressionDomainTranslator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/RowExpressionDomainTranslator.java
@@ -563,7 +563,7 @@ public final class RowExpressionDomainTranslator
         private Optional<FunctionHandle> getSaturatedFloorCastOperator(Type fromType, Type toType)
         {
             try {
-                return Optional.of(metadata.getFunctionAndTypeManager().lookupCast(SATURATED_FLOOR_CAST, fromType.getTypeSignature(), toType.getTypeSignature()));
+                return Optional.of(metadata.getFunctionAndTypeManager().lookupCast(SATURATED_FLOOR_CAST, fromType, toType));
             }
             catch (OperatorNotFoundException e) {
                 return Optional.empty();
@@ -572,7 +572,7 @@ public final class RowExpressionDomainTranslator
 
         private int compareOriginalValueToCoerced(Type originalValueType, Object originalValue, Type coercedValueType, Object coercedValue)
         {
-            FunctionHandle castToOriginalTypeOperator = metadata.getFunctionAndTypeManager().lookupCast(CAST, coercedValueType.getTypeSignature(), originalValueType.getTypeSignature());
+            FunctionHandle castToOriginalTypeOperator = metadata.getFunctionAndTypeManager().lookupCast(CAST, coercedValueType, originalValueType);
             Object coercedValueInOriginalType = functionInvoker.invoke(castToOriginalTypeOperator, session.getSqlFunctionProperties(), coercedValue);
             Block originalValueBlock = Utils.nativeValueToBlock(originalValueType, originalValue);
             Block coercedValueBlock = Utils.nativeValueToBlock(originalValueType, coercedValueInOriginalType);

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/SqlToRowExpressionTranslator.java
@@ -358,7 +358,7 @@ public final class SqlToRowExpressionTranslator
             return call(
                     getSourceLocation(node),
                     CAST.name(),
-                    functionAndTypeManager.lookupCast(CAST, VARCHAR.getTypeSignature(), getType(node).getTypeSignature()),
+                    functionAndTypeManager.lookupCast(CAST, VARCHAR, getType(node)),
                     getType(node),
                     constant(utf8Slice(node.getValue()), VARCHAR));
         }
@@ -548,10 +548,10 @@ public final class SqlToRowExpressionTranslator
             RowExpression value = process(node.getExpression(), context);
 
             if (node.isSafe()) {
-                return call(getSourceLocation(node), TRY_CAST.name(), functionAndTypeManager.lookupCast(TRY_CAST, value.getType().getTypeSignature(), getType(node).getTypeSignature()), getType(node), value);
+                return call(getSourceLocation(node), TRY_CAST.name(), functionAndTypeManager.lookupCast(TRY_CAST, value.getType(), getType(node)), getType(node), value);
             }
 
-            return call(getSourceLocation(node), CAST.name(), functionAndTypeManager.lookupCast(CAST, value.getType().getTypeSignature(), getType(node).getTypeSignature()), getType(node), value);
+            return call(getSourceLocation(node), CAST.name(), functionAndTypeManager.lookupCast(CAST, value.getType(), getType(node)), getType(node), value);
         }
 
         @Override
@@ -752,7 +752,7 @@ public final class SqlToRowExpressionTranslator
                 return likeFunctionCall(value, call(getSourceLocation(node), "LIKE_PATTERN", functionResolution.likePatternFunction(), LIKE_PATTERN, pattern, escape));
             }
 
-            return likeFunctionCall(value, call(getSourceLocation(node), CAST.name(), functionAndTypeManager.lookupCast(CAST, VARCHAR.getTypeSignature(), LIKE_PATTERN.getTypeSignature()), LIKE_PATTERN, pattern));
+            return likeFunctionCall(value, call(getSourceLocation(node), CAST.name(), functionAndTypeManager.lookupCast(CAST, VARCHAR, LIKE_PATTERN), LIKE_PATTERN, pattern));
         }
 
         private RowExpression likeFunctionCall(RowExpression value, RowExpression pattern)

--- a/presto-main/src/main/java/com/facebook/presto/type/CodePointsType.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/CodePointsType.java
@@ -17,14 +17,14 @@ import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockBuilder;
 import com.facebook.presto.common.block.BlockBuilderStatus;
 import com.facebook.presto.common.function.SqlFunctionProperties;
-import com.facebook.presto.common.type.AbstractType;
+import com.facebook.presto.common.type.AbstractPrimitiveType;
 import com.facebook.presto.common.type.TypeSignature;
 import com.facebook.presto.spi.PrestoException;
 
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 
 public class CodePointsType
-        extends AbstractType
+        extends AbstractPrimitiveType
 {
     public static final CodePointsType CODE_POINTS = new CodePointsType();
     public static final String NAME = "CodePoints";

--- a/presto-main/src/main/java/com/facebook/presto/type/DistinctTypeCasts.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/DistinctTypeCasts.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.type;
+
+import com.facebook.presto.common.type.DistinctType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.metadata.BoundVariables;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.metadata.SqlOperator;
+import com.facebook.presto.operator.scalar.BuiltInScalarFunctionImplementation;
+import com.facebook.presto.spi.PrestoException;
+import com.google.common.collect.ImmutableList;
+
+import static com.facebook.presto.common.function.OperatorType.CAST;
+import static com.facebook.presto.common.type.DistinctType.hasAncestorRelationship;
+import static com.facebook.presto.common.type.StandardTypes.DISTINCT_TYPE;
+import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementationChoice.ArgumentProperty.valueTypeArgumentProperty;
+import static com.facebook.presto.operator.scalar.ScalarFunctionImplementationChoice.NullConvention.RETURN_NULL_ON_NULL;
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_CAST_ARGUMENT;
+import static com.facebook.presto.spi.function.Signature.typeVariable;
+import static com.facebook.presto.spi.function.Signature.withVariadicBound;
+import static java.lang.String.format;
+import static java.lang.invoke.MethodHandles.identity;
+
+public class DistinctTypeCasts
+{
+    private DistinctTypeCasts() {}
+
+    public static final DistinctTypeToCast DISTINCT_TYPE_TO_CAST = new DistinctTypeToCast();
+    public static final DistinctTypeFromCast DISTINCT_TYPE_FROM_CAST = new DistinctTypeFromCast();
+
+    public static class DistinctTypeToCast
+            extends SqlOperator
+    {
+        private DistinctTypeToCast()
+        {
+            super(CAST,
+                    ImmutableList.of(typeVariable("T1"), withVariadicBound("T2", DISTINCT_TYPE)),
+                    ImmutableList.of(),
+                    parseTypeSignature("T2"),
+                    ImmutableList.of(parseTypeSignature("T1")));
+        }
+
+        @Override
+        public BuiltInScalarFunctionImplementation specialize(BoundVariables boundVariables, int arity, FunctionAndTypeManager functionAndTypeManager)
+        {
+            Type fromType = boundVariables.getTypeVariable("T1");
+            Type toType = boundVariables.getTypeVariable("T2");
+            checkCanCast(fromType, toType);
+            return new BuiltInScalarFunctionImplementation(
+                    false,
+                    ImmutableList.of(
+                            valueTypeArgumentProperty(RETURN_NULL_ON_NULL),
+                            valueTypeArgumentProperty(RETURN_NULL_ON_NULL)),
+                    identity(fromType.getJavaType()));
+        }
+    }
+
+    public static class DistinctTypeFromCast
+            extends SqlOperator
+    {
+        private DistinctTypeFromCast()
+        {
+            super(CAST,
+                    ImmutableList.of(typeVariable("T2"), withVariadicBound("T1", DISTINCT_TYPE)),
+                    ImmutableList.of(),
+                    parseTypeSignature("T2"),
+                    ImmutableList.of(parseTypeSignature("T1")));
+        }
+
+        @Override
+        public BuiltInScalarFunctionImplementation specialize(BoundVariables boundVariables, int arity, FunctionAndTypeManager functionAndTypeManager)
+        {
+            Type fromType = boundVariables.getTypeVariable("T1");
+            Type toType = boundVariables.getTypeVariable("T2");
+            checkCanCast(fromType, toType);
+            return new BuiltInScalarFunctionImplementation(
+                    false,
+                    ImmutableList.of(
+                            valueTypeArgumentProperty(RETURN_NULL_ON_NULL),
+                            valueTypeArgumentProperty(RETURN_NULL_ON_NULL)),
+                    identity(fromType.getJavaType()));
+        }
+    }
+
+    private static void checkCanCast(Type fromType, Type toType)
+    {
+        if (fromType instanceof DistinctType && toType instanceof DistinctType) {
+            DistinctType fromDistinctType = (DistinctType) fromType;
+            DistinctType toDistinctType = (DistinctType) toType;
+
+            if (!hasAncestorRelationship(fromDistinctType, toDistinctType)) {
+                throw new PrestoException(INVALID_CAST_ARGUMENT, format("Cannot cast %s to %s", fromDistinctType.getName(), toDistinctType.getName()));
+            }
+        }
+        else if (fromType instanceof DistinctType) {
+            DistinctType fromDistinctType = (DistinctType) fromType;
+            if (!fromDistinctType.getBaseType().equals(toType)) {
+                throw new PrestoException(INVALID_CAST_ARGUMENT, format("Cannot cast %s to %s", fromDistinctType.getName(), toType));
+            }
+        }
+        else if (toType instanceof DistinctType) {
+            DistinctType toDistinctType = (DistinctType) toType;
+            if (!toDistinctType.getBaseType().equals(fromType)) {
+                throw new PrestoException(INVALID_CAST_ARGUMENT, format("Cannot cast %s to %s", fromType, toDistinctType.getName()));
+            }
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/type/IpAddressType.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/IpAddressType.java
@@ -19,7 +19,7 @@ import com.facebook.presto.common.block.BlockBuilderStatus;
 import com.facebook.presto.common.block.Int128ArrayBlockBuilder;
 import com.facebook.presto.common.block.PageBuilderStatus;
 import com.facebook.presto.common.function.SqlFunctionProperties;
-import com.facebook.presto.common.type.AbstractType;
+import com.facebook.presto.common.type.AbstractPrimitiveType;
 import com.facebook.presto.common.type.FixedWidthType;
 import com.facebook.presto.common.type.StandardTypes;
 import com.google.common.net.InetAddresses;
@@ -36,7 +36,7 @@ import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
 import static java.lang.Long.reverseBytes;
 
 public class IpAddressType
-        extends AbstractType
+        extends AbstractPrimitiveType
         implements FixedWidthType
 {
     public static final IpAddressType IPADDRESS = new IpAddressType();

--- a/presto-main/src/main/java/com/facebook/presto/type/IpPrefixType.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/IpPrefixType.java
@@ -19,7 +19,7 @@ import com.facebook.presto.common.block.BlockBuilderStatus;
 import com.facebook.presto.common.block.PageBuilderStatus;
 import com.facebook.presto.common.block.VariableWidthBlockBuilder;
 import com.facebook.presto.common.function.SqlFunctionProperties;
-import com.facebook.presto.common.type.AbstractType;
+import com.facebook.presto.common.type.AbstractPrimitiveType;
 import com.facebook.presto.common.type.FixedWidthType;
 import com.facebook.presto.common.type.StandardTypes;
 import com.google.common.net.InetAddresses;
@@ -32,7 +32,7 @@ import java.net.UnknownHostException;
 import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
 
 public class IpPrefixType
-        extends AbstractType
+        extends AbstractPrimitiveType
         implements FixedWidthType
 {
     public static final IpPrefixType IPPREFIX = new IpPrefixType();

--- a/presto-main/src/main/java/com/facebook/presto/type/JoniRegexpType.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/JoniRegexpType.java
@@ -17,7 +17,7 @@ import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockBuilder;
 import com.facebook.presto.common.block.BlockBuilderStatus;
 import com.facebook.presto.common.function.SqlFunctionProperties;
-import com.facebook.presto.common.type.AbstractType;
+import com.facebook.presto.common.type.AbstractPrimitiveType;
 import com.facebook.presto.common.type.TypeSignature;
 import com.facebook.presto.spi.PrestoException;
 import io.airlift.joni.Regex;
@@ -25,7 +25,7 @@ import io.airlift.joni.Regex;
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 
 public class JoniRegexpType
-        extends AbstractType
+        extends AbstractPrimitiveType
 {
     public static final JoniRegexpType JONI_REGEXP = new JoniRegexpType();
     public static final String NAME = "JoniRegExp";

--- a/presto-main/src/main/java/com/facebook/presto/type/JsonPathType.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/JsonPathType.java
@@ -17,7 +17,7 @@ import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockBuilder;
 import com.facebook.presto.common.block.BlockBuilderStatus;
 import com.facebook.presto.common.function.SqlFunctionProperties;
-import com.facebook.presto.common.type.AbstractType;
+import com.facebook.presto.common.type.AbstractPrimitiveType;
 import com.facebook.presto.common.type.TypeSignature;
 import com.facebook.presto.operator.scalar.JsonPath;
 import com.facebook.presto.spi.PrestoException;
@@ -25,7 +25,7 @@ import com.facebook.presto.spi.PrestoException;
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 
 public class JsonPathType
-        extends AbstractType
+        extends AbstractPrimitiveType
 {
     public static final JsonPathType JSON_PATH = new JsonPathType();
     public static final String NAME = "JsonPath";

--- a/presto-main/src/main/java/com/facebook/presto/type/LikePatternType.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/LikePatternType.java
@@ -17,7 +17,7 @@ import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockBuilder;
 import com.facebook.presto.common.block.BlockBuilderStatus;
 import com.facebook.presto.common.function.SqlFunctionProperties;
-import com.facebook.presto.common.type.AbstractType;
+import com.facebook.presto.common.type.AbstractPrimitiveType;
 import com.facebook.presto.common.type.TypeSignature;
 import com.facebook.presto.spi.PrestoException;
 import io.airlift.joni.Regex;
@@ -25,7 +25,7 @@ import io.airlift.joni.Regex;
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 
 public class LikePatternType
-        extends AbstractType
+        extends AbstractPrimitiveType
 {
     public static final LikePatternType LIKE_PATTERN = new LikePatternType();
     public static final String NAME = "LikePattern";

--- a/presto-main/src/main/java/com/facebook/presto/type/Re2JRegexpType.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/Re2JRegexpType.java
@@ -17,14 +17,14 @@ import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockBuilder;
 import com.facebook.presto.common.block.BlockBuilderStatus;
 import com.facebook.presto.common.function.SqlFunctionProperties;
-import com.facebook.presto.common.type.AbstractType;
+import com.facebook.presto.common.type.AbstractPrimitiveType;
 import com.facebook.presto.common.type.TypeSignature;
 import com.facebook.presto.spi.PrestoException;
 
 import static com.facebook.presto.spi.StandardErrorCode.GENERIC_INTERNAL_ERROR;
 
 public class Re2JRegexpType
-        extends AbstractType
+        extends AbstractPrimitiveType
 {
     public static final Re2JRegexpType RE2J_REGEXP = new Re2JRegexpType();
     public static final String NAME = "Re2JRegExp";

--- a/presto-main/src/main/java/com/facebook/presto/type/RowParametricType.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/RowParametricType.java
@@ -13,7 +13,6 @@
  */
 package com.facebook.presto.type;
 
-import com.facebook.presto.common.type.NamedTypeSignature;
 import com.facebook.presto.common.type.ParameterKind;
 import com.facebook.presto.common.type.ParametricType;
 import com.facebook.presto.common.type.RowFieldName;
@@ -21,8 +20,6 @@ import com.facebook.presto.common.type.RowType;
 import com.facebook.presto.common.type.StandardTypes;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.TypeParameter;
-import com.facebook.presto.common.type.TypeSignature;
-import com.facebook.presto.common.type.TypeSignatureParameter;
 
 import java.util.List;
 
@@ -53,16 +50,11 @@ public final class RowParametricType
                 "Expected only named types as a parameters, got %s",
                 parameters);
 
-        List<TypeSignatureParameter> typeSignatureParameters = parameters.stream()
-                .map(TypeParameter::getNamedType)
-                .map(parameter -> TypeSignatureParameter.of(new NamedTypeSignature(parameter.getName(), parameter.getType().getTypeSignature())))
-                .collect(toList());
-
         List<RowType.Field> fields = parameters.stream()
                 .map(TypeParameter::getNamedType)
-                .map(parameter -> new RowType.Field(parameter.getName().map(RowFieldName::getName), parameter.getType()))
+                .map(parameter -> new RowType.Field(parameter.getName().map(RowFieldName::getName), parameter.getType(), parameter.getName().map(RowFieldName::isDelimited).orElse(false)))
                 .collect(toList());
 
-        return RowType.createWithTypeSignature(new TypeSignature(StandardTypes.ROW, typeSignatureParameters), fields);
+        return RowType.from(fields);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/type/TypeCoercer.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/TypeCoercer.java
@@ -16,6 +16,7 @@ package com.facebook.presto.type;
 import com.facebook.presto.common.type.ArrayType;
 import com.facebook.presto.common.type.CharType;
 import com.facebook.presto.common.type.DecimalType;
+import com.facebook.presto.common.type.DistinctType;
 import com.facebook.presto.common.type.MapType;
 import com.facebook.presto.common.type.RowType;
 import com.facebook.presto.common.type.StandardTypes;
@@ -37,6 +38,7 @@ import java.util.Optional;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.CharType.createCharType;
 import static com.facebook.presto.common.type.DecimalType.createDecimalType;
+import static com.facebook.presto.common.type.DistinctType.getLowestCommonSuperType;
 import static com.facebook.presto.common.type.DoubleType.DOUBLE;
 import static com.facebook.presto.common.type.HyperLogLogType.HYPER_LOG_LOG;
 import static com.facebook.presto.common.type.IntegerType.INTEGER;
@@ -348,6 +350,16 @@ public class TypeCoercer
     {
         Type standardFromType = toStandardType(fromType);
         Type standardToType = toStandardType(toType);
+
+        // For distinct types, we only allow implicit coercion among themselves if they have a common supertype.
+        // We don't allow any implicit coercion to/from its base type.
+        if (standardFromType instanceof DistinctType && standardToType instanceof DistinctType) {
+            DistinctType fromDistinctType = (DistinctType) standardFromType;
+            DistinctType toDistinctType = (DistinctType) standardToType;
+            Optional<DistinctType> commonSuperType = getLowestCommonSuperType(fromDistinctType, toDistinctType);
+            return commonSuperType.map(distinctType -> TypeCompatibility.compatible(distinctType, distinctType.equals(standardToType)))
+                    .orElseGet(TypeCompatibility::incompatible);
+        }
 
         if (standardFromType.equals(standardToType)) {
             return TypeCompatibility.compatible(toSemanticType(toType, standardToType), true);

--- a/presto-main/src/main/java/com/facebook/presto/type/UuidType.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/UuidType.java
@@ -19,7 +19,7 @@ import com.facebook.presto.common.block.BlockBuilderStatus;
 import com.facebook.presto.common.block.Int128ArrayBlockBuilder;
 import com.facebook.presto.common.block.PageBuilderStatus;
 import com.facebook.presto.common.function.SqlFunctionProperties;
-import com.facebook.presto.common.type.AbstractType;
+import com.facebook.presto.common.type.AbstractPrimitiveType;
 import com.facebook.presto.common.type.FixedWidthType;
 import com.facebook.presto.common.type.StandardTypes;
 import io.airlift.slice.Slice;
@@ -33,7 +33,7 @@ import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
 import static io.airlift.slice.SizeOf.SIZE_OF_LONG;
 
 public class UuidType
-        extends AbstractType
+        extends AbstractPrimitiveType
         implements FixedWidthType
 {
     public static final UuidType UUID = new UuidType();

--- a/presto-main/src/test/java/com/facebook/presto/metadata/TestFunctionAndTypeManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/metadata/TestFunctionAndTypeManager.java
@@ -83,7 +83,7 @@ public class TestFunctionAndTypeManager
     public void testIdentityCast()
     {
         FunctionAndTypeManager functionAndTypeManager = createTestFunctionAndTypeManager();
-        FunctionHandle exactOperator = functionAndTypeManager.lookupCast(CastType.CAST, HYPER_LOG_LOG.getTypeSignature(), HYPER_LOG_LOG.getTypeSignature());
+        FunctionHandle exactOperator = functionAndTypeManager.lookupCast(CastType.CAST, HYPER_LOG_LOG, HYPER_LOG_LOG);
         assertEquals(exactOperator, new BuiltInFunctionHandle(new Signature(CAST.getFunctionName(), SCALAR, HYPER_LOG_LOG.getTypeSignature(), HYPER_LOG_LOG.getTypeSignature())));
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkJsonToArrayCast.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkJsonToArrayCast.java
@@ -114,7 +114,7 @@ public class BenchmarkJsonToArrayCast
 
             MetadataManager metadata = createTestMetadataManager();
             FunctionAndTypeManager functionAndTypeManager = metadata.getFunctionAndTypeManager();
-            FunctionHandle functionHandle = functionAndTypeManager.lookupCast(CAST, JSON.getTypeSignature(), (new ArrayType(elementType)).getTypeSignature());
+            FunctionHandle functionHandle = functionAndTypeManager.lookupCast(CAST, JSON, new ArrayType(elementType));
 
             List<RowExpression> projections = ImmutableList.of(
                     new CallExpression(CAST.name(), functionHandle, new ArrayType(elementType), ImmutableList.of(field(0, JSON))));

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkJsonToMapCast.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkJsonToMapCast.java
@@ -99,7 +99,7 @@ public class BenchmarkJsonToMapCast
         {
             MetadataManager metadata = createTestMetadataManager();
             FunctionAndTypeManager functionAndTypeManager = metadata.getFunctionAndTypeManager();
-            FunctionHandle functionHandle = functionAndTypeManager.lookupCast(CAST, JSON.getTypeSignature(), mapType(VARCHAR, BIGINT).getTypeSignature());
+            FunctionHandle functionHandle = functionAndTypeManager.lookupCast(CAST, JSON, mapType(VARCHAR, BIGINT));
 
             Type valueType;
             switch (valueTypeName) {

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkMapToMapCast.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkMapToMapCast.java
@@ -93,7 +93,7 @@ public class BenchmarkMapToMapCast
         public void setup()
         {
             MetadataManager metadata = createTestMetadataManager();
-            FunctionHandle functionHandle = metadata.getFunctionAndTypeManager().lookupCast(CAST, mapType(DOUBLE, BIGINT).getTypeSignature(), mapType(BIGINT, DOUBLE).getTypeSignature());
+            FunctionHandle functionHandle = metadata.getFunctionAndTypeManager().lookupCast(CAST, mapType(DOUBLE, BIGINT), mapType(BIGINT, DOUBLE));
 
             List<RowExpression> projections = ImmutableList.of(
                     new CallExpression(CAST.name(), functionHandle, mapType(BIGINT, DOUBLE), ImmutableList.of(field(0, mapType(DOUBLE, BIGINT)))));

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkRowToRowCast.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/BenchmarkRowToRowCast.java
@@ -93,7 +93,7 @@ public class BenchmarkRowToRowCast
         public void setup()
         {
             MetadataManager metadata = createTestMetadataManager();
-            FunctionHandle functionHandle = metadata.getFunctionAndTypeManager().lookupCast(CAST, RowType.anonymous(fromFieldTypes).getTypeSignature(), RowType.anonymous(toFieldTypes).getTypeSignature());
+            FunctionHandle functionHandle = metadata.getFunctionAndTypeManager().lookupCast(CAST, RowType.anonymous(fromFieldTypes), RowType.anonymous(toFieldTypes));
 
             List<RowExpression> projections = ImmutableList.of(
                     new CallExpression(CAST.name(), functionHandle, RowType.anonymous(fromFieldTypes), ImmutableList.of(field(0, RowType.anonymous(toFieldTypes)))));

--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/TestInCodeGenerator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/TestInCodeGenerator.java
@@ -53,7 +53,7 @@ public class TestInCodeGenerator
         assertEquals(checkSwitchGenerationCase(INTEGER, values), DIRECT_SWITCH);
         values.add(new CallExpression(
                 CAST.name(),
-                functionAndTypeManager.lookupCast(CAST, DOUBLE.getTypeSignature(), INTEGER.getTypeSignature()),
+                functionAndTypeManager.lookupCast(CAST, DOUBLE, INTEGER),
                 INTEGER,
                 Collections.singletonList(constant(12345678901234.0, DOUBLE))));
         assertEquals(checkSwitchGenerationCase(INTEGER, values), DIRECT_SWITCH);
@@ -81,7 +81,7 @@ public class TestInCodeGenerator
         assertEquals(checkSwitchGenerationCase(BIGINT, values), HASH_SWITCH);
         values.add(new CallExpression(
                 CAST.name(),
-                functionAndTypeManager.lookupCast(CAST, DOUBLE.getTypeSignature(), BIGINT.getTypeSignature()),
+                functionAndTypeManager.lookupCast(CAST, DOUBLE, BIGINT),
                 BIGINT,
                 Collections.singletonList(constant(12345678901234.0, DOUBLE))));
         assertEquals(checkSwitchGenerationCase(BIGINT, values), HASH_SWITCH);

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestRowExpressionDomainTranslator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestRowExpressionDomainTranslator.java
@@ -1233,7 +1233,7 @@ public class TestRowExpressionDomainTranslator
 
     private RowExpression cast(RowExpression expression, Type toType)
     {
-        FunctionHandle cast = metadata.getFunctionAndTypeManager().lookupCast(CastType.CAST, expression.getType().getTypeSignature(), toType.getTypeSignature());
+        FunctionHandle cast = metadata.getFunctionAndTypeManager().lookupCast(CastType.CAST, expression.getType(), toType);
         return call(CastType.CAST.name(), cast, toType, expression);
     }
 
@@ -1329,7 +1329,7 @@ public class TestRowExpressionDomainTranslator
         RowExpression random = call("random", metadata.getFunctionAndTypeManager().lookupFunction("random", fromTypes()), DOUBLE);
         return greaterThan(
                 expression,
-                call(CastType.CAST.name(), metadata.getFunctionAndTypeManager().lookupCast(CastType.CAST, DOUBLE.getTypeSignature(), expression.getType().getTypeSignature()), expression.getType(), random));
+                call(CastType.CAST.name(), metadata.getFunctionAndTypeManager().lookupCast(CastType.CAST, DOUBLE, expression.getType()), expression.getType(), random));
     }
 
     private void assertUnsupportedPredicate(RowExpression expression)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestRowExpressionFormatter.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestRowExpressionFormatter.java
@@ -227,7 +227,7 @@ public class TestRowExpressionFormatter
         // cast
         callExpression = call(
                 CAST.name(),
-                FUNCTION_AND_TYPE_MANAGER.lookupCast(CastType.CAST, TINYINT.getTypeSignature(), BIGINT.getTypeSignature()),
+                FUNCTION_AND_TYPE_MANAGER.lookupCast(CastType.CAST, TINYINT, BIGINT),
                 BIGINT,
                 constant(1L, TINYINT));
         assertEquals(format(callExpression), "CAST(TINYINT'1' AS bigint)");
@@ -258,7 +258,7 @@ public class TestRowExpressionFormatter
                 C_VARCHAR,
                 call(
                         CAST.name(),
-                        FUNCTION_AND_TYPE_MANAGER.lookupCast(CastType.CAST, VARCHAR.getTypeSignature(), LIKE_PATTERN.getTypeSignature()),
+                        FUNCTION_AND_TYPE_MANAGER.lookupCast(CastType.CAST, VARCHAR, LIKE_PATTERN),
                         LIKE_PATTERN,
                         constant(utf8Slice("prefix%"), VARCHAR)));
         assertEquals(format(callExpression), "c_varchar LIKE VARCHAR'prefix%'");

--- a/presto-main/src/test/java/com/facebook/presto/sql/relational/TestRowExpressionOptimizer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/relational/TestRowExpressionOptimizer.java
@@ -101,7 +101,7 @@ public class TestRowExpressionOptimizer
         FunctionHandle jsonParseFunctionHandle = functionAndTypeManager.lookupFunction("json_parse", fromTypes(VARCHAR));
 
         // constant
-        FunctionHandle jsonCastFunctionHandle = functionAndTypeManager.lookupCast(CAST, JSON.getTypeSignature(), parseTypeSignature("array(integer)"));
+        FunctionHandle jsonCastFunctionHandle = functionAndTypeManager.lookupCast(CAST, JSON, functionAndTypeManager.getType(parseTypeSignature("array(integer)")));
         RowExpression jsonCastExpression = new CallExpression(CAST.name(), jsonCastFunctionHandle, new ArrayType(INTEGER), ImmutableList.of(call("json_parse", jsonParseFunctionHandle, JSON, constant(utf8Slice("[1, 2]"), VARCHAR))));
         RowExpression resultExpression = optimize(jsonCastExpression);
         assertInstanceOf(resultExpression, ConstantExpression.class);
@@ -110,28 +110,28 @@ public class TestRowExpressionOptimizer
         assertEquals(toValues(INTEGER, (IntArrayBlock) resultValue), ImmutableList.of(1, 2));
 
         // varchar to array
-        jsonCastFunctionHandle = functionAndTypeManager.lookupCast(CAST, JSON.getTypeSignature(), parseTypeSignature("array(varchar)"));
+        jsonCastFunctionHandle = functionAndTypeManager.lookupCast(CAST, JSON, functionAndTypeManager.getType(parseTypeSignature("array(varchar)")));
         jsonCastExpression = call(CAST.name(), jsonCastFunctionHandle, new ArrayType(VARCHAR), ImmutableList.of(call("json_parse", jsonParseFunctionHandle, JSON, field(1, VARCHAR))));
         resultExpression = optimize(jsonCastExpression);
         assertEquals(
                 resultExpression,
-                call(JSON_TO_ARRAY_CAST.name(), functionAndTypeManager.lookupCast(JSON_TO_ARRAY_CAST, VARCHAR.getTypeSignature(), parseTypeSignature("array(varchar)")), new ArrayType(VARCHAR), field(1, VARCHAR)));
+                call(JSON_TO_ARRAY_CAST.name(), functionAndTypeManager.lookupCast(JSON_TO_ARRAY_CAST, VARCHAR, functionAndTypeManager.getType(parseTypeSignature("array(varchar)"))), new ArrayType(VARCHAR), field(1, VARCHAR)));
 
         // varchar to map
-        jsonCastFunctionHandle = functionAndTypeManager.lookupCast(CAST, JSON.getTypeSignature(), parseTypeSignature("map(integer,varchar)"));
+        jsonCastFunctionHandle = functionAndTypeManager.lookupCast(CAST, JSON, functionAndTypeManager.getType(parseTypeSignature("map(integer,varchar)")));
         jsonCastExpression = call(CAST.name(), jsonCastFunctionHandle, mapType(INTEGER, VARCHAR), ImmutableList.of(call("json_parse", jsonParseFunctionHandle, JSON, field(1, VARCHAR))));
         resultExpression = optimize(jsonCastExpression);
         assertEquals(
                 resultExpression,
-                call(JSON_TO_MAP_CAST.name(), functionAndTypeManager.lookupCast(JSON_TO_MAP_CAST, VARCHAR.getTypeSignature(), parseTypeSignature("map(integer, varchar)")), mapType(INTEGER, VARCHAR), field(1, VARCHAR)));
+                call(JSON_TO_MAP_CAST.name(), functionAndTypeManager.lookupCast(JSON_TO_MAP_CAST, VARCHAR, functionAndTypeManager.getType(parseTypeSignature("map(integer, varchar)"))), mapType(INTEGER, VARCHAR), field(1, VARCHAR)));
 
         // varchar to row
-        jsonCastFunctionHandle = functionAndTypeManager.lookupCast(CAST, JSON.getTypeSignature(), parseTypeSignature("row(varchar,bigint)"));
+        jsonCastFunctionHandle = functionAndTypeManager.lookupCast(CAST, JSON, functionAndTypeManager.getType(parseTypeSignature("row(varchar,bigint)")));
         jsonCastExpression = call(CAST.name(), jsonCastFunctionHandle, RowType.anonymous(ImmutableList.of(VARCHAR, BIGINT)), ImmutableList.of(call("json_parse", jsonParseFunctionHandle, JSON, field(1, VARCHAR))));
         resultExpression = optimize(jsonCastExpression);
         assertEquals(
                 resultExpression,
-                call(JSON_TO_ROW_CAST.name(), functionAndTypeManager.lookupCast(JSON_TO_ROW_CAST, VARCHAR.getTypeSignature(), parseTypeSignature("row(varchar,bigint)")), RowType.anonymous(ImmutableList.of(VARCHAR, BIGINT)), field(1, VARCHAR)));
+                call(JSON_TO_ROW_CAST.name(), functionAndTypeManager.lookupCast(JSON_TO_ROW_CAST, VARCHAR, functionAndTypeManager.getType(parseTypeSignature("row(varchar,bigint)"))), RowType.anonymous(ImmutableList.of(VARCHAR, BIGINT)), field(1, VARCHAR)));
     }
 
     private static RowExpression ifExpression(RowExpression condition, long trueValue, long falseValue)

--- a/presto-main/src/test/java/com/facebook/presto/type/TestBuiltInTypeRegistry.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestBuiltInTypeRegistry.java
@@ -249,7 +249,7 @@ public class TestBuiltInTypeRegistry
             for (Type resultType : types) {
                 if (functionAndTypeManager.canCoerce(sourceType, resultType) && sourceType != UNKNOWN && resultType != UNKNOWN) {
                     try {
-                        functionAndTypeManager.lookupCast(CAST, sourceType.getTypeSignature(), resultType.getTypeSignature());
+                        functionAndTypeManager.lookupCast(CAST, sourceType, resultType);
                     }
                     catch (OperatorNotFoundException e) {
                         fail(format("'%s' -> '%s' coercion exists but there is no cast operator", sourceType, resultType));

--- a/presto-tests/src/main/java/com/facebook/presto/tests/H2QueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/H2QueryRunner.java
@@ -17,6 +17,7 @@ import com.facebook.presto.Session;
 import com.facebook.presto.common.type.ArrayType;
 import com.facebook.presto.common.type.CharType;
 import com.facebook.presto.common.type.DecimalType;
+import com.facebook.presto.common.type.DistinctType;
 import com.facebook.presto.common.type.RowType;
 import com.facebook.presto.common.type.TimestampType;
 import com.facebook.presto.common.type.Type;
@@ -312,6 +313,9 @@ public class H2QueryRunner
                 }
                 else if (type instanceof TypeWithName) {
                     return getValue(((TypeWithName) type).getType(), resultSet, position);
+                }
+                else if (type instanceof DistinctType) {
+                    return getValue(((DistinctType) type).getBaseType(), resultSet, position);
                 }
                 else {
                     throw new AssertionError("unhandled type: " + type);

--- a/presto-tests/src/main/java/com/facebook/presto/tests/TestingPrestoClient.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/TestingPrestoClient.java
@@ -21,6 +21,7 @@ import com.facebook.presto.client.QueryStatusInfo;
 import com.facebook.presto.common.type.ArrayType;
 import com.facebook.presto.common.type.BigintEnumType;
 import com.facebook.presto.common.type.DecimalType;
+import com.facebook.presto.common.type.DistinctType;
 import com.facebook.presto.common.type.JsonType;
 import com.facebook.presto.common.type.MapType;
 import com.facebook.presto.common.type.RowType;
@@ -266,6 +267,9 @@ public class TestingPrestoClient
         }
         else if (type instanceof BigintEnumType) {
             return ((Number) value).longValue();
+        }
+        else if (type instanceof DistinctType) {
+            return convertToRowValue(((DistinctType) type).getBaseType(), value);
         }
         else if (type instanceof TypeWithName) {
             return convertToRowValue(((TypeWithName) type).getType(), value);


### PR DESCRIPTION
Added implicit and explicit casting for presto distinct types.

A bit hacky. We seem to be converting between type signatures and types. We can lose some information this way if we only do some operations after converting to type signature but dont convert back. This happens when we do distinct type LCA check in specialize(). To circumvent this, some hacks are done in lookupCast(). 

Also made DistinctType threadsafe, as it was cached in parametricTypesCache, specializedfunctionkeycache etc.

Depended by https://github.com/facebookexternal/presto-facebook/pull/1820

```
== NO RELEASE NOTE ==
```
