### PR TITLE
Add OrcReaderOptions builder

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcReaderOptions.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcReaderOptions.java
@@ -15,6 +15,7 @@ package com.facebook.presto.orc;
 
 import io.airlift.units.DataSize;
 
+import static com.google.common.base.MoreObjects.toStringHelper;
 import static java.util.Objects.requireNonNull;
 
 public class OrcReaderOptions
@@ -96,5 +97,91 @@ public class OrcReaderOptions
     public boolean appendRowNumber()
     {
         return appendRowNumber;
+    }
+
+    @Override
+    public String toString()
+    {
+        return toStringHelper(this)
+                .add("maxMergeDistance", maxMergeDistance)
+                .add("tinyStripeThreshold", tinyStripeThreshold)
+                .add("maxBlockSize", maxBlockSize)
+                .add("zstdJniDecompressionEnabled", zstdJniDecompressionEnabled)
+                .add("mapNullKeysEnabled", mapNullKeysEnabled)
+                .add("enableTimestampMicroPrecision", enableTimestampMicroPrecision)
+                .add("appendRowNumber", appendRowNumber)
+                .toString();
+    }
+
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    public static final class Builder
+    {
+        private DataSize maxMergeDistance;
+        private DataSize tinyStripeThreshold;
+        private DataSize maxBlockSize;
+        private boolean zstdJniDecompressionEnabled;
+        private boolean mapNullKeysEnabled;
+        private boolean enableTimestampMicroPrecision;
+        private boolean appendRowNumber;
+
+        private Builder() {}
+
+        public Builder withMaxMergeDistance(DataSize maxMergeDistance)
+        {
+            this.maxMergeDistance = requireNonNull(maxMergeDistance, "maxMergeDistance is null");
+            return this;
+        }
+
+        public Builder withTinyStripeThreshold(DataSize tinyStripeThreshold)
+        {
+            this.tinyStripeThreshold = requireNonNull(tinyStripeThreshold, "tinyStripeThreshold is null");
+            return this;
+        }
+
+        public Builder withMaxBlockSize(DataSize maxBlockSize)
+        {
+            this.maxBlockSize = requireNonNull(maxBlockSize, "maxBlockSize is null");
+            return this;
+        }
+
+        public Builder withZstdJniDecompressionEnabled(boolean zstdJniDecompressionEnabled)
+        {
+            this.zstdJniDecompressionEnabled = zstdJniDecompressionEnabled;
+            return this;
+        }
+
+        public Builder withMapNullKeysEnabled(boolean mapNullKeysEnabled)
+        {
+            this.mapNullKeysEnabled = mapNullKeysEnabled;
+            return this;
+        }
+
+        public Builder withEnableTimestampMicroPrecision(boolean enableTimestampMicroPrecision)
+        {
+            this.enableTimestampMicroPrecision = enableTimestampMicroPrecision;
+            return this;
+        }
+
+        public Builder withAppendRowNumber(boolean appendRowNumber)
+        {
+            this.appendRowNumber = appendRowNumber;
+            return this;
+        }
+
+        public OrcReaderOptions build()
+        {
+            return new OrcReaderOptions(
+                    maxMergeDistance,
+                    tinyStripeThreshold,
+                    maxBlockSize,
+                    zstdJniDecompressionEnabled,
+                    mapNullKeysEnabled,
+                    enableTimestampMicroPrecision,
+                    appendRowNumber);
+        }
     }
 }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/OrcReaderTestingUtils.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/OrcReaderTestingUtils.java
@@ -28,10 +28,12 @@ public class OrcReaderTestingUtils
 
     public static OrcReaderOptions createTestingReaderOptions(boolean zstdJniDecompressionEnabled)
     {
-        return new OrcReaderOptions(
-                new DataSize(1, MEGABYTE),
-                new DataSize(1, MEGABYTE),
-                new DataSize(1, MEGABYTE),
-                zstdJniDecompressionEnabled);
+        DataSize dataSize = new DataSize(1, MEGABYTE);
+        return OrcReaderOptions.builder()
+                .withMaxMergeDistance(dataSize)
+                .withTinyStripeThreshold(dataSize)
+                .withMaxBlockSize(dataSize)
+                .withZstdJniDecompressionEnabled(zstdJniDecompressionEnabled)
+                .build();
     }
 }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
@@ -1474,14 +1474,12 @@ public class OrcTester
                 orcFileTailSource,
                 stripeMetadataSource,
                 NOOP_ORC_AGGREGATED_MEMORY_CONTEXT,
-                new OrcReaderOptions(
-                        new DataSize(1, MEGABYTE),
-                        new DataSize(1, MEGABYTE),
-                        MAX_BLOCK_SIZE,
-                        false,
-                        mapNullKeysEnabled,
-                        false,
-                        false),
+                OrcReaderOptions.builder()
+                        .withMaxMergeDistance(new DataSize(1, MEGABYTE))
+                        .withTinyStripeThreshold(new DataSize(1, MEGABYTE))
+                        .withMaxBlockSize(MAX_BLOCK_SIZE)
+                        .withMapNullKeysEnabled(mapNullKeysEnabled)
+                        .build(),
                 cacheable,
                 new DwrfEncryptionProvider(new UnsupportedEncryptionLibrary(), new TestingEncryptionLibrary()),
                 DwrfKeyProvider.of(intermediateEncryptionKeys),
@@ -1510,14 +1508,12 @@ public class OrcTester
                 new StorageOrcFileTailSource(),
                 new StorageStripeMetadataSource(),
                 NOOP_ORC_AGGREGATED_MEMORY_CONTEXT,
-                new OrcReaderOptions(
-                        new DataSize(1, MEGABYTE),
-                        new DataSize(1, MEGABYTE),
-                        MAX_BLOCK_SIZE,
-                        false,
-                        mapNullKeysEnabled,
-                        false,
-                        false),
+                OrcReaderOptions.builder()
+                        .withMaxMergeDistance(new DataSize(1, MEGABYTE))
+                        .withTinyStripeThreshold(new DataSize(1, MEGABYTE))
+                        .withMaxBlockSize(MAX_BLOCK_SIZE)
+                        .withMapNullKeysEnabled(mapNullKeysEnabled)
+                        .build(),
                 false,
                 new DwrfEncryptionProvider(new UnsupportedEncryptionLibrary(), new TestingEncryptionLibrary()),
                 DwrfKeyProvider.of(intermediateEncryptionKeys),
@@ -1574,11 +1570,12 @@ public class OrcTester
                 new StorageOrcFileTailSource(),
                 new StorageStripeMetadataSource(),
                 NOOP_ORC_AGGREGATED_MEMORY_CONTEXT,
-                new OrcReaderOptions(
-                        dataSize,
-                        dataSize,
-                        dataSize,
-                        zstdJniDecompressionEnabled),
+                OrcReaderOptions.builder()
+                        .withMaxMergeDistance(dataSize)
+                        .withTinyStripeThreshold(dataSize)
+                        .withMaxBlockSize(dataSize)
+                        .withZstdJniDecompressionEnabled(zstdJniDecompressionEnabled)
+                        .build(),
                 false,
                 NO_ENCRYPTION,
                 DwrfKeyProvider.EMPTY,
@@ -1698,14 +1695,13 @@ public class OrcTester
                 new StorageOrcFileTailSource(),
                 new StorageStripeMetadataSource(),
                 NOOP_ORC_AGGREGATED_MEMORY_CONTEXT,
-                new OrcReaderOptions(
-                        new DataSize(1, MEGABYTE),
-                        new DataSize(1, MEGABYTE),
-                        MAX_BLOCK_SIZE,
-                        false,
-                        mapNullKeysEnabled,
-                        false,
-                        appendRowNumber),
+                OrcReaderOptions.builder()
+                        .withMaxMergeDistance(new DataSize(1, MEGABYTE))
+                        .withTinyStripeThreshold(new DataSize(1, MEGABYTE))
+                        .withMaxBlockSize(MAX_BLOCK_SIZE)
+                        .withMapNullKeysEnabled(mapNullKeysEnabled)
+                        .withAppendRowNumber(appendRowNumber)
+                        .build(),
                 false,
                 new DwrfEncryptionProvider(new UnsupportedEncryptionLibrary(), new TestingEncryptionLibrary()),
                 DwrfKeyProvider.of(intermediateEncryptionKeys),

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcLz4.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcLz4.java
@@ -55,11 +55,11 @@ public class TestOrcLz4
                 new StorageOrcFileTailSource(),
                 new StorageStripeMetadataSource(),
                 NOOP_ORC_AGGREGATED_MEMORY_CONTEXT,
-                new OrcReaderOptions(
-                        SIZE,
-                        SIZE,
-                        SIZE,
-                        false),
+                OrcReaderOptions.builder()
+                        .withMaxMergeDistance(SIZE)
+                        .withTinyStripeThreshold(SIZE)
+                        .withMaxBlockSize(SIZE)
+                        .build(),
                 false,
                 NO_ENCRYPTION,
                 DwrfKeyProvider.EMPTY,


### PR DESCRIPTION
OrcReaderOptions is getting more and more fields, time to make its construction a bit more verbose by adding a builder.

Test plan:
* updated existing tests

```
== NO RELEASE NOTE ==
```
