### PR TITLE
Reorder predicates in FilterNode by est. CPU cost greedily

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/cost/PredicateCPUCostEstimator.java
+++ b/presto-main/src/main/java/com/facebook/presto/cost/PredicateCPUCostEstimator.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.cost;
+
+import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.SpecialFormExpression;
+
+public enum PredicateCPUCostEstimator
+{;
+    public static int estimateCost(RowExpression predicate)
+    {
+        if (predicate instanceof SpecialFormExpression) {
+            int childCost = 0;
+            for (RowExpression child : ((SpecialFormExpression) predicate).getArguments()) {
+                childCost += estimateCost(child);
+            }
+            return childCost;
+        }
+        else if (predicate instanceof CallExpression) {
+            CallExpression callExpr = (CallExpression) predicate;
+            for (FunctionCategory category : FunctionCategory.values()) {
+                if (callExpr.getDisplayName().startsWith(category.getFnFamily())) {
+                    return category.getCost();
+                }
+            }
+        }
+        return FunctionCategory.OTHER.getCost();
+    }
+
+    private enum FunctionCategory
+    {
+        JSON("json", 100),
+        ARRAY("array", 10),
+        REGEX("regexp", 100),
+        OTHER("", 1);
+
+        private final String fnFamily;
+        private final int cost;
+
+        FunctionCategory(String fnFamily, int cost)
+        {
+            this.fnFamily = fnFamily;
+            this.cost = cost;
+        }
+
+        public String getFnFamily()
+        {
+            return fnFamily;
+        }
+
+        public int getCost()
+        {
+            return cost;
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PlanOptimizers.java
@@ -132,6 +132,7 @@ import com.facebook.presto.sql.planner.optimizations.PlanOptimizer;
 import com.facebook.presto.sql.planner.optimizations.PredicatePushDown;
 import com.facebook.presto.sql.planner.optimizations.PruneUnreferencedOutputs;
 import com.facebook.presto.sql.planner.optimizations.PushdownSubfields;
+import com.facebook.presto.sql.planner.optimizations.ReorderPredicates;
 import com.facebook.presto.sql.planner.optimizations.ReplicateSemiJoinInDelete;
 import com.facebook.presto.sql.planner.optimizations.SetFlatteningOptimizer;
 import com.facebook.presto.sql.planner.optimizations.StatsRecordingPlanOptimizer;
@@ -579,6 +580,7 @@ public class PlanOptimizers
         builder.add(new RemoveUnsupportedDynamicFilters(metadata.getFunctionAndTypeManager()));
         builder.add(simplifyRowExpressionOptimizer); // Should be always run after PredicatePushDown
         builder.add(projectionPushDown);
+        builder.add(new ReorderPredicates()); // Swap predicate orderings after pushdowns are done
         builder.add(inlineProjections);
         builder.add(new UnaliasSymbolReferences(metadata.getFunctionAndTypeManager())); // Run unalias after merging projections to simplify projections more efficiently
         builder.add(new PruneUnreferencedOutputs());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ReorderPredicates.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/ReorderPredicates.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.cost.PredicateCPUCostEstimator;
+import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.plan.FilterNode;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.SpecialFormExpression;
+import com.facebook.presto.sql.planner.PlanVariableAllocator;
+import com.facebook.presto.sql.planner.TypeProvider;
+import com.facebook.presto.sql.planner.plan.SimplePlanRewriter;
+
+import java.util.List;
+
+import static com.facebook.presto.spi.relation.SpecialFormExpression.Form.SWITCH;
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+public class ReorderPredicates
+        implements PlanOptimizer
+{
+    @Override
+    public PlanNode optimize(PlanNode plan, Session session, TypeProvider types, PlanVariableAllocator variableAllocator, PlanNodeIdAllocator idAllocator, WarningCollector warningCollector)
+    {
+        requireNonNull(plan, "plan is null");
+        requireNonNull(session, "session is null");
+        requireNonNull(types, "types is null");
+        requireNonNull(variableAllocator, "variableAllocator is null");
+        requireNonNull(idAllocator, "idAllocator is null");
+
+        return SimplePlanRewriter.rewriteWith(new Rewriter(), plan, null);
+    }
+
+    private static class Rewriter
+            extends SimplePlanRewriter<Void>
+    {
+        private static boolean canSwap(RowExpression pred)
+        {
+            if (pred instanceof SpecialFormExpression) {
+                // Special case: when filtering on a subquery output
+                // like 'WHERE a = (SELECT b from c)'
+                // we must place the check for the subquery size first
+                // meaning we cannot swap.
+                return ((SpecialFormExpression) pred).getForm() != SWITCH;
+            }
+            return true;
+        }
+
+        @Override
+        public PlanNode visitFilter(FilterNode node, RewriteContext<Void> v)
+        {
+            return new FilterNode(
+                    node.getSourceLocation(),
+                    node.getId(),
+                    node.getSource(),
+                    reorderPredicates(node, node.getPredicate()));
+        }
+
+        private RowExpression reorderPredicates(FilterNode planNode, RowExpression expression)
+        {
+            if (expression instanceof SpecialFormExpression) {
+                SpecialFormExpression specialFormExpr = (SpecialFormExpression) expression;
+                SpecialFormExpression.Form op = specialFormExpr.getForm();
+                if (!(op == SpecialFormExpression.Form.AND || op == SpecialFormExpression.Form.OR)) {
+                    return expression;
+                }
+
+                List<RowExpression> binaryOpArgs = specialFormExpr.getArguments();
+                checkState(binaryOpArgs.size() == 2);
+                RowExpression leftPred = binaryOpArgs.get(0);
+                RowExpression rightPred = binaryOpArgs.get(1);
+
+                int leftCost = PredicateCPUCostEstimator.estimateCost(leftPred);
+                int rightCost = PredicateCPUCostEstimator.estimateCost(rightPred);
+
+                RowExpression newLeftSide = reorderPredicates(planNode, leftPred);
+                RowExpression newRightSide = reorderPredicates(planNode, rightPred);
+
+                if (rightCost < leftCost && canSwap(leftPred) && canSwap(rightPred)) {
+                    RowExpression swapTemp = newLeftSide;
+                    newLeftSide = newRightSide;
+                    newRightSide = swapTemp;
+                }
+
+                return new SpecialFormExpression(op, specialFormExpr.getType(), newLeftSide, newRightSide);
+            }
+            return expression;
+        }
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestReorderPredicates.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/optimizations/TestReorderPredicates.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.optimizations;
+
+import com.facebook.presto.sql.planner.assertions.BasePlanTest;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.anyTree;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.filter;
+import static com.facebook.presto.sql.planner.assertions.PlanMatchPattern.tableScan;
+
+public class TestReorderPredicates
+        extends BasePlanTest
+{
+    @Test
+    public void testBasicPredicateReordering()
+    {
+        assertPlan("SELECT COUNT(*) FROM lineitem WHERE REGEXP_LIKE(comment, '.*') AND tax = 0.01",
+                anyTree(
+                        filter("tax = DOUBLE'0.01' AND REGEXP_LIKE(comment, CAST('.*' AS JoniRegExp))",
+                                tableScan("lineitem",
+                                        ImmutableMap.of("tax", "tax", "comment", "comment")))));
+    }
+
+    @Test
+    public void testMultipleReordering()
+    {
+        assertPlan("SELECT COUNT(*) FROM lineitem WHERE (REGEXP_LIKE(comment, '.*') OR tax = 0.02) AND tax > 0.01",
+                anyTree(
+                        filter("tax > DOUBLE'0.01' AND (tax = DOUBLE'0.02' OR REGEXP_LIKE(comment, CAST('.*' AS JoniRegExp)))",
+                                tableScan("lineitem",
+                                        ImmutableMap.of("tax", "tax", "comment", "comment")))));
+    }
+
+    @Test
+    public void testNestedReordering()
+    {
+        assertPlan("SELECT * FROM (" +
+                        "SELECT COUNT(*) FROM lineitem WHERE REGEXP_LIKE(comment, '.*') AND tax = 0.01" +
+                        ") t",
+                anyTree(
+                        filter("tax = DOUBLE'0.01' AND REGEXP_LIKE(comment, CAST('.*' AS JoniRegExp))",
+                                tableScan("lineitem",
+                                        ImmutableMap.of("tax", "tax", "comment", "comment")))));
+
+        assertPlan("SELECT COUNT(*) FROM (" +
+                        "SELECT * FROM lineitem WHERE tax > 0" +
+                        ") t WHERE REGEXP_LIKE(comment, '.*') AND tax = 0.01",
+                anyTree(
+                        filter("tax = DOUBLE'0.01' AND REGEXP_LIKE(comment, CAST('.*' AS JoniRegExp))",
+                                tableScan("lineitem",
+                                        ImmutableMap.of("tax", "tax", "comment", "comment")))));
+    }
+}


### PR DESCRIPTION
Tackles https://github.com/prestodb/presto/issues/17137. Reorders predicates in FilterNodes by estimated cost according to a crude model. This should let us save some CPU when expensive functions like regexp or json parsing is used. The model assumes regex, JSON parse, and array operations are more expensive than everything else (see PredicateCPUCostEstimator).

The reordering algorithm greedily swaps the order of left/right arguments in AND/OR operations in FilterNodes without considering global optimality. Because at the point of the plan optimizer we don't have AST information anymore we can't globally reorder predicates between AND/OR statements to optimally arrange them. The greedy swap also makes it easier to reason about correctness since swapping the order of AND/OR arguments is always correct.

Test plan - Added 3 unit tests, passes all Presto unit tests and basic+TPC-H queries on my local machine, checked that reorder was occurring in EXPLAIN output

Benchmark:

M1 Pro 10C, Rosetta, macOS 12.2.1, Amazon Corretto 1.8 JDK. Using TPC-H built-in connector with SF 100, best of 4 runs for both reorder/no reorder. This query represents a best case scenario where there are multiple cheap predicates that run after an expensive one.

```
SELECT COUNT(*) FROM lineitem WHERE REGEXP_LIKE(comment, '.*package.*') AND tax < 0.05 AND LENGTH(comment) < 15

Reorder

CPU Time: 241.5s total, 2.48M rows/s,     0B/s, 90% active
Per Node: 3.6 parallelism, 8.91M rows/s,     0B/sParallelism: 3.6
logicalPlannerTimeNanos: sum=182ms count=1 min=182ms max=182ms1:07 [600M rows, 0B] [8.91M rows/s, 0B/s]

No reorder

CPU Time: 254.5s total, 2.36M rows/s,     0B/s, 94% active
Per Node: 3.6 parallelism, 8.48M rows/s,     0B/sParallelism: 3.6
logicalPlannerTimeNanos: sum=129ms count=1 min=129ms max=129ms1:11 [600M rows, 0B] [8.48M rows/s, 0B/s]

Perf gain 5.38%
```

```
== RELEASE NOTES ==

General Changes
* Reorder filter predicates based on their CPU cost