### PR TITLE
Make ExpressionTreeRewriter for LogicalBinaryExpression iterative

### DIFF
--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
@@ -929,6 +929,12 @@ public abstract class AbstractTestDistributedQueries
     }
 
     @Test
+    public void testExtraLargeQuerySuccess()
+    {
+        assertQuery("SELECT " + Joiner.on(" AND ").join(nCopies(1000, "1 = 1")), "SELECT true");
+    }
+
+    @Test
     public void testShowSchemasFromOther()
     {
         MaterializedResult result = computeActual("SHOW SCHEMAS FROM tpch");


### PR DESCRIPTION
We were seeing occasional test failures due to StackOverflow in this method as it was recursive. Now we made it iterative because it's relatively common to have a number of chained AND/OR. This is just general cleanup.

Test plan - N/A


```
== NO RELEASE NOTE ==
```
