### PR TITLE
Make sure that quoted identifiers remain quoted in formatter

### DIFF
--- a/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
+++ b/presto-parser/src/main/java/com/facebook/presto/sql/SqlFormatter.java
@@ -1245,7 +1245,7 @@ public final class SqlFormatter
         public Void visitSetSession(SetSession node, Integer context)
         {
             builder.append("SET SESSION ")
-                    .append(node.getName())
+                    .append(formatName(node.getName()))
                     .append(" = ")
                     .append(formatExpression(node.getValue(), parameters));
 
@@ -1256,7 +1256,7 @@ public final class SqlFormatter
         public Void visitResetSession(ResetSession node, Integer context)
         {
             builder.append("RESET SESSION ")
-                    .append(node.getName());
+                    .append(formatName(node.getName()));
 
             return null;
         }

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -697,6 +697,19 @@ public class TestSqlParser
     }
 
     @Test
+    public void testSessionIdentifiers()
+    {
+        assertStatement("SET SESSION \"foo-bar\".baz = 'x'",
+                new SetSession(QualifiedName.of("foo-bar", "baz"), new StringLiteral("x")));
+        assertInvalidStatement("SET SESSION foo-bar.name = 'value'",
+                "mismatched input '-'. Expecting: '.', '='");
+        assertStatement("RESET SESSION \"foo-bar\".baz",
+                new ResetSession(QualifiedName.of("foo-bar", "baz")));
+        assertInvalidStatement("RESET SESSION foo-bar.name",
+                "mismatched input '-'. Expecting: '.', <EOF>");
+    }
+
+    @Test
     public void testShowSession()
     {
         assertStatement("SHOW SESSION", new ShowSession());


### PR DESCRIPTION
Cherry-pick of https://github.com/trinodb/trino/pull/11171
The SqlFormatter effectively drops quotes from the quoted identifiers
when formatting 'SET SESSION' statement.
This causes valid queries to fail: e.g. SET SESSION
"name-suffix".property = 'value' PrestoException: Formatted query does
not parse even when identifier (name-suffix) is quoted.

Follow up https://github.com/prestodb/presto/pull/17186

Co-authored-by: Sergey Melnychuk <sergey.melnychuk@starburstdata.com>

Test plan - Added a test

```
== RELEASE NOTES ==

General Changes
* Make sure that quoted identifiers remain quoted in formatter
```
