### PR TITLE
Fixing Disaggregated Coordinator Queue Issue

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/resourcemanager/ResourceManagerClusterStateProvider.java
+++ b/presto-main/src/main/java/com/facebook/presto/resourcemanager/ResourceManagerClusterStateProvider.java
@@ -52,6 +52,7 @@ import java.util.stream.Stream;
 
 import static com.facebook.presto.SystemSessionProperties.resourceOvercommit;
 import static com.facebook.presto.execution.QueryState.QUEUED;
+import static com.facebook.presto.execution.QueryState.WAITING_FOR_PREREQUISITES;
 import static com.facebook.presto.memory.LocalMemoryManager.GENERAL_POOL;
 import static com.facebook.presto.memory.LocalMemoryManager.RESERVED_POOL;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -189,7 +190,7 @@ public class ResourceManagerClusterStateProvider
                     if (info.getState() == QUEUED) {
                         builder.addQueuedQueries(1);
                     }
-                    else if (!info.getState().isDone()) {
+                    else if (!info.getState().isDone() && info.getState() != WAITING_FOR_PREREQUISITES) {
                         builder.addRunningQueries(1);
                     }
                     builder.addUserMemoryReservationBytes(info.getQueryStats().getUserMemoryReservation().toBytes());
@@ -199,7 +200,7 @@ public class ResourceManagerClusterStateProvider
                         if (info.getState() == QUEUED) {
                             parentBuilder.addDescendantQueuedQueries(1);
                         }
-                        else if (!info.getState().isDone()) {
+                        else if (!info.getState().isDone() && info.getState() != WAITING_FOR_PREREQUISITES) {
                             parentBuilder.addDescendantRunningQueries(1);
                         }
                     }


### PR DESCRIPTION
When a query moved to WAITING_FOR_PREREQUISITE, resource manager end up couting them towards running query.
This gives a wrong impression to coordinator about running queries and it ended up running less queri than configured.
With the fix RM will ignore such queries from running queries.

Test plan - Unit tests

```
== RELEASE NOTES ==

General Changes
* Fix Disaggregated Coordinator resource group aggregation issue related to WAITING_FOR_PREREQUISITE queries
