### PR TITLE
Modify DirectoryLister interface to pass partition information

### DIFF
--- a/presto-hive-common/src/main/java/com/facebook/presto/hive/HiveFileInfo.java
+++ b/presto-hive-common/src/main/java/com/facebook/presto/hive/HiveFileInfo.java
@@ -13,10 +13,12 @@
  */
 package com.facebook.presto.hive;
 
+import com.google.common.collect.ImmutableMap;
 import org.apache.hadoop.fs.BlockLocation;
 import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
 
+import java.util.Map;
 import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
@@ -30,8 +32,17 @@ public class HiveFileInfo
     private final long length;
     private final long fileModifiedTime;
     private final Optional<byte[]> extraFileInfo;
+    private final Map<String, String> customSplitInfo;
 
     public static HiveFileInfo createHiveFileInfo(LocatedFileStatus locatedFileStatus, Optional<byte[]> extraFileContext)
+    {
+        return createHiveFileInfo(
+                locatedFileStatus,
+                extraFileContext,
+                ImmutableMap.of());
+    }
+
+    public static HiveFileInfo createHiveFileInfo(LocatedFileStatus locatedFileStatus, Optional<byte[]> extraFileContext, Map<String, String> customSplitInfo)
     {
         return new HiveFileInfo(
                 locatedFileStatus.getPath(),
@@ -39,10 +50,11 @@ public class HiveFileInfo
                 locatedFileStatus.getBlockLocations(),
                 locatedFileStatus.getLen(),
                 locatedFileStatus.getModificationTime(),
-                extraFileContext);
+                extraFileContext,
+                customSplitInfo);
     }
 
-    private HiveFileInfo(Path path, boolean isDirectory, BlockLocation[] blockLocations, long length, long fileModifiedTime, Optional<byte[]> extraFileInfo)
+    private HiveFileInfo(Path path, boolean isDirectory, BlockLocation[] blockLocations, long length, long fileModifiedTime, Optional<byte[]> extraFileInfo, Map<String, String> customSplitInfo)
     {
         this.path = requireNonNull(path, "path is null");
         this.isDirectory = isDirectory;
@@ -50,6 +62,7 @@ public class HiveFileInfo
         this.length = length;
         this.fileModifiedTime = fileModifiedTime;
         this.extraFileInfo = requireNonNull(extraFileInfo, "extraFileInfo is null");
+        this.customSplitInfo = requireNonNull(customSplitInfo, "customSplitInfo is null");
     }
 
     public Path getPath()
@@ -80,6 +93,11 @@ public class HiveFileInfo
     public Optional<byte[]> getExtraFileInfo()
     {
         return extraFileInfo;
+    }
+
+    public Map<String, String> getCustomSplitInfo()
+    {
+        return customSplitInfo;
     }
 
     @Override

--- a/presto-hive/src/main/java/com/facebook/presto/hive/CachingDirectoryLister.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/CachingDirectoryLister.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.hive;
 
 import com.facebook.presto.hive.filesystem.ExtendedFileSystem;
+import com.facebook.presto.hive.metastore.Partition;
 import com.facebook.presto.hive.metastore.Table;
 import com.facebook.presto.spi.SchemaTableName;
 import com.google.common.cache.Cache;
@@ -30,6 +31,7 @@ import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
@@ -72,6 +74,7 @@ public class CachingDirectoryLister
             ExtendedFileSystem fileSystem,
             Table table,
             Path path,
+            Optional<Partition> partition,
             NamenodeStats namenodeStats,
             HiveDirectoryContext hiveDirectoryContext)
     {
@@ -80,7 +83,7 @@ public class CachingDirectoryLister
             return files.iterator();
         }
 
-        Iterator<HiveFileInfo> iterator = delegate.list(fileSystem, table, path, namenodeStats, hiveDirectoryContext);
+        Iterator<HiveFileInfo> iterator = delegate.list(fileSystem, table, path, partition, namenodeStats, hiveDirectoryContext);
         if (hiveDirectoryContext.isCacheable() && cachedTableChecker.isCachedTable(table.getSchemaTableName())) {
             return cachingIterator(iterator, path);
         }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/DirectoryLister.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/DirectoryLister.java
@@ -14,10 +14,12 @@
 package com.facebook.presto.hive;
 
 import com.facebook.presto.hive.filesystem.ExtendedFileSystem;
+import com.facebook.presto.hive.metastore.Partition;
 import com.facebook.presto.hive.metastore.Table;
 import org.apache.hadoop.fs.Path;
 
 import java.util.Iterator;
+import java.util.Optional;
 
 public interface DirectoryLister
 {
@@ -25,6 +27,7 @@ public interface DirectoryLister
             ExtendedFileSystem fileSystem,
             Table table,
             Path path,
+            Optional<Partition> partition,
             NamenodeStats namenodeStats,
             HiveDirectoryContext hiveDirectoryContext);
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HadoopDirectoryLister.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HadoopDirectoryLister.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.hive;
 
 import com.facebook.presto.hive.filesystem.ExtendedFileSystem;
+import com.facebook.presto.hive.metastore.Partition;
 import com.facebook.presto.hive.metastore.Table;
 import com.facebook.presto.hive.util.HiveFileIterator;
 import org.apache.hadoop.fs.LocatedFileStatus;
@@ -35,6 +36,7 @@ public class HadoopDirectoryLister
             ExtendedFileSystem fileSystem,
             Table table,
             Path path,
+            Optional<Partition> partition,
             NamenodeStats namenodeStats,
             HiveDirectoryContext hiveDirectoryContext)
     {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HudiDirectoryLister.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HudiDirectoryLister.java
@@ -15,6 +15,7 @@ package com.facebook.presto.hive;
 
 import com.facebook.airlift.log.Logger;
 import com.facebook.presto.hive.filesystem.ExtendedFileSystem;
+import com.facebook.presto.hive.metastore.Partition;
 import com.facebook.presto.hive.metastore.Table;
 import com.facebook.presto.hive.util.HiveFileIterator;
 import com.facebook.presto.spi.ConnectorSession;
@@ -75,6 +76,7 @@ public class HudiDirectoryLister
             ExtendedFileSystem fileSystem,
             Table table,
             Path path,
+            Optional<Partition> partition,
             NamenodeStats namenodeStats,
             HiveDirectoryContext hiveDirectoryContext)
     {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/ManifestPartitionLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/ManifestPartitionLoader.java
@@ -188,7 +188,7 @@ public class ManifestPartitionLoader
         ExtendedFileSystem fileSystem = hdfsEnvironment.getFileSystem(hdfsContext, path);
         HiveDirectoryContext hiveDirectoryContext = new HiveDirectoryContext(recursiveDirWalkerEnabled ? RECURSE : IGNORED, false);
 
-        Iterator<HiveFileInfo> fileInfoIterator = directoryLister.list(fileSystem, table, path, namenodeStats, hiveDirectoryContext);
+        Iterator<HiveFileInfo> fileInfoIterator = directoryLister.list(fileSystem, table, path, partition.getPartition(), namenodeStats, hiveDirectoryContext);
         int fileCount = 0;
         while (fileInfoIterator.hasNext()) {
             HiveFileInfo fileInfo = fileInfoIterator.next();

--- a/presto-hive/src/main/java/com/facebook/presto/hive/StoragePartitionLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/StoragePartitionLoader.java
@@ -280,9 +280,9 @@ public class StoragePartitionLoader
                 checkState(
                         tableBucketInfo.get().getTableBucketCount() == tableBucketInfo.get().getReadBucketCount(),
                         "Table and read bucket count should be the same for virtual bucket");
-                return hiveSplitSource.addToQueue(getVirtuallyBucketedSplits(path, fs, splitFactory, tableBucketInfo.get().getReadBucketCount(), splittable));
+                return hiveSplitSource.addToQueue(getVirtuallyBucketedSplits(path, fs, splitFactory, tableBucketInfo.get().getReadBucketCount(), partition.getPartition(), splittable));
             }
-            return hiveSplitSource.addToQueue(getBucketedSplits(path, fs, splitFactory, tableBucketInfo.get(), bucketConversion, partitionName, splittable));
+            return hiveSplitSource.addToQueue(getBucketedSplits(path, fs, splitFactory, tableBucketInfo.get(), bucketConversion, partitionName, partition.getPartition(), splittable));
         }
 
         fileIterators.addLast(createInternalHiveSplitIterator(path, fs, splitFactory, splittable, partition.getPartition()));
@@ -314,7 +314,7 @@ public class StoragePartitionLoader
         }
 
         HiveDirectoryContext hiveDirectoryContext = new HiveDirectoryContext(recursiveDirWalkerEnabled ? RECURSE : IGNORED, cacheable);
-        return stream(directoryLister.list(fileSystem, table, path, namenodeStats, hiveDirectoryContext))
+        return stream(directoryLister.list(fileSystem, table, path, partition, namenodeStats, hiveDirectoryContext))
                 .map(status -> splitFactory.createInternalHiveSplit(status, splittable))
                 .filter(Optional::isPresent)
                 .map(Optional::get)
@@ -328,6 +328,7 @@ public class StoragePartitionLoader
             BucketSplitInfo bucketSplitInfo,
             Optional<HiveSplit.BucketConversion> bucketConversion,
             String partitionName,
+            Optional<Partition> partition,
             boolean splittable)
     {
         int readBucketCount = bucketSplitInfo.getReadBucketCount();
@@ -340,7 +341,7 @@ public class StoragePartitionLoader
         // list all files in the partition
         List<HiveFileInfo> fileInfos = new ArrayList<>(partitionBucketCount);
         try {
-            Iterators.addAll(fileInfos, directoryLister.list(fileSystem, table, path, namenodeStats, new HiveDirectoryContext(FAIL, isUseListDirectoryCache(session))));
+            Iterators.addAll(fileInfos, directoryLister.list(fileSystem, table, path, partition, namenodeStats, new HiveDirectoryContext(FAIL, isUseListDirectoryCache(session))));
         }
         catch (HiveFileIterator.NestedDirectoryNotAllowedException e) {
             // Fail here to be on the safe side. This seems to be the same as what Hive does
@@ -459,11 +460,11 @@ public class StoragePartitionLoader
         return splitList;
     }
 
-    private List<InternalHiveSplit> getVirtuallyBucketedSplits(Path path, ExtendedFileSystem fileSystem, InternalHiveSplitFactory splitFactory, int bucketCount, boolean splittable)
+    private List<InternalHiveSplit> getVirtuallyBucketedSplits(Path path, ExtendedFileSystem fileSystem, InternalHiveSplitFactory splitFactory, int bucketCount, Optional<Partition> partition, boolean splittable)
     {
         // List all files recursively in the partition and assign virtual bucket number to each of them
         HiveDirectoryContext hiveDirectoryContext = new HiveDirectoryContext(recursiveDirWalkerEnabled ? RECURSE : IGNORED, isUseListDirectoryCache(session));
-        return stream(directoryLister.list(fileSystem, table, path, namenodeStats, hiveDirectoryContext))
+        return stream(directoryLister.list(fileSystem, table, path, partition, namenodeStats, hiveDirectoryContext))
                 .map(fileInfo -> {
                     int virtualBucketNumber = getVirtualBucketNumber(bucketCount, fileInfo.getPath());
                     return splitFactory.createInternalHiveSplit(fileInfo, virtualBucketNumber, virtualBucketNumber, splittable);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/util/InternalHiveSplitFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/util/InternalHiveSplitFactory.java
@@ -23,7 +23,6 @@ import com.facebook.presto.hive.S3SelectPushdown;
 import com.facebook.presto.spi.HostAddress;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import io.airlift.units.DataSize;
 import org.apache.hadoop.fs.BlockLocation;
 import org.apache.hadoop.fs.FileStatus;
@@ -110,7 +109,7 @@ public class InternalHiveSplitFactory
                 tableBucketNumber,
                 splittable,
                 fileInfo.getExtraFileInfo(),
-                ImmutableMap.of());
+                fileInfo.getCustomSplitInfo());
     }
 
     public Optional<InternalHiveSplit> createInternalHiveSplit(FileSplit split)

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitManager.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitManager.java
@@ -629,7 +629,7 @@ public class TestHiveSplitManager
             implements DirectoryLister
     {
         @Override
-        public Iterator<HiveFileInfo> list(ExtendedFileSystem fileSystem, Table table, Path path, NamenodeStats namenodeStats, HiveDirectoryContext hiveDirectoryContext)
+        public Iterator<HiveFileInfo> list(ExtendedFileSystem fileSystem, Table table, Path path, Optional<Partition> partition, NamenodeStats namenodeStats, HiveDirectoryContext hiveDirectoryContext)
         {
             try {
                 return ImmutableList.of(

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHudiDirectoryLister.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHudiDirectoryLister.java
@@ -89,7 +89,7 @@ public class TestHudiDirectoryLister
         assertEquals(metaClient.getBasePath(), mockTable.getStorage().getLocation());
         Path path = new Path(mockTable.getStorage().getLocation());
         ExtendedFileSystem fs = (ExtendedFileSystem) path.getFileSystem(hadoopConf);
-        Iterator<HiveFileInfo> fileInfoIterator = directoryLister.list(fs, mockTable, path, new NamenodeStats(), new HiveDirectoryContext(IGNORED, false));
+        Iterator<HiveFileInfo> fileInfoIterator = directoryLister.list(fs, mockTable, path, Optional.empty(), new NamenodeStats(), new HiveDirectoryContext(IGNORED, false));
         assertTrue(fileInfoIterator.hasNext());
         HiveFileInfo fileInfo = fileInfoIterator.next();
         assertEquals(fileInfo.getPath().getName(), "d0875d00-483d-4e8b-bbbe-c520366c47a0-0_0-6-11_20211217110514527.parquet");


### PR DESCRIPTION
In order to support mutation of partitions, we need partition information during listing time. We are changing the Directory lister interface for the same. We also need to inject additional split related information which has complicated structure and cannot be represented by the existing map structure in HiveSplit. We are going to use existing "extraFileInfo" field of type:byte[] and will leverage properties in customSplitInfo map for information necessary to deserialize the byte[]. 

Test plan - unit test

```
== NO RELEASE NOTE ==
```
