### PR TITLE
Fix reserved thrift keyword usage

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/TaskStatus.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TaskStatus.java
@@ -168,7 +168,7 @@ public class TaskStatus
     }
 
     @JsonProperty
-    @ThriftField(5)
+    @ThriftField(value = 5, name = "selfUri")
     public URI getSelf()
     {
         return self;


### PR DESCRIPTION
`self` is a [reserved](https://github.com/apache/thrift/blob/master/doc/specs/idl.md#reserved-keywords) thrift keyword and cannot be used in IDL.
This commit refactors the usage into `selfUri`.

Test plan 

Ran the idl generator to create the IDL and verified.
`mvn  com.facebook.drift:drift-maven-plugin:generate-thrift-idl  -Dgenerate.thrift.idl.classes="com.facebook.presto.execution.TaskStatus" -Dgenerate.thrift.idl.recursive=true -Dgenerate.thrift.idl.outputFile=out.txt `
```
struct TaskStatus {
  1: i64 taskInstanceIdLeastSignificantBits;
  2: i64 taskInstanceIdMostSignificantBits;
  3: i64 version;
  4: TaskState state;
  5: string selfUri;
  ...
  ```



```
== NO RELEASE NOTE ==
```
