### PR TITLE
Retained block size improvements

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/block/ArrayBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/ArrayBlock.java
@@ -31,6 +31,7 @@ public class ArrayBlock
 
     private final int arrayOffset;
     private final int positionCount;
+    @Nullable
     private final boolean[] valueIsNull;
     private final Block values;
     private final int[] offsets;
@@ -159,7 +160,9 @@ public class ArrayBlock
     {
         consumer.accept(values, values.getRetainedSizeInBytes());
         consumer.accept(offsets, sizeOf(offsets));
-        consumer.accept(valueIsNull, sizeOf(valueIsNull));
+        if (valueIsNull != null) {
+            consumer.accept(valueIsNull, sizeOf(valueIsNull));
+        }
         consumer.accept(this, (long) INSTANCE_SIZE);
     }
 

--- a/presto-common/src/main/java/com/facebook/presto/common/block/ArrayBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/ArrayBlock.java
@@ -18,7 +18,7 @@ import org.openjdk.jol.info.ClassLayout;
 import javax.annotation.Nullable;
 
 import java.util.Optional;
-import java.util.function.BiConsumer;
+import java.util.function.ObjLongConsumer;
 
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.String.format;
@@ -156,14 +156,14 @@ public class ArrayBlock
     }
 
     @Override
-    public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
+    public void retainedBytesForEachPart(ObjLongConsumer<Object> consumer)
     {
         consumer.accept(values, values.getRetainedSizeInBytes());
         consumer.accept(offsets, sizeOf(offsets));
         if (valueIsNull != null) {
             consumer.accept(valueIsNull, sizeOf(valueIsNull));
         }
-        consumer.accept(this, (long) INSTANCE_SIZE);
+        consumer.accept(this, INSTANCE_SIZE);
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/block/ArrayBlockBuilder.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/ArrayBlockBuilder.java
@@ -20,7 +20,7 @@ import org.openjdk.jol.info.ClassLayout;
 import javax.annotation.Nullable;
 
 import java.util.Arrays;
-import java.util.function.BiConsumer;
+import java.util.function.ObjLongConsumer;
 
 import static com.facebook.presto.common.block.ArrayBlock.createArrayBlockInternal;
 import static com.facebook.presto.common.block.BlockUtil.calculateBlockResetSize;
@@ -109,12 +109,12 @@ public class ArrayBlockBuilder
     }
 
     @Override
-    public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
+    public void retainedBytesForEachPart(ObjLongConsumer<Object> consumer)
     {
         consumer.accept(values, values.getRetainedSizeInBytes());
         consumer.accept(offsets, sizeOf(offsets));
         consumer.accept(valueIsNull, sizeOf(valueIsNull));
-        consumer.accept(this, (long) INSTANCE_SIZE);
+        consumer.accept(this, INSTANCE_SIZE);
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/block/Block.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/Block.java
@@ -17,7 +17,7 @@ import io.airlift.slice.Slice;
 import io.airlift.slice.SliceOutput;
 
 import java.util.OptionalInt;
-import java.util.function.BiConsumer;
+import java.util.function.ObjLongConsumer;
 
 import static com.facebook.presto.common.block.BlockUtil.checkArrayRange;
 import static com.facebook.presto.common.block.DictionaryId.randomDictionaryId;
@@ -276,7 +276,7 @@ public interface Block
      * {@code consumer} should be called at least once with the current block and
      * must include the instance size of the current block
      */
-    void retainedBytesForEachPart(BiConsumer<Object, Long> consumer);
+    void retainedBytesForEachPart(ObjLongConsumer<Object> consumer);
 
     /**
      * Get the encoding for this block.

--- a/presto-common/src/main/java/com/facebook/presto/common/block/ByteArrayBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/ByteArrayBlock.java
@@ -20,7 +20,7 @@ import javax.annotation.Nullable;
 
 import java.util.Optional;
 import java.util.OptionalInt;
-import java.util.function.BiConsumer;
+import java.util.function.ObjLongConsumer;
 
 import static com.facebook.presto.common.array.Arrays.ExpansionFactor.SMALL;
 import static com.facebook.presto.common.array.Arrays.ExpansionOption.PRESERVE;
@@ -113,13 +113,13 @@ public class ByteArrayBlock
     }
 
     @Override
-    public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
+    public void retainedBytesForEachPart(ObjLongConsumer<Object> consumer)
     {
         consumer.accept(values, sizeOf(values));
         if (valueIsNull != null) {
             consumer.accept(valueIsNull, sizeOf(valueIsNull));
         }
-        consumer.accept(this, (long) INSTANCE_SIZE);
+        consumer.accept(this, INSTANCE_SIZE);
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/block/ByteArrayBlockBuilder.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/ByteArrayBlockBuilder.java
@@ -21,7 +21,7 @@ import javax.annotation.Nullable;
 
 import java.util.Arrays;
 import java.util.OptionalInt;
-import java.util.function.BiConsumer;
+import java.util.function.ObjLongConsumer;
 
 import static com.facebook.presto.common.block.BlockUtil.calculateBlockResetSize;
 import static com.facebook.presto.common.block.BlockUtil.checkArrayRange;
@@ -182,11 +182,11 @@ public class ByteArrayBlockBuilder
     }
 
     @Override
-    public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
+    public void retainedBytesForEachPart(ObjLongConsumer<Object> consumer)
     {
         consumer.accept(values, sizeOf(values));
         consumer.accept(valueIsNull, sizeOf(valueIsNull));
-        consumer.accept(this, (long) INSTANCE_SIZE);
+        consumer.accept(this, INSTANCE_SIZE);
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/block/DictionaryBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/DictionaryBlock.java
@@ -22,7 +22,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.OptionalInt;
-import java.util.function.BiConsumer;
+import java.util.function.ObjLongConsumer;
 
 import static com.facebook.presto.common.block.BlockUtil.checkArrayRange;
 import static com.facebook.presto.common.block.BlockUtil.checkValidPosition;
@@ -377,11 +377,11 @@ public class DictionaryBlock
     }
 
     @Override
-    public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
+    public void retainedBytesForEachPart(ObjLongConsumer<Object> consumer)
     {
         consumer.accept(dictionary, dictionary.getRetainedSizeInBytes());
         consumer.accept(ids, sizeOf(ids));
-        consumer.accept(this, (long) INSTANCE_SIZE);
+        consumer.accept(this, INSTANCE_SIZE);
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/block/Int128ArrayBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/Int128ArrayBlock.java
@@ -22,7 +22,7 @@ import javax.annotation.Nullable;
 
 import java.util.Optional;
 import java.util.OptionalInt;
-import java.util.function.BiConsumer;
+import java.util.function.ObjLongConsumer;
 
 import static com.facebook.presto.common.array.Arrays.ExpansionFactor.SMALL;
 import static com.facebook.presto.common.array.Arrays.ExpansionOption.PRESERVE;
@@ -119,13 +119,13 @@ public class Int128ArrayBlock
     }
 
     @Override
-    public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
+    public void retainedBytesForEachPart(ObjLongConsumer<Object> consumer)
     {
         consumer.accept(values, sizeOf(values));
         if (valueIsNull != null) {
             consumer.accept(valueIsNull, sizeOf(valueIsNull));
         }
-        consumer.accept(this, (long) INSTANCE_SIZE);
+        consumer.accept(this, INSTANCE_SIZE);
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/block/Int128ArrayBlockBuilder.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/Int128ArrayBlockBuilder.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
 
 import java.util.Arrays;
 import java.util.OptionalInt;
-import java.util.function.BiConsumer;
+import java.util.function.ObjLongConsumer;
 
 import static com.facebook.presto.common.block.BlockUtil.calculateBlockResetSize;
 import static com.facebook.presto.common.block.BlockUtil.checkArrayRange;
@@ -200,11 +200,11 @@ public class Int128ArrayBlockBuilder
     }
 
     @Override
-    public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
+    public void retainedBytesForEachPart(ObjLongConsumer<Object> consumer)
     {
         consumer.accept(values, sizeOf(values));
         consumer.accept(valueIsNull, sizeOf(valueIsNull));
-        consumer.accept(this, (long) INSTANCE_SIZE);
+        consumer.accept(this, INSTANCE_SIZE);
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/block/IntArrayBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/IntArrayBlock.java
@@ -22,7 +22,7 @@ import java.util.Arrays;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
-import java.util.function.BiConsumer;
+import java.util.function.ObjLongConsumer;
 
 import static com.facebook.presto.common.array.Arrays.ExpansionFactor.SMALL;
 import static com.facebook.presto.common.array.Arrays.ExpansionOption.PRESERVE;
@@ -115,13 +115,13 @@ public class IntArrayBlock
     }
 
     @Override
-    public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
+    public void retainedBytesForEachPart(ObjLongConsumer<Object> consumer)
     {
         consumer.accept(values, sizeOf(values));
         if (valueIsNull != null) {
             consumer.accept(valueIsNull, sizeOf(valueIsNull));
         }
-        consumer.accept(this, (long) INSTANCE_SIZE);
+        consumer.accept(this, INSTANCE_SIZE);
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/block/IntArrayBlockBuilder.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/IntArrayBlockBuilder.java
@@ -21,7 +21,7 @@ import javax.annotation.Nullable;
 
 import java.util.Arrays;
 import java.util.OptionalInt;
-import java.util.function.BiConsumer;
+import java.util.function.ObjLongConsumer;
 
 import static com.facebook.presto.common.block.BlockUtil.calculateBlockResetSize;
 import static com.facebook.presto.common.block.BlockUtil.checkArrayRange;
@@ -182,11 +182,11 @@ public class IntArrayBlockBuilder
     }
 
     @Override
-    public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
+    public void retainedBytesForEachPart(ObjLongConsumer<Object> consumer)
     {
         consumer.accept(values, sizeOf(values));
         consumer.accept(valueIsNull, sizeOf(valueIsNull));
-        consumer.accept(this, (long) INSTANCE_SIZE);
+        consumer.accept(this, INSTANCE_SIZE);
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/block/LazyBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/LazyBlock.java
@@ -18,7 +18,7 @@ import io.airlift.slice.SliceOutput;
 import org.openjdk.jol.info.ClassLayout;
 
 import java.util.OptionalInt;
-import java.util.function.BiConsumer;
+import java.util.function.ObjLongConsumer;
 
 import static java.util.Objects.requireNonNull;
 
@@ -229,11 +229,11 @@ public class LazyBlock
     }
 
     @Override
-    public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
+    public void retainedBytesForEachPart(ObjLongConsumer<Object> consumer)
     {
         assureLoaded();
         block.retainedBytesForEachPart(consumer);
-        consumer.accept(this, (long) INSTANCE_SIZE);
+        consumer.accept(this, INSTANCE_SIZE);
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/block/LongArrayBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/LongArrayBlock.java
@@ -20,7 +20,7 @@ import javax.annotation.Nullable;
 
 import java.util.Optional;
 import java.util.OptionalInt;
-import java.util.function.BiConsumer;
+import java.util.function.ObjLongConsumer;
 
 import static com.facebook.presto.common.array.Arrays.ExpansionFactor.SMALL;
 import static com.facebook.presto.common.array.Arrays.ExpansionOption.PRESERVE;
@@ -114,13 +114,13 @@ public class LongArrayBlock
     }
 
     @Override
-    public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
+    public void retainedBytesForEachPart(ObjLongConsumer<Object> consumer)
     {
         consumer.accept(values, sizeOf(values));
         if (valueIsNull != null) {
             consumer.accept(valueIsNull, sizeOf(valueIsNull));
         }
-        consumer.accept(this, (long) INSTANCE_SIZE);
+        consumer.accept(this, INSTANCE_SIZE);
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/block/LongArrayBlockBuilder.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/LongArrayBlockBuilder.java
@@ -21,7 +21,7 @@ import javax.annotation.Nullable;
 
 import java.util.Arrays;
 import java.util.OptionalInt;
-import java.util.function.BiConsumer;
+import java.util.function.ObjLongConsumer;
 
 import static com.facebook.presto.common.block.BlockUtil.calculateBlockResetSize;
 import static com.facebook.presto.common.block.BlockUtil.checkArrayRange;
@@ -182,11 +182,11 @@ public class LongArrayBlockBuilder
     }
 
     @Override
-    public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
+    public void retainedBytesForEachPart(ObjLongConsumer<Object> consumer)
     {
         consumer.accept(values, sizeOf(values));
         consumer.accept(valueIsNull, sizeOf(valueIsNull));
-        consumer.accept(this, (long) INSTANCE_SIZE);
+        consumer.accept(this, INSTANCE_SIZE);
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/block/MapBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/MapBlock.java
@@ -35,6 +35,7 @@ public class MapBlock
     private final int startOffset;
     private final int positionCount;
 
+    @Nullable
     private final boolean[] mapIsNull;
     private final int[] offsets;
     private final Block keyBlock;
@@ -253,7 +254,9 @@ public class MapBlock
         consumer.accept(keyBlock, keyBlock.getRetainedSizeInBytes());
         consumer.accept(valueBlock, valueBlock.getRetainedSizeInBytes());
         consumer.accept(offsets, sizeOf(offsets));
-        consumer.accept(mapIsNull, sizeOf(mapIsNull));
+        if (mapIsNull != null) {
+            consumer.accept(mapIsNull, sizeOf(mapIsNull));
+        }
         consumer.accept(hashTables, hashTables.getRetainedSizeInBytes());
         consumer.accept(this, (long) INSTANCE_SIZE);
     }

--- a/presto-common/src/main/java/com/facebook/presto/common/block/MapBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/MapBlock.java
@@ -20,7 +20,7 @@ import javax.annotation.Nullable;
 
 import java.lang.invoke.MethodHandle;
 import java.util.Optional;
-import java.util.function.BiConsumer;
+import java.util.function.ObjLongConsumer;
 
 import static io.airlift.slice.SizeOf.sizeOf;
 import static java.lang.String.format;
@@ -249,7 +249,7 @@ public class MapBlock
     }
 
     @Override
-    public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
+    public void retainedBytesForEachPart(ObjLongConsumer<Object> consumer)
     {
         consumer.accept(keyBlock, keyBlock.getRetainedSizeInBytes());
         consumer.accept(valueBlock, valueBlock.getRetainedSizeInBytes());
@@ -258,7 +258,7 @@ public class MapBlock
             consumer.accept(mapIsNull, sizeOf(mapIsNull));
         }
         consumer.accept(hashTables, hashTables.getRetainedSizeInBytes());
-        consumer.accept(this, (long) INSTANCE_SIZE);
+        consumer.accept(this, INSTANCE_SIZE);
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/block/MapBlockBuilder.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/MapBlockBuilder.java
@@ -24,7 +24,7 @@ import javax.annotation.Nullable;
 import java.lang.invoke.MethodHandle;
 import java.util.Arrays;
 import java.util.Optional;
-import java.util.function.BiConsumer;
+import java.util.function.ObjLongConsumer;
 
 import static com.facebook.presto.common.block.BlockUtil.calculateBlockResetSize;
 import static com.facebook.presto.common.block.MapBlock.createMapBlockInternal;
@@ -160,14 +160,14 @@ public class MapBlockBuilder
     }
 
     @Override
-    public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
+    public void retainedBytesForEachPart(ObjLongConsumer<Object> consumer)
     {
         consumer.accept(keyBlockBuilder, keyBlockBuilder.getRetainedSizeInBytes());
         consumer.accept(valueBlockBuilder, valueBlockBuilder.getRetainedSizeInBytes());
         consumer.accept(offsets, sizeOf(offsets));
         consumer.accept(mapIsNull, sizeOf(mapIsNull));
         consumer.accept(hashTables, hashTables.getRetainedSizeInBytes());
-        consumer.accept(this, (long) INSTANCE_SIZE);
+        consumer.accept(this, INSTANCE_SIZE);
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/block/RowBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/RowBlock.java
@@ -34,6 +34,7 @@ public class RowBlock
     private final int startOffset;
     private final int positionCount;
 
+    @Nullable
     private final boolean[] rowIsNull;
     private final int[] fieldBlockOffsets;
     private final Block[] fieldBlocks;
@@ -240,7 +241,9 @@ public class RowBlock
             consumer.accept(fieldBlocks[i], fieldBlocks[i].getRetainedSizeInBytes());
         }
         consumer.accept(fieldBlockOffsets, sizeOf(fieldBlockOffsets));
-        consumer.accept(rowIsNull, sizeOf(rowIsNull));
+        if (rowIsNull != null) {
+            consumer.accept(rowIsNull, sizeOf(rowIsNull));
+        }
         consumer.accept(this, (long) INSTANCE_SIZE);
     }
 

--- a/presto-common/src/main/java/com/facebook/presto/common/block/RowBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/RowBlock.java
@@ -18,7 +18,7 @@ import org.openjdk.jol.info.ClassLayout;
 import javax.annotation.Nullable;
 
 import java.util.Optional;
-import java.util.function.BiConsumer;
+import java.util.function.ObjLongConsumer;
 
 import static com.facebook.presto.common.block.BlockUtil.ensureBlocksAreLoaded;
 import static io.airlift.slice.SizeOf.sizeOf;
@@ -235,7 +235,7 @@ public class RowBlock
     }
 
     @Override
-    public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
+    public void retainedBytesForEachPart(ObjLongConsumer<Object> consumer)
     {
         for (int i = 0; i < numFields; i++) {
             consumer.accept(fieldBlocks[i], fieldBlocks[i].getRetainedSizeInBytes());
@@ -244,7 +244,7 @@ public class RowBlock
         if (rowIsNull != null) {
             consumer.accept(rowIsNull, sizeOf(rowIsNull));
         }
-        consumer.accept(this, (long) INSTANCE_SIZE);
+        consumer.accept(this, INSTANCE_SIZE);
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/block/RowBlockBuilder.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/RowBlockBuilder.java
@@ -22,7 +22,7 @@ import javax.annotation.Nullable;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.function.BiConsumer;
+import java.util.function.ObjLongConsumer;
 
 import static com.facebook.presto.common.block.BlockUtil.calculateBlockResetSize;
 import static com.facebook.presto.common.block.RowBlock.createRowBlockInternal;
@@ -146,14 +146,14 @@ public class RowBlockBuilder
     }
 
     @Override
-    public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
+    public void retainedBytesForEachPart(ObjLongConsumer<Object> consumer)
     {
         for (int i = 0; i < numFields; i++) {
             consumer.accept(fieldBlockBuilders[i], fieldBlockBuilders[i].getRetainedSizeInBytes());
         }
         consumer.accept(fieldBlockOffsets, sizeOf(fieldBlockOffsets));
         consumer.accept(rowIsNull, sizeOf(rowIsNull));
-        consumer.accept(this, (long) INSTANCE_SIZE);
+        consumer.accept(this, INSTANCE_SIZE);
     }
 
     public BlockBuilder getBlockBuilder(int fieldIndex)

--- a/presto-common/src/main/java/com/facebook/presto/common/block/RunLengthEncodedBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/RunLengthEncodedBlock.java
@@ -22,7 +22,7 @@ import org.openjdk.jol.info.ClassLayout;
 import javax.annotation.Nullable;
 
 import java.util.OptionalInt;
-import java.util.function.BiConsumer;
+import java.util.function.ObjLongConsumer;
 
 import static com.facebook.presto.common.block.BlockUtil.checkArrayRange;
 import static com.facebook.presto.common.block.BlockUtil.checkValidPosition;
@@ -111,10 +111,10 @@ public class RunLengthEncodedBlock
     }
 
     @Override
-    public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
+    public void retainedBytesForEachPart(ObjLongConsumer<Object> consumer)
     {
         consumer.accept(value, value.getRetainedSizeInBytes());
-        consumer.accept(this, (long) INSTANCE_SIZE);
+        consumer.accept(this, INSTANCE_SIZE);
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/block/ShortArrayBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/ShortArrayBlock.java
@@ -20,7 +20,7 @@ import javax.annotation.Nullable;
 
 import java.util.Optional;
 import java.util.OptionalInt;
-import java.util.function.BiConsumer;
+import java.util.function.ObjLongConsumer;
 
 import static com.facebook.presto.common.array.Arrays.ensureCapacity;
 import static com.facebook.presto.common.block.BlockUtil.appendNullToIsNullArray;
@@ -111,13 +111,13 @@ public class ShortArrayBlock
     }
 
     @Override
-    public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
+    public void retainedBytesForEachPart(ObjLongConsumer<Object> consumer)
     {
         consumer.accept(values, sizeOf(values));
         if (valueIsNull != null) {
             consumer.accept(valueIsNull, sizeOf(valueIsNull));
         }
-        consumer.accept(this, (long) INSTANCE_SIZE);
+        consumer.accept(this, INSTANCE_SIZE);
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/block/ShortArrayBlockBuilder.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/ShortArrayBlockBuilder.java
@@ -21,7 +21,7 @@ import javax.annotation.Nullable;
 
 import java.util.Arrays;
 import java.util.OptionalInt;
-import java.util.function.BiConsumer;
+import java.util.function.ObjLongConsumer;
 
 import static com.facebook.presto.common.block.BlockUtil.calculateBlockResetSize;
 import static com.facebook.presto.common.block.BlockUtil.checkArrayRange;
@@ -182,11 +182,11 @@ public class ShortArrayBlockBuilder
     }
 
     @Override
-    public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
+    public void retainedBytesForEachPart(ObjLongConsumer<Object> consumer)
     {
         consumer.accept(values, sizeOf(values));
         consumer.accept(valueIsNull, sizeOf(valueIsNull));
-        consumer.accept(this, (long) INSTANCE_SIZE);
+        consumer.accept(this, INSTANCE_SIZE);
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/block/SingleArrayBlockWriter.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/SingleArrayBlockWriter.java
@@ -18,7 +18,7 @@ import io.airlift.slice.SliceInput;
 import org.openjdk.jol.info.ClassLayout;
 
 import java.util.OptionalInt;
-import java.util.function.BiConsumer;
+import java.util.function.ObjLongConsumer;
 
 import static java.lang.String.format;
 
@@ -66,10 +66,10 @@ public class SingleArrayBlockWriter
     }
 
     @Override
-    public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
+    public void retainedBytesForEachPart(ObjLongConsumer<Object> consumer)
     {
         consumer.accept(blockBuilder, blockBuilder.getRetainedSizeInBytes());
-        consumer.accept(this, (long) INSTANCE_SIZE);
+        consumer.accept(this, INSTANCE_SIZE);
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/block/SingleMapBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/SingleMapBlock.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
 
 import java.lang.invoke.MethodHandle;
 import java.util.OptionalInt;
-import java.util.function.BiConsumer;
+import java.util.function.ObjLongConsumer;
 
 import static com.facebook.presto.common.block.AbstractMapBlock.HASH_MULTIPLIER;
 import static com.facebook.presto.common.block.MapBlockBuilder.computePosition;
@@ -78,12 +78,12 @@ public class SingleMapBlock
     }
 
     @Override
-    public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
+    public void retainedBytesForEachPart(ObjLongConsumer<Object> consumer)
     {
         consumer.accept(mapBlock.getRawKeyBlock(), mapBlock.getRawKeyBlock().getRetainedSizeInBytes());
         consumer.accept(mapBlock.getRawValueBlock(), mapBlock.getRawValueBlock().getRetainedSizeInBytes());
         consumer.accept(mapBlock.getHashTables(), mapBlock.getHashTables().getRetainedSizeInBytes());
-        consumer.accept(this, (long) INSTANCE_SIZE);
+        consumer.accept(this, INSTANCE_SIZE);
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/block/SingleMapBlockWriter.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/SingleMapBlockWriter.java
@@ -18,7 +18,7 @@ import io.airlift.slice.SliceInput;
 import org.openjdk.jol.info.ClassLayout;
 
 import java.util.OptionalInt;
-import java.util.function.BiConsumer;
+import java.util.function.ObjLongConsumer;
 
 import static java.lang.String.format;
 
@@ -85,11 +85,11 @@ public class SingleMapBlockWriter
     }
 
     @Override
-    public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
+    public void retainedBytesForEachPart(ObjLongConsumer<Object> consumer)
     {
         consumer.accept(keyBlockBuilder, keyBlockBuilder.getRetainedSizeInBytes());
         consumer.accept(valueBlockBuilder, valueBlockBuilder.getRetainedSizeInBytes());
-        consumer.accept(this, (long) INSTANCE_SIZE);
+        consumer.accept(this, INSTANCE_SIZE);
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/block/SingleRowBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/SingleRowBlock.java
@@ -17,7 +17,7 @@ package com.facebook.presto.common.block;
 import org.openjdk.jol.info.ClassLayout;
 
 import java.util.OptionalInt;
-import java.util.function.BiConsumer;
+import java.util.function.ObjLongConsumer;
 
 import static com.facebook.presto.common.block.BlockUtil.ensureBlocksAreLoaded;
 import static java.lang.String.format;
@@ -79,12 +79,12 @@ public class SingleRowBlock
     }
 
     @Override
-    public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
+    public void retainedBytesForEachPart(ObjLongConsumer<Object> consumer)
     {
         for (Block fieldBlock : fieldBlocks) {
             consumer.accept(fieldBlock, fieldBlock.getRetainedSizeInBytes());
         }
-        consumer.accept(this, (long) INSTANCE_SIZE);
+        consumer.accept(this, INSTANCE_SIZE);
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/block/SingleRowBlockWriter.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/SingleRowBlockWriter.java
@@ -18,7 +18,7 @@ import io.airlift.slice.SliceInput;
 import org.openjdk.jol.info.ClassLayout;
 
 import java.util.OptionalInt;
-import java.util.function.BiConsumer;
+import java.util.function.ObjLongConsumer;
 
 import static java.lang.String.format;
 
@@ -100,12 +100,12 @@ public class SingleRowBlockWriter
     }
 
     @Override
-    public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
+    public void retainedBytesForEachPart(ObjLongConsumer<Object> consumer)
     {
         for (BlockBuilder fieldBlockBuilder : fieldBlockBuilders) {
             consumer.accept(fieldBlockBuilder, fieldBlockBuilder.getRetainedSizeInBytes());
         }
-        consumer.accept(this, (long) INSTANCE_SIZE);
+        consumer.accept(this, INSTANCE_SIZE);
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/block/VariableWidthBlock.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/VariableWidthBlock.java
@@ -23,7 +23,7 @@ import javax.annotation.Nullable;
 
 import java.util.Optional;
 import java.util.OptionalInt;
-import java.util.function.BiConsumer;
+import java.util.function.ObjLongConsumer;
 
 import static com.facebook.presto.common.block.BlockUtil.appendNullToIsNullArray;
 import static com.facebook.presto.common.block.BlockUtil.appendNullToOffsetsArray;
@@ -162,14 +162,14 @@ public class VariableWidthBlock
     }
 
     @Override
-    public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
+    public void retainedBytesForEachPart(ObjLongConsumer<Object> consumer)
     {
         consumer.accept(slice, slice.getRetainedSize());
         consumer.accept(offsets, sizeOf(offsets));
         if (valueIsNull != null) {
             consumer.accept(valueIsNull, sizeOf(valueIsNull));
         }
-        consumer.accept(this, (long) INSTANCE_SIZE);
+        consumer.accept(this, INSTANCE_SIZE);
     }
 
     @Override

--- a/presto-common/src/main/java/com/facebook/presto/common/block/VariableWidthBlockBuilder.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/VariableWidthBlockBuilder.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Arrays;
 import java.util.OptionalInt;
-import java.util.function.BiConsumer;
+import java.util.function.ObjLongConsumer;
 
 import static com.facebook.presto.common.block.BlockUtil.MAX_ARRAY_SIZE;
 import static com.facebook.presto.common.block.BlockUtil.calculateBlockResetSize;
@@ -160,12 +160,12 @@ public class VariableWidthBlockBuilder
     }
 
     @Override
-    public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
+    public void retainedBytesForEachPart(ObjLongConsumer<Object> consumer)
     {
         consumer.accept(sliceOutput, sliceOutput.getRetainedSize());
         consumer.accept(offsets, sizeOf(offsets));
         consumer.accept(valueIsNull, sizeOf(valueIsNull));
-        consumer.accept(this, (long) INSTANCE_SIZE);
+        consumer.accept(this, INSTANCE_SIZE);
     }
 
     @Override

--- a/presto-common/src/test/java/com/facebook/presto/common/block/TestBlockRetainedSizeBreakdown.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/block/TestBlockRetainedSizeBreakdown.java
@@ -21,7 +21,7 @@ import org.testng.annotations.Test;
 
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.BiConsumer;
+import java.util.function.ObjLongConsumer;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.DoubleType.DOUBLE;
@@ -140,7 +140,7 @@ public class TestBlockRetainedSizeBreakdown
         AtomicLong objectSize = new AtomicLong();
         Object2LongOpenCustomHashMap<Object> trackedObjects = new Object2LongOpenCustomHashMap<>(new ObjectStrategy());
 
-        BiConsumer<Object, Long> consumer = (object, size) -> {
+        ObjLongConsumer<Object> consumer = (object, size) -> {
             objectSize.addAndGet(size);
             trackedObjects.addTo(object, 1);
         };

--- a/presto-main/src/main/java/com/facebook/presto/operator/GroupByIdBlock.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/GroupByIdBlock.java
@@ -20,7 +20,7 @@ import io.airlift.slice.SliceOutput;
 import org.openjdk.jol.info.ClassLayout;
 
 import java.util.OptionalInt;
-import java.util.function.BiConsumer;
+import java.util.function.ObjLongConsumer;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -226,10 +226,10 @@ public class GroupByIdBlock
     }
 
     @Override
-    public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
+    public void retainedBytesForEachPart(ObjLongConsumer<Object> consumer)
     {
         consumer.accept(block, block.getRetainedSizeInBytes());
-        consumer.accept(this, (long) INSTANCE_SIZE);
+        consumer.accept(this, INSTANCE_SIZE);
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/SegmentedSliceBlockBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/SegmentedSliceBlockBuilder.java
@@ -26,7 +26,7 @@ import org.openjdk.jol.info.ClassLayout;
 
 import java.util.Arrays;
 import java.util.OptionalInt;
-import java.util.function.BiConsumer;
+import java.util.function.ObjLongConsumer;
 
 import static com.facebook.presto.orc.writer.SegmentedSliceBlockBuilder.Segments.INITIAL_SEGMENTS;
 import static com.facebook.presto.orc.writer.SegmentedSliceBlockBuilder.Segments.SEGMENT_SIZE;
@@ -174,7 +174,7 @@ public class SegmentedSliceBlockBuilder
     }
 
     @Override
-    public void retainedBytesForEachPart(BiConsumer<Object, Long> consumer)
+    public void retainedBytesForEachPart(ObjLongConsumer<Object> consumer)
     {
         throw new UnsupportedOperationException("retainedBytesForEachPart is not supported by SegmentedSliceBlockBuilder");
     }


### PR DESCRIPTION
Comparable changes extracted from https://github.com/trinodb/trino/pull/11398

1. Refactors `MapBlock`, `RowBlock`, and `ArrayBlock` to not pass null values into the consumer as part of `Block#retainedBytesForEachPart`, making them consistent with the implementations of other block types and avoids unnecessary entries in the maps tracking each retained part. Passing null was benign, but was unnecessary.
2. Changes the signature of `Block#retainedBytesForEachPart` to take an `ObjLongConsumer<Object>` instead of `BiConsumer<Object, Long>`. This technically is a breaking SPI change that will require custom `Block` implementations to implement the method using the new signature, but is a very straightforward change to make. By using `ObjLongConsumer`, the retained bytes argument need not be boxed into a `Long` for each invocation.

```
== NO RELEASE NOTE ==
```
