### PR TITLE
Fix enum parsing in aggregation analyzer

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/AggregationAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/AggregationAnalyzer.java
@@ -543,6 +543,11 @@ class AggregationAnalyzer
 
         private boolean isGroupingKey(Expression node)
         {
+            // If no column references are found, then the expression must be a constant, so return true.
+            // We can hit this case when parsing enum constants.
+            if (!columnReferences.containsKey(node)) {
+                return true;
+            }
             FieldId fieldId = checkAndGetColumnReferenceField(node, columnReferences);
 
             if (orderByScope.isPresent() && isFieldFromScope(fieldId, orderByScope.get())) {

--- a/presto-tests/src/test/java/com/facebook/presto/tests/TestEnums.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/TestEnums.java
@@ -138,6 +138,14 @@ public class TestEnums
     }
 
     @Test
+    public void testEnumInAggregation()
+    {
+        assertQueryResultUnordered(
+                "WITH tmp_table AS (SELECT TRY_CAST(1 AS test.enum.mood) AS x) SELECT (CASE x WHEN test.enum.mood.SAD THEN 1 END) AS col1 FROM tmp_table GROUP BY x",
+                singletonList(ImmutableList.of(1)));
+    }
+
+    @Test
     public void testEnumCasts()
     {
         assertSingleValue("CAST(CAST(1 AS TINYINT) AS test.enum.mood)", 1L);


### PR DESCRIPTION
In AggregationAnalyzer, we considered fb.std.enum.country.INDIA as a column dereference, while its an enum constant. This tries to check if an expression doesnt contain a column reference, we assume its some constant.

```
== NO RELEASE NOTE ==
```
