### PR TITLE
Fix merge join plan generation for scenarios of multi partitions, grouped-execution and phased execution

### DIFF
--- a/presto-hive/src/test/java/com/facebook/presto/hive/TestMergeJoinPlan.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/TestMergeJoinPlan.java
@@ -67,12 +67,17 @@ public class TestMergeJoinPlan
                     "  sorted_by = ARRAY['custkey'], partitioned_by=array['ds']) AS \n" +
                     "SELECT *, '2021-07-11' as ds FROM tpch.sf1.\"orders\" LIMIT 1000");
 
-            // By default, we don't enable merge join
+            // By default, we can't enable merge join
             assertPlan(
                     "select * from test_join_customer join test_join_order on test_join_customer.custkey = test_join_order.custkey",
                     joinPlan("test_join_customer", "test_join_order", ImmutableList.of("custkey"), ImmutableList.of("custkey"), false));
 
-            // When merge join is preferred and data properties requirements for merge join are met
+            // when we miss session property, we can't enable merge join
+            assertPlan(
+                    "select * from test_join_customer join test_join_order on test_join_customer.custkey = test_join_order.custkey",
+                    joinPlan("test_join_customer", "test_join_order", ImmutableList.of("custkey"), ImmutableList.of("custkey"), false));
+
+            // When merge join session property is turned on and data properties requirements for merge join are met
             assertPlan(
                     mergeJoinEnabled(),
                     "select * from test_join_customer join test_join_order on test_join_customer.custkey = test_join_order.custkey",
@@ -174,26 +179,64 @@ public class TestMergeJoinPlan
         QueryRunner queryRunner = getQueryRunner();
 
         try {
-            queryRunner.execute("CREATE TABLE test_join_customer5 WITH ( \n" +
-                    "  bucket_count = 4, bucketed_by = ARRAY['custkey', 'phone'], \n" +
-                    "  sorted_by = ARRAY['custkey', 'phone'], partitioned_by=array['ds'], \n" +
-                    "  format = 'DWRF' ) AS \n" +
-                    "SELECT *, '2021-07-11' as ds FROM customer LIMIT 1000\n");
+            queryRunner.execute("CREATE TABLE test_join_customer5(" +
+                    " \"custkey\" bigint, \"name\" varchar(25), \"address\" varchar(40), \"orderkey\" bigint, \"phone\" varchar(15),                                \n" +
+                    " \"acctbal\" double, \"mktsegment\" varchar(10), \"comment\" varchar(117), \"ds\" varchar(10)) WITH ( \n" +
+                    "  bucket_count = 4, bucketed_by = ARRAY['custkey', 'orderkey'], \n" +
+                    "  sorted_by = ARRAY['custkey', 'orderkey'], partitioned_by=array['ds'], \n" +
+                    "  format = 'DWRF' )");
+            queryRunner.execute("INSERT INTO test_join_customer5 \n" +
+                    "SELECT *, '2021-07-11' as ds FROM tpch.sf1.customer LIMIT 1000");
 
-            queryRunner.execute("CREATE TABLE test_join_order5 WITH ( \n" +
-                    "  bucket_count = 4, bucketed_by = ARRAY['custkey', 'clerk'], \n" +
-                    "  sorted_by = ARRAY['custkey', 'clerk'], partitioned_by=array['ds']) AS \n" +
-                    "SELECT *, '2021-07-11' as ds FROM orders LIMIT 1000");
+            queryRunner.execute("CREATE TABLE test_join_order5(" +
+                    " \"orderkey\" bigint, \"custkey\" bigint, \"orderstatus\" varchar(1), \"totalprice\" double, \"orderdate\" date," +
+                    " \"orderpriority\" varchar(15), \"clerk\" varchar(15), \"shippriority\" integer, \"comment\" varchar(79),  \"ds\" varchar(10)) WITH ( \n" +
+                    "  bucket_count = 4, bucketed_by = ARRAY['custkey', 'orderkey'], \n" +
+                    "  sorted_by = ARRAY['custkey', 'orderkey'], partitioned_by=array['ds'])");
+            queryRunner.execute("INSERT INTO test_join_order5 \n" +
+                    "SELECT *, '2021-07-11' as ds FROM tpch.sf1.orders LIMIT 1000");
 
-            // merge join can't be enabled
+            // merge join can be enabled
             assertPlan(
                     mergeJoinEnabled(),
-                    "select * from test_join_customer5 join test_join_order5 on test_join_customer5.custkey = test_join_order5.custkey and test_join_customer5.phone = test_join_order5.clerk",
-                    joinPlan("test_join_customer5", "test_join_order5", ImmutableList.of("custkey", "phone"), ImmutableList.of("custkey", "clerk"), true));
+                    "select * from test_join_customer5 join test_join_order5 on test_join_customer5.custkey = test_join_order5.custkey and test_join_customer5.orderkey = test_join_order5.orderkey",
+                    joinPlan("test_join_customer5", "test_join_order5", ImmutableList.of("custkey", "orderkey"), ImmutableList.of("custkey", "orderkey"), true));
         }
         finally {
             queryRunner.execute("DROP TABLE IF EXISTS test_join_customer5");
             queryRunner.execute("DROP TABLE IF EXISTS test_join_order5");
+        }
+    }
+
+    @Test
+    public void testMultiplePartitions()
+    {
+        QueryRunner queryRunner = getQueryRunner();
+
+        try {
+            queryRunner.execute("CREATE TABLE test_join_customer_multi_partitions WITH ( \n" +
+                    "  bucket_count = 4, bucketed_by = ARRAY['custkey'], \n" +
+                    "  sorted_by = ARRAY['custkey'], partitioned_by=array['ds']) AS \n" +
+                    "SELECT *, '2021-07-11' as ds FROM tpch.sf1.customer LIMIT 1000");
+            queryRunner.execute("INSERT INTO test_join_customer_multi_partitions \n" +
+                    "SELECT *, '2021-07-12' as ds FROM tpch.sf1.customer LIMIT 1000");
+
+            queryRunner.execute("CREATE TABLE test_join_order_multi_partitions WITH ( \n" +
+                    "  bucket_count = 4, bucketed_by = ARRAY['custkey'], \n" +
+                    "  sorted_by = ARRAY['custkey'], partitioned_by=array['ds']) AS \n" +
+                    "SELECT *, '2021-07-11' as ds FROM tpch.sf1.\"orders\" LIMIT 1000");
+            queryRunner.execute("INSERT INTO test_join_order_multi_partitions \n" +
+                    "SELECT *, '2021-07-12' as ds FROM tpch.sf1.orders LIMIT 1000");
+
+            // When partition key doesn't not appear in join keys and we query multiple partitions, we can't enable merge join
+            assertPlan(
+                    mergeJoinEnabled(),
+                    "select * from test_join_customer_multi_partitions join test_join_order_multi_partitions on test_join_customer_multi_partitions.custkey = test_join_order_multi_partitions.custkey",
+                    joinPlan("test_join_customer_multi_partitions", "test_join_order_multi_partitions", ImmutableList.of("custkey"), ImmutableList.of("custkey"), false));
+        }
+        finally {
+            queryRunner.execute("DROP TABLE IF EXISTS test_join_customer_multi_partitions");
+            queryRunner.execute("DROP TABLE IF EXISTS test_join_order_multi_partitions");
         }
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/execution/scheduler/PhasedExecutionSchedule.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/scheduler/PhasedExecutionSchedule.java
@@ -22,6 +22,7 @@ import com.facebook.presto.sql.planner.plan.ExchangeNode;
 import com.facebook.presto.sql.planner.plan.IndexJoinNode;
 import com.facebook.presto.sql.planner.plan.InternalPlanVisitor;
 import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.sql.planner.plan.MergeJoinNode;
 import com.facebook.presto.sql.planner.plan.PlanFragmentId;
 import com.facebook.presto.sql.planner.plan.RemoteSourceNode;
 import com.facebook.presto.sql.planner.plan.SemiJoinNode;
@@ -224,6 +225,12 @@ public class PhasedExecutionSchedule
         public Set<PlanFragmentId> visitIndexJoin(IndexJoinNode node, PlanFragmentId currentFragmentId)
         {
             return processJoin(node.getIndexSource(), node.getProbeSource(), currentFragmentId);
+        }
+
+        @Override
+        public Set<PlanFragmentId> visitMergeJoin(MergeJoinNode node, PlanFragmentId currentFragmentId)
+        {
+            return processJoin(node.getRight(), node.getLeft(), currentFragmentId);
         }
 
         private Set<PlanFragmentId> processJoin(PlanNode build, PlanNode probe, PlanFragmentId currentFragmentId)


### PR DESCRIPTION
```
== NO RELEASE NOTE ==
```

This PR fixes three issues

- When join keys don't contain partition key and we query multiple partitions of data, we can't enable merge join. Currently such sanity check is missing
We fix it by adding stream property check

- When grouped execution is enabled, its GroupedExecutionProperties is missing when we generate Merge join node.
We fix it by adding the missing visitMergeJoin function in GroupedExecutionTagger

- When phased execution scheduling is enabled, it will throw exceptions when trying to schedule for Merge join node.
We fix it by adding the missing visitMergeJoin function in PhasedExecutionSchedule

Next step

- Discussion on the solution when grouped execution can't be applied to a MergeJoinNode during fragmenting phase
- Currently Merge join feature only supports cases where the sorting order is ASC and in case of multiple keys, the order of the keys is the same as in "criteria", next step would be introducing additional fields in MergeJoinNode to support more scenarios
