### PR TITLE
Return early for non-system Iceberg tables

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHadoopMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHadoopMetadata.java
@@ -130,6 +130,10 @@ public class IcebergHadoopMetadata
     public Optional<SystemTable> getSystemTable(ConnectorSession session, SchemaTableName tableName)
     {
         IcebergTableName name = IcebergTableName.from(tableName.getTableName());
+        if (name.getTableType() == DATA) {
+            return Optional.empty();
+        }
+
         TableIdentifier tableIdentifier = toIcebergTableIdentifier(tableName.getSchemaName(), name.getTableName());
         Table table;
         try {

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
@@ -143,6 +143,9 @@ public class IcebergHiveMetadata
     private Optional<SystemTable> getRawSystemTable(ConnectorSession session, SchemaTableName tableName)
     {
         IcebergTableName name = IcebergTableName.from(tableName.getTableName());
+        if (name.getTableType() == DATA) {
+            return Optional.empty();
+        }
 
         MetastoreContext metastoreContext = new MetastoreContext(session.getIdentity(), session.getQueryId(), session.getClientInfo(), session.getSource(), Optional.empty(), false, HiveColumnConverterProvider.DEFAULT_COLUMN_CONVERTER_PROVIDER);
         Optional<Table> hiveTable = metastore.getTable(metastoreContext, tableName.getSchemaName(), name.getTableName());


### PR DESCRIPTION
Avoid redundant metastore calls for non-system Iceberg tables.
Cherry-pick of https://github.com/trinodb/trino/commit/d29fcd983afba99c3e3b76e530ebc9b5713fc3c3

Co-Authored-By: Piotr Findeisen <piotr.findeisen@gmail.com>

```
== NO RELEASE NOTE ==
```
