### PR TITLE
Fix close idempotency for JDBC PreparedStatement

### DIFF
--- a/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoPreparedStatement.java
+++ b/presto-jdbc/src/main/java/com/facebook/presto/jdbc/PrestoPreparedStatement.java
@@ -74,6 +74,7 @@ public class PrestoPreparedStatement
     private final Map<Integer, String> parameters = new HashMap<>();
     private final String statementName;
     private final String originalSql;
+    private boolean isClosed;
 
     PrestoPreparedStatement(PrestoConnection connection, String statementName, String sql)
             throws SQLException
@@ -88,8 +89,12 @@ public class PrestoPreparedStatement
     public void close()
             throws SQLException
     {
+        if (isClosed) {
+            return;
+        }
         super.execute(format("DEALLOCATE PREPARE %s", statementName));
         super.close();
+        isClosed = true;
     }
 
     @Override

--- a/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestJdbcPreparedStatement.java
+++ b/presto-jdbc/src/test/java/com/facebook/presto/jdbc/TestJdbcPreparedStatement.java
@@ -233,6 +233,17 @@ public class TestJdbcPreparedStatement
     }
 
     @Test
+    public void testCloseIdempotency()
+            throws Exception
+    {
+        try (Connection connection = createConnection()) {
+            PreparedStatement statement = connection.prepareStatement("SELECT 123");
+            statement.close();
+            statement.close();
+        }
+    }
+
+    @Test
     public void testExecuteUpdate()
             throws Exception
     {


### PR DESCRIPTION
Fix the behavior of PreparedStatement.close() so that it may be called
multiple times without throwing an exception on subsequent invocations,
which is required per the JDBC specification:
```
Calling the method close on a Statement object that
is already closed has no effect.
```

Cherry-pick of https://github.com/trinodb/trino/pull/11620

Co-authored-by: David Phillips <david@acz.org>

Test plan - Added Unit Tests

```
== NO RELEASE NOTE ==
```
