### PR TITLE
Fix checkState param placeholders in ColumnEncoding

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/ColumnEncoding.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/ColumnEncoding.java
@@ -81,13 +81,13 @@ public class ColumnEncoding
 
         checkState(
                 additionalSequenceEncodings.isPresent(),
-                "Got non-zero sequence: %d, but there are no additional sequence encodings: %s", sequence, this);
+                "Got non-zero sequence: %s, but there are no additional sequence encodings: %s", sequence, this);
 
         DwrfSequenceEncoding sequenceEncoding = additionalSequenceEncodings.get().get(sequence);
 
         checkState(
                 sequenceEncoding != null,
-                "Non-zero sequence %d is not present in the ColumnEncoding's additional sequences: %s",
+                "Non-zero sequence %s is not present in the ColumnEncoding's additional sequences: %s",
                 sequence,
                 additionalSequenceEncodings.get().keySet());
 


### PR DESCRIPTION
Guava's Preconditions only supports `%s` placeholder, it doesn't use String.format so usage of `%d` placeholders is incorrect.

Test plan:
- existing tests

```
== NO RELEASE NOTE ==
```
