### PR TITLE
Add Presto CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+/** @prestodb/committers


### PR DESCRIPTION
Add a CODEOWNERS file to document committer rights to the codebase.  This will allow more granular commit rules in the future.

Fixes #17644

Test plan - N/A

```
== NO RELEASE NOTE ==
```
