### PR TITLE
Add join table reference check in JOIN ON clause

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
@@ -1660,8 +1660,12 @@ public class TestAnalyzer
                         "performance issues as it may lead to a cross join with filter");
         assertNoWarning(analyzeWithWarnings("select * FROM t1 a1 LEFT JOIN t2 a2 ON a1.a = a2.a LEFT JOIN t3 a3  ON a3.a = a3.b AND a3.b = a1.b"));
         assertHasWarning(analyzeWithWarnings("select * from t1 inner join ( select t2.a as t2_a, t3.a from t2 inner join t3 on t2.a=t3.a) al ON t1.a = t1.a"),
-                PERFORMANCE_WARNING, "line 1:104: JOIN ON condition(s) do not reference the joined table 'al' and other tables in the same expression that can cause " +
+                PERFORMANCE_WARNING, "line 1:104: JOIN ON condition(s) do not reference the joined relation and other relation in the same expression that can cause " +
                         "performance issues as it may lead to a cross join with filter");
+        assertHasWarning(analyzeWithWarnings("select * from t1 inner join (select t2.a as t2_a, t3.a t3_a from t2 inner join t3 on t2.a=t3.a) ON t2_a = t3_a"),
+                PERFORMANCE_WARNING, "line 1:105: JOIN ON condition(s) do not reference the joined relation and other relation in the same expression that can cause " +
+                        "performance issues as it may lead to a cross join with filter");
+        assertNoWarning(analyzeWithWarnings("select * from t1 inner join (select t2.a as t2_a, t3.a t3_a from t2 inner join t3 on t2.a=t3.a) ON t2_a = a"));
     }
 
     @Test


### PR DESCRIPTION
Often times, while specifying the joining condition in JOIN ON clause,
users make mistakes and not referencing the joining table along side
with other table in join condition that result in performance issue due
to conditional join resulting in CROSS JOIN.

This change will extend the number of cases when user is shown the
PERFORMANCE_WARNING when JOIN ON clause misses the comparison expression
with joining table and other table. Specifically, it covers the cases
when  user does not explicitly refer to the relation through table name
or alias in JOIN ON clause.

Resolves:#17382
See also: #17333

```
== NO RELEASE NOTE ==
```
