### PR TITLE
Add support to pass appendRowNumber  to HiveClientConfig

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -217,6 +217,7 @@ public class HiveClientConfig
 
     private boolean columnIndexFilterEnabled;
     private boolean fileSplittable = true;
+    private boolean isAppendRowNumberEnabled;
 
     @Min(0)
     public int getMaxInitialSplits()
@@ -1824,6 +1825,19 @@ public class HiveClientConfig
     public boolean isFileSplittable()
     {
         return fileSplittable;
+    }
+
+    @Config("hive.append-row-number-enabled")
+    @ConfigDescription("enable appending row number config")
+    public HiveClientConfig setAppendRowNumberEnabled(boolean isAppendRowNumberEnabled)
+    {
+        this.isAppendRowNumberEnabled = isAppendRowNumberEnabled;
+        return this;
+    }
+
+    public boolean isAppendRowNumberEnabled()
+    {
+        return isAppendRowNumberEnabled;
     }
 
     @Config("hive.file-splittable")

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSessionProperties.java
@@ -139,6 +139,7 @@ public final class HiveSessionProperties
     public static final String MAX_INITIAL_SPLITS = "max_initial_splits";
     public static final String FILE_SPLITTABLE = "file_splittable";
     private static final String HUDI_METADATA_ENABLED = "hudi_metadata_enabled";
+    private static final String APPEND_ROW_NUMBER_ENABLED = "append_row_number_enabled";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -670,6 +671,11 @@ public final class HiveSessionProperties
                         HUDI_METADATA_ENABLED,
                         "For Hudi tables prefer to fetch the list of file names, sizes and other metadata from the internal metadata table rather than storage",
                         hiveClientConfig.isHudiMetadataEnabled(),
+                        false),
+                booleanProperty(
+                        APPEND_ROW_NUMBER_ENABLED,
+                        "If set to true, row number (long) column is appended",
+                        hiveClientConfig.isAppendRowNumberEnabled(),
                         false));
     }
 
@@ -1169,5 +1175,10 @@ public final class HiveSessionProperties
     public static boolean isHudiMetadataEnabled(ConnectorSession session)
     {
         return session.getProperty(HUDI_METADATA_ENABLED, Boolean.class);
+    }
+
+    public static boolean isAppendRowNumberEnabled(ConnectorSession session)
+    {
+        return session.getProperty(APPEND_ROW_NUMBER_ENABLED, Boolean.class);
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcSelectivePageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcSelectivePageSourceFactory.java
@@ -115,6 +115,7 @@ import static com.facebook.presto.hive.HiveSessionProperties.getOrcMaxReadBlockS
 import static com.facebook.presto.hive.HiveSessionProperties.getOrcStreamBufferSize;
 import static com.facebook.presto.hive.HiveSessionProperties.getOrcTinyStripeThreshold;
 import static com.facebook.presto.hive.HiveSessionProperties.isAdaptiveFilterReorderingEnabled;
+import static com.facebook.presto.hive.HiveSessionProperties.isAppendRowNumberEnabled;
 import static com.facebook.presto.hive.HiveSessionProperties.isOrcBloomFiltersEnabled;
 import static com.facebook.presto.hive.HiveSessionProperties.isOrcZstdJniDecompressionEnabled;
 import static com.facebook.presto.hive.HiveUtil.getPhysicalHiveColumnHandles;
@@ -295,7 +296,12 @@ public class OrcSelectivePageSourceFactory
         DataSize streamBufferSize = getOrcStreamBufferSize(session);
         DataSize tinyStripeThreshold = getOrcTinyStripeThreshold(session);
         DataSize maxReadBlockSize = getOrcMaxReadBlockSize(session);
-        OrcReaderOptions orcReaderOptions = new OrcReaderOptions(maxMergeDistance, tinyStripeThreshold, maxReadBlockSize, isOrcZstdJniDecompressionEnabled(session));
+        boolean appendRowNumberEnabled = isAppendRowNumberEnabled(session);
+        OrcReaderOptions orcReaderOptions = new OrcReaderOptions(maxMergeDistance,
+                tinyStripeThreshold,
+                maxReadBlockSize,
+                isOrcZstdJniDecompressionEnabled(session),
+                appendRowNumberEnabled);
         boolean lazyReadSmallRanges = getOrcLazyReadSmallRanges(session);
 
         OrcDataSource orcDataSource;

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSessionProperties.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSessionProperties.java
@@ -20,6 +20,7 @@ import com.facebook.presto.testing.TestingConnectorSession;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.hive.HiveSessionProperties.getNodeSelectionStrategy;
+import static com.facebook.presto.hive.HiveSessionProperties.isAppendRowNumberEnabled;
 import static com.facebook.presto.hive.HiveSessionProperties.isCacheEnabled;
 import static com.facebook.presto.spi.schedule.NodeSelectionStrategy.HARD_AFFINITY;
 import static com.facebook.presto.spi.schedule.NodeSelectionStrategy.NO_PREFERENCE;
@@ -62,6 +63,18 @@ public class TestHiveSessionProperties
                         new ParquetFileWriterConfig(),
                         new CacheConfig()).getSessionProperties());
         assertEquals(getNodeSelectionStrategy(connectorSession), HARD_AFFINITY);
+    }
+
+    @Test
+    public void testAppendRowNumberConfig()
+    {
+        ConnectorSession connectorSession = new TestingConnectorSession(
+                new HiveSessionProperties(
+                        new HiveClientConfig().setAppendRowNumberEnabled(true),
+                        new OrcFileWriterConfig(),
+                        new ParquetFileWriterConfig(),
+                        new CacheConfig()).getSessionProperties());
+        assertTrue(isAppendRowNumberEnabled(connectorSession));
     }
 
     @Test


### PR DESCRIPTION
Add support to HiveClientConfig and HiveSessionProperties to enable adding 
row number column 

```
Test plan
```
Added unit tests 

```
== NO RELEASE NOTE ==
```
