### PR TITLE
Store input table/partition info into QueryInputMetadata

### DIFF
--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/Partition.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/Partition.java
@@ -44,6 +44,7 @@ public class Partition
     private final boolean eligibleToIgnore;
     private final boolean sealedPartition;
     private final int createTime;
+    private final int lastAccessTime;
 
     @JsonCreator
     public Partition(
@@ -56,7 +57,8 @@ public class Partition
             @JsonProperty("partitionVersion") Optional<Long> partitionVersion,
             @JsonProperty("eligibleToIgnore") boolean eligibleToIgnore,
             @JsonProperty("sealedPartition") boolean sealedPartition,
-            @JsonProperty("createTime") int createTime)
+            @JsonProperty("createTime") int createTime,
+            @JsonProperty("lastAccessTime") int lastAccessTime)
     {
         this.databaseName = requireNonNull(databaseName, "databaseName is null");
         this.tableName = requireNonNull(tableName, "tableName is null");
@@ -68,6 +70,7 @@ public class Partition
         this.eligibleToIgnore = eligibleToIgnore;
         this.sealedPartition = sealedPartition;
         this.createTime = createTime;
+        this.lastAccessTime = requireNonNull(lastAccessTime, "lastAccessTime is null");
     }
 
     @JsonProperty
@@ -136,6 +139,12 @@ public class Partition
         return createTime;
     }
 
+    @JsonProperty
+    public int getLastAccessTime()
+    {
+        return lastAccessTime;
+    }
+
     @Override
     public String toString()
     {
@@ -166,13 +175,14 @@ public class Partition
                 Objects.equals(partitionVersion, partition.partitionVersion) &&
                 Objects.equals(eligibleToIgnore, partition.eligibleToIgnore) &&
                 Objects.equals(sealedPartition, partition.sealedPartition) &&
-                Objects.equals(createTime, partition.getCreateTime());
+                Objects.equals(createTime, partition.getCreateTime()) &&
+                lastAccessTime == partition.getLastAccessTime();
     }
 
     @Override
     public int hashCode()
     {
-        return Objects.hash(databaseName, tableName, values, storage, columns, parameters, partitionVersion, eligibleToIgnore, sealedPartition, createTime);
+        return Objects.hash(databaseName, tableName, values, storage, columns, parameters, partitionVersion, eligibleToIgnore, sealedPartition, createTime, lastAccessTime);
     }
 
     public static Builder builder()
@@ -197,6 +207,7 @@ public class Partition
         private boolean isEligibleToIgnore;
         private boolean isSealedPartition = true;
         private int createTime;
+        private int lastAccessTime;
 
         private Builder()
         {
@@ -214,6 +225,7 @@ public class Partition
             this.partitionVersion = partition.getPartitionVersion();
             this.isEligibleToIgnore = partition.isEligibleToIgnore();
             this.createTime = partition.getCreateTime();
+            this.lastAccessTime = partition.getLastAccessTime();
         }
 
         public Builder setDatabaseName(String databaseName)
@@ -281,9 +293,26 @@ public class Partition
             return this;
         }
 
+        public Builder setLastAccessTime(int lastAccessTime)
+        {
+            this.lastAccessTime = lastAccessTime;
+            return this;
+        }
+
         public Partition build()
         {
-            return new Partition(databaseName, tableName, values, storageBuilder.build(), columns, parameters, partitionVersion, isEligibleToIgnore, isSealedPartition, createTime);
+            return new Partition(
+                    databaseName,
+                    tableName,
+                    values,
+                    storageBuilder.build(),
+                    columns,
+                    parameters,
+                    partitionVersion,
+                    isEligibleToIgnore,
+                    isSealedPartition,
+                    createTime,
+                    lastAccessTime);
         }
     }
 }

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/Table.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/Table.java
@@ -47,6 +47,7 @@ public class Table
     private final Map<String, String> parameters;
     private final Optional<String> viewOriginalText;
     private final Optional<String> viewExpandedText;
+    private final int lastAccessTime;
 
     @JsonCreator
     public Table(
@@ -59,7 +60,8 @@ public class Table
             @JsonProperty("partitionColumns") List<Column> partitionColumns,
             @JsonProperty("parameters") Map<String, String> parameters,
             @JsonProperty("viewOriginalText") Optional<String> viewOriginalText,
-            @JsonProperty("viewExpandedText") Optional<String> viewExpandedText)
+            @JsonProperty("viewExpandedText") Optional<String> viewExpandedText,
+            @JsonProperty("lastAccessTime") int lastAccessTime)
     {
         this.databaseName = requireNonNull(databaseName, "databaseName is null");
         this.tableName = requireNonNull(tableName, "tableName is null");
@@ -71,6 +73,7 @@ public class Table
         this.parameters = ImmutableMap.copyOf(requireNonNull(parameters, "parameters is null"));
         this.viewOriginalText = requireNonNull(viewOriginalText, "viewOriginalText is null");
         this.viewExpandedText = requireNonNull(viewExpandedText, "viewExpandedText is null");
+        this.lastAccessTime = lastAccessTime;
     }
 
     @JsonProperty
@@ -144,6 +147,12 @@ public class Table
     public Optional<String> getViewExpandedText()
     {
         return viewExpandedText;
+    }
+
+    @JsonProperty
+    public int getLastAccessTime()
+    {
+        return lastAccessTime;
     }
 
     public static Builder builder()
@@ -224,6 +233,7 @@ public class Table
         private Map<String, String> parameters = new LinkedHashMap<>();
         private Optional<String> viewOriginalText = Optional.empty();
         private Optional<String> viewExpandedText = Optional.empty();
+        private int lastAccessTime;
 
         private Builder()
         {
@@ -242,6 +252,7 @@ public class Table
             parameters = new LinkedHashMap<>(table.parameters);
             viewOriginalText = table.viewOriginalText;
             viewExpandedText = table.viewExpandedText;
+            lastAccessTime = table.lastAccessTime;
         }
 
         public Builder setDatabaseName(String databaseName)
@@ -321,6 +332,12 @@ public class Table
             return this;
         }
 
+        public Builder setLastAccessTime(int lastAccessTime)
+        {
+            this.lastAccessTime = lastAccessTime;
+            return this;
+        }
+
         public Table build()
         {
             return new Table(
@@ -333,7 +350,8 @@ public class Table
                     partitionColumns,
                     parameters,
                     viewOriginalText,
-                    viewExpandedText);
+                    viewExpandedText,
+                    lastAccessTime);
         }
     }
 }

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/file/PartitionMetadata.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/file/PartitionMetadata.java
@@ -231,6 +231,7 @@ public class PartitionMetadata
                 Optional.empty(),
                 eligibleToIgnore,
                 sealedPartition,
+                0,
                 0);
     }
 }

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/file/TableMetadata.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/file/TableMetadata.java
@@ -333,6 +333,7 @@ public class TableMetadata
                 partitionColumns,
                 parameters,
                 viewOriginalText,
-                viewExpandedText);
+                viewExpandedText,
+                0);
     }
 }

--- a/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftMetastoreUtil.java
+++ b/presto-hive-metastore/src/main/java/com/facebook/presto/hive/metastore/thrift/ThriftMetastoreUtil.java
@@ -439,7 +439,8 @@ public final class ThriftMetastoreUtil
                         .collect(toList()))
                 .setParameters(table.getParameters() == null ? ImmutableMap.of() : table.getParameters())
                 .setViewOriginalText(Optional.ofNullable(emptyToNull(table.getViewOriginalText())))
-                .setViewExpandedText(Optional.ofNullable(emptyToNull(table.getViewExpandedText())));
+                .setViewExpandedText(Optional.ofNullable(emptyToNull(table.getViewExpandedText())))
+                .setLastAccessTime(table.getLastAccessTime());
 
         fromMetastoreApiStorageDescriptor(storageDescriptor, tableBuilder.getStorageBuilder(), table.getTableName());
 
@@ -493,7 +494,8 @@ public final class ThriftMetastoreUtil
                         .map(fieldSchema -> columnConverter.toColumn(fieldSchema))
                         .collect(toList()))
                 .setParameters(partition.getParameters())
-                .setCreateTime(partition.getCreateTime());
+                .setCreateTime(partition.getCreateTime())
+                .setLastAccessTime(partition.getLastAccessTime());
 
         // mutate apache partition to Presto partition
         partitionMutator.mutate(partitionBuilder, partition);

--- a/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/TestRecordingHiveMetastore.java
+++ b/presto-hive-metastore/src/test/java/com/facebook/presto/hive/metastore/TestRecordingHiveMetastore.java
@@ -89,7 +89,8 @@ public class TestRecordingHiveMetastore
             ImmutableList.of(TABLE_COLUMN),
             ImmutableMap.of("param", "value3"),
             Optional.of("original_text"),
-            Optional.of("expanded_text"));
+            Optional.of("expanded_text"),
+            0);
     private static final Partition PARTITION = new Partition(
             "database",
             "table",
@@ -100,6 +101,7 @@ public class TestRecordingHiveMetastore
             Optional.empty(),
             false,
             true,
+            0,
             0);
     private static final PartitionStatistics PARTITION_STATISTICS = new PartitionStatistics(
             new HiveBasicStatistics(10, 11, 10000, 10001),

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveInputInfo.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveInputInfo.java
@@ -13,25 +13,32 @@
  */
 package com.facebook.presto.hive;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
 
+import static java.util.Objects.requireNonNull;
+
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 public class HiveInputInfo
 {
     private final List<String> partitionIds;
     // Code that serialize HiveInputInfo into log would often need the ability to limit the length of log entries.
     // This boolean field allows such code to mark the log entry as length limited.
     private final boolean truncated;
+    public final List<Integer> lastAccessTimes;
 
     @JsonCreator
     public HiveInputInfo(
             @JsonProperty("partitionIds") List<String> partitionIds,
-            @JsonProperty("truncated") boolean truncated)
+            @JsonProperty("truncated") boolean truncated,
+            @JsonProperty("lastAccessTimes") List<Integer> lastAccessTimes)
     {
         this.partitionIds = partitionIds;
         this.truncated = truncated;
+        this.lastAccessTimes = requireNonNull(lastAccessTimes, "lastAccessTimes is null");
     }
 
     @JsonProperty
@@ -44,5 +51,11 @@ public class HiveInputInfo
     public boolean isTruncated()
     {
         return truncated;
+    }
+
+    @JsonProperty
+    public List<Integer> getLastAccessTimes()
+    {
+        return lastAccessTimes;
     }
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestAbstractDwrfEncryptionInformationSource.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestAbstractDwrfEncryptionInformationSource.java
@@ -69,7 +69,8 @@ public class TestAbstractDwrfEncryptionInformationSource
                 isPartitioned ? ImmutableList.of(new Column("ds", HIVE_STRING, Optional.empty(), Optional.empty())) : ImmutableList.of(),
                 tableEncryptionProperties.map(DwrfTableEncryptionProperties::toHiveProperties).orElse(ImmutableMap.of()),
                 Optional.empty(),
-                Optional.empty());
+                Optional.empty(),
+                0);
     }
 
     @Test
@@ -109,8 +110,8 @@ public class TestAbstractDwrfEncryptionInformationSource
                                 ImmutableList.of(new Subfield("col_struct.a"), new Subfield("col_struct.b.b2")),
                                 Optional.empty()))),
                 ImmutableMap.of(
-                        "ds=2020-01-01", new Partition("dbName", "tableName", ImmutableList.of("2020-01-01"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty(), false, true, 0),
-                        "ds=2020-01-02", new Partition("dbName", "tableName", ImmutableList.of("2020-01-02"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty(), false, true, 0)));
+                        "ds=2020-01-01", new Partition("dbName", "tableName", ImmutableList.of("2020-01-01"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty(), false, true, 0, 0),
+                        "ds=2020-01-02", new Partition("dbName", "tableName", ImmutableList.of("2020-01-02"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty(), false, true, 0, 0)));
 
         assertTrue(encryptionInformation.isPresent());
         assertEquals(
@@ -129,8 +130,8 @@ public class TestAbstractDwrfEncryptionInformationSource
                 table,
                 Optional.of(ImmutableSet.of()),
                 ImmutableMap.of(
-                        "ds=2020-01-01", new Partition("dbName", "tableName", ImmutableList.of("2020-01-01"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty(), false, true, 0),
-                        "ds=2020-01-02", new Partition("dbName", "tableName", ImmutableList.of("2020-01-02"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty(), false, true, 0)));
+                        "ds=2020-01-01", new Partition("dbName", "tableName", ImmutableList.of("2020-01-01"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty(), false, true, 0, 0),
+                        "ds=2020-01-02", new Partition("dbName", "tableName", ImmutableList.of("2020-01-02"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty(), false, true, 0, 0)));
 
         assertTrue(encryptionInformation.isPresent());
         assertEquals(
@@ -161,8 +162,8 @@ public class TestAbstractDwrfEncryptionInformationSource
                                 ImmutableList.of(new Subfield("col_struct.a"), new Subfield("col_struct.b.b2")),
                                 Optional.empty()))),
                 ImmutableMap.of(
-                        "ds=2020-01-01", new Partition("dbName", "tableName", ImmutableList.of("2020-01-01"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty(), false, true, 0),
-                        "ds=2020-01-02", new Partition("dbName", "tableName", ImmutableList.of("2020-01-02"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty(), false, true, 0)));
+                        "ds=2020-01-01", new Partition("dbName", "tableName", ImmutableList.of("2020-01-01"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty(), false, true, 0, 0),
+                        "ds=2020-01-02", new Partition("dbName", "tableName", ImmutableList.of("2020-01-02"), table.getStorage(), table.getDataColumns(), ImmutableMap.of(), Optional.empty(), false, true, 0, 0)));
 
         Map<String, byte[]> expectedFieldToKeyData = ImmutableMap.of("col_bigint", "key2".getBytes(), "col_struct.a", "key2".getBytes(), "col_struct.b.b2", "key1".getBytes());
         assertTrue(encryptionInformation.isPresent());

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveEncryptionInformationProvider.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveEncryptionInformationProvider.java
@@ -52,7 +52,8 @@ public class TestHiveEncryptionInformationProvider
             ImmutableList.of(),
             ImmutableMap.of(),
             Optional.empty(),
-            Optional.empty());
+            Optional.empty(),
+            0);
 
     @Test
     public void testNoOneReturns()

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMaterializedViewUtils.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMaterializedViewUtils.java
@@ -634,7 +634,8 @@ public class TestHiveMaterializedViewUtils
                 partitionColumns,
                 ImmutableMap.of(),
                 Optional.empty(),
-                Optional.empty());
+                Optional.empty(),
+                0);
     }
 
     private static class TestingPartitionResult

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMetadata.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveMetadata.java
@@ -104,7 +104,8 @@ public class TestHiveMetadata
                 ImmutableList.of(partitionColumn),
                 ImmutableMap.of(),
                 Optional.empty(),
-                Optional.empty());
+                Optional.empty(),
+                0);
 
         ColumnMetadata actual = HiveMetadata.columnMetadataGetter(mockTable, mockTypeManager, new HiveColumnConverter()).apply(hiveColumnHandle1);
         ColumnMetadata expected = new ColumnMetadata("c1", IntegerType.INTEGER);

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePartitionManager.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHivePartitionManager.java
@@ -78,7 +78,8 @@ public class TestHivePartitionManager
             ImmutableList.of(PARTITION_COLUMN),
             ImmutableMap.of(),
             Optional.empty(),
-            Optional.empty());
+            Optional.empty(),
+            0);
 
     private static final List<String> PARTITIONS = ImmutableList.of("ds=2019-07-23", "ds=2019-08-23");
 

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitManager.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHiveSplitManager.java
@@ -149,7 +149,8 @@ public class TestHiveSplitManager
             ImmutableList.of(new Column("ds", HIVE_STRING, Optional.empty(), Optional.empty())),
             ImmutableMap.of(),
             Optional.empty(),
-            Optional.empty());
+            Optional.empty(),
+            0);
 
     private ListeningExecutorService executor;
 
@@ -471,6 +472,7 @@ public class TestHiveSplitManager
                         Optional.empty(),
                         false,
                         true,
+                        0,
                         0),
                 PARTITION_NAME,
                 partitionStatistics);

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHudiDirectoryLister.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHudiDirectoryLister.java
@@ -82,7 +82,8 @@ public class TestHudiDirectoryLister
                 ImmutableList.of(),
                 ImmutableMap.of(),
                 Optional.empty(),
-                Optional.empty());
+                Optional.empty(),
+                0);
 
         HudiDirectoryLister directoryLister = new HudiDirectoryLister(hadoopConf, SESSION, mockTable);
         HoodieTableMetaClient metaClient = directoryLister.getMetaClient();
@@ -118,7 +119,8 @@ public class TestHudiDirectoryLister
                 ImmutableList.of(),
                 ImmutableMap.of(),
                 Optional.empty(),
-                Optional.empty());
+                Optional.empty(),
+                0);
 
         assertThrows(TableNotFoundException.class, () -> new HudiDirectoryLister(hadoopConf, SESSION, mockTable));
     }

--- a/presto-main/src/main/java/com/facebook/presto/metadata/HandleJsonModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/HandleJsonModule.java
@@ -14,6 +14,7 @@
 package com.facebook.presto.metadata;
 
 import com.facebook.presto.index.IndexHandleJacksonModule;
+import com.fasterxml.jackson.datatype.joda.JodaModule;
 import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.Scopes;

--- a/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/MetadataManager.java
@@ -488,7 +488,7 @@ public class MetadataManager
     {
         ConnectorId connectorId = handle.getConnectorId();
         ConnectorMetadata metadata = getMetadata(session, connectorId);
-        return handle.getLayout().flatMap(tableLayout -> metadata.getInfo(tableLayout));
+        return handle.getLayout().flatMap(tableLayout -> metadata.getInfo(session.toConnectorSession(), tableLayout));
     }
 
     @Override

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/ConnectorMetadata.java
@@ -206,7 +206,7 @@ public interface ConnectorMetadata
      *
      * @throws RuntimeException if table handle is no longer valid
      */
-    default Optional<Object> getInfo(ConnectorTableLayoutHandle layoutHandle)
+    default Optional<Object> getInfo(ConnectorSession session, ConnectorTableLayoutHandle layoutHandle)
     {
         return Optional.empty();
     }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/connector/classloader/ClassLoaderSafeConnectorMetadata.java
@@ -246,10 +246,10 @@ public class ClassLoaderSafeConnectorMetadata
     }
 
     @Override
-    public Optional<Object> getInfo(ConnectorTableLayoutHandle table)
+    public Optional<Object> getInfo(ConnectorSession session, ConnectorTableLayoutHandle table)
     {
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            return delegate.getInfo(table);
+            return delegate.getInfo(session, table);
         }
     }
 


### PR DESCRIPTION
To record the last access time of a table or a partition,
we store it into QueryInputMetadata for further logging.

```
== NO RELEASE NOTE ==
```
