### PR TITLE
Iceberg: Add new fields in files system table

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/util/PageListBuilder.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/util/PageListBuilder.java
@@ -114,6 +114,16 @@ public final class PageListBuilder
         VARBINARY.writeSlice(nextColumn(), value);
     }
 
+    public void appendIntegerArray(Iterable<Integer> values)
+    {
+        BlockBuilder column = nextColumn();
+        BlockBuilder array = column.beginBlockEntry();
+        for (Integer value : values) {
+            INTEGER.writeLong(array, value);
+        }
+        column.closeEntry();
+    }
+
     public void appendBigintArray(Iterable<Long> values)
     {
         BlockBuilder column = nextColumn();

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergSystemTables.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergSystemTables.java
@@ -167,7 +167,8 @@ public class TestIcebergSystemTables
     public void testFilesTable()
     {
         assertQuery("SHOW COLUMNS FROM test_schema.\"test_table$files\"",
-                "VALUES ('file_path', 'varchar', '', '')," +
+                "VALUES ('content', 'integer', '', '')," +
+                        "('file_path', 'varchar', '', '')," +
                         "('file_format', 'varchar', '', '')," +
                         "('record_count', 'bigint', '', '')," +
                         "('file_size_in_bytes', 'bigint', '', '')," +
@@ -178,7 +179,8 @@ public class TestIcebergSystemTables
                         "('lower_bounds', 'map(integer, varchar)', '', '')," +
                         "('upper_bounds', 'map(integer, varchar)', '', '')," +
                         "('key_metadata', 'varbinary', '', '')," +
-                        "('split_offsets', 'array(bigint)', '', '')");
+                        "('split_offsets', 'array(bigint)', '', '')," +
+                        "('equality_ids', 'array(integer)', '', '')");
         assertQuerySucceeds("SELECT * FROM test_schema.\"test_table$files\"");
     }
 


### PR DESCRIPTION
Cherry-pick of https://github.com/trinodb/trino/pull/8536

Add new fields introduced in Iceberg in files table, to match:
https://github.com/apache/iceberg/blob/0.11.x/api/src/main/java/org/apache/iceberg/DataFile.java#L72-L88

Co-authored-by: Jack Ye <yzhaoqin@amazon.com>

Test plan - Added tests

```
== RELEASE NOTES ==

General Changes
* Add new fields in Iceberg files system table
```

