### PR TITLE
Add adaptive execution policy

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -218,6 +218,7 @@ public final class SystemSessionProperties
     public static final String DISTRIBUTED_TRACING_MODE = "distributed_tracing_mode";
     public static final String VERBOSE_RUNTIME_STATS_ENABLED = "verbose_runtime_stats_enabled";
     public static final String STREAMING_FOR_PARTIAL_AGGREGATION_ENABLED = "streaming_for_partial_aggregation_enabled";
+    public static final String MAX_STAGE_COUNT_FOR_EAGER_SCHEDULING = "max_stage_count_for_eager_scheduling";
 
     //TODO: Prestissimo related session properties that are temporarily put here. They will be relocated in the future
     public static final String PRESTISSIMO_SIMPLIFIED_EXPRESSION_EVALUATION_ENABLED = "simplified_expression_evaluation_enabled";
@@ -1229,6 +1230,11 @@ public final class SystemSessionProperties
                         HASH_BASED_DISTINCT_LIMIT_ENABLED,
                         "Hash based distinct limit enabled",
                         featuresConfig.isHashBasedDistinctLimitEnabled(),
+                        false),
+                integerProperty(
+                        MAX_STAGE_COUNT_FOR_EAGER_SCHEDULING,
+                        "Maximum stage count to use eager scheduling when using the adaptive scheduling policy",
+                        featuresConfig.getMaxStageCountForEagerScheduling(),
                         false));
     }
 
@@ -2063,5 +2069,10 @@ public final class SystemSessionProperties
     public static String getHeapDumpFileDirectory(Session session)
     {
         return session.getSystemProperty(EXCEEDED_MEMORY_LIMIT_HEAP_DUMP_FILE_DIRECTORY, String.class);
+    }
+
+    public static int getMaxStageCountForEagerScheduling(Session session)
+    {
+        return session.getSystemProperty(MAX_STAGE_COUNT_FOR_EAGER_SCHEDULING, Integer.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/AdaptivePhasedExecutionPolicy.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/AdaptivePhasedExecutionPolicy.java
@@ -17,12 +17,19 @@ import com.facebook.presto.Session;
 
 import java.util.Collection;
 
-public class AllAtOnceExecutionPolicy
+import static com.facebook.presto.SystemSessionProperties.getMaxStageCountForEagerScheduling;
+
+public class AdaptivePhasedExecutionPolicy
         implements ExecutionPolicy
 {
     @Override
     public ExecutionSchedule createExecutionSchedule(Session session, Collection<StageExecutionAndScheduler> stages)
     {
-        return new AllAtOnceExecutionSchedule(stages);
+        if (stages.size() > getMaxStageCountForEagerScheduling(session)) {
+            return new PhasedExecutionSchedule(stages);
+        }
+        else {
+            return new AllAtOnceExecutionSchedule(stages);
+        }
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/ExecutionPolicy.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/ExecutionPolicy.java
@@ -13,9 +13,11 @@
  */
 package com.facebook.presto.execution.scheduler;
 
+import com.facebook.presto.Session;
+
 import java.util.Collection;
 
 public interface ExecutionPolicy
 {
-    ExecutionSchedule createExecutionSchedule(Collection<StageExecutionAndScheduler> stages);
+    ExecutionSchedule createExecutionSchedule(Session session, Collection<StageExecutionAndScheduler> stages);
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/LegacySqlQueryScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/LegacySqlQueryScheduler.java
@@ -413,7 +413,7 @@ public class LegacySqlQueryScheduler
                 sectionStageExecutions.stream()
                         .map(executionInfos -> executionInfos.stream()
                                 .collect(toImmutableList()))
-                        .map(executionPolicy::createExecutionSchedule)
+                        .map(stages -> executionPolicy.createExecutionSchedule(session, stages))
                         .forEach(sectionExecutionSchedules::add);
 
                 while (sectionExecutionSchedules.stream().noneMatch(ExecutionSchedule::isFinished)) {

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/PhasedExecutionPolicy.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/PhasedExecutionPolicy.java
@@ -13,13 +13,15 @@
  */
 package com.facebook.presto.execution.scheduler;
 
+import com.facebook.presto.Session;
+
 import java.util.Collection;
 
 public class PhasedExecutionPolicy
         implements ExecutionPolicy
 {
     @Override
-    public ExecutionSchedule createExecutionSchedule(Collection<StageExecutionAndScheduler> stages)
+    public ExecutionSchedule createExecutionSchedule(Session session, Collection<StageExecutionAndScheduler> stages)
     {
         return new PhasedExecutionSchedule(stages);
     }

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SqlQueryScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/SqlQueryScheduler.java
@@ -320,7 +320,7 @@ public class SqlQueryScheduler
                 sectionExecutions.forEach(sectionExecution -> scheduledStageExecutions.addAll(sectionExecution.getSectionStages()));
                 sectionExecutions.stream()
                         .map(SectionExecution::getSectionStages)
-                        .map(executionPolicy::createExecutionSchedule)
+                        .map(stages -> executionPolicy.createExecutionSchedule(session, stages))
                         .forEach(executionSchedules::add);
 
                 while (!executionSchedules.isEmpty() && executionSchedules.stream().noneMatch(ExecutionSchedule::isFinished)) {

--- a/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
@@ -50,6 +50,7 @@ import com.facebook.presto.execution.TaskManagerConfig;
 import com.facebook.presto.execution.resourceGroups.InternalResourceGroupManager;
 import com.facebook.presto.execution.resourceGroups.LegacyResourceGroupConfigurationManager;
 import com.facebook.presto.execution.resourceGroups.ResourceGroupManager;
+import com.facebook.presto.execution.scheduler.AdaptivePhasedExecutionPolicy;
 import com.facebook.presto.execution.scheduler.AllAtOnceExecutionPolicy;
 import com.facebook.presto.execution.scheduler.ExecutionPolicy;
 import com.facebook.presto.execution.scheduler.PhasedExecutionPolicy;
@@ -291,6 +292,7 @@ public class CoordinatorModule
         MapBinder<String, ExecutionPolicy> executionPolicyBinder = newMapBinder(binder, String.class, ExecutionPolicy.class);
         executionPolicyBinder.addBinding("all-at-once").to(AllAtOnceExecutionPolicy.class);
         executionPolicyBinder.addBinding("phased").to(PhasedExecutionPolicy.class);
+        executionPolicyBinder.addBinding("adaptive").to(AdaptivePhasedExecutionPolicy.class);
 
         configBinder(binder).bindConfig(NodeResourceStatusConfig.class);
         binder.bind(NodeResourceStatusProvider.class).to(NodeResourceStatus.class).in(Scopes.SINGLETON);

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -216,6 +216,8 @@ public class FeaturesConfig
 
     private boolean streamingForPartialAggregationEnabled;
 
+    private int maxStageCountForEagerScheduling = 25;
+
     public enum PartitioningPrecisionStrategy
     {
         // Let Presto decide when to repartition
@@ -1967,6 +1969,20 @@ public class FeaturesConfig
     public FeaturesConfig setStreamingForPartialAggregationEnabled(boolean streamingForPartialAggregationEnabled)
     {
         this.streamingForPartialAggregationEnabled = streamingForPartialAggregationEnabled;
+        return this;
+    }
+
+    public int getMaxStageCountForEagerScheduling()
+    {
+        return maxStageCountForEagerScheduling;
+    }
+
+    @Min(1)
+    @Config("execution-policy.max-stage-count-for-eager-scheduling")
+    @ConfigDescription("When execution policy is set to adaptive, this number determines when to switch to phased execution.")
+    public FeaturesConfig setMaxStageCountForEagerScheduling(int maxStageCountForEagerScheduling)
+    {
+        this.maxStageCountForEagerScheduling = maxStageCountForEagerScheduling;
         return this;
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestAdaptivePhasedExecutionPolicy.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/scheduler/TestAdaptivePhasedExecutionPolicy.java
@@ -1,0 +1,184 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution.scheduler;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.SystemSessionProperties;
+import com.facebook.presto.cost.StatsAndCosts;
+import com.facebook.presto.execution.MockRemoteTaskFactory;
+import com.facebook.presto.execution.NodeTaskMap;
+import com.facebook.presto.execution.QueryManagerConfig;
+import com.facebook.presto.execution.SqlStageExecution;
+import com.facebook.presto.execution.StageExecutionId;
+import com.facebook.presto.execution.StageId;
+import com.facebook.presto.execution.TaskManagerConfig;
+import com.facebook.presto.execution.warnings.WarningCollectorConfig;
+import com.facebook.presto.failureDetector.NoOpFailureDetector;
+import com.facebook.presto.memory.MemoryManagerConfig;
+import com.facebook.presto.memory.NodeMemoryConfig;
+import com.facebook.presto.metadata.SessionPropertyManager;
+import com.facebook.presto.operator.StageExecutionDescriptor;
+import com.facebook.presto.spi.ConnectorId;
+import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.spi.TableHandle;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.PlanNodeId;
+import com.facebook.presto.spi.plan.TableScanNode;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.spiller.NodeSpillConfig;
+import com.facebook.presto.sql.analyzer.FeaturesConfig;
+import com.facebook.presto.sql.planner.Partitioning;
+import com.facebook.presto.sql.planner.PartitioningScheme;
+import com.facebook.presto.sql.planner.PlanFragment;
+import com.facebook.presto.sql.planner.plan.PlanFragmentId;
+import com.facebook.presto.sql.planner.plan.RemoteSourceNode;
+import com.facebook.presto.testing.TestingMetadata;
+import com.facebook.presto.testing.TestingTransactionHandle;
+import com.facebook.presto.tracing.TracingConfig;
+import com.facebook.presto.util.FinalizerService;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+import java.util.Collection;
+import java.util.Optional;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.stream.IntStream;
+
+import static com.facebook.airlift.concurrent.Threads.daemonThreadsNamed;
+import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.execution.SqlStageExecution.createSqlStageExecution;
+import static com.facebook.presto.sql.planner.SystemPartitioningHandle.SINGLE_DISTRIBUTION;
+import static com.facebook.presto.sql.planner.SystemPartitioningHandle.SOURCE_DISTRIBUTION;
+import static com.facebook.presto.sql.planner.plan.ExchangeNode.Type.REPARTITION;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.util.concurrent.MoreExecutors.directExecutor;
+import static com.google.common.util.concurrent.MoreExecutors.newDirectExecutorService;
+import static java.util.concurrent.Executors.newScheduledThreadPool;
+import static org.testng.Assert.assertTrue;
+
+public class TestAdaptivePhasedExecutionPolicy
+{
+    private static final ConnectorTransactionHandle TRANSACTION_HANDLE = TestingTransactionHandle.create();
+    private static final PlanNodeId TABLE_SCAN_NODE_ID = new PlanNodeId("tableScan");
+    private static final ConnectorId CONNECTOR_ID = new ConnectorId("test");
+
+    private final ScheduledExecutorService scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("testAdaptivePhasedExecutionPolicy-%s"));
+
+    @AfterClass
+    public void tearDownExecutor()
+    {
+        scheduledExecutor.shutdownNow();
+    }
+
+    @Test
+    public void testCreateExecutionSchedule()
+    {
+        Session session = testSessionBuilder(new SessionPropertyManager(new SystemSessionProperties(
+                new QueryManagerConfig(),
+                new TaskManagerConfig(),
+                new MemoryManagerConfig(),
+                new FeaturesConfig().setMaxStageCountForEagerScheduling(5),
+                new NodeMemoryConfig(),
+                new WarningCollectorConfig(),
+                new NodeSchedulerConfig(),
+                new NodeSpillConfig(),
+                new TracingConfig()))).build();
+
+        AdaptivePhasedExecutionPolicy policy = new AdaptivePhasedExecutionPolicy();
+        Collection<StageExecutionAndScheduler> schedulers = getStageExecutionAndSchedulers(4);
+        assertTrue(policy.createExecutionSchedule(session, schedulers) instanceof AllAtOnceExecutionSchedule);
+        schedulers = getStageExecutionAndSchedulers(5);
+        assertTrue(policy.createExecutionSchedule(session, schedulers) instanceof AllAtOnceExecutionSchedule);
+        schedulers = getStageExecutionAndSchedulers(6);
+        assertTrue(policy.createExecutionSchedule(session, schedulers) instanceof PhasedExecutionSchedule);
+    }
+
+    private Collection<StageExecutionAndScheduler> getStageExecutionAndSchedulers(int count)
+    {
+        PlanNode node = getTableScanNode();
+
+        ImmutableList<StageExecutionAndScheduler> exchanges = IntStream.rangeClosed(1, count - 1)
+                .mapToObj(stage -> getStageExecutionAndScheduler(stage, getRemoteSourcePlanNode(new PlanFragmentId(stage))))
+                .collect(toImmutableList());
+        return ImmutableList.<StageExecutionAndScheduler>builder()
+            .add(getStageExecutionAndScheduler(0, node))
+            .addAll(exchanges)
+            .build();
+    }
+
+    private StageExecutionAndScheduler getStageExecutionAndScheduler(int stage, PlanNode fragementNode)
+    {
+        PlanFragmentId fragmentId = new PlanFragmentId(stage);
+        StageId stageId = new StageId(new QueryId("query"), stage);
+        SqlStageExecution stageExecution = createSqlStageExecution(
+                new StageExecutionId(stageId, stage),
+                createPlanFragment(fragmentId, fragementNode),
+                new MockRemoteTaskFactory(directExecutor(), scheduledExecutor),
+                TEST_SESSION,
+                true,
+                new NodeTaskMap(new FinalizerService()),
+                newDirectExecutorService(),
+                new NoOpFailureDetector(),
+                new SplitSchedulerStats(),
+                new TableWriteInfo(Optional.empty(), Optional.empty(), Optional.empty()));
+        StageLinkage stageLinkage = new StageLinkage(fragmentId, (id, tasks, noMoreExchangeLocations) -> {}, ImmutableSet.of());
+        StageScheduler stageScheduler = new FixedCountScheduler(stageExecution, ImmutableList.of());
+        StageExecutionAndScheduler scheduler = new StageExecutionAndScheduler(stageExecution, stageLinkage, stageScheduler);
+        return scheduler;
+    }
+
+    private static PlanFragment createPlanFragment(PlanFragmentId fragmentId, PlanNode remoteSourcePlanNode)
+    {
+        return new PlanFragment(
+                fragmentId,
+                remoteSourcePlanNode,
+                ImmutableSet.copyOf(remoteSourcePlanNode.getOutputVariables()),
+                SOURCE_DISTRIBUTION,
+                ImmutableList.of(remoteSourcePlanNode.getId()),
+                new PartitioningScheme(Partitioning.create(SINGLE_DISTRIBUTION, ImmutableList.of()), remoteSourcePlanNode.getOutputVariables()),
+                StageExecutionDescriptor.ungroupedExecution(),
+                false,
+                StatsAndCosts.empty(),
+                Optional.empty());
+    }
+
+    private PlanNode getTableScanNode()
+    {
+        return new TableScanNode(
+                Optional.empty(),
+                TABLE_SCAN_NODE_ID,
+                new TableHandle(CONNECTOR_ID, new TestingMetadata.TestingTableHandle(), TRANSACTION_HANDLE, Optional.empty()),
+                ImmutableList.of(),
+                ImmutableMap.of());
+    }
+
+    private static PlanNode getRemoteSourcePlanNode(PlanFragmentId fragmentId)
+    {
+        PlanNode planNode = new RemoteSourceNode(
+                Optional.empty(),
+                new PlanNodeId("exchange"),
+                ImmutableList.of(new PlanFragmentId(fragmentId.getId() - 1)),
+                ImmutableList.of(new VariableReferenceExpression(Optional.empty(), "column", VARCHAR)),
+                false,
+                Optional.empty(),
+                REPARTITION);
+        return planNode;
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -188,7 +188,8 @@ public class TestFeaturesConfig
                 .setAggregationIfToFilterRewriteStrategy(AggregationIfToFilterRewriteStrategy.DISABLED)
                 .setHashBasedDistinctLimitEnabled(false)
                 .setHashBasedDistinctLimitThreshold(10000)
-                .setStreamingForPartialAggregationEnabled(false));
+                .setStreamingForPartialAggregationEnabled(false)
+                .setMaxStageCountForEagerScheduling(25));
     }
 
     @Test
@@ -328,6 +329,7 @@ public class TestFeaturesConfig
                 .put("hash-based-distinct-limit-enabled", "true")
                 .put("hash-based-distinct-limit-threshold", "500")
                 .put("streaming-for-partial-aggregation-enabled", "true")
+                .put("execution-policy.max-stage-count-for-eager-scheduling", "123")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -464,7 +466,8 @@ public class TestFeaturesConfig
                 .setAggregationIfToFilterRewriteStrategy(AggregationIfToFilterRewriteStrategy.FILTER_WITH_IF)
                 .setHashBasedDistinctLimitEnabled(true)
                 .setHashBasedDistinctLimitThreshold(500)
-                .setStreamingForPartialAggregationEnabled(true);
+                .setStreamingForPartialAggregationEnabled(true)
+                .setMaxStageCountForEagerScheduling(123);
         assertFullMapping(properties, expected);
     }
 


### PR DESCRIPTION
Add a simple adaptive execution policy that delegates to all-at-once scheduling for low stage queries, and phased scheduling for high stage queries.  The aim is to keep lower stage queries at a reasonable latency, while making high stage queries more reliable at the potential cost of higher latency--reducing the maximum concurrent running task count can improve reliability in heavily loaded clusters that run very high-stage queries, as may be generated by BI tools, ETL jobs, or complex analytical queries.

Test plan - Ran this configuration with a workload that skewed toward high stage queries and observed improvement in running task count.  While this test may not always reflect the real world, in reality reliability issues are typically seen when a burst of high stage queries are executed in tandem in a cluster.  In other words, this change should keep typical task counts constant, but improve (lower) the running task count in the worst case where reliability issues are encountered.

![ods_pxlcld_tim_meehan_2022_03_03t14_31_15_099z_](https://user-images.githubusercontent.com/7980573/156586756-5df59175-7368-45fd-aeb8-4d25628924ec.png)

```
== RELEASE NOTES ==

General Changes


* Add an adaptive stage scheduling policy that switches to phased execution mode once a query's stage count exceeds a configurable upper bound. This can be enabled by setting the session property ``execution_policy`` to ``phased`` and the stage count limit can be configured by the session property ``max_stage_count_for_eager_scheduling``.

```
