### PR TITLE
Removing scheduler hard coded request timeout value

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
@@ -247,7 +247,6 @@ public class CoordinatorModule
                 .withTracing()
                 .withFilter(GenerateTraceTokenRequestFilter.class)
                 .withConfigDefaults(config -> {
-                    config.setRequestTimeout(new Duration(10, SECONDS));
                     config.setMaxConnectionsPerServer(250);
                 });
 


### PR DESCRIPTION
When coordinator gets full GC pause which lasts more than 10 second, all scheduler requests to workers times out.
This result in retrying those requests. With 100s of tasks requests retry, causing memory pressure on coordinator if it's
running on low memory machine. Removing this config to make it configurable so we can tune it per cluster.

Test plan - unit tests and verifier run

```
== RELEASE NOTES ==

General Changes
* Remove hard coded scheduler http client request timeout. The value can be set using `scheduler.http-client.request-timeout` 
