### PR TITLE
Fix configuration used in CachingJobConf

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/cache/HiveCachingHdfsConfiguration.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/cache/HiveCachingHdfsConfiguration.java
@@ -103,7 +103,7 @@ public class HiveCachingHdfsConfiguration
         @Override
         public FileSystem createFileSystem(URI uri)
         {
-            return factory.apply(getConfig(), uri);
+            return factory.apply(this, uri);
         }
     }
 }


### PR DESCRIPTION
With recent changes in #17625, the configuration instance used inside
CachingJobConf for creating a filesystem has been changed from
CachingJobConf to CopyOnWriteConfiguration. This commit fixes it
to use CachingJobConf during filesystem creation.

Test plan - (Please fill in how you tested your changes)


```
== NO RELEASE NOTE ==
```
