### PR TITLE
Allow customization of StreamKind for Boolean streams

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/BooleanOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/BooleanOutputStream.java
@@ -18,6 +18,7 @@ import com.facebook.presto.orc.DwrfDataEncryptor;
 import com.facebook.presto.orc.OrcOutputBuffer;
 import com.facebook.presto.orc.checkpoint.BooleanStreamCheckpoint;
 import com.facebook.presto.orc.checkpoint.ByteStreamCheckpoint;
+import com.facebook.presto.orc.metadata.Stream.StreamKind;
 import com.google.common.collect.ImmutableList;
 import org.openjdk.jol.info.ClassLayout;
 
@@ -161,6 +162,12 @@ public class BooleanOutputStream
     {
         checkState(closed);
         return byteOutputStream.getStreamDataOutput(column);
+    }
+
+    public StreamDataOutput getStreamDataOutput(int column, StreamKind streamKind)
+    {
+        checkState(closed);
+        return byteOutputStream.getStreamDataOutput(column, streamKind);
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/ByteOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/ByteOutputStream.java
@@ -18,6 +18,7 @@ import com.facebook.presto.orc.DwrfDataEncryptor;
 import com.facebook.presto.orc.OrcOutputBuffer;
 import com.facebook.presto.orc.checkpoint.ByteStreamCheckpoint;
 import com.facebook.presto.orc.metadata.Stream;
+import com.facebook.presto.orc.metadata.Stream.StreamKind;
 import com.google.common.collect.ImmutableList;
 import io.airlift.slice.SizeOf;
 import org.openjdk.jol.info.ClassLayout;
@@ -151,7 +152,12 @@ public class ByteOutputStream
     @Override
     public StreamDataOutput getStreamDataOutput(int column)
     {
-        return new StreamDataOutput(buffer::writeDataTo, new Stream(column, DATA, toIntExact(buffer.getOutputDataSize()), false));
+        return getStreamDataOutput(column, DATA);
+    }
+
+    public StreamDataOutput getStreamDataOutput(int column, StreamKind streamKind)
+    {
+        return new StreamDataOutput(buffer::writeDataTo, new Stream(column, streamKind, toIntExact(buffer.getOutputDataSize()), false));
     }
 
     @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/PresentOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/PresentOutputStream.java
@@ -17,7 +17,6 @@ import com.facebook.presto.orc.ColumnWriterOptions;
 import com.facebook.presto.orc.DwrfDataEncryptor;
 import com.facebook.presto.orc.OrcOutputBuffer;
 import com.facebook.presto.orc.checkpoint.BooleanStreamCheckpoint;
-import com.facebook.presto.orc.metadata.Stream;
 import org.openjdk.jol.info.ClassLayout;
 
 import javax.annotation.Nullable;
@@ -29,7 +28,6 @@ import java.util.Optional;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
-import static java.lang.Math.toIntExact;
 
 public class PresentOutputStream
 {
@@ -108,15 +106,10 @@ public class PresentOutputStream
         if (booleanOutputStream == null) {
             return Optional.empty();
         }
-        StreamDataOutput streamDataOutput = booleanOutputStream.getStreamDataOutput(column);
-        // rewrite the DATA stream created by the boolean output stream to a PRESENT stream
-        Stream stream = new Stream(column, PRESENT, toIntExact(streamDataOutput.size()), streamDataOutput.getStream().isUseVInts());
-        return Optional.of(new StreamDataOutput(
-                sliceOutput -> {
-                    streamDataOutput.writeData(sliceOutput);
-                    return stream.getLength();
-                },
-                stream));
+
+        // get boolean output DATA stream as PRESENT stream
+        StreamDataOutput streamDataOutput = booleanOutputStream.getStreamDataOutput(column, PRESENT);
+        return Optional.of(streamDataOutput);
     }
 
     public long getBufferedBytes()


### PR DESCRIPTION
Allow customization of StreamKind of a stream produced by BooleanOutputStream. This is already done by PresentOutputStream, and I'd need to do it one more time for IN_MAP output stream.

Test plan:
- existing tests


```
== NO RELEASE NOTE ==
```
