### PR TITLE
Minor optimization of MapFlatSelectiveStreamReader

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapFlatSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapFlatSelectiveStreamReader.java
@@ -70,6 +70,7 @@ import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
 import static com.facebook.presto.orc.reader.SelectiveStreamReaders.initializeOutputPositions;
 import static com.facebook.presto.orc.stream.MissingInputStreamSource.missingStreamSource;
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -411,7 +412,7 @@ public class MapFlatSelectiveStreamReader
         presentStream = presentStreamSource.openStream();
 
         for (int i = 0; i < keyCount; i++) {
-            BooleanInputStream inMapStream = requireNonNull(inMapStreamSources.get(i).openStream(), "missing inMapStream at position " + i);
+            BooleanInputStream inMapStream = checkNotNull(inMapStreamSources.get(i).openStream(), "missing inMapStream at position %s", i);
             inMapStreams.add(inMapStream);
         }
 
@@ -795,6 +796,9 @@ public class MapFlatSelectiveStreamReader
     public void startRowGroup(InputStreamSources dataStreamSources)
             throws IOException
     {
+        presentStream = null;
+        inMapStreams.clear();
+
         presentStreamSource = dataStreamSources.getInputStreamSource(streamDescriptor, PRESENT, BooleanInputStream.class);
 
         for (int i = 0; i < keyCount; i++) {
@@ -809,9 +813,6 @@ public class MapFlatSelectiveStreamReader
         nestedPositions = ensureCapacity(nestedPositions, keyCount);
         nestedPositionCounts = ensureCapacity(nestedPositionCounts, keyCount);
         inMap = ensureCapacity(inMap, keyCount);
-
-        presentStream = null;
-        inMapStreams.clear();
 
         rowGroupOpen = false;
 


### PR DESCRIPTION
Found these two minor issues while working on the flat map writer. 
Fix #1: Avoid string concatenation when loading inMap streams
Fix #2: Free up memory a bit faster.

Test plan:
- existing tests

Benchmarking results for replaced `requireNonNull("...." + i)`:
```
Benchmark                           Mode  Cnt   Score   Error  Units
BenchmarkAAAA.preconditions         avgt   30   0.229 ± 0.008  ms/op
BenchmarkAAAA.requireNonNullLambda  avgt   30   1.203 ± 0.045  ms/op
BenchmarkAAAA.requireNonNullString  avgt   30  18.557 ± 0.507  ms/op
```

Benchmark source:
```
package com.facebook.presto.orc;

import com.facebook.presto.common.predicate.TupleDomainFilter;
import com.google.common.base.Preconditions;
import com.google.common.collect.ImmutableList;
import org.openjdk.jmh.annotations.Benchmark;
import org.openjdk.jmh.annotations.BenchmarkMode;
import org.openjdk.jmh.annotations.Fork;
import org.openjdk.jmh.annotations.Measurement;
import org.openjdk.jmh.annotations.Mode;
import org.openjdk.jmh.annotations.OutputTimeUnit;
import org.openjdk.jmh.annotations.Scope;
import org.openjdk.jmh.annotations.Setup;
import org.openjdk.jmh.annotations.State;
import org.openjdk.jmh.annotations.Warmup;
import org.openjdk.jmh.runner.Runner;
import org.openjdk.jmh.runner.options.Options;
import org.openjdk.jmh.runner.options.OptionsBuilder;
import org.openjdk.jmh.runner.options.VerboseMode;

import java.util.ArrayList;
import java.util.List;

import static java.util.Objects.requireNonNull;
import static java.util.concurrent.TimeUnit.MILLISECONDS;
import static java.util.concurrent.TimeUnit.NANOSECONDS;

@State(Scope.Thread)
@OutputTimeUnit(MILLISECONDS)
@Fork(3)
@Warmup(iterations = 10, time = 1000, timeUnit = MILLISECONDS)
@Measurement(iterations = 10, time = 1000, timeUnit = MILLISECONDS)
@BenchmarkMode(Mode.AverageTime)
public class BenchmarkAAAA
{
    @Benchmark
    public int requireNonNullString(BenchmarkData data)
    {
        int hits = 0;
        List<Object> list = data.data;
        for (int i = 0; i < list.size(); i++) {
            requireNonNull(list.get(i), "missing inMapStream at position " + i);
            hits++;
        }
        return hits;
    }

    @Benchmark
    public int requireNonNullLambda(BenchmarkData data)
    {
        int hits = 0;
        List<Object> list = data.data;
        for (int i = 0; i < list.size(); i++) {
            final int k = i;
            requireNonNull(list.get(i), () -> ("missing inMapStream at position " + k));
            hits++;
        }
        return hits;
    }

    @Benchmark
    public int preconditions(BenchmarkData data)
    {
        int hits = 0;
        List<Object> list = data.data;
        for (int i = 0; i < list.size(); i++) {
            Preconditions.checkNotNull(list.get(i), "missing inMapStream at position %s", i);
            hits++;
        }
        return hits;
    }

    @State(Scope.Thread)
    public static class BenchmarkData
    {
        private List<Object> data;

        @Setup
        public void setup()
                throws Exception
        {
            data = new ArrayList<>();
            for (int i = 0; i < 1000_000; i++) {
                data.add(i);
            }
        }
    }

    public static void main(String[] args)
            throws Throwable
    {
        Options options = new OptionsBuilder()
                .verbosity(VerboseMode.NORMAL)
                .include(".*" + BenchmarkAAAA.class.getSimpleName() + ".*")
                .build();

        new Runner(options).run();
    }
}
```

```
== NO RELEASE NOTE ==
```
