### PR TITLE
Fix cleanup yml syntax error

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -13,30 +13,30 @@ jobs:
           token: ${{ github.token }}
           workflow: hive-tests.yml
       - uses: n1hility/cancel-previous-runs@2e3c1893986568a2197c41957b9c809cbcf1a61e
-          with:
+        with:
             token: ${{ github.token }}
             workflow: kudu.yml
       - uses: n1hility/cancel-previous-runs@2e3c1893986568a2197c41957b9c809cbcf1a61e
-          with:
+        with:
             token: ${{ github.token }}
             workflow: maven-checks.yml
       - uses: n1hility/cancel-previous-runs@2e3c1893986568a2197c41957b9c809cbcf1a61e
-          with:
+        with:
             token: ${{ github.token }}
             workflow: product-test-basic-environment.yml
       - uses: n1hility/cancel-previous-runs@2e3c1893986568a2197c41957b9c809cbcf1a61e
-          with:
+        with:
             token: ${{ github.token }}
             workflow: product-tests-specific-environment.yml
       - uses: n1hility/cancel-previous-runs@2e3c1893986568a2197c41957b9c809cbcf1a61e
-          with:
+        with:
             token: ${{ github.token }}
             workflow: spark-integration.yml
       - uses: n1hility/cancel-previous-runs@2e3c1893986568a2197c41957b9c809cbcf1a61e
-          with:
+        with:
             token: ${{ github.token }}
             workflow: tests.yml
       - uses: n1hility/cancel-previous-runs@2e3c1893986568a2197c41957b9c809cbcf1a61e
-          with:
+        with:
             token: ${{ github.token }}
             workflow: web-ui-checks.yml


### PR DESCRIPTION
Cleanup.yml has a syntax error.

uses and with should have the same level of indentation.
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-2

Test plan - (Please fill in how you tested your changes)
After the cleanup.yml the IDEA stylesheet error validation is fiixed.

```
== NO RELEASE NOTE ==
```
