### PR TITLE
Update testng to 6.14.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
              Do not change this without also making sure it matches -->
         <dep.joda.version>2.10.8</dep.joda.version>
         <dep.tempto.version>1.51</dep.tempto.version>
-        <dep.testng.version>6.10</dep.testng.version>
+        <dep.testng.version>6.14.3</dep.testng.version>
         <dep.assertj-core.version>3.8.0</dep.assertj-core.version>
         <dep.logback.version>1.2.3</dep.logback.version>
         <dep.parquet.version>1.12.0</dep.parquet.version>


### PR DESCRIPTION
TestNG 6.10 uses reflection to compare arrays in assertEquals which makes it super slow. TestNG 6.14.3 has dedicated assertEquals for arrays.

Test plan:
- made sure everything compiles
- will rely on existing tests

```
== NO RELEASE NOTE ==
```
