### PR TITLE
Reduce number of hdfsConfiguration copies

### DIFF
--- a/presto-cache/src/main/java/com/facebook/presto/cache/alluxio/AlluxioCachingConfigurationProvider.java
+++ b/presto-cache/src/main/java/com/facebook/presto/cache/alluxio/AlluxioCachingConfigurationProvider.java
@@ -65,4 +65,11 @@ public class AlluxioCachingConfigurationProvider
             configuration.set("alluxio.user.client.cache.shadow.window", String.valueOf(alluxioCacheConfig.getShadowCacheWindow().toMillis()));
         }
     }
+
+    @Override
+    public boolean isUriIndependentConfigurationProvider()
+    {
+        // All the config set above are independent of the URI
+        return true;
+    }
 }

--- a/presto-hive-common/src/main/java/com/facebook/presto/hive/DynamicConfigurationProvider.java
+++ b/presto-hive-common/src/main/java/com/facebook/presto/hive/DynamicConfigurationProvider.java
@@ -20,4 +20,9 @@ import java.net.URI;
 public interface DynamicConfigurationProvider
 {
     void updateConfiguration(Configuration configuration, HdfsContext context, URI uri);
+
+    default boolean isUriIndependentConfigurationProvider()
+    {
+        return false;
+    }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/CopyOnWriteConfiguration.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/CopyOnWriteConfiguration.java
@@ -1,0 +1,524 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.Reader;
+import java.io.Writer;
+import java.net.InetSocketAddress;
+import java.net.URL;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+
+import static java.util.Objects.requireNonNull;
+
+public class CopyOnWriteConfiguration
+        extends Configuration
+{
+    private final Object lock = new Object();
+
+    private Configuration config;
+    private boolean isMutable;
+
+    // This a wrapper class around Configuration object, that creates a copy of Configuration object on write
+    public CopyOnWriteConfiguration(Configuration config)
+    {
+        this.config = requireNonNull(config, "config is null");
+        this.isMutable = false;
+    }
+
+    public Configuration getConfig()
+    {
+        return config;
+    }
+
+    @Override
+    public void set(String name, String value)
+    {
+        checkAndSet(() -> config.set(name, value));
+    }
+
+    @Override
+    public void set(String name, String value, String source)
+    {
+        checkAndSet(() -> config.set(name, value, source));
+    }
+
+    @Override
+    public synchronized void setIfUnset(String name, String value)
+    {
+        checkAndSet(() -> config.setIfUnset(name, value));
+    }
+
+    @Override
+    public void setInt(String name, int value)
+    {
+        checkAndSet(() -> config.setInt(name, value));
+    }
+
+    @Override
+    public void setLong(String name, long value)
+    {
+        checkAndSet(() -> config.setLong(name, value));
+    }
+
+    @Override
+    public void setFloat(String name, float value)
+    {
+        checkAndSet(() -> config.setFloat(name, value));
+    }
+
+    @Override
+    public void setDouble(String name, double value)
+    {
+        checkAndSet(() -> config.setDouble(name, value));
+    }
+
+    @Override
+    public void setBoolean(String name, boolean value)
+    {
+        checkAndSet(() -> config.setBoolean(name, value));
+    }
+
+    @Override
+    public void setBooleanIfUnset(String name, boolean value)
+    {
+        checkAndSet(() -> config.setBooleanIfUnset(name, value));
+    }
+
+    @Override
+    public <T extends Enum<T>> void setEnum(String name, T value)
+    {
+        checkAndSet(() -> config.setEnum(name, value));
+    }
+
+    @Override
+    public void setTimeDuration(String name, long value, TimeUnit unit)
+    {
+        checkAndSet(() -> config.setTimeDuration(name, value, unit));
+    }
+
+    @Override
+    public void setPattern(String name, Pattern pattern)
+    {
+        checkAndSet(() -> config.setPattern(name, pattern));
+    }
+
+    @Override
+    public void setStrings(String name, String... values)
+    {
+        checkAndSet(() -> config.setStrings(name, values));
+    }
+
+    @Override
+    public void setSocketAddr(String name, InetSocketAddress addr)
+    {
+        checkAndSet(() -> config.setSocketAddr(name, addr));
+    }
+
+    @Override
+    public void setClass(String name, Class<?> theClass, Class<?> xface)
+    {
+        checkAndSet(() -> config.setClass(name, theClass, xface));
+    }
+
+    @Override
+    public void setClassLoader(ClassLoader classLoader)
+    {
+        checkAndSet(() -> config.setClassLoader(classLoader));
+    }
+
+    @Override
+    public synchronized void setQuietMode(boolean quietMode)
+    {
+        checkAndSet(() -> config.setQuietMode(quietMode));
+    }
+
+    @Override
+    public void setDeprecatedProperties()
+    {
+        checkAndSet(() -> config.setDeprecatedProperties());
+    }
+
+    @Override
+    public synchronized void unset(String name)
+    {
+        checkAndSet(() -> config.unset(name));
+    }
+
+    @Override
+    public String get(String name)
+    {
+        return config.get(name);
+    }
+
+    @Override
+    public String get(String name, String defaultValue)
+    {
+        return config.get(name, defaultValue);
+    }
+
+    @Override
+    public String getTrimmed(String name)
+    {
+        return config.getTrimmed(name);
+    }
+
+    @Override
+    public String getTrimmed(String name, String defaultValue)
+    {
+        return config.getTrimmed(name, defaultValue);
+    }
+
+    @Override
+    public String getRaw(String name)
+    {
+        return config.getRaw(name);
+    }
+
+    @Override
+    public int getInt(String name, int defaultValue)
+    {
+        return config.getInt(name, defaultValue);
+    }
+
+    @Override
+    public int[] getInts(String name)
+    {
+        return config.getInts(name);
+    }
+
+    @Override
+    public long getLong(String name, long defaultValue)
+    {
+        return config.getLong(name, defaultValue);
+    }
+
+    @Override
+    public long getLongBytes(String name, long defaultValue)
+    {
+        return config.getLongBytes(name, defaultValue);
+    }
+
+    @Override
+    public float getFloat(String name, float defaultValue)
+    {
+        return config.getFloat(name, defaultValue);
+    }
+
+    @Override
+    public double getDouble(String name, double defaultValue)
+    {
+        return config.getDouble(name, defaultValue);
+    }
+
+    @Override
+    public boolean getBoolean(String name, boolean defaultValue)
+    {
+        return config.getBoolean(name, defaultValue);
+    }
+
+    @Override
+    public <T extends Enum<T>> T getEnum(String name, T defaultValue)
+    {
+        return config.getEnum(name, defaultValue);
+    }
+
+    @Override
+    public long getTimeDuration(String name, long defaultValue, TimeUnit unit)
+    {
+        return config.getTimeDuration(name, defaultValue, unit);
+    }
+
+    @Override
+    public Pattern getPattern(String name, Pattern defaultValue)
+    {
+        return config.getPattern(name, defaultValue);
+    }
+
+    @Override
+    public Configuration.IntegerRanges getRange(String name, String defaultValue)
+    {
+        return config.getRange(name, defaultValue);
+    }
+
+    @Override
+    public Collection<String> getStringCollection(String name)
+    {
+        return config.getStringCollection(name);
+    }
+
+    @Override
+    public String[] getStrings(String name)
+    {
+        return config.getStrings(name);
+    }
+
+    @Override
+    public String[] getStrings(String name, String... defaultValue)
+    {
+        return config.getStrings(name, defaultValue);
+    }
+
+    @Override
+    public Collection<String> getTrimmedStringCollection(String name)
+    {
+        return config.getTrimmedStringCollection(name);
+    }
+
+    @Override
+    public String[] getTrimmedStrings(String name)
+    {
+        return config.getTrimmedStrings(name);
+    }
+
+    @Override
+    public String[] getTrimmedStrings(String name, String... defaultValue)
+    {
+        return config.getTrimmedStrings(name, defaultValue);
+    }
+
+    @Override
+    public char[] getPassword(String name)
+            throws IOException
+    {
+        return config.getPassword(name);
+    }
+
+    @Override
+    public InetSocketAddress getSocketAddr(String hostProperty, String addressProperty, String defaultAddressValue, int defaultPort)
+    {
+        return config.getSocketAddr(hostProperty, addressProperty, defaultAddressValue, defaultPort);
+    }
+
+    @Override
+    public InetSocketAddress getSocketAddr(String name, String defaultAddress, int defaultPort)
+    {
+        return config.getSocketAddr(name, defaultAddress, defaultPort);
+    }
+
+    @Override
+    public Class<?> getClassByName(String name)
+            throws ClassNotFoundException
+    {
+        return config.getClassByName(name);
+    }
+
+    @Override
+    public Class<?> getClassByNameOrNull(String name)
+    {
+        return config.getClassByNameOrNull(name);
+    }
+
+    @Override
+    public Class<?>[] getClasses(String name, Class<?>... defaultValue)
+    {
+        return config.getClasses(name, defaultValue);
+    }
+
+    @Override
+    public Class<?> getClass(String name, Class<?> defaultValue)
+    {
+        return config.getClass(name, defaultValue);
+    }
+
+    @Override
+    public <U> Class<? extends U> getClass(String name, Class<? extends U> defaultValue, Class<U> xface)
+    {
+        return config.getClass(name, defaultValue, xface);
+    }
+
+    @Override
+    public <U> List<U> getInstances(String name, Class<U> xface)
+    {
+        return config.getInstances(name, xface);
+    }
+
+    @Override
+    public Path getLocalPath(String dirsProp, String path)
+            throws IOException
+    {
+        return config.getLocalPath(dirsProp, path);
+    }
+
+    @Override
+    public File getFile(String dirsProp, String path)
+            throws IOException
+    {
+        return config.getFile(dirsProp, path);
+    }
+
+    @Override
+    public URL getResource(String name)
+    {
+        return config.getResource(name);
+    }
+
+    @Override
+    public InputStream getConfResourceAsInputStream(String name)
+    {
+        return config.getConfResourceAsInputStream(name);
+    }
+
+    @Override
+    public Reader getConfResourceAsReader(String name)
+    {
+        return config.getConfResourceAsReader(name);
+    }
+
+    @Override
+    public Set<String> getFinalParameters()
+    {
+        return config.getFinalParameters();
+    }
+
+    @Override
+    public int size()
+    {
+        return config.size();
+    }
+
+    @Override
+    public void clear()
+    {
+        config.clear();
+    }
+
+    @Override
+    public Iterator<Map.Entry<String, String>> iterator()
+    {
+        return config.iterator();
+    }
+
+    @Override
+    public ClassLoader getClassLoader()
+    {
+        return config.getClassLoader();
+    }
+
+    @Override
+    public void readFields(DataInput in)
+            throws IOException
+    {
+        config.readFields(in);
+    }
+
+    @Override
+    public void write(DataOutput out)
+            throws IOException
+    {
+        config.write(out);
+    }
+
+    @Override
+    public void writeXml(OutputStream out)
+            throws IOException
+    {
+        config.writeXml(out);
+    }
+
+    @Override
+    public void writeXml(Writer out)
+            throws IOException
+    {
+        config.writeXml(out);
+    }
+
+    @Override
+    public Map<String, String> getValByRegex(String regex)
+    {
+        return config.getValByRegex(regex);
+    }
+
+    @Override
+    public String toString()
+    {
+        return config.toString();
+    }
+
+    @Override
+    public void addResource(String name)
+    {
+        config.addResource(name);
+    }
+
+    @Override
+    public void addResource(URL url)
+    {
+        config.addResource(url);
+    }
+
+    @Override
+    public void addResource(Path file)
+    {
+        config.addResource(file);
+    }
+
+    @Override
+    public void addResource(InputStream in)
+    {
+        config.addResource(in);
+    }
+
+    @Override
+    public void addResource(InputStream in, String name)
+    {
+        config.addResource(in, name);
+    }
+
+    @Override
+    public void addResource(Configuration conf)
+    {
+        config.addResource(conf);
+    }
+
+    @Override
+    public synchronized void reloadConfiguration()
+    {
+        config.reloadConfiguration();
+    }
+
+    @Override
+    public synchronized String[] getPropertySources(String name)
+    {
+        return config.getPropertySources(name);
+    }
+
+    private void checkAndSet(Runnable action)
+    {
+        if (isMutable) {
+            action.run();
+            return;
+        }
+        synchronized (lock) {
+            Configuration originalConfig = config;
+            config = new Configuration(originalConfig);
+            isMutable = true;
+            action.run();
+        }
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveHdfsConfiguration.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveHdfsConfiguration.java
@@ -46,25 +46,51 @@ public class HiveHdfsConfiguration
     private final HdfsConfigurationInitializer initializer;
     private final Set<DynamicConfigurationProvider> dynamicProviders;
 
+    // This is set to TRUE if the configuration providers are empty or they do NOT dependent on the URI
+    private final boolean isConfigReusable;
+
+    // This is set to TRUE after the ThreadLocal config object is updated by all configuration providers
+    private boolean isConfigUpdated;
+
     @Inject
     public HiveHdfsConfiguration(HdfsConfigurationInitializer initializer, Set<DynamicConfigurationProvider> dynamicProviders)
     {
         this.initializer = requireNonNull(initializer, "initializer is null");
         this.dynamicProviders = ImmutableSet.copyOf(requireNonNull(dynamicProviders, "dynamicProviders is null"));
+        boolean isUriIndependentConfig = true;
+        for (DynamicConfigurationProvider provider : dynamicProviders) {
+            isUriIndependentConfig = isUriIndependentConfig && provider.isUriIndependentConfigurationProvider();
+        }
+        this.isConfigReusable = isUriIndependentConfig;
     }
 
     @Override
     public Configuration getConfiguration(HdfsContext context, URI uri)
     {
         if (dynamicProviders.isEmpty()) {
-            // use the same configuration for everything
             return hadoopConfiguration.get();
         }
 
-        Configuration config = new Configuration(hadoopConfiguration.get());
+        if (isConfigReusable && isConfigUpdated) {
+            // use the same configuration for everything
+            return new CopyOnWriteConfiguration(hadoopConfiguration.get());
+        }
+
+        Configuration config = hadoopConfiguration.get();
+        if (!isConfigReusable) {
+            config = new Configuration(hadoopConfiguration.get());
+        }
+
         for (DynamicConfigurationProvider provider : dynamicProviders) {
             provider.updateConfiguration(config, context, uri);
         }
+
+        if (isConfigReusable && !isConfigUpdated) {
+            // Return a CopyOnWrite config so that we make a copy before modifying it down the lane
+            isConfigUpdated = true;
+            return new CopyOnWriteConfiguration(config);
+        }
+
         return config;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/StoragePartitionLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/StoragePartitionLoader.java
@@ -165,7 +165,7 @@ public class StoragePartitionLoader
         Path path = new Path(location);
         Configuration configuration = hdfsEnvironment.getConfiguration(hdfsContext, path);
         InputFormat<?, ?> inputFormat = getInputFormat(configuration, inputFormatName, false);
-        ExtendedFileSystem fs = hdfsEnvironment.getFileSystem(hdfsContext, path);
+        ExtendedFileSystem fs = hdfsEnvironment.getFileSystem(hdfsContext.getIdentity().getUser(), path, configuration);
         boolean s3SelectPushdownEnabled = shouldEnablePushdownForTable(session, table, path.toString(), partition.getPartition());
 
         if (inputFormat instanceof SymlinkTextInputFormat) {

--- a/presto-hive/src/main/java/com/facebook/presto/hive/WrapperJobConf.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/WrapperJobConf.java
@@ -1,0 +1,212 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.mapred.JobConf;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+public class WrapperJobConf
+        extends JobConf
+{
+    private final Configuration config;
+
+    public WrapperJobConf(Configuration config)
+    {
+        super();
+        this.config = requireNonNull(config, "config is null");
+    }
+
+    public Configuration getConfig()
+    {
+        return config;
+    }
+
+    @Override
+    public Iterator<Map.Entry<String, String>> iterator()
+    {
+        return config.iterator();
+    }
+
+    @Override
+    public Class<?> getClassByName(String name)
+            throws ClassNotFoundException
+    {
+        return config.getClassByName(name);
+    }
+
+    @Override
+    public Class<?> getClassByNameOrNull(String name)
+    {
+        return config.getClassByNameOrNull(name);
+    }
+
+    @Override
+    public Class<?> getClass(String name, Class<?> defaultValue)
+    {
+        return config.getClass(name, defaultValue);
+    }
+
+    @Override
+    public <U> Class<? extends U> getClass(String name, Class<? extends U> defaultValue, Class<U> xface)
+    {
+        return config.getClass(name, defaultValue, xface);
+    }
+
+    @Override
+    public void setClassLoader(ClassLoader classLoader)
+    {
+        config.setClassLoader(classLoader);
+    }
+
+    @Override
+    public ClassLoader getClassLoader()
+    {
+        return config.getClassLoader();
+    }
+
+    @Override
+    public void set(String name, String value)
+    {
+        config.set(name, value);
+    }
+
+    @Override
+    public String get(String name, String defaultValue)
+    {
+        return config.get(name, defaultValue);
+    }
+
+    @Override
+    public String get(String name)
+    {
+        if (config == null) {
+            return super.get(name);
+        }
+        String result = config.get(name);
+        return result != null ? result : super.get(name);
+    }
+
+    @Override
+    public void setBoolean(String name, boolean value)
+    {
+        config.setBoolean(name, value);
+    }
+
+    @Override
+    public void setBooleanIfUnset(String name, boolean value)
+    {
+        config.setBooleanIfUnset(name, value);
+    }
+
+    @Override
+    public boolean getBoolean(String name, boolean defaultValue)
+    {
+        return config.getBoolean(name, defaultValue);
+    }
+
+    @Override
+    public void setInt(String name, int value)
+    {
+        config.setInt(name, value);
+    }
+
+    @Override
+    public int getInt(String name, int defaultValue)
+    {
+        return config.getInt(name, defaultValue);
+    }
+
+    @Override
+    public int[] getInts(String name)
+    {
+        return config.getInts(name);
+    }
+
+    @Override
+    public void setDouble(String name, double value)
+    {
+        config.setDouble(name, value);
+    }
+
+    @Override
+    public double getDouble(String name, double defaultValue)
+    {
+        return config.getDouble(name, defaultValue);
+    }
+
+    @Override
+    public void setFloat(String name, float value)
+    {
+        config.setFloat(name, value);
+    }
+
+    @Override
+    public float getFloat(String name, float defaultValue)
+    {
+        return config.getFloat(name, defaultValue);
+    }
+
+    @Override
+    public void setLong(String name, long value)
+    {
+        config.setLong(name, value);
+    }
+
+    @Override
+    public long getLong(String name, long defaultValue)
+    {
+        return config.getLong(name, defaultValue);
+    }
+
+    @Override
+    public synchronized void unset(String name)
+    {
+        config.unset(name);
+    }
+
+    @Override
+    public synchronized void setIfUnset(String name, String value)
+    {
+        config.setIfUnset(name, value);
+    }
+
+    @Override
+    public void readFields(DataInput in)
+            throws IOException
+    {
+        config.readFields(in);
+    }
+
+    @Override
+    public void write(DataOutput out)
+            throws IOException
+    {
+        config.write(out);
+    }
+
+    @Override
+    public void clear()
+    {
+        super.clear();
+        config.clear();
+    }
+}

--- a/presto-hive/src/main/java/com/facebook/presto/hive/cache/HiveCachingHdfsConfiguration.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/cache/HiveCachingHdfsConfiguration.java
@@ -21,12 +21,12 @@ import com.facebook.presto.hadoop.FileSystemFactory;
 import com.facebook.presto.hive.HdfsConfiguration;
 import com.facebook.presto.hive.HdfsContext;
 import com.facebook.presto.hive.HiveSessionProperties;
+import com.facebook.presto.hive.WrapperJobConf;
 import com.facebook.presto.hive.filesystem.ExtendedFileSystem;
 import com.facebook.presto.spi.PrestoException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.mapred.JobConf;
 
 import javax.inject.Inject;
 
@@ -89,21 +89,21 @@ public class HiveCachingHdfsConfiguration
     }
 
     private static class CachingJobConf
-            extends JobConf
+            extends WrapperJobConf
             implements FileSystemFactory
     {
         private final BiFunction<Configuration, URI, FileSystem> factory;
 
-        private CachingJobConf(BiFunction<Configuration, URI, FileSystem> factory, Configuration conf)
+        private CachingJobConf(BiFunction<Configuration, URI, FileSystem> factory, Configuration config)
         {
-            super(conf);
+            super(config);
             this.factory = requireNonNull(factory, "factory is null");
         }
 
         @Override
         public FileSystem createFileSystem(URI uri)
         {
-            return factory.apply(this, uri);
+            return factory.apply(getConfig(), uri);
         }
     }
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestCopyOnWriteConfiguration.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestCopyOnWriteConfiguration.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.hive;
+
+import org.apache.hadoop.conf.Configuration;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNotSame;
+import static org.testng.Assert.assertSame;
+
+public class TestCopyOnWriteConfiguration
+{
+    private static final String TEST_KEY = "test-key";
+    private static final String TEST_VALUE = "test-value";
+    private static final String TEST_UPDATED_VALUE = "test-updated-value";
+    private static final String TEST_KEY_INT = "test-key-int";
+    private static final int TEST_VALUE_INT = 1;
+
+    @Test
+    public void testCopyOnWriteConfiguration()
+    {
+        Configuration originalConfig = new Configuration();
+        originalConfig.set(TEST_KEY, TEST_VALUE);
+
+        CopyOnWriteConfiguration copyOnWriteConfig = new CopyOnWriteConfiguration(originalConfig);
+
+        // Assert the config remains same after a get call
+        assertEquals(originalConfig.get(TEST_KEY), copyOnWriteConfig.get(TEST_KEY));
+        assertEquals(TEST_VALUE, copyOnWriteConfig.get(TEST_KEY));
+        assertSame(originalConfig, copyOnWriteConfig.getConfig());
+
+        // Set the updated value
+        copyOnWriteConfig.set(TEST_KEY, TEST_UPDATED_VALUE);
+
+        // Assert value is different from the value in original config
+        assertEquals(TEST_UPDATED_VALUE, copyOnWriteConfig.get(TEST_KEY));
+        assertNotEquals(originalConfig.get(TEST_KEY), copyOnWriteConfig.get(TEST_KEY));
+
+        // Assert that the config object inside the CopyOnWriteConfiguration has changed
+        Configuration configAfterUpdate1 = copyOnWriteConfig.getConfig();
+        assertNotSame(originalConfig, configAfterUpdate1);
+
+        // Set a new key, value
+        copyOnWriteConfig.setInt(TEST_KEY_INT, TEST_VALUE_INT);
+
+        // Assert the config object after 2nd update is same as after 1st update
+        Configuration configAfterUpdate2 = copyOnWriteConfig.getConfig();
+        assertSame(configAfterUpdate1, configAfterUpdate2);
+    }
+}


### PR DESCRIPTION
![277766702_1020108805547687_4141416906474676589_n](https://user-images.githubusercontent.com/10070724/162848311-5689f2dc-6ffb-4b48-a5b7-36e791dc43a3.png)

We observed that we are spending significant CPU in creating Configuration objects. These are mainly created when we try to load a partition and list the files in the partition by making call to the filesystem. 

`1. HdfsEnvironment.getConfiguration() --> 2. HiveCachingHdfsConfiguration.getConfiguration() --> 3. WarmStorageHdfsConfiguration() --> 4. HiveHdfsConfiguration.getConfiguration()`

We first create a copy in 4) , then we do a copy of that in 3) , then finally we do a copy of that in 2) and then return it. So for a single partition we are creating multiple copies of the Configuration object. Copying this object is CPU intensive since it iterates through all the keys in the Configuration and manually copies them. 

This PR tries to avoid so many copies by using a wrapper class. Thereby avoiding creating another copy of Configuration object in 2), 3) levels. 

In `HiveHdfsConfiguration` we create a new config for every `getConfiguration` request. This is not needed since the `Configuration` is same for majority of the requests. So this PR has code changes to return `CopyOnWriteConfiguration` that creates a copy before if it is modified. The 2nd commit in this PR has those changes.

<img width="757" alt="Screen Shot 2022-04-11 at 4 26 41 PM" src="https://user-images.githubusercontent.com/10070724/162849390-cd68bc53-ad78-466d-b1b3-2dd64ab1f508.png">

<img width="608" alt="Screen Shot 2022-04-11 at 4 27 19 PM" src="https://user-images.githubusercontent.com/10070724/162849422-11fb258f-28e2-4765-9cbd-1d224bacbfb7.png">

Testing:
- Created custom presto version `0.273-20220410.182238-81` and tested by replaying traffic. 
- Initial numbers showed upto 10% CPU wins. Need to double check this by replaying production traffic.

```
== NO RELEASE NOTE ==
```
