### PR TITLE
Add dockerized Hive with MinIO test containers for data lake tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,7 @@
         <dep.jaxb.version>2.3.1</dep.jaxb.version>
         <dep.hudi.version>0.10.1</dep.hudi.version>
         <dep.testcontainers.version>1.15.1</dep.testcontainers.version>
+        <dep.docker-java.version>3.2.12</dep.docker-java.version>
         <!--
           America/Bahia_Banderas has:
            - offset change since 1970 (offset Jan 1970: -08:00, offset Jan 2018: -06:00)
@@ -516,6 +517,12 @@
                 <groupId>org.testcontainers</groupId>
                 <artifactId>testcontainers</artifactId>
                 <version>${dep.testcontainers.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.github.docker-java</groupId>
+                <artifactId>docker-java-api</artifactId>
+                <version>${dep.docker-java.version}</version>
             </dependency>
 
             <dependency>

--- a/presto-hive/pom.xml
+++ b/presto-hive/pom.xml
@@ -373,6 +373,18 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
         <!-- for benchmark -->
         <dependency>
             <groupId>com.facebook.presto</groupId>
@@ -395,6 +407,12 @@
         <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-tpcds</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testing-docker</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/presto-hive/src/test/java/com/facebook/presto/hive/containers/HiveHadoopContainer.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/containers/HiveHadoopContainer.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.containers;
+
+import com.facebook.presto.testing.containers.BaseTestContainer;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.net.HostAndPort;
+import org.testcontainers.containers.Network;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+public class HiveHadoopContainer
+        extends BaseTestContainer
+{
+    private static final String IMAGE_VERSION = "10";
+    public static final String DEFAULT_IMAGE = "prestodb/hdp2.6-hive:" + IMAGE_VERSION;
+    public static final String HIVE3_IMAGE = "prestodb/hive3.1-hive:" + IMAGE_VERSION;
+
+    public static final String HOST_NAME = "hadoop-master";
+
+    public static final int PROXY_PORT = 1180;
+    public static final int HIVE_SERVER_PORT = 10000;
+    public static final int HIVE_METASTORE_PORT = 9083;
+
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    private HiveHadoopContainer(
+            String image,
+            String hostName,
+            Set<Integer> ports,
+            Map<String, String> filesToMount,
+            Map<String, String> envVars,
+            Optional<Network> network,
+            int startupRetryLimit)
+    {
+        super(
+                image,
+                hostName,
+                ports,
+                filesToMount,
+                envVars,
+                network,
+                startupRetryLimit);
+    }
+
+    public HostAndPort getMappedHdfsSocksProxy()
+    {
+        return getMappedHostAndPortForExposedPort(PROXY_PORT);
+    }
+
+    public HostAndPort getHiveServerEndpoint()
+    {
+        return getMappedHostAndPortForExposedPort(HIVE_SERVER_PORT);
+    }
+
+    public HostAndPort getHiveMetastoreEndpoint()
+    {
+        return getMappedHostAndPortForExposedPort(HIVE_METASTORE_PORT);
+    }
+
+    public static class Builder
+            extends BaseTestContainer.Builder<HiveHadoopContainer.Builder, HiveHadoopContainer>
+    {
+        private Builder()
+        {
+            this.image = DEFAULT_IMAGE;
+            this.hostName = HOST_NAME;
+            this.exposePorts =
+                    ImmutableSet.of(
+                            HIVE_METASTORE_PORT,
+                            PROXY_PORT);
+        }
+
+        @Override
+        public HiveHadoopContainer build()
+        {
+            return new HiveHadoopContainer(image, hostName, exposePorts, filesToMount, envVars, network, startupRetryLimit);
+        }
+    }
+}

--- a/presto-hive/src/test/java/com/facebook/presto/hive/containers/HiveMinIODataLake.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/containers/HiveMinIODataLake.java
@@ -1,0 +1,145 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.containers;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import com.facebook.presto.testing.containers.MinIOContainer;
+import com.facebook.presto.util.AutoCloseableCloser;
+import com.google.common.collect.ImmutableMap;
+import org.testcontainers.containers.Network;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static com.facebook.presto.hive.containers.HiveHadoopContainer.HIVE3_IMAGE;
+import static java.util.Objects.requireNonNull;
+import static org.testcontainers.containers.Network.newNetwork;
+
+public class HiveMinIODataLake
+        implements Closeable
+{
+    public static final String ACCESS_KEY = "accesskey";
+    public static final String SECRET_KEY = "secretkey";
+
+    private final String bucketName;
+    private final MinIOContainer minIOContainer;
+    private final HiveHadoopContainer hiveHadoopContainer;
+
+    private final AtomicBoolean isStarted = new AtomicBoolean(false);
+    private final AutoCloseableCloser closer = AutoCloseableCloser.create();
+
+    public HiveMinIODataLake(String bucketName, Map<String, String> hiveHadoopFilesToMount)
+    {
+        this(bucketName, hiveHadoopFilesToMount, HiveHadoopContainer.DEFAULT_IMAGE);
+    }
+
+    public HiveMinIODataLake(String bucketName, Map<String, String> hiveHadoopFilesToMount, String hiveHadoopImage)
+    {
+        this.bucketName = requireNonNull(bucketName, "bucketName is null");
+        Network network = closer.register(newNetwork());
+        this.minIOContainer = closer.register(
+                MinIOContainer.builder()
+                        .withNetwork(network)
+                        .withEnvVars(ImmutableMap.<String, String>builder()
+                                .put("MINIO_ACCESS_KEY", ACCESS_KEY)
+                                .put("MINIO_SECRET_KEY", SECRET_KEY)
+                                .build())
+                        .build());
+
+        ImmutableMap.Builder filesToMount = ImmutableMap.<String, String>builder()
+                .putAll(hiveHadoopFilesToMount);
+
+        String hadoopCoreSitePath = "/etc/hadoop/conf/core-site.xml";
+        if (hiveHadoopImage == HIVE3_IMAGE) {
+            hadoopCoreSitePath = "/opt/hadoop/etc/hadoop/core-site.xml";
+            filesToMount.put("hive_s3_insert_overwrite/hive-site.xml", "/opt/hive/conf/hive-site.xml");
+        }
+        filesToMount.put("hive_s3_insert_overwrite/hadoop-core-site.xml", hadoopCoreSitePath);
+
+        this.hiveHadoopContainer = closer.register(
+                HiveHadoopContainer.builder()
+                        .withFilesToMount(filesToMount.build())
+                        .withImage(hiveHadoopImage)
+                        .withNetwork(network)
+                        .build());
+    }
+
+    public void start()
+    {
+        if (isStarted()) {
+            return;
+        }
+        try {
+            this.minIOContainer.start();
+            this.hiveHadoopContainer.start();
+            AmazonS3 s3Client = AmazonS3ClientBuilder
+                    .standard()
+                    .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(
+                            "http://localhost:" + minIOContainer.getMinioApiEndpoint().getPort(),
+                            "us-east-1"))
+                    .withPathStyleAccessEnabled(true)
+                    .withCredentials(new AWSStaticCredentialsProvider(
+                            new BasicAWSCredentials(ACCESS_KEY, SECRET_KEY)))
+                    .build();
+            s3Client.createBucket(this.bucketName);
+        }
+        finally {
+            isStarted.set(true);
+        }
+    }
+
+    public boolean isStarted()
+    {
+        return isStarted.get();
+    }
+
+    public void stop()
+    {
+        if (!isStarted()) {
+            return;
+        }
+        try {
+            closer.close();
+        }
+        catch (Exception e) {
+            throw new RuntimeException("Failed to stop HiveMinioDataLake", e);
+        }
+        finally {
+            isStarted.set(false);
+        }
+    }
+
+    public MinIOContainer getMinio()
+    {
+        return minIOContainer;
+    }
+
+    public HiveHadoopContainer getHiveHadoop()
+    {
+        return hiveHadoopContainer;
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        stop();
+    }
+}

--- a/presto-testing-docker/pom.xml
+++ b/presto-testing-docker/pom.xml
@@ -37,6 +37,28 @@
         </dependency>
 
         <dependency>
+            <groupId>com.github.docker-java</groupId>
+            <artifactId>docker-java-api</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
             <groupId>net.jodah</groupId>
             <artifactId>failsafe</artifactId>
         </dependency>

--- a/presto-testing-docker/src/main/java/com/facebook/presto/testing/containers/BaseTestContainer.java
+++ b/presto-testing-docker/src/main/java/com/facebook/presto/testing/containers/BaseTestContainer.java
@@ -1,0 +1,200 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.testing.containers;
+
+import com.facebook.airlift.log.Logger;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.net.HostAndPort;
+import net.jodah.failsafe.Failsafe;
+import net.jodah.failsafe.RetryPolicy;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.startupcheck.IsRunningStartupCheckStrategy;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.net.HostAndPort.fromParts;
+import static java.util.Objects.requireNonNull;
+import static org.testcontainers.utility.MountableFile.forClasspathResource;
+import static org.testcontainers.utility.MountableFile.forHostPath;
+
+public abstract class BaseTestContainer
+        implements AutoCloseable
+{
+    private static final Logger log = Logger.get(BaseTestContainer.class);
+
+    private final String hostName;
+    private final Set<Integer> ports;
+    private final Map<String, String> filesToMount;
+    private final Map<String, String> envVars;
+    private final Optional<Network> network;
+    private final int startupRetryLimit;
+
+    private final GenericContainer<?> container;
+
+    protected BaseTestContainer(
+            String image,
+            String hostName,
+            Set<Integer> ports,
+            Map<String, String> filesToMount,
+            Map<String, String> envVars,
+            Optional<Network> network,
+            int startupRetryLimit)
+    {
+        checkArgument(startupRetryLimit > 0, "startupRetryLimit needs to be greater or equal to 0");
+        this.container = new GenericContainer<>(requireNonNull(image, "image is null"));
+        this.ports = requireNonNull(ports, "ports is null");
+        this.hostName = requireNonNull(hostName, "hostName is null");
+        this.filesToMount = requireNonNull(filesToMount, "filesToMount is null");
+        this.envVars = requireNonNull(envVars, "envVars is null");
+        this.network = requireNonNull(network, "network is null");
+        this.startupRetryLimit = startupRetryLimit;
+        setupContainer();
+    }
+
+    protected void setupContainer()
+    {
+        for (int port : this.ports) {
+            container.addExposedPort(port);
+        }
+        filesToMount.forEach(this::copyFileToContainer);
+        container.withEnv(envVars);
+        container.withCreateContainerCmdModifier(c -> c.withHostName(hostName))
+                .withStartupCheckStrategy(new IsRunningStartupCheckStrategy())
+                .waitingFor(Wait.forListeningPort())
+                .withStartupTimeout(Duration.ofMinutes(5));
+        network.ifPresent(container::withNetwork);
+    }
+
+    protected void withRunCommand(List<String> runCommand)
+    {
+        container.withCommand(runCommand.toArray(new String[runCommand.size()]));
+    }
+
+    protected void copyFileToContainer(String resourcePath, String dockerPath)
+    {
+        container.withCopyFileToContainer(
+                forHostPath(
+                        forClasspathResource(resourcePath)
+                                // Container fails to mount jar:file:/<host_path>!<resource_path> resources
+                                // This assures that JAR resources are being copied out to tmp locations
+                                // and mounted from there.
+                                .getResolvedPath()),
+                dockerPath);
+    }
+
+    protected void startContainer()
+    {
+        Failsafe.with(new RetryPolicy<>()
+                .withMaxRetries(startupRetryLimit)
+                .onRetry(event -> log.warn(
+                        "%s initialization failed (attempt %s), will retry. Exception: %s",
+                        this.getClass().getSimpleName(),
+                        event.getAttemptCount(),
+                        event.getLastFailure().getMessage())))
+                .get(() -> TestContainers.startOrReuse(this.container));
+    }
+
+    protected HostAndPort getMappedHostAndPortForExposedPort(int exposedPort)
+    {
+        return fromParts(container.getHost(), container.getMappedPort(exposedPort));
+    }
+
+    public void start()
+    {
+        setupContainer();
+        startContainer();
+    }
+
+    public void stop()
+    {
+        container.stop();
+    }
+
+    @Override
+    public void close()
+    {
+        stop();
+    }
+
+    protected abstract static class Builder<S extends BaseTestContainer.Builder, B extends BaseTestContainer>
+    {
+        protected String image;
+        protected String hostName;
+        protected Set<Integer> exposePorts = ImmutableSet.of();
+        protected Map<String, String> filesToMount = ImmutableMap.of();
+        protected Map<String, String> envVars = ImmutableMap.of();
+        protected Optional<Network> network = Optional.empty();
+        protected int startupRetryLimit = 1;
+
+        protected S self;
+
+        @SuppressWarnings("unchecked")
+        public Builder()
+        {
+            this.self = (S) this;
+        }
+
+        public S withImage(String image)
+        {
+            this.image = image;
+            return self;
+        }
+
+        public S withHostName(String hostName)
+        {
+            this.hostName = hostName;
+            return self;
+        }
+
+        public S withExposePorts(Set<Integer> exposePorts)
+        {
+            this.exposePorts = exposePorts;
+            return self;
+        }
+
+        public S withFilesToMount(Map<String, String> filesToMount)
+        {
+            this.filesToMount = filesToMount;
+            return self;
+        }
+
+        public S withEnvVars(Map<String, String> envVars)
+        {
+            this.envVars = envVars;
+            return self;
+        }
+
+        public S withNetwork(Network network)
+        {
+            this.network = Optional.of(network);
+            return self;
+        }
+
+        public S withStartupRetryLimit(int startupRetryLimit)
+        {
+            this.startupRetryLimit = startupRetryLimit;
+            return self;
+        }
+
+        public abstract B build();
+    }
+}

--- a/presto-testing-docker/src/main/java/com/facebook/presto/testing/containers/MinIOContainer.java
+++ b/presto-testing-docker/src/main/java/com/facebook/presto/testing/containers/MinIOContainer.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.testing.containers;
+
+import com.facebook.airlift.log.Logger;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.net.HostAndPort;
+import org.testcontainers.containers.Network;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static java.lang.String.format;
+
+public class MinIOContainer
+        extends BaseTestContainer
+{
+    private static final Logger log = Logger.get(MinIOContainer.class);
+
+    public static final String DEFAULT_IMAGE = "minio/minio:RELEASE.2021-07-15T22-27-34Z";
+    public static final String DEFAULT_HOST_NAME = "minio";
+
+    public static final int MINIO_API_PORT = 4566;
+    public static final int MINIO_CONSOLE_PORT = 4567;
+
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    private MinIOContainer(
+            String image,
+            String hostName,
+            Set<Integer> exposePorts,
+            Map<String, String> filesToMount,
+            Map<String, String> envVars,
+            Optional<Network> network,
+            int retryLimit)
+    {
+        super(
+                image,
+                hostName,
+                exposePorts,
+                filesToMount,
+                envVars,
+                network,
+                retryLimit);
+    }
+
+    @Override
+    protected void setupContainer()
+    {
+        super.setupContainer();
+        withRunCommand(
+                ImmutableList.of(
+                        "server",
+                        "--address", "0.0.0.0:" + MINIO_API_PORT,
+                        "--console-address", "0.0.0.0:" + MINIO_CONSOLE_PORT,
+                        "/data"));
+    }
+
+    @Override
+    protected void startContainer()
+    {
+        super.startContainer();
+        log.info(format(
+                "MinIO container started with address for api: http://%s and console: http://%s",
+                getMinioApiEndpoint().toString(),
+                getMinioConsoleEndpoint().toString()));
+    }
+
+    public HostAndPort getMinioApiEndpoint()
+    {
+        return getMappedHostAndPortForExposedPort(MINIO_API_PORT);
+    }
+
+    public HostAndPort getMinioConsoleEndpoint()
+    {
+        return getMappedHostAndPortForExposedPort(MINIO_CONSOLE_PORT);
+    }
+
+    public static class Builder
+            extends BaseTestContainer.Builder<MinIOContainer.Builder, MinIOContainer>
+    {
+        private Builder()
+        {
+            this.image = DEFAULT_IMAGE;
+            this.hostName = DEFAULT_HOST_NAME;
+            this.exposePorts =
+                    ImmutableSet.of(
+                            MINIO_API_PORT,
+                            MINIO_CONSOLE_PORT);
+        }
+
+        @Override
+        public MinIOContainer build()
+        {
+            return new MinIOContainer(image, hostName, exposePorts, filesToMount, envVars, network, startupRetryLimit);
+        }
+    }
+}

--- a/presto-testing-docker/src/main/java/com/facebook/presto/testing/containers/TestContainers.java
+++ b/presto-testing-docker/src/main/java/com/facebook/presto/testing/containers/TestContainers.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.testing.containers;
+
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.TestcontainersConfiguration;
+
+import java.io.Closeable;
+
+import static com.google.common.base.Preconditions.checkState;
+import static java.lang.Boolean.parseBoolean;
+import static java.lang.System.getenv;
+
+public final class TestContainers
+{
+    // To reuse container set TESTCONTAINERS_REUSE_ENABLE=true environment variable.
+    // TESTCONTAINERS_REUSE_ENABLE is an environment variable defined in testcontainers library.
+    private static final boolean TESTCONTAINERS_REUSE_ENABLE = parseBoolean(getenv("TESTCONTAINERS_REUSE_ENABLE"));
+
+    private TestContainers() {}
+
+    // You should not close the container directly if you want to reuse it.
+    // Instead you should close closeable returned by {@link this::startOrReuse}
+    public static Closeable startOrReuse(GenericContainer<?> container)
+    {
+        boolean reuse = TestcontainersConfiguration.getInstance().environmentSupportsReuse();
+        checkState(reuse == TESTCONTAINERS_REUSE_ENABLE, "Unable to enable or disable container reuse");
+
+        container.withReuse(TESTCONTAINERS_REUSE_ENABLE);
+        container.start();
+        if (reuse) {
+            return () -> {};
+        }
+        return container::stop;
+    }
+}


### PR DESCRIPTION
Adds test containers HiveHadoopContainer, MinIOContainer and class HiveMinIODataLake to start these containers for data lake tests.

```
== NO RELEASE NOTE ==
```
