### PR TITLE
Overwrite partition using previous partition information

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePartitionObjectBuilder.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePartitionObjectBuilder.java
@@ -21,6 +21,7 @@ import com.facebook.presto.spi.ConnectorSession;
 import com.google.common.collect.ImmutableMap;
 
 import java.util.Map;
+import java.util.Optional;
 
 import static com.facebook.presto.hive.HiveSessionProperties.getNewPartitionUserSuppliedParameter;
 
@@ -33,7 +34,8 @@ public class HivePartitionObjectBuilder
             Table table,
             PartitionUpdate partitionUpdate,
             String prestoVersion,
-            Map<String, String> extraParameters)
+            Map<String, String> extraParameters,
+            Optional<Long> partitionVersion)
     {
         ImmutableMap.Builder extraParametersBuilder = ImmutableMap.builder()
                 .put(HiveMetadata.PRESTO_VERSION_NAME, prestoVersion)

--- a/presto-hive/src/main/java/com/facebook/presto/hive/PartitionObjectBuilder.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/PartitionObjectBuilder.java
@@ -18,6 +18,7 @@ import com.facebook.presto.hive.metastore.Table;
 import com.facebook.presto.spi.ConnectorSession;
 
 import java.util.Map;
+import java.util.Optional;
 
 public interface PartitionObjectBuilder
 {
@@ -26,5 +27,6 @@ public interface PartitionObjectBuilder
             Table table,
             PartitionUpdate partitionUpdate,
             String prestoVersion,
-            Map<String, String> extraParameters);
+            Map<String, String> extraParameters,
+            Optional<Long> partitionVersion);
 }

--- a/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/AbstractTestHiveClient.java
@@ -375,7 +375,7 @@ public abstract class AbstractTestHiveClient
             .add(new ColumnMetadata("ds", createUnboundedVarcharType()))
             .build();
 
-    private static final MaterializedResult CREATE_TABLE_PARTITIONED_DATA = new MaterializedResult(
+    protected static final MaterializedResult CREATE_TABLE_PARTITIONED_DATA = new MaterializedResult(
             CREATE_TABLE_DATA.getMaterializedRows().stream()
                     .map(row -> new MaterializedRow(row.getPrecision(), newArrayList(concat(row.getFields(), ImmutableList.of("2015-07-0" + row.getField(0))))))
                     .collect(toList()),
@@ -4621,7 +4621,13 @@ public abstract class AbstractTestHiveClient
     /**
      * @return query id
      */
-    private String insertData(SchemaTableName tableName, MaterializedResult data)
+    protected String insertData(SchemaTableName tableName, MaterializedResult data)
+            throws Exception
+    {
+        return insertData(tableName, data, newSession());
+    }
+
+    protected String insertData(SchemaTableName tableName, MaterializedResult data, ConnectorSession session)
             throws Exception
     {
         Path writePath;
@@ -4629,7 +4635,6 @@ public abstract class AbstractTestHiveClient
         String queryId;
         try (Transaction transaction = newTransaction()) {
             ConnectorMetadata metadata = transaction.getMetadata();
-            ConnectorSession session = newSession();
             ConnectorTableHandle tableHandle = getTableHandle(metadata, tableName);
             HiveInsertTableHandle insertTableHandle = (HiveInsertTableHandle) metadata.beginInsert(session, tableHandle);
             queryId = session.getQueryId();


### PR DESCRIPTION
We need previous partition information(for example previous partition version) in order to support optimistic concurrency control in overwriting an existing partition. We have made changes to provide previous partition version as one of the additional metadata to partition builder.

Test plan - unit test

```
== NO RELEASE NOTE ==
```
