### PR TITLE
Spelling

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ Presto welcomes contributions from everyone.
 Contributions to Presto should be made in the form of GitHub pull request submissions and reviews. 
 
 Each pull request submission will be reviewed by a contributor or [committer](https://github.com/prestodb/presto/wiki/committers) 
-in the project. Only committers may merge a pull request. Large contributions should have an associated Github issue.
+in the project. Only committers may merge a pull request. Large contributions should have an associated GitHub issue.
 
 Pull request reviews are encouraged for anyone in the community who would like to contribute to Presto, and are
 expected from contributors and committers in at least equal proportion to their code contributions.

--- a/README.md
+++ b/README.md
@@ -95,11 +95,11 @@ To learn how to build the docs, see the [docs README](presto-docs/README.md).
 
 ## Building the Web UI
 
-The Presto Web UI is composed of several React components and is written in JSX and ES6. This source code is compiled and packaged into browser-compatible Javascript, which is then checked in to the Presto source code (in the `dist` folder). You must have [Node.js](https://nodejs.org/en/download/) and [Yarn](https://yarnpkg.com/en/) installed to execute these commands. To update this folder after making changes, simply run:
+The Presto Web UI is composed of several React components and is written in JSX and ES6. This source code is compiled and packaged into browser-compatible JavaScript, which is then checked in to the Presto source code (in the `dist` folder). You must have [Node.js](https://nodejs.org/en/download/) and [Yarn](https://yarnpkg.com/en/) installed to execute these commands. To update this folder after making changes, simply run:
 
     yarn --cwd presto-main/src/main/resources/webapp/src install
 
-If no Javascript dependencies have changed (i.e., no changes to `package.json`), it is faster to run:
+If no JavaScript dependencies have changed (i.e., no changes to `package.json`), it is faster to run:
 
     yarn --cwd presto-main/src/main/resources/webapp/src run package
 

--- a/mvnw
+++ b/mvnw
@@ -130,7 +130,7 @@ if $cygwin ; then
     CLASSPATH=`cygpath --path --unix "$CLASSPATH"`
 fi
 
-# For Migwn, ensure paths are in UNIX format before anything is touched
+# For Mingw, ensure paths are in UNIX format before anything is touched
 if $mingw ; then
   [ -n "$M2_HOME" ] &&
     M2_HOME="`(cd "$M2_HOME"; pwd)`"

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/AccumuloClient.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/AccumuloClient.java
@@ -204,7 +204,7 @@ public class AccumuloClient
             if (columnMapping.get().values().stream()
                     .filter(pair -> pair.getKey().equals(reservedRowIdColumn) && pair.getValue().equals(reservedRowIdColumn))
                     .count() > 0) {
-                throw new PrestoException(INVALID_TABLE_PROPERTY, format("Column familiy/qualifier mapping of %s:%s is reserved", reservedRowIdColumn, reservedRowIdColumn));
+                throw new PrestoException(INVALID_TABLE_PROPERTY, format("Column family/qualifier mapping of %s:%s is reserved", reservedRowIdColumn, reservedRowIdColumn));
             }
         }
         else if (AccumuloTableProperties.isExternal(meta.getProperties())) {

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/AccumuloModule.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/AccumuloModule.java
@@ -56,7 +56,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * Presto module to do all kinds of run Guice injection stuff!
  * <p>
- * WARNING: Contains black magick
+ * WARNING: Contains black magic
  */
 public class AccumuloModule
         implements Module

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/IndexLookup.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/index/IndexLookup.java
@@ -371,7 +371,7 @@ public class IndexLookup
 
     private static void binRanges(int numRangesPerBin, List<Range> splitRanges, List<TabletSplitMetadata> prestoSplits)
     {
-        checkArgument(numRangesPerBin > 0, "number of ranges per bin must positivebe greater than zero");
+        checkArgument(numRangesPerBin > 0, "number of ranges per bin must be greater than zero");
         int toAdd = splitRanges.size();
         int fromIndex = 0;
         int toIndex = Math.min(toAdd, numRangesPerBin);

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/io/AccumuloRecordCursor.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/io/AccumuloRecordCursor.java
@@ -281,7 +281,7 @@ public class AccumuloRecordCursor
      * so we can configure Accumulo to only give us the first key/value pair in the row
      *
      * @param rowIdName Row ID column name
-     * @return True if scanner should retriev eonly row IDs, false otherwise
+     * @return True if scanner should retrieve only row IDs, false otherwise
      */
     private boolean retrieveOnlyRowIds(String rowIdName)
     {

--- a/presto-accumulo/src/main/java/com/facebook/presto/accumulo/io/AccumuloRecordSet.java
+++ b/presto-accumulo/src/main/java/com/facebook/presto/accumulo/io/AccumuloRecordSet.java
@@ -82,7 +82,7 @@ public class AccumuloRecordSet
             throw new PrestoException(NOT_FOUND, "Failed to factory serializer class.  Is it on the classpath?", e);
         }
 
-        // Save off the column handles and createa list of the Accumulo types
+        // Save off the column handles and create a list of the Accumulo types
         this.columnHandles = requireNonNull(columnHandles, "column handles is null");
         ImmutableList.Builder<Type> types = ImmutableList.builder();
         for (AccumuloColumnHandle column : columnHandles) {

--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/SqlJoniRegexpBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/SqlJoniRegexpBenchmark.java
@@ -27,7 +27,7 @@ public class SqlJoniRegexpBenchmark
 
     public static void main(String[] args)
     {
-        new SqlJoniRegexpBenchmark(createLocalQueryRunner(), "SELECT array_agg(regexp_extract_all(comment||cast(random() as varchar), '[a-z]* ')) FROM orders cross join unnest(sequence(1, 10))", "sql_regexp_extract_alll").runBenchmark(new SimpleLineBenchmarkResultWriter(System.out));
+        new SqlJoniRegexpBenchmark(createLocalQueryRunner(), "SELECT array_agg(regexp_extract_all(comment||cast(random() as varchar), '[a-z]* ')) FROM orders cross join unnest(sequence(1, 10))", "sql_regexp_extract_all").runBenchmark(new SimpleLineBenchmarkResultWriter(System.out));
         new SqlJoniRegexpBenchmark(createLocalQueryRunner(), "SELECT array_agg(regexp_replace(comment||cast(random() as varchar), '[a-z]* ', cast(random() as varchar))) FROM orders cross join unnest(sequence(1, 10))", "sql_regexp_replace").runBenchmark(new SimpleLineBenchmarkResultWriter(System.out));
     }
 }

--- a/presto-benchto-benchmarks/src/main/resources/sql/presto/tpcds/q63.sql
+++ b/presto-benchto-benchmarks/src/main/resources/sql/presto/tpcds/q63.sql
@@ -15,7 +15,7 @@ FROM
       AND ("ss_store_sk" = "s_store_sk")
       AND ("d_month_seq" IN (1200   , (1200 + 1)   , (1200 + 2)   , (1200 + 3)   , (1200 + 4)   , (1200 + 5)   , (1200 + 6)   , (1200 + 7)   , (1200 + 8)   , (1200 + 9)   , (1200 + 10)   , (1200 + 11)))
       AND ((("i_category" IN ('Books'         , 'Children'         , 'Electronics'))
-            AND ("i_class" IN ('personal'         , 'portable'         , 'refernece'         , 'self-help'))
+            AND ("i_class" IN ('personal'         , 'portable'         , 'reference'         , 'self-help'))
             AND ("i_brand" IN ('scholaramalgamalg #14'         , 'scholaramalgamalg #7'         , 'exportiunivamalg #9'         , 'scholaramalgamalg #9')))
          OR (("i_category" IN ('Women'         , 'Music'         , 'Men'))
             AND ("i_class" IN ('accessories'         , 'classical'         , 'fragrances'         , 'pants'))

--- a/presto-bytecode/src/main/java/com/facebook/presto/bytecode/expression/CastBytecodeExpression.java
+++ b/presto-bytecode/src/main/java/com/facebook/presto/bytecode/expression/CastBytecodeExpression.java
@@ -66,7 +66,7 @@ public class CastBytecodeExpression
                     case PRIMITIVE:
                         castPrimitiveToPrimitive(block, sourceType.getPrimitiveType(), targetType.getPrimitiveType());
                         return block;
-                    case BOXED_PRIMITVE:
+                    case BOXED_PRIMITIVE:
                         checkArgument(sourceType.getPrimitiveType() == unwrapPrimitiveType(targetType), "Type %s can not be cast to %s", sourceType, targetType);
                         return block.invokeStatic(targetType, "valueOf", targetType, sourceType);
                     case OTHER:
@@ -76,12 +76,12 @@ public class CastBytecodeExpression
                                 .invokeStatic(wrap(sourceClass), "valueOf", wrap(sourceClass), sourceClass)
                                 .checkCast(targetType);
                 }
-            case BOXED_PRIMITVE:
+            case BOXED_PRIMITIVE:
                 switch (getTypeKind(targetType)) {
                     case PRIMITIVE:
                         checkArgument(unwrapPrimitiveType(sourceType) == targetType.getPrimitiveType(), "Type %s can not be cast to %s", sourceType, targetType);
                         return block.invokeVirtual(sourceType, targetType.getPrimitiveType().getSimpleName() + "Value", targetType);
-                    case BOXED_PRIMITVE:
+                    case BOXED_PRIMITIVE:
                         checkArgument(sourceType.equals(targetType), "Type %s can not be cast to %s", sourceType, targetType);
                         return block;
                     case OTHER:
@@ -94,7 +94,7 @@ public class CastBytecodeExpression
                         return block
                                 .checkCast(wrap(targetType.getPrimitiveType()))
                                 .invokeVirtual(wrap(targetType.getPrimitiveType()), targetType.getPrimitiveType().getSimpleName() + "Value", targetType.getPrimitiveType());
-                    case BOXED_PRIMITVE:
+                    case BOXED_PRIMITIVE:
                     case OTHER:
                         return block.checkCast(targetType);
                 }
@@ -282,7 +282,7 @@ public class CastBytecodeExpression
             return TypeKind.PRIMITIVE;
         }
         if (unwrapPrimitiveType(type) != null) {
-            return TypeKind.BOXED_PRIMITVE;
+            return TypeKind.BOXED_PRIMITIVE;
         }
         return TypeKind.OTHER;
     }
@@ -325,6 +325,6 @@ public class CastBytecodeExpression
 
     private enum TypeKind
     {
-        PRIMITIVE, BOXED_PRIMITVE, OTHER
+        PRIMITIVE, BOXED_PRIMITIVE, OTHER
     }
 }

--- a/presto-bytecode/src/test/java/com/facebook/presto/bytecode/expression/TestCastBytecodeExpression.java
+++ b/presto-bytecode/src/test/java/com/facebook/presto/bytecode/expression/TestCastBytecodeExpression.java
@@ -51,7 +51,7 @@ public class TestCastBytecodeExpression
     }
 
     @Test
-    public void testInvalildCast()
+    public void testInvalidCast()
     {
         // Cast between a boxed primitive and a primitive that are different
         assertInvalidCast(getStatic(getClass(), "INT_FIELD"), Double.class);

--- a/presto-cache/src/main/java/com/facebook/presto/cache/filemerge/FileMergeCacheManager.java
+++ b/presto-cache/src/main/java/com/facebook/presto/cache/filemerge/FileMergeCacheManager.java
@@ -407,7 +407,7 @@ public class FileMergeCacheManager
 
         // no lock is needed for the following operation
         if (updated) {
-            // remove the the previous or following file as well
+            // remove the previous or following file as well
             if (previousCacheFile != null) {
                 cacheFilesToDelete.add(previousCacheFile.getPath());
             }

--- a/presto-cassandra/src/test/resources/cu-cassandra.yaml
+++ b/presto-cassandra/src/test/resources/cu-cassandra.yaml
@@ -77,7 +77,7 @@ permissions_validity_in_ms: 2000
 #
 # - RandomPartitioner distributes rows across the cluster evenly by md5.
 #   This is the default prior to 1.2 and is retained for compatibility.
-# - Murmur3Partitioner is similar to RandomPartioner but uses Murmur3_128
+# - Murmur3Partitioner is similar to RandomPartitioner but uses Murmur3_128
 #   Hash Function instead of md5.  When in doubt, this is the best option.
 # - ByteOrderedPartitioner orders rows lexically by key bytes.  BOP allows
 #   scanning rows in key order, but the ordering can generate hot spots
@@ -525,10 +525,10 @@ request_scheduler: org.apache.cassandra.scheduler.NoScheduler
 # the request scheduling. Currently the only valid option is keyspace.
 # request_scheduler_id: keyspace
 
-# index_interval controls the sampling of entries from the primrary
+# index_interval controls the sampling of entries from the primary
 # row index in terms of space versus time.  The larger the interval,
-# the smaller and less effective the sampling will be.  In technicial
-# terms, the interval coresponds to the number of index entries that
+# the smaller and less effective the sampling will be.  In technical
+# terms, the interval corresponds to the number of index entries that
 # are skipped between taking each sample.  All the sampled entries
 # must fit in memory.  Generally, a value between 128 and 512 here
 # coupled with a large key cache size on CFs results in the best trade

--- a/presto-cli/src/main/java/com/facebook/presto/cli/Pager.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/Pager.java
@@ -163,10 +163,10 @@ public class Pager
 
     private static Pager createNullPager()
     {
-        return new Pager(uncloseableOutputStream(System.out), null);
+        return new Pager(unclosableOutputStream(System.out), null);
     }
 
-    private static OutputStream uncloseableOutputStream(OutputStream out)
+    private static OutputStream unclosableOutputStream(OutputStream out)
     {
         return new FilterOutputStream(out)
         {

--- a/presto-client/src/main/java/com/facebook/presto/client/ClientTypeSignatureParameter.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/ClientTypeSignatureParameter.java
@@ -144,7 +144,7 @@ public class ClientTypeSignatureParameter
         private static final ObjectMapper MAPPER = new JsonObjectMapperProvider().get();
 
         @Override
-        public ClientTypeSignatureParameter deserialize(JsonParser jp, DeserializationContext ctxt)
+        public ClientTypeSignatureParameter deserialize(JsonParser jp, DeserializationContext ctx)
                 throws IOException
         {
             JsonNode node = jp.getCodec().readTree(jp);

--- a/presto-common/src/main/java/com/facebook/presto/common/array/IntBigArrays.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/array/IntBigArrays.java
@@ -113,7 +113,7 @@ public class IntBigArrays
         if (len > SMALL) {
             long l = from;
             long n = to - 1;
-            if (len > MEDIUM) { // Big arrays, pseudomedian of 9
+            if (len > MEDIUM) { // Big arrays, pseudo-median of 9
                 long s = len / 8;
                 l = med3(x, l, l + s, l + 2 * s, comp);
                 m = med3(x, m - s, m, m + s, comp);

--- a/presto-common/src/main/java/com/facebook/presto/common/predicate/TupleDomainFilterUtils.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/predicate/TupleDomainFilterUtils.java
@@ -62,12 +62,12 @@ public class TupleDomainFilterUtils
         boolean nullAllowed = domain.isNullAllowed();
 
         if (values.isAll()) {
-            checkArgument(!nullAllowed, "Unexpected allways-true filter");
+            checkArgument(!nullAllowed, "Unexpected always-true filter");
             return IS_NOT_NULL;
         }
 
         if (values.isNone()) {
-            checkArgument(nullAllowed, "Unexpected allways-false filter");
+            checkArgument(nullAllowed, "Unexpected always-false filter");
             return IS_NULL;
         }
 

--- a/presto-common/src/main/java/com/facebook/presto/common/type/TypeSignature.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TypeSignature.java
@@ -353,7 +353,7 @@ public class TypeSignature
         VarcharEnumMap getVarcharEnumMap()
         {
             checkArgument(!isBigintEnum, "Invalid enum map format");
-            // Varchar enum values are base32-encoded so that they are case-insensitive, which is expected of TypeSigntures
+            // Varchar enum values are base32-encoded so that they are case-insensitive, which is expected of TypeSignatures
             Base32 base32 = new Base32();
             return new VarcharEnumMap(
                     typeName,

--- a/presto-common/src/main/java/com/facebook/presto/common/type/UnscaledDecimal128Arithmetic.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/UnscaledDecimal128Arithmetic.java
@@ -1434,7 +1434,7 @@ public final class UnscaledDecimal128Arithmetic
         }
         // wordShifts = shifts / 32
         int wordShifts = shifts >>> 5;
-        // we don't wan't to loose any leading bits
+        // we don't want to lose any leading bits
         for (int i = 0; i < wordShifts; i++) {
             checkState(number[length - i - 1] == 0);
         }
@@ -1445,7 +1445,7 @@ public final class UnscaledDecimal128Arithmetic
         // bitShifts = shifts % 32
         int bitShifts = shifts & 0b11111;
         if (bitShifts > 0) {
-            // we don't wan't to loose any leading bits
+            // we don't want to lose any leading bits
             checkState(number[length - 1] >>> (Integer.SIZE - bitShifts) == 0);
             for (int position = length - 1; position > 0; position--) {
                 number[position] = (number[position] << bitShifts) | (number[position - 1] >>> (Integer.SIZE - bitShifts));
@@ -1463,7 +1463,7 @@ public final class UnscaledDecimal128Arithmetic
         }
         // wordShifts = shifts / 32
         int wordShifts = shifts >>> 5;
-        // we don't wan't to loose any trailing bits
+        // we don't want to lose any trailing bits
         for (int i = 0; i < wordShifts; i++) {
             checkState(number[i] == 0);
         }
@@ -1474,7 +1474,7 @@ public final class UnscaledDecimal128Arithmetic
         // bitShifts = shifts % 32
         int bitShifts = shifts & 0b11111;
         if (bitShifts > 0) {
-            // we don't wan't to loose any trailing bits
+            // we don't want to lose any trailing bits
             checkState(number[0] << (Integer.SIZE - bitShifts) == 0);
             for (int position = 0; position < length - 1; position++) {
                 number[position] = (number[position] >>> bitShifts) | (number[position + 1] << (Integer.SIZE - bitShifts));

--- a/presto-common/src/main/java/com/facebook/presto/common/type/VarcharEnumType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/VarcharEnumType.java
@@ -118,7 +118,7 @@ public class VarcharEnumType
         @Override
         public String toString()
         {
-            // Varchar enum values are base32-encoded so that they are case-insensitive, which is expected of TypeSigntures
+            // Varchar enum values are base32-encoded so that they are case-insensitive, which is expected of TypeSignatures
             Base32 base32 = new Base32();
             return format("%s{%s}", typeName, enumMap.entrySet().stream()
                     .sorted(Comparator.comparing(Map.Entry::getKey))

--- a/presto-common/src/main/java/com/facebook/presto/common/type/encoding/Base32.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/encoding/Base32.java
@@ -526,7 +526,7 @@ public class Base32
      * Returns whether or not the {@code octet} is in the Base32 alphabet.
      *
      * @param octet The value to test
-     * @return {@code true} if the value is defined in the the Base32 alphabet {@code false} otherwise.
+     * @return {@code true} if the value is defined in the Base32 alphabet {@code false} otherwise.
      */
     @Override
     public boolean isInAlphabet(final byte octet)

--- a/presto-common/src/main/java/com/facebook/presto/common/type/encoding/BaseNCodec.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/encoding/BaseNCodec.java
@@ -334,7 +334,7 @@ public abstract class BaseNCodec
      * Encodes a byte[] containing binary data, into a byte[] containing characters in the alphabet.
      *
      * @param pArray a byte array containing binary data
-     * @return A byte array containing only the basen alphabetic character data
+     * @return A byte array containing only the base-n alphabetic character data
      */
     public byte[] encode(final byte[] pArray)
     {

--- a/presto-common/src/test/java/com/facebook/presto/common/block/TestBlockFlattener.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/block/TestBlockFlattener.java
@@ -37,7 +37,7 @@ import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 
 @Test(singleThreaded = true)
-public class TestBlockFlattenner
+public class TestBlockFlattener
 {
     private ArrayAllocator allocator;
     private BlockFlattener flattener;

--- a/presto-docs/Makefile
+++ b/presto-docs/Makefile
@@ -10,7 +10,7 @@ SOURCEDIR     = src/main/sphinx
 
 # User-friendly check for sphinx-build
 ifeq ($(shell which $(PYTHON3) >/dev/null 2>&1; echo $$?), 1)
-$(error The '$(PYTHON3)' command was not found. Make sure you have Python3 instaled. You can grab it from https://www.python.org/)
+$(error The '$(PYTHON3)' command was not found. Make sure you have Python3 installed. You can grab it from https://www.python.org/)
 endif
 
 # Internal variables.

--- a/presto-docs/src/main/sphinx/admin/resource-groups.rst
+++ b/presto-docs/src/main/sphinx/admin/resource-groups.rst
@@ -76,7 +76,7 @@ Resource Group Properties
     * ``totalMemoryLimit`` (optional): Specify an absolute value (i.e. ``1GB``)
        for the maximum distributed memory a query may consume.
 
-    * ``cpuTimeLimit`` (optional): Specify Specify an absolute value (i.e. ``1h``)
+    * ``cpuTimeLimit`` (optional): Specify an absolute value (i.e. ``1h``)
        for the maximum CPU time a query may use.
 
 * ``subGroups`` (optional): list of sub-groups.

--- a/presto-docs/src/main/sphinx/connector/accumulo.rst
+++ b/presto-docs/src/main/sphinx/connector/accumulo.rst
@@ -181,7 +181,7 @@ You can then issue ``INSERT`` statements to put data into Accumulo.
     (2 rows)
 
 As you'd expect, rows inserted into Accumulo via the shell or
-programatically will also show up when queried. (The Accumulo shell
+programmatically will also show up when queried. (The Accumulo shell
 thinks "-5321" is an option and not a number... so we'll just make TBL a
 little younger.)
 
@@ -514,7 +514,7 @@ Serializers
 
 The Presto connector for Accumulo has a pluggable serializer framework
 for handling I/O between Presto and Accumulo. This enables end-users the
-ability to programatically serialized and deserialize their special data
+ability to programmatically serialized and deserialize their special data
 formats within Accumulo, while abstracting away the complexity of the
 connector itself.
 

--- a/presto-docs/src/main/sphinx/connector/bigquery.rst
+++ b/presto-docs/src/main/sphinx/connector/bigquery.rst
@@ -84,9 +84,9 @@ your setup:
 Multiple GCP Projects
 ^^^^^^^^^^^^^^^^^^^^^
 
-The BigQuery connector can only access a single GCP project.Thus, if you have
+The BigQuery connector can only access a single GCP project. Thus, if you have
 data in multiple GCP projects, You need to create several catalogs, each
-pointingto a different GCP project. For example, if you have two GCP projects,
+pointing to a different GCP project. For example, if you have two GCP projects,
 one for the sales and one for analytics, you can create two properties files in
 ``etc/catalog`` named ``sales.properties`` and ``analytics.properties``, both
 having ``connector.name=bigquery`` but with different ``project-id``. This will

--- a/presto-docs/src/main/sphinx/connector/cassandra.rst
+++ b/presto-docs/src/main/sphinx/connector/cassandra.rst
@@ -87,7 +87,7 @@ Property Name                                                 Description
 ``cassandra.fetch-size``                                      Number of rows fetched at a time in a Cassandra query.
 
 ``cassandra.partition-size-for-batch-select``                 Number of partitions batched together into a single select for a
-                                                              single partion key column table.
+                                                              single partition key column table.
 
 ``cassandra.split-size``                                      Number of keys per split when querying Cassandra.
 

--- a/presto-docs/src/main/sphinx/connector/kafka-tutorial.rst
+++ b/presto-docs/src/main/sphinx/connector/kafka-tutorial.rst
@@ -604,6 +604,6 @@ This allows the raw data to be mapped onto a Presto timestamp column:
     (5 rows)
 
 The Kafka connector contains converters for ISO 8601, RFC 2822 text
-formats and for number-based timestamps using seconds or miilliseconds
+formats and for number-based timestamps using seconds or milliseconds
 since the epoch. There is also a generic, text-based formatter which uses
 Joda-Time format strings to parse text columns.

--- a/presto-docs/src/main/sphinx/connector/mongodb.rst
+++ b/presto-docs/src/main/sphinx/connector/mongodb.rst
@@ -138,7 +138,7 @@ This property is optional; the default is ``PRIMARY``.
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The write concern to use. The available values are
-``ACKNOWLEDGED``, ``FSYNC_SAFE``, ``FSYNCED``, ``JOURNAL_SAFEY``, ``JOURNALED``, ``MAJORITY``,
+``ACKNOWLEDGED``, ``FSYNC_SAFE``, ``FSYNCED``, ``JOURNAL_SAFE``, ``JOURNALED``, ``MAJORITY``,
 ``NORMAL``, ``REPLICA_ACKNOWLEDGED``, ``REPLICAS_SAFE`` and ``UNACKNOWLEDGED``.
 
 This property is optional; the default is ``ACKNOWLEDGED``.

--- a/presto-docs/src/main/sphinx/connector/pinot.rst
+++ b/presto-docs/src/main/sphinx/connector/pinot.rst
@@ -54,7 +54,7 @@ Property Name                                               Description
 ``pinot.connection-timeout``                                Connection Timeout to talk to Pinot servers, default is 1 minute.
 ``pinot.metadata-expiry``                                   Pinot metadata cache expiration time, default is 2 minutes.
 ``pinot.estimated-size-in-bytes-for-non-numeric-column``    Estimated byte size for non-numeric column, default is 20.
-``pinot.service-header-param``                              RPC service service header key, default is "RPC-Service".
+``pinot.service-header-param``                              RPC service header key, default is "RPC-Service".
 ``pinot.caller-header-param``                               RPC service caller header key, default is "RPC-Caller".
 ``pinot.caller-header-value``                               RPC service caller header value, default is "presto".
 ``pinot.forbid-broker-queries``                             No broker request pushing down, default is false.

--- a/presto-docs/src/main/sphinx/connector/system.rst
+++ b/presto-docs/src/main/sphinx/connector/system.rst
@@ -69,7 +69,7 @@ was queued and analyzed.
 ^^^^^^^^^^^^^^^^^
 
 The tasks table contains information about the tasks involved in a
-Presto query including where they were executed and and how many rows
+Presto query including where they were executed and how many rows
 and bytes each task processed.
 
 ``runtime.transactions``

--- a/presto-docs/src/main/sphinx/develop/client-protocol.rst
+++ b/presto-docs/src/main/sphinx/develop/client-protocol.rst
@@ -106,7 +106,7 @@ Request Header Name                    Description
                                        ``X-Presto-Started-Transaction-Id`` and cleared by ``X-Presto-Clear-Transaction-Id``.
 ``X-Presto-Client-Info``               Contains arbitrary information about the client program submitting the query.
 ``X-Presto-Client-Tags``               A comma-separated list of "tag" strings, used to identify Presto resource groups.
-``X-Presto-Resource-Estimate``         A comma-separated list of ``resource=value`` type assigments.  The possible choices
+``X-Presto-Resource-Estimate``         A comma-separated list of ``resource=value`` type assignments.  The possible choices
                                        of ``resource`` are "EXECUTION_TIME", "CPU_TIME",  "PEAK_MEMORY" and "PEAK_TASK_MEMORY".
                                        "EXECUTION_TIME" and "CPU_TIME" have values specified as airlift ``Duration`` strings,
                                        whose format is a double precision number followed by a ``TimeUnit`` string, e.g.,
@@ -127,7 +127,7 @@ This table lists the supported client response headers.  After receiving a respo
 request headers that will be used in subsequent requests to be consistent with the response headers received.
 
 ====================================== =================================================================================================
-Respone Header Name                    Description
+Response Header Name                   Description
 ====================================== =================================================================================================
 ``X-Presto-Set-Catalog``               Instructs the client to set the catalog that will be sent in the
                                        ``X-Presto-Catalog`` request header in subsequent client requests.

--- a/presto-docs/src/main/sphinx/develop/functions.rst
+++ b/presto-docs/src/main/sphinx/develop/functions.rst
@@ -7,7 +7,7 @@ Plugin Implementation
 
 The function framework is used to implement SQL functions. Presto includes a
 number of built-in functions. In order to implement new functions, you can
-write a plugin that returns one more more functions from ``getFunctions()``:
+write a plugin that returns one more functions from ``getFunctions()``:
 
 .. code-block:: java
 

--- a/presto-docs/src/main/sphinx/functions/aggregate.rst
+++ b/presto-docs/src/main/sphinx/functions/aggregate.rst
@@ -754,7 +754,7 @@ where :math:`f(x)` is the partial density function of :math:`x`.
     or string type.
 
     The function uses the stream summary data structure proposed in the paper
-    `Efficient computation of frequent and top-k elements in data streams <https://www.cse.ust.hk/~raywong/comp5331/References/EfficientComputationOfFrequentAndTop-kElementsInDataStreams.pdf>`_ by A.Metwalley, D.Agrawl and A.Abbadi.
+    `Efficient computation of frequent and top-k elements in data streams <https://www.cse.ust.hk/~raywong/comp5331/References/EfficientComputationOfFrequentAndTop-kElementsInDataStreams.pdf>`_ by A.Metwally, D.Agrawal and A.Abbadi.
 
 
 ---------------------------

--- a/presto-docs/src/main/sphinx/functions/tdigest.rst
+++ b/presto-docs/src/main/sphinx/functions/tdigest.rst
@@ -80,5 +80,5 @@ Functions
 
     Returns a row that represents a ``tdigest`` data structure in the form of
     its component parts. These include arrays of the centroid means and weights,
-    the compression factor, and the the maximum, minimum, sum and count of the
+    the compression factor, and the maximum, minimum, sum and count of the
     values in the digest.

--- a/presto-docs/src/main/sphinx/functions/window.rst
+++ b/presto-docs/src/main/sphinx/functions/window.rst
@@ -132,7 +132,7 @@ Value Functions
 
 Value functions provide an option to specify how null values should be treated when evaluating the
 function. Nulls can either be ignored (``IGNORE NULLS``) or respected (``RESPECT NULLS``). By default,
-null values are respected. If ``IGNORE NULLS`` is specified, all rows where the value expresssion is
+null values are respected. If ``IGNORE NULLS`` is specified, all rows where the value expression is
 null are excluded from the calculation. If ``IGNORE NULLS`` is specified and the value expression is
 null for all rows, the ``default_value`` is returned, or if it is not specified, ``null`` is returned.
 

--- a/presto-docs/src/main/sphinx/installation/deployment.rst
+++ b/presto-docs/src/main/sphinx/installation/deployment.rst
@@ -418,7 +418,7 @@ The files are:
 
 The four files directly under ``etc`` are documented above (using the single-node Coordinator configuration for ``config.properties``).
 The file called ``etc/catalog/tpch.properties`` is used to defined the ``tpch`` catalog.  Each connector has their own set
-of configuration properites that are specific to the connector.
+of configuration properties that are specific to the connector.
 You can find a connector's configuration properties documented along with the connector.  The TPCH connector has no special
 configuration, so we just specify the name of the connector for the catalog, also ``tpch``.
 

--- a/presto-docs/src/main/sphinx/installation/spark.rst
+++ b/presto-docs/src/main/sphinx/installation/spark.rst
@@ -13,7 +13,7 @@ Steps
 -----
 
 Download the Presto Spark package tarball, :maven_download:`spark-package` 
-and the Presto Spark laucher, :maven_download:`spark-launcher`. Keep both the
+and the Presto Spark launcher, :maven_download:`spark-launcher`. Keep both the
 files at, say, *example* directory. We assume here a two node Spark cluster
 with four cores each, thus giving us eight total cores.
 

--- a/presto-docs/src/main/sphinx/rest/node.rst
+++ b/presto-docs/src/main/sphinx/rest/node.rst
@@ -57,7 +57,7 @@ Node Resource
 
 
          HTTP/1.1 200 OK
-	 Vry: Accept
+	 Vary: Accept
 	 Content-Type: text/javascript
 
 	 [

--- a/presto-docs/src/main/sphinx/rest/query.rst
+++ b/presto-docs/src/main/sphinx/rest/query.rst
@@ -12,7 +12,7 @@ on a Presto installation.
    This service returns information and statistics about queries that
    are currently being executed on a Presto coordinator.
 
-   When you point a web broswer at a Presto coordinate you'll see a
+   When you point a web browser at a Presto coordinate you'll see a
    rendered version of the output from this service which will display
    recent queries that have executed on a Presto installation.
 

--- a/presto-docs/src/main/sphinx/security/built-in-system-access-control.rst
+++ b/presto-docs/src/main/sphinx/security/built-in-system-access-control.rst
@@ -229,7 +229,7 @@ and Kerberos authentication:
       ]
     }
 
-If you want to allow users to use the extractly same name as their Kerberos principal
+If you want to allow users to use exactly the same name as their Kerberos principal
 name, and allow ``alice`` and ``bob`` to use a group principal named as
 ``group@example.net``, you can use the following rules.
 

--- a/presto-docs/src/main/sphinx/security/cli.rst
+++ b/presto-docs/src/main/sphinx/security/cli.rst
@@ -74,7 +74,7 @@ Option                          Description
                                 connections on.
 ``--krb5-config-path``          Kerberos configuration file.
 ``--krb5-principal``            The principal to use when authenticating to the coordinator.
-``--krb5-keytab-path``          The location of the the keytab that can be used to
+``--krb5-keytab-path``          The location of the keytab that can be used to
                                 authenticate the principal specified by ``--krb5-principal``
 ``--krb5-remote-service-name``  Presto coordinator Kerberos service name.
 ``--keystore-path``             The location of the Java Keystore file that will be used

--- a/presto-docs/src/main/sphinx/security/jce-policy.fragment
+++ b/presto-docs/src/main/sphinx/security/jce-policy.fragment
@@ -6,7 +6,7 @@ strength of the cryptographic keys that can be used. Kerberos, by default, uses
 keys that are larger than those supported by the included policy files. There
 are two possible solutions to the problem:
 
-  * Update the :abbr:`JCE (Java Cryptograhy Extension)` policy files.
+  * Update the :abbr:`JCE (Java Cryptography Extension)` policy files.
   * Configure Kerberos to use reduced-strength keys.
 
 Of the two options, updating the JCE policy files is recommended. The JCE

--- a/presto-docs/src/main/sphinx/sql/create-view.rst
+++ b/presto-docs/src/main/sphinx/sql/create-view.rst
@@ -16,7 +16,7 @@ Description
 
 Create a new view of a :doc:`select` query. The view is a logical table
 that can be referenced by future queries. Views do not contain any data.
-Instead, the query stored by the view is executed everytime the view is
+Instead, the query stored by the view is executed every time the view is
 referenced by another query.
 
 The optional ``OR REPLACE`` clause causes the view to be replaced if it

--- a/presto-docs/src/main/sphinx/sql/select.rst
+++ b/presto-docs/src/main/sphinx/sql/select.rst
@@ -797,7 +797,7 @@ CROSS JOIN
 ^^^^^^^^^^
 
 A cross join returns the Cartesian product (all combinations) of two
-relations. Cross joins can either be specified using the explit
+relations. Cross joins can either be specified using the explicit
 ``CROSS JOIN`` syntax or by specifying multiple relations in the
 ``FROM`` clause.
 

--- a/presto-druid/src/main/java/com/facebook/presto/druid/ingestion/DruidIngestTask.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/ingestion/DruidIngestTask.java
@@ -38,7 +38,7 @@ public class DruidIngestTask
     {
         private String dataSource;
         private String timestampColumn;
-        private List<DruidIngestDimension> dimentions;
+        private List<DruidIngestDimension> dimensions;
         private DruidIngestInputSource inputSource;
         private boolean appendToExisting;
 
@@ -56,7 +56,7 @@ public class DruidIngestTask
 
         public Builder withDimensions(List<DruidIngestDimension> dimensions)
         {
-            this.dimentions = dimensions;
+            this.dimensions = dimensions;
             return this;
         }
 
@@ -87,7 +87,7 @@ public class DruidIngestTask
             DruidIngestDataSchema dataSchema = new DruidIngestDataSchema(
                     dataSource,
                     new DruidIngestTimestampSpec(timestampColumn),
-                    new DruidIngestDimensionsSpec(dimentions));
+                    new DruidIngestDimensionsSpec(dimensions));
             DruidIngestIOConfig ioConfig = new DruidIngestIOConfig(
                     TASK_TYPE_INDEX_PARALLEL,
                     inputSource,

--- a/presto-expressions/src/main/java/com/facebook/presto/expressions/LogicalRowExpressions.java
+++ b/presto-expressions/src/main/java/com/facebook/presto/expressions/LogicalRowExpressions.java
@@ -292,7 +292,7 @@ public final class LogicalRowExpressions
     }
 
     /**
-     * Given a logical expression, the goal is to convert to conjuctive normal form (CNF).
+     * Given a logical expression, the goal is to convert to conjunctive normal form (CNF).
      * This requires making a call to `pushNegationToLeaves`. There is no guarantee as to
      * the balance of the resulting expression tree.
      *

--- a/presto-expressions/src/main/java/com/facebook/presto/expressions/RowExpressionTreeRewriter.java
+++ b/presto-expressions/src/main/java/com/facebook/presto/expressions/RowExpressionTreeRewriter.java
@@ -51,11 +51,11 @@ public final class RowExpressionTreeRewriter<C>
 
     private List<RowExpression> rewrite(List<RowExpression> items, Context<C> context)
     {
-        List<RowExpression> rewritenExpressions = new ArrayList<>();
+        List<RowExpression> rewrittenExpressions = new ArrayList<>();
         for (RowExpression expression : items) {
-            rewritenExpressions.add(rewrite(expression, context.get()));
+            rewrittenExpressions.add(rewrite(expression, context.get()));
         }
-        return Collections.unmodifiableList(rewritenExpressions);
+        return Collections.unmodifiableList(rewrittenExpressions);
     }
 
     @SuppressWarnings("unchecked")

--- a/presto-geospatial-toolkit/src/main/java/com/facebook/presto/geospatial/GeometryUtils.java
+++ b/presto-geospatial-toolkit/src/main/java/com/facebook/presto/geospatial/GeometryUtils.java
@@ -125,7 +125,7 @@ public final class GeometryUtils
     /**
      * Get the bounding box for an OGCGeometry.
      * <p>
-     * If the geometry is empty, return a Retangle with NaN coordinates.
+     * If the geometry is empty, return a Rectangle with NaN coordinates.
      *
      * @param ogcGeometry
      * @return Rectangle bounding box
@@ -138,7 +138,7 @@ public final class GeometryUtils
     /**
      * Get the bounding box for an OGCGeometry, inflated by radius.
      * <p>
-     * If the geometry is empty, return a Retangle with NaN coordinates.
+     * If the geometry is empty, return a Rectangle with NaN coordinates.
      *
      * @param ogcGeometry
      * @return Rectangle bounding box

--- a/presto-geospatial-toolkit/src/main/java/com/facebook/presto/geospatial/Rectangle.java
+++ b/presto-geospatial-toolkit/src/main/java/com/facebook/presto/geospatial/Rectangle.java
@@ -126,7 +126,7 @@ public final class Rectangle
      *
      * @return if xMax==xMin and yMax==yMin
      */
-    public boolean isPointlike()
+    public boolean isPointLike()
     {
         return xMin == xMax && yMin == yMax;
     }

--- a/presto-geospatial-toolkit/src/main/java/com/facebook/presto/geospatial/rtree/Flatbush.java
+++ b/presto-geospatial-toolkit/src/main/java/com/facebook/presto/geospatial/rtree/Flatbush.java
@@ -65,7 +65,7 @@ import static java.util.Objects.requireNonNull;
  * matter.  This could be done with quicksort, stopping once all items at index
  * `n * degree` are correctly placed.
  * <p>
- * Original implementation in Javascript: https://github.com/mourner/flatbush
+ * Original implementation in JavaScript: https://github.com/mourner/flatbush
  */
 public class Flatbush<T extends HasExtent>
 {

--- a/presto-hive-common/src/main/java/org/apache/hadoop/fs/HadoopExtendedFileSystem.java
+++ b/presto-hive-common/src/main/java/org/apache/hadoop/fs/HadoopExtendedFileSystem.java
@@ -495,10 +495,10 @@ public class HadoopExtendedFileSystem
 
     @Override
     @SuppressWarnings("deprecation")
-    protected boolean primitiveMkdir(Path f, FsPermission abdolutePermission)
+    protected boolean primitiveMkdir(Path f, FsPermission absolutePermission)
             throws IOException
     {
-        return fs.primitiveMkdir(f, abdolutePermission);
+        return fs.primitiveMkdir(f, absolutePermission);
     }
 
     @Override // FileSystem

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/alluxio/AlluxioHiveMetastore.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/alluxio/AlluxioHiveMetastore.java
@@ -159,9 +159,9 @@ public class AlluxioHiveMetastore
         List<String> dataColumns = table.getDataColumns().stream()
                 .map(Column::getName)
                 .collect(toImmutableList());
-        Map<String, List<ColumnStatisticsInfo>> columnStatisticss;
+        Map<String, List<ColumnStatisticsInfo>> rawPartitionColumnStatistics;
         try {
-            columnStatisticss = client.getPartitionColumnStatistics(
+            rawPartitionColumnStatistics = client.getPartitionColumnStatistics(
                     table.getDatabaseName(),
                     table.getTableName(),
                     partitionBasicStatistics.keySet().stream().collect(toImmutableList()),
@@ -171,7 +171,7 @@ public class AlluxioHiveMetastore
             throw new PrestoException(HIVE_METASTORE_ERROR, e);
         }
 
-        Map<String, Map<String, HiveColumnStatistics>> partitionColumnStatistics = columnStatisticss.entrySet().stream()
+        Map<String, Map<String, HiveColumnStatistics>> partitionColumnStatistics = rawPartitionColumnStatistics.entrySet().stream()
                 .filter(entry -> !entry.getValue().isEmpty())
                 .collect(toImmutableMap(
                         Map.Entry::getKey,

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveCoercer.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveCoercer.java
@@ -242,7 +242,7 @@ public interface HiveCoercer
                 maxValue = Long.MAX_VALUE;
             }
             else {
-                throw new PrestoException(NOT_SUPPORTED, format("Could not create Coercer from from varchar to %s", toType));
+                throw new PrestoException(NOT_SUPPORTED, format("Could not create Coercer from varchar to %s", toType));
             }
         }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -675,7 +675,7 @@ public class HiveMetadata
             properties.put(ORC_BLOOM_FILTER_FPP, Double.parseDouble(orcBloomFilterFfp));
         }
 
-        // Avro specfic property
+        // Avro specific property
         String avroSchemaUrl = table.get().getParameters().get(AVRO_SCHEMA_URL_KEY);
         if (avroSchemaUrl != null) {
             properties.put(AVRO_SCHEMA_URL, avroSchemaUrl);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
@@ -1136,7 +1136,7 @@ public final class HiveSessionProperties
         return session.getProperty(DWRF_WRITER_STRIPE_CACHE_ENABLED, Boolean.class);
     }
 
-    public static DataSize getDwrfWriterStripeCacheeMaxSize(ConnectorSession session)
+    public static DataSize getDwrfWriterStripeCacheMaxSize(ConnectorSession session)
     {
         return session.getProperty(DWRF_WRITER_STRIPE_CACHE_SIZE, DataSize.class);
     }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveUtil.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveUtil.java
@@ -1110,7 +1110,7 @@ public final class HiveUtil
             Integer physicalOrdinal = physicalNameOrdinalMap.get(column.getName());
             if (physicalOrdinal == null) {
                 // if the column is missing from the file, assign it a column number larger than the number of columns in the
-                // file so the reader will fill it with nulls.  If the index is negative, i.e. this is a sythesized column like
+                // file so the reader will fill it with nulls.  If the index is negative, i.e. this is a synthesized column like
                 // a partitioning key, $bucket or $path, leave it as is.
                 if (column.getHiveColumnIndex() < 0) {
                     physicalOrdinal = column.getHiveColumnIndex();

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriterFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveWriterFactory.java
@@ -313,7 +313,7 @@ public class HiveWriterFactory
 
         this.hiveWriterStats = requireNonNull(hiveWriterStats, "hiveWriterStats is null");
 
-        // In Hive connector, bucket commit is fulfilled by writing to temporary file in TableWriterOperator, and rename in TableFinishOpeartor
+        // In Hive connector, bucket commit is fulfilled by writing to temporary file in TableWriterOperator, and rename in TableFinishOperator
         // (note Presto partition here loosely maps to Hive bucket)
         this.writeToTempFile = commitRequired;
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriterFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/OrcFileWriterFactory.java
@@ -60,7 +60,7 @@ import java.util.stream.IntStream;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_UNSUPPORTED_FORMAT;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_WRITER_OPEN_ERROR;
 import static com.facebook.presto.hive.HiveErrorCode.HIVE_WRITE_VALIDATION_FAILED;
-import static com.facebook.presto.hive.HiveSessionProperties.getDwrfWriterStripeCacheeMaxSize;
+import static com.facebook.presto.hive.HiveSessionProperties.getDwrfWriterStripeCacheMaxSize;
 import static com.facebook.presto.hive.HiveSessionProperties.getOrcMaxBufferSize;
 import static com.facebook.presto.hive.HiveSessionProperties.getOrcMaxMergeDistance;
 import static com.facebook.presto.hive.HiveSessionProperties.getOrcOptimizedWriterMaxDictionaryMemory;
@@ -234,7 +234,7 @@ public class OrcFileWriterFactory
                             .withMaxStringStatisticsLimit(getOrcStringStatisticsLimit(session))
                             .withIgnoreDictionaryRowGroupSizes(isExecutionBasedMemoryAccountingEnabled(session))
                             .withDwrfStripeCacheEnabled(isDwrfWriterStripeCacheEnabled(session))
-                            .withDwrfStripeCacheMaxSize(getDwrfWriterStripeCacheeMaxSize(session))
+                            .withDwrfStripeCacheMaxSize(getDwrfWriterStripeCacheMaxSize(session))
                             .build(),
                     fileInputColumnIndexes,
                     ImmutableMap.<String, String>builder()

--- a/presto-hive/src/main/java/com/facebook/presto/hive/SubfieldExtractor.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/SubfieldExtractor.java
@@ -59,7 +59,7 @@ public final class SubfieldExtractor
             ConnectorSession connectorSession)
     {
         this.functionResolution = requireNonNull(functionResolution, "functionResolution is null");
-        this.expressionOptimizer = requireNonNull(expressionOptimizer, "expressionOptimzier is null");
+        this.expressionOptimizer = requireNonNull(expressionOptimizer, "expressionOptimizer is null");
         this.connectorSession = requireNonNull(connectorSession, "connectorSession is null");
     }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -1308,8 +1308,8 @@ public abstract class AbstractTestHiveClient
         try (Transaction transaction = newTransaction()) {
             ConnectorMetadata metadata = transaction.getMetadata();
             ConnectorTableHandle tableHandle = getTableHandle(metadata, tablePartitionFormat);
-            ConnectorTableLayout actuaTableLayout = getTableLayout(newSession(), metadata, tableHandle, new Constraint<>(withColumnDomains(ImmutableMap.of(intColumn, Domain.singleValue(BIGINT, 5L)))), transaction);
-            assertExpectedTableLayout(actuaTableLayout, tableLayout);
+            ConnectorTableLayout actualTableLayout = getTableLayout(newSession(), metadata, tableHandle, new Constraint<>(withColumnDomains(ImmutableMap.of(intColumn, Domain.singleValue(BIGINT, 5L)))), transaction);
+            assertExpectedTableLayout(actualTableLayout, tableLayout);
         }
     }
 
@@ -1753,7 +1753,7 @@ public abstract class AbstractTestHiveClient
                 ConnectorSplitSource splitSource = splitManager.getSplits(transaction.getTransactionHandle(), session, tableLayout.getHandle(), SPLIT_SCHEDULING_CONTEXT);
                 List<ConnectorSplit> allSplits = getAllSplits(splitSource);
 
-                assertTrue(allSplits.size() >= 1, "There should be atleast 1 split");
+                assertTrue(allSplits.size() >= 1, "There should be at least 1 split");
 
                 for (ConnectorSplit split : allSplits) {
                     HiveSplit hiveSplit = (HiveSplit) split;
@@ -1784,7 +1784,7 @@ public abstract class AbstractTestHiveClient
                 ConnectorSplitSource splitSource = splitManager.getSplits(transaction.getTransactionHandle(), session, tableLayout.getHandle(), SPLIT_SCHEDULING_CONTEXT);
                 List<ConnectorSplit> allSplits = getAllSplits(splitSource);
 
-                assertTrue(allSplits.size() >= 1, "There should be atleast 1 split");
+                assertTrue(allSplits.size() >= 1, "There should be at least 1 split");
 
                 for (ConnectorSplit split : allSplits) {
                     HiveSplit hiveSplit = (HiveSplit) split;
@@ -5284,11 +5284,11 @@ public abstract class AbstractTestHiveClient
         return createTableProperties(storageFormat, ImmutableList.of());
     }
 
-    private static Map<String, Object> createTableProperties(HiveStorageFormat storageFormat, Iterable<String> parititonedBy)
+    private static Map<String, Object> createTableProperties(HiveStorageFormat storageFormat, Iterable<String> partitionedBy)
     {
         return ImmutableMap.<String, Object>builder()
                 .put(STORAGE_FORMAT_PROPERTY, storageFormat)
-                .put(PARTITIONED_BY_PROPERTY, ImmutableList.copyOf(parititonedBy))
+                .put(PARTITIONED_BY_PROPERTY, ImmutableList.copyOf(partitionedBy))
                 .put(BUCKETED_BY_PROPERTY, ImmutableList.of())
                 .put(BUCKET_COUNT_PROPERTY, 0)
                 .put(SORTED_BY_PROPERTY, ImmutableList.of())
@@ -5507,7 +5507,7 @@ public abstract class AbstractTestHiveClient
                             temporaryDeleteInsert,
                             domainToDrop,
                             insertData,
-                            testCase.isExpectCommitedData() ? afterData : beforeData,
+                            testCase.isExpectCommittedData() ? afterData : beforeData,
                             testCase.getTag(),
                             testCase.isExpectQuerySucceed(),
                             testCase.getConflictTrigger());
@@ -5639,22 +5639,22 @@ public abstract class AbstractTestHiveClient
 
     protected static class TransactionDeleteInsertTestCase
     {
-        private final boolean expectCommitedData;
+        private final boolean expectCommittedData;
         private final boolean expectQuerySucceed;
         private final TransactionDeleteInsertTestTag tag;
         private final Optional<ConflictTrigger> conflictTrigger;
 
-        public TransactionDeleteInsertTestCase(boolean expectCommitedData, boolean expectQuerySucceed, TransactionDeleteInsertTestTag tag, Optional<ConflictTrigger> conflictTrigger)
+        public TransactionDeleteInsertTestCase(boolean expectCommittedData, boolean expectQuerySucceed, TransactionDeleteInsertTestTag tag, Optional<ConflictTrigger> conflictTrigger)
         {
-            this.expectCommitedData = expectCommitedData;
+            this.expectCommittedData = expectCommittedData;
             this.expectQuerySucceed = expectQuerySucceed;
             this.tag = tag;
             this.conflictTrigger = conflictTrigger;
         }
 
-        public boolean isExpectCommitedData()
+        public boolean isExpectCommittedData()
         {
-            return expectCommitedData;
+            return expectCommittedData;
         }
 
         public boolean isExpectQuerySucceed()
@@ -5678,7 +5678,7 @@ public abstract class AbstractTestHiveClient
             return toStringHelper(this)
                     .add("tag", tag)
                     .add("conflictTrigger", conflictTrigger.map(conflictTrigger -> conflictTrigger.getClass().getName()))
-                    .add("expectCommitedData", expectCommitedData)
+                    .add("expectCommittedData", expectCommittedData)
                     .add("expectQuerySucceed", expectQuerySucceed)
                     .toString();
         }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientFileMetastore.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientFileMetastore.java
@@ -73,8 +73,8 @@ public class TestHiveClientFileMetastore
         File baseDir = new File(tempDir, "metastore");
         HiveClientConfig hiveConfig = new HiveClientConfig();
         MetastoreClientConfig metastoreClientConfig = new MetastoreClientConfig();
-        HdfsConfigurationInitializer updator = new HdfsConfigurationInitializer(hiveConfig, metastoreClientConfig);
-        HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(updator, ImmutableSet.of());
+        HdfsConfigurationInitializer updater = new HdfsConfigurationInitializer(hiveConfig, metastoreClientConfig);
+        HdfsConfiguration hdfsConfiguration = new HiveHdfsConfiguration(updater, ImmutableSet.of());
         HdfsEnvironment hdfsEnvironment = new HdfsEnvironment(hdfsConfiguration, metastoreClientConfig, new NoHdfsAuthentication());
         return new FileHiveMetastore(hdfsEnvironment, baseDir.toURI().toString(), "test");
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveDecimalParser.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveDecimalParser.java
@@ -33,7 +33,7 @@ public class TestHiveDecimalParser
         checkParseDecimal("3.11", 2, 1, new BigDecimal("3.1"));
         checkParseDecimal("3.16", 2, 1, new BigDecimal("3.2"));
 
-        // rouding of half (odd and even)
+        // rounding of half (odd and even)
         checkParseDecimal("3.15", 2, 1, new BigDecimal("3.2"));
         checkParseDecimal("3.25", 2, 1, new BigDecimal("3.3"));
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveDistributedQueriesWithOptimizedRepartitioning.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveDistributedQueriesWithOptimizedRepartitioning.java
@@ -32,7 +32,7 @@ public class TestHiveDistributedQueriesWithOptimizedRepartitioning
                 getTables(),
                 ImmutableMap.of(
                         "experimental.optimized-repartitioning", "true",
-                        // Use small SerialiedPages to force flushing
+                        // Use small SerializedPages to force flushing
                         "driver.max-page-partitioning-buffer-size", "10000B"),
                 Optional.empty());
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMaterializedViewUtils.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMaterializedViewUtils.java
@@ -154,7 +154,7 @@ public class TestHiveMaterializedViewUtils
     }
 
     @Test
-    public void testMaterializedDataPredicatesWithIntParitionType()
+    public void testMaterializedDataPredicatesWithIntPartitionType()
     {
         TestingTypeManager typeManager = new TestingTypeManager();
         TestingSemiTransactionalHiveMetastore testMetastore = TestingSemiTransactionalHiveMetastore.create();

--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/AbstractTestParquetReader.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/AbstractTestParquetReader.java
@@ -213,10 +213,10 @@ public abstract class AbstractTestParquetReader
     }
 
     @Test
-    public void testCustomSchemaArrayOfStucts()
+    public void testCustomSchemaArrayOfStructs()
             throws Exception
     {
-        MessageType customSchemaArrayOfStucts = parseMessageType("message ParquetSchema { " +
+        MessageType customSchemaArrayOfStructs = parseMessageType("message ParquetSchema { " +
                 "  optional group self (LIST) { " +
                 "    repeated group self_tuple { " +
                 "      optional int64 a; " +
@@ -235,11 +235,11 @@ public abstract class AbstractTestParquetReader
         Type structType = RowType.from(asList(field("a", BIGINT), field("b", BOOLEAN), field("c", VARCHAR)));
         tester.testSingleLevelArrayRoundTrip(
                 getStandardListObjectInspector(getStandardStructObjectInspector(structFieldNames, asList(javaLongObjectInspector, javaBooleanObjectInspector, javaStringObjectInspector))),
-                values, values, "self", new ArrayType(structType), Optional.of(customSchemaArrayOfStucts));
+                values, values, "self", new ArrayType(structType), Optional.of(customSchemaArrayOfStructs));
     }
 
     @Test
-    public void testSingleLevelSchemaArrayOfStucts()
+    public void testSingleLevelSchemaArrayOfStructs()
             throws Exception
     {
         Iterable<Long> aValues = limit(cycle(asList(1L, null, 3L, 5L, null, null, null, 7L, 11L, null, 13L, 17L)), 30_000);

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionTable.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/PartitionTable.java
@@ -281,7 +281,7 @@ public class PartitionTable
             return value.toString();
         }
         if (type instanceof Types.BinaryType) {
-            // TODO the client sees the bytearray's tostring ouput instead of seeing actual bytes, needs to be fixed.
+            // TODO the client sees the bytearray's tostring output instead of seeing actual bytes, needs to be fixed.
             return ((ByteBuffer) value).array();
         }
         if (type instanceof Types.FloatType) {

--- a/presto-jdbc/src/test/resources/how_to_regenerate_test_keys.txt
+++ b/presto-jdbc/src/test/resources/how_to_regenerate_test_keys.txt
@@ -1,6 +1,6 @@
 # To regenerate the test public and private keys
 
-# Generate an RSA private key and convert it to PKCS8 wraped in PEM
+# Generate an RSA private key and convert it to PKCS8 wrapped in PEM
 openssl genrsa 2048 | openssl pkcs8 -topk8 -inform pem -outform pem -nocrypt -out rsa.key
 # Extract public key from private key
 openssl rsa -in rsa.key -pubout -out rsa.pub

--- a/presto-kafka/src/main/java/com/facebook/presto/kafka/encoder/raw/RawRowEncoder.java
+++ b/presto-kafka/src/main/java/com/facebook/presto/kafka/encoder/raw/RawRowEncoder.java
@@ -206,7 +206,7 @@ public class RawRowEncoder
         private static void checkFieldTypeOneOf(FieldType declaredFieldType, String columnName, Type columnType, FieldType... allowedFieldTypes)
         {
             checkArgument(Arrays.asList(allowedFieldTypes).contains(declaredFieldType),
-                    format("Wrong dataformat '%s' specified for column '%s'; %s type implies use of %s",
+                    format("Wrong data format '%s' specified for column '%s'; %s type implies use of %s",
                             declaredFieldType.name(),
                             columnName,
                             columnType,

--- a/presto-kudu/bin/run_kudu_tests.sh
+++ b/presto-kudu/bin/run_kudu_tests.sh
@@ -4,7 +4,7 @@
 #
 # ./run_kudu_tests.sh <nodes> <inferSchemaPrefix>
 #
-# <nodes>                Number of tablet servers (1 oder 3). Also used for number of replicas.
+# <nodes>                Number of tablet servers (1 or 3). Also used for number of replicas.
 # <inferSchemaPrefix>    InferSchema setup: "null" = disabled,
 #                                           ""     = enabled, using empty prefix,
 #                                           "presto::" = enabled, using standard prefix

--- a/presto-kudu/src/main/java/com/facebook/presto/kudu/properties/RangeBoundValueDeserializer.java
+++ b/presto-kudu/src/main/java/com/facebook/presto/kudu/properties/RangeBoundValueDeserializer.java
@@ -28,7 +28,7 @@ public class RangeBoundValueDeserializer
         extends JsonDeserializer
 {
     @Override
-    public RangeBoundValue deserialize(JsonParser jp, DeserializationContext ctxt)
+    public RangeBoundValue deserialize(JsonParser jp, DeserializationContext ctx)
             throws IOException
     {
         JsonNode node = jp.getCodec().readTree(jp);

--- a/presto-main/bin/check_webui.sh
+++ b/presto-main/bin/check_webui.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Perform basic validations on the Web UI Javascript code
+# Perform basic validations on the Web UI JavaScript code
 #
 # 1. Validate that the generated files that have been checked in to the webapp folder are in sync
 #    with the source.

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -565,7 +565,7 @@ public final class SystemSessionProperties
                         JoinReorderingStrategy::name),
                 new PropertyMetadata<>(
                         PARTIAL_MERGE_PUSHDOWN_STRATEGY,
-                        format("Experimental: Partial merge pushdown strategy to use. Optionas are %s",
+                        format("Experimental: Partial merge pushdown strategy to use. Options are %s",
                                 Stream.of(PartialMergePushdownStrategy.values())
                                         .map(PartialMergePushdownStrategy::name)
                                         .collect(joining(","))),
@@ -685,7 +685,7 @@ public final class SystemSessionProperties
                         false),
                 new PropertyMetadata<>(
                         AGGREGATION_OPERATOR_UNSPILL_MEMORY_LIMIT,
-                        "Experimental: How much memory can should be allocated per aggragation operator in unspilling process",
+                        "Experimental: How much memory can should be allocated per aggregation operator in unspilling process",
                         VARCHAR,
                         DataSize.class,
                         featuresConfig.getAggregationOperatorUnspillMemoryLimit(),

--- a/presto-main/src/main/java/com/facebook/presto/connector/system/SystemPageSourceProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/system/SystemPageSourceProvider.java
@@ -100,13 +100,13 @@ public class SystemPageSourceProvider
             String columnName = ((SystemColumnHandle) entry.getKey()).getColumnName();
             newConstraints.put(columnsByName.get(columnName), entry.getValue());
         }
-        TupleDomain<Integer> newContraint = withColumnDomains(newConstraints.build());
+        TupleDomain<Integer> newConstraint = withColumnDomains(newConstraints.build());
 
         try {
-            return new MappedPageSource(systemTable.pageSource(systemTransaction.getConnectorTransactionHandle(), session, newContraint), userToSystemFieldIndex.build());
+            return new MappedPageSource(systemTable.pageSource(systemTransaction.getConnectorTransactionHandle(), session, newConstraint), userToSystemFieldIndex.build());
         }
         catch (UnsupportedOperationException e) {
-            return new RecordPageSource(new MappedRecordSet(toRecordSet(systemTransaction.getConnectorTransactionHandle(), systemTable, session, newContraint), userToSystemFieldIndex.build()));
+            return new RecordPageSource(new MappedRecordSet(toRecordSet(systemTransaction.getConnectorTransactionHandle(), systemTable, session, newConstraint), userToSystemFieldIndex.build()));
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/cost/FilterStatsCalculator.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/FilterStatsCalculator.java
@@ -601,12 +601,12 @@ public class FilterStatsCalculator
 
             // NOT case
             if (node.getFunctionHandle().equals(functionResolution.notFunction())) {
-                RowExpression arguemnt = node.getArguments().get(0);
-                if (arguemnt instanceof SpecialFormExpression && ((SpecialFormExpression) arguemnt).getForm().equals(IS_NULL)) {
+                RowExpression argument = node.getArguments().get(0);
+                if (argument instanceof SpecialFormExpression && ((SpecialFormExpression) argument).getForm().equals(IS_NULL)) {
                     // IS NOT NULL case
-                    RowExpression innerArugment = ((SpecialFormExpression) arguemnt).getArguments().get(0);
-                    if (innerArugment instanceof VariableReferenceExpression) {
-                        VariableReferenceExpression variable = (VariableReferenceExpression) innerArugment;
+                    RowExpression innerArgument = ((SpecialFormExpression) argument).getArguments().get(0);
+                    if (innerArgument instanceof VariableReferenceExpression) {
+                        VariableReferenceExpression variable = (VariableReferenceExpression) innerArgument;
                         VariableStatsEstimate variableStats = input.getVariableStatistics(variable);
                         PlanNodeStatsEstimate.Builder result = PlanNodeStatsEstimate.buildFrom(input);
                         result.setOutputRowCount(input.getOutputRowCount() * (1 - variableStats.getNullsFraction()));
@@ -615,7 +615,7 @@ public class FilterStatsCalculator
                     }
                     return PlanNodeStatsEstimate.unknown();
                 }
-                return subtractSubsetStats(input, process(arguemnt));
+                return subtractSubsetStats(input, process(argument));
             }
 
             // BETWEEN case

--- a/presto-main/src/main/java/com/facebook/presto/cost/SimpleFilterProjectSemiJoinStatsRule.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/SimpleFilterProjectSemiJoinStatsRule.java
@@ -198,9 +198,9 @@ public class SimpleFilterProjectSemiJoinStatsRule
 
     private static boolean isSemiJoinOutputReference(Expression conjunct, VariableReferenceExpression semiJoinOutput)
     {
-        SymbolReference semiJoinOuputSymbolReference = createSymbolReference(semiJoinOutput);
-        return conjunct.equals(semiJoinOuputSymbolReference) ||
-                (conjunct instanceof NotExpression && ((NotExpression) conjunct).getValue().equals(semiJoinOuputSymbolReference));
+        SymbolReference semiJoinOutputSymbolReference = createSymbolReference(semiJoinOutput);
+        return conjunct.equals(semiJoinOutputSymbolReference) ||
+                (conjunct instanceof NotExpression && ((NotExpression) conjunct).getValue().equals(semiJoinOutputSymbolReference));
     }
 
     private boolean isNotFunction(RowExpression expression)

--- a/presto-main/src/main/java/com/facebook/presto/execution/LocationFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/LocationFactory.java
@@ -27,7 +27,7 @@ public interface LocationFactory
     URI createLocalTaskLocation(TaskId taskId);
 
     /**
-     * TODO: this method is required since not not all RPC call is supported by thrift.
+     * TODO: this method is required since not all RPC calls are supported by thrift.
      *     It should be merged into {@code createTaskLocation} once full thrift support is in-place for v1/task
      */
     @Deprecated

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryInfo.java
@@ -133,7 +133,7 @@ public class QueryInfo
         requireNonNull(setSchema, "setSchema is null");
         requireNonNull(setSessionProperties, "setSessionProperties is null");
         requireNonNull(resetSessionProperties, "resetSessionProperties is null");
-        requireNonNull(addedPreparedStatements, "addedPreparedStatemetns is null");
+        requireNonNull(addedPreparedStatements, "addedPreparedStatements is null");
         requireNonNull(deallocatedPreparedStatements, "deallocatedPreparedStatements is null");
         requireNonNull(startedTransactionId, "startedTransactionId is null");
         requireNonNull(query, "query is null");

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryManagerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryManagerConfig.java
@@ -318,7 +318,7 @@ public class QueryManagerConfig
     }
 
     @Config("concurrency-threshold-to-enable-resource-group-refresh")
-    @ConfigDescription("Resource group concurrency threshold precentage, once crossed new queries won't run till updated resource group info comes from resource manager")
+    @ConfigDescription("Resource group concurrency threshold percentage, once crossed new queries won't run till updated resource group info comes from resource manager")
     public QueryManagerConfig setConcurrencyThresholdToEnableResourceGroupRefresh(double concurrencyThresholdToEnableResourceGroupRefresh)
     {
         this.concurrencyThresholdToEnableResourceGroupRefresh = concurrencyThresholdToEnableResourceGroupRefresh;

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlTask.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlTask.java
@@ -145,7 +145,7 @@ public class SqlTask
                 taskNotificationExecutor,
                 maxBufferSize,
                 // Pass a memory context supplier instead of a memory context to the output buffer,
-                // because we haven't created the task context that holds the the memory context yet.
+                // because we haven't created the task context that holds the memory context yet.
                 () -> queryContext.getTaskContextByTaskId(taskId).localSystemMemoryContext(),
                 spoolingOutputBufferFactory);
         taskStateMachine = new TaskStateMachine(taskId, taskNotificationExecutor);
@@ -254,7 +254,7 @@ public class SqlTask
 
     private TaskStatus createTaskStatus(TaskHolder taskHolder)
     {
-        long taskStatusAgeInMilis = System.currentTimeMillis() - creationTimeInMillis;
+        long taskStatusAgeInMillis = System.currentTimeMillis() - creationTimeInMillis;
         // Always return a new TaskInfo with a larger version number;
         // otherwise a client will not accept the update
         long versionNumber = nextTaskInfoVersion.getAndIncrement();
@@ -329,7 +329,7 @@ public class SqlTask
                 fullGcCount,
                 fullGcTimeInMillis,
                 totalCpuTimeInNanos,
-                taskStatusAgeInMilis,
+                taskStatusAgeInMillis,
                 queuedPartitionedSplitsWeight,
                 runningPartitionedSplitsWeight);
     }

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlTaskExecution.java
@@ -1270,7 +1270,7 @@ public class SqlTaskExecution
                     break;
                 case GROUPED_EXECUTION:
                     if (!noMoreLifespans) {
-                        // There may still still be new driver groups, which means potentially new splits.
+                        // There may still be new driver groups, which means potentially new splits.
                         return false;
                     }
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/executor/MultilevelSplitQueue.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/executor/MultilevelSplitQueue.java
@@ -154,7 +154,7 @@ public class MultilevelSplitQueue
      * Presto attempts to give each level a target amount of scheduled time, which is configurable
      * using levelTimeMultiplier.
      * <p>
-     * This function selects the level that has the the lowest ratio of actual to the target time
+     * This function selects the level that has the lowest ratio of actual to the target time
      * with the objective of minimizing deviation from the target scheduled time. From this level,
      * we pick the split with the lowest priority.
      */

--- a/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/StochasticPriorityQueue.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/resourceGroups/StochasticPriorityQueue.java
@@ -215,16 +215,16 @@ final class StochasticPriorityQueue<E>
 
         public Node<E> findLeaf()
         {
-            int leftDecendants = left.map(node -> node.descendants).orElse(0);
-            int rightDecendants = right.map(node -> node.descendants).orElse(0);
+            int leftDescendants = left.map(node -> node.descendants).orElse(0);
+            int rightDescendants = right.map(node -> node.descendants).orElse(0);
 
-            if (leftDecendants == 0 && rightDecendants == 0) {
+            if (leftDescendants == 0 && rightDescendants == 0) {
                 return left.orElse(right.orElse(this));
             }
-            if (leftDecendants > rightDecendants) {
+            if (leftDescendants > rightDescendants) {
                 return left.get().findLeaf();
             }
-            if (rightDecendants > leftDecendants) {
+            if (rightDescendants > leftDescendants) {
                 return right.get().findLeaf();
             }
             // For ties just go left

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/LegacySqlQueryScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/LegacySqlQueryScheduler.java
@@ -338,7 +338,7 @@ public class LegacySqlQueryScheduler
         ImmutableList.Builder<StageExecutionAndScheduler> stages = ImmutableList.builder();
 
         for (StreamingPlanSection childSection : section.getChildren()) {
-            ExchangeLocationsConsumer childLocationsConsumer = (fragmentId, tasks, noMoreExhchangeLocations) -> {};
+            ExchangeLocationsConsumer childLocationsConsumer = (fragmentId, tasks, noMoreExchangeLocations) -> {};
             stages.addAll(createStageExecutions(
                     sectionExecutionFactory,
                     childLocationsConsumer,

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NodeScheduler.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/NodeScheduler.java
@@ -185,7 +185,7 @@ public class NodeScheduler
     public NodeSelector createNodeSelector(Session session, ConnectorId connectorId, int maxTasksPerStage)
     {
         // this supplier is thread-safe. TODO: this logic should probably move to the scheduler since the choice of which node to run in should be
-        // done as close to when the the split is about to be scheduled
+        // done as close to when the split is about to be scheduled
         Supplier<NodeMap> nodeMap = nodeMapRefreshInterval.toMillis() > 0 ?
                 memoizeWithExpiration(createNodeMapSupplier(connectorId), nodeMapRefreshInterval.toMillis(), MILLISECONDS) : createNodeMapSupplier(connectorId);
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/DriverFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/DriverFactory.java
@@ -69,7 +69,7 @@ public class DriverFactory
                 .map(SourceOperatorFactory.class::cast)
                 .map(SourceOperatorFactory::getSourceId)
                 .collect(toImmutableList());
-        checkArgument(sourceIds.size() <= 1, "Expected at most one source operator in driver facotry, but found %s", sourceIds);
+        checkArgument(sourceIds.size() <= 1, "Expected at most one source operator in driver factory, but found %s", sourceIds);
         this.sourceId = sourceIds.isEmpty() ? Optional.empty() : Optional.of(sourceIds.get(0));
     }
 
@@ -122,7 +122,7 @@ public class DriverFactory
     {
         checkState(!closed, "DriverFactory is already closed");
         requireNonNull(driverContext, "driverContext is null");
-        checkState(!closedLifespans.contains(driverContext.getLifespan()), "DriverFatory is already closed for driver group %s", driverContext.getLifespan());
+        checkState(!closedLifespans.contains(driverContext.getLifespan()), "DriverFactory is already closed for driver group %s", driverContext.getLifespan());
         encounteredLifespans.add(driverContext.getLifespan());
         ImmutableList.Builder<Operator> operators = ImmutableList.builder();
         for (OperatorFactory operatorFactory : operatorFactories) {

--- a/presto-main/src/main/java/com/facebook/presto/operator/DynamicFilterSourceOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/DynamicFilterSourceOperator.java
@@ -362,7 +362,7 @@ public class DynamicFilterSourceOperator
         ImmutableMap.Builder<String, Domain> domainsBuilder = ImmutableMap.builder();
         if (valueSets == null) {
             if (minValues == null) {
-                // there were too many rows to collect collect min/max range
+                // there were too many rows to collect min/max range
                 // dynamicPredicateConsumer was notified with 'all' in handleTooLargePredicate if there are no orderable types,
                 // else it was notified with 'all' in handleMinMaxCollectionLimitExceeded
                 return;

--- a/presto-main/src/main/java/com/facebook/presto/operator/ExchangeClientStatus.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ExchangeClientStatus.java
@@ -124,7 +124,7 @@ public class ExchangeClientStatus
                 mergeAvgs(averageBytesPerRequest, successfulRequestsCount, other.averageBytesPerRequest, other.successfulRequestsCount),
                 successfulRequestsCount + other.successfulRequestsCount,
                 bufferedPages + other.bufferedPages,
-                noMoreLocations && other.noMoreLocations, // if at least one has some locations, mergee has some too
+                noMoreLocations && other.noMoreLocations, // if at least one has some locations, merge has some too
                 ImmutableList.of()); // pageBufferClientStatuses may be long, so we don't want to combine the lists
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/GroupByHash.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/GroupByHash.java
@@ -75,7 +75,7 @@ public interface GroupByHash
 
     boolean contains(int position, Page page, int[] hashChannels);
 
-    long getRawHash(int groupyId);
+    long getRawHash(int groupId);
 
     @VisibleForTesting
     int getCapacity();

--- a/presto-main/src/main/java/com/facebook/presto/operator/NoChannelGroupByHash.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/NoChannelGroupByHash.java
@@ -97,7 +97,7 @@ public class NoChannelGroupByHash
     }
 
     @Override
-    public long getRawHash(int groupyId)
+    public long getRawHash(int groupId)
     {
         throw new UnsupportedOperationException("NoChannelGroupByHash does not support getHashCollisions");
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/PagesIndexOrdering.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PagesIndexOrdering.java
@@ -68,7 +68,7 @@ public class PagesIndexOrdering
         if (len > SMALL) {
             int l = from;
             int n = to - 1;
-            if (len > MEDIUM) { // Big arrays, pseudomedian of 9
+            if (len > MEDIUM) { // Big arrays, pseudo-median of 9
                 int s = len / 8;
                 l = median3(pagesIndex, l, l + s, l + 2 * s);
                 m = median3(pagesIndex, m - s, m, m + s);

--- a/presto-main/src/main/java/com/facebook/presto/operator/PagesRTreeIndex.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/PagesRTreeIndex.java
@@ -162,12 +162,12 @@ public class PagesRTreeIndex
         IntArrayList matchingPositions = new IntArrayList();
 
         Rectangle queryRectangle = getExtent(probeGeometry);
-        boolean probeIsPoint = queryRectangle.isPointlike();
+        boolean probeIsPoint = queryRectangle.isPointLike();
         rtree.findIntersections(queryRectangle, geometryWithPosition -> {
             OGCGeometry buildGeometry = geometryWithPosition.getGeometry();
             Rectangle buildEnvelope = geometryWithPosition.getExtent();
             if (partitions.isEmpty() || (probePartition == geometryWithPosition.getPartition() &&
-                    (probeIsPoint || buildEnvelope.isPointlike() || testReferencePoint(queryRectangle, buildEnvelope, probePartition)))) {
+                    (probeIsPoint || buildEnvelope.isPointLike() || testReferencePoint(queryRectangle, buildEnvelope, probePartition)))) {
                 OptionalDouble radius = radiusChannel == -1 ?
                         OptionalDouble.empty() :
                         OptionalDouble.of(getRadius(geometryWithPosition.getPosition()));

--- a/presto-main/src/main/java/com/facebook/presto/operator/SetBuilderOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/SetBuilderOperator.java
@@ -148,7 +148,7 @@ public class SetBuilderOperator
             this.sourceChannels = new int[]{setChannel};
         }
 
-        // Set builder is has a single channel which goes in channel 0, if hash is present, add a hachBlock to channel 1
+        // Set builder is has a single channel which goes in channel 0, if hash is present, add a hashBlock to channel 1
         Optional<Integer> channelSetHashChannel = hashChannel.isPresent() ? Optional.of(1) : Optional.empty();
         this.channelSetBuilder = new ChannelSetBuilder(
                 setSupplier.getType(),

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AccumulatorCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AccumulatorCompiler.java
@@ -126,7 +126,7 @@ public class AccumulatorCompiler
                     definition.declareField(a(PRIVATE, FINAL), "state_" + i, grouped ? stateDescriptors.get(i).getFactory().getGroupedStateClass() : stateDescriptors.get(i).getFactory().getSingleStateClass()),
                     stateDescriptors.get(i)));
         }
-        List<FieldDefinition> stateFileds = stateFieldAndDescriptors.stream()
+        List<FieldDefinition> stateFields = stateFieldAndDescriptors.stream()
                 .map(StateFieldAndDescriptor::getStateField)
                 .collect(toImmutableList());
 
@@ -156,7 +156,7 @@ public class AccumulatorCompiler
         // Generate methods
         generateAddInput(
                 definition,
-                stateFileds,
+                stateFields,
                 inputChannelFields,
                 maskChannelField,
                 metadata.getValueInputMetadata(),
@@ -167,13 +167,13 @@ public class AccumulatorCompiler
                 grouped);
         generateAddInputWindowIndex(
                 definition,
-                stateFileds,
+                stateFields,
                 metadata.getValueInputMetadata(),
                 metadata.getLambdaInterfaces(),
                 lambdaProviderFields,
                 metadata.getInputFunction(),
                 callSiteBinder);
-        generateGetEstimatedSize(definition, stateFileds);
+        generateGetEstimatedSize(definition, stateFields);
 
         generateGetIntermediateType(
                 definition,
@@ -201,10 +201,10 @@ public class AccumulatorCompiler
         }
 
         if (grouped) {
-            generateGroupedEvaluateFinal(definition, stateFileds, metadata.getOutputFunction(), callSiteBinder);
+            generateGroupedEvaluateFinal(definition, stateFields, metadata.getOutputFunction(), callSiteBinder);
         }
         else {
-            generateEvaluateFinal(definition, stateFileds, metadata.getOutputFunction(), callSiteBinder);
+            generateEvaluateFinal(definition, stateFields, metadata.getOutputFunction(), callSiteBinder);
         }
 
         if (grouped) {

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AggregationUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AggregationUtils.java
@@ -153,7 +153,7 @@ public final class AggregationUtils
         double dividend = state.getC2();
         double divisor = state.getM2X();
 
-        // divisor deliberately not checked for zero because the result can be Infty or NaN even if it is not zero
+        // divisor deliberately not checked for zero because the result can be Infinity or NaN even if it is not zero
         return dividend / divisor;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ParametricAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/ParametricAggregation.java
@@ -108,7 +108,7 @@ public class ParametricAggregation
                         stateFactory)),
                 outputType);
 
-        // Create specialized InternalAggregregationFunction for Presto
+        // Create specialized InternalAggregationFunction for Presto
         return new InternalAggregationFunction(getSignature().getNameSuffix(),
                 inputTypes,
                 ImmutableList.of(stateSerializer.getSerializedType()),

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/SetOfValues.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/SetOfValues.java
@@ -94,7 +94,7 @@ public final class SetOfValues
 
     public void add(Block value, int valuePosition)
     {
-        int hashPosition = getHashPositionOfvalue(value, valuePosition);
+        int hashPosition = getHashPositionOfValue(value, valuePosition);
         if (valuePositionByHash[hashPosition] == EMPTY_SLOT) {
             valueType.appendTo(value, valuePosition, valueBlockBuilder);
             valuePositionByHash[hashPosition] = valueBlockBuilder.getPositionCount() - 1;
@@ -104,7 +104,7 @@ public final class SetOfValues
         }
     }
 
-    private int getHashPositionOfvalue(Block value, int position)
+    private int getHashPositionOfValue(Block value, int position)
     {
         int hashPosition = getMaskedHash(hashPosition(valueType, value, position));
         while (true) {
@@ -131,7 +131,7 @@ public final class SetOfValues
         valuePositionByHash = new int[newCapacity];
         Arrays.fill(valuePositionByHash, EMPTY_SLOT);
         for (int position = 0; position < valueBlockBuilder.getPositionCount(); position++) {
-            valuePositionByHash[getHashPositionOfvalue(valueBlockBuilder, position)] = position;
+            valuePositionByHash[getHashPositionOfValue(valueBlockBuilder, position)] = position;
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/histogram/GroupedTypedHistogram.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/histogram/GroupedTypedHistogram.java
@@ -267,10 +267,10 @@ public class GroupedTypedHistogram
      *
      * @param nodeReader - will be passed every non-null nodePointer
      */
-    private void iterateGroupNodes(long groupdId, NodeReader nodeReader)
+    private void iterateGroupNodes(long groupId, NodeReader nodeReader)
     {
         // while the index can be a long, the value is always an int
-        int currentPointer = (int) headPointers.get(groupdId);
+        int currentPointer = (int) headPointers.get(groupId);
         checkArgument(currentPointer != NULL, "valid group must have non-null head pointer");
 
         while (currentPointer != NULL) {

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/histogram/HashUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/histogram/HashUtil.java
@@ -66,7 +66,7 @@ public class HashUtil
      * uses HashCommon.arraySize() which does this calculation. this is just a wrapper to name the use of this case
      *
      * @param expectedSize - expected number of elements to store in the hash
-     * @param fillRatio - expected fill ratio of buckets by elemements
+     * @param fillRatio - expected fill ratio of buckets by elements
      * @return nextPowerOfTwo(expectedSize / fillRatio)
      */
     public static int computeBucketCount(int expectedSize, float fillRatio)

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/histogram/ValueStore.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/histogram/ValueStore.java
@@ -151,7 +151,7 @@ public class ValueStore
         }
 
         buckets = newBuckets;
-        // worst case is every bucket has a unique value, so pre-emptively keep this large enough to have a value for ever bucket
+        // worst case is every bucket has a unique value, so preemptively keep this large enough to have a value for ever bucket
         // TODO: could optimize the growth algorithm to be resize this only when necessary; this wastes memory but guarantees that if every value has a distinct hash, we have space
         valueHashes.ensureCapacity(newBucketCount);
         bucketCount = newBucketCount;

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/AbstractBlockEncodingBuffer.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/AbstractBlockEncodingBuffer.java
@@ -143,8 +143,8 @@ public abstract class AbstractBlockEncodingBuffer
         // decodedBlock could be a block or ColumnarArray/Map/Row
         Object decodedBlock = decodedBlockNode.getDecodedBlock();
 
-        // Skip the Dictionary/Rle block node. The mapping info is not needed when creating buffers.
-        // This is because the AbstractBlockEncodingBuffer is only created once, while position mapping for Dictionar/Rle blocks
+        // Skip the Dictionary/RLE block node. The mapping info is not needed when creating buffers.
+        // This is because the AbstractBlockEncodingBuffer is only created once, while position mapping for Dictionary/RLE blocks
         // need to be done for every incoming block.
         if (decodedBlock instanceof DictionaryBlock) {
             decodedBlockNode = decodedBlockNode.getChildren().get(0);

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/DecodedBlockNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/DecodedBlockNode.java
@@ -20,7 +20,7 @@ import java.util.List;
 import static java.util.Objects.requireNonNull;
 
 /**
- * A tree structure to represent a decoded block. Dictionary/Rle blocks will be kept as a
+ * A tree structure to represent a decoded block. Dictionary/RLE blocks will be kept as a
  * separate node because we need the position mappings. For example, a block of map<int, bigint> where the key
  * is dictionary encoded will result in the following tree structure:
  *
@@ -34,7 +34,7 @@ class DecodedBlockNode
 {
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(DecodedBlockNode.class).instanceSize();
 
-    // The decodedBlock could be primitive block, Dictionary/Rle block, or ColumnarArray/Map/Row object
+    // The decodedBlock could be primitive block, Dictionary/RLE block, or ColumnarArray/Map/Row object
     private final Object decodedBlock;
     private final List<DecodedBlockNode> children;
     private final long retainedSizeInBytes;

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayFilterFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayFilterFunction.java
@@ -52,7 +52,7 @@ public final class ArrayFilterFunction
             }
 
             if (position == positionCount) {
-                // Nothing fitered out. So just return the original.
+                // Nothing filtered out. So just return the original.
                 return arrayBlock;
             }
 
@@ -114,7 +114,7 @@ public final class ArrayFilterFunction
             }
 
             if (position == positionCount) {
-                // Nothing fitered out. So just return the original.
+                // Nothing filtered out. So just return the original.
                 return arrayBlock;
             }
 
@@ -175,7 +175,7 @@ public final class ArrayFilterFunction
             }
 
             if (position == positionCount) {
-                // Nothing fitered out. So just return the original.
+                // Nothing filtered out. So just return the original.
                 return arrayBlock;
             }
 
@@ -236,7 +236,7 @@ public final class ArrayFilterFunction
             }
 
             if (position == positionCount) {
-                // Nothing fitered out. So just return the original.
+                // Nothing filtered out. So just return the original.
                 return arrayBlock;
             }
 
@@ -297,7 +297,7 @@ public final class ArrayFilterFunction
             }
 
             if (position == positionCount) {
-                // Nothing fitered out. So just return the original.
+                // Nothing filtered out. So just return the original.
                 return arrayBlock;
             }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/annotations/CodegenScalarFromAnnotationsParser.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/annotations/CodegenScalarFromAnnotationsParser.java
@@ -95,7 +95,7 @@ public class CodegenScalarFromAnnotationsParser
     {
         return Arrays.stream(method.getParameters())
                 .map(p -> {
-                    checkCondition(p.getType() == Type.class, FUNCTION_IMPLEMENTATION_ERROR, "Codegen scalar function %s must have paramter [%s] of type Type", method, p.getName());
+                    checkCondition(p.getType() == Type.class, FUNCTION_IMPLEMENTATION_ERROR, "Codegen scalar function %s must have parameter [%s] of type Type", method, p.getName());
                     checkCondition(p.getAnnotationsByType(BlockPosition.class).length == 0, FUNCTION_IMPLEMENTATION_ERROR, "Block and Position format is not supported for codegen function %s", method);
                     checkCondition(p.getAnnotationsByType(IsNull.class).length == 0, FUNCTION_IMPLEMENTATION_ERROR, "Null flag format is not supported for codegen function %s", method);
                     TypeSignature signature = parseTypeSignature(p.getAnnotation(SqlType.class).value());

--- a/presto-main/src/main/java/com/facebook/presto/server/BasicQueryStats.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/BasicQueryStats.java
@@ -347,7 +347,7 @@ public class BasicQueryStats
 
     @ThriftField(value = 19, name = "peakNodeTotalMemoryReservation")
     @JsonProperty
-    public DataSize getPeakNodeTotalMemorReservation()
+    public DataSize getPeakNodeTotalMemoryReservation()
     {
         return peakNodeTotalMemoryReservation;
     }

--- a/presto-main/src/main/java/com/facebook/presto/server/HttpRequestSessionContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/HttpRequestSessionContext.java
@@ -125,7 +125,7 @@ public final class HttpRequestSessionContext
     /**
      * @param servletRequest
      * @param sqlParserOptions
-     * @param tracerProvider This passed-in {@link TracerProvider} will only be used when isTracingEabled() returns true.
+     * @param tracerProvider This passed-in {@link TracerProvider} will only be used when isTracingEnabled() returns true.
      * @param sessionPropertyManager is used to provide with some default session values. In some scenarios we need
      * those default values even before session for a query is created. This is how we can get it at this
      * session context creation stage.

--- a/presto-main/src/main/java/com/facebook/presto/server/protocol/QueuedStatementResource.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/protocol/QueuedStatementResource.java
@@ -428,7 +428,7 @@ public class QueuedStatementResource
 
         private ListenableFuture<?> waitForDispatched()
         {
-            // if query query submission has not finished, wait for it to finish
+            // if query submission has not finished, wait for it to finish
             synchronized (this) {
                 if (querySubmissionFuture == null) {
                     querySubmissionFuture = dispatchManager.createQuery(queryId, slug, retryCount, sessionContext, query);

--- a/presto-main/src/main/java/com/facebook/presto/sql/Serialization.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/Serialization.java
@@ -116,7 +116,7 @@ public final class Serialization
         }
 
         @Override
-        public Object deserializeKey(String key, DeserializationContext ctxt)
+        public Object deserializeKey(String key, DeserializationContext ctx)
         {
             int p = key.indexOf(VARIABLE_TYPE_OPEN_BRACKET);
             if (p <= 0 || key.charAt(key.length() - 1) != VARIABLE_TYPE_CLOSE_BRACKET) {

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
@@ -779,9 +779,9 @@ public class Analysis
         return tableColumnReferences;
     }
 
-    public void addUtilizedTableColumnReferences(AccessControlInfo accessControlInfo, Map<QualifiedObjectName, Set<String>> utilizedTableColumms)
+    public void addUtilizedTableColumnReferences(AccessControlInfo accessControlInfo, Map<QualifiedObjectName, Set<String>> utilizedTableColumns)
     {
-        utilizedTableColumnReferences.put(accessControlInfo, utilizedTableColumms);
+        utilizedTableColumnReferences.put(accessControlInfo, utilizedTableColumns);
     }
 
     public Map<AccessControlInfo, Map<QualifiedObjectName, Set<String>>> getUtilizedTableColumnReferences()

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -631,7 +631,7 @@ class StatementAnalyzer
             if (node.getColumnAliases().isPresent()) {
                 validateColumnAliases(node.getColumnAliases().get(), queryScope.getRelationType().getVisibleFieldCount());
 
-                // analzie only column types in subquery if column alias exists
+                // analyze only column types in subquery if column alias exists
                 for (Field field : queryScope.getRelationType().getVisibleFields()) {
                     if (field.getType().equals(UNKNOWN)) {
                         throw new SemanticException(COLUMN_TYPE_UNKNOWN, node, "Column type is unknown at position %s", queryScope.getRelationType().indexOf(field) + 1);

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/AndCodeGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/AndCodeGenerator.java
@@ -71,7 +71,7 @@ public class AndCodeGenerator
             block.comment("do { eval arg; if (wasNull) { hasNull = true; wasNull = false; } else if (false) goto ret_false; }")
                     .append(generator.generate(expression, Optional.empty()));
 
-            IfStatement ifOperandIsNull = new IfStatement("if left wasNulll...").condition(wasNull);
+            IfStatement ifOperandIsNull = new IfStatement("if left wasNull...").condition(wasNull);
             ifOperandIsNull.ifTrue()
                     .comment("clear the null flag and remember there was a null")
                     .putVariable(hasNulls, true)

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/CommonSubExpressionRewriter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/CommonSubExpressionRewriter.java
@@ -338,10 +338,10 @@ public class CommonSubExpressionRewriter
 
         private int addAtLevel(int level, RowExpression expression)
         {
-            Set<RowExpression> rowExpressions = getExpresssionsAtLevel(level, expressionsByLevel);
+            Set<RowExpression> rowExpressions = getExpressionsAtLevel(level, expressionsByLevel);
             expressionCount.putIfAbsent(expression, 1);
             if (rowExpressions.contains(expression)) {
-                getExpresssionsAtLevel(level, cseByLevel).add(expression);
+                getExpressionsAtLevel(level, cseByLevel).add(expression);
                 int count = expressionCount.get(expression) + 1;
                 expressionCount.put(expression, count);
             }
@@ -349,7 +349,7 @@ public class CommonSubExpressionRewriter
             return level;
         }
 
-        private static Set<RowExpression> getExpresssionsAtLevel(int level, Map<Integer, Set<RowExpression>> expressionsByLevel)
+        private static Set<RowExpression> getExpressionsAtLevel(int level, Map<Integer, Set<RowExpression>> expressionsByLevel)
         {
             expressionsByLevel.putIfAbsent(level, new HashSet<>());
             return expressionsByLevel.get(level);

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/CursorProcessorCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/CursorProcessorCompiler.java
@@ -205,7 +205,7 @@ public class CursorProcessorCompiler
                 .comment("boolean finished = false;")
                 .putVariable(finishedVariable, false);
 
-        // while loop loop body
+        // while loop body
         LabelNode done = new LabelNode("done");
 
         BytecodeBlock whileFunctionBlock = new BytecodeBlock()

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/ExpressionProfiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/ExpressionProfiler.java
@@ -26,13 +26,13 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
 public class ExpressionProfiler
 {
     private static final Duration EXPENSIVE_EXPRESSION_THRESHOLD = SPLIT_RUN_QUANTA;
-    private static final int NOT_INITALIZED = -1;
+    private static final int NOT_INITIALIZED = -1;
 
     private final Ticker ticker;
     private final double expensiveExpressionThresholdNanos;
     private double totalExecutionTimeNanos;
     private int samples;
-    private long previousTimestamp = NOT_INITALIZED;
+    private long previousTimestamp = NOT_INITIALIZED;
     private boolean isExpressionExpensive = true;
 
     public ExpressionProfiler()
@@ -56,7 +56,7 @@ public class ExpressionProfiler
 
     public void stop(int batchSize)
     {
-        verify(previousTimestamp != NOT_INITALIZED, "start() is not called");
+        verify(previousTimestamp != NOT_INITIALIZED, "start() is not called");
         verify(batchSize > 0, "batchSize must be positive");
 
         long now = ticker.read();
@@ -66,7 +66,7 @@ public class ExpressionProfiler
         if ((totalExecutionTimeNanos / samples) < expensiveExpressionThresholdNanos) {
             isExpressionExpensive = false;
         }
-        previousTimestamp = NOT_INITALIZED;
+        previousTimestamp = NOT_INITIALIZED;
     }
 
     public boolean isExpressionExpensive()

--- a/presto-main/src/main/java/com/facebook/presto/sql/gen/OrCodeGenerator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/gen/OrCodeGenerator.java
@@ -70,7 +70,7 @@ public class OrCodeGenerator
         for (RowExpression expression : flattenedArgs.build()) {
             block.comment("do { eval arg; if (wasNull) { hasNull = true; wasNull = false; } else if (true) goto ret_true; }")
                     .append(generator.generate(expression, Optional.empty()));
-            IfStatement ifOperandIsNull = new IfStatement("if left wasNulll...").condition(wasNull);
+            IfStatement ifOperandIsNull = new IfStatement("if left wasNull...").condition(wasNull);
             ifOperandIsNull.ifTrue()
                     .comment("clear the null flag and remember there was a null")
                     .putVariable(hasNulls, true)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/EffectivePredicateExtractor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/EffectivePredicateExtractor.java
@@ -414,7 +414,7 @@ public class EffectivePredicateExtractor
                     .build();
 
             ImmutableList.Builder<RowExpression> effectiveConjuncts = ImmutableList.builder();
-            for (RowExpression conjunct : new EqualityInference.Builder(functionManger).nonInferrableConjuncts(expression)) {
+            for (RowExpression conjunct : new EqualityInference.Builder(functionManger).nonInferableConjuncts(expression)) {
                 if (determinismEvaluator.isDeterministic(conjunct)) {
                     RowExpression rewritten = equalityInference.rewriteExpression(conjunct, in(variables));
                     if (rewritten != null) {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/EqualityInference.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/EqualityInference.java
@@ -244,7 +244,7 @@ public class EqualityInference
     }
 
     /**
-     * Returns the most preferrable expression to be used as the canonical expression
+     * Returns the most preferable expression to be used as the canonical expression
      */
     private static RowExpression getCanonical(Iterable<RowExpression> expressions)
     {
@@ -364,14 +364,14 @@ public class EqualityInference
         /**
          * Provides a convenience Iterable of RowExpression conjuncts which have not been added to the inference
          */
-        public Iterable<RowExpression> nonInferrableConjuncts(RowExpression expression)
+        public Iterable<RowExpression> nonInferableConjuncts(RowExpression expression)
         {
             return filter(extractConjuncts(expression), not(isInferenceCandidate()));
         }
 
-        public static Iterable<RowExpression> nonInferrableConjuncts(Metadata metadata, RowExpression expression)
+        public static Iterable<RowExpression> nonInferableConjuncts(Metadata metadata, RowExpression expression)
         {
-            return new Builder(metadata).nonInferrableConjuncts(expression);
+            return new Builder(metadata).nonInferableConjuncts(expression);
         }
 
         public Builder addEqualityInference(RowExpression... expressions)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/ExpressionInterpreter.java
@@ -554,7 +554,7 @@ public class ExpressionInterpreter
                 if (!isDeterministic(expression) || visitedExpression.add(expression)) {
                     operandsBuilder.add(expression);
                 }
-                // TODO: Replace this logic with an anlyzer which specifies whether it evaluates to null
+                // TODO: Replace this logic with an analyzer which specifies whether it evaluates to null
                 if (expression instanceof Literal && !(expression instanceof NullLiteral)) {
                     break;
                 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -1687,7 +1687,7 @@ public class LocalExecutionPlanner
             // The probe key channels will be handed to the index according to probeVariable order
             Map<VariableReferenceExpression, Integer> probeKeyLayout = new HashMap<>();
             for (int i = 0; i < probeVariables.size(); i++) {
-                // Duplicate variables can appear and we only need to take take one of the Inputs
+                // Duplicate variables can appear and we only need to take one of the Inputs
                 probeKeyLayout.put(probeVariables.get(i), i);
             }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/Partitioning.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/Partitioning.java
@@ -407,9 +407,9 @@ public final class Partitioning
         return Optional.of(new Partitioning(handle, newArguments.build()));
     }
 
-    public Partitioning withAlternativePartitiongingHandle(PartitioningHandle partitiongingHandle)
+    public Partitioning withAlternativePartitioningHandle(PartitioningHandle partitioningHandle)
     {
-        return new Partitioning(partitiongingHandle, this.arguments);
+        return new Partitioning(partitioningHandle, this.arguments);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanFragmenter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanFragmenter.java
@@ -315,7 +315,7 @@ public class PlanFragmenter
         Partitioning newOutputPartitioning = outputPartitioningScheme.getPartitioning();
         if (outputPartitioningScheme.getPartitioning().getHandle().getConnectorId().isPresent()) {
             // Do not replace the handle if the source's output handle is a system one, e.g. broadcast.
-            newOutputPartitioning = newOutputPartitioning.withAlternativePartitiongingHandle(newOutputPartitioningHandle);
+            newOutputPartitioning = newOutputPartitioning.withAlternativePartitioningHandle(newOutputPartitioningHandle);
         }
         PlanFragment newFragment = new PlanFragment(
                 fragment.getId(),

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -52,7 +52,7 @@ import com.facebook.presto.sql.planner.iterative.rule.MergeLimitWithTopN;
 import com.facebook.presto.sql.planner.iterative.rule.MergeLimits;
 import com.facebook.presto.sql.planner.iterative.rule.MultipleDistinctAggregationToMarkDistinct;
 import com.facebook.presto.sql.planner.iterative.rule.PickTableLayout;
-import com.facebook.presto.sql.planner.iterative.rule.PlanRemotePojections;
+import com.facebook.presto.sql.planner.iterative.rule.PlanRemoteProjections;
 import com.facebook.presto.sql.planner.iterative.rule.PruneAggregationColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneAggregationSourceColumns;
 import com.facebook.presto.sql.planner.iterative.rule.PruneCountAggregationOverScalar;
@@ -486,7 +486,7 @@ public class PlanOptimizers
                 costCalculator,
                 ImmutableSet.of(
                         new RewriteFilterWithExternalFunctionToProject(metadata.getFunctionAndTypeManager()),
-                        new PlanRemotePojections(metadata.getFunctionAndTypeManager()))));
+                        new PlanRemoteProjections(metadata.getFunctionAndTypeManager()))));
 
         // Pass a supplier so that we pickup connector optimizers that are installed later
         builder.add(
@@ -518,7 +518,7 @@ public class PlanOptimizers
 
         builder.add(new IterativeOptimizer(
                 // Because ReorderJoins runs only once,
-                // PredicatePushDown, PruneUnreferenedOutputpus and RemoveRedundantIdentityProjections
+                // PredicatePushDown, PruneUnreferencedOutputs and RemoveRedundantIdentityProjections
                 // need to run beforehand in order to produce an optimal join order
                 // It also needs to run after EliminateCrossJoins so that its chosen order doesn't get undone.
                 ruleStats,

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/RelationPlanner.java
@@ -330,9 +330,9 @@ class RelationPlanner
             for (int i = 0; i < leftComparisonExpressions.size(); i++) {
                 if (joinConditionComparisonOperators.get(i) == ComparisonExpression.Operator.EQUAL) {
                     VariableReferenceExpression leftVariable = leftPlanBuilder.translateToVariable(leftComparisonExpressions.get(i));
-                    VariableReferenceExpression righVariable = rightPlanBuilder.translateToVariable(rightComparisonExpressions.get(i));
+                    VariableReferenceExpression rightVariable = rightPlanBuilder.translateToVariable(rightComparisonExpressions.get(i));
 
-                    equiClauses.add(new JoinNode.EquiJoinClause(leftVariable, righVariable));
+                    equiClauses.add(new JoinNode.EquiJoinClause(leftVariable, rightVariable));
                 }
                 else {
                     Expression leftExpression = leftPlanBuilder.rewrite(leftComparisonExpressions.get(i));

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/TypeProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/TypeProvider.java
@@ -62,7 +62,7 @@ public class TypeProvider
         requireNonNull(expression, "expression is null");
         Symbol symbol = Symbol.from(expression);
         Type type = types.get(symbol.getName());
-        checkArgument(type != null, "no type found found for symbol '%s'", symbol);
+        checkArgument(type != null, "no type found for symbol '%s'", symbol);
 
         return type;
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/EliminateEmptyJoins.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/EliminateEmptyJoins.java
@@ -88,12 +88,12 @@ public class EliminateEmptyJoins
         /*
         This covers the cases where the whole join can not be pruned for outer join cases.
         In this case, we optimize the join using a projection over the non-empty child.
-        The follwoing are 4 scenarios:
+        The following are 4 scenarios:
         1. S1 left outer join S2 and S2 is empty. The join is rewritten as Projection over S1 with null values for fields of S2. For example,
            "select t1.X, dt.Y from t1 left outer (select * from t2 where 1=0) is rewritten as select t1.X, null as Y from t1
-        2. S1 right outer join S2 and S1 is empty. Similiar to #1.
+        2. S1 right outer join S2 and S1 is empty. Similar to #1.
         3. S1 full outer join S2 and S1 is empty. This is can be reduce to S2 left outer join S1 and S1 is empty. Same logic of #1 is used.
-        4. S1 full outer join S2 and S2 is empty. Similiar to #3 and full outer join is reduced to S1 left outer join S2. Same logic is #1.
+        4. S1 full outer join S2 and S2 is empty. Similar to #3 and full outer join is reduced to S1 left outer join S2. Same logic is #1.
          */
         if (leftChildEmpty || rightChildEmpty) {
             PlanNode nonEmptyChild;

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PlanRemoteProjections.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PlanRemoteProjections.java
@@ -55,14 +55,14 @@ import static com.google.common.collect.Iterables.getOnlyElement;
 import static java.util.Objects.requireNonNull;
 import static java.util.function.Function.identity;
 
-public class PlanRemotePojections
+public class PlanRemoteProjections
         implements Rule<ProjectNode>
 {
     private static final Pattern<ProjectNode> PATTERN = project();
 
     private final FunctionAndTypeManager functionAndTypeManager;
 
-    public PlanRemotePojections(FunctionAndTypeManager functionAndTypeManager)
+    public PlanRemoteProjections(FunctionAndTypeManager functionAndTypeManager)
     {
         this.functionAndTypeManager = requireNonNull(functionAndTypeManager, "functionManager is null");
     }
@@ -121,7 +121,7 @@ public class PlanRemotePojections
 
     private static List<ProjectionContext> dedupVariables(List<ProjectionContext> projectionContexts)
     {
-        ImmutableList.Builder<ProjectionContext> deduppedProjectionContexts = ImmutableList.builder();
+        ImmutableList.Builder<ProjectionContext> dedupedProjectionContexts = ImmutableList.builder();
         Set<VariableReferenceExpression> originalVariable = projectionContexts.get(projectionContexts.size() - 1).getProjections().keySet();
         SymbolMapper mapper = null;
         for (int i = 0; i < projectionContexts.size(); i++) {
@@ -141,7 +141,7 @@ public class PlanRemotePojections
             ImmutableMultimap<RowExpression, VariableReferenceExpression> reverseProjections = reverseProjectionsBuilder.build();
             if (reverseProjections.keySet().size() == projectionContexts.get(i).getProjections().size() && reverseProjections.keySet().stream().noneMatch(VariableReferenceExpression.class::isInstance)) {
                 // No duplication
-                deduppedProjectionContexts.add(new ProjectionContext(projections, projectionContexts.get(i).isRemote()));
+                dedupedProjectionContexts.add(new ProjectionContext(projections, projectionContexts.get(i).isRemote()));
                 mapper = null;
             }
             else {
@@ -169,11 +169,11 @@ public class PlanRemotePojections
                         dedupedProjectionsBuilder.put(values.get(0), key);
                     }
                 }
-                deduppedProjectionContexts.add(new ProjectionContext(dedupedProjectionsBuilder.build(), projectionContexts.get(i).isRemote()));
+                dedupedProjectionContexts.add(new ProjectionContext(dedupedProjectionsBuilder.build(), projectionContexts.get(i).isRemote()));
                 mapper = mapperBuilder.build();
             }
         }
-        return deduppedProjectionContexts.build();
+        return dedupedProjectionContexts.build();
     }
 
     private static List<ProjectionContext> mergeProjectionContexts(List<List<ProjectionContext>> projectionContexts)

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushAggregationThroughOuterJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushAggregationThroughOuterJoin.java
@@ -229,7 +229,7 @@ public class PushAggregationThroughOuterJoin
     // When the aggregation is done after the join, there will be a null value that gets aggregated over
     // where rows did not exist in the inner table.  For some aggregate functions, such as count, the result
     // of an aggregation over a single null row is one or zero rather than null. In order to ensure correct results,
-    // we add a coalesce function with the output of the new outer join and the agggregation performed over a single
+    // we add a coalesce function with the output of the new outer join and the aggregation performed over a single
     // null row.
     private Optional<PlanNode> coalesceWithNullAggregation(AggregationNode aggregationNode, PlanNode outerJoin, PlanVariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, Lookup lookup)
     {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushPartialAggregationThroughExchange.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushPartialAggregationThroughExchange.java
@@ -187,7 +187,7 @@ public class PushPartialAggregationThroughExchange
         for (PlanNode node : partials) {
             verify(aggregation.getOutputVariables().equals(node.getOutputVariables()));
         }
-        // Since this exchange source is now guaranteed to have the same symbols as the inputs to the the partial
+        // Since this exchange source is now guaranteed to have the same symbols as the inputs to the partial
         // aggregation, we don't need to rewrite symbols in the partitioning function
         List<VariableReferenceExpression> aggregationOutputs = aggregation.getOutputVariables();
         PartitioningScheme partitioning = new PartitioningScheme(

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ReorderJoins.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/ReorderJoins.java
@@ -332,7 +332,7 @@ public class ReorderJoins
             // could not be used for equality inference.
             // If they use both the left and right variables, we add them to the list of joinPredicates
             EqualityInference.Builder builder = new EqualityInference.Builder(metadata);
-            StreamSupport.stream(builder.nonInferrableConjuncts(allFilter).spliterator(), false)
+            StreamSupport.stream(builder.nonInferableConjuncts(allFilter).spliterator(), false)
                     .map(conjunct -> allFilterInference.rewriteExpression(
                             conjunct,
                             variable -> leftVariables.contains(variable) || rightVariables.contains(variable)))
@@ -359,7 +359,7 @@ public class ReorderJoins
                 ImmutableList.Builder<RowExpression> predicates = ImmutableList.builder();
                 predicates.addAll(allFilterInference.generateEqualitiesPartitionedBy(outputVariables::contains).getScopeEqualities());
                 EqualityInference.Builder builder = new EqualityInference.Builder(metadata);
-                StreamSupport.stream(builder.nonInferrableConjuncts(allFilter).spliterator(), false)
+                StreamSupport.stream(builder.nonInferableConjuncts(allFilter).spliterator(), false)
                         .map(conjunct -> allFilterInference.rewriteExpression(conjunct, outputVariables::contains))
                         .filter(Objects::nonNull)
                         .forEach(predicates::add);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/KeyBasedSampler.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/KeyBasedSampler.java
@@ -204,7 +204,7 @@ public class KeyBasedSampler
             PlanNode rewrittenLeft = rewriteWith(this, left);
             PlanNode rewrittenRight = rewriteWith(this, right);
 
-            // If at leasst one of them is unchanged means it had no join. So one side has a table scan.
+            // If at least one of them is unchanged means it had no join. So one side has a table scan.
             // So we apply filter on both sides.
             if (left == rewrittenLeft || right == rewrittenRight) {
                 // Sample both sides if at least one side is not already sampled

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PredicatePushDown.java
@@ -251,8 +251,8 @@ public class PredicatePushDown
         @Override
         public PlanNode visitWindow(WindowNode node, RewriteContext<RowExpression> context)
         {
-            // TODO: This could be broader. We can push down conjucts if they are constant for all rows in a window partition.
-            // The simplest way to guarantee this is if the conjucts are deterministic functions of the partitioning variables.
+            // TODO: This could be broader. We can push down conjuncts if they are constant for all rows in a window partition.
+            // The simplest way to guarantee this is if the conjuncts are deterministic functions of the partitioning variables.
             // This can leave out cases where they're both functions of some set of common expressions and the partitioning
             // function is injective, but that's a rare case. The majority of window nodes are expected to be partitioned by
             // pre-projected variables.
@@ -966,7 +966,7 @@ public class PredicatePushDown
             EqualityInference potentialNullSymbolInference = createEqualityInference(outerOnlyInheritedEqualities, outerEffectivePredicate, innerEffectivePredicate, joinPredicate);
 
             // See if we can push inherited predicates down
-            for (RowExpression conjunct : nonInferrableConjuncts(inheritedPredicate)) {
+            for (RowExpression conjunct : nonInferableConjuncts(inheritedPredicate)) {
                 RowExpression outerRewritten = outerInference.rewriteExpression(conjunct, in(outerVariables));
                 if (outerRewritten != null) {
                     outerPushdownConjuncts.add(outerRewritten);
@@ -987,7 +987,7 @@ public class PredicatePushDown
             postJoinConjuncts.addAll(equalityPartition.getScopeStraddlingEqualities());
 
             // See if we can push down any outer effective predicates to the inner side
-            for (RowExpression conjunct : nonInferrableConjuncts(outerEffectivePredicate)) {
+            for (RowExpression conjunct : nonInferableConjuncts(outerEffectivePredicate)) {
                 RowExpression rewritten = potentialNullSymbolInference.rewriteExpression(conjunct, not(in(outerVariables)));
                 if (rewritten != null) {
                     innerPushdownConjuncts.add(rewritten);
@@ -995,7 +995,7 @@ public class PredicatePushDown
             }
 
             // See if we can push down join predicates to the inner side
-            for (RowExpression conjunct : nonInferrableConjuncts(joinPredicate)) {
+            for (RowExpression conjunct : nonInferableConjuncts(joinPredicate)) {
                 RowExpression innerRewritten = potentialNullSymbolInference.rewriteExpression(conjunct, not(in(outerVariables)));
                 if (innerRewritten != null) {
                     innerPushdownConjuncts.add(innerRewritten);
@@ -1090,7 +1090,7 @@ public class PredicatePushDown
                     .build();
 
             // Sort through conjuncts in inheritedPredicate that were not used for inference
-            for (RowExpression conjunct : new EqualityInference.Builder(functionAndTypeManager).nonInferrableConjuncts(inheritedPredicate)) {
+            for (RowExpression conjunct : new EqualityInference.Builder(functionAndTypeManager).nonInferableConjuncts(inheritedPredicate)) {
                 RowExpression leftRewrittenConjunct = allInference.rewriteExpression(conjunct, in(leftVariables));
                 if (leftRewrittenConjunct != null) {
                     leftPushDownConjuncts.add(leftRewrittenConjunct);
@@ -1108,7 +1108,7 @@ public class PredicatePushDown
             }
 
             // See if we can push the right effective predicate to the left side
-            for (RowExpression conjunct : new EqualityInference.Builder(functionAndTypeManager).nonInferrableConjuncts(rightEffectivePredicate)) {
+            for (RowExpression conjunct : new EqualityInference.Builder(functionAndTypeManager).nonInferableConjuncts(rightEffectivePredicate)) {
                 RowExpression rewritten = allInference.rewriteExpression(conjunct, in(leftVariables));
                 if (rewritten != null) {
                     leftPushDownConjuncts.add(rewritten);
@@ -1116,7 +1116,7 @@ public class PredicatePushDown
             }
 
             // See if we can push the left effective predicate to the right side
-            for (RowExpression conjunct : new EqualityInference.Builder(functionAndTypeManager).nonInferrableConjuncts(leftEffectivePredicate)) {
+            for (RowExpression conjunct : new EqualityInference.Builder(functionAndTypeManager).nonInferableConjuncts(leftEffectivePredicate)) {
                 RowExpression rewritten = allInference.rewriteExpression(conjunct, not(in(leftVariables)));
                 if (rewritten != null) {
                     rightPushDownConjuncts.add(rewritten);
@@ -1124,7 +1124,7 @@ public class PredicatePushDown
             }
 
             // See if we can push any parts of the join predicates to either side
-            for (RowExpression conjunct : new EqualityInference.Builder(functionAndTypeManager).nonInferrableConjuncts(joinPredicate)) {
+            for (RowExpression conjunct : new EqualityInference.Builder(functionAndTypeManager).nonInferableConjuncts(joinPredicate)) {
                 RowExpression leftRewritten = allInference.rewriteExpression(conjunct, in(leftVariables));
                 if (leftRewritten != null) {
                     leftPushDownConjuncts.add(leftRewritten);
@@ -1358,7 +1358,7 @@ public class PredicatePushDown
             EqualityInference inheritedInference = new EqualityInference.Builder(functionAndTypeManager)
                     .addEqualityInference(inheritedPredicate)
                     .build();
-            for (RowExpression conjunct : new EqualityInference.Builder(functionAndTypeManager).nonInferrableConjuncts(inheritedPredicate)) {
+            for (RowExpression conjunct : new EqualityInference.Builder(functionAndTypeManager).nonInferableConjuncts(inheritedPredicate)) {
                 RowExpression rewrittenConjunct = inheritedInference.rewriteExpressionAllowNonDeterministic(conjunct, in(node.getSource().getOutputVariables()));
                 // Since each source row is reflected exactly once in the output, ok to push non-deterministic predicates down
                 if (rewrittenConjunct != null) {
@@ -1409,7 +1409,7 @@ public class PredicatePushDown
             EqualityInference allInferenceWithoutFilteringSourceInferred = createEqualityInference(deterministicInheritedPredicate, sourceEffectivePredicate, joinExpression);
 
             // Push inheritedPredicates down to the source if they don't involve the semi join output
-            for (RowExpression conjunct : nonInferrableConjuncts(inheritedPredicate)) {
+            for (RowExpression conjunct : nonInferableConjuncts(inheritedPredicate)) {
                 RowExpression rewrittenConjunct = allInference.rewriteExpressionAllowNonDeterministic(conjunct, in(sourceVariables));
                 // Since each source row is reflected exactly once in the output, ok to push non-deterministic predicates down
                 if (rewrittenConjunct != null) {
@@ -1421,7 +1421,7 @@ public class PredicatePushDown
             }
 
             // Push inheritedPredicates down to the filtering source if possible
-            for (RowExpression conjunct : nonInferrableConjuncts(deterministicInheritedPredicate)) {
+            for (RowExpression conjunct : nonInferableConjuncts(deterministicInheritedPredicate)) {
                 RowExpression rewrittenConjunct = allInference.rewriteExpression(conjunct, in(filteringSourceVariables));
                 // We cannot push non-deterministic predicates to filtering side. Each filtering side row have to be
                 // logically reevaluated for each source row.
@@ -1432,15 +1432,15 @@ public class PredicatePushDown
 
             // move effective predicate conjuncts source <-> filter
             // See if we can push the filtering source effective predicate to the source side
-            for (RowExpression conjunct : nonInferrableConjuncts(filteringSourceEffectivePredicate)) {
+            for (RowExpression conjunct : nonInferableConjuncts(filteringSourceEffectivePredicate)) {
                 RowExpression rewritten = allInference.rewriteExpression(conjunct, in(sourceVariables));
                 if (rewritten != null) {
                     sourceConjuncts.add(rewritten);
                 }
             }
 
-            // See if we can push the source effective predicate to the filtering soruce side
-            for (RowExpression conjunct : nonInferrableConjuncts(sourceEffectivePredicate)) {
+            // See if we can push the source effective predicate to the filtering source side
+            for (RowExpression conjunct : nonInferableConjuncts(sourceEffectivePredicate)) {
                 RowExpression rewritten = allInference.rewriteExpression(conjunct, in(filteringSourceVariables));
                 if (rewritten != null) {
                     filteringSourceConjuncts.add(rewritten);
@@ -1483,10 +1483,10 @@ public class PredicatePushDown
             return output;
         }
 
-        private Iterable<RowExpression> nonInferrableConjuncts(RowExpression inheritedPredicate)
+        private Iterable<RowExpression> nonInferableConjuncts(RowExpression inheritedPredicate)
         {
             return new EqualityInference.Builder(functionAndTypeManager)
-                    .nonInferrableConjuncts(inheritedPredicate);
+                    .nonInferableConjuncts(inheritedPredicate);
         }
 
         private EqualityInference createEqualityInference(RowExpression... expressions)
@@ -1519,7 +1519,7 @@ public class PredicatePushDown
             inheritedPredicate = logicalRowExpressions.filterDeterministicConjuncts(inheritedPredicate);
 
             // Sort non-equality predicates by those that can be pushed down and those that cannot
-            for (RowExpression conjunct : nonInferrableConjuncts(inheritedPredicate)) {
+            for (RowExpression conjunct : nonInferableConjuncts(inheritedPredicate)) {
                 if (node.getGroupIdVariable().isPresent() && VariablesExtractor.extractUnique(conjunct).contains(node.getGroupIdVariable().get())) {
                     // aggregation operator synthesizes outputs for group ids corresponding to the global grouping set (i.e., ()), so we
                     // need to preserve any predicates that evaluate the group id to run after the aggregation
@@ -1580,7 +1580,7 @@ public class PredicatePushDown
             inheritedPredicate = logicalRowExpressions.filterDeterministicConjuncts(inheritedPredicate);
 
             // Sort non-equality predicates by those that can be pushed down and those that cannot
-            for (RowExpression conjunct : nonInferrableConjuncts(inheritedPredicate)) {
+            for (RowExpression conjunct : nonInferableConjuncts(inheritedPredicate)) {
                 RowExpression rewrittenConjunct = equalityInference.rewriteExpression(conjunct, in(node.getReplicateVariables()));
                 if (rewrittenConjunct != null) {
                     pushdownConjuncts.add(rewrittenConjunct);

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/StreamPropertyDerivations.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/StreamPropertyDerivations.java
@@ -659,9 +659,9 @@ public final class StreamPropertyDerivations
         private StreamProperties unordered(boolean unordered)
         {
             if (unordered) {
-                ActualProperties updatedProperies = null;
+                ActualProperties updatedProperties = null;
                 if (otherActualProperties != null) {
-                    updatedProperies = ActualProperties.builderFrom(otherActualProperties)
+                    updatedProperties = ActualProperties.builderFrom(otherActualProperties)
                             .unordered(true)
                             .build();
                 }
@@ -669,7 +669,7 @@ public final class StreamPropertyDerivations
                         distribution,
                         partitioningColumns,
                         false,
-                        updatedProperies);
+                        updatedProperties);
             }
             return this;
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/StatisticAggregationsDescriptor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/StatisticAggregationsDescriptor.java
@@ -181,7 +181,7 @@ public class StatisticAggregationsDescriptor<T>
             extends KeyDeserializer
     {
         @Override
-        public ColumnStatisticMetadata deserializeKey(String key, DeserializationContext ctxt)
+        public ColumnStatisticMetadata deserializeKey(String key, DeserializationContext ctx)
         {
             return deserialize(requireNonNull(key, "key is null"));
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
@@ -919,7 +919,7 @@ public class PlanPrinter
 
             TupleDomain<ColumnHandle> predicate = node.getCurrentConstraint();
             if (predicate == null) {
-                // This happens when printing the plan framgnet on worker for debug purpose
+                // This happens when printing the plan fragment on worker for debug purpose
                 nodeOutput.appendDetailsLine(":: PREDICATE INFORMATION UNAVAILABLE");
             }
             else if (predicate.isNone()) {

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateStreamingJoins.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/sanity/ValidateStreamingJoins.java
@@ -59,9 +59,9 @@ public class ValidateStreamingJoins
         private final TypeProvider types;
         private final WarningCollector warningCollector;
 
-        private Visitor(Session sesstion, Metadata metadata, SqlParser sqlParser, TypeProvider types, WarningCollector warningCollector)
+        private Visitor(Session session, Metadata metadata, SqlParser sqlParser, TypeProvider types, WarningCollector warningCollector)
         {
-            this.session = sesstion;
+            this.session = session;
             this.metadata = metadata;
             this.sqlParser = sqlParser;
             this.types = types;

--- a/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowQueriesRewrite.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/rewrite/ShowQueriesRewrite.java
@@ -622,7 +622,7 @@ final class ShowQueriesRewrite
                 String propertyName = propertyEntry.getKey();
                 Object value = propertyEntry.getValue();
                 if (value == null) {
-                    throw new PrestoException(errorCode, format("Property %s for %s cannot have a null value", propertyName, toQualifedName(objectName, columnName)));
+                    throw new PrestoException(errorCode, format("Property %s for %s cannot have a null value", propertyName, toQualifiedName(objectName, columnName)));
                 }
 
                 PropertyMetadata<?> property = allProperties.get(propertyName);
@@ -630,7 +630,7 @@ final class ShowQueriesRewrite
                     throw new PrestoException(errorCode, format(
                             "Property %s for %s should have value of type %s, not %s",
                             propertyName,
-                            toQualifedName(objectName, columnName),
+                            toQualifiedName(objectName, columnName),
                             property.getJavaType().getName(),
                             value.getClass().getName()));
                 }
@@ -644,7 +644,7 @@ final class ShowQueriesRewrite
                     .collect(toImmutableList());
         }
 
-        private static String toQualifedName(Object objectName, Optional<String> columnName)
+        private static String toQualifiedName(Object objectName, Optional<String> columnName)
         {
             return columnName.map(s -> format("column %s of table %s", s, objectName))
                     .orElseGet(() -> "table " + objectName);

--- a/presto-main/src/main/java/com/facebook/presto/tdigest/TDigestUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/tdigest/TDigestUtils.java
@@ -189,7 +189,7 @@ public final class TDigestUtils
                 swap(order, from++, to--);
             }
             if (from == low) {
-                // ran out of things to copy.  This means that the the last destination is the boundary
+                // ran out of things to copy.  This means that the last destination is the boundary
                 low = to + 1;
             }
             else {
@@ -221,7 +221,7 @@ public final class TDigestUtils
      * reordered as well in the same way.
      *
      * @param key    Values to sort on
-     * @param values The auxilliary values to sort.
+     * @param values The auxiliary values to sort.
      */
     public static void sort(double[] key, double[]... values)
     {
@@ -234,7 +234,7 @@ public final class TDigestUtils
      *  @param key    Values to sort on
      * @param start  The first element to sort
      * @param n      The number of values to sort
-     * @param values The auxilliary values to sort.
+     * @param values The auxiliary values to sort.
      */
     public static void sort(double[] key, int start, int n, double[]... values)
     {
@@ -246,7 +246,7 @@ public final class TDigestUtils
      * Standard quick sort except that sorting rearranges parallel arrays
      *
      * @param key    Values to sort on
-     * @param values The auxilliary values to sort.
+     * @param values The auxiliary values to sort.
      * @param start  The beginning of the values to sort
      * @param end    The value after the last value to sort
      * @param limit  The minimum size to recurse down to.
@@ -357,7 +357,7 @@ public final class TDigestUtils
                 swap(from++, to--, key, values);
             }
             if (from == low) {
-                // ran out of things to copy.  This means that the the last destination is the boundary
+                // ran out of things to copy.  This means that the last destination is the boundary
                 low = to + 1;
             }
             else {

--- a/presto-main/src/main/java/com/facebook/presto/testing/TestingTempStorageManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/TestingTempStorageManager.java
@@ -30,7 +30,7 @@ public class TestingTempStorageManager
     {
         // For tests like TestSpilled{Aggregations, Window, OrderBy}WithTemporaryStorage, TestDistributedSpilledQueriesWithTempStorage
         // Each of them will create their own TempStorage
-        // Since TempStorage#initilaize is called lazily, the temporary directory might be cleaned up when other tests is still spilling.
+        // Since TempStorage#initialize is called lazily, the temporary directory might be cleaned up when other tests is still spilling.
         this(Paths.get(System.getProperty("java.io.tmpdir"), "presto", "temp_storage", UUID.randomUUID().toString().replaceAll("-", "_"))
                 .toAbsolutePath()
                 .toString());

--- a/presto-main/src/main/java/com/facebook/presto/type/VarbinaryOperators.java
+++ b/presto-main/src/main/java/com/facebook/presto/type/VarbinaryOperators.java
@@ -98,7 +98,7 @@ public final class VarbinaryOperators
     public static long hashCode(@SqlType(StandardTypes.VARBINARY) Slice value)
     {
         // This needs to match the hash function for VARBINARY blocks
-        // (i.e. AstractVariableWidthBlock.hash(...))
+        // (i.e. AbstractVariableWidthBlock.hash(...))
         // TODO: we need to get rid of hash from Block and rely on HASH_CODE operators only
         return xxHash64(value);
     }

--- a/presto-main/src/main/java/com/facebook/presto/util/JsonUtil.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/JsonUtil.java
@@ -296,7 +296,7 @@ public final class JsonUtil
                         return new ShortDecimalJsonGeneratorWriter((DecimalType) type);
                     }
                     else {
-                        return new LongDeicmalJsonGeneratorWriter((DecimalType) type);
+                        return new LongDecimalJsonGeneratorWriter((DecimalType) type);
                     }
                 case StandardTypes.VARCHAR:
                     return new VarcharJsonGeneratorWriter(type);
@@ -440,12 +440,12 @@ public final class JsonUtil
         }
     }
 
-    private static class LongDeicmalJsonGeneratorWriter
+    private static class LongDecimalJsonGeneratorWriter
             implements JsonGeneratorWriter
     {
         private final DecimalType type;
 
-        public LongDeicmalJsonGeneratorWriter(DecimalType type)
+        public LongDecimalJsonGeneratorWriter(DecimalType type)
         {
             this.type = type;
         }

--- a/presto-main/src/main/resources/webapp/assets/presto.css
+++ b/presto-main/src/main/resources/webapp/assets/presto.css
@@ -40,8 +40,8 @@ pre {
     border: none;
 }
 
-/** Boostrap overrides **/
-/** ================== **/
+/** Bootstrap overrides **/
+/** =================== **/
 
 .container {
     min-width: 960px;

--- a/presto-main/src/test/java/com/facebook/presto/block/TestDirectEntryBlockBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestDirectEntryBlockBuilder.java
@@ -101,13 +101,13 @@ public class TestDirectEntryBlockBuilder
             directEntryBlockBuilder.closeEntry();
         }
 
-        Slice beginEntrySlice = getSlilce(beginEntryBlockBuilder);
-        Slice directEntrySlice = getSlilce(directEntryBlockBuilder);
+        Slice beginEntrySlice = getSlice(beginEntryBlockBuilder);
+        Slice directEntrySlice = getSlice(directEntryBlockBuilder);
 
         assertEquals(beginEntrySlice.compareTo(directEntrySlice), 0);
     }
 
-    private Slice getSlilce(BlockBuilder beginEntryBlockBuilder)
+    private Slice getSlice(BlockBuilder beginEntryBlockBuilder)
     {
         DynamicSliceOutput sliceOutput = new DynamicSliceOutput(1024);
         blockEncodingSerde.writeBlock(sliceOutput, beginEntryBlockBuilder);
@@ -213,8 +213,8 @@ public class TestDirectEntryBlockBuilder
             directEntryBlockBuilder.appendNull();
         }
 
-        Slice beginEntrySlice = getSlilce(beginEntryBlockBuilder);
-        Slice directEntrySlice = getSlilce(directEntryBlockBuilder);
+        Slice beginEntrySlice = getSlice(beginEntryBlockBuilder);
+        Slice directEntrySlice = getSlice(directEntryBlockBuilder);
         assertEquals(beginEntrySlice.compareTo(directEntrySlice), 0);
     }
 
@@ -289,8 +289,8 @@ public class TestDirectEntryBlockBuilder
             directEntryBlockBuilder.closeEntry();
         }
 
-        Slice beginEntrySlice = getSlilce(beginEntryBlockBuilder);
-        Slice directEntrySlice = getSlilce(directEntryBlockBuilder);
+        Slice beginEntrySlice = getSlice(beginEntryBlockBuilder);
+        Slice directEntrySlice = getSlice(directEntryBlockBuilder);
         assertEquals(beginEntrySlice.compareTo(directEntrySlice), 0);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/block/TestRunLengthEncodedBlock.java
+++ b/presto-main/src/test/java/com/facebook/presto/block/TestRunLengthEncodedBlock.java
@@ -99,8 +99,8 @@ public class TestRunLengthEncodedBlock
         int positionCount = 10;
         Slice expectedValue = createExpectedValue(5);
         Block block = new RunLengthEncodedBlock(createSingleValueBlock(expectedValue), positionCount);
-        for (int postition = 0; postition < positionCount; postition++) {
-            assertEquals(block.getEstimatedDataSizeForStats(postition), expectedValue.length());
+        for (int position = 0; position < positionCount; position++) {
+            assertEquals(block.getEstimatedDataSizeForStats(position), expectedValue.length());
         }
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/connector/MockConnectorFactory.java
+++ b/presto-main/src/test/java/com/facebook/presto/connector/MockConnectorFactory.java
@@ -260,9 +260,9 @@ public class MockConnectorFactory
             return this;
         }
 
-        public Builder withGetTableStatistics(Supplier<TableStatistics> getTableStatitics)
+        public Builder withGetTableStatistics(Supplier<TableStatistics> getTableStatistics)
         {
-            this.getTableStatistics = requireNonNull(getTableStatitics, "getTableStatistics is null");
+            this.getTableStatistics = requireNonNull(getTableStatistics, "getTableStatistics is null");
             return this;
         }
 

--- a/presto-main/src/test/java/com/facebook/presto/cost/StatsCalculatorAssertion.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/StatsCalculatorAssertion.java
@@ -43,7 +43,7 @@ public class StatsCalculatorAssertion
     public StatsCalculatorAssertion(StatsCalculator statsCalculator, Session session, PlanNode planNode, TypeProvider types)
     {
         this.statsCalculator = requireNonNull(statsCalculator, "statsCalculator can not be null");
-        this.session = requireNonNull(session, "sesssion can not be null");
+        this.session = requireNonNull(session, "session can not be null");
         this.planNode = requireNonNull(planNode, "planNode is null");
         this.types = requireNonNull(types, "types is null");
 

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestExchangeStatsRule.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestExchangeStatsRule.java
@@ -39,7 +39,7 @@ public class TestExchangeStatsRule
                 .exchange(exchangeBuilder -> exchangeBuilder
                         .addInputsSet(pb.variable("i11", BIGINT), pb.variable("i12", BIGINT), pb.variable("i13", BIGINT), pb.variable("i14", BIGINT))
                         .addInputsSet(pb.variable("i21", BIGINT), pb.variable("i22", BIGINT), pb.variable("i23", BIGINT), pb.variable("i24", BIGINT))
-                        .fixedHashDistributionParitioningScheme(
+                        .fixedHashDistributionPartitioningScheme(
                                 ImmutableList.of(pb.variable("o1", BIGINT), pb.variable("o2", BIGINT), pb.variable("o3", BIGINT), pb.variable("o4", BIGINT)),
                                 emptyList())
                         .addSource(pb.values(pb.variable("i11", BIGINT), pb.variable("i12", BIGINT), pb.variable("i13", BIGINT), pb.variable("i14", BIGINT)))

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestFilterStatsRule.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestFilterStatsRule.java
@@ -47,7 +47,7 @@ public class TestFilterStatsRule
     }
 
     @Test
-    public void testEstimatableFilter()
+    public void testEstimableFilter()
     {
         tester().assertStatsFor(pb -> pb
                 .filter(expression("i1 = 5"),

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestSemiJoinStatsCalculator.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestSemiJoinStatsCalculator.java
@@ -214,7 +214,7 @@ public class TestSemiJoinStatsCalculator
                 .variableStats(z, stats -> stats.isEqualTo(zStats))
                 .outputRowsCount(inputStatistics.getOutputRowCount() * uStats.getValuesFraction() * (1 - xStats.getDistinctValuesCount() / uStats.getDistinctValuesCount()));
 
-        // overlapping ranges, everything filtered out (but we leave 0.5 due to safety coeeficient)
+        // overlapping ranges, everything filtered out (but we leave 0.5 due to safety coefficient)
         assertThat(computeAntiJoin(inputStatistics, inputStatistics, x, u))
                 .variableStats(x, stats -> stats
                         .lowValue(xStats.getLowValue())

--- a/presto-main/src/test/java/com/facebook/presto/cost/TestUnnestStatsRule.java
+++ b/presto-main/src/test/java/com/facebook/presto/cost/TestUnnestStatsRule.java
@@ -43,7 +43,7 @@ public class TestUnnestStatsRule
     }
 
     @Test
-    public void testUnntestStatsPopulated()
+    public void testUnnestStatsPopulated()
     {
         tester().assertStatsFor(
                 pb -> pb.unnest(

--- a/presto-main/src/test/java/com/facebook/presto/dispatcher/TestLocalDispatchQuery.java
+++ b/presto-main/src/test/java/com/facebook/presto/dispatcher/TestLocalDispatchQuery.java
@@ -217,7 +217,7 @@ public class TestLocalDispatchQuery
     {
         QueryStateMachine stateMachine = createStateMachine();
         CountingEventListener eventListener = new CountingEventListener();
-        CompletableFuture<?> prequisitesFuture = new CompletableFuture<>();
+        CompletableFuture<?> prerequisitesFuture = new CompletableFuture<>();
         AtomicBoolean queryFinishedCalled = new AtomicBoolean();
 
         LocalDispatchQuery query = new LocalDispatchQuery(
@@ -233,7 +233,7 @@ public class TestLocalDispatchQuery
                     @Override
                     public CompletableFuture<?> waitForPrerequisites(QueryId queryId, QueryPrerequisitesContext context, WarningCollector warningCollector)
                     {
-                        return prequisitesFuture;
+                        return prerequisitesFuture;
                     }
 
                     @Override
@@ -247,7 +247,7 @@ public class TestLocalDispatchQuery
         assertFalse(eventListener.getQueryCompletedEvent().isPresent());
 
         query.startWaitingForPrerequisites();
-        prequisitesFuture.complete(null);
+        prerequisitesFuture.complete(null);
         query.fail(new PrestoException(ABANDONED_QUERY, "foo"));
 
         assertTrue(queryFinishedCalled.get());
@@ -258,7 +258,7 @@ public class TestLocalDispatchQuery
     {
         QueryStateMachine stateMachine = createStateMachine();
         CountingEventListener eventListener = new CountingEventListener();
-        CompletableFuture<?> prequisitesFuture = new CompletableFuture<>();
+        CompletableFuture<?> prerequisitesFuture = new CompletableFuture<>();
 
         LocalDispatchQuery query = new LocalDispatchQuery(
                 stateMachine,
@@ -269,7 +269,7 @@ public class TestLocalDispatchQuery
                 dispatchQuery -> {},
                 execution -> {},
                 false,
-                (queryId, context, warningCollector) -> prequisitesFuture);
+                (queryId, context, warningCollector) -> prerequisitesFuture);
 
         assertEquals(query.getBasicQueryInfo().getState(), WAITING_FOR_PREREQUISITES);
         assertFalse(eventListener.getQueryCompletedEvent().isPresent());
@@ -277,7 +277,7 @@ public class TestLocalDispatchQuery
         query.startWaitingForPrerequisites();
         query.fail(new PrestoException(ABANDONED_QUERY, "foo"));
 
-        assertTrue(prequisitesFuture.isCancelled());
+        assertTrue(prerequisitesFuture.isCancelled());
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestMemoryRevokingScheduler.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestMemoryRevokingScheduler.java
@@ -93,7 +93,7 @@ import static org.testng.Assert.assertTrue;
 public class TestMemoryRevokingScheduler
 {
     public static final OutputBuffers.OutputBufferId OUT = new OutputBuffers.OutputBufferId(0);
-    private final AtomicInteger idGeneator = new AtomicInteger();
+    private final AtomicInteger idGenerator = new AtomicInteger();
     private final SpillSpaceTracker spillSpaceTracker = new SpillSpaceTracker(new DataSize(10, GIGABYTE));
 
     private final Map<QueryId, QueryContext> queryContexts = new HashMap<>();
@@ -784,7 +784,7 @@ public class TestMemoryRevokingScheduler
     {
         QueryContext queryContext = getOrCreateQueryContext(queryId, memoryPool);
 
-        TaskId taskId = new TaskId(queryId.getId(), 0, 0, idGeneator.incrementAndGet());
+        TaskId taskId = new TaskId(queryId.getId(), 0, 0, idGenerator.incrementAndGet());
         URI location = URI.create("fake://task/" + taskId);
 
         return createSqlTask(

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskExecution.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestSqlTaskExecution.java
@@ -158,7 +158,7 @@ public class TestSqlTaskExecution
             //      |
             //    Scan
             //
-            // See #testComplex for all the bahaviors that are tested. Not all of them apply here.
+            // See #testComplex for all the behaviors that are tested. Not all of them apply here.
             TestingScanOperatorFactory testingScanOperatorFactory = new TestingScanOperatorFactory(0, TABLE_SCAN_NODE_ID, ImmutableList.of(VARCHAR));
             TaskOutputOperatorFactory taskOutputOperatorFactory = new TaskOutputOperatorFactory(
                     1,

--- a/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestArbitraryOutputBuffer.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestArbitraryOutputBuffer.java
@@ -501,7 +501,7 @@ public class TestArbitraryOutputBuffer
         ListenableFuture<BufferResult> future = buffer.get(FIRST, 0L, sizeOfPages(1));
         assertFalse(future.isDone());
 
-        // abort that buffer, and verify the future is finishd
+        // abort that buffer, and verify the future is finished
         buffer.abort(FIRST);
         assertBufferResultEquals(TYPES, getFuture(future, NO_WAIT), emptyResults(TASK_INSTANCE_ID, 0, false));
         assertBufferResultEquals(TYPES, getBufferResult(buffer, FIRST, 0, sizeOfPages(10), NO_WAIT), emptyResults(TASK_INSTANCE_ID, 0, true));

--- a/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestBroadcastOutputBuffer.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestBroadcastOutputBuffer.java
@@ -440,7 +440,7 @@ public class TestBroadcastOutputBuffer
     }
 
     @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = ".*does not contain.*\\[0]")
-    public void testSetFinalBuffersWihtoutDeclaringUsedBuffer()
+    public void testSetFinalBuffersWithoutDeclaringUsedBuffer()
     {
         BroadcastOutputBuffer buffer = createBroadcastBuffer(createInitialEmptyOutputBuffers(BROADCAST), sizeOfPages(10));
         assertFalse(buffer.isFinished());

--- a/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestClientBuffer.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestClientBuffer.java
@@ -202,7 +202,7 @@ public class TestClientBuffer
         // acknowledge the pages
         buffer.getPages(3, sizeOfPages(10)).cancel(true);
 
-        // attempt to get the three elements again, which will return an empty resilt
+        // attempt to get the three elements again, which will return an empty result
         assertBufferResultEquals(TYPES, getBufferResult(buffer, 0, sizeOfPages(10), NO_WAIT), emptyResults(TASK_INSTANCE_ID, 0, false));
         // pages not acknowledged yet so state is the same
         assertBufferInfo(buffer, 0, 3);

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestAnnotationEngineForAggregates.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestAnnotationEngineForAggregates.java
@@ -90,19 +90,19 @@ public class TestAnnotationEngineForAggregates
         @InputFunction
         public static void input(@AggregationState NullableDoubleState state, @SqlType(DOUBLE) double value)
         {
-            // noop this is only for annotation testing puproses
+            // noop this is only for annotation testing purposes
         }
 
         @CombineFunction
         public static void combine(@AggregationState NullableDoubleState combine1, @AggregationState NullableDoubleState combine2)
         {
-            // noop this is only for annotation testing puproses
+            // noop this is only for annotation testing purposes
         }
 
         @OutputFunction(DOUBLE)
         public static void output(@AggregationState NullableDoubleState state, BlockBuilder out)
         {
-            // noop this is only for annotation testing puproses
+            // noop this is only for annotation testing purposes
         }
     }
 
@@ -142,19 +142,19 @@ public class TestAnnotationEngineForAggregates
         @InputFunction
         public static void input(@SqlType(DOUBLE) double value, @AggregationState NullableDoubleState state)
         {
-            // noop this is only for annotation testing puproses
+            // noop this is only for annotation testing purposes
         }
 
         @CombineFunction
         public static void combine(@AggregationState NullableDoubleState combine1, @AggregationState NullableDoubleState combine2)
         {
-            // noop this is only for annotation testing puproses
+            // noop this is only for annotation testing purposes
         }
 
         @OutputFunction(DOUBLE)
         public static void output(BlockBuilder out, @AggregationState NullableDoubleState state)
         {
-            // noop this is only for annotation testing puproses
+            // noop this is only for annotation testing purposes
         }
     }
 
@@ -183,19 +183,19 @@ public class TestAnnotationEngineForAggregates
         @InputFunction
         public static void input(NullableDoubleState state, @SqlType(DOUBLE) double value)
         {
-            // noop this is only for annotation testing puproses
+            // noop this is only for annotation testing purposes
         }
 
         @CombineFunction
         public static void combine(NullableDoubleState combine1, NullableDoubleState combine2)
         {
-            // noop this is only for annotation testing puproses
+            // noop this is only for annotation testing purposes
         }
 
         @OutputFunction(DOUBLE)
         public static void output(NullableDoubleState state, BlockBuilder out)
         {
-            // noop this is only for annotation testing puproses
+            // noop this is only for annotation testing purposes
         }
     }
 
@@ -228,7 +228,7 @@ public class TestAnnotationEngineForAggregates
                 @AggregationState NullableDoubleState state,
                 @SqlType(DOUBLE) double value)
         {
-            // noop this is only for annotation testing puproses
+            // noop this is only for annotation testing purposes
         }
 
         @CombineFunction
@@ -236,13 +236,13 @@ public class TestAnnotationEngineForAggregates
                 @AggregationState NullableDoubleState combine1,
                 @AggregationState NullableDoubleState combine2)
         {
-            // noop this is only for annotation testing puproses
+            // noop this is only for annotation testing purposes
         }
 
         @OutputFunction(DOUBLE)
         public static void output(@AggregationState NullableDoubleState state, BlockBuilder out)
         {
-            // noop this is only for annotation testing puproses
+            // noop this is only for annotation testing purposes
         }
 
         @AggregationStateSerializerFactory(NullableDoubleState.class)
@@ -275,7 +275,7 @@ public class TestAnnotationEngineForAggregates
                 @AggregationState NullableDoubleState state,
                 @SqlType(DOUBLE) double value)
         {
-            // noop this is only for annotation testing puproses
+            // noop this is only for annotation testing purposes
         }
 
         @CombineFunction
@@ -283,7 +283,7 @@ public class TestAnnotationEngineForAggregates
                 @AggregationState NullableDoubleState combine1,
                 @AggregationState NullableDoubleState combine2)
         {
-            // noop this is only for annotation testing puproses
+            // noop this is only for annotation testing purposes
         }
 
         @OutputFunction(DOUBLE)
@@ -291,7 +291,7 @@ public class TestAnnotationEngineForAggregates
                 @AggregationState NullableDoubleState state,
                 BlockBuilder out)
         {
-            // noop this is only for annotation testing puproses
+            // noop this is only for annotation testing purposes
         }
 
         @AggregationStateSerializerFactory(NullableDoubleState.class)
@@ -331,7 +331,7 @@ public class TestAnnotationEngineForAggregates
                 @AggregationState NullableDoubleState state,
                 @SqlType("T") double value)
         {
-            // noop this is only for annotation testing puproses
+            // noop this is only for annotation testing purposes
         }
 
         @InputFunction
@@ -340,7 +340,7 @@ public class TestAnnotationEngineForAggregates
                 @AggregationState NullableLongState state,
                 @SqlType("T") long value)
         {
-            // noop this is only for annotation testing puproses
+            // noop this is only for annotation testing purposes
         }
 
         @CombineFunction
@@ -348,7 +348,7 @@ public class TestAnnotationEngineForAggregates
                 @AggregationState NullableLongState state,
                 @AggregationState NullableLongState otherState)
         {
-            // noop this is only for annotation testing puproses
+            // noop this is only for annotation testing purposes
         }
 
         @CombineFunction
@@ -356,7 +356,7 @@ public class TestAnnotationEngineForAggregates
                 @AggregationState NullableDoubleState state,
                 @AggregationState NullableDoubleState otherState)
         {
-            // noop this is only for annotation testing puproses
+            // noop this is only for annotation testing purposes
         }
 
         @OutputFunction("T")
@@ -364,7 +364,7 @@ public class TestAnnotationEngineForAggregates
                 @AggregationState NullableLongState state,
                 BlockBuilder out)
         {
-            // noop this is only for annotation testing puproses
+            // noop this is only for annotation testing purposes
         }
 
         @OutputFunction("T")
@@ -372,7 +372,7 @@ public class TestAnnotationEngineForAggregates
                 @AggregationState NullableDoubleState state,
                 BlockBuilder out)
         {
-            // noop this is only for annotation testing puproses
+            // noop this is only for annotation testing purposes
         }
     }
 
@@ -431,7 +431,7 @@ public class TestAnnotationEngineForAggregates
                 @BlockPosition @SqlType(DOUBLE) Block value,
                 @BlockIndex int id)
         {
-            // noop this is only for annotation testing puproses
+            // noop this is only for annotation testing purposes
         }
 
         @CombineFunction
@@ -439,7 +439,7 @@ public class TestAnnotationEngineForAggregates
                 @AggregationState NullableDoubleState combine1,
                 @AggregationState NullableDoubleState combine2)
         {
-            // noop this is only for annotation testing puproses
+            // noop this is only for annotation testing purposes
         }
 
         @OutputFunction(DOUBLE)
@@ -447,7 +447,7 @@ public class TestAnnotationEngineForAggregates
                 @AggregationState NullableDoubleState state,
                 BlockBuilder out)
         {
-            // noop this is only for annotation testing puproses
+            // noop this is only for annotation testing purposes
         }
     }
 
@@ -490,7 +490,7 @@ public class TestAnnotationEngineForAggregates
                 @AggregationState NullableDoubleState state,
                 @SqlType("array(T)") Block arrayBlock, @SqlType("T") double additionalValue)
         {
-            // noop this is only for annotation testing puproses
+            // noop this is only for annotation testing purposes
         }
 
         @InputFunction
@@ -499,7 +499,7 @@ public class TestAnnotationEngineForAggregates
                 @AggregationState NullableLongState state,
                 @SqlType("array(T)") Block arrayBlock, @SqlType("T") long additionalValue)
         {
-            // noop this is only for annotation testing puproses
+            // noop this is only for annotation testing purposes
         }
 
         @CombineFunction
@@ -507,7 +507,7 @@ public class TestAnnotationEngineForAggregates
                 @AggregationState NullableLongState state,
                 @AggregationState NullableLongState otherState)
         {
-            // noop this is only for annotation testing puproses
+            // noop this is only for annotation testing purposes
         }
 
         @CombineFunction
@@ -515,7 +515,7 @@ public class TestAnnotationEngineForAggregates
                 @AggregationState NullableDoubleState state,
                 @AggregationState NullableDoubleState otherState)
         {
-            // noop this is only for annotation testing puproses
+            // noop this is only for annotation testing purposes
         }
 
         @OutputFunction("T")
@@ -523,7 +523,7 @@ public class TestAnnotationEngineForAggregates
                 @AggregationState NullableLongState state,
                 BlockBuilder out)
         {
-            // noop this is only for annotation testing puproses
+            // noop this is only for annotation testing purposes
         }
 
         @OutputFunction("T")
@@ -531,7 +531,7 @@ public class TestAnnotationEngineForAggregates
                 @AggregationState NullableDoubleState state,
                 BlockBuilder out)
         {
-            // noop this is only for annotation testing puproses
+            // noop this is only for annotation testing purposes
         }
     }
 
@@ -582,7 +582,7 @@ public class TestAnnotationEngineForAggregates
                 @AggregationState NullableDoubleState state,
                 @SqlType("array(T)") Block arrayBlock)
         {
-            // noop this is only for annotation testing puproses
+            // noop this is only for annotation testing purposes
         }
 
         @InputFunction
@@ -591,7 +591,7 @@ public class TestAnnotationEngineForAggregates
                 @AggregationState NullableLongState state,
                 @SqlType("array(T)") Block arrayBlock)
         {
-            // noop this is only for annotation testing puproses
+            // noop this is only for annotation testing purposes
         }
 
         @CombineFunction
@@ -599,7 +599,7 @@ public class TestAnnotationEngineForAggregates
                 @AggregationState NullableLongState state,
                 @AggregationState NullableLongState otherState)
         {
-            // noop this is only for annotation testing puproses
+            // noop this is only for annotation testing purposes
         }
 
         @CombineFunction
@@ -607,7 +607,7 @@ public class TestAnnotationEngineForAggregates
                 @AggregationState NullableDoubleState state,
                 @AggregationState NullableDoubleState otherState)
         {
-            // noop this is only for annotation testing puproses
+            // noop this is only for annotation testing purposes
         }
 
         @OutputFunction("T")
@@ -615,7 +615,7 @@ public class TestAnnotationEngineForAggregates
                 @AggregationState NullableLongState state,
                 BlockBuilder out)
         {
-            // noop this is only for annotation testing puproses
+            // noop this is only for annotation testing purposes
         }
 
         @OutputFunction("T")
@@ -623,7 +623,7 @@ public class TestAnnotationEngineForAggregates
                 @AggregationState NullableDoubleState state,
                 BlockBuilder out)
         {
-            // noop this is only for annotation testing puproses
+            // noop this is only for annotation testing purposes
         }
     }
 
@@ -671,7 +671,7 @@ public class TestAnnotationEngineForAggregates
                 @AggregationState NullableDoubleState state,
                 @SqlType(DOUBLE) double value)
         {
-            // noop this is only for annotation testing puproses
+            // noop this is only for annotation testing purposes
         }
 
         @CombineFunction
@@ -679,7 +679,7 @@ public class TestAnnotationEngineForAggregates
                 @AggregationState NullableDoubleState combine1,
                 @AggregationState NullableDoubleState combine2)
         {
-            // noop this is only for annotation testing puproses
+            // noop this is only for annotation testing purposes
         }
 
         @AggregationFunction("multi_output_aggregate_1")
@@ -689,7 +689,7 @@ public class TestAnnotationEngineForAggregates
                 @AggregationState NullableDoubleState state,
                 BlockBuilder out)
         {
-            // noop this is only for annotation testing puproses
+            // noop this is only for annotation testing purposes
         }
 
         @AggregationFunction("multi_output_aggregate_2")
@@ -698,7 +698,7 @@ public class TestAnnotationEngineForAggregates
                 @AggregationState NullableDoubleState state,
                 BlockBuilder out)
         {
-            // noop this is only for annotation testing puproses
+            // noop this is only for annotation testing purposes
         }
     }
 
@@ -759,7 +759,7 @@ public class TestAnnotationEngineForAggregates
                 @AggregationState NullableDoubleState state,
                 @SqlType(DOUBLE) double value)
         {
-            // noop this is only for annotation testing puproses
+            // noop this is only for annotation testing purposes
         }
 
         @CombineFunction
@@ -768,7 +768,7 @@ public class TestAnnotationEngineForAggregates
                 @AggregationState NullableDoubleState combine1,
                 @AggregationState NullableDoubleState combine2)
         {
-            // noop this is only for annotation testing puproses
+            // noop this is only for annotation testing purposes
         }
 
         @OutputFunction(DOUBLE)
@@ -777,7 +777,7 @@ public class TestAnnotationEngineForAggregates
                 @AggregationState NullableDoubleState state,
                 BlockBuilder out)
         {
-            // noop this is only for annotation testing puproses
+            // noop this is only for annotation testing purposes
         }
 
         @AggregationStateSerializerFactory(NullableDoubleState.class)
@@ -837,7 +837,7 @@ public class TestAnnotationEngineForAggregates
                 @AggregationState NullableDoubleState state,
                 @SqlType("T") double value)
         {
-            // noop this is only for annotation testing puproses
+            // noop this is only for annotation testing purposes
         }
 
         @CombineFunction
@@ -846,7 +846,7 @@ public class TestAnnotationEngineForAggregates
                 @AggregationState NullableDoubleState combine1,
                 @AggregationState NullableDoubleState combine2)
         {
-            // noop this is only for annotation testing puproses
+            // noop this is only for annotation testing purposes
         }
 
         @OutputFunction("T")
@@ -855,7 +855,7 @@ public class TestAnnotationEngineForAggregates
                 @AggregationState NullableDoubleState state,
                 BlockBuilder out)
         {
-            // noop this is only for annotation testing puproses
+            // noop this is only for annotation testing purposes
         }
 
         @AggregationStateSerializerFactory(NullableDoubleState.class)
@@ -919,7 +919,7 @@ public class TestAnnotationEngineForAggregates
                 @AggregationState SliceState state,
                 @SqlType("varchar(x)") Slice slice)
         {
-            // noop this is only for annotation testing puproses
+            // noop this is only for annotation testing purposes
         }
 
         @CombineFunction
@@ -928,7 +928,7 @@ public class TestAnnotationEngineForAggregates
                 @AggregationState SliceState combine1,
                 @AggregationState SliceState combine2)
         {
-            // noop this is only for annotation testing puproses
+            // noop this is only for annotation testing purposes
         }
 
         @OutputFunction("varchar(x)")
@@ -937,7 +937,7 @@ public class TestAnnotationEngineForAggregates
                 @AggregationState SliceState state,
                 BlockBuilder out)
         {
-            // noop this is only for annotation testing puproses
+            // noop this is only for annotation testing purposes
         }
 
         @AggregationStateSerializerFactory(SliceState.class)
@@ -999,7 +999,7 @@ public class TestAnnotationEngineForAggregates
                 @SqlType("varchar(x)") Slice slice1,
                 @SqlType("varchar(y)") Slice slice2)
         {
-            // noop this is only for annotation testing puproses
+            // noop this is only for annotation testing purposes
         }
 
         @CombineFunction
@@ -1007,7 +1007,7 @@ public class TestAnnotationEngineForAggregates
                 @AggregationState SliceState combine1,
                 @AggregationState SliceState combine2)
         {
-            // noop this is only for annotation testing puproses
+            // noop this is only for annotation testing purposes
         }
 
         @OutputFunction("varchar(z)")
@@ -1015,7 +1015,7 @@ public class TestAnnotationEngineForAggregates
                 @AggregationState SliceState state,
                 BlockBuilder out)
         {
-            // noop this is only for annotation testing puproses
+            // noop this is only for annotation testing purposes
         }
     }
 
@@ -1072,7 +1072,7 @@ public class TestAnnotationEngineForAggregates
                 @AggregationState NullableDoubleState state,
                 @SqlType("double") double value)
         {
-            // noop this is only for annotation testing puproses
+            // noop this is only for annotation testing purposes
         }
 
         @CombineFunction
@@ -1081,7 +1081,7 @@ public class TestAnnotationEngineForAggregates
                 @AggregationState NullableDoubleState state,
                 @AggregationState NullableDoubleState otherState)
         {
-            // noop this is only for annotation testing puproses
+            // noop this is only for annotation testing purposes
         }
 
         @OutputFunction("double")
@@ -1090,7 +1090,7 @@ public class TestAnnotationEngineForAggregates
                 @AggregationState NullableDoubleState state,
                 BlockBuilder out)
         {
-            // noop this is only for annotation testing puproses
+            // noop this is only for annotation testing purposes
         }
     }
 
@@ -1134,7 +1134,7 @@ public class TestAnnotationEngineForAggregates
                 @AggregationState NullableDoubleState state,
                 @SqlType("double") double value)
         {
-            // noop this is only for annotation testing puproses
+            // noop this is only for annotation testing purposes
         }
 
         @CombineFunction
@@ -1145,7 +1145,7 @@ public class TestAnnotationEngineForAggregates
                 @AggregationState NullableDoubleState state,
                 @AggregationState NullableDoubleState otherState)
         {
-            // noop this is only for annotation testing puproses
+            // noop this is only for annotation testing purposes
         }
 
         @OutputFunction("double")
@@ -1156,7 +1156,7 @@ public class TestAnnotationEngineForAggregates
                 @AggregationState NullableDoubleState state,
                 BlockBuilder out)
         {
-            // noop this is only for annotation testing puproses
+            // noop this is only for annotation testing purposes
         }
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/BenchmarkGroupedTypedHistogram.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/BenchmarkGroupedTypedHistogram.java
@@ -79,7 +79,7 @@ public class BenchmarkGroupedTypedHistogram
         // these must be manually set in each class now; the mechanism to change and test was removed; the enum was kept in case we want to revisit. Retesting showed linear was superior
         //        //        @Param({"LINEAR", "SUM_OF_COUNT", "SUM_OF_SQUARE"})
 //        @Param({"LINEAR"}) // found to be best, by about 10-15%
-//        private ProbeType mainProbeTyepe;
+//        private ProbeType mainProbeType;
 //        //        @Param({"LINEAR", "SUM_OF_COUNT", "SUM_OF_SQUARE"})
 //        @Param({"LINEAR"}) // found to best
 //        private ProbeType valueStoreProbeType;

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestHistogram.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/TestHistogram.java
@@ -211,7 +211,7 @@ public class TestHistogram
     @Test
     public void testLargerHistograms()
     {
-        InternalAggregationFunction aggregationFunction = getInternalDefaultVarCharAggregationn();
+        InternalAggregationFunction aggregationFunction = getInternalDefaultVarcharAggregation();
         assertAggregation(
                 aggregationFunction,
                 ImmutableMap.of("a", 25L, "b", 10L, "c", 12L, "d", 1L, "e", 2L),
@@ -221,7 +221,7 @@ public class TestHistogram
     @Test
     public void testEmptyHistogramOutputsNull()
     {
-        InternalAggregationFunction function = getInternalDefaultVarCharAggregationn();
+        InternalAggregationFunction function = getInternalDefaultVarcharAggregation();
         GroupedAccumulator groupedAccumulator = function.bind(Ints.asList(new int[] {}), Optional.empty())
                 .createGroupedAccumulator(UpdateMemory.NOOP);
         BlockBuilder blockBuilder = groupedAccumulator.getFinalType().createBlockBuilder(null, 1000);
@@ -233,8 +233,8 @@ public class TestHistogram
     @Test
     public void testSharedGroupByWithOverlappingValuesRunner()
     {
-        InternalAggregationFunction classicFunction = getInternalDefaultVarCharAggregationn();
-        InternalAggregationFunction singleInstanceFunction = getInternalDefaultVarCharAggregationn();
+        InternalAggregationFunction classicFunction = getInternalDefaultVarcharAggregation();
+        InternalAggregationFunction singleInstanceFunction = getInternalDefaultVarcharAggregation();
 
         testSharedGroupByWithOverlappingValuesRunner(classicFunction);
         testSharedGroupByWithOverlappingValuesRunner(singleInstanceFunction);
@@ -244,8 +244,8 @@ public class TestHistogram
     public void testSharedGroupByWithDistinctValuesPerGroup()
     {
         // test that two groups don't affect one another
-        InternalAggregationFunction classicFunction = getInternalDefaultVarCharAggregationn();
-        InternalAggregationFunction singleInstanceFunction = getInternalDefaultVarCharAggregationn();
+        InternalAggregationFunction classicFunction = getInternalDefaultVarcharAggregation();
+        InternalAggregationFunction singleInstanceFunction = getInternalDefaultVarcharAggregation();
         testSharedGroupByWithDistinctValuesPerGroupRunner(classicFunction);
         testSharedGroupByWithDistinctValuesPerGroupRunner(singleInstanceFunction);
     }
@@ -254,8 +254,8 @@ public class TestHistogram
     public void testSharedGroupByWithOverlappingValuesPerGroup()
     {
         // test that two groups don't affect one another
-        InternalAggregationFunction classicFunction = getInternalDefaultVarCharAggregationn();
-        InternalAggregationFunction singleInstanceFunction = getInternalDefaultVarCharAggregationn();
+        InternalAggregationFunction classicFunction = getInternalDefaultVarcharAggregation();
+        InternalAggregationFunction singleInstanceFunction = getInternalDefaultVarcharAggregation();
         testSharedGroupByWithOverlappingValuesPerGroupRunner(classicFunction);
         testSharedGroupByWithOverlappingValuesPerGroupRunner(singleInstanceFunction);
     }
@@ -264,8 +264,8 @@ public class TestHistogram
     public void testSharedGroupByWithManyGroups()
     {
         // uses a large enough data set to induce rehashing and test correctness
-        InternalAggregationFunction classicFunction = getInternalDefaultVarCharAggregationn();
-        InternalAggregationFunction singleInstanceFunction = getInternalDefaultVarCharAggregationn();
+        InternalAggregationFunction classicFunction = getInternalDefaultVarcharAggregation();
+        InternalAggregationFunction singleInstanceFunction = getInternalDefaultVarcharAggregation();
 
         // this is to validate the test as there have been test-bugs that looked like code bugs--if both fail, likely a test bug
         testManyValuesInducingRehash(classicFunction);
@@ -382,7 +382,7 @@ public class TestHistogram
         test1.runPagesOnAccumulatorWithAssertion(0L, test1.createGroupedAccumulator(), aggregationTestOutput1);
     }
 
-    private InternalAggregationFunction getInternalDefaultVarCharAggregationn()
+    private InternalAggregationFunction getInternalDefaultVarcharAggregation()
     {
         return getAggregation(VARCHAR);
     }

--- a/presto-main/src/test/java/com/facebook/presto/operator/aggregation/groupByAggregations/AggregationTestInputBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/aggregation/groupByAggregations/AggregationTestInputBuilder.java
@@ -23,7 +23,7 @@ public class AggregationTestInputBuilder
     private final InternalAggregationFunction function;
 
     private int offset = -1;
-    private boolean isRerversed;
+    private boolean isReversed;
     private Page[] pages;
 
     public AggregationTestInputBuilder(Block[] blocks, InternalAggregationFunction function)
@@ -46,15 +46,15 @@ public class AggregationTestInputBuilder
         return this;
     }
 
-    public AggregationTestInputBuilder setRerversed(boolean rerversed)
+    public AggregationTestInputBuilder setReversed(boolean reversed)
     {
-        isRerversed = rerversed;
+        isReversed = reversed;
 
         return this;
     }
 
     public AggregationTestInput build()
     {
-        return new AggregationTestInput(function, pages, offset, isRerversed);
+        return new AggregationTestInput(function, pages, offset, isReversed);
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/operator/project/TestPageProcessor.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/project/TestPageProcessor.java
@@ -157,7 +157,7 @@ public class TestPageProcessor
         testPartialFilterAsList(BIGINT, 100, 0.5f, 0.5f, true, ImmutableList.of());
         testPartialFilterAsList(VARCHAR, 100, 0.5f, 0.5f, true, ImmutableList.of());
 
-        // Complext types
+        // Complex types
 
         testPartialFilterAsList(new ArrayType(BIGINT), 100, 0.5f, 0.5f, false, ImmutableList.of());
         testPartialFilterAsList(new ArrayType(VARCHAR), 100, 0.5f, 0.5f, false, ImmutableList.of());

--- a/presto-main/src/test/java/com/facebook/presto/operator/repartition/BenchmarkPartitionedOutputOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/repartition/BenchmarkPartitionedOutputOperator.java
@@ -280,7 +280,7 @@ public class BenchmarkPartitionedOutputOperator
                 default:
                     throw new UnsupportedOperationException("Unsupported dataType");
             }
-            // We built the dataPage with added pre-computed hash block at channel 0, so types needs to be udpated
+            // We built the dataPage with added pre-computed hash block at channel 0, so types needs to be updated
             types = updateBlockTypesWithHashBlockAndNullBlock(types, true, false);
         }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/repartition/TestBlockEncodingBuffers.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/repartition/TestBlockEncodingBuffers.java
@@ -702,7 +702,7 @@ public class TestBlockEncodingBuffers
     private BlockStatus buildRleBlockStatus(BlockStatus blockStatus, int positionCount)
     {
         int[] expectedRowSizes = new int[positionCount];
-        // When we contructed the Rle block, we chose the row at the middle.
+        // When we constructed the Rle block, we chose the row at the middle.
         Arrays.setAll(expectedRowSizes, i -> blockStatus.expectedRowSizes[blockStatus.block.getPositionCount() / 2]);
         return new BlockStatus(
                 createRleBlockWithRandomValue(blockStatus.block, positionCount),

--- a/presto-main/src/test/java/com/facebook/presto/operator/repartition/TestOptimizedPartitionedOutputOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/repartition/TestOptimizedPartitionedOutputOperator.java
@@ -624,14 +624,14 @@ public class TestOptimizedPartitionedOutputOperator
     {
         List<Type> types = updateBlockTypesWithHashBlockAndNullBlock(targetTypes, true, false);
 
-        // Test plain blocks: no block views, no Dicrtionary/RLE blocks
+        // Test plain blocks: no block views, no Dictionary/RLE blocks
         Page page = PageAssertions.createPageWithRandomData(targetTypes, POSITION_COUNT, true, false, 0.2f, 0.2f, false, ImmutableList.of());
 
         // First test for the cases where the buffer can hold the whole page, then force flushing for every a few rows.
         testPartitioned(types, ImmutableList.of(page), new DataSize(128, MEGABYTE));
         testPartitioned(types, ImmutableList.of(page), new DataSize(1, KILOBYTE));
 
-        // Test block views and Dicrtionary/RLE blocks
+        // Test block views and Dictionary/RLE blocks
         page = PageAssertions.createPageWithRandomData(targetTypes, POSITION_COUNT, true, false, 0.2f, 0.2f, true, ImmutableList.of(DICTIONARY, RUN_LENGTH, DICTIONARY, RUN_LENGTH));
         testPartitioned(types, ImmutableList.of(page), new DataSize(128, MEGABYTE));
         testPartitioned(types, ImmutableList.of(page), new DataSize(1, KILOBYTE));
@@ -757,13 +757,13 @@ public class TestOptimizedPartitionedOutputOperator
         }
         operator.finish();
 
-        Map<Integer, List<Page>> acutualPageLists = outputBuffer.getPages();
+        Map<Integer, List<Page>> actualPageLists = outputBuffer.getPages();
 
-        assertEquals(acutualPageLists.size(), PARTITION_COUNT);
+        assertEquals(actualPageLists.size(), PARTITION_COUNT);
 
         Page expectedPage = mergePages(types, pages);
 
-        acutualPageLists.values().forEach(pageList -> assertPageEquals(types, mergePages(types, pageList), expectedPage));
+        actualPageLists.values().forEach(pageList -> assertPageEquals(types, mergePages(types, pageList), expectedPage));
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestBlockAndPositionNullConvention.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestBlockAndPositionNullConvention.java
@@ -124,7 +124,7 @@ public class TestBlockAndPositionNullConvention
         @TypeParameter("E")
         @SqlNullable
         @SqlType("E")
-        public static Boolean speciailizedBoolean(@TypeParameter("E") Type type, @SqlNullable @SqlType("E") Boolean bool)
+        public static Boolean specializedBoolean(@TypeParameter("E") Type type, @SqlNullable @SqlType("E") Boolean bool)
         {
             return bool;
         }
@@ -132,7 +132,7 @@ public class TestBlockAndPositionNullConvention
         @TypeParameter("E")
         @SqlNullable
         @SqlType("E")
-        public static Boolean speciailizedBoolean(@TypeParameter("E") Type type, @BlockPosition @SqlType(value = "E", nativeContainerType = boolean.class) Block block, @BlockIndex int position)
+        public static Boolean specializedBoolean(@TypeParameter("E") Type type, @BlockPosition @SqlType(value = "E", nativeContainerType = boolean.class) Block block, @BlockIndex int position)
         {
             hitBlockPositionBoolean.set(true);
             return type.getBoolean(block, position);

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestScalarValidation.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestScalarValidation.java
@@ -160,12 +160,12 @@ public class TestScalarValidation
     }
 
     @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Annotated method \\[.*\\] must be public")
-    public void testNonPublicAnnnotatedMethod()
+    public void testNonPublicAnnotatedMethod()
     {
-        extractScalars(NonPublicAnnnotatedMethod.class);
+        extractScalars(NonPublicAnnotatedMethod.class);
     }
 
-    public static final class NonPublicAnnnotatedMethod
+    public static final class NonPublicAnnotatedMethod
     {
         @ScalarFunction
         @SqlType(StandardTypes.BIGINT)

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestStringFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestStringFunctions.java
@@ -177,7 +177,7 @@ public class TestStringFunctions
 
         // Test for invalid utf-8 characters
         assertInvalidFunction("LEVENSHTEIN_DISTANCE('hello world', utf8(from_hex('81')))", "Invalid UTF-8 encoding in characters: �");
-        assertInvalidFunction("LEVENSHTEIN_DISTANCE('hello wolrd', utf8(from_hex('3281')))", "Invalid UTF-8 encoding in characters: 2�");
+        assertInvalidFunction("LEVENSHTEIN_DISTANCE('hello world', utf8(from_hex('3281')))", "Invalid UTF-8 encoding in characters: 2�");
 
         // Test for maximum length
         assertFunction(format("LEVENSHTEIN_DISTANCE('hello', '%s')", repeat("e", 100_000)), BIGINT, 99999L);
@@ -725,7 +725,7 @@ public class TestStringFunctions
         assertFunction("CAST(LTRIM(CONCAT(' ', utf8(from_hex('81'))), ' ') AS VARBINARY)", VARBINARY, varbinary(0x81));
         assertFunction("CAST(LTRIM(CONCAT(' ', utf8(from_hex('81')), ' '), ' ') AS VARBINARY)", VARBINARY, varbinary(0x81, ' '));
         assertInvalidFunction("LTRIM('hello world', utf8(from_hex('81')))", "Invalid UTF-8 encoding in characters: �");
-        assertInvalidFunction("LTRIM('hello wolrd', utf8(from_hex('3281')))", "Invalid UTF-8 encoding in characters: 2�");
+        assertInvalidFunction("LTRIM('hello world', utf8(from_hex('3281')))", "Invalid UTF-8 encoding in characters: 2�");
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStateProvider.java
+++ b/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestResourceManagerClusterStateProvider.java
@@ -483,7 +483,7 @@ public class TestResourceManagerClusterStateProvider
                 "environment",
                 false,
                 new Duration(1, SECONDS),
-                "http://exernalAddress",
+                "http://externalAddress",
                 "http://internalAddress",
                 new MemoryInfo(new DataSize(1, MEGABYTE), ImmutableMap.of(memoryPoolId, memoryPoolInfo)),
                 1,

--- a/presto-main/src/test/java/com/facebook/presto/security/TestFileBasedSystemAccessControl.java
+++ b/presto-main/src/test/java/com/facebook/presto/security/TestFileBasedSystemAccessControl.java
@@ -75,7 +75,7 @@ public class TestFileBasedSystemAccessControl
 
         try {
             accessControlManager.checkCanSetUser(alice, context, Optional.empty(), alice.getUser());
-            throw new AssertionError("expected AccessDeniedExeption");
+            throw new AssertionError("expected AccessDeniedException");
         }
         catch (AccessDeniedException expected) {
         }
@@ -84,7 +84,7 @@ public class TestFileBasedSystemAccessControl
         accessControlManager.checkCanSetUser(kerberosValidNonAsciiUser, context, kerberosValidNonAsciiUser.getPrincipal(), kerberosValidNonAsciiUser.getUser());
         try {
             accessControlManager.checkCanSetUser(kerberosInvalidAlice, context, kerberosInvalidAlice.getPrincipal(), kerberosInvalidAlice.getUser());
-            throw new AssertionError("expected AccessDeniedExeption");
+            throw new AssertionError("expected AccessDeniedException");
         }
         catch (AccessDeniedException expected) {
         }
@@ -92,7 +92,7 @@ public class TestFileBasedSystemAccessControl
         accessControlManager.checkCanSetUser(kerberosValidShare, context, kerberosValidShare.getPrincipal(), kerberosValidShare.getUser());
         try {
             accessControlManager.checkCanSetUser(kerberosInValidShare, context, kerberosInValidShare.getPrincipal(), kerberosInValidShare.getUser());
-            throw new AssertionError("expected AccessDeniedExeption");
+            throw new AssertionError("expected AccessDeniedException");
         }
         catch (AccessDeniedException expected) {
         }
@@ -101,7 +101,7 @@ public class TestFileBasedSystemAccessControl
         accessControlManager.checkCanSetUser(validSpecialRegexEndQuote, context, validSpecialRegexEndQuote.getPrincipal(), validSpecialRegexEndQuote.getUser());
         try {
             accessControlManager.checkCanSetUser(invalidSpecialRegex, context, invalidSpecialRegex.getPrincipal(), invalidSpecialRegex.getUser());
-            throw new AssertionError("expected AccessDeniedExeption");
+            throw new AssertionError("expected AccessDeniedException");
         }
         catch (AccessDeniedException expected) {
         }

--- a/presto-main/src/test/java/com/facebook/presto/server/TestBasicQueryInfo.java
+++ b/presto-main/src/test/java/com/facebook/presto/server/TestBasicQueryInfo.java
@@ -165,7 +165,7 @@ public class TestBasicQueryInfo
         assertEquals(basicInfo.getQueryStats().getPeakUserMemoryReservation(), DataSize.valueOf("23GB"));
         assertEquals(basicInfo.getQueryStats().getPeakTotalMemoryReservation(), DataSize.valueOf("24GB"));
         assertEquals(basicInfo.getQueryStats().getPeakTaskTotalMemoryReservation(), DataSize.valueOf("26GB"));
-        assertEquals(basicInfo.getQueryStats().getPeakNodeTotalMemorReservation(), DataSize.valueOf("42GB"));
+        assertEquals(basicInfo.getQueryStats().getPeakNodeTotalMemoryReservation(), DataSize.valueOf("42GB"));
 
         assertEquals(basicInfo.getQueryStats().getTotalCpuTime(), Duration.valueOf("24m"));
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestUtilizedColumnsAnalyzer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestUtilizedColumnsAnalyzer.java
@@ -70,7 +70,7 @@ public class TestUtilizedColumnsAnalyzer
         assertUtilizedTableColumns("SELECT x FROM (SELECT *, a as x FROM t1)",
                 ImmutableMap.of(QualifiedObjectName.valueOf("tpch.s1.t1"), ImmutableSet.of("a")));
 
-        // Test alias expression wih multiple columns referenced in alias
+        // Test alias expression with multiple columns referenced in alias
         assertUtilizedTableColumns("SELECT x FROM (SELECT *, a + b as x FROM t1)",
                 ImmutableMap.of(QualifiedObjectName.valueOf("tpch.s1.t1"), ImmutableSet.of("a", "b")));
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/BenchmarkPageProcessor.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/BenchmarkPageProcessor.java
@@ -183,7 +183,7 @@ public class BenchmarkPageProcessor
                     .compilePageProcessor(TEST_SESSION.getSqlFunctionProperties(), Optional.of(createFilterExpression(functionManager)), ImmutableList.of(createProjectExpression(functionManager)))
                     .get();
             handcodedProcessor = new Tpch1FilterAndProject();
-            identityProjectionProcessor = createIndentityProjectionPageProcessor();
+            identityProjectionProcessor = createIdentityProjectionPageProcessor();
         }
 
         private static Page createInputPage()
@@ -289,7 +289,7 @@ public class BenchmarkPageProcessor
             }
         }
 
-        private PageProcessor createIndentityProjectionPageProcessor()
+        private PageProcessor createIdentityProjectionPageProcessor()
         {
             PageFilter filter;
             if (filterFails.equals("always")) {

--- a/presto-main/src/test/java/com/facebook/presto/sql/gen/TestCommonSubExpressionRewriter.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/gen/TestCommonSubExpressionRewriter.java
@@ -42,7 +42,7 @@ import static com.facebook.presto.sql.gen.CommonSubExpressionRewriter.getExpress
 import static com.facebook.presto.sql.gen.CommonSubExpressionRewriter.rewriteExpressionWithCSE;
 import static org.testng.Assert.assertEquals;
 
-public class TestCommonSubExpressionRewritter
+public class TestCommonSubExpressionRewriter
 {
     private static final Session SESSION = TEST_SESSION;
     private static final Metadata METADATA = MetadataManager.createTestMetadataManager();

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEffectivePredicateExtractor.java
@@ -80,7 +80,7 @@ import static com.facebook.presto.spi.plan.AggregationNode.singleGroupingSet;
 import static com.facebook.presto.spi.plan.LimitNode.Step.FINAL;
 import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.IS_NULL;
 import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
-import static com.facebook.presto.sql.planner.EqualityInference.Builder.nonInferrableConjuncts;
+import static com.facebook.presto.sql.planner.EqualityInference.Builder.nonInferableConjuncts;
 import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.assignment;
 import static com.facebook.presto.sql.planner.optimizations.AggregationNodeUtils.count;
 import static com.facebook.presto.sql.relational.Expressions.call;
@@ -830,7 +830,7 @@ public class TestEffectivePredicateExtractor
         EqualityInference inference = EqualityInference.createEqualityInference(metadata, predicate);
 
         Set<RowExpression> rewrittenSet = new HashSet<>();
-        for (RowExpression expression : nonInferrableConjuncts(metadata, predicate)) {
+        for (RowExpression expression : nonInferableConjuncts(metadata, predicate)) {
             RowExpression rewritten = inference.rewriteExpression(expression, Predicates.alwaysTrue());
             Preconditions.checkState(rewritten != null, "Rewrite with full symbol scope should always be possible");
             rewrittenSet.add(rewritten);

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEqualityInference.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestEqualityInference.java
@@ -159,7 +159,7 @@ public class TestEqualityInference
     }
 
     @Test
-    public void testExtractInferrableEqualities()
+    public void testExtractInferableEqualities()
     {
         EqualityInference inference = new EqualityInference.Builder(METADATA)
                 .extractInferenceCandidates(and(equals("a1", "b1"), equals("b1", "c1"), someExpression("c1", "d1")))
@@ -194,12 +194,12 @@ public class TestEqualityInference
 
         EqualityInference.EqualityPartition equalityPartition = inference.generateEqualitiesPartitionedBy(matchesVariables("c1"));
 
-        // There should be equalities in the scope, that only use c1 and are all inferrable equalities
+        // There should be equalities in the scope, that only use c1 and are all inferable equalities
         assertFalse(equalityPartition.getScopeEqualities().isEmpty());
         assertTrue(Iterables.all(equalityPartition.getScopeEqualities(), matchesVariableScope(matchesVariables("c1"))));
         assertTrue(Iterables.all(equalityPartition.getScopeEqualities(), isInferenceCandidate(METADATA)));
 
-        // There should be equalities in the inverse scope, that never use c1 and are all inferrable equalities
+        // There should be equalities in the inverse scope, that never use c1 and are all inferable equalities
         assertFalse(equalityPartition.getScopeComplementEqualities().isEmpty());
         assertTrue(Iterables.all(equalityPartition.getScopeComplementEqualities(), matchesVariableScope(not(matchesVariables("c1")))));
         assertTrue(Iterables.all(equalityPartition.getScopeComplementEqualities(), isInferenceCandidate(METADATA)));
@@ -241,12 +241,12 @@ public class TestEqualityInference
         // Generating equalities for disjoint groups
         EqualityInference.EqualityPartition equalityPartition = inference.generateEqualitiesPartitionedBy(variableBeginsWith("a", "b"));
 
-        // There should be equalities in the scope, that only use a* and b* symbols and are all inferrable equalities
+        // There should be equalities in the scope, that only use a* and b* symbols and are all inferable equalities
         assertFalse(equalityPartition.getScopeEqualities().isEmpty());
         assertTrue(Iterables.all(equalityPartition.getScopeEqualities(), matchesVariableScope(variableBeginsWith("a", "b"))));
         assertTrue(Iterables.all(equalityPartition.getScopeEqualities(), isInferenceCandidate(METADATA)));
 
-        // There should be equalities in the inverse scope, that never use a* and b* symbols and are all inferrable equalities
+        // There should be equalities in the inverse scope, that never use a* and b* symbols and are all inferable equalities
         assertFalse(equalityPartition.getScopeComplementEqualities().isEmpty());
         assertTrue(Iterables.all(equalityPartition.getScopeComplementEqualities(), matchesVariableScope(not(variableBeginsWith("a", "b")))));
         assertTrue(Iterables.all(equalityPartition.getScopeComplementEqualities(), isInferenceCandidate(METADATA)));

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestExpressionDomainTranslator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestExpressionDomainTranslator.java
@@ -645,7 +645,7 @@ public class TestExpressionDomainTranslator
     }
 
     @Test
-    void testNonImplictCastOnSymbolSide()
+    void testNonImplicitCastOnSymbolSide()
     {
         // we expect TupleDomain.all here().
         // see comment in ExpressionDomainTranslator.Visitor.visitComparisonExpression()
@@ -1340,9 +1340,9 @@ public class TestExpressionDomainTranslator
         return new IsNullPredicate(expression);
     }
 
-    private InPredicate in(Expression expression, Type expressisonType, List<?> values)
+    private InPredicate in(Expression expression, Type expressionType, List<?> values)
     {
-        List<Type> types = nCopies(values.size(), expressisonType);
+        List<Type> types = nCopies(values.size(), expressionType);
         List<Expression> expressions = literalEncoder.toExpressions(values, types);
         return new InPredicate(expression, new InListExpression(expressions));
     }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestRowExpressionDomainTranslator.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestRowExpressionDomainTranslator.java
@@ -611,7 +611,7 @@ public class TestRowExpressionDomainTranslator
     }
 
     @Test
-    void testNonImplictCastOnSymbolSide()
+    void testNonImplicitCastOnSymbolSide()
     {
         // we expect TupleDomain.all here().
         // see comment in ExpressionDomainTranslator.Visitor.visitComparisonExpression()

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/TestRowExpressionFormatter.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/TestRowExpressionFormatter.java
@@ -289,7 +289,7 @@ public class TestRowExpressionFormatter
     {
         RowExpression specialFormExpression;
 
-        // or and and
+        // or / and
         specialFormExpression = new SpecialFormExpression(OR, BOOLEAN, createCallExpression(NOT_EQUAL), createCallExpression(IS_DISTINCT_FROM));
         assertEquals(format(specialFormExpression), "((c_bigint) <> (BIGINT'5')) OR ((c_bigint) IS DISTINCT FROM (BIGINT'5'))");
         specialFormExpression = new SpecialFormExpression(AND, BOOLEAN, createCallExpression(EQUAL), createCallExpression(GREATER_THAN));

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/AggregationMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/AggregationMatcher.java
@@ -136,7 +136,7 @@ public class AggregationMatcher
                 .add("groupingSets", groupingSets)
                 .add("preGroupedSymbols", preGroupedSymbols)
                 .add("masks", masks)
-                .add("groudId", groupId)
+                .add("groupId", groupId)
                 .add("step", step)
                 .toString();
     }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/GroupIdMatcher.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/GroupIdMatcher.java
@@ -54,9 +54,9 @@ public class GroupIdMatcher
     {
         checkState(shapeMatches(node), "Plan testing framework error: shapeMatches returned false in detailMatches in %s", this.getClass().getName());
 
-        GroupIdNode groudIdNode = (GroupIdNode) node;
-        List<List<VariableReferenceExpression>> actualGroups = groudIdNode.getGroupingSets();
-        List<VariableReferenceExpression> actualAggregationArguments = groudIdNode.getAggregationArguments();
+        GroupIdNode groupIdNode = (GroupIdNode) node;
+        List<List<VariableReferenceExpression>> actualGroups = groupIdNode.getGroupingSets();
+        List<VariableReferenceExpression> actualAggregationArguments = groupIdNode.getAggregationArguments();
 
         if (actualGroups.size() != groups.size()) {
             return NO_MATCH;
@@ -72,7 +72,7 @@ public class GroupIdMatcher
             return NO_MATCH;
         }
 
-        return match(groupIdAlias, createSymbolReference(groudIdNode.getGroupIdVariable()));
+        return match(groupIdAlias, createSymbolReference(groupIdNode.getGroupIdVariable()));
     }
 
     @Override

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
@@ -280,10 +280,10 @@ public final class PlanMatchPattern
         return rowNumberMatcherBuilder.build();
     }
 
-    public static PlanMatchPattern topNRowNumber(Consumer<TopNRowNumberMatcher.Builder> topNRowNumberMatcherBuilderComsumer, PlanMatchPattern source)
+    public static PlanMatchPattern topNRowNumber(Consumer<TopNRowNumberMatcher.Builder> topNRowNumberMatcherBuilderConsumer, PlanMatchPattern source)
     {
         TopNRowNumberMatcher.Builder topNRowNumberMatcherBuilder = new TopNRowNumberMatcher.Builder(source);
-        topNRowNumberMatcherBuilderComsumer.accept(topNRowNumberMatcherBuilder);
+        topNRowNumberMatcherBuilderConsumer.accept(topNRowNumberMatcherBuilder);
         return topNRowNumberMatcherBuilder.build();
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchingVisitor.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchingVisitor.java
@@ -121,7 +121,7 @@ final class PlanMatchingVisitor
                 continue;
             }
 
-            // Try upMatching this node with the the aliases gathered from the source nodes.
+            // Try upMatching this node with the aliases gathered from the source nodes.
             SymbolAliases allSourceAliases = sourcesMatch.getAliases();
             MatchResult matchResult = pattern.detailMatches(node, statsProvider, session, metadata, allSourceAliases);
             if (matchResult.isMatch()) {

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/SymbolAliases.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/SymbolAliases.java
@@ -235,7 +235,7 @@ public final class SymbolAliases
         }
 
         /*
-         * This is supplied specifically for updateAssigments, which needs to
+         * This is supplied specifically for updateAssignments, which needs to
          * update existing bindings that have already been added. Unless you're
          * certain you want this behavior, you don't want it.
          */

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPlanRemoteProjections.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPlanRemoteProjections.java
@@ -54,7 +54,7 @@ import static com.facebook.presto.spi.function.RoutineCharacteristics.NullCallCl
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.project;
 import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.values;
-import static com.facebook.presto.sql.planner.iterative.rule.PlanRemotePojections.ProjectionContext;
+import static com.facebook.presto.sql.planner.iterative.rule.PlanRemoteProjections.ProjectionContext;
 import static org.testng.Assert.assertEquals;
 
 public class TestPlanRemoteProjections
@@ -128,7 +128,7 @@ public class TestPlanRemoteProjections
         planBuilder.variable("x", INTEGER);
         planBuilder.variable("y", INTEGER);
 
-        PlanRemotePojections rule = new PlanRemotePojections(getFunctionAndTypeManager());
+        PlanRemoteProjections rule = new PlanRemoteProjections(getFunctionAndTypeManager());
         List<ProjectionContext> rewritten = rule.planRemoteAssignments(Assignments.builder()
                 .put(planBuilder.variable("a"), planBuilder.rowExpression("abs(x) + abs(y)"))
                 .put(planBuilder.variable("b", BOOLEAN), planBuilder.rowExpression("x is null and y is null"))
@@ -142,7 +142,7 @@ public class TestPlanRemoteProjections
     {
         PlanBuilder planBuilder = new PlanBuilder(TEST_SESSION, new PlanNodeIdAllocator(), getMetadata());
 
-        PlanRemotePojections rule = new PlanRemotePojections(getFunctionAndTypeManager());
+        PlanRemoteProjections rule = new PlanRemoteProjections(getFunctionAndTypeManager());
         List<ProjectionContext> rewritten = rule.planRemoteAssignments(Assignments.builder()
                 .put(planBuilder.variable("a"), planBuilder.rowExpression("unittest.memory.remote_foo()"))
                 .put(planBuilder.variable("b"), planBuilder.rowExpression("unittest.memory.remote_foo(unittest.memory.remote_foo())"))
@@ -158,7 +158,7 @@ public class TestPlanRemoteProjections
         planBuilder.variable("x", INTEGER);
         planBuilder.variable("y", INTEGER);
 
-        PlanRemotePojections rule = new PlanRemotePojections(getFunctionAndTypeManager());
+        PlanRemoteProjections rule = new PlanRemoteProjections(getFunctionAndTypeManager());
         List<ProjectionContext> rewritten = rule.planRemoteAssignments(Assignments.builder()
                 .put(planBuilder.variable("a"), planBuilder.rowExpression("unittest.memory.remote_foo(x, y + unittest.memory.remote_foo(x))"))
                 .put(planBuilder.variable("b"), planBuilder.rowExpression("abs(x)"))
@@ -176,7 +176,7 @@ public class TestPlanRemoteProjections
         planBuilder.variable("x", INTEGER);
         planBuilder.variable("y", INTEGER);
 
-        PlanRemotePojections rule = new PlanRemotePojections(getFunctionAndTypeManager());
+        PlanRemoteProjections rule = new PlanRemoteProjections(getFunctionAndTypeManager());
         List<ProjectionContext> rewritten = rule.planRemoteAssignments(Assignments.builder()
                 .put(planBuilder.variable("a"), planBuilder.rowExpression("unittest.memory.remote_foo(x, y + unittest.memory.remote_foo(x))"))
                 .put(planBuilder.variable("b"), planBuilder.rowExpression("x IS NULL OR y IS NULL"))
@@ -191,7 +191,7 @@ public class TestPlanRemoteProjections
     @Test
     void testRemoteFunctionRewrite()
     {
-        tester.assertThat(new PlanRemotePojections(getFunctionAndTypeManager()))
+        tester.assertThat(new PlanRemoteProjections(getFunctionAndTypeManager()))
                 .on(p -> {
                     p.variable("x", INTEGER);
                     p.variable("y", INTEGER);
@@ -219,7 +219,7 @@ public class TestPlanRemoteProjections
     @Test
     void testMixedExpressionRewrite()
     {
-        tester.assertThat(new PlanRemotePojections(getFunctionAndTypeManager()))
+        tester.assertThat(new PlanRemoteProjections(getFunctionAndTypeManager()))
                 .on(p -> {
                     p.variable("x", INTEGER);
                     p.variable("y", INTEGER);
@@ -283,7 +283,7 @@ public class TestPlanRemoteProjections
                                 new NoopSqlFunctionExecutor()),
                         new SqlInvokedFunctionNamespaceManagerConfig().setSupportedFunctionLanguages("sql,java")));
         functionAndTypeManager.createFunction(FUNCTION_REMOTE_FOO_1, true);
-        tester.assertThat(new PlanRemotePojections(functionAndTypeManager))
+        tester.assertThat(new PlanRemoteProjections(functionAndTypeManager))
                 .on(p -> {
                     p.variable("x", INTEGER);
                     return p.project(

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPushProjectionThroughExchange.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestPushProjectionThroughExchange.java
@@ -129,7 +129,7 @@ public class TestPushProjectionThroughExchange
                                     .addSource(
                                             p.values(a, b, h))
                                     .addInputsSet(a, b, h)
-                                    .fixedHashDistributionParitioningScheme(
+                                    .fixedHashDistributionPartitioningScheme(
                                             ImmutableList.of(a, b, h),
                                             ImmutableList.of(b),
                                             h)));

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestRuntimeReorderJoinSides.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/TestRuntimeReorderJoinSides.java
@@ -150,7 +150,7 @@ public class TestRuntimeReorderJoinSides
                             p.exchange(e -> e
                                     .addSource(suppNode)
                                     .addInputsSet(ImmutableList.of(p.variable("nationkeyS", BIGINT), p.variable("suppkey", BIGINT)))
-                                    .fixedHashDistributionParitioningScheme(ImmutableList.of(p.variable("nationkeyS", BIGINT), p.variable("suppkey", BIGINT)), ImmutableList.of(p.variable("nationkeyS", BIGINT)))),
+                                    .fixedHashDistributionPartitioningScheme(ImmutableList.of(p.variable("nationkeyS", BIGINT), p.variable("suppkey", BIGINT)), ImmutableList.of(p.variable("nationkeyS", BIGINT)))),
                             ImmutableList.of(new JoinNode.EquiJoinClause(p.variable("nationkeyN", BIGINT), p.variable("nationkeyS", BIGINT))),
                             ImmutableList.of(p.variable("nationkeyN", BIGINT), p.variable("nationkeyS", BIGINT), p.variable("suppkey", BIGINT)),
                             Optional.empty());
@@ -181,7 +181,7 @@ public class TestRuntimeReorderJoinSides
                             p.exchange(e -> e
                                     .addSource(suppNode)
                                     .addInputsSet(ImmutableList.of(p.variable("nationkeyS", BIGINT), p.variable("suppkey", BIGINT)))
-                                    .fixedHashDistributionParitioningScheme(ImmutableList.of(p.variable("nationkeyS", BIGINT), p.variable("suppkey", BIGINT)), ImmutableList.of(p.variable("nationkeyS", BIGINT)))),
+                                    .fixedHashDistributionPartitioningScheme(ImmutableList.of(p.variable("nationkeyS", BIGINT), p.variable("suppkey", BIGINT)), ImmutableList.of(p.variable("nationkeyS", BIGINT)))),
                             ImmutableList.of(new JoinNode.EquiJoinClause(p.variable("nationkeyN", BIGINT), p.variable("nationkeyS", BIGINT))),
                             ImmutableList.of(p.variable("nationkeyN", BIGINT), p.variable("nationkeyS", BIGINT), p.variable("suppkey", BIGINT)),
                             Optional.empty());
@@ -215,7 +215,7 @@ public class TestRuntimeReorderJoinSides
                             p.exchange(e -> e
                                     .addSource(suppNode)
                                     .addInputsSet(ImmutableList.of(p.variable("nationkeyS", BIGINT), p.variable("suppkey", BIGINT)))
-                                    .fixedHashDistributionParitioningScheme(ImmutableList.of(p.variable("nationkeyS", BIGINT), p.variable("suppkey", BIGINT)), ImmutableList.of(p.variable("nationkeyS", BIGINT)))),
+                                    .fixedHashDistributionPartitioningScheme(ImmutableList.of(p.variable("nationkeyS", BIGINT), p.variable("suppkey", BIGINT)), ImmutableList.of(p.variable("nationkeyS", BIGINT)))),
                             ImmutableList.of(new JoinNode.EquiJoinClause(p.variable("nationkeyN", BIGINT), p.variable("nationkeyS", BIGINT))),
                             ImmutableList.of(p.variable("nationkeyN", BIGINT), p.variable("nationkeyS", BIGINT), p.variable("suppkey", BIGINT)),
                             Optional.empty(),
@@ -250,7 +250,7 @@ public class TestRuntimeReorderJoinSides
                             p.exchange(e -> e
                                     .addSource(suppNode)
                                     .addInputsSet(ImmutableList.of(p.variable("nationkeyS", BIGINT), p.variable("suppkey", BIGINT)))
-                                    .fixedHashDistributionParitioningScheme(ImmutableList.of(p.variable("nationkeyS", BIGINT), p.variable("suppkey", BIGINT)), ImmutableList.of(p.variable("nationkeyS", BIGINT)))),
+                                    .fixedHashDistributionPartitioningScheme(ImmutableList.of(p.variable("nationkeyS", BIGINT), p.variable("suppkey", BIGINT)), ImmutableList.of(p.variable("nationkeyS", BIGINT)))),
                             ImmutableList.of(new JoinNode.EquiJoinClause(p.variable("nationkeyN", BIGINT), p.variable("nationkeyS", BIGINT))),
                             ImmutableList.of(p.variable("nationkeyN", BIGINT), p.variable("nationkeyS", BIGINT), p.variable("suppkey", BIGINT)),
                             Optional.empty(),

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/rule/test/PlanBuilder.java
@@ -659,7 +659,7 @@ public class PlanBuilder
             return partitioningScheme(new PartitioningScheme(Partitioning.create(SINGLE_DISTRIBUTION, ImmutableList.of()), outputVariables));
         }
 
-        public ExchangeBuilder fixedHashDistributionParitioningScheme(List<VariableReferenceExpression> outputVariables, List<VariableReferenceExpression> partitioningVariables)
+        public ExchangeBuilder fixedHashDistributionPartitioningScheme(List<VariableReferenceExpression> outputVariables, List<VariableReferenceExpression> partitioningVariables)
         {
             return partitioningScheme(new PartitioningScheme(Partitioning.create(
                     FIXED_HASH_DISTRIBUTION,
@@ -667,7 +667,7 @@ public class PlanBuilder
                     ImmutableList.copyOf(outputVariables)));
         }
 
-        public ExchangeBuilder fixedHashDistributionParitioningScheme(List<VariableReferenceExpression> outputVariables, List<VariableReferenceExpression> partitioningVariables, VariableReferenceExpression hashVariable)
+        public ExchangeBuilder fixedHashDistributionPartitioningScheme(List<VariableReferenceExpression> outputVariables, List<VariableReferenceExpression> partitioningVariables, VariableReferenceExpression hashVariable)
         {
             return partitioningScheme(new PartitioningScheme(Partitioning.create(
                     FIXED_HASH_DISTRIBUTION,
@@ -888,14 +888,14 @@ public class PlanBuilder
                 0);
     }
 
-    public RowNumberNode rowNumber(List<VariableReferenceExpression> partitionBy, Optional<Integer> maxRowCountPerPartition, VariableReferenceExpression rownNumberVariable, PlanNode source)
+    public RowNumberNode rowNumber(List<VariableReferenceExpression> partitionBy, Optional<Integer> maxRowCountPerPartition, VariableReferenceExpression rowNumberVariable, PlanNode source)
     {
         return new RowNumberNode(
                 Optional.empty(),
                 idAllocator.getNextId(),
                 source,
                 partitionBy,
-                rownNumberVariable,
+                rowNumberVariable,
                 maxRowCountPerPartition,
                 Optional.empty());
     }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestLocalProperties.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestLocalProperties.java
@@ -151,7 +151,7 @@ public class TestLocalProperties
     }
 
     @Test
-    public void testNormalizeSingleSmbolGroup()
+    public void testNormalizeSingleSymbolGroup()
     {
         List<LocalProperty<String>> localProperties = builder().grouped("a").build();
         assertNormalize(localProperties, Optional.of(grouped("a")));

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestMergeWindows.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestMergeWindows.java
@@ -129,13 +129,13 @@ public class TestMergeWindows
      * "unit" tests in that they verify the behavior of MW with as few
      * external dependencies as possible. Those dependencies to include the
      * parser and analyzer, so the phrase "unit" tests should be taken with a
-     * grain of salt. Using the parser and anayzler instead of creating plan
+     * grain of salt. Using the parser and analyzer instead of creating plan
      * nodes by hand does have a couple of advantages over a true unit test:
      * 1) The tests are more self-maintaining.
      * 2) They're a lot easier to read.
      * 3) It's a lot less typing.
      * <p>
-     * The test that runs with all of the optimzers acts as an integration test
+     * The test that runs with all of the optimizers acts as an integration test
      * and ensures that MW is effective when run with the complete set of
      * optimizers.
      */

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestUnion.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestUnion.java
@@ -85,10 +85,10 @@ public class TestUnion
         assertEquals(remotes.size(), 1, "There should be exactly one RemoteExchange");
         assertEquals(((ExchangeNode) Iterables.getOnlyElement(remotes)).getType(), GATHER);
 
-        int numberOfpartialTopN = searchFrom(plan.getRoot())
+        int numberOfPartialTopN = searchFrom(plan.getRoot())
                 .where(planNode -> planNode instanceof TopNNode && ((TopNNode) planNode).getStep().equals(TopNNode.Step.PARTIAL))
                 .count();
-        assertEquals(numberOfpartialTopN, 2, "There should be exactly two partial TopN nodes");
+        assertEquals(numberOfPartialTopN, 2, "There should be exactly two partial TopN nodes");
         assertPlanIsFullyDistributed(plan);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/sanity/TestValidateAggregationsWithDefaultValues.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/sanity/TestValidateAggregationsWithDefaultValues.java
@@ -122,7 +122,7 @@ public class TestValidateAggregationsWithDefaultValues
                         .source(builder.exchange(e -> e
                                 .type(REPARTITION)
                                 .scope(REMOTE_STREAMING)
-                                .fixedHashDistributionParitioningScheme(ImmutableList.of(variable), ImmutableList.of(variable))
+                                .fixedHashDistributionPartitioningScheme(ImmutableList.of(variable), ImmutableList.of(variable))
                                 .addInputsSet(variable)
                                 .addSource(builder.aggregation(ap -> ap
                                         .step(PARTIAL)
@@ -140,7 +140,7 @@ public class TestValidateAggregationsWithDefaultValues
                         .source(builder.exchange(e -> e
                                 .type(REPARTITION)
                                 .scope(LOCAL)
-                                .fixedHashDistributionParitioningScheme(ImmutableList.of(variable), ImmutableList.of(variable))
+                                .fixedHashDistributionPartitioningScheme(ImmutableList.of(variable), ImmutableList.of(variable))
                                 .addInputsSet(variable)
                                 .addSource(builder.aggregation(ap -> ap
                                         .step(PARTIAL)
@@ -160,7 +160,7 @@ public class TestValidateAggregationsWithDefaultValues
                                 builder.exchange(e -> e
                                         .type(REPARTITION)
                                         .scope(LOCAL)
-                                        .fixedHashDistributionParitioningScheme(ImmutableList.of(variable), ImmutableList.of(variable))
+                                        .fixedHashDistributionPartitioningScheme(ImmutableList.of(variable), ImmutableList.of(variable))
                                         .addInputsSet(variable)
                                         .addSource(builder.aggregation(ap -> ap
                                                 .step(PARTIAL)

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/sanity/TestValidateStreamingJoins.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/sanity/TestValidateStreamingJoins.java
@@ -108,7 +108,7 @@ public class TestValidateStreamingJoins
                                 .type(ExchangeNode.Type.REPARTITION)
                                 .addSource(p.tableScan(supplierTableHandle, ImmutableList.of(p.variable("nationkeyS", BIGINT), p.variable("suppkey", BIGINT)), ImmutableMap.of(p.variable("nationkeyS", BIGINT), nationColumnHandle, p.variable("suppkey", BIGINT), suppColumnHandle)))
                                 .addInputsSet(ImmutableList.of(p.variable("nationkeyS", BIGINT), p.variable("suppkey", BIGINT)))
-                                .fixedHashDistributionParitioningScheme(ImmutableList.of(p.variable("nationkeyS", BIGINT), p.variable("suppkey", BIGINT)), ImmutableList.of(p.variable("nationkeyS", BIGINT)))),
+                                .fixedHashDistributionPartitioningScheme(ImmutableList.of(p.variable("nationkeyS", BIGINT), p.variable("suppkey", BIGINT)), ImmutableList.of(p.variable("nationkeyS", BIGINT)))),
                         ImmutableList.of(new JoinNode.EquiJoinClause(p.variable("nationkeyN", BIGINT), p.variable("nationkeyS", BIGINT))),
                         ImmutableList.of(p.variable("nationkeyN", BIGINT), p.variable("nationkeyS", BIGINT), p.variable("suppkey", BIGINT)),
                         Optional.empty()));

--- a/presto-memory-context/src/test/java/com/facebook/presto/memory/context/TestMemoryContexts.java
+++ b/presto-memory-context/src/test/java/com/facebook/presto/memory/context/TestMemoryContexts.java
@@ -122,7 +122,7 @@ public class TestMemoryContexts
     }
 
     @Test
-    public void testHieararchicalMemoryContexts()
+    public void testHierarchicalMemoryContexts()
     {
         TestMemoryReservationHandler reservationHandler = new TestMemoryReservationHandler(1_000, 1_000);
         AggregatedMemoryContext parentContext = newRootAggregatedMemoryContext(reservationHandler, GUARANTEED_MEMORY);

--- a/presto-ml/src/main/java/com/facebook/presto/ml/ModelUtils.java
+++ b/presto-ml/src/main/java/com/facebook/presto/ml/ModelUtils.java
@@ -136,7 +136,7 @@ public final class ModelUtils
 
         int id = slice.getInt(ALGORITHM_OFFSET);
         Class<? extends Model> algorithm = MODEL_SERIALIZATION_IDS.inverse().get(id);
-        requireNonNull(algorithm, format("Unsupported algorith %d", id));
+        requireNonNull(algorithm, format("Unsupported algorithm %d", id));
 
         int hyperparameterLength = slice.getInt(HYPERPARAMETER_LENGTH_OFFSET);
 

--- a/presto-ml/src/test/java/com/facebook/presto/ml/TestLearnAggregations.java
+++ b/presto-ml/src/test/java/com/facebook/presto/ml/TestLearnAggregations.java
@@ -63,7 +63,7 @@ public class TestLearnAggregations
     {
         Type mapType = functionAndTypeManager.getParameterizedType("map", ImmutableList.of(TypeSignatureParameter.of(parseTypeSignature(StandardTypes.BIGINT)), TypeSignatureParameter.of(parseTypeSignature(StandardTypes.DOUBLE))));
         InternalAggregationFunction aggregation = generateInternalAggregationFunction(LearnClassifierAggregation.class, ClassifierType.BIGINT_CLASSIFIER.getTypeSignature(), ImmutableList.of(BIGINT.getTypeSignature(), mapType.getTypeSignature()), functionAndTypeManager);
-        assertLearnClassifer(aggregation.bind(ImmutableList.of(0, 1), Optional.empty()).createAccumulator(UpdateMemory.NOOP));
+        assertLearnClassifier(aggregation.bind(ImmutableList.of(0, 1), Optional.empty()).createAccumulator(UpdateMemory.NOOP));
     }
 
     @Test
@@ -75,10 +75,10 @@ public class TestLearnAggregations
                 ClassifierType.BIGINT_CLASSIFIER.getTypeSignature(),
                 ImmutableList.of(BIGINT.getTypeSignature(), mapType.getTypeSignature(), VarcharType.getParametrizedVarcharSignature("x"))
         ).specialize(BoundVariables.builder().setLongVariable("x", (long) Integer.MAX_VALUE).build(), 3, functionAndTypeManager);
-        assertLearnClassifer(aggregation.bind(ImmutableList.of(0, 1, 2), Optional.empty()).createAccumulator(UpdateMemory.NOOP));
+        assertLearnClassifier(aggregation.bind(ImmutableList.of(0, 1, 2), Optional.empty()).createAccumulator(UpdateMemory.NOOP));
     }
 
-    private static void assertLearnClassifer(Accumulator accumulator)
+    private static void assertLearnClassifier(Accumulator accumulator)
     {
         accumulator.addInput(getPage());
         BlockBuilder finalOut = accumulator.getFinalType().createBlockBuilder(null, 1);

--- a/presto-mongodb/src/main/java/com/facebook/presto/mongodb/WriteConcernType.java
+++ b/presto-mongodb/src/main/java/com/facebook/presto/mongodb/WriteConcernType.java
@@ -22,7 +22,7 @@ public enum WriteConcernType
     ACKNOWLEDGED(WriteConcern.ACKNOWLEDGED),
     FSYNC_SAFE(WriteConcern.FSYNC_SAFE),
     FSYNCED(WriteConcern.FSYNCED),
-    JOURNAL_SAFEY(WriteConcern.JOURNAL_SAFE),
+    JOURNAL_SAFE(WriteConcern.JOURNAL_SAFE),
     JOURNALED(WriteConcern.JOURNALED),
     MAJORITY(WriteConcern.MAJORITY),
     NORMAL(WriteConcern.NORMAL),

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
@@ -508,7 +508,7 @@ public class OrcWriter
     }
 
     /**
-     * Collect the data for for the stripe.  This is not the actual data, but
+     * Collect the data for the stripe.  This is not the actual data, but
      * instead are functions that know how to write the data.
      */
     private List<DataOutput> bufferStripeData(long stripeStartOffset, FlushReason flushReason)
@@ -669,7 +669,7 @@ public class OrcWriter
     }
 
     /**
-     * Collect the data for for the file footer.  This is not the actual data, but
+     * Collect the data for the file footer.  This is not the actual data, but
      * instead are functions that know how to write the data.
      */
     private List<DataOutput> bufferFileFooter()

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapFlatSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapFlatSelectiveStreamReader.java
@@ -332,7 +332,7 @@ public class MapFlatSelectiveStreamReader
         readOffset = offset + streamPosition;
 
         if (!nonNullsAllowed) {
-            checkState(nullPositionCount == (positionCount - nonNullPositionCount), "nullPositionCount should be equal to postitionCount - nonNullPositionCount");
+            checkState(nullPositionCount == (positionCount - nonNullPositionCount), "nullPositionCount should be equal to positionCount - nonNullPositionCount");
             outputPositionCount = nullPositionCount;
             allNulls = true;
             System.arraycopy(nullPositions, 0, outputPositions, 0, nullPositionCount);

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamV2.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/LongOutputStreamV2.java
@@ -628,7 +628,7 @@ public class LongOutputStreamV2
         patchLength = gapIdx;
 
         // if the element to be patched is the first and only element then
-        // max gap will be 0, but to store the gap as 0 we need atleast 1 bit
+        // max gap will be 0, but to store the gap as 0 we need at least 1 bit
         if (maxGap == 0 && patchLength != 0) {
             patchGapWidth = 1;
         }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestListFilter.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestListFilter.java
@@ -188,8 +188,8 @@ public class TestListFilter
         int[] lengths = Arrays.stream(data).mapToInt(v -> v.length).toArray();
         filter.populateElementFilters(data.length, null, lengths, Arrays.stream(lengths).sum());
 
-        int[] nestedLenghts = Arrays.stream(data).flatMap(Arrays::stream).mapToInt(v -> v.length).toArray();
-        ((ListFilter) filter.getChild()).populateElementFilters(Arrays.stream(lengths).sum(), null, nestedLenghts, Arrays.stream(nestedLenghts).sum());
+        int[] nestedLengths = Arrays.stream(data).flatMap(Arrays::stream).mapToInt(v -> v.length).toArray();
+        ((ListFilter) filter.getChild()).populateElementFilters(Arrays.stream(lengths).sum(), null, nestedLengths, Arrays.stream(nestedLengths).sum());
 
         return filter;
     }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestPositionalFilter.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestPositionalFilter.java
@@ -31,7 +31,7 @@ public class TestPositionalFilter
         PositionalFilter filter = new PositionalFilter();
 
         // a[1] = '1' and a[3] = '3' The test data is converted to byte[]'s and the comparison is done using testLength()
-        // followed by testBytes() so as to cover the double use of the position when testLength succeeeds and testBytes
+        // followed by testBytes() so as to cover the double use of the position when testLength succeeds and testBytes
         // fails.
         TupleDomainFilter[] filters = new TupleDomainFilter[] {
                 equals(1), null, equals(3), null,

--- a/presto-orc/src/test/java/com/facebook/presto/orc/writer/TestSegmentedSliceBlockBuilder.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/writer/TestSegmentedSliceBlockBuilder.java
@@ -109,7 +109,7 @@ public class TestSegmentedSliceBlockBuilder
             assertEquals(blockBuilder.getSizeInBytes(), blockBuilder.getPositionCount() * (1L + Integer.BYTES));
 
             if (blockBuilder.getOpenSegmentIndex() > lastOpenSegmentIndex) {
-                // When new segment is created, retained should should increase due to
+                // When new segment is created, retained should increase due to
                 // copied slices and new offsets array allocation.
                 assertGreaterThan(blockBuilder.getRetainedSizeInBytes(), retainedSize);
             }

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/predicate/PredicateUtils.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/predicate/PredicateUtils.java
@@ -145,9 +145,9 @@ public final class PredicateUtils
             }
 
             Slice compressedData = wrappedBuffer(data, data.length - inputStream.available(), pageHeader.getCompressed_page_size());
-            DictionaryPageHeader dicHeader = pageHeader.getDictionary_page_header();
-            ParquetEncoding encoding = getParquetEncoding(Encoding.valueOf(dicHeader.getEncoding().name()));
-            int dictionarySize = dicHeader.getNum_values();
+            DictionaryPageHeader dictHeader = pageHeader.getDictionary_page_header();
+            ParquetEncoding encoding = getParquetEncoding(Encoding.valueOf(dictHeader.getEncoding().name()));
+            int dictionarySize = dictHeader.getNum_values();
 
             return Optional.of(new DictionaryPage(decompress(codecName, compressedData, pageHeader.getUncompressed_page_size()), dictionarySize, encoding));
         }

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/reader/ParquetColumnChunk.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/reader/ParquetColumnChunk.java
@@ -125,12 +125,12 @@ public class ParquetColumnChunk
     private DictionaryPage readDictionaryPage(PageHeader pageHeader, int uncompressedPageSize, int compressedPageSize)
             throws IOException
     {
-        DictionaryPageHeader dicHeader = pageHeader.getDictionary_page_header();
+        DictionaryPageHeader dictHeader = pageHeader.getDictionary_page_header();
         return new DictionaryPage(
                 getSlice(compressedPageSize),
                 uncompressedPageSize,
-                dicHeader.getNum_values(),
-                getParquetEncoding(Encoding.valueOf(dicHeader.getEncoding().name())));
+                dictHeader.getNum_values(),
+                getParquetEncoding(Encoding.valueOf(dictHeader.getEncoding().name())));
     }
 
     private long readDataPageV1(PageHeader pageHeader,

--- a/presto-parquet/src/test/java/com/facebook/presto/parquet/reader/TestColumnIndexBuilder.java
+++ b/presto-parquet/src/test/java/com/facebook/presto/parquet/reader/TestColumnIndexBuilder.java
@@ -207,7 +207,7 @@ public class TestColumnIndexBuilder
         }
     }
 
-    public static class IntegerIsDivisableWith3
+    public static class IntegerIsDivisibleWith3
             extends UserDefinedPredicate<Integer>
     {
         @Override
@@ -233,7 +233,7 @@ public class TestColumnIndexBuilder
         }
     }
 
-    public static class LongIsDivisableWith3
+    public static class LongIsDivisibleWith3
             extends UserDefinedPredicate<Long>
     {
         @Override
@@ -1048,8 +1048,8 @@ public class TestColumnIndexBuilder
         assertCorrectFiltering(columnIndex, gtEq(col, 2), 0, 1, 2, 4, 5);
         assertCorrectFiltering(columnIndex, lt(col, 2), 0, 1, 4, 5);
         assertCorrectFiltering(columnIndex, ltEq(col, 2), 0, 1, 2, 4, 5);
-        assertCorrectFiltering(columnIndex, userDefined(col, IntegerIsDivisableWith3.class), 0, 1, 5);
-        assertCorrectFiltering(columnIndex, invert(userDefined(col, IntegerIsDivisableWith3.class)), 0, 1, 2, 3, 4, 5);
+        assertCorrectFiltering(columnIndex, userDefined(col, IntegerIsDivisibleWith3.class), 0, 1, 5);
+        assertCorrectFiltering(columnIndex, invert(userDefined(col, IntegerIsDivisibleWith3.class)), 0, 1, 2, 3, 4, 5);
 
         builder = ColumnIndexBuilder.getBuilder(type, Integer.MAX_VALUE);
         sb = new StatsBuilder();
@@ -1078,8 +1078,8 @@ public class TestColumnIndexBuilder
         assertCorrectFiltering(columnIndex, gtEq(col, 2), 5, 7);
         assertCorrectFiltering(columnIndex, lt(col, 2), 1, 2, 5);
         assertCorrectFiltering(columnIndex, ltEq(col, 2), 1, 2, 5);
-        assertCorrectFiltering(columnIndex, userDefined(col, IntegerIsDivisableWith3.class), 1, 2, 5, 7);
-        assertCorrectFiltering(columnIndex, invert(userDefined(col, IntegerIsDivisableWith3.class)), 0, 1, 2, 3, 4, 5, 6, 7,
+        assertCorrectFiltering(columnIndex, userDefined(col, IntegerIsDivisibleWith3.class), 1, 2, 5, 7);
+        assertCorrectFiltering(columnIndex, invert(userDefined(col, IntegerIsDivisibleWith3.class)), 0, 1, 2, 3, 4, 5, 6, 7,
                 8);
 
         builder = ColumnIndexBuilder.getBuilder(type, Integer.MAX_VALUE);
@@ -1109,8 +1109,8 @@ public class TestColumnIndexBuilder
         assertCorrectFiltering(columnIndex, gtEq(col, 2), 1, 3, 5);
         assertCorrectFiltering(columnIndex, lt(col, 2), 5, 8);
         assertCorrectFiltering(columnIndex, ltEq(col, 2), 5, 8);
-        assertCorrectFiltering(columnIndex, userDefined(col, IntegerIsDivisableWith3.class), 1, 3, 5, 8);
-        assertCorrectFiltering(columnIndex, invert(userDefined(col, IntegerIsDivisableWith3.class)), 0, 1, 2, 3, 4, 5, 6, 7,
+        assertCorrectFiltering(columnIndex, userDefined(col, IntegerIsDivisibleWith3.class), 1, 3, 5, 8);
+        assertCorrectFiltering(columnIndex, invert(userDefined(col, IntegerIsDivisibleWith3.class)), 0, 1, 2, 3, 4, 5, 6, 7,
                 8);
     }
 
@@ -1163,8 +1163,8 @@ public class TestColumnIndexBuilder
         assertCorrectFiltering(columnIndex, gtEq(col, 2), 0, 1, 2, 4, 5);
         assertCorrectFiltering(columnIndex, lt(col, 0xEF), 0, 1, 2, 4);
         assertCorrectFiltering(columnIndex, ltEq(col, 0xEF), 0, 1, 2, 4, 5);
-        assertCorrectFiltering(columnIndex, userDefined(col, IntegerIsDivisableWith3.class), 0, 1, 4, 5);
-        assertCorrectFiltering(columnIndex, invert(userDefined(col, IntegerIsDivisableWith3.class)), 0, 1, 2, 3, 4, 5);
+        assertCorrectFiltering(columnIndex, userDefined(col, IntegerIsDivisibleWith3.class), 0, 1, 4, 5);
+        assertCorrectFiltering(columnIndex, invert(userDefined(col, IntegerIsDivisibleWith3.class)), 0, 1, 2, 3, 4, 5);
 
         builder = ColumnIndexBuilder.getBuilder(type, Integer.MAX_VALUE);
         sb = new StatsBuilder();
@@ -1193,8 +1193,8 @@ public class TestColumnIndexBuilder
         assertCorrectFiltering(columnIndex, gtEq(col, 0xEE), 5, 7);
         assertCorrectFiltering(columnIndex, lt(col, 42), 1, 2);
         assertCorrectFiltering(columnIndex, ltEq(col, 42), 1, 2, 5);
-        assertCorrectFiltering(columnIndex, userDefined(col, IntegerIsDivisableWith3.class), 1, 2, 5, 7);
-        assertCorrectFiltering(columnIndex, invert(userDefined(col, IntegerIsDivisableWith3.class)), 0, 1, 2, 3, 4, 5, 6, 7,
+        assertCorrectFiltering(columnIndex, userDefined(col, IntegerIsDivisibleWith3.class), 1, 2, 5, 7);
+        assertCorrectFiltering(columnIndex, invert(userDefined(col, IntegerIsDivisibleWith3.class)), 0, 1, 2, 3, 4, 5, 6, 7,
                 8);
 
         builder = ColumnIndexBuilder.getBuilder(type, Integer.MAX_VALUE);
@@ -1224,8 +1224,8 @@ public class TestColumnIndexBuilder
         assertCorrectFiltering(columnIndex, gtEq(col, 0xFF), 1);
         assertCorrectFiltering(columnIndex, lt(col, 42), 8);
         assertCorrectFiltering(columnIndex, ltEq(col, 42), 5, 8);
-        assertCorrectFiltering(columnIndex, userDefined(col, IntegerIsDivisableWith3.class), 1, 3, 5, 8);
-        assertCorrectFiltering(columnIndex, invert(userDefined(col, IntegerIsDivisableWith3.class)), 0, 2, 3, 4, 5, 6, 7,
+        assertCorrectFiltering(columnIndex, userDefined(col, IntegerIsDivisibleWith3.class), 1, 3, 5, 8);
+        assertCorrectFiltering(columnIndex, invert(userDefined(col, IntegerIsDivisibleWith3.class)), 0, 2, 3, 4, 5, 6, 7,
                 8);
     }
 
@@ -1261,8 +1261,8 @@ public class TestColumnIndexBuilder
         assertCorrectFiltering(columnIndex, gtEq(col, 2L), 0, 1, 2, 4, 5);
         assertCorrectFiltering(columnIndex, lt(col, -21L));
         assertCorrectFiltering(columnIndex, ltEq(col, -21L), 5);
-        assertCorrectFiltering(columnIndex, userDefined(col, LongIsDivisableWith3.class), 0, 1, 5);
-        assertCorrectFiltering(columnIndex, invert(userDefined(col, LongIsDivisableWith3.class)), 0, 1, 2, 3, 4, 5);
+        assertCorrectFiltering(columnIndex, userDefined(col, LongIsDivisibleWith3.class), 0, 1, 5);
+        assertCorrectFiltering(columnIndex, invert(userDefined(col, LongIsDivisibleWith3.class)), 0, 1, 2, 3, 4, 5);
 
         builder = ColumnIndexBuilder.getBuilder(type, Integer.MAX_VALUE);
         sb = new StatsBuilder();
@@ -1291,8 +1291,8 @@ public class TestColumnIndexBuilder
         assertCorrectFiltering(columnIndex, gtEq(col, 2L), 5, 7);
         assertCorrectFiltering(columnIndex, lt(col, -42L), 1, 2);
         assertCorrectFiltering(columnIndex, ltEq(col, -42L), 1, 2, 5);
-        assertCorrectFiltering(columnIndex, userDefined(col, LongIsDivisableWith3.class), 1, 2, 5, 7);
-        assertCorrectFiltering(columnIndex, invert(userDefined(col, LongIsDivisableWith3.class)), 0, 1, 2, 3, 4, 5, 6, 7,
+        assertCorrectFiltering(columnIndex, userDefined(col, LongIsDivisibleWith3.class), 1, 2, 5, 7);
+        assertCorrectFiltering(columnIndex, invert(userDefined(col, LongIsDivisibleWith3.class)), 0, 1, 2, 3, 4, 5, 6, 7,
                 8);
 
         builder = ColumnIndexBuilder.getBuilder(type, Integer.MAX_VALUE);
@@ -1322,8 +1322,8 @@ public class TestColumnIndexBuilder
         assertCorrectFiltering(columnIndex, gtEq(col, 2L), 1, 3, 5);
         assertCorrectFiltering(columnIndex, lt(col, -42L));
         assertCorrectFiltering(columnIndex, ltEq(col, -42L), 8);
-        assertCorrectFiltering(columnIndex, userDefined(col, LongIsDivisableWith3.class), 1, 3, 5, 8);
-        assertCorrectFiltering(columnIndex, invert(userDefined(col, LongIsDivisableWith3.class)), 0, 1, 2, 3, 4, 5, 6, 7,
+        assertCorrectFiltering(columnIndex, userDefined(col, LongIsDivisibleWith3.class), 1, 3, 5, 8);
+        assertCorrectFiltering(columnIndex, invert(userDefined(col, LongIsDivisibleWith3.class)), 0, 1, 2, 3, 4, 5, 6, 7,
                 8);
     }
 

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/query/PinotQueryGenerator.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/query/PinotQueryGenerator.java
@@ -489,7 +489,7 @@ public class PinotQueryGenerator
         {
             List<AggregationColumnNode> aggregationColumnNodes = computeAggregationNodes(node);
 
-            // Make two passes over the aggregatinColumnNodes: In the first pass identify all the variables that will be used
+            // Make two passes over the aggregationColumnNodes: In the first pass identify all the variables that will be used
             // Then pass that context to the source
             // And finally, in the second pass actually generate the PQL
 

--- a/presto-product-tests/conf/docker/common/compose-commons.sh
+++ b/presto-product-tests/conf/docker/common/compose-commons.sh
@@ -51,7 +51,7 @@ export_canonical_path PRODUCT_TESTS_JAR
 
 export HIVE_PROXY_PORT=${HIVE_PROXY_PORT:-1180}
 
-export LDAP_SERVER_HOST=${LDAP_SERVER_HOST:-doesntmatter}
+export LDAP_SERVER_HOST=${LDAP_SERVER_HOST:-doesnotmatter}
 export LDAP_SERVER_IP=${LDAP_SERVER_IP:-127.0.1.1}
 
 if [[ -z "${PRESTO_JDBC_DRIVER_JAR:-}" ]]; then

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/cassandra/TestInsertIntoCassandraTable.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/cassandra/TestInsertIntoCassandraTable.java
@@ -140,12 +140,12 @@ public class TestInsertIntoCassandraTable
     }
 
     @Test(groups = CASSANDRA)
-    public void testInsertIntoValuesToCassandraMaterizedView()
+    public void testInsertIntoValuesToCassandraMaterializedView()
             throws Exception
     {
         TableName table = mutableTablesState().get(CASSANDRA_INSERT_TABLE).getTableName();
-        onCasssandra(format("DROP MATERIALIZED VIEW IF EXISTS %s.%s", KEY_SPACE, CASSANDRA_MATERIALIZED_VIEW));
-        onCasssandra(format("CREATE MATERIALIZED VIEW %s.%s AS " +
+        onCassandra(format("DROP MATERIALIZED VIEW IF EXISTS %s.%s", KEY_SPACE, CASSANDRA_MATERIALIZED_VIEW));
+        onCassandra(format("CREATE MATERIALIZED VIEW %s.%s AS " +
                         "SELECT * FROM %s " +
                         "WHERE b IS NOT NULL " +
                         "PRIMARY KEY (a, b) " +
@@ -164,10 +164,10 @@ public class TestInsertIntoCassandraTable
         assertThat(() -> query(format("DROP TABLE %s.%s.%s", CONNECTOR_NAME, KEY_SPACE, CASSANDRA_MATERIALIZED_VIEW)))
                 .failsWithMessage("Dropping materialized views not yet supported");
 
-        onCasssandra(format("DROP MATERIALIZED VIEW IF EXISTS %s.%s", KEY_SPACE, CASSANDRA_MATERIALIZED_VIEW));
+        onCassandra(format("DROP MATERIALIZED VIEW IF EXISTS %s.%s", KEY_SPACE, CASSANDRA_MATERIALIZED_VIEW));
     }
 
-    private void onCasssandra(String query)
+    private void onCassandra(String query)
     {
         CassandraQueryExecutor queryExecutor = new CassandraQueryExecutor(configuration);
         queryExecutor.executeQuery(query);

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/cli/PrestoLdapCliTests.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/cli/PrestoLdapCliTests.java
@@ -119,11 +119,11 @@ public class PrestoLdapCliTests
     public void shouldRunQueryFromFileWithLdap()
             throws IOException
     {
-        File temporayFile = File.createTempFile("test-sql", null);
-        temporayFile.deleteOnExit();
-        Files.write("select * from hive.default.nation;\n", temporayFile, UTF_8);
+        File temporaryFile = File.createTempFile("test-sql", null);
+        temporaryFile.deleteOnExit();
+        Files.write("select * from hive.default.nation;\n", temporaryFile, UTF_8);
 
-        launchPrestoCliWithServerArgument("--file", temporayFile.getAbsolutePath());
+        launchPrestoCliWithServerArgument("--file", temporaryFile.getAbsolutePath());
         assertThat(trimLines(presto.readRemainingOutputLines())).containsAll(nationTableBatchLines);
     }
 

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestCsv.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestCsv.java
@@ -142,7 +142,7 @@ public class TestCsv
     }
 
     @Test(groups = STORAGE_FORMATS)
-    public void testCreatePartitionedCsvTableAsWithCustomParamters()
+    public void testCreatePartitionedCsvTableAsWithCustomParameters()
     {
         testCreatePartitionedCsvTableAs(
                 "storage_formats_test_create_table_as_select_partitioned_csv_with_custom_parameters",

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestInsertIntoHiveTable.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestInsertIntoHiveTable.java
@@ -141,7 +141,7 @@ public class TestInsertIntoHiveTable
     }
 
     @Test(groups = {POST_HIVE_1_0_1})
-    public void testInsertIntoPartitionedWithSerdePropety()
+    public void testInsertIntoPartitionedWithSerdeProperty()
     {
         String tableNameInDatabase = mutableTablesState().get(PARTITIONED_TABLE_WITH_SERDE).getNameInDatabase();
         assertThat(query("INSERT INTO " + tableNameInDatabase + " SELECT 1, 'presto', '2018-01-01'")).containsExactly(row(1));

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/jdbc/JdbcTests.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/jdbc/JdbcTests.java
@@ -236,7 +236,7 @@ public class JdbcTests
             // These functions, which are defined in the ODBC standard, are implemented within
             // the Simba JDBC and ODBC drivers.  The drivers translate them into equivalent Presto syntax.
             // The translated SQL is executed by Presto.  These tests do not make use of edge-case values or null
-            // values because those code paths are covered by other (non-Simba specifc) tests.
+            // values because those code paths are covered by other (non-Simba specific) tests.
 
             assertThat(query("select {fn char(40)}")).containsExactly(row("("));
             assertThat(query("select {fn convert('2016-10-10', SQL_DATE)}")).containsExactly(row(Date.valueOf("2016-10-10")));

--- a/presto-prometheus/src/test/java/com/facebook/presto/plugin/prometheus/TestPrometheusConnectorConfig.java
+++ b/presto-prometheus/src/test/java/com/facebook/presto/plugin/prometheus/TestPrometheusConnectorConfig.java
@@ -69,7 +69,7 @@ public class TestPrometheusConnectorConfig
             throws Exception
     {
         PrometheusConnectorConfig config = new PrometheusConnectorConfig();
-        config.setPrometheusURI(new URI("http://doesnotmatter.com"));
+        config.setPrometheusURI(new URI("http://doesnotmatter.example.com:"));
         config.setQueryChunkSizeDuration(Duration.valueOf("21d"));
         config.setMaxQueryRangeDuration(Duration.valueOf("1d"));
         config.setCacheDuration(Duration.valueOf("30s"));

--- a/presto-prometheus/src/test/java/com/facebook/presto/plugin/prometheus/TestPrometheusSplit.java
+++ b/presto-prometheus/src/test/java/com/facebook/presto/plugin/prometheus/TestPrometheusSplit.java
@@ -223,7 +223,7 @@ public class TestPrometheusSplit
                 config.getQueryChunkSizeDuration().toMillis() -
                 OFFSET_MILLIS * 20);
         assertEquals(queryInSplit,
-                new URI("http://doesnotmatter:9090/api/v1/query?query=up+now[" + getQueryChunkSizeDurationAsPrometheusCompatibleDurationString(config) + "]" + "&time=" +
+                new URI("http://doesnotmatter.example:9090/api/v1/query?query=up+now[" + getQueryChunkSizeDurationAsPrometheusCompatibleDurationString(config) + "]" + "&time=" +
                         timeShouldBe).getQuery());
     }
 
@@ -254,7 +254,7 @@ public class TestPrometheusSplit
                 config.getQueryChunkSizeDuration().toMillis() -
                 OFFSET_MILLIS * 20);
         assertEquals(queryInSplit,
-                new URI("http://doesnotmatter:9090/api/v1/query?query=up[" + getQueryChunkSizeDurationAsPrometheusCompatibleDurationString(config) + "]" + "&time=" +
+                new URI("http://doesnotmatter.example:9090/api/v1/query?query=up[" + getQueryChunkSizeDurationAsPrometheusCompatibleDurationString(config) + "]" + "&time=" +
                         timeShouldBe).getQuery());
     }
 
@@ -283,7 +283,7 @@ public class TestPrometheusSplit
         PrometheusSplit lastSplit = (PrometheusSplit) splits.get(lastSplitIndex);
         String queryInSplit = lastSplit.getUri().getQuery();
         String timeShouldBe = decimalSecondString(now.toEpochMilli());
-        URI uriAsFormed = new URI("http://doesnotmatter:9090/api/v1/query?query=up[" +
+        URI uriAsFormed = new URI("http://doesnotmatter.example:9090/api/v1/query?query=up[" +
                 getQueryChunkSizeDurationAsPrometheusCompatibleDurationString(config) + "]" +
                 "&time=" + timeShouldBe);
         assertEquals(queryInSplit, uriAsFormed.getQuery());

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/DatabaseShardManager.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/metadata/DatabaseShardManager.java
@@ -564,7 +564,7 @@ public class DatabaseShardManager
      *
      * (A, B) won't happen at the same time
      * (A, C)
-     *        A first, B: after updating shard's delta, verfiy updated shard count
+     *        A first, B: after updating shard's delta, verify updated shard count
      *        B first, A: when deleting shard, check its delta, after deleting, verify deleted shard count
      * (A, D) won't happen at the same time
      * (B, C) won't happen at the same time
@@ -1081,9 +1081,9 @@ public class DatabaseShardManager
     }
 
     @Override
-    public List<BucketNode> getBucketNodes(long distibutionId)
+    public List<BucketNode> getBucketNodes(long distributionId)
     {
-        return dao.getBucketNodes(distibutionId);
+        return dao.getBucketNodes(distributionId);
     }
 
     @Override

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/BucketBalancer.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/storage/BucketBalancer.java
@@ -71,7 +71,7 @@ import static java.util.stream.Collectors.toSet;
  * to every node may not achieve this, as bucket sizes may vary dramatically across distributions.
  * </ol>
  * <p> This prioritizes query performance over total cluster storage capacity, and therefore may
- * produce a cluster state that is imbalanced in terms of disk utilization.
+ * produce a cluster state that is uneven in terms of disk utilization.
  */
 public class BucketBalancer
 {

--- a/presto-rcfile/src/main/java/com/facebook/presto/rcfile/binary/TimestampEncoding.java
+++ b/presto-rcfile/src/main/java/com/facebook/presto/rcfile/binary/TimestampEncoding.java
@@ -123,7 +123,7 @@ public class TimestampEncoding
         if (lowest31BitsOfSecondsAndFlag < 0) {
             // read nanos
             // this is an inline version of readVint so it can be stitched together
-            // the the code to read the seconds high bits below
+            // the code to read the seconds high bits below
             byte nanosFirstByte = slice.getByte(offset);
             int nanosLength = decodeVIntSize(nanosFirstByte);
             nanos = (int) readVInt(slice, offset, nanosLength);

--- a/presto-rcfile/src/test/java/com/facebook/presto/rcfile/TestRcFileReaderManual.java
+++ b/presto-rcfile/src/test/java/com/facebook/presto/rcfile/TestRcFileReaderManual.java
@@ -89,7 +89,7 @@ public class TestRcFileReaderManual
             // straddle segment start
             assertEquals(segment.getValues(), readValues(file, segment.getOffset() - 1, 2));
 
-            // regions entirely within the the segment
+            // regions entirely within the segment
             assertEquals(ImmutableList.of(), readValues(file, segment.getOffset() + 1, 1));
             assertEquals(ImmutableList.of(), readValues(file, segment.getOffset() + 1, segment.getLength() - 1));
 

--- a/presto-redis/src/main/java/com/facebook/presto/redis/RedisRecordCursor.java
+++ b/presto-redis/src/main/java/com/facebook/presto/redis/RedisRecordCursor.java
@@ -55,7 +55,7 @@ public class RedisRecordCursor
     private final List<RedisColumnHandle> columnHandles;
     private final RedisJedisManager redisJedisManager;
     private final JedisPool jedisPool;
-    private final ScanParams scanParms;
+    private final ScanParams scanParams;
 
     private ScanResult<String> redisCursor;
     private Iterator<String> keysIterator;
@@ -85,7 +85,7 @@ public class RedisRecordCursor
         this.columnHandles = columnHandles;
         this.redisJedisManager = redisJedisManager;
         this.jedisPool = redisJedisManager.getJedisPool(split.getNodes().get(0));
-        this.scanParms = setScanParms();
+        this.scanParams = setScanParams();
         this.currentRowValues = new FieldValueProvider[columnHandles.size()];
 
         fetchKeys();
@@ -260,11 +260,11 @@ public class RedisRecordCursor
     {
     }
 
-    private ScanParams setScanParms()
+    private ScanParams setScanParams()
     {
         if (split.getKeyDataType() == RedisDataType.STRING) {
-            ScanParams scanParms = new ScanParams();
-            scanParms.count(redisJedisManager.getRedisConnectorConfig().getRedisScanCount());
+            ScanParams scanParams = new ScanParams();
+            scanParams.count(redisJedisManager.getRedisConnectorConfig().getRedisScanCount());
 
             // when Redis key string follows "schema:table:*" format
             // scan command can efficiently query tables
@@ -282,9 +282,9 @@ public class RedisRecordCursor
                     keyMatch = split.getSchemaName() + Character.toString(redisJedisManager.getRedisConnectorConfig().getRedisKeyDelimiter());
                 }
                 keyMatch = keyMatch + split.getTableName() + Character.toString(redisJedisManager.getRedisConnectorConfig().getRedisKeyDelimiter()) + "*";
-                scanParms.match(keyMatch);
+                scanParams.match(keyMatch);
             }
-            return scanParms;
+            return scanParams;
         }
 
         return null;
@@ -304,7 +304,7 @@ public class RedisRecordCursor
 
                     log.debug("Scanning new Redis keys from cursor %s . %d values read so far", cursor, totalValues);
 
-                    redisCursor = jedis.scan(cursor, scanParms);
+                    redisCursor = jedis.scan(cursor, scanParams);
                     List<String> keys = redisCursor.getResult();
                     keysIterator = keys.iterator();
                 }

--- a/presto-session-property-managers/src/test/java/com/facebook/presto/session/TestFileSessionPropertyManager.java
+++ b/presto-session-property-managers/src/test/java/com/facebook/presto/session/TestFileSessionPropertyManager.java
@@ -170,7 +170,7 @@ public class TestFileSessionPropertyManager
                 Optional.empty(),
                 defaultProperties);
 
-        // PROPERTY1 should be an override property with the value from the default (non-override, higher precendence)
+        // PROPERTY1 should be an override property with the value from the default (non-override, higher precedence)
         // spec.
         // PROPERTY2 should be a default property
         assertProperties(defaultProperties, ImmutableMap.of("PROPERTY1", "VALUE2"), specOverride, specDefault);

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkTaskExecutorFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkTaskExecutorFactory.java
@@ -515,7 +515,7 @@ public class PrestoSparkTaskExecutorFactory
                 }
 
                 if (inMemoryInput != null) {
-                    // for inmemory inputs pages can be released incrementally to save memory
+                    // for in-memory inputs pages can be released incrementally to save memory
                     remoteSourcePageInputs.add(getNullifyingIterator(inMemoryInput));
                     continue;
                 }

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkQueryRunner.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkQueryRunner.java
@@ -1038,7 +1038,7 @@ public class TestPrestoSparkQueryRunner
         // Grant user
         assertQuerySucceeds("GRANT SELECT,INSERT,DELETE,UPDATE ON hive.hive_test_new.test to user");
         MaterializedResult actual = computeActual("SHOW GRANTS ON TABLE hive.hive_test_new.test");
-        // permissions are in the eigth field
+        // permissions are in the eighth field
         List<String> grants = actual.getMaterializedRows().stream().map(row -> row.getField(7).toString()).collect(Collectors.toList());
         assertEquals(Ordering.natural().sortedCopy(grants), ImmutableList.of("DELETE", "INSERT", "SELECT", "UPDATE"));
 
@@ -1176,7 +1176,7 @@ public class TestPrestoSparkQueryRunner
         assertQuerySucceeds(format("CALL system.create_empty_partition('%s', '%s', ARRAY['orderstatus'], ARRAY['%s'])", "tpch", "test_partition_table", "y"));
         actual = computeActual("SELECT count(*) FROM \"test_partition_table$partitions\"");
 
-        // 2 new paritions added
+        // 2 new partitions added
         assertEquals(actual.getOnlyValue().toString(), "5");
         assertQuerySucceeds("DROP TABLE test_partition_table");
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/LocalProperty.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/LocalProperty.java
@@ -44,7 +44,7 @@ public interface LocalProperty<E>
     boolean isSimplifiedBy(LocalProperty<E> actual);
 
     /**
-     * Simplfies this LocalProperty provided that the specified inputs are constants
+     * Simplifies this LocalProperty provided that the specified inputs are constants
      */
     default Optional<LocalProperty<E>> withConstants(Set<E> constants)
     {

--- a/presto-spi/src/main/java/com/facebook/presto/spi/MaterializedViewNotFoundException.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/MaterializedViewNotFoundException.java
@@ -34,7 +34,7 @@ public class MaterializedViewNotFoundException
 
     public MaterializedViewNotFoundException(SchemaTableName viewName, Throwable cause)
     {
-        this(viewName, format("Materialzied view '%s' not found", viewName), cause);
+        this(viewName, format("Materialized view '%s' not found", viewName), cause);
     }
 
     public MaterializedViewNotFoundException(SchemaTableName viewName, String message, Throwable cause)

--- a/presto-spi/src/main/java/com/facebook/presto/spi/TableLayoutFilterCoverage.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/TableLayoutFilterCoverage.java
@@ -14,7 +14,7 @@
 package com.facebook.presto.spi;
 
 /**
- * Result indicating whether a set of filters on partition columns retricts the range of values
+ * Result indicating whether a set of filters on partition columns restricts the range of values
  * on the columns
  */
 public enum TableLayoutFilterCoverage

--- a/presto-testng-services/src/main/java/com/facebook/presto/testng/services/Listeners.java
+++ b/presto-testng-services/src/main/java/com/facebook/presto/testng/services/Listeners.java
@@ -24,7 +24,7 @@ final class Listeners
     /**
      * Print error to standard error and exit JVM.
      *
-     * @apiNote A TestNG listener cannot throw an exception, as this are not currently properly handlded by TestNG.
+     * @apiNote A TestNG listener cannot throw an exception, as this are not currently properly handled by TestNG.
      */
     public static void reportListenerFailure(Class<? extends ITestNGListener> listenerClass, String format, Object... args)
     {

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestJoinQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestJoinQueries.java
@@ -174,7 +174,7 @@ public abstract class AbstractTestJoinQueries
     }
 
     @Test
-    public void testJoinWithRangePredicatesinJoinClause()
+    public void testJoinWithRangePredicatesInJoinClause()
     {
         assertQuery("SELECT COUNT(*) " +
                 "FROM (SELECT * FROM lineitem WHERE orderkey % 16 = 0 AND partkey % 2 = 0) lineitem " +
@@ -559,7 +559,7 @@ public abstract class AbstractTestJoinQueries
     }
 
     @Test
-    public void testNonEqalityJoinWithScalarRequiringSessionParameter()
+    public void testNonEqualityJoinWithScalarRequiringSessionParameter()
     {
         assertQuery("SELECT * FROM (VALUES (1,1), (1,2)) t1(a,b) LEFT OUTER JOIN (VALUES (1,1), (1,2)) t2(c,d) ON a=c AND from_unixtime(b) > current_timestamp",
                 "VALUES (1, 1, NULL, NULL), (1, 2, NULL, NULL)");
@@ -1637,7 +1637,7 @@ public abstract class AbstractTestJoinQueries
     }
 
     @Test
-    public void testUnionWithJoinOnNonTranslateableSymbols()
+    public void testUnionWithJoinOnNonTranslatableSymbols()
     {
         assertQuery("SELECT *\n" +
                 "FROM (SELECT orderdate ds, orderkey\n" +

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueries.java
@@ -846,7 +846,7 @@ public abstract class AbstractTestQueries
                         "SELECT * FROM a",
                 "VALUES (1.1, 2), (sin(3.3), 2+2)");
 
-        // implicit coersions
+        // implicit coercions
         assertQuery("VALUES 1, 2.2, 3, 4.4");
         assertQuery("VALUES (1, 2), (3.3, 4.4)");
         assertQuery("VALUES true, 1.0 in (1, 2, 3)");
@@ -2670,7 +2670,7 @@ public abstract class AbstractTestQueries
 
         // Until we migrate all connectors to parametrized varchar we check two options
         assertTrue(actual.equals(expectedParametrizedVarchar) || actual.equals(expectedUnparametrizedVarchar),
-                format("%s does not matche neither of %s and %s", actual, expectedParametrizedVarchar, expectedUnparametrizedVarchar));
+                format("%s matches neither %s nor %s", actual, expectedParametrizedVarchar, expectedUnparametrizedVarchar));
     }
 
     @Test
@@ -3983,7 +3983,7 @@ public abstract class AbstractTestQueries
     @Test
     public void testTwoCorrelatedExistsSubqueries()
     {
-        // This is simpliefied TPC-H q21
+        // This is simplified TPC-H q21
         assertQuery("SELECT\n" +
                         "  count(*) AS numwait\n" +
                         "FROM\n" +
@@ -5875,9 +5875,9 @@ public abstract class AbstractTestQueries
                 "select count(1) from (select distinct orderkey, custkey from orders)",
         };
 
-        int[] unsampledResuts = new int[] {60175, 1000, 15000, 5408941, 60175, 9256, 15000};
+        int[] unsampledResults = new int[] {60175, 1000, 15000, 5408941, 60175, 9256, 15000};
         for (int i = 0; i < queries.length; i++) {
-            assertQuery(queries[i], "select " + unsampledResuts[i]);
+            assertQuery(queries[i], "select " + unsampledResults[i]);
         }
 
         Session sessionWithKeyBasedSampling = Session.builder(getSession())
@@ -5885,9 +5885,9 @@ public abstract class AbstractTestQueries
                 .setSystemProperty(KEY_BASED_SAMPLING_PERCENTAGE, "0.2")
                 .build();
 
-        int[] sampled20PercentResuts = new int[] {37170, 616, 9189, 5408941, 37170, 5721, 9278};
+        int[] sampled20PercentResults = new int[] {37170, 616, 9189, 5408941, 37170, 5721, 9278};
         for (int i = 0; i < queries.length; i++) {
-            assertQuery(sessionWithKeyBasedSampling, queries[i], "select " + sampled20PercentResuts[i]);
+            assertQuery(sessionWithKeyBasedSampling, queries[i], "select " + sampled20PercentResults[i]);
         }
 
         sessionWithKeyBasedSampling = Session.builder(getSession())
@@ -5895,9 +5895,9 @@ public abstract class AbstractTestQueries
                 .setSystemProperty(KEY_BASED_SAMPLING_PERCENTAGE, "0.1")
                 .build();
 
-        int[] sampled10PercentResuts = new int[] {33649, 557, 8377, 4644937, 33649, 5098, 8397};
+        int[] sampled10PercentResults = new int[] {33649, 557, 8377, 4644937, 33649, 5098, 8397};
         for (int i = 0; i < queries.length; i++) {
-            assertQuery(sessionWithKeyBasedSampling, queries[i], "select " + sampled10PercentResuts[i]);
+            assertQuery(sessionWithKeyBasedSampling, queries[i], "select " + sampled10PercentResults[i]);
         }
     }
 

--- a/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/DistributedQueryRunner.java
@@ -265,10 +265,10 @@ public class DistributedQueryRunner
             }
         }
 
-        int availableCoordinaors = 0;
-        while (availableCoordinaors != coordinators.size()) {
+        int availableCoordinators = 0;
+        while (availableCoordinators != coordinators.size()) {
             MILLISECONDS.sleep(10);
-            availableCoordinaors = getResourceManager().get().getNodeManager().getCoordinators().size();
+            availableCoordinators = getResourceManager().get().getNodeManager().getCoordinators().size();
         }
     }
 

--- a/presto-tests/src/test/java/com/facebook/presto/resourcemanager/TestDistributedQueryInfoResource.java
+++ b/presto-tests/src/test/java/com/facebook/presto/resourcemanager/TestDistributedQueryInfoResource.java
@@ -102,10 +102,10 @@ public class TestDistributedQueryInfoResource
         }
     }
 
-    private void waitUntilCoordinatorsDiscoveredHealthyInRM(long timeoutInMilis)
+    private void waitUntilCoordinatorsDiscoveredHealthyInRM(long timeoutInMillis)
             throws TimeoutException, InterruptedException
     {
-        long deadline = System.currentTimeMillis() + timeoutInMilis;
+        long deadline = System.currentTimeMillis() + timeoutInMillis;
         while (System.currentTimeMillis() < deadline) {
             AllNodes allNodes = this.resourceManager.refreshNodes();
             if (allNodes.getActiveCoordinators().size() == COORDINATOR_COUNT) {
@@ -113,6 +113,6 @@ public class TestDistributedQueryInfoResource
             }
             sleep(100);
         }
-        throw new TimeoutException(format("one of the nodes is still missing after: %s ms", timeoutInMilis));
+        throw new TimeoutException(format("one of the nodes is still missing after: %s ms", timeoutInMillis));
     }
 }

--- a/presto-tests/src/test/java/com/facebook/presto/resourcemanager/TestDistributedQueryResource.java
+++ b/presto-tests/src/test/java/com/facebook/presto/resourcemanager/TestDistributedQueryResource.java
@@ -195,7 +195,7 @@ public class TestDistributedQueryResource
     }
 
     @Test
-    public void testGetAllQueryInfoRetunsAllQueriesWithNoLimitSpecified()
+    public void testGetAllQueryInfoReturnsAllQueriesWithNoLimitSpecified()
             throws InterruptedException
     {
         runToFirstResult(client, coordinator1, "SELECT * from tpch.sf100.orders");

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestProcedureCreation.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestProcedureCreation.java
@@ -48,7 +48,7 @@ public class TestProcedureCreation
     }
 
     @Test
-    public void shouldThrowExceptionWhenArgumentNameRepeates()
+    public void shouldThrowExceptionWhenArgumentNameRepeats()
     {
         assertThatThrownBy(() -> createTestProcedure(ImmutableList.of(
                 new Procedure.Argument("name", VARCHAR, false, null),

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestTupleDomainFilterUtils.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestTupleDomainFilterUtils.java
@@ -493,9 +493,9 @@ public class TestTupleDomainFilterUtils
         return new IsNullPredicate(expression);
     }
 
-    private InPredicate in(Expression expression, Type expressisonType, List<?> values)
+    private InPredicate in(Expression expression, Type expressionType, List<?> values)
     {
-        List<Type> types = nCopies(values.size(), expressisonType);
+        List<Type> types = nCopies(values.size(), expressionType);
         List<Expression> expressions = literalEncoder.toExpressions(values, types);
         return new InPredicate(expression, new InListExpression(expressions));
     }

--- a/presto-tpcds/src/test/java/com/facebook/presto/tpcds/TestTpcdsMetadataStatistics.java
+++ b/presto-tpcds/src/test/java/com/facebook/presto/tpcds/TestTpcdsMetadataStatistics.java
@@ -178,13 +178,13 @@ public class TestTpcdsMetadataStatistics
 
         Entry<ColumnHandle, ColumnStatistics> entry = tableStatistics.getColumnStatistics().entrySet().iterator().next();
 
-        TableStatistics expectedTableStatictics = tableStatistics.builder()
+        TableStatistics expectedTableStatistics = tableStatistics.builder()
                 .setRowCount(tableStatistics.getRowCount())
                 .setColumnStatistics(entry.getKey(), entry.getValue())
                 .build();
 
         JsonCodec<TableStatistics> codec = JsonCodec.jsonCodec(TableStatistics.class);
-        String json = codec.toJson(expectedTableStatictics);
+        String json = codec.toJson(expectedTableStatistics);
         assertEquals(json, "{\n" +
                 "  \"rowCount\" : {\n" +
                 "    \"value\" : 30.0\n" +

--- a/presto-tpch/src/main/resources/tpch/statistics/sf3000.0/README.txt
+++ b/presto-tpch/src/main/resources/tpch/statistics/sf3000.0/README.txt
@@ -1,2 +1,2 @@
-This statistics are copied from from hive connector from TPCH schema with sf3000.
+This statistics are copied from hive connector from TPCH schema with sf3000.
 So distinct values are not exact and also there are no min nor max values for char-based columns.

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestLimitQueryDeterminismAnalyzer.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestLimitQueryDeterminismAnalyzer.java
@@ -114,7 +114,7 @@ public class TestLimitQueryDeterminismAnalyzer
         MockPrestoAction prestoAction = createPrestoAction(1000);
 
         // Unsupported statement types
-        assertAnalysis(prestoAction, "CREATE TABLE test (x varchar, ds varhcar) WITH (partitioned_by = ARRAY[\"ds\"])", NOT_RUN);
+        assertAnalysis(prestoAction, "CREATE TABLE test (x varchar, ds varchar) WITH (partitioned_by = ARRAY[\"ds\"])", NOT_RUN);
         assertAnalysis(prestoAction, "SELECT * FROM source LIMIT 10", NOT_RUN);
 
         // ORDER BY clause


### PR DESCRIPTION
Test plan


This PR corrects misspellings identified by the [check-spelling action](https://github.com/marketplace/actions/check-spelling).

The misspellings have been reported at https://github.com/jsoref/presto/commit/f42e814f49298c89781cbcb2948cc0276719f6b4#commitcomment-67876501

The action reports that the changes in this PR would make it happy: https://github.com/jsoref/presto/commit/4a11b58320bdb94c4d2ede978298bbbc45253c65

- A bunch of things failed, but it looked like GitHub CI was broken overnight. I don't expect this to be merged as-is.

Note: this PR does not include the action. If you're interested in running a spell check on every PR and push, that can be offered separately.

Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines. Don't forget to follow our [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution) for any code copied from other projects.

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== RELEASE NOTES ==

MongoDB Connector Changes
* Fix the spelling of the write concern option ``JOURNAL_SAFE`` for the property ``mongodb.write-concern``.
```
