### PR TITLE
Use system memory contexts from OperatorContext

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/AggregationOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/AggregationOperator.java
@@ -93,7 +93,7 @@ public class AggregationOperator
     public AggregationOperator(OperatorContext operatorContext, Step step, List<AccumulatorFactory> accumulatorFactories, boolean useSystemMemory)
     {
         this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
-        this.systemMemoryContext = operatorContext.newLocalSystemMemoryContext(AggregationOperator.class.getSimpleName());
+        this.systemMemoryContext = operatorContext.localSystemMemoryContext();
         this.userMemoryContext = operatorContext.localUserMemoryContext();
         this.useSystemMemory = useSystemMemory;
 
@@ -126,7 +126,7 @@ public class AggregationOperator
     public void close()
     {
         userMemoryContext.setBytes(0);
-        systemMemoryContext.close();
+        systemMemoryContext.setBytes(0);
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/FilterAndProjectOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/FilterAndProjectOperator.java
@@ -50,7 +50,7 @@ public class FilterAndProjectOperator
         this.processor = requireNonNull(processor, "processor is null");
         this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
         this.pageProcessorMemoryContext = newSimpleAggregatedMemoryContext().newLocalMemoryContext(ScanFilterAndProjectOperator.class.getSimpleName());
-        this.outputMemoryContext = operatorContext.newLocalSystemMemoryContext(FilterAndProjectOperator.class.getSimpleName());
+        this.outputMemoryContext = operatorContext.localSystemMemoryContext();
         this.mergingOutput = requireNonNull(mergingOutput, "mergingOutput is null");
         this.sqlFunctionProperties = operatorContext.getSession().getSqlFunctionProperties();
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/HashBuilderOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/HashBuilderOperator.java
@@ -419,7 +419,7 @@ public class HashBuilderOperator
         spiller = Optional.of(singleStreamSpillerFactory.create(
                 index.getTypes(),
                 operatorContext.getSpillContext().newLocalSpillContext(),
-                operatorContext.newLocalSystemMemoryContext(HashBuilderOperator.class.getSimpleName())));
+                operatorContext.localSystemMemoryContext()));
         return getSpiller().spill(index.getPages());
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/LookupJoinOperator.java
@@ -244,7 +244,7 @@ public class LookupJoinOperator
                     probeTypes,
                     getPartitionGenerator(),
                     operatorContext.getSpillContext().newLocalSpillContext(),
-                    operatorContext.newAggregateSystemMemoryContext()));
+                    operatorContext.aggregateSystemMemoryContext()));
         }
 
         PartitioningSpillResult result = spiller.get().partitionAndSpill(page, spillMask);

--- a/presto-main/src/main/java/com/facebook/presto/operator/MergeHashSort.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/MergeHashSort.java
@@ -19,7 +19,6 @@ import com.facebook.presto.common.type.Type;
 import com.facebook.presto.memory.context.AggregatedMemoryContext;
 import com.facebook.presto.util.MergeSortedPages.PageWithPosition;
 
-import java.io.Closeable;
 import java.util.List;
 import java.util.function.BiPredicate;
 import java.util.stream.IntStream;
@@ -35,7 +34,6 @@ import static com.google.common.collect.ImmutableList.toImmutableList;
  * stream of Pages can have interleaved positions with same hash value.
  */
 public class MergeHashSort
-        implements Closeable
 {
     private final AggregatedMemoryContext memoryContext;
 
@@ -59,12 +57,6 @@ public class MergeHashSort
                 true,
                 memoryContext,
                 driverYieldSignal);
-    }
-
-    @Override
-    public void close()
-    {
-        memoryContext.close();
     }
 
     private static BiPredicate<PageBuilder, PageWithPosition> keepSameHashValuesWithinSinglePage(InterpretedHashGenerator hashGenerator)

--- a/presto-main/src/main/java/com/facebook/presto/operator/OperatorContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/OperatorContext.java
@@ -261,6 +261,10 @@ public class OperatorContext
         return revocableMemoryFuture.get();
     }
 
+    // Create a new LocalMemoryContext if either of the following are true
+    // 1. you need more than one memory context for the operator (calls to setBytes that should be aggregated rather than override each other)
+    // 2. you want to use a different allocation tag
+    // Otherwise call localSystemMemoryContext() to use the LocalMemoryContext already associated with the operator
     // caller should close this context as it's a new context
     public LocalMemoryContext newLocalSystemMemoryContext(String allocationTag)
     {

--- a/presto-main/src/main/java/com/facebook/presto/operator/OperatorContext.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/OperatorContext.java
@@ -301,10 +301,10 @@ public class OperatorContext
         return new InternalAggregatedMemoryContext(operatorMemoryContext.aggregateRevocableMemoryContext(), memoryFuture, this::updateTaskRevocableMemoryReservation, false);
     }
 
-    // caller should close this context as it's a new context
-    public AggregatedMemoryContext newAggregateSystemMemoryContext()
+    // caller shouldn't close this context as it's managed by the OperatorContext
+    public AggregatedMemoryContext aggregateSystemMemoryContext()
     {
-        return new InternalAggregatedMemoryContext(operatorMemoryContext.newAggregateSystemMemoryContext(), memoryFuture, this::updatePeakMemoryReservations, true);
+        return new InternalAggregatedMemoryContext(operatorMemoryContext.aggregateSystemMemoryContext(), memoryFuture, this::updatePeakMemoryReservations, false);
     }
 
     // listen to all memory allocations and update the peak memory reservations accordingly

--- a/presto-main/src/main/java/com/facebook/presto/operator/OrderByOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/OrderByOperator.java
@@ -307,7 +307,7 @@ public class OrderByOperator
             spiller = Optional.of(spillerFactory.get().create(
                     sourceTypes,
                     operatorContext.getSpillContext(),
-                    operatorContext.newAggregateSystemMemoryContext()));
+                    operatorContext.aggregateSystemMemoryContext()));
         }
 
         pageIndex.sort(sortChannels, sortOrder);

--- a/presto-main/src/main/java/com/facebook/presto/operator/StreamingAggregationOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/StreamingAggregationOperator.java
@@ -102,7 +102,7 @@ public class StreamingAggregationOperator
     public StreamingAggregationOperator(OperatorContext operatorContext, List<Type> sourceTypes, List<Type> groupByTypes, List<Integer> groupByChannels, Step step, List<AccumulatorFactory> accumulatorFactories, JoinCompiler joinCompiler)
     {
         this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
-        this.systemMemoryContext = operatorContext.newLocalSystemMemoryContext(StreamingAggregationOperator.class.getSimpleName());
+        this.systemMemoryContext = operatorContext.localSystemMemoryContext();
         this.userMemoryContext = operatorContext.localUserMemoryContext();
         this.groupByTypes = ImmutableList.copyOf(requireNonNull(groupByTypes, "groupByTypes is null"));
         this.groupByChannels = Ints.toArray(requireNonNull(groupByChannels, "groupByChannels is null"));

--- a/presto-main/src/main/java/com/facebook/presto/operator/TableScanOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TableScanOperator.java
@@ -127,7 +127,7 @@ public class TableScanOperator
         this.pageSourceProvider = requireNonNull(pageSourceProvider, "pageSourceProvider is null");
         this.table = requireNonNull(table, "table is null");
         this.columns = ImmutableList.copyOf(requireNonNull(columns, "columns is null"));
-        this.systemMemoryContext = operatorContext.newLocalSystemMemoryContext(TableScanOperator.class.getSimpleName());
+        this.systemMemoryContext = operatorContext.localSystemMemoryContext();
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/TableWriterMergeOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TableWriterMergeOperator.java
@@ -22,7 +22,6 @@ import com.facebook.presto.common.block.RunLengthEncodedBlock;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.memory.context.LocalMemoryContext;
 import com.facebook.presto.operator.OperationTimer.OperationTiming;
-import com.facebook.presto.operator.aggregation.builder.InMemoryHashAggregationBuilder;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -129,7 +128,7 @@ public class TableWriterMergeOperator
     {
         this.context = requireNonNull(context, "context is null");
         this.statisticsAggregationOperator = requireNonNull(statisticsAggregationOperator, "statisticAggregationOperator is null");
-        this.systemMemoryContext = context.newLocalSystemMemoryContext(InMemoryHashAggregationBuilder.class.getSimpleName());
+        this.systemMemoryContext = context.newLocalSystemMemoryContext(TableWriterMergeOperator.class.getSimpleName());
         this.tableCommitContextCodec = requireNonNull(tableCommitContextCodec, "tableCommitContextCodec is null");
         this.statisticsCpuTimerEnabled = statisticsCpuTimerEnabled;
         this.types = ImmutableList.copyOf(requireNonNull(types, "types is null"));

--- a/presto-main/src/main/java/com/facebook/presto/operator/TableWriterMergeOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TableWriterMergeOperator.java
@@ -128,7 +128,7 @@ public class TableWriterMergeOperator
     {
         this.context = requireNonNull(context, "context is null");
         this.statisticsAggregationOperator = requireNonNull(statisticsAggregationOperator, "statisticAggregationOperator is null");
-        this.systemMemoryContext = context.newLocalSystemMemoryContext(TableWriterMergeOperator.class.getSimpleName());
+        this.systemMemoryContext = context.localSystemMemoryContext();
         this.tableCommitContextCodec = requireNonNull(tableCommitContextCodec, "tableCommitContextCodec is null");
         this.statisticsCpuTimerEnabled = statisticsCpuTimerEnabled;
         this.types = ImmutableList.copyOf(requireNonNull(types, "types is null"));

--- a/presto-main/src/main/java/com/facebook/presto/operator/TableWriterOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/TableWriterOperator.java
@@ -253,7 +253,7 @@ public class TableWriterOperator
             PageSinkCommitStrategy pageSinkCommitStrategy)
     {
         this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
-        this.pageSinkMemoryContext = operatorContext.newLocalSystemMemoryContext(TableWriterOperator.class.getSimpleName());
+        this.pageSinkMemoryContext = operatorContext.localSystemMemoryContext();
         this.pageSink = requireNonNull(pageSink, "pageSink is null");
         this.columnChannels = requireNonNull(columnChannels, "columnChannels is null");
         this.notNullChannelColumnNames = requireNonNull(notNullChannelColumnNames, "notNullChannelColumnNames is null");
@@ -449,7 +449,7 @@ public class TableWriterOperator
             }
         }
         closer.register(statisticAggregationOperator);
-        closer.register(() -> pageSinkMemoryContext.close());
+        closer.register(() -> pageSinkMemoryContext.setBytes(0));
         closer.close();
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/WindowOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/WindowOperator.java
@@ -679,7 +679,7 @@ public class WindowOperator
                 spiller = Optional.of(spillerFactory.create(
                         sourceTypes,
                         operatorContext.getSpillContext(),
-                        operatorContext.newAggregateSystemMemoryContext()));
+                        operatorContext.aggregateSystemMemoryContext()));
             }
 
             verify(inMemoryPagesIndexWithHashStrategies.pagesIndex.getPositionCount() > 0);

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/builder/SpillableHashAggregationBuilder.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/builder/SpillableHashAggregationBuilder.java
@@ -231,7 +231,6 @@ public class SpillableHashAggregationBuilder
             }
             merger.ifPresent(closer::register);
             spiller.ifPresent(closer::register);
-            mergeHashSort.ifPresent(closer::register);
             closer.register(() -> localUserMemoryContext.setBytes(0));
             closer.register(() -> localRevocableMemoryContext.setBytes(0));
         }
@@ -249,7 +248,7 @@ public class SpillableHashAggregationBuilder
             spiller = Optional.of(spillerFactory.create(
                     hashAggregationBuilder.buildTypes(),
                     operatorContext.getSpillContext(),
-                    operatorContext.newAggregateSystemMemoryContext()));
+                    operatorContext.aggregateSystemMemoryContext()));
         }
 
         // start spilling process with current content of the hashAggregationBuilder builder...
@@ -266,7 +265,7 @@ public class SpillableHashAggregationBuilder
         checkState(spiller.isPresent());
 
         hashAggregationBuilder.setOutputPartial();
-        mergeHashSort = Optional.of(new MergeHashSort(operatorContext.newAggregateSystemMemoryContext()));
+        mergeHashSort = Optional.of(new MergeHashSort(operatorContext.aggregateSystemMemoryContext()));
 
         WorkProcessor<Page> mergedSpilledPages = mergeHashSort.get().merge(
                 groupByTypes,
@@ -286,7 +285,7 @@ public class SpillableHashAggregationBuilder
     {
         checkState(spiller.isPresent());
 
-        mergeHashSort = Optional.of(new MergeHashSort(operatorContext.newAggregateSystemMemoryContext()));
+        mergeHashSort = Optional.of(new MergeHashSort(operatorContext.aggregateSystemMemoryContext()));
 
         WorkProcessor<Page> mergedSpilledPages = mergeHashSort.get().merge(
                 groupByTypes,

--- a/presto-main/src/main/java/com/facebook/presto/operator/repartition/PartitionedOutputOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/repartition/PartitionedOutputOperator.java
@@ -278,7 +278,7 @@ public class PartitionedOutputOperator
     @Override
     public void close()
     {
-        partitionFunction.closeMemoryContext();
+        partitionFunction.zeroMemoryContext();
     }
 
     private static class PagePartitioner
@@ -328,7 +328,7 @@ public class PartitionedOutputOperator
             this.sourceTypes = requireNonNull(sourceTypes, "sourceTypes is null").toArray(new Type[0]);
             this.serde = requireNonNull(serdeFactory, "serdeFactory is null").createPagesSerde();
             this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
-            this.systemMemoryContext = operatorContext.newLocalSystemMemoryContext(PartitionedOutputOperator.class.getSimpleName());
+            this.systemMemoryContext = operatorContext.localSystemMemoryContext();
             this.systemMemoryContext.setBytes(getRetainedSizeInBytes());
 
             //  Ensure partition channels align with constant arguments provided
@@ -349,9 +349,9 @@ public class PartitionedOutputOperator
             }
         }
 
-        public void closeMemoryContext()
+        public void zeroMemoryContext()
         {
-            systemMemoryContext.close();
+            systemMemoryContext.setBytes(0);
         }
 
         public ListenableFuture<?> isFull()

--- a/presto-main/src/main/java/com/facebook/presto/operator/unnest/UnnestOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/unnest/UnnestOperator.java
@@ -26,7 +26,6 @@ import com.facebook.presto.operator.DriverContext;
 import com.facebook.presto.operator.Operator;
 import com.facebook.presto.operator.OperatorContext;
 import com.facebook.presto.operator.OperatorFactory;
-import com.facebook.presto.operator.repartition.PartitionedOutputOperator;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
@@ -130,7 +129,7 @@ public class UnnestOperator
     public UnnestOperator(OperatorContext operatorContext, List<Integer> replicateChannels, List<Type> replicateTypes, List<Integer> unnestChannels, List<Type> unnestTypes, boolean withOrdinality, boolean isLegacyUnnest)
     {
         this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
-        this.systemMemoryContext = operatorContext.newLocalSystemMemoryContext(PartitionedOutputOperator.class.getSimpleName());
+        this.systemMemoryContext = operatorContext.newLocalSystemMemoryContext(UnnestOperator.class.getSimpleName());
 
         this.replicateChannels = ImmutableList.copyOf(requireNonNull(replicateChannels, "replicateChannels is null"));
         this.replicateTypes = ImmutableList.copyOf(requireNonNull(replicateTypes, "replicateTypes is null"));

--- a/presto-main/src/main/java/com/facebook/presto/operator/unnest/UnnestOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/unnest/UnnestOperator.java
@@ -129,7 +129,7 @@ public class UnnestOperator
     public UnnestOperator(OperatorContext operatorContext, List<Integer> replicateChannels, List<Type> replicateTypes, List<Integer> unnestChannels, List<Type> unnestTypes, boolean withOrdinality, boolean isLegacyUnnest)
     {
         this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
-        this.systemMemoryContext = operatorContext.newLocalSystemMemoryContext(UnnestOperator.class.getSimpleName());
+        this.systemMemoryContext = operatorContext.localSystemMemoryContext();
 
         this.replicateChannels = ImmutableList.copyOf(requireNonNull(replicateChannels, "replicateChannels is null"));
         this.replicateTypes = ImmutableList.copyOf(requireNonNull(replicateTypes, "replicateTypes is null"));

--- a/presto-main/src/main/java/com/facebook/presto/spiller/GenericPartitioningSpiller.java
+++ b/presto-main/src/main/java/com/facebook/presto/spiller/GenericPartitioningSpiller.java
@@ -75,7 +75,6 @@ public class GenericPartitioningSpiller
         this.spillContext = closer.register(requireNonNull(spillContext, "spillContext is null"));
 
         requireNonNull(memoryContext, "memoryContext is null");
-        closer.register(memoryContext::close);
         this.memoryContext = memoryContext;
         int partitionCount = partitionFunction.getPartitionCount();
         this.pageBuilders = new PageBuilder[partitionCount];

--- a/presto-main/src/test/java/com/facebook/presto/memory/TestMemoryTracking.java
+++ b/presto-main/src/test/java/com/facebook/presto/memory/TestMemoryTracking.java
@@ -132,7 +132,7 @@ public class TestMemoryTracking
     public void testOperatorAllocations()
     {
         MemoryTrackingContext operatorMemoryContext = operatorContext.getOperatorMemoryContext();
-        LocalMemoryContext systemMemory = operatorContext.newLocalSystemMemoryContext("test");
+        LocalMemoryContext systemMemory = operatorContext.localSystemMemoryContext();
         LocalMemoryContext userMemory = operatorContext.localUserMemoryContext();
         LocalMemoryContext revocableMemory = operatorContext.localRevocableMemoryContext();
         userMemory.setBytes(100);
@@ -155,7 +155,7 @@ public class TestMemoryTracking
     @Test
     public void testLocalTotalMemoryLimitExceeded()
     {
-        LocalMemoryContext systemMemoryContext = operatorContext.newLocalSystemMemoryContext("test");
+        LocalMemoryContext systemMemoryContext = operatorContext.localSystemMemoryContext();
         systemMemoryContext.setBytes(100);
         assertOperatorMemoryAllocations(operatorContext.getOperatorMemoryContext(), 0, 100, 0);
         systemMemoryContext.setBytes(queryMaxTotalMemory.toBytes());
@@ -165,7 +165,7 @@ public class TestMemoryTracking
             fail("allocation should hit the per-node total memory limit");
         }
         catch (ExceededMemoryLimitException e) {
-            assertEquals(e.getMessage(), format("Query exceeded per-node total memory limit of %1$s [Allocated: %1$s, Delta: 1B, Top Consumers: {test=%1$s}]", queryMaxTotalMemory));
+            assertEquals(e.getMessage(), format("Query exceeded per-node total memory limit of %1$s [Allocated: %1$s, Delta: 1B, Top Consumers: {test-operator=%1$s}]", queryMaxTotalMemory));
         }
     }
 
@@ -224,7 +224,7 @@ public class TestMemoryTracking
     @Test
     public void testStats()
     {
-        LocalMemoryContext systemMemory = operatorContext.newLocalSystemMemoryContext("test");
+        LocalMemoryContext systemMemory = operatorContext.localSystemMemoryContext();
         LocalMemoryContext userMemory = operatorContext.localUserMemoryContext();
         userMemory.setBytes(100_000_000);
         systemMemory.setBytes(200_000_000);
@@ -284,7 +284,7 @@ public class TestMemoryTracking
     @Test
     public void testRevocableMemoryAllocations()
     {
-        LocalMemoryContext systemMemory = operatorContext.newLocalSystemMemoryContext("test");
+        LocalMemoryContext systemMemory = operatorContext.localSystemMemoryContext();
         LocalMemoryContext userMemory = operatorContext.localUserMemoryContext();
         LocalMemoryContext revocableMemory = operatorContext.localRevocableMemoryContext();
         revocableMemory.setBytes(100_000_000);
@@ -368,7 +368,7 @@ public class TestMemoryTracking
     @Test
     public void testDestroy()
     {
-        LocalMemoryContext newLocalSystemMemoryContext = operatorContext.newLocalSystemMemoryContext("test");
+        LocalMemoryContext newLocalSystemMemoryContext = operatorContext.localSystemMemoryContext();
         LocalMemoryContext newLocalUserMemoryContext = operatorContext.localUserMemoryContext();
         LocalMemoryContext newLocalRevocableMemoryContext = operatorContext.localRevocableMemoryContext();
         newLocalSystemMemoryContext.setBytes(100_000);

--- a/presto-main/src/test/java/com/facebook/presto/spiller/TestGenericPartitioningSpiller.java
+++ b/presto-main/src/test/java/com/facebook/presto/spiller/TestGenericPartitioningSpiller.java
@@ -218,7 +218,7 @@ public class TestGenericPartitioningSpiller
     private static AggregatedMemoryContext mockMemoryContext(ScheduledExecutorService scheduledExecutor)
     {
         // It's important to use OperatorContext's system memory context, because it does additional bookkeeping.
-        return TestingOperatorContext.create(scheduledExecutor).newAggregateSystemMemoryContext();
+        return TestingOperatorContext.create(scheduledExecutor).aggregateSystemMemoryContext();
     }
 
     private static SpillContext mockSpillContext()

--- a/presto-memory-context/src/main/java/com/facebook/presto/memory/context/MemoryTrackingContext.java
+++ b/presto-memory-context/src/main/java/com/facebook/presto/memory/context/MemoryTrackingContext.java
@@ -97,11 +97,6 @@ public final class MemoryTrackingContext
         return revocableLocalMemoryContext;
     }
 
-    public LocalMemoryContext newUserMemoryContext(String allocationTag)
-    {
-        return userAggregateMemoryContext.newLocalMemoryContext(allocationTag);
-    }
-
     public LocalMemoryContext newSystemMemoryContext(String allocationTag)
     {
         return systemAggregateMemoryContext.newLocalMemoryContext(allocationTag);

--- a/presto-memory-context/src/main/java/com/facebook/presto/memory/context/MemoryTrackingContext.java
+++ b/presto-memory-context/src/main/java/com/facebook/presto/memory/context/MemoryTrackingContext.java
@@ -112,9 +112,9 @@ public final class MemoryTrackingContext
         return revocableAggregateMemoryContext;
     }
 
-    public AggregatedMemoryContext newAggregateSystemMemoryContext()
+    public AggregatedMemoryContext aggregateSystemMemoryContext()
     {
-        return systemAggregateMemoryContext.newAggregatedMemoryContext();
+        return systemAggregateMemoryContext;
     }
 
     public long getUserMemory()

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkRemoteSourceOperator.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkRemoteSourceOperator.java
@@ -40,11 +40,11 @@ public class PrestoSparkRemoteSourceOperator
 
     private boolean finished;
 
-    public PrestoSparkRemoteSourceOperator(PlanNodeId sourceId, OperatorContext operatorContext, LocalMemoryContext systemMemoryContext, PrestoSparkPageInput pageInput, boolean isFirstOperator)
+    public PrestoSparkRemoteSourceOperator(PlanNodeId sourceId, OperatorContext operatorContext, PrestoSparkPageInput pageInput, boolean isFirstOperator)
     {
         this.sourceId = requireNonNull(sourceId, "sourceId is null");
         this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
-        this.systemMemoryContext = requireNonNull(systemMemoryContext, "systemMemoryContext is null");
+        this.systemMemoryContext = operatorContext.localSystemMemoryContext();
         this.pageInput = requireNonNull(pageInput, "pageInput is null");
         this.isFirstOperator = isFirstOperator;
     }
@@ -119,7 +119,7 @@ public class PrestoSparkRemoteSourceOperator
     @Override
     public void close()
     {
-        systemMemoryContext.close();
+        systemMemoryContext.setBytes(0);
     }
 
     private void updateMemoryContext()
@@ -169,7 +169,6 @@ public class PrestoSparkRemoteSourceOperator
             SourceOperator operator = new PrestoSparkRemoteSourceOperator(
                     planNodeId,
                     operatorContext,
-                    operatorContext.newLocalSystemMemoryContext(PrestoSparkRemoteSourceOperator.class.getSimpleName()),
                     pageInput,
                     isFirstOperator);
             isFirstOperator = false;

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkRowOutputOperator.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkRowOutputOperator.java
@@ -185,7 +185,6 @@ public class PrestoSparkRowOutputOperator
             OperatorContext operatorContext = driverContext.addOperatorContext(operatorId, planNodeId, PrestoSparkRowOutputOperator.class.getSimpleName());
             return new PrestoSparkRowOutputOperator(
                     operatorContext,
-                    operatorContext.newLocalSystemMemoryContext(PrestoSparkRowOutputOperator.class.getSimpleName()),
                     outputBuffer,
                     pagePreprocessor,
                     partitionFunction,
@@ -237,7 +236,6 @@ public class PrestoSparkRowOutputOperator
 
     public PrestoSparkRowOutputOperator(
             OperatorContext operatorContext,
-            LocalMemoryContext systemMemoryContext,
             PrestoSparkOutputBuffer<PrestoSparkRowBatch> outputBuffer,
             Function<Page, Page> pagePreprocessor,
             PartitionFunction partitionFunction,
@@ -248,7 +246,7 @@ public class PrestoSparkRowOutputOperator
             int targetAverageRowSizeInBytes)
     {
         this.operatorContext = requireNonNull(operatorContext, "operatorContext is null");
-        this.systemMemoryContext = requireNonNull(systemMemoryContext, "systemMemoryContext is null");
+        this.systemMemoryContext = operatorContext.localSystemMemoryContext();
         this.outputBuffer = requireNonNull(outputBuffer, "outputBuffer is null");
         this.pagePreprocessor = requireNonNull(pagePreprocessor, "pagePreprocessor is null");
         this.partitionFunction = requireNonNull(partitionFunction, "partitionFunction is null");


### PR DESCRIPTION
Don't create new system memory contexts every time an operator needs one as there doesn't seem to be a good reason to do this unless an operator needs multiple memory contexts or a different allocation tag.  Instead use the one already created for the operator.  This change simplifies the memory handling by making system memory work similar to user and revocable memory.

Test plan - CI tests

```
== RELEASE NOTES ==
General Changes

* Fix memory tagging for UnnestOperator and TableWriterMergeOperator
```
