### PR TITLE
Store input info into QueryInputMetadata

### DIFF
--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/Partition.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/Partition.java
@@ -44,6 +44,7 @@ public class Partition
     private final boolean eligibleToIgnore;
     private final boolean sealedPartition;
     private final int createTime;
+    private final int lastAccessTime;
 
     @JsonCreator
     public Partition(
@@ -56,7 +57,8 @@ public class Partition
             @JsonProperty("partitionVersion") Optional<Long> partitionVersion,
             @JsonProperty("eligibleToIgnore") boolean eligibleToIgnore,
             @JsonProperty("sealedPartition") boolean sealedPartition,
-            @JsonProperty("createTime") int createTime)
+            @JsonProperty("createTime") int createTime,
+            @JsonProperty("lastAccessTime") int lastAccessTime)
     {
         this.databaseName = requireNonNull(databaseName, "databaseName is null");
         this.tableName = requireNonNull(tableName, "tableName is null");
@@ -68,6 +70,7 @@ public class Partition
         this.eligibleToIgnore = eligibleToIgnore;
         this.sealedPartition = sealedPartition;
         this.createTime = createTime;
+        this.lastAccessTime = lastAccessTime;
     }
 
     @JsonProperty
@@ -136,6 +139,12 @@ public class Partition
         return createTime;
     }
 
+    @JsonProperty
+    public int getLastAccessTime()
+    {
+        return lastAccessTime;
+    }
+
     @Override
     public String toString()
     {
@@ -166,13 +175,14 @@ public class Partition
                 Objects.equals(partitionVersion, partition.partitionVersion) &&
                 Objects.equals(eligibleToIgnore, partition.eligibleToIgnore) &&
                 Objects.equals(sealedPartition, partition.sealedPartition) &&
-                Objects.equals(createTime, partition.getCreateTime());
+                Objects.equals(createTime, partition.getCreateTime()) &&
+                Objects.equals(lastAccessTime, partition.getLastAccessTime());
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(databaseName, tableName, values, storage, columns, parameters, partitionVersion, eligibleToIgnore, sealedPartition, createTime);
+        return Objects.hash(databaseName, tableName, values, storage, columns, parameters, partitionVersion, eligibleToIgnore, sealedPartition, createTime, lastAccessTime);
     }
 
     public static Builder builder()
@@ -197,6 +207,7 @@ public class Partition
         private boolean isEligibleToIgnore;
         private boolean isSealedPartition = true;
         private int createTime;
+        private int lastAccessTime;
 
         private Builder()
         {
@@ -214,6 +225,7 @@ public class Partition
             this.partitionVersion = partition.getPartitionVersion();
             this.isEligibleToIgnore = partition.isEligibleToIgnore();
             this.createTime = partition.getCreateTime();
+            this.lastAccessTime = partition.getLastAccessTime();
         }
 
         public Builder setDatabaseName(String databaseName)
@@ -281,9 +293,15 @@ public class Partition
             return this;
         }
 
+        public Builder setLastAccessTime(int lastAccessTime)
+        {
+            this.lastAccessTime = lastAccessTime;
+            return this;
+        }
+
         public Partition build()
         {
-            return new Partition(databaseName, tableName, values, storageBuilder.build(), columns, parameters, partitionVersion, isEligibleToIgnore, isSealedPartition, createTime);
+            return new Partition(databaseName, tableName, values, storageBuilder.build(), columns, parameters, partitionVersion, isEligibleToIgnore, isSealedPartition, createTime, lastAccessTime);
         }
     }
 }

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/Table.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/Table.java
@@ -47,6 +47,7 @@ public class Table
     private final Map<String, String> parameters;
     private final Optional<String> viewOriginalText;
     private final Optional<String> viewExpandedText;
+    private final int lastAccessTime;
 
     @JsonCreator
     public Table(
@@ -59,7 +60,8 @@ public class Table
             @JsonProperty("partitionColumns") List<Column> partitionColumns,
             @JsonProperty("parameters") Map<String, String> parameters,
             @JsonProperty("viewOriginalText") Optional<String> viewOriginalText,
-            @JsonProperty("viewExpandedText") Optional<String> viewExpandedText)
+            @JsonProperty("viewExpandedText") Optional<String> viewExpandedText,
+            @JsonProperty("lastAccessTime") int lastAccessTime)
     {
         this.databaseName = requireNonNull(databaseName, "databaseName is null");
         this.tableName = requireNonNull(tableName, "tableName is null");
@@ -71,6 +73,7 @@ public class Table
         this.parameters = ImmutableMap.copyOf(requireNonNull(parameters, "parameters is null"));
         this.viewOriginalText = requireNonNull(viewOriginalText, "viewOriginalText is null");
         this.viewExpandedText = requireNonNull(viewExpandedText, "viewExpandedText is null");
+        this.lastAccessTime = requireNonNull(lastAccessTime, "lastAccessTime is null");
     }
 
     @JsonProperty
@@ -146,6 +149,12 @@ public class Table
         return viewExpandedText;
     }
 
+    @JsonProperty
+    public int getLastAccessTime()
+    {
+        return lastAccessTime;
+    }
+
     public static Builder builder()
     {
         return new Builder();
@@ -170,6 +179,7 @@ public class Table
                 .add("parameters", parameters)
                 .add("viewOriginalText", viewOriginalText)
                 .add("viewExpandedText", viewExpandedText)
+                .add("lastAccessTime", lastAccessTime)
                 .toString();
     }
 
@@ -193,7 +203,8 @@ public class Table
                 Objects.equals(storage, table.storage) &&
                 Objects.equals(parameters, table.parameters) &&
                 Objects.equals(viewOriginalText, table.viewOriginalText) &&
-                Objects.equals(viewExpandedText, table.viewExpandedText);
+                Objects.equals(viewExpandedText, table.viewExpandedText) &&
+                Objects.equals(lastAccessTime, table.lastAccessTime);
     }
 
     @Override
@@ -209,7 +220,8 @@ public class Table
                 storage,
                 parameters,
                 viewOriginalText,
-                viewExpandedText);
+                viewExpandedText,
+                lastAccessTime);
     }
 
     public static class Builder
@@ -224,6 +236,7 @@ public class Table
         private Map<String, String> parameters = new LinkedHashMap<>();
         private Optional<String> viewOriginalText = Optional.empty();
         private Optional<String> viewExpandedText = Optional.empty();
+        private int lastAccessTime;
 
         private Builder()
         {
@@ -242,6 +255,7 @@ public class Table
             parameters = new LinkedHashMap<>(table.parameters);
             viewOriginalText = table.viewOriginalText;
             viewExpandedText = table.viewExpandedText;
+            lastAccessTime = table.lastAccessTime;
         }
 
         public Builder setDatabaseName(String databaseName)
@@ -315,6 +329,12 @@ public class Table
             return this;
         }
 
+        public Builder setLastAccessTime(int lastAccessTime)
+        {
+            this.lastAccessTime = lastAccessTime;
+            return this;
+        }
+
         public Builder withStorage(Consumer<Storage.Builder> consumer)
         {
             consumer.accept(storageBuilder);
@@ -333,7 +353,8 @@ public class Table
                     partitionColumns,
                     parameters,
                     viewOriginalText,
-                    viewExpandedText);
+                    viewExpandedText,
+                    lastAccessTime);
         }
     }
 }

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/file/PartitionMetadata.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/file/PartitionMetadata.java
@@ -231,6 +231,7 @@ public class PartitionMetadata
                 Optional.empty(),
                 eligibleToIgnore,
                 sealedPartition,
+                0,
                 0);
     }
 }

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/file/TableMetadata.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/file/TableMetadata.java
@@ -333,6 +333,7 @@ public class TableMetadata
                 partitionColumns,
                 parameters,
                 viewOriginalText,
-                viewExpandedText);
+                viewExpandedText,
+                0);
     }
 }

--- a/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/TestRecordingHiveMetastore.java
+++ b/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/TestRecordingHiveMetastore.java
@@ -89,7 +89,8 @@ public class TestRecordingHiveMetastore
             ImmutableList.of(TABLE_COLUMN),
             ImmutableMap.of("param", "value3"),
             Optional.of("original_text"),
-            Optional.of("expanded_text"));
+            Optional.of("expanded_text"),
+            0);
     private static final Partition PARTITION = new Partition(
             "database",
             "table",
@@ -100,6 +101,7 @@ public class TestRecordingHiveMetastore
             Optional.empty(),
             false,
             true,
+            0,
             0);
     private static final PartitionStatistics PARTITION_STATISTICS = new PartitionStatistics(
             new HiveBasicStatistics(10, 11, 10000, 10001),

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveInputInfo.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveInputInfo.java
@@ -13,25 +13,32 @@
  */
 package com.facebook.presto.hive;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
 
+import static java.util.Objects.requireNonNull;
+
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 public class HiveInputInfo
 {
     private final List<String> partitionIds;
     // Code that serialize HiveInputInfo into log would often need the ability to limit the length of log entries.
     // This boolean field allows such code to mark the log entry as length limited.
     private final boolean truncated;
+    public final List<Integer> lastAccessTimes;
 
     @JsonCreator
     public HiveInputInfo(
             @JsonProperty("partitionIds") List<String> partitionIds,
-            @JsonProperty("truncated") boolean truncated)
+            @JsonProperty("truncated") boolean truncated,
+            @JsonProperty("truncated") List<Integer> lastAccessTimes)
     {
         this.partitionIds = partitionIds;
         this.truncated = truncated;
+        this.lastAccessTimes = requireNonNull(lastAccessTimes, "lastAccessTimes is null");
     }
 
     @JsonProperty
@@ -44,5 +51,11 @@ public class HiveInputInfo
     public boolean isTruncated()
     {
         return truncated;
+    }
+
+    @JsonProperty
+    public List<Integer> getLastAccessTimes()
+    {
+        return lastAccessTimes;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -370,6 +370,9 @@ public class HiveMetadata
 
     private static final String PRESTO_TEMPORARY_TABLE_NAME_PREFIX = "__presto_temporary_table_";
 
+    private static final int MAX_NUM_OF_FETCHED_PARTITIONS = 15000;
+    private static final String DUMMY_PARTITION_NAME = "<UNPARTITIONED>";
+
     // Comma is not a reserved keyword with or without quote
     // See https://cwiki.apache.org/confluence/display/Hive/LanguageManual+DDL#LanguageManualDDL-Keywords,Non-reservedKeywordsandReservedKeywords
     private static final char COMMA = ',';
@@ -730,18 +733,88 @@ public class HiveMetadata
     }
 
     @Override
-    public Optional<Object> getInfo(ConnectorTableLayoutHandle layoutHandle)
+    public Optional<Object> getInfo(ConnectorSession session, ConnectorTableLayoutHandle layoutHandle)
     {
         HiveTableLayoutHandle tableLayoutHandle = (HiveTableLayoutHandle) layoutHandle;
-        if (tableLayoutHandle.getPartitions().isPresent()) {
-            return Optional.of(new HiveInputInfo(
-                    tableLayoutHandle.getPartitions().get().stream()
-                            .map(HivePartition::getPartitionId)
-                            .collect(toList()),
-                    false));
+        if (!tableLayoutHandle.getPartitions().isPresent()
+                || 0 == tableLayoutHandle.getPartitions().get().size()) {
+            return Optional.empty();
         }
 
-        return Optional.empty();
+        MetastoreContext metastoreContext = new MetastoreContext(
+                session.getIdentity(),
+                session.getQueryId(),
+                session.getClientInfo(),
+                session.getSource(),
+                getMetastoreHeaders(session),
+                isUserDefinedTypeEncodingEnabled(session),
+                metastore.getColumnConverterProvider());
+
+        if (isUnpartitionedTable(tableLayoutHandle)) {
+            return getHiveInputInfoForUnpartitionedTable(metastoreContext, tableLayoutHandle);
+        }
+        return getHiveInputInfoForPartitionedTable(metastoreContext, tableLayoutHandle);
+    }
+
+    @VisibleForTesting
+    static boolean isUnpartitionedTable(HiveTableLayoutHandle tableLayoutHandle)
+    {
+        List<HivePartition> partitions = tableLayoutHandle.getPartitions().get();
+        if (1 == partitions.size()
+                && 0 == partitions.get(0).getPartitionId().compareTo(DUMMY_PARTITION_NAME)) {
+            return true;
+        }
+        return false;
+    }
+
+    @VisibleForTesting
+    private Optional<Object> getHiveInputInfoForUnpartitionedTable(
+            MetastoreContext metastoreContext, HiveTableLayoutHandle tableLayoutHandle)
+    {
+        Optional<Table> table = metastore.getTable(
+                metastoreContext,
+                tableLayoutHandle.getSchemaTableName().getSchemaName(),
+                tableLayoutHandle.getSchemaTableName().getTableName());
+
+        int lastAccessTime = 0;
+        if (table.isPresent()) {
+            lastAccessTime = table.get().getLastAccessTime();
+        }
+        return Optional.of(new HiveInputInfo(
+                ImmutableList.of(DUMMY_PARTITION_NAME),
+                false,
+                ImmutableList.of(lastAccessTime)));
+    }
+
+    @VisibleForTesting
+    private Optional<Object> getHiveInputInfoForPartitionedTable(
+            MetastoreContext metastoreContext, HiveTableLayoutHandle tableLayoutHandle)
+    {
+        List<String> partitionNames = tableLayoutHandle
+                .getPartitions().get().stream()
+                .map(HivePartition::getPartitionId)
+                .limit(MAX_NUM_OF_FETCHED_PARTITIONS)
+                .collect(toList());
+
+        Map<String, Optional<Partition>> partitions = metastore.getPartitionsByNames(
+                metastoreContext,
+                tableLayoutHandle.getSchemaTableName().getSchemaName(),
+                tableLayoutHandle.getSchemaTableName().getTableName(),
+                partitionNames);
+
+        List<Integer> lastAccessTimes = partitionNames.stream()
+                .map(partitionName -> partitions.get(partitionName))
+                .map(partition -> {
+                    if (partition.isPresent()) {
+                        return partition.get().getLastAccessTime();
+                    }
+                    else {
+                        return 0;
+                    }
+                })
+                .collect(toList());
+
+        return Optional.of(new HiveInputInfo(partitionNames, false, lastAccessTimes));
     }
 
     @Override

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestAbstractDwrfEncryptionInformationSource.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestAbstractDwrfEncryptionInformationSource.java
@@ -69,7 +69,8 @@ public class TestAbstractDwrfEncryptionInformationSource
                 isPartitioned ? ImmutableList.of(new Column("ds", HIVE_STRING, Optional.empty(), Optional.empty())) : ImmutableList.of(),
                 tableEncryptionProperties.map(DwrfTableEncryptionProperties::toHiveProperties).orElse(ImmutableMap.of()),
                 Optional.empty(),
-                Optional.empty());
+                Optional.empty(),
+                0);
     }
 
     @Test
@@ -109,8 +110,8 @@ public class TestAbstractDwrfEncryptionInformationSource
                                 ImmutableList.of(new Subfield("col_struct.a"), new Subfield("col_struct.b.b2")),
                                 Optional.empty()))),
                 ImmutableMap.of(
-                        "ds=2020-01-01", new Partition("dbName", "tableName", ImmutableList.of("2020-01-01"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty(), false, true, 0),
-                        "ds=2020-01-02", new Partition("dbName", "tableName", ImmutableList.of("2020-01-02"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty(), false, true, 0)));
+                        "ds=2020-01-01", new Partition("dbName", "tableName", ImmutableList.of("2020-01-01"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty(), false, true, 0, 0),
+                        "ds=2020-01-02", new Partition("dbName", "tableName", ImmutableList.of("2020-01-02"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty(), false, true, 0, 0)));
 
         assertTrue(encryptionInformation.isPresent());
         assertEquals(
@@ -129,8 +130,8 @@ public class TestAbstractDwrfEncryptionInformationSource
                 table,
                 Optional.of(ImmutableSet.of()),
                 ImmutableMap.of(
-                        "ds=2020-01-01", new Partition("dbName", "tableName", ImmutableList.of("2020-01-01"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty(), false, true, 0),
-                        "ds=2020-01-02", new Partition("dbName", "tableName", ImmutableList.of("2020-01-02"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty(), false, true, 0)));
+                        "ds=2020-01-01", new Partition("dbName", "tableName", ImmutableList.of("2020-01-01"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty(), false, true, 0, 0),
+                        "ds=2020-01-02", new Partition("dbName", "tableName", ImmutableList.of("2020-01-02"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty(), false, true, 0, 0)));
 
         assertTrue(encryptionInformation.isPresent());
         assertEquals(
@@ -161,8 +162,8 @@ public class TestAbstractDwrfEncryptionInformationSource
                                 ImmutableList.of(new Subfield("col_struct.a"), new Subfield("col_struct.b.b2")),
                                 Optional.empty()))),
                 ImmutableMap.of(
-                        "ds=2020-01-01", new Partition("dbName", "tableName", ImmutableList.of("2020-01-01"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty(), false, true, 0),
-                        "ds=2020-01-02", new Partition("dbName", "tableName", ImmutableList.of("2020-01-02"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty(), false, true, 0)));
+                        "ds=2020-01-01", new Partition("dbName", "tableName", ImmutableList.of("2020-01-01"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty(), false, true, 0, 0),
+                        "ds=2020-01-02", new Partition("dbName", "tableName", ImmutableList.of("2020-01-02"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty(), false, true, 0, 0)));
 
         Map<String, byte[]> expectedFieldToKeyData = ImmutableMap.of("col_bigint", "key2".getBytes(), "col_struct.a", "key2".getBytes(), "col_struct.b.b2", "key1".getBytes());
         assertTrue(encryptionInformation.isPresent());

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveEncryptionInformationProvider.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveEncryptionInformationProvider.java
@@ -52,7 +52,8 @@ public class TestHiveEncryptionInformationProvider
             ImmutableList.of(),
             ImmutableMap.of(),
             Optional.empty(),
-            Optional.empty());
+            Optional.empty(),
+            0);
 
     @Test
     public void testNoOneReturns()

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMaterializedViewUtils.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMaterializedViewUtils.java
@@ -634,7 +634,8 @@ public class TestHiveMaterializedViewUtils
                 partitionColumns,
                 ImmutableMap.of(),
                 Optional.empty(),
-                Optional.empty());
+                Optional.empty(),
+                0);
     }
 
     private static class TestingPartitionResult

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePartitionManager.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePartitionManager.java
@@ -78,7 +78,8 @@ public class TestHivePartitionManager
             ImmutableList.of(PARTITION_COLUMN),
             ImmutableMap.of(),
             Optional.empty(),
-            Optional.empty());
+            Optional.empty(),
+            0);
 
     private static final List<String> PARTITIONS = ImmutableList.of("ds=2019-07-23", "ds=2019-08-23");
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitManager.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitManager.java
@@ -149,7 +149,8 @@ public class TestHiveSplitManager
             ImmutableList.of(new Column("ds", HIVE_STRING, Optional.empty(), Optional.empty())),
             ImmutableMap.of(),
             Optional.empty(),
-            Optional.empty());
+            Optional.empty(),
+            0);
 
     private ListeningExecutorService executor;
 
@@ -471,6 +472,7 @@ public class TestHiveSplitManager
                         Optional.empty(),
                         false,
                         true,
+                        0,
                         0),
                 PARTITION_NAME,
                 partitionStatistics);

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHudiDirectoryLister.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHudiDirectoryLister.java
@@ -82,7 +82,8 @@ public class TestHudiDirectoryLister
                 ImmutableList.of(),
                 ImmutableMap.of(),
                 Optional.empty(),
-                Optional.empty());
+                Optional.empty(),
+                0);
 
         HudiDirectoryLister directoryLister = new HudiDirectoryLister(hadoopConf, SESSION, mockTable);
         HoodieTableMetaClient metaClient = directoryLister.getMetaClient();
@@ -118,7 +119,8 @@ public class TestHudiDirectoryLister
                 ImmutableList.of(),
                 ImmutableMap.of(),
                 Optional.empty(),
-                Optional.empty());
+                Optional.empty(),
+                0);
 
         assertThrows(TableNotFoundException.class, () -> new HudiDirectoryLister(hadoopConf, SESSION, mockTable));
     }

--- a/presto-main/src/main/java/com/facebook/presto/event/QueryMonitor.java
+++ b/presto-main/src/main/java/com/facebook/presto/event/QueryMonitor.java
@@ -414,7 +414,8 @@ public class QueryMonitor
                             queryInfo.getOutput().get().getSchema(),
                             queryInfo.getOutput().get().getTable(),
                             tableFinishInfo.map(TableFinishInfo::getSerializedConnectorOutputMetadata),
-                            tableFinishInfo.map(TableFinishInfo::isJsonLengthLimitExceeded)));
+                            tableFinishInfo.map(TableFinishInfo::isJsonLengthLimitExceeded),
+                            queryInfo.getOutput().get().getLastDataCommitTimes()));
         }
         return new QueryIOMetadata(inputs.build(), output);
     }

--- a/presto-main/src/main/java/com/facebook/presto/execution/Output.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/Output.java
@@ -16,9 +16,11 @@ package com.facebook.presto.execution;
 import com.facebook.presto.spi.ConnectorId;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.joda.time.DateTime;
 
 import javax.annotation.concurrent.Immutable;
 
+import java.util.List;
 import java.util.Objects;
 
 import static java.util.Objects.requireNonNull;
@@ -29,16 +31,20 @@ public final class Output
     private final ConnectorId connectorId;
     private final String schema;
     private final String table;
+    private List<DateTime> lastDataCommitTimes;
 
     @JsonCreator
     public Output(
             @JsonProperty("connectorId") ConnectorId connectorId,
             @JsonProperty("schema") String schema,
-            @JsonProperty("table") String table)
+            @JsonProperty("table") String table,
+            @JsonProperty("lastDataCommitTimes") List<DateTime> lastDataCommitTimes)
     {
         this.connectorId = requireNonNull(connectorId, "connectorId is null");
         this.schema = requireNonNull(schema, "schema is null");
         this.table = requireNonNull(table, "table is null");
+        this.lastDataCommitTimes = requireNonNull(
+                lastDataCommitTimes, "lastDataCommitTimes is null");
     }
 
     @JsonProperty
@@ -59,6 +65,12 @@ public final class Output
         return table;
     }
 
+    @JsonProperty
+    public List<DateTime> getLastDataCommitTimes()
+    {
+        return lastDataCommitTimes;
+    }
+
     @Override
     public boolean equals(Object o)
     {
@@ -71,12 +83,13 @@ public final class Output
         Output output = (Output) o;
         return Objects.equals(connectorId, output.connectorId) &&
                 Objects.equals(schema, output.schema) &&
-                Objects.equals(table, output.table);
+                Objects.equals(table, output.table) &&
+                Objects.equals(lastDataCommitTimes, output.lastDataCommitTimes);
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(connectorId, schema, table);
+        return Objects.hash(connectorId, schema, table, lastDataCommitTimes);
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
@@ -487,7 +487,7 @@ public class MetadataManager
     {
         ConnectorId connectorId = handle.getConnectorId();
         ConnectorMetadata metadata = getMetadata(session, connectorId);
-        return handle.getLayout().flatMap(tableLayout -> metadata.getInfo(tableLayout));
+        return handle.getLayout().flatMap(tableLayout -> metadata.getInfo(session.toConnectorSession(), tableLayout));
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/OutputExtractor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/OutputExtractor.java
@@ -21,6 +21,7 @@ import com.facebook.presto.sql.planner.plan.InternalPlanVisitor;
 import com.facebook.presto.sql.planner.plan.TableWriterNode;
 import com.google.common.base.VerifyException;
 
+import java.util.Collections;
 import java.util.Optional;
 
 import static com.google.common.base.Preconditions.checkState;
@@ -39,7 +40,8 @@ public class OutputExtractor
         return Optional.of(new Output(
                 visitor.getConnectorId(),
                 visitor.getSchemaTableName().getSchemaName(),
-                visitor.getSchemaTableName().getTableName()));
+                visitor.getSchemaTableName().getTableName(),
+                Collections.emptyList()));
     }
 
     private class Visitor

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestOutput.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestOutput.java
@@ -17,6 +17,8 @@ import com.facebook.airlift.json.JsonCodec;
 import com.facebook.presto.spi.ConnectorId;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
+
 import static org.testng.Assert.assertEquals;
 
 public class TestOutput
@@ -26,7 +28,11 @@ public class TestOutput
     @Test
     public void testRoundTrip()
     {
-        Output expected = new Output(new ConnectorId("connectorId"), "schema", "table");
+        Output expected = new Output(
+                new ConnectorId("connectorId"),
+                "schema",
+                "table",
+                Collections.emptyList());
 
         String json = codec.toJson(expected);
         Output actual = codec.fromJson(json);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorCommitHandle.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorCommitHandle.java
@@ -13,6 +13,14 @@
  */
 package com.facebook.presto.spi.connector;
 
+import com.facebook.presto.spi.SchemaTableName;
+
+import java.util.Collections;
+
 public interface ConnectorCommitHandle
 {
+    default Object getLastDataCommitTimes(SchemaTableName table)
+    {
+        return Collections.emptyList();
+    }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
@@ -206,7 +206,7 @@ public interface ConnectorMetadata
      *
      * @throws RuntimeException if table handle is no longer valid
      */
-    default Optional<Object> getInfo(ConnectorTableLayoutHandle layoutHandle)
+    default Optional<Object> getInfo(ConnectorSession session, ConnectorTableLayoutHandle layoutHandle)
     {
         return Optional.empty();
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -246,10 +246,10 @@ public class ClassLoaderSafeConnectorMetadata
     }
 
     @Override
-    public Optional<Object> getInfo(ConnectorTableLayoutHandle table)
+    public Optional<Object> getInfo(ConnectorSession session, ConnectorTableLayoutHandle table)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getInfo(table);
+            return delegate.getInfo(session, table);
         }
     }
 

--- a/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/QueryOutputMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/eventlistener/QueryOutputMetadata.java
@@ -28,13 +28,22 @@ public class QueryOutputMetadata
     private final Optional<String> connectorOutputMetadata;
     private final Optional<Boolean> jsonLengthLimitExceeded;
 
-    public QueryOutputMetadata(String catalogName, String schema, String table, Optional<String> connectorOutputMetadata, Optional<Boolean> jsonLengthLimitExceeded)
+    private final Object lastDataCommitTimes;
+
+    public QueryOutputMetadata(
+            String catalogName,
+            String schema,
+            String table,
+            Optional<String> connectorOutputMetadata,
+            Optional<Boolean> jsonLengthLimitExceeded,
+            Object lastDataCommitTimes)
     {
         this.catalogName = requireNonNull(catalogName, "catalogName is null");
         this.schema = requireNonNull(schema, "schema is null");
         this.table = requireNonNull(table, "table is null");
         this.connectorOutputMetadata = requireNonNull(connectorOutputMetadata, "connectorOutputMetadata is null");
         this.jsonLengthLimitExceeded = requireNonNull(jsonLengthLimitExceeded, "jsonLengthLimitExceeded is null");
+        this.lastDataCommitTimes = requireNonNull(lastDataCommitTimes, "lastDataCommitTimes is null");
     }
 
     @JsonProperty
@@ -65,5 +74,11 @@ public class QueryOutputMetadata
     public Optional<Boolean> getJsonLengthLimitExceeded()
     {
         return jsonLengthLimitExceeded;
+    }
+
+    @JsonProperty
+    public Object getLastDataCommitTimes()
+    {
+        return lastDataCommitTimes;
     }
 }


### PR DESCRIPTION
After Input information has been parsed, we fetch information about the data access time for the input table/partitions from metastore, and store them into QueryInputMetadata.

```
== NO RELEASE NOTE ==
```
