### PR TITLE
Avoid status check if consistency is not enabled

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/RuntimeMetricName.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/RuntimeMetricName.java
@@ -26,7 +26,9 @@ public class RuntimeMetricName
 
     public static final String DRIVER_COUNT_PER_TASK = "driverCountPerTask";
     public static final String TASK_ELAPSED_TIME_NANOS = "taskElapsedTimeNanos";
-    public static final String OPTIMIZED_WITH_MATERIALIZED_VIEW = "optimizedWithMaterializedView";
+    public static final String OPTIMIZED_WITH_MATERIALIZED_VIEW_COUNT = "optimizedWithMaterializedViewCount";
+    public static final String MANY_PARTITIONS_MISSING_IN_MATERIALIZED_VIEW_COUNT = "manyPartitionsMissingInMaterializedViewCount";
+    public static final String SKIP_READING_FROM_MATERIALIZED_VIEW_COUNT = "skipReadingFromMaterializedViewCount";
     public static final String FRAGMENT_RESULT_CACHE_HIT = "fragmentResultCacheHitCount";
     public static final String FRAGMENT_RESULT_CACHE_MISS = "fragmentResultCacheMissCount";
     public static final String GET_VIEW_TIME_NANOS = "getViewTimeNanos";

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewQueryOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewQueryOptimizer.java
@@ -133,7 +133,7 @@ public class MaterializedViewQueryOptimizer
             return process(node);
         }
         catch (Exception ex) {
-            logger.warn(ex.getMessage());
+            logger.warn("Failed to rewrite query with materialized view with following exception: %s", ex.getMessage());
             return node;
         }
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -176,6 +176,7 @@ import static com.facebook.presto.common.RuntimeMetricName.GET_MATERIALIZED_VIEW
 import static com.facebook.presto.common.RuntimeMetricName.GET_TABLE_HANDLE_TIME_NANOS;
 import static com.facebook.presto.common.RuntimeMetricName.GET_TABLE_METADATA_TIME_NANOS;
 import static com.facebook.presto.common.RuntimeMetricName.GET_VIEW_TIME_NANOS;
+import static com.facebook.presto.common.RuntimeMetricName.SKIP_READING_FROM_MATERIALIZED_VIEW_COUNT;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
 import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
@@ -331,9 +332,7 @@ class StatementAnalyzer
         {
             Scope returnScope = super.process(node, scope);
             checkState(returnScope.getOuterQueryParent().equals(outerQueryScope), "result scope should have outer query scope equal with parameter outer query scope");
-            if (scope.isPresent()) {
-                checkState(hasScopeAsLocalParent(returnScope, scope.get()), "return scope should have context scope as one of ancestors");
-            }
+            scope.ifPresent(value -> checkState(hasScopeAsLocalParent(returnScope, value), "return scope should have context scope as one of ancestors"));
             return returnScope;
         }
 
@@ -1379,6 +1378,7 @@ class StatementAnalyzer
             String materializedViewCreateSql = connectorMaterializedViewDefinition.getOriginalSql();
 
             if (materializedViewStatus.isNotMaterialized() || materializedViewStatus.isTooManyPartitionsMissing()) {
+                session.getRuntimeStats().addMetricValue(SKIP_READING_FROM_MATERIALIZED_VIEW_COUNT, 1);
                 return materializedViewCreateSql;
             }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/rewrite/MaterializedViewOptimizationRewriteUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/rewrite/MaterializedViewOptimizationRewriteUtils.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.sql.rewrite;
 
+import com.facebook.airlift.log.Logger;
 import com.facebook.presto.Session;
 import com.facebook.presto.common.QualifiedObjectName;
 import com.facebook.presto.metadata.Metadata;
@@ -29,10 +30,13 @@ import com.facebook.presto.sql.tree.Table;
 
 import java.util.Set;
 
+import static com.facebook.presto.SystemSessionProperties.isMaterializedViewDataConsistencyEnabled;
 import static com.facebook.presto.common.RuntimeMetricName.OPTIMIZED_WITH_MATERIALIZED_VIEW;
 
 public class MaterializedViewOptimizationRewriteUtils
 {
+    private static final Logger log = Logger.get(MaterializedViewOptimizationRewriteUtils.class);
+
     private MaterializedViewOptimizationRewriteUtils() {}
 
     public static Query optimizeQueryUsingMaterializedView(
@@ -50,8 +54,15 @@ public class MaterializedViewOptimizationRewriteUtils
         for (QualifiedObjectName candidate : materializedViewCandidates) {
             Query optimizedQuery = getQueryWithMaterializedViewOptimization(metadata, session, sqlParser, accessControl, node, candidate);
             if (node != optimizedQuery) {
-                MaterializedViewStatus materializedViewStatus = metadata.getMaterializedViewStatus(session, candidate);
-                if (materializedViewStatus.isFullyMaterialized() || materializedViewStatus.isPartiallyMaterialized()) {
+                if (isMaterializedViewDataConsistencyEnabled(session)) {
+                    //TODO: We should be able to leverage this information in the StatementAnalyzer as well.
+                    MaterializedViewStatus materializedViewStatus = metadata.getMaterializedViewStatus(session, candidate);
+                    if (materializedViewStatus.isFullyMaterialized() || materializedViewStatus.isPartiallyMaterialized()) {
+                        session.getRuntimeStats().addMetricValue(OPTIMIZED_WITH_MATERIALIZED_VIEW, 1);
+                        return optimizedQuery;
+                    }
+                }
+                else {
                     session.getRuntimeStats().addMetricValue(OPTIMIZED_WITH_MATERIALIZED_VIEW, 1);
                     return optimizedQuery;
                 }
@@ -68,10 +79,16 @@ public class MaterializedViewOptimizationRewriteUtils
             Query statement,
             QualifiedObjectName materializedViewQualifiedObjectName)
     {
-        ConnectorMaterializedViewDefinition materializedView = metadata.getMaterializedView(session, materializedViewQualifiedObjectName).get();
-        Table materializedViewTable = new Table(QualifiedName.of(materializedView.getTable()));
+        try {
+            ConnectorMaterializedViewDefinition materializedView = metadata.getMaterializedView(session, materializedViewQualifiedObjectName).get();
+            Table materializedViewTable = new Table(QualifiedName.of(materializedView.getTable()));
 
-        Query materializedViewDefinition = (Query) sqlParser.createStatement(materializedView.getOriginalSql());
-        return (Query) new MaterializedViewQueryOptimizer(metadata, session, sqlParser, accessControl, new RowExpressionDomainTranslator(metadata), materializedViewTable, materializedViewDefinition).rewrite(statement);
+            Query materializedViewDefinition = (Query) sqlParser.createStatement(materializedView.getOriginalSql());
+            return (Query) new MaterializedViewQueryOptimizer(metadata, session, sqlParser, accessControl, new RowExpressionDomainTranslator(metadata), materializedViewTable, materializedViewDefinition).rewrite(statement);
+        }
+        catch (RuntimeException ex) {
+            log.warn("Failed to get materialized view for %s, with exception: %s", materializedViewQualifiedObjectName, ex.getMessage());
+            return statement;
+        }
     }
 }


### PR DESCRIPTION
Materialized view optimizer should optimize query irrespective of materialized view status, if consistency check is disabled.
Also adding few runtime stats for cases in materialized view optimization. 


```
== NO RELEASE NOTE ==
```
