### PR TITLE
Kill queries aggressively under high task pressure

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/execution/MockQueryExecution.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/MockQueryExecution.java
@@ -25,11 +25,34 @@ import io.airlift.units.Duration;
 import org.joda.time.DateTime;
 
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 
 public class MockQueryExecution
         implements QueryExecution
 {
+    private static final AtomicLong ID_COUNTER = new AtomicLong(0);
+
+    private final QueryId queryId;
+    private final int runningTaskCount;
+    private Optional<Throwable> failureReason = Optional.empty();
+
+    public MockQueryExecution()
+    {
+        this(0);
+    }
+
+    private MockQueryExecution(int runningTaskCount)
+    {
+        this.queryId = QueryId.valueOf(String.valueOf(ID_COUNTER.getAndIncrement()));
+        this.runningTaskCount = runningTaskCount;
+    }
+
+    public static MockQueryExecution withRunningTaskCount(int runningTaskCount)
+    {
+        return new MockQueryExecution(runningTaskCount);
+    }
+
     @Override
     public QueryState getState()
     {
@@ -101,7 +124,7 @@ public class MockQueryExecution
     @Override
     public int getRunningTaskCount()
     {
-        return 0;
+        return runningTaskCount;
     }
 
     @Override
@@ -125,7 +148,7 @@ public class MockQueryExecution
     @Override
     public QueryId getQueryId()
     {
-        return null;
+        return queryId;
     }
 
     @Override
@@ -172,7 +195,14 @@ public class MockQueryExecution
 
     @Override
     public void fail(Throwable cause)
-    { }
+    {
+        this.failureReason = Optional.ofNullable(cause);
+    }
+
+    public Optional<Throwable> getFailureReason()
+    {
+        return failureReason;
+    }
 
     @Override
     public void pruneInfo()

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestQueryTrackerHighTaskCountKill.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestQueryTrackerHighTaskCountKill.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution;
+
+import com.facebook.presto.spi.PrestoException;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.ScheduledExecutorService;
+
+import static com.facebook.presto.spi.StandardErrorCode.QUERY_HAS_TOO_MANY_STAGES;
+import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestQueryTrackerHighTaskCountKill
+{
+    @Test
+    public void testMultipleQueriesKilledDueToTaskCount()
+    {
+        QueryManagerConfig config = new QueryManagerConfig()
+                .setMaxQueryRunningTaskCount(100)
+                .setMaxTotalRunningTaskCountToKillQuery(200);
+        ScheduledExecutorService scheduledExecutorService = newSingleThreadScheduledExecutor();
+        try {
+            QueryTracker<MockQueryExecution> queryTracker = new QueryTracker<>(config, scheduledExecutorService);
+            MockQueryExecution smallQuery1 = MockQueryExecution.withRunningTaskCount(50);
+            MockQueryExecution largeQueryButNotKilled = MockQueryExecution.withRunningTaskCount(101);
+            MockQueryExecution largeQueryToBeKilled1 = MockQueryExecution.withRunningTaskCount(200);
+            MockQueryExecution largeQueryToBeKilled2 = MockQueryExecution.withRunningTaskCount(250);
+
+            queryTracker.addQuery(smallQuery1);
+            queryTracker.addQuery(largeQueryButNotKilled);
+            queryTracker.addQuery(largeQueryToBeKilled1);
+            queryTracker.addQuery(largeQueryToBeKilled2);
+
+            queryTracker.enforceTaskLimits();
+
+            assertFalse(smallQuery1.getFailureReason().isPresent(), "small query should not be killed");
+            assertFalse(
+                    largeQueryButNotKilled.getFailureReason().isPresent(),
+                    "query exceeds per query limit, but not killed since not heaviest and cluster can get into better state");
+            assertTrue(largeQueryToBeKilled1.getFailureReason().isPresent(), "Query should be killed");
+            Throwable failureReason1 = largeQueryToBeKilled1.getFailureReason().get();
+            assertTrue(failureReason1 instanceof PrestoException);
+            assertEquals(((PrestoException) failureReason1).getErrorCode(), QUERY_HAS_TOO_MANY_STAGES.toErrorCode());
+            assertTrue(largeQueryToBeKilled2.getFailureReason().isPresent(), "Query should be killed");
+            Throwable failureReason2 = largeQueryToBeKilled2.getFailureReason().get();
+            assertTrue(failureReason2 instanceof PrestoException);
+            assertEquals(((PrestoException) failureReason2).getErrorCode(), QUERY_HAS_TOO_MANY_STAGES.toErrorCode());
+        }
+        finally {
+            scheduledExecutorService.shutdownNow();
+        }
+    }
+}


### PR DESCRIPTION
In the situations that the cluster is under high task pressure,
instead of killing one query per second, kill queries aggressively
to bring the cluster in a healthier state quicker.

Test plan - Added a new unit test and ensured that the current unittest can succeed

```
== NO RELEASE NOTE ==
```
