### PR TITLE
Add RuntimeStats to track read calls to underlying storage

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/RuntimeMetricName.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/RuntimeMetricName.java
@@ -44,4 +44,8 @@ public class RuntimeMetricName
     public static final String TASK_SCHEDULED_TIME_NANOS = "taskScheduledTimeNanos";
     // Blocked time for the operators due to waiting for inputs.
     public static final String TASK_BLOCKED_TIME_NANOS = "taskBlockedTimeNanos";
+    // Time taken for a read call to storage
+    public static final String STORAGE_READ_TIME_NANOS = "storageReadTimeNanos";
+    // Size of the data retrieved by read call to storage
+    public static final String STORAGE_READ_DATA_BYTES = "storageReadDataBytes";
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/ScanFilterAndProjectOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ScanFilterAndProjectOperator.java
@@ -15,6 +15,7 @@ package com.facebook.presto.operator;
 
 import com.facebook.presto.common.Page;
 import com.facebook.presto.common.PageBuilder;
+import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.LazyBlock;
 import com.facebook.presto.common.block.LazyBlockLoader;
@@ -53,6 +54,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 
 import static com.facebook.airlift.concurrent.MoreFutures.toListenableFuture;
+import static com.facebook.presto.common.RuntimeMetricName.STORAGE_READ_DATA_BYTES;
+import static com.facebook.presto.common.RuntimeMetricName.STORAGE_READ_TIME_NANOS;
 import static com.facebook.presto.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext;
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
@@ -344,10 +347,16 @@ public class ScanFilterAndProjectOperator
         long endCompletedPositions = pageSource.getCompletedPositions();
         long endReadTimeNanos = pageSource.getReadTimeNanos();
         long inputBytes = endCompletedBytes - completedBytes;
+        long inputBytesReadTime = endReadTimeNanos - readTimeNanos;
         long positionCount = endCompletedPositions - completedPositions;
         operatorContext.recordProcessedInput(inputBytes, positionCount);
-        operatorContext.recordRawInputWithTiming(inputBytes, positionCount, endReadTimeNanos - readTimeNanos);
-        operatorContext.updateStats(pageSource.getRuntimeStats());
+        operatorContext.recordRawInputWithTiming(inputBytes, positionCount, inputBytesReadTime);
+        RuntimeStats runtimeStats = pageSource.getRuntimeStats();
+        if (runtimeStats != null) {
+            runtimeStats.addMetricValueIgnoreZero(STORAGE_READ_TIME_NANOS, inputBytesReadTime);
+            runtimeStats.addMetricValueIgnoreZero(STORAGE_READ_DATA_BYTES, inputBytes);
+            operatorContext.updateStats(runtimeStats);
+        }
         completedBytes = endCompletedBytes;
         completedPositions = endCompletedPositions;
         readTimeNanos = endReadTimeNanos;

--- a/presto-main/src/main/java/com/facebook/presto/operator/TableScanOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TableScanOperator.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.operator;
 
 import com.facebook.presto.common.Page;
+import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.memory.context.LocalMemoryContext;
 import com.facebook.presto.metadata.Split;
 import com.facebook.presto.spi.ColumnHandle;
@@ -38,6 +39,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 
 import static com.facebook.airlift.concurrent.MoreFutures.toListenableFuture;
+import static com.facebook.presto.common.RuntimeMetricName.STORAGE_READ_DATA_BYTES;
+import static com.facebook.presto.common.RuntimeMetricName.STORAGE_READ_TIME_NANOS;
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
 
@@ -272,10 +275,16 @@ public class TableScanOperator
         long endCompletedPositions = source.getCompletedPositions();
         long endReadTimeNanos = source.getReadTimeNanos();
         long inputBytes = endCompletedBytes - completedBytes;
+        long inputBytesReadTime = endReadTimeNanos - readTimeNanos;
         long positionCount = endCompletedPositions - completedPositions;
         operatorContext.recordProcessedInput(inputBytes, positionCount);
-        operatorContext.recordRawInputWithTiming(inputBytes, positionCount, endReadTimeNanos - readTimeNanos);
-        operatorContext.updateStats(source.getRuntimeStats());
+        operatorContext.recordRawInputWithTiming(inputBytes, positionCount, inputBytesReadTime);
+        RuntimeStats runtimeStats = source.getRuntimeStats();
+        if (runtimeStats != null) {
+            runtimeStats.addMetricValueIgnoreZero(STORAGE_READ_TIME_NANOS, inputBytesReadTime);
+            runtimeStats.addMetricValueIgnoreZero(STORAGE_READ_DATA_BYTES, inputBytes);
+            operatorContext.updateStats(runtimeStats);
+        }
         completedBytes = endCompletedBytes;
         completedPositions = endCompletedPositions;
         readTimeNanos = endReadTimeNanos;


### PR DESCRIPTION
```
== NO RELEASE NOTE ==
```

Testing:
Ran a simple query in local setup. We can see the metrics as follows:
<img width="582" alt="Screen Shot 2022-03-07 at 8 22 30 PM" src="https://user-images.githubusercontent.com/10070724/157165788-f7d47c56-021a-42d6-8697-0702971bdee4.png">

