### PR TITLE
Only support single statement writes by default

### DIFF
--- a/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcConnector.java
+++ b/presto-base-jdbc/src/main/java/com/facebook/presto/plugin/jdbc/JdbcConnector.java
@@ -105,12 +105,6 @@ public class JdbcConnector
     }
 
     @Override
-    public boolean isSingleStatementWritesOnly()
-    {
-        return true;
-    }
-
-    @Override
     public ConnectorTransactionHandle beginTransaction(IsolationLevel isolationLevel, boolean readOnly)
     {
         checkConnectorSupports(READ_COMMITTED, isolationLevel);

--- a/presto-blackhole/src/main/java/com/facebook/presto/plugin/blackhole/BlackHoleConnector.java
+++ b/presto-blackhole/src/main/java/com/facebook/presto/plugin/blackhole/BlackHoleConnector.java
@@ -81,13 +81,6 @@ public class BlackHoleConnector
     }
 
     @Override
-    public boolean isSingleStatementWritesOnly()
-    {
-        // TODO: support transactional metadata
-        return true;
-    }
-
-    @Override
     public ConnectorMetadata getMetadata(ConnectorTransactionHandle transactionHandle)
     {
         return metadata;

--- a/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraConnector.java
+++ b/presto-cassandra/src/main/java/com/facebook/presto/cassandra/CassandraConnector.java
@@ -69,12 +69,6 @@ public class CassandraConnector
     }
 
     @Override
-    public boolean isSingleStatementWritesOnly()
-    {
-        return true;
-    }
-
-    @Override
     public ConnectorMetadata getMetadata(ConnectorTransactionHandle transactionHandle)
     {
         return metadata;

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveConnectorFactory.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveConnectorFactory.java
@@ -28,6 +28,7 @@ import java.util.Optional;
 import static com.facebook.airlift.testing.Assertions.assertContains;
 import static com.facebook.airlift.testing.Assertions.assertInstanceOf;
 import static com.facebook.presto.spi.transaction.IsolationLevel.READ_UNCOMMITTED;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.fail;
 
 public class TestHiveConnectorFactory
@@ -44,6 +45,20 @@ public class TestHiveConnectorFactory
         assertCreateConnectorFails("abc::", "metastoreUri scheme must be thrift: abc::");
         assertCreateConnectorFails("", "metastoreUris must specify at least one URI");
         assertCreateConnectorFails("thrift://localhost:1234,thrift://test-1", "metastoreUri port is missing: thrift://test-1");
+    }
+
+    @Test
+    public void testSingleStatementWritesOnly()
+    {
+        HiveConnectorFactory connectorFactory = new HiveConnectorFactory(
+                "hive-test",
+                HiveConnector.class.getClassLoader(),
+                Optional.empty());
+        Map<String, String> config = ImmutableMap.<String, String>builder()
+                .put("hive.metastore.uri", "thrift://localhost:1234")
+                .build();
+        Connector connector = connectorFactory.create("hive-test", config, new TestingConnectorContext());
+        assertFalse(connector.isSingleStatementWritesOnly());
     }
 
     private static void assertCreateConnector(String metastoreUri)

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergConnector.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergConnector.java
@@ -96,12 +96,6 @@ public class IcebergConnector
     }
 
     @Override
-    public boolean isSingleStatementWritesOnly()
-    {
-        return true;
-    }
-
-    @Override
     public Set<ConnectorCapabilities> getCapabilities()
     {
         return immutableEnumSet(NOT_NULL_COLUMN_CONSTRAINT);

--- a/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoConnector.java
+++ b/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoConnector.java
@@ -64,12 +64,6 @@ public class MongoConnector
     }
 
     @Override
-    public boolean isSingleStatementWritesOnly()
-    {
-        return true;
-    }
-
-    @Override
     public ConnectorMetadata getMetadata(ConnectorTransactionHandle transaction)
     {
         MongoMetadata metadata = transactions.get(transaction);

--- a/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorConnector.java
+++ b/presto-raptor/src/main/java/com/facebook/presto/raptor/RaptorConnector.java
@@ -121,12 +121,6 @@ public class RaptorConnector
     }
 
     @Override
-    public boolean isSingleStatementWritesOnly()
-    {
-        return true;
-    }
-
-    @Override
     public ConnectorTransactionHandle beginTransaction(IsolationLevel isolationLevel, boolean readOnly)
     {
         checkConnectorSupports(READ_COMMITTED, isolationLevel);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/Connector.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/Connector.java
@@ -175,10 +175,11 @@ public interface Connector
 
     /**
      * True if the connector only supports write statements in independent transactions.
+     * The engine will enforce this for the connector by requiring auto-commit mode for writes.
      */
     default boolean isSingleStatementWritesOnly()
     {
-        return false;
+        return true;
     }
 
     /**


### PR DESCRIPTION
Cherry-pick of https://github.com/trinodb/trino/pull/8872

This changes the default behavior of
Connector.isSingleStatementWritesOnly() to return true by default,
since most connectors do not support multi-statement writes. This
also fixes the behavior of many connectors that did not override this
method and thus pretended to support transactions but would execute
the operations immediately and silently ignore rollback.

Co-authored-by: David Phillips <david@acz.org>

Test plan - No test needed


```
== NO RELEASE NOTE ==
```
