### PR TITLE
Fix calculation error in deepInstanceSize of BlockBuilderStatus

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/block/BlockBuilderStatus.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/BlockBuilderStatus.java
@@ -15,15 +15,11 @@ package com.facebook.presto.common.block;
 
 import org.openjdk.jol.info.ClassLayout;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
-
-import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
 public class BlockBuilderStatus
 {
-    public static final int INSTANCE_SIZE = deepInstanceSize(BlockBuilderStatus.class);
+    public static final int INSTANCE_SIZE = ClassLayout.parseClass(BlockBuilderStatus.class).instanceSize() + PageBuilderStatus.INSTANCE_SIZE;
 
     private final PageBuilderStatus pageBuilderStatus;
 
@@ -52,33 +48,5 @@ public class BlockBuilderStatus
         buffer.append(", currentSize=").append(currentSize);
         buffer.append('}');
         return buffer.toString();
-    }
-
-    /**
-     * Computes the size of an instance of this class assuming that all reference fields are non-null
-     */
-    private static int deepInstanceSize(Class<?> clazz)
-    {
-        if (clazz.isArray()) {
-            throw new IllegalArgumentException(format("Cannot determine size of %s because it contains an array", clazz.getSimpleName()));
-        }
-        if (clazz.isInterface()) {
-            throw new IllegalArgumentException(format("%s is an interface", clazz.getSimpleName()));
-        }
-        if (Modifier.isAbstract(clazz.getModifiers())) {
-            throw new IllegalArgumentException(format("%s is abstract", clazz.getSimpleName()));
-        }
-        if (!clazz.getSuperclass().equals(Object.class)) {
-            throw new IllegalArgumentException(format("Cannot determine size of a subclass. %s extends from %s", clazz.getSimpleName(), clazz.getSuperclass().getSimpleName()));
-        }
-
-        int size = ClassLayout.parseClass(clazz).instanceSize();
-        for (Field field : clazz.getDeclaredFields()) {
-            // The !field.isSynthetic() condition is specifically for jacoco which adds synthetic members $jacocoData and $jacocoInit() to classes.
-            if (!field.getType().isPrimitive() && !field.isSynthetic()) {
-                size += deepInstanceSize(field.getType());
-            }
-        }
-        return size;
     }
 }

--- a/presto-common/src/main/java/com/facebook/presto/common/block/PageBuilderStatus.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/block/PageBuilderStatus.java
@@ -13,8 +13,11 @@
  */
 package com.facebook.presto.common.block;
 
+import org.openjdk.jol.info.ClassLayout;
+
 public class PageBuilderStatus
 {
+    public static final int INSTANCE_SIZE = ClassLayout.parseClass(PageBuilderStatus.class).instanceSize();
     public static final int DEFAULT_MAX_PAGE_SIZE_IN_BYTES = 1024 * 1024;
 
     private final int maxPageSizeInBytes;


### PR DESCRIPTION
Cherry-pick of https://github.com/trinodb/trino/pull/11710
Currently, in the deepInstanceSize function of BlockBuilderStatus
class, we recursively calculate the size of one BlockBuilderStatus
instance. However, we should exclude the static field which is not
the size for one instance, it's the size for the whole class and is
shared by each intance.

Co-authored-by: JackieTien97 <jackietien97@gmail.com>

```
== NO RELEASE NOTE ==
```
