### PR TITLE
Fix int overflow bug in ListFilter

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/ListFilter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/ListFilter.java
@@ -379,7 +379,7 @@ public class ListFilter
         long[] filterCodes = new long[maxSubscript + 1];
         for (int i = 0; i < subscripts.length; i++) {
             if (subscripts[i] != -1) {
-                filterCodes[subscripts[i]] |= 1 << i;
+                filterCodes[subscripts[i]] |= 1L << i;
             }
         }
 

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestListFilter.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestListFilter.java
@@ -68,6 +68,29 @@ public class TestListFilter
                 2, BigintRange.of(25, 50, false)), data);
     }
 
+    @Test
+    public void testArrayFilterCodeOverflowBug()
+    {
+        Integer[][] data = new Integer[ROW_COUNT][];
+        for (int i = 0; i < data.length; i++) {
+            data[i] = new Integer[100];
+            for (int j = 0; j < data[i].length; j++) {
+                data[i][j] = j;
+            }
+        }
+
+        // build filters checking for exact value from the data
+        ImmutableMap.Builder<Integer, TupleDomainFilter> filters = ImmutableMap.builder();
+
+        // ListFilter allows up to 64 filters
+        for (int j = 1; j <= 64; j++) {
+            long value = j - 1;
+            filters.put(j, BigintRange.of(value, value, false));
+        }
+
+        assertPositionalFilter(filters.build(), data);
+    }
+
     private void assertPositionalFilter(Map<Integer, TupleDomainFilter> filters, Integer[][] data)
     {
         ListFilter listFilter = buildListFilter(filters, data);


### PR DESCRIPTION
ListFilter would not work correctly if there are more than 32 filters due to int overflow.

Test plan:
- added a new unit test reproducing the issue
- I couldn't reproduce it using a query like `select * from T where col1[0]=0 AND col1[1]=1 AND .... AND col[123]`, probably I'm missing something

```
== NO RELEASE NOTE ==
```
