### PR TITLE
Fix small inefficiency in StripeReader

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/StripeReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/StripeReader.java
@@ -236,7 +236,7 @@ public class StripeReader
         ImmutableMap.Builder<StreamId, DiskRange> diskRangesBuilder = ImmutableMap.builder();
         for (Entry<StreamId, DiskRange> entry : getDiskRanges(allStreams).entrySet()) {
             StreamId streamId = entry.getKey();
-            if (includedStreams.keySet().contains(streamId)) {
+            if (includedStreams.containsKey(streamId)) {
                 diskRangesBuilder.put(entry);
             }
         }


### PR DESCRIPTION
Test plan:
* existing tests

```
== NO RELEASE NOTE ==
```
