### PR TITLE
Add rate limiting functionality for coordinator

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/QueryManagerConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/QueryManagerConfig.java
@@ -90,6 +90,10 @@ public class QueryManagerConfig
     private int globalQueryRetryFailureLimit = 150;
     private Duration globalQueryRetryFailureWindow = new Duration(5, MINUTES);
 
+    private long rateLimiterBucketMaxSize = 100;
+    private int rateLimiterCacheLimit = 1000;
+    private int rateLimiterCacheWindowMinutes = 5;
+
     @Min(1)
     public int getScheduleSplitBatchSize()
     {
@@ -619,6 +623,45 @@ public class QueryManagerConfig
     public QueryManagerConfig setGlobalQueryRetryFailureWindow(Duration globalQueryRetryFailureWindow)
     {
         this.globalQueryRetryFailureWindow = globalQueryRetryFailureWindow;
+        return this;
+    }
+
+    public long getRateLimiterBucketMaxSize()
+    {
+        return rateLimiterBucketMaxSize;
+    }
+
+    @Config("query-manager.rate-limiter-bucket-max-size")
+    @ConfigDescription("rate limiter token bucket max size, number of permits per second")
+    public QueryManagerConfig setRateLimiterBucketMaxSize(long rateLimiterBucketMaxSize)
+    {
+        this.rateLimiterBucketMaxSize = rateLimiterBucketMaxSize;
+        return this;
+    }
+
+    public int getRateLimiterCacheLimit()
+    {
+        return rateLimiterCacheLimit;
+    }
+
+    @Config("query-manager.rate-limiter-cache-limit")
+    @ConfigDescription("rate limiter cache size limit, used together with rateLimiterCacheWindowMinutes")
+    public QueryManagerConfig setRateLimiterCacheLimit(int rateLimiterCacheLimit)
+    {
+        this.rateLimiterCacheLimit = rateLimiterCacheLimit;
+        return this;
+    }
+
+    public int getRateLimiterCacheWindowMinutes()
+    {
+        return rateLimiterCacheWindowMinutes;
+    }
+
+    @Config("query-manager.rate-limiter-cache-window-minutes")
+    @ConfigDescription("rate limiter cache window size in minutes, used together with rateLimiterCacheLimit")
+    public QueryManagerConfig setRateLimiterCacheWindowMinutes(int rateLimiterCacheWindowMinutes)
+    {
+        this.rateLimiterCacheWindowMinutes = rateLimiterCacheWindowMinutes;
         return this;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
@@ -73,6 +73,7 @@ import com.facebook.presto.resourcemanager.ForResourceManager;
 import com.facebook.presto.resourcemanager.ResourceManagerProxy;
 import com.facebook.presto.server.protocol.ExecutingStatementResource;
 import com.facebook.presto.server.protocol.LocalQueryProvider;
+import com.facebook.presto.server.protocol.QueryBlockingRateLimiter;
 import com.facebook.presto.server.protocol.QueuedStatementResource;
 import com.facebook.presto.server.protocol.RetryCircuitBreaker;
 import com.facebook.presto.server.remotetask.HttpRemoteTaskFactory;
@@ -187,6 +188,9 @@ public class CoordinatorModule
         binder.bind(LegacyResourceGroupConfigurationManager.class).in(Scopes.SINGLETON);
         binder.bind(RetryCircuitBreaker.class).in(Scopes.SINGLETON);
         newExporter(binder).export(RetryCircuitBreaker.class).withGeneratedName();
+
+        binder.bind(QueryBlockingRateLimiter.class).in(Scopes.SINGLETON);
+        newExporter(binder).export(QueryBlockingRateLimiter.class).withGeneratedName();
 
         binder.bind(LocalQueryProvider.class).in(Scopes.SINGLETON);
 

--- a/presto-main/src/main/java/com/facebook/presto/server/protocol/QueryBlockingRateLimiter.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/protocol/QueryBlockingRateLimiter.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.server.protocol;
+
+import com.facebook.airlift.stats.CounterStat;
+import com.facebook.airlift.stats.TimeStat;
+import com.facebook.presto.execution.QueryManagerConfig;
+import com.facebook.presto.spi.QueryId;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.RateLimiter;
+import com.google.inject.Inject;
+import io.airlift.units.Duration;
+import org.weakref.jmx.Managed;
+import org.weakref.jmx.Nested;
+
+import javax.annotation.PreDestroy;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import static com.facebook.airlift.concurrent.Threads.daemonThreadsNamed;
+import static com.google.common.util.concurrent.Futures.immediateFailedFuture;
+import static com.google.common.util.concurrent.Futures.immediateFuture;
+import static com.google.common.util.concurrent.MoreExecutors.listeningDecorator;
+import static java.util.Objects.requireNonNull;
+
+/*
+ * Rate Limiting per query with token bucket
+ * Rate = rateLimitBucketMaxSize/second
+ * When having sufficient tokens, Request will be responded immediately.
+ * When not having enough tokens available, it uses the delayed processing method.
+ */
+public class QueryBlockingRateLimiter
+{
+    private final long rateLimiterBucketMaxSize;
+    private final ListeningExecutorService rateLimiterExecutorService;
+    private final LoadingCache<QueryId, RateLimiter> rateLimiterCache;
+    private final CounterStat rateLimiterTriggeredCounter = new CounterStat();
+    private final TimeStat rateLimiterBlockTime = new TimeStat();
+
+    @Inject
+    public QueryBlockingRateLimiter(QueryManagerConfig queryManagerConfig)
+    {
+        requireNonNull(queryManagerConfig, "queryManagerConfig is null");
+        this.rateLimiterBucketMaxSize = queryManagerConfig.getRateLimiterBucketMaxSize();
+        // Using a custom thread pool with size 1-10 to reduce initial thread resources
+        ExecutorService executorService = new ThreadPoolExecutor(1, 10, 60, TimeUnit.SECONDS, new LinkedBlockingQueue<>(), daemonThreadsNamed("rate-limiter-listener"));
+        rateLimiterExecutorService = listeningDecorator(executorService);
+        rateLimiterCache = CacheBuilder.newBuilder().maximumSize(queryManagerConfig.getRateLimiterCacheLimit()).expireAfterAccess(queryManagerConfig.getRateLimiterCacheWindowMinutes(), TimeUnit.MINUTES).build(CacheLoader.from(key -> RateLimiter.create(rateLimiterBucketMaxSize)));
+    }
+
+    /*
+     * For accidental bug-caused DoS, we will use delayed processing method to reduce the requests, even when user do not have back-off logic implemented
+     * Optimized to avoid blocking for normal usages with TryRequire first
+     * Fall back to delayed processing method to acquire a permit, in a separate thread pool
+     * Internal guava rate limiter returns time spent sleeping to enforce rate, in seconds; 0.0 if not rate-limited, we use a future to wrap around that.
+     */
+    public ListenableFuture<Double> acquire(QueryId queryId)
+    {   // if rateLimitBucketMaxSize < 0, we disable rate limiting by returning immediately
+        if (rateLimiterBucketMaxSize < 0) {
+            return immediateFuture(0.0);
+        }
+        if (queryId == null) {
+            return immediateFailedFuture(new IllegalArgumentException("queryId should not be null"));
+        }
+        RateLimiter rateLimiter = rateLimiterCache.getUnchecked(queryId);
+        if (rateLimiter.tryAcquire()) {
+            return immediateFuture(0.0);
+        }
+        ListenableFuture<Double> asyncTask = rateLimiterExecutorService.submit(() -> rateLimiter.acquire());
+        rateLimiterTriggeredCounter.update(1);
+        return asyncTask;
+    }
+
+    @Managed
+    @Nested
+    public CounterStat getRateLimiterTriggeredCounter()
+    {
+        return rateLimiterTriggeredCounter;
+    }
+
+    public TimeStat getRateLimiterBlockTime()
+    {
+        return rateLimiterBlockTime;
+    }
+
+    public void addRateLimiterBlockTime(Duration duration)
+    {
+        rateLimiterBlockTime.add(duration);
+    }
+
+    @PreDestroy
+    public void destroy()
+    {
+        rateLimiterExecutorService.shutdownNow();
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/execution/TestQueryManagerConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/TestQueryManagerConfig.java
@@ -74,7 +74,10 @@ public class TestQueryManagerConfig
                 .setPerQueryRetryLimit(0)
                 .setPerQueryRetryMaxExecutionTime(new Duration(5, MINUTES))
                 .setGlobalQueryRetryFailureLimit(150)
-                .setGlobalQueryRetryFailureWindow(new Duration(5, MINUTES)));
+                .setGlobalQueryRetryFailureWindow(new Duration(5, MINUTES))
+                .setRateLimiterBucketMaxSize(100)
+                .setRateLimiterCacheLimit(1000)
+                .setRateLimiterCacheWindowMinutes(5));
     }
 
     @Test
@@ -120,6 +123,9 @@ public class TestQueryManagerConfig
                 .put("per-query-retry-max-execution-time", "1h")
                 .put("global-query-retry-failure-limit", "200")
                 .put("global-query-retry-failure-window", "1h")
+                .put("query-manager.rate-limiter-bucket-max-size", "200")
+                .put("query-manager.rate-limiter-cache-limit", "10000")
+                .put("query-manager.rate-limiter-cache-window-minutes", "60")
                 .build();
 
         QueryManagerConfig expected = new QueryManagerConfig()
@@ -161,8 +167,10 @@ public class TestQueryManagerConfig
                 .setPerQueryRetryLimit(10)
                 .setPerQueryRetryMaxExecutionTime(new Duration(1, HOURS))
                 .setGlobalQueryRetryFailureLimit(200)
-                .setGlobalQueryRetryFailureWindow(new Duration(1, HOURS));
-
+                .setGlobalQueryRetryFailureWindow(new Duration(1, HOURS))
+                .setRateLimiterBucketMaxSize(200)
+                .setRateLimiterCacheLimit(10000)
+                .setRateLimiterCacheWindowMinutes(60);
         ConfigAssertions.assertFullMapping(properties, expected);
     }
 }


### PR DESCRIPTION
Add rate limiting functionality for coordinator

For accidental bug-caused DoS, we will use delayed processing method 
to reduce the requests, even when user do not have back-off logic implemented.

Rate Limiting is per each query level with token bucket logic, based on Guava 
SmoothBursty implementation. 
Currently rate limiter is used on /queued and /executing endpoints.
Rate = rateLimitBucketMaxSize/second. 
By default, for each query, we allow 100 requests/s, in a sliding window manner.

Test plan - 
testBlockingRateLimitShouldNotDelay
testBlockingRateLimitShouldDelay


```
== RELEASE NOTES ==

General Changes
* Add rate limiting functionality for each query on coordinator http endpoints.

```
