### PR TITLE
Add optimization rule REWRITE OR IN JOIN CONDITION TO UNION ALL (FOR INNER JOINS)

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/CanonicalTableScanNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/CanonicalTableScanNode.java
@@ -19,8 +19,10 @@ import com.facebook.presto.spi.ConnectorTableHandle;
 import com.facebook.presto.spi.ConnectorTableLayoutHandle;
 import com.facebook.presto.spi.SourceLocation;
 import com.facebook.presto.spi.TableHandle;
+import com.facebook.presto.spi.VariableAllocator;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeId;
+import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.planner.plan.InternalPlanNode;
 import com.facebook.presto.sql.planner.plan.InternalPlanVisitor;
@@ -118,6 +120,25 @@ public class CanonicalTableScanNode
     public int hashCode()
     {
         return Objects.hash(table, assignments, outputVariables);
+    }
+
+    @Override
+    public CanonicalTableScanNode deepCopy(
+            PlanNodeIdAllocator planNodeIdAllocator,
+            VariableAllocator variableAllocator,
+            Map<VariableReferenceExpression, VariableReferenceExpression> variableMappings)
+    {
+        CanonicalTableHandle canonicalTableHandle = new CanonicalTableHandle(
+                getTable().getConnectorId(),
+                getTable().getTableHandle(),
+                getTable().getLayoutIdentifier(),
+                getTable().getLayoutHandle());
+        return new CanonicalTableScanNode(
+                getSourceLocation(),
+                planNodeIdAllocator.getNextId(),
+                canonicalTableHandle,
+                getOutputVariables(),
+                getAssignments());
     }
 
     public static class CanonicalTableHandle

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PartitioningScheme.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PartitioningScheme.java
@@ -20,9 +20,11 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -162,5 +164,14 @@ public class PartitioningScheme
                 .add("replicateNullsAndAny", replicateNullsAndAny)
                 .add("bucketToPartition", bucketToPartition)
                 .toString();
+    }
+    public PartitioningScheme deepCopy(
+            Map<VariableReferenceExpression, VariableReferenceExpression> variableMappings)
+    {
+        return new PartitioningScheme(
+                Partitioning.create(
+                        getPartitioning().getHandle(),
+                        getPartitioning().getArguments().stream().map(argument -> argument.deepCopy(variableMappings)).collect(Collectors.toList())),
+                getOutputLayout().stream().map(variableMappings::get).collect(Collectors.toList()));
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/GroupReference.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/GroupReference.java
@@ -14,14 +14,17 @@
 package com.facebook.presto.sql.planner.iterative;
 
 import com.facebook.presto.spi.SourceLocation;
+import com.facebook.presto.spi.VariableAllocator;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeId;
+import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.planner.plan.InternalPlanNode;
 import com.facebook.presto.sql.planner.plan.InternalPlanVisitor;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 public class GroupReference
@@ -64,5 +67,18 @@ public class GroupReference
     public PlanNode replaceChildren(List<PlanNode> newChildren)
     {
         throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public GroupReference deepCopy(
+            PlanNodeIdAllocator planNodeIdAllocator,
+            VariableAllocator variableAllocator,
+            Map<VariableReferenceExpression, VariableReferenceExpression> variableMappings)
+    {
+        return new GroupReference(
+                getSourceLocation(),
+                planNodeIdAllocator.getNextId(),
+                getGroupId(),
+                getOutputVariables());
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/AssignUniqueId.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/AssignUniqueId.java
@@ -14,8 +14,10 @@
 package com.facebook.presto.sql.planner.plan;
 
 import com.facebook.presto.spi.SourceLocation;
+import com.facebook.presto.spi.VariableAllocator;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeId;
+import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -23,6 +25,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkArgument;
@@ -84,5 +87,21 @@ public class AssignUniqueId
     {
         checkArgument(newChildren.size() == 1, "expected newChildren to contain 1 node");
         return new AssignUniqueId(newChildren.get(0).getSourceLocation(), getId(), Iterables.getOnlyElement(newChildren), idVariable);
+    }
+
+    @Override
+    public AssignUniqueId deepCopy(
+            PlanNodeIdAllocator planNodeIdAllocator,
+            VariableAllocator variableAllocator,
+            Map<VariableReferenceExpression, VariableReferenceExpression> variableMappings)
+    {
+        PlanNode sourceDeepCopy = getSource().deepCopy(planNodeIdAllocator, variableAllocator, variableMappings);
+        VariableReferenceExpression idVariableCopy = variableAllocator.newVariable(getIdVariable().getSourceLocation(), getIdVariable().getName(), getIdVariable().getType());
+        variableMappings.put(idVariable, idVariableCopy);
+        return new AssignUniqueId(
+                getSourceLocation(),
+                planNodeIdAllocator.getNextId(),
+                sourceDeepCopy,
+                idVariableCopy);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/DeleteNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/DeleteNode.java
@@ -14,8 +14,10 @@
 package com.facebook.presto.sql.planner.plan;
 
 import com.facebook.presto.spi.SourceLocation;
+import com.facebook.presto.spi.VariableAllocator;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeId;
+import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -25,6 +27,7 @@ import com.google.common.collect.Iterables;
 import javax.annotation.concurrent.Immutable;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
@@ -87,5 +90,20 @@ public class DeleteNode
     public PlanNode replaceChildren(List<PlanNode> newChildren)
     {
         return new DeleteNode(getSourceLocation(), getId(), Iterables.getOnlyElement(newChildren), rowId, outputVariables);
+    }
+
+    public DeleteNode deepCopy(
+            PlanNodeIdAllocator planNodeIdAllocator,
+            VariableAllocator variableAllocator,
+            Map<VariableReferenceExpression, VariableReferenceExpression> variableMappings)
+    {
+        PlanNode sourceDeepCopy = getSource().deepCopy(planNodeIdAllocator, variableAllocator, variableMappings);
+
+        return new DeleteNode(
+                getSourceLocation(),
+                planNodeIdAllocator.getNextId(),
+                sourceDeepCopy,
+                getRowId().deepCopy(variableMappings),
+                sourceDeepCopy.getOutputVariables());
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/EnforceSingleRowNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/EnforceSingleRowNode.java
@@ -14,8 +14,10 @@
 package com.facebook.presto.sql.planner.plan;
 
 import com.facebook.presto.spi.SourceLocation;
+import com.facebook.presto.spi.VariableAllocator;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeId;
+import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -25,6 +27,7 @@ import com.google.common.collect.Iterables;
 import javax.annotation.concurrent.Immutable;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
@@ -74,5 +77,16 @@ public class EnforceSingleRowNode
     public PlanNode replaceChildren(List<PlanNode> newChildren)
     {
         return new EnforceSingleRowNode(getSourceLocation(), getId(), Iterables.getOnlyElement(newChildren));
+    }
+
+    public EnforceSingleRowNode deepCopy(
+            PlanNodeIdAllocator planNodeIdAllocator,
+            VariableAllocator variableAllocator,
+            Map<VariableReferenceExpression, VariableReferenceExpression> variableMappings)
+    {
+        return new EnforceSingleRowNode(
+                getSourceLocation(),
+                planNodeIdAllocator.getNextId(),
+                getSource().deepCopy(planNodeIdAllocator, variableAllocator, variableMappings));
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ExchangeNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/ExchangeNode.java
@@ -14,9 +14,12 @@
 package com.facebook.presto.sql.planner.plan;
 
 import com.facebook.presto.spi.SourceLocation;
+import com.facebook.presto.spi.VariableAllocator;
+import com.facebook.presto.spi.plan.Ordering;
 import com.facebook.presto.spi.plan.OrderingScheme;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeId;
+import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.planner.Partitioning;
 import com.facebook.presto.sql.planner.PartitioningHandle;
@@ -28,7 +31,9 @@ import com.google.common.collect.ImmutableList;
 import javax.annotation.concurrent.Immutable;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static com.facebook.presto.sql.planner.SystemPartitioningHandle.FIXED_ARBITRARY_DISTRIBUTION;
 import static com.facebook.presto.sql.planner.SystemPartitioningHandle.FIXED_BROADCAST_DISTRIBUTION;
@@ -315,5 +320,40 @@ public class ExchangeNode
     public PlanNode replaceChildren(List<PlanNode> newChildren)
     {
         return new ExchangeNode(getSourceLocation(), getId(), type, scope, partitioningScheme, newChildren, inputs, ensureSourceOrdering, orderingScheme);
+    }
+    public ExchangeNode deepCopy(
+            PlanNodeIdAllocator planNodeIdAllocator,
+            VariableAllocator variableAllocator,
+            Map<VariableReferenceExpression, VariableReferenceExpression> variableMappings)
+    {
+        List<PlanNode> sourcesDeepCopy = getSources().stream().
+                map(planNode -> planNode.deepCopy(planNodeIdAllocator, variableAllocator, variableMappings)).
+                collect(Collectors.toList());
+        List<List<VariableReferenceExpression>> inputsDeepCopy = getInputs().
+                stream().
+                map(variables -> variables.stream().
+                        map(variableMappings::get).
+                        collect(Collectors.toList())).
+                collect(Collectors.toList());
+        return new ExchangeNode(
+                getSourceLocation(),
+                planNodeIdAllocator.getNextId(),
+                getType(),
+                getScope(),
+                new PartitioningScheme(
+                        Partitioning.create(
+                                partitioningScheme.getPartitioning().getHandle(),
+                                partitioningScheme.getPartitioning().getArguments().
+                                        stream().
+                                        map(argument -> argument.deepCopy(variableMappings)).collect(Collectors.toList())),
+                        partitioningScheme.getOutputLayout().stream().map(variableMappings::get).collect(Collectors.toList())),
+                sourcesDeepCopy,
+                inputsDeepCopy,
+                isEnsureSourceOrdering(),
+                getOrderingScheme().isPresent() ?
+                        Optional.of(new OrderingScheme( getOrderingScheme().get().getOrderBy().stream().
+                                map(ordering -> new Ordering(variableMappings.get(ordering.getVariable()), ordering.getSortOrder())).
+                                collect(Collectors.toList()))) :
+                        Optional.empty());
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/OutputNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/OutputNode.java
@@ -14,8 +14,10 @@
 package com.facebook.presto.sql.planner.plan;
 
 import com.facebook.presto.spi.SourceLocation;
+import com.facebook.presto.spi.VariableAllocator;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeId;
+import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -25,7 +27,9 @@ import com.google.common.collect.Iterables;
 
 import javax.annotation.concurrent.Immutable;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
@@ -92,5 +96,19 @@ public class OutputNode
     public PlanNode replaceChildren(List<PlanNode> newChildren)
     {
         return new OutputNode(getSourceLocation(), getId(), Iterables.getOnlyElement(newChildren), columnNames, outputVariables);
+    }
+
+    public OutputNode deepCopy(
+            PlanNodeIdAllocator planNodeIdAllocator,
+            VariableAllocator variableAllocator,
+            Map<VariableReferenceExpression, VariableReferenceExpression> variableMappings)
+    {
+        PlanNode sourcesDeepCopy = getSource().deepCopy(planNodeIdAllocator, variableAllocator, variableMappings);
+        return new OutputNode(
+                getSourceLocation(),
+                planNodeIdAllocator.getNextId(),
+                sourcesDeepCopy,
+                new ArrayList<>(columnNames),
+                sourcesDeepCopy.getOutputVariables());
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/OriginalExpressionUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/OriginalExpressionUtils.java
@@ -22,6 +22,7 @@ import com.facebook.presto.sql.analyzer.ExpressionTreeUtils;
 import com.facebook.presto.sql.tree.Expression;
 import com.facebook.presto.sql.tree.SymbolReference;
 
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -129,6 +130,12 @@ public final class OriginalExpressionUtils
 
         @Override
         public <R, C> R accept(RowExpressionVisitor<R, C> visitor, C context)
+        {
+            throw new UnsupportedOperationException("OriginalExpression cannot appear in a RowExpression tree");
+        }
+
+        @Override
+        public OriginalExpression deepCopy(Map<VariableReferenceExpression, VariableReferenceExpression> variableMappings)
         {
             throw new UnsupportedOperationException("OriginalExpression cannot appear in a RowExpression tree");
         }

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestAnalyzer.java
@@ -1660,8 +1660,12 @@ public class TestAnalyzer
                         "performance issues as it may lead to a cross join with filter");
         assertNoWarning(analyzeWithWarnings("select * FROM t1 a1 LEFT JOIN t2 a2 ON a1.a = a2.a LEFT JOIN t3 a3  ON a3.a = a3.b AND a3.b = a1.b"));
         assertHasWarning(analyzeWithWarnings("select * from t1 inner join ( select t2.a as t2_a, t3.a from t2 inner join t3 on t2.a=t3.a) al ON t1.a = t1.a"),
-                PERFORMANCE_WARNING, "line 1:104: JOIN ON condition(s) do not reference the joined table 'al' and other tables in the same expression that can cause " +
+                PERFORMANCE_WARNING, "line 1:104: JOIN ON condition(s) do not reference the joined relation and other relation in the same expression that can cause " +
                         "performance issues as it may lead to a cross join with filter");
+        assertHasWarning(analyzeWithWarnings("select * from t1 inner join (select t2.a as t2_a, t3.a t3_a from t2 inner join t3 on t2.a=t3.a) ON t2_a = t3_a"),
+                PERFORMANCE_WARNING, "line 1:105: JOIN ON condition(s) do not reference the joined relation and other relation in the same expression that can cause " +
+                        "performance issues as it may lead to a cross join with filter");
+        assertNoWarning(analyzeWithWarnings("select * from t1 inner join (select t2.a as t2_a, t3.a t3_a from t2 inner join t3 on t2.a=t3.a) ON t2_a = a"));
     }
 
     @Test

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/TestMemo.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/TestMemo.java
@@ -15,6 +15,7 @@ package com.facebook.presto.sql.planner.iterative;
 
 import com.facebook.presto.cost.PlanCostEstimate;
 import com.facebook.presto.cost.PlanNodeStatsEstimate;
+import com.facebook.presto.spi.VariableAllocator;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
@@ -23,6 +24,7 @@ import com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
@@ -309,6 +311,15 @@ public class TestMemo
         public PlanNode replaceChildren(List<PlanNode> newChildren)
         {
             return new GenericNode(getId(), newChildren);
+        }
+
+        @Override
+        public GenericNode deepCopy(
+                PlanNodeIdAllocator planNodeIdAllocator,
+                VariableAllocator variableAllocator,
+                Map<VariableReferenceExpression, VariableReferenceExpression> variableMappings)
+        {
+            return new GenericNode(planNodeIdAllocator.getNextId(), getSources());
         }
     }
 }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/plan/TestPlanNodeDeepCopy.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/plan/TestPlanNodeDeepCopy.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.sql.planner.plan;
+
+import com.facebook.presto.spi.VariableAllocator;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
+import com.facebook.presto.spi.plan.ValuesNode;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.Plan;
+import com.facebook.presto.sql.planner.PlanVariableAllocator;
+import com.facebook.presto.sql.planner.assertions.BasePlanTest;
+import org.testng.annotations.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotSame;
+
+public class TestPlanNodeDeepCopy
+        extends BasePlanTest
+{
+    /// TODO Remove this test
+    @Test
+    public void test()
+    {
+        Plan queryPlan = plan("SELECT * FROM (VALUES 1, 2, 3) t(x)");
+
+
+        PlanNodeIdAllocator planNodeIdAllocator = new PlanNodeIdAllocator();
+        VariableAllocator variableAllocator = new PlanVariableAllocator(queryPlan.getTypes().allVariables());
+        Map<VariableReferenceExpression, VariableReferenceExpression> variableMappings = new HashMap<>();
+        PlanNode rootNodeCopy = queryPlan.getRoot().deepCopy(planNodeIdAllocator, variableAllocator, variableMappings);
+        assertNodesAreDeepCopied(queryPlan.getRoot(), rootNodeCopy, variableMappings);
+    }
+
+    @Test
+    public void testValuesNode()
+    {
+        Plan queryPlan = plan("SELECT * FROM (VALUES 1, 2, 3) t(x)");
+
+
+        PlanNodeIdAllocator planNodeIdAllocator = new PlanNodeIdAllocator();
+        VariableAllocator variableAllocator = new PlanVariableAllocator(queryPlan.getTypes().allVariables());
+        Map<VariableReferenceExpression, VariableReferenceExpression> variableMappings = new HashMap<>();
+        PlanNode rootNodeCopy = queryPlan.getRoot().deepCopy(planNodeIdAllocator, variableAllocator, variableMappings);
+        assertNodesAreDeepCopied(queryPlan.getRoot(), rootNodeCopy, variableMappings);
+    }
+
+    private void assertNodesAreDeepCopied(PlanNode original, PlanNode copy,  Map<VariableReferenceExpression, VariableReferenceExpression> variableMappings)
+    {
+        assertEquals(original.getClass(), copy.getClass(), String.format("'%s' type of the plan node does not match the type '%s' of original node", copy.getClass(), original.getClass()));
+        assertNotSame(original.getId(), copy.getId());
+        assertEquals(original.getSourceLocation(), copy.getSourceLocation());
+        assertOutputVariablesDeepCopied(original, copy, variableMappings);
+        if (copy instanceof OutputNode)
+        {
+            OutputNode originalOutputNode = (OutputNode) original;
+            OutputNode copyOutputNode = (OutputNode) copy;
+            assertNotSame(originalOutputNode, copyOutputNode, "Two nodes are pointing to the same heap location and thus not copied");
+            assertNodesAreDeepCopied(originalOutputNode.getSource(), ((OutputNode) copy).getSource(), variableMappings);
+            assertEquals(originalOutputNode.getColumnNames().size(), copyOutputNode.getColumnNames().size());
+            for (int i = 0; i < originalOutputNode.getColumnNames().size(); ++i)
+            {
+                assertEquals(originalOutputNode.getColumnNames().get(i), copyOutputNode.getColumnNames().get(i));
+            }
+        }
+        else if (copy instanceof ValuesNode)
+        {
+            ValuesNode originalOutputNode = (ValuesNode) original;
+            ValuesNode copyOutputNode = (ValuesNode) copy;
+            assertNotSame(originalOutputNode, copyOutputNode, "Two nodes are pointing to the same heap location and thus not copied");
+            for (int row = 0; row < originalOutputNode.getRows().size(); ++row)
+            {
+                for (int col = 0; col < originalOutputNode.getRows().get(row).size(); ++col)
+                {
+                    assertNotSame(originalOutputNode.getRows().get(row).get(col), copyOutputNode.getRows().get(row).get(col));
+                    assertEquals(originalOutputNode.getRows().get(row).get(col), copyOutputNode.getRows().get(row).get(col));
+                }
+            }
+        }
+    }
+
+    private void assertOutputVariablesDeepCopied(PlanNode original, PlanNode copy, Map<VariableReferenceExpression, VariableReferenceExpression> variableMappings)
+    {
+        assertEquals(original.getOutputVariables().size(), copy.getOutputVariables().size());
+        for(int i = 0; i < original.getOutputVariables().size(); ++i)
+        {
+            assertNotSame(original.getOutputVariables().get(i), copy.getOutputVariables().get(i));
+            assertEquals(variableMappings.get(original.getOutputVariables().get(i)), copy.getOutputVariables().get(i));
+        }
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/plan/PlanNode.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/plan/PlanNode.java
@@ -14,11 +14,14 @@
 package com.facebook.presto.spi.plan;
 
 import com.facebook.presto.spi.SourceLocation;
+import com.facebook.presto.spi.VariableAllocator;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
@@ -67,6 +70,41 @@ public abstract class PlanNode
      * Alter the upstream PlanNodes of the current PlanNode.
      */
     public abstract PlanNode replaceChildren(List<PlanNode> newChildren);
+
+    /**
+     * Create a deep copy of the current PlanNode.
+     */
+//    TODO Uncomment this code
+//    public abstract PlanNode deepCopy(
+//            PlanNodeIdAllocator planNodeIdAllocator,
+//            VariableAllocator variableAllocator,
+//            Map<VariableReferenceExpression, VariableReferenceExpression> variableMappings);
+    public  PlanNode deepCopy(
+            PlanNodeIdAllocator planNodeIdAllocator,
+            VariableAllocator variableAllocator,
+            Map<VariableReferenceExpression, VariableReferenceExpression> variableMappings)
+    {
+        return null;
+    }
+
+    public static List<VariableReferenceExpression> translateVariableReferences(
+            List<VariableReferenceExpression> originalVariables,
+            VariableAllocator variableAllocator,
+            Map<VariableReferenceExpression, VariableReferenceExpression> variableMappings)
+    {
+        List<VariableReferenceExpression> newVariables = new ArrayList<>();
+        for(int i = 0; i < originalVariables.size(); ++i)
+        {
+            if (!variableMappings.containsKey(originalVariables.get(i)))
+            {
+                variableMappings.put(
+                        originalVariables.get(i),
+                        variableAllocator.newVariable(originalVariables.get(i).getName(), originalVariables.get(i).getType()));
+            }
+            newVariables.add(variableMappings.get(originalVariables.get(i)));
+        }
+        return newVariables;
+    }
 
     /**
      * A visitor pattern interface to operate on IR.

--- a/presto-spi/src/main/java/com/facebook/presto/spi/relation/CallExpression.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/relation/CallExpression.java
@@ -23,6 +23,7 @@ import javax.annotation.concurrent.Immutable;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -123,5 +124,15 @@ public final class CallExpression
     public <R, C> R accept(RowExpressionVisitor<R, C> visitor, C context)
     {
         return visitor.visitCall(this, context);
+    }
+
+    @Override
+    public CallExpression deepCopy(Map<VariableReferenceExpression, VariableReferenceExpression> variableMappings)
+    {
+        return new CallExpression(
+                getDisplayName(),
+                getFunctionHandle(),
+                getType(),
+                arguments.stream().map(argument -> argument.deepCopy(variableMappings)).collect(Collectors.toList()));
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/relation/ConstantExpression.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/relation/ConstantExpression.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.annotation.concurrent.Immutable;
 
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -113,5 +114,11 @@ public final class ConstantExpression
     public <R, C> R accept(RowExpressionVisitor<R, C> visitor, C context)
     {
         return visitor.visitConstant(this, context);
+    }
+
+    @Override
+    public ConstantExpression deepCopy(Map<VariableReferenceExpression, VariableReferenceExpression> variableMappings)
+    {
+        return new ConstantExpression(getSourceLocation(), getValue(), getType());
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/relation/InputReferenceExpression.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/relation/InputReferenceExpression.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.annotation.concurrent.Immutable;
 
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -87,5 +88,11 @@ public final class InputReferenceExpression
         }
         InputReferenceExpression other = (InputReferenceExpression) obj;
         return Objects.equals(this.field, other.field) && Objects.equals(this.type, other.type);
+    }
+
+    @Override
+    public InputReferenceExpression deepCopy(Map<VariableReferenceExpression, VariableReferenceExpression> variableMappings)
+    {
+        return new InputReferenceExpression(getSourceLocation(), getField(), getType());
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/relation/LambdaDefinitionExpression.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/relation/LambdaDefinitionExpression.java
@@ -106,6 +106,12 @@ public final class LambdaDefinitionExpression
     }
 
     @Override
+    public LambdaDefinitionExpression deepCopy(Map<VariableReferenceExpression, VariableReferenceExpression> variableMappings)
+    {
+        return new LambdaDefinitionExpression(getSourceLocation(), getArgumentTypes(), getArguments(), getBody().deepCopy(variableMappings));
+    }
+
+    @Override
     public int hashCode()
     {
         return Objects.hash(argumentTypes, canonicalizedBody);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/relation/RowExpression.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/relation/RowExpression.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
+import java.util.Map;
 import java.util.Optional;
 
 @JsonTypeInfo(
@@ -55,6 +56,8 @@ public abstract class RowExpression
     }
 
     public abstract Type getType();
+
+    public abstract RowExpression deepCopy(Map<VariableReferenceExpression, VariableReferenceExpression> variableMappings);
 
     @Override
     public abstract boolean equals(Object other);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/relation/SpecialFormExpression.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/relation/SpecialFormExpression.java
@@ -20,13 +20,16 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.annotation.concurrent.Immutable;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
 import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toCollection;
 import static java.util.stream.Collectors.toList;
 
 @Immutable
@@ -113,6 +116,16 @@ public class SpecialFormExpression
         SpecialFormExpression other = (SpecialFormExpression) obj;
         return this.form == other.form &&
                 Objects.equals(this.arguments, other.arguments);
+    }
+
+    @Override
+    public SpecialFormExpression deepCopy(Map<VariableReferenceExpression, VariableReferenceExpression> variableMappings)
+    {
+        return new SpecialFormExpression(
+                getSourceLocation(),
+                getForm(),
+                getType(),
+                getArguments().stream().map(argument -> argument.deepCopy(variableMappings)).collect(toCollection(ArrayList::new)));
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/relation/VariableReferenceExpression.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/relation/VariableReferenceExpression.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.annotation.concurrent.Immutable;
 
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -96,5 +97,10 @@ public final class VariableReferenceExpression
             return nameComparison;
         }
         return type.getTypeSignature().toString().compareTo(o.type.getTypeSignature().toString());
+    }
+
+    public VariableReferenceExpression deepCopy(Map<VariableReferenceExpression, VariableReferenceExpression> variableMappings)
+    {
+        return variableMappings.get(this);
     }
 }


### PR DESCRIPTION
Complex OR expressions in join conditions generally result in heavy overhead, especially if the CNF does not result in a good equality condition - which turns this into a “cross join” + filter which can be very slow -  mainly because we evaluate all the clauses in OR with no short-circuit - for every row (to handle NULL properly).So the idea is to build the DNF in that case and generate a UNION ALL with one condition per branch and successively negating the previous conditions as we go along. So:
SELECT .. FROM T1 JOIN T2 ON T1.k1 = T2.k1 OR T1.k2 = T2.k2 OR ..
Can be rewritten as:
SELECT .. FROM T1 JOIN T2 ON T1.k1 = T2.k1 UNION ALL SELECT .. FROM T1 JOIN T2 ON COALESCE(T1.k1 <> T2.k1, true) AND T1.k2 = T2.k2 ...
So we will only have conjunctions which are easier to pushdown and process in general. 

```
== NO RELEASE NOTE ==
```
