### PR TITLE
Add to_base32 and from_base32 varbinary functions

### DIFF
--- a/presto-docs/src/main/sphinx/functions/binary.rst
+++ b/presto-docs/src/main/sphinx/functions/binary.rst
@@ -53,6 +53,14 @@ Binary Functions
 
     Decodes binary data from the base64 encoded ``string`` using the URL safe alphabet.
 
+.. function:: from_base32(string) -> varbinary
+
+    Decodes binary data from the base32 encoded ``string``.
+
+.. function:: to_base32(binary) -> varchar
+
+    Encodes ``binary`` into a base32 string representation.
+
 .. function:: to_hex(binary) -> varchar
 
     Encodes ``binary`` into a hex string representation.

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/VarbinaryFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/VarbinaryFunctions.java
@@ -132,6 +132,53 @@ public final class VarbinaryFunctions
         }
     }
 
+    @Description("Encode binary data as base32")
+    @ScalarFunction
+    @SqlType(StandardTypes.VARCHAR)
+    public static Slice toBase32(@SqlType(StandardTypes.VARBINARY) Slice slice)
+    {
+        String encoded;
+        if (slice.hasByteArray()) {
+            encoded = BaseEncoding.base32().encode(slice.byteArray(), slice.byteArrayOffset(), slice.length());
+        }
+        else {
+            encoded = BaseEncoding.base32().encode(slice.getBytes());
+        }
+        return Slices.utf8Slice(encoded);
+    }
+
+    @Description("Decode base32 encoded binary data")
+    @ScalarFunction("from_base32")
+    @LiteralParameters("x")
+    @SqlType(StandardTypes.VARBINARY)
+    public static Slice fromBase32Varchar(@SqlType("varchar(x)") Slice slice)
+    {
+        return decodeBase32(slice);
+    }
+
+    @Description("Decode base32 encoded binary data")
+    @ScalarFunction("from_base32")
+    @SqlType(StandardTypes.VARBINARY)
+    public static Slice fromBase32Varbinary(@SqlType(StandardTypes.VARBINARY) Slice slice)
+    {
+        return decodeBase32(slice);
+    }
+
+    private static Slice decodeBase32(Slice slice)
+    {
+        try {
+            return Slices.wrappedBuffer(BaseEncoding.base32().decode(slice.toStringUtf8()));
+        }
+        catch (IllegalArgumentException e) {
+            // Get cause because the root exception contains the package name in the message:
+            // com.google.common.io.BaseEncoding$DecodingException: Invalid input length 1
+            if (e.getCause() instanceof BaseEncoding.DecodingException) {
+                throw new PrestoException(INVALID_FUNCTION_ARGUMENT, e.getCause().getMessage(), e);
+            }
+            throw new PrestoException(INVALID_FUNCTION_ARGUMENT, e);
+        }
+    }
+
     @Description("encode binary data as hex")
     @ScalarFunction
     @SqlType(StandardTypes.VARCHAR)

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestVarbinaryFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestVarbinaryFunctions.java
@@ -16,6 +16,7 @@ package com.facebook.presto.operator.scalar;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.type.SqlVarbinary;
 import com.facebook.presto.type.VarbinaryOperators;
+import com.google.common.io.BaseEncoding;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
 import org.testng.annotations.Test;
@@ -137,6 +138,43 @@ public class TestVarbinaryFunctions
         assertFunction("from_base64url(CAST(to_base64url(CAST('a' AS VARBINARY)) AS VARBINARY))", VARBINARY, sqlVarbinary("a"));
         assertFunction("from_base64url(CAST(to_base64url(CAST('abc' AS VARBINARY)) AS VARBINARY))", VARBINARY, sqlVarbinary("abc"));
         assertFunction(format("to_base64url(from_base64url('%s'))", encodeBase64Url(ALL_BYTES)), VARCHAR, encodeBase64Url(ALL_BYTES));
+    }
+
+    @Test
+    public void testToBase32()
+    {
+        assertFunction("to_base32(CAST('' AS VARBINARY))", VARCHAR, encodeBase32(""));
+        assertFunction("to_base32(CAST('a' AS VARBINARY))", VARCHAR, encodeBase32("a"));
+        assertFunction("to_base32(CAST('abc' AS VARBINARY))", VARCHAR, encodeBase32("abc"));
+        assertFunction("to_base32(CAST('hello world' AS VARBINARY))", VARCHAR, "NBSWY3DPEB3W64TMMQ======");
+        assertFunction("to_base32(NULL)", VARCHAR, null);
+    }
+
+    @Test
+    public void testFromBase32()
+    {
+        assertFunction("from_base32('')", VARBINARY, sqlVarbinary(""));
+        assertFunction("from_base32('ME======')", VARBINARY, sqlVarbinary("a"));
+        assertFunction("from_base32('MFRGG===')", VARBINARY, sqlVarbinary("abc"));
+        assertFunction("from_base32('NBSWY3DPEB3W64TMMQ======')", VARBINARY, sqlVarbinary("hello world"));
+
+        assertFunction("from_base32(to_base32(CAST('' AS VARBINARY)))", VARBINARY, sqlVarbinary(""));
+        assertFunction("from_base32(to_base32(CAST('a' AS VARBINARY)))", VARBINARY, sqlVarbinary("a"));
+        assertFunction("from_base32(to_base32(CAST('abc' AS VARBINARY)))", VARBINARY, sqlVarbinary("abc"));
+        assertFunction("from_base32(to_base32(CAST('hello world' AS VARBINARY)))", VARBINARY, sqlVarbinary("hello world"));
+        assertFunction("from_base32(CAST(to_base32(CAST('' AS VARBINARY)) AS VARBINARY))", VARBINARY, sqlVarbinary(""));
+        assertFunction("from_base32(CAST(to_base32(CAST('a' AS VARBINARY)) AS VARBINARY))", VARBINARY, sqlVarbinary("a"));
+        assertFunction("from_base32(CAST(to_base32(CAST('abc' AS VARBINARY)) AS VARBINARY))", VARBINARY, sqlVarbinary("abc"));
+        assertFunction("from_base32(CAST(to_base32(CAST('hello world' AS VARBINARY)) AS VARBINARY))", VARBINARY, sqlVarbinary("hello world"));
+        assertFunction(format("to_base32(from_base32('%s'))", encodeBase32(ALL_BYTES)), VARCHAR, encodeBase32(ALL_BYTES));
+
+        assertFunction("from_base32(CAST(NULL AS VARCHAR))", VARBINARY, null);
+        assertFunction("from_base32(CAST(NULL AS VARBINARY))", VARBINARY, null);
+
+        assertInvalidFunction("from_base32('1=')", "Invalid input length 1");
+        assertInvalidFunction("from_base32('M1======')", "Unrecognized character: 1");
+        assertInvalidFunction("from_base32(CAST('1=' AS VARBINARY))", "Invalid input length 1");
+        assertInvalidFunction("from_base32(CAST('M1======' AS VARBINARY))", "Unrecognized character: 1");
     }
 
     @Test
@@ -488,6 +526,16 @@ public class TestVarbinaryFunctions
     private static String encodeBase64Url(String value)
     {
         return encodeBase64Url(value.getBytes(UTF_8));
+    }
+
+    private static String encodeBase32(String value)
+    {
+        return encodeBase32(value.getBytes(UTF_8));
+    }
+
+    private static String encodeBase32(byte[] value)
+    {
+        return BaseEncoding.base32().encode(value);
     }
 
     private static String encodeHex(String value)


### PR DESCRIPTION
Cherry-pick of https://github.com/trinodb/trino/pull/11439

Co-authored-by: Yuya Ebihara <ebyhry@gmail.com>

Test plan - Added a test

```
== RELEASE NOTES ==

General Changes
* Add `to_base32` and `from_base32` varbinary functions

```
