### PR TITLE
Deprecate joda-time for java.time in presto-tpcds

### DIFF
--- a/presto-tpcds/pom.xml
+++ b/presto-tpcds/pom.xml
@@ -27,11 +27,6 @@
         </dependency>
 
         <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>com.facebook.airlift</groupId>
             <artifactId>json</artifactId>
         </dependency>

--- a/presto-tpcds/src/main/java/com/facebook/presto/tpcds/TpcdsRecordSet.java
+++ b/presto-tpcds/src/main/java/com/facebook/presto/tpcds/TpcdsRecordSet.java
@@ -25,10 +25,9 @@ import com.teradata.tpcds.column.Column;
 import com.teradata.tpcds.column.ColumnType;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
-import org.joda.time.Days;
-import org.joda.time.LocalDate;
-import org.joda.time.LocalTime;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
 import java.util.Iterator;
 import java.util.List;
 
@@ -39,6 +38,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static java.lang.Double.parseDouble;
 import static java.lang.Integer.parseInt;
 import static java.lang.Long.parseLong;
+import static java.time.temporal.ChronoField.MILLI_OF_DAY;
 import static java.util.Objects.requireNonNull;
 
 public class TpcdsRecordSet
@@ -131,10 +131,10 @@ public class TpcdsRecordSet
             checkState(row != null, "No current row");
             Column column = columns.get(field);
             if (column.getType().getBase() == ColumnType.Base.DATE) {
-                return Days.daysBetween(new LocalDate(0), LocalDate.parse(row.get(column.getPosition()))).getDays();
+                return LocalDate.parse(row.get(column.getPosition())).toEpochDay();
             }
             if (column.getType().getBase() == ColumnType.Base.TIME) {
-                return LocalTime.parse(row.get(column.getPosition())).getMillisOfDay();
+                return LocalTime.parse(row.get(column.getPosition())).get(MILLI_OF_DAY);
             }
             if (column.getType().getBase() == ColumnType.Base.INTEGER) {
                 return parseInt(row.get(column.getPosition()));

--- a/presto-tpcds/src/test/java/com/facebook/presto/tpcds/TestTpcdsRecordSet.java
+++ b/presto-tpcds/src/test/java/com/facebook/presto/tpcds/TestTpcdsRecordSet.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tpcds;
+
+import com.facebook.presto.spi.RecordCursor;
+import com.facebook.presto.spi.RecordSet;
+import com.google.common.collect.ImmutableList;
+import com.teradata.tpcds.Results;
+import com.teradata.tpcds.Session;
+import com.teradata.tpcds.Table;
+import com.teradata.tpcds.column.Column;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.CharType.createCharType;
+import static com.facebook.presto.common.type.DateType.DATE;
+import static com.facebook.presto.common.type.DecimalType.createDecimalType;
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.common.type.TimeType.TIME;
+import static com.facebook.presto.common.type.VarcharType.createVarcharType;
+import static com.teradata.tpcds.Results.constructResults;
+import static com.teradata.tpcds.Table.CALL_CENTER;
+import static com.teradata.tpcds.Table.DBGEN_VERSION;
+import static com.teradata.tpcds.Table.getTable;
+import static com.teradata.tpcds.column.CallCenterColumn.CC_CALL_CENTER_SK;
+import static com.teradata.tpcds.column.CallCenterColumn.CC_MANAGER;
+import static com.teradata.tpcds.column.CallCenterColumn.CC_NAME;
+import static com.teradata.tpcds.column.CallCenterColumn.CC_REC_END_DATE;
+import static com.teradata.tpcds.column.CallCenterColumn.CC_REC_START_DATE;
+import static com.teradata.tpcds.column.CallCenterColumn.CC_SQ_FT;
+import static com.teradata.tpcds.column.CallCenterColumn.CC_STATE;
+import static com.teradata.tpcds.column.CallCenterColumn.CC_TAX_PERCENTAGE;
+import static com.teradata.tpcds.column.DbgenVersionColumn.DV_CREATE_DATE;
+import static com.teradata.tpcds.column.DbgenVersionColumn.DV_CREATE_TIME;
+import static com.teradata.tpcds.column.DbgenVersionColumn.DV_VERSION;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class TestTpcdsRecordSet
+{
+    private final Session session = Session.getDefaultSession().withScale(.01);
+
+    @Test
+    public void testGetColumnTypes()
+    {
+        Table table = getTable(CALL_CENTER.getName());
+        List<Column> columns = ImmutableList.of(
+                CC_CALL_CENTER_SK,  // Big Int
+                CC_SQ_FT,           // Integer
+                CC_NAME,            // Varchar
+                CC_STATE,           // CharType
+                CC_TAX_PERCENTAGE); // Decimal
+        RecordSet recordSet = new TpcdsRecordSet(constructResults(table, session), columns);
+        assertEquals(recordSet.getColumnTypes(), ImmutableList.of(
+                BIGINT,
+                INTEGER,
+                createVarcharType(50),
+                createCharType(2),
+                createDecimalType(5, 2)));
+
+        table = getTable(DBGEN_VERSION.getName());
+        columns = ImmutableList.of(
+                DV_CREATE_DATE, // Date
+                DV_CREATE_TIME, // Time
+                DV_VERSION);    // Varchar
+        recordSet = new TpcdsRecordSet(constructResults(table, session), columns);
+        assertEquals(recordSet.getColumnTypes(), ImmutableList.of(
+                DATE,
+                TIME,
+                createVarcharType(16)));
+
+        table = getTable(DBGEN_VERSION.getName());
+        columns = ImmutableList.of();
+        recordSet = new TpcdsRecordSet(constructResults(table, session), columns);
+        assertEquals(recordSet.getColumnTypes(), ImmutableList.of());
+    }
+
+    @Test
+    public void testCursor()
+    {
+        Table table = getTable(CALL_CENTER.getName());
+        Results result = constructResults(table, session);
+        RecordSet recordSet = new TpcdsRecordSet(result, ImmutableList.copyOf(table.getColumns()));
+
+        try (RecordCursor cursor = recordSet.cursor()) {
+            if (cursor.advanceNextPosition()) {
+                // Date
+                assertFalse(cursor.isNull(CC_REC_START_DATE.ordinal()));
+                assertEquals(cursor.getLong(CC_REC_START_DATE.ordinal()), 10227);
+                assertTrue(cursor.isNull(CC_REC_END_DATE.ordinal()));
+
+                // Big Int
+                assertFalse(cursor.isNull(CC_CALL_CENTER_SK.ordinal()));
+                assertEquals(cursor.getLong(CC_CALL_CENTER_SK.ordinal()), 1);
+
+                // Integer
+                assertFalse(cursor.isNull(CC_SQ_FT.ordinal()));
+                assertEquals(cursor.getLong(CC_SQ_FT.ordinal()), 1138);
+
+                // Varchar
+                assertFalse(cursor.isNull(CC_MANAGER.ordinal()));
+                assertEquals(cursor.getSlice(CC_MANAGER.ordinal()).toStringUtf8(), "Bob Belcher");
+
+                // Character
+                assertFalse(cursor.isNull(CC_STATE.ordinal()));
+                assertEquals(cursor.getSlice(CC_STATE.ordinal()).toStringUtf8(), "TN");
+
+                // Decimal
+                assertFalse(cursor.isNull(CC_TAX_PERCENTAGE.ordinal()));
+                assertEquals(cursor.getDouble(CC_TAX_PERCENTAGE.ordinal()), .11);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Test plan:
The following command passes
`mvn clean test -pl presto-tpcds -T1C
`

General Changes:
Removed joda-time dependency and replaced occurrences with java.time equivalents


Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines. Don't forget to follow our [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution) for any code copied from other projects.