### PR TITLE
Add microsecond precision support for timestamp

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/type/SqlTimestamp.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/SqlTimestamp.java
@@ -73,6 +73,19 @@ public final class SqlTimestamp
         return precision.toMillis(value);
     }
 
+    public long getMicros()
+    {
+        checkState(!isLegacyTimestamp(), "getMicros() can be called in new timestamp semantics only");
+        return precision.toMicros(value);
+    }
+
+    @Deprecated
+    public long getMicrosUtc()
+    {
+        checkState(isLegacyTimestamp(), "getMicrosUtc() can be called in legacy timestamp semantics only");
+        return precision.toMicros(value);
+    }
+
     @Deprecated
     public Optional<TimeZoneKey> getSessionTimeZoneKey()
     {

--- a/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
@@ -282,6 +282,7 @@ import static com.facebook.presto.common.type.TDigestParametricType.TDIGEST;
 import static com.facebook.presto.common.type.TimeType.TIME;
 import static com.facebook.presto.common.type.TimeWithTimeZoneType.TIME_WITH_TIME_ZONE;
 import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP_MICROSECONDS;
 import static com.facebook.presto.common.type.TimestampWithTimeZoneType.TIMESTAMP_WITH_TIME_ZONE;
 import static com.facebook.presto.common.type.TinyintType.TINYINT;
 import static com.facebook.presto.common.type.TypeSignature.parseTypeSignature;

--- a/presto-main/src/main/java/com/facebook/presto/testing/DateTimeTestingUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/DateTimeTestingUtils.java
@@ -26,6 +26,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneId;
+import java.util.concurrent.TimeUnit;
 
 import static com.facebook.presto.util.DateTimeZoneIndex.getDateTimeZone;
 import static java.lang.Math.toIntExact;
@@ -106,6 +107,18 @@ public final class DateTimeTestingUtils
         }
         else {
             return new SqlTimestamp(millis, MILLISECONDS);
+        }
+    }
+
+    public static SqlTimestamp sqlTimestampOf(long value, ConnectorSession session, TimeUnit timeUnit)
+    {
+        SqlFunctionProperties properties = session.getSqlFunctionProperties();
+
+        if (properties.isLegacyTimestamp()) {
+            return new SqlTimestamp(value, properties.getTimeZoneKey(), timeUnit);
+        }
+        else {
+            return new SqlTimestamp(value, timeUnit);
         }
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcType.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcType.java
@@ -41,6 +41,7 @@ import static com.facebook.presto.common.type.StandardTypes.ARRAY;
 import static com.facebook.presto.common.type.StandardTypes.MAP;
 import static com.facebook.presto.common.type.StandardTypes.ROW;
 import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP_MICROSECONDS;
 import static com.facebook.presto.common.type.TinyintType.TINYINT;
 import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -229,7 +230,7 @@ public class OrcType
         if (DATE.equals(type)) {
             return ImmutableList.of(new OrcType(OrcTypeKind.DATE));
         }
-        if (TIMESTAMP.equals(type)) {
+        if (TIMESTAMP.equals(type) || TIMESTAMP_MICROSECONDS.equals(type)) {
             return ImmutableList.of(new OrcType(OrcTypeKind.TIMESTAMP));
         }
         if (type instanceof DecimalType) {

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/ApacheHiveTimestampDecoder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/ApacheHiveTimestampDecoder.java
@@ -22,7 +22,7 @@ final class ApacheHiveTimestampDecoder
     // This comes from the Apache Hive ORC code
     public static long decodeTimestamp(long seconds, long serializedNanos, DecodeTimestampOptions options)
     {
-        long millis = (seconds + options.getBaseSeconds()) * options.getUnitsPerSecond();
+        long value = (seconds + options.getBaseSeconds()) * options.getUnitsPerSecond();
         long nanos = parseNanos(serializedNanos);
         if (nanos > 999999999 || nanos < 0) {
             throw new IllegalArgumentException("nanos field of an encoded timestamp in ORC must be between 0 and 999999999 inclusive, got " + nanos);
@@ -33,11 +33,11 @@ final class ApacheHiveTimestampDecoder
         // to get the correct value we need
         // (-42 - 1)*1000 + 999 = -42001
         // (42)*1000 + 1 = 42001
-        if (millis < 0 && nanos != 0) {
-            millis -= options.getUnitsPerSecond();
+        if (value < 0 && nanos != 0) {
+            value -= options.getUnitsPerSecond();
         }
-        // Truncate nanos to millis and add to mills
-        return millis + (nanos / options.getNanosPerUnit());
+        // Truncate nanos to required units (millis / micros) and add to value
+        return value + (nanos / options.getNanosPerUnit());
     }
 
     // This comes from the Apache Hive ORC code

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestDecryption.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestDecryption.java
@@ -634,7 +634,8 @@ public class TestDecryption
                     requiredSubfields,
                     readerIntermediateKeys,
                     includedColumns,
-                    outputColumns);
+                    outputColumns,
+                    false);
 
             validateFileStatistics(tempFile, dwrfWriterEncryption, readerIntermediateKeys);
         }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestDictionaryColumnWriter.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestDictionaryColumnWriter.java
@@ -855,6 +855,7 @@ public class TestDictionaryColumnWriter
                     type,
                     INITIAL_BATCH_SIZE,
                     true,
+                    false,
                     false)) {
                 while (index < values.size()) {
                     Page page = reader.getNextPage();

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcMapNullKey.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcMapNullKey.java
@@ -101,6 +101,7 @@ public class TestOrcMapNullKey
                     mapType,
                     INITIAL_BATCH_SIZE,
                     mapNullKeysEnabled,
+                    false,
                     false)) {
                 assertEquals(readMap(reader.getNextPage().getBlock(0).getLoadedBlock(), 0), expectedToRead);
 

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcReaderPositions.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcReaderPositions.java
@@ -157,7 +157,7 @@ public class TestOrcReaderPositions
             createSequentialFile(tempFile.getFile(), rowCount);
             List<Long> expectedValues = new ArrayList<>();
             expectedValues.addAll(LongStream.range(0, 142_000).collect(ArrayList::new, List::add, List::addAll));
-            OrcSelectiveRecordReader reader = createCustomOrcSelectiveRecordReader(tempFile, ORC, OrcPredicate.TRUE, BIGINT, MAX_BATCH_SIZE, false, true);
+            OrcSelectiveRecordReader reader = createCustomOrcSelectiveRecordReader(tempFile, ORC, OrcPredicate.TRUE, BIGINT, MAX_BATCH_SIZE, false, true, false);
             verifyAppendNumber(expectedValues, reader);
         }
     }
@@ -172,7 +172,7 @@ public class TestOrcReaderPositions
             createSequentialFile(tempFile.getFile(), rowCount);
             List<Long> expectedValues = new ArrayList<>();
             expectedValues.addAll(LongStream.range(0, 142_000).collect(ArrayList::new, List::add, List::addAll));
-            OrcSelectiveRecordReader reader = createCustomOrcSelectiveRecordReader(tempFile, ORC, OrcPredicate.TRUE, BIGINT, MAX_BATCH_SIZE, false, true);
+            OrcSelectiveRecordReader reader = createCustomOrcSelectiveRecordReader(tempFile, ORC, OrcPredicate.TRUE, BIGINT, MAX_BATCH_SIZE, false, true, false);
             verifyAppendNumber(expectedValues, reader);
         }
     }
@@ -204,7 +204,8 @@ public class TestOrcReaderPositions
                     ImmutableList.of(0),
                     false,
                     new TestingHiveOrcAggregatedMemoryContext(),
-                    true);
+                    true,
+                    false);
             verifyAppendNumber(expectedValues, reader);
         }
     }
@@ -228,7 +229,7 @@ public class TestOrcReaderPositions
             List<Long> expectedValues = new ArrayList<>();
             expectedValues.addAll(LongStream.range(50_000, 60_000).collect(ArrayList::new, List::add, List::addAll));
             expectedValues.addAll(LongStream.range(70_000, 80_000).collect(ArrayList::new, List::add, List::addAll));
-            OrcSelectiveRecordReader reader = createCustomOrcSelectiveRecordReader(tempFile, ORC, predicate, BIGINT, MAX_BATCH_SIZE, false, true);
+            OrcSelectiveRecordReader reader = createCustomOrcSelectiveRecordReader(tempFile, ORC, predicate, BIGINT, MAX_BATCH_SIZE, false, true, false);
             verifyAppendNumber(expectedValues, reader);
         }
     }
@@ -255,7 +256,7 @@ public class TestOrcReaderPositions
             expectedValues.addAll(LongStream.range(60, 80).collect(ArrayList::new, List::add, List::addAll));
 
             List<Long> actualValues = new ArrayList<>();
-            OrcSelectiveRecordReader reader = createCustomOrcSelectiveRecordReader(tempFile, ORC, predicate, BIGINT, MAX_BATCH_SIZE, false, true);
+            OrcSelectiveRecordReader reader = createCustomOrcSelectiveRecordReader(tempFile, ORC, predicate, BIGINT, MAX_BATCH_SIZE, false, true, false);
             assertNotNull(reader);
             Page returnPage;
             while (true) {

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcSelectiveStreamReaders.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestOrcSelectiveStreamReaders.java
@@ -106,6 +106,7 @@ public class TestOrcSelectiveStreamReaders
                         outputColumns,
                         false,
                         systemMemoryUsage,
+                        false,
                         false)) {
                     assertEquals(recordReader.getReaderPosition(), 0);
                     assertEquals(recordReader.getFilePosition(), 0);

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestSelectiveOrcReader.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestSelectiveOrcReader.java
@@ -979,6 +979,7 @@ public class TestSelectiveOrcReader
                 outputColumns,
                 false,
                 systemMemoryUsage,
+                false,
                 false)) {
             assertEquals(recordReader.getReaderPosition(), 0);
             assertEquals(recordReader.getFilePosition(), 0);
@@ -1042,6 +1043,7 @@ public class TestSelectiveOrcReader
                 outputColumns,
                 false,
                 new TestingHiveOrcAggregatedMemoryContext(),
+                false,
                 false)) {
             assertEquals(recordReader.getReaderPosition(), 0);
             assertEquals(recordReader.getFilePosition(), 0);
@@ -1096,7 +1098,7 @@ public class TestSelectiveOrcReader
 
         writeOrcColumnsPresto(tempFile.getFile(), DWRF, NONE, Optional.empty(), types, ImmutableList.of(values), new NoOpOrcWriterStats());
 
-        try (OrcSelectiveRecordReader recordReader = createCustomOrcSelectiveRecordReader(tempFile, OrcEncoding.DWRF, OrcPredicate.TRUE, type, MAX_BATCH_SIZE, false, false)) {
+        try (OrcSelectiveRecordReader recordReader = createCustomOrcSelectiveRecordReader(tempFile, OrcEncoding.DWRF, OrcPredicate.TRUE, type, MAX_BATCH_SIZE, false, false, false)) {
             assertEquals(recordReader.getFileRowCount(), rowCount);
             assertEquals(recordReader.getReaderRowCount(), rowCount);
             assertEquals(recordReader.getFilePosition(), 0);
@@ -1163,6 +1165,7 @@ public class TestSelectiveOrcReader
                 outputColumns,
                 false,
                 systemMemoryUsage,
+                false,
                 false)) {
             Page page = recordReader.getNextPage();
             assertEquals(page.getPositionCount(), 1);

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestTimestampWriteAndRead.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestTimestampWriteAndRead.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc;
+
+import com.facebook.presto.common.type.SqlTimestamp;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.orc.metadata.CompressionKind;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP_MICROSECONDS;
+import static com.facebook.presto.orc.OrcTester.Format.DWRF;
+import static com.facebook.presto.orc.OrcTester.assertFileContentsPresto;
+import static com.facebook.presto.orc.OrcTester.writeOrcColumnsPresto;
+import static com.facebook.presto.testing.DateTimeTestingUtils.sqlTimestampOf;
+import static com.facebook.presto.testing.TestingConnectorSession.SESSION;
+import static java.lang.Math.floorDiv;
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.stream.Collectors.toList;
+
+public class TestTimestampWriteAndRead
+{
+    // Few positive, negative timestamp values
+    private static final List<SqlTimestamp> MICROSECOND_VALUES = ImmutableList.of(
+            sqlTimestampOf(0L, SESSION, MICROSECONDS), // 1970-01-01 00:00:00.000000
+            sqlTimestampOf(1L, SESSION, MICROSECONDS), // 1970-01-01 00:00:00.000001
+            sqlTimestampOf(999_999L, SESSION, MICROSECONDS), // 1970-01-01 00:00:00.999999
+            sqlTimestampOf(1_000_000L, SESSION, MICROSECONDS), // 1970-01-01 00:00:01.000000
+            sqlTimestampOf(-60_000_000_000_000_789L, SESSION, MICROSECONDS), // 0068-09-03 13:19:59.999211
+            sqlTimestampOf(-230_000_000_000_999_999L, SESSION, MICROSECONDS), // -5319-08-03 23:06:39.000001
+            sqlTimestampOf(1_650_483_250_000_507L, SESSION, MICROSECONDS), // 2022-04-20 19:34:10.000507
+            sqlTimestampOf(60_000_000_000_123_789L, SESSION, MICROSECONDS), // 3871-04-29 10:40:00.123789
+            sqlTimestampOf(230_000_000_000_999_999L, SESSION, MICROSECONDS)); // 9258-05-30 00:53:20.999999
+
+    @Test
+    public void testMicroWriteAndRead()
+            throws Exception
+    {
+        testPrestoRoundTrip(TIMESTAMP_MICROSECONDS, MICROSECOND_VALUES, TIMESTAMP_MICROSECONDS, MICROSECOND_VALUES, true);
+    }
+
+    @Test
+    public void testMicroWriteAndMilliRead()
+            throws Exception
+    {
+        List<SqlTimestamp> microSecondValuesInMilli = MICROSECOND_VALUES.stream()
+                .map(microTimestamp -> new SqlTimestamp(
+                        floorDiv(microTimestamp.getMicrosUtc(), 1000),
+                        microTimestamp.getSessionTimeZoneKey().get(),
+                        TimeUnit.MILLISECONDS))
+                .collect(toList());
+
+        testPrestoRoundTrip(TIMESTAMP_MICROSECONDS, MICROSECOND_VALUES, TIMESTAMP, microSecondValuesInMilli, false);
+    }
+
+    @Test
+    public void testMilliWriteAndMicroRead()
+            throws Exception
+    {
+        List<SqlTimestamp> milliSecondValues = ImmutableList.of(
+                sqlTimestampOf(0L, SESSION, MILLISECONDS), // 1970-01-01 00:00:00.000
+                sqlTimestampOf(1L, SESSION, MILLISECONDS), // 1970-01-01 00:00:00.001
+                sqlTimestampOf(999L, SESSION, MILLISECONDS), // 1970-01-01 00:00:00.999
+                sqlTimestampOf(1_000L, SESSION, MILLISECONDS), // 1970-01-01 00:00:01.000
+                sqlTimestampOf(-60_000_000_000_789L, SESSION, MILLISECONDS), // 0068-09-03 13:19:59.211
+                sqlTimestampOf(-230_000_000_999_999L, SESSION, MILLISECONDS), // -5319-08-03 22:50:00.001
+                sqlTimestampOf(1_650_483_250_507L, SESSION, MILLISECONDS), // 2022-04-20 19:34:10.507
+                sqlTimestampOf(60_000_000_000_789L, SESSION, MILLISECONDS), // 3871-04-29 10:40:00.789
+                sqlTimestampOf(230_000_000_000_999L, SESSION, MILLISECONDS)); // 9258-05-30 00:53:20.999
+
+        List<SqlTimestamp> milliSecondValuesInMicro = milliSecondValues.stream()
+                .map(milliTimestamp -> new SqlTimestamp(
+                        milliTimestamp.getMillisUtc() * 1000,
+                        milliTimestamp.getSessionTimeZoneKey().get(),
+                        MICROSECONDS))
+                .collect(toList());
+
+        testPrestoRoundTrip(TIMESTAMP, milliSecondValues, TIMESTAMP_MICROSECONDS, milliSecondValuesInMicro, true);
+    }
+
+    // Flaw in ORC encoding makes timestamp between 1969-12-31 23:59:59.000000, exclusive, and 1970-01-01 00:00:00.000000, exclusive.
+    // to be 1 second later than the original value written.
+    @Test
+    public void testOrcEncodingTimestampFlaw()
+            throws Exception
+    {
+        // Written Values
+        // (-1L, MICROSECONDS),         "1969-12-31 23:59:59.999999"
+        // (-999_999L, MICROSECONDS),   "1969-12-31 23:59:59.000001"
+        List<SqlTimestamp> timestampsWithFlaw = ImmutableList.of(
+                sqlTimestampOf(-1L, SESSION, MICROSECONDS),
+                sqlTimestampOf(-999_999L, SESSION, MICROSECONDS));
+
+        // Expected Values
+        // (999_999L, MICROSECONDS),    "1970-01-01 00:00:00.999999"
+        // (1L, MICROSECONDS),          "1970-01-01 00:00:00:000001"
+        List<SqlTimestamp> expectedTimestamps = ImmutableList.of(
+                sqlTimestampOf(999_999L, SESSION, MICROSECONDS),
+                sqlTimestampOf(1L, SESSION, MICROSECONDS));
+
+        testPrestoRoundTrip(TIMESTAMP_MICROSECONDS, timestampsWithFlaw, TIMESTAMP_MICROSECONDS, expectedTimestamps, true);
+    }
+
+    private void testPrestoRoundTrip(Type writeType, List<SqlTimestamp> writeValues, Type readType, List<SqlTimestamp> expectedValues, boolean readWithMicroPrecision)
+            throws Exception
+    {
+        try (TempFile tempFile = new TempFile()) {
+            writeOrcColumnsPresto(
+                    tempFile.getFile(),
+                    DWRF,
+                    CompressionKind.ZLIB,
+                    Optional.empty(),
+                    ImmutableList.of(writeType),
+                    ImmutableList.of(writeValues),
+                    new NoOpOrcWriterStats());
+
+            assertFileContentsPresto(
+                    ImmutableList.of(readType),
+                    tempFile,
+                    ImmutableList.of(expectedValues),
+                    false,
+                    false,
+                    DWRF.getOrcEncoding(),
+                    DWRF,
+                    false,
+                    true,
+                    ImmutableList.of(),
+                    ImmutableMap.of(),
+                    readWithMicroPrecision);
+        }
+    }
+}

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestingOrcPredicate.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestingOrcPredicate.java
@@ -48,6 +48,7 @@ import static com.facebook.presto.common.type.StandardTypes.ARRAY;
 import static com.facebook.presto.common.type.StandardTypes.MAP;
 import static com.facebook.presto.common.type.StandardTypes.ROW;
 import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP_MICROSECONDS;
 import static com.facebook.presto.common.type.TinyintType.TINYINT;
 import static com.facebook.presto.orc.OrcTester.Format.DWRF;
 import static com.google.common.base.Predicates.equalTo;
@@ -98,6 +99,14 @@ public final class TestingOrcPredicate
                     columnIndex,
                     expectedValues.stream()
                             .map(value -> value == null ? null : ((SqlTimestamp) value).getMillisUtc())
+                            .collect(toList()),
+                    false);
+        }
+        if (TIMESTAMP_MICROSECONDS.equals(type)) {
+            return new LongOrcPredicate(false,
+                    columnIndex,
+                    expectedValues.stream()
+                            .map(value -> value == null ? null : ((SqlTimestamp) value).getMicrosUtc())
                             .collect(toList()),
                     false);
         }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/writer/TestColumnWriters.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/writer/TestColumnWriters.java
@@ -36,6 +36,7 @@ import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static com.facebook.presto.common.type.RealType.REAL;
 import static com.facebook.presto.common.type.SmallintType.SMALLINT;
 import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP_MICROSECONDS;
 import static com.facebook.presto.common.type.TinyintType.TINYINT;
 import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
@@ -96,6 +97,7 @@ public class TestColumnWriters
                 {toOrcTypes(DOUBLE), DOUBLE, DOUBLE.createFixedSizeBlockBuilder(2).appendNull().writeLong(1).build()},
                 {toOrcTypes(REAL), REAL, REAL.createFixedSizeBlockBuilder(2).appendNull().writeInt(1).build()},
                 {toOrcTypes(TIMESTAMP), TIMESTAMP, TIMESTAMP.createFixedSizeBlockBuilder(2).appendNull().writeLong(1).build()},
+                {toOrcTypes(TIMESTAMP_MICROSECONDS), TIMESTAMP_MICROSECONDS, TIMESTAMP_MICROSECONDS.createFixedSizeBlockBuilder(2).appendNull().writeLong(1).build()},
                 {toOrcTypes(VARCHAR), VARCHAR, stringBlock},
                 {toOrcTypes(VARBINARY), VARBINARY, stringBlock},
                 {toOrcTypes(arrayType), arrayType, arrayBlock},


### PR DESCRIPTION
TL;DR Presto supports Millisecond precision for Timestamp read / write. This change provides an option in presto-orc to enable Timestamp writes and reads with microsecond precision. 

This change is limited only to presto-orc, we use this as a standalone reader / writer library. 

A new timestamp type TIMESTAMP_MICROSECONDS was introduced earlier to handle microsecond precision. This change enables this new type to be used by TimestampColumnWriter to write with either microsecond precision. This allows the existing type TIMESTAMP to continue to work with millisecond precision by presto.

OrcSelectiveRecordReader is already able to support reading timestamps in microsecond precision if enableTimestampMicroPrecision is set as true in OrcReaderOptions. Validated this read works as expected.

Test plan:

- Added new unit tests to validate changes
- Tested in Validation service for about 4 hours, no issues found

```
== NO RELEASE NOTE ==
```
