### PR TITLE
Add IN_MAP output stream for flat map writer

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/InMapOutputStream.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/InMapOutputStream.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.stream;
+
+import com.facebook.presto.orc.ColumnWriterOptions;
+import com.facebook.presto.orc.DwrfDataEncryptor;
+import org.openjdk.jol.info.ClassLayout;
+
+import java.util.Optional;
+
+import static com.facebook.presto.orc.metadata.Stream.StreamKind.IN_MAP;
+
+public class InMapOutputStream
+        extends BooleanOutputStream
+{
+    private static final int INSTANCE_SIZE = ClassLayout.parseClass(InMapOutputStream.class).instanceSize();
+
+    public InMapOutputStream(ColumnWriterOptions columnWriterOptions, Optional<DwrfDataEncryptor> dwrfEncryptor)
+    {
+        super(columnWriterOptions, dwrfEncryptor);
+    }
+
+    @Override
+    public StreamDataOutput getStreamDataOutput(int column)
+    {
+        // get boolean output DATA stream as IN_MAP stream
+        return super.getStreamDataOutput(column, IN_MAP);
+    }
+
+    @Override
+    public long getRetainedBytes()
+    {
+        return INSTANCE_SIZE + super.getRetainedBytes();
+    }
+}

--- a/presto-orc/src/test/java/com/facebook/presto/orc/stream/AbstractTestValueStream.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/stream/AbstractTestValueStream.java
@@ -30,6 +30,7 @@ import java.util.Optional;
 
 import static com.facebook.presto.orc.OrcDecompressor.createOrcDecompressor;
 import static com.facebook.presto.orc.metadata.CompressionKind.SNAPPY;
+import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static io.airlift.units.DataSize.Unit.KILOBYTE;
 import static java.lang.Math.toIntExact;
 import static org.testng.Assert.assertEquals;
@@ -60,7 +61,7 @@ public abstract class AbstractTestValueStream<T, C extends StreamCheckpoint, W e
             StreamDataOutput streamDataOutput = outputStream.getStreamDataOutput(33);
             streamDataOutput.writeData(sliceOutput);
             Stream stream = streamDataOutput.getStream();
-            assertEquals(stream.getStreamKind(), StreamKind.DATA);
+            assertEquals(stream.getStreamKind(), getExpectedStreamKind());
             assertEquals(stream.getColumn(), 33);
             assertEquals(stream.getLength(), sliceOutput.size());
 
@@ -88,6 +89,11 @@ public abstract class AbstractTestValueStream<T, C extends StreamCheckpoint, W e
                 }
             }
         }
+    }
+
+    public StreamKind getExpectedStreamKind()
+    {
+        return DATA;
     }
 
     protected ColumnWriterOptions getColumnWriterOptions()

--- a/presto-orc/src/test/java/com/facebook/presto/orc/stream/TestBooleanStream.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/stream/TestBooleanStream.java
@@ -17,7 +17,6 @@ import com.facebook.presto.orc.OrcCorruptionException;
 import com.facebook.presto.orc.TestingHiveOrcAggregatedMemoryContext;
 import com.facebook.presto.orc.checkpoint.BooleanStreamCheckpoint;
 import com.facebook.presto.orc.metadata.Stream;
-import com.facebook.presto.orc.metadata.Stream.StreamKind;
 import io.airlift.slice.DynamicSliceOutput;
 import io.airlift.slice.Slice;
 import it.unimi.dsi.fastutil.booleans.BooleanArrayList;
@@ -184,7 +183,7 @@ public class TestBooleanStream
         StreamDataOutput streamDataOutput = outputStream.getStreamDataOutput(33);
         streamDataOutput.writeData(sliceOutput);
         Stream stream = streamDataOutput.getStream();
-        assertEquals(stream.getStreamKind(), StreamKind.DATA);
+        assertEquals(stream.getStreamKind(), getExpectedStreamKind());
         assertEquals(stream.getColumn(), 33);
         assertEquals(stream.getLength(), sliceOutput.size());
 

--- a/presto-orc/src/test/java/com/facebook/presto/orc/stream/TestInMapOutputStream.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/stream/TestInMapOutputStream.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.stream;
+
+import com.facebook.presto.orc.metadata.Stream;
+
+import java.util.Optional;
+
+import static com.facebook.presto.orc.metadata.Stream.StreamKind.IN_MAP;
+
+public class TestInMapOutputStream
+        extends TestBooleanStream
+{
+    @Override
+    protected InMapOutputStream createValueOutputStream()
+    {
+        return new InMapOutputStream(getColumnWriterOptions(), Optional.empty());
+    }
+
+    public Stream.StreamKind getExpectedStreamKind()
+    {
+        return IN_MAP;
+    }
+}


### PR DESCRIPTION
Add a new eager output stream producing streams with IN_MAP stream kind. 

This output stream is a boolean output stream disguised under IN_MAP stream kind instead of DATA. 
It's not lazy as PresentOutputStream.

Test plan:
- added new unit test

```
== NO RELEASE NOTE ==
```
