### PR TITLE
Avoid status check if consistency is not enabled

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/RuntimeMetricName.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/RuntimeMetricName.java
@@ -27,6 +27,8 @@ public class RuntimeMetricName
     public static final String DRIVER_COUNT_PER_TASK = "driverCountPerTask";
     public static final String TASK_ELAPSED_TIME_NANOS = "taskElapsedTimeNanos";
     public static final String OPTIMIZED_WITH_MATERIALIZED_VIEW = "optimizedWithMaterializedView";
+    public static final String MANY_PARTITIONS_MISSING_IN_MATERIALIZED_VIEW = "manyPartitionsMissingInMaterializedView";
+    public static final String SKIP_READING_FROM_MATERIALIZED_VIEW = "skipReadingFromMaterializedView";
     public static final String FRAGMENT_RESULT_CACHE_HIT = "fragmentResultCacheHitCount";
     public static final String FRAGMENT_RESULT_CACHE_MISS = "fragmentResultCacheMissCount";
     public static final String GET_VIEW_TIME_NANOS = "getViewTimeNanos";

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewQueryOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewQueryOptimizer.java
@@ -133,7 +133,7 @@ public class MaterializedViewQueryOptimizer
             return process(node);
         }
         catch (Exception ex) {
-            logger.warn(ex.getMessage());
+            logger.warn("Failed to rewrite query with Materialized view with following exception: %s", ex.getMessage());
             return node;
         }
     }


### PR DESCRIPTION
Materialized view optimizer should always optimize query irrespective of materialized view status if consistency check is disabled.

```
== NO RELEASE NOTE ==
```
