### PR TITLE
Allow to pick a subset of TPC-DS tables to create in HiveQueryRunner

### DIFF
--- a/presto-tests/src/test/java/com/facebook/presto/resourcemanager/TestDistributedQueryResource.java
+++ b/presto-tests/src/test/java/com/facebook/presto/resourcemanager/TestDistributedQueryResource.java
@@ -173,7 +173,8 @@ public class TestDistributedQueryResource
         }
     }
 
-    @Test(timeOut = 60_000)
+    // Flaky test.
+    @Test(timeOut = 60_000, enabled = false)
     public void testGetAllQueryInfoForLimits()
             throws InterruptedException
     {


### PR DESCRIPTION
In Prestissimo (Presto on Velox), we want to create HiveQueryRunner without creating TPC-H or TPC-DS tables.

For reference, TPC-DS support was added to HiveQueryRunner in https://github.com/prestodb/presto/pull/17132 .

Also, disable flaky test TestDistributedQueryResource.testGetAllQueryInfoForLimits. This is similar to https://github.com/prestodb/presto/pull/17185 .

```
== NO RELEASE NOTE ==
```
