### PR TITLE
Add query stage to verifier client info

### DIFF
--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/prestoaction/ClientInfo.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/prestoaction/ClientInfo.java
@@ -30,13 +30,15 @@ public class ClientInfo
     private final Optional<String> testName;
     private final String sourceQueryName;
     private final String suite;
+    private final String queryStage;
 
-    public ClientInfo(String testId, Optional<String> testName, String sourceQueryName, String suite)
+    public ClientInfo(String testId, Optional<String> testName, String sourceQueryName, String suite, String queryStage)
     {
         this.testId = requireNonNull(testId, "testId is null");
         this.testName = requireNonNull(testName, "testName is null");
         this.sourceQueryName = requireNonNull(sourceQueryName, "sourceQueryName is null");
         this.suite = requireNonNull(suite, "suite is null");
+        this.queryStage = requireNonNull(queryStage, "queryStage is null");
     }
 
     @JsonProperty
@@ -67,6 +69,12 @@ public class ClientInfo
     public String getSuite()
     {
         return suite;
+    }
+
+    @JsonProperty
+    public String getQueryStage()
+    {
+        return queryStage;
     }
 
     public String serialize()

--- a/presto-verifier/src/main/java/com/facebook/presto/verifier/prestoaction/JdbcPrestoAction.java
+++ b/presto-verifier/src/main/java/com/facebook/presto/verifier/prestoaction/JdbcPrestoAction.java
@@ -135,7 +135,8 @@ public class JdbcPrestoAction
                 testId,
                 testName,
                 verificationContext.getSourceQueryName(),
-                verificationContext.getSuite()).serialize();
+                verificationContext.getSuite(),
+                queryStage.name()).serialize();
 
         try (PrestoConnection connection = getConnection(queryStage, clientInfo)) {
             try (java.sql.Statement jdbcStatement = connection.createStatement()) {


### PR DESCRIPTION
Test plan - Existing unit tests, checking that the new field appears inside client info

When querying verification tests it's hard to select out just the test and control queries. This makes it easy to identify them using JSON_EXTRACT.

https://github.com/facebookexternal/presto-facebook/pull/1859

```
== NO RELEASE NOTE ==
```