### PR TITLE
Additional property in HiveDirectoryContext

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveDirectoryContext.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveDirectoryContext.java
@@ -13,17 +13,23 @@
  */
 package com.facebook.presto.hive;
 
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+
 import static java.util.Objects.requireNonNull;
 
 public class HiveDirectoryContext
 {
     private final NestedDirectoryPolicy nestedDirectoryPolicy;
     private final boolean cacheable;
+    private final Map<String, String> additionalProperties;
 
-    public HiveDirectoryContext(NestedDirectoryPolicy nestedDirectoryPolicy, boolean cacheable)
+    public HiveDirectoryContext(NestedDirectoryPolicy nestedDirectoryPolicy, boolean cacheable, Map<String, String> additionalProperties)
     {
         this.nestedDirectoryPolicy = requireNonNull(nestedDirectoryPolicy, "nestedDirectoryPolicy is null");
         this.cacheable = cacheable;
+        this.additionalProperties = ImmutableMap.copyOf(requireNonNull(additionalProperties, "additionalProperties is null"));
     }
 
     public NestedDirectoryPolicy getNestedDirectoryPolicy()
@@ -34,5 +40,10 @@ public class HiveDirectoryContext
     public boolean isCacheable()
     {
         return cacheable;
+    }
+
+    public Map<String, String> getAdditionalProperties()
+    {
+        return additionalProperties;
     }
 }

--- a/presto-hive/src/main/java/com/facebook/presto/hive/ManifestPartitionLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/ManifestPartitionLoader.java
@@ -48,6 +48,7 @@ import static com.facebook.presto.hive.HiveSessionProperties.getMaxInitialSplitS
 import static com.facebook.presto.hive.HiveSessionProperties.getMaxSplitSize;
 import static com.facebook.presto.hive.HiveSessionProperties.getNodeSelectionStrategy;
 import static com.facebook.presto.hive.HiveSessionProperties.isManifestVerificationEnabled;
+import static com.facebook.presto.hive.HiveUtil.buildDirectoryContextProperties;
 import static com.facebook.presto.hive.HiveUtil.getInputFormat;
 import static com.facebook.presto.hive.NestedDirectoryPolicy.IGNORED;
 import static com.facebook.presto.hive.NestedDirectoryPolicy.RECURSE;
@@ -113,7 +114,7 @@ public class ManifestPartitionLoader
 
         if (isManifestVerificationEnabled(session)) {
             // Verify that the file names and sizes in manifest are the same as listed by directory lister
-            validateManifest(partition, path, fileNames, fileSizes);
+            validateManifest(session, partition, path, fileNames, fileSizes);
         }
 
         ImmutableList.Builder<HiveFileInfo> fileListBuilder = ImmutableList.builder();
@@ -182,11 +183,11 @@ public class ManifestPartitionLoader
                 partition.getEncryptionInformation());
     }
 
-    private void validateManifest(HivePartitionMetadata partition, Path path, List<String> manifestFileNames, List<Long> manifestFileSizes)
+    private void validateManifest(ConnectorSession session, HivePartitionMetadata partition, Path path, List<String> manifestFileNames, List<Long> manifestFileSizes)
             throws IOException
     {
         ExtendedFileSystem fileSystem = hdfsEnvironment.getFileSystem(hdfsContext, path);
-        HiveDirectoryContext hiveDirectoryContext = new HiveDirectoryContext(recursiveDirWalkerEnabled ? RECURSE : IGNORED, false);
+        HiveDirectoryContext hiveDirectoryContext = new HiveDirectoryContext(recursiveDirWalkerEnabled ? RECURSE : IGNORED, false, buildDirectoryContextProperties(session));
 
         Iterator<HiveFileInfo> fileInfoIterator = directoryLister.list(fileSystem, table, path, partition.getPartition(), namenodeStats, hiveDirectoryContext);
         int fileCount = 0;

--- a/presto-hive/src/main/java/com/facebook/presto/hive/StoragePartitionLoader.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/StoragePartitionLoader.java
@@ -65,6 +65,7 @@ import static com.facebook.presto.hive.HiveSessionProperties.getNodeSelectionStr
 import static com.facebook.presto.hive.HiveSessionProperties.isFileSplittable;
 import static com.facebook.presto.hive.HiveSessionProperties.isStreamingAggregationEnabled;
 import static com.facebook.presto.hive.HiveSessionProperties.isUseListDirectoryCache;
+import static com.facebook.presto.hive.HiveUtil.buildDirectoryContextProperties;
 import static com.facebook.presto.hive.HiveUtil.getFooterCount;
 import static com.facebook.presto.hive.HiveUtil.getHeaderCount;
 import static com.facebook.presto.hive.HiveUtil.getInputFormat;
@@ -313,7 +314,7 @@ public class StoragePartitionLoader
             cacheable &= partition.get().isSealedPartition();
         }
 
-        HiveDirectoryContext hiveDirectoryContext = new HiveDirectoryContext(recursiveDirWalkerEnabled ? RECURSE : IGNORED, cacheable);
+        HiveDirectoryContext hiveDirectoryContext = new HiveDirectoryContext(recursiveDirWalkerEnabled ? RECURSE : IGNORED, cacheable, buildDirectoryContextProperties(session));
         return stream(directoryLister.list(fileSystem, table, path, partition, namenodeStats, hiveDirectoryContext))
                 .map(status -> splitFactory.createInternalHiveSplit(status, splittable))
                 .filter(Optional::isPresent)
@@ -341,7 +342,7 @@ public class StoragePartitionLoader
         // list all files in the partition
         List<HiveFileInfo> fileInfos = new ArrayList<>(partitionBucketCount);
         try {
-            Iterators.addAll(fileInfos, directoryLister.list(fileSystem, table, path, partition, namenodeStats, new HiveDirectoryContext(FAIL, isUseListDirectoryCache(session))));
+            Iterators.addAll(fileInfos, directoryLister.list(fileSystem, table, path, partition, namenodeStats, new HiveDirectoryContext(FAIL, isUseListDirectoryCache(session), buildDirectoryContextProperties(session))));
         }
         catch (HiveFileIterator.NestedDirectoryNotAllowedException e) {
             // Fail here to be on the safe side. This seems to be the same as what Hive does
@@ -463,7 +464,7 @@ public class StoragePartitionLoader
     private List<InternalHiveSplit> getVirtuallyBucketedSplits(Path path, ExtendedFileSystem fileSystem, InternalHiveSplitFactory splitFactory, int bucketCount, Optional<Partition> partition, boolean splittable)
     {
         // List all files recursively in the partition and assign virtual bucket number to each of them
-        HiveDirectoryContext hiveDirectoryContext = new HiveDirectoryContext(recursiveDirWalkerEnabled ? RECURSE : IGNORED, isUseListDirectoryCache(session));
+        HiveDirectoryContext hiveDirectoryContext = new HiveDirectoryContext(recursiveDirWalkerEnabled ? RECURSE : IGNORED, isUseListDirectoryCache(session), buildDirectoryContextProperties(session));
         return stream(directoryLister.list(fileSystem, table, path, partition, namenodeStats, hiveDirectoryContext))
                 .map(fileInfo -> {
                     int virtualBucketNumber = getVirtualBucketNumber(bucketCount, fileInfo.getPath());

--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestHudiDirectoryLister.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestHudiDirectoryLister.java
@@ -89,7 +89,7 @@ public class TestHudiDirectoryLister
         assertEquals(metaClient.getBasePath(), mockTable.getStorage().getLocation());
         Path path = new Path(mockTable.getStorage().getLocation());
         ExtendedFileSystem fs = (ExtendedFileSystem) path.getFileSystem(hadoopConf);
-        Iterator<HiveFileInfo> fileInfoIterator = directoryLister.list(fs, mockTable, path, Optional.empty(), new NamenodeStats(), new HiveDirectoryContext(IGNORED, false));
+        Iterator<HiveFileInfo> fileInfoIterator = directoryLister.list(fs, mockTable, path, Optional.empty(), new NamenodeStats(), new HiveDirectoryContext(IGNORED, false, ImmutableMap.of()));
         assertTrue(fileInfoIterator.hasNext());
         HiveFileInfo fileInfo = fileInfoIterator.next();
         assertEquals(fileInfo.getPath().getName(), "d0875d00-483d-4e8b-bbbe-c520366c47a0-0_0-6-11_20211217110514527.parquet");


### PR DESCRIPTION
We need some of the query context information during listing time. So a new properties field is introduced in  HiveDirectoryContext and we are populating the same from hive partition loader implementations.


Test plan - Unit test

```
== NO RELEASE NOTE ==
```
