### PR TITLE
Add partial support for flat map stuff to DwrfMetadataWriter

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfMetadataWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfMetadataWriter.java
@@ -297,7 +297,8 @@ public class DwrfMetadataWriter
         return streamBuilder.build();
     }
 
-    private static DwrfProto.Stream.Kind toStreamKind(StreamKind streamKind)
+    @VisibleForTesting
+    static DwrfProto.Stream.Kind toStreamKind(StreamKind streamKind)
     {
         switch (streamKind) {
             case PRESENT:
@@ -314,6 +315,8 @@ public class DwrfMetadataWriter
                 return DwrfProto.Stream.Kind.DICTIONARY_COUNT;
             case ROW_INDEX:
                 return DwrfProto.Stream.Kind.ROW_INDEX;
+            case IN_MAP:
+                return DwrfProto.Stream.Kind.IN_MAP;
         }
         throw new IllegalArgumentException("Unsupported stream kind: " + streamKind);
     }
@@ -339,6 +342,8 @@ public class DwrfMetadataWriter
                 return DwrfProto.ColumnEncoding.Kind.DIRECT;
             case DICTIONARY:
                 return DwrfProto.ColumnEncoding.Kind.DICTIONARY;
+            case DWRF_MAP_FLAT:
+                return DwrfProto.ColumnEncoding.Kind.MAP_FLAT;
         }
         throw new IllegalArgumentException("Unsupported column encoding kind: " + columnEncodingKind);
     }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/metadata/TestDwrfMetadataWriter.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/metadata/TestDwrfMetadataWriter.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.metadata;
+
+import com.facebook.presto.orc.proto.DwrfProto;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.orc.metadata.ColumnEncoding.ColumnEncodingKind.DICTIONARY;
+import static com.facebook.presto.orc.metadata.ColumnEncoding.ColumnEncodingKind.DIRECT;
+import static com.facebook.presto.orc.metadata.ColumnEncoding.ColumnEncodingKind.DWRF_MAP_FLAT;
+import static com.facebook.presto.orc.metadata.DwrfMetadataWriter.toColumnEncoding;
+import static com.facebook.presto.orc.metadata.DwrfMetadataWriter.toStreamKind;
+import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
+import static com.facebook.presto.orc.metadata.Stream.StreamKind.DICTIONARY_COUNT;
+import static com.facebook.presto.orc.metadata.Stream.StreamKind.DICTIONARY_DATA;
+import static com.facebook.presto.orc.metadata.Stream.StreamKind.IN_MAP;
+import static com.facebook.presto.orc.metadata.Stream.StreamKind.LENGTH;
+import static com.facebook.presto.orc.metadata.Stream.StreamKind.PRESENT;
+import static com.facebook.presto.orc.metadata.Stream.StreamKind.ROW_INDEX;
+import static com.facebook.presto.orc.metadata.Stream.StreamKind.SECONDARY;
+import static org.testng.Assert.assertEquals;
+
+public class TestDwrfMetadataWriter
+{
+    private static final int COLUMN_ID = 3;
+
+    @Test
+    public void testToColumnEncodingDirect()
+    {
+        int expectedDictionarySize = 0;
+        ColumnEncoding columnEncoding = new ColumnEncoding(DIRECT, expectedDictionarySize);
+
+        DwrfProto.ColumnEncoding actual = toColumnEncoding(COLUMN_ID, columnEncoding);
+
+        assertEquals(actual.getColumn(), COLUMN_ID);
+        assertEquals(actual.getKind(), DwrfProto.ColumnEncoding.Kind.DIRECT);
+        assertEquals(actual.getDictionarySize(), expectedDictionarySize);
+        assertEquals(actual.getSequence(), 0);
+    }
+
+    @Test
+    public void testToColumnEncodingDictionary()
+    {
+        int expectedDictionarySize = 5;
+        ColumnEncoding columnEncoding = new ColumnEncoding(DICTIONARY, expectedDictionarySize);
+
+        DwrfProto.ColumnEncoding actual = toColumnEncoding(COLUMN_ID, columnEncoding);
+
+        assertEquals(actual.getColumn(), COLUMN_ID);
+        assertEquals(actual.getKind(), DwrfProto.ColumnEncoding.Kind.DICTIONARY);
+        assertEquals(actual.getDictionarySize(), expectedDictionarySize);
+        assertEquals(actual.getSequence(), 0);
+    }
+
+    @Test
+    public void testToColumnEncodingFlatMap()
+    {
+        int expectedDictionarySize = 0;
+        ColumnEncoding columnEncoding = new ColumnEncoding(DWRF_MAP_FLAT, expectedDictionarySize);
+
+        DwrfProto.ColumnEncoding actual = toColumnEncoding(COLUMN_ID, columnEncoding);
+
+        assertEquals(actual.getColumn(), COLUMN_ID);
+        assertEquals(actual.getKind(), DwrfProto.ColumnEncoding.Kind.MAP_FLAT);
+        assertEquals(actual.getDictionarySize(), expectedDictionarySize);
+        assertEquals(actual.getSequence(), 0);
+    }
+
+    @Test
+    public void testToStreamKind()
+    {
+        assertEquals(toStreamKind(PRESENT), DwrfProto.Stream.Kind.PRESENT);
+        assertEquals(toStreamKind(IN_MAP), DwrfProto.Stream.Kind.IN_MAP);
+        assertEquals(toStreamKind(DATA), DwrfProto.Stream.Kind.DATA);
+        assertEquals(toStreamKind(SECONDARY), DwrfProto.Stream.Kind.NANO_DATA);
+        assertEquals(toStreamKind(LENGTH), DwrfProto.Stream.Kind.LENGTH);
+        assertEquals(toStreamKind(DICTIONARY_DATA), DwrfProto.Stream.Kind.DICTIONARY_DATA);
+        assertEquals(toStreamKind(DICTIONARY_COUNT), DwrfProto.Stream.Kind.DICTIONARY_COUNT);
+        assertEquals(toStreamKind(ROW_INDEX), DwrfProto.Stream.Kind.ROW_INDEX);
+    }
+}


### PR DESCRIPTION
Allow converting IN_MAP stream kind and DWRF_MAP_FLAT column encoding from Presto domain model to DWRF proto.

This change doesn't add support for converting sequences and stream keys. I'll add it later in a follow up PR.

Test plan:
- added new tests

```
== NO RELEASE NOTE ==
```
