### PR TITLE
Add min compressible size to OrcOutputBuffer

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/CompressionKind.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/CompressionKind.java
@@ -15,5 +15,24 @@ package com.facebook.presto.orc.metadata;
 
 public enum CompressionKind
 {
-    NONE, ZLIB, SNAPPY, LZ4, ZSTD
+    NONE(0),
+    ZLIB(9),
+    SNAPPY(17),
+    LZ4(14),
+    ZSTD(21);
+
+    /**
+     * Minimum size of the input data that would benefit from compression.
+     */
+    private final int minCompressibleSize;
+
+    CompressionKind(int minCompressibleSize)
+    {
+        this.minCompressibleSize = minCompressibleSize;
+    }
+
+    public int getMinCompressibleSize()
+    {
+        return minCompressibleSize;
+    }
 }


### PR DESCRIPTION
Add a min size threshold for OrcOutputBuffer input to be eligible for compression.

All compression mechanisms used by presto-orc have minimum storage costs required for frames, blocks, and other stuff. For example ZStandard uses frames with a minimum size of 2 bytes up to a maximum of 14 bytes, in addition to this there are additional costs to maintain info about data blocks (see RFC 8878).

After looking at some statistics I decided that it doesn't make sense to try to compress something if we know beforehand that the size after compression will be greater than the input size.

How I got these thresholds:
I wrote a small program assuming that an input array with a repeating value is the best candidate for compressions (LZ RLE). Then I ran compression for various compression levels and various input sizes. Threshold was selected as an input size where the compressed size was smaller than the uncompressed size.

```
import com.facebook.presto.orc.ColumnWriterOptions;
import com.facebook.presto.orc.OrcOutputBuffer;
import com.facebook.presto.orc.metadata.CompressionKind;

import java.util.ArrayList;
import java.util.Arrays;
import java.util.List;
import java.util.Optional;
import java.util.OptionalInt;

public class OrcOutputInputSizesTest
{
    public static void main(String[] args)
    {
        byte[] b = new byte[32];
        Arrays.fill(b, (byte) 0xA);

        for (int size = 1; size < b.length; size++) {
            List<Long> outputSizes = new ArrayList<>();
            for (int level = 0; level <=9; level++) {
                outputSizes.add(compress(level, b, size));
            }

            System.out.printf("%,d", size);
            outputSizes.forEach(v -> System.out.printf("\t%,d", v));
            System.out.println();
        }
    }

    private static long compress(int level, byte[] b, int size)
    {
        ColumnWriterOptions options = ColumnWriterOptions.builder()
                .setCompressionKind(CompressionKind.LZ4)
                .setCompressionLevel(OptionalInt.of(level))
                .build();
        OrcOutputBuffer buffer = new OrcOutputBuffer(options, Optional.empty());

        buffer.writeBytes(b, 0, size);

        buffer.close();
        return buffer.getOutputDataSize();
    }
}
```

Test plan:
* added new unit test

```
== NO RELEASE NOTE ==
```
