### PR TITLE
Minor fixes for presto-orc

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
@@ -60,13 +60,13 @@ import javax.annotation.Nullable;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.OptionalLong;
-import java.util.TreeSet;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -859,13 +859,15 @@ public class OrcWriter
         if (expectedSize == 0) {
             return ImmutableList.of();
         }
-        ArrayList<T> list = new ArrayList<>(expectedSize);
-        TreeSet<Integer> sortedKeys = new TreeSet<>();
-        sortedKeys.addAll(data.keySet());
+
+        List<Integer> sortedKeys = new ArrayList<>(data.keySet());
+        Collections.sort(sortedKeys);
+
+        ImmutableList.Builder<T> denseList = ImmutableList.builderWithExpectedSize(expectedSize);
         for (Integer key : sortedKeys) {
-            list.add(data.get(key));
+            denseList.add(data.get(key));
         }
-        return ImmutableList.copyOf(list);
+        return denseList.build();
     }
 
     private static List<ColumnStatistics> toFileStats(List<List<ColumnStatistics>> stripes)

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcType.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcType.java
@@ -44,6 +44,7 @@ import static com.facebook.presto.common.type.TinyintType.TINYINT;
 import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
 import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -311,15 +312,11 @@ public class OrcType
             return ImmutableSet.of();
         }
 
-        ImmutableSet.Builder<Integer> nodes = ImmutableSet.builder();
         OrcType rootType = orcTypes.get(0);
-
-        for (int columnIndex = 0; columnIndex < rootType.getFieldCount(); columnIndex++) {
-            if (columnIndexes.contains(columnIndex)) {
-                int nodeIndex = rootType.getFieldTypeIndex(columnIndex);
-                nodes.add(nodeIndex);
-            }
-        }
-        return nodes.build();
+        int fieldCount = rootType.getFieldCount();
+        return columnIndexes.stream()
+                .filter(columnIndex -> columnIndex < fieldCount)
+                .map(rootType::getFieldTypeIndex)
+                .collect(toImmutableSet());
     }
 }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestSelectiveOrcReader.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestSelectiveOrcReader.java
@@ -1081,7 +1081,6 @@ public class TestSelectiveOrcReader
         int rowCount = 10000;
         int longStringLength = 5000;
         Random random = new Random();
-        long start = System.currentTimeMillis();
         for (int i = 0; i < rowCount; ++i) {
             if (i < MAX_BATCH_SIZE) {
                 StringBuilder builder = new StringBuilder();
@@ -1094,7 +1093,7 @@ public class TestSelectiveOrcReader
                 values.add("");
             }
         }
-        System.out.println(System.currentTimeMillis() - start);
+
         writeOrcColumnsPresto(tempFile.getFile(), DWRF, NONE, Optional.empty(), types, ImmutableList.of(values), new OrcWriterStats());
 
         try (OrcSelectiveRecordReader recordReader = createCustomOrcSelectiveRecordReader(tempFile, OrcEncoding.DWRF, OrcPredicate.TRUE, type, MAX_BATCH_SIZE, false, false)) {
@@ -1128,8 +1127,7 @@ public class TestSelectiveOrcReader
     public void testHiddenConstantColumns()
             throws Exception
     {
-        Type type = BIGINT;
-        List<Type> types = ImmutableList.of(type);
+        List<Type> types = ImmutableList.of(BIGINT);
         List<List<?>> values = ImmutableList.of(ImmutableList.of(1L, 2L));
 
         TempFile tempFile = new TempFile();


### PR DESCRIPTION
Some minor fixes:
- follow up on mapColumnToNode to improve iteration
- more memory efficient sorting in OrcWriter.toDenseList
- removed printing time in a unit test

Test plan:
- existing tests

```
== NO RELEASE NOTE ==
```
