### PR TITLE
Add appendRowNumber option to presto-hive

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -2706,6 +2706,7 @@ public class HiveMetadata
                                 false,
                                 createTableLayoutString(session, handle.getSchemaTableName(), hivePartitionResult.getBucketHandle(), hivePartitionResult.getBucketFilter(), TRUE_CONSTANT, domainPredicate),
                                 desiredColumns.map(columns -> columns.stream().map(column -> (HiveColumnHandle) column).collect(toImmutableSet())),
+                                false,
                                 false)),
                 hivePartitionResult.getUnenforcedConstraint()));
     }
@@ -2978,7 +2979,8 @@ public class HiveMetadata
                 hiveLayoutHandle.isPushdownFilterEnabled(),
                 hiveLayoutHandle.getLayoutString(),
                 hiveLayoutHandle.getRequestedColumns(),
-                hiveLayoutHandle.isPartialAggregationsPushedDown());
+                hiveLayoutHandle.isPartialAggregationsPushedDown(),
+                hiveLayoutHandle.isAppendRowNumberEnabled());
     }
 
     @Override

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSourceProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSourceProvider.java
@@ -333,7 +333,8 @@ public class HivePageSourceProvider
                             Optional.of(split.getFileSize()),
                             split.getFileModifiedTime(),
                             HiveSessionProperties.isVerboseRuntimeStatsEnabled(session)),
-                    encryptionInformation);
+                    encryptionInformation,
+                    layout.isAppendRowNumberEnabled());
             if (pageSource.isPresent()) {
                 return Optional.of(pageSource.get());
             }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePartialAggregationPushdown.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePartialAggregationPushdown.java
@@ -263,7 +263,8 @@ public class HivePartialAggregationPushdown
                     oldTableLayoutHandle.isPushdownFilterEnabled(),
                     oldTableLayoutHandle.getLayoutString(),
                     oldTableLayoutHandle.getRequestedColumns(),
-                    true);
+                    true,
+                    oldTableLayoutHandle.isAppendRowNumberEnabled());
 
             TableHandle newTableHandle = new TableHandle(
                     oldTableHandle.getConnectorId(),

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveSelectivePageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveSelectivePageSourceFactory.java
@@ -46,5 +46,6 @@ public interface HiveSelectivePageSourceFactory
             RowExpression remainingPredicate,               // refers to columns by name; already optimized
             DateTimeZone hiveStorageTimeZone,
             HiveFileContext hiveFileContext,
-            Optional<EncryptionInformation> encryptionInformation);
+            Optional<EncryptionInformation> encryptionInformation,
+            boolean appendRowNumberEnabled);
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveTableLayoutHandle.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveTableLayoutHandle.java
@@ -58,7 +58,7 @@ public final class HiveTableLayoutHandle
     private final String layoutString;
     private final Optional<Set<HiveColumnHandle>> requestedColumns;
     private final boolean partialAggregationsPushedDown;
-
+    private final boolean appendRowNumberEnabled;
     // coordinator-only properties
     @Nullable
     private final List<HivePartition> partitions;
@@ -79,7 +79,8 @@ public final class HiveTableLayoutHandle
             @JsonProperty("pushdownFilterEnabled") boolean pushdownFilterEnabled,
             @JsonProperty("layoutString") String layoutString,
             @JsonProperty("requestedColumns") Optional<Set<HiveColumnHandle>> requestedColumns,
-            @JsonProperty("partialAggregationsPushedDown") boolean partialAggregationsPushedDown)
+            @JsonProperty("partialAggregationsPushedDown") boolean partialAggregationsPushedDown,
+            @JsonProperty("appendRowNumber") boolean appendRowNumberEnabled)
     {
         this.schemaTableName = requireNonNull(schemaTableName, "table is null");
         this.tablePath = requireNonNull(tablePath, "tablePath is null");
@@ -97,6 +98,7 @@ public final class HiveTableLayoutHandle
         this.layoutString = requireNonNull(layoutString, "layoutString is null");
         this.requestedColumns = requireNonNull(requestedColumns, "requestedColumns is null");
         this.partialAggregationsPushedDown = partialAggregationsPushedDown;
+        this.appendRowNumberEnabled = appendRowNumberEnabled;
     }
 
     public HiveTableLayoutHandle(
@@ -115,7 +117,8 @@ public final class HiveTableLayoutHandle
             boolean pushdownFilterEnabled,
             String layoutString,
             Optional<Set<HiveColumnHandle>> requestedColumns,
-            boolean partialAggregationsPushedDown)
+            boolean partialAggregationsPushedDown,
+            boolean appendRowNumberEnabled)
     {
         this.schemaTableName = requireNonNull(schemaTableName, "table is null");
         this.tablePath = requireNonNull(tablePath, "tablePath is null");
@@ -133,6 +136,7 @@ public final class HiveTableLayoutHandle
         this.layoutString = requireNonNull(layoutString, "layoutString is null");
         this.requestedColumns = requireNonNull(requestedColumns, "requestedColumns is null");
         this.partialAggregationsPushedDown = partialAggregationsPushedDown;
+        this.appendRowNumberEnabled = appendRowNumberEnabled;
     }
 
     @JsonProperty
@@ -240,6 +244,12 @@ public final class HiveTableLayoutHandle
     public boolean isPartialAggregationsPushedDown()
     {
         return partialAggregationsPushedDown;
+    }
+
+    @JsonProperty
+    public boolean isAppendRowNumberEnabled()
+    {
+        return appendRowNumberEnabled;
     }
 
     @Override

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/DwrfSelectivePageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/DwrfSelectivePageSourceFactory.java
@@ -109,7 +109,8 @@ public class DwrfSelectivePageSourceFactory
             RowExpression remainingPredicate,
             DateTimeZone hiveStorageTimeZone,
             HiveFileContext hiveFileContext,
-            Optional<EncryptionInformation> encryptionInformation)
+            Optional<EncryptionInformation> encryptionInformation,
+            boolean appendRowNumberEnabled)
     {
         if (!OrcSerde.class.getName().equals(storage.getStorageFormat().getSerDe())) {
             return Optional.empty();
@@ -148,6 +149,7 @@ public class DwrfSelectivePageSourceFactory
                 hiveFileContext,
                 tupleDomainFilterCache,
                 encryptionInformation,
-                dwrfEncryptionProvider));
+                dwrfEncryptionProvider,
+                appendRowNumberEnabled));
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcSelectivePageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/orc/OrcSelectivePageSourceFactory.java
@@ -214,7 +214,8 @@ public class OrcSelectivePageSourceFactory
             RowExpression remainingPredicate,
             DateTimeZone hiveStorageTimeZone,
             HiveFileContext hiveFileContext,
-            Optional<EncryptionInformation> encryptionInformation)
+            Optional<EncryptionInformation> encryptionInformation,
+            boolean appendRowNumberEnabled)
     {
         if (!OrcSerde.class.getName().equals(storage.getStorageFormat().getSerDe())) {
             return Optional.empty();
@@ -254,7 +255,8 @@ public class OrcSelectivePageSourceFactory
                 hiveFileContext,
                 tupleDomainFilterCache,
                 encryptionInformation,
-                NO_ENCRYPTION));
+                NO_ENCRYPTION,
+                appendRowNumberEnabled));
     }
 
     public static ConnectorPageSource createOrcPageSource(
@@ -286,7 +288,8 @@ public class OrcSelectivePageSourceFactory
             HiveFileContext hiveFileContext,
             TupleDomainFilterCache tupleDomainFilterCache,
             Optional<EncryptionInformation> encryptionInformation,
-            DwrfEncryptionProvider dwrfEncryptionProvider)
+            DwrfEncryptionProvider dwrfEncryptionProvider,
+            boolean appendRowNumberEnabled)
     {
         checkArgument(domainCompactionThreshold >= 1, "domainCompactionThreshold must be at least 1");
 
@@ -295,7 +298,11 @@ public class OrcSelectivePageSourceFactory
         DataSize streamBufferSize = getOrcStreamBufferSize(session);
         DataSize tinyStripeThreshold = getOrcTinyStripeThreshold(session);
         DataSize maxReadBlockSize = getOrcMaxReadBlockSize(session);
-        OrcReaderOptions orcReaderOptions = new OrcReaderOptions(maxMergeDistance, tinyStripeThreshold, maxReadBlockSize, isOrcZstdJniDecompressionEnabled(session));
+        OrcReaderOptions orcReaderOptions = new OrcReaderOptions(maxMergeDistance,
+                tinyStripeThreshold,
+                maxReadBlockSize,
+                isOrcZstdJniDecompressionEnabled(session),
+                appendRowNumberEnabled);
         boolean lazyReadSmallRanges = getOrcLazyReadSmallRanges(session);
 
         OrcDataSource orcDataSource;

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetSelectivePageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetSelectivePageSourceFactory.java
@@ -39,6 +39,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
+import static com.google.common.base.Preconditions.checkState;
 
 public class ParquetSelectivePageSourceFactory
         implements HiveSelectivePageSourceFactory
@@ -71,12 +72,13 @@ public class ParquetSelectivePageSourceFactory
             RowExpression remainingPredicate,
             DateTimeZone hiveStorageTimeZone,
             HiveFileContext hiveFileContext,
-            Optional<EncryptionInformation> encryptionInformation)
+            Optional<EncryptionInformation> encryptionInformation,
+            boolean appendRowNumberEnabled)
     {
         if (!PARQUET_SERDE_CLASS_NAMES.contains(storage.getStorageFormat().getSerDe())) {
             return Optional.empty();
         }
-
+        checkState(!appendRowNumberEnabled, "append row number is not supported for Parquet Reader");
         throw new PrestoException(NOT_SUPPORTED, "Parquet reader doesn't support filter pushdown yet");
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/rule/HiveAddRequestedColumnsToLayout.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/rule/HiveAddRequestedColumnsToLayout.java
@@ -90,7 +90,8 @@ public class HiveAddRequestedColumnsToLayout
                     Optional.of(tableScan.getOutputVariables().stream()
                             .map(output -> (HiveColumnHandle) tableScan.getAssignments().get(output))
                             .collect(toImmutableSet())),
-                    hiveLayout.isPartialAggregationsPushedDown());
+                    hiveLayout.isPartialAggregationsPushedDown(),
+                    hiveLayout.isAppendRowNumberEnabled());
 
             return new TableScanNode(
                     tableScan.getSourceLocation(),

--- a/presto-hive/src/main/java/com/facebook/presto/hive/rule/HiveFilterPushdown.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/rule/HiveFilterPushdown.java
@@ -294,7 +294,8 @@ public class HiveFilterPushdown
                                         remainingExpression,
                                         domainPredicate),
                                 currentLayoutHandle.map(layout -> ((HiveTableLayoutHandle) layout).getRequestedColumns()).orElse(Optional.empty()),
-                                false)),
+                                false,
+                                currentLayoutHandle.map(layout -> ((HiveTableLayoutHandle) layout).isAppendRowNumberEnabled()).orElse(false))),
                 dynamicFilterExpression);
     }
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -793,6 +793,7 @@ public abstract class AbstractTestHiveClient
                 false,
                 "layout",
                 Optional.empty(),
+                false,
                 false);
 
         int partitionColumnIndex = MAX_PARTITION_KEY_COLUMN_INDEX;
@@ -862,6 +863,7 @@ public abstract class AbstractTestHiveClient
                         false,
                         "layout",
                         Optional.empty(),
+                        false,
                         false),
                 Optional.empty(),
                 withColumnDomains(ImmutableMap.of(
@@ -907,6 +909,7 @@ public abstract class AbstractTestHiveClient
                 false,
                 "layout",
                 Optional.empty(),
+                false,
                 false));
         timeZone = DateTimeZone.forTimeZone(TimeZone.getTimeZone(ZoneId.of(timeZoneId)));
     }
@@ -2098,6 +2101,7 @@ public abstract class AbstractTestHiveClient
                     false,
                     "layout",
                     Optional.empty(),
+                    false,
                     false);
 
             List<ConnectorSplit> splits = getAllSplits(session, transaction, modifiedReadBucketCountLayoutHandle);

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestDynamicPruning.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestDynamicPruning.java
@@ -178,6 +178,7 @@ public class TestDynamicPruning
                         false,
                         "layout",
                         Optional.empty(),
+                        false,
                         false)));
         HivePageSourceProvider provider = new HivePageSourceProvider(config, createTestHdfsEnvironment(config, metastoreClientConfig), getDefaultHiveRecordCursorProvider(config, metastoreClientConfig), getDefaultHiveBatchPageSourceFactories(config, metastoreClientConfig), getDefaultHiveSelectivePageSourceFactories(config, metastoreClientConfig), FUNCTION_AND_TYPE_MANAGER, ROW_EXPRESSION_SERVICE);
         return provider.createPageSource(transaction, getSession(config), split, tableHandle.getLayout().get(), ImmutableList.copyOf(getColumnHandles()), splitContext);

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSink.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePageSink.java
@@ -280,6 +280,7 @@ public class TestHivePageSink
                         false,
                         "layout",
                         Optional.empty(),
+                        false,
                         false)));
         HivePageSourceProvider provider = new HivePageSourceProvider(config, createTestHdfsEnvironment(config, metastoreClientConfig), getDefaultHiveRecordCursorProvider(config, metastoreClientConfig), getDefaultHiveBatchPageSourceFactories(config, metastoreClientConfig), getDefaultHiveSelectivePageSourceFactories(config, metastoreClientConfig), FUNCTION_AND_TYPE_MANAGER, ROW_EXPRESSION_SERVICE);
         return provider.createPageSource(transaction, getSession(config), split, tableHandle.getLayout().get(), ImmutableList.copyOf(getColumnHandles()), NON_CACHEABLE);

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitManager.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitManager.java
@@ -569,6 +569,7 @@ public class TestHiveSplitManager
                         false,
                         "layout",
                         Optional.empty(),
+                        false,
                         false),
                 SPLIT_SCHEDULING_CONTEXT);
         List<Set<ColumnHandle>> actualRedundantColumnDomains = splitSource.getNextBatch(NOT_PARTITIONED, 100).get().getSplits().stream()


### PR DESCRIPTION
OrcSelectiveReader now supports appending rowNumber column to a page. This change allows
enabling that option through the hive selective page source factory 

Test plan
Ensure all existing tests pass

```
== NO RELEASE NOTE ==
```
