### PR TITLE
Add segmented aggregation in AggregationNode

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -2819,36 +2819,33 @@ public class HiveMetadata
             predicate = createPredicate(partitionColumns, partitions);
         }
 
-        // Expose ordering property of the table.
-        ImmutableList.Builder<LocalProperty<ColumnHandle>> localProperties = ImmutableList.builder();
+        // Expose ordering property of the table when order based execution is enabled.
+        ImmutableList.Builder<LocalProperty<ColumnHandle>> localPropertyBuilder = ImmutableList.builder();
         Optional<Set<ColumnHandle>> streamPartitionColumns = Optional.empty();
-        if (table.getStorage().getBucketProperty().isPresent() && !table.getStorage().getBucketProperty().get().getSortedBy().isEmpty()) {
+        if (table.getStorage().getBucketProperty().isPresent()
+                && !table.getStorage().getBucketProperty().get().getSortedBy().isEmpty()
+                && isOrderBasedExecutionEnabled(session)) {
             ImmutableSet.Builder<ColumnHandle> streamPartitionColumnsBuilder = ImmutableSet.builder();
+            Map<String, ColumnHandle> columnHandles = hiveColumnHandles(table).stream()
+                    .collect(toImmutableMap(HiveColumnHandle::getName, identity()));
 
             // streamPartitioningColumns is how we partition the data across splits.
             // localProperty is how we partition the data within a split.
-            // 1. add partition columns to streamPartitionColumns
-            partitionColumns.forEach(streamPartitionColumnsBuilder::add);
 
-            // 2. add sorted columns to streamPartitionColumns and localProperties
-            HiveBucketProperty bucketProperty = table.getStorage().getBucketProperty().get();
-            Map<String, ColumnHandle> columnHandles = hiveColumnHandles(table).stream()
-                    .collect(toImmutableMap(HiveColumnHandle::getName, identity()));
-            bucketProperty.getSortedBy().forEach(sortingColumn -> {
-                ColumnHandle columnHandle = columnHandles.get(sortingColumn.getColumnName());
-                localProperties.add(new SortingProperty<>(columnHandle, sortingColumn.getOrder().getSortOrder()));
+            // 1. add partition columns and bucketed-by columns to streamPartitionColumns
+            // when order based execution is enabled, splitting is disabled and data is sharded across splits when table is bucketed.
+            partitionColumns.forEach(streamPartitionColumnsBuilder::add);
+            table.getStorage().getBucketProperty().get().getBucketedBy().forEach(bucketedByColumn -> {
+                ColumnHandle columnHandle = columnHandles.get(bucketedByColumn);
                 streamPartitionColumnsBuilder.add(columnHandle);
             });
 
-            // We currently only set streamPartitionColumns when it enables streaming aggregation and also it's eligible to enable streaming aggregation
-            // 1. When the bucket columns are the same as the prefix of the sort columns
-            // 2. When all rows of the same value group are guaranteed to be in the same split. We disable splitting a file when isStreamingAggregationEnabled is true to make sure the property is guaranteed.
-            List<String> sortColumns = bucketProperty.getSortedBy().stream().map(SortingColumn::getColumnName).collect(toImmutableList());
-            if (bucketProperty.getBucketedBy().size() <= sortColumns.size()
-                    && bucketProperty.getBucketedBy().containsAll(sortColumns.subList(0, bucketProperty.getBucketedBy().size()))
-                    && isOrderBasedExecutionEnabled(session)) {
-                streamPartitionColumns = Optional.of(streamPartitionColumnsBuilder.build());
-            }
+            // 2. add sorted-by columns to localPropertyBuilder
+            table.getStorage().getBucketProperty().get().getSortedBy().forEach(sortingColumn -> {
+                ColumnHandle columnHandle = columnHandles.get(sortingColumn.getColumnName());
+                localPropertyBuilder.add(new SortingProperty<>(columnHandle, sortingColumn.getOrder().getSortOrder()));
+            });
+            streamPartitionColumns = Optional.of(streamPartitionColumnsBuilder.build());
         }
 
         return new ConnectorTableLayout(
@@ -2858,7 +2855,7 @@ public class HiveMetadata
                 tablePartitioning,
                 streamPartitionColumns,
                 discretePredicates,
-                localProperties.build(),
+                localPropertyBuilder.build(),
                 Optional.of(hiveLayoutHandle.getRemainingPredicate()));
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -223,6 +223,7 @@ import static com.facebook.presto.hive.HiveSessionProperties.isFileRenamingEnabl
 import static com.facebook.presto.hive.HiveSessionProperties.isOfflineDataDebugModeEnabled;
 import static com.facebook.presto.hive.HiveSessionProperties.isOptimizedMismatchedBucketCount;
 import static com.facebook.presto.hive.HiveSessionProperties.isOptimizedPartitionUpdateSerializationEnabled;
+import static com.facebook.presto.hive.HiveSessionProperties.isOrderBasedExecutionEnabled;
 import static com.facebook.presto.hive.HiveSessionProperties.isParquetPushdownFilterEnabled;
 import static com.facebook.presto.hive.HiveSessionProperties.isPreferManifestsToListFiles;
 import static com.facebook.presto.hive.HiveSessionProperties.isRespectTableFormat;
@@ -230,7 +231,6 @@ import static com.facebook.presto.hive.HiveSessionProperties.isShufflePartitione
 import static com.facebook.presto.hive.HiveSessionProperties.isSortedWriteToTempPathEnabled;
 import static com.facebook.presto.hive.HiveSessionProperties.isSortedWritingEnabled;
 import static com.facebook.presto.hive.HiveSessionProperties.isStatisticsEnabled;
-import static com.facebook.presto.hive.HiveSessionProperties.isStreamingAggregationEnabled;
 import static com.facebook.presto.hive.HiveSessionProperties.isUsePageFileForHiveUnsupportedType;
 import static com.facebook.presto.hive.HiveSessionProperties.shouldCreateEmptyBucketFilesForTemporaryTable;
 import static com.facebook.presto.hive.HiveStorageFormat.AVRO;
@@ -2846,7 +2846,7 @@ public class HiveMetadata
             List<String> sortColumns = bucketProperty.getSortedBy().stream().map(SortingColumn::getColumnName).collect(toImmutableList());
             if (bucketProperty.getBucketedBy().size() <= sortColumns.size()
                     && bucketProperty.getBucketedBy().containsAll(sortColumns.subList(0, bucketProperty.getBucketedBy().size()))
-                    && isStreamingAggregationEnabled(session)) {
+                    && isOrderBasedExecutionEnabled(session)) {
                 streamPartitionColumns = Optional.of(streamPartitionColumnsBuilder.build());
             }
         }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
@@ -899,7 +899,7 @@ public final class HiveSessionProperties
         return session.getProperty(S3_SELECT_PUSHDOWN_ENABLED, Boolean.class);
     }
 
-    public static boolean isStreamingAggregationEnabled(ConnectorSession session)
+    public static boolean isOrderBasedExecutionEnabled(ConnectorSession session)
     {
         return session.getProperty(ORDER_BASED_EXECUTION_ENABLED, Boolean.class);
     }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/StoragePartitionLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/StoragePartitionLoader.java
@@ -63,7 +63,7 @@ import static com.facebook.presto.hive.HiveMetadata.shouldCreateFilesForMissingB
 import static com.facebook.presto.hive.HiveSessionProperties.getMaxInitialSplitSize;
 import static com.facebook.presto.hive.HiveSessionProperties.getNodeSelectionStrategy;
 import static com.facebook.presto.hive.HiveSessionProperties.isFileSplittable;
-import static com.facebook.presto.hive.HiveSessionProperties.isStreamingAggregationEnabled;
+import static com.facebook.presto.hive.HiveSessionProperties.isOrderBasedExecutionEnabled;
 import static com.facebook.presto.hive.HiveSessionProperties.isUseListDirectoryCache;
 import static com.facebook.presto.hive.HiveUtil.getFooterCount;
 import static com.facebook.presto.hive.HiveUtil.getHeaderCount;
@@ -267,7 +267,7 @@ public class StoragePartitionLoader
         // therefore we must not split files when either is enabled.
         // Skip header / footer lines are not splittable except for a special case when skip.header.line.count=1
         boolean splittable = isFileSplittable(session) &&
-                !isStreamingAggregationEnabled(session) &&
+                !isOrderBasedExecutionEnabled(session) &&
                 !s3SelectPushdownEnabled &&
                 !partialAggregationsPushedDown &&
                 getFooterCount(schema) == 0 && getHeaderCount(schema) <= 1;

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestSegmentedAggregation.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestSegmentedAggregation.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static com.facebook.presto.SystemSessionProperties.SEGMENTED_AGGREGATION_ENABLED;
+import static com.facebook.presto.hive.HiveQueryRunner.HIVE_CATALOG;
+import static com.facebook.presto.hive.HiveSessionProperties.ORDER_BASED_EXECUTION_ENABLED;
+import static com.facebook.presto.spi.plan.AggregationNode.Step.SINGLE;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.aggregation;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.functionCall;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.singleGroupingSet;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.tableScan;
+import static io.airlift.tpch.TpchTable.CUSTOMER;
+import static io.airlift.tpch.TpchTable.LINE_ITEM;
+import static io.airlift.tpch.TpchTable.NATION;
+import static io.airlift.tpch.TpchTable.ORDERS;
+
+public class TestSegmentedAggregation
+        extends AbstractTestQueryFramework
+{
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return HiveQueryRunner.createQueryRunner(
+                ImmutableList.of(ORDERS, LINE_ITEM, CUSTOMER, NATION),
+                ImmutableMap.of("experimental.pushdown-subfields-enabled", "true"),
+                Optional.empty());
+    }
+
+    @Test
+    public void testAndSortedByKeysArePrefixOfGroupbyKeys()
+    {
+        QueryRunner queryRunner = getQueryRunner();
+
+        try {
+            queryRunner.execute("CREATE TABLE test_segmented_streaming_customer WITH ( \n" +
+                    "  bucket_count = 4, bucketed_by = ARRAY['custkey', 'name'], \n" +
+                    "  sorted_by = ARRAY['custkey', 'name'], partitioned_by=array['ds'], \n" +
+                    "  format = 'DWRF' ) AS \n" +
+                    "SELECT *, '2021-07-11' as ds FROM customer LIMIT 1000\n");
+
+            assertPlan(
+                    orderBasedExecutionEnabled(),
+                    "SELECT custkey, name, nationkey, COUNT(*) FROM test_segmented_streaming_customer \n" +
+                            "WHERE ds = '2021-07-11' GROUP BY 1, 2, 3",
+                    anyTree(aggregation(
+                            singleGroupingSet("custkey", "name", "nationkey"),
+                            ImmutableMap.of(Optional.empty(), functionCall("count", ImmutableList.of())),
+                            ImmutableList.of("custkey", "name"), // segmented streaming
+                            ImmutableMap.of(),
+                            Optional.empty(),
+                            SINGLE,
+                            tableScan("test_segmented_streaming_customer", ImmutableMap.of("custkey", "custkey", "name", "name", "nationkey", "nationkey")))));
+        }
+        finally {
+            queryRunner.execute("DROP TABLE IF EXISTS test_segmented_streaming_customer");
+        }
+    }
+
+    //todo:add test when Group-by Keys And prefix of Sorted-by Keys share the same elemens
+
+    private Session orderBasedExecutionEnabled()
+    {
+        return Session.builder(getQueryRunner().getDefaultSession())
+                .setCatalogSessionProperty(HIVE_CATALOG, ORDER_BASED_EXECUTION_ENABLED, "true")
+                .setSystemProperty(SEGMENTED_AGGREGATION_ENABLED, "true")
+                .build();
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestStreamingAggregationPlan.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestStreamingAggregationPlan.java
@@ -70,7 +70,7 @@ public class TestStreamingAggregationPlan
 
             // even with streaming aggregation enabled, non-ordered table that can't be applied streaming aggregation would use hash based aggregation
             assertPlan(
-                    streamingAggregationEnabled(),
+                    orderBasedExecutionEnabled(),
                     "SELECT custkey, COUNT(*) FROM test_customer \n" +
                             "WHERE ds = '2021-07-11' GROUP BY 1",
                     aggregationPlanWithNoStreaming("test_customer", false, "custkey"));
@@ -102,7 +102,7 @@ public class TestStreamingAggregationPlan
 
             // streaming aggregation enabled
             assertPlan(
-                    streamingAggregationEnabled(),
+                    orderBasedExecutionEnabled(),
                     "SELECT custkey, COUNT(*) FROM test_customer2 \n" +
                             "WHERE ds = '2021-07-11' GROUP BY 1",
                     node(
@@ -137,14 +137,14 @@ public class TestStreamingAggregationPlan
 
             // can't enable stream
             assertPlan(
-                    streamingAggregationEnabled(),
+                    orderBasedExecutionEnabled(),
                     "SELECT custkey, COUNT(*) FROM test_customer3 \n" +
                             "WHERE ds = '2021-07-11' GROUP BY 1",
                     aggregationPlanWithNoStreaming("test_customer3", false, "custkey"));
 
             // can't enable stream
             assertPlan(
-                    streamingAggregationEnabled(),
+                    orderBasedExecutionEnabled(),
                     "SELECT name, COUNT(*) FROM test_customer3 \n" +
                             "WHERE ds = '2021-07-11' GROUP BY 1",
                     aggregationPlanWithNoStreaming("test_customer3", true, "name"));
@@ -168,7 +168,7 @@ public class TestStreamingAggregationPlan
 
             // streaming aggregation enabled
             assertPlan(
-                    streamingAggregationEnabled(),
+                    orderBasedExecutionEnabled(),
                     "SELECT custkey, name, COUNT(*) FROM test_customer4 \n" +
                             "WHERE ds = '2021-07-11' GROUP BY 1, 2",
                     node(
@@ -202,7 +202,7 @@ public class TestStreamingAggregationPlan
                     "SELECT *, '2021-07-11' as ds FROM customer LIMIT 1000\n");
 
             // can't enable stream
-            assertPlan(streamingAggregationEnabled(),
+            assertPlan(orderBasedExecutionEnabled(),
                     "SELECT custkey, COUNT(*) FROM test_customer5 \n" +
                             "WHERE ds = '2021-07-11' GROUP BY 1", aggregationPlanWithNoStreaming("test_customer5", false, "custkey"));
         }
@@ -225,7 +225,7 @@ public class TestStreamingAggregationPlan
                     "SELECT *, '2021-07-11' as ds FROM customer LIMIT 1000\n");
 
             // can enable streaming aggregation
-            assertPlan(streamingAggregationEnabled(),
+            assertPlan(orderBasedExecutionEnabled(),
                     "SELECT custkey, name, COUNT(*) FROM test_customer6 \n" +
                             "WHERE ds = '2021-07-11' GROUP BY 1, 2",
                     node(
@@ -246,7 +246,6 @@ public class TestStreamingAggregationPlan
         }
     }
 
-    @Test
     public void testGroupbyKeysNotPrefixOfSortedKeys()
     {
         QueryRunner queryRunner = getQueryRunner();
@@ -260,7 +259,7 @@ public class TestStreamingAggregationPlan
 
             // can't enable streaming aggregation
             assertPlan(
-                    streamingAggregationEnabled(),
+                    orderBasedExecutionEnabled(),
                     "SELECT name, COUNT(*) FROM test_customer8 \n" +
                             "WHERE ds = '2021-07-11' GROUP BY 1",
                     aggregationPlanWithNoStreaming("test_customer8", true, "name"));
@@ -289,7 +288,7 @@ public class TestStreamingAggregationPlan
 
             // can't enable streaming aggregation when querying multiple partitions without grouping by partition keys
             assertPlan(
-                    streamingAggregationEnabled(),
+                    orderBasedExecutionEnabled(),
                     "SELECT custkey, COUNT(*) FROM test_customer9 \n" +
                             "WHERE ds = '2021-07-11' or ds = '2021-07-12' GROUP BY 1",
                     aggregationPlanWithNoStreaming("test_customer9", false, "custkey"));
@@ -301,7 +300,7 @@ public class TestStreamingAggregationPlan
         }
     }
 
-    private Session streamingAggregationEnabled()
+    private Session orderBasedExecutionEnabled()
     {
         return Session.builder(getQueryRunner().getDefaultSession())
                 .setCatalogSessionProperty(HIVE_CATALOG, ORDER_BASED_EXECUTION_ENABLED, "true")

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -223,6 +223,7 @@ public final class SystemSessionProperties
     public static final String MAX_STAGE_COUNT_FOR_EAGER_SCHEDULING = "max_stage_count_for_eager_scheduling";
     public static final String HYPERLOGLOG_STANDARD_ERROR_WARNING_THRESHOLD = "hyperloglog_standard_error_warning_threshold";
     public static final String PREFER_MERGE_JOIN = "prefer_merge_join";
+    public static final String SEGMENTED_AGGREGATION_ENABLED = "segmented_aggregation_enabled";
 
     //TODO: Prestissimo related session properties that are temporarily put here. They will be relocated in the future
     public static final String PRESTISSIMO_SIMPLIFIED_EXPRESSION_EVALUATION_ENABLED = "simplified_expression_evaluation_enabled";
@@ -1190,6 +1191,11 @@ public final class SystemSessionProperties
                                 "To make it work, the connector needs to guarantee and expose the data properties of the underlying table.",
                         featuresConfig.isPreferMergeJoin(),
                         true),
+                booleanProperty(
+                        SEGMENTED_AGGREGATION_ENABLED,
+                        "Enable segmented aggregation.",
+                        featuresConfig.isSegmentedAggregationEnabled(),
+                        true),
                 new PropertyMetadata<>(
                         AGGREGATION_IF_TO_FILTER_REWRITE_STRATEGY,
                         format("Set the strategy used to rewrite AGG IF to AGG FILTER. Options are %s",
@@ -2099,6 +2105,11 @@ public final class SystemSessionProperties
     public static boolean preferMergeJoin(Session session)
     {
         return session.getSystemProperty(PREFER_MERGE_JOIN, Boolean.class);
+    }
+
+    public static boolean isSegmentedAggregationEnabled(Session session)
+    {
+        return session.getSystemProperty(SEGMENTED_AGGREGATION_ENABLED, Boolean.class);
     }
 
     public static AggregationIfToFilterRewriteStrategy getAggregationIfToFilterRewriteStrategy(Session session)

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -219,6 +219,7 @@ public class FeaturesConfig
 
     private boolean streamingForPartialAggregationEnabled;
     private boolean preferMergeJoin;
+    private boolean segmentedAggregationEnabled;
 
     private int maxStageCountForEagerScheduling = 25;
     private boolean quickDistinctLimitEnabled;
@@ -2055,6 +2056,18 @@ public class FeaturesConfig
     public FeaturesConfig setPreferMergeJoin(boolean preferMergeJoin)
     {
         this.preferMergeJoin = preferMergeJoin;
+        return this;
+    }
+
+    public boolean isSegmentedAggregationEnabled()
+    {
+        return segmentedAggregationEnabled;
+    }
+
+    @Config("optimizer.segmented-aggregation-enabled")
+    public FeaturesConfig setSegmentedAggregationEnabled(boolean segmentedAggregationEnabled)
+    {
+        this.segmentedAggregationEnabled = segmentedAggregationEnabled;
         return this;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushPartialAggregationThroughJoin.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PushPartialAggregationThroughJoin.java
@@ -56,8 +56,8 @@ public class PushPartialAggregationThroughJoin
 
     private static boolean isSupportedAggregationNode(AggregationNode aggregationNode)
     {
-        // Don't split streaming aggregations
-        if (aggregationNode.isStreamable()) {
+        // Don't split streaming aggregations or segmented aggregations
+        if (aggregationNode.isStreamable() || aggregationNode.isSegmentedAggregationEligible()) {
             return false;
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/HashGenerationOptimizer.java
@@ -166,7 +166,8 @@ public class HashGenerationOptimizer
         {
             Optional<HashComputation> groupByHash = Optional.empty();
             List<VariableReferenceExpression> groupingKeys = node.getGroupingKeys();
-            if (!node.isStreamable() && !canSkipHashGeneration(node.getGroupingKeys())) {
+            if (!node.isStreamable() && !node.isSegmentedAggregationEligible() && !canSkipHashGeneration(node.getGroupingKeys())) {
+                // todo: for segmented aggregation, add optimizations for the fields that need to compute hash
                 groupByHash = computeHash(groupingKeys, functionAndTypeManager);
             }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/planPrinter/PlanPrinter.java
@@ -612,6 +612,9 @@ public class PlanPrinter
             if (node.getStep() != AggregationNode.Step.SINGLE) {
                 type = format("(%s)", node.getStep().toString());
             }
+            if (node.isSegmentedAggregationEligible()) {
+                type = format("%s(SEGMENTED, %s)", type, node.getPreGroupedVariables());
+            }
             if (node.isStreamable()) {
                 type = format("%s(STREAMING)", type);
             }

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -194,6 +194,7 @@ public class TestFeaturesConfig
                 .setMaxStageCountForEagerScheduling(25)
                 .setHyperloglogStandardErrorWarningThreshold(0.004)
                 .setPreferMergeJoin(false)
+                .setSegmentedAggregationEnabled(false)
                 .setQueryAnalyzerTimeout(new Duration(3, MINUTES))
                 .setQuickDistinctLimitEnabled(false));
     }
@@ -340,6 +341,7 @@ public class TestFeaturesConfig
                 .put("execution-policy.max-stage-count-for-eager-scheduling", "123")
                 .put("hyperloglog-standard-error-warning-threshold", "0.02")
                 .put("optimizer.prefer-merge-join", "true")
+                .put("optimizer.segmented-aggregation-enabled", "true")
                 .put("planner.query-analyzer-timeout", "10s")
                 .put("optimizer.quick-distinct-limit-enabled", "true")
                 .build();
@@ -484,6 +486,7 @@ public class TestFeaturesConfig
                 .setMaxStageCountForEagerScheduling(123)
                 .setHyperloglogStandardErrorWarningThreshold(0.02)
                 .setPreferMergeJoin(true)
+                .setSegmentedAggregationEnabled(true)
                 .setQueryAnalyzerTimeout(new Duration(10, SECONDS))
                 .setQuickDistinctLimitEnabled(true);
         assertFullMapping(properties, expected);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/plan/AggregationNode.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/plan/AggregationNode.java
@@ -210,7 +210,18 @@ public final class AggregationNode
 
     public boolean isStreamable()
     {
-        return !preGroupedVariables.isEmpty() && groupingSets.getGroupingSetCount() == 1 && groupingSets.getGlobalGroupingSets().isEmpty();
+        return !preGroupedVariables.isEmpty()
+                && groupingSets.getGroupingSetCount() == 1
+                && groupingSets.getGlobalGroupingSets().isEmpty()
+                && preGroupedVariables.size() == groupingSets.groupingKeys.size();
+    }
+
+    public boolean isSegmentedAggregationEligible()
+    {
+        return !preGroupedVariables.isEmpty()
+                && groupingSets.getGroupingSetCount() == 1
+                && groupingSets.getGlobalGroupingSets().isEmpty()
+                && preGroupedVariables.size() < groupingSets.groupingKeys.size();
     }
 
     @Override


### PR DESCRIPTION
```
== NO RELEASE NOTE ==
```

If the grouped-by keys contains elements from the prefix of the sorted-by key, we can enable segmented aggregation 

For example:the table is sorted by F1, F3 and and we do Group by F1, F2
F2 is not sorted, so we can’t do streaming aggregation for each <F1, F2> group; however since F1 is sorted, we segment the data by F1’s value, for example the first segment, F1’s values are all a, now we can build a hashtable for each segment and do calculation and flush the data once a segment is finished

so it still saves CPU because we don’t do look up for F1, and the result hash table we keep is also smaller compared to the full hash table
<img width="565" alt="image" src="https://user-images.githubusercontent.com/50636602/165151336-a5249301-4362-480d-9294-a96e505d84cf.png">
