### PR TITLE
Use same operator type for index join builders

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/index/IndexBuildDriverFactoryProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/index/IndexBuildDriverFactoryProvider.java
@@ -32,6 +32,7 @@ import static java.util.Objects.requireNonNull;
 
 public class IndexBuildDriverFactoryProvider
 {
+    private static final String INDEX_BUILDER = "IndexBuilder";
     private final int pipelineId;
     private final int outputOperatorId;
     private final PlanNodeId planNodeId;
@@ -82,7 +83,7 @@ public class IndexBuildDriverFactoryProvider
                 false,
                 ImmutableList.<OperatorFactory>builder()
                         .addAll(coreOperatorFactories)
-                        .add(new PagesIndexBuilderOperatorFactory(outputOperatorId, planNodeId, indexSnapshotBuilder))
+                        .add(new PagesIndexBuilderOperatorFactory(outputOperatorId, planNodeId, indexSnapshotBuilder, INDEX_BUILDER))
                         .build(),
                 OptionalInt.empty(),
                 UNGROUPED_EXECUTION,
@@ -99,7 +100,7 @@ public class IndexBuildDriverFactoryProvider
             operatorFactories.add(dynamicTupleFilterFactory.get().filterWithTuple(indexKeyTuple));
         }
 
-        operatorFactories.add(new PageBufferOperatorFactory(outputOperatorId, planNodeId, pageBuffer));
+        operatorFactories.add(new PageBufferOperatorFactory(outputOperatorId, planNodeId, pageBuffer, INDEX_BUILDER));
 
         return new DriverFactory(pipelineId, inputDriver, false, operatorFactories.build(), OptionalInt.empty(), UNGROUPED_EXECUTION, Optional.empty());
     }

--- a/presto-main/src/main/java/com/facebook/presto/operator/index/PageBufferOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/index/PageBufferOperator.java
@@ -33,18 +33,20 @@ public class PageBufferOperator
         private final int operatorId;
         private final PlanNodeId planNodeId;
         private final PageBuffer pageBuffer;
+        private final String operatorType;
 
-        public PageBufferOperatorFactory(int operatorId, PlanNodeId planNodeId, PageBuffer pageBuffer)
+        public PageBufferOperatorFactory(int operatorId, PlanNodeId planNodeId, PageBuffer pageBuffer, String operatorType)
         {
             this.operatorId = operatorId;
             this.planNodeId = requireNonNull(planNodeId, "planNodeId is null");
             this.pageBuffer = requireNonNull(pageBuffer, "pageBuffer is null");
+            this.operatorType = requireNonNull(operatorType, "operatorType is null");
         }
 
         @Override
         public Operator createOperator(DriverContext driverContext)
         {
-            OperatorContext operatorContext = driverContext.addOperatorContext(operatorId, planNodeId, PageBufferOperator.class.getSimpleName());
+            OperatorContext operatorContext = driverContext.addOperatorContext(operatorId, planNodeId, operatorType);
             return new PageBufferOperator(operatorContext, pageBuffer);
         }
 
@@ -56,7 +58,7 @@ public class PageBufferOperator
         @Override
         public OperatorFactory duplicate()
         {
-            return new PageBufferOperatorFactory(operatorId, planNodeId, pageBuffer);
+            return new PageBufferOperatorFactory(operatorId, planNodeId, pageBuffer, operatorType);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/operator/index/PagesIndexBuilderOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/index/PagesIndexBuilderOperator.java
@@ -35,13 +35,15 @@ public class PagesIndexBuilderOperator
         private final int operatorId;
         private final PlanNodeId planNodeId;
         private final IndexSnapshotBuilder indexSnapshotBuilder;
+        private final String operatorType;
         private boolean closed;
 
-        public PagesIndexBuilderOperatorFactory(int operatorId, PlanNodeId planNodeId, IndexSnapshotBuilder indexSnapshotBuilder)
+        public PagesIndexBuilderOperatorFactory(int operatorId, PlanNodeId planNodeId, IndexSnapshotBuilder indexSnapshotBuilder, String operatorType)
         {
             this.operatorId = operatorId;
             this.planNodeId = requireNonNull(planNodeId, "planNodeId is null");
             this.indexSnapshotBuilder = requireNonNull(indexSnapshotBuilder, "indexSnapshotBuilder is null");
+            this.operatorType = requireNonNull(operatorType, "operatorType is null");
         }
 
         @Override
@@ -49,7 +51,7 @@ public class PagesIndexBuilderOperator
         {
             checkState(!closed, "Factory is already closed");
 
-            OperatorContext operatorContext = driverContext.addOperatorContext(operatorId, planNodeId, PagesIndexBuilderOperator.class.getSimpleName());
+            OperatorContext operatorContext = driverContext.addOperatorContext(operatorId, planNodeId, operatorType);
             return new PagesIndexBuilderOperator(operatorContext, indexSnapshotBuilder);
         }
 
@@ -62,7 +64,7 @@ public class PagesIndexBuilderOperator
         @Override
         public OperatorFactory duplicate()
         {
-            return new PagesIndexBuilderOperatorFactory(operatorId, planNodeId, indexSnapshotBuilder);
+            return new PagesIndexBuilderOperatorFactory(operatorId, planNodeId, indexSnapshotBuilder, operatorType);
         }
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestHashJoinOperator.java
@@ -113,6 +113,7 @@ public class TestHashJoinOperator
     private static final LookupJoinOperators LOOKUP_JOIN_OPERATORS = new LookupJoinOperators();
     private static final SingleStreamSpillerFactory SINGLE_STREAM_SPILLER_FACTORY = new DummySpillerFactory();
     private static final PartitioningSpillerFactory PARTITIONING_SPILLER_FACTORY = new GenericPartitioningSpillerFactory(SINGLE_STREAM_SPILLER_FACTORY);
+    private static final String PAGE_BUFFER = "PageBuffer";
 
     private ExecutorService executor;
     private ScheduledExecutorService scheduledExecutor;
@@ -444,7 +445,7 @@ public class TestHashJoinOperator
             ValuesOperatorFactory valuesOperatorFactory = new ValuesOperatorFactory(17, new PlanNodeId("values"), probePages.build());
 
             PageBuffer pageBuffer = new PageBuffer(10);
-            PageBufferOperatorFactory pageBufferOperatorFactory = new PageBufferOperatorFactory(18, new PlanNodeId("pageBuffer"), pageBuffer);
+            PageBufferOperatorFactory pageBufferOperatorFactory = new PageBufferOperatorFactory(18, new PlanNodeId(PAGE_BUFFER), pageBuffer, PAGE_BUFFER);
 
             Driver joinDriver = Driver.createDriver(
                     joinDriverContext,
@@ -561,7 +562,7 @@ public class TestHashJoinOperator
         ValuesOperatorFactory valuesOperatorFactory2 = new ValuesOperatorFactory(18, new PlanNodeId("values2"), probe2Pages.build());
         ValuesOperatorFactory valuesOperatorFactory3 = new ValuesOperatorFactory(18, new PlanNodeId("values3"), ImmutableList.of());
         PageBuffer pageBuffer = new PageBuffer(10);
-        PageBufferOperatorFactory pageBufferOperatorFactory = new PageBufferOperatorFactory(19, new PlanNodeId("pageBuffer"), pageBuffer);
+        PageBufferOperatorFactory pageBufferOperatorFactory = new PageBufferOperatorFactory(19, new PlanNodeId(PAGE_BUFFER), pageBuffer, PAGE_BUFFER);
 
         Driver joinDriver1 = Driver.createDriver(
                 joinDriverContext1,


### PR DESCRIPTION
Cherry-pick of https://github.com/trinodb/trino/pull/11758

This prevents failures when adding operator stats
(operators at same pipeline index should have same type).

Co-authored-by: Karol Sobczak <napewnotrafi@gmail.com>

Test plan - Make sure CI tests pass

```
== NO RELEASE NOTE ==
```