### PR TITLE
Revert "Tighten allowed characters for non-delimited identifiers"

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/server/TestHttpRequestSessionContext.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestHttpRequestSessionContext.java
@@ -161,7 +161,7 @@ public class TestHttpRequestSessionContext
                         .put(PRESTO_LANGUAGE, "zh-TW")
                         .put(PRESTO_TIME_ZONE, "Asia/Taipei")
                         .put(PRESTO_CLIENT_INFO, "null")
-                        .put(PRESTO_PREPARED_STATEMENT, "query1=select * from \"tbl:ns\"")
+                        .put(PRESTO_PREPARED_STATEMENT, "query1=select * from tbl:ns")
                         .build(),
                 "testRemote");
         SqlParserOptions options = new SqlParserOptions();

--- a/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
@@ -123,6 +123,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static com.facebook.presto.sql.ExpressionFormatter.formatExpression;
@@ -137,6 +138,7 @@ import static java.util.stream.Collectors.joining;
 public final class SqlFormatter
 {
     private static final String INDENT = "   ";
+    private static final Pattern NAME_PATTERN = Pattern.compile("[a-z_][a-z0-9_]*");
 
     private SqlFormatter() {}
 

--- a/presto-parser/src/main/java/com/facebook/presto/sql/tree/Identifier.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/tree/Identifier.java
@@ -25,7 +25,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 public class Identifier
         extends Expression
 {
-    private static final Pattern NAME_PATTERN = Pattern.compile("[a-zA-Z_]([a-zA-Z0-9_])*");
+    private static final Pattern NAME_PATTERN = Pattern.compile("[a-zA-Z_]([a-zA-Z0-9_:@])*");
 
     private final String value;
     private final boolean delimited;

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -618,7 +618,7 @@ public class TestSqlParser
     public void testAllowIdentifierColon()
     {
         SqlParser sqlParser = new SqlParser(new SqlParserOptions().allowIdentifierSymbol(COLON));
-        sqlParser.createStatement("select * from \"foo:bar\"");
+        sqlParser.createStatement("select * from foo:bar");
     }
 
     @SuppressWarnings("deprecation")
@@ -626,7 +626,7 @@ public class TestSqlParser
     public void testAllowIdentifierAtSign()
     {
         SqlParser sqlParser = new SqlParser(new SqlParserOptions().allowIdentifierSymbol(AT_SIGN));
-        sqlParser.createStatement("select * from \"foo@bar\"");
+        sqlParser.createStatement("select * from foo@bar");
     }
 
     @Test

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/checksum/TestChecksumValidator.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/checksum/TestChecksumValidator.java
@@ -163,7 +163,7 @@ public class TestChecksumValidator
                         ", \"count\"(\"row\".\"r\"[1]) FILTER (WHERE (\"row\".\"r\"[1] = -\"infinity\"())) \"row.r._col1$neg_inf_count\"\n" +
                         ", \"checksum\"(\"row\".\"r\".\"b\") \"row.r.b$checksum\"\n" +
                         "FROM\n" +
-                        "  \"test:di\"\n",
+                        "  test:di\n",
                 PARSING_OPTIONS);
         assertEquals(formatSql(checksumQuery, Optional.empty()), formatSql(expectedChecksumQuery, Optional.empty()));
     }


### PR DESCRIPTION
This reverts commit d370d62975a311476fb3724e173f5dfa03b2a28d.

The original commit breaks the functionality that allows users to set the parser options to allow `:` and `@` in unquoted identifiers.  I'm not sure what issue that commit is trying to resolve since Identifier is an internal structure, but if it is needed, the proper fix would be to have a custom identifier pattern based on parser options

Test plan - unit tests

```
== NO RELEASE NOTE ==
```
