### PR TITLE
allow worker nodes to skip discovering other worker nodes

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/metadata/TestDiscoveryNodeManager.java
+++ b/presto-main/src/test/java/com/facebook/presto/metadata/TestDiscoveryNodeManager.java
@@ -18,7 +18,6 @@ import com.facebook.airlift.discovery.client.ServiceSelector;
 import com.facebook.airlift.http.client.HttpClient;
 import com.facebook.airlift.http.client.testing.TestingHttpClient;
 import com.facebook.airlift.http.client.testing.TestingResponse;
-import com.facebook.airlift.node.NodeConfig;
 import com.facebook.airlift.node.NodeInfo;
 import com.facebook.presto.client.NodeVersion;
 import com.facebook.presto.failureDetector.NoOpFailureDetector;
@@ -54,16 +53,25 @@ import static org.testng.Assert.assertNotSame;
 @Test(singleThreaded = true)
 public class TestDiscoveryNodeManager
 {
-    private final NodeInfo nodeInfo = new NodeInfo("test");
+    private final NodeInfo workerNodeInfo = new NodeInfo("test");
+    private final NodeInfo coordinatorNodeInfo = new NodeInfo("test");
+    private final NodeInfo resourceManagerNodeInfo = new NodeInfo("test");
     private final InternalCommunicationConfig internalCommunicationConfig = new InternalCommunicationConfig();
     private NodeVersion expectedVersion;
     private Set<InternalNode> activeNodes;
+    private Set<InternalNode> workerNodes;
     private Set<InternalNode> inactiveNodes;
     private InternalNode coordinator;
+    private InternalNode inActiveCoordinator;
+    private InternalNode inActiveResourceManager;
     private InternalNode resourceManager;
-    private InternalNode currentNode;
+    private InternalNode workerNode1;
     private final PrestoNodeServiceSelector selector = new PrestoNodeServiceSelector();
     private HttpClient testHttpClient;
+    private InternalNode workerNode2;
+    private InternalNode workerNode3;
+    private InternalNode inActiveWorkerNode1;
+    private InternalNode inActiveWorkerNode2;
 
     @BeforeMethod
     public void setup()
@@ -71,27 +79,103 @@ public class TestDiscoveryNodeManager
         testHttpClient = new TestingHttpClient(input -> new TestingResponse(OK, ArrayListMultimap.create(), ACTIVE.name().getBytes()));
 
         expectedVersion = new NodeVersion("1");
-        coordinator = new InternalNode(UUID.randomUUID().toString(), URI.create("https://192.0.2.8"), expectedVersion, true);
-        resourceManager = new InternalNode(UUID.randomUUID().toString(), URI.create("https://192.0.2.9"), expectedVersion, false, true);
-        currentNode = new InternalNode(nodeInfo.getNodeId(), URI.create("http://192.0.1.1"), expectedVersion, false);
+        coordinator = new InternalNode(coordinatorNodeInfo.getNodeId(), URI.create("https://192.0.2.8"), expectedVersion, true);
+        resourceManager = new InternalNode(resourceManagerNodeInfo.getNodeId(), URI.create("https://192.0.2.9"), expectedVersion, false, true);
+        workerNode1 = new InternalNode(workerNodeInfo.getNodeId(), URI.create("http://192.0.1.1"), expectedVersion, false);
+        workerNode2 = new InternalNode(UUID.randomUUID().toString(), URI.create("http://192.0.2.1:8080"), expectedVersion, false);
+        workerNode3 = new InternalNode(UUID.randomUUID().toString(), URI.create("http://192.0.2.3"), expectedVersion, false);
+        inActiveResourceManager = new InternalNode(resourceManagerNodeInfo.getNodeId(), URI.create("https://192.0.2.9"), new NodeVersion("2"), false, true);
+        inActiveCoordinator = new InternalNode(UUID.randomUUID().toString(), URI.create("https://192.0.3.1"), new NodeVersion("2"), true);
+        inActiveWorkerNode1 = new InternalNode(UUID.randomUUID().toString(), URI.create("https://192.0.3.9"), NodeVersion.UNKNOWN, false);
+        inActiveWorkerNode2 = new InternalNode(UUID.randomUUID().toString(), URI.create("https://192.0.4.9"), new NodeVersion("2"), false);
 
-        activeNodes = ImmutableSet.of(
-                currentNode,
-                new InternalNode(UUID.randomUUID().toString(), URI.create("http://192.0.2.1:8080"), expectedVersion, false),
-                new InternalNode(UUID.randomUUID().toString(), URI.create("http://192.0.2.3"), expectedVersion, false),
-                coordinator,
-                resourceManager);
+        workerNodes = ImmutableSet.of(workerNode1, workerNode2, workerNode3);
+        activeNodes = ImmutableSet.<InternalNode>builder()
+                .addAll(workerNodes)
+                .add(coordinator)
+                .add(resourceManager)
+                .build();
         inactiveNodes = ImmutableSet.of(
-                new InternalNode(UUID.randomUUID().toString(), URI.create("https://192.0.3.9"), NodeVersion.UNKNOWN, false),
-                new InternalNode(UUID.randomUUID().toString(), URI.create("https://192.0.4.9"), new NodeVersion("2"), false));
+                inActiveCoordinator,
+                inActiveResourceManager,
+                inActiveWorkerNode1,
+                inActiveWorkerNode2);
 
         selector.announceNodes(activeNodes, inactiveNodes);
     }
 
     @Test
-    public void testGetAllNodes()
+    public void testGetAllNodesForWorkerNode()
     {
-        DiscoveryNodeManager manager = new DiscoveryNodeManager(selector, nodeInfo, new NoOpFailureDetector(), Optional.empty(), expectedVersion, testHttpClient, new TestingDriftClient<>(), internalCommunicationConfig);
+        DiscoveryNodeManager manager = new DiscoveryNodeManager(selector, workerNodeInfo, new NoOpFailureDetector(), Optional.empty(), expectedVersion, testHttpClient, new TestingDriftClient<>(), internalCommunicationConfig);
+        try {
+            AllNodes allNodes = manager.getAllNodes();
+
+            Set<InternalNode> activeNodes = allNodes.getActiveNodes();
+            assertEqualsIgnoreOrder(activeNodes, ImmutableSet.of(resourceManager));
+
+            for (InternalNode actual : activeNodes) {
+                for (InternalNode expected : this.activeNodes) {
+                    assertNotSame(actual, expected);
+                }
+            }
+
+            assertEqualsIgnoreOrder(activeNodes, manager.getNodes(ACTIVE));
+
+            Set<InternalNode> inactiveNodes = allNodes.getInactiveNodes();
+            assertEqualsIgnoreOrder(inactiveNodes, ImmutableSet.of(inActiveResourceManager));
+
+            for (InternalNode actual : inactiveNodes) {
+                for (InternalNode expected : this.inactiveNodes) {
+                    assertNotSame(actual, expected);
+                }
+            }
+
+            assertEqualsIgnoreOrder(inactiveNodes, manager.getNodes(INACTIVE));
+        }
+        finally {
+            manager.stop();
+        }
+    }
+
+    @Test
+    public void testGetAllNodesForCoordinator()
+    {
+        DiscoveryNodeManager manager = new DiscoveryNodeManager(selector, coordinatorNodeInfo, new NoOpFailureDetector(), Optional.empty(), expectedVersion, testHttpClient, new TestingDriftClient<>(), internalCommunicationConfig);
+        try {
+            AllNodes allNodes = manager.getAllNodes();
+
+            Set<InternalNode> activeNodes = allNodes.getActiveNodes();
+            assertEqualsIgnoreOrder(activeNodes, this.activeNodes);
+
+            for (InternalNode actual : activeNodes) {
+                for (InternalNode expected : this.activeNodes) {
+                    assertNotSame(actual, expected);
+                }
+            }
+
+            assertEqualsIgnoreOrder(activeNodes, manager.getNodes(ACTIVE));
+
+            Set<InternalNode> inactiveNodes = allNodes.getInactiveNodes();
+            assertEqualsIgnoreOrder(inactiveNodes, this.inactiveNodes);
+
+            for (InternalNode actual : inactiveNodes) {
+                for (InternalNode expected : this.inactiveNodes) {
+                    assertNotSame(actual, expected);
+                }
+            }
+
+            assertEqualsIgnoreOrder(inactiveNodes, manager.getNodes(INACTIVE));
+        }
+        finally {
+            manager.stop();
+        }
+    }
+
+    @Test
+    public void testGetAllNodesForResourceManager()
+    {
+        DiscoveryNodeManager manager = new DiscoveryNodeManager(selector, resourceManagerNodeInfo, new NoOpFailureDetector(), Optional.empty(), expectedVersion, testHttpClient, new TestingDriftClient<>(), internalCommunicationConfig);
         try {
             AllNodes allNodes = manager.getAllNodes();
 
@@ -125,13 +209,9 @@ public class TestDiscoveryNodeManager
     @Test
     public void testGetCurrentNode()
     {
-        NodeInfo nodeInfo = new NodeInfo(new NodeConfig()
-                .setEnvironment("test")
-                .setNodeId(currentNode.getNodeIdentifier()));
-
-        DiscoveryNodeManager manager = new DiscoveryNodeManager(selector, nodeInfo, new NoOpFailureDetector(), Optional.empty(), expectedVersion, testHttpClient, new TestingDriftClient<>(), internalCommunicationConfig);
+        DiscoveryNodeManager manager = new DiscoveryNodeManager(selector, workerNodeInfo, new NoOpFailureDetector(), Optional.empty(), expectedVersion, testHttpClient, new TestingDriftClient<>(), internalCommunicationConfig);
         try {
-            assertEquals(manager.getCurrentNode(), currentNode);
+            assertEquals(manager.getCurrentNode(), workerNode1);
         }
         finally {
             manager.stop();
@@ -141,7 +221,7 @@ public class TestDiscoveryNodeManager
     @Test
     public void testGetCoordinators()
     {
-        DiscoveryNodeManager manager = new DiscoveryNodeManager(selector, nodeInfo, new NoOpFailureDetector(), Optional.empty(), expectedVersion, testHttpClient, new TestingDriftClient<>(), internalCommunicationConfig);
+        DiscoveryNodeManager manager = new DiscoveryNodeManager(selector, resourceManagerNodeInfo, new NoOpFailureDetector(), Optional.empty(), expectedVersion, testHttpClient, new TestingDriftClient<>(), internalCommunicationConfig);
         try {
             assertEquals(manager.getCoordinators(), ImmutableSet.of(coordinator));
         }
@@ -153,7 +233,7 @@ public class TestDiscoveryNodeManager
     @Test
     public void testGetResourceManagers()
     {
-        DiscoveryNodeManager manager = new DiscoveryNodeManager(selector, nodeInfo, new NoOpFailureDetector(), Optional.of(host -> false), expectedVersion, testHttpClient, new TestingDriftClient<>(), internalCommunicationConfig);
+        DiscoveryNodeManager manager = new DiscoveryNodeManager(selector, workerNodeInfo, new NoOpFailureDetector(), Optional.of(host -> false), expectedVersion, testHttpClient, new TestingDriftClient<>(), internalCommunicationConfig);
         try {
             assertEquals(manager.getResourceManagers(), ImmutableSet.of(resourceManager));
         }
@@ -173,7 +253,7 @@ public class TestDiscoveryNodeManager
     public void testNodeChangeListener()
             throws Exception
     {
-        DiscoveryNodeManager manager = new DiscoveryNodeManager(selector, nodeInfo, new NoOpFailureDetector(), Optional.empty(), expectedVersion, testHttpClient, new TestingDriftClient<>(), internalCommunicationConfig);
+        DiscoveryNodeManager manager = new DiscoveryNodeManager(selector, coordinatorNodeInfo, new NoOpFailureDetector(), Optional.empty(), expectedVersion, testHttpClient, new TestingDriftClient<>(), internalCommunicationConfig);
         try {
             manager.startPollingNodeStates();
 
@@ -183,9 +263,9 @@ public class TestDiscoveryNodeManager
             assertEquals(allNodes.getActiveNodes(), activeNodes);
             assertEquals(allNodes.getInactiveNodes(), inactiveNodes);
 
-            selector.announceNodes(ImmutableSet.of(currentNode), ImmutableSet.of(coordinator));
+            selector.announceNodes(ImmutableSet.of(workerNode1), ImmutableSet.of(coordinator));
             allNodes = notifications.take();
-            assertEquals(allNodes.getActiveNodes(), ImmutableSet.of(currentNode, coordinator));
+            assertEquals(allNodes.getActiveNodes(), ImmutableSet.of(workerNode1, coordinator));
             assertEquals(allNodes.getActiveCoordinators(), ImmutableSet.of(coordinator));
 
             selector.announceNodes(activeNodes, inactiveNodes);


### PR DESCRIPTION
* if current node is coordinator or resource manager then store all discovered nodes
* else store only the nodes that are resource manager.

Test plan - (Please fill in how you tested your changes)
Added unit test to verify the DiscoverNodeManager behaviour

```
== NO RELEASE NOTE ==
```
