### PR TITLE
Fix cleanup CI

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -13,30 +13,30 @@ jobs:
           token: ${{ github.token }}
           workflow: hive-tests.yml
       - uses: n1hility/cancel-previous-runs@2e3c1893986568a2197c41957b9c809cbcf1a61e
-          with:
-            token: ${{ github.token }}
-            workflow: kudu.yml
+        with:
+          token: ${{ github.token }}
+          workflow: kudu.yml
       - uses: n1hility/cancel-previous-runs@2e3c1893986568a2197c41957b9c809cbcf1a61e
-          with:
-            token: ${{ github.token }}
-            workflow: maven-checks.yml
+        with:
+          token: ${{ github.token }}
+          workflow: maven-checks.yml
       - uses: n1hility/cancel-previous-runs@2e3c1893986568a2197c41957b9c809cbcf1a61e
-          with:
-            token: ${{ github.token }}
-            workflow: product-test-basic-environment.yml
+        with:
+          token: ${{ github.token }}
+          workflow: product-test-basic-environment.yml
       - uses: n1hility/cancel-previous-runs@2e3c1893986568a2197c41957b9c809cbcf1a61e
-          with:
-            token: ${{ github.token }}
-            workflow: product-tests-specific-environment.yml
+        with:
+          token: ${{ github.token }}
+          workflow: product-tests-specific-environment.yml
       - uses: n1hility/cancel-previous-runs@2e3c1893986568a2197c41957b9c809cbcf1a61e
-          with:
-            token: ${{ github.token }}
-            workflow: spark-integration.yml
+        with:
+          token: ${{ github.token }}
+          workflow: spark-integration.yml
       - uses: n1hility/cancel-previous-runs@2e3c1893986568a2197c41957b9c809cbcf1a61e
-          with:
-            token: ${{ github.token }}
-            workflow: tests.yml
+        with:
+          token: ${{ github.token }}
+          workflow: tests.yml
       - uses: n1hility/cancel-previous-runs@2e3c1893986568a2197c41957b9c809cbcf1a61e
-          with:
-            token: ${{ github.token }}
-            workflow: web-ui-checks.yml
+        with:
+          token: ${{ github.token }}
+          workflow: web-ui-checks.yml


### PR DESCRIPTION
Cleanup.yml fails with syntax error. 
uses and with have different level of indentation and this causes the
cleanup.yml to fail with errors.
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-2

Test plan - 
None

```
== NO RELEASE NOTE ==
```
