### PR TITLE
Add thread timeout that interrupts query analyzer thread

### DIFF
--- a/presto-docs/src/main/sphinx/admin/properties.rst
+++ b/presto-docs/src/main/sphinx/admin/properties.rst
@@ -737,6 +737,18 @@ Optimizer Properties
     .. warning:: The number of possible join orders scales factorially with the number of relations,
                  so increasing this value can cause serious performance issues.
 
+Planner Properties
+--------------------------------------
+
+``planner.query-analyzer-timeout``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+    * **Type:** ``duration``
+    * **Default value:** ``3m``
+
+    Maximum running time for the query analyzer in case the processing takes too long or is stuck in an infinite loop.
+    When timeout expires the planner thread is interrupted and throws exception.
+
 Regular Expression Function Properties
 --------------------------------------
 

--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -141,6 +141,7 @@ public final class SystemSessionProperties
     public static final String LEGACY_MAP_SUBSCRIPT = "do_not_use_legacy_map_subscript";
     public static final String ITERATIVE_OPTIMIZER = "iterative_optimizer_enabled";
     public static final String ITERATIVE_OPTIMIZER_TIMEOUT = "iterative_optimizer_timeout";
+    public static final String QUERY_ANALYZER_TIMEOUT = "query_analyzer_timeout";
     public static final String RUNTIME_OPTIMIZER_ENABLED = "runtime_optimizer_enabled";
     public static final String EXCHANGE_COMPRESSION = "exchange_compression";
     public static final String EXCHANGE_CHECKSUM = "exchange_checksum";
@@ -741,6 +742,15 @@ public final class SystemSessionProperties
                         VARCHAR,
                         Duration.class,
                         featuresConfig.getIterativeOptimizerTimeout(),
+                        false,
+                        value -> Duration.valueOf((String) value),
+                        Duration::toString),
+                new PropertyMetadata<>(
+                        QUERY_ANALYZER_TIMEOUT,
+                        "Maximum processing time for query analyzer",
+                        VARCHAR,
+                        Duration.class,
+                        featuresConfig.getQueryAnalyzerTimeout(),
                         false,
                         value -> Duration.valueOf((String) value),
                         Duration::toString),
@@ -1700,6 +1710,11 @@ public final class SystemSessionProperties
     public static Duration getOptimizerTimeout(Session session)
     {
         return session.getSystemProperty(ITERATIVE_OPTIMIZER_TIMEOUT, Duration.class);
+    }
+
+    public static Duration getQueryAnalyzerTimeout(Session session)
+    {
+        return session.getSystemProperty(QUERY_ANALYZER_TIMEOUT, Duration.class);
     }
 
     public static boolean isExchangeCompressionEnabled(Session session)

--- a/presto-main/src/main/java/com/facebook/presto/execution/ForTimeoutThread.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/ForTimeoutThread.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution;
+
+import javax.inject.Qualifier;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Retention(RUNTIME)
+@Target({FIELD, PARAMETER, METHOD})
+@Qualifier
+public @interface ForTimeoutThread
+{
+}

--- a/presto-main/src/main/java/com/facebook/presto/execution/TimeoutThread.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/TimeoutThread.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.execution;
+
+import io.airlift.units.Duration;
+
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+/**
+ * TimeoutThread spins up a background task
+ * that interrupts given thread after the timeout expires.
+ */
+public class TimeoutThread
+        implements AutoCloseable
+{
+    private final Future<?> future;
+
+    /**
+     * @param thread Thread to be interrupted after timeout expires.
+     * @param executor Executor to run the background task.
+     * @param timeout Expiration time of the thread.
+     */
+    public TimeoutThread(Thread thread, ScheduledExecutorService executor, Duration timeout)
+    {
+        requireNonNull(thread, "thread is null");
+        requireNonNull(executor, "executor is null");
+        requireNonNull(timeout, "timeout is null");
+
+        this.future = executor.schedule(thread::interrupt, timeout.roundTo(NANOSECONDS), NANOSECONDS);
+    }
+
+    @Override
+    public void close()
+    {
+        future.cancel(true);
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/CoordinatorModule.java
@@ -34,6 +34,7 @@ import com.facebook.presto.event.QueryMonitorConfig;
 import com.facebook.presto.execution.ClusterSizeMonitor;
 import com.facebook.presto.execution.ExplainAnalyzeContext;
 import com.facebook.presto.execution.ForQueryExecution;
+import com.facebook.presto.execution.ForTimeoutThread;
 import com.facebook.presto.execution.NodeResourceStatusConfig;
 import com.facebook.presto.execution.PartialResultQueryManager;
 import com.facebook.presto.execution.QueryExecution;
@@ -105,6 +106,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 
 import static com.facebook.airlift.concurrent.Threads.daemonThreadsNamed;
 import static com.facebook.airlift.concurrent.Threads.threadsNamed;
@@ -374,6 +376,16 @@ public class CoordinatorModule
             @ForTransactionManager ExecutorService finishingExecutor)
     {
         return InMemoryTransactionManager.create(config, idleCheckExecutor, catalogManager, finishingExecutor);
+    }
+
+    @Provides
+    @Singleton
+    @ForTimeoutThread
+    public static ScheduledExecutorService createTimeoutThreadExecutor()
+    {
+        ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(1, daemonThreadsNamed("thread-timeout"));
+        executor.setRemoveOnCancelPolicy(true);
+        return executor;
     }
 
     private void bindLowMemoryKiller(String name, Class<? extends LowMemoryKiller> clazz)

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -156,6 +156,7 @@ public class FeaturesConfig
     private boolean pushLimitThroughOuterJoin = true;
 
     private Duration iterativeOptimizerTimeout = new Duration(3, MINUTES); // by default let optimizer wait a long time in case it retrieves some data from ConnectorMetadata
+    private Duration queryAnalyzerTimeout = new Duration(3, MINUTES);
     private boolean enableDynamicFiltering;
     private int dynamicFilteringMaxPerDriverRowCount = 100;
     private DataSize dynamicFilteringMaxPerDriverSize = new DataSize(10, KILOBYTE);
@@ -1107,6 +1108,19 @@ public class FeaturesConfig
     public FeaturesConfig setIterativeOptimizerTimeout(Duration timeout)
     {
         this.iterativeOptimizerTimeout = timeout;
+        return this;
+    }
+
+    public Duration getQueryAnalyzerTimeout()
+    {
+        return this.queryAnalyzerTimeout;
+    }
+
+    @Config("planner.query-analyzer-timeout")
+    @ConfigDescription("Maximum running time for the query analyzer in case the processing takes too long or is stuck in an infinite loop.")
+    public FeaturesConfig setQueryAnalyzerTimeout(Duration timeout)
+    {
+        this.queryAnalyzerTimeout = timeout;
         return this;
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestFeaturesConfig.java
@@ -194,7 +194,8 @@ public class TestFeaturesConfig
                 .setMaxStageCountForEagerScheduling(25)
                 .setHyperloglogStandardErrorWarningThreshold(0.004)
                 .setPreferMergeJoin(false)
-                .setRoundRobinShuffleBeforePartialDistinctLimit(false));
+                .setRoundRobinShuffleBeforePartialDistinctLimit(false)
+                .setQueryAnalyzerTimeout(new Duration(3, MINUTES)));
     }
 
     @Test
@@ -340,6 +341,7 @@ public class TestFeaturesConfig
                 .put("hyperloglog-standard-error-warning-threshold", "0.02")
                 .put("optimizer.prefer-merge-join", "true")
                 .put("optimizer.round-robin-shuffle-before-partial-distinct-limit", "true")
+                .put("planner.query-analyzer-timeout", "10s")
                 .build();
 
         FeaturesConfig expected = new FeaturesConfig()
@@ -482,7 +484,8 @@ public class TestFeaturesConfig
                 .setMaxStageCountForEagerScheduling(123)
                 .setHyperloglogStandardErrorWarningThreshold(0.02)
                 .setPreferMergeJoin(true)
-                .setRoundRobinShuffleBeforePartialDistinctLimit(true);
+                .setRoundRobinShuffleBeforePartialDistinctLimit(true)
+                .setQueryAnalyzerTimeout(new Duration(10, SECONDS));
         assertFullMapping(properties, expected);
     }
 

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestDistributedQueries.java
@@ -333,6 +333,16 @@ public abstract class AbstractTestDistributedQueries
         assertFalse(getQueryRunner().tableExists(session, table));
     }
 
+    @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "Regexp matching interrupted", timeOut = 30_000)
+    public void testRunawayRegexAnalyzerTimeout()
+    {
+        Session session = Session.builder(getSession())
+                .setSystemProperty(SystemSessionProperties.QUERY_ANALYZER_TIMEOUT, "1s")
+                .build();
+
+        computeActual(session, "select REGEXP_EXTRACT('runaway_regex-is-evaluated-infinitely - xxx\"}', '.*runaway_(.*?)+-+xxx.*')");
+    }
+
     @Test
     public void testInsertIntoNotNullColumn()
     {


### PR DESCRIPTION
It was discovered that runaway regex can run for very long or even end up in infinite loop and block the query analyzer thread. The fix introduces a thread timeout that interrupts the runaway regex matcher after a certain timeout.

Example of a query that can cause issues:

```
select REGEXP_EXTRACT('runaway_regex-is-evaluated-infinitely - xxx"}', '.*runaway_(.*?)+-+xxx.*')
```

Test plan - unit test


```
== RELEASE NOTES ==

General Changes
* Add support to set timeout on the query analyzer runtime to prevent long running query analysis like complex regular expressions. The timeout duration can be set by the configuration property `planner.query-analyzer-timeout` or session property `query_analyzer_timeout`.
```