### PR TITLE
Use Collections#isEmpty() instead of comparing size()

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/WindowInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/WindowInfo.java
@@ -96,7 +96,7 @@ public class WindowInfo
             }
 
             List<IndexInfo> indexInfos = indexInfosBuilder.build();
-            if (indexInfos.size() == 0) {
+            if (indexInfos.isEmpty()) {
                 return new DriverWindowInfo(0.0, 0.0, 0.0, 0, 0, 0);
             }
             long totalRowsCount = indexInfos.stream()
@@ -214,7 +214,7 @@ public class WindowInfo
         public Optional<IndexInfo> build()
         {
             List<Integer> partitions = partitionsSizes.build();
-            if (partitions.size() == 0) {
+            if (partitions.isEmpty()) {
                 return Optional.empty();
             }
             double avgSize = partitions.stream().mapToLong(Integer::longValue).average().getAsDouble();

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/StateCompiler.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/state/StateCompiler.java
@@ -274,7 +274,7 @@ public class StateCompiler
         Scope scope = method.getScope();
         BytecodeBlock serializerBody = method.getBody();
 
-        if (fields.size() == 0) {
+        if (fields.isEmpty()) {
             serializerBody.append(out.invoke("appendNull", BlockBuilder.class).pop());
         }
         else if (fields.size() == 1) {

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/ScalarFunctionImplementationChoice.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/ScalarFunctionImplementationChoice.java
@@ -57,7 +57,7 @@ public class ScalarFunctionImplementationChoice
 
         if (instanceFactory.isPresent()) {
             Class<?> instanceType = instanceFactory.get().type().returnType();
-            checkArgument(instanceFactory.get().type().parameterList().size() == 0, "instanceFactory should have no parameter");
+            checkArgument(instanceFactory.get().type().parameterList().isEmpty(), "instanceFactory should have no parameter");
             checkArgument(instanceType.equals(methodHandle.type().parameterType(0)), "methodHandle is not an instance method");
         }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/LambdaCaptureDesugaringRewriter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/LambdaCaptureDesugaringRewriter.java
@@ -88,7 +88,7 @@ public class LambdaCaptureDesugaringRewriter
             Function<VariableReferenceExpression, Expression> variableMapping = variable -> createSymbolReference(variablesMap.getOrDefault(variable, variable));
             Expression rewrittenExpression = new LambdaExpression(newLambdaArguments.build(), inlineVariables(variableMapping, rewrittenBody, variableAllocator.getTypes()));
 
-            if (captureVariables.size() != 0) {
+            if (!captureVariables.isEmpty()) {
                 List<Expression> capturedValues = captureVariables.stream()
                         .map(variable -> createSymbolReference(variable))
                         .collect(toImmutableList());

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PlanRemoteProjections.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/PlanRemoteProjections.java
@@ -261,7 +261,7 @@ public class PlanRemoteProjections
                     newArguments);
 
             if (local) {
-                if (processedArguments.size() == 0 || (processedArguments.size() == 1 && !processedArguments.get(0).isRemote())) {
+                if (processedArguments.isEmpty() || (processedArguments.size() == 1 && !processedArguments.get(0).isRemote())) {
                     // This call and all its arguments are local
                     return ImmutableList.of();
                 }
@@ -332,7 +332,7 @@ public class PlanRemoteProjections
             ImmutableList.Builder<RowExpression> newArgumentsBuilder = ImmutableList.builder();
             List<ProjectionContext> processedArguments = processArguments(specialForm.getArguments(), newArgumentsBuilder, true);
             List<RowExpression> newArguments = newArgumentsBuilder.build();
-            if (processedArguments.size() == 0 || (processedArguments.size() == 1 && !processedArguments.get(0).isRemote())) {
+            if (processedArguments.isEmpty() || (processedArguments.size() == 1 && !processedArguments.get(0).isRemote())) {
                 // Arguments do not contain remote projection
                 return ImmutableList.of();
             }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformCorrelatedSingleRowSubqueryToProject.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/iterative/rule/TransformCorrelatedSingleRowSubqueryToProject.java
@@ -72,7 +72,7 @@ public class TransformCorrelatedSingleRowSubqueryToProject
                 .where(node -> node instanceof ProjectNode && !node.getOutputVariables().equals(parent.getCorrelation()))
                 .findAll();
 
-        if (subqueryProjections.size() == 0) {
+        if (subqueryProjections.isEmpty()) {
             return Result.ofPlanNode(parent.getInput());
         }
         else if (subqueryProjections.size() == 1) {
@@ -93,6 +93,6 @@ public class TransformCorrelatedSingleRowSubqueryToProject
 
     private static boolean isSingleRowValuesWithNoColumns(ValuesNode values)
     {
-        return values.getRows().size() == 1 && values.getRows().get(0).size() == 0;
+        return values.getRows().size() == 1 && values.getRows().get(0).isEmpty();
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PlanNodeSearcher.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/PlanNodeSearcher.java
@@ -120,7 +120,7 @@ public class PlanNodeSearcher
     public <T extends PlanNode> T findOnlyElement(T defaultValue)
     {
         List<T> all = findAll();
-        if (all.size() == 0) {
+        if (all.isEmpty()) {
             return defaultValue;
         }
         return getOnlyElement(all);

--- a/presto-main/src/main/java/com/facebook/presto/util/StringTableUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/StringTableUtils.java
@@ -25,7 +25,7 @@ public class StringTableUtils
 
     public static String getShortestTableStringFormat(List<List<String>> table)
     {
-        if (table.size() == 0) {
+        if (table.isEmpty()) {
             throw new IllegalArgumentException("Table must include at least one row");
         }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
@@ -858,7 +858,7 @@ public final class PlanMatchPattern
     public static GroupingSetDescriptor singleGroupingSet(List<String> groupingKeys)
     {
         Set<Integer> globalGroupingSets;
-        if (groupingKeys.size() == 0) {
+        if (groupingKeys.isEmpty()) {
             globalGroupingSets = ImmutableSet.of(0);
         }
         else {

--- a/presto-main/src/test/java/com/facebook/presto/tests/QueryTemplate.java
+++ b/presto-main/src/test/java/com/facebook/presto/tests/QueryTemplate.java
@@ -95,7 +95,7 @@ public class QueryTemplate
 
     private void replaceAll(String queryTemplate, Consumer<String> queryConsumer, List<List<Parameter>> parametersLists)
     {
-        if (parametersLists.size() == 0) {
+        if (parametersLists.isEmpty()) {
             checkQueryHasAllParametersReplaced(queryTemplate);
             queryConsumer.accept(queryTemplate);
         }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/AbstractOrcRecordReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/AbstractOrcRecordReader.java
@@ -849,7 +849,7 @@ abstract class AbstractOrcRecordReader<T extends StreamReader>
 
         public static OrcBatchRecordReader.LinearProbeRangeFinder createTinyStripesRangeFinder(List<StripeInformation> stripes, DataSize maxMergeDistance, DataSize tinyStripeThreshold)
         {
-            if (stripes.size() == 0) {
+            if (stripes.isEmpty()) {
                 return new OrcBatchRecordReader.LinearProbeRangeFinder(ImmutableList.of());
             }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcReader.java
@@ -179,7 +179,7 @@ public class OrcReader
                 orcFileTail.getFooterSize())) {
             this.footer = metadataReader.readFooter(hiveWriterVersion, footerInputStream, dwrfEncryptionProvider, dwrfKeyProvider, orcDataSource, decompressor);
         }
-        if (this.footer.getTypes().size() == 0) {
+        if (this.footer.getTypes().isEmpty()) {
             throw new OrcCorruptionException(orcDataSource.getId(), "File has no columns");
         }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/ColumnStatistics.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/ColumnStatistics.java
@@ -179,7 +179,7 @@ public class ColumnStatistics
 
     public static ColumnStatistics mergeColumnStatistics(List<ColumnStatistics> stats)
     {
-        if (stats.size() == 0) {
+        if (stats.isEmpty()) {
             return new ColumnStatistics(0L, null);
         }
 

--- a/presto-parquet/src/main/java/com/facebook/presto/parquet/predicate/TupleDomainParquetPredicate.java
+++ b/presto-parquet/src/main/java/com/facebook/presto/parquet/predicate/TupleDomainParquetPredicate.java
@@ -160,7 +160,7 @@ public class TupleDomainParquetPredicate
 
             if (columnIndexStore.isPresent()) {
                 ColumnIndex columnIndex = columnIndexStore.get().getColumnIndex(ColumnPath.get(column.getPath()));
-                if (columnIndex == null || columnIndex.getMinValues().size() == 0 || columnIndex.getMaxValues().size() == 0 || columnIndex.getMinValues().size() != columnIndex.getMaxValues().size()) {
+                if (columnIndex == null || columnIndex.getMinValues().isEmpty() || columnIndex.getMaxValues().isEmpty() || columnIndex.getMinValues().size() != columnIndex.getMaxValues().size()) {
                     continue;
                 }
                 else {
@@ -440,7 +440,7 @@ public class TupleDomainParquetPredicate
 
     private static <T extends Comparable<T>> Domain createDomain(Type type, ColumnIndex columnIndex, boolean hasNullValue, List<T> mins, List<T> maxs)
     {
-        if (mins.size() == 0 || maxs.size() == 0 || mins.size() != maxs.size()) {
+        if (mins.isEmpty() || maxs.isEmpty() || mins.size() != maxs.size()) {
             return Domain.create(ValueSet.all(type), hasNullValue);
         }
         int pageCount = columnIndex.getMinValues().size();
@@ -491,7 +491,7 @@ public class TupleDomainParquetPredicate
     // Caller should verify isCorruptedColumnIndex is false first
     private boolean isEmptyColumnIndex(ColumnIndex columnIndex)
     {
-        return columnIndex.getMaxValues().size() == 0;
+        return columnIndex.getMaxValues().isEmpty();
     }
 
     public FilterPredicate getParquetUserDefinedPredicate()

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotSegmentPageSource.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotSegmentPageSource.java
@@ -167,7 +167,7 @@ public class PinotSegmentPageSource
         if (currentDataTable != null) {
             estimatedMemoryUsageInBytes -= currentDataTable.getEstimatedSizeInBytes();
         }
-        if (dataTableList.size() == 0) {
+        if (dataTableList.isEmpty()) {
             close();
             return null;
         }

--- a/presto-spi/src/main/java/com/facebook/presto/spi/plan/ValuesNode.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/plan/ValuesNode.java
@@ -50,7 +50,7 @@ public final class ValuesNode
         this.rows = immutableListCopyOf(requireNonNull(rows, "lists is null").stream().map(ValuesNode::immutableListCopyOf).collect(Collectors.toList()));
 
         for (List<RowExpression> row : rows) {
-            if (!(row.size() == outputVariables.size() || row.size() == 0)) {
+            if (!(row.size() == outputVariables.size() || row.isEmpty())) {
                 throw new IllegalArgumentException(format("Expected row to have %s values, but row has %s values", outputVariables.size(), row.size()));
             }
         }

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestH2QueryRunner.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestH2QueryRunner.java
@@ -56,7 +56,7 @@ public class TestH2QueryRunner
 
         // date, which midnight was skipped in JVM zone
         LocalDate forwardOffsetChangeAtMidnightInJvmZone = LocalDate.of(1970, 1, 1);
-        checkState(ZoneId.systemDefault().getRules().getValidOffsets(forwardOffsetChangeAtMidnightInJvmZone.atStartOfDay()).size() == 0, "This test assumes certain JVM time zone");
+        checkState(ZoneId.systemDefault().getRules().getValidOffsets(forwardOffsetChangeAtMidnightInJvmZone.atStartOfDay()).isEmpty(), "This test assumes certain JVM time zone");
         rows = h2QueryRunner.execute(TEST_SESSION, DateTimeFormatter.ofPattern("'SELECT DATE '''uuuu-MM-dd''").format(forwardOffsetChangeAtMidnightInJvmZone), ImmutableList.of(TIMESTAMP));
         assertEquals(rows.getOnlyValue(), forwardOffsetChangeAtMidnightInJvmZone.atStartOfDay());
     }


### PR DESCRIPTION
Non functional change to improve the code quality. See https://rules.sonarsource.com/java/RSPEC-1155

This is the result of running the recipe `org.openrewrite.java.cleanup.IsEmptyCallOnCollections` from the OpenRewrite project

Read more : https://docs.openrewrite.org/reference/recipes/java/cleanup/isemptycalloncollections



Created with: [Moderne](https://app.moderne.io)

```
== NO RELEASE NOTE ==
```