### PR TITLE
Fix typo in docs of kafka connector

### DIFF
--- a/presto-docs/src/main/sphinx/connector/kafka.rst
+++ b/presto-docs/src/main/sphinx/connector/kafka.rst
@@ -314,7 +314,7 @@ message used for decoding. It can be one or two numbers separated by a colon (``
 
 If only a start position is given:
 
- * For fixed width types the column will use the appropriate number of bytes for the specified ``dateFormat`` (see above).
+ * For fixed width types the column will use the appropriate number of bytes for the specified ``dataFormat`` (see above).
  * When ``VARCHAR`` value is decoded all bytes from start position till the end of the message will be used.
 
 If start and end position are given, then:


### PR DESCRIPTION
https://github.com/trinodb/trino/pull/11809

Co-authored-by: yushengnan <ysnakie@hotmail.com>

```
== NO RELEASE NOTE ==
```
