### PR TITLE
Support case insensitive identifiers in MongoDB

### DIFF
--- a/presto-docs/src/main/sphinx/connector/mongodb.rst
+++ b/presto-docs/src/main/sphinx/connector/mongodb.rst
@@ -34,24 +34,25 @@ Configuration Properties
 
 The following configuration properties are available:
 
-===================================== ==============================================================
-Property Name                         Description
-===================================== ==============================================================
-``mongodb.seeds``                     List of all mongod servers
-``mongodb.schema-collection``         A collection which contains schema information
-``mongodb.credentials``               List of credentials
-``mongodb.min-connections-per-host``  The minimum size of the connection pool per host
-``mongodb.connections-per-host``      The maximum size of the connection pool per host
-``mongodb.max-wait-time``             The maximum wait time
-``mongodb.connection-timeout``        The socket connect timeout
-``mongodb.socket-timeout``            The socket timeout
-``mongodb.socket-keep-alive``         Whether keep-alive is enabled on each socket
-``mongodb.ssl.enabled``               Use TLS/SSL for connections to mongod/mongos
-``mongodb.read-preference``           The read preference
-``mongodb.write-concern``             The write concern
-``mongodb.required-replica-set``      The required replica set name
-``mongodb.cursor-batch-size``         The number of elements to return in a batch
-===================================== ==============================================================
+========================================== ==============================================================
+Property Name                              Description
+========================================== ==============================================================
+``mongodb.seeds``                          List of all mongod servers
+``mongodb.schema-collection``              A collection which contains schema information
+``mongodb.case-insensitive-name-matching`` Match database and collection names case insensitively
+``mongodb.credentials``                    List of credentials
+``mongodb.min-connections-per-host``       The minimum size of the connection pool per host
+``mongodb.connections-per-host``           The maximum size of the connection pool per host
+``mongodb.max-wait-time``                  The maximum wait time
+``mongodb.connection-timeout``             The socket connect timeout
+``mongodb.socket-timeout``                 The socket timeout
+``mongodb.socket-keep-alive``              Whether keep-alive is enabled on each socket
+``mongodb.ssl.enabled``                    Use TLS/SSL for connections to mongod/mongos
+``mongodb.read-preference``                The read preference
+``mongodb.write-concern``                  The write concern
+``mongodb.required-replica-set``           The required replica set name
+``mongodb.cursor-batch-size``              The number of elements to return in a batch
+========================================== ==============================================================
 
 ``mongodb.seeds``
 ^^^^^^^^^^^^^^^^^

--- a/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoClientConfig.java
+++ b/presto-mongodb/src/main/java/com/facebook/presto/mongodb/MongoClientConfig.java
@@ -41,6 +41,7 @@ public class MongoClientConfig
     private static final Splitter TAG_SPLITTER = Splitter.on(':').trimResults().omitEmptyStrings();
 
     private String schemaCollection = "_schema";
+    private boolean caseInsensitiveNameMatching;
     private List<ServerAddress> seeds = ImmutableList.of();
     private List<MongoCredential> credentials = ImmutableList.of();
 
@@ -71,6 +72,18 @@ public class MongoClientConfig
     public MongoClientConfig setSchemaCollection(String schemaCollection)
     {
         this.schemaCollection = schemaCollection;
+        return this;
+    }
+
+    public boolean isCaseInsensitiveNameMatching()
+    {
+        return caseInsensitiveNameMatching;
+    }
+
+    @Config("mongodb.case-insensitive-name-matching")
+    public MongoClientConfig setCaseInsensitiveNameMatching(boolean caseInsensitiveNameMatching)
+    {
+        this.caseInsensitiveNameMatching = caseInsensitiveNameMatching;
         return this;
     }
 

--- a/presto-mongodb/src/test/java/com/facebook/presto/mongodb/MongoQueryRunner.java
+++ b/presto-mongodb/src/test/java/com/facebook/presto/mongodb/MongoQueryRunner.java
@@ -67,6 +67,7 @@ public class MongoQueryRunner
             queryRunner.createCatalog("tpch", "tpch");
 
             Map<String, String> properties = ImmutableMap.of(
+                    "mongodb.case-insensitive-name-matching", "true",
                     "mongodb.seeds", queryRunner.getAddress().getHostString() + ":" + queryRunner.getAddress().getPort(),
                     "mongodb.socket-keep-alive", "true");
 

--- a/presto-mongodb/src/test/java/com/facebook/presto/mongodb/TestMongoClientConfig.java
+++ b/presto-mongodb/src/test/java/com/facebook/presto/mongodb/TestMongoClientConfig.java
@@ -29,6 +29,7 @@ public class TestMongoClientConfig
     {
         ConfigAssertions.assertRecordedDefaults(ConfigAssertions.recordDefaults(MongoClientConfig.class)
                 .setSchemaCollection("_schema")
+                .setCaseInsensitiveNameMatching(false)
                 .setSeeds("")
                 .setCredentials("")
                 .setMinConnectionsPerHost(0)
@@ -51,6 +52,7 @@ public class TestMongoClientConfig
     {
         Map<String, String> properties = new ImmutableMap.Builder<String, String>()
                 .put("mongodb.schema-collection", "_my_schema")
+                .put("mongodb.case-insensitive-name-matching", "true")
                 .put("mongodb.seeds", "host1,host2:27016")
                 .put("mongodb.credentials", "username:password@collection")
                 .put("mongodb.min-connections-per-host", "1")
@@ -70,6 +72,7 @@ public class TestMongoClientConfig
 
         MongoClientConfig expected = new MongoClientConfig()
                 .setSchemaCollection("_my_schema")
+                .setCaseInsensitiveNameMatching(true)
                 .setSeeds("host1", "host2:27016")
                 .setCredentials("username:password@collection")
                 .setMinConnectionsPerHost(1)

--- a/presto-mongodb/src/test/java/com/facebook/presto/mongodb/TestMongoIntegrationSmokeTest.java
+++ b/presto-mongodb/src/test/java/com/facebook/presto/mongodb/TestMongoIntegrationSmokeTest.java
@@ -270,4 +270,23 @@ public class TestMongoIntegrationSmokeTest
         assertQuery("SELECT value FROM test_rename.tmp_rename_new_table", "SELECT 1");
         assertUpdate("DROP TABLE test_rename.tmp_rename_new_table");
     }
+
+    public void testCaseInsensitive()
+            throws Exception
+    {
+        MongoCollection<Document> collection = mongoQueryRunner.getMongoClient().getDatabase("testCase").getCollection("testInsensitive");
+        collection.insertOne(new Document(ImmutableMap.of("Name", "abc", "Value", 1)));
+
+        assertQuery("SHOW SCHEMAS IN mongodb LIKE 'testcase'", "SELECT 'testcase'");
+        assertQuery("SHOW TABLES IN testcase", "SELECT 'testinsensitive'");
+        assertQuery(
+                "SHOW COLUMNS FROM testcase.testInsensitive",
+                "VALUES ('name', 'varchar', '', ''), ('value', 'bigint', '', '')");
+
+        assertQuery("SELECT name, value FROM testcase.testinsensitive", "SELECT 'abc', 1");
+        assertUpdate("INSERT INTO testcase.testinsensitive VALUES('def', 2)", 1);
+
+        assertQuery("SELECT value FROM testcase.testinsensitive WHERE name = 'def'", "SELECT 2");
+        assertUpdate("DROP TABLE testcase.testinsensitive");
+    }
 }


### PR DESCRIPTION
Cherry-pick of https://github.com/trinodb/trino/pull/3453

Co-authored-by: Yuya Ebihara <ebyhry@gmail.com>

Test plan - added tests

```
== RELEASE NOTES ==

General Changes
* Support case insensitive identifiers in MongoDB
```
