### PR TITLE
Fix null partitionNames in metastore.getPartitionsByNames

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -2205,19 +2205,21 @@ public class HiveMetadata
         ImmutableSet.Builder<String> existingPartitions = ImmutableSet.builder();
         ImmutableSet.Builder<String> potentiallyNewPartitions = ImmutableSet.builder();
 
-        for (PartitionUpdate update : partitionUpdates) {
-            switch (update.getUpdateMode()) {
-                case APPEND:
-                    existingPartitions.add(update.getName());
-                    break;
-                case NEW:
-                case OVERWRITE:
-                    potentiallyNewPartitions.add(update.getName());
-                    break;
-                default:
-                    throw new IllegalArgumentException("unexpected update mode: " + update.getUpdateMode());
-            }
-        }
+        partitionUpdates.stream()
+                .filter(update -> !update.getName().isEmpty())
+                .forEach(update -> {
+                    switch (update.getUpdateMode()) {
+                        case APPEND:
+                            existingPartitions.add(update.getName());
+                            break;
+                        case NEW:
+                        case OVERWRITE:
+                            potentiallyNewPartitions.add(update.getName());
+                            break;
+                        default:
+                            throw new IllegalArgumentException("unexpected update mode: " + update.getUpdateMode());
+                    }
+                });
 
         // try to load potentially new partitions in batches to check if any of them exist
         Lists.partition(ImmutableList.copyOf(potentiallyNewPartitions.build()), maxPartitionBatchSize).stream()


### PR DESCRIPTION
### Describe:
The name of partitionUpdate is null in `HiveMetadata#finishInsertInternal` when the table is unpartitioned table, which will cause the partitionNames is empty in `metastore.getPartitionsByNames(metastoreContext, databaseName, tableName,  partitionNames)` when `partitionUpdate.updateMode` is `OVERWRITE`. 
Finally it will throw an IllegalArgumentException.

<img width="953" alt="image" src="https://user-images.githubusercontent.com/86234715/164240715-d89b2b8a-30f2-4762-a9e5-a1365ceb6b91.png">

```
== NO RELEASE NOTE ==
```
