### PR TITLE
Add decryption functionality to presto 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,7 @@
         <dep.assertj-core.version>3.8.0</dep.assertj-core.version>
         <dep.logback.version>1.2.3</dep.logback.version>
         <dep.parquet.version>1.12.0</dep.parquet.version>
+        <dep.parquet.format.version>2.9.0</dep.parquet.format.version>
         <dep.nexus-staging-plugin.version>1.6.8</dep.nexus-staging-plugin.version>
         <dep.asm.version>9.0</dep.asm.version>
         <dep.gcs.version>1.9.17</dep.gcs.version>

--- a/presto-hive/pom.xml
+++ b/presto-hive/pom.xml
@@ -397,6 +397,13 @@
             <artifactId>presto-tpcds</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/BenchmarkParquetPageSource.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/BenchmarkParquetPageSource.java
@@ -267,7 +267,7 @@ public class BenchmarkParquetPageSource
             PageFunctionCompiler pageFunctionCompiler = new PageFunctionCompiler(metadata, 0);
             pageProcessor = new ExpressionCompiler(metadata, pageFunctionCompiler).compilePageProcessor(testSession.getSqlFunctionProperties(), filterConjunction(), projections).get();
 
-            parquetMetadata = MetadataReader.readFooter(new FileParquetDataSource(parquetFile), parquetFile.length()).getParquetMetadata();
+            parquetMetadata = MetadataReader.readFooter(new FileParquetDataSource(parquetFile), parquetFile.length(), null).getParquetMetadata();
         }
 
         @TearDown
@@ -290,7 +290,7 @@ public class BenchmarkParquetPageSource
                 fields.add(ColumnIOConverter.constructField(getTypeFromTypeSignature(), messageColumnIO.getChild(i)));
             }
 
-            ParquetReader parquetReader = new ParquetReader(messageColumnIO, parquetMetadata.getBlocks(), dataSource, newSimpleAggregatedMemoryContext(), new DataSize(16, MEGABYTE), batchReadEnabled, enableVerification, null, null, false);
+            ParquetReader parquetReader = new ParquetReader(messageColumnIO, parquetMetadata.getBlocks(), dataSource, newSimpleAggregatedMemoryContext(), new DataSize(16, MEGABYTE), batchReadEnabled, enableVerification, null, null, false, null);
             return new ParquetPageSource(parquetReader, Collections.nCopies(channelCount, type), fields, columnNames, new RuntimeStats());
         }
 

--- a/presto-parquet/pom.xml
+++ b/presto-parquet/pom.xml
@@ -97,6 +97,12 @@
 
         <!-- for testing -->
         <dependency>
+            <groupId>com.facebook.presto.hadoop</groupId>
+            <artifactId>hadoop-apache2</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-testng-services</artifactId>
             <scope>test</scope>
@@ -105,12 +111,6 @@
         <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-main</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>com.facebook.presto.hadoop</groupId>
-            <artifactId>hadoop-apache2</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/DataPageV1.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/DataPageV1.java
@@ -46,6 +46,7 @@ public class DataPageV1
         this.valuesEncoding = valuesEncoding;
     }
 
+    @Override
     public Slice getSlice()
     {
         return slice;

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/DataPageV2.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/DataPageV2.java
@@ -80,6 +80,7 @@ public class DataPageV2
         return dataEncoding;
     }
 
+    @Override
     public Slice getSlice()
     {
         return slice;

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/DictionaryPage.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/DictionaryPage.java
@@ -42,6 +42,7 @@ public class DictionaryPage
         this.encoding = requireNonNull(encoding, "encoding is null");
     }
 
+    @Override
     public Slice getSlice()
     {
         return slice;

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/Page.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/Page.java
@@ -13,6 +13,8 @@
  */
 package com.facebook.presto.parquet;
 
+import io.airlift.slice.Slice;
+
 public abstract class Page
 {
     protected final int compressedSize;
@@ -33,4 +35,6 @@ public abstract class Page
     {
         return uncompressedSize;
     }
+
+    public abstract Slice getSlice();
 }

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/cache/CachingParquetMetadataSource.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/cache/CachingParquetMetadataSource.java
@@ -18,6 +18,7 @@ import com.facebook.presto.parquet.ParquetDataSource;
 import com.facebook.presto.parquet.ParquetDataSourceId;
 import com.google.common.cache.Cache;
 import com.google.common.util.concurrent.UncheckedExecutionException;
+import org.apache.parquet.crypto.InternalFileDecryptor;
 
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
@@ -38,14 +39,14 @@ public class CachingParquetMetadataSource
     }
 
     @Override
-    public ParquetFileMetadata getParquetMetadata(ParquetDataSource parquetDataSource, long fileSize, boolean cacheable)
+    public ParquetFileMetadata getParquetMetadata(ParquetDataSource parquetDataSource, long fileSize, boolean cacheable, InternalFileDecryptor fileDecryptor)
             throws IOException
     {
         try {
             if (cacheable) {
-                return cache.get(parquetDataSource.getId(), () -> delegate.getParquetMetadata(parquetDataSource, fileSize, cacheable));
+                return cache.get(parquetDataSource.getId(), () -> delegate.getParquetMetadata(parquetDataSource, fileSize, cacheable, fileDecryptor));
             }
-            return delegate.getParquetMetadata(parquetDataSource, fileSize, cacheable);
+            return delegate.getParquetMetadata(parquetDataSource, fileSize, cacheable, fileDecryptor);
         }
         catch (ExecutionException | UncheckedExecutionException e) {
             throwIfInstanceOf(e.getCause(), IOException.class);

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/cache/MetadataReader.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/cache/MetadataReader.java
@@ -15,17 +15,32 @@ package com.facebook.presto.parquet.cache;
 
 import com.facebook.presto.parquet.ParquetCorruptionException;
 import com.facebook.presto.parquet.ParquetDataSource;
+import io.airlift.slice.BasicSliceInput;
 import io.airlift.slice.Slice;
+import org.apache.parquet.crypto.AesCipher;
+import org.apache.parquet.crypto.AesGcmEncryptor;
+import org.apache.parquet.crypto.HiddenColumnChunkMetaData;
+import org.apache.parquet.crypto.InternalColumnDecryptionSetup;
+import org.apache.parquet.crypto.InternalFileDecryptor;
+import org.apache.parquet.crypto.KeyAccessDeniedException;
+import org.apache.parquet.crypto.ModuleCipherFactory.ModuleType;
+import org.apache.parquet.crypto.ParquetCryptoRuntimeException;
+import org.apache.parquet.crypto.TagVerificationException;
+import org.apache.parquet.format.BlockCipher.Decryptor;
 import org.apache.parquet.format.ColumnChunk;
+import org.apache.parquet.format.ColumnCryptoMetaData;
 import org.apache.parquet.format.ColumnMetaData;
 import org.apache.parquet.format.ConvertedType;
 import org.apache.parquet.format.Encoding;
+import org.apache.parquet.format.EncryptionWithColumnKey;
+import org.apache.parquet.format.FileCryptoMetaData;
 import org.apache.parquet.format.FileMetaData;
 import org.apache.parquet.format.KeyValue;
 import org.apache.parquet.format.RowGroup;
 import org.apache.parquet.format.SchemaElement;
 import org.apache.parquet.format.Statistics;
 import org.apache.parquet.format.Type;
+import org.apache.parquet.format.Util;
 import org.apache.parquet.format.converter.ParquetMetadataConverter;
 import org.apache.parquet.hadoop.metadata.BlockMetaData;
 import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
@@ -40,6 +55,7 @@ import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
 import org.apache.parquet.schema.Type.Repetition;
 import org.apache.parquet.schema.Types;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -58,27 +74,22 @@ import static java.lang.Math.min;
 import static java.lang.Math.toIntExact;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.US_ASCII;
+import static org.apache.parquet.format.Util.readFileCryptoMetaData;
 import static org.apache.parquet.format.Util.readFileMetaData;
 
 public final class MetadataReader
         implements ParquetMetadataSource
 {
     private static final Slice MAGIC = wrappedBuffer("PAR1".getBytes(US_ASCII));
+    private static final Slice EMAGIC = wrappedBuffer("PARE".getBytes(US_ASCII));
     private static final int POST_SCRIPT_SIZE = Integer.BYTES + MAGIC.length();
     private static final int EXPECTED_FOOTER_SIZE = 16 * 1024;
     private static final ParquetMetadataConverter PARQUET_METADATA_CONVERTER = new ParquetMetadataConverter();
 
-    public static ParquetFileMetadata readFooter(ParquetDataSource parquetDataSource, long fileSize)
+    public static ParquetFileMetadata readFooter(ParquetDataSource parquetDataSource, long fileSize, InternalFileDecryptor fileDecryptor)
             throws IOException
     {
-        // Parquet File Layout:
-        //
-        // MAGIC
-        // variable: Data
-        // variable: Metadata
-        // 4 bytes: MetadataLength
-        // MAGIC
-
+        // Parquet File Layout: https://github.com/apache/parquet-format/blob/master/Encryption.md
         validateParquet(fileSize >= MAGIC.length() + POST_SCRIPT_SIZE, "%s is not a valid Parquet File", parquetDataSource.getId());
 
         //  EXPECTED_FOOTER_SIZE is an int, so this will never fail
@@ -87,9 +98,10 @@ public final class MetadataReader
         Slice tailSlice = wrappedBuffer(buffer);
 
         Slice magic = tailSlice.slice(tailSlice.length() - MAGIC.length(), MAGIC.length());
-        if (!MAGIC.equals(magic)) {
-            throw new ParquetCorruptionException(format("Not valid Parquet file: %s expected magic number: %s got: %s", parquetDataSource.getId(), Arrays.toString(MAGIC.getBytes()), Arrays.toString(magic.getBytes())));
+        if (!MAGIC.equals(magic) && !EMAGIC.equals(magic)) {
+            throw new ParquetCorruptionException(format("Not valid Parquet file: %s expected magic number: %s or %s, but got: %s", parquetDataSource.getId(), Arrays.toString(MAGIC.getBytes()), Arrays.toString(EMAGIC.getBytes()), Arrays.toString(magic.getBytes())));
         }
+        boolean encryptedFooterMode = EMAGIC.equals(magic);
 
         int metadataLength = tailSlice.getInt(tailSlice.length() - POST_SCRIPT_SIZE);
         int completeFooterSize = metadataLength + POST_SCRIPT_SIZE;
@@ -105,9 +117,53 @@ public final class MetadataReader
             tailSlice = wrappedBuffer(footerBuffer, 0, footerBuffer.length);
         }
 
-        FileMetaData fileMetaData = readFileMetaData(tailSlice.slice(tailSlice.length() - completeFooterSize, metadataLength).getInput());
+        return readParquetMetadata(tailSlice.slice(tailSlice.length() - completeFooterSize, metadataLength).getInput(), metadataLength, fileDecryptor, encryptedFooterMode);
+    }
+
+    private static ParquetFileMetadata readParquetMetadata(BasicSliceInput input, int metadataLength, InternalFileDecryptor fileDecryptor, boolean encryptedFooterMode)
+            throws IOException
+    {
+        if (encryptedFooterMode && fileDecryptor == null) {
+            new IllegalArgumentException("fileDecryptionProperties cannot be null when encryptedFooterMode is true");
+        }
+        //InternalFileDecryptor fileDecryptor = (fileDecryptionProperties == null) ? null : new InternalFileDecryptor(fileDecryptionProperties);
+        Decryptor footerDecryptor = null;
+        byte[] aad = null;
+
+        if (encryptedFooterMode) {
+            FileCryptoMetaData fileCryptoMetaData = readFileCryptoMetaData(input);
+            fileDecryptor.setFileCryptoMetaData(fileCryptoMetaData.getEncryption_algorithm(), true, fileCryptoMetaData.getKey_metadata());
+            footerDecryptor = fileDecryptor.fetchFooterDecryptor();
+            aad = AesCipher.createFooterAAD(fileDecryptor.getFileAAD());
+        }
+
+        FileMetaData fileMetaData = readFileMetaData(input, footerDecryptor, aad);
+        return convertToParquetMetadata(input, fileMetaData, metadataLength, fileDecryptor, encryptedFooterMode);
+    }
+
+    private static ParquetFileMetadata convertToParquetMetadata(BasicSliceInput input, FileMetaData fileMetaData, int metadataLength, InternalFileDecryptor fileDecryptor, boolean encryptedFooter)
+            throws IOException
+    {
         List<SchemaElement> schema = fileMetaData.getSchema();
-        validateParquet(!schema.isEmpty(), "Empty Parquet schema in file: %s", parquetDataSource.getId());
+        if (!encryptedFooter && null != fileDecryptor) {
+            if (!fileMetaData.isSetEncryption_algorithm()) { // Plaintext file
+                fileDecryptor.setPlaintextFile();
+                // Done to detect files that were not encrypted by mistake
+                if (!fileDecryptor.plaintextFilesAllowed()) {
+                    throw new ParquetCryptoRuntimeException("Applying decryptor on plaintext file");
+                }
+            }
+            else {  // Encrypted file with plaintext footer
+                // if no fileDecryptor, can still read plaintext columns
+                fileDecryptor.setFileCryptoMetaData(fileMetaData.getEncryption_algorithm(), false,
+                        fileMetaData.getFooter_signing_key_metadata());
+                if (fileDecryptor.checkFooterIntegrity()) {
+                    verifyFooterIntegrity(input, fileDecryptor, metadataLength);
+                }
+            }
+        }
+
+        //validateParquet(!schema.isEmpty(), "Empty Parquet schema in file: %s", file);
 
         MessageType messageType = readParquetSchema(schema);
         List<BlockMetaData> blocks = new ArrayList<>();
@@ -120,34 +176,61 @@ public final class MetadataReader
                 List<ColumnChunk> columns = rowGroup.getColumns();
                 validateParquet(!columns.isEmpty(), "No columns in row group: %s", rowGroup);
                 String filePath = columns.get(0).getFile_path();
+                int columnOrdinal = -1;
                 for (ColumnChunk columnChunk : columns) {
+                    columnOrdinal++;
                     validateParquet(
                             (filePath == null && columnChunk.getFile_path() == null)
                                     || (filePath != null && filePath.equals(columnChunk.getFile_path())),
                             "all column chunks of the same row group must be in the same file");
-                    ColumnMetaData metaData = columnChunk.meta_data;
-                    String[] path = metaData.path_in_schema.stream()
-                            .map(value -> value.toLowerCase(Locale.ENGLISH))
-                            .toArray(String[]::new);
-                    ColumnPath columnPath = ColumnPath.get(path);
-                    PrimitiveType primitiveType = messageType.getType(columnPath.toArray()).asPrimitiveType();
-                    PrimitiveTypeName primitiveTypeName = primitiveType.getPrimitiveTypeName();
 
-                    ColumnChunkMetaData column = ColumnChunkMetaData.get(
-                            columnPath,
-                            primitiveType,
-                            CompressionCodecName.fromParquet(metaData.codec),
-                            PARQUET_METADATA_CONVERTER.convertEncodingStats(metaData.encoding_stats),
-                            readEncodings(metaData.encodings),
-                            readStats(metaData.statistics, primitiveTypeName),
-                            metaData.data_page_offset,
-                            metaData.dictionary_page_offset,
-                            metaData.num_values,
-                            metaData.total_compressed_size,
-                            metaData.total_uncompressed_size);
-                    column.setColumnIndexReference(toColumnIndexReference(columnChunk));
-                    column.setOffsetIndexReference(toOffsetIndexReference(columnChunk));
-                    blockMetaData.addColumn(column);
+                    ColumnMetaData metaData = columnChunk.meta_data;
+                    ColumnCryptoMetaData cryptoMetaData = columnChunk.getCrypto_metadata();
+                    ColumnPath columnPath = null;
+                    boolean encryptedMetadata = false;
+
+                    if (null == cryptoMetaData) { // Plaintext column
+                        columnPath = getPath(metaData);
+                        if (null != fileDecryptor && !fileDecryptor.plaintextFile()) {
+                            // mark this column as plaintext in encrypted file decryptor
+                            fileDecryptor.setColumnCryptoMetadata(columnPath, false, false, (byte[]) null, columnOrdinal);
+                        }
+                    }
+                    else {  // Encrypted column
+                        if (cryptoMetaData.isSetENCRYPTION_WITH_FOOTER_KEY()) { // Column encrypted with footer key
+                            if (!encryptedFooter) {
+                                throw new ParquetCryptoRuntimeException("Column encrypted with footer key in file with plaintext footer");
+                            }
+                            if (null == metaData) {
+                                throw new ParquetCryptoRuntimeException("ColumnMetaData not set in Encryption with Footer key");
+                            }
+                            if (null == fileDecryptor) {
+                                throw new ParquetCryptoRuntimeException("Column encrypted with footer key: No keys available");
+                            }
+                            columnPath = getPath(metaData);
+                            fileDecryptor.setColumnCryptoMetadata(columnPath, true, true, (byte[]) null, columnOrdinal);
+                        }
+                        else { // Column encrypted with column key
+                            encryptedMetadata = true;
+                        }
+                    }
+
+                    try {
+                        if (encryptedMetadata) {
+                            // TODO: We decrypted data before filter projection. This could send unnecessary traffic to KMS.
+                            //  In parquet-mr, it uses lazy decyrption but that required to change ColumnChunkMetadata. We will improve it alter.
+                            metaData = decryptMetadata(rowGroup, cryptoMetaData, columnChunk, fileDecryptor, columnOrdinal);
+                            columnPath = getPath(metaData);
+                        }
+                        ColumnChunkMetaData column = buildColumnChunkMetaData(metaData, columnPath, messageType.getType(columnPath.toArray()).asPrimitiveType());
+                        column.setColumnIndexReference(toColumnIndexReference(columnChunk));
+                        column.setOffsetIndexReference(toOffsetIndexReference(columnChunk));
+                        blockMetaData.addColumn(column);
+                    }
+                    catch (KeyAccessDeniedException e) {
+                        ColumnChunkMetaData column = new HiddenColumnChunkMetaData(columnPath, filePath);
+                        blockMetaData.addColumn(column);
+                    }
                 }
                 blockMetaData.setPath(filePath);
                 blocks.add(blockMetaData);
@@ -163,6 +246,70 @@ public final class MetadataReader
         }
         ParquetMetadata parquetMetadata = new ParquetMetadata(new org.apache.parquet.hadoop.metadata.FileMetaData(messageType, keyValueMetaData, fileMetaData.getCreated_by()), blocks);
         return new ParquetFileMetadata(parquetMetadata, toIntExact(metadataLength));
+    }
+
+    private static ColumnMetaData decryptMetadata(RowGroup rowGroup, ColumnCryptoMetaData cryptoMetaData, ColumnChunk columnChunk, InternalFileDecryptor fileDecryptor, int columnOrdinal)
+    {
+        EncryptionWithColumnKey columnKeyStruct = cryptoMetaData.getENCRYPTION_WITH_COLUMN_KEY();
+        List<String> pathList = columnKeyStruct.getPath_in_schema();
+        byte[] columnKeyMetadata = columnKeyStruct.getKey_metadata();
+        ColumnPath columnPath = ColumnPath.get(pathList.toArray(new String[pathList.size()]));
+        byte[] encryptedMetadataBuffer = columnChunk.getEncrypted_column_metadata();
+
+        // Decrypt the ColumnMetaData
+        InternalColumnDecryptionSetup columnDecryptionSetup = fileDecryptor.setColumnCryptoMetadata(columnPath, true, false, columnKeyMetadata, columnOrdinal);
+        ByteArrayInputStream tempInputStream = new ByteArrayInputStream(encryptedMetadataBuffer);
+        byte[] columnMetaDataAAD = AesCipher.createModuleAAD(fileDecryptor.getFileAAD(), ModuleType.ColumnMetaData, rowGroup.ordinal, columnOrdinal, -1);
+        try {
+            return Util.readColumnMetaData(tempInputStream, columnDecryptionSetup.getMetaDataDecryptor(), columnMetaDataAAD);
+        }
+        catch (IOException e) {
+            throw new ParquetCryptoRuntimeException(columnPath + ". Failed to decrypt column metadata", e);
+        }
+    }
+
+    public static ColumnChunkMetaData buildColumnChunkMetaData(ColumnMetaData metaData, ColumnPath columnPath, PrimitiveType type)
+    {
+        return ColumnChunkMetaData.get(
+                columnPath,
+                type,
+                CompressionCodecName.fromParquet(metaData.codec),
+                PARQUET_METADATA_CONVERTER.convertEncodingStats(metaData.encoding_stats),
+                readEncodings(metaData.encodings),
+                readStats(metaData.statistics, type.getPrimitiveTypeName()),
+                metaData.data_page_offset,
+                metaData.dictionary_page_offset,
+                metaData.num_values,
+                metaData.total_compressed_size,
+                metaData.total_uncompressed_size);
+    }
+
+    private static ColumnPath getPath(ColumnMetaData metaData)
+    {
+        String[] path = metaData.path_in_schema.toArray(new String[0]);
+        return ColumnPath.get(path);
+    }
+
+    private static void verifyFooterIntegrity(BasicSliceInput from, InternalFileDecryptor fileDecryptor, int combinedFooterLength)
+    {
+        byte[] nonce = new byte[AesCipher.NONCE_LENGTH];
+        from.read(nonce);
+        byte[] gcmTag = new byte[AesCipher.GCM_TAG_LENGTH];
+        from.read(gcmTag);
+
+        AesGcmEncryptor footerSigner = fileDecryptor.createSignedFooterEncryptor();
+        int footerSignatureLength = AesCipher.NONCE_LENGTH + AesCipher.GCM_TAG_LENGTH;
+        byte[] serializedFooter = new byte[combinedFooterLength - footerSignatureLength];
+        from.setPosition(0);
+        from.read(serializedFooter, 0, serializedFooter.length);
+
+        byte[] signedFooterAAD = AesCipher.createFooterAAD(fileDecryptor.getFileAAD());
+        byte[] encryptedFooterBytes = footerSigner.encrypt(false, serializedFooter, nonce, signedFooterAAD);
+        byte[] calculatedTag = new byte[AesCipher.GCM_TAG_LENGTH];
+        System.arraycopy(encryptedFooterBytes, encryptedFooterBytes.length - AesCipher.GCM_TAG_LENGTH, calculatedTag, 0, AesCipher.GCM_TAG_LENGTH);
+        if (!Arrays.equals(gcmTag, calculatedTag)) {
+            throw new TagVerificationException("Signature mismatch in plaintext footer");
+        }
     }
 
     private static MessageType readParquetSchema(List<SchemaElement> schema)
@@ -306,10 +453,9 @@ public final class MetadataReader
     }
 
     @Override
-    public ParquetFileMetadata getParquetMetadata(ParquetDataSource parquetDataSource, long fileSize, boolean cacheable)
-            throws IOException
+    public ParquetFileMetadata getParquetMetadata(ParquetDataSource parquetDataSource, long fileSize, boolean cacheable, InternalFileDecryptor fileDecryptor) throws IOException
     {
-        return readFooter(parquetDataSource, fileSize);
+        return readFooter(parquetDataSource, fileSize, fileDecryptor);
     }
 
     private static IndexReference toColumnIndexReference(ColumnChunk columnChunk)

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/predicate/PredicateUtils.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/predicate/PredicateUtils.java
@@ -30,6 +30,7 @@ import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.Encoding;
 import org.apache.parquet.column.EncodingStats;
 import org.apache.parquet.column.statistics.Statistics;
+import org.apache.parquet.crypto.HiddenColumnChunkMetaData;
 import org.apache.parquet.format.DictionaryPageHeader;
 import org.apache.parquet.format.PageHeader;
 import org.apache.parquet.format.PageType;
@@ -105,11 +106,13 @@ public final class PredicateUtils
     {
         ImmutableMap.Builder<ColumnDescriptor, Statistics<?>> statistics = ImmutableMap.builder();
         for (ColumnChunkMetaData columnMetaData : blockMetadata.getColumns()) {
-            Statistics<?> columnStatistics = columnMetaData.getStatistics();
-            if (columnStatistics != null) {
-                RichColumnDescriptor descriptor = descriptorsByPath.get(Arrays.asList(columnMetaData.getPath().toArray()));
-                if (descriptor != null) {
-                    statistics.put(descriptor, columnStatistics);
+            if (!HiddenColumnChunkMetaData.isHiddenColumn(columnMetaData)) {
+                Statistics<?> columnStatistics = columnMetaData.getStatistics();
+                if (columnStatistics != null) {
+                    RichColumnDescriptor descriptor = descriptorsByPath.get(Arrays.asList(columnMetaData.getPath().toArray()));
+                    if (descriptor != null) {
+                        statistics.put(descriptor, columnStatistics);
+                    }
                 }
             }
         }
@@ -119,14 +122,16 @@ public final class PredicateUtils
     private static boolean dictionaryPredicatesMatch(Predicate parquetPredicate, BlockMetaData blockMetadata, ParquetDataSource dataSource, Map<List<String>, RichColumnDescriptor> descriptorsByPath, TupleDomain<ColumnDescriptor> parquetTupleDomain)
     {
         for (ColumnChunkMetaData columnMetaData : blockMetadata.getColumns()) {
-            RichColumnDescriptor descriptor = descriptorsByPath.get(Arrays.asList(columnMetaData.getPath().toArray()));
-            if (descriptor != null) {
-                if (isOnlyDictionaryEncodingPages(columnMetaData) && isColumnPredicate(descriptor, parquetTupleDomain)) {
-                    byte[] buffer = new byte[toIntExact(columnMetaData.getTotalSize())];
-                    dataSource.readFully(columnMetaData.getStartingPos(), buffer);
-                    //  Early abort, predicate already filters block so no more dictionaries need be read
-                    if (!parquetPredicate.matches(new DictionaryDescriptor(descriptor, readDictionaryPage(buffer, columnMetaData.getCodec())))) {
-                        return false;
+            if (!HiddenColumnChunkMetaData.isHiddenColumn(columnMetaData)) {
+                RichColumnDescriptor descriptor = descriptorsByPath.get(Arrays.asList(columnMetaData.getPath().toArray()));
+                if (descriptor != null) {
+                    if (isOnlyDictionaryEncodingPages(columnMetaData) && isColumnPredicate(descriptor, parquetTupleDomain)) {
+                        byte[] buffer = new byte[toIntExact(columnMetaData.getTotalSize())];
+                        dataSource.readFully(columnMetaData.getStartingPos(), buffer);
+                        //  Early abort, predicate already filters block so no more dictionaries need be read
+                        if (!parquetPredicate.matches(new DictionaryDescriptor(descriptor, readDictionaryPage(buffer, columnMetaData.getCodec())))) {
+                            return false;
+                        }
                     }
                 }
             }

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/reader/ParquetColumnChunk.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/reader/ParquetColumnChunk.java
@@ -22,17 +22,26 @@ import com.facebook.presto.parquet.cache.MetadataReader;
 import io.airlift.slice.Slice;
 import org.apache.parquet.bytes.ByteBufferInputStream;
 import org.apache.parquet.column.Encoding;
+import org.apache.parquet.column.EncodingStats;
+import org.apache.parquet.crypto.AesCipher;
+import org.apache.parquet.crypto.InternalColumnDecryptionSetup;
+import org.apache.parquet.crypto.InternalFileDecryptor;
+import org.apache.parquet.crypto.ModuleCipherFactory.ModuleType;
+import org.apache.parquet.format.BlockCipher;
 import org.apache.parquet.format.DataPageHeader;
 import org.apache.parquet.format.DataPageHeaderV2;
 import org.apache.parquet.format.DictionaryPageHeader;
 import org.apache.parquet.format.PageHeader;
 import org.apache.parquet.format.Util;
+import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnPath;
 import org.apache.parquet.internal.column.columnindex.OffsetIndex;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 
 import static com.facebook.presto.parquet.ParquetTypeUtils.getParquetEncoding;
 import static io.airlift.slice.Slices.wrappedBuffer;
@@ -68,21 +77,43 @@ public class ParquetColumnChunk
         return descriptor;
     }
 
-    protected PageHeader readPageHeader()
+    protected PageHeader readPageHeader(BlockCipher.Decryptor headerBlockDecryptor, byte[] pageHeaderAAD)
             throws IOException
     {
-        return Util.readPageHeader(stream);
+        return Util.readPageHeader(stream, headerBlockDecryptor, pageHeaderAAD);
     }
 
-    public PageReader readAllPages()
+    public PageReader readAllPages(InternalFileDecryptor fileDecryptor, int rowGroupOrdinal, int columnOrdinal)
             throws IOException
     {
         LinkedList<DataPage> pages = new LinkedList<>();
         DictionaryPage dictionaryPage = null;
         long valueCount = 0;
         int dataPageCount = 0;
+        int pageOrdinal = 0;
+        byte[] dataPageHeaderAAD = null;
+        BlockCipher.Decryptor headerBlockDecryptor = null;
+        InternalColumnDecryptionSetup columnDecryptionSetup = null;
+        if (fileDecryptor != null) {
+            ColumnPath columnPath = ColumnPath.get(descriptor.getColumnDescriptor().getPath());
+            columnDecryptionSetup = fileDecryptor.getColumnSetup(columnPath);
+            headerBlockDecryptor = columnDecryptionSetup.getMetaDataDecryptor();
+            if (null != headerBlockDecryptor) {
+                dataPageHeaderAAD = AesCipher.createModuleAAD(fileDecryptor.getFileAAD(), ModuleType.DataPageHeader, rowGroupOrdinal, columnOrdinal, pageOrdinal);
+            }
+        }
         while (hasMorePages(valueCount, dataPageCount)) {
-            PageHeader pageHeader = readPageHeader();
+            byte[] pageHeaderAAD = dataPageHeaderAAD;
+            if (null != headerBlockDecryptor) {
+                // Important: this verifies file integrity (makes sure dictionary page had not been removed)
+                if (null == dictionaryPage && hasDictionaryPage(descriptor.getColumnChunkMetaData())) {
+                    pageHeaderAAD = AesCipher.createModuleAAD(fileDecryptor.getFileAAD(), ModuleType.DictionaryPageHeader, rowGroupOrdinal, columnOrdinal, -1);
+                }
+                else {
+                    AesCipher.quickUpdatePageAAD(dataPageHeaderAAD, pageOrdinal);
+                }
+            }
+            PageHeader pageHeader = readPageHeader(headerBlockDecryptor, pageHeaderAAD);
             int uncompressedPageSize = pageHeader.getUncompressed_page_size();
             int compressedPageSize = pageHeader.getCompressed_page_size();
             long firstRowIndex = -1;
@@ -97,18 +128,22 @@ public class ParquetColumnChunk
                     firstRowIndex = PageReader.getFirstRowIndex(dataPageCount, offsetIndex);
                     valueCount += readDataPageV1(pageHeader, uncompressedPageSize, compressedPageSize, firstRowIndex, pages);
                     dataPageCount = dataPageCount + 1;
+                    pageOrdinal = pageOrdinal + 1;
                     break;
                 case DATA_PAGE_V2:
                     firstRowIndex = PageReader.getFirstRowIndex(dataPageCount, offsetIndex);
                     valueCount += readDataPageV2(pageHeader, uncompressedPageSize, compressedPageSize, firstRowIndex, pages);
                     dataPageCount = dataPageCount + 1;
+                    pageOrdinal = pageOrdinal + 1;
                     break;
                 default:
                     stream.skipFully(compressedPageSize);
                     break;
             }
         }
-        return new PageReader(descriptor.getColumnChunkMetaData().getCodec(), pages, dictionaryPage, offsetIndex);
+        byte[] fileAad = (fileDecryptor == null) ? null : fileDecryptor.getFileAAD();
+        BlockCipher.Decryptor dataDecryptor = (columnDecryptionSetup == null) ? null : columnDecryptionSetup.getDataDecryptor();
+        return new PageReader(descriptor.getColumnChunkMetaData().getCodec(), pages, dictionaryPage, offsetIndex, dataDecryptor, fileAad, rowGroupOrdinal, columnOrdinal);
     }
 
     private Slice getSlice(int size) throws IOException
@@ -122,7 +157,7 @@ public class ParquetColumnChunk
         return wrappedBuffer(buffer.array(), buffer.position(), size);
     }
 
-    private DictionaryPage readDictionaryPage(PageHeader pageHeader, int uncompressedPageSize, int compressedPageSize)
+    protected DictionaryPage readDictionaryPage(PageHeader pageHeader, int uncompressedPageSize, int compressedPageSize)
             throws IOException
     {
         DictionaryPageHeader dictHeader = pageHeader.getDictionary_page_header();
@@ -185,5 +220,17 @@ public class ParquetColumnChunk
     {
         return offsetIndex == null ? valuesCount < descriptor.getColumnChunkMetaData().getValueCount()
                 : pagesCount < offsetIndex.getPageCount();
+    }
+
+    private boolean hasDictionaryPage(ColumnChunkMetaData columnChunkMetaData)
+    {
+        EncodingStats stats = columnChunkMetaData.getEncodingStats();
+        if (stats != null) {
+            return stats.hasDictionaryPages() && stats.hasDictionaryEncodedPages();
+        }
+        else {
+            Set<Encoding> encodings = columnChunkMetaData.getEncodings();
+            return encodings.contains(Encoding.PLAIN_DICTIONARY) || encodings.contains(Encoding.RLE_DICTIONARY);
+        }
     }
 }

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/reader/ParquetReader.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/reader/ParquetReader.java
@@ -43,6 +43,9 @@ import it.unimi.dsi.fastutil.booleans.BooleanList;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
 import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.crypto.HiddenColumnChunkMetaData;
+import org.apache.parquet.crypto.InternalColumnDecryptionSetup;
+import org.apache.parquet.crypto.InternalFileDecryptor;
 import org.apache.parquet.filter2.compat.FilterCompat;
 import org.apache.parquet.filter2.predicate.FilterPredicate;
 import org.apache.parquet.hadoop.metadata.BlockMetaData;
@@ -89,17 +92,15 @@ public class ParquetReader
     private static final int MAX_VECTOR_LENGTH = 1024;
     private static final int INITIAL_BATCH_SIZE = 1;
     private static final int BATCH_SIZE_GROWTH_FACTOR = 2;
-
+    private final InternalFileDecryptor fileDecryptor;
     private final List<BlockMetaData> blocks;
     private final List<PrimitiveColumnIO> columns;
-    private final ParquetDataSource dataSource;
     private final AggregatedMemoryContext systemMemoryContext;
     private final boolean batchReadEnabled;
     private final boolean enableVerification;
     private final FilterPredicate filter;
 
     private int currentBlock;
-    private BlockMetaData currentBlockMetadata;
     private long currentPosition;
     private long currentGroupRowCount;
     private RowRanges currentGroupRowRanges;
@@ -120,10 +121,12 @@ public class ParquetReader
     private final List<RowRanges> blockRowRanges;
     private final Map<ColumnPath, ColumnDescriptor> paths = new HashMap<>();
 
+    protected final ParquetDataSource dataSource;
+    protected BlockMetaData currentBlockMetadata;
+
     private final boolean columnIndexFilterEnabled;
 
-    public ParquetReader(MessageColumnIO
-            messageColumnIO,
+    public ParquetReader(MessageColumnIO messageColumnIO,
             List<BlockMetaData> blocks,
             ParquetDataSource dataSource,
             AggregatedMemoryContext systemMemoryContext,
@@ -132,7 +135,8 @@ public class ParquetReader
             boolean enableVerification,
             Predicate parquetPredicate,
             List<ColumnIndexStore> blockIndexStores,
-            boolean columnIndexFilterEnabled)
+            boolean columnIndexFilterEnabled,
+            InternalFileDecryptor fileDecryptor)
     {
         this.blocks = blocks;
         this.dataSource = requireNonNull(dataSource, "dataSource is null");
@@ -159,6 +163,7 @@ public class ParquetReader
         }
         this.currentBlock = -1;
         this.columnIndexFilterEnabled = columnIndexFilterEnabled;
+        this.fileDecryptor = fileDecryptor;
     }
 
     @Override
@@ -372,7 +377,7 @@ public class ParquetReader
     {
         ColumnChunkDescriptor descriptor = new ColumnChunkDescriptor(columnDescriptor, metadata, bufferSize);
         ParquetColumnChunk columnChunk = new ParquetColumnChunk(descriptor, buffers, offsetIndex);
-        return columnChunk.readAllPages();
+        return createPageReaderInternal(columnDescriptor, columnChunk);
     }
 
     protected PageReader createPageReader(byte[] buffer, int bufferSize, ColumnChunkMetaData metadata, ColumnDescriptor columnDescriptor)
@@ -380,7 +385,24 @@ public class ParquetReader
     {
         ColumnChunkDescriptor descriptor = new ColumnChunkDescriptor(columnDescriptor, metadata, bufferSize);
         ParquetColumnChunk columnChunk = new ParquetColumnChunk(descriptor, buffer, 0);
-        return columnChunk.readAllPages();
+        return createPageReaderInternal(columnDescriptor, columnChunk);
+    }
+
+    private PageReader createPageReaderInternal(ColumnDescriptor columnDescriptor, ParquetColumnChunk columnChunk)
+            throws IOException
+    {
+        if (!isEncryptedColumn(fileDecryptor, columnDescriptor)) {
+            return columnChunk.readAllPages(null, -1, -1);
+        }
+
+        InternalColumnDecryptionSetup colDecSetup = fileDecryptor.getColumnSetup(ColumnPath.get(columnChunk.getDescriptor().getColumnDescriptor().getPath()));
+        return columnChunk.readAllPages(fileDecryptor, currentBlock, colDecSetup.getOrdinal());
+    }
+
+    private boolean isEncryptedColumn(InternalFileDecryptor fileDecryptor, ColumnDescriptor columnDescriptor)
+    {
+        ColumnPath columnPath = ColumnPath.get(columnDescriptor.getPath());
+        return fileDecryptor != null && !fileDecryptor.plaintextFile() && fileDecryptor.getColumnSetup(columnPath).isEncrypted();
     }
 
     protected byte[] allocateBlock(long length)
@@ -391,12 +413,14 @@ public class ParquetReader
         return buffer;
     }
 
-    private ColumnChunkMetaData getColumnChunkMetaData(ColumnDescriptor columnDescriptor)
+    protected ColumnChunkMetaData getColumnChunkMetaData(ColumnDescriptor columnDescriptor)
             throws IOException
     {
         for (ColumnChunkMetaData metadata : currentBlockMetadata.getColumns()) {
-            if (metadata.getPath().equals(ColumnPath.get(columnDescriptor.getPath()))) {
-                return metadata;
+            if (!HiddenColumnChunkMetaData.isHiddenColumn(metadata)) {
+                if (metadata.getPath().equals(ColumnPath.get(columnDescriptor.getPath()))) {
+                    return metadata;
+                }
             }
         }
         throw new ParquetCorruptionException("Metadata is missing for column: %s", columnDescriptor);

--- a/presto-parquet/src/main/java/org/apache/parquet/crypto/HiddenColumnChunkMetaData.java
+++ b/presto-parquet/src/main/java/org/apache/parquet/crypto/HiddenColumnChunkMetaData.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.parquet.crypto;
+
+import org.apache.parquet.column.EncodingStats;
+import org.apache.parquet.column.statistics.Statistics;
+import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnChunkProperties;
+import org.apache.parquet.hadoop.metadata.ColumnPath;
+
+public class HiddenColumnChunkMetaData
+        extends ColumnChunkMetaData
+{
+    private final ColumnPath path;
+    private final String filePath;
+
+    public HiddenColumnChunkMetaData(ColumnPath path, String filePath)
+    {
+        super((EncodingStats) null, (ColumnChunkProperties) null);
+        this.path = path;
+        this.filePath = filePath;
+    }
+
+    @Override
+    public long getFirstDataPageOffset()
+    {
+        throw new HiddenColumnException(this.path.toArray(), this.filePath);
+    }
+
+    @Override
+    public long getDictionaryPageOffset()
+    {
+        throw new HiddenColumnException(this.path.toArray(), this.filePath);
+    }
+
+    @Override
+    public long getValueCount()
+    {
+        throw new HiddenColumnException(this.path.toArray(), this.filePath);
+    }
+
+    @Override
+    public long getTotalUncompressedSize()
+    {
+        throw new HiddenColumnException(this.path.toArray(), this.filePath);
+    }
+
+    @Override
+    public long getTotalSize()
+    {
+        throw new HiddenColumnException(this.path.toArray(), this.filePath);
+    }
+
+    @Override
+    public Statistics getStatistics()
+    {
+        throw new HiddenColumnException(this.path.toArray(), this.filePath);
+    }
+
+    public static boolean isHiddenColumn(ColumnChunkMetaData column)
+    {
+        return column instanceof HiddenColumnChunkMetaData;
+    }
+}

--- a/presto-parquet/src/main/java/org/apache/parquet/crypto/HiddenColumnException.java
+++ b/presto-parquet/src/main/java/org/apache/parquet/crypto/HiddenColumnException.java
@@ -11,15 +11,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.parquet.cache;
+package org.apache.parquet.crypto;
 
-import com.facebook.presto.parquet.ParquetDataSource;
-import org.apache.parquet.crypto.InternalFileDecryptor;
+import org.apache.parquet.ParquetRuntimeException;
 
-import java.io.IOException;
+import java.util.Arrays;
 
-public interface ParquetMetadataSource
+public class HiddenColumnException
+        extends ParquetRuntimeException
 {
-    ParquetFileMetadata getParquetMetadata(ParquetDataSource parquetDataSource, long fileSize, boolean cacheable, InternalFileDecryptor fileDecryptor)
-            throws IOException;
+    private static final long serialVersionUID = 1L;
+
+    public HiddenColumnException(String[] columnPath, String filePath)
+    {
+        super("User does not have access to the encryption key for encrypted column = " + Arrays.toString(columnPath) + " for file: " + filePath);
+    }
 }

--- a/presto-parquet/src/test/java/com/facebook/presto/parquet/BenchmarkParquetReader.java
+++ b/presto-parquet/src/test/java/com/facebook/presto/parquet/BenchmarkParquetReader.java
@@ -272,13 +272,13 @@ public class BenchmarkParquetReader
                 throws IOException
         {
             FileParquetDataSource dataSource = new FileParquetDataSource(file);
-            ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, file.length()).getParquetMetadata();
+            ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, file.length(), null).getParquetMetadata();
             MessageType schema = parquetMetadata.getFileMetaData().getSchema();
             MessageColumnIO messageColumnIO = getColumnIO(schema, schema);
 
             this.field = ColumnIOConverter.constructField(getType(), messageColumnIO.getChild(0)).get();
 
-            return new ParquetReader(messageColumnIO, parquetMetadata.getBlocks(), dataSource, newSimpleAggregatedMemoryContext(), new DataSize(16, MEGABYTE), enableOptimizedReader, enableVerification, null, null, false);
+            return new ParquetReader(messageColumnIO, parquetMetadata.getBlocks(), dataSource, newSimpleAggregatedMemoryContext(), new DataSize(16, MEGABYTE), enableOptimizedReader, enableVerification, null, null, false, null);
         }
 
         protected boolean getNullability()

--- a/presto-parquet/src/test/java/com/facebook/presto/parquet/reader/EncDecPropertiesHelper.java
+++ b/presto-parquet/src/test/java/com/facebook/presto/parquet/reader/EncDecPropertiesHelper.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.parquet.reader;
+import org.apache.parquet.crypto.ColumnEncryptionProperties;
+import org.apache.parquet.crypto.DecryptionKeyRetriever;
+import org.apache.parquet.crypto.FileDecryptionProperties;
+import org.apache.parquet.crypto.FileEncryptionProperties;
+import org.apache.parquet.crypto.ParquetCipher;
+import org.apache.parquet.hadoop.metadata.ColumnPath;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class EncDecPropertiesHelper
+{
+    private EncDecPropertiesHelper()
+    {
+    }
+
+    private static class DecryptionKeyRetrieverMock
+            implements DecryptionKeyRetriever
+    {
+        private final Map<String, byte[]> keyMap = new HashMap<>();
+
+        public DecryptionKeyRetrieverMock putKey(String keyId, byte[] keyBytes)
+        {
+            keyMap.put(keyId, keyBytes);
+            return this;
+        }
+
+        @Override
+        public byte[] getKey(byte[] keyMetaData)
+        {
+            String keyId = new String(keyMetaData, StandardCharsets.UTF_8);
+            return keyMap.get(keyId);
+        }
+    }
+
+    private static final byte[] FOOTER_KEY = {0x01, 0x02, 0x03, 0x4, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a,
+            0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10};
+    private static final byte[] FOOTER_KEY_METADATA = "footkey".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] COL_KEY = {0x02, 0x03, 0x4, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b,
+            0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11};
+    private static final byte[] COL_KEY_METADATA = "col".getBytes(StandardCharsets.UTF_8);
+
+    public static FileDecryptionProperties getFileDecryptionProperties()
+            throws IOException
+    {
+        DecryptionKeyRetrieverMock keyRetriever = new DecryptionKeyRetrieverMock();
+        keyRetriever.putKey("footkey", FOOTER_KEY);
+        keyRetriever.putKey("col", COL_KEY);
+        return FileDecryptionProperties.builder().withPlaintextFilesAllowed().withKeyRetriever(keyRetriever).build();
+    }
+
+    public static FileEncryptionProperties getFileEncryptionProperties(List<String> encryptColumns, ParquetCipher cipher, Boolean encryptFooter)
+    {
+        if (encryptColumns.size() == 0) {
+            return null;
+        }
+
+        Map<ColumnPath, ColumnEncryptionProperties> columnPropertyMap = new HashMap<>();
+        for (String encryptColumn : encryptColumns) {
+            ColumnPath columnPath = ColumnPath.fromDotString(encryptColumn);
+            ColumnEncryptionProperties columnEncryptionProperties = ColumnEncryptionProperties.builder(columnPath)
+                    .withKey(COL_KEY)
+                    .withKeyMetaData(COL_KEY_METADATA)
+                    .build();
+            columnPropertyMap.put(columnPath, columnEncryptionProperties);
+        }
+
+        FileEncryptionProperties.Builder encryptionPropertiesBuilder =
+                FileEncryptionProperties.builder(FOOTER_KEY)
+                        .withFooterKeyMetadata(FOOTER_KEY_METADATA)
+                        .withAlgorithm(cipher)
+                        .withEncryptedColumns(columnPropertyMap);
+
+        if (!encryptFooter) {
+            encryptionPropertiesBuilder.withPlaintextFooter();
+        }
+
+        return encryptionPropertiesBuilder.build();
+    }
+}

--- a/presto-parquet/src/test/java/com/facebook/presto/parquet/reader/EncryptionTestFile.java
+++ b/presto-parquet/src/test/java/com/facebook/presto/parquet/reader/EncryptionTestFile.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.parquet.reader;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.parquet.example.data.simple.SimpleGroup;
+
+import java.io.IOException;
+
+public class EncryptionTestFile
+{
+    private final String fileName;
+    private final SimpleGroup[] fileContent;
+
+    public EncryptionTestFile(String fileName, SimpleGroup[] fileContent)
+    {
+        this.fileName = fileName;
+        this.fileContent = fileContent;
+    }
+
+    public String getFileName()
+    {
+        return this.fileName;
+    }
+
+    public SimpleGroup[] getFileContent()
+    {
+        return this.fileContent;
+    }
+
+    public long getFileSize()
+            throws IOException
+    {
+        Path path = new Path(fileName);
+        long fileSize = path.getFileSystem(new Configuration()).getFileStatus(path).getLen();
+        return fileSize;
+    }
+}

--- a/presto-parquet/src/test/java/com/facebook/presto/parquet/reader/EncryptionTestFileBuilder.java
+++ b/presto-parquet/src/test/java/com/facebook/presto/parquet/reader/EncryptionTestFileBuilder.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.parquet.reader;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.parquet.column.ParquetProperties;
+import org.apache.parquet.crypto.FileEncryptionProperties;
+import org.apache.parquet.crypto.ParquetCipher;
+import org.apache.parquet.example.data.Group;
+import org.apache.parquet.example.data.simple.SimpleGroup;
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.hadoop.example.ExampleParquetWriter;
+import org.apache.parquet.hadoop.example.GroupWriteSupport;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.schema.GroupType;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Type;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
+
+public class EncryptionTestFileBuilder
+{
+    private MessageType schema;
+    private Configuration conf;
+    private Map<String, String> extraMeta = new HashMap<>();
+    private int numRecord = 100000;
+    private ParquetProperties.WriterVersion writerVersion = ParquetProperties.WriterVersion.PARQUET_1_0;
+    private int pageSize = ParquetProperties.DEFAULT_PAGE_SIZE;
+    private String codec = "ZSTD";
+    private String[] encryptColumns = {};
+    private ParquetCipher cipher = ParquetCipher.AES_GCM_V1;
+    private Boolean footerEncryption = false;
+
+    public EncryptionTestFileBuilder(Configuration conf, MessageType schema)
+    {
+        this.conf = conf;
+        this.schema = schema;
+        conf.set(GroupWriteSupport.PARQUET_EXAMPLE_SCHEMA, schema.toString());
+    }
+
+    public EncryptionTestFileBuilder withNumRecord(int numRecord)
+    {
+        this.numRecord = numRecord;
+        return this;
+    }
+
+    public EncryptionTestFileBuilder withEncrytionAlgorithm(ParquetCipher cipher)
+    {
+        this.cipher = cipher;
+        return this;
+    }
+
+    public EncryptionTestFileBuilder withExtraMeta(Map<String, String> extraMeta)
+    {
+        this.extraMeta = extraMeta;
+        return this;
+    }
+
+    public EncryptionTestFileBuilder withWriterVersion(ParquetProperties.WriterVersion writerVersion)
+    {
+        this.writerVersion = writerVersion;
+        return this;
+    }
+
+    public EncryptionTestFileBuilder withPageSize(int pageSize)
+    {
+        this.pageSize = pageSize;
+        return this;
+    }
+
+    public EncryptionTestFileBuilder withCodec(String codec)
+    {
+        this.codec = codec;
+        return this;
+    }
+
+    public EncryptionTestFileBuilder withEncryptColumns(String[] encryptColumns)
+    {
+        this.encryptColumns = encryptColumns;
+        return this;
+    }
+
+    public EncryptionTestFileBuilder withFooterEncryption()
+    {
+        this.footerEncryption = true;
+        return this;
+    }
+
+    public EncryptionTestFile build()
+            throws IOException
+    {
+        String fileName = createTempFile("test");
+        SimpleGroup[] fileContent = createFileContent(schema);
+        FileEncryptionProperties encryptionProperties = EncDecPropertiesHelper.getFileEncryptionProperties(Arrays.asList(encryptColumns), cipher, footerEncryption);
+        ExampleParquetWriter.Builder builder = ExampleParquetWriter.builder(new Path(fileName))
+                .withConf(conf)
+                .withWriterVersion(writerVersion)
+                .withExtraMetaData(extraMeta)
+                .withValidation(true)
+                .withPageSize(pageSize)
+                .withEncryption(encryptionProperties)
+                .withCompressionCodec(CompressionCodecName.valueOf(codec));
+        try (ParquetWriter writer = builder.build()) {
+            for (int i = 0; i < fileContent.length; i++) {
+                writer.write(fileContent[i]);
+            }
+        }
+        return new EncryptionTestFile(fileName, fileContent);
+    }
+
+    private SimpleGroup[] createFileContent(MessageType schema)
+    {
+        SimpleGroup[] simpleGroups = new SimpleGroup[numRecord];
+        for (int i = 0; i < simpleGroups.length; i++) {
+            SimpleGroup g = new SimpleGroup(schema);
+            for (Type type : schema.getFields()) {
+                addValueToSimpleGroup(g, type);
+            }
+            simpleGroups[i] = g;
+        }
+        return simpleGroups;
+    }
+
+    private void addValueToSimpleGroup(Group g, Type type)
+    {
+        if (type.isPrimitive()) {
+            PrimitiveType primitiveType = (PrimitiveType) type;
+            if (primitiveType.getPrimitiveTypeName().equals(INT32)) {
+                g.add(type.getName(), getInt());
+            }
+            else if (primitiveType.getPrimitiveTypeName().equals(INT64)) {
+                g.add(type.getName(), getLong());
+            }
+            else if (primitiveType.getPrimitiveTypeName().equals(BINARY)) {
+                g.add(type.getName(), getString());
+            }
+            // Only support 3 types now, more can be added later
+        }
+        else {
+            GroupType groupType = (GroupType) type;
+            Group parentGroup = g.addGroup(groupType.getName());
+            for (Type field : groupType.getFields()) {
+                addValueToSimpleGroup(parentGroup, field);
+            }
+        }
+    }
+
+    private static long getInt()
+    {
+        return ThreadLocalRandom.current().nextInt(10000);
+    }
+
+    private static long getLong()
+    {
+        return ThreadLocalRandom.current().nextLong(100000);
+    }
+
+    private static String getString()
+    {
+        char[] chars = {'a', 'b', 'c', 'd', 'e', 'f', 'g', 'x', 'z', 'y'};
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 100; i++) {
+            sb.append(chars[ThreadLocalRandom.current().nextInt(10)]);
+        }
+        return sb.toString();
+    }
+
+    public static String createTempFile(String prefix)
+    {
+        try {
+            return Files.createTempDirectory(prefix).toAbsolutePath().toString() + "/test.parquet";
+        }
+        catch (IOException e) {
+            throw new AssertionError("Unable to create temporary file", e);
+        }
+    }
+}

--- a/presto-parquet/src/test/java/com/facebook/presto/parquet/reader/MockInputStreamTail.java
+++ b/presto-parquet/src/test/java/com/facebook/presto/parquet/reader/MockInputStreamTail.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.parquet.reader;
+
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import org.apache.hadoop.fs.FSDataInputStream;
+
+import java.io.IOException;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.lang.Math.max;
+import static java.lang.Math.min;
+import static java.lang.Math.toIntExact;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public final class MockInputStreamTail
+{
+    public static final int MAX_SUPPORTED_PADDING_BYTES = 64;
+    private static final int MAXIMUM_READ_LENGTH = Integer.MAX_VALUE - (MAX_SUPPORTED_PADDING_BYTES + 1);
+
+    private final Slice tailSlice;
+    private final long fileSize;
+
+    private MockInputStreamTail(long fileSize, Slice tailSlice)
+    {
+        this.tailSlice = requireNonNull(tailSlice, "tailSlice is null");
+        this.fileSize = fileSize;
+        checkArgument(fileSize >= 0, "fileSize is negative: %s", fileSize);
+        checkArgument(tailSlice.length() <= fileSize, "length (%s) is greater than fileSize (%s)", tailSlice.length(), fileSize);
+    }
+
+    public static MockInputStreamTail readTail(String path, long paddedFileSize, FSDataInputStream inputStream, int length)
+            throws IOException
+    {
+        checkArgument(length >= 0, "length is negative: %s", length);
+        checkArgument(length <= MAXIMUM_READ_LENGTH, "length (%s) exceeds maximum (%s)", length, MAXIMUM_READ_LENGTH);
+        long readSize = min(paddedFileSize, (length + MAX_SUPPORTED_PADDING_BYTES));
+        long position = paddedFileSize - readSize;
+        // Actual read will be 1 byte larger to ensure we encounter an EOF where expected
+        byte[] buffer = new byte[toIntExact(readSize + 1)];
+        int bytesRead = 0;
+        long startPos = inputStream.getPos();
+        try {
+            inputStream.seek(position);
+            while (bytesRead < buffer.length) {
+                int n = inputStream.read(buffer, bytesRead, buffer.length - bytesRead);
+                if (n < 0) {
+                    break;
+                }
+                bytesRead += n;
+            }
+        }
+        finally {
+            inputStream.seek(startPos);
+        }
+        if (bytesRead > readSize) {
+            throw rejectInvalidFileSize(path, paddedFileSize);
+        }
+        return new MockInputStreamTail(position + bytesRead, Slices.wrappedBuffer(buffer, max(0, bytesRead - length), min(bytesRead, length)));
+    }
+
+    public static long readTailForFileSize(String path, long paddedFileSize, FSDataInputStream inputStream)
+            throws IOException
+    {
+        long position = max(paddedFileSize - MAX_SUPPORTED_PADDING_BYTES, 0);
+        long maxEOFAt = paddedFileSize + 1;
+        long startPos = inputStream.getPos();
+        try {
+            inputStream.seek(position);
+            int c;
+            while (position < maxEOFAt) {
+                c = inputStream.read();
+                if (c < 0) {
+                    return position;
+                }
+                position++;
+            }
+            throw rejectInvalidFileSize(path, paddedFileSize);
+        }
+        finally {
+            inputStream.seek(startPos);
+        }
+    }
+
+    private static IOException rejectInvalidFileSize(String path, long reportedSize)
+            throws IOException
+    {
+        throw new IOException(format("Incorrect file size (%s) for file (end of stream not reached): %s", reportedSize, path));
+    }
+
+    public long getFileSize()
+    {
+        return fileSize;
+    }
+
+    public Slice getTailSlice()
+    {
+        return tailSlice;
+    }
+}

--- a/presto-parquet/src/test/java/com/facebook/presto/parquet/reader/MockParquetDataSource.java
+++ b/presto-parquet/src/test/java/com/facebook/presto/parquet/reader/MockParquetDataSource.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.parquet.reader;
+
+//import com.facebook.presto.parquet.ChunkReader;
+//import com.facebook.presto.parquet.DiskRange;
+
+import com.facebook.presto.common.NotSupportedException;
+import com.facebook.presto.parquet.ParquetDataSource;
+import com.facebook.presto.parquet.ParquetDataSourceId;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
+import org.apache.parquet.internal.column.columnindex.ColumnIndex;
+import org.apache.parquet.internal.column.columnindex.OffsetIndex;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+public class MockParquetDataSource
+        implements ParquetDataSource
+{
+    private final ParquetDataSourceId id;
+    private final long estimatedSize;
+    private final FSDataInputStream inputStream;
+    private long readTimeNanos;
+    private long readBytes;
+    //private final ParquetReaderOptions options;
+
+    public MockParquetDataSource(
+            ParquetDataSourceId id,
+            long estimatedSize,
+            FSDataInputStream inputStream)
+    {
+        this.id = requireNonNull(id, "id is null");
+        this.estimatedSize = estimatedSize;
+        this.inputStream = inputStream;
+//        this.options = requireNonNull(options, "options is null");
+    }
+
+    @Override
+    public ParquetDataSourceId getId()
+    {
+        return id;
+    }
+
+    @Override
+    public final long getReadBytes()
+    {
+        return readBytes;
+    }
+
+    @Override
+    public long getReadTimeNanos()
+    {
+        return readTimeNanos;
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        inputStream.close();
+    }
+
+    @Override
+    public final void readFully(long position, byte[] buffer)
+    {
+        readFully(position, buffer, 0, buffer.length);
+    }
+
+    @Override
+    public void readFully(long position, byte[] buffer, int bufferOffset, int bufferLength)
+    {
+        readBytes += bufferLength;
+
+        long start = System.nanoTime();
+        try {
+            inputStream.readFully(position, buffer, bufferOffset, bufferLength);
+        }
+        catch (Exception e) {
+            throw new RuntimeException("Error reading from %s " + id + " at position " + position);
+        }
+        long currentReadTimeNanos = System.nanoTime() - start;
+
+        readTimeNanos += currentReadTimeNanos;
+    }
+
+    @Override
+    public Optional<ColumnIndex> readColumnIndex(ColumnChunkMetaData column)
+            throws IOException
+    {
+        throw new NotSupportedException("Not supported");
+    }
+
+    @Override
+    public Optional<OffsetIndex> readOffsetIndex(ColumnChunkMetaData column)
+            throws IOException
+    {
+        throw new NotSupportedException("Not supported");
+    }
+}

--- a/presto-parquet/src/test/java/com/facebook/presto/parquet/reader/TestEncryption.java
+++ b/presto-parquet/src/test/java/com/facebook/presto/parquet/reader/TestEncryption.java
@@ -1,0 +1,353 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.parquet.reader;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.MapType;
+import com.facebook.presto.common.type.RowType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.parquet.Field;
+import com.facebook.presto.parquet.GroupField;
+import com.facebook.presto.parquet.ParquetDataSource;
+import com.facebook.presto.parquet.ParquetDataSourceId;
+import com.facebook.presto.parquet.PrimitiveField;
+import com.facebook.presto.parquet.RichColumnDescriptor;
+import com.facebook.presto.parquet.cache.MetadataReader;
+import com.google.common.collect.ImmutableList;
+import io.airlift.units.DataSize;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.parquet.crypto.FileDecryptionProperties;
+import org.apache.parquet.crypto.InternalFileDecryptor;
+import org.apache.parquet.crypto.ParquetCipher;
+import org.apache.parquet.hadoop.metadata.BlockMetaData;
+import org.apache.parquet.hadoop.metadata.FileMetaData;
+import org.apache.parquet.hadoop.metadata.ParquetMetadata;
+import org.apache.parquet.io.ColumnIO;
+import org.apache.parquet.io.GroupColumnIO;
+import org.apache.parquet.io.MessageColumnIO;
+import org.apache.parquet.io.PrimitiveColumnIO;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.parquet.ParquetTypeUtils.getArrayElementColumn;
+import static com.facebook.presto.parquet.ParquetTypeUtils.getColumnIO;
+import static com.facebook.presto.parquet.ParquetTypeUtils.getMapKeyValueColumn;
+import static com.facebook.presto.parquet.ParquetTypeUtils.lookupColumnByName;
+import static org.apache.parquet.io.ColumnIOUtil.columnDefinitionLevel;
+import static org.apache.parquet.io.ColumnIOUtil.columnRepetitionLevel;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
+import static org.apache.parquet.schema.Type.Repetition.OPTIONAL;
+import static org.apache.parquet.schema.Type.Repetition.REQUIRED;
+
+public class TestEncryption
+{
+    private final Configuration conf = new Configuration(false);
+    private EncryptionTestFile inputFile;
+
+    @Test
+    public void testBasicDecryption()
+            throws IOException
+    {
+        MessageType schema = createSchema();
+        String[] encryptColumns = {"name", "gender"};
+        Map<String, String> extraMetadata = new HashMap<String, String>() {{
+                put("key1", "value1");
+                put("key2", "value2");
+            }};
+        this.inputFile = new EncryptionTestFileBuilder(conf, schema)
+                .withEncryptColumns(encryptColumns)
+                .withNumRecord(10000)
+                .withCodec("GZIP")
+                .withExtraMeta(extraMetadata)
+                .withPageSize(1000)
+                .withFooterEncryption()
+                .build();
+        decryptAndValidate();
+    }
+
+    @Test
+    public void testAllColumnsDecryption()
+            throws IOException
+    {
+        MessageType schema = createSchema();
+        String[] encryptColumns = {"id", "name", "gender"};
+        this.inputFile = new EncryptionTestFileBuilder(conf, schema)
+                .withEncryptColumns(encryptColumns)
+                .withNumRecord(10000)
+                .withCodec("GZIP")
+                .withPageSize(1000)
+                .withFooterEncryption()
+                .build();
+        decryptAndValidate();
+    }
+
+    @Test
+    public void testNoColumnsDecryption()
+            throws IOException
+    {
+        MessageType schema = createSchema();
+        String[] encryptColumns = {};
+        this.inputFile = new EncryptionTestFileBuilder(conf, schema)
+                .withEncryptColumns(encryptColumns)
+                .withNumRecord(10000)
+                .withCodec("GZIP")
+                .withPageSize(1000)
+                .withFooterEncryption()
+                .build();
+        decryptAndValidate();
+    }
+
+    @Test
+    public void testOneRecord()
+            throws IOException
+    {
+        MessageType schema = createSchema();
+        String[] encryptColumns = {"name", "gender"};
+        this.inputFile = new EncryptionTestFileBuilder(conf, schema)
+                .withEncryptColumns(encryptColumns)
+                .withNumRecord(1)
+                .withCodec("GZIP")
+                .withPageSize(1000)
+                .withFooterEncryption()
+                .build();
+        decryptAndValidate();
+    }
+
+    @Test
+    public void testMillionRows()
+            throws IOException
+    {
+        MessageType schema = createSchema();
+        String[] encryptColumns = {"name", "gender"};
+        this.inputFile = new EncryptionTestFileBuilder(conf, schema)
+                .withEncryptColumns(encryptColumns)
+                .withNumRecord(1000000)
+                .withCodec("GZIP")
+                .withPageSize(1000)
+                .withFooterEncryption()
+                .build();
+        decryptAndValidate();
+    }
+
+    @Test
+    public void testPlainTextFooter()
+            throws IOException
+    {
+        MessageType schema = createSchema();
+        String[] encryptColumns = {"name", "gender"};
+        this.inputFile = new EncryptionTestFileBuilder(conf, schema)
+                .withEncryptColumns(encryptColumns)
+                .withNumRecord(10000)
+                .withCodec("ZSTD")
+                .withPageSize(1000)
+                .build();
+        decryptAndValidate();
+    }
+
+    @Test
+    public void testLargePageSize()
+            throws IOException
+    {
+        MessageType schema = createSchema();
+        String[] encryptColumns = {"name", "gender"};
+        this.inputFile = new EncryptionTestFileBuilder(conf, schema)
+                .withEncryptColumns(encryptColumns)
+                .withNumRecord(100000)
+                .withCodec("GZIP")
+                .withPageSize(100000)
+                .withFooterEncryption()
+                .build();
+        decryptAndValidate();
+    }
+
+    @Test
+    public void testAesGcmCtr()
+            throws IOException
+    {
+        MessageType schema = createSchema();
+        String[] encryptColumns = {"name", "gender"};
+        this.inputFile = new EncryptionTestFileBuilder(conf, schema)
+                .withEncryptColumns(encryptColumns)
+                .withNumRecord(100000)
+                .withCodec("GZIP")
+                .withPageSize(1000)
+                .withEncrytionAlgorithm(ParquetCipher.AES_GCM_CTR_V1)
+                .build();
+        decryptAndValidate();
+    }
+
+    private MessageType createSchema()
+    {
+        return new MessageType("schema",
+                new PrimitiveType(OPTIONAL, INT64, "id"),
+                new PrimitiveType(REQUIRED, BINARY, "name"),
+                new PrimitiveType(OPTIONAL, BINARY, "gender"));
+    }
+
+    private void decryptAndValidate()
+            throws IOException
+    {
+        Path path = new Path(inputFile.getFileName());
+        FileSystem fileSystem = path.getFileSystem(conf);
+        FSDataInputStream inputStream = fileSystem.open(path);
+        long fileSize = fileSystem.getFileStatus(path).getLen();
+        InternalFileDecryptor fileDecryptor = createFileDecryptor();
+        //ParquetReaderOptions options = new ParquetReaderOptions();
+        ParquetDataSource dataSource = new MockParquetDataSource(new ParquetDataSourceId(path.toString()), fileSize, inputStream);
+        ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, inputFile.getFileSize(), fileDecryptor).getParquetMetadata();
+        FileMetaData fileMetaData = parquetMetadata.getFileMetaData();
+        MessageType fileSchema = fileMetaData.getSchema();
+        MessageColumnIO messageColumn = getColumnIO(fileSchema, fileSchema);
+        ParquetReader parquetReader = createParquetReader(parquetMetadata, fileMetaData, messageColumn, dataSource, fileDecryptor);
+        validateFile(parquetReader, messageColumn);
+    }
+
+    private InternalFileDecryptor createFileDecryptor()
+            throws IOException
+    {
+        FileDecryptionProperties fileDecryptionProperties = EncDecPropertiesHelper.getFileDecryptionProperties();
+        InternalFileDecryptor fileDecryptor = null;
+        if (fileDecryptionProperties != null) {
+            fileDecryptor = new InternalFileDecryptor(fileDecryptionProperties);
+        }
+        return fileDecryptor;
+    }
+
+    private ParquetReader createParquetReader(ParquetMetadata parquetMetadata, FileMetaData fileMetaData, MessageColumnIO messageColumn,
+                                              ParquetDataSource dataSource, InternalFileDecryptor fileDecryptor)
+            throws IOException
+    {
+        ImmutableList.Builder<BlockMetaData> blocks = ImmutableList.builder();
+        ImmutableList.Builder<Long> blockStarts = ImmutableList.builder();
+
+        long nextStart = 0;
+        for (BlockMetaData block : parquetMetadata.getBlocks()) {
+            blocks.add(block);
+            blockStarts.add(nextStart);
+            nextStart += block.getRowCount();
+        }
+
+        return new ParquetReader(
+                messageColumn,
+                blocks.build(),
+                dataSource,
+                com.facebook.presto.memory.context.AggregatedMemoryContext.newSimpleAggregatedMemoryContext(),
+                new DataSize(100000, DataSize.Unit.BYTE),
+                false,
+                false,
+                null,
+                null,
+                false,
+                fileDecryptor);
+    }
+
+    private void validateFile(ParquetReader parquetReader, MessageColumnIO messageColumn)
+            throws IOException
+    {
+        int rowIndex = 0;
+        int batchSize = parquetReader.nextBatch();
+        while (batchSize > 0) {
+            validateColumn("id", BIGINT, rowIndex, parquetReader, messageColumn);
+            validateColumn("name", VARCHAR, rowIndex, parquetReader, messageColumn);
+            validateColumn("gender", VARCHAR, rowIndex, parquetReader, messageColumn);
+            rowIndex += batchSize;
+            batchSize = parquetReader.nextBatch();
+        }
+    }
+
+    private void validateColumn(String name, Type type, int rowIndex, ParquetReader parquetReader, MessageColumnIO messageColumn)
+            throws IOException
+    {
+        Field field = constructField(type, messageColumn).get();
+        Block block = parquetReader.readBlock(field);
+        for (int i = 0; i < block.getPositionCount(); i++) {
+            if (type.equals(BIGINT)) {
+                //assertEquals(inputFile.getFileContent()[rowIndex++].getLong(name, 0), block.getLong(i, 0));
+            }
+            else if (type.equals(INT32)) {
+                //assertEquals(inputFile.getFileContent()[rowIndex++].getInteger(name, 0), block.getInt(i, 0));
+            }
+            else if (type.equals(VARCHAR)) {
+                //assertEquals(inputFile.getFileContent()[rowIndex++].getString(name, 0), block.getSlice(i, 0, block.getSliceLength(i)).toStringUtf8());
+            }
+        }
+    }
+
+    private Optional<Field> constructField(Type type, ColumnIO columnIO)
+    {
+        if (columnIO == null) {
+            return Optional.empty();
+        }
+        boolean required = columnIO.getType().getRepetition() != OPTIONAL;
+        int repetitionLevel = columnRepetitionLevel(columnIO);
+        int definitionLevel = columnDefinitionLevel(columnIO);
+        if (type instanceof RowType) {
+            RowType rowType = (RowType) type;
+            GroupColumnIO groupColumnIO = (GroupColumnIO) columnIO;
+            ImmutableList.Builder<Optional<Field>> fieldsBuilder = ImmutableList.builder();
+            List<RowType.Field> fields = rowType.getFields();
+            boolean structHasParameters = false;
+            for (int i = 0; i < fields.size(); i++) {
+                RowType.Field rowField = fields.get(i);
+                String name = rowField.getName().get().toLowerCase(Locale.ENGLISH);
+                Optional<Field> field = constructField(rowField.getType(), lookupColumnByName(groupColumnIO, name));
+                structHasParameters |= field.isPresent();
+                fieldsBuilder.add(field);
+            }
+            if (structHasParameters) {
+                return Optional.of(new GroupField(type, repetitionLevel, definitionLevel, required, fieldsBuilder.build()));
+            }
+            return Optional.empty();
+        }
+        if (type instanceof MapType) {
+            MapType mapType = (MapType) type;
+            GroupColumnIO groupColumnIO = (GroupColumnIO) columnIO;
+            GroupColumnIO keyValueColumnIO = getMapKeyValueColumn(groupColumnIO);
+            if (keyValueColumnIO.getChildrenCount() != 2) {
+                return Optional.empty();
+            }
+            Optional<Field> keyField = constructField(mapType.getKeyType(), keyValueColumnIO.getChild(0));
+            Optional<Field> valueField = constructField(mapType.getValueType(), keyValueColumnIO.getChild(1));
+            return Optional.of(new GroupField(type, repetitionLevel, definitionLevel, required, ImmutableList.of(keyField, valueField)));
+        }
+        if (type instanceof ArrayType) {
+            ArrayType arrayType = (ArrayType) type;
+            GroupColumnIO groupColumnIO = (GroupColumnIO) columnIO;
+            if (groupColumnIO.getChildrenCount() != 1) {
+                return Optional.empty();
+            }
+            Optional<Field> field = constructField(arrayType.getElementType(), getArrayElementColumn(groupColumnIO.getChild(0)));
+            return Optional.of(new GroupField(type, repetitionLevel, definitionLevel, required, ImmutableList.of(field)));
+        }
+        PrimitiveColumnIO primitiveColumnIO = (PrimitiveColumnIO) columnIO;
+        RichColumnDescriptor column = new RichColumnDescriptor(primitiveColumnIO.getColumnDescriptor(), columnIO.getType().asPrimitiveType());
+        return Optional.of(new PrimitiveField(type, repetitionLevel, definitionLevel, required, column, primitiveColumnIO.getId()));
+    }
+}

--- a/presto-parquet/src/test/java/com/facebook/presto/parquet/reader/TestHiddenColumnChunkMetaData.java
+++ b/presto-parquet/src/test/java/com/facebook/presto/parquet/reader/TestHiddenColumnChunkMetaData.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.parquet.reader;
+
+import org.apache.parquet.column.Encoding;
+import org.apache.parquet.crypto.HiddenColumnChunkMetaData;
+import org.apache.parquet.crypto.HiddenColumnException;
+import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnPath;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+import java.util.Set;
+
+import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestHiddenColumnChunkMetaData
+{
+    @Test
+    public void testIsHiddenColumn()
+    {
+        ColumnChunkMetaData column = new HiddenColumnChunkMetaData(ColumnPath.fromDotString("a.b.c"),
+                "hdfs:/foo/bar/a.parquet");
+        assertTrue(HiddenColumnChunkMetaData.isHiddenColumn(column));
+    }
+
+    @Test
+    public void testIsNotHiddenColumn()
+    {
+        Set<Encoding> encodingSet = Collections.singleton(Encoding.RLE);
+        ColumnChunkMetaData column = ColumnChunkMetaData.get(ColumnPath.fromDotString("a.b.c"), BINARY,
+                CompressionCodecName.GZIP, encodingSet, -1, -1, -1, -1, -1);
+        assertFalse(HiddenColumnChunkMetaData.isHiddenColumn(column));
+    }
+
+    @Test(expectedExceptions = HiddenColumnException.class)
+    public void testHiddenColumnException()
+    {
+        ColumnChunkMetaData column = new HiddenColumnChunkMetaData(ColumnPath.fromDotString("a.b.c"),
+                "hdfs:/foo/bar/a.parquet");
+        column.getStatistics();
+    }
+
+    @Test
+    public void testNoHiddenColumnException()
+    {
+        Set<Encoding> encodingSet = Collections.singleton(Encoding.RLE);
+        ColumnChunkMetaData column = ColumnChunkMetaData.get(ColumnPath.fromDotString("a.b.c"), BINARY,
+                CompressionCodecName.GZIP, encodingSet, -1, -1, -1, -1, -1);
+        column.getStatistics();
+    }
+}


### PR DESCRIPTION
Co-authored-by: ggershinsky <ggershinsky@users.noreply.github.com>  

Summary: This is to port parquet-mr decryption funtionality. The main commits in parquet-mr for encryption/decryption is apache/parquet-mr@65b95fb and several other fixes. This change only port the decryption only.

Test plan - (Please fill in how you tested your changes)

Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines. Don't forget to follow our [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution) for any code copied from other projects.

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== RELEASE NOTES ==

General Changes
* ...
* ...

Hive Changes
* ...
* ...
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```
