### PR TITLE
Fix Pinot timestamp format error

### DIFF
--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotBrokerPageSourceBase.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotBrokerPageSourceBase.java
@@ -42,7 +42,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.airlift.slice.Slice;
 import io.airlift.slice.Slices;
-import org.apache.pinot.spi.utils.TimestampUtils;
 
 import java.net.URI;
 import java.util.ArrayList;
@@ -51,13 +50,14 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import static com.facebook.presto.pinot.PinotErrorCode.PINOT_DECODE_ERROR;
 import static com.facebook.presto.pinot.PinotErrorCode.PINOT_EXCEPTION;
 import static com.facebook.presto.pinot.PinotErrorCode.PINOT_INSUFFICIENT_SERVER_RESPONSE;
 import static com.facebook.presto.pinot.PinotErrorCode.PINOT_REQUEST_GENERATOR_FAILURE;
 import static com.facebook.presto.pinot.PinotErrorCode.PINOT_UNEXPECTED_RESPONSE;
 import static com.facebook.presto.pinot.PinotErrorCode.PINOT_UNSUPPORTED_COLUMN_TYPE;
 import static com.facebook.presto.pinot.PinotUtils.doWithRetries;
+import static com.facebook.presto.pinot.PinotUtils.parseDouble;
+import static com.facebook.presto.pinot.PinotUtils.parseTimestamp;
 import static com.google.common.base.Preconditions.checkState;
 import static java.lang.Boolean.parseBoolean;
 import static java.lang.Long.parseLong;
@@ -66,11 +66,6 @@ import static java.util.Objects.requireNonNull;
 public abstract class PinotBrokerPageSourceBase
         implements ConnectorPageSource
 {
-    private static final String PINOT_INFINITY = "∞";
-    private static final String PINOT_POSITIVE_INFINITY = "+" + PINOT_INFINITY;
-    private static final String PINOT_NEGATIVE_INFINITY = "-" + PINOT_INFINITY;
-    private static final Double PRESTO_INFINITY = Double.POSITIVE_INFINITY;
-    private static final Double PRESTO_NEGATIVE_INFINITY = Double.NEGATIVE_INFINITY;
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     protected final PinotConfig pinotConfig;
@@ -95,23 +90,6 @@ public abstract class PinotBrokerPageSourceBase
         this.columnHandles = ImmutableList.copyOf(columnHandles);
         this.session = requireNonNull(session, "session is null");
         this.objectMapper = requireNonNull(objectMapper, "object mapper is null");
-    }
-
-    private static Double parseDouble(String value)
-    {
-        try {
-            return Double.valueOf(value);
-        }
-        catch (NumberFormatException ne) {
-            switch (value) {
-                case PINOT_INFINITY:
-                case PINOT_POSITIVE_INFINITY:
-                    return PRESTO_INFINITY;
-                case PINOT_NEGATIVE_INFINITY:
-                    return PRESTO_NEGATIVE_INFINITY;
-            }
-            throw new PinotException(PINOT_DECODE_ERROR, Optional.empty(), "Cannot decode double value from pinot " + value, ne);
-        }
     }
 
     protected void setValue(Type type, BlockBuilder blockBuilder, JsonNode value)
@@ -184,16 +162,6 @@ public abstract class PinotBrokerPageSourceBase
             Slice slice = Slices.utf8Slice(value);
             blockBuilder.writeBytes(slice, 0, slice.length()).closeEntry();
             completedBytes += slice.length();
-        }
-    }
-
-    private long parseTimestamp(String value)
-    {
-        try {
-            return parseLong(value);
-        }
-        catch (Exception e) {
-            return TimestampUtils.toMillisSinceEpoch(value);
         }
     }
 

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotUtils.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotUtils.java
@@ -13,14 +13,25 @@
  */
 package com.facebook.presto.pinot;
 
+import org.apache.pinot.spi.utils.TimestampUtils;
+
+import java.util.Optional;
 import java.util.function.Function;
 
+import static com.facebook.presto.pinot.PinotErrorCode.PINOT_DECODE_ERROR;
 import static com.google.common.base.Preconditions.checkState;
+import static java.lang.Long.parseLong;
 import static java.net.HttpURLConnection.HTTP_MULT_CHOICE;
 import static java.net.HttpURLConnection.HTTP_OK;
 
 public class PinotUtils
 {
+    private static final String PINOT_INFINITY = "∞";
+    private static final String PINOT_POSITIVE_INFINITY = "+" + PINOT_INFINITY;
+    private static final String PINOT_NEGATIVE_INFINITY = "-" + PINOT_INFINITY;
+    private static final Double PRESTO_INFINITY = Double.POSITIVE_INFINITY;
+    private static final Double PRESTO_NEGATIVE_INFINITY = Double.NEGATIVE_INFINITY;
+
     private PinotUtils()
     {
     }
@@ -48,5 +59,40 @@ public class PinotUtils
             }
         }
         throw firstError;
+    }
+
+    public static long parseTimestamp(String value)
+    {
+        try {
+            return parseLong(value);
+        }
+        catch (NumberFormatException e) {
+            // Sometimes Pinot returns float point string in a field that we expect timestamp.
+            // This can happen because of JsonParser, Pinot Query Engine, etc.
+            // In this case we may still go through by reading a float value
+            try {
+                return parseDouble(value).longValue();
+            }
+            catch (Exception ignoredEx) {
+                return TimestampUtils.toMillisSinceEpoch(value);
+            }
+        }
+    }
+
+    public static Double parseDouble(String value)
+    {
+        try {
+            return Double.valueOf(value);
+        }
+        catch (NumberFormatException ne) {
+            switch (value) {
+                case PINOT_INFINITY:
+                case PINOT_POSITIVE_INFINITY:
+                    return PRESTO_INFINITY;
+                case PINOT_NEGATIVE_INFINITY:
+                    return PRESTO_NEGATIVE_INFINITY;
+            }
+            throw new PinotException(PINOT_DECODE_ERROR, Optional.empty(), "Cannot decode double value from pinot " + value, ne);
+        }
     }
 }

--- a/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotUtils.java
+++ b/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotUtils.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.pinot;
+
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.pinot.PinotUtils.parseTimestamp;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+public class TestPinotUtils
+{
+    @Test
+    public void testParseTimestamp()
+    {
+        long epoch = parseTimestamp("1.672528152E12");
+        assertEquals(epoch, 1672528152000L);
+        long epoch2 = parseTimestamp("1652374863000");
+        assertEquals(epoch2, 1652374863000L);
+        long epoch3 = parseTimestamp("2022-05-12 10:48:06.5");
+        assertEquals(epoch3, 1652370486500L);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testParseTimestampWithException()
+    {
+        parseTimestamp("some string");
+        fail("Should throw exception for parsing wrong timestamp");
+    }
+}


### PR DESCRIPTION
## Description
Fixed some cases of Pinot result error when reading timestamp columns. Described in https://github.com/prestodb/presto/issues/17755
That if aggregate function is applied in timestamp column, Pinot returns float point format for TIMESTAMP columns, where Pinot Driver parse as long.

Now we do another try with double format.

## Test plan 
Added unit tests for 3 possible parsing;
Also locally ran a cluster with `select max(time_column)` that sees the crash before this patch

```
== RELEASE NOTES ==

Pinot Changes
* Fix query error when applying aggregation function over timestamp columns

