### PR TITLE
Add concurrent control and test to verifier

### DIFF
--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/CreateTableVerification.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/CreateTableVerification.java
@@ -22,6 +22,7 @@ import com.facebook.presto.verifier.prestoaction.PrestoAction.ResultSetConverter
 import com.facebook.presto.verifier.prestoaction.QueryActions;
 import com.facebook.presto.verifier.prestoaction.SqlExceptionClassifier;
 import com.facebook.presto.verifier.rewrite.QueryRewriter;
+import com.google.common.util.concurrent.ListeningExecutorService;
 
 import java.sql.SQLException;
 import java.util.Objects;
@@ -52,9 +53,10 @@ public class CreateTableVerification
             QueryRewriter queryRewriter,
             SqlExceptionClassifier exceptionClassifier,
             VerificationContext verificationContext,
-            VerifierConfig verifierConfig)
+            VerifierConfig verifierConfig,
+            ListeningExecutorService executor)
     {
-        super(sqlParser, queryActions, sourceQuery, exceptionClassifier, verificationContext, verifierConfig, SHOW_CREATE_TABLE_CONVERTER);
+        super(sqlParser, queryActions, sourceQuery, exceptionClassifier, verificationContext, verifierConfig, SHOW_CREATE_TABLE_CONVERTER, executor);
         this.queryRewriter = requireNonNull(queryRewriter, "queryRewriter is null");
     }
 

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/CreateViewVerification.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/CreateViewVerification.java
@@ -22,6 +22,7 @@ import com.facebook.presto.verifier.prestoaction.PrestoAction.ResultSetConverter
 import com.facebook.presto.verifier.prestoaction.QueryActions;
 import com.facebook.presto.verifier.prestoaction.SqlExceptionClassifier;
 import com.facebook.presto.verifier.rewrite.QueryRewriter;
+import com.google.common.util.concurrent.ListeningExecutorService;
 
 import java.sql.SQLException;
 import java.util.Objects;
@@ -52,9 +53,10 @@ public class CreateViewVerification
             QueryRewriter queryRewriter,
             SqlExceptionClassifier exceptionClassifier,
             VerificationContext verificationContext,
-            VerifierConfig verifierConfig)
+            VerifierConfig verifierConfig,
+            ListeningExecutorService executor)
     {
-        super(sqlParser, queryActions, sourceQuery, exceptionClassifier, verificationContext, verifierConfig, SHOW_CREATE_VIEW_CONVERTER);
+        super(sqlParser, queryActions, sourceQuery, exceptionClassifier, verificationContext, verifierConfig, SHOW_CREATE_VIEW_CONVERTER, executor);
         this.queryRewriter = requireNonNull(queryRewriter, "queryRewriter is null");
     }
 

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DataVerification.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DataVerification.java
@@ -25,6 +25,7 @@ import com.facebook.presto.verifier.prestoaction.QueryActions;
 import com.facebook.presto.verifier.prestoaction.SqlExceptionClassifier;
 import com.facebook.presto.verifier.resolver.FailureResolverManager;
 import com.facebook.presto.verifier.rewrite.QueryRewriter;
+import com.google.common.util.concurrent.ListeningExecutorService;
 
 import java.util.List;
 import java.util.Optional;
@@ -57,9 +58,10 @@ public class DataVerification
             VerificationContext verificationContext,
             VerifierConfig verifierConfig,
             TypeManager typeManager,
-            ChecksumValidator checksumValidator)
+            ChecksumValidator checksumValidator,
+            ListeningExecutorService executor)
     {
-        super(queryActions, sourceQuery, exceptionClassifier, verificationContext, Optional.empty(), verifierConfig);
+        super(queryActions, sourceQuery, exceptionClassifier, verificationContext, Optional.empty(), verifierConfig, executor);
         this.queryRewriter = requireNonNull(queryRewriter, "queryRewriter is null");
         this.determinismAnalyzer = requireNonNull(determinismAnalyzer, "determinismAnalyzer is null");
         this.failureResolverManager = requireNonNull(failureResolverManager, "failureResolverManager is null");

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DdlVerification.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/DdlVerification.java
@@ -21,6 +21,7 @@ import com.facebook.presto.verifier.event.DeterminismAnalysisDetails;
 import com.facebook.presto.verifier.prestoaction.PrestoAction.ResultSetConverter;
 import com.facebook.presto.verifier.prestoaction.QueryActions;
 import com.facebook.presto.verifier.prestoaction.SqlExceptionClassifier;
+import com.google.common.util.concurrent.ListeningExecutorService;
 
 import java.util.Optional;
 
@@ -48,9 +49,10 @@ public abstract class DdlVerification<S extends Statement>
             SqlExceptionClassifier exceptionClassifier,
             VerificationContext verificationContext,
             VerifierConfig verifierConfig,
-            ResultSetConverter<String> checksumConverter)
+            ResultSetConverter<String> checksumConverter,
+            ListeningExecutorService executor)
     {
-        super(queryActions, sourceQuery, exceptionClassifier, verificationContext, Optional.empty(), verifierConfig);
+        super(queryActions, sourceQuery, exceptionClassifier, verificationContext, Optional.empty(), verifierConfig, executor);
         this.sqlParser = requireNonNull(sqlParser, "sqlParser");
         this.checksumConverter = requireNonNull(checksumConverter, "checksumConverter is null");
     }

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/ExplainVerification.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/ExplainVerification.java
@@ -25,6 +25,7 @@ import com.facebook.presto.verifier.prestoaction.PrestoAction.ResultSetConverter
 import com.facebook.presto.verifier.prestoaction.QueryActions;
 import com.facebook.presto.verifier.prestoaction.SqlExceptionClassifier;
 import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.ListeningExecutorService;
 
 import java.util.Objects;
 import java.util.Optional;
@@ -53,9 +54,10 @@ public class ExplainVerification
             SqlExceptionClassifier exceptionClassifier,
             VerificationContext verificationContext,
             VerifierConfig verifierConfig,
-            SqlParser sqlParser)
+            SqlParser sqlParser,
+            ListeningExecutorService executor)
     {
-        super(queryActions, sourceQuery, exceptionClassifier, verificationContext, Optional.of(QUERY_PLAN_RESULT_SET_CONVERTER), verifierConfig);
+        super(queryActions, sourceQuery, exceptionClassifier, verificationContext, Optional.of(QUERY_PLAN_RESULT_SET_CONVERTER), verifierConfig, executor);
         this.sqlParser = requireNonNull(sqlParser, "sqlParser is null");
     }
 

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerifierConfig.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/framework/VerifierConfig.java
@@ -52,6 +52,7 @@ public class VerifierConfig
     private boolean teardownOnMainClusters = true;
     private boolean skipControl;
     private boolean skipChecksum;
+    private boolean concurrentControlAndTest;
 
     private boolean explain;
 
@@ -329,6 +330,19 @@ public class VerifierConfig
     public VerifierConfig setExplain(boolean explain)
     {
         this.explain = explain;
+        return this;
+    }
+
+    public boolean isConcurrentControlAndTest()
+    {
+        return concurrentControlAndTest;
+    }
+
+    @ConfigDescription("Run control and test query concurrently")
+    @Config("concurrent-control-and-test")
+    public VerifierConfig setConcurrentControlAndTest(boolean concurrentControlAndTest)
+    {
+        this.concurrentControlAndTest = concurrentControlAndTest;
         return this;
     }
 }

--- a/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestVerifierConfig.java
+++ b/presto-verifier/src/test/java/com/facebook/presto/verifier/framework/TestVerifierConfig.java
@@ -47,7 +47,8 @@ public class TestVerifierConfig
                 .setTeardownOnMainClusters(true)
                 .setSkipControl(false)
                 .setSkipChecksum(false)
-                .setExplain(false));
+                .setExplain(false)
+                .setConcurrentControlAndTest(false));
     }
 
     @Test
@@ -74,6 +75,7 @@ public class TestVerifierConfig
                 .put("skip-control", "true")
                 .put("skip-checksum", "true")
                 .put("explain", "true")
+                .put("concurrent-control-and-test", "true")
                 .build();
         VerifierConfig expected = new VerifierConfig()
                 .setWhitelist("a,b,c")
@@ -95,7 +97,8 @@ public class TestVerifierConfig
                 .setTeardownOnMainClusters(false)
                 .setSkipControl(true)
                 .setSkipChecksum(true)
-                .setExplain(true);
+                .setExplain(true)
+                .setConcurrentControlAndTest(true);
 
         assertFullMapping(properties, expected);
     }


### PR DESCRIPTION
Test plan - Added unit tests

In some cases it is useful to run control and test queries concurrently. It can ensure long running queries are run at roughly the same time of day so the ambient load and queuing is the same, and it can also allow the overall latency of a test run to be lower.

```
== RELEASE NOTES ==

General Changes
* Add support to verifier for running control and test queries concurrently using the `concurrent-control-and-test` and test property.
```
