### PR TITLE
Fix page retained size by accounting slice base object once for a page

### DIFF
--- a/presto-common/src/test/java/com/facebook/presto/common/TestPage.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/TestPage.java
@@ -17,13 +17,18 @@ import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.BlockBuilder;
 import com.facebook.presto.common.block.DictionaryBlock;
 import com.facebook.presto.common.block.DictionaryId;
+import com.facebook.presto.common.block.VariableWidthBlock;
 import io.airlift.slice.DynamicSliceOutput;
 import io.airlift.slice.Slice;
 import org.testng.annotations.Test;
 
+import java.util.UUID;
+import java.util.stream.LongStream;
+
 import static com.facebook.presto.common.block.DictionaryId.randomDictionaryId;
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
 import static org.testng.Assert.assertEquals;
@@ -129,6 +134,24 @@ public class TestPage
             assertEquals(page.getBlock(i).getLong(3), 2);
             assertEquals(page.getBlock(i).getLong(4), 5);
         }
+    }
+
+    @Test
+    public void testRetainedSizeIsCorrect()
+    {
+        BlockBuilder variableWidthBlockBuilder = VARCHAR.createBlockBuilder(null, 256);
+
+        LongStream.range(0, 100).forEach(value -> VARCHAR.writeString(variableWidthBlockBuilder, UUID.randomUUID().toString()));
+        VariableWidthBlock variableWidthBlock = (VariableWidthBlock) variableWidthBlockBuilder.build();
+        Page page = new Page(
+                variableWidthBlock, // Original block
+                variableWidthBlock, // Same block twice
+                variableWidthBlock.getRegion(0, 50), // Block with same underlying slice
+                variableWidthBlockBuilder.getRegion(51, 25)); // Block with slice having same underlying base object/byte array
+        // Account for extra overhead of objects to be around 20%.
+        // Close attention should be paid when this needs to be updated to 2x or higher as that case may introduce double counting
+        double expectedMaximumSizeOfPage = variableWidthBlock.getRawSlice(0).getRetainedSize() * 1.2;
+        assertTrue(page.getRetainedSizeInBytes() < expectedMaximumSizeOfPage, "Expected slice & underlying object to be counted once");
     }
 
     private static Slice[] createExpectedValues(int positionCount)

--- a/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestPagesSerde.java
+++ b/presto-main/src/test/java/com/facebook/presto/execution/buffer/TestPagesSerde.java
@@ -25,6 +25,8 @@ import org.testng.annotations.Test;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.UUID;
+import java.util.stream.LongStream;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
@@ -33,6 +35,7 @@ import static com.facebook.presto.spi.page.PagesSerdeUtil.readPages;
 import static com.facebook.presto.spi.page.PagesSerdeUtil.writePages;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 public class TestPagesSerde
 {
@@ -105,6 +108,34 @@ public class TestPagesSerde
         page = new Page(builder.build());
         int secondValueSize = serializedSize(ImmutableList.of(VARCHAR), page) - (pageSize + firstValueSize);
         assertEquals(secondValueSize, 4 + 3); // length + "bob" (null shared with first entry)
+    }
+
+    @Test
+    public void testRoundTripSizeForCompactPageStaysWithinTwentyPercent()
+    {
+        PagesSerde serde = new TestingPagesSerdeFactory().createPagesSerde();
+        BlockBuilder variableWidthBlockBuilder1 = VARCHAR.createBlockBuilder(null, 128);
+        BlockBuilder variableWidthBlockBuilder2 = VARCHAR.createBlockBuilder(null, 256);
+        BlockBuilder bigintBlockBuilder = BIGINT.createBlockBuilder(null, 128);
+        Block emptyVariableWidthBlock = VARCHAR.createBlockBuilder(null, 128).build();
+
+        LongStream.range(0, 100).forEach(value -> {
+            VARCHAR.writeString(variableWidthBlockBuilder1, UUID.randomUUID().toString());
+            VARCHAR.writeString(variableWidthBlockBuilder2, UUID.randomUUID().toString());
+            VARCHAR.writeString(variableWidthBlockBuilder2, UUID.randomUUID().toString());
+            BIGINT.writeLong(bigintBlockBuilder, value);
+        });
+        Page compactPage = new Page(
+                emptyVariableWidthBlock,
+                variableWidthBlockBuilder1.build(),
+                variableWidthBlockBuilder2.build(),
+                bigintBlockBuilder.build())
+                .compact();
+        Page deserializedPage = serde.deserialize(serde.serialize(compactPage));
+
+        double expectedMaxSize = compactPage.getRetainedSizeInBytes() * 1.2; // 120%
+        double actualSize = deserializedPage.getRetainedSizeInBytes();
+        assertTrue(actualSize < expectedMaxSize, "Expected round trip size difference less than 20% of original page");
     }
 
     private static int serializedSize(List<? extends Type> types, Page expectedPage)


### PR DESCRIPTION
Test plan - 
Tested with Presto on Spark failing broadcast queries & Presto small & large queries in production

```
== RELEASE NOTES ==

General Changes
* Fix memory overcounting for ``VariableWidthBlocks`` that could cause queries to fail with exceeded memory limit errors
