### PR TITLE
Fix failure when indexes share same alias

### DIFF
--- a/presto-elasticsearch/src/main/java/com/facebook/presto/elasticsearch/client/ElasticsearchClient.java
+++ b/presto-elasticsearch/src/main/java/com/facebook/presto/elasticsearch/client/ElasticsearchClient.java
@@ -437,18 +437,21 @@ public class ElasticsearchClient
         });
     }
 
-    public List<String> getAliases()
+    public Map<String, List<String>> getAliases()
     {
         return doRequest("/_aliases", body -> {
             try {
-                ImmutableList.Builder<String> result = ImmutableList.builder();
+                ImmutableMap.Builder<String, List<String>> result = ImmutableMap.builder();
                 JsonNode root = OBJECT_MAPPER.readTree(body);
 
-                Iterator<JsonNode> elements = root.elements();
+                Iterator<Map.Entry<String, JsonNode>> elements = root.fields();
                 while (elements.hasNext()) {
-                    JsonNode element = elements.next();
-                    JsonNode aliases = element.get("aliases");
-                    result.addAll(aliases.fieldNames());
+                    Map.Entry<String, JsonNode> element = elements.next();
+                    JsonNode aliases = element.getValue().get("aliases");
+                    Iterator<String> aliasNames = aliases.fieldNames();
+                    if (aliasNames.hasNext()) {
+                        result.put(element.getKey(), ImmutableList.copyOf(aliasNames));
+                    }
                 }
                 return result.build();
             }

--- a/presto-elasticsearch/src/test/java/com/facebook/presto/elasticsearch/ElasticsearchConnectorTest.java
+++ b/presto-elasticsearch/src/test/java/com/facebook/presto/elasticsearch/ElasticsearchConnectorTest.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.elasticsearch;
+
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.tests.AbstractTestIntegrationSmokeTest;
+import io.airlift.tpch.TpchTable;
+import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest;
+import org.intellij.lang.annotations.Language;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.elasticsearch.ElasticsearchQueryRunner.createElasticsearchQueryRunner;
+import static com.facebook.presto.elasticsearch.EmbeddedElasticsearchNode.createEmbeddedElasticsearchNode;
+import static org.elasticsearch.client.Requests.indexAliasesRequest;
+import static org.elasticsearch.client.Requests.refreshRequest;
+
+public class ElasticsearchConnectorTest
+        extends AbstractTestIntegrationSmokeTest
+{
+    private EmbeddedElasticsearchNode embeddedElasticsearchNode;
+
+    @Test
+    public void testSelectInformationSchemaForMultiIndexAlias()
+    {
+        addAlias("nation", "multi_alias");
+        addAlias("region", "multi_alias");
+
+        // No duplicate entries should be found in information_schema.tables or information_schema.columns.
+        testSelectInformationSchemaTables();
+        testSelectInformationSchemaColumns();
+    }
+
+    @Test
+    public void testSelectInformationSchemaTables()
+    {
+        String catalog = getSession().getCatalog().get();
+        String schema = getSession().getSchema().get();
+        String schemaPattern = schema.replaceAll("^.", "_");
+
+        @Language("SQL") String expectedTables = "VALUES " +
+                "('customer'), " +
+                "('lineitem'), " +
+                "('nation'), " +
+                "('part'), " +
+                "('orders'), " +
+                "('partsupp'), " +
+                "('region'), " +
+                "('supplier'), " +
+                "('multi_alias')";
+
+        assertQuery("SELECT table_name FROM information_schema.tables WHERE table_schema = '" + schema + "'", expectedTables);
+
+        assertQuery("SELECT table_name FROM information_schema.tables WHERE table_schema = '" + schema + "' AND table_name = 'orders'", "VALUES 'orders'");
+        assertQuery("SELECT table_name FROM information_schema.tables WHERE table_schema LIKE '" + schema + "' AND table_name LIKE '%rders'", "VALUES 'orders'");
+        assertQuery("SELECT table_name FROM information_schema.tables WHERE table_schema LIKE '" + schemaPattern + "' AND table_name LIKE '%rders'", "VALUES 'orders'");
+        assertQuery(
+                "SELECT table_name FROM information_schema.tables " +
+                        "WHERE table_catalog = '" + catalog + "' AND table_schema LIKE '" + schema + "' AND table_name LIKE '%orders'",
+                "VALUES 'orders'");
+        assertQuery("SELECT table_name FROM information_schema.tables WHERE table_catalog = 'something_else'", "SELECT '' WHERE false");
+
+        assertQuery(
+                "SELECT DISTINCT table_name FROM information_schema.tables WHERE table_schema = 'information_schema' OR rand() = 42 ORDER BY 1",
+                "VALUES " +
+                        "('applicable_roles'), " +
+                        "('columns'), " +
+                        "('enabled_roles'), " +
+                        "('roles'), " +
+                        "('schemata'), " +
+                        "('table_privileges'), " +
+                        "('tables'), " +
+                        "('views')");
+    }
+
+    @Test
+    public void testSelectInformationSchemaColumns()
+    {
+        String catalog = getSession().getCatalog().get();
+        String schema = getSession().getSchema().get();
+        String schemaPattern = schema.replaceAll(".$", "_");
+
+        @Language("SQL") String ordersTableWithColumns = "VALUES " +
+                "('orders', 'orderkey'), " +
+                "('orders', 'custkey'), " +
+                "('orders', 'orderstatus'), " +
+                "('orders', 'totalprice'), " +
+                "('orders', 'orderdate'), " +
+                "('orders', 'orderpriority'), " +
+                "('orders', 'clerk'), " +
+                "('orders', 'shippriority'), " +
+                "('orders', 'comment')";
+
+        assertQuery("SELECT table_schema FROM information_schema.columns WHERE table_schema = '" + schema + "' GROUP BY table_schema", "VALUES '" + schema + "'");
+        assertQuery("SELECT table_name FROM information_schema.columns WHERE table_name = 'orders' GROUP BY table_name", "VALUES 'orders'");
+        assertQuery("SELECT table_name, column_name FROM information_schema.columns WHERE table_schema = '" + schema + "' AND table_name = 'orders'", ordersTableWithColumns);
+        assertQuery("SELECT table_name, column_name FROM information_schema.columns WHERE table_schema = '" + schema + "' AND table_name LIKE '%rders'", ordersTableWithColumns);
+        assertQuery("SELECT table_name, column_name FROM information_schema.columns WHERE table_schema LIKE '" + schemaPattern + "' AND table_name LIKE '_rder_'", ordersTableWithColumns);
+
+        assertQuerySucceeds("SELECT * FROM information_schema.columns");
+        assertQuery("SELECT DISTINCT table_name, column_name FROM information_schema.columns WHERE table_name LIKE '_rders'", ordersTableWithColumns);
+        assertQuerySucceeds("SELECT * FROM information_schema.columns WHERE table_catalog = '" + catalog + "'");
+        assertQuerySucceeds("SELECT * FROM information_schema.columns WHERE table_catalog = '" + catalog + "' AND table_schema = '" + schema + "'");
+        assertQuery("SELECT table_name, column_name FROM information_schema.columns WHERE table_catalog = '" + catalog + "' AND table_schema = '" + schema + "' AND table_name LIKE '_rders'", ordersTableWithColumns);
+        assertQuerySucceeds("SELECT * FROM information_schema.columns WHERE table_catalog = '" + catalog + "' AND table_name LIKE '%'");
+        assertQuery("SELECT column_name FROM information_schema.columns WHERE table_catalog = 'something_else'", "SELECT '' WHERE false");
+
+        assertQuery(
+                "SELECT DISTINCT table_name FROM information_schema.columns WHERE table_schema = 'information_schema' OR rand() = 42 ORDER BY 1",
+                "VALUES " +
+                        "('applicable_roles'), " +
+                        "('columns'), " +
+                        "('enabled_roles'), " +
+                        "('roles'), " +
+                        "('schemata'), " +
+                        "('table_privileges'), " +
+                        "('tables'), " +
+                        "('views')");
+    }
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        embeddedElasticsearchNode = createEmbeddedElasticsearchNode();
+        return createElasticsearchQueryRunner(embeddedElasticsearchNode, TpchTable.getTables());
+    }
+
+    private void addAlias(String index, String alias)
+    {
+        embeddedElasticsearchNode.getClient()
+                .admin()
+                .indices()
+                .aliases(indexAliasesRequest()
+                        .addAliasAction(IndicesAliasesRequest.AliasActions.add()
+                                .index(index)
+                                .alias(alias)))
+                .actionGet();
+
+        embeddedElasticsearchNode.getClient()
+                .admin()
+                .indices()
+                .refresh(refreshRequest(alias))
+                .actionGet();
+    }
+}


### PR DESCRIPTION
Multiple indices sharing the same alias result in duplicate tables. 
Those duplicate tables create the same entries in the columns table 
resulting in 'Multiple entries for same key' error.

Cherry-pick of https://github.com/trinodb/trino/pull/8293

Co-authored-by: Suman Newton <sumannewton@gmail.com>

Test plan - Added Integration tests

```
== NO RELEASE NOTE ==
```
