### PR TITLE
Add Microseconds Timestamp Type

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/type/SqlTimestamp.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/SqlTimestamp.java
@@ -23,12 +23,23 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 import static com.facebook.presto.common.type.TimeZoneKey.UTC_KEY;
+import static java.lang.Math.floorDiv;
+import static java.lang.Math.floorMod;
+import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 public final class SqlTimestamp
 {
+    private static final long MICROS_PER_SECOND = 1_000_000;
+    private static final long NANOS_PER_MICROS = 1_000;
+
     // This needs to be Locale-independent, Java Time's DateTimeFormatter compatible and should never change, as it defines the external API data format.
     private static final String JSON_MILLIS_FORMAT = "uuuu-MM-dd HH:mm:ss.SSS";
     public static final DateTimeFormatter JSON_MILLIS_FORMATTER = DateTimeFormatter.ofPattern(JSON_MILLIS_FORMAT);
+
+    private static final String JSON_MICROS_FORMAT = "uuuu-MM-dd HH:mm:ss.SSSSSS";
+    public static final DateTimeFormatter JSON_MICROS_FORMATTER = DateTimeFormatter.ofPattern(JSON_MICROS_FORMAT);
 
     private final long value;
     private final Optional<TimeZoneKey> sessionTimeZoneKey;
@@ -38,28 +49,28 @@ public final class SqlTimestamp
     {
         this.value = value;
         sessionTimeZoneKey = Optional.empty();
-        this.precision = precision;
+        this.precision = validatePrecision(precision);
     }
 
     @Deprecated
-    public SqlTimestamp(long millisUtc, TimeZoneKey sessionTimeZoneKey, TimeUnit precision)
+    public SqlTimestamp(long valueUTC, TimeZoneKey sessionTimeZoneKey, TimeUnit precision)
     {
-        this.value = millisUtc;
+        this.value = valueUTC;
         this.sessionTimeZoneKey = Optional.of(sessionTimeZoneKey);
-        this.precision = precision;
+        this.precision = validatePrecision(precision);
     }
 
     public long getMillis()
     {
         checkState(!isLegacyTimestamp(), "getMillis() can be called in new timestamp semantics only");
-        return value;
+        return precision.toMillis(value);
     }
 
     @Deprecated
     public long getMillisUtc()
     {
         checkState(isLegacyTimestamp(), "getMillisUtc() can be called in legacy timestamp semantics only");
-        return value;
+        return precision.toMillis(value);
     }
 
     @Deprecated
@@ -77,7 +88,7 @@ public final class SqlTimestamp
     @Override
     public int hashCode()
     {
-        return Objects.hash(value, sessionTimeZoneKey);
+        return Objects.hash(value, precision, sessionTimeZoneKey);
     }
 
     @Override
@@ -90,7 +101,10 @@ public final class SqlTimestamp
             return false;
         }
         SqlTimestamp other = (SqlTimestamp) obj;
-        return Objects.equals(this.value, other.value) &&
+        // The current semantics returns NOT equal for millis and micros timestamp,
+        // even though they represent the same time. (ex. same second, millis/micros set to 0).
+        return this.value == other.value &&
+                this.precision == other.precision &&
                 Objects.equals(this.sessionTimeZoneKey, other.sessionTimeZoneKey);
     }
 
@@ -98,12 +112,44 @@ public final class SqlTimestamp
     @Override
     public String toString()
     {
+        if (precision == MILLISECONDS) {
+            return formatInstant(millisToInstant(value), JSON_MILLIS_FORMATTER);
+        }
+        if (precision == MICROSECONDS) {
+            return formatInstant(microsToInstant(value), JSON_MICROS_FORMATTER);
+        }
+        throw new UnsupportedOperationException("Precision not supported " + precision);
+    }
+
+    private String formatInstant(Instant instant, DateTimeFormatter formatter)
+    {
         if (isLegacyTimestamp()) {
-            return Instant.ofEpochMilli(value).atZone(ZoneId.of(sessionTimeZoneKey.get().getId())).format(JSON_MILLIS_FORMATTER);
+            return instant.atZone(ZoneId.of(sessionTimeZoneKey.get().getId())).format(formatter);
         }
         else {
-            return Instant.ofEpochMilli(value).atZone(ZoneId.of(UTC_KEY.getId())).format(JSON_MILLIS_FORMATTER);
+            return instant.atZone(ZoneId.of(UTC_KEY.getId())).format(formatter);
         }
+    }
+
+    private static TimeUnit validatePrecision(TimeUnit precision)
+    {
+        requireNonNull(precision, "precision");
+        if (precision == MILLISECONDS || precision == MICROSECONDS) {
+            return precision;
+        }
+        throw new UnsupportedOperationException("Precision not supported " + precision);
+    }
+
+    private static Instant millisToInstant(long epochMillis)
+    {
+        return Instant.ofEpochMilli(epochMillis);
+    }
+
+    private static Instant microsToInstant(long epochMicros)
+    {
+        long seconds = floorDiv(epochMicros, MICROS_PER_SECOND);
+        long micros = floorMod(epochMicros, MICROS_PER_SECOND);
+        return Instant.ofEpochSecond(seconds, micros * NANOS_PER_MICROS);
     }
 
     private static void checkState(boolean condition, String message)

--- a/presto-common/src/main/java/com/facebook/presto/common/type/StandardTypes.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/StandardTypes.java
@@ -37,6 +37,7 @@ public final class StandardTypes
     public static final String INTERVAL_DAY_TO_SECOND = "interval day to second";
     public static final String INTERVAL_YEAR_TO_MONTH = "interval year to month";
     public static final String TIMESTAMP = "timestamp";
+    public static final String TIMESTAMP_MICROSECONDS = "timestamp microseconds";
     public static final String TIMESTAMP_WITH_TIME_ZONE = "timestamp with time zone";
     public static final String TIME = "time";
     public static final String TIME_WITH_TIME_ZONE = "time with time zone";

--- a/presto-common/src/main/java/com/facebook/presto/common/type/TimestampType.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/TimestampType.java
@@ -17,6 +17,7 @@ import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.function.SqlFunctionProperties;
 
 import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 //
 // A timestamp is stored as milliseconds from 1970-01-01T00:00:00 UTC.  When performing calculations
@@ -40,10 +41,10 @@ public final class TimestampType
         }
 
         if (properties.isLegacyTimestamp()) {
-            return new SqlTimestamp(block.getLong(position), properties.getTimeZoneKey());
+            return new SqlTimestamp(block.getLong(position), properties.getTimeZoneKey(), MILLISECONDS);
         }
         else {
-            return new SqlTimestamp(block.getLong(position));
+            return new SqlTimestamp(block.getLong(position), MILLISECONDS);
         }
     }
 

--- a/presto-common/src/test/java/com/facebook/presto/common/type/TestSqlTimestamp.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/type/TestSqlTimestamp.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.common.type;
+
+import org.testng.annotations.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+
+public class TestSqlTimestamp
+{
+    @Test
+    public void testMillisToString()
+    {
+        assertEquals(toSqlTimestampString(0L, MILLISECONDS), "1970-01-01 00:00:00.000");
+        assertEquals(toSqlTimestampString(1L, MILLISECONDS), "1970-01-01 00:00:00.001");
+        assertEquals(toSqlTimestampString(999L, MILLISECONDS), "1970-01-01 00:00:00.999");
+        assertEquals(toSqlTimestampString(1_000L, MILLISECONDS), "1970-01-01 00:00:01.000");
+
+        // Some negative times.
+        assertEquals(toSqlTimestampString(-1L, MILLISECONDS), "1969-12-31 23:59:59.999");
+        assertEquals(toSqlTimestampString(-999L, MILLISECONDS), "1969-12-31 23:59:59.001");
+        assertEquals(toSqlTimestampString(-60_000_000_000_789L, MILLISECONDS), "0068-09-03 13:19:59.211");
+
+        // Some positive times
+        assertEquals(toSqlTimestampString(1_650_483_250_507L, MILLISECONDS), "2022-04-20 19:34:10.507");
+        assertEquals(toSqlTimestampString(60_000_000_000_789L, MILLISECONDS), "3871-04-29 10:40:00.789");
+        assertEquals(toSqlTimestampString(230_000_000_000_999L, MILLISECONDS), "9258-05-30 00:53:20.999");
+    }
+
+    @Test
+    public void testEqualsHashcodeMillis()
+    {
+        SqlTimestamp t1Millis = new SqlTimestamp(0, MILLISECONDS);
+        assertEquals(t1Millis.toString(), "1970-01-01 00:00:00.000");
+
+        SqlTimestamp t2Millis = new SqlTimestamp(0, MILLISECONDS);
+        assertEquals(t1Millis, t2Millis);
+        assertEquals(t1Millis.hashCode(), t2Millis.hashCode());
+
+        SqlTimestamp t3Millis = new SqlTimestamp(1, MILLISECONDS);
+        assertNotEquals(t1Millis, t3Millis);
+    }
+
+    private static String toSqlTimestampString(long value, TimeUnit precision)
+    {
+        SqlTimestamp timestamp = new SqlTimestamp(value, precision);
+        return timestamp.toString();
+    }
+}

--- a/presto-common/src/test/java/com/facebook/presto/common/type/TestSqlTimestamp.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/type/TestSqlTimestamp.java
@@ -44,10 +44,28 @@ public class TestSqlTimestamp
     }
 
     @Test
+    public void testMicrosToString()
+    {
+        assertEquals(toSqlTimestampString(0L, MICROSECONDS), "1970-01-01 00:00:00.000000");
+        assertEquals(toSqlTimestampString(1L, MICROSECONDS), "1970-01-01 00:00:00.000001");
+        assertEquals(toSqlTimestampString(999_999L, MICROSECONDS), "1970-01-01 00:00:00.999999");
+        assertEquals(toSqlTimestampString(1_000_000L, MICROSECONDS), "1970-01-01 00:00:01.000000");
+
+        // Some negative times.
+        assertEquals(toSqlTimestampString(-1L, MICROSECONDS), "1969-12-31 23:59:59.999999");
+        assertEquals(toSqlTimestampString(-999_999L, MICROSECONDS), "1969-12-31 23:59:59.000001");
+        assertEquals(toSqlTimestampString(-60_000_000_000_000_789L, MICROSECONDS), "0068-09-03 13:19:59.999211");
+
+        // Some positive times
+        assertEquals(toSqlTimestampString(1_650_483_250_000_507L, MICROSECONDS), "2022-04-20 19:34:10.000507");
+        assertEquals(toSqlTimestampString(60_000_000_000_123_789L, MICROSECONDS), "3871-04-29 10:40:00.123789");
+        assertEquals(toSqlTimestampString(230_000_000_000_999_999L, MICROSECONDS), "9258-05-30 00:53:20.999999");
+    }
+
+    @Test
     public void testEqualsHashcodeMillis()
     {
         SqlTimestamp t1Millis = new SqlTimestamp(0, MILLISECONDS);
-        assertEquals(t1Millis.toString(), "1970-01-01 00:00:00.000");
 
         SqlTimestamp t2Millis = new SqlTimestamp(0, MILLISECONDS);
         assertEquals(t1Millis, t2Millis);
@@ -55,6 +73,25 @@ public class TestSqlTimestamp
 
         SqlTimestamp t3Millis = new SqlTimestamp(1, MILLISECONDS);
         assertNotEquals(t1Millis, t3Millis);
+
+        SqlTimestamp t1Micros = new SqlTimestamp(0, MICROSECONDS);
+        assertNotEquals(t1Millis, t1Micros);
+    }
+
+    @Test
+    public void testEqualsHashcodeMicroseconds()
+    {
+        SqlTimestamp t1Micros = new SqlTimestamp(0, MICROSECONDS);
+
+        SqlTimestamp t2Micros = new SqlTimestamp(0, MICROSECONDS);
+        assertEquals(t1Micros, t2Micros);
+        assertEquals(t1Micros.hashCode(), t2Micros.hashCode());
+
+        SqlTimestamp t3Micros = new SqlTimestamp(1, MICROSECONDS);
+        assertNotEquals(t1Micros, t3Micros);
+
+        SqlTimestamp t1Millis = new SqlTimestamp(0, MILLISECONDS);
+        assertNotEquals(t1Micros, t1Millis);
     }
 
     private static String toSqlTimestampString(long value, TimeUnit precision)

--- a/presto-druid/src/main/java/com/facebook/presto/druid/DruidPushdownUtils.java
+++ b/presto-druid/src/main/java/com/facebook/presto/druid/DruidPushdownUtils.java
@@ -52,6 +52,7 @@ import static com.facebook.presto.druid.DruidErrorCode.DRUID_PUSHDOWN_UNSUPPORTE
 import static com.google.common.base.Preconditions.checkState;
 import static java.lang.Float.intBitsToFloat;
 import static java.lang.String.format;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 public class DruidPushdownUtils
 {
@@ -202,7 +203,7 @@ public class DruidPushdownUtils
     private static String getTimestampLiteralAsString(ConnectorSession session, long millisUtc)
     {
         SqlTimestamp sqlTimestamp = session.getSqlFunctionProperties().isLegacyTimestamp() ?
-                new SqlTimestamp(millisUtc, session.getSqlFunctionProperties().getTimeZoneKey()) : new SqlTimestamp(millisUtc);
+                new SqlTimestamp(millisUtc, session.getSqlFunctionProperties().getTimeZoneKey(), MILLISECONDS) : new SqlTimestamp(millisUtc, MILLISECONDS);
         return "TIMESTAMP '" + sqlTimestamp.toString() + "'";
     }
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/AbstractTestParquetReader.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/AbstractTestParquetReader.java
@@ -888,7 +888,7 @@ public abstract class AbstractTestParquetReader
         ContiguousSet<Long> longValues = longsBetween(1_000_000, 1_001_000);
         ImmutableList.Builder<SqlTimestamp> expectedValues = new ImmutableList.Builder<>();
         for (Long value : longValues) {
-            expectedValues.add(new SqlTimestamp(value / 1000L, UTC_KEY));
+            expectedValues.add(new SqlTimestamp(value / 1000L, UTC_KEY, MILLISECONDS));
         }
         tester.testRoundTrip(javaTimestampObjectInspector, longValues, expectedValues.build(), TIMESTAMP, parquetSchema);
     }
@@ -901,7 +901,7 @@ public abstract class AbstractTestParquetReader
         ContiguousSet<Long> longValues = longsBetween(1_000_000, 1_001_000);
         ImmutableList.Builder<SqlTimestamp> expectedValues = new ImmutableList.Builder<>();
         for (Long value : longValues) {
-            expectedValues.add(new SqlTimestamp(value, UTC_KEY));
+            expectedValues.add(new SqlTimestamp(value, UTC_KEY, MILLISECONDS));
         }
         tester.testRoundTrip(javaLongObjectInspector, longValues, expectedValues.build(), TIMESTAMP, Optional.of(parquetSchema));
     }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/parquet/ParquetTester.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/parquet/ParquetTester.java
@@ -133,6 +133,7 @@ import static io.airlift.units.DataSize.succinctBytes;
 import static java.lang.Math.toIntExact;
 import static java.util.Arrays.stream;
 import static java.util.Collections.singletonList;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory.getStandardStructObjectInspector;
 import static org.apache.parquet.column.ParquetProperties.WriterVersion.PARQUET_1_0;
 import static org.apache.parquet.hadoop.ParquetOutputFormat.COMPRESSION;
@@ -603,7 +604,7 @@ public class ParquetTester
             return new SqlDate(((Long) fieldFromCursor).intValue());
         }
         if (TIMESTAMP.equals(type)) {
-            return new SqlTimestamp((long) fieldFromCursor, UTC_KEY);
+            return new SqlTimestamp((long) fieldFromCursor, UTC_KEY, MILLISECONDS);
         }
         return fieldFromCursor;
     }

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/LiteralInterpreter.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/LiteralInterpreter.java
@@ -86,6 +86,7 @@ import static com.google.common.base.Preconditions.checkState;
 import static io.airlift.slice.Slices.utf8Slice;
 import static java.lang.Float.intBitsToFloat;
 import static java.lang.String.format;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 public final class LiteralInterpreter
 {
@@ -148,9 +149,9 @@ public final class LiteralInterpreter
         if (type instanceof TimestampType) {
             try {
                 if (properties.isLegacyTimestamp()) {
-                    return new SqlTimestamp((long) node.getValue(), properties.getTimeZoneKey());
+                    return new SqlTimestamp((long) node.getValue(), properties.getTimeZoneKey(), MILLISECONDS);
                 }
-                return new SqlTimestamp((long) node.getValue());
+                return new SqlTimestamp((long) node.getValue(), MILLISECONDS);
             }
             catch (RuntimeException e) {
                 throw new PrestoException(GENERIC_USER_ERROR, format("'%s' is not a valid timestamp literal", (String) node.getValue()));

--- a/presto-main/src/main/java/com/facebook/presto/testing/DateTimeTestingUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/DateTimeTestingUtils.java
@@ -74,7 +74,7 @@ public final class DateTimeTestingUtils
             ConnectorSession session)
     {
         if (session.getSqlFunctionProperties().isLegacyTimestamp()) {
-            return new SqlTimestamp(new DateTime(year, monthOfYear, dayOfMonth, hourOfDay, minuteOfHour, secondOfMinute, millisOfSecond, baseZone).getMillis(), timestampZone);
+            return new SqlTimestamp(new DateTime(year, monthOfYear, dayOfMonth, hourOfDay, minuteOfHour, secondOfMinute, millisOfSecond, baseZone).getMillis(), timestampZone, MILLISECONDS);
         }
         return sqlTimestampOf(LocalDateTime.of(year, monthOfYear, dayOfMonth, hourOfDay, minuteOfHour, secondOfMinute, millisToNanos(millisOfSecond)));
     }
@@ -84,7 +84,7 @@ public final class DateTimeTestingUtils
      */
     public static SqlTimestamp sqlTimestampOf(LocalDateTime dateTime)
     {
-        return new SqlTimestamp(DAYS.toMillis(dateTime.toLocalDate().toEpochDay()) + NANOSECONDS.toMillis(dateTime.toLocalTime().toNanoOfDay()));
+        return new SqlTimestamp(DAYS.toMillis(dateTime.toLocalDate().toEpochDay()) + NANOSECONDS.toMillis(dateTime.toLocalTime().toNanoOfDay()), MILLISECONDS);
     }
 
     public static SqlTimestamp sqlTimestampOf(DateTime dateTime, Session session)
@@ -102,10 +102,10 @@ public final class DateTimeTestingUtils
         SqlFunctionProperties properties = session.getSqlFunctionProperties();
 
         if (properties.isLegacyTimestamp()) {
-            return new SqlTimestamp(millis, properties.getTimeZoneKey());
+            return new SqlTimestamp(millis, properties.getTimeZoneKey(), MILLISECONDS);
         }
         else {
-            return new SqlTimestamp(millis);
+            return new SqlTimestamp(millis, MILLISECONDS);
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/testing/MaterializedResult.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/MaterializedResult.java
@@ -382,7 +382,7 @@ public class MaterializedResult
                         zone);
             }
             else if (prestoValue instanceof SqlTimestamp) {
-                convertedValue = SqlTimestamp.JSON_FORMATTER.parse(prestoValue.toString(), LocalDateTime::from);
+                convertedValue = SqlTimestamp.JSON_MILLIS_FORMATTER.parse(prestoValue.toString(), LocalDateTime::from);
             }
             else if (prestoValue instanceof SqlTimestampWithTimeZone) {
                 convertedValue = Instant.ofEpochMilli(((SqlTimestampWithTimeZone) prestoValue).getMillisUtc())

--- a/presto-main/src/test/java/com/facebook/presto/type/AbstractTestType.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/AbstractTestType.java
@@ -39,7 +39,9 @@ import java.util.Map.Entry;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
+import static com.facebook.airlift.testing.Assertions.assertGreaterThan;
 import static com.facebook.airlift.testing.Assertions.assertInstanceOf;
+import static com.facebook.airlift.testing.Assertions.assertLessThan;
 import static com.facebook.presto.common.block.BlockSerdeUtil.writeBlock;
 import static com.facebook.presto.common.block.SortOrder.ASC_NULLS_FIRST;
 import static com.facebook.presto.common.block.SortOrder.ASC_NULLS_LAST;
@@ -205,10 +207,10 @@ public abstract class AbstractTestType
 
         if (type.isOrderable() && expectedStackValue != Boolean.TRUE) {
             Block greaterValue = toBlock(getGreaterValue(expectedStackValue));
-            assertTrue(ASC_NULLS_FIRST.compareBlockValue(type, block, position, greaterValue, 0) < 0);
-            assertTrue(ASC_NULLS_LAST.compareBlockValue(type, block, position, greaterValue, 0) < 0);
-            assertTrue(DESC_NULLS_FIRST.compareBlockValue(type, block, position, greaterValue, 0) > 0);
-            assertTrue(DESC_NULLS_LAST.compareBlockValue(type, block, position, greaterValue, 0) > 0);
+            assertLessThan(ASC_NULLS_FIRST.compareBlockValue(type, block, position, greaterValue, 0), 0);
+            assertLessThan(ASC_NULLS_LAST.compareBlockValue(type, block, position, greaterValue, 0), 0);
+            assertGreaterThan(DESC_NULLS_FIRST.compareBlockValue(type, block, position, greaterValue, 0), 0);
+            assertGreaterThan(DESC_NULLS_LAST.compareBlockValue(type, block, position, greaterValue, 0), 0);
         }
 
         if (type.getJavaType() == boolean.class) {

--- a/presto-main/src/test/java/com/facebook/presto/type/TestTimestampMicrosecondsType.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestTimestampMicrosecondsType.java
@@ -21,31 +21,33 @@ import org.testng.annotations.Test;
 
 import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
 import static com.facebook.presto.common.type.TimestampType.TIMESTAMP_MICROSECONDS;
+import static java.lang.Long.MAX_VALUE;
+import static java.lang.Long.MIN_VALUE;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
 
-public class TestTimestampType
+public class TestTimestampMicrosecondsType
         extends AbstractTestType
 {
-    public TestTimestampType()
+    public TestTimestampMicrosecondsType()
     {
-        super(TIMESTAMP, SqlTimestamp.class, createTestBlock());
+        super(TIMESTAMP_MICROSECONDS, SqlTimestamp.class, createTestBlock());
     }
 
     public static Block createTestBlock()
     {
-        BlockBuilder blockBuilder = TIMESTAMP.createBlockBuilder(null, 15);
-        TIMESTAMP.writeLong(blockBuilder, 1111);
-        TIMESTAMP.writeLong(blockBuilder, 1111);
-        TIMESTAMP.writeLong(blockBuilder, 1111);
-        TIMESTAMP.writeLong(blockBuilder, 2222);
-        TIMESTAMP.writeLong(blockBuilder, 2222);
-        TIMESTAMP.writeLong(blockBuilder, 2222);
-        TIMESTAMP.writeLong(blockBuilder, 2222);
-        TIMESTAMP.writeLong(blockBuilder, 2222);
-        TIMESTAMP.writeLong(blockBuilder, 3333);
-        TIMESTAMP.writeLong(blockBuilder, 3333);
-        TIMESTAMP.writeLong(blockBuilder, 4444);
+        BlockBuilder blockBuilder = TIMESTAMP_MICROSECONDS.createBlockBuilder(null, 15);
+        TIMESTAMP_MICROSECONDS.writeLong(blockBuilder, MIN_VALUE);
+        TIMESTAMP_MICROSECONDS.writeLong(blockBuilder, MIN_VALUE + 1_000_000);
+        TIMESTAMP_MICROSECONDS.writeLong(blockBuilder, 0);
+        TIMESTAMP_MICROSECONDS.writeLong(blockBuilder, 1_000_000L);
+        TIMESTAMP_MICROSECONDS.writeLong(blockBuilder, 1_000_000_000L);
+        TIMESTAMP_MICROSECONDS.writeLong(blockBuilder, 1_000_000_000L);
+        TIMESTAMP_MICROSECONDS.writeLong(blockBuilder, 1_000_000_000L);
+        TIMESTAMP_MICROSECONDS.writeLong(blockBuilder, 1_000_000_000L);
+        TIMESTAMP_MICROSECONDS.writeLong(blockBuilder, 1_000_000_000L);
+        TIMESTAMP_MICROSECONDS.writeLong(blockBuilder, 1_000_000_000_000L);
+        TIMESTAMP_MICROSECONDS.writeLong(blockBuilder, MAX_VALUE - 1);
         return blockBuilder.build();
     }
 
@@ -58,10 +60,10 @@ public class TestTimestampType
     @Test
     public void testEqualsHashcode()
     {
-        TimestampType timeStampType = TIMESTAMP;
-        assertEquals(timeStampType, TIMESTAMP);
-        assertEquals(timeStampType.hashCode(), TIMESTAMP.hashCode());
+        TimestampType timeStampType = TIMESTAMP_MICROSECONDS;
+        assertEquals(timeStampType, TIMESTAMP_MICROSECONDS);
+        assertEquals(timeStampType.hashCode(), TIMESTAMP_MICROSECONDS.hashCode());
 
-        assertNotEquals(timeStampType, TIMESTAMP_MICROSECONDS);
+        assertNotEquals(timeStampType, TIMESTAMP);
     }
 }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkBatchStreamReaders.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkBatchStreamReaders.java
@@ -49,7 +49,6 @@ import java.math.BigInteger;
 import java.util.Collections;
 import java.util.List;
 import java.util.Random;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 
 import static com.facebook.presto.common.type.DecimalType.createDecimalType;
@@ -73,7 +72,7 @@ import static org.joda.time.DateTimeZone.UTC;
 
 @SuppressWarnings("MethodMayBeStatic")
 @State(Scope.Thread)
-@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@OutputTimeUnit(MILLISECONDS)
 @Fork(3)
 @Warmup(iterations = 20, time = 500, timeUnit = MILLISECONDS)
 @Measurement(iterations = 20, time = 500, timeUnit = MILLISECONDS)
@@ -186,7 +185,7 @@ public class BenchmarkBatchStreamReaders
                 case "decimal(30,10)":
                     return new SqlDecimal(BigInteger.valueOf(random.nextLong() % 10_000_000_000L), LONG_DECIMAL_TYPE.getPrecision(), LONG_DECIMAL_TYPE.getScale());
                 case "timestamp":
-                    return new SqlTimestamp((random.nextLong()), UTC_KEY);
+                    return new SqlTimestamp((random.nextLong()), UTC_KEY, MILLISECONDS);
                 case "real":
                     return random.nextFloat();
                 case "double":

--- a/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkBatchStreamReadersWithZstd.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkBatchStreamReadersWithZstd.java
@@ -198,7 +198,7 @@ public class BenchmarkBatchStreamReadersWithZstd
                 case "decimal(30,10)":
                     return new SqlDecimal(BigInteger.valueOf(random.nextLong() % 10_000_000_000L), LONG_DECIMAL_TYPE.getPrecision(), LONG_DECIMAL_TYPE.getScale());
                 case "timestamp":
-                    return new SqlTimestamp((random.nextLong()), UTC_KEY);
+                    return new SqlTimestamp((random.nextLong()), UTC_KEY, MILLISECONDS);
                 case "real":
                     return random.nextFloat();
                 case "double":

--- a/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkSelectiveStreamReaders.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/BenchmarkSelectiveStreamReaders.java
@@ -66,7 +66,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Random;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -102,7 +101,7 @@ import static org.joda.time.DateTimeZone.UTC;
 
 @SuppressWarnings("MethodMayBeStatic")
 @State(Scope.Thread)
-@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@OutputTimeUnit(MILLISECONDS)
 @Fork(2)
 @Warmup(iterations = 10, time = 1000, timeUnit = MILLISECONDS)
 @Measurement(iterations = 10, time = 1000, timeUnit = MILLISECONDS)
@@ -425,7 +424,7 @@ public class BenchmarkSelectiveStreamReaders
             if (type == TIMESTAMP) {
                 // We use int because longs will be converted to int when being written.
                 long value = random.nextInt();
-                return new SqlTimestamp(value, TimeZoneKey.UTC_KEY);
+                return new SqlTimestamp(value, TimeZoneKey.UTC_KEY, MILLISECONDS);
             }
 
             if (type == REAL) {

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestMapFlatBatchStreamReader.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestMapFlatBatchStreamReader.java
@@ -68,6 +68,7 @@ import static com.google.common.collect.Iterators.advance;
 import static com.google.common.io.Resources.getResource;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static java.lang.Math.toIntExact;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 
@@ -505,7 +506,7 @@ public class TestMapFlatBatchStreamReader
 
     private static SqlTimestamp intToTimestamp(int i)
     {
-        return new SqlTimestamp(i, TimeZoneKey.UTC_KEY);
+        return new SqlTimestamp(i, TimeZoneKey.UTC_KEY, MILLISECONDS);
     }
 
     private static List<Integer> intToList(int i)

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestMapFlatSelectiveStreamReader.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestMapFlatSelectiveStreamReader.java
@@ -72,6 +72,7 @@ import static com.facebook.presto.testing.TestingEnvironment.FUNCTION_AND_TYPE_M
 import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.io.Resources.getResource;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.stream.Collectors.toList;
 
 public class TestMapFlatSelectiveStreamReader
@@ -531,7 +532,7 @@ public class TestMapFlatSelectiveStreamReader
 
     private static SqlTimestamp intToTimestamp(int i)
     {
-        return new SqlTimestamp(i, TimeZoneKey.UTC_KEY);
+        return new SqlTimestamp(i, TimeZoneKey.UTC_KEY, MILLISECONDS);
     }
 
     private static List<Integer> intToList(int i)

--- a/presto-raptor/src/test/java/com/facebook/presto/raptor/TestRaptorConnector.java
+++ b/presto-raptor/src/test/java/com/facebook/presto/raptor/TestRaptorConnector.java
@@ -76,6 +76,7 @@ import static com.facebook.presto.util.DateTimeUtils.parseTimestampLiteral;
 import static com.google.common.io.MoreFiles.deleteRecursively;
 import static com.google.common.io.RecursiveDeleteOption.ALLOW_INSECURE;
 import static java.util.Locale.ENGLISH;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
@@ -252,8 +253,8 @@ public class TestRaptorConnector
         Object timestamp1 = null;
         Object timestamp2 = null;
         if (temporalType.equals(TIMESTAMP)) {
-            timestamp1 = new SqlTimestamp(parseTimestampLiteral(getTimeZoneKey(userTimeZone), min), getTimeZoneKey(userTimeZone));
-            timestamp2 = new SqlTimestamp(parseTimestampLiteral(getTimeZoneKey(userTimeZone), max), getTimeZoneKey(userTimeZone));
+            timestamp1 = new SqlTimestamp(parseTimestampLiteral(getTimeZoneKey(userTimeZone), min), getTimeZoneKey(userTimeZone), MILLISECONDS);
+            timestamp2 = new SqlTimestamp(parseTimestampLiteral(getTimeZoneKey(userTimeZone), max), getTimeZoneKey(userTimeZone), MILLISECONDS);
         }
         else if (temporalType.equals(DATE)) {
             timestamp1 = new SqlDate(parseDate(min));

--- a/presto-rcfile/src/test/java/com/facebook/presto/rcfile/RcFileTester.java
+++ b/presto-rcfile/src/test/java/com/facebook/presto/rcfile/RcFileTester.java
@@ -156,6 +156,7 @@ import static io.airlift.units.DataSize.Unit.BYTE;
 import static io.airlift.units.DataSize.Unit.KILOBYTE;
 import static io.airlift.units.DataSize.Unit.MEGABYTE;
 import static java.lang.Math.toIntExact;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.stream.Collectors.toList;
 import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.META_TABLE_COLUMNS;
 import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.META_TABLE_COLUMN_TYPES;
@@ -852,10 +853,10 @@ public class RcFileTester
         else if (actualValue instanceof TimestampWritable) {
             TimestampWritable timestamp = (TimestampWritable) actualValue;
             if (SESSION.getSqlFunctionProperties().isLegacyTimestamp()) {
-                actualValue = new SqlTimestamp((timestamp.getSeconds() * 1000) + (timestamp.getNanos() / 1000000L), UTC_KEY);
+                actualValue = new SqlTimestamp((timestamp.getSeconds() * 1000) + (timestamp.getNanos() / 1000000L), UTC_KEY, MILLISECONDS);
             }
             else {
-                actualValue = new SqlTimestamp((timestamp.getSeconds() * 1000) + (timestamp.getNanos() / 1000000L));
+                actualValue = new SqlTimestamp((timestamp.getSeconds() * 1000) + (timestamp.getNanos() / 1000000L), MILLISECONDS);
             }
         }
         else if (actualValue instanceof StructObject) {

--- a/presto-tests/src/main/java/com/facebook/presto/tests/TestingPrestoClient.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/TestingPrestoClient.java
@@ -224,7 +224,7 @@ public class TestingPrestoClient
             }
         }
         else if (TIMESTAMP.equals(type)) {
-            return SqlTimestamp.JSON_FORMATTER.parse((String) value, LocalDateTime::from);
+            return SqlTimestamp.JSON_MILLIS_FORMATTER.parse((String) value, LocalDateTime::from);
         }
         else if (TIMESTAMP_WITH_TIME_ZONE.equals(type)) {
             return timestampWithTimeZoneFormat.parse((String) value, ZonedDateTime::from);


### PR DESCRIPTION
Presto only supports Milliseconds precision for Timestamp Type. This
change introduces Microseconds precision to the Presto Type system.
This change is first change, though many following changes are required
to fully support the Microseconds timestamp type.

1. Parser change to support the Microseconds as type.
2. Built-in functions should work with Microseconds precision.
3. Connectors (via configuration or session property) can switch to
high precision Microseconds timestamp type.

We use the Presto ORC reader as stand alone library in one of our
projects. Our project requires Microseconds precision. So we plan to
add this type to the Type system and will support Microseconds
precision in the Presto ORC library.

Existing Presto use cases (except direct Presto ORC) will not see any
benefit from this change. But this change is a step in the right
direction for supporting Microseconds Timestamp in the future.

Test plan - 
Added new tests.

```
== NO RELEASE NOTE ==
```
