### PR TITLE
Remove transitionToRunning on Stage schedulingComplete()

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlStageExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlStageExecution.java
@@ -286,9 +286,6 @@ public final class SqlStageExecution
             return;
         }
 
-        if (getAllTasks().stream().anyMatch(task -> getState() == StageExecutionState.RUNNING)) {
-            stateMachine.transitionToRunning();
-        }
         if (finishedTasks.size() == allTasks.size()) {
             stateMachine.transitionToFinished();
         }


### PR DESCRIPTION
The origin is `dead` code, since the check condition for each
task used SqlStageExecution#getState().
The stage could never lead to RUNNING by this condition.

We remove it because it is safe and can reduce the task iteration
checks and code is clear(there is only one point to RUNNING)

Cherry-pick of https://github.com/trinodb/trino/pull/9004

Co-authored-by: guhanjie <guhanjiehao@163.com>

Test plan - no tests added

```
== NO RELEASE NOTE ==
```
