### PR TITLE
Update jgrapht version for code migration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1767,7 +1767,7 @@
             <dependency>
                 <groupId>org.jgrapht</groupId>
                 <artifactId>jgrapht-core</artifactId>
-                <version>0.9.0</version>
+                <version>1.3.1</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Graph inherited all of the DirectedGraph's methods and properties in
newer versions.

The StrongConnectivityInspector class was replaced by
implementation specifc class names.

Test plan -  mvn install -DskipTests

```
== NO RELEASE NOTE ==
```
