### PR TITLE
Return ConnectorCommitHandle from HiveConnector

### DIFF
--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveConnector.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveConnector.java
@@ -42,7 +42,6 @@ import java.util.function.Supplier;
 
 import static com.facebook.presto.spi.connector.ConnectorCapabilities.SUPPORTS_PAGE_SINK_COMMIT;
 import static com.facebook.presto.spi.connector.ConnectorCapabilities.SUPPORTS_REWINDABLE_SPLIT_SOURCE;
-import static com.facebook.presto.spi.connector.EmptyConnectorCommitHandle.INSTANCE;
 import static com.facebook.presto.spi.transaction.IsolationLevel.READ_UNCOMMITTED;
 import static com.facebook.presto.spi.transaction.IsolationLevel.checkConnectorSupports;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -220,9 +219,8 @@ public class HiveConnector
         TransactionalMetadata metadata = transactionManager.remove(transaction);
         checkArgument(metadata != null, "no such transaction: %s", transaction);
         try (ThreadContextClassLoader ignored = new ThreadContextClassLoader(classLoader)) {
-            metadata.commit();
+            return metadata.commit();
         }
-        return INSTANCE;
     }
 
     @Override

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HiveMetadata.java
@@ -76,6 +76,7 @@ import com.facebook.presto.spi.SystemTable;
 import com.facebook.presto.spi.TableLayoutFilterCoverage;
 import com.facebook.presto.spi.TableNotFoundException;
 import com.facebook.presto.spi.ViewNotFoundException;
+import com.facebook.presto.spi.connector.ConnectorCommitHandle;
 import com.facebook.presto.spi.connector.ConnectorOutputMetadata;
 import com.facebook.presto.spi.connector.ConnectorPartitioningHandle;
 import com.facebook.presto.spi.connector.ConnectorPartitioningMetadata;
@@ -3776,9 +3777,9 @@ public class HiveMetadata
     }
 
     @Override
-    public void commit()
+    public ConnectorCommitHandle commit()
     {
-        metastore.commit();
+        return metastore.commit();
     }
 
     @Override

--- a/presto-hive/src/main/java/com/facebook/presto/hive/TransactionalMetadata.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/TransactionalMetadata.java
@@ -14,12 +14,13 @@
 package com.facebook.presto.hive;
 
 import com.facebook.presto.hive.metastore.SemiTransactionalHiveMetastore;
+import com.facebook.presto.spi.connector.ConnectorCommitHandle;
 import com.facebook.presto.spi.connector.ConnectorMetadata;
 
 public interface TransactionalMetadata
         extends ConnectorMetadata
 {
-    void commit();
+    ConnectorCommitHandle commit();
 
     void rollback();
 


### PR DESCRIPTION
The underlying metastore already returns ConnectorCommitHandle.
Here we pass the handle further to connector, whose output commit
result will be logged.

```
== NO RELEASE NOTE ==
```
