### PR TITLE
add presto delegation token client option

### DIFF
--- a/presto-benchmark-driver/src/main/java/com/facebook/presto/benchmark/driver/BenchmarkDriverOptions.java
+++ b/presto-benchmark-driver/src/main/java/com/facebook/presto/benchmark/driver/BenchmarkDriverOptions.java
@@ -99,6 +99,7 @@ public class BenchmarkDriverOptions
                 null,
                 catalog,
                 schema,
+                null,
                 TimeZone.getDefault().getID(),
                 Locale.getDefault(),
                 ImmutableMap.of(),

--- a/presto-cli/src/main/java/com/facebook/presto/cli/ClientOptions.java
+++ b/presto-cli/src/main/java/com/facebook/presto/cli/ClientOptions.java
@@ -83,6 +83,9 @@ public class ClientOptions
     @Option(name = "--access-token", title = "access token", description = "Access token")
     public String accessToken;
 
+    @Option(name = "--delegation-token", title = "delegation token", description = "HDFS delegation token")
+    public String delegationToken;
+
     @Option(name = "--user", title = "user", description = "Username")
     public String user = System.getProperty("user.name");
 
@@ -165,6 +168,7 @@ public class ClientOptions
                 clientInfo,
                 catalog,
                 schema,
+                delegationToken,
                 TimeZone.getDefault().getID(),
                 Locale.getDefault(),
                 toResourceEstimates(resourceEstimates),

--- a/presto-cli/src/test/java/com/facebook/presto/cli/AbstractCliTest.java
+++ b/presto-cli/src/test/java/com/facebook/presto/cli/AbstractCliTest.java
@@ -73,6 +73,7 @@ public abstract class AbstractCliTest
                 "clientInfo",
                 "catalog",
                 "schema",
+                "delegation",
                 "America/Los_Angeles",
                 Locale.ENGLISH,
                 ImmutableMap.of(),

--- a/presto-client/pom.xml
+++ b/presto-client/pom.xml
@@ -116,5 +116,11 @@
             <artifactId>drift-codec-utils</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/presto-client/src/main/java/com/facebook/presto/client/ClientSession.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/ClientSession.java
@@ -42,6 +42,7 @@ public class ClientSession
     private final String clientInfo;
     private final String catalog;
     private final String schema;
+    private final String delegation;
     private final TimeZoneKey timeZone;
     private final Locale locale;
     private final Map<String, String> resourceEstimates;
@@ -76,6 +77,7 @@ public class ClientSession
             String clientInfo,
             String catalog,
             String schema,
+            String delegation,
             String timeZoneId,
             Locale locale,
             Map<String, String> resourceEstimates,
@@ -97,6 +99,7 @@ public class ClientSession
         this.clientInfo = clientInfo;
         this.catalog = catalog;
         this.schema = schema;
+        this.delegation = delegation;
         this.locale = locale;
         this.timeZone = TimeZoneKey.getTimeZoneKey(timeZoneId);
         this.transactionId = transactionId;
@@ -185,6 +188,11 @@ public class ClientSession
     public String getSchema()
     {
         return schema;
+    }
+
+    public String getDelegation()
+    {
+        return delegation;
     }
 
     public TimeZoneKey getTimeZone()
@@ -284,6 +292,7 @@ public class ClientSession
         private String clientInfo;
         private String catalog;
         private String schema;
+        private String delegation;
         private TimeZoneKey timeZone;
         private Locale locale;
         private Map<String, String> resourceEstimates;
@@ -308,6 +317,7 @@ public class ClientSession
             clientInfo = clientSession.getClientInfo();
             catalog = clientSession.getCatalog();
             schema = clientSession.getSchema();
+            delegation = clientSession.getDelegation();
             timeZone = clientSession.getTimeZone();
             locale = clientSession.getLocale();
             resourceEstimates = clientSession.getResourceEstimates();
@@ -343,6 +353,12 @@ public class ClientSession
         public Builder withRoles(Map<String, SelectedRole> roles)
         {
             this.roles = roles;
+            return this;
+        }
+
+        public Builder withDelegation(String delegation)
+        {
+            this.delegation = requireNonNull(delegation, "delegation is null");
             return this;
         }
 
@@ -399,6 +415,7 @@ public class ClientSession
                     clientInfo,
                     catalog,
                     schema,
+                    delegation,
                     timeZone.getId(),
                     locale,
                     resourceEstimates,

--- a/presto-client/src/main/java/com/facebook/presto/client/OkHttpUtil.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/OkHttpUtil.java
@@ -50,6 +50,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
+import static com.facebook.presto.client.PrestoHeaders.PRESTO_DELEGATION_TOKEN;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.net.HttpHeaders.AUTHORIZATION;
 import static com.google.common.net.HttpHeaders.USER_AGENT;
@@ -90,6 +91,15 @@ public final class OkHttpUtil
         String credential = Credentials.basic(user, password);
         return chain -> chain.proceed(chain.request().newBuilder()
                 .header(AUTHORIZATION, credential)
+                .build());
+    }
+
+    public static Interceptor delegationTokenAuth(String delegationToken)
+    {
+        requireNonNull(delegationToken, "delegation token is null");
+
+        return chain -> chain.proceed(chain.request().newBuilder()
+                .header(PRESTO_DELEGATION_TOKEN, delegationToken)
                 .build());
     }
 

--- a/presto-client/src/main/java/com/facebook/presto/client/PrestoHeaders.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/PrestoHeaders.java
@@ -23,6 +23,7 @@ public final class PrestoHeaders
     public static final String PRESTO_LANGUAGE = "X-Presto-Language";
     public static final String PRESTO_TRACE_TOKEN = "X-Presto-Trace-Token";
     public static final String PRESTO_SESSION = "X-Presto-Session";
+    public static final String PRESTO_DELEGATION_TOKEN = "X-Presto-delegation-token";
     public static final String PRESTO_SET_CATALOG = "X-Presto-Set-Catalog";
     public static final String PRESTO_SET_SCHEMA = "X-Presto-Set-Schema";
     public static final String PRESTO_SET_SESSION = "X-Presto-Set-Session";

--- a/presto-client/src/main/java/com/facebook/presto/client/StatementClientV1.java
+++ b/presto-client/src/main/java/com/facebook/presto/client/StatementClientV1.java
@@ -54,6 +54,7 @@ import static com.facebook.presto.client.PrestoHeaders.PRESTO_CLEAR_TRANSACTION_
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_CLIENT_INFO;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_CLIENT_TAGS;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_DEALLOCATED_PREPARE;
+import static com.facebook.presto.client.PrestoHeaders.PRESTO_DELEGATION_TOKEN;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_EXTRA_CREDENTIAL;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_LANGUAGE;
 import static com.facebook.presto.client.PrestoHeaders.PRESTO_PREPARED_STATEMENT;
@@ -155,6 +156,10 @@ class StatementClientV1
         Map<String, String> customHeaders = session.getCustomHeaders();
         for (Entry<String, String> entry : customHeaders.entrySet()) {
             builder.addHeader(entry.getKey(), entry.getValue());
+        }
+
+        if (session.getDelegation() != null) {
+            builder.addHeader(PRESTO_DELEGATION_TOKEN, session.getDelegation());
         }
 
         if (session.getSource() != null) {

--- a/presto-client/src/test/java/com/facebook/presto/client/TestClientAuthenticationWithDT.java
+++ b/presto-client/src/test/java/com/facebook/presto/client/TestClientAuthenticationWithDT.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.client;
+
+import com.facebook.airlift.json.JsonCodec;
+import com.google.common.collect.ImmutableList;
+import okhttp3.Call;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.QueueDispatcher;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+import static com.facebook.airlift.json.JsonCodec.jsonCodec;
+import static com.facebook.presto.client.OkHttpUtil.setupSsl;
+import static com.facebook.presto.client.PrestoHeaders.PRESTO_DELEGATION_TOKEN;
+import static com.facebook.presto.client.TestMockWebServerFactory.MockWebServerInfo;
+import static com.google.common.net.HttpHeaders.CONTENT_TYPE;
+import static java.lang.String.format;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+public class TestClientAuthenticationWithDT
+{
+    private static final String VALID_DELEGATION_TOKEN = "This is valid token!";
+    private static final JsonCodec<QueryResults> QUERY_RESULTS_CODEC = jsonCodec(QueryResults.class);
+    private static final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
+    private MockWebServerInfo serverInfo;
+
+    @BeforeTest
+    public void setup()
+            throws Exception
+    {
+        serverInfo = TestMockWebServerFactory.getMockWebServerWithSSL();
+        serverInfo.server.start();
+        setupDispatcher();
+    }
+
+    @Test
+    public void testValidDelegationToken()
+            throws Exception
+    {
+        OkHttpClient client = setupHttpClient();
+        Call callFirst = client.newCall(new Request.Builder().post(RequestBody.create(JSON, "test query")).header(PRESTO_DELEGATION_TOKEN, VALID_DELEGATION_TOKEN).url(serverInfo.server.url("/v1/statement")).build());
+        Response responseFirst = callFirst.execute();
+        QueryResults first = QUERY_RESULTS_CODEC.fromJson(responseFirst.body().string());
+        assertEquals(200, responseFirst.code());
+        assertEquals("20220211_214710_00012_rk69b", first.getId());
+        assertEquals("/v1/statement/20220211_214710_00012_rk69b/1", first.getNextUri().getPath());
+
+        Call callSecond = client.newCall(new Request.Builder().header(PRESTO_DELEGATION_TOKEN, VALID_DELEGATION_TOKEN).url(serverInfo.server.url(first.getNextUri().getPath())).build());
+        Response responseSecond = callSecond.execute();
+        QueryResults second = QUERY_RESULTS_CODEC.fromJson(responseSecond.body().string());
+        assertEquals("20220211_214710_00012_rk69b", second.getId());
+        assertEquals("/v1/statement/20220211_214710_00012_rk69b/2", second.getNextUri().getPath());
+        assertEquals(100L, second.getData().iterator().next().iterator().next());
+
+        Call callThird = client.newCall(new Request.Builder().header(PRESTO_DELEGATION_TOKEN, VALID_DELEGATION_TOKEN).url(serverInfo.server.url(second.getNextUri().getPath())).build());
+        Response responseThird = callThird.execute();
+        QueryResults third = QUERY_RESULTS_CODEC.fromJson(responseThird.body().string());
+        assertEquals("20220211_214710_00012_rk69b", third.getId());
+        assertNull(third.getNextUri());
+    }
+
+    @Test
+    public void testInValidDelegationToken()
+            throws Exception
+    {
+        OkHttpClient client = setupHttpClient();
+        Call call = client.newCall(new Request.Builder().header(PRESTO_DELEGATION_TOKEN, "Wrong Token").url(serverInfo.server.url("/v1/info")).build());
+        Response response = call.execute();
+        assertEquals(401, response.code());
+    }
+
+    @AfterTest
+    public void teardown()
+            throws IOException
+    {
+        serverInfo.server.close();
+    }
+
+    private OkHttpClient setupHttpClient()
+    {
+        OkHttpClient.Builder httpClientBuilder = new OkHttpClient().newBuilder();
+
+        setupSsl(httpClientBuilder, Optional.empty(), Optional.empty(), Optional.of(serverInfo.trustStorePath), Optional.of(serverInfo.trustStorePassword));
+        OkHttpClient httpClient = httpClientBuilder.build();
+
+        OkHttpClient.Builder builder = httpClient.newBuilder();
+        return builder.build();
+    }
+
+    private void setupDispatcher()
+    {
+        QueueDispatcherWithAuth dispatcherWithAuth = new QueueDispatcherWithAuth();
+        for (String response : createResults()) {
+            dispatcherWithAuth.enqueueResponse(new MockResponse()
+                    .addHeader(CONTENT_TYPE, "application/json")
+                    .setBody(response));
+        }
+        serverInfo.server.setDispatcher(dispatcherWithAuth);
+    }
+
+    private static class QueueDispatcherWithAuth
+            extends QueueDispatcher
+    {
+        @Override
+        public MockResponse dispatch(RecordedRequest request) throws InterruptedException
+        {
+            final String delegationToken = request.getHeaders().get(PRESTO_DELEGATION_TOKEN);
+            if (!VALID_DELEGATION_TOKEN.equals(delegationToken)) {
+                return new MockResponse().setStatus("HTTP/1.1 401 Not Authorized");
+            }
+
+            return super.dispatch(request);
+        }
+    }
+
+    private List<String> createResults()
+    {
+        List<Column> columns = ImmutableList.of(new Column("_col0", "bigint", new ClientTypeSignature("bigint", ImmutableList.of())));
+        return ImmutableList.<String>builder()
+                .add(newQueryResults(1, null, null, "QUEUED"))
+                .add(newQueryResults(2, columns, ImmutableList.of(ImmutableList.of(100)), "RUNNING"))
+                .add(newQueryResults(null, columns, null, "FINISHED"))
+                .build();
+    }
+
+    private String newQueryResults(Integer nextUriId, List<Column> responseColumns, List<List<Object>> data, String state)
+    {
+        String queryId = "20220211_214710_00012_rk69b";
+
+        QueryResults queryResults = new QueryResults(
+                queryId,
+                serverInfo.server.url("/query.html?" + queryId).uri(),
+                null,
+                nextUriId == null ? null : serverInfo.server.url(format("/v1/statement/%s/%s", queryId, nextUriId)).uri(),
+                responseColumns,
+                data,
+                new StatementStats(state, false, state.equals("QUEUED"), true, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, null, null),
+                null,
+                null,
+                null,
+                null);
+
+        return QUERY_RESULTS_CODEC.toJson(queryResults);
+    }
+}

--- a/presto-client/src/test/java/com/facebook/presto/client/TestMockWebServerFactory.java
+++ b/presto-client/src/test/java/com/facebook/presto/client/TestMockWebServerFactory.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.client;
+
+import okhttp3.internal.tls.SslClient;
+import okhttp3.mockwebserver.MockWebServer;
+
+import java.io.File;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+import java.security.KeyStore;
+import java.security.cert.X509Certificate;
+
+public class TestMockWebServerFactory
+{
+    private static final String TRUSTSTORE_PASSWORD = "a password!";
+
+    private TestMockWebServerFactory()
+    {
+    }
+
+    public static class MockWebServerInfo
+    {
+        public MockWebServer server;
+        public String trustStorePath;
+        public String trustStorePassword;
+        public MockWebServerInfo(MockWebServer server, String trustStorePath, String trustStorePassword)
+        {
+            this.server = server;
+            this.trustStorePath = trustStorePath;
+            this.trustStorePassword = trustStorePassword;
+        }
+    }
+
+    public static MockWebServerInfo getMockWebServerWithSSL()
+            throws Exception
+    {
+        MockWebServer server = new MockWebServer();
+        final SslClient sslClient = SslClient.localhost();
+        server.useHttps(sslClient.socketFactory, false);
+        // generate the truststore file from certificates
+        KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
+        trustStore.load(null, null);
+
+        File trustStoreFile = File.createTempFile("truststore", "jks");
+        int id = 0;
+        for (X509Certificate cert : sslClient.trustManager.getAcceptedIssuers()) {
+            trustStore.setEntry("TestCert" + id,
+                    new KeyStore.TrustedCertificateEntry(cert), null);
+            id++;
+        }
+
+        try (OutputStream stream = Files.newOutputStream(trustStoreFile.toPath(), StandardOpenOption.WRITE)) {
+            trustStore.store(stream, TRUSTSTORE_PASSWORD.toCharArray());
+        }
+        return new MockWebServerInfo(server, trustStoreFile.getPath(), TRUSTSTORE_PASSWORD);
+    }
+}

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoConnection.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoConnection.java
@@ -751,6 +751,7 @@ public class PrestoConnection
                 clientInfo.get("ClientInfo"),
                 catalog.get(),
                 schema.get(),
+                null,
                 timeZoneId.get(),
                 locale.get(),
                 ImmutableMap.of(),

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestingPrestoClient.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestingPrestoClient.java
@@ -161,6 +161,7 @@ public abstract class AbstractTestingPrestoClient<T>
                 session.getClientInfo().orElse(null),
                 session.getCatalog().orElse(null),
                 session.getSchema().orElse(null),
+                null,
                 session.getTimeZoneKey().getId(),
                 session.getLocale(),
                 resourceEstimates.build(),

--- a/presto-tests/src/test/java/com/facebook/presto/execution/TestFinalQueryInfo.java
+++ b/presto-tests/src/test/java/com/facebook/presto/execution/TestFinalQueryInfo.java
@@ -71,6 +71,7 @@ public class TestFinalQueryInfo
                     null,
                     null,
                     null,
+                    null,
                     "America/Los_Angeles",
                     Locale.ENGLISH,
                     ImmutableMap.of(),


### PR DESCRIPTION
Test plan - unit test
```
== RELEASE NOTES ==

General Changes
* Adding a client option to pass in a delegation token parameter to the server (X-Presto-delegation-token). The cli can accept it using --delegation-token

```
