### PR TITLE
Break down product-tests-specific-environment from 2 to 4 steps

### DIFF
--- a/.github/workflows/product-tests-specific-environment.yml
+++ b/.github/workflows/product-tests-specific-environment.yml
@@ -12,7 +12,7 @@ env:
   RETRY: .github/bin/retry
 
 jobs:
-  product-tests-specific-environment1:
+  product-tests-specific-environment1-1:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -37,18 +37,42 @@ jobs:
           ./mvnw install ${MAVEN_FAST_INSTALL} -am -pl '!presto-docs,!presto-server-rpm,!presto-spark-package,!presto-spark-launcher,!presto-spark-testing'
       - name: Product Tests Specific 1.1
         run: presto-product-tests/bin/run_on_docker.sh singlenode -g hdfs_no_impersonation,avro
-      - name: Product Tests Specific 1.2
-        run: presto-product-tests/bin/run_on_docker.sh singlenode-kerberos-hdfs-no-impersonation -g hdfs_no_impersonation
       - name: Product Tests Specific 1.3
         run: presto-product-tests/bin/run_on_docker.sh singlenode-hdfs-impersonation -g storage_formats,cli,hdfs_impersonation
-      - name: Product Tests Specific 1.4
-        run: presto-product-tests/bin/run_on_docker.sh singlenode-kerberos-hdfs-impersonation -g storage_formats,cli,hdfs_impersonation,authorization,hive_file_header
       - name: Product Tests Specific 1.5
         run: presto-product-tests/bin/run_on_docker.sh singlenode-kerberos-hdfs-impersonation-cross-realm -g storage_formats,cli,hdfs_impersonation
+
+  product-tests-specific-environment1-2:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - name: Cache local Maven repository
+        id: cache-maven
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-2-
+      - name: Populate maven cache
+        if: steps.cache-maven.outputs.cache-hit != 'true'
+        run: ./mvnw de.qaware.maven:go-offline-maven-plugin:resolve-dependencies
+      - name: Mave install
+        run: |
+          export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
+          ./mvnw install ${MAVEN_FAST_INSTALL} -am -pl '!presto-docs,!presto-server-rpm,!presto-spark-package,!presto-spark-launcher,!presto-spark-testing'
+      - name: Product Tests Specific 1.2
+        run: presto-product-tests/bin/run_on_docker.sh singlenode-kerberos-hdfs-no-impersonation -g hdfs_no_impersonation
+      - name: Product Tests Specific 1.4
+        run: presto-product-tests/bin/run_on_docker.sh singlenode-kerberos-hdfs-impersonation -g storage_formats,cli,hdfs_impersonation,authorization,hive_file_header
       - name: Product Tests Specific 1.6
         run: presto-product-tests/bin/run_on_docker.sh multinode-tls-kerberos -g cli,group-by,join,tls
 
-  product-tests-specific-environment2:
+  product-tests-specific-environment2-1:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -89,6 +113,30 @@ jobs:
         run: presto-product-tests/bin/run_on_docker.sh singlenode-postgresql -g postgresql_connector
       - name: Product Tests Specific 2.5
         run: presto-product-tests/bin/run_on_docker.sh singlenode-cassandra -g cassandra
+
+  product-tests-specific-environment2-2:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - name: Cache local Maven repository
+        id: cache-maven
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-2-
+      - name: Populate maven cache
+        if: steps.cache-maven.outputs.cache-hit != 'true'
+        run: ./mvnw de.qaware.maven:go-offline-maven-plugin:resolve-dependencies
+      - name: Maven install
+        run: |
+          export MAVEN_OPTS="${MAVEN_INSTALL_OPTS}"
+          ./mvnw install ${MAVEN_FAST_INSTALL} -am -pl '!presto-docs,!presto-server-rpm,!presto-spark-package,!presto-spark-launcher,!presto-spark-testing'
       - name: Product Tests Specific 2.6
         run: presto-product-tests/bin/run_on_docker.sh singlenode-kerberos-hdfs-impersonation-with-wire-encryption -g storage_formats,cli,hdfs_impersonation,authorization
       - name: Product Tests Specific 2.7


### PR DESCRIPTION
Break down product-tests-specific-environment to more granular steps to reduce **overall execution time** of this check by 30-40%. There are 3 more checks taking 40+ minutes, I'll try to break them down as well in subsequent PRs. I'm trying to achieve total time spent on all checks to be less than 30-35 minutes comparing to current 60+ minutes.

Let me know if Presto's test environment cannot handle increased number of checks or if we won't benefit from it because the fleet size is too small. I'll discard this PR.

I measured execution time of each test and regrouped test to make overall time of each step roughly the same. I left the original test names so that it would be easier to track what happened in this PR.

```
Env 1:
Test 1 - 5m 40s
Test 3 - 7m 42s
Test 5 - 7m 31s

Test 2 - 2m 43s
Test 4 - 11m 55s
Test 6 - 6m 12s
```

```
Env 2:
Test 1 - 3m 48s
Test 2 - 6m 24s
Test 3 - 2m 46s
Test 4 - 2m 28s

Test 5 - 3m 45s
Test 6 - 12m 15s
Test 7 - 2m 36s
```

Test plan:
- check that PR "ci product-tests-specific-environment" have 4 steps and overall executions time of this step went down

## Testing results
There are 4 new testing steps taking 22 minutes on average comparing to 2 old steps taking 40 and 48 minutes.

New:
```
https://github.com/prestodb/presto/runs/5890414934?check_suite_focus=true
product-tests-specific-environment1-1 succeeded 39 minutes ago in 24m 34s
product-tests-specific-environment1-2 succeeded 41 minutes ago in 22m 59s
product-tests-specific-environment2-1 succeeded 41 minutes ago in 23m 26s
product-tests-specific-environment2-2 succeeded 44 minutes ago in 20m 4s
```

Old:
```
https://github.com/prestodb/presto/runs/5889515589?check_suite_focus=true
product-tests-specific-environment1 succeeded 2 hours ago in 48m 5s
product-tests-specific-environment2 succeeded 2 hours ago in 40m 38s
```


```
== NO RELEASE NOTE ==
```
