### PR TITLE
Add column comments for iceberg tables

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHadoopMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHadoopMetadata.java
@@ -282,7 +282,7 @@ public class IcebergHadoopMetadata
     {
         TableIdentifier tableIdentifier = toIcebergTableIdentifier(((IcebergTableHandle) tableHandle).getSchemaTableName());
         Table icebergTable = resourceFactory.getCatalog(session).loadTable(tableIdentifier);
-        icebergTable.updateSchema().addColumn(column.getName(), toIcebergType(column.getType())).commit();
+        icebergTable.updateSchema().addColumn(column.getName(), toIcebergType(column.getType()), column.getComment()).commit();
     }
 
     @Override

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergHiveMetadata.java
@@ -322,7 +322,7 @@ public class IcebergHiveMetadata
     {
         IcebergTableHandle handle = (IcebergTableHandle) tableHandle;
         org.apache.iceberg.Table icebergTable = getHiveIcebergTable(metastore, hdfsEnvironment, session, handle.getSchemaTableName());
-        icebergTable.updateSchema().addColumn(column.getName(), toIcebergType(column.getType())).commit();
+        icebergTable.updateSchema().addColumn(column.getName(), toIcebergType(column.getType()), column.getComment()).commit();
     }
 
     @Override

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestAbstractIcebergSmoke.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestAbstractIcebergSmoke.java
@@ -371,6 +371,11 @@ public class TestAbstractIcebergSmoke
         assertQuery(session, "SHOW COLUMNS FROM test_column_comments",
                 "VALUES ('_bigint', 'bigint', '', 'test column comment')");
 
+        assertUpdate("ALTER TABLE test_column_comments ADD COLUMN _varchar VARCHAR COMMENT 'test new column comment'");
+        assertQuery(
+                "SHOW COLUMNS FROM test_column_comments",
+                "VALUES ('_bigint', 'bigint', '', 'test column comment'), ('_varchar', 'varchar', '', 'test new column comment')");
+
         dropTable(session, "test_column_comments");
     }
 


### PR DESCRIPTION
Add column comments for iceberg tables 
Cherry-pick of https://github.com/trinodb/trino/commit/bc61aca90faac134195c1e94b577e7ab92042f4e

Co-Authored-By: Yuya Ebihara <yuya.ebihara@starburstdata.com>

```
== RELEASE NOTES ==

Iceberg Changes
* Store column comments for iceberg tables
```
