### PR TITLE
Add support casting timestamp of micro/nanosecond

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/util/DateTimeUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/util/DateTimeUtils.java
@@ -84,7 +84,9 @@ public final class DateTimeUtils
                 DateTimeFormat.forPattern("yyyy-M-d").getParser(),
                 DateTimeFormat.forPattern("yyyy-M-d H:m").getParser(),
                 DateTimeFormat.forPattern("yyyy-M-d H:m:s").getParser(),
-                DateTimeFormat.forPattern("yyyy-M-d H:m:s.SSS").getParser()};
+                DateTimeFormat.forPattern("yyyy-M-d H:m:s.SSS").getParser(),
+                DateTimeFormat.forPattern("yyyy-M-d H:m:s.SSSSSS").getParser(),
+                DateTimeFormat.forPattern("yyyy-M-d H:m:s.SSSSSSSSS").getParser()};
         DateTimePrinter timestampWithoutTimeZonePrinter = DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss.SSS").getPrinter();
         LEGACY_TIMESTAMP_WITHOUT_TIME_ZONE_FORMATTER = new DateTimeFormatterBuilder()
                 .append(timestampWithoutTimeZonePrinter, timestampWithoutTimeZoneParser)
@@ -105,6 +107,10 @@ public final class DateTimeUtils
                 DateTimeFormat.forPattern("yyyy-M-d H:m:s Z").getParser(),
                 DateTimeFormat.forPattern("yyyy-M-d H:m:s.SSSZ").getParser(),
                 DateTimeFormat.forPattern("yyyy-M-d H:m:s.SSS Z").getParser(),
+                DateTimeFormat.forPattern("yyyy-M-d H:m:s.SSSSSSZ").getParser(),
+                DateTimeFormat.forPattern("yyyy-M-d H:m:s.SSSSSS Z").getParser(),
+                DateTimeFormat.forPattern("yyyy-M-d H:m:s.SSSSSSSSSZ").getParser(),
+                DateTimeFormat.forPattern("yyyy-M-d H:m:s.SSSSSSSSS Z").getParser(),
                 DateTimeFormat.forPattern("yyyy-M-dZZZ").getParser(),
                 DateTimeFormat.forPattern("yyyy-M-d ZZZ").getParser(),
                 DateTimeFormat.forPattern("yyyy-M-d H:mZZZ").getParser(),
@@ -112,7 +118,11 @@ public final class DateTimeUtils
                 DateTimeFormat.forPattern("yyyy-M-d H:m:sZZZ").getParser(),
                 DateTimeFormat.forPattern("yyyy-M-d H:m:s ZZZ").getParser(),
                 DateTimeFormat.forPattern("yyyy-M-d H:m:s.SSSZZZ").getParser(),
-                DateTimeFormat.forPattern("yyyy-M-d H:m:s.SSS ZZZ").getParser()};
+                DateTimeFormat.forPattern("yyyy-M-d H:m:s.SSS ZZZ").getParser(),
+                DateTimeFormat.forPattern("yyyy-M-d H:m:s.SSSSSSZZZ").getParser(),
+                DateTimeFormat.forPattern("yyyy-M-d H:m:s.SSSSSS ZZZ").getParser(),
+                DateTimeFormat.forPattern("yyyy-M-d H:m:s.SSSSSSSSSZZZ").getParser(),
+                DateTimeFormat.forPattern("yyyy-M-d H:m:s.SSSSSSSSS ZZZ").getParser()};
         DateTimePrinter timestampWithTimeZonePrinter = DateTimeFormat.forPattern("yyyy-MM-dd HH:mm:ss.SSS ZZZ").getPrinter();
         TIMESTAMP_WITH_TIME_ZONE_FORMATTER = new DateTimeFormatterBuilder()
                 .append(timestampWithTimeZonePrinter, timestampWithTimeZoneParser)

--- a/presto-main/src/test/java/com/facebook/presto/type/TestTimestamp.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestTimestamp.java
@@ -36,6 +36,14 @@ public class TestTimestamp
                 TIMESTAMP,
                 sqlTimestampOf(LocalDateTime.of(2001, 1, 22, 3, 4, 5, 321_000_000)));
         assertFunction(
+                "cast('2001-1-22 03:04:05.321123 +07:09' as timestamp)",
+                TIMESTAMP,
+                sqlTimestampOf(LocalDateTime.of(2001, 1, 22, 3, 4, 5, 321_000_000)));
+        assertFunction(
+                "cast('2001-1-22 03:04:05.321123456 +07:09' as timestamp)",
+                TIMESTAMP,
+                sqlTimestampOf(LocalDateTime.of(2001, 1, 22, 3, 4, 5, 321_000_000)));
+        assertFunction(
                 "cast('2001-1-22 03:04:05 +07:09' as timestamp)",
                 TIMESTAMP,
                 sqlTimestampOf(LocalDateTime.of(2001, 1, 22, 3, 4, 5)));
@@ -50,6 +58,14 @@ public class TestTimestamp
 
         assertFunction(
                 "cast('2001-1-22 03:04:05.321 Asia/Oral' as timestamp)",
+                TIMESTAMP,
+                sqlTimestampOf(LocalDateTime.of(2001, 1, 22, 3, 4, 5, 321_000_000)));
+        assertFunction(
+                "cast('2001-1-22 03:04:05.321123 Asia/Oral' as timestamp)",
+                TIMESTAMP,
+                sqlTimestampOf(LocalDateTime.of(2001, 1, 22, 3, 4, 5, 321_000_000)));
+        assertFunction(
+                "cast('2001-1-22 03:04:05.321123456 Asia/Oral' as timestamp)",
                 TIMESTAMP,
                 sqlTimestampOf(LocalDateTime.of(2001, 1, 22, 3, 4, 5, 321_000_000)));
         assertFunction(

--- a/presto-main/src/test/java/com/facebook/presto/type/TestTimestampBase.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestTimestampBase.java
@@ -226,6 +226,12 @@ public abstract class TestTimestampBase
         assertFunction("cast('2001-1-22 03:04:05.321' as timestamp)",
                 TIMESTAMP,
                 sqlTimestampOf(2001, 1, 22, 3, 4, 5, 321, session));
+        assertFunction("cast('2001-1-22 03:04:05.321123' as timestamp)",
+                TIMESTAMP,
+                sqlTimestampOf(2001, 1, 22, 3, 4, 5, 321, session));
+        assertFunction("cast('2001-1-22 03:04:05.321123456' as timestamp)",
+                TIMESTAMP,
+                sqlTimestampOf(2001, 1, 22, 3, 4, 5, 321, session));
         assertFunction("cast('2001-1-22 03:04:05' as timestamp)",
                 TIMESTAMP,
                 sqlTimestampOf(2001, 1, 22, 3, 4, 5, 0, session));

--- a/presto-main/src/test/java/com/facebook/presto/type/TestTimestampLegacy.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestTimestampLegacy.java
@@ -33,6 +33,14 @@ public class TestTimestampLegacy
                 TIMESTAMP,
                 sqlTimestampOf(2001, 1, 21, 8, 55, 5, 321, session));
         assertFunction(
+                "cast('2001-1-22 03:04:05.321123 +07:09' as timestamp)",
+                TIMESTAMP,
+                sqlTimestampOf(2001, 1, 21, 8, 55, 5, 321, session));
+        assertFunction(
+                "cast('2001-1-22 03:04:05.321123456 +07:09' as timestamp)",
+                TIMESTAMP,
+                sqlTimestampOf(2001, 1, 21, 8, 55, 5, 321, session));
+        assertFunction(
                 "cast('2001-1-22 03:04:05 +07:09' as timestamp)",
                 TIMESTAMP,
                 sqlTimestampOf(2001, 1, 21, 8, 55, 5, 0, session));
@@ -47,6 +55,14 @@ public class TestTimestampLegacy
 
         assertFunction(
                 "cast('2001-1-22 03:04:05.321 Asia/Oral' as timestamp)",
+                TIMESTAMP,
+                sqlTimestampOf(2001, 1, 21, 12, 4, 5, 321, session));
+        assertFunction(
+                "cast('2001-1-22 03:04:05.321123 Asia/Oral' as timestamp)",
+                TIMESTAMP,
+                sqlTimestampOf(2001, 1, 21, 12, 4, 5, 321, session));
+        assertFunction(
+                "cast('2001-1-22 03:04:05.321123456 Asia/Oral' as timestamp)",
                 TIMESTAMP,
                 sqlTimestampOf(2001, 1, 21, 12, 4, 5, 321, session));
         assertFunction(

--- a/presto-main/src/test/java/com/facebook/presto/type/TestTimestampWithTimeZone.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestTimestampWithTimeZone.java
@@ -40,6 +40,22 @@ public class TestTimestampWithTimeZone
         functionAssertions.assertFunctionString("cast(TIMESTAMP '2001-1-22 03:04:05.321 +07:09' as time)",
                 TIME,
                 "03:04:05.321");
+
+        assertFunction("cast(TIMESTAMP '2001-1-22 03:04:05.321123 +07:09' as time)",
+                TIME,
+                sqlTimeOf(3, 4, 5, 321, session));
+
+        functionAssertions.assertFunctionString("cast(TIMESTAMP '2001-1-22 03:04:05.321123 +07:09' as time)",
+                TIME,
+                "03:04:05.321");
+
+        assertFunction("cast(TIMESTAMP '2001-1-22 03:04:05.321123456 +07:09' as time)",
+                TIME,
+                sqlTimeOf(3, 4, 5, 321, session));
+
+        functionAssertions.assertFunctionString("cast(TIMESTAMP '2001-1-22 03:04:05.321123456 +07:09' as time)",
+                TIME,
+                "03:04:05.321");
     }
 
     @Test
@@ -54,6 +70,18 @@ public class TestTimestampWithTimeZone
         functionAssertions.assertFunctionString("cast(TIMESTAMP '2017-06-06 10:00:00.000 Asia/Kathmandu' as time with time zone)",
                 TIME_WITH_TIME_ZONE,
                 "10:00:00.000 Asia/Kathmandu");
+        functionAssertions.assertFunctionString("cast(TIMESTAMP '2017-06-06 10:00:00.000123 Europe/Warsaw' as time with time zone)",
+                TIME_WITH_TIME_ZONE,
+                "10:00:00.000 Europe/Warsaw");
+        functionAssertions.assertFunctionString("cast(TIMESTAMP '2017-06-06 10:00:00.000123 Asia/Kathmandu' as time with time zone)",
+                TIME_WITH_TIME_ZONE,
+                "10:00:00.000 Asia/Kathmandu");
+        functionAssertions.assertFunctionString("cast(TIMESTAMP '2017-06-06 10:00:00.000123456 Europe/Warsaw' as time with time zone)",
+                TIME_WITH_TIME_ZONE,
+                "10:00:00.000 Europe/Warsaw");
+        functionAssertions.assertFunctionString("cast(TIMESTAMP '2017-06-06 10:00:00.000123456 Asia/Kathmandu' as time with time zone)",
+                TIME_WITH_TIME_ZONE,
+                "10:00:00.000 Asia/Kathmandu");
     }
 
     @Test
@@ -64,8 +92,24 @@ public class TestTimestampWithTimeZone
                 TIMESTAMP,
                 sqlTimestampOf(2001, 1, 22, 3, 4, 5, 321, session));
 
+        assertFunction("cast(TIMESTAMP '2001-1-22 03:04:05.321123 +07:09' as timestamp)",
+                TIMESTAMP,
+                sqlTimestampOf(2001, 1, 22, 3, 4, 5, 321, session));
+
+        assertFunction("cast(TIMESTAMP '2001-1-22 03:04:05.321123456 +07:09' as timestamp)",
+                TIMESTAMP,
+                sqlTimestampOf(2001, 1, 22, 3, 4, 5, 321, session));
+
         // This TZ had switch in 2014, so if we test for 2014 and used unpacked value we would use wrong shift
         assertFunction("cast(TIMESTAMP '2001-1-22 03:04:05.321 Pacific/Bougainville' as timestamp)",
+                TIMESTAMP,
+                sqlTimestampOf(2001, 1, 22, 3, 4, 5, 321, session));
+
+        assertFunction("cast(TIMESTAMP '2001-1-22 03:04:05.321123 Pacific/Bougainville' as timestamp)",
+                TIMESTAMP,
+                sqlTimestampOf(2001, 1, 22, 3, 4, 5, 321, session));
+
+        assertFunction("cast(TIMESTAMP '2001-1-22 03:04:05.321123456 Pacific/Bougainville' as timestamp)",
                 TIMESTAMP,
                 sqlTimestampOf(2001, 1, 22, 3, 4, 5, 321, session));
     }

--- a/presto-main/src/test/java/com/facebook/presto/type/TestTimestampWithTimeZoneBase.java
+++ b/presto-main/src/test/java/com/facebook/presto/type/TestTimestampWithTimeZoneBase.java
@@ -281,6 +281,12 @@ public abstract class TestTimestampWithTimeZoneBase
         assertFunction("cast('2001-1-22 03:04:05.321' as timestamp with time zone)",
                 TIMESTAMP_WITH_TIME_ZONE,
                 new SqlTimestampWithTimeZone(new DateTime(2001, 1, 22, 3, 4, 5, 321, DATE_TIME_ZONE).getMillis(), TIME_ZONE_KEY));
+        assertFunction("cast('2001-1-22 03:04:05.321123' as timestamp with time zone)",
+                TIMESTAMP_WITH_TIME_ZONE,
+                new SqlTimestampWithTimeZone(new DateTime(2001, 1, 22, 3, 4, 5, 321, DATE_TIME_ZONE).getMillis(), TIME_ZONE_KEY));
+        assertFunction("cast('2001-1-22 03:04:05.321123456' as timestamp with time zone)",
+                TIMESTAMP_WITH_TIME_ZONE,
+                new SqlTimestampWithTimeZone(new DateTime(2001, 1, 22, 3, 4, 5, 321, DATE_TIME_ZONE).getMillis(), TIME_ZONE_KEY));
         assertFunction("cast('2001-1-22 03:04:05' as timestamp with time zone)",
                 TIMESTAMP_WITH_TIME_ZONE,
                 new SqlTimestampWithTimeZone(new DateTime(2001, 1, 22, 3, 4, 5, 0, DATE_TIME_ZONE).getMillis(), TIME_ZONE_KEY));
@@ -294,6 +300,12 @@ public abstract class TestTimestampWithTimeZoneBase
         assertFunction("cast('2001-1-22 03:04:05.321 +07:09' as timestamp with time zone)",
                 TIMESTAMP_WITH_TIME_ZONE,
                 new SqlTimestampWithTimeZone(new DateTime(2001, 1, 22, 3, 4, 5, 321, WEIRD_ZONE).getMillis(), WEIRD_TIME_ZONE_KEY));
+        assertFunction("cast('2001-1-22 03:04:05.321123 +07:09' as timestamp with time zone)",
+                TIMESTAMP_WITH_TIME_ZONE,
+                new SqlTimestampWithTimeZone(new DateTime(2001, 1, 22, 3, 4, 5, 321, WEIRD_ZONE).getMillis(), WEIRD_TIME_ZONE_KEY));
+        assertFunction("cast('2001-1-22 03:04:05.321123456 +07:09' as timestamp with time zone)",
+                TIMESTAMP_WITH_TIME_ZONE,
+                new SqlTimestampWithTimeZone(new DateTime(2001, 1, 22, 3, 4, 5, 321, WEIRD_ZONE).getMillis(), WEIRD_TIME_ZONE_KEY));
         assertFunction("cast('2001-1-22 03:04:05 +07:09' as timestamp with time zone)",
                 TIMESTAMP_WITH_TIME_ZONE,
                 new SqlTimestampWithTimeZone(new DateTime(2001, 1, 22, 3, 4, 5, 0, WEIRD_ZONE).getMillis(), WEIRD_TIME_ZONE_KEY));
@@ -305,6 +317,12 @@ public abstract class TestTimestampWithTimeZoneBase
                 new SqlTimestampWithTimeZone(new DateTime(2001, 1, 22, 0, 0, 0, 0, WEIRD_ZONE).getMillis(), WEIRD_TIME_ZONE_KEY));
 
         assertFunction("cast('2001-1-22 03:04:05.321 Europe/Berlin' as timestamp with time zone)",
+                TIMESTAMP_WITH_TIME_ZONE,
+                new SqlTimestampWithTimeZone(new DateTime(2001, 1, 22, 3, 4, 5, 321, BERLIN_ZONE).getMillis(), BERLIN_TIME_ZONE_KEY));
+        assertFunction("cast('2001-1-22 03:04:05.321123 Europe/Berlin' as timestamp with time zone)",
+                TIMESTAMP_WITH_TIME_ZONE,
+                new SqlTimestampWithTimeZone(new DateTime(2001, 1, 22, 3, 4, 5, 321, BERLIN_ZONE).getMillis(), BERLIN_TIME_ZONE_KEY));
+        assertFunction("cast('2001-1-22 03:04:05.321123456 Europe/Berlin' as timestamp with time zone)",
                 TIMESTAMP_WITH_TIME_ZONE,
                 new SqlTimestampWithTimeZone(new DateTime(2001, 1, 22, 3, 4, 5, 321, BERLIN_ZONE).getMillis(), BERLIN_TIME_ZONE_KEY));
         assertFunction("cast('2001-1-22 03:04:05 Europe/Berlin' as timestamp with time zone)",
@@ -324,6 +342,9 @@ public abstract class TestTimestampWithTimeZoneBase
                 TIMESTAMP_WITH_TIME_ZONE,
                 new SqlTimestampWithTimeZone(new DateTime(2001, 1, 22, 3, 4, 5, 321, BERLIN_ZONE).getMillis(), BERLIN_TIME_ZONE_KEY));
         assertFunction("cast('\n\t 2001-1-22 03:04:05.321 Europe/Berlin \t\n' as timestamp with time zone)",
+                TIMESTAMP_WITH_TIME_ZONE,
+                new SqlTimestampWithTimeZone(new DateTime(2001, 1, 22, 3, 4, 5, 321, BERLIN_ZONE).getMillis(), BERLIN_TIME_ZONE_KEY));
+        assertFunction("cast('\n\t 2001-1-22 03:04:05.321123456 Europe/Berlin \t\n' as timestamp with time zone)",
                 TIMESTAMP_WITH_TIME_ZONE,
                 new SqlTimestampWithTimeZone(new DateTime(2001, 1, 22, 3, 4, 5, 321, BERLIN_ZONE).getMillis(), BERLIN_TIME_ZONE_KEY));
     }


### PR DESCRIPTION
Some tables would have date time formats (columns of VARCHAR type) with microsecond or nanosecond precision. When trying to cast these to TIMESTAMP type, Presto will throw a cast error. We should support casting these higher precision date time formats to timestamp for better usability of Presto. Since timestamp only supports millisecond precision, the behavior of the casting should be to truncate to millisecond precision. 

Test plan - Unit tests

```
General Changes
* Add support for casting microseconds/nanoseconds to Timestamp type, though with precision loss to Milliseconds.
```
