### PR TITLE
Add implementation of DWRF flat map column writer

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriteValidation.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriteValidation.java
@@ -227,10 +227,6 @@ public class OrcWriteValidation
 
         int rowGroupCount = expectedRowGroupStatistics.size();
         for (Entry<StreamId, List<RowGroupIndex>> entry : actualRowGroupStatistics.entrySet()) {
-            // TODO: Remove once the Presto writer supports flat map
-            if (entry.getKey().getSequence() > 0) {
-                throw new OrcCorruptionException(orcDataSourceId, "Unexpected sequence ID for column %s at offset %s", entry.getKey().getColumn(), stripeOffset);
-            }
             if (entry.getValue().size() != rowGroupCount) {
                 throw new OrcCorruptionException(orcDataSourceId, "Unexpected row group count stripe in at offset %s", stripeOffset);
             }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/MapFlatColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/MapFlatColumnWriter.java
@@ -15,27 +15,62 @@ package com.facebook.presto.orc.writer;
 
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.block.ColumnarMap;
+import com.facebook.presto.common.type.FixedWidthType;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.common.type.VarcharType;
 import com.facebook.presto.orc.ColumnWriterOptions;
 import com.facebook.presto.orc.DwrfDataEncryptor;
 import com.facebook.presto.orc.checkpoint.StreamCheckpoint;
 import com.facebook.presto.orc.metadata.ColumnEncoding;
 import com.facebook.presto.orc.metadata.CompressedMetadataWriter;
+import com.facebook.presto.orc.metadata.DwrfSequenceEncoding;
 import com.facebook.presto.orc.metadata.MetadataWriter;
+import com.facebook.presto.orc.metadata.RowGroupIndex;
+import com.facebook.presto.orc.metadata.Stream;
 import com.facebook.presto.orc.metadata.statistics.ColumnStatistics;
+import com.facebook.presto.orc.metadata.statistics.StatisticsBuilder;
+import com.facebook.presto.orc.proto.DwrfProto;
+import com.facebook.presto.orc.protobuf.ByteString;
+import com.facebook.presto.orc.stream.PresentOutputStream;
 import com.facebook.presto.orc.stream.StreamDataOutput;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSortedMap;
+import io.airlift.slice.Slice;
+import io.airlift.slice.Slices;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntList;
+import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import org.openjdk.jol.info.ClassLayout;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.IntFunction;
 import java.util.function.Supplier;
 
+import static com.facebook.presto.common.array.Arrays.ExpansionFactor.MEDIUM;
+import static com.facebook.presto.common.array.Arrays.ExpansionOption.PRESERVE;
+import static com.facebook.presto.common.array.Arrays.ensureCapacity;
 import static com.facebook.presto.common.block.ColumnarMap.toColumnarMap;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.common.type.SmallintType.SMALLINT;
+import static com.facebook.presto.common.type.TinyintType.TINYINT;
+import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
+import static com.facebook.presto.orc.metadata.ColumnEncoding.ColumnEncodingKind.DIRECT;
 import static com.facebook.presto.orc.metadata.ColumnEncoding.ColumnEncodingKind.DWRF_MAP_FLAT;
+import static com.facebook.presto.orc.metadata.ColumnEncoding.DEFAULT_SEQUENCE_ID;
 import static com.facebook.presto.orc.metadata.CompressionKind.NONE;
+import static com.facebook.presto.orc.metadata.Stream.StreamKind.ROW_INDEX;
+import static com.facebook.presto.orc.metadata.statistics.ColumnStatistics.mergeColumnStatistics;
+import static com.facebook.presto.orc.writer.ColumnWriterUtils.buildRowGroupIndexes;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 import static java.util.Objects.requireNonNull;
@@ -43,91 +78,291 @@ import static java.util.Objects.requireNonNull;
 public class MapFlatColumnWriter
         implements ColumnWriter
 {
+    // sequence must start from 1 because presto-orc treats sequence 0 the same as a missing sequence
+    private static final int SEQUENCE_START_INDEX = 1;
+    private static final ColumnEncoding FLAT_MAP_COLUMN_ENCODING = new ColumnEncoding(DWRF_MAP_FLAT, 0);
+    private static final DwrfProto.KeyInfo EMPTY_SLICE_KEY = DwrfProto.KeyInfo.newBuilder().setBytesKey(ByteString.EMPTY).build();
     private static final int INSTANCE_SIZE = ClassLayout.parseClass(MapFlatColumnWriter.class).instanceSize();
-    private final int column;
+    private static final int MIN_CAPACITY = 16;
+
+    private final int nodeIndex;
+    private final int keyNodeIndex;
+    private final int valueNodeIndex;
+    private final Type keyType;
+    private final ColumnWriterOptions columnWriterOptions;
+    private final Optional<DwrfDataEncryptor> dwrfEncryptor;
     private final boolean compressed;
-    private final ColumnEncoding columnEncoding;
+    private final PresentOutputStream presentStream;
     private final CompressedMetadataWriter metadataWriter;
-    private final Supplier<ColumnWriter> valueWriterFactory;
+    private final KeyManager keyManager;
+
+    // Pre-create a value block with a single null value to avoid creating a block
+    // region for null values.
+    private final Block nullValueBlock;
+
+    private final List<MapFlatValueWriter> valueWriters = new ArrayList<>();
+    private final IntFunction<ColumnWriter> valueWriterFactory;
+    private final IntList rowsInFinishedRowGroups = new IntArrayList();
+    private final List<ColumnStatistics> rowGroupColumnStatistics = new ArrayList<>();
 
     private boolean closed;
 
-    public MapFlatColumnWriter(int column,
-            ColumnWriterOptions columnWriterOptions,
-            Supplier<ColumnWriter> valueWriterFactory,
-            Optional<DwrfDataEncryptor> dwrfEncryptor,
-            MetadataWriter metadataWriter)
-    {
-        // TODO: Flat map needs to get factories for key and value writers, instead of already initialized writers
-        checkArgument(column >= 0, "column is negative");
-        requireNonNull(columnWriterOptions, "columnWriterOptions is null");
+    // Number of non-null rows in the current row group. Used for statistics and
+    // to catch up value writers on missing keys
+    private int nonNullRowGroupValueCount;
 
-        this.column = column;
+    // Contains the last row written by a certain value writer.
+    // It is used to catch up on missing keys.
+    private int[] valueWritersLastRow = new int[0];
+
+    // If no value has been written, then valueWriters list will be empty, and we
+    // won't be able to get required column statistics for all sub nodes.
+    // This field contains cached stripe column statistics for the value node(s)
+    // for this edge case.
+    // TODO: Extend the ColumnStatisticsBuilders to create builders to all ORC
+    //  types to able to build empty stats without initializing value writers
+    private Map<Integer, ColumnStatistics> emptyValueColumnStripeStatistics;
+
+    public MapFlatColumnWriter(
+            int nodeIndex,
+            int keyNodeIndex,
+            int valueNodeIndex,
+            Type keyType,
+            Type valueType,
+            Supplier<StatisticsBuilder> keyStatisticsBuilderSupplier,
+            ColumnWriterOptions columnWriterOptions,
+            Optional<DwrfDataEncryptor> dwrfEncryptor,
+            MetadataWriter metadataWriter,
+            IntFunction<ColumnWriter> valueWriterFactory)
+    {
+        checkArgument(nodeIndex > 0, "nodeIndex is invalid: %s", nodeIndex);
+        checkArgument(keyNodeIndex > 0, "keyNodeIndex is invalid: %s", keyNodeIndex);
+        checkArgument(valueNodeIndex > 0, "valueNodeIndex is invalid: %s", valueNodeIndex);
+        requireNonNull(keyStatisticsBuilderSupplier, "keyStatisticsBuilderSupplier is null");
+
+        this.nodeIndex = nodeIndex;
+        this.keyNodeIndex = keyNodeIndex;
+        this.valueNodeIndex = valueNodeIndex;
+        this.keyType = requireNonNull(keyType, "keyType is null");
+        this.nullValueBlock = createNullValueBlock(requireNonNull(valueType, "valueType is null"));
+
+        this.columnWriterOptions = requireNonNull(columnWriterOptions, "columnWriterOptions is null");
+        this.dwrfEncryptor = requireNonNull(dwrfEncryptor, "dwrfEncryptor is null");
+        this.keyManager = getKeyManager(keyType, keyStatisticsBuilderSupplier);
         this.valueWriterFactory = requireNonNull(valueWriterFactory, "valueWriterFactory is null");
+
         this.compressed = columnWriterOptions.getCompressionKind() != NONE;
-        this.columnEncoding = new ColumnEncoding(DWRF_MAP_FLAT, 0); // TODO Use c'tor with additionalSequenceEncodings
         this.metadataWriter = new CompressedMetadataWriter(metadataWriter, columnWriterOptions, dwrfEncryptor);
+        this.presentStream = new PresentOutputStream(columnWriterOptions, dwrfEncryptor);
     }
 
     @Override
     public List<ColumnWriter> getNestedColumnWriters()
     {
-        // TODO: implement me
-        return ImmutableList.of();
+        ImmutableList.Builder<ColumnWriter> nestedWriters = ImmutableList.builderWithExpectedSize(valueWriters.size() * 2);
+        for (MapFlatValueWriter mapValueWriter : valueWriters) {
+            ColumnWriter valueWriter = mapValueWriter.getValueWriter();
+            nestedWriters.add(valueWriter);
+            nestedWriters.addAll(valueWriter.getNestedColumnWriters());
+        }
+        return nestedWriters.build();
     }
 
     @Override
     public Map<Integer, ColumnEncoding> getColumnEncodings()
     {
-        ImmutableMap.Builder<Integer, ColumnEncoding> encodings = ImmutableMap.builder();
-        encodings.put(column, columnEncoding);
-        // TODO: Add key/value encodings
-        return encodings.build();
+        return ImmutableMap.<Integer, ColumnEncoding>builder()
+                .put(nodeIndex, FLAT_MAP_COLUMN_ENCODING)
+                .putAll(getValueColumnEncodings())
+                .build();
+    }
+
+    private Map<Integer, ColumnEncoding> getValueColumnEncodings()
+    {
+        // Gather all sub encodings as nodeId -> Map<SequenceId, DwrfSequenceEncoding[dwrfKey, valueEncoding]>
+        Map<Integer, ImmutableSortedMap.Builder<Integer, DwrfSequenceEncoding>> sequenceEncodingsByNode = new HashMap<>();
+        for (MapFlatValueWriter valueWriter : valueWriters) {
+            DwrfProto.KeyInfo dwrfKey = valueWriter.getDwrfKey();
+            Integer sequence = valueWriter.getSequence();
+            Map<Integer, ColumnEncoding> valueEncodings = valueWriter.getValueWriter().getColumnEncodings();
+
+            valueEncodings.forEach((nodeIndex, valueEncoding) -> {
+                ImmutableSortedMap.Builder<Integer, DwrfSequenceEncoding> sequenceEncodings =
+                        sequenceEncodingsByNode.computeIfAbsent(nodeIndex, (ignore) -> ImmutableSortedMap.naturalOrder());
+                sequenceEncodings.put(sequence, new DwrfSequenceEncoding(dwrfKey, valueEncoding));
+            });
+        }
+
+        ImmutableMap.Builder<Integer, ColumnEncoding> columnEncoding = ImmutableMap.builder();
+
+        // Put a parent ColumnEncoding on top of all collected sub encodings.
+        // Kind of parent's ColumnEncodingKind doesn't matter, it will be ignored by the metadata writer.
+        sequenceEncodingsByNode.forEach((nodeIndex, sequenceEncodings) -> {
+            ColumnEncoding valueEncoding = new ColumnEncoding(DIRECT, 0, Optional.of(sequenceEncodings.build()));
+            columnEncoding.put(nodeIndex, valueEncoding);
+        });
+        return columnEncoding.build();
     }
 
     @Override
     public void beginRowGroup()
     {
-        // TODO: implement me
-    }
-
-    @Override
-    public long writeBlock(Block block)
-    {
-        checkState(!closed);
-        checkArgument(block.getPositionCount() > 0, "Block is empty");
-
-        ColumnarMap columnarMap = toColumnarMap(block);
-        return writeColumnarMap(columnarMap);
-    }
-
-    private long writeColumnarMap(ColumnarMap columnarMap)
-    {
-        // TODO: implement me
-        return 0;
+        presentStream.recordCheckpoint();
+        valueWriters.forEach(MapFlatValueWriter::beginRowGroup);
     }
 
     @Override
     public Map<Integer, ColumnStatistics> finishRowGroup()
     {
         checkState(!closed);
-        // TODO: implement me
-        return ImmutableMap.of();
-    }
 
-    @Override
-    public void close()
-    {
-        // TODO: implement me
-        closed = true;
+        // catch up on missing key before finishing the row group
+        for (int i = 0; i < valueWriters.size(); i++) {
+            if (valueWritersLastRow[i] < nonNullRowGroupValueCount) {
+                valueWriters.get(i).writeNotInMap(nonNullRowGroupValueCount - valueWritersLastRow[i]);
+            }
+        }
+        Arrays.fill(valueWritersLastRow, 0);
+
+        ColumnStatistics mapStats = new ColumnStatistics((long) nonNullRowGroupValueCount, null);
+        rowGroupColumnStatistics.add(mapStats);
+        rowsInFinishedRowGroups.add(nonNullRowGroupValueCount);
+        nonNullRowGroupValueCount = 0;
+
+        Map<Integer, ColumnStatistics> valueStats;
+        if (valueWriters.isEmpty()) {
+            valueStats = getEmptyValueColumnStatistics();
+        }
+        else {
+            valueStats = getValueColumnStatistics(ColumnWriter::finishRowGroup);
+        }
+
+        return ImmutableMap.<Integer, ColumnStatistics>builder()
+                .put(nodeIndex, mapStats)
+                .put(keyNodeIndex, keyManager.getRowGroupColumnStatistics())
+                .putAll(valueStats)
+                .build();
     }
 
     @Override
     public Map<Integer, ColumnStatistics> getColumnStripeStatistics()
     {
         checkState(closed);
-        // TODO: implement me
-        return ImmutableMap.of();
+
+        Map<Integer, ColumnStatistics> valueStats;
+        if (valueWriters.isEmpty()) {
+            valueStats = getEmptyValueColumnStatistics();
+        }
+        else {
+            valueStats = getValueColumnStatistics(ColumnWriter::getColumnStripeStatistics);
+        }
+        return ImmutableMap.<Integer, ColumnStatistics>builder()
+                .put(nodeIndex, mergeColumnStatistics(rowGroupColumnStatistics))
+                .put(keyNodeIndex, keyManager.getStripeColumnStatistics())
+                .putAll(valueStats)
+                .build();
+    }
+
+    // Create and cache value columnStripeStatistics for cases when the there are no value writers,
+    // but we still need to write valid column stripe statistics for all nested writers.
+    private Map<Integer, ColumnStatistics> getEmptyValueColumnStatistics()
+    {
+        if (emptyValueColumnStripeStatistics == null) {
+            ColumnWriter valueWriter = valueWriterFactory.apply(0);
+            valueWriter.close();
+            // stats are the same for row group and stripe
+            emptyValueColumnStripeStatistics = valueWriter.getColumnStripeStatistics();
+        }
+        return emptyValueColumnStripeStatistics;
+    }
+
+    private Map<Integer, ColumnStatistics> getValueColumnStatistics(Function<ColumnWriter, Map<Integer, ColumnStatistics>> getStats)
+    {
+        ImmutableListMultimap.Builder<Integer, ColumnStatistics> allValueStats = ImmutableListMultimap.builder();
+        for (MapFlatValueWriter valueWriter : valueWriters) {
+            Map<Integer, ColumnStatistics> valueColumnStatistic = getStats.apply(valueWriter.getValueWriter());
+            allValueStats.putAll(valueColumnStatistic.entrySet());
+        }
+
+        ImmutableMap.Builder<Integer, ColumnStatistics> columnStatistics = ImmutableMap.builder();
+        allValueStats.build().asMap().forEach((nodeIndex, nodeStats) -> {
+            ColumnStatistics mergedNodeStats = mergeColumnStatistics((List<ColumnStatistics>) nodeStats);
+            columnStatistics.put(nodeIndex, mergedNodeStats);
+        });
+
+        return columnStatistics.build();
+    }
+
+    @Override
+    public long writeBlock(Block block)
+    {
+        checkState(!closed);
+        checkArgument(block.getPositionCount() > 0, "block is empty");
+
+        ColumnarMap columnarMap = toColumnarMap(block);
+        Block keysBlock = columnarMap.getKeysBlock();
+        Block valuesBlock = columnarMap.getValuesBlock();
+
+        long childRawSize = 0;
+        int nonNullValueCountBefore = nonNullRowGroupValueCount;
+
+        // write key+value entries one by one
+        for (int position = 0; position < columnarMap.getPositionCount(); position++) {
+            boolean present = !columnarMap.isNull(position);
+            presentStream.writeBoolean(present);
+            if (present) {
+                int entryCount = columnarMap.getEntryCount(position);
+                int entryOffset = columnarMap.getOffset(position);
+                for (int i = 0; i < entryCount; i++) {
+                    childRawSize += writeMapKeyValue(keysBlock, valuesBlock, entryOffset + i);
+                }
+                nonNullRowGroupValueCount++;
+            }
+        }
+
+        // TODO Implement size reporting
+        int blockNonNullValueCount = nonNullRowGroupValueCount - nonNullValueCountBefore;
+        return (columnarMap.getPositionCount() - blockNonNullValueCount) * NULL_SIZE + childRawSize;
+    }
+
+    private long writeMapKeyValue(Block keysBlock, Block valuesBlock, int position)
+    {
+        checkArgument(!keysBlock.isNull(position), "Flat map key cannot be null. Node %s", nodeIndex);
+        MapFlatValueWriter valueWriter = keyManager.getOrCreateValueWriter(position, keysBlock);
+
+        // catch up value writer on missing rows
+        int valueWriterIdx = valueWriter.getSequence() - SEQUENCE_START_INDEX;
+        if (valueWritersLastRow[valueWriterIdx] < nonNullRowGroupValueCount) {
+            valueWriter.writeNotInMap(nonNullRowGroupValueCount - valueWritersLastRow[valueWriterIdx]);
+        }
+        valueWritersLastRow[valueWriterIdx] = nonNullRowGroupValueCount + 1;
+
+        Block singleValueBlock;
+        if (valuesBlock.isNull(position)) {
+            singleValueBlock = nullValueBlock;
+        }
+        else {
+            // TODO valueBlock.getRegion is really-really-really inefficient.
+            //  Options:
+            //  1. Create a new type of ColumnarMap optimized for flat maps;
+            //  2. Extend ColumnWriter to write block regions;
+            //  3. Write entries in batches using block.getPositions() to make it more efficient
+            //     and keep memory consumption in check.
+            singleValueBlock = valuesBlock.getRegion(position, 1);
+        }
+        return valueWriter.writeSingleEntryBlock(singleValueBlock);
+    }
+
+    @Override
+    public List<StreamDataOutput> getDataStreams()
+    {
+        checkState(closed);
+        ImmutableList.Builder<StreamDataOutput> streams = ImmutableList.builder();
+        for (MapFlatValueWriter valueWriter : valueWriters) {
+            streams.addAll(valueWriter.getDataStreams());
+        }
+        presentStream.getStreamDataOutput(nodeIndex, DEFAULT_SEQUENCE_ID).ifPresent(streams::add);
+        return streams.build();
     }
 
     @Override
@@ -135,36 +370,211 @@ public class MapFlatColumnWriter
             throws IOException
     {
         checkState(closed);
-        // TODO: implement me
-        return ImmutableList.of();
-    }
+        ImmutableList.Builder<StreamDataOutput> streams = ImmutableList.builder();
 
-    @Override
-    public List<StreamDataOutput> getDataStreams()
-    {
-        checkState(closed);
-        // TODO: implement me
-        return ImmutableList.of();
+        // add map node row indexes
+        List<RowGroupIndex> rowGroupIndexes = buildRowGroupIndexes(compressed, rowGroupColumnStatistics, prependCheckpoints, presentStream);
+        Slice slice = metadataWriter.writeRowIndexes(rowGroupIndexes);
+        Stream stream = new Stream(nodeIndex, DEFAULT_SEQUENCE_ID, ROW_INDEX, slice.length(), false);
+        streams.add(new StreamDataOutput(slice, stream));
+
+        // add index streams for value nodes
+        for (MapFlatValueWriter valueWriter : valueWriters) {
+            streams.addAll(valueWriter.getIndexStreams());
+        }
+        return streams.build();
     }
 
     @Override
     public long getBufferedBytes()
     {
-        // TODO: implement me
-        return 0;
+        long bufferedBytes = 0;
+        for (MapFlatValueWriter valueWriter : valueWriters) {
+            bufferedBytes += valueWriter.getValueWriter().getBufferedBytes();
+        }
+        // TODO Implement me
+        return bufferedBytes;
     }
 
     @Override
     public long getRetainedBytes()
     {
-        // TODO: implement me
-        return INSTANCE_SIZE;
+        long retainedBytes = 0;
+        for (MapFlatValueWriter valueWriter : valueWriters) {
+            retainedBytes += valueWriter.getValueWriter().getRetainedBytes();
+        }
+        // TODO Implement me
+        return INSTANCE_SIZE + retainedBytes;
+    }
+
+    @Override
+    public void close()
+    {
+        closed = true;
+        valueWriters.forEach(MapFlatValueWriter::close);
+        presentStream.close();
     }
 
     @Override
     public void reset()
     {
-        // TODO: implement me
         closed = false;
+        presentStream.reset();
+        keyManager.reset();
+        valueWriters.clear();
+        rowGroupColumnStatistics.clear();
+        rowsInFinishedRowGroups.clear();
+        nonNullRowGroupValueCount = 0;
+        Arrays.fill(valueWritersLastRow, 0);
+    }
+
+    private MapFlatValueWriter createNewValueWriter(DwrfProto.KeyInfo dwrfKey)
+    {
+        int valueWriterIdx = valueWriters.size();
+        int sequence = valueWriterIdx + SEQUENCE_START_INDEX;
+        ColumnWriter columnWriter = valueWriterFactory.apply(sequence);
+        MapFlatValueWriter valueWriter = new MapFlatValueWriter(valueNodeIndex, sequence, dwrfKey, columnWriter, columnWriterOptions, dwrfEncryptor);
+        valueWriters.add(valueWriter);
+        growCapacity();
+
+        // catch up on missing rows
+        valueWriter.writeNotInMap(rowsInFinishedRowGroups, nonNullRowGroupValueCount);
+        valueWritersLastRow[valueWriterIdx] = nonNullRowGroupValueCount + 1;
+
+        return valueWriter;
+    }
+
+    // Make sure the size of valueWritersLastRow is same or larger than the number of value writers
+    private void growCapacity()
+    {
+        if (valueWritersLastRow.length < valueWriters.size()) {
+            valueWritersLastRow = ensureCapacity(valueWritersLastRow, Math.max(MIN_CAPACITY, valueWriters.size()), MEDIUM, PRESERVE);
+        }
+    }
+
+    private static Block createNullValueBlock(Type valueType)
+    {
+        if (valueType instanceof FixedWidthType) {
+            FixedWidthType fixedWidthType = (FixedWidthType) valueType;
+            return fixedWidthType.createFixedSizeBlockBuilder(1).appendNull().build();
+        }
+        return valueType.createBlockBuilder(null, 1).appendNull().build();
+    }
+
+    private KeyManager getKeyManager(Type type, Supplier<StatisticsBuilder> statisticsBuilderSupplier)
+    {
+        if (type == BIGINT || type == INTEGER || type == SMALLINT || type == TINYINT) {
+            return new NumericKeyManager(statisticsBuilderSupplier);
+        }
+        else if (type instanceof VarcharType || type == VARBINARY) {
+            return new SliceKeyManager(statisticsBuilderSupplier);
+        }
+        throw new IllegalArgumentException("Unsupported flat map key type: " + type);
+    }
+
+    private abstract static class KeyManager<T extends Map<?, MapFlatValueWriter>>
+    {
+        protected StatisticsBuilder rowGroupStatsBuilder;
+        protected final T keyToWriter;
+        private final Supplier<StatisticsBuilder> statisticsBuilderSupplier;
+        private final List<ColumnStatistics> rowGroupColumnStatistics = new ArrayList<>();
+
+        public KeyManager(T keyToWriter, Supplier<StatisticsBuilder> statisticsBuilderSupplier)
+        {
+            this.keyToWriter = requireNonNull(keyToWriter, "keyToWriter is null");
+            this.statisticsBuilderSupplier = requireNonNull(statisticsBuilderSupplier, "statisticsBuilderSupplier is null");
+            this.rowGroupStatsBuilder = statisticsBuilderSupplier.get();
+        }
+
+        public abstract MapFlatValueWriter getOrCreateValueWriter(int position, Block keyBlock);
+
+        public ColumnStatistics getRowGroupColumnStatistics()
+        {
+            ColumnStatistics columnStatistics = rowGroupStatsBuilder.buildColumnStatistics();
+            rowGroupColumnStatistics.add(columnStatistics);
+            return columnStatistics;
+        }
+
+        public ColumnStatistics getStripeColumnStatistics()
+        {
+            return mergeColumnStatistics(rowGroupColumnStatistics);
+        }
+
+        public void reset()
+        {
+            keyToWriter.clear();
+            rowGroupColumnStatistics.clear();
+            rowGroupStatsBuilder = statisticsBuilderSupplier.get();
+        }
+    }
+
+    // Key manager for byte, short, int, long keys.
+    private class NumericKeyManager
+            extends KeyManager<Long2ObjectOpenHashMap<MapFlatValueWriter>>
+    {
+        public NumericKeyManager(Supplier<StatisticsBuilder> statisticsBuilderSupplier)
+        {
+            super(new Long2ObjectOpenHashMap<>(), statisticsBuilderSupplier);
+        }
+
+        @Override
+        public MapFlatValueWriter getOrCreateValueWriter(int position, Block keyBlock)
+        {
+            rowGroupStatsBuilder.addValue(keyType, keyBlock, position);
+
+            long key = keyType.getLong(keyBlock, position);
+            MapFlatValueWriter valueWriter = keyToWriter.get(key);
+            if (valueWriter == null) {
+                valueWriter = createNewValueWriter(createDwrfKey(key));
+                keyToWriter.put(key, valueWriter);
+            }
+            return valueWriter;
+        }
+
+        private DwrfProto.KeyInfo createDwrfKey(long key)
+        {
+            return DwrfProto.KeyInfo.newBuilder().setIntKey(key).build();
+        }
+    }
+
+    // Key manager for string and byte[] keys
+    private class SliceKeyManager
+            extends KeyManager<Map<Slice, MapFlatValueWriter>>
+    {
+        public SliceKeyManager(Supplier<StatisticsBuilder> statisticsBuilderSupplier)
+        {
+            super(new HashMap<>(), statisticsBuilderSupplier);
+        }
+
+        @Override
+        public MapFlatValueWriter getOrCreateValueWriter(int position, Block keyBlock)
+        {
+            rowGroupStatsBuilder.addValue(keyType, keyBlock, position);
+
+            Slice key = keyType.getSlice(keyBlock, position);
+            MapFlatValueWriter valueWriter = keyToWriter.get(key);
+            if (valueWriter == null) {
+                if (!key.isCompact()) {
+                    key = Slices.copyOf(key);
+                }
+                valueWriter = createNewValueWriter(createDwrfKey(key));
+                keyToWriter.put(key, valueWriter);
+            }
+            return valueWriter;
+        }
+
+        private DwrfProto.KeyInfo createDwrfKey(Slice key)
+        {
+            int sliceLength = key.length();
+            DwrfProto.KeyInfo dwrfKey;
+            if (sliceLength == 0) {
+                dwrfKey = EMPTY_SLICE_KEY;
+            }
+            else {
+                ByteString byteString = ByteString.copyFrom(key.getBytes(), 0, sliceLength);
+                dwrfKey = DwrfProto.KeyInfo.newBuilder().setBytesKey(byteString).build();
+            }
+            return dwrfKey;
+        }
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/MapFlatKeyWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/MapFlatKeyWriter.java
@@ -1,0 +1,5 @@
+package com.facebook.presto.orc.writer;
+
+public class MapFlatKeyWriter
+{
+}

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/MapFlatKeyWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/MapFlatKeyWriter.java
@@ -1,5 +1,0 @@
-package com.facebook.presto.orc.writer;
-
-public class MapFlatKeyWriter
-{
-}

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/MapFlatValueWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/MapFlatValueWriter.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.writer;
+
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.orc.ColumnWriterOptions;
+import com.facebook.presto.orc.DwrfDataEncryptor;
+import com.facebook.presto.orc.proto.DwrfProto;
+import com.facebook.presto.orc.stream.InMapOutputStream;
+import com.facebook.presto.orc.stream.StreamDataOutput;
+import com.google.common.collect.ImmutableList;
+import it.unimi.dsi.fastutil.ints.IntList;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Holds flat map value writer for a certain sequence/key.
+ */
+class MapFlatValueWriter
+{
+    private final int nodeIndex;
+    private final int sequence;
+    private final ColumnWriter valueWriter;
+    private final DwrfProto.KeyInfo dwrfKey;
+    private final InMapOutputStream inMapStream;
+
+    public MapFlatValueWriter(
+            int nodeIndex,
+            int sequence,
+            DwrfProto.KeyInfo dwrfKey,
+            ColumnWriter valueWriter,
+            ColumnWriterOptions columnWriterOptions,
+            Optional<DwrfDataEncryptor> dwrfEncryptor)
+    {
+        checkArgument(nodeIndex > 0, "nodeIndex is invalid: %s", nodeIndex);
+        checkArgument(sequence > 0, "sequence must be positive: %s", sequence);
+        requireNonNull(columnWriterOptions, "columnWriterOptions is null");
+        requireNonNull(dwrfEncryptor, "dwrfEncryptor is null");
+
+        this.nodeIndex = nodeIndex;
+        this.sequence = sequence;
+        this.dwrfKey = requireNonNull(dwrfKey, "dwrfKey is null");
+        this.valueWriter = requireNonNull(valueWriter, "valueWriter is null");
+        this.inMapStream = new InMapOutputStream(columnWriterOptions, dwrfEncryptor);
+    }
+
+    public int getSequence()
+    {
+        return sequence;
+    }
+
+    public ColumnWriter getValueWriter()
+    {
+        return valueWriter;
+    }
+
+    public DwrfProto.KeyInfo getDwrfKey()
+    {
+        return dwrfKey;
+    }
+
+    public void beginRowGroup()
+    {
+        inMapStream.recordCheckpoint();
+        valueWriter.beginRowGroup();
+    }
+
+    public long writeSingleEntryBlock(Block block)
+    {
+        // TODO: Implement correct size
+        long size = valueWriter.writeBlock(block);
+        inMapStream.writeBoolean(true);
+        return size;
+    }
+
+    /**
+     * Mark a row for this key as missing.
+     */
+    public long writeNotInMap(int count)
+    {
+        // TODO: Implement correct size
+        inMapStream.writeBooleans(count, false);
+        return count;
+    }
+
+    /**
+     * Catch up on the `not-in-map` rows.
+     */
+    public void writeNotInMap(IntList rowsInFinishedRowGroups, int rowsInCurrentRowGroup)
+    {
+        for (int i = 0; i < rowsInFinishedRowGroups.size(); i++) {
+            beginRowGroup();
+            int rows = rowsInFinishedRowGroups.getInt(i);
+            inMapStream.writeBooleans(rows, false);
+            valueWriter.finishRowGroup();
+        }
+
+        beginRowGroup();
+        if (rowsInCurrentRowGroup > 0) {
+            inMapStream.writeBooleans(rowsInCurrentRowGroup, false);
+        }
+    }
+
+    public List<StreamDataOutput> getDataStreams()
+    {
+        return ImmutableList.<StreamDataOutput>builder()
+                .add(inMapStream.getStreamDataOutput(nodeIndex, sequence))
+                .addAll(valueWriter.getDataStreams())
+                .build();
+    }
+
+    public List<StreamDataOutput> getIndexStreams()
+            throws IOException
+    {
+        return valueWriter.getIndexStreams(Optional.of(inMapStream.getCheckpoints()));
+    }
+
+    public void close()
+    {
+        inMapStream.close();
+        valueWriter.close();
+    }
+}

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestFlatMapWriter.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestFlatMapWriter.java
@@ -1,0 +1,220 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc;
+
+import com.facebook.presto.common.type.SqlVarbinary;
+import com.facebook.presto.common.type.Type;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Random;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.BooleanType.BOOLEAN;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.common.type.RealType.REAL;
+import static com.facebook.presto.common.type.SmallintType.SMALLINT;
+import static com.facebook.presto.common.type.TinyintType.TINYINT;
+import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.orc.OrcTester.arrayType;
+import static com.facebook.presto.orc.OrcTester.mapType;
+import static com.facebook.presto.orc.OrcTester.rowType;
+import static com.google.common.collect.Iterables.cycle;
+import static com.google.common.collect.Iterables.limit;
+import static com.google.common.collect.Lists.newArrayList;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.expectThrows;
+
+public class TestFlatMapWriter
+{
+    // Number of rows should be larger than DEFAULT_ROW_GROUP_MAX_ROW_COUNT=10_000 to write multiple row groups
+    private static final int ROWS = 50_000;
+    private static final Map<?, ?> EMPTY_MAP = ImmutableMap.of();
+
+    @Test
+    public void testComplexValueType()
+            throws Exception
+    {
+        runTest(mapType(INTEGER, arrayType(INTEGER)),
+                1, 2, 3,
+                ImmutableList.of(1, 2), ImmutableList.of(3), ImmutableList.of(4, 5), ImmutableList.of(6), ImmutableList.of(9, 10));
+
+        runTest(mapType(INTEGER, rowType(INTEGER, VARCHAR)),
+                1, 2, 3,
+                ImmutableList.of(10, "20"), ImmutableList.of(11, "22"), ImmutableList.of(12, "23"), ImmutableList.of(13, "24"), ImmutableList.of(14, "25"));
+
+        runTest(mapType(INTEGER, mapType(INTEGER, VARCHAR)),
+                1, 2, 3,
+                ImmutableMap.of(10, "20"), ImmutableMap.of(11, "22"), ImmutableMap.of(12, "23"), ImmutableMap.of(13, "24"), ImmutableMap.of(14, "25"));
+
+        // do one deeply nested value type
+        runTest(mapType(INTEGER, arrayType(arrayType(INTEGER))),
+                1, 2, 3,
+                ImmutableList.of(ImmutableList.of(1, 2)),
+                ImmutableList.of(ImmutableList.of(3), ImmutableList.of(33)),
+                ImmutableList.of(ImmutableList.of(4, 5), ImmutableList.of(44, 55)),
+                ImmutableList.of(ImmutableList.of(6)),
+                ImmutableList.of(ImmutableList.of(9, 10)));
+    }
+
+    @Test
+    public void testByteKey()
+            throws Exception
+    {
+        runTest(mapType(TINYINT, INTEGER),
+                (byte) 1, (byte) 2, (byte) 3,
+                10, 11, 12, 13, 14);
+    }
+
+    @Test
+    public void testShortKey()
+            throws Exception
+    {
+        runTest(mapType(SMALLINT, INTEGER),
+                (short) 1, (short) 2, (short) 3,
+                10, 11, 12, 13, 14);
+    }
+
+    @Test
+    public void testIntKey()
+            throws Exception
+    {
+        runTest(mapType(INTEGER, INTEGER),
+                1, 2, 3,
+                10, 11, 12, 13, 14);
+    }
+
+    @Test
+    public void testLongKey()
+            throws Exception
+    {
+        runTest(mapType(BIGINT, INTEGER),
+                1L, 2L, 3L,
+                10, 11, 12, 13, 14);
+    }
+
+    @Test
+    public void testStringKey()
+            throws Exception
+    {
+        runTest(mapType(VARCHAR, INTEGER),
+                "k1", "k2", "3",
+                10, 11, 12, 13, 14);
+    }
+
+    @Test
+    public void testVarbinaryKey()
+            throws Exception
+    {
+        runTest(mapType(VARBINARY, VARCHAR),
+                new SqlVarbinary("k1".getBytes(UTF_8)), new SqlVarbinary("k2".getBytes(UTF_8)), new SqlVarbinary("k3".getBytes(UTF_8)),
+                "10", "11", "12", "13", "14");
+    }
+
+    @Test
+    public void testNullKeyUnsupported()
+    {
+        OrcTester tester = OrcTester.quickDwrfFlatMapTester();
+        Map<?, ?> nullKeyMap = new HashMap<>();
+        nullKeyMap.put(null, null);
+
+        IllegalStateException ex = expectThrows(IllegalStateException.class, () -> tester.testRoundTrip(mapType(INTEGER, INTEGER), newArrayList(nullKeyMap)));
+        assertEquals(ex.getMessage(), "Map key is null at position: 0");
+    }
+
+    @Test
+    public void testUnsupportedKeyType()
+    {
+        OrcTester tester = OrcTester.quickDwrfFlatMapTester();
+        for (Type keyType : ImmutableList.of(BOOLEAN, REAL, DOUBLE, mapType(INTEGER, INTEGER), arrayType(INTEGER), rowType(INTEGER))) {
+            expectThrows(IllegalArgumentException.class, () -> tester.testRoundTrip(mapType(keyType, INTEGER), newArrayList(EMPTY_MAP)));
+        }
+    }
+
+    @Test
+    public void testMixedNullMapAndEmptyMap()
+            throws Exception
+    {
+        Type mapType = mapType(INTEGER, DOUBLE);
+        OrcTester tester = OrcTester.quickDwrfFlatMapTester();
+
+        tester.testRoundTrip(mapType, newArrayList(limit(cycle((Map) null), ROWS)));
+        tester.testRoundTrip(mapType, newArrayList(limit(cycle((Map) null, EMPTY_MAP), ROWS)));
+        tester.testRoundTrip(mapType, newArrayList(limit(cycle(EMPTY_MAP, (Map) null), ROWS)));
+    }
+
+    private static <K, V> void runTest(Type mapType, K key1, K key2, K key3, V value1, V value2, V value3, V value4, V value5)
+            throws Exception
+    {
+        OrcTester tester = OrcTester.quickDwrfFlatMapTester();
+        Map<K, ?> nullValue = new HashMap<>();
+        nullValue.put(key1, null);
+
+        Map<K, V> map1 = ImmutableMap.of(key1, value1);
+        Map<K, V> map2 = ImmutableMap.of(key1, value2);
+        Map<K, V> map3 = ImmutableMap.of(key2, value3);
+        Map<K, V> map4 = ImmutableMap.of(key3, value4);
+        Map<K, V> map5 = ImmutableMap.of(key1, value5, key2, value4, key3, value2);
+
+        // empty and null value maps
+        tester.testRoundTrip(mapType, newArrayList(limit(cycle(EMPTY_MAP), ROWS)));
+        tester.testRoundTrip(mapType, newArrayList(limit(cycle(nullValue), ROWS)));
+        tester.testRoundTrip(mapType, newArrayList(limit(cycle(nullValue, EMPTY_MAP), ROWS)));
+        tester.testRoundTrip(mapType, newArrayList(limit(cycle(EMPTY_MAP, nullValue), ROWS)));
+
+        // same keys
+        tester.testRoundTrip(mapType, newArrayList(limit(cycle(map1, map2), ROWS)));
+        tester.testRoundTrip(mapType, newArrayList(limit(cycle(map1, map2, EMPTY_MAP), ROWS)));
+        tester.testRoundTrip(mapType, newArrayList(limit(cycle(map5, EMPTY_MAP), ROWS)));
+        tester.testRoundTrip(mapType, newArrayList(limit(cycle(map1, map2, nullValue), ROWS)));
+        tester.testRoundTrip(mapType, newArrayList(limit(cycle(map1, map2, nullValue, EMPTY_MAP), ROWS)));
+
+        // zig-zag keys
+        tester.testRoundTrip(mapType, newArrayList(limit(cycle(map1, map3, map4, map5), ROWS)));
+        tester.testRoundTrip(mapType, newArrayList(limit(cycle(map1, map3, map4, map5, EMPTY_MAP), ROWS)));
+        tester.testRoundTrip(mapType, newArrayList(limit(cycle(map1, map3, map4, map5, nullValue), ROWS)));
+        tester.testRoundTrip(mapType, newArrayList(limit(cycle(map1, map3, map4, map5, nullValue, EMPTY_MAP), ROWS)));
+
+        // randomize keys
+        tester.testRoundTrip(mapType, newArrayList(limit(random(map1, map2, map3, map4, map5, nullValue, EMPTY_MAP), ROWS)));
+    }
+
+    private static <T> Iterable<T> random(T... elements)
+    {
+        Random rnd = new Random(LocalDate.now().toEpochDay());
+        Iterator<T> iterator = new Iterator<T>()
+        {
+            @Override
+            public boolean hasNext()
+            {
+                return true;
+            }
+
+            @Override
+            public T next()
+            {
+                return elements[rnd.nextInt(elements.length)];
+            }
+        };
+        return () -> iterator;
+    }
+}


### PR DESCRIPTION
This change adds fully working initial implementation of the flat map column writer.

What's included in this PR:
* fully working and tested implementation
* content verification tests
* working column stats

What doesn't work and will be added in the follow up PRs, ordered by priority:
1. selective reader validation is disabled because I found a rare bug (😱) in the reader
2. writer validation is disabled because it's not compatible with flat map streams, stats, etc. Row group stats validation fails because stats needs to be reconstructed from ROW_INDEX and also missing columns should be taken into account. 
3. Figure out a better way to write values instead if creating a region for every value, it's the number one performance killer atm.
4. Disable dictionary encoding for the value writers.
5. Update StatsBuilders to be able to create empty stripe stats without creating entire value writer graph just for the empty stats
6. writer data size reporting is broken
7. writer retained memory size is broken
8. max keys limit will be added later
9. new map stats will be added later
10. wiring into hive connector is under a question
11. OrcTester has poor coverage of complex types, I'll improve it later.
12. Switch byte stats from generic stats to Integer stats

Test plan:
- added new tests
- Vader validation with 500 tables/11k files flat map enabled tables with Velox and BBIO cross validation

```
== NO RELEASE NOTE ==
```
