### PR TITLE
Add an override method read for class HdfsInputStream

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/HdfsInputFile.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/HdfsInputFile.java
@@ -89,6 +89,13 @@ public class HdfsInputFile
         }
 
         @Override
+        public int read(byte[] b, int off, int len)
+                throws IOException
+        {
+            return delegate.read(b, off, len);
+        }
+
+        @Override
         public long getPos() throws IOException
         {
             return delegate.getPos();


### PR DESCRIPTION
Cherry-pick of Trino https://github.com/trinodb/trino/pull/11322

Add an override method read(byte[] b, int off, int len) for class
HdfsInputStream to avoid poor performance when load iceberg metadata.
This helps avoid poor performance, since previously the invocation
was delegated to `read()`.

Co-authored-by: xiangakun <xiangakun@126.com>

```
== NO RELEASE NOTE ==
```
