### PR TITLE
Fail on driver if broadcast table exceeds broadcast or node max limit

### DIFF
--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkBufferedSerializedPage.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkBufferedSerializedPage.java
@@ -24,15 +24,22 @@ public class PrestoSparkBufferedSerializedPage
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(PrestoSparkBufferedSerializedPage.class).instanceSize();
 
     private final SerializedPage serializedPage;
+    private final long deserializedRetainedSizeInBytes;
 
-    public PrestoSparkBufferedSerializedPage(SerializedPage serializedPage)
+    public PrestoSparkBufferedSerializedPage(SerializedPage serializedPage, long deserializedRetainedSizeInBytes)
     {
         this.serializedPage = requireNonNull(serializedPage, "serializedPage is null");
+        this.deserializedRetainedSizeInBytes = deserializedRetainedSizeInBytes;
     }
 
     public SerializedPage getSerializedPage()
     {
         return serializedPage;
+    }
+
+    public long getDeserializedRetainedSizeInBytes()
+    {
+        return deserializedRetainedSizeInBytes;
     }
 
     @Override

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkPageOutputOperator.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkPageOutputOperator.java
@@ -181,8 +181,7 @@ public class PrestoSparkPageOutputOperator
         }
 
         List<PrestoSparkBufferedSerializedPage> serializedPages = splitPage(page, DEFAULT_MAX_PAGE_SIZE_IN_BYTES).stream()
-                .map(pagesSerde::serialize)
-                .map(PrestoSparkBufferedSerializedPage::new)
+                .map(p -> new PrestoSparkBufferedSerializedPage(pagesSerde.serialize(p), p.getRetainedSizeInBytes()))
                 .collect(toImmutableList());
 
         serializedPages.forEach(outputBuffer::enqueue);

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkQueryRunner.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkQueryRunner.java
@@ -907,7 +907,23 @@ public class TestPrestoSparkQueryRunner
         assertQueryFails(
                 session,
                 "select * from lineitem l join orders o on l.orderkey = o.orderkey",
-                "Query exceeded per-node total memory limit of 1MB \\[Compressed broadcast size: .*kB; Uncompressed broadcast size: .*MB\\]");
+                "Query exceeded per-node total memory limit of 1MB \\[Broadcast size: .*MB\\]");
+    }
+
+    @Test
+    public void testStorageBasedBroadcastJoinDeserializedMaxThreshold()
+    {
+        Session session = Session.builder(getSession())
+                .setSystemProperty(JOIN_DISTRIBUTION_TYPE, "BROADCAST")
+                .setSystemProperty(STORAGE_BASED_BROADCAST_JOIN_ENABLED, "true")
+                .setSystemProperty(SPARK_BROADCAST_JOIN_MAX_MEMORY_OVERRIDE, "2MB")
+                .setSystemProperty(QUERY_MAX_TOTAL_MEMORY_PER_NODE, "100MB")
+                .build();
+
+        assertQueryFails(
+                session,
+                "select * from lineitem l join orders o on l.orderkey = o.orderkey",
+                "Query exceeded per-node broadcast memory limit of 2MB \\[Broadcast size: 2.*MB\\]");
     }
 
     @Test
@@ -924,7 +940,7 @@ public class TestPrestoSparkQueryRunner
         assertQueryFails(
                 session,
                 "select * from lineitem l join orders o on l.orderkey = o.orderkey",
-                "Query exceeded per-node broadcast memory limit of 10B \\[Compressed broadcast size: .*kB\\]");
+                "Query exceeded per-node broadcast memory limit of 10B \\[Broadcast size: .*MB\\]");
 
         session = Session.builder(getSession())
                 .setSystemProperty(JOIN_DISTRIBUTION_TYPE, "BROADCAST")

--- a/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkStorageHandle.java
+++ b/presto-spark-classloader-interface/src/main/java/com/facebook/presto/spark/classloader_interface/PrestoSparkStorageHandle.java
@@ -23,6 +23,7 @@ public class PrestoSparkStorageHandle
     private final byte[] serializedStorageHandle;
     private final long uncompressedSizeInBytes;
     private final long compressedSizeInBytes;
+    private final long deserializedRetainedSizeInBytes;
     private final long checksum;
     private final int positionCount;
 
@@ -30,12 +31,14 @@ public class PrestoSparkStorageHandle
             byte[] serializedStorageHandle,
             long uncompressedSizeInBytes,
             long compressedSizeInBytes,
+            long deserializedRetainedSizeInBytes,
             long checksum,
             int positionCount)
     {
         this.serializedStorageHandle = requireNonNull(serializedStorageHandle, "serializedStorageHandle is null");
         this.uncompressedSizeInBytes = uncompressedSizeInBytes;
         this.compressedSizeInBytes = compressedSizeInBytes;
+        this.deserializedRetainedSizeInBytes = deserializedRetainedSizeInBytes;
         this.checksum = requireNonNull(checksum, "checksum is null");
         this.positionCount = positionCount;
     }
@@ -48,6 +51,11 @@ public class PrestoSparkStorageHandle
     public long getCompressedSizeInBytes()
     {
         return compressedSizeInBytes;
+    }
+
+    public long getDeserializedRetainedSizeInBytes()
+    {
+        return deserializedRetainedSizeInBytes;
     }
 
     public byte[] getSerializedStorageHandle()


### PR DESCRIPTION
For Presto on Spark queries - driver doesn't have transparency into deserialized size of broadcast table. When deserialized size of broadcast table is bigger than broadcast limit or node memory limit - we still end up broadcasting table to executors if serialized size is under broadcast/node memory limit. This causes executors to OOM while loading broadcast table.

This changelist is to fail a query on driver if broadcast table exceeds broadcast or node max limit. This allows query to fail early on driver rather than executors running into memory limits while loading broadcast table

Test plan - 
Unit tests

```
== RELEASE NOTES ==

Spark Changes
* Improve handling of scenario where a query fails due to broadcast table violating node memory limit or broadcast limit. Previously the query failed while workers tried to load broadcast table causing container out of memory.
```