### PR TITLE
Add the execution support for segmented aggregation

### DIFF
--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HandTpchQuery1.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HandTpchQuery1.java
@@ -113,6 +113,7 @@ public class HandTpchQuery1
                 getColumnTypes("lineitem", "returnflag", "linestatus"),
                 Ints.asList(0, 1),
                 ImmutableList.of(),
+                ImmutableList.of(),
                 Step.SINGLE,
                 ImmutableList.of(
                         doubleSum.bind(ImmutableList.of(2), Optional.empty()),

--- a/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashAggregationBenchmark.java
+++ b/presto-benchmark/src/main/java/com/facebook/presto/benchmark/HashAggregationBenchmark.java
@@ -58,6 +58,7 @@ public class HashAggregationBenchmark
                 ImmutableList.of(tableTypes.get(0)),
                 Ints.asList(0),
                 ImmutableList.of(),
+                ImmutableList.of(),
                 Step.SINGLE,
                 ImmutableList.of(doubleSum.bind(ImmutableList.of(1), Optional.empty())),
                 Optional.empty(),

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -1201,7 +1201,7 @@ public final class SystemSessionProperties
                         SEGMENTED_AGGREGATION_ENABLED,
                         "Enable segmented aggregation.",
                         featuresConfig.isSegmentedAggregationEnabled(),
-                        true),
+                        false),
                 new PropertyMetadata<>(
                         AGGREGATION_IF_TO_FILTER_REWRITE_STRATEGY,
                         format("Set the strategy used to rewrite AGG IF to AGG FILTER. Options are %s",

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LocalExecutionPlanner.java
@@ -2550,6 +2550,7 @@ public class LocalExecutionPlanner
                         false,
                         false,
                         false,
+                        ImmutableList.of(),
                         new DataSize(0, BYTE),
                         context,
                         STATS_START_CHANNEL,
@@ -2655,6 +2656,7 @@ public class LocalExecutionPlanner
                         false,
                         false,
                         false,
+                        ImmutableList.of(),
                         new DataSize(0, BYTE),
                         context,
                         STATS_START_CHANNEL,
@@ -2709,6 +2711,7 @@ public class LocalExecutionPlanner
                         false,
                         false,
                         false,
+                        ImmutableList.of(),
                         new DataSize(0, BYTE),
                         context,
                         0,
@@ -3084,6 +3087,7 @@ public class LocalExecutionPlanner
                     distinctAggregationSpillEnabled,
                     orderByAggregationSpillEnabled,
                     node.isStreamable(),
+                    node.getPreGroupedVariables(),
                     unspillMemoryLimit,
                     context,
                     0,
@@ -3108,6 +3112,7 @@ public class LocalExecutionPlanner
                 boolean distinctSpillEnabled,
                 boolean orderBySpillEnabled,
                 boolean isStreamable,
+                List<VariableReferenceExpression> preGroupedVariables,
                 DataSize unspillMemoryLimit,
                 LocalExecutionPlanContext context,
                 int startOutputChannel,
@@ -3167,11 +3172,13 @@ public class LocalExecutionPlanner
             }
             else {
                 Optional<Integer> hashChannel = hashVariable.map(variableChannelGetter(source));
+                List<Integer> preGroupedChannels = getChannelsForVariables(preGroupedVariables, source.getLayout());
                 return new HashAggregationOperatorFactory(
                         context.getNextOperatorId(),
                         planNodeId,
                         groupByTypes,
                         groupByChannels,
+                        preGroupedChannels,
                         ImmutableList.copyOf(globalGroupingSets),
                         step,
                         hasDefaultOutput,

--- a/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkHashAndSegmentedAggregationOperators.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/BenchmarkHashAndSegmentedAggregationOperators.java
@@ -19,7 +19,6 @@ import com.facebook.presto.common.block.BlockBuilder;
 import com.facebook.presto.metadata.FunctionAndTypeManager;
 import com.facebook.presto.metadata.MetadataManager;
 import com.facebook.presto.operator.HashAggregationOperator.HashAggregationOperatorFactory;
-import com.facebook.presto.operator.StreamingAggregationOperator.StreamingAggregationOperatorFactory;
 import com.facebook.presto.operator.aggregation.InternalAggregationFunction;
 import com.facebook.presto.spi.plan.AggregationNode;
 import com.facebook.presto.spi.plan.PlanNodeId;
@@ -62,7 +61,6 @@ import static com.facebook.presto.sql.analyzer.TypeSignatureProvider.fromTypes;
 import static io.airlift.units.DataSize.Unit.GIGABYTE;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static io.airlift.units.DataSize.succinctBytes;
-import static java.lang.String.format;
 import static java.util.concurrent.Executors.newCachedThreadPool;
 import static java.util.concurrent.Executors.newScheduledThreadPool;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -77,7 +75,7 @@ import static org.testng.Assert.assertEquals;
 @Fork(3)
 @Warmup(iterations = 5)
 @Measurement(iterations = 10, time = 2, timeUnit = SECONDS)
-public class BenchmarkHashAndStreamingAggregationOperators
+public class BenchmarkHashAndSegmentedAggregationOperators
 {
     private static final MetadataManager metadata = MetadataManager.createTestMetadataManager();
     private static final FunctionAndTypeManager FUNCTION_AND_TYPE_MANAGER = metadata.getFunctionAndTypeManager();
@@ -90,13 +88,13 @@ public class BenchmarkHashAndStreamingAggregationOperators
     @State(Thread)
     public static class Context
     {
-        public static final int TOTAL_PAGES = 140;
-        public static final int ROWS_PER_PAGE = 10_000;
+        public static final int TOTAL_PAGES = 100;
+        public static final int ROWS_PER_PAGE = 1000;
 
-        @Param({"1", "10", "1000"})
-        public int rowsPerGroup;
+        @Param({"1", "10", "800", "100000"})
+        public int rowsPerSegment;
 
-        @Param({"streaming", "hash"})
+        @Param({"segmented", "hash"})
         public String operatorType;
 
         private ExecutorService executor;
@@ -110,45 +108,23 @@ public class BenchmarkHashAndStreamingAggregationOperators
             executor = newCachedThreadPool(daemonThreadsNamed("test-executor-%s"));
             scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%s"));
 
-            int groupsPerPage = ROWS_PER_PAGE / rowsPerGroup;
+            boolean segmentedAggregation = operatorType.equalsIgnoreCase("segmented");
 
-            boolean hashAggregation = operatorType.equalsIgnoreCase("hash");
-
-            RowPagesBuilder pagesBuilder = RowPagesBuilder.rowPagesBuilder(hashAggregation, ImmutableList.of(0), VARCHAR, BIGINT);
+            RowPagesBuilder pagesBuilder = RowPagesBuilder.rowPagesBuilder(true, ImmutableList.of(0, 1), VARCHAR, BIGINT, BIGINT);
             for (int i = 0; i < TOTAL_PAGES; i++) {
-                BlockBuilder blockBuilder = VARCHAR.createBlockBuilder(null, ROWS_PER_PAGE);
-                for (int j = 0; j < groupsPerPage; j++) {
-                    String groupKey = format("%s", i * groupsPerPage + j);
-                    repeatToStringBlock(groupKey, rowsPerGroup, blockBuilder);
+                BlockBuilder sortedBlockBuilder = VARCHAR.createBlockBuilder(null, ROWS_PER_PAGE);
+                for (int j = 0; j < ROWS_PER_PAGE; j++) {
+                    int currentSegment = (i * ROWS_PER_PAGE + j) / rowsPerSegment;
+                    VARCHAR.writeString(sortedBlockBuilder, String.valueOf(currentSegment));
                 }
-                pagesBuilder.addBlocksPage(blockBuilder.build(), createLongSequenceBlock(0, ROWS_PER_PAGE));
+                pagesBuilder.addBlocksPage(sortedBlockBuilder, createLongSequenceBlock(0, ROWS_PER_PAGE), createLongSequenceBlock(0, ROWS_PER_PAGE));
             }
 
             pages = pagesBuilder.build();
-
-            if (hashAggregation) {
-                operatorFactory = createHashAggregationOperatorFactory(pagesBuilder.getHashChannel());
-            }
-            else {
-                operatorFactory = createStreamingAggregationOperatorFactory();
-            }
+            operatorFactory = createHashAggregationOperatorFactory(pagesBuilder.getHashChannel(), segmentedAggregation);
         }
 
-        private OperatorFactory createStreamingAggregationOperatorFactory()
-        {
-            return new StreamingAggregationOperatorFactory(
-                    0,
-                    new PlanNodeId("test"),
-                    ImmutableList.of(VARCHAR),
-                    ImmutableList.of(VARCHAR),
-                    ImmutableList.of(0),
-                    AggregationNode.Step.SINGLE,
-                    ImmutableList.of(COUNT.bind(ImmutableList.of(0), Optional.empty()),
-                            LONG_SUM.bind(ImmutableList.of(1), Optional.empty())),
-                    new JoinCompiler(metadata, new FeaturesConfig()));
-        }
-
-        private OperatorFactory createHashAggregationOperatorFactory(Optional<Integer> hashChannel)
+        private OperatorFactory createHashAggregationOperatorFactory(Optional<Integer> hashChannel, boolean segmentedAggregation)
         {
             JoinCompiler joinCompiler = new JoinCompiler(metadata, new FeaturesConfig());
             SpillerFactory spillerFactory = (types, localSpillContext, aggregatedMemoryContext) -> null;
@@ -158,12 +134,12 @@ public class BenchmarkHashAndStreamingAggregationOperators
                     new PlanNodeId("test"),
                     ImmutableList.of(VARCHAR),
                     ImmutableList.of(0),
-                    ImmutableList.of(),
+                    segmentedAggregation ? ImmutableList.of(0) : ImmutableList.of(),
                     ImmutableList.of(),
                     AggregationNode.Step.SINGLE,
                     false,
                     ImmutableList.of(COUNT.bind(ImmutableList.of(0), Optional.empty()),
-                            LONG_SUM.bind(ImmutableList.of(1), Optional.empty())),
+                            LONG_SUM.bind(ImmutableList.of(2), Optional.empty())),
                     hashChannel,
                     Optional.empty(),
                     100_000,
@@ -174,13 +150,6 @@ public class BenchmarkHashAndStreamingAggregationOperators
                     spillerFactory,
                     joinCompiler,
                     false);
-        }
-
-        private static void repeatToStringBlock(String value, int count, BlockBuilder blockBuilder)
-        {
-            for (int i = 0; i < count; i++) {
-                VARCHAR.writeString(blockBuilder, value);
-            }
         }
 
         public TaskContext createTaskContext()
@@ -231,26 +200,28 @@ public class BenchmarkHashAndStreamingAggregationOperators
     }
 
     @Test
-    public void verifyStreaming()
-    {
-        verify(1, "streaming");
-        verify(10, "streaming");
-        verify(1000, "streaming");
-    }
-
-    @Test
     public void verifyHash()
     {
         verify(1, "hash");
-        verify(10, "hash");
-        verify(1000, "hash");
+        verify(100, "hash");
+        verify(800, "hash");
+        verify(100000, "hash");
     }
 
-    private void verify(int rowsPerGroup, String operatorType)
+    @Test
+    public void verifySegmented()
+    {
+        verify(1, "segmented");
+        verify(100, "segmented");
+        verify(800, "segmented");
+        verify(100000, "segmented");
+    }
+
+    private void verify(int rowsPerSegment, String operatorType)
     {
         Context context = new Context();
         context.operatorType = operatorType;
-        context.rowsPerGroup = rowsPerGroup;
+        context.rowsPerSegment = rowsPerSegment;
         context.setup();
 
         assertEquals(TOTAL_PAGES, context.getPages().size());
@@ -259,7 +230,7 @@ public class BenchmarkHashAndStreamingAggregationOperators
         }
 
         List<Page> outputPages = benchmark(context);
-        assertEquals(TOTAL_PAGES * ROWS_PER_PAGE / rowsPerGroup, outputPages.stream().mapToInt(Page::getPositionCount).sum());
+        assertEquals(TOTAL_PAGES * ROWS_PER_PAGE / rowsPerSegment, outputPages.stream().mapToInt(Page::getPositionCount).sum());
     }
 
     public static void main(String[] args)
@@ -267,7 +238,7 @@ public class BenchmarkHashAndStreamingAggregationOperators
     {
         Options options = new OptionsBuilder()
                 .verbosity(VerboseMode.NORMAL)
-                .include(".*" + BenchmarkHashAndStreamingAggregationOperators.class.getSimpleName() + ".*")
+                .include(".*" + BenchmarkHashAndSegmentedAggregationOperators.class.getSimpleName() + ".*")
                 .build();
 
         new Runner(options).run();


### PR DESCRIPTION
Depends on #17458 

Benchmark:
```
Benchmark                                                (operatorType)  (rowsPerSegment)  Mode  Cnt    Score   Error  Units
BenchmarkHashAndSegmentedAggregationOperators.benchmark       segmented                 1  avgt   30  109.391 ± 7.813  ms/op
BenchmarkHashAndSegmentedAggregationOperators.benchmark       segmented                10  avgt   30   52.914 ± 5.455  ms/op
BenchmarkHashAndSegmentedAggregationOperators.benchmark       segmented               800  avgt   30   28.937 ± 5.291  ms/op
BenchmarkHashAndSegmentedAggregationOperators.benchmark       segmented            100000  avgt   30    6.492 ± 0.184  ms/op
BenchmarkHashAndSegmentedAggregationOperators.benchmark            hash                 1  avgt   30   18.439 ± 1.193  ms/op
BenchmarkHashAndSegmentedAggregationOperators.benchmark            hash                10  avgt   30   18.707 ± 2.586  ms/op
BenchmarkHashAndSegmentedAggregationOperators.benchmark            hash               800  avgt   30   17.132 ± 0.495  ms/op
BenchmarkHashAndSegmentedAggregationOperators.benchmark            hash            100000  avgt   30    5.660 ± 0.174  ms/op
```
Manual testing(717,977,748,003 rows / 3.02 TB):
|                               | QueryID                     | Splits | Latency  | CPU         | Memory    | Per wall sec |
|-------------------------------|-----------------------------|--------|----------|-------------|-----------|--------------|
|                      Baseline | 20220506_014308_00006_iiy5d |  84.9K |  36.96 s | 23.54 hours | 416.32 GB | 83.51 GB     |
|      File Splittable Disabled | 20220506_014507_00008_iiy5d |  6.86K | 1.50 min | 20.49 hours | 405.88 GB | 34.32 GB     |
| Segmented Aggregation Enabled | 20220506_015126_00011_iiy5d |  2.06K | 1.88 min | 33.31 hours | 30.60 GB  | 27.37 GB     |

Latency regression is observed during testing, which is expected. In order to enable segmented aggregation, splitting files needs to be disabled to preserve the order. As the result, much less splits are generated and it decreased the table scan concurrency drastically especially when there are a lot of big files to scan.


```
== RELEASE NOTES ==

General Changes
* Add ability to flush the aggregated data when the current input segment is exhausted. It reduces the memory footprint and improves the performance of aggregation when the data is already ordered by a subset of the group-by keys.
This can be enabled with the ``segmented_aggregation_enabled`` session property or the ``optimizer.segmented-aggregation-enabled`` configuration property.

Hive Changes
* Add support for segmented aggregation to reduce the memory footprint and improve query performance when the order-by keys are a subset of the group-by keys. This can be enabled with the ``order_based_execution_enabled`` session property or the ``hive.order-based-execution-enabled`` configuration property.
```
