### PR TITLE
Support iceberg metrics nanValueCounts

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/FilesTable.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/FilesTable.java
@@ -80,6 +80,9 @@ public class FilesTable
                         .add(new ColumnMetadata("null_value_counts", typeManager.getParameterizedType(StandardTypes.MAP, ImmutableList.of(
                                 TypeSignatureParameter.of(INTEGER.getTypeSignature()),
                                 TypeSignatureParameter.of(BIGINT.getTypeSignature())))))
+                        .add(new ColumnMetadata("nan_value_counts", typeManager.getParameterizedType(StandardTypes.MAP, ImmutableList.of(
+                                TypeSignatureParameter.of(INTEGER.getTypeSignature()),
+                                TypeSignatureParameter.of(BIGINT.getTypeSignature())))))
                         .add(new ColumnMetadata("lower_bounds", typeManager.getParameterizedType(StandardTypes.MAP, ImmutableList.of(
                                 TypeSignatureParameter.of(INTEGER.getTypeSignature()),
                                 TypeSignatureParameter.of(VARCHAR.getTypeSignature())))))
@@ -131,6 +134,9 @@ public class FilesTable
             }
             if (checkNonNull(dataFile.nullValueCounts(), pagesBuilder)) {
                 pagesBuilder.appendIntegerBigintMap(dataFile.nullValueCounts());
+            }
+            if (checkNonNull(dataFile.nanValueCounts(), pagesBuilder)) {
+                pagesBuilder.appendIntegerBigintMap(dataFile.nanValueCounts());
             }
             if (checkNonNull(dataFile.lowerBounds(), pagesBuilder)) {
                 pagesBuilder.appendIntegerVarcharMap(dataFile.lowerBounds().entrySet().stream()

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergOrcFileWriter.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergOrcFileWriter.java
@@ -95,7 +95,7 @@ public class IcebergOrcFileWriter
     private static Metrics computeMetrics(Schema icebergSchema, List<OrcType> orcRowTypes, long fileRowCount, List<ColumnStatistics> columnStatistics)
     {
         if (columnStatistics.isEmpty()) {
-            return new Metrics(fileRowCount, null, null, null, null, null);
+            return new Metrics(fileRowCount, null, null, null, null, null, null);
         }
         // Columns that are descendants of LIST or MAP types are excluded because:
         // 1. Their stats are not used by Apache Iceberg to filter out data files
@@ -136,6 +136,7 @@ public class IcebergOrcFileWriter
                 null, // TODO: Add column size accounting to ORC column writers
                 valueCounts.isEmpty() ? null : valueCounts,
                 nullCounts.isEmpty() ? null : nullCounts,
+                null,
                 lowerBounds.isEmpty() ? null : lowerBounds,
                 upperBounds.isEmpty() ? null : upperBounds);
     }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/MetricsWrapper.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/MetricsWrapper.java
@@ -32,6 +32,7 @@ public class MetricsWrapper
             @JsonProperty("columnSizes") Map<Integer, Long> columnSizes,
             @JsonProperty("valueCounts") Map<Integer, Long> valueCounts,
             @JsonProperty("nullValueCounts") Map<Integer, Long> nullValueCounts,
+            @JsonProperty("nanValueCounts") Map<Integer, Long> nanValueCounts,
             @JsonProperty("lowerBounds") Map<Integer, ByteBuffer> lowerBounds,
             @JsonProperty("upperBounds") Map<Integer, ByteBuffer> upperBounds)
     {
@@ -40,6 +41,7 @@ public class MetricsWrapper
                 columnSizes,
                 valueCounts,
                 nullValueCounts,
+                nanValueCounts,
                 lowerBounds,
                 upperBounds));
     }
@@ -76,6 +78,12 @@ public class MetricsWrapper
     public Map<Integer, Long> nullValueCounts()
     {
         return metrics.nullValueCounts();
+    }
+
+    @JsonProperty
+    public Map<Integer, Long> nanValueCounts()
+    {
+        return metrics.nanValueCounts();
     }
 
     @JsonProperty

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergOrcMetricsCollection.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergOrcMetricsCollection.java
@@ -209,12 +209,14 @@ public class TestIcebergOrcMetricsCollection
         private final Map<Integer, Long> columnSizes;
         private final Map<Integer, Long> valueCounts;
         private final Map<Integer, Long> nullValueCounts;
+        private final Map<Integer, Long> nanValueCounts;
+
         private final Map<Integer, String> lowerBounds;
         private final Map<Integer, String> upperBounds;
 
         public static DataFileRecord toDataFileRecord(MaterializedRow row)
         {
-            assertEquals(row.getFieldCount(), 11);
+            assertEquals(row.getFieldCount(), 12);
             return new DataFileRecord(
                     (String) row.getField(0),
                     (String) row.getField(1),
@@ -223,8 +225,9 @@ public class TestIcebergOrcMetricsCollection
                     row.getField(4) != null ? ImmutableMap.copyOf((Map<Integer, Long>) row.getField(4)) : null,
                     row.getField(5) != null ? ImmutableMap.copyOf((Map<Integer, Long>) row.getField(5)) : null,
                     row.getField(6) != null ? ImmutableMap.copyOf((Map<Integer, Long>) row.getField(6)) : null,
-                    row.getField(7) != null ? ImmutableMap.copyOf((Map<Integer, String>) row.getField(7)) : null,
-                    row.getField(8) != null ? ImmutableMap.copyOf((Map<Integer, String>) row.getField(8)) : null);
+                    row.getField(7) != null ? ImmutableMap.copyOf((Map<Integer, Long>) row.getField(7)) : null,
+                    row.getField(8) != null ? ImmutableMap.copyOf((Map<Integer, String>) row.getField(8)) : null,
+                    row.getField(9) != null ? ImmutableMap.copyOf((Map<Integer, String>) row.getField(9)) : null);
         }
 
         private DataFileRecord(
@@ -235,6 +238,7 @@ public class TestIcebergOrcMetricsCollection
                 Map<Integer, Long> columnSizes,
                 Map<Integer, Long> valueCounts,
                 Map<Integer, Long> nullValueCounts,
+                Map<Integer, Long> nanValueCounts,
                 Map<Integer, String> lowerBounds,
                 Map<Integer, String> upperBounds)
         {
@@ -245,6 +249,7 @@ public class TestIcebergOrcMetricsCollection
             this.columnSizes = columnSizes;
             this.valueCounts = valueCounts;
             this.nullValueCounts = nullValueCounts;
+            this.nanValueCounts = nanValueCounts;
             this.lowerBounds = lowerBounds;
             this.upperBounds = upperBounds;
         }
@@ -282,6 +287,11 @@ public class TestIcebergOrcMetricsCollection
         public Map<Integer, Long> getNullValueCounts()
         {
             return nullValueCounts;
+        }
+
+        public Map<Integer, Long> getNanValueCounts()
+        {
+            return nanValueCounts;
         }
 
         public Map<Integer, String> getLowerBounds()

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergSystemTables.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergSystemTables.java
@@ -165,6 +165,7 @@ public class TestIcebergSystemTables
                         "('column_sizes', 'map(integer, bigint)', '', '')," +
                         "('value_counts', 'map(integer, bigint)', '', '')," +
                         "('null_value_counts', 'map(integer, bigint)', '', '')," +
+                        "('nan_value_counts', 'map(integer, bigint)', '', '')," +
                         "('lower_bounds', 'map(integer, varchar)', '', '')," +
                         "('upper_bounds', 'map(integer, varchar)', '', '')," +
                         "('key_metadata', 'varbinary', '', '')," +

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestMetricsWrapper.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestMetricsWrapper.java
@@ -43,10 +43,11 @@ public class TestMetricsWrapper
         Map<Integer, Long> columnSizes = ImmutableMap.of(3, 321L, 5, 543L);
         Map<Integer, Long> valueCounts = ImmutableMap.of(7, 765L, 9, 987L);
         Map<Integer, Long> nullValueCounts = ImmutableMap.of(2, 234L, 4, 456L);
+        Map<Integer, Long> nanValueCounts = ImmutableMap.of(2, 234L, 4, 456L);
         Map<Integer, ByteBuffer> lowerBounds = ImmutableMap.of(13, ByteBuffer.wrap(new byte[] {0, 8, 9}));
         Map<Integer, ByteBuffer> upperBounds = ImmutableMap.of(17, ByteBuffer.wrap(new byte[] {5, 4, 0}));
 
-        Metrics expected = new Metrics(recordCount, columnSizes, valueCounts, nullValueCounts, lowerBounds, upperBounds);
+        Metrics expected = new Metrics(recordCount, columnSizes, valueCounts, nullValueCounts, nanValueCounts, lowerBounds, upperBounds);
 
         Metrics actual = CODEC.fromJson(CODEC.toJson(new MetricsWrapper(expected))).metrics();
 
@@ -54,6 +55,7 @@ public class TestMetricsWrapper
         assertEquals(actual.columnSizes(), columnSizes);
         assertEquals(actual.valueCounts(), valueCounts);
         assertEquals(actual.nullValueCounts(), nullValueCounts);
+        assertEquals(actual.nanValueCounts(), nanValueCounts);
         assertEquals(actual.lowerBounds(), lowerBounds);
         assertEquals(actual.upperBounds(), upperBounds);
     }


### PR DESCRIPTION
In iceberg 0.12.0, the prior `Metrics` is deprecated with a new constructor requiring an extra parameter `nanValueCounts` (https://javadoc.io/static/org.apache.iceberg/iceberg-api/0.12.0/org/apache/iceberg/Metrics.html). Supports this parameter in the iceberg connector.

Test plan - Unit tests

```
== NO RELEASE NOTE ==
```
