### PR TITLE
remove -masm=intel

### DIFF
--- a/presto-native-execution/CMakeLists.txt
+++ b/presto-native-execution/CMakeLists.txt
@@ -19,7 +19,7 @@ set(VELOX_ROOT ${CMAKE_BINARY_DIR}/velox)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(CMAKE_CXX_FLAGS
-    "${CMAKE_CXX_FLAGS} -mavx2 -mfma -mavx -mf16c -masm=intel -mlzcnt")
+    "${CMAKE_CXX_FLAGS} -mavx2 -mfma -mavx -mf16c -mlzcnt")
 if("${TREAT_WARNINGS_AS_ERRORS}")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
 endif()


### PR DESCRIPTION
Since the presto/presto-native-execution/[velox @ 342c20d](https://github.com/facebookincubator/velox/tree/342c20d165cd9cee811af82a94fc8dd3b29f31bb) has removed `-march=intel` in its env setup bash script in https://github.com/facebookincubator/velox/commit/b97db15b3d290b79cf24a2dc0f79fc9c6df9de93, presto-native-execution/CMakeLists.txt should also remove it. Otherwise, it can't be built successfully.