### PR TITLE
Add release notes for 0.272

### DIFF
--- a/presto-docs/src/main/sphinx/release.rst
+++ b/presto-docs/src/main/sphinx/release.rst
@@ -5,6 +5,7 @@ Release Notes
 .. toctree::
     :maxdepth: 1
 
+    release/release-0.272
     release/release-0.271
     release/release-0.270
     release/release-0.269

--- a/presto-docs/src/main/sphinx/release/release-0.272.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.272.rst
@@ -1,0 +1,44 @@
+=============
+Release 0.272
+=============
+
+**Highlights**
+==============
+
+**Details**
+===========
+
+General Changes
+_______________
+* Fix parquet data page offset calculation in parquet writer.
+* Add a new JDBC driver parameter - timeZoneID :doc:`/installation/jdbc` :issue:`16680`.
+* Add secure_random() and secure_random(lower, upper) with uniform distribution.
+* Add support to use Parquet page-level statistics to skip pages.
+* Bumped Alluxio client from `2.7.0` to `2.7.3`.
+* Enable cost based optimization by default.
+* Ensure Parameters are in proper order for queries having WITH clause.
+* Follow the SQL standard in cast from double or real to varchar.
+* Preserve quotedness for Identifier when formatting Query.
+
+Mongodb Connector Changes
+_________________________
+* Fix the spelling of the write concern option ``JOURNAL_SAFE`` for the property ``mongodb.write-concern``.
+
+Hive Changes
+____________
+* Introduce a flag "hive.parquet-column-index-filter-enabled" to turn on/off this feature. By default it is off.
+* Support metadata-based listing and bootstrap for Hudi tables.
+* Upgrade Hudi version to 0.10.1.
+
+Iceberg Changes
+_______________
+* Support concurrent insertion from the same presto cluster or mutiple presto clusters which sharing the same metastore.
+
+Pinot Changes
+_____________
+* Support querying Pinot JSON type.
+
+**Credits**
+===========
+
+Alan Xu, Amit Dutta, Ariel Weisberg, Arjun Gupta, Arunachalam Thirupathi, Beinan Wang, Chen, Chunxu Tang, Darren Fu, David N Perkins, George Wang, Guy Moore, Harsha Rastogi, James Petty, James Sun, Josh Soref, Ke Wang, Maksim Dmitriyevich Podkorytov, Masha Basmanova, Mayank Garg, Neerad Somanchi, Nikhil Collooru, Pranjal Shankhdhar, Rebecca Schlussel, Rongrong Zhong, Ruslan Mardugalliamov, Sagar Sumit, Sergey Smirnov, Sergii Druzkin, Swapnil Tailor, Tim Meehan, Todd Gao, Varun Gajjala, Xiang Fu, Xinli shang, Ying, Zhenxiao Luo, ahouzheng, guojianhua, mengdilin, panyliu, v-jizhang, zhangyanbing


### PR DESCRIPTION
# Missing Release Notes
## Amit Dutta
- [ ] https://github.com/prestodb/presto/pull/17363 Throw proper error code when timezone is invalid from packDateTimeWit… (Merged by: Timothy Meehan)
- [ ] 3913a1a18d30c87fe4e38d976e523ff4bda5230d Enable Retrying max requests queued exception.

## George Wang
- [ ] https://github.com/prestodb/presto/pull/17132 Add TPCDS schema to HiveQueryRunner (Merged by: Ying)

## Ke Wang
- [ ] https://github.com/prestodb/presto/pull/17281 Add streaming aggregation (Merged by: James Sun)

## Sergey Smirnov
- [ ] https://github.com/prestodb/presto/pull/17391 Thriftify ServerInfo (Merged by: Timothy Meehan)

## Tim Meehan
- [ ] https://github.com/prestodb/presto/pull/17378 Add adaptive execution policy (Merged by: Timothy Meehan)
- [ ] 290bc4a4dc84ae3815eafc16967a1c7cd8344c4b Fix buffer size calculation in TDigest

## Todd Gao
- [ ] https://github.com/prestodb/presto/pull/17218 Add lark sheets connector (Merged by: Beinan)

## guojianhua
- [ ] https://github.com/prestodb/presto/pull/17365 Wrapper the input and output stream of HadoopExtendedFileSystem (Merged by: James Sun)

# Extracted Release Notes
- #16756 (Author: v-jizhang): Add a new JDBC driver parameter - timeZoneID
  - Add a new JDBC driver parameter - timeZoneID :doc:`/installation/jdbc` :issue:`16680`.
- #16983 (Author: panyliu): Support iceberg connector concurrent insertion
  - Support concurrent insertion from the same presto cluster or mutiple presto clusters which sharing the same metastore.
- #17083 (Author: v-jizhang): Ensure Parameters are in proper order for queries having WITH clause
  - Ensure Parameters are in proper order for queries having WITH clause.
- #17186 (Author: v-jizhang): Preserve quotedness for Identifier when formatting Query
  - Preserve quotedness for Identifier when formatting Query.
- #17232 (Author: v-jizhang): Follow the SQL standard in cast from double or real to varchar
  - Follow the SQL standard in cast from double or real to varchar.
- #17244 (Author: Sagar Sumit): Improve listing performance of Hudi tables
  - Upgrade Hudi version to 0.10.1.
  - Support metadata-based listing and bootstrap for Hudi tables.
- #17284 (Author: Xinli shang): Skip reading Parquet pages using Column Indexes feature.
  - Add support to use Parquet page-level statistics to skip pages.
  - Introduce a flag "hive.parquet-column-index-filter-enabled" to turn on/off this feature. By default it is off.
- #17288 (Author: Rongrong Zhong): Enable cost based optimization by default
  - Enable cost based optimization by default.
- #17295 (Author: v-jizhang): Fix parquet data page offset calculation in parquet writer
  - Fix parquet data page offset calculation in parquet writer.
- #17323 (Author: Xiang Fu): [Pinot Connector] Support querying Pinot JSON type
  - Support querying Pinot JSON type.
- #17327 (Author: David N Perkins): Bump Alluxio client from 2.7.0 to 2.7.3
  - Bumped Alluxio client from `2.7.0` to `2.7.3`.
- #17393 (Author: Josh Soref): Spelling
  - Fix the spelling of the write concern option ``JOURNAL_SAFE`` for the property ``mongodb.write-concern``.
- #17399 (Author: Darren Fu): Add secure_random functions
  - Add secure_random() and secure_random(lower, upper) with uniform distribution.

# All Commits
- 290bc4a4dc84ae3815eafc16967a1c7cd8344c4b Fix buffer size calculation in TDigest (Tim Meehan)
- 3913a1a18d30c87fe4e38d976e523ff4bda5230d Enable Retrying max requests queued exception. (Amit Dutta)
- 8479f26d18842c55aa0776c89adcacf722cf133e Fix presto on spark tests being skipped (Ariel Weisberg)
- e7f140162f5022b45e7bc30e8c30e4f65d68edea Kill queries aggressively under high task pressure (Mayank Garg)
- 1e64daf7598d5210711bb8c9e1fded1d3e56c6b0 Expose ORC writer compression level as session property (Sergii Druzkin)
- 028ef8e6a8f6c20451861bcbb82e050396c68677 Fix TestPrestoQueries (Ariel Weisberg)
- 87508957a780f3b88126a51dcbd2289931110d88 Add lark sheets connector (Todd Gao)
- eff77883d0d24dc6022ecde252612d1430c9fbac Revert "Preserve quotedness for Identifier when formatting Query" (Varun Gajjala)
- 36cfca4b75b86372b2be8f780e0f579f7ba846ed Support isOrderable trait for distinct types (Pranjal Shankhdhar)
- 3c800f068a4191e8a491673b1074c171d1298721 Add tests for DictionaryBlock size methods (James Petty)
- 2a79ba1d601e833a00e83bc9623a91b0e5306f0f Make DictionaryBlock sizeInBytes calculation consistent (James Petty)
- f0ea5b96e15db572ab9d1e8e8e823650f9a172d8 Add more benchmark for block position sizes (James Petty)
- 028016585c636abd8424c87c20e4d1fc85bee9dc Record that the result of DictionaryBlock#copyPositions is compact (James Petty)
- 4871cee5b33d556d18e399bb86ca45b3266dc633 Opportunistically record computed dictionary size and uniqueIds (James Petty)
- e4f477cc8a6b97dbd4b4f865a5e14f8499654793 Add support for fixed width blocks computing their size more efficiently (James Petty)
- bb0ee5c468703bc6900dddc32743cf387ead7466 Avoid redundant metastore calls for non-system Iceberg tables (Chunxu Tang)
- 1066c994405625e2c507c8aba1ca8a65f3e24bcd Revert "Wrapper the input and oupput stream from HadoopExtendedFileSystem" (Varun Gajjala)
- 7e138de0749bc6b61391e32dd50ae0b8d8d4d02b Support distinct type in hive (Pranjal Shankhdhar)
- 40a79cd11d8bbe4487347c8db44532e66f05b851 Make TestPinotSegmentPageSource single threaded (Neerad Somanchi)
- f63dfbc2506ed888817699a2caca7105dd81b978 Add runtimeStats to track read calls to underlying storage (Nikhil Collooru)
- 9faf7d53e2bc431e4c5dbfece63911e0cf3678e8 Support directly writing bytes to VariableWidthBlockBuilder (Arunachalam Thirupathi)
- 0233d34c23114c1462afbf491d31784c6385b0f7 Write data directly to OutputBuffer (Arunachalam Thirupathi)
- 807cb3313507160d794eb77368478c81a2a4143b Avoid Slice allocation for Statistics (Arunachalam Thirupathi)
- 733d444e9fecc9e48a6357dc62be82a38d531d54 Generalize storage format in file metastore (Todd Gao)
- 2823595dea738950fa8cff89f68993e59f1b4186 Add some tests on serialization for file metastore (Todd Gao)
- 9a50892a7fefe59c5447383fb4a128f2a90feeae Propagate session's connector properties in analyzeView (mengdilin)
- 85a5aa5f03009c4ea23adc9cad40a39d907eac12 Add operators for distinct types (Pranjal Shankhdhar)
- 5c6efc723fc739f5c172330359fee1aecd0e0305 Fix spelling (Josh Soref)
- 7c1b76400ed3af5e8b6a99b22f029ca0a6cdeb00 Fix out-of-date links in Cassandra connector doc (v-jizhang)
- f11dcb6b22758face542441348b5a139a8c8ac1b Fix incorrect type mapping in Cassandra documentation (v-jizhang)
- 1329da05691ad14ebfcb0a465ff8b4732973fd64 Fix typo in Cassandra doc (v-jizhang)
- 3020df1578df355d081a17e0a56138052de9d35c implement secure_random function with uniform distribution (Darren Fu)
- 7b212bbb85e512f6015d0ffd7826601688fdac5d Reduce hadoop configuration construction time (zhangyanbing)
- 0ebe1dee77c0fb33619d9e1c6bbfc8c58b558c7d Fix small inefficiency in StripeReader (Sergii Druzkin)
- 6e8846890c3c66bffe4f62a0287703351810ccaf Add OrcReaderOptions builder (Sergii Druzkin)
- 5eae5e583e545c740faebf4127b0933a3e531ac6 Add adaptive execution policy (Tim Meehan)
- ba99b74e989fa5ddc95295afabcc90f33b831d25 Add Thrift serde support for ServerInfo (Sergey Smirnov)
- 668d495821aa4ebb74f61ee5b63b82417ac5a533 get raw filesystem should consider CachingFileSystem (guojianhua)
- 1788358e673e35b2e2fd0b56dd9ceacfba5dcf2a Add casts and operators for distinct types (Pranjal Shankhdhar)
- 8982bab6bcad40331185c85113d6c252f8738a8c Refactor lookupCast(). Use Type instead of TypeSignature (Pranjal Shankhdhar)
- ef1fd25c582631513ccdd097e0a654cda44ec3dc Improve listing performance of Hudi tables (Sagar Sumit)
- 195ce18f68fffbc2d876544b2025d99d5847f478 Wrapper the input and oupput stream from HadoopExtendedFileSystem (guojianhua)
- a9e6b6eabea47bac49804930b435024c31223a74 Fix TestMemoryManager#testQueryMemoryPerNodeLimit flaky test (Swapnil Tailor)
- fce330189b14a2b13067865939b5b2c7d4e2d399 Disable flaky TestDistributedQueryResource.testGetAllQueryInfoForLimits (Masha Basmanova)
- 143c6f67cd90354855956caa584b62788c7230c7 Allow to pick a subset of TPC-DS tables to create in HiveQueryRunner (Masha Basmanova)
- c8624579e71a70dd980bd5031d4629c6d1ca35f1 Export DispatchManager counters (Mayank Garg)
- a6610c081f937c09121e671c3640cd9e3ddc7339 Revert "Tighten allowed characters for non-delimited identifiers" (Rebecca Schlussel)
- de18be1cf17968d16c5b6b4980bc22077ab96fdb Add TPCDS schema to HiveQueryRunner (George Wang)
- 172763fa01ddccaa7ee0f4cc8379a4851b7e8768 refactor logic to support create TPC tables for HiveQueryRunner (George Wang)
- 7830670cb02fbcecf5f082b452864d8d3a06da30 Throw proper error code when timezone is invalid from packDateTimeWithZone function. (Amit Dutta)
- 241adf197a88d6cac99d445463ce704be1b87348 Add join table reference check in JOIN ON clause (Ruslan Mardugalliamov)
- 761cd55b974a47a91a16f60be5276b646c96cc45 Fix cleanup workflow reference (Josh Soref)
- 8c50171f3dc7df99050886ca87c8ffd3f5fa00ab Align intermediate types for AVG aggregate function (Masha Basmanova)
- 65ecdd6553c1cf476a6b9b8bc0ffd50678cdfdcd Fix cast from real to varchar: follow the SQL standard in formatting (v-jizhang)
- 62b0d7b308e3b7b698389c5c6050c02301696b3a Fix cast from double to varchar: follow the SQL standard in formatting (v-jizhang)
- 19e5853137efac6ea9e91eba9fe068017164de72 Fix cast from real to varchar: do not return values overflowing the type (v-jizhang)
- a8d85317f5c3cb5efb7d1ffc93974d74630a9148 Fix cast from double to varchar (v-jizhang)
- 0ae645b1bb8af1babc3e525552eea6d04496e221 Test casts of approximate numeric types to bounded varchar (v-jizhang)
- 4350f2225684e23eed10de5d7b5a51780f702031 Handle the scalar subqueries for unnest (Maksim Dmitriyevich Podkorytov)
- e5c35a6fdf89037f447ca45ce5708f014bc6d675 Fix cleanup CI (Josh Soref)
- e91cbb06f997783184a360e1fd6de330f8c8b159 Add min compressible size to OrcOutputBuffer (Sergii Druzkin)
- 25b2f255a3c3b80447d3a92c7575514cd9a64fd3 Ensure Parameters are in proper order for queries having WITH clause (v-jizhang)
- dd673a94df64f46cedd1ec180bba20fb711c60b1 Fix bug in OrcOutputBuffer leading to severe undercompression of large blobs (Sergii Druzkin)
- ae9f55968916f34fef2bb793f8b81b7142353c35 Refactor iceberg multi-catalog smoke tests (Chunxu Tang)
- 2081ec904c50a3e4fe863b2c38e6d6d1549512f6 Add getDefaultBlockSize and getDefaultReplication to CachingFileSystem (Chen)
- bcf13da6a10f24a754ca1f635bba7c4be8bac8c7 Refactor null handling in ORC Dictionary writers (Arunachalam Thirupathi)
- f7774e57a1d3c04c24d74066d67b754cc9a49a53 Fixing TestServerInfoResource (Swapnil Tailor)
- 2ebf7ea409ffc0b5a9f8743400de3880980663e7 Add distinct type definition (Pranjal Shankhdhar)
- e01d5ca5e22de01ebfd098543b45dc813802aef1 Add ORC writer flush policy (Sergii Druzkin)
- b6eb0a0009e6d41f0c59cd32bccc4e996bbb9311 Bumped Alluxio client to 2.7.3 (David N Perkins)
- 79370de22a9b05d91cefaf3a50f3c63e59567d38 Add a new JDBC driver parameter timeZoneId (v-jizhang)
- d370d62975a311476fb3724e173f5dfa03b2a28d Tighten allowed characters for non-delimited identifiers (v-jizhang)
- d8323f56f8b2828163a6161311115257beda2cc8 Preserve quotedness for Identifier when formatting Query (v-jizhang)
- 35097189c34f6a977a8e28fe1c49f6e1c2322847 Support optional row numbers in OrcSelectiveReader (Harsha Rastogi)
- aab1acf068bccd753c00ba4a02f67641ebe0bd28 Add default implementation to HiveMetastore to fix the build (Beinan Wang)
- 7b83d6a30fab68dcc91c3a3357063b35d2afefec Skip synthetic members to enable code coverage (Guy Moore)
- 39b6cea59b0d4c3876fd3290a837f665c68fed55 Remove the junit dependency to fix the build (Beinan Wang)
- b1402dc09eb8cd4f23deee08a1aee7bb84a7f244 Create an abstract class for metadata of multiple iceberg catalogs (Chunxu Tang)
- e3c9af6c4b386c4dd366e3fea4760a2a49592086 Enable cost based optimization by default (Rongrong Zhong)
- ca90676880d4eea9f59180da30855c88e39f4647 Improve memory accounting for broadcast table (Arjun Gupta)
- 5edaef8ddaddf251e440636c764a2479782b3dfd check field runtimeStats to prevent accessing undefined properties (ahouzheng)
- 2fb2c31bd20cbab9f36c1a2cde6a2a550c511ac8 Add ability to do streaming for partial aggregation (Ke Wang)
- f66c85bbc8184d5acb5b45daa9a929dc3ae54f10 Add ability to do streaming aggregation for hive table scans (Ke Wang)
- 39d20a8ffc848611751a7dc21cba8570311aece5 Add ability to disable splitting file in hive connector (Ke Wang)
- afd4d2f06393710ed76784366fc76086b1529949 fixing presto pinot doc for pinot catalog configs and add session property pinot.topn_large (Xiang Fu)
- 59d092c542c206b08878474fe96936526d7659bf Support iceberg connector concurrent insertion (panyliu)
- fe1e84d1779a44cc220d1d6efa25e223727bd772 Fixing Distributed Query Runner (Swapnil Tailor)
- 3cb1ee2d8f412b82baf6b9d23ce0e56755ef16d5 Skip reading Parquet pages using Column Indexes feature (Xinli shang)
- c9116896023c4405a5ed1792c4090750af65dd5d Add unit test for ThreadResource (Alan Xu)
- c07106b0963b7ecc0ea7548bedf87838ffdace5b ThreadResource supports JSON serde at present. (Alan Xu)
- 6b5da9acfec9ed5bd9d401278b5e9b99b1db6d5a Support json type in PinotSegmentPageSource (Xiang Fu)
- 4d8aad1d222642bbb8a973e660b682298f0c720e Fix parquet data page offset calculation in parquet writer (v-jizhang)