### PR TITLE
Thrifity SplitOperatorInfo

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplit.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSplit.java
@@ -316,6 +316,25 @@ public class HiveSplit
     }
 
     @Override
+    public Map<String, String> getInfoMap()
+    {
+        return ImmutableMap.<String, String>builder()
+                .put("path", path)
+                .put("start", Long.toString(start))
+                .put("length", Long.toString(length))
+                .put("fileSize", Long.toString(fileSize))
+                .put("fileModifiedTime", Long.toString(fileModifiedTime))
+                .put("hosts", addresses.toString())
+                .put("database", database)
+                .put("table", table)
+                .put("nodeSelectionStrategy", nodeSelectionStrategy.toString())
+                .put("partitionName", partitionName)
+                .put("s3SelectPushdownEnabled", Boolean.toString(s3SelectPushdownEnabled))
+                .put("cacheQuotaRequirement", cacheQuotaRequirement.toString())
+                .build();
+    }
+
+    @Override
     public Object getSplitIdentifier()
     {
         return ImmutableMap.builder()

--- a/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaSplit.java
+++ b/presto-main/src/main/java/com/facebook/presto/connector/informationSchema/InformationSchemaSplit.java
@@ -21,9 +21,11 @@ import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static com.facebook.presto.spi.schedule.NodeSelectionStrategy.HARD_AFFINITY;
@@ -86,6 +88,16 @@ public class InformationSchemaSplit
     public Object getInfo()
     {
         return this;
+    }
+
+    @Override
+    public Map<String, String> getInfoMap()
+    {
+        return ImmutableMap.<String, String>builder()
+                .put("tableHandle", tableHandle.toString())
+                .put("prefixes", prefixes.toString())
+                .put("addresses", addresses.toString())
+                .build();
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/metadata/Split.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/Split.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import static com.facebook.presto.spi.SplitContext.NON_CACHEABLE;
@@ -91,9 +92,19 @@ public final class Split
         return splitContext;
     }
 
+    /**
+     * This method returns a raw object.
+     * <p> Instead use {@link #getInfoMap()} method which returns a <pre>{@code Map<String, String>}</pre>
+     */
+    @Deprecated
     public Object getInfo()
     {
         return connectorSplit.getInfo();
+    }
+
+    public Map<String, String> getInfoMap()
+    {
+        return connectorSplit.getInfoMap();
     }
 
     public List<HostAddress> getPreferredNodes(NodeProvider nodeProvider)

--- a/presto-main/src/main/java/com/facebook/presto/operator/ScanFilterAndProjectOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/ScanFilterAndProjectOperator.java
@@ -49,6 +49,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
@@ -144,9 +145,16 @@ public class ScanFilterAndProjectOperator
         this.split = split;
 
         Object splitInfo = split.getInfo();
+        Map<String, String> infoMap = split.getInfoMap();
+
+        //Make the implicit assumption that if infoMap is populated we can use that instead of the raw object.
         if (splitInfo != null) {
             operatorContext.setInfoSupplier(Suppliers.ofInstance(new SplitOperatorInfo(splitInfo)));
         }
+        else if (!infoMap.isEmpty()) {
+            operatorContext.setInfoSupplier(Suppliers.ofInstance(new SplitOperatorInfo(infoMap)));
+        }
+
         blocked.set(null);
 
         if (split.getConnectorSplit() instanceof EmptySplit) {

--- a/presto-main/src/main/java/com/facebook/presto/operator/SplitOperatorInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/SplitOperatorInfo.java
@@ -13,20 +13,36 @@
  */
 package com.facebook.presto.operator;
 
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Map;
+
+@ThriftStruct
 public class SplitOperatorInfo
         implements OperatorInfo
 {
     // NOTE: this deserializes to a map instead of the expected type
-    private final Object splitInfo;
+    private Object splitInfo;
+    private Map<String, String> splitInfoMap;
 
     @JsonCreator
     public SplitOperatorInfo(
             @JsonProperty("splitInfo") Object splitInfo)
     {
         this.splitInfo = splitInfo;
+    }
+
+    @ThriftConstructor
+    public SplitOperatorInfo(
+            Map<String, String> splitInfoMap)
+    {
+        this.splitInfoMap = splitInfoMap;
+        this.splitInfo = splitInfoMap;
     }
 
     @Override
@@ -39,5 +55,12 @@ public class SplitOperatorInfo
     public Object getSplitInfo()
     {
         return splitInfo;
+    }
+
+    @JsonIgnore
+    @ThriftField(1)
+    public Map<String, String> getSplitInfoMap()
+    {
+        return splitInfoMap;
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/operator/TableScanOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TableScanOperator.java
@@ -34,6 +34,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
@@ -154,8 +155,14 @@ public class TableScanOperator
         this.split = split;
 
         Object splitInfo = split.getInfo();
+        Map<String, String> infoMap = split.getInfoMap();
+
+        //Make the implicit assumption that if infoMap is populated we can use that instead of the raw object.
         if (splitInfo != null) {
             operatorContext.setInfoSupplier(Suppliers.ofInstance(new SplitOperatorInfo(splitInfo)));
+        }
+        else if (!infoMap.isEmpty()) {
+            operatorContext.setInfoSupplier(Suppliers.ofInstance(new SplitOperatorInfo(infoMap)));
         }
 
         blocked.set(null);

--- a/presto-main/src/main/java/com/facebook/presto/operator/index/IndexSourceOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/index/IndexSourceOperator.java
@@ -30,6 +30,7 @@ import com.facebook.presto.spi.UpdatablePageSource;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import com.google.common.base.Suppliers;
 
+import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -131,8 +132,14 @@ public class IndexSourceOperator
         source = new PageSourceOperator(result, operatorContext);
 
         Object splitInfo = split.getInfo();
+        Map<String, String> infoMap = split.getInfoMap();
+
+        //Make the implicit assumption that if infoMap is populated we can use that instead of the raw object.
         if (splitInfo != null) {
             operatorContext.setInfoSupplier(Suppliers.ofInstance(new SplitOperatorInfo(splitInfo)));
+        }
+        else if (!infoMap.isEmpty()) {
+            operatorContext.setInfoSupplier(Suppliers.ofInstance(new SplitOperatorInfo(infoMap)));
         }
 
         return Optional::empty;

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestSplitOperatorInfoSerde.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestSplitOperatorInfoSerde.java
@@ -1,0 +1,110 @@
+package com.facebook.presto.operator;
+
+import com.facebook.drift.codec.ThriftCodec;
+import com.facebook.drift.codec.ThriftCodecManager;
+import com.facebook.drift.codec.internal.compiler.CompilerThriftCodecFactory;
+import com.facebook.drift.codec.internal.reflection.ReflectionThriftCodecFactory;
+import com.facebook.drift.protocol.TBinaryProtocol;
+import com.facebook.drift.protocol.TCompactProtocol;
+import com.facebook.drift.protocol.TFacebookCompactProtocol;
+import com.facebook.drift.protocol.TMemoryBuffer;
+import com.facebook.drift.protocol.TProtocol;
+import com.facebook.drift.protocol.TTransport;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+import java.util.function.Function;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+@Test(singleThreaded = true)
+public class TestSplitOperatorInfoSerde
+{
+    private static final ThriftCodecManager COMPILER_READ_CODEC_MANAGER = new ThriftCodecManager(new CompilerThriftCodecFactory(false));
+    private static final ThriftCodecManager COMPILER_WRITE_CODEC_MANAGER = new ThriftCodecManager(new CompilerThriftCodecFactory(false));
+    private static final ThriftCodec<SplitOperatorInfo> COMPILER_READ_CODEC = COMPILER_READ_CODEC_MANAGER.getCodec(SplitOperatorInfo.class);
+    private static final ThriftCodec<SplitOperatorInfo> COMPILER_WRITE_CODEC = COMPILER_WRITE_CODEC_MANAGER.getCodec(SplitOperatorInfo.class);
+    private static final ThriftCodecManager REFLECTION_READ_CODEC_MANAGER = new ThriftCodecManager(new ReflectionThriftCodecFactory());
+    private static final ThriftCodecManager REFLECTION_WRITE_CODEC_MANAGER = new ThriftCodecManager(new ReflectionThriftCodecFactory());
+    private static final ThriftCodec<SplitOperatorInfo> REFLECTION_READ_CODEC = REFLECTION_READ_CODEC_MANAGER.getCodec(SplitOperatorInfo.class);
+    private static final ThriftCodec<SplitOperatorInfo> REFLECTION_WRITE_CODEC = REFLECTION_WRITE_CODEC_MANAGER.getCodec(SplitOperatorInfo.class);
+    private static final TMemoryBuffer transport = new TMemoryBuffer(100 * 1024);
+    private SplitOperatorInfo splitOperatorInfo;
+
+    @BeforeMethod
+    public void setUp()
+    {
+        splitOperatorInfo = getSplitOperatorInfo();
+    }
+
+    @DataProvider
+    public Object[][] codecCombinations()
+    {
+        return new Object[][] {
+                {COMPILER_READ_CODEC, COMPILER_WRITE_CODEC},
+                {COMPILER_READ_CODEC, REFLECTION_WRITE_CODEC},
+                {REFLECTION_READ_CODEC, COMPILER_WRITE_CODEC},
+                {REFLECTION_READ_CODEC, REFLECTION_WRITE_CODEC}
+        };
+    }
+
+    @Test(dataProvider = "codecCombinations")
+    public void testRoundTripSerializeBinaryProtocol(ThriftCodec<SplitOperatorInfo> readCodec, ThriftCodec<SplitOperatorInfo> writeCodec)
+            throws Exception
+    {
+        SplitOperatorInfo splitOperatorInfo = getRoundTripSerialize(readCodec, writeCodec, TBinaryProtocol::new);
+        assertSerde(splitOperatorInfo);
+    }
+
+    @Test(dataProvider = "codecCombinations")
+    public void testRoundTripSerializeTCompactProtocol(ThriftCodec<SplitOperatorInfo> readCodec, ThriftCodec<SplitOperatorInfo> writeCodec)
+            throws Exception
+    {
+        SplitOperatorInfo splitOperatorInfo = getRoundTripSerialize(readCodec, writeCodec, TCompactProtocol::new);
+        assertSerde(splitOperatorInfo);
+    }
+
+    @Test(dataProvider = "codecCombinations")
+    public void testRoundTripSerializeTFacebookCompactProtocol(ThriftCodec<SplitOperatorInfo> readCodec, ThriftCodec<SplitOperatorInfo> writeCodec)
+            throws Exception
+    {
+        SplitOperatorInfo splitOperatorInfo = getRoundTripSerialize(readCodec, writeCodec, TFacebookCompactProtocol::new);
+        assertSerde(splitOperatorInfo);
+    }
+
+    private SplitOperatorInfo getRoundTripSerialize(ThriftCodec<SplitOperatorInfo> readCodec, ThriftCodec<SplitOperatorInfo> writeCodec, Function<TTransport, TProtocol> protocolFactory)
+            throws Exception
+    {
+        TProtocol protocol = protocolFactory.apply(transport);
+        writeCodec.write(splitOperatorInfo, protocol);
+        return readCodec.read(protocol);
+    }
+
+    private void assertSerde(SplitOperatorInfo splitOperatorInfo)
+    {
+        assertEquals(splitOperatorInfo.getSplitInfoMap(), getInfoMap());
+        assertNull(splitOperatorInfo.getSplitInfo());
+    }
+
+    private SplitOperatorInfo getSplitOperatorInfo()
+    {
+        Map<String, String> infoMap = getInfoMap();
+
+        return new SplitOperatorInfo(infoMap);
+    }
+
+    private Map<String, String> getInfoMap()
+    {
+        Map<String, String> infoMap = ImmutableMap.<String, String>builder()
+                .put("path", "path")
+                .put("start", Long.toString(100))
+                .put("length", Long.toString(200))
+                .put("fileSize", Long.toString(300))
+                .build();
+        return infoMap;
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorSplit.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ConnectorSplit.java
@@ -15,7 +15,9 @@ package com.facebook.presto.spi;
 
 import com.facebook.presto.spi.schedule.NodeSelectionStrategy;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.OptionalLong;
 
 public interface ConnectorSplit
@@ -37,7 +39,17 @@ public interface ConnectorSplit
      */
     List<HostAddress> getPreferredNodes(NodeProvider nodeProvider);
 
+    /**
+     * This method returns a raw object.
+     * <p> Instead use {@link #getInfoMap()} method which returns a <pre>{@code Map<String, String>}</pre>
+     */
+    @Deprecated
     Object getInfo();
+
+    default Map<String, String> getInfoMap()
+    {
+        return new HashMap<>();
+    }
 
     default Object getSplitIdentifier()
     {


### PR DESCRIPTION
- Add info map to ConnectorSplit
- Use the new getInfoMap method from ConnectorSplit
- Use the info map from Split in operators
- Thriftify SplitOperatorInfo

Test plan - Verifier test https://www.internalfb.com/intern/presto/verifier/results/?test_id=77926


```
== NO RELEASE NOTE ==
```
