### PR TITLE
Support Hive metastore impersonation for no-auth

### DIFF
--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/MetastoreClientConfig.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/MetastoreClientConfig.java
@@ -50,6 +50,7 @@ public class MetastoreClientConfig
     private boolean metastoreImpersonationEnabled;
     private double partitionCacheValidationPercentage;
     private int partitionCacheColumnCountLimit = 500;
+    private HiveMetastoreAuthenticationType hiveMetastoreAuthenticationType = HiveMetastoreAuthenticationType.NONE;
 
     public HostAndPort getMetastoreSocksProxy()
     {
@@ -266,6 +267,26 @@ public class MetastoreClientConfig
     public MetastoreClientConfig setPartitionCacheColumnCountLimit(int partitionCacheColumnCountLimit)
     {
         this.partitionCacheColumnCountLimit = partitionCacheColumnCountLimit;
+        return this;
+    }
+
+    public enum HiveMetastoreAuthenticationType
+    {
+        NONE,
+        KERBEROS
+    }
+
+    @NotNull
+    public HiveMetastoreAuthenticationType getHiveMetastoreAuthenticationType()
+    {
+        return hiveMetastoreAuthenticationType;
+    }
+
+    @Config("hive.metastore.authentication.type")
+    @ConfigDescription("Hive Metastore authentication type")
+    public MetastoreClientConfig setHiveMetastoreAuthenticationType(HiveMetastoreAuthenticationType hiveMetastoreAuthenticationType)
+    {
+        this.hiveMetastoreAuthenticationType = hiveMetastoreAuthenticationType;
         return this;
     }
 }

--- a/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/TestMetastoreClientConfig.java
+++ b/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/TestMetastoreClientConfig.java
@@ -15,6 +15,7 @@ package com.facebook.presto.hive.metastore;
 
 import com.facebook.airlift.configuration.testing.ConfigAssertions;
 import com.facebook.presto.hive.MetastoreClientConfig;
+import com.facebook.presto.hive.MetastoreClientConfig.HiveMetastoreAuthenticationType;
 import com.facebook.presto.hive.metastore.CachingHiveMetastore.MetastoreCacheScope;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.net.HostAndPort;
@@ -46,7 +47,8 @@ public class TestMetastoreClientConfig
                 .setMetastoreCacheScope(MetastoreCacheScope.ALL)
                 .setMetastoreImpersonationEnabled(false)
                 .setPartitionCacheValidationPercentage(0)
-                .setPartitionCacheColumnCountLimit(500));
+                .setPartitionCacheColumnCountLimit(500)
+                .setHiveMetastoreAuthenticationType(HiveMetastoreAuthenticationType.NONE));
     }
 
     @Test
@@ -70,6 +72,7 @@ public class TestMetastoreClientConfig
                 .put("hive.metastore-impersonation-enabled", "true")
                 .put("hive.partition-cache-validation-percentage", "60.0")
                 .put("hive.partition-cache-column-count-limit", "50")
+                .put("hive.metastore.authentication.type", "KERBEROS")
                 .build();
 
         MetastoreClientConfig expected = new MetastoreClientConfig()
@@ -89,7 +92,8 @@ public class TestMetastoreClientConfig
                 .setMetastoreCacheScope(MetastoreCacheScope.PARTITION)
                 .setMetastoreImpersonationEnabled(true)
                 .setPartitionCacheValidationPercentage(60.0)
-                .setPartitionCacheColumnCountLimit(50);
+                .setPartitionCacheColumnCountLimit(50)
+                .setHiveMetastoreAuthenticationType(HiveMetastoreAuthenticationType.KERBEROS);
 
         ConfigAssertions.assertFullMapping(properties, expected);
     }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveClientConfig.java
@@ -130,7 +130,6 @@ public class HiveClientConfig
     private boolean rcfileOptimizedWriterEnabled = true;
     private boolean rcfileWriterValidate;
 
-    private HiveMetastoreAuthenticationType hiveMetastoreAuthenticationType = HiveMetastoreAuthenticationType.NONE;
     private HdfsAuthenticationType hdfsAuthenticationType = HdfsAuthenticationType.NONE;
     private boolean hdfsImpersonationEnabled;
     private boolean hdfsWireEncryptionEnabled;
@@ -1059,26 +1058,6 @@ public class HiveClientConfig
     public HiveClientConfig setFileStatusCacheExpireAfterWrite(Duration fileStatusCacheExpireAfterWrite)
     {
         this.fileStatusCacheExpireAfterWrite = fileStatusCacheExpireAfterWrite;
-        return this;
-    }
-
-    public enum HiveMetastoreAuthenticationType
-    {
-        NONE,
-        KERBEROS
-    }
-
-    @NotNull
-    public HiveMetastoreAuthenticationType getHiveMetastoreAuthenticationType()
-    {
-        return hiveMetastoreAuthenticationType;
-    }
-
-    @Config("hive.metastore.authentication.type")
-    @ConfigDescription("Hive Metastore authentication type")
-    public HiveClientConfig setHiveMetastoreAuthenticationType(HiveMetastoreAuthenticationType hiveMetastoreAuthenticationType)
-    {
-        this.hiveMetastoreAuthenticationType = hiveMetastoreAuthenticationType;
         return this;
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/authentication/HiveAuthenticationModule.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/authentication/HiveAuthenticationModule.java
@@ -16,7 +16,8 @@ package com.facebook.presto.hive.authentication;
 import com.facebook.airlift.configuration.AbstractConfigurationAwareModule;
 import com.facebook.presto.hive.HiveClientConfig;
 import com.facebook.presto.hive.HiveClientConfig.HdfsAuthenticationType;
-import com.facebook.presto.hive.HiveClientConfig.HiveMetastoreAuthenticationType;
+import com.facebook.presto.hive.MetastoreClientConfig;
+import com.facebook.presto.hive.MetastoreClientConfig.HiveMetastoreAuthenticationType;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 
@@ -36,11 +37,11 @@ public class HiveAuthenticationModule
     @Override
     protected void setup(Binder binder)
     {
-        bindAuthenticationModule(
+        bindMetastoreAuthenticationModule(
                 config -> config.getHiveMetastoreAuthenticationType() == HiveMetastoreAuthenticationType.NONE,
                 noHiveMetastoreAuthenticationModule());
 
-        bindAuthenticationModule(
+        bindMetastoreAuthenticationModule(
                 config -> config.getHiveMetastoreAuthenticationType() == HiveMetastoreAuthenticationType.KERBEROS,
                 kerberosHiveMetastoreAuthenticationModule());
 
@@ -64,6 +65,11 @@ public class HiveAuthenticationModule
     private void bindAuthenticationModule(Predicate<HiveClientConfig> predicate, Module module)
     {
         install(installModuleIf(HiveClientConfig.class, predicate, module));
+    }
+
+    private void bindMetastoreAuthenticationModule(Predicate<MetastoreClientConfig> predicate, Module module)
+    {
+        install(installModuleIf(MetastoreClientConfig.class, predicate, module));
     }
 
     private static boolean noHdfsAuth(HiveClientConfig config)

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveClientConfig.java
@@ -15,7 +15,6 @@ package com.facebook.presto.hive;
 
 import com.facebook.airlift.configuration.testing.ConfigAssertions;
 import com.facebook.presto.hive.HiveClientConfig.HdfsAuthenticationType;
-import com.facebook.presto.hive.HiveClientConfig.HiveMetastoreAuthenticationType;
 import com.facebook.presto.hive.s3.S3FileSystemType;
 import com.facebook.presto.orc.OrcWriteValidation.OrcWriteValidationMode;
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
@@ -103,7 +102,6 @@ public class TestHiveClientConfig
                 .setOrcOptimizedWriterEnabled(true)
                 .setOrcWriterValidationPercentage(0.0)
                 .setOrcWriterValidationMode(OrcWriteValidationMode.BOTH)
-                .setHiveMetastoreAuthenticationType(HiveMetastoreAuthenticationType.NONE)
                 .setHdfsAuthenticationType(HdfsAuthenticationType.NONE)
                 .setHdfsImpersonationEnabled(false)
                 .setSkipDeletionForAlter(false)
@@ -228,7 +226,6 @@ public class TestHiveClientConfig
                 .put("hive.orc.optimized-writer.enabled", "false")
                 .put("hive.orc.writer.validation-percentage", "0.16")
                 .put("hive.orc.writer.validation-mode", "DETAILED")
-                .put("hive.metastore.authentication.type", "KERBEROS")
                 .put("hive.hdfs.authentication.type", "KERBEROS")
                 .put("hive.hdfs.impersonation.enabled", "true")
                 .put("hive.skip-deletion-for-alter", "true")
@@ -350,7 +347,6 @@ public class TestHiveClientConfig
                 .setOrcOptimizedWriterEnabled(false)
                 .setOrcWriterValidationPercentage(0.16)
                 .setOrcWriterValidationMode(OrcWriteValidationMode.DETAILED)
-                .setHiveMetastoreAuthenticationType(HiveMetastoreAuthenticationType.KERBEROS)
                 .setHdfsAuthenticationType(HdfsAuthenticationType.KERBEROS)
                 .setHdfsImpersonationEnabled(true)
                 .setSkipDeletionForAlter(true)


### PR DESCRIPTION
please see https://github.com/prestodb/presto/issues/17573

Test plan
Locally deployed testing



```
== NO RELEASE NOTE ==
```
Refer to trinodb code, and call `set_ugi()`  after getting  a metastore client when no-auth.
https://github.com/trinodb/trino/blob/master/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastore.java#L2084