### PR TITLE
Fix wrong result due to column position mismatch in BigQuery

### DIFF
--- a/presto-bigquery/src/main/java/com/facebook/presto/plugin/bigquery/BigQueryPageSourceProvider.java
+++ b/presto-bigquery/src/main/java/com/facebook/presto/plugin/bigquery/BigQueryPageSourceProvider.java
@@ -65,6 +65,6 @@ public class BigQueryPageSourceProvider
                 .map(BigQueryColumnHandle.class::cast)
                 .collect(toImmutableList());
 
-        return new BigQueryResultPageSource(bigQueryStorageClientFactory, maxReadRowsRetries, bigQuerySplit, bigQueryTableHandle, bigQueryColumnHandles);
+        return new BigQueryResultPageSource(bigQueryStorageClientFactory, maxReadRowsRetries, bigQuerySplit, bigQueryColumnHandles);
     }
 }


### PR DESCRIPTION
Cherry-pick of https://github.com/trinodb/trino/pull/8201

Fixes the bug https://github.com/trinodb/trino/issues/8183

Co-authored-by: yuya.ebihara <yuya.ebihara@linecorp.com>


```
== NO RELEASE NOTE ==
```

