### PR TITLE
Store Commit Output Info into QueryOutputMetadata

### DIFF
--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/HiveCommitHandle.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/HiveCommitHandle.java
@@ -13,20 +13,29 @@
  */
 package com.facebook.presto.hive.metastore;
 
+import com.facebook.airlift.json.JsonCodec;
 import com.facebook.presto.spi.SchemaTableName;
 import com.facebook.presto.spi.connector.ConnectorCommitHandle;
 import com.google.common.collect.ImmutableMap;
+import io.airlift.units.DataSize;
 import org.joda.time.DateTime;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
+import static com.facebook.airlift.json.JsonCodec.jsonCodec;
+import static com.facebook.presto.spi.connector.ConnectorCommitHandle.EMPTY_COMMIT_OUTPUT;
+import static io.airlift.units.DataSize.Unit.MEGABYTE;
+import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
 public class HiveCommitHandle
         implements ConnectorCommitHandle
 {
     public static final HiveCommitHandle EMPTY_HIVE_COMMIT_HANDLE = new HiveCommitHandle(ImmutableMap.of());
+    private static final int JSON_LENGTH_LIMIT = toIntExact(new DataSize(10, MEGABYTE).toBytes());
+    private static final JsonCodec<Object> JSON_CODEC = jsonCodec(Object.class);
 
     private final Map<SchemaTableName, List<DateTime>> lastDataCommitTimes;
 
@@ -35,8 +44,10 @@ public class HiveCommitHandle
         this.lastDataCommitTimes = requireNonNull(lastDataCommitTimes, "lastDataCommitTimes is null");
     }
 
-    public List<DateTime> getLastDataCommitTimes(SchemaTableName table)
+    @Override
+    public String getSerializedCommitOutput(SchemaTableName table)
     {
-        return lastDataCommitTimes.get(table);
+        Optional<String> serializedCommitOutput = JSON_CODEC.toJsonWithLengthLimit(lastDataCommitTimes.get(table), JSON_LENGTH_LIMIT);
+        return serializedCommitOutput.orElse(EMPTY_COMMIT_OUTPUT);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/event/QueryMonitor.java
+++ b/presto-main/src/main/java/com/facebook/presto/event/QueryMonitor.java
@@ -414,7 +414,8 @@ public class QueryMonitor
                             queryInfo.getOutput().get().getSchema(),
                             queryInfo.getOutput().get().getTable(),
                             tableFinishInfo.map(TableFinishInfo::getSerializedConnectorOutputMetadata),
-                            tableFinishInfo.map(TableFinishInfo::isJsonLengthLimitExceeded)));
+                            tableFinishInfo.map(TableFinishInfo::isJsonLengthLimitExceeded),
+                            queryInfo.getOutput().get().getSerializedCommitOutput()));
         }
         return new QueryIOMetadata(inputs.build(), output);
     }

--- a/presto-main/src/main/java/com/facebook/presto/execution/Output.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/Output.java
@@ -29,16 +29,19 @@ public final class Output
     private final ConnectorId connectorId;
     private final String schema;
     private final String table;
+    private final String serializedCommitOutput;
 
     @JsonCreator
     public Output(
             @JsonProperty("connectorId") ConnectorId connectorId,
             @JsonProperty("schema") String schema,
-            @JsonProperty("table") String table)
+            @JsonProperty("table") String table,
+            @JsonProperty("serializedCommitOutput") String serializedCommitOutput)
     {
         this.connectorId = requireNonNull(connectorId, "connectorId is null");
         this.schema = requireNonNull(schema, "schema is null");
         this.table = requireNonNull(table, "table is null");
+        this.serializedCommitOutput = requireNonNull(serializedCommitOutput, "connectorCommitOutput is null");
     }
 
     @JsonProperty
@@ -59,6 +62,12 @@ public final class Output
         return table;
     }
 
+    @JsonProperty
+    public String getSerializedCommitOutput()
+    {
+        return serializedCommitOutput;
+    }
+
     @Override
     public boolean equals(Object o)
     {
@@ -71,12 +80,13 @@ public final class Output
         Output output = (Output) o;
         return Objects.equals(connectorId, output.connectorId) &&
                 Objects.equals(schema, output.schema) &&
-                Objects.equals(table, output.table);
+                Objects.equals(table, output.table) &&
+                Objects.equals(serializedCommitOutput, output.serializedCommitOutput);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(connectorId, schema, table);
+        return Objects.hash(connectorId, schema, table, serializedCommitOutput);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/OutputExtractor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/OutputExtractor.java
@@ -23,6 +23,7 @@ import com.google.common.base.VerifyException;
 
 import java.util.Optional;
 
+import static com.facebook.presto.spi.connector.ConnectorCommitHandle.EMPTY_COMMIT_OUTPUT;
 import static com.google.common.base.Preconditions.checkState;
 
 public class OutputExtractor
@@ -39,7 +40,8 @@ public class OutputExtractor
         return Optional.of(new Output(
                 visitor.getConnectorId(),
                 visitor.getSchemaTableName().getSchemaName(),
-                visitor.getSchemaTableName().getTableName()));
+                visitor.getSchemaTableName().getTableName(),
+                EMPTY_COMMIT_OUTPUT));
     }
 
     private class Visitor

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestOutput.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestOutput.java
@@ -17,6 +17,7 @@ import com.facebook.airlift.json.JsonCodec;
 import com.facebook.presto.spi.ConnectorId;
 import org.testng.annotations.Test;
 
+import static com.facebook.presto.spi.connector.ConnectorCommitHandle.EMPTY_COMMIT_OUTPUT;
 import static org.testng.Assert.assertEquals;
 
 public class TestOutput
@@ -26,7 +27,11 @@ public class TestOutput
     @Test
     public void testRoundTrip()
     {
-        Output expected = new Output(new ConnectorId("connectorId"), "schema", "table");
+        Output expected = new Output(
+                new ConnectorId("connectorId"),
+                "schema",
+                "table",
+                EMPTY_COMMIT_OUTPUT);
 
         String json = codec.toJson(expected);
         Output actual = codec.fromJson(json);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorCommitHandle.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorCommitHandle.java
@@ -13,6 +13,14 @@
  */
 package com.facebook.presto.spi.connector;
 
+import com.facebook.presto.spi.SchemaTableName;
+
 public interface ConnectorCommitHandle
 {
+    String EMPTY_COMMIT_OUTPUT = "";
+
+    default String getSerializedCommitOutput(SchemaTableName table)
+    {
+        return EMPTY_COMMIT_OUTPUT;
+    }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/QueryOutputMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/QueryOutputMetadata.java
@@ -28,13 +28,22 @@ public class QueryOutputMetadata
     private final Optional<String> connectorOutputMetadata;
     private final Optional<Boolean> jsonLengthLimitExceeded;
 
-    public QueryOutputMetadata(String catalogName, String schema, String table, Optional<String> connectorOutputMetadata, Optional<Boolean> jsonLengthLimitExceeded)
+    private final String serializedCommitOutput;
+
+    public QueryOutputMetadata(
+            String catalogName,
+            String schema,
+            String table,
+            Optional<String> connectorOutputMetadata,
+            Optional<Boolean> jsonLengthLimitExceeded,
+            String serializedCommitOutput)
     {
         this.catalogName = requireNonNull(catalogName, "catalogName is null");
         this.schema = requireNonNull(schema, "schema is null");
         this.table = requireNonNull(table, "table is null");
         this.connectorOutputMetadata = requireNonNull(connectorOutputMetadata, "connectorOutputMetadata is null");
         this.jsonLengthLimitExceeded = requireNonNull(jsonLengthLimitExceeded, "jsonLengthLimitExceeded is null");
+        this.serializedCommitOutput = requireNonNull(serializedCommitOutput, "connectorCommitHandle is null");
     }
 
     @JsonProperty
@@ -65,5 +74,11 @@ public class QueryOutputMetadata
     public Optional<Boolean> getJsonLengthLimitExceeded()
     {
         return jsonLengthLimitExceeded;
+    }
+
+    @JsonProperty
+    public String getSerializedCommitOutput()
+    {
+        return serializedCommitOutput;
     }
 }


### PR DESCRIPTION
We store the commit output information into QueryOutputMetadata,
which will further pass it down for further processing.

Test plan
Ran presto verifier tests to confirm the accuracy of this PR.

```
== NO RELEASE NOTE ==
```
