### PR TITLE
Create warning for approx_distinct and approx_set with low maxStandardError

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -219,6 +219,7 @@ public final class SystemSessionProperties
     public static final String VERBOSE_RUNTIME_STATS_ENABLED = "verbose_runtime_stats_enabled";
     public static final String STREAMING_FOR_PARTIAL_AGGREGATION_ENABLED = "streaming_for_partial_aggregation_enabled";
     public static final String MAX_STAGE_COUNT_FOR_EAGER_SCHEDULING = "max_stage_count_for_eager_scheduling";
+    public static final String HYPERLOGLOG_STANDARD_ERROR_WARNING_THRESHOLD = "hyperloglog_standard_error_warning_threshold";
 
     //TODO: Prestissimo related session properties that are temporarily put here. They will be relocated in the future
     public static final String PRESTISSIMO_SIMPLIFIED_EXPRESSION_EVALUATION_ENABLED = "simplified_expression_evaluation_enabled";
@@ -1235,6 +1236,11 @@ public final class SystemSessionProperties
                         MAX_STAGE_COUNT_FOR_EAGER_SCHEDULING,
                         "Maximum stage count to use eager scheduling when using the adaptive scheduling policy",
                         featuresConfig.getMaxStageCountForEagerScheduling(),
+                        false),
+                doubleProperty(
+                        HYPERLOGLOG_STANDARD_ERROR_WARNING_THRESHOLD,
+                        "Threshold for obtaining precise results from aggregation functions",
+                        featuresConfig.getHyperloglogStandardErrorWarningThreshold(),
                         false));
     }
 
@@ -2074,5 +2080,10 @@ public final class SystemSessionProperties
     public static int getMaxStageCountForEagerScheduling(Session session)
     {
         return session.getSystemProperty(MAX_STAGE_COUNT_FOR_EAGER_SCHEDULING, Integer.class);
+    }
+
+    public static double getHyperloglogStandardErrorWarningThreshold(Session session)
+    {
+        return session.getSystemProperty(HYPERLOGLOG_STANDARD_ERROR_WARNING_THRESHOLD, Double.class);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/execution/warnings/DefaultWarningCollector.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/warnings/DefaultWarningCollector.java
@@ -18,13 +18,13 @@ import com.facebook.presto.spi.PrestoWarning;
 import com.facebook.presto.spi.WarningCode;
 import com.facebook.presto.spi.WarningCollector;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.LinkedHashMultimap;
+import com.google.common.collect.Multimap;
 
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 
 import static com.facebook.presto.spi.StandardErrorCode.WARNING_AS_ERROR;
 import static com.facebook.presto.spi.StandardWarningCode.PARSER_WARNING;
@@ -35,7 +35,7 @@ public class DefaultWarningCollector
         implements WarningCollector
 {
     @GuardedBy("this")
-    private final Map<WarningCode, PrestoWarning> warnings = new LinkedHashMap<>();
+    private final Multimap<WarningCode, PrestoWarning> warnings = LinkedHashMultimap.create();
     private final WarningCollectorConfig config;
     private final WarningHandlingLevel warningHandlingLevel;
 
@@ -77,7 +77,7 @@ public class DefaultWarningCollector
     private synchronized void addWarningIfNumWarningsLessThanConfig(PrestoWarning warning)
     {
         if (warnings.size() < config.getMaxWarnings()) {
-            warnings.putIfAbsent(warning.getWarningCode(), warning);
+            warnings.put(warning.getWarningCode(), warning);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/DefaultApproximateCountDistinctAggregation.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/DefaultApproximateCountDistinctAggregation.java
@@ -37,7 +37,7 @@ import static com.facebook.presto.common.function.OperatorType.XX_HASH_64;
 @AggregationFunction("approx_distinct")
 public final class DefaultApproximateCountDistinctAggregation
 {
-    private static final double DEFAULT_STANDARD_ERROR = 0.023;
+    public static final double DEFAULT_STANDARD_ERROR = 0.023;
 
     private DefaultApproximateCountDistinctAggregation() {}
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -218,6 +218,8 @@ public class FeaturesConfig
 
     private int maxStageCountForEagerScheduling = 25;
 
+    private double hyperloglogStandardErrorWarningThreshold = 0.004;
+
     public enum PartitioningPrecisionStrategy
     {
         // Let Presto decide when to repartition
@@ -1983,6 +1985,19 @@ public class FeaturesConfig
     public FeaturesConfig setMaxStageCountForEagerScheduling(int maxStageCountForEagerScheduling)
     {
         this.maxStageCountForEagerScheduling = maxStageCountForEagerScheduling;
+        return this;
+    }
+
+    public double getHyperloglogStandardErrorWarningThreshold()
+    {
+        return hyperloglogStandardErrorWarningThreshold;
+    }
+
+    @Config("hyperloglog-standard-error-warning-threshold")
+    @ConfigDescription("aggregation functions can produce low-precision results when the max standard error lower than this value.")
+    public FeaturesConfig setHyperloglogStandardErrorWarningThreshold(double hyperloglogStandardErrorWarningThreshold)
+    {
+        this.hyperloglogStandardErrorWarningThreshold = hyperloglogStandardErrorWarningThreshold;
         return this;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -2554,11 +2554,11 @@ class StatementAnalyzer
                         .collect(toImmutableList());
 
                 for (Expression expression : outputExpressions) {
-                    verifySourceAggregations(distinctGroupingColumns, sourceScope, expression, metadata, analysis, warningCollector);
+                    verifySourceAggregations(distinctGroupingColumns, sourceScope, expression, metadata, analysis, warningCollector, session);
                 }
 
                 for (Expression expression : orderByExpressions) {
-                    verifyOrderByAggregations(distinctGroupingColumns, sourceScope, orderByScope.get(), expression, metadata, analysis, warningCollector);
+                    verifyOrderByAggregations(distinctGroupingColumns, sourceScope, orderByScope.get(), expression, metadata, analysis, warningCollector, session);
                 }
             }
         }

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/FunctionResolution.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/FunctionResolution.java
@@ -303,4 +303,28 @@ public final class FunctionResolution
     {
         return functionAndTypeManager.lookupFunction("min", fromTypes(valueType));
     }
+
+    @Override
+    public boolean isApproximateCountDistinctFunction(FunctionHandle functionHandle)
+    {
+        return functionAndTypeManager.getFunctionMetadata(functionHandle).getName().equals(QualifiedObjectName.valueOf(DEFAULT_NAMESPACE, "approx_distinct"));
+    }
+
+    @Override
+    public FunctionHandle approximateCountDistinctFunction(Type valueType)
+    {
+        return functionAndTypeManager.lookupFunction("approx_distinct", fromTypes(valueType));
+    }
+
+    @Override
+    public boolean isApproximateSetFunction(FunctionHandle functionHandle)
+    {
+        return functionAndTypeManager.getFunctionMetadata(functionHandle).getName().equals(QualifiedObjectName.valueOf(DEFAULT_NAMESPACE, "approx_set"));
+    }
+
+    @Override
+    public FunctionHandle approximateSetFunction(Type valueType)
+    {
+        return functionAndTypeManager.lookupFunction("approx_set", fromTypes(valueType));
+    }
 }

--- a/presto-main/src/main/java/com/facebook/presto/testing/TestingWarningCollector.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/TestingWarningCollector.java
@@ -19,13 +19,13 @@ import com.facebook.presto.spi.WarningCode;
 import com.facebook.presto.spi.WarningCollector;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.LinkedHashMultimap;
+import com.google.common.collect.Multimap;
 
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.lang.String.format;
@@ -36,7 +36,7 @@ public class TestingWarningCollector
         implements WarningCollector
 {
     @GuardedBy("this")
-    private final Map<WarningCode, PrestoWarning> warnings = new LinkedHashMap<>();
+    private final Multimap<WarningCode, PrestoWarning> warnings = LinkedHashMultimap.create();
     private final WarningCollectorConfig config;
 
     private final boolean addWarnings;
@@ -59,7 +59,7 @@ public class TestingWarningCollector
     {
         requireNonNull(warning, "warning is null");
         if (warnings.size() < config.getMaxWarnings()) {
-            warnings.putIfAbsent(warning.getWarningCode(), warning);
+            warnings.put(warning.getWarningCode(), warning);
         }
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/execution/warnings/TestDefaultWarningCollector.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/warnings/TestDefaultWarningCollector.java
@@ -43,6 +43,17 @@ public class TestDefaultWarningCollector
     }
 
     @Test
+    public void testAddingSameTypeWarnings()
+    {
+        WarningCollector warningCollector = new DefaultWarningCollector(new WarningCollectorConfig(), WarningHandlingLevel.NORMAL);
+        warningCollector.add(new PrestoWarning(new WarningCode(1, "1"), "warning 1-1"));
+        warningCollector.add(new PrestoWarning(new WarningCode(1, "1"), "warning 1-2"));
+        warningCollector.add(new PrestoWarning(new WarningCode(2, "2"), "warning 2"));
+        warningCollector.add(new PrestoWarning(new WarningCode(3, "3"), "warning 3"));
+        assertEquals(warningCollector.getWarnings().size(), 4);
+    }
+
+    @Test
     public void testWarningSuppress()
     {
         WarningCollector warningCollector = new DefaultWarningCollector(new WarningCollectorConfig(), WarningHandlingLevel.SUPPRESS);

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -189,7 +189,8 @@ public class TestFeaturesConfig
                 .setHashBasedDistinctLimitEnabled(false)
                 .setHashBasedDistinctLimitThreshold(10000)
                 .setStreamingForPartialAggregationEnabled(false)
-                .setMaxStageCountForEagerScheduling(25));
+                .setMaxStageCountForEagerScheduling(25)
+                .setHyperloglogStandardErrorWarningThreshold(0.004));
     }
 
     @Test
@@ -330,6 +331,7 @@ public class TestFeaturesConfig
                 .put("hash-based-distinct-limit-threshold", "500")
                 .put("streaming-for-partial-aggregation-enabled", "true")
                 .put("execution-policy.max-stage-count-for-eager-scheduling", "123")
+                .put("hyperloglog-standard-error-warning-threshold", "0.02")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -467,7 +469,8 @@ public class TestFeaturesConfig
                 .setHashBasedDistinctLimitEnabled(true)
                 .setHashBasedDistinctLimitThreshold(500)
                 .setStreamingForPartialAggregationEnabled(true)
-                .setMaxStageCountForEagerScheduling(123);
+                .setMaxStageCountForEagerScheduling(123)
+                .setHyperloglogStandardErrorWarningThreshold(0.02);
         assertFullMapping(properties, expected);
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/function/StandardFunctionResolution.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/function/StandardFunctionResolution.java
@@ -71,4 +71,12 @@ public interface StandardFunctionResolution
     boolean isMinFunction(FunctionHandle functionHandle);
 
     FunctionHandle minFunction(Type valueType);
+
+    boolean isApproximateCountDistinctFunction(FunctionHandle functionHandle);
+
+    FunctionHandle approximateCountDistinctFunction(Type valueType);
+
+    boolean isApproximateSetFunction(FunctionHandle functionHandle);
+
+    FunctionHandle approximateSetFunction(Type valueType);
 }


### PR DESCRIPTION
approx_distinct and approx_set can produce imprecise results when the max standard error is low, this commit issues a performance warning when approx_distinct or approx_set is invoked with a maxStandardError less than or equal to the threshold (currently set to 0.004).

Test plan 
- Unit tests
 - Testing on local client (`presto-cli/target/presto-cli-*-executable.jar --catalog tpch --schema sf1 --debug`)
```
SELECT approx_distinct(nationkey) FROM customer GROUP BY mktsegment;
_col0 
-------
    25 
    25 
    25 
    25 
    25 
(5 rows)

WARNING: approx_distinct can produce low-precision results with the current standard error: 0.0230 (<=0.0230)


SELECT approx_distinct(nationkey, 0.0229E0) FROM customer GROUP BY mktsegment;
_col0 
-------
    25 
    25 
    25 
    25 
    25 
(5 rows)

WARNING: approx_distinct can produce low-precision results with the current standard error: 0.0229 (<=0.0230)


SELECT approx_distinct(nationkey, 0.0245E0) FROM customer GROUP BY mktsegment;
_col0 
-------
    25 
    25 
    25 
    25 
    25 
(5 rows)

```
```
SELECT approx_set(nationkey) FROM customer GROUP BY mktsegment;
_col0                      
-------------------------------------------------
 02 0c 19 00 80 03 44 00 40 ec c9 06 c0 c5 d4 0f+
 00 34 2f 12 86 1d 34 1b 80 ae 15 28 80 63 df 28+
 81 29 e1 30 00 63 ae 38 82 d2 87 39 00 fd db 53+
 00 58 3d 5b 41 3e 9a 5d 82 a9 3b 61 02 62 14 7c+
 c0 88 eb 91 c2 f7 e1 95 80 bb 20 9d 42 ba 62 a7+
 81 9e 0c a9 01 d2 19 b4 00 e5 ec bb 80 20 08 de+
 40 0e c3 ec 81 e2 49 f2                         
 02 0c 19 00 80 03 44 00 40 ec c9 06 c0 c5 d4 0f+
 00 34 2f 12 86 1d 34 1b 80 ae 15 28 80 63 df 28+
 81 29 e1 30 00 63 ae 38 82 d2 87 39 00 fd db 53+
 00 58 3d 5b 41 3e 9a 5d 82 a9 3b 61 02 62 14 7c+
 c0 88 eb 91 c2 f7 e1 95 80 bb 20 9d 42 ba 62 a7+
 81 9e 0c a9 01 d2 19 b4 00 e5 ec bb 80 20 08 de+
 40 0e c3 ec 81 e2 49 f2                         
 02 0c 19 00 80 03 44 00 40 ec c9 06 c0 c5 d4 0f+
 00 34 2f 12 86 1d 34 1b 80 ae 15 28 80 63 df 28+

WARNING: approx_set can produce low-precision results with the current standard error: 0.0163 (<=0.0163)


SELECT approx_set(nationkey, 0.01550E0) FROM customer GROUP BY mktsegment;
_col0                      
-------------------------------------------------
 02 0d 19 00 80 03 44 00 40 ec c9 06 c0 c5 d4 0f+
 00 34 2f 12 86 1d 34 1b 80 ae 15 28 80 63 df 28+
 81 29 e1 30 00 63 ae 38 82 d2 87 39 00 fd db 53+
 00 58 3d 5b 41 3e 9a 5d 82 a9 3b 61 02 62 14 7c+
 c0 88 eb 91 c2 f7 e1 95 80 bb 20 9d 42 ba 62 a7+
 81 9e 0c a9 01 d2 19 b4 00 e5 ec bb 80 20 08 de+
 40 0e c3 ec 81 e2 49 f2                         
 02 0d 19 00 80 03 44 00 40 ec c9 06 c0 c5 d4 0f+
 00 34 2f 12 86 1d 34 1b 80 ae 15 28 80 63 df 28+
 81 29 e1 30 00 63 ae 38 82 d2 87 39 00 fd db 53+
 00 58 3d 5b 41 3e 9a 5d 82 a9 3b 61 02 62 14 7c+
 c0 88 eb 91 c2 f7 e1 95 80 bb 20 9d 42 ba 62 a7+
 81 9e 0c a9 01 d2 19 b4 00 e5 ec bb 80 20 08 de+
 40 0e c3 ec 81 e2 49 f2                         
 02 0d 19 00 80 03 44 00 40 ec c9 06 c0 c5 d4 0f+
 00 34 2f 12 86 1d 34 1b 80 ae 15 28 80 63 df 28+

WARNING: approx_set can produce low-precision results with the current standard error: 0.0155 (<=0.0163)

SELECT approx_set(nationkey, 0.02530E0) FROM customer GROUP BY mktsegment;
_col0                      
-------------------------------------------------
 02 0b 19 00 80 03 44 00 40 ec c9 06 c0 c5 d4 0f+
 00 34 2f 12 86 1d 34 1b 80 ae 15 28 80 63 df 28+
 81 29 e1 30 00 63 ae 38 82 d2 87 39 00 fd db 53+
 00 58 3d 5b 41 3e 9a 5d 82 a9 3b 61 02 62 14 7c+
 c0 88 eb 91 c2 f7 e1 95 80 bb 20 9d 42 ba 62 a7+
 81 9e 0c a9 01 d2 19 b4 00 e5 ec bb 80 20 08 de+
 40 0e c3 ec 81 e2 49 f2                         
 02 0b 19 00 80 03 44 00 40 ec c9 06 c0 c5 d4 0f+
 00 34 2f 12 86 1d 34 1b 80 ae 15 28 80 63 df 28+
 81 29 e1 30 00 63 ae 38 82 d2 87 39 00 fd db 53+
 00 58 3d 5b 41 3e 9a 5d 82 a9 3b 61 02 62 14 7c+
 c0 88 eb 91 c2 f7 e1 95 80 bb 20 9d 42 ba 62 a7+
 81 9e 0c a9 01 d2 19 b4 00 e5 ec bb 80 20 08 de+
 40 0e c3 ec 81 e2 49 f2                         
 02 0b 19 00 80 03 44 00 40 ec c9 06 c0 c5 d4 0f+
 00 34 2f 12 86 1d 34 1b 80 ae 15 28 80 63 df 28+
```

SELECT approx_distinct(nationkey, 0.0041E0), approx_set(nationkey, 0.0051E0) FROM customer GROUP BY mktsegment;
```
 _col0 |                      _col1                      
-------+-------------------------------------------------
    25 | 02 10 19 00 80 03 44 00 40 ec c9 06 c0 c5 d4 0f+
       | 00 34 2f 12 86 1d 34 1b 80 ae 15 28 80 63 df 28+
       | 81 29 e1 30 00 63 ae 38 82 d2 87 39 00 fd db 53+
       | 00 58 3d 5b 41 3e 9a 5d 82 a9 3b 61 02 62 14 7c+
       | c0 88 eb 91 c2 f7 e1 95 80 bb 20 9d 42 ba 62 a7+
       | 81 9e 0c a9 01 d2 19 b4 00 e5 ec bb 80 20 08 de+
       | 40 0e c3 ec 81 e2 49 f2                         
    25 | 02 10 19 00 80 03 44 00 40 ec c9 06 c0 c5 d4 0f+
       | 00 34 2f 12 86 1d 34 1b 80 ae 15 28 80 63 df 28+
       | 81 29 e1 30 00 63 ae 38 82 d2 87 39 00 fd db 53+
       | 00 58 3d 5b 41 3e 9a 5d 82 a9 3b 61 02 62 14 7c+
       | c0 88 eb 91 c2 f7 e1 95 80 bb 20 9d 42 ba 62 a7+
       | 81 9e 0c a9 01 d2 19 b4 00 e5 ec bb 80 20 08 de+
       | 40 0e c3 ec 81 e2 49 f2                         
    25 | 02 10 19 00 80 03 44 00 40 ec c9 06 c0 c5 d4 0f+
       | 00 34 2f 12 86 1d 34 1b 80 ae 15 28 80 63 df 28+

WARNING: approx_distinct can produce low-precision results with the current standard error: 0.0041 (<=0.0080)
WARNING: approx_set can produce low-precision results with the current standard error: 0.0051 (<=0.0080)
```

```
== RELEASE NOTES ==

General Changes

* Raise warnings on functions ``approx_distinct`` and ``approx_set`` producing low-precision results when the input standard error is too large. The threshold can be set through session property `hyperloglog_standard_error_warning_threshold` or config `hyperloglog-standard-error-warning-threshold` with a default value of `0.4%`
```