### PR TITLE
Add flat map config to OrcWriter

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriterOptions.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriterOptions.java
@@ -16,10 +16,12 @@ package com.facebook.presto.orc;
 import com.facebook.presto.orc.metadata.DwrfStripeCacheMode;
 import com.facebook.presto.orc.writer.StreamLayoutFactory;
 import com.facebook.presto.orc.writer.StreamLayoutFactory.ColumnSizeLayoutFactory;
+import com.google.common.collect.ImmutableSet;
 import io.airlift.units.DataSize;
 
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.Set;
 
 import static com.facebook.presto.orc.metadata.DwrfStripeCacheMode.INDEX_AND_FOOTER;
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -63,6 +65,11 @@ public class OrcWriterOptions
     private final Optional<DwrfStripeCacheOptions> dwrfWriterOptions;
     private final int preserveDirectEncodingStripeCount;
 
+    /**
+     * Contains indexes of columns (not nodes!) for which writer should use flattened encoding, e.g. flat maps.
+     */
+    private final Set<Integer> flattenedColumns;
+
     private OrcWriterOptions(
             OrcWriterFlushPolicy flushPolicy,
             int rowGroupMaxRowCount,
@@ -79,7 +86,8 @@ public class OrcWriterOptions
             boolean stringDictionaryEncodingEnabled,
             Optional<DwrfStripeCacheOptions> dwrfWriterOptions,
             boolean ignoreDictionaryRowGroupSizes,
-            int preserveDirectEncodingStripeCount)
+            int preserveDirectEncodingStripeCount,
+            Set<Integer> flattenedColumns)
     {
         requireNonNull(flushPolicy, "flushPolicy is null");
         checkArgument(rowGroupMaxRowCount >= 1, "rowGroupMaxRowCount must be at least 1");
@@ -91,6 +99,7 @@ public class OrcWriterOptions
         requireNonNull(compressionLevel, "compressionLevel is null");
         requireNonNull(streamLayoutFactory, "streamLayoutFactory is null");
         requireNonNull(dwrfWriterOptions, "dwrfWriterOptions is null");
+        requireNonNull(flattenedColumns, "flattenedColumns is null");
 
         this.flushPolicy = flushPolicy;
         this.rowGroupMaxRowCount = rowGroupMaxRowCount;
@@ -108,6 +117,7 @@ public class OrcWriterOptions
         this.dwrfWriterOptions = dwrfWriterOptions;
         this.ignoreDictionaryRowGroupSizes = ignoreDictionaryRowGroupSizes;
         this.preserveDirectEncodingStripeCount = preserveDirectEncodingStripeCount;
+        this.flattenedColumns = flattenedColumns;
     }
 
     public OrcWriterFlushPolicy getFlushPolicy()
@@ -190,6 +200,11 @@ public class OrcWriterOptions
         return preserveDirectEncodingStripeCount;
     }
 
+    public Set<Integer> getFlattenedColumns()
+    {
+        return flattenedColumns;
+    }
+
     @Override
     public String toString()
     {
@@ -210,6 +225,7 @@ public class OrcWriterOptions
                 .add("dwrfWriterOptions", dwrfWriterOptions)
                 .add("ignoreDictionaryRowGroupSizes", ignoreDictionaryRowGroupSizes)
                 .add("preserveDirectEncodingStripeCount", preserveDirectEncodingStripeCount)
+                .add("flattenedColumns", flattenedColumns)
                 .toString();
     }
 
@@ -243,6 +259,7 @@ public class OrcWriterOptions
         private DataSize dwrfStripeCacheMaxSize = DEFAULT_DWRF_STRIPE_CACHE_MAX_SIZE;
         private boolean ignoreDictionaryRowGroupSizes;
         private int preserveDirectEncodingStripeCount = DEFAULT_PRESERVE_DIRECT_ENCODING_STRIPE_COUNT;
+        private Set<Integer> flattenedColumns = ImmutableSet.of();
 
         public Builder withFlushPolicy(OrcWriterFlushPolicy flushPolicy)
         {
@@ -354,6 +371,12 @@ public class OrcWriterOptions
             return this;
         }
 
+        public Builder withFlattenedColumns(Set<Integer> flattenedColumns)
+        {
+            this.flattenedColumns = ImmutableSet.copyOf(flattenedColumns);
+            return this;
+        }
+
         public OrcWriterOptions build()
         {
             Optional<DwrfStripeCacheOptions> dwrfWriterOptions;
@@ -380,7 +403,8 @@ public class OrcWriterOptions
                     stringDictionaryEncodingEnabled,
                     dwrfWriterOptions,
                     ignoreDictionaryRowGroupSizes,
-                    preserveDirectEncodingStripeCount);
+                    preserveDirectEncodingStripeCount,
+                    flattenedColumns);
         }
     }
 }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcWriterOptions.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcWriterOptions.java
@@ -17,6 +17,7 @@ import com.facebook.presto.orc.metadata.DwrfStripeCacheMode;
 import com.facebook.presto.orc.writer.StreamLayoutFactory;
 import com.facebook.presto.orc.writer.StreamLayoutFactory.ColumnSizeLayoutFactory;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import io.airlift.units.DataSize;
 import org.testng.annotations.Test;
 
@@ -58,6 +59,14 @@ public class TestOrcWriterOptions
     }
 
     @Test
+    public void tesDefaultValues()
+    {
+        OrcWriterOptions options = OrcWriterOptions.builder().build();
+
+        assertEquals(ImmutableSet.of(), options.getFlattenedColumns());
+    }
+
+    @Test
     public void testProperties()
     {
         DataSize stripeMinSize = new DataSize(13, MEGABYTE);
@@ -95,7 +104,8 @@ public class TestOrcWriterOptions
                 .withIntegerDictionaryEncodingEnabled(integerDictionaryEncodingEnabled)
                 .withStringDictionarySortingEnabled(stringDictionarySortingEnabled)
                 .withStringDictionaryEncodingEnabled(stringDictionaryEncodingEnabled)
-                .withPreserveDirectEncodingStripeCount(preserveDirectEncodingStripeCount);
+                .withPreserveDirectEncodingStripeCount(preserveDirectEncodingStripeCount)
+                .withFlattenedColumns(ImmutableSet.of(4, 3));
 
         OrcWriterOptions options = builder.build();
 
@@ -116,6 +126,7 @@ public class TestOrcWriterOptions
         assertEquals(stringDictionaryEncodingEnabled, options.isStringDictionaryEncodingEnabled());
         assertEquals(Optional.empty(), options.getDwrfStripeCacheOptions());
         assertEquals(preserveDirectEncodingStripeCount, options.getPreserveDirectEncodingStripeCount());
+        assertEquals(ImmutableSet.of(4, 3), options.getFlattenedColumns());
     }
 
     @Test
@@ -160,6 +171,7 @@ public class TestOrcWriterOptions
                 .withDwrfStripeCacheMaxSize(dwrfStripeCacheMaxSize)
                 .withDwrfStripeCacheMode(dwrfStripeCacheMode)
                 .withPreserveDirectEncodingStripeCount(preserveDirectEncodingStripeCount)
+                .withFlattenedColumns(ImmutableSet.of(4))
                 .build();
 
         String expectedString = "OrcWriterOptions{flushPolicy=DefaultOrcWriterFlushPolicy{stripeMaxRowCount=1100000, " +
@@ -169,7 +181,7 @@ public class TestOrcWriterOptions
                 "compressionLevel=OptionalInt[5], streamLayoutFactory=ColumnSizeLayoutFactory{}, integerDictionaryEncodingEnabled=false, " +
                 "stringDictionarySortingEnabled=true, stringDictionaryEncodingEnabled=true, " +
                 "dwrfWriterOptions=Optional[DwrfStripeCacheOptions{stripeCacheMode=INDEX_AND_FOOTER, stripeCacheMaxSize=4MB}], " +
-                "ignoreDictionaryRowGroupSizes=false, preserveDirectEncodingStripeCount=0}";
+                "ignoreDictionaryRowGroupSizes=false, preserveDirectEncodingStripeCount=0, flattenedColumns=[4]}";
         assertEquals(expectedString, writerOptions.toString());
     }
 }


### PR DESCRIPTION
Add a simple way to indicate which column needs to use flat encoding. 

As of now we do not have plans to extend flat encoding to any sub field, only columns are going to be using flat encoding. Integration with the metastore + enable/disable session property will be done as last steps.

Test plan:
- existing tests
- full integration with e2e tests will be added in the subsequent PRs.

```
== NO RELEASE NOTE ==
```
