### PR TITLE
Add optimization rule REWRITE OR IN JOIN CONDITION TO UNION ALL (FOR INNER JOINS)

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/PartitioningScheme.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/PartitioningScheme.java
@@ -20,9 +20,11 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -162,5 +164,14 @@ public class PartitioningScheme
                 .add("replicateNullsAndAny", replicateNullsAndAny)
                 .add("bucketToPartition", bucketToPartition)
                 .toString();
+    }
+    public PartitioningScheme deepCopy(
+            Map<VariableReferenceExpression, VariableReferenceExpression> variableMappings)
+    {
+        return new PartitioningScheme(
+                Partitioning.create(
+                        getPartitioning().getHandle(),
+                        getPartitioning().getArguments().stream().map(argument -> argument.deepCopy(variableMappings)).collect(Collectors.toList())),
+                getOutputLayout().stream().map(variableMappings::get).collect(Collectors.toList()));
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/GroupReference.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/GroupReference.java
@@ -14,14 +14,17 @@
 package com.facebook.presto.sql.planner.iterative;
 
 import com.facebook.presto.spi.SourceLocation;
+import com.facebook.presto.spi.VariableAllocator;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeId;
+import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.planner.plan.InternalPlanNode;
 import com.facebook.presto.sql.planner.plan.InternalPlanVisitor;
 import com.google.common.collect.ImmutableList;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 public class GroupReference
@@ -64,5 +67,18 @@ public class GroupReference
     public PlanNode replaceChildren(List<PlanNode> newChildren)
     {
         throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public GroupReference deepCopy(
+            PlanNodeIdAllocator planNodeIdAllocator,
+            VariableAllocator variableAllocator,
+            Map<VariableReferenceExpression, VariableReferenceExpression> variableMappings)
+    {
+        return new GroupReference(
+                getSourceLocation(),
+                planNodeIdAllocator.getNextId(),
+                getGroupId(),
+                getOutputVariables());
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/DeleteNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/DeleteNode.java
@@ -14,8 +14,10 @@
 package com.facebook.presto.sql.planner.plan;
 
 import com.facebook.presto.spi.SourceLocation;
+import com.facebook.presto.spi.VariableAllocator;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeId;
+import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -25,6 +27,7 @@ import com.google.common.collect.Iterables;
 import javax.annotation.concurrent.Immutable;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
@@ -87,5 +90,20 @@ public class DeleteNode
     public PlanNode replaceChildren(List<PlanNode> newChildren)
     {
         return new DeleteNode(getSourceLocation(), getId(), Iterables.getOnlyElement(newChildren), rowId, outputVariables);
+    }
+
+    public DeleteNode deepCopy(
+            PlanNodeIdAllocator planNodeIdAllocator,
+            VariableAllocator variableAllocator,
+            Map<VariableReferenceExpression, VariableReferenceExpression> variableMappings)
+    {
+        PlanNode sourceDeepCopy = getSource().deepCopy(planNodeIdAllocator, variableAllocator, variableMappings);
+
+        return new DeleteNode(
+                getSourceLocation(),
+                planNodeIdAllocator.getNextId(),
+                sourceDeepCopy,
+                getRowId().deepCopy(variableMappings),
+                sourceDeepCopy.getOutputVariables());
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/EnforceSingleRowNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/EnforceSingleRowNode.java
@@ -14,8 +14,10 @@
 package com.facebook.presto.sql.planner.plan;
 
 import com.facebook.presto.spi.SourceLocation;
+import com.facebook.presto.spi.VariableAllocator;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeId;
+import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -25,6 +27,7 @@ import com.google.common.collect.Iterables;
 import javax.annotation.concurrent.Immutable;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
@@ -74,5 +77,16 @@ public class EnforceSingleRowNode
     public PlanNode replaceChildren(List<PlanNode> newChildren)
     {
         return new EnforceSingleRowNode(getSourceLocation(), getId(), Iterables.getOnlyElement(newChildren));
+    }
+
+    public EnforceSingleRowNode deepCopy(
+            PlanNodeIdAllocator planNodeIdAllocator,
+            VariableAllocator variableAllocator,
+            Map<VariableReferenceExpression, VariableReferenceExpression> variableMappings)
+    {
+        return new EnforceSingleRowNode(
+                getSourceLocation(),
+                planNodeIdAllocator.getNextId(),
+                getSource().deepCopy(planNodeIdAllocator, variableAllocator, variableMappings));
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/OutputNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/OutputNode.java
@@ -14,8 +14,10 @@
 package com.facebook.presto.sql.planner.plan;
 
 import com.facebook.presto.spi.SourceLocation;
+import com.facebook.presto.spi.VariableAllocator;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeId;
+import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -25,7 +27,9 @@ import com.google.common.collect.Iterables;
 
 import javax.annotation.concurrent.Immutable;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
@@ -92,5 +96,19 @@ public class OutputNode
     public PlanNode replaceChildren(List<PlanNode> newChildren)
     {
         return new OutputNode(getSourceLocation(), getId(), Iterables.getOnlyElement(newChildren), columnNames, outputVariables);
+    }
+
+    public OutputNode deepCopy(
+            PlanNodeIdAllocator planNodeIdAllocator,
+            VariableAllocator variableAllocator,
+            Map<VariableReferenceExpression, VariableReferenceExpression> variableMappings)
+    {
+        PlanNode sourcesDeepCopy = getSource().deepCopy(planNodeIdAllocator, variableAllocator, variableMappings);
+        return new OutputNode(
+                getSourceLocation(),
+                planNodeIdAllocator.getNextId(),
+                sourcesDeepCopy,
+                new ArrayList<>(columnNames),
+                sourcesDeepCopy.getOutputVariables());
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/SortNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/plan/SortNode.java
@@ -14,9 +14,12 @@
 package com.facebook.presto.sql.planner.plan;
 
 import com.facebook.presto.spi.SourceLocation;
+import com.facebook.presto.spi.VariableAllocator;
+import com.facebook.presto.spi.plan.Ordering;
 import com.facebook.presto.spi.plan.OrderingScheme;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeId;
+import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -24,7 +27,9 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static java.util.Objects.requireNonNull;
 
@@ -93,5 +98,23 @@ public class SortNode
     public PlanNode replaceChildren(List<PlanNode> newChildren)
     {
         return new SortNode(getSourceLocation(), getId(), Iterables.getOnlyElement(newChildren), orderingScheme, isPartial);
+    }
+
+    public SortNode deepCopy(
+            PlanNodeIdAllocator planNodeIdAllocator,
+            VariableAllocator variableAllocator,
+            Map<VariableReferenceExpression, VariableReferenceExpression> variableMappings)
+    {
+        getOutputVariables().stream().forEach(v -> variableMappings.put(v, variableAllocator.newVariable(v.getSourceLocation(), v.getName(), v.getType())));
+        PlanNode sourcesDeepCopy = getSource().deepCopy(planNodeIdAllocator, variableAllocator, variableMappings);
+        OrderingScheme orderingSchemeDeepCopy = new OrderingScheme(getOrderingScheme().getOrderBy().stream()
+                .map(ordering -> new Ordering(variableMappings.get(ordering.getVariable()), ordering.getSortOrder()))
+                .collect(Collectors.toList()));
+        return new SortNode(
+                getSourceLocation(),
+                planNodeIdAllocator.getNextId(),
+                sourcesDeepCopy,
+                orderingSchemeDeepCopy,
+                isPartial());
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/relational/OriginalExpressionUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/relational/OriginalExpressionUtils.java
@@ -20,8 +20,10 @@ import com.facebook.presto.spi.relation.RowExpressionVisitor;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.facebook.presto.sql.analyzer.ExpressionTreeUtils;
 import com.facebook.presto.sql.tree.Expression;
+import com.facebook.presto.sql.tree.InPredicate;
 import com.facebook.presto.sql.tree.SymbolReference;
 
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -130,6 +132,18 @@ public final class OriginalExpressionUtils
         @Override
         public <R, C> R accept(RowExpressionVisitor<R, C> visitor, C context)
         {
+            throw new UnsupportedOperationException("OriginalExpression cannot appear in a RowExpression tree");
+        }
+
+        @Override
+        public OriginalExpression deepCopy(Map<VariableReferenceExpression, VariableReferenceExpression> variableMappings)
+        {
+            // TODO For testing only. Remove it before commit.
+            if (expression instanceof InPredicate) {
+                InPredicate inPredicateExpression = (InPredicate) expression;
+                return new OriginalExpression(new InPredicate(inPredicateExpression.getValue(), inPredicateExpression.getValueList()));
+            }
+            // END TODO
             throw new UnsupportedOperationException("OriginalExpression cannot appear in a RowExpression tree");
         }
     }

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/TestMemo.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/iterative/TestMemo.java
@@ -15,6 +15,7 @@ package com.facebook.presto.sql.planner.iterative;
 
 import com.facebook.presto.cost.PlanCostEstimate;
 import com.facebook.presto.cost.PlanNodeStatsEstimate;
+import com.facebook.presto.spi.VariableAllocator;
 import com.facebook.presto.spi.plan.PlanNode;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
@@ -23,7 +24,9 @@ import com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static org.testng.Assert.assertEquals;
@@ -309,6 +312,19 @@ public class TestMemo
         public PlanNode replaceChildren(List<PlanNode> newChildren)
         {
             return new GenericNode(getId(), newChildren);
+        }
+
+        @Override
+        public GenericNode deepCopy(
+                PlanNodeIdAllocator planNodeIdAllocator,
+                VariableAllocator variableAllocator,
+                Map<VariableReferenceExpression, VariableReferenceExpression> variableMappings)
+        {
+            List<PlanNode> sourcesDeepCopy = getSources().stream()
+                    .map(planNode -> planNode.deepCopy(planNodeIdAllocator, variableAllocator, variableMappings))
+                    .collect(Collectors.toList());
+
+            return new GenericNode(planNodeIdAllocator.getNextId(), sourcesDeepCopy);
         }
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/plan/FilterNode.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/plan/FilterNode.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.spi.plan;
 
 import com.facebook.presto.spi.SourceLocation;
+import com.facebook.presto.spi.VariableAllocator;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -22,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import javax.annotation.concurrent.Immutable;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -113,5 +115,15 @@ public final class FilterNode
     public int hashCode()
     {
         return Objects.hash(source, predicate);
+    }
+
+    public FilterNode deepCopy(
+            PlanNodeIdAllocator planNodeIdAllocator,
+            VariableAllocator variableAllocator,
+            Map<VariableReferenceExpression, VariableReferenceExpression> variableMappings)
+    {
+        PlanNode sourcesDeepCopy = getSource().deepCopy(planNodeIdAllocator, variableAllocator, variableMappings);
+        RowExpression predicateCopy = predicate.deepCopy(variableMappings);
+        return new FilterNode(getSourceLocation(), planNodeIdAllocator.getNextId(), sourcesDeepCopy, predicateCopy);
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/plan/PlanNode.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/plan/PlanNode.java
@@ -14,11 +14,14 @@
 package com.facebook.presto.spi.plan;
 
 import com.facebook.presto.spi.SourceLocation;
+import com.facebook.presto.spi.VariableAllocator;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
@@ -67,6 +70,39 @@ public abstract class PlanNode
      * Alter the upstream PlanNodes of the current PlanNode.
      */
     public abstract PlanNode replaceChildren(List<PlanNode> newChildren);
+
+    /**
+     * Create a deep copy of the current PlanNode.
+     */
+//    TODO Uncomment this code
+//    public abstract PlanNode deepCopy(
+//            PlanNodeIdAllocator planNodeIdAllocator,
+//            VariableAllocator variableAllocator,
+//            Map<VariableReferenceExpression, VariableReferenceExpression> variableMappings);
+    public PlanNode deepCopy(
+            PlanNodeIdAllocator planNodeIdAllocator,
+            VariableAllocator variableAllocator,
+            Map<VariableReferenceExpression, VariableReferenceExpression> variableMappings)
+    {
+        return null;
+    }
+
+    public static List<VariableReferenceExpression> translateVariableReferences(
+            List<VariableReferenceExpression> originalVariables,
+            VariableAllocator variableAllocator,
+            Map<VariableReferenceExpression, VariableReferenceExpression> variableMappings)
+    {
+        List<VariableReferenceExpression> newVariables = new ArrayList<>();
+        for (int i = 0; i < originalVariables.size(); ++i) {
+            if (!variableMappings.containsKey(originalVariables.get(i))) {
+                variableMappings.put(
+                        originalVariables.get(i),
+                        variableAllocator.newVariable(originalVariables.get(i).getName(), originalVariables.get(i).getType()));
+            }
+            newVariables.add(variableMappings.get(originalVariables.get(i)));
+        }
+        return newVariables;
+    }
 
     /**
      * A visitor pattern interface to operate on IR.

--- a/presto-spi/src/main/java/com/facebook/presto/spi/plan/ValuesNode.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/plan/ValuesNode.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.spi.plan;
 
 import com.facebook.presto.spi.SourceLocation;
+import com.facebook.presto.spi.VariableAllocator;
 import com.facebook.presto.spi.relation.RowExpression;
 import com.facebook.presto.spi.relation.VariableReferenceExpression;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -23,13 +24,14 @@ import javax.annotation.concurrent.Immutable;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import static java.lang.String.format;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
 
 @Immutable
 public final class ValuesNode
@@ -47,7 +49,7 @@ public final class ValuesNode
     {
         super(sourceLocation, id);
         this.outputVariables = immutableListCopyOf(outputVariables);
-        this.rows = immutableListCopyOf(requireNonNull(rows, "lists is null").stream().map(ValuesNode::immutableListCopyOf).collect(Collectors.toList()));
+        this.rows = immutableListCopyOf(requireNonNull(rows, "lists is null").stream().map(ValuesNode::immutableListCopyOf).collect(toList()));
 
         for (List<RowExpression> row : rows) {
             if (!(row.size() == outputVariables.size() || row.size() == 0)) {
@@ -93,5 +95,28 @@ public final class ValuesNode
     private static <T> List<T> immutableListCopyOf(List<T> list)
     {
         return unmodifiableList(new ArrayList<>(requireNonNull(list, "list is null")));
+    }
+
+    public ValuesNode deepCopy(
+            PlanNodeIdAllocator planNodeIdAllocator,
+            VariableAllocator variableAllocator,
+            Map<VariableReferenceExpression, VariableReferenceExpression> variableMappings)
+    {
+        List<VariableReferenceExpression> outputVariablesCopy = new ArrayList<>();
+        for (VariableReferenceExpression variable : getOutputVariables()) {
+            variableMappings.put(variable, variableAllocator.newVariable(variable.getSourceLocation(), variable.getName(), variable.getType()));
+            outputVariablesCopy.add(variableMappings.get(variable));
+        }
+
+        List<List<RowExpression>> rowsCopy = new ArrayList<>();
+        for (List<RowExpression> columns : getRows()) {
+            List<RowExpression> columnsCopy = new ArrayList<>();
+            for (RowExpression item : columns) {
+                columnsCopy.add(item.deepCopy(variableMappings));
+            }
+            rowsCopy.add(unmodifiableList(new ArrayList<>(columnsCopy)));
+        }
+
+        return new ValuesNode(getSourceLocation(), planNodeIdAllocator.getNextId(), unmodifiableList(outputVariablesCopy), unmodifiableList(rowsCopy));
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/relation/CallExpression.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/relation/CallExpression.java
@@ -23,6 +23,7 @@ import javax.annotation.concurrent.Immutable;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -123,5 +124,15 @@ public final class CallExpression
     public <R, C> R accept(RowExpressionVisitor<R, C> visitor, C context)
     {
         return visitor.visitCall(this, context);
+    }
+
+    @Override
+    public CallExpression deepCopy(Map<VariableReferenceExpression, VariableReferenceExpression> variableMappings)
+    {
+        return new CallExpression(
+                getDisplayName(),
+                getFunctionHandle(),
+                getType(),
+                arguments.stream().map(argument -> argument.deepCopy(variableMappings)).collect(Collectors.toList()));
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/relation/ConstantExpression.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/relation/ConstantExpression.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.annotation.concurrent.Immutable;
 
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -113,5 +114,11 @@ public final class ConstantExpression
     public <R, C> R accept(RowExpressionVisitor<R, C> visitor, C context)
     {
         return visitor.visitConstant(this, context);
+    }
+
+    @Override
+    public ConstantExpression deepCopy(Map<VariableReferenceExpression, VariableReferenceExpression> variableMappings)
+    {
+        return new ConstantExpression(getSourceLocation(), getValue(), getType());
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/relation/InputReferenceExpression.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/relation/InputReferenceExpression.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.annotation.concurrent.Immutable;
 
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -87,5 +88,11 @@ public final class InputReferenceExpression
         }
         InputReferenceExpression other = (InputReferenceExpression) obj;
         return Objects.equals(this.field, other.field) && Objects.equals(this.type, other.type);
+    }
+
+    @Override
+    public InputReferenceExpression deepCopy(Map<VariableReferenceExpression, VariableReferenceExpression> variableMappings)
+    {
+        return new InputReferenceExpression(getSourceLocation(), getField(), getType());
     }
 }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/relation/LambdaDefinitionExpression.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/relation/LambdaDefinitionExpression.java
@@ -106,6 +106,12 @@ public final class LambdaDefinitionExpression
     }
 
     @Override
+    public LambdaDefinitionExpression deepCopy(Map<VariableReferenceExpression, VariableReferenceExpression> variableMappings)
+    {
+        return new LambdaDefinitionExpression(getSourceLocation(), getArgumentTypes(), getArguments(), getBody().deepCopy(variableMappings));
+    }
+
+    @Override
     public int hashCode()
     {
         return Objects.hash(argumentTypes, canonicalizedBody);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/relation/RowExpression.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/relation/RowExpression.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
+import java.util.Map;
 import java.util.Optional;
 
 @JsonTypeInfo(
@@ -55,6 +56,8 @@ public abstract class RowExpression
     }
 
     public abstract Type getType();
+
+    public abstract RowExpression deepCopy(Map<VariableReferenceExpression, VariableReferenceExpression> variableMappings);
 
     @Override
     public abstract boolean equals(Object other);

--- a/presto-spi/src/main/java/com/facebook/presto/spi/relation/SpecialFormExpression.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/relation/SpecialFormExpression.java
@@ -20,13 +20,16 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.annotation.concurrent.Immutable;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
 import static java.util.Collections.unmodifiableList;
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toCollection;
 import static java.util.stream.Collectors.toList;
 
 @Immutable
@@ -113,6 +116,16 @@ public class SpecialFormExpression
         SpecialFormExpression other = (SpecialFormExpression) obj;
         return this.form == other.form &&
                 Objects.equals(this.arguments, other.arguments);
+    }
+
+    @Override
+    public SpecialFormExpression deepCopy(Map<VariableReferenceExpression, VariableReferenceExpression> variableMappings)
+    {
+        return new SpecialFormExpression(
+                getSourceLocation(),
+                getForm(),
+                getType(),
+                getArguments().stream().map(argument -> argument.deepCopy(variableMappings)).collect(toCollection(ArrayList::new)));
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/relation/VariableReferenceExpression.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/relation/VariableReferenceExpression.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.annotation.concurrent.Immutable;
 
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -96,5 +97,10 @@ public final class VariableReferenceExpression
             return nameComparison;
         }
         return type.getTypeSignature().toString().compareTo(o.type.getTypeSignature().toString());
+    }
+
+    public VariableReferenceExpression deepCopy(Map<VariableReferenceExpression, VariableReferenceExpression> variableMappings)
+    {
+        return variableMappings.get(this);
     }
 }

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestPlanNodeDeepCopy.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestPlanNodeDeepCopy.java
@@ -1,0 +1,436 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.tests;
+
+import com.facebook.presto.common.predicate.TupleDomain;
+import com.facebook.presto.spi.ConnectorId;
+import com.facebook.presto.spi.VariableAllocator;
+import com.facebook.presto.spi.WarningCollector;
+import com.facebook.presto.spi.plan.Assignments;
+import com.facebook.presto.spi.plan.OrderingScheme;
+import com.facebook.presto.spi.plan.PlanNode;
+import com.facebook.presto.spi.plan.PlanNodeIdAllocator;
+import com.facebook.presto.spi.plan.ValuesNode;
+import com.facebook.presto.spi.relation.CallExpression;
+import com.facebook.presto.spi.relation.ConstantExpression;
+import com.facebook.presto.spi.relation.InputReferenceExpression;
+import com.facebook.presto.spi.relation.LambdaDefinitionExpression;
+import com.facebook.presto.spi.relation.RowExpression;
+import com.facebook.presto.spi.relation.SpecialFormExpression;
+import com.facebook.presto.spi.relation.VariableReferenceExpression;
+import com.facebook.presto.sql.planner.CanonicalTableScanNode;
+import com.facebook.presto.sql.planner.LogicalPlanner;
+import com.facebook.presto.sql.planner.Plan;
+import com.facebook.presto.sql.planner.PlanVariableAllocator;
+import com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder;
+import com.facebook.presto.sql.planner.plan.ApplyNode;
+import com.facebook.presto.sql.planner.plan.AssignUniqueId;
+import com.facebook.presto.sql.planner.plan.ExchangeNode;
+import com.facebook.presto.sql.planner.plan.OutputNode;
+import com.facebook.presto.sql.planner.plan.SortNode;
+import com.facebook.presto.sql.tree.InListExpression;
+import com.facebook.presto.sql.tree.InPredicate;
+import com.facebook.presto.sql.tree.LongLiteral;
+import com.facebook.presto.testing.LocalQueryRunner;
+import com.facebook.presto.tpch.TpchColumnHandle;
+import com.facebook.presto.tpch.TpchTableHandle;
+import com.facebook.presto.tpch.TpchTableLayoutHandle;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.sql.planner.iterative.rule.test.PlanBuilder.assignment;
+import static java.util.Collections.emptyList;
+import static java.util.stream.Collectors.collectingAndThen;
+import static java.util.stream.Collectors.toList;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotSame;
+import static org.testng.Assert.assertTrue;
+
+public class TestPlanNodeDeepCopy
+{
+    private LocalQueryRunner queryRunner;
+    PlanNodeIdAllocator planNodeIdAllocator;
+    Map<VariableReferenceExpression, VariableReferenceExpression> variableMappings;
+    PlanBuilder p;
+    PlanNodeDeepCopyChecker planNodeDeepCopyChecker;
+
+    @BeforeClass
+    public void setUp()
+    {
+        queryRunner = new LocalQueryRunner(TEST_SESSION);
+        planNodeIdAllocator = new PlanNodeIdAllocator();
+        variableMappings = new HashMap<>();
+//        Session tpchSession = testSessionBuilder()
+//            .setCatalog("tpch")
+//            .setSchema(TINY_SCHEMA_NAME)
+//            .build();
+        p = new PlanBuilder(TEST_SESSION, planNodeIdAllocator, queryRunner.getMetadata());
+        planNodeDeepCopyChecker = new PlanNodeDeepCopyChecker(variableMappings);
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void tearDown()
+    {
+        queryRunner = null;
+        planNodeIdAllocator = null;
+        variableMappings = null;
+        p = null;
+        planNodeDeepCopyChecker = null;
+    }
+
+    public ConnectorId getCurrentConnectorId()
+    {
+        return queryRunner.inTransaction(transactionSession -> queryRunner.getMetadata().getCatalogHandle(transactionSession, transactionSession.getCatalog().get())).get();
+    }
+
+    @Test
+    public void test()
+    {
+        Plan queryPlan = queryRunner.createPlan(TEST_SESSION, "SELECT * FROM (VALUES 1, 2, 3) t(x) WHERE t.x IN (SELECT * FROM (VALUES 1,2,3))", LogicalPlanner.Stage.OPTIMIZED_AND_VALIDATED, WarningCollector.NOOP);
+        TpchTableHandle nationTpchTableHandle = new TpchTableHandle("nation", 1.0);
+        PlanNode node = new CanonicalTableScanNode(
+                Optional.empty(),
+                planNodeIdAllocator.getNextId(),
+                new CanonicalTableScanNode.CanonicalTableHandle(
+                        new ConnectorId("tpch"),
+                        new TpchTableHandle("nation", 1.0),
+                        Optional.of(new TpchTableLayoutHandle(nationTpchTableHandle, TupleDomain.all()))),
+                ImmutableList.of(p.variable("nationkey", BIGINT)),
+                ImmutableMap.of(p.variable("nationkey", BIGINT), new TpchColumnHandle("nationkey", BIGINT)));
+        VariableAllocator variableAllocator = new PlanVariableAllocator(p.getTypes().allVariables());
+        planNodeDeepCopyChecker.validate(node, node.deepCopy(planNodeIdAllocator, variableAllocator, variableMappings));
+    }
+
+    @Test
+    public void testCanonicalTableScanNode()
+    {
+        TpchTableHandle nationTpchTableHandle = new TpchTableHandle("nation", 1.0);
+        PlanNode node = new CanonicalTableScanNode(
+                Optional.empty(),
+                planNodeIdAllocator.getNextId(),
+                new CanonicalTableScanNode.CanonicalTableHandle(
+                        new ConnectorId("tpch"),
+                        new TpchTableHandle("nation", 1.0),
+                        Optional.of(new TpchTableLayoutHandle(nationTpchTableHandle, TupleDomain.all()))),
+                ImmutableList.of(p.variable("nationkey", BIGINT)),
+                ImmutableMap.of(p.variable("nationkey", BIGINT), new TpchColumnHandle("nationkey", BIGINT)));
+        VariableAllocator variableAllocator = new PlanVariableAllocator(p.getTypes().allVariables());
+        planNodeDeepCopyChecker.validate(node, node.deepCopy(planNodeIdAllocator, variableAllocator, variableMappings));
+    }
+
+    @Test
+    public void testAssignUniqueId()
+    {
+        PlanNode node = p.assignUniqueId(p.variable("id"), p.values(p.variable("col1"), p.variable("col2")));
+        VariableAllocator variableAllocator = new PlanVariableAllocator(p.getTypes().allVariables());
+        planNodeDeepCopyChecker.validate(node, node.deepCopy(planNodeIdAllocator, variableAllocator, variableMappings));
+    }
+
+    @Test
+    public void testSortNode()
+    {
+        VariableReferenceExpression a = p.variable("a");
+        VariableReferenceExpression b = p.variable("b");
+        PlanNode node = p.sort(
+                ImmutableList.of(a),
+                p.values(a, b));
+        VariableAllocator variableAllocator = new PlanVariableAllocator(p.getTypes().allVariables());
+        planNodeDeepCopyChecker.validate(node, node.deepCopy(planNodeIdAllocator, variableAllocator, variableMappings));
+    }
+
+    @Test
+    public void testExchangeNode()
+    {
+        PlanNode node = p.exchange(exchangeBuilder -> exchangeBuilder
+                .addInputsSet(p.variable("i11", BIGINT), p.variable("i12", BIGINT), p.variable("i13", BIGINT), p.variable("i14", BIGINT))
+                .addInputsSet(p.variable("i21", BIGINT), p.variable("i22", BIGINT), p.variable("i23", BIGINT), p.variable("i24", BIGINT))
+                .fixedHashDistributionPartitioningScheme(
+                        ImmutableList.of(p.variable("o1", BIGINT), p.variable("o2", BIGINT), p.variable("o3", BIGINT), p.variable("o4", BIGINT)),
+                        emptyList())
+                .addSource(p.values(p.variable("i11", BIGINT), p.variable("i12", BIGINT), p.variable("i13", BIGINT), p.variable("i14", BIGINT)))
+                .addSource(p.values(p.variable("i21", BIGINT), p.variable("i22", BIGINT), p.variable("i23", BIGINT), p.variable("i24", BIGINT))));
+        VariableAllocator variableAllocator = new PlanVariableAllocator(p.getTypes().allVariables());
+        planNodeDeepCopyChecker.validate(node, node.deepCopy(planNodeIdAllocator, variableAllocator, variableMappings));
+    }
+
+    @Test
+    public void testApplyNode()
+    {
+        PlanNode node = p.apply(
+                assignment(
+                        p.variable("a", BIGINT),
+                        new InPredicate(
+                                new LongLiteral("1"),
+                                new InListExpression(ImmutableList.of(
+                                        new LongLiteral("1"),
+                                        new LongLiteral("2"))))),
+                ImmutableList.of(),
+                p.values(3, p.variable("input_field")),
+                p.values(3, p.variable("subquery_field")));
+        VariableAllocator variableAllocator = new PlanVariableAllocator(p.getTypes().allVariables());
+        planNodeDeepCopyChecker.validate(node, node.deepCopy(planNodeIdAllocator, variableAllocator, variableMappings));
+    }
+
+    @Test
+    public void testValuesNode()
+    {
+        Plan queryPlan = queryRunner.createPlan(TEST_SESSION, "SELECT * FROM (VALUES 1, 2, 3) t(x)", WarningCollector.NOOP);
+        PlanNode node = p.values(3, p.variable("field"));
+        VariableAllocator variableAllocator = new PlanVariableAllocator(p.getTypes().allVariables());
+        planNodeDeepCopyChecker.validate(node, node.deepCopy(planNodeIdAllocator, variableAllocator, variableMappings));
+    }
+
+    @Test
+    public void test1()
+    {
+        Plan queryPlan = queryRunner.createPlan(TEST_SESSION, "SELECT * FROM (VALUES 1, 2, 3) t(x)", WarningCollector.NOOP);
+
+        PlanNodeIdAllocator planNodeIdAllocator = new PlanNodeIdAllocator();
+        VariableAllocator variableAllocator = new PlanVariableAllocator(queryPlan.getTypes().allVariables());
+        Map<VariableReferenceExpression, VariableReferenceExpression> variableMappings = new HashMap<>();
+        PlanNode rootNodeCopy = queryPlan.getRoot().deepCopy(planNodeIdAllocator, variableAllocator, variableMappings);
+        PlanNodeDeepCopyChecker planNodeDeepCopyChecker = new PlanNodeDeepCopyChecker(variableMappings);
+        planNodeDeepCopyChecker.validate(queryPlan.getRoot(), rootNodeCopy);
+    }
+
+    public static class PlanNodeDeepCopyChecker
+    {
+        Map<VariableReferenceExpression, VariableReferenceExpression> variableMappings;
+        PlanNodeDeepCopyChecker(Map<VariableReferenceExpression, VariableReferenceExpression> variableMappings)
+        {
+            this.variableMappings = variableMappings;
+        }
+        public void validate(PlanNode original, PlanNode copy)
+        {
+            assertEquals(original.getClass(), copy.getClass(), String.format("'%s' type of the plan node does not match the type '%s' of original node", copy.getClass(), original.getClass()));
+            assertNotSame(original.getId(), copy.getId());
+            assertEquals(original.getSourceLocation(), copy.getSourceLocation());
+            assertVariablesDeepCopied(original.getOutputVariables(), copy.getOutputVariables());
+            if (copy instanceof OutputNode) {
+                OutputNode originalOutputNode = (OutputNode) original;
+                OutputNode copyOutputNode = (OutputNode) copy;
+                assertNotSame(originalOutputNode, copyOutputNode);
+                validate(originalOutputNode.getSource(), ((OutputNode) copy).getSource());
+                assertEquals(originalOutputNode.getColumnNames(), copyOutputNode.getColumnNames());
+            }
+            else if (copy instanceof ValuesNode) {
+                ValuesNode originalValuesNode = (ValuesNode) original;
+                ValuesNode copyValuesNode = (ValuesNode) copy;
+                assertNotSame(originalValuesNode, copyValuesNode, "Two nodes are pointing to the same heap location and thus not copied");
+                for (int row = 0; row < originalValuesNode.getRows().size(); ++row) {
+                    for (int col = 0; col < originalValuesNode.getRows().get(row).size(); ++col) {
+                        assertNotSame(originalValuesNode.getRows().get(row).get(col), copyValuesNode.getRows().get(row).get(col));
+                        assertEquals(originalValuesNode.getRows().get(row).get(col), copyValuesNode.getRows().get(row).get(col));
+                    }
+                }
+            }
+            else if (copy instanceof CanonicalTableScanNode) {
+                CanonicalTableScanNode originalCanonicalTableScanNode = (CanonicalTableScanNode) original;
+                CanonicalTableScanNode copyCanonicalTableScanNode = (CanonicalTableScanNode) copy;
+                assertNotSame(originalCanonicalTableScanNode, copyCanonicalTableScanNode);
+                assertEquals(originalCanonicalTableScanNode.getTable(), copyCanonicalTableScanNode.getTable());
+                for (VariableReferenceExpression originalVariable : originalCanonicalTableScanNode.getAssignments().keySet()) {
+                    assertEquals(
+                            originalCanonicalTableScanNode.getAssignments().get(originalVariable),
+                            copyCanonicalTableScanNode.getAssignments().get(variableMappings.get(originalVariable)));
+                }
+            }
+            else if (copy instanceof AssignUniqueId) {
+                AssignUniqueId originalAssignUniqueId = (AssignUniqueId) original;
+                AssignUniqueId copyAssignUniqueId = (AssignUniqueId) copy;
+                assertNotSame(originalAssignUniqueId, copyAssignUniqueId);
+                assertRowExpressionDeepCopied(originalAssignUniqueId.getIdVariable(), copyAssignUniqueId.getIdVariable());
+                validate(originalAssignUniqueId.getSource(), copyAssignUniqueId.getSource());
+            }
+            else if (copy instanceof SortNode) {
+                SortNode originalSortNode = (SortNode) original;
+                SortNode copySortNode = (SortNode) copy;
+                assertNotSame(originalSortNode, copySortNode);
+                assertEquals(originalSortNode.isPartial(), copySortNode.isPartial());
+                assertOrderingSchemeDeepCopied(originalSortNode.getOrderingScheme(), copySortNode.getOrderingScheme());
+
+                validate(originalSortNode.getSource(), copySortNode.getSource());
+            }
+            else if (copy instanceof ApplyNode) {
+                ApplyNode originalApplyNode = (ApplyNode) original;
+                ApplyNode copyApplyNode = (ApplyNode) copy;
+                assertNotSame(originalApplyNode, copyApplyNode, "Two nodes are pointing to the same heap location and thus not copied");
+                validate(originalApplyNode.getInput(), copyApplyNode.getInput());
+                validate(originalApplyNode.getSubquery(), copyApplyNode.getSubquery());
+                assertAssignmentsDeepCopied(originalApplyNode.getSubqueryAssignments(), copyApplyNode.getSubqueryAssignments());
+            }
+            else if (copy instanceof ExchangeNode) {
+                ExchangeNode originalExchangeNode = (ExchangeNode) original;
+                ExchangeNode copyExchangeNode = (ExchangeNode) copy;
+                assertNotSame(originalExchangeNode, copyExchangeNode);
+                assertEquals(originalExchangeNode.getType(), copyExchangeNode.getType());
+                assertEquals(originalExchangeNode.getScope(), copyExchangeNode.getScope());
+                assertEquals(originalExchangeNode.getScope(), copyExchangeNode.getScope());
+                assertPlanNodesDeepCopied(originalExchangeNode.getSources(), copyExchangeNode.getSources());
+                assertEquals(
+                        copyExchangeNode.getInputs(),
+                        originalExchangeNode.getInputs().stream()
+                                .map(variables -> variables.stream()
+                                        .map(v -> variableMappings.get(v))
+                                        .collect(collectingAndThen(toList(), ImmutableList::copyOf)))
+                                .collect(collectingAndThen(toList(), ImmutableList::copyOf)));
+                assertEquals(originalExchangeNode.isEnsureSourceOrdering(), copyExchangeNode.isEnsureSourceOrdering());
+                assertEquals(originalExchangeNode.getOrderingScheme().isPresent(), copyExchangeNode.getOrderingScheme().isPresent());
+                if (originalExchangeNode.getOrderingScheme().isPresent()) {
+                    assertOrderingSchemeDeepCopied(originalExchangeNode.getOrderingScheme().get(), originalExchangeNode.getOrderingScheme().get());
+                }
+            }
+        }
+
+        private void assertOrderingSchemeDeepCopied(OrderingScheme original, OrderingScheme copy)
+        {
+            for (VariableReferenceExpression variable : original.getOrderingsMap().keySet()) {
+                assertEquals(original.getOrdering(variable), copy.getOrdering(variableMappings.get(variable)));
+            }
+        }
+
+        static void assertStreamEquals(Stream<?> s1, Stream<?> s2)
+        {
+            Iterator<?> it1 = s1.iterator();
+            Iterator<?> it2 = s2.iterator();
+            while (it1.hasNext() && it2.hasNext()) {
+                assertEquals(it1.next(), it2.next());
+            }
+            assertTrue(!it1.hasNext() && !it2.hasNext());
+        }
+
+        private void assertVariablesDeepCopied(List<VariableReferenceExpression> original, List<VariableReferenceExpression> copy)
+        {
+            assertEquals(original.size(), copy.size());
+            for (int i = 0; i < original.size(); ++i) {
+                assertNotSame(original.get(i), copy.get(i));
+                assertEquals(variableMappings.get(original.get(i)), copy.get(i));
+            }
+        }
+
+        private void assertAssignmentsDeepCopied(Assignments original, Assignments copy)
+        {
+            assertNotSame(original, copy);
+            assertVariablesDeepCopied(original.getOutputs(), copy.getOutputs());
+            assertEquals(original.getVariables().size(), copy.getVariables().size());
+            for (VariableReferenceExpression key : original.getVariables()) {
+                assertEquals(copy.getMap().containsKey(variableMappings.get(key)), true);
+                assertRowExpressionDeepCopied(original.get(key), copy.get(variableMappings.get(key)));
+            }
+        }
+
+        private void assertPlanNodesDeepCopied(List<PlanNode> original, List<PlanNode> copy)
+        {
+            if (original != copy) {
+                if (original == null || copy == null) {
+                    if (copy != null) {
+                        throw new AssertionError();
+                    }
+                    else {
+                        throw new AssertionError("Plan node lists are not equal: " + original + " and " + copy);
+                    }
+                }
+                if (original.size() != copy.size()) {
+                    throw new AssertionError("Plan node list sizes are not equal: " + original.size() + " and " + copy.size());
+                }
+                for (int i = 0; i < original.size(); ++i) {
+                    validate(original.get(i), copy.get(i));
+                }
+            }
+        }
+        private void assertRowExpressionListDeepCopied(List<RowExpression> original, List<RowExpression> copy)
+        {
+            if (original != copy) {
+                if (original == null || copy == null) {
+                    if (copy != null) {
+                        throw new AssertionError();
+                    }
+                    else {
+                        throw new AssertionError("Expressions are not equal: " + original + " and " + copy);
+                    }
+                }
+                if (original.size() != copy.size()) {
+                    throw new AssertionError("Expression list sizes are not equal: " + original.size() + " and " + copy.size());
+                }
+                for (int i = 0; i < original.size(); ++i) {
+                    assertRowExpressionDeepCopied(original.get(i), copy.get(i));
+                }
+            }
+        }
+
+        private void assertRowExpressionDeepCopied(RowExpression original, RowExpression copy)
+        {
+            assertEquals(original.getClass(), copy.getClass(), String.format("'%s' type of the expression does not match the type '%s' of original expression", copy.getClass(), original.getClass()));
+            assertEquals(original.getSourceLocation(), copy.getSourceLocation());
+            assertNotSame(original, copy);
+            if (original instanceof CallExpression) {
+                CallExpression originalCallExpression = (CallExpression) original;
+                CallExpression copyCallExpression = (CallExpression) copy;
+                assertNotSame(originalCallExpression, copyCallExpression);
+                assertEquals(originalCallExpression.getDisplayName(), copyCallExpression.getDisplayName());
+                assertEquals(originalCallExpression.getFunctionHandle(), copyCallExpression.getFunctionHandle());
+                assertEquals(originalCallExpression.getType(), copyCallExpression.getType());
+                assertEquals(originalCallExpression.getArguments(), copyCallExpression.getArguments());
+            }
+            else if (original instanceof ConstantExpression) {
+                ConstantExpression originalConstantExpression = (ConstantExpression) original;
+                ConstantExpression copyConstantExpression = (ConstantExpression) copy;
+                assertEquals(originalConstantExpression.getType(), copyConstantExpression.getType());
+                assertEquals(originalConstantExpression.getValue(), copyConstantExpression.getValue());
+            }
+            else if (original instanceof InputReferenceExpression) {
+                InputReferenceExpression originalInputReferenceExpression = (InputReferenceExpression) original;
+                InputReferenceExpression copyInputReferenceExpression = (InputReferenceExpression) copy;
+                assertEquals(originalInputReferenceExpression.getType(), copyInputReferenceExpression.getType());
+                assertEquals(originalInputReferenceExpression.getField(), copyInputReferenceExpression.getField());
+            }
+            else if (original instanceof LambdaDefinitionExpression) {
+                LambdaDefinitionExpression originalLambdaDefinitionExpression = (LambdaDefinitionExpression) original;
+                LambdaDefinitionExpression copyLambdaDefinitionExpression = (LambdaDefinitionExpression) copy;
+                assertEquals(originalLambdaDefinitionExpression.getType(), copyLambdaDefinitionExpression.getType());
+                assertEquals(originalLambdaDefinitionExpression.getArguments(), copyLambdaDefinitionExpression.getArguments());
+                assertEquals(originalLambdaDefinitionExpression.getArgumentTypes(), copyLambdaDefinitionExpression.getArgumentTypes());
+                assertRowExpressionDeepCopied(originalLambdaDefinitionExpression.getBody(), copyLambdaDefinitionExpression.getBody());
+            }
+            else if (original instanceof SpecialFormExpression) {
+                SpecialFormExpression originalSpecialFormExpression = (SpecialFormExpression) original;
+                SpecialFormExpression copySpecialFormExpression = (SpecialFormExpression) copy;
+                assertEquals(originalSpecialFormExpression.getType(), copySpecialFormExpression.getType());
+                assertEquals(originalSpecialFormExpression.getForm(), copySpecialFormExpression.getForm());
+                assertEquals(originalSpecialFormExpression.getArguments().size(), copySpecialFormExpression.getArguments().size());
+                for (int i = 0; i < originalSpecialFormExpression.getArguments().size(); ++i) {
+                    assertRowExpressionDeepCopied(originalSpecialFormExpression.getArguments().get(i), copySpecialFormExpression.getArguments().get(i));
+                }
+            }
+            else if (original instanceof VariableReferenceExpression) {
+                VariableReferenceExpression originalVariableReferenceExpression = (VariableReferenceExpression) original;
+                VariableReferenceExpression copyVariableReferenceExpression = (VariableReferenceExpression) copy;
+                assertEquals(originalVariableReferenceExpression.getType(), copyVariableReferenceExpression.getType());
+                assertEquals(variableMappings.get(originalVariableReferenceExpression), copyVariableReferenceExpression);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Complex OR expressions in join conditions generally result in heavy overhead, especially if the CNF does not result in a good equality condition - which turns this into a “cross join” + filter which can be very slow - mainly because we evaluate all the clauses in OR with no short-circuit - for every row (to handle NULL properly).So the idea is to build the DNF in that case and generate a UNION ALL with one condition per branch and successively negating the previous conditions as we go along. So:
SELECT .. FROM T1 JOIN T2 ON T1.k1 = T2.k1 OR T1.k2 = T2.k2 OR ..
Can be rewritten as:
SELECT .. FROM T1 JOIN T2 ON T1.k1 = T2.k1 UNION ALL SELECT .. FROM T1 JOIN T2 ON COALESCE(T1.k1 <> T2.k1, true) AND T1.k2 = T2.k2 ...
So we will only have conjunctions which are easier to pushdown and process in general.

== NO RELEASE NOTE ==