### PR TITLE
Add column count limit for partition caching

### DIFF
--- a/presto-delta/src/main/java/com/facebook/presto/delta/DeltaModule.java
+++ b/presto-delta/src/main/java/com/facebook/presto/delta/DeltaModule.java
@@ -40,7 +40,9 @@ import com.facebook.presto.hive.gcs.HiveGcsConfig;
 import com.facebook.presto.hive.gcs.HiveGcsConfigurationInitializer;
 import com.facebook.presto.hive.metastore.CachingHiveMetastore;
 import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
+import com.facebook.presto.hive.metastore.HiveMetastoreCacheStats;
 import com.facebook.presto.hive.metastore.HivePartitionMutator;
+import com.facebook.presto.hive.metastore.MetastoreCacheStats;
 import com.facebook.presto.hive.metastore.MetastoreConfig;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.deser.std.FromStringDeserializer;
@@ -100,6 +102,8 @@ public class DeltaModule
         configBinder(binder).bindConfig(MetastoreConfig.class);
         configBinder(binder).bindConfig(HiveClientConfig.class);
         configBinder(binder).bindConfig(MetastoreClientConfig.class);
+        binder.bind(MetastoreCacheStats.class).to(HiveMetastoreCacheStats.class).in(Scopes.SINGLETON);
+        newExporter(binder).export(MetastoreCacheStats.class).as(generatedNameOf(MetastoreCacheStats.class, connectorId));
         binder.bind(ExtendedHiveMetastore.class).to(CachingHiveMetastore.class).in(Scopes.SINGLETON);
         binder.bind(HdfsConfiguration.class).annotatedWith(ForMetastoreHdfsEnvironment.class).to(HiveCachingHdfsConfiguration.class).in(Scopes.SINGLETON);
 

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/MetastoreClientConfig.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/MetastoreClientConfig.java
@@ -49,6 +49,7 @@ public class MetastoreClientConfig
     private MetastoreCacheScope metastoreCacheScope = MetastoreCacheScope.ALL;
     private boolean metastoreImpersonationEnabled;
     private double partitionCacheValidationPercentage;
+    private int partitionCacheColumnCountLimit = 500;
 
     public HostAndPort getMetastoreSocksProxy()
     {
@@ -252,6 +253,19 @@ public class MetastoreClientConfig
     public MetastoreClientConfig setPartitionCacheValidationPercentage(double partitionCacheValidationPercentage)
     {
         this.partitionCacheValidationPercentage = partitionCacheValidationPercentage;
+        return this;
+    }
+
+    public int getPartitionCacheColumnCountLimit()
+    {
+        return partitionCacheColumnCountLimit;
+    }
+
+    @Config("hive.partition-cache-column-count-limit")
+    @ConfigDescription("The max limit on the column count for a partition to be cached")
+    public MetastoreClientConfig setPartitionCacheColumnCountLimit(int partitionCacheColumnCountLimit)
+    {
+        this.partitionCacheColumnCountLimit = partitionCacheColumnCountLimit;
         return this;
     }
 }

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/HiveMetastoreCacheStats.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/HiveMetastoreCacheStats.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.metastore;
+
+import com.google.common.cache.LoadingCache;
+import org.weakref.jmx.Managed;
+
+public class HiveMetastoreCacheStats
+        implements MetastoreCacheStats
+{
+    private LoadingCache<?, ?> partitionCache;
+
+    @Override
+    public void setPartitionCache(LoadingCache<?, ?> partitionCache)
+    {
+        this.partitionCache = partitionCache;
+    }
+
+    @Managed
+    @Override
+    public long getPartitionCacheHit()
+    {
+        return partitionCache.stats().hitCount();
+    }
+
+    @Managed
+    @Override
+    public long getPartitionCacheMiss()
+    {
+        return partitionCache.stats().missCount();
+    }
+
+    @Managed
+    @Override
+    public long getPartitionCacheEviction()
+    {
+        return partitionCache.stats().evictionCount();
+    }
+
+    @Managed
+    @Override
+    public long getPartitionCacheSize()
+    {
+        return partitionCache.size();
+    }
+}

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/HiveMetastoreCacheStats.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/HiveMetastoreCacheStats.java
@@ -13,18 +13,27 @@
  */
 package com.facebook.presto.hive.metastore;
 
+import com.facebook.airlift.stats.CounterStat;
 import com.google.common.cache.LoadingCache;
 import org.weakref.jmx.Managed;
+import org.weakref.jmx.Nested;
 
 public class HiveMetastoreCacheStats
         implements MetastoreCacheStats
 {
+    private final CounterStat partitionsWithColumnCountGreaterThanThreshold = new CounterStat();
     private LoadingCache<?, ?> partitionCache;
 
     @Override
     public void setPartitionCache(LoadingCache<?, ?> partitionCache)
     {
         this.partitionCache = partitionCache;
+    }
+
+    @Override
+    public void incrementPartitionsWithColumnCountGreaterThanThreshold()
+    {
+        partitionsWithColumnCountGreaterThanThreshold.update(1);
     }
 
     @Managed
@@ -53,5 +62,13 @@ public class HiveMetastoreCacheStats
     public long getPartitionCacheSize()
     {
         return partitionCache.size();
+    }
+
+    @Managed
+    @Nested
+    @Override
+    public CounterStat getPartitionsWithColumnCountGreaterThanThreshold()
+    {
+        return partitionsWithColumnCountGreaterThanThreshold;
     }
 }

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/MetastoreCacheStats.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/MetastoreCacheStats.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.metastore;
+
+import com.google.common.cache.LoadingCache;
+
+public interface MetastoreCacheStats
+{
+    void setPartitionCache(LoadingCache<?, ?> partitionCache);
+
+    long getPartitionCacheHit();
+
+    long getPartitionCacheMiss();
+
+    long getPartitionCacheEviction();
+
+    long getPartitionCacheSize();
+}

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/MetastoreCacheStats.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/MetastoreCacheStats.java
@@ -13,11 +13,14 @@
  */
 package com.facebook.presto.hive.metastore;
 
+import com.facebook.airlift.stats.CounterStat;
 import com.google.common.cache.LoadingCache;
 
 public interface MetastoreCacheStats
 {
     void setPartitionCache(LoadingCache<?, ?> partitionCache);
+
+    void incrementPartitionsWithColumnCountGreaterThanThreshold();
 
     long getPartitionCacheHit();
 
@@ -26,4 +29,6 @@ public interface MetastoreCacheStats
     long getPartitionCacheEviction();
 
     long getPartitionCacheSize();
+
+    CounterStat getPartitionsWithColumnCountGreaterThanThreshold();
 }

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/NoopMetastoreCacheStats.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/NoopMetastoreCacheStats.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.hive.metastore;
 
+import com.facebook.airlift.stats.CounterStat;
 import com.google.common.cache.LoadingCache;
 
 public class NoopMetastoreCacheStats
@@ -21,6 +22,11 @@ public class NoopMetastoreCacheStats
     public static final NoopMetastoreCacheStats NOOP_METASTORE_CACHE_STATS = new NoopMetastoreCacheStats();
 
     public void setPartitionCache(LoadingCache<?, ?> partitionCache)
+    {
+    }
+
+    @Override
+    public void incrementPartitionsWithColumnCountGreaterThanThreshold()
     {
     }
 
@@ -42,5 +48,11 @@ public class NoopMetastoreCacheStats
     public long getPartitionCacheSize()
     {
         return 0;
+    }
+
+    @Override
+    public CounterStat getPartitionsWithColumnCountGreaterThanThreshold()
+    {
+        return null;
     }
 }

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/NoopMetastoreCacheStats.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/NoopMetastoreCacheStats.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive.metastore;
+
+import com.google.common.cache.LoadingCache;
+
+public class NoopMetastoreCacheStats
+        implements MetastoreCacheStats
+{
+    public static final NoopMetastoreCacheStats NOOP_METASTORE_CACHE_STATS = new NoopMetastoreCacheStats();
+
+    public void setPartitionCache(LoadingCache<?, ?> partitionCache)
+    {
+    }
+
+    public long getPartitionCacheHit()
+    {
+        return 0;
+    }
+
+    public long getPartitionCacheMiss()
+    {
+        return 0;
+    }
+
+    public long getPartitionCacheEviction()
+    {
+        return 0;
+    }
+
+    public long getPartitionCacheSize()
+    {
+        return 0;
+    }
+}

--- a/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/TestCachingHiveMetastore.java
+++ b/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/TestCachingHiveMetastore.java
@@ -38,6 +38,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
 import static com.facebook.airlift.concurrent.Threads.daemonThreadsNamed;
+import static com.facebook.presto.hive.metastore.NoopMetastoreCacheStats.NOOP_METASTORE_CACHE_STATS;
 import static com.facebook.presto.hive.metastore.Partition.Builder;
 import static com.facebook.presto.hive.metastore.thrift.MockHiveMetastoreClient.BAD_DATABASE;
 import static com.facebook.presto.hive.metastore.thrift.MockHiveMetastoreClient.PARTITION_VERSION;
@@ -84,7 +85,8 @@ public class TestCachingHiveMetastore
                 1000,
                 false,
                 MetastoreCacheScope.ALL,
-                0.0);
+                0.0,
+                NOOP_METASTORE_CACHE_STATS);
         stats = thriftHiveMetastore.getStats();
     }
 
@@ -223,7 +225,8 @@ public class TestCachingHiveMetastore
                 1000,
                 true,
                 MetastoreCacheScope.PARTITION,
-                0.0);
+                0.0,
+                NOOP_METASTORE_CACHE_STATS);
 
         assertEquals(mockClient.getAccessCount(), 0);
         assertEquals(partitionCachingEnabledmetastore.getPartitionNamesByFilter(TEST_METASTORE_CONTEXT, TEST_DATABASE, TEST_TABLE, ImmutableMap.of()), EXPECTED_PARTITIONS);
@@ -270,7 +273,8 @@ public class TestCachingHiveMetastore
                 1000,
                 true,
                 MetastoreCacheScope.PARTITION,
-                0.0);
+                0.0,
+                NOOP_METASTORE_CACHE_STATS);
 
         int clientAccessCount = 0;
         for (int i = 0; i < 100; i++) {
@@ -305,7 +309,8 @@ public class TestCachingHiveMetastore
                 1000,
                 true,
                 MetastoreCacheScope.PARTITION,
-                100.0);
+                100.0,
+                NOOP_METASTORE_CACHE_STATS);
 
         // Warmup the cache
         partitionCacheVerificationEnabledMetastore.getPartitionsByNames(TEST_METASTORE_CONTEXT, TEST_DATABASE, TEST_TABLE, ImmutableList.of(TEST_PARTITION1, TEST_PARTITION2));

--- a/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/TestMetastoreClientConfig.java
+++ b/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/TestMetastoreClientConfig.java
@@ -45,7 +45,8 @@ public class TestMetastoreClientConfig
                 .setPartitionVersioningEnabled(false)
                 .setMetastoreCacheScope(MetastoreCacheScope.ALL)
                 .setMetastoreImpersonationEnabled(false)
-                .setPartitionCacheValidationPercentage(0));
+                .setPartitionCacheValidationPercentage(0)
+                .setPartitionCacheColumnCountLimit(500));
     }
 
     @Test
@@ -68,6 +69,7 @@ public class TestMetastoreClientConfig
                 .put("hive.metastore-cache-scope", "PARTITION")
                 .put("hive.metastore-impersonation-enabled", "true")
                 .put("hive.partition-cache-validation-percentage", "60.0")
+                .put("hive.partition-cache-column-count-limit", "50")
                 .build();
 
         MetastoreClientConfig expected = new MetastoreClientConfig()
@@ -86,7 +88,8 @@ public class TestMetastoreClientConfig
                 .setPartitionVersioningEnabled(true)
                 .setMetastoreCacheScope(MetastoreCacheScope.PARTITION)
                 .setMetastoreImpersonationEnabled(true)
-                .setPartitionCacheValidationPercentage(60.0);
+                .setPartitionCacheValidationPercentage(60.0)
+                .setPartitionCacheColumnCountLimit(50);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/thrift/MockHiveMetastoreClient.java
+++ b/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/thrift/MockHiveMetastoreClient.java
@@ -74,7 +74,19 @@ public class MockHiveMetastoreClient
             new RolePrincipalGrant("role2", "role1", ROLE, true, 0, "grantor2", ROLE));
 
     private static final StorageDescriptor DEFAULT_STORAGE_DESCRIPTOR =
-            new StorageDescriptor(ImmutableList.of(), "", null, null, false, 0, new SerDeInfo(TEST_TABLE, null, ImmutableMap.of()), null, null, ImmutableMap.of());
+            new StorageDescriptor(
+                    ImmutableList.of(
+                            new FieldSchema("col_bigint", "bigint", "comment"),
+                            new FieldSchema("col_string", "string", "comment")),
+                    "",
+                    null,
+                    null,
+                    false,
+                    0,
+                    new SerDeInfo(TEST_TABLE, null, ImmutableMap.of()),
+                    null,
+                    null,
+                    ImmutableMap.of());
 
     private final AtomicInteger accessCount = new AtomicInteger();
     private boolean throwException;

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientModule.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientModule.java
@@ -22,7 +22,9 @@ import com.facebook.presto.hive.HiveDwrfEncryptionProvider.ForUnknown;
 import com.facebook.presto.hive.cache.HiveCachingHdfsConfiguration;
 import com.facebook.presto.hive.datasink.DataSinkFactory;
 import com.facebook.presto.hive.datasink.OutputStreamDataSinkFactory;
+import com.facebook.presto.hive.metastore.HiveMetastoreCacheStats;
 import com.facebook.presto.hive.metastore.HivePartitionMutator;
+import com.facebook.presto.hive.metastore.MetastoreCacheStats;
 import com.facebook.presto.hive.orc.DwrfBatchPageSourceFactory;
 import com.facebook.presto.hive.orc.DwrfSelectivePageSourceFactory;
 import com.facebook.presto.hive.orc.OrcBatchPageSourceFactory;
@@ -205,6 +207,9 @@ public class HiveClientModule
 
         configBinder(binder).bindConfig(ParquetFileWriterConfig.class);
         fileWriterFactoryBinder.addBinding().to(ParquetFileWriterFactory.class).in(Scopes.SINGLETON);
+
+        binder.bind(MetastoreCacheStats.class).to(HiveMetastoreCacheStats.class).in(Scopes.SINGLETON);
+        newExporter(binder).export(MetastoreCacheStats.class).as(generatedNameOf(MetastoreCacheStats.class, connectorId));
         binder.install(new MetastoreClientModule());
 
         binder.bind(HiveEncryptionInformationProvider.class).in(Scopes.SINGLETON);

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadataFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadataFactory.java
@@ -47,6 +47,7 @@ public class HiveMetadataFactory
     private final int maxPartitionBatchSize;
     private final long perTransactionCacheMaximumSize;
     private final boolean metastoreImpersonationEnabled;
+    private final int metastorePartitionCacheMaxColumnCount;
     private final ExtendedHiveMetastore metastore;
     private final HdfsEnvironment hdfsEnvironment;
     private final HivePartitionManager partitionManager;
@@ -111,6 +112,7 @@ public class HiveMetadataFactory
                 hiveClientConfig.getMaxPartitionBatchSize(),
                 metastoreClientConfig.getPerTransactionMetastoreCacheMaximumSize(),
                 metastoreClientConfig.isMetastoreImpersonationEnabled(),
+                metastoreClientConfig.getPartitionCacheColumnCountLimit(),
                 typeManager,
                 locationService,
                 functionResolution,
@@ -145,6 +147,7 @@ public class HiveMetadataFactory
             int maxPartitionBatchSize,
             long perTransactionCacheMaximumSize,
             boolean metastoreImpersonationEnabled,
+            int metastorePartitionCacheMaxColumnCount,
             TypeManager typeManager,
             LocationService locationService,
             StandardFunctionResolution functionResolution,
@@ -173,6 +176,7 @@ public class HiveMetadataFactory
         this.maxPartitionBatchSize = maxPartitionBatchSize;
         this.perTransactionCacheMaximumSize = perTransactionCacheMaximumSize;
         this.metastoreImpersonationEnabled = metastoreImpersonationEnabled;
+        this.metastorePartitionCacheMaxColumnCount = metastorePartitionCacheMaxColumnCount;
         this.metastore = requireNonNull(metastore, "metastore is null");
         this.hdfsEnvironment = requireNonNull(hdfsEnvironment, "hdfsEnvironment is null");
         this.partitionManager = requireNonNull(partitionManager, "partitionManager is null");
@@ -209,7 +213,7 @@ public class HiveMetadataFactory
     {
         SemiTransactionalHiveMetastore metastore = new SemiTransactionalHiveMetastore(
                 hdfsEnvironment,
-                CachingHiveMetastore.memoizeMetastore(this.metastore, metastoreImpersonationEnabled, perTransactionCacheMaximumSize), // per-transaction cache
+                CachingHiveMetastore.memoizeMetastore(this.metastore, metastoreImpersonationEnabled, perTransactionCacheMaximumSize, metastorePartitionCacheMaxColumnCount), // per-transaction cache
                 fileRenameExecutor,
                 skipDeletionForAlter,
                 skipTargetCleanupOnRollback,

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSinkProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSinkProvider.java
@@ -78,6 +78,7 @@ public class HivePageSinkProvider
     private final OrcFileWriterFactory orcFileWriterFactory;
     private final long perTransactionMetastoreCacheMaximumSize;
     private final boolean metastoreImpersonationEnabled;
+    private final int metastorePartitionCacheMaxColumnCount;
     private final ColumnConverterProvider columnConverterProvider;
 
     @Inject
@@ -124,6 +125,7 @@ public class HivePageSinkProvider
         this.columnConverterProvider = requireNonNull(columnConverterProvider, "columnConverterProvider is null");
         this.perTransactionMetastoreCacheMaximumSize = metastoreClientConfig.getPerTransactionMetastoreCacheMaximumSize();
         this.metastoreImpersonationEnabled = metastoreClientConfig.isMetastoreImpersonationEnabled();
+        this.metastorePartitionCacheMaxColumnCount = metastoreClientConfig.getPartitionCacheColumnCountLimit();
     }
 
     @Override
@@ -174,7 +176,10 @@ public class HivePageSinkProvider
                 session.getQueryId(),
                 // The scope of metastore cache is within a single HivePageSink object
                 // TODO: Extend metastore cache scope to the entire transaction
-                new HivePageSinkMetadataProvider(handle.getPageSinkMetadata(), memoizeMetastore(metastore, metastoreImpersonationEnabled, perTransactionMetastoreCacheMaximumSize), new MetastoreContext(session.getIdentity(), session.getQueryId(), session.getClientInfo(), session.getSource(), getMetastoreHeaders(session), isUserDefinedTypeEncodingEnabled(session), columnConverterProvider)),
+                new HivePageSinkMetadataProvider(
+                        handle.getPageSinkMetadata(),
+                        memoizeMetastore(metastore, metastoreImpersonationEnabled, perTransactionMetastoreCacheMaximumSize, metastorePartitionCacheMaxColumnCount),
+                        new MetastoreContext(session.getIdentity(), session.getQueryId(), session.getClientInfo(), session.getSource(), getMetastoreHeaders(session), isUserDefinedTypeEncodingEnabled(session), columnConverterProvider)),
                 typeManager,
                 hdfsEnvironment,
                 pageSorter,

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -933,6 +933,7 @@ public abstract class AbstractTestHiveClient
                 false,
                 MetastoreCacheScope.ALL,
                 0.0,
+                metastoreClientConfig.getPartitionCacheColumnCountLimit(),
                 NOOP_METASTORE_CACHE_STATS);
 
         setup(databaseName, hiveClientConfig, cacheConfig, metastoreClientConfig, metastore);
@@ -963,6 +964,7 @@ public abstract class AbstractTestHiveClient
                 getHiveClientConfig().getMaxPartitionBatchSize(),
                 getHiveClientConfig().getMaxPartitionsPerScan(),
                 false,
+                10_000,
                 FUNCTION_AND_TYPE_MANAGER,
                 locationService,
                 FUNCTION_RESOLUTION,

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -272,6 +272,7 @@ import static com.facebook.presto.hive.metastore.MetastoreUtil.PRESTO_QUERY_ID_N
 import static com.facebook.presto.hive.metastore.MetastoreUtil.createDirectory;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.getMetastoreHeaders;
 import static com.facebook.presto.hive.metastore.MetastoreUtil.toPartitionValues;
+import static com.facebook.presto.hive.metastore.NoopMetastoreCacheStats.NOOP_METASTORE_CACHE_STATS;
 import static com.facebook.presto.hive.metastore.PrestoTableType.MANAGED_TABLE;
 import static com.facebook.presto.hive.metastore.StorageFormat.fromHiveStorageFormat;
 import static com.facebook.presto.hive.rule.HiveFilterPushdown.pushdownFilter;
@@ -931,7 +932,8 @@ public abstract class AbstractTestHiveClient
                 10000,
                 false,
                 MetastoreCacheScope.ALL,
-                0.0);
+                0.0,
+                NOOP_METASTORE_CACHE_STATS);
 
         setup(databaseName, hiveClientConfig, cacheConfig, metastoreClientConfig, metastore);
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystem.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveFileSystem.java
@@ -107,6 +107,7 @@ import static com.facebook.presto.hive.HiveTestUtils.getDefaultHiveSelectivePage
 import static com.facebook.presto.hive.HiveTestUtils.getDefaultOrcFileWriterFactory;
 import static com.facebook.presto.hive.HiveTestUtils.getTypes;
 import static com.facebook.presto.hive.metastore.MetastoreOperationResult.EMPTY_RESULT;
+import static com.facebook.presto.hive.metastore.NoopMetastoreCacheStats.NOOP_METASTORE_CACHE_STATS;
 import static com.facebook.presto.spi.SplitContext.NON_CACHEABLE;
 import static com.facebook.presto.spi.connector.ConnectorSplitManager.SplitSchedulingStrategy.UNGROUPED_SCHEDULING;
 import static com.facebook.presto.testing.MaterializedResult.materializeSourceDataStream;
@@ -500,7 +501,7 @@ public abstract class AbstractTestHiveFileSystem
 
         public TestingHiveMetastore(ExtendedHiveMetastore delegate, ExecutorService executor, MetastoreClientConfig metastoreClientConfig, Path basePath, HdfsEnvironment hdfsEnvironment)
         {
-            super(delegate, executor, metastoreClientConfig);
+            super(delegate, executor, NOOP_METASTORE_CACHE_STATS, metastoreClientConfig);
             this.basePath = basePath;
             this.hdfsEnvironment = hdfsEnvironment;
         }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMetadataFileFormatEncryptionSettings.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMetadataFileFormatEncryptionSettings.java
@@ -122,6 +122,7 @@ public class TestHiveMetadataFileFormatEncryptionSettings
                 HIVE_CLIENT_CONFIG.getMaxPartitionBatchSize(),
                 HIVE_CLIENT_CONFIG.getMaxPartitionsPerScan(),
                 false,
+                10_000,
                 FUNCTION_AND_TYPE_MANAGER,
                 new HiveLocationService(HDFS_ENVIRONMENT),
                 FUNCTION_RESOLUTION,

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitManager.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitManager.java
@@ -494,6 +494,7 @@ public class TestHiveSplitManager
                 hiveClientConfig.getMaxPartitionBatchSize(),
                 hiveClientConfig.getMaxPartitionsPerScan(),
                 false,
+                10_000,
                 FUNCTION_AND_TYPE_MANAGER,
                 new HiveLocationService(hdfsEnvironment),
                 FUNCTION_RESOLUTION,

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergModule.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergModule.java
@@ -40,7 +40,9 @@ import com.facebook.presto.hive.gcs.HiveGcsConfig;
 import com.facebook.presto.hive.gcs.HiveGcsConfigurationInitializer;
 import com.facebook.presto.hive.metastore.CachingHiveMetastore;
 import com.facebook.presto.hive.metastore.ExtendedHiveMetastore;
+import com.facebook.presto.hive.metastore.HiveMetastoreCacheStats;
 import com.facebook.presto.hive.metastore.HivePartitionMutator;
+import com.facebook.presto.hive.metastore.MetastoreCacheStats;
 import com.facebook.presto.hive.metastore.MetastoreConfig;
 import com.facebook.presto.iceberg.optimizer.IcebergPlanOptimizer;
 import com.facebook.presto.orc.CachingStripeMetadataSource;
@@ -114,6 +116,8 @@ public class IcebergModule
         binder.bind(HdfsConfiguration.class).annotatedWith(ForMetastoreHdfsEnvironment.class).to(HiveCachingHdfsConfiguration.class).in(Scopes.SINGLETON);
         binder.bind(HdfsConfiguration.class).annotatedWith(ForCachingFileSystem.class).to(HiveHdfsConfiguration.class).in(Scopes.SINGLETON);
         binder.bind(PartitionMutator.class).to(HivePartitionMutator.class).in(Scopes.SINGLETON);
+        binder.bind(MetastoreCacheStats.class).to(HiveMetastoreCacheStats.class).in(Scopes.SINGLETON);
+        newExporter(binder).export(MetastoreCacheStats.class).as(generatedNameOf(MetastoreCacheStats.class, connectorId));
         binder.bind(ExtendedHiveMetastore.class).to(CachingHiveMetastore.class).in(Scopes.SINGLETON);
         binder.bind(MBeanServer.class).toInstance(new TestingMBeanServer());
 


### PR DESCRIPTION
- Added stats for metastore cache
- Added support to NOT cache partitions with high number of columns. this way we can prevent bad partitions(1000's of columns) from being cached and prevent GC.

Depended by https://github.com/facebookexternal/presto-facebook/pull/1850

Test plan
- Added unit test
- Created custom presto version and ran tests.
- Checked that metrics are being updated correctly.

```
== RELEASE NOTES ==

Hive Changes
* Add a limit that prevents caching partitions with column counts greater than a configured threshold. This threshold can be set using the `hive.partition-cache-column-count-limit` configuration parameter.
```
