### PR TITLE
Add trim_array function

### DIFF
--- a/presto-docs/src/main/sphinx/functions/array.rst
+++ b/presto-docs/src/main/sphinx/functions/array.rst
@@ -286,6 +286,16 @@ Array Functions
     Subsets array ``x`` starting from index ``start`` (or starting from the end
     if ``start`` is negative) with a length of ``length``.
 
+.. function:: trim_array(x, n) -> array
+
+    Remove ``n`` elements from the end of array::
+
+        SELECT trim_array(ARRAY[1, 2, 3, 4], 1);
+        -- [1, 2, 3]
+
+        SELECT trim_array(ARRAY[1, 2, 3, 4], 2);
+        -- [1, 2]
+
 .. function:: transform(array(T), function(T,U)) -> array(U)
 
     Returns an array that is the result of applying ``function`` to each element of ``array``::

--- a/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
@@ -114,6 +114,7 @@ import com.facebook.presto.operator.scalar.ArrayShuffleFunction;
 import com.facebook.presto.operator.scalar.ArraySliceFunction;
 import com.facebook.presto.operator.scalar.ArraySortComparatorFunction;
 import com.facebook.presto.operator.scalar.ArraySortFunction;
+import com.facebook.presto.operator.scalar.ArrayTrimFunction;
 import com.facebook.presto.operator.scalar.ArrayUnionFunction;
 import com.facebook.presto.operator.scalar.ArraysOverlapFunction;
 import com.facebook.presto.operator.scalar.BitwiseFunctions;
@@ -752,6 +753,7 @@ public class BuiltInTypeAndFunctionNamespaceManager
                 .scalar(ArrayUnionFunction.class)
                 .scalar(ArrayExceptFunction.class)
                 .scalar(ArraySliceFunction.class)
+                .scalar(ArrayTrimFunction.class)
                 .scalar(ArrayIndeterminateOperator.class)
                 .scalar(ArrayCombinationsFunction.class)
                 .scalar(ArrayNgramsFunction.class)

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayTrimFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ArrayTrimFunction.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.type.StandardTypes;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.spi.function.Description;
+import com.facebook.presto.spi.function.ScalarFunction;
+import com.facebook.presto.spi.function.SqlType;
+import com.facebook.presto.spi.function.TypeParameter;
+
+import static com.facebook.presto.spi.StandardErrorCode.INVALID_FUNCTION_ARGUMENT;
+import static com.facebook.presto.util.Failures.checkCondition;
+import static java.lang.Math.toIntExact;
+
+@ScalarFunction("trim_array")
+@Description("Remove elements from the end of array")
+public final class ArrayTrimFunction
+{
+    private ArrayTrimFunction() {}
+
+    @TypeParameter("E")
+    @SqlType("array(E)")
+    public static Block trim(
+            @TypeParameter("E") Type type,
+            @SqlType("array(E)") Block array,
+            @SqlType(StandardTypes.BIGINT) long size)
+    {
+        checkCondition(size >= 0, INVALID_FUNCTION_ARGUMENT, "size must not be negative: %s", size);
+        checkCondition(size <= array.getPositionCount(), INVALID_FUNCTION_ARGUMENT, "size must not exceed array cardinality %s: %s", array.getPositionCount(), size);
+
+        return array.getRegion(0, toIntExact(array.getPositionCount() - size));
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestArrayTrimFunction.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestArrayTrimFunction.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.scalar;
+
+import com.facebook.presto.common.type.ArrayType;
+import com.google.common.collect.ImmutableList;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.common.type.VarcharType.createVarcharType;
+import static java.util.Arrays.asList;
+
+public class TestArrayTrimFunction
+        extends AbstractTestFunctions
+{
+    @Test
+    public void testTrimArray()
+    {
+        assertFunction("trim_array(ARRAY[1, 2, 3, 4], 0)", new ArrayType(INTEGER), ImmutableList.of(1, 2, 3, 4));
+        assertFunction("trim_array(ARRAY[1, 2, 3, 4], 1)", new ArrayType(INTEGER), ImmutableList.of(1, 2, 3));
+        assertFunction("trim_array(ARRAY[1, 2, 3, 4], 2)", new ArrayType(INTEGER), ImmutableList.of(1, 2));
+        assertFunction("trim_array(ARRAY[1, 2, 3, 4], 3)", new ArrayType(INTEGER), ImmutableList.of(1));
+        assertFunction("trim_array(ARRAY[1, 2, 3, 4], 4)", new ArrayType(INTEGER), ImmutableList.of());
+
+        assertFunction("trim_array(ARRAY['a', 'b', 'c', 'd'], 1)", new ArrayType(createVarcharType(1)), ImmutableList.of("a", "b", "c"));
+        assertFunction("trim_array(ARRAY['a', 'b', null, 'd'], 1)", new ArrayType(createVarcharType(1)), asList("a", "b", null));
+        assertFunction("trim_array(ARRAY[ARRAY[1, 2, 3], ARRAY[4, 5, 6]], 1)", new ArrayType(new ArrayType(INTEGER)), ImmutableList.of(ImmutableList.of(1, 2, 3)));
+
+        assertInvalidFunction("trim_array(ARRAY[1, 2, 3, 4], 5)", "size must not exceed array cardinality 4: 5");
+        assertInvalidFunction("trim_array(ARRAY[1, 2, 3, 4], -1)", "size must not be negative: -1");
+    }
+}


### PR DESCRIPTION
Cherry-pick of https://github.com/trinodb/trino/pull/11238

Add trim_array function. ANSI SQL syntax:

<trim array function> ::=
  TRIM_ARRAY <left paren>  <array value expression>  <comma>
  <numeric value expression>  <right paren>

Co-authored-by: Yuya Ebihara <yuya.ebihara@starburstdata.com>

Test plan - Added a test

```
== RELEASE NOTES ==

General Changes
* Add trim_array function
* ...

Hive Changes
* ...
```
