### PR TITLE
Enable retrying max requests queued exception.

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/server/RequestErrorTracker.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/RequestErrorTracker.java
@@ -116,7 +116,14 @@ public class RequestErrorTracker
         }
 
         if (reason instanceof RejectedExecutionException) {
-            throw new PrestoException(errorCode, reason);
+            if (reason.getMessage() == null) {
+                throw new PrestoException(errorCode, reason);
+            }
+
+            // We want to do exponential backoff to allow OOT killer to kill queries and not fail immediately.
+            if (!reason.getMessage().contains("Max requests queued per destination")) {
+                throw new PrestoException(errorCode, reason);
+            }
         }
 
         // log failure message


### PR DESCRIPTION
Presto server kills queries to keep overall task count within a threshold. Sometimes, a number of queries comes with very high stages that spikes overall task count. Now, these queries usually fails with Remote Task Error very quickly and query killing mechanism does not get a chance to kill those properly. In this case, we are retrying such errors that will keep the query alive for a bit longer period of time, which will allow to gracefully kill queries.
