### PR TITLE
Upgrade zstd-jni to 1.5.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1929,7 +1929,7 @@
             <dependency>
                 <groupId>com.github.luben</groupId>
                 <artifactId>zstd-jni</artifactId>
-                <version>1.5.0-4</version>
+                <version>1.5.2-2</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
zstd 1.5.2 includes a few improvement (i.e. fix of performance regression introduced in 1.5.0, compression perf improvement, and Huffman improvements: https://github.com/facebook/zstd/releases)
Internal test showed around ~2% overall cpu reduction (decompress dropped from 6% to 4.9%, and compress dropped from 1.9% to 1.6% based on cpu profiling).

Test plan -
Built presto and test internally.

```
== RELEASE NOTES ==

General Changes
* Upgrade zstandard compression to version 1.5.2.2. This can improved about 2% overall CPU with data compressed with zstandard.
```
