### PR TITLE
Disable frequently failing test until the root cause is fixed

### DIFF
--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/integration/TestRaptorDistributedQueries.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/integration/TestRaptorDistributedQueries.java
@@ -16,6 +16,7 @@ package com.facebook.presto.raptor.integration;
 import com.facebook.presto.testing.QueryRunner;
 import com.facebook.presto.tests.AbstractTestDistributedQueries;
 import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
 
 import static com.facebook.presto.raptor.RaptorQueryRunner.createRaptorQueryRunner;
 
@@ -33,5 +34,12 @@ public class TestRaptorDistributedQueries
     protected boolean supportsNotNullColumns()
     {
         return false;
+    }
+
+    @Test(enabled = false)
+    @Override
+    public void testLargeQuerySuccess()
+    {
+        // TODO: disabled until we fix stackoverflow error in ExpressionTreeRewriter
     }
 }


### PR DESCRIPTION
RaptorDistributedQueries test fails frequently for a large chain of AND expressions due to stackoverflow error. Disabling it for now until https://github.com/prestodb/presto/pull/17607 is merged.

Test plan - N/A

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```
