### PR TITLE
Add runtime stats for materialized view status

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/RuntimeMetricName.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/RuntimeMetricName.java
@@ -33,6 +33,7 @@ public class RuntimeMetricName
     public static final String FRAGMENT_RESULT_CACHE_MISS = "fragmentResultCacheMissCount";
     public static final String GET_VIEW_TIME_NANOS = "getViewTimeNanos";
     public static final String GET_MATERIALIZED_VIEW_TIME_NANOS = "getMaterializedViewTimeNanos";
+    public static final String GET_MATERIALIZED_VIEW_STATUS_TIME_NANOS = "getMaterializedViewStatusTimeNanos";
     public static final String GET_TABLE_HANDLE_TIME_NANOS = "getTableHandleTimeNanos";
     public static final String GET_TABLE_METADATA_TIME_NANOS = "getTableMetadataTimeNanos";
     public static final String GET_SPLITS_TIME_NANOS = "getSplitsTimeNanos";

--- a/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
@@ -100,6 +100,7 @@ import java.util.concurrent.ConcurrentMap;
 import static com.facebook.airlift.concurrent.MoreFutures.toListenableFuture;
 import static com.facebook.presto.SystemSessionProperties.isIgnoreStatsCalculatorFailures;
 import static com.facebook.presto.common.RuntimeMetricName.GET_LAYOUT_TIME_NANOS;
+import static com.facebook.presto.common.RuntimeMetricName.GET_MATERIALIZED_VIEW_STATUS_TIME_NANOS;
 import static com.facebook.presto.common.function.OperatorType.BETWEEN;
 import static com.facebook.presto.common.function.OperatorType.EQUAL;
 import static com.facebook.presto.common.function.OperatorType.GREATER_THAN;
@@ -1089,7 +1090,10 @@ public class MetadataManager
 
         ConnectorId connectorId = materializedViewHandle.get().getConnectorId();
         ConnectorMetadata metadata = getMetadata(session, connectorId);
-        return metadata.getMaterializedViewStatus(session.toConnectorSession(connectorId), toSchemaTableName(materializedViewName));
+
+        return session.getRuntimeStats().profileNanos(
+                GET_MATERIALIZED_VIEW_STATUS_TIME_NANOS,
+                () -> metadata.getMaterializedViewStatus(session.toConnectorSession(connectorId), toSchemaTableName(materializedViewName)));
     }
 
     @Override


### PR DESCRIPTION
Adding runtime stats for measuring the performance of getMaterializedViewStatus method.
 
```
== NO RELEASE NOTE ==
```
