### PR TITLE
Add support for GRANT UPDATE statement

### DIFF
--- a/presto-docs/src/main/sphinx/sql/grant.rst
+++ b/presto-docs/src/main/sphinx/sql/grant.rst
@@ -16,7 +16,7 @@ Description
 
 Grants the specified privileges to the specified grantee.
 
-Specifying ``ALL PRIVILEGES`` grants :doc:`delete`, :doc:`insert` and :doc:`select` privileges.
+Specifying ``ALL PRIVILEGES`` grants :doc:`delete`, :doc:`insert`, :doc:`update` and :doc:`select` privileges.
 
 Specifying ``ROLE PUBLIC`` grants privileges to the ``PUBLIC`` role and hence to all users.
 

--- a/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
+++ b/presto-parser/src/main/antlr4/com/facebook/presto/sql/parser/SqlBase.g4
@@ -519,7 +519,7 @@ callArgument
     ;
 
 privilege
-    : SELECT | DELETE | INSERT | identifier
+    : SELECT | DELETE | INSERT | UPDATE | identifier
     ;
 
 qualifiedName

--- a/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
+++ b/presto-parser/src/test/java/com/facebook/presto/sql/parser/TestSqlParser.java
@@ -1767,6 +1767,13 @@ public class TestSqlParser
                         QualifiedName.of("t"),
                         new PrincipalSpecification(PrincipalSpecification.Type.UNSPECIFIED, new Identifier("u")),
                         false));
+        assertStatement("GRANT UPDATE ON t TO u",
+                new Grant(
+                        Optional.of(ImmutableList.of("UPDATE")),
+                        false,
+                        QualifiedName.of("t"),
+                        new PrincipalSpecification(PrincipalSpecification.Type.UNSPECIFIED, new Identifier("u")),
+                        false));
         assertStatement("GRANT SELECT ON t TO ROLE PUBLIC WITH GRANT OPTION",
                 new Grant(
                         Optional.of(ImmutableList.of("SELECT")),
@@ -1796,6 +1803,13 @@ public class TestSqlParser
                 new Revoke(
                         false,
                         Optional.of(ImmutableList.of("INSERT", "DELETE")),
+                        false,
+                        QualifiedName.of("t"),
+                        new PrincipalSpecification(PrincipalSpecification.Type.UNSPECIFIED, new Identifier("u"))));
+        assertStatement("REVOKE UPDATE ON t FROM u",
+                new Revoke(
+                        false,
+                        Optional.of(ImmutableList.of("UPDATE")),
                         false,
                         QualifiedName.of("t"),
                         new PrincipalSpecification(PrincipalSpecification.Type.UNSPECIFIED, new Identifier("u"))));

--- a/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestSqlStandardAccessControlChecks.java
+++ b/presto-product-tests/src/main/java/com/facebook/presto/tests/hive/TestSqlStandardAccessControlChecks.java
@@ -84,6 +84,21 @@ public class TestSqlStandardAccessControlChecks
     }
 
     @Test(groups = {AUTHORIZATION, PROFILE_SPECIFIC_TESTS})
+    public void testAccessControlUpdate()
+    {
+        assertThat(() -> bobExecutor.executeQuery(format("UPDATE %s SET month=3, day=22", tableName)))
+                .failsWithMessage(format("Access Denied: Cannot update columns [month, day] in table default.%s", tableName));
+
+        aliceExecutor.executeQuery(format("GRANT INSERT ON %s TO bob", tableName));
+        assertThat(() -> bobExecutor.executeQuery(format("UPDATE %s SET month=3, day=22", tableName)))
+                .failsWithMessage(format("Access Denied: Cannot update columns [month, day] in table default.%s", tableName));
+
+        aliceExecutor.executeQuery(format("GRANT UPDATE ON %s TO bob", tableName));
+        assertThat(() -> bobExecutor.executeQuery(format("UPDATE %s SET month=3, day=22", tableName)))
+                .failsWithMessage("Hive update is only supported for ACID transactional tables");
+    }
+
+    @Test(groups = {AUTHORIZATION, PROFILE_SPECIFIC_TESTS})
     public void testAccessControlDelete()
     {
         aliceExecutor.executeQuery(format("INSERT INTO %s VALUES (4, 13)", tableName));


### PR DESCRIPTION
Cherry-pick of https://github.com/trinodb/trino/pull/8279

Co-authored-by: Raunaq Morarka <raunaqmorarka@gmail.com>

Test plan - Added tests

```
== RELEASE NOTES ==

General Changes
* Add support for GRANT UPDATE statement

```

