### PR TITLE
Bump postgresql driver to 42.3.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1116,7 +1116,7 @@
             <dependency>
                 <groupId>org.postgresql</groupId>
                 <artifactId>postgresql</artifactId>
-                <version>42.2.5</version>
+                <version>42.3.3</version>
             </dependency>
 
             <dependency>
@@ -1956,6 +1956,12 @@
                         <artifactId>slf4j-log4j12</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.checkerframework</groupId>
+                <artifactId>checker-qual</artifactId>
+                <version>3.20.0</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Cherry-pick of https://github.com/trinodb/trino/pull/11449

It addresses [CVE-2022-21724](https://github.com/advisories/GHSA-v7wg-cpwc-24m4).

It also includes some fixes around calendars being used in thread-safe
way, result of PgObject#isNull, possible connection leak and loss of
microseconds when reading TIME(6) via getTimestamp.

Co-authored-by: Ashhar Hasan <ashhar.hasan@starburstdata.com>

```
== RELEASE NOTES ==

General Changes
* Bump postgresql driver to 42.3.3

```

