### PR TITLE
Make TestPinotSegmentPageSource single threaded

### DIFF
--- a/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotSegmentPageSource.java
+++ b/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotSegmentPageSource.java
@@ -49,6 +49,7 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 
+@Test(singleThreaded = true)
 public class TestPinotSegmentPageSource
         extends TestPinotQueryBase
 {


### PR DESCRIPTION
The different tests in this file share the same `mockPinotQueryClient` object and when the tests are run in parallel, we see exceptions due to this.

```
== NO RELEASE NOTE ==
```
