### PR TITLE
Improve QueryInfo and StatementStats performance

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/event/QueryMonitor.java
+++ b/presto-main/src/main/java/com/facebook/presto/event/QueryMonitor.java
@@ -328,7 +328,7 @@ public class QueryMonitor
                 queryStats.getCumulativeUserMemory(),
                 queryStats.getCumulativeTotalMemory(),
                 queryStats.getCompletedDrivers(),
-                queryInfo.isCompleteInfo(),
+                queryInfo.isFinalQueryInfo(),
                 queryStats.getRuntimeStats());
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
@@ -420,7 +420,7 @@ public class QueryStateMachine
             }
         }
 
-        boolean completeInfo = getAllStages(rootStage).stream().allMatch(StageInfo::isFinalStageInfo);
+        boolean finalInfo = getAllStages(rootStage).stream().allMatch(StageInfo::isFinalStageInfo);
         Optional<List<TaskId>> failedTasks;
         // Traversing all tasks is expensive, thus only construct failedTasks list when query finished.
         if (state.isDone()) {
@@ -465,7 +465,7 @@ public class QueryStateMachine
                 warningCollector.getWarnings(),
                 inputs.get(),
                 output.get(),
-                completeInfo,
+                finalInfo,
                 Optional.of(resourceGroup),
                 queryType,
                 failedTasks,
@@ -959,7 +959,7 @@ public class QueryStateMachine
                 queryInfo.getWarnings(),
                 queryInfo.getInputs(),
                 queryInfo.getOutput(),
-                queryInfo.isCompleteInfo(),
+                queryInfo.isFinalQueryInfo(),
                 queryInfo.getResourceGroupId(),
                 queryInfo.getQueryType(),
                 queryInfo.getFailedTasks(),

--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryStateMachine.java
@@ -420,11 +420,12 @@ public class QueryStateMachine
             }
         }
 
-        boolean finalInfo = getAllStages(rootStage).stream().allMatch(StageInfo::isFinalStageInfo);
+        List<StageInfo> allStages = getAllStages(rootStage);
+        boolean finalInfo = state.isDone() && allStages.stream().allMatch(StageInfo::isFinalStageInfo);
         Optional<List<TaskId>> failedTasks;
         // Traversing all tasks is expensive, thus only construct failedTasks list when query finished.
         if (state.isDone()) {
-            failedTasks = Optional.of(getAllStages(rootStage).stream()
+            failedTasks = Optional.of(allStages.stream()
                     .flatMap(stageInfo -> Streams.concat(ImmutableList.of(stageInfo.getLatestAttemptExecutionInfo()).stream(), stageInfo.getPreviousAttemptsExecutionInfos().stream()))
                     .flatMap(execution -> execution.getTasks().stream())
                     .filter(taskInfo -> taskInfo.getTaskStatus().getState() == TaskState.FAILED)
@@ -435,8 +436,8 @@ public class QueryStateMachine
             failedTasks = Optional.empty();
         }
 
-        List<StageId> runtimeOptimizedStages = getAllStages(rootStage).stream().filter(StageInfo::isRuntimeOptimized).map(StageInfo::getStageId).collect(toImmutableList());
-        QueryStats queryStats = getQueryStats(rootStage);
+        List<StageId> runtimeOptimizedStages = allStages.stream().filter(StageInfo::isRuntimeOptimized).map(StageInfo::getStageId).collect(toImmutableList());
+        QueryStats queryStats = getQueryStats(rootStage, allStages);
         return new QueryInfo(
                 queryId,
                 session.toSessionRepresentation(),
@@ -474,11 +475,12 @@ public class QueryStateMachine
                 removedSessionFunctions);
     }
 
-    private QueryStats getQueryStats(Optional<StageInfo> rootStage)
+    private QueryStats getQueryStats(Optional<StageInfo> rootStage, List<StageInfo> allStages)
     {
         return QueryStats.create(
                 queryStateTimer,
                 rootStage,
+                allStages,
                 getPeakRunningTaskCount(),
                 succinctBytes(getPeakUserMemoryInBytes()),
                 succinctBytes(getPeakTotalMemoryInBytes()),

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestQueryInfo.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestQueryInfo.java
@@ -1,0 +1,184 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution;
+
+import com.facebook.airlift.bootstrap.Bootstrap;
+import com.facebook.airlift.json.JsonCodec;
+import com.facebook.airlift.json.JsonModule;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.TypeManager;
+import com.facebook.presto.metadata.FunctionAndTypeManager;
+import com.facebook.presto.metadata.HandleJsonModule;
+import com.facebook.presto.server.SliceDeserializer;
+import com.facebook.presto.server.SliceSerializer;
+import com.facebook.presto.spi.ConnectorId;
+import com.facebook.presto.spi.PrestoWarning;
+import com.facebook.presto.spi.QueryId;
+import com.facebook.presto.spi.WarningCode;
+import com.facebook.presto.spi.memory.MemoryPoolId;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.spi.resourceGroups.QueryType;
+import com.facebook.presto.spi.security.SelectedRole;
+import com.facebook.presto.sql.Serialization;
+import com.facebook.presto.sql.analyzer.FeaturesConfig;
+import com.facebook.presto.sql.parser.SqlParser;
+import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.FunctionCall;
+import com.facebook.presto.transaction.TransactionId;
+import com.facebook.presto.type.TypeDeserializer;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.Module;
+import io.airlift.slice.Slice;
+import org.testng.annotations.Test;
+
+import java.net.URI;
+import java.util.Optional;
+
+import static com.facebook.airlift.configuration.ConfigBinder.configBinder;
+import static com.facebook.airlift.json.JsonBinder.jsonBinder;
+import static com.facebook.airlift.json.JsonCodecBinder.jsonCodecBinder;
+import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
+import static com.facebook.presto.execution.QueryState.FINISHED;
+import static com.facebook.presto.metadata.FunctionAndTypeManager.createTestFunctionAndTypeManager;
+import static com.google.inject.multibindings.Multibinder.newSetBinder;
+import static org.testng.Assert.assertEquals;
+
+public class TestQueryInfo
+{
+    @Test
+    public void testQueryInfoRoundTrip()
+    {
+        JsonCodec<QueryInfo> codec = createJsonCodec();
+        QueryInfo expected = createQueryInfo();
+        QueryInfo actual = codec.fromJson(codec.toJson(expected));
+
+        assertEquals(actual.getQueryId(), expected.getQueryId());
+        // Note: SessionRepresentation.equals?
+        assertEquals(actual.getState(), expected.getState());
+        assertEquals(actual.getMemoryPool(), expected.getMemoryPool());
+        assertEquals(actual.isScheduled(), expected.isScheduled());
+
+        assertEquals(actual.getSelf(), expected.getSelf());
+        assertEquals(actual.getFieldNames(), expected.getFieldNames());
+        assertEquals(actual.getQuery(), expected.getQuery());
+        assertEquals(actual.getExpandedQuery(), expected.getExpandedQuery());
+        assertEquals(actual.getPreparedQuery(), expected.getPreparedQuery());
+        // Assert all of queryStats
+        TestQueryStats.assertExpectedQueryStats(actual.getQueryStats());
+
+        assertEquals(actual.getSetCatalog(), expected.getSetCatalog());
+        assertEquals(actual.getSetSchema(), expected.getSetSchema());
+        assertEquals(actual.getSetSessionProperties(), expected.getSetSessionProperties());
+        assertEquals(actual.getResetSessionProperties(), expected.getResetSessionProperties());
+        assertEquals(actual.getSetRoles(), expected.getSetRoles());
+        assertEquals(actual.getAddedPreparedStatements(), expected.getAddedPreparedStatements());
+        assertEquals(actual.getDeallocatedPreparedStatements(), expected.getDeallocatedPreparedStatements());
+
+        assertEquals(actual.getStartedTransactionId(), expected.getStartedTransactionId());
+        assertEquals(actual.isClearTransactionId(), expected.isClearTransactionId());
+
+        assertEquals(actual.getUpdateType(), expected.getUpdateType());
+        assertEquals(actual.getOutputStage(), expected.getOutputStage());
+
+        assertEquals(actual.getFailureInfo(), expected.getFailureInfo());
+        assertEquals(actual.getErrorCode(), expected.getErrorCode());
+        assertEquals(actual.getWarnings(), expected.getWarnings());
+
+        assertEquals(actual.getInputs(), expected.getInputs());
+        assertEquals(actual.getOutput(), expected.getOutput());
+
+        assertEquals(actual.isFinalQueryInfo(), expected.isFinalQueryInfo());
+
+        assertEquals(actual.getResourceGroupId(), expected.getResourceGroupId());
+        assertEquals(actual.getQueryType(), expected.getQueryType());
+
+        assertEquals(actual.getFailedTasks(), expected.getFailedTasks());
+        assertEquals(actual.getRuntimeOptimizedStages(), actual.getRuntimeOptimizedStages());
+
+        assertEquals(actual.getAddedSessionFunctions(), expected.getAddedSessionFunctions());
+        assertEquals(actual.getRemovedSessionFunctions(), expected.getRemovedSessionFunctions());
+    }
+
+    private static JsonCodec<QueryInfo> createJsonCodec()
+    {
+        Module module = binder -> {
+            SqlParser sqlParser = new SqlParser();
+            FunctionAndTypeManager functionAndTypeManager = createTestFunctionAndTypeManager();
+            binder.install(new JsonModule());
+            binder.install(new HandleJsonModule());
+            binder.bind(SqlParser.class).toInstance(sqlParser);
+            binder.bind(TypeManager.class).toInstance(functionAndTypeManager);
+            configBinder(binder).bindConfig(FeaturesConfig.class);
+            newSetBinder(binder, Type.class);
+            jsonBinder(binder).addSerializerBinding(Slice.class).to(SliceSerializer.class);
+            jsonBinder(binder).addDeserializerBinding(Slice.class).to(SliceDeserializer.class);
+            jsonBinder(binder).addDeserializerBinding(Type.class).to(TypeDeserializer.class);
+            jsonBinder(binder).addSerializerBinding(Expression.class).to(Serialization.ExpressionSerializer.class);
+            jsonBinder(binder).addDeserializerBinding(Expression.class).to(Serialization.ExpressionDeserializer.class);
+            jsonBinder(binder).addDeserializerBinding(FunctionCall.class).to(Serialization.FunctionCallDeserializer.class);
+            jsonBinder(binder).addKeySerializerBinding(VariableReferenceExpression.class).to(Serialization.VariableReferenceExpressionSerializer.class);
+            jsonBinder(binder).addKeyDeserializerBinding(VariableReferenceExpression.class).to(Serialization.VariableReferenceExpressionDeserializer.class);
+            jsonCodecBinder(binder).bindJsonCodec(QueryInfo.class);
+        };
+        Bootstrap app = new Bootstrap(ImmutableList.of(module));
+        Injector injector = app
+                .doNotInitializeLogging()
+                .quiet()
+                .initialize();
+        return injector.getInstance(new Key<JsonCodec<QueryInfo>>() {});
+    }
+
+    private static QueryInfo createQueryInfo()
+    {
+        return new QueryInfo(
+                new QueryId("0"),
+                TEST_SESSION.toSessionRepresentation(),
+                FINISHED,
+                new MemoryPoolId("memory_pool"),
+                true,
+                URI.create("1"),
+                ImmutableList.of("number"),
+                "SELECT 1",
+                Optional.of("expanded_query"),
+                Optional.of("prepared_query"),
+                TestQueryStats.EXPECTED,
+                Optional.of("set_catalog"),
+                Optional.of("set_schema"),
+                ImmutableMap.of("set_property", "set_value"),
+                ImmutableSet.of("reset_property"),
+                ImmutableMap.of("set_roles", new SelectedRole(SelectedRole.Type.ROLE, Optional.of("role"))),
+                ImmutableMap.of("added_prepared_statement", "statement"),
+                ImmutableSet.of("deallocated_prepared_statement", "statement"),
+                Optional.of(TransactionId.create()),
+                true,
+                "update_type",
+                Optional.empty(),
+                null,
+                null,
+                ImmutableList.of(new PrestoWarning(new WarningCode(1, "name"), "message")),
+                ImmutableSet.of(new Input(new ConnectorId("connector"), "schema", "table", Optional.empty(), ImmutableList.of(new Column("name", "type")), Optional.empty())),
+                Optional.empty(),
+                true,
+                Optional.empty(),
+                Optional.of(QueryType.SELECT),
+                Optional.of(ImmutableList.of(new TaskId("0", 1, 1, 1))),
+                Optional.of(ImmutableList.of(new StageId("0", 1))),
+                ImmutableMap.of(),
+                ImmutableSet.of());
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestQueryStats.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestQueryStats.java
@@ -166,7 +166,7 @@ public class TestQueryStats
                     null,
                     new RuntimeStats()));
 
-    private static final QueryStats EXPECTED = new QueryStats(
+    static final QueryStats EXPECTED = new QueryStats(
             new DateTime(1),
             new DateTime(2),
             new DateTime(3),
@@ -254,7 +254,7 @@ public class TestQueryStats
         assertExpectedQueryStats(actual);
     }
 
-    private static void assertExpectedQueryStats(QueryStats actual)
+    static void assertExpectedQueryStats(QueryStats actual)
     {
         assertEquals(actual.getCreateTime(), new DateTime(1, UTC));
         assertEquals(actual.getExecutionStartTime(), new DateTime(2, UTC));

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
@@ -644,7 +644,9 @@ public class PrestoSparkQueryExecutionFactory
         long peakTaskTotalMemoryInBytes = 0;
         long peakNodeTotalMemoryInBytes = 0;
 
-        for (StageInfo stageInfo : getAllStages(rootStage)) {
+        List<StageInfo> allStages = getAllStages(rootStage);
+
+        for (StageInfo stageInfo : allStages) {
             StageExecutionInfo stageExecutionInfo = stageInfo.getLatestAttemptExecutionInfo();
             for (TaskInfo taskInfo : stageExecutionInfo.getTasks()) {
                 // there's no way to know how many tasks were running in parallel in Spark
@@ -663,6 +665,7 @@ public class PrestoSparkQueryExecutionFactory
         QueryStats queryStats = QueryStats.create(
                 queryStateTimer,
                 rootStage,
+                allStages,
                 peakRunningTasks,
                 succinctBytes(peakUserMemoryReservationInBytes),
                 succinctBytes(peakTotalMemoryReservationInBytes),

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkQueryExecutionFactory.java
@@ -699,7 +699,7 @@ public class PrestoSparkQueryExecutionFactory
                 warningCollector.getWarnings(),
                 planAndMore.map(PlanAndMore::getInputs).orElse(ImmutableSet.of()),
                 planAndMore.flatMap(PlanAndMore::getOutput),
-                true,
+                queryState.isDone(),
                 sparkQueueName.map(ResourceGroupId::new),
                 planAndMore.flatMap(PlanAndMore::getQueryType),
                 Optional.empty(),


### PR DESCRIPTION
Similar changes extracted from https://github.com/trinodb/trino/pull/11580

Refactors logic that creates `QueryInfo` and `StatementStats` to reduce overhead and avoid repeated work. This code sits in the critical path of the coordinator producing query result responses.

Each commit has a more specific description of the exact change being made. At a high level, they are:
- Remove redundant copies and traversals from the conversion process of `QueryInfo` / `StageInfo` to `StatementStats` / `StageStats`
- Refactor `QueryInfo` to consolidate `isCompletedInfo()` and `isFinalInfo()` into a single method
- Reuse the result of `StageInfo.getAllStages` so that child stages only need to be flattened into a single list once, instead of four times as was the case before this change

```
== NO RELEASE NOTE ==
```
