### PR TITLE
Optimize byte[] asserts in TestOrcOutputBuffer

### DIFF
--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcOutputBuffer.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcOutputBuffer.java
@@ -321,7 +321,7 @@ public class TestOrcOutputBuffer
         List<Integer> expectedSizes = expectedChunkSizes.stream().map(size -> (int) size.toBytes()).collect(toList());
 
         DecompressionResult result = decompress(output.slice());
-        assertEquals(result.bytes, expectedBytes);
+        assertEquals(wrappedBuffer(result.bytes), wrappedBuffer(expectedBytes));
         assertEquals(result.sizes, expectedSizes);
     }
 


### PR DESCRIPTION
Currently used TestNG 6.10 doesn't have performant assertEquals for arrays, which were added in 6.11. In this change I switched a _heavy_ testWriteBytes test case to do byte array assertions using a Slice similar to other  methods in this test. This change reduces testWriteBytes run time from 3+ minutes to 30 seconds.

I also didn't manage to update TestNG dependency successfully due to 6.14 having a bit different execution model for parallel test execution.

Test plan:
- existing tests

```
== NO RELEASE NOTE ==
```
