### PR TITLE
Fix close idempotency for JDBC PreparedStatement

### DIFF
--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoConnection.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoConnection.java
@@ -786,6 +786,11 @@ public class PrestoConnection
         }
     }
 
+    void removePreparedStatement(String name)
+    {
+        preparedStatements.remove(name);
+    }
+
     WarningsManager getWarningsManager()
     {
         return warningsManager;

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoPreparedStatement.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoPreparedStatement.java
@@ -88,7 +88,7 @@ public class PrestoPreparedStatement
     public void close()
             throws SQLException
     {
-        super.execute(format("DEALLOCATE PREPARE %s", statementName));
+        optionalConnection().ifPresent(x -> x.removePreparedStatement(statementName));
         super.close();
     }
 

--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoStatement.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoStatement.java
@@ -662,6 +662,11 @@ public class PrestoStatement
         return connection;
     }
 
+    protected final Optional<PrestoConnection> optionalConnection()
+    {
+        return Optional.ofNullable(connection.get());
+    }
+
     private void closeResultSet()
             throws SQLException
     {

--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestJdbcPreparedStatement.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestJdbcPreparedStatement.java
@@ -649,6 +649,17 @@ public class TestJdbcPreparedStatement
         }
     }
 
+    @Test
+    public void testCloseIdempotency()
+            throws Exception
+    {
+        try (Connection connection = createConnection()) {
+            PreparedStatement statement = connection.prepareStatement("SELECT 123");
+            statement.close();
+            statement.close();
+        }
+    }
+
     private interface Binder
     {
         void bind(PreparedStatement ps, int i)


### PR DESCRIPTION
Cherry-pick of https://github.com/trinodb/trino/pull/11620
Fix the behavior of PreparedStatement.close() so that it may be called
multiple times without throwing an exception on subsequent invocations,
which is required per the JDBC specification:

Calling the method close on a Statement object that is already closed
has no effect.

Co-authored-by: David Phillips <david@acz.org>

Test plan - Added a test

```
== RELEASE NOTES ==

General Changes
* Fix close idempotency for JDBC PreparedStatement

```
