### PR TITLE
Add support for Nessie Catalog in Iceberg Connector

### DIFF
--- a/presto-docs/src/main/sphinx/connector/iceberg.rst
+++ b/presto-docs/src/main/sphinx/connector/iceberg.rst
@@ -76,8 +76,8 @@ The default is ``GZIP``.
 ``iceberg.catalog.type``
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-The catalog type for Iceberg tables. The available values are ``hive``
-and ``hadoop``, corresponding to the catalogs in the Iceberg.
+The catalog type for Iceberg tables. The available values are ``hive``/``hadoop``/``nessie``,
+ corresponding to the catalogs in Iceberg.
 
 The default is ``hive``.
 
@@ -113,6 +113,58 @@ Otherwise, it will be ignored.
 The Maximum number of partitions handled per writer.
 
 The default is 100.
+
+Nessie catalog
+^^^^^^^^^^^^^^
+
+In order to use a Nessie catalog, ensure to configure the catalog type with
+``iceberg.catalog.type=nessie`` and provide further details with the following
+properties:
+
+==================================================== ============================================================
+Property Name                                        Description
+==================================================== ============================================================
+``iceberg.nessie.ref``                               The branch/tag to use for Nessie, defaults to ``main``.
+
+``iceberg.nessie.uri``                               Nessie API endpoint URI (required).
+                                                     Example: ``https://localhost:19120/api/v1``
+
+``iceberg.nessie.auth.type``                         The authentication type to use.
+                                                     Available values are ``BASIC`` or ``BEARER``.
+                                                     Example: ``BEARER``
+
+``iceberg.nessie.auth.basic.username``               The username to use with ``BASIC`` authentication.
+                                                     Example: ``test_user``
+
+``iceberg.nessie.auth.basic.password``               The password to use with ``BASIC`` authentication.
+                                                     Example: ``my$ecretPass``
+
+``iceberg.nessie.auth.bearer.token``                 The token to use with ``BEARER`` authentication.
+                                                     Example: ``SXVLUXUhIExFQ0tFUiEK``
+
+``iceberg.nessie.read-timeout-ms``                   The read timeout in milliseconds for requests
+                                                     to the Nessie server.
+                                                     Example: ``5000``
+
+``iceberg.nessie.connect-timeout-ms``                The connection timeout in milliseconds for connection
+                                                     requests to the Nessie server.
+                                                     Example: ``10000``
+
+``iceberg.nessie.compression-enabled``               Configuration of whether compression should be enabled or
+                                                     not for requests to the Nessie server, defaults to ``true``.
+
+``iceberg.nessie.client-builder-impl``               Configuration of the custom ClientBuilder implementation
+                                                     class to be used.
+
+==================================================== ============================================================
+
+.. code-block:: none
+
+    connector.name=iceberg
+    iceberg.catalog.type=nessie
+    iceberg.catalog.warehouse=/tmp
+    iceberg.nessie.uri=https://localhost:19120/api/v1
+
 
 Schema Evolution
 ------------------------

--- a/presto-iceberg/pom.xml
+++ b/presto-iceberg/pom.xml
@@ -13,6 +13,7 @@
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
         <dep.iceberg.version>0.13.1</dep.iceberg.version>
+        <dep.nessie.version>0.30.0</dep.nessie.version>
     </properties>
 
     <dependencies>
@@ -322,6 +323,30 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.iceberg</groupId>
+            <artifactId>iceberg-nessie</artifactId>
+            <version>${dep.iceberg.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.projectnessie</groupId>
+            <artifactId>nessie-model</artifactId>
+            <version>${dep.nessie.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.projectnessie</groupId>
+            <artifactId>nessie-client</artifactId>
+            <version>${dep.nessie.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.weakref</groupId>
             <artifactId>jmxutils</artifactId>
             <scope>compile</scope>
@@ -413,6 +438,17 @@
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-testing-docker</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-compress</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergMetadataFactory.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergMetadataFactory.java
@@ -56,7 +56,8 @@ public class IcebergMetadataFactory
     {
         switch (catalogType) {
             case HADOOP:
-                return new IcebergHadoopMetadata(resourceFactory, typeManager, commitTaskCodec);
+            case NESSIE:
+                return new IcebergNativeMetadata(resourceFactory, typeManager, commitTaskCodec, catalogType);
             case HIVE:
                 return new IcebergHiveMetadata(metastore, hdfsEnvironment, typeManager, commitTaskCodec);
         }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergModule.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergModule.java
@@ -44,6 +44,7 @@ import com.facebook.presto.hive.metastore.HiveMetastoreCacheStats;
 import com.facebook.presto.hive.metastore.HivePartitionMutator;
 import com.facebook.presto.hive.metastore.MetastoreCacheStats;
 import com.facebook.presto.hive.metastore.MetastoreConfig;
+import com.facebook.presto.iceberg.nessie.NessieConfig;
 import com.facebook.presto.iceberg.optimizer.IcebergPlanOptimizer;
 import com.facebook.presto.orc.CachingStripeMetadataSource;
 import com.facebook.presto.orc.DwrfAwareStripeMetadataSourceFactory;
@@ -132,6 +133,7 @@ public class IcebergModule
         configBinder(binder).bindConfig(HiveClientConfig.class);
         configBinder(binder).bindConfig(IcebergConfig.class);
         configBinder(binder).bindConfig(MetastoreConfig.class);
+        configBinder(binder).bindConfig(NessieConfig.class);
 
         binder.bind(IcebergSessionProperties.class).in(Scopes.SINGLETON);
         binder.bind(IcebergTableProperties.class).in(Scopes.SINGLETON);

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSessionProperties.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSessionProperties.java
@@ -18,6 +18,7 @@ import com.facebook.presto.hive.HiveClientConfig;
 import com.facebook.presto.hive.HiveCompressionCodec;
 import com.facebook.presto.hive.OrcFileWriterConfig;
 import com.facebook.presto.hive.ParquetFileWriterConfig;
+import com.facebook.presto.iceberg.nessie.NessieConfig;
 import com.facebook.presto.orc.OrcWriteValidation;
 import com.facebook.presto.spi.ConnectorSession;
 import com.facebook.presto.spi.PrestoException;
@@ -71,6 +72,8 @@ public final class IcebergSessionProperties
     private static final String ORC_COMPRESSION_CODEC = "orc_compression_codec";
     private static final String CACHE_ENABLED = "cache_enabled";
     private static final String NODE_SELECTION_STRATEGY = "node_selection_strategy";
+    private static final String NESSIE_REFERENCE_NAME = "nessie_reference_name";
+    private static final String NESSIE_REFERENCE_HASH = "nessie_reference_hash";
     private final List<PropertyMetadata<?>> sessionProperties;
 
     @Inject
@@ -79,7 +82,8 @@ public final class IcebergSessionProperties
             HiveClientConfig hiveClientConfig,
             ParquetFileWriterConfig parquetFileWriterConfig,
             OrcFileWriterConfig orcFileWriterConfig,
-            CacheConfig cacheConfig)
+            CacheConfig cacheConfig,
+            NessieConfig nessieConfig)
     {
         sessionProperties = ImmutableList.of(
                 new PropertyMetadata<>(
@@ -240,6 +244,16 @@ public final class IcebergSessionProperties
                         CACHE_ENABLED,
                         "Enable cache for Iceberg",
                         cacheConfig.isCachingEnabled(),
+                        false),
+                stringProperty(
+                        NESSIE_REFERENCE_NAME,
+                        "Nessie reference name to use",
+                        nessieConfig.getDefaultReferenceName(),
+                        false),
+                stringProperty(
+                        NESSIE_REFERENCE_HASH,
+                        "Nessie reference hash to use",
+                        null,
                         false));
     }
 
@@ -386,5 +400,15 @@ public final class IcebergSessionProperties
     public static NodeSelectionStrategy getNodeSelectionStrategy(ConnectorSession session)
     {
         return session.getProperty(NODE_SELECTION_STRATEGY, NodeSelectionStrategy.class);
+    }
+
+    public static String getNessieReferenceName(ConnectorSession session)
+    {
+        return session.getProperty(NESSIE_REFERENCE_NAME, String.class);
+    }
+
+    public static String getNessieReferenceHash(ConnectorSession session)
+    {
+        return session.getProperty(NESSIE_REFERENCE_HASH, String.class);
     }
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSplitManager.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSplitManager.java
@@ -28,9 +28,10 @@ import org.apache.iceberg.TableScan;
 import javax.inject.Inject;
 
 import static com.facebook.presto.iceberg.CatalogType.HADOOP;
+import static com.facebook.presto.iceberg.CatalogType.NESSIE;
 import static com.facebook.presto.iceberg.ExpressionConverter.toIcebergExpression;
-import static com.facebook.presto.iceberg.IcebergUtil.getHadoopIcebergTable;
 import static com.facebook.presto.iceberg.IcebergUtil.getHiveIcebergTable;
+import static com.facebook.presto.iceberg.IcebergUtil.getNativeIcebergTable;
 import static java.util.Objects.requireNonNull;
 
 public class IcebergSplitManager
@@ -70,8 +71,8 @@ public class IcebergSplitManager
         }
 
         Table icebergTable;
-        if (catalogType == HADOOP) {
-            icebergTable = getHadoopIcebergTable(resourceFactory, session, table.getSchemaTableName());
+        if (catalogType == HADOOP || catalogType == NESSIE) {
+            icebergTable = getNativeIcebergTable(resourceFactory, session, table.getSchemaTableName());
         }
         else {
             ExtendedHiveMetastore metastore = ((IcebergHiveMetadata) transactionManager.get(transaction)).getMetastore();

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergUtil.java
@@ -82,7 +82,7 @@ public final class IcebergUtil
         return new BaseTable(operations, quotedTableName(table));
     }
 
-    public static Table getHadoopIcebergTable(IcebergResourceFactory resourceFactory, ConnectorSession session, SchemaTableName table)
+    public static Table getNativeIcebergTable(IcebergResourceFactory resourceFactory, ConnectorSession session, SchemaTableName table)
     {
         return resourceFactory.getCatalog(session).loadTable(toIcebergTableIdentifier(table));
     }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/RollbackToSnapshotProcedure.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/RollbackToSnapshotProcedure.java
@@ -31,6 +31,7 @@ import static com.facebook.presto.common.block.MethodHandleUtil.methodHandle;
 import static com.facebook.presto.common.type.StandardTypes.BIGINT;
 import static com.facebook.presto.common.type.StandardTypes.VARCHAR;
 import static com.facebook.presto.iceberg.CatalogType.HADOOP;
+import static com.facebook.presto.iceberg.CatalogType.NESSIE;
 import static com.facebook.presto.iceberg.IcebergUtil.getHiveIcebergTable;
 import static com.facebook.presto.iceberg.util.IcebergPrestoModelConverters.toIcebergTableIdentifier;
 import static java.util.Objects.requireNonNull;
@@ -83,7 +84,7 @@ public class RollbackToSnapshotProcedure
         SchemaTableName schemaTableName = new SchemaTableName(schema, table);
         ConnectorMetadata metadata = metadataFactory.create();
         Table icebergTable;
-        if (catalogType == HADOOP) {
+        if (catalogType == HADOOP || catalogType == NESSIE) {
             icebergTable = resourceFactory.getCatalog(clientSession).loadTable(toIcebergTableIdentifier(schema, table));
         }
         else {

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/nessie/AuthenticationType.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/nessie/AuthenticationType.java
@@ -11,29 +11,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.iceberg;
+package com.facebook.presto.iceberg.nessie;
 
-import org.apache.iceberg.hadoop.HadoopCatalog;
-import org.apache.iceberg.hive.HiveCatalog;
-import org.apache.iceberg.nessie.NessieCatalog;
-
-public enum CatalogType
+public enum AuthenticationType
 {
-    HADOOP(HadoopCatalog.class.getName()),
-    HIVE(HiveCatalog.class.getName()),
-    NESSIE(NessieCatalog.class.getName()),
-
-    /**/;
-
-    private final String catalogImpl;
-
-    CatalogType(String catalogImpl)
-    {
-        this.catalogImpl = catalogImpl;
-    }
-
-    public String getCatalogImpl()
-    {
-        return catalogImpl;
-    }
+    BASIC,
+    BEARER
 }

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/nessie/NessieConfig.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/nessie/NessieConfig.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.nessie;
+
+import com.facebook.airlift.configuration.Config;
+import com.facebook.airlift.configuration.ConfigDescription;
+
+import javax.validation.constraints.NotEmpty;
+
+import java.util.Optional;
+
+public class NessieConfig
+{
+    private String defaultReferenceName = "main";
+    private String serverUri;
+    private AuthenticationType authenticationType;
+    private String username;
+    private String password;
+    private String bearerToken;
+    private Integer readTimeoutMillis;
+    private Integer connectTimeoutMillis;
+    private String clientBuilderImpl;
+    private boolean compressionEnabled = true;
+
+    @NotEmpty(message = "must not be null or empty")
+    public String getDefaultReferenceName()
+    {
+        return defaultReferenceName;
+    }
+
+    @Config("iceberg.nessie.ref")
+    @ConfigDescription("The default Nessie reference to work on")
+    public NessieConfig setDefaultReferenceName(String defaultReferenceName)
+    {
+        this.defaultReferenceName = defaultReferenceName;
+        return this;
+    }
+
+    public Optional<String> getServerUri()
+    {
+        return Optional.ofNullable(serverUri);
+    }
+
+    @Config("iceberg.nessie.uri")
+    @ConfigDescription("The URI to connect to the Nessie server")
+    public NessieConfig setServerUri(String serverUri)
+    {
+        this.serverUri = serverUri;
+        return this;
+    }
+
+    @Config("iceberg.nessie.auth.type")
+    @ConfigDescription("The authentication type to use. Available values are BASIC | BEARER")
+    public NessieConfig setAuthenticationType(AuthenticationType authenticationType)
+    {
+        this.authenticationType = authenticationType;
+        return this;
+    }
+
+    public Optional<AuthenticationType> getAuthenticationType()
+    {
+        return Optional.ofNullable(authenticationType);
+    }
+
+    @Config("iceberg.nessie.auth.basic.username")
+    @ConfigDescription("The username to use with BASIC authentication")
+    public NessieConfig setUsername(String username)
+    {
+        this.username = username;
+        return this;
+    }
+
+    public Optional<String> getUsername()
+    {
+        return Optional.ofNullable(username);
+    }
+
+    @Config("iceberg.nessie.auth.basic.password")
+    @ConfigDescription("The password to use with BASIC authentication")
+    public NessieConfig setPassword(String password)
+    {
+        this.password = password;
+        return this;
+    }
+
+    public Optional<String> getPassword()
+    {
+        return Optional.ofNullable(password);
+    }
+
+    @Config("iceberg.nessie.auth.bearer.token")
+    @ConfigDescription("The token to use with BEARER authentication")
+    public NessieConfig setBearerToken(String bearerToken)
+    {
+        this.bearerToken = bearerToken;
+        return this;
+    }
+
+    public Optional<String> getBearerToken()
+    {
+        return Optional.ofNullable(bearerToken);
+    }
+
+    @Config("iceberg.nessie.read-timeout-ms")
+    @ConfigDescription("The read timeout in milliseconds for the client")
+    public NessieConfig setReadTimeoutMillis(Integer readTimeoutMillis)
+    {
+        this.readTimeoutMillis = readTimeoutMillis;
+        return this;
+    }
+
+    public Optional<Integer> getReadTimeoutMillis()
+    {
+        return Optional.ofNullable(readTimeoutMillis);
+    }
+
+    @Config("iceberg.nessie.connect-timeout-ms")
+    @ConfigDescription("The connection timeout in milliseconds for the client")
+    public NessieConfig setConnectTimeoutMillis(Integer connectTimeoutMillis)
+    {
+        this.connectTimeoutMillis = connectTimeoutMillis;
+        return this;
+    }
+
+    public Optional<Integer> getConnectTimeoutMillis()
+    {
+        return Optional.ofNullable(connectTimeoutMillis);
+    }
+
+    @Config("iceberg.nessie.compression-enabled")
+    @ConfigDescription("Configure whether compression should be enabled or not. Default: true")
+    public NessieConfig setCompressionEnabled(boolean compressionEnabled)
+    {
+        this.compressionEnabled = compressionEnabled;
+        return this;
+    }
+
+    public boolean isCompressionEnabled()
+    {
+        return compressionEnabled;
+    }
+
+    public boolean isCompressionDisabled()
+    {
+        return !compressionEnabled;
+    }
+
+    @Config("iceberg.nessie.client-builder-impl")
+    @ConfigDescription("Configure the custom ClientBuilder implementation class to be used")
+    public NessieConfig setClientBuilderImpl(String clientBuilderImpl)
+    {
+        this.clientBuilderImpl = clientBuilderImpl;
+        return this;
+    }
+
+    public Optional<String> getClientBuilderImpl()
+    {
+        return Optional.ofNullable(clientBuilderImpl);
+    }
+}

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergSystemTables.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/TestIcebergSystemTables.java
@@ -62,8 +62,11 @@ public class TestIcebergSystemTables
     }
 
     @BeforeClass
-    public void setUp()
+    @Override
+    public void init()
+            throws Exception
     {
+        super.init();
         assertUpdate("CREATE SCHEMA test_schema");
         assertUpdate("CREATE TABLE test_schema.test_table (_bigint BIGINT, _date DATE) WITH (partitioning = ARRAY['_date'])");
         assertUpdate("INSERT INTO test_schema.test_table VALUES (0, CAST('2019-09-08' AS DATE)), (1, CAST('2019-09-09' AS DATE)), (2, CAST('2019-09-09' AS DATE))", 3);

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/NessieTestUtil.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/NessieTestUtil.java
@@ -11,29 +11,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.iceberg;
+package com.facebook.presto.iceberg.nessie;
 
-import org.apache.iceberg.hadoop.HadoopCatalog;
-import org.apache.iceberg.hive.HiveCatalog;
-import org.apache.iceberg.nessie.NessieCatalog;
+import com.google.common.collect.ImmutableMap;
 
-public enum CatalogType
+import java.util.Map;
+
+import static com.facebook.presto.iceberg.CatalogType.NESSIE;
+
+public class NessieTestUtil
 {
-    HADOOP(HadoopCatalog.class.getName()),
-    HIVE(HiveCatalog.class.getName()),
-    NESSIE(NessieCatalog.class.getName()),
-
-    /**/;
-
-    private final String catalogImpl;
-
-    CatalogType(String catalogImpl)
+    private NessieTestUtil()
     {
-        this.catalogImpl = catalogImpl;
     }
 
-    public String getCatalogImpl()
+    public static Map<String, String> nessieConnectorProperties(String serverUri)
     {
-        return catalogImpl;
+        return ImmutableMap.of("iceberg.catalog.type", NESSIE.name(), "iceberg.nessie.uri", serverUri);
     }
 }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestIcebergDistributedNessie.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestIcebergDistributedNessie.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.nessie;
+
+import com.facebook.presto.iceberg.IcebergQueryRunner;
+import com.facebook.presto.iceberg.TestAbstractIcebergDistributed;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.testing.containers.NessieContainer;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.iceberg.CatalogType.NESSIE;
+import static com.facebook.presto.iceberg.nessie.NessieTestUtil.nessieConnectorProperties;
+
+@Test
+public class TestIcebergDistributedNessie
+        extends TestAbstractIcebergDistributed
+{
+    private NessieContainer nessieContainer;
+
+    protected TestIcebergDistributedNessie()
+    {
+        super(NESSIE);
+    }
+
+    @BeforeClass
+    @Override
+    public void init()
+            throws Exception
+    {
+        nessieContainer = NessieContainer.builder().build();
+        nessieContainer.start();
+        super.init();
+    }
+
+    @AfterClass
+    public void tearDown()
+    {
+        if (nessieContainer != null) {
+            nessieContainer.stop();
+        }
+    }
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return IcebergQueryRunner.createIcebergQueryRunner(ImmutableMap.of(), nessieConnectorProperties(nessieContainer.getRestApiUri()));
+    }
+}

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestIcebergSmokeNessie.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestIcebergSmokeNessie.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.nessie;
+
+import com.facebook.presto.iceberg.IcebergQueryRunner;
+import com.facebook.presto.iceberg.TestAbstractIcebergSmoke;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.testing.containers.NessieContainer;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+
+import static com.facebook.presto.iceberg.CatalogType.NESSIE;
+import static com.facebook.presto.iceberg.nessie.NessieTestUtil.nessieConnectorProperties;
+
+public class TestIcebergSmokeNessie
+        extends TestAbstractIcebergSmoke
+{
+    private NessieContainer nessieContainer;
+
+    public TestIcebergSmokeNessie()
+    {
+        super(NESSIE);
+    }
+
+    @BeforeClass
+    @Override
+    public void init()
+            throws Exception
+    {
+        nessieContainer = NessieContainer.builder().build();
+        nessieContainer.start();
+        super.init();
+    }
+
+    @AfterClass
+    public void tearDown()
+    {
+        if (nessieContainer != null) {
+            nessieContainer.stop();
+        }
+    }
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return IcebergQueryRunner.createIcebergQueryRunner(ImmutableMap.of(), nessieConnectorProperties(nessieContainer.getRestApiUri()));
+    }
+}

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestIcebergSystemTablesNessie.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestIcebergSystemTablesNessie.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.nessie;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.iceberg.IcebergPlugin;
+import com.facebook.presto.iceberg.TestIcebergSystemTables;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.testing.containers.NessieContainer;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+
+import java.nio.file.Path;
+import java.util.Map;
+
+import static com.facebook.presto.iceberg.IcebergQueryRunner.ICEBERG_CATALOG;
+import static com.facebook.presto.iceberg.nessie.NessieTestUtil.nessieConnectorProperties;
+import static com.facebook.presto.testing.TestingSession.testSessionBuilder;
+
+public class TestIcebergSystemTablesNessie
+        extends TestIcebergSystemTables
+{
+    private NessieContainer nessieContainer;
+
+    @BeforeClass
+    @Override
+    public void init()
+            throws Exception
+    {
+        nessieContainer = NessieContainer.builder().build();
+        nessieContainer.start();
+        super.init();
+    }
+
+    @AfterClass(alwaysRun = true)
+    @Override
+    public void tearDown()
+    {
+        super.tearDown();
+        if (nessieContainer != null) {
+            nessieContainer.stop();
+        }
+    }
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        Session session = testSessionBuilder()
+                .setCatalog(ICEBERG_CATALOG)
+                .build();
+        DistributedQueryRunner queryRunner = DistributedQueryRunner.builder(session).build();
+
+        Path catalogDir = queryRunner.getCoordinator().getBaseDataDir().resolve("iceberg_data").resolve("catalog");
+
+        queryRunner.installPlugin(new IcebergPlugin());
+        Map<String, String> icebergProperties = ImmutableMap.<String, String>builder()
+                .putAll(nessieConnectorProperties(nessieContainer.getRestApiUri()))
+                .put("hive.metastore", "file")
+                .put("hive.metastore.catalog.dir", catalogDir.toFile().toURI().toString())
+                .put("iceberg.catalog.warehouse", catalogDir.getParent().toFile().toURI().toString())
+                .build();
+
+        queryRunner.createCatalog(ICEBERG_CATALOG, "iceberg", icebergProperties);
+
+        return queryRunner;
+    }
+}

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestNessieConfig.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestNessieConfig.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.nessie;
+
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.recordDefaults;
+
+public class TestNessieConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        assertRecordedDefaults(recordDefaults(NessieConfig.class)
+                .setClientBuilderImpl(null)
+                .setAuthenticationType(null)
+                .setBearerToken(null)
+                .setCompressionEnabled(true)
+                .setDefaultReferenceName("main")
+                .setConnectTimeoutMillis(null)
+                .setPassword(null)
+                .setReadTimeoutMillis(null)
+                .setReadTimeoutMillis(null)
+                .setServerUri(null)
+                .setUsername(null));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = ImmutableMap.<String, String>builder()
+                .put("iceberg.nessie.uri", "http://localhost:xxx/api/v1")
+                .put("iceberg.nessie.ref", "someRef")
+                .put("iceberg.nessie.auth.type", "BASIC")
+                .put("iceberg.nessie.auth.basic.username", "user")
+                .put("iceberg.nessie.auth.basic.password", "pass")
+                .put("iceberg.nessie.auth.bearer.token", "bearerToken")
+                .put("iceberg.nessie.compression-enabled", "false")
+                .put("iceberg.nessie.connect-timeout-ms", "123")
+                .put("iceberg.nessie.read-timeout-ms", "456")
+                .put("iceberg.nessie.client-builder-impl", "org.projectnessie.example.ClientBuilderImpl")
+                .build();
+
+        NessieConfig expected = new NessieConfig()
+                .setServerUri("http://localhost:xxx/api/v1")
+                .setDefaultReferenceName("someRef")
+                .setAuthenticationType(AuthenticationType.BASIC)
+                .setUsername("user")
+                .setPassword("pass")
+                .setBearerToken("bearerToken")
+                .setCompressionEnabled(false)
+                .setConnectTimeoutMillis(123)
+                .setReadTimeoutMillis(456)
+                .setClientBuilderImpl("org.projectnessie.example.ClientBuilderImpl");
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestNessieMultiBranching.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/nessie/TestNessieMultiBranching.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.iceberg.nessie;
+
+import com.facebook.presto.Session;
+import com.facebook.presto.iceberg.IcebergQueryRunner;
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.testing.QueryRunner;
+import com.facebook.presto.testing.containers.NessieContainer;
+import com.facebook.presto.tests.AbstractTestQueryFramework;
+import com.google.common.collect.ImmutableMap;
+import org.projectnessie.client.api.NessieApiV1;
+import org.projectnessie.client.http.HttpClientBuilder;
+import org.projectnessie.error.NessieConflictException;
+import org.projectnessie.error.NessieNotFoundException;
+import org.projectnessie.model.Branch;
+import org.projectnessie.model.LogResponse;
+import org.projectnessie.model.Reference;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static com.facebook.presto.iceberg.nessie.NessieTestUtil.nessieConnectorProperties;
+import static com.facebook.presto.testing.MaterializedResult.resultBuilder;
+import static com.facebook.presto.tests.QueryAssertions.assertEqualsIgnoreOrder;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestNessieMultiBranching
+        extends AbstractTestQueryFramework
+{
+    private NessieContainer nessieContainer;
+    private NessieApiV1 nessieApiV1;
+
+    @BeforeClass
+    public void init()
+            throws Exception
+    {
+        nessieContainer = NessieContainer.builder().build();
+        nessieContainer.start();
+        nessieApiV1 = HttpClientBuilder.builder().withUri(nessieContainer.getRestApiUri()).build(NessieApiV1.class);
+        super.init();
+    }
+
+    @AfterClass
+    public void tearDown()
+    {
+        if (nessieContainer != null) {
+            nessieContainer.stop();
+        }
+
+        if (nessieApiV1 != null) {
+            nessieApiV1.close();
+        }
+    }
+
+    @Override
+    protected QueryRunner createQueryRunner()
+            throws Exception
+    {
+        return IcebergQueryRunner.createIcebergQueryRunner(ImmutableMap.of(), nessieConnectorProperties(nessieContainer.getRestApiUri()));
+    }
+
+    @Test
+    public void testWithUnknownBranch()
+    {
+        assertQueryFails(sessionOnRef("unknownRef"), "CREATE SCHEMA nessie_namespace", ".*Nessie ref 'unknownRef' does not exist. This ref must exist before creating a NessieCatalog.");
+    }
+
+    @Test
+    public void testNamespaceVisibility()
+            throws NessieConflictException, NessieNotFoundException
+    {
+        Reference one = createBranch("branchOne");
+        Reference two = createBranch("branchTwo");
+        Session sessionOne = sessionOnRef(one.getName());
+        Session sessionTwo = sessionOnRef(two.getName());
+        assertQuerySucceeds(sessionOne, "CREATE SCHEMA namespace_one");
+        assertQuerySucceeds(sessionOne, "SHOW SCHEMAS FROM iceberg LIKE 'namespace_one'");
+        assertQuerySucceeds(sessionTwo, "CREATE SCHEMA namespace_two");
+        assertQuerySucceeds(sessionTwo, "SHOW SCHEMAS FROM iceberg LIKE 'namespace_two'");
+
+        // TODO: enable this after bump to Iceberg 0.14.0
+        // namespace_two shouldn't be visible on branchOne
+        // assertQueryFails(sessionOne, "SHOW SCHEMAS FROM iceberg LIKE 'namespace_two'", ".*Schema 'iceberg.namespace_two' does not exist");
+        // namespace_one shouldn't be visible on branchTwo
+        // assertQueryFails(sessionTwo, "SHOW SCHEMAS FROM iceberg LIKE 'namespace_one'", ".*Schema 'iceberg.namespace_one' does not exist");
+    }
+
+    @Test
+    public void testTableDataVisibility()
+            throws NessieConflictException, NessieNotFoundException
+    {
+        assertQuerySucceeds("CREATE SCHEMA namespace_one");
+        assertQuerySucceeds("CREATE TABLE namespace_one.tbl (a int)");
+        assertQuerySucceeds("INSERT INTO namespace_one.tbl (a) VALUES (1)");
+        assertQuerySucceeds("INSERT INTO namespace_one.tbl (a) VALUES (2)");
+
+        Reference one = createBranch("branchOneWithTable");
+        Reference two = createBranch("branchTwoWithTable");
+        Session sessionOne = sessionOnRef(one.getName());
+        Session sessionTwo = sessionOnRef(two.getName());
+
+        assertQuerySucceeds(sessionOne, "INSERT INTO namespace_one.tbl (a) VALUES (3)");
+
+        assertQuerySucceeds(sessionTwo, "INSERT INTO namespace_one.tbl (a) VALUES (5)");
+        assertQuerySucceeds(sessionTwo, "INSERT INTO namespace_one.tbl (a) VALUES (6)");
+
+        // main branch should still have 2 entries
+        assertThat(computeScalar("SELECT count(*) FROM namespace_one.tbl")).isEqualTo(2L);
+        MaterializedResult rows = computeActual("SELECT * FROM namespace_one.tbl");
+        assertThat(rows.getMaterializedRows()).hasSize(2);
+        assertEqualsIgnoreOrder(rows.getMaterializedRows(), resultBuilder(getSession(), rows.getTypes()).row(1).row(2).build().getMaterializedRows());
+
+        // there should be 3 entries on this branch
+        assertThat(computeScalar(sessionOne, "SELECT count(*) FROM namespace_one.tbl")).isEqualTo(3L);
+        rows = computeActual(sessionOne, "SELECT * FROM namespace_one.tbl");
+        assertThat(rows.getMaterializedRows()).hasSize(3);
+        assertEqualsIgnoreOrder(rows.getMaterializedRows(), resultBuilder(sessionOne, rows.getTypes()).row(1).row(2).row(3).build().getMaterializedRows());
+
+        // and 4 entries on this branch
+        assertThat(computeScalar(sessionTwo, "SELECT count(*) FROM namespace_one.tbl")).isEqualTo(4L);
+        rows = computeActual(sessionTwo, "SELECT * FROM namespace_one.tbl");
+        assertThat(rows.getMaterializedRows()).hasSize(4);
+        assertEqualsIgnoreOrder(rows.getMaterializedRows(), resultBuilder(sessionTwo, rows.getTypes()).row(1).row(2).row(5).row(6).build().getMaterializedRows());
+
+        // retrieve the second to the last commit hash and query the table with that hash
+        List<LogResponse.LogEntry> logEntries = nessieApiV1.getCommitLog().refName(two.getName()).get().getLogEntries();
+        assertThat(logEntries).isNotEmpty();
+        String hash = logEntries.get(1).getCommitMeta().getHash();
+        Session sessionTwoAtHash = sessionOnRef(two.getName(), hash);
+
+        // TODO: enable this after bump to Iceberg 0.14.0
+        // at this hash there were only 3 rows
+        // assertThat(computeScalar(sessionTwoAtHash, "SELECT count(*) FROM namespace_one.tbl")).isEqualTo(3L);
+        // rows = computeActual(sessionTwoAtHash, "SELECT * FROM namespace_one.tbl");
+        // assertThat(rows.getMaterializedRows()).hasSize(3);
+        // assertEqualsIgnoreOrder(rows.getMaterializedRows(), resultBuilder(sessionTwoAtHash, rows.getTypes()).row(1).row(2).row(5).build().getMaterializedRows());
+    }
+
+    private Session sessionOnRef(String reference)
+    {
+        return Session.builder(getSession()).setCatalogSessionProperty("iceberg", "nessie_reference_name", reference).build();
+    }
+
+    private Session sessionOnRef(String reference, String hash)
+    {
+        return Session.builder(getSession()).setCatalogSessionProperty("iceberg", "nessie_reference_name", reference).setCatalogSessionProperty("iceberg", "nessie_reference_hash", hash).build();
+    }
+
+    private Reference createBranch(String branchName)
+            throws NessieConflictException, NessieNotFoundException
+    {
+        Reference main = nessieApiV1.getReference().refName("main").get();
+        return nessieApiV1.createReference().sourceRefName(main.getName()).reference(Branch.of(branchName, main.getHash())).create();
+    }
+}

--- a/presto-testing-docker/src/main/java/com/facebook/presto/testing/containers/NessieContainer.java
+++ b/presto-testing-docker/src/main/java/com/facebook/presto/testing/containers/NessieContainer.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.testing.containers;
+
+import com.facebook.airlift.log.Logger;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.testcontainers.containers.Network;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+public class NessieContainer
+        extends BaseTestContainer
+{
+    private static final Logger log = Logger.get(NessieContainer.class);
+
+    public static final String DEFAULT_IMAGE = "projectnessie/nessie:0.28.0";
+    public static final String DEFAULT_HOST_NAME = "nessie";
+    public static final String VERSION_STORE_TYPE = "INMEMORY";
+
+    public static final int PORT = 19121;
+
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    private NessieContainer(String image, String hostName, Set<Integer> exposePorts, Map<String, String> filesToMount, Map<String, String> envVars, Optional<Network> network, int retryLimit)
+    {
+        super(image, hostName, exposePorts, filesToMount, envVars, network, retryLimit);
+    }
+
+    @Override
+    public void start()
+    {
+        super.start();
+        log.info("Nessie server container started with address for REST API: %s", getRestApiUri());
+    }
+
+    public String getRestApiUri()
+    {
+        return "http://" + getMappedHostAndPortForExposedPort(PORT) + "/api/v1";
+    }
+
+    public static class Builder
+            extends BaseTestContainer.Builder<NessieContainer.Builder, NessieContainer>
+    {
+        private Builder()
+        {
+            this.image = DEFAULT_IMAGE;
+            this.hostName = DEFAULT_HOST_NAME;
+            this.exposePorts = ImmutableSet.of(PORT);
+            this.envVars = ImmutableMap.of("QUARKUS_HTTP_PORT", String.valueOf(PORT), "NESSIE_VERSION_STORE_TYPE", VERSION_STORE_TYPE);
+        }
+
+        @Override
+        public NessieContainer build()
+        {
+            return new NessieContainer(image, hostName, exposePorts, filesToMount, envVars, network, startupRetryLimit);
+        }
+    }
+}

--- a/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/AbstractTestQueryFramework.java
@@ -128,6 +128,11 @@ public abstract class AbstractTestQueryFramework
         return computeActual(sql).getOnlyValue();
     }
 
+    protected Object computeScalar(Session session, @Language("SQL") String sql)
+    {
+        return computeActual(session, sql).getOnlyValue();
+    }
+
     protected void assertQuery(@Language("SQL") String sql)
     {
         assertQuery(getSession(), sql);


### PR DESCRIPTION
This PR integrates the [Nessie catalog functionality](https://github.com/apache/iceberg/tree/master/nessie/src/main/java/org/apache/iceberg/nessie) to the Iceberg connector.
Roughtly, it adds the following new things:

* adds a new `NESSIE` catalog type, that uses `NessieCatalog`
* renames `IcebergHadoopMetadata` to `IcebergNativeMetadata` and adds the particular `CatalogType`. This allows reusing that class for both `HADOOP` + `NESSIE`.
* adds 2 new `IcebergSessionProperties` to control which referenceName / referenceHash to use with Nessie
* some minor adjustments in `IcebergResourceFactory` that make sure to pass the correct properties to the `NessieCatalog`
* adds `NessieConfig` that controls different Nessie settings and passes those to the underyling `NessieCatalog`
* adds `NessieContainer` that allows to bring up a Nessie server for testing
* additional details about Nessie itself can be found at https://projectnessie.org/

```
== RELEASE NOTES ==

Iceberg Changes
* Add support for NessieCatalog
```

