### PR TITLE
Add nested field ids to Iceberg column handler

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/ColumnIdentity.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/ColumnIdentity.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
+import org.apache.iceberg.types.Types;
+
+import java.util.List;
+import java.util.Objects;
+
+import static com.facebook.presto.iceberg.ColumnIdentity.TypeCategory.ARRAY;
+import static com.facebook.presto.iceberg.ColumnIdentity.TypeCategory.MAP;
+import static com.facebook.presto.iceberg.ColumnIdentity.TypeCategory.PRIMITIVE;
+import static com.facebook.presto.iceberg.ColumnIdentity.TypeCategory.STRUCT;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+public class ColumnIdentity
+{
+    private final int id;
+    private final String name;
+    private final TypeCategory typeCategory;
+    private final List<ColumnIdentity> children;
+
+    @JsonCreator
+    public ColumnIdentity(
+            @JsonProperty("id") int id,
+            @JsonProperty("name") String name,
+            @JsonProperty("typeCategory") TypeCategory typeCategory,
+            @JsonProperty("children") List<ColumnIdentity> children)
+    {
+        this.id = id;
+        this.name = requireNonNull(name, "name is null");
+        this.typeCategory = requireNonNull(typeCategory, "typeCategory is null");
+        this.children = requireNonNull(children, "children is null");
+        checkArgument(
+                children.isEmpty() == (typeCategory == PRIMITIVE),
+                "Children should be empty if and only if column type is primitive");
+    }
+
+    @JsonProperty
+    public int getId()
+    {
+        return id;
+    }
+
+    @JsonProperty
+    public String getName()
+    {
+        return name;
+    }
+
+    @JsonProperty
+    public TypeCategory getTypeCategory()
+    {
+        return typeCategory;
+    }
+
+    @JsonProperty
+    public List<ColumnIdentity> getChildren()
+    {
+        return children;
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ColumnIdentity that = (ColumnIdentity) o;
+        return id == that.id &&
+                name.equals(that.name) &&
+                typeCategory == that.typeCategory &&
+                children.equals(that.children);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return Objects.hash(id, name, typeCategory, children);
+    }
+
+    @Override
+    public String toString()
+    {
+        return id + ":" + name;
+    }
+
+    public enum TypeCategory
+    {
+        PRIMITIVE,
+        STRUCT,
+        ARRAY,
+        MAP
+    }
+
+    public static ColumnIdentity primitiveColumnIdentity(int id, String name)
+    {
+        return new ColumnIdentity(id, name, PRIMITIVE, ImmutableList.of());
+    }
+
+    public static ColumnIdentity createColumnIdentity(Types.NestedField column)
+    {
+        int id = column.fieldId();
+        String name = column.name();
+        org.apache.iceberg.types.Type fieldType = column.type();
+
+        if (!fieldType.isNestedType()) {
+            return new ColumnIdentity(id, name, PRIMITIVE, ImmutableList.of());
+        }
+
+        if (fieldType.isListType()) {
+            ColumnIdentity elementColumn = createColumnIdentity(getOnlyElement(fieldType.asListType().fields()));
+            return new ColumnIdentity(id, name, ARRAY, ImmutableList.of(elementColumn));
+        }
+
+        if (fieldType.isStructType()) {
+            List<ColumnIdentity> fieldColumns = fieldType.asStructType().fields().stream()
+                    .map(ColumnIdentity::createColumnIdentity)
+                    .collect(toImmutableList());
+            return new ColumnIdentity(id, name, STRUCT, fieldColumns);
+        }
+
+        if (fieldType.isMapType()) {
+            List<ColumnIdentity> keyValueColumns = fieldType.asMapType().fields().stream()
+                    .map(ColumnIdentity::createColumnIdentity)
+                    .collect(toImmutableList());
+            checkArgument(keyValueColumns.size() == 2, "Expected map type to have two fields");
+            return new ColumnIdentity(id, name, MAP, keyValueColumns);
+        }
+
+        throw new UnsupportedOperationException(format("Iceberg column type %s is not supported", fieldType.typeId()));
+    }
+}

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergAbstractMetadata.java
@@ -61,6 +61,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.iceberg.IcebergColumnHandle.primitiveIcebergColumnHandle;
 import static com.facebook.presto.iceberg.IcebergTableProperties.FILE_FORMAT_PROPERTY;
 import static com.facebook.presto.iceberg.IcebergTableProperties.PARTITIONING_PROPERTY;
 import static com.facebook.presto.iceberg.IcebergUtil.getColumns;
@@ -256,7 +257,7 @@ public abstract class IcebergAbstractMetadata
     @Override
     public ColumnHandle getUpdateRowIdColumnHandle(ConnectorSession session, ConnectorTableHandle tableHandle)
     {
-        return new IcebergColumnHandle(0, "$row_id", BIGINT, Optional.empty());
+        return primitiveIcebergColumnHandle(0, "$row_id", BIGINT, Optional.empty());
     }
 
     @Override

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
@@ -45,7 +45,6 @@ import java.util.regex.Pattern;
 
 import static com.facebook.presto.hive.HiveMetadata.TABLE_COMMENT;
 import static com.facebook.presto.iceberg.IcebergErrorCode.ICEBERG_INVALID_SNAPSHOT_ID;
-import static com.facebook.presto.iceberg.TypeConverter.toPrestoType;
 import static com.facebook.presto.iceberg.util.IcebergPrestoModelConverters.toIcebergTableIdentifier;
 import static com.facebook.presto.spi.StandardErrorCode.NOT_SUPPORTED;
 import static com.google.common.collect.ImmutableList.toImmutableList;
@@ -115,11 +114,7 @@ public final class IcebergUtil
     public static List<IcebergColumnHandle> getColumns(Schema schema, TypeManager typeManager)
     {
         return schema.columns().stream()
-                .map(column -> new IcebergColumnHandle(
-                        column.fieldId(),
-                        column.name(),
-                        toPrestoType(column.type(), typeManager),
-                        Optional.ofNullable(column.doc())))
+                .map(column -> IcebergColumnHandle.create(column, typeManager))
                 .collect(toImmutableList());
     }
 

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergColumnHandle.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergColumnHandle.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg;
+
+import com.facebook.airlift.json.JsonCodec;
+import com.facebook.airlift.json.JsonCodecFactory;
+import com.facebook.airlift.json.JsonObjectMapperProvider;
+import com.facebook.airlift.json.ObjectMapperProvider;
+import com.facebook.presto.common.type.ArrayType;
+import com.facebook.presto.common.type.RowType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.type.TypeDeserializer;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.iceberg.ColumnIdentity.TypeCategory.ARRAY;
+import static com.facebook.presto.iceberg.ColumnIdentity.TypeCategory.PRIMITIVE;
+import static com.facebook.presto.iceberg.ColumnIdentity.TypeCategory.STRUCT;
+import static com.facebook.presto.iceberg.IcebergColumnHandle.primitiveIcebergColumnHandle;
+import static com.facebook.presto.metadata.FunctionAndTypeManager.createTestFunctionAndTypeManager;
+import static org.testng.Assert.assertEquals;
+
+public class TestIcebergColumnHandle
+{
+    @Test
+    public void testRoundTrip()
+    {
+        testRoundTrip(primitiveIcebergColumnHandle(12, "blah", BIGINT, Optional.of("this is a comment")));
+
+        // Nested column
+        ColumnIdentity foo1 = new ColumnIdentity(1, "foo1", PRIMITIVE, ImmutableList.of());
+        ColumnIdentity foo2 = new ColumnIdentity(2, "foo2", PRIMITIVE, ImmutableList.of());
+        ColumnIdentity foo3 = new ColumnIdentity(3, "foo3", ARRAY, ImmutableList.of(foo1));
+        IcebergColumnHandle nestedColumn = new IcebergColumnHandle(
+                new ColumnIdentity(
+                        5,
+                        "foo5",
+                        STRUCT,
+                        ImmutableList.of(foo2, foo3)),
+                RowType.from(ImmutableList.of(
+                        RowType.field("foo2", BIGINT),
+                        RowType.field("foo3", new ArrayType(BIGINT)))),
+                Optional.empty());
+        testRoundTrip(nestedColumn);
+    }
+
+    private void testRoundTrip(IcebergColumnHandle expected)
+    {
+        ObjectMapperProvider objectMapperProvider = new JsonObjectMapperProvider();
+        objectMapperProvider.setJsonDeserializers(ImmutableMap.of(Type.class, new TypeDeserializer(createTestFunctionAndTypeManager())));
+        JsonCodec<IcebergColumnHandle> codec = new JsonCodecFactory(objectMapperProvider).jsonCodec(IcebergColumnHandle.class);
+        String json = codec.toJson(expected);
+        IcebergColumnHandle actual = codec.fromJson(json);
+
+        assertEquals(actual, expected);
+        assertEquals(actual.getName(), expected.getName());
+        assertEquals(actual.getColumnIdentity(), expected.getColumnIdentity());
+        assertEquals(actual.getId(), actual.getId());
+        assertEquals(actual.getType(), expected.getType());
+        assertEquals(actual.getComment(), expected.getComment());
+    }
+}


### PR DESCRIPTION
Add nested field ids to Iceberg column handler

Cherry-pick from https://github.com/trinodb/trino/commit/284a43b0
Co-Author-By: Pratham Desai <prathamd94@gmail.com>

Test plan - Unit tests

```
== NO RELEASE NOTE ==
```
