### PR TITLE
Support timely invalidation of parquet metadata cache

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSourceFactory.java
@@ -222,7 +222,11 @@ public class ParquetPageSourceFactory
         try {
             FSDataInputStream inputStream = hdfsEnvironment.getFileSystem(user, path, configuration).openFile(path, hiveFileContext);
             dataSource = buildHdfsParquetDataSource(inputStream, path, stats);
-            ParquetMetadata parquetMetadata = parquetMetadataSource.getParquetMetadata(dataSource, fileSize, hiveFileContext.isCacheable()).getParquetMetadata();
+            ParquetMetadata parquetMetadata = parquetMetadataSource.getParquetMetadata(
+                    dataSource,
+                    fileSize,
+                    hiveFileContext.isCacheable(),
+                    hiveFileContext.getModificationTime()).getParquetMetadata();
 
             if (!columns.isEmpty() && columns.stream().allMatch(hiveColumnHandle -> hiveColumnHandle.getColumnType() == AGGREGATED)) {
                 return new AggregatedParquetPageSource(columns, parquetMetadata, typeManager, functionResolution);

--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/ParquetTester.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/ParquetTester.java
@@ -858,7 +858,8 @@ public class ParquetTester
             List<String> columnNames,
             List<Type> columnTypes,
             ParquetMetadataSource parquetMetadataSource,
-            File dataFile)
+            File dataFile,
+            long modificationTime)
     {
         HiveClientConfig config = new HiveClientConfig()
                 .setHiveStorageFormat(HiveStorageFormat.PARQUET)
@@ -871,7 +872,7 @@ public class ParquetTester
                 new CacheConfig()).getSessionProperties());
 
         HiveBatchPageSourceFactory pageSourceFactory = new ParquetPageSourceFactory(FUNCTION_AND_TYPE_MANAGER, FUNCTION_RESOLUTION, HDFS_ENVIRONMENT, new FileFormatDataSourceStats(), parquetMetadataSource);
-        ConnectorPageSource connectorPageSource = createPageSource(pageSourceFactory, session, dataFile, columnNames, columnTypes, HiveStorageFormat.PARQUET);
+        ConnectorPageSource connectorPageSource = createPageSource(pageSourceFactory, session, dataFile, columnNames, columnTypes, HiveStorageFormat.PARQUET, modificationTime);
 
         Iterator<?>[] expectedValues = stream(readValues).map(Iterable::iterator).toArray(size -> new Iterator<?>[size]);
         if (connectorPageSource instanceof RecordPageSource) {

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/cache/ParquetFileMetadata.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/cache/ParquetFileMetadata.java
@@ -21,11 +21,13 @@ public class ParquetFileMetadata
 {
     private final ParquetMetadata parquetMetadata;
     private final int metadataSize;
+    private final long modificationTime;
 
-    public ParquetFileMetadata(ParquetMetadata parquetMetadata, int metadataSize)
+    public ParquetFileMetadata(ParquetMetadata parquetMetadata, int metadataSize, long modificationTime)
     {
         this.parquetMetadata = requireNonNull(parquetMetadata, "parquetMetadata is null");
         this.metadataSize = metadataSize;
+        this.modificationTime = modificationTime;
     }
 
     public int getMetadataSize()
@@ -36,5 +38,10 @@ public class ParquetFileMetadata
     public ParquetMetadata getParquetMetadata()
     {
         return parquetMetadata;
+    }
+
+    public long getModificationTime()
+    {
+        return modificationTime;
     }
 }

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/cache/ParquetMetadataSource.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/cache/ParquetMetadataSource.java
@@ -19,6 +19,10 @@ import java.io.IOException;
 
 public interface ParquetMetadataSource
 {
-    ParquetFileMetadata getParquetMetadata(ParquetDataSource parquetDataSource, long fileSize, boolean cacheable)
+    ParquetFileMetadata getParquetMetadata(
+            ParquetDataSource parquetDataSource,
+            long fileSize,
+            boolean cacheable,
+            long modificationTime)
             throws IOException;
 }


### PR DESCRIPTION
Test plan 
- Use existing unit tests, and add some test cases about invalidation of the cache.

The reason of this pr is detailed in this issue: https://github.com/prestodb/presto/issues/17472  

Thank you.

```
== RELEASE NOTES ==

General Changes
* If hive files are changed, the modification time can be used to invalidate parquet metadata cache immediately.

```
