### PR TITLE
Replace CpuTimer to avoid sampling user time

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/executor/PrioritizedSplitRunner.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/executor/PrioritizedSplitRunner.java
@@ -15,7 +15,6 @@ package com.facebook.presto.execution.executor;
 
 import com.facebook.airlift.log.Logger;
 import com.facebook.airlift.stats.CounterStat;
-import com.facebook.airlift.stats.CpuTimer;
 import com.facebook.airlift.stats.TimeStat;
 import com.facebook.presto.execution.SplitRunner;
 import com.google.common.base.Ticker;
@@ -23,6 +22,8 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
 import io.airlift.units.Duration;
 
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadMXBean;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
@@ -40,6 +41,8 @@ public class PrioritizedSplitRunner
 
     // each time we run a split, run it for this length before returning to the pool
     public static final Duration SPLIT_RUN_QUANTA = new Duration(1, TimeUnit.SECONDS);
+
+    private static final ThreadMXBean THREAD_MX_BEAN = ManagementFactory.getThreadMXBean();
 
     private final long createdNanos = System.nanoTime();
 
@@ -158,9 +161,11 @@ public class PrioritizedSplitRunner
 
             waitNanos.getAndAdd(startNanos - lastReady.get());
 
-            CpuTimer timer = new CpuTimer();
+            long wallStart = System.nanoTime();
+            long cpuStart = THREAD_MX_BEAN.getCurrentThreadCpuTime();
             ListenableFuture<?> blocked = split.processFor(SPLIT_RUN_QUANTA);
-            CpuTimer.CpuDuration elapsed = timer.elapsedTime();
+            long quantaCpuNanos = THREAD_MX_BEAN.getCurrentThreadCpuTime() - cpuStart;
+            Duration wallDuration = new Duration(System.nanoTime() - wallStart, NANOSECONDS);
 
             long quantaScheduledNanos = ticker.read() - startNanos;
             scheduledNanos.addAndGet(quantaScheduledNanos);
@@ -169,13 +174,12 @@ public class PrioritizedSplitRunner
             lastRun.set(ticker.read());
 
             if (blocked == NOT_BLOCKED) {
-                unblockedQuantaWallTime.add(elapsed.getWall());
+                unblockedQuantaWallTime.add(wallDuration);
             }
             else {
-                blockedQuantaWallTime.add(elapsed.getWall());
+                blockedQuantaWallTime.add(wallDuration);
             }
 
-            long quantaCpuNanos = elapsed.getCpu().roundTo(NANOSECONDS);
             cpuTimeNanos.addAndGet(quantaCpuNanos);
 
             globalCpuTimeMicros.update(quantaCpuNanos / 1000);


### PR DESCRIPTION
CpuTimer will sample wall time, cpu time, and user time.  The latter is
relatively expensive on Linux since it requires parsing files in /proc.
In an internal run, Presto spent around 5% of its total cpu time fetching
this metric that is immediately discarded.

This diff fetches the two required stats directly, reducing CPU usage by
those 5%.

Test plan - Ran a few thousand shadow traffic queries and confirmed that `ThreadImpl.getCurrentThreadUserTime` no longer shows up in profiling traces.

```
== NO RELEASE NOTE ==
```
