### PR TITLE
Fix some 'Populate maven cache' steps

### DIFF
--- a/.github/workflows/maven-checks.yml
+++ b/.github/workflows/maven-checks.yml
@@ -34,7 +34,7 @@ jobs:
             ${{ runner.os }}-maven-2-
       - name: Populate maven cache
         if: steps.cache-maven.outputs.cache-hit != 'true'
-        run: ./mvnw de.qaware.maven:go-offline-maven-plugin:resolve-dependencies
+        run: ./mvnw de.qaware.maven:go-offline-maven-plugin:resolve-dependencies -P ci
       - name: Maven Checks
         run: |
           export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"

--- a/pom.xml
+++ b/pom.xml
@@ -2161,8 +2161,30 @@
                     <dynamicDependencies>
                         <DynamicDependency>
                             <groupId>org.apache.maven.surefire</groupId>
+                            <artifactId>surefire-testng</artifactId>
+                            <version>2.22.0</version>
+                            <repositoryType>PLUGIN</repositoryType>
+                        </DynamicDependency>
+                        <DynamicDependency>
+                            <groupId>org.apache.maven.surefire</groupId>
                             <artifactId>surefire-junit4</artifactId>
                             <version>2.22.0</version>
+                            <repositoryType>PLUGIN</repositoryType>
+                        </DynamicDependency>
+                        <DynamicDependency>
+                            <groupId>com.google.protobuf</groupId>
+                            <artifactId>protoc</artifactId>
+                            <version>3.0.0</version>
+                            <classifier>${os.detected.classifier}</classifier>
+                            <type>exe</type>
+                            <repositoryType>PLUGIN</repositoryType>
+                        </DynamicDependency>
+                        <DynamicDependency>
+                            <groupId>io.grpc</groupId>
+                            <artifactId>protoc-gen-grpc-java</artifactId>
+                            <version>1.0.0</version>
+                            <classifier>${os.detected.classifier}</classifier>
+                            <type>exe</type>
                             <repositoryType>PLUGIN</repositoryType>
                         </DynamicDependency>
                         <DynamicDependency>


### PR DESCRIPTION
* Add surefire-testng plugin as a dynamic dependency to `go offline` plugin, this addresses https://github.com/prestodb/presto/runs/5874182087?check_suite_focus=true
* Add protobuf compiler dependencies from presto-grpc-api to address https://github.com/prestodb/presto/runs/5776527541?check_suite_focus=true
* Add Maven profile `-P ci` to `maven checks` step to address https://github.com/prestodb/presto/runs/5874181946?check_suite_focus=true

Test plan:
- post a PR and see if it works
- Verified that `mvn de.qaware.maven:go-offline-maven-plugin:resolve-dependencies -P ci` indeed pulls missing dependencies after running `mvn de.qaware.maven:go-offline-maven-plugin:resolve-dependencies` without profile.
- Verified that `go offline` pulls protobuf:compiler:exe dependencies

```
== NO RELEASE NOTE ==
```
