### PR TITLE
Fix Iceberg statistics for empty table

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/TableStatisticsMaker.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/TableStatisticsMaker.java
@@ -73,7 +73,9 @@ public class TableStatisticsMaker
     private TableStatistics makeTableStatistics(IcebergTableHandle tableHandle, Constraint constraint)
     {
         if (!tableHandle.getSnapshotId().isPresent() || constraint.getSummary().isNone()) {
-            return TableStatistics.empty();
+            return TableStatistics.builder()
+                    .setRowCount(Estimate.of(0))
+                    .build();
         }
 
         TupleDomain<IcebergColumnHandle> intersection = constraint.getSummary()
@@ -81,7 +83,9 @@ public class TableStatisticsMaker
                 .intersect(tableHandle.getPredicate());
 
         if (intersection.isNone()) {
-            return TableStatistics.empty();
+            return TableStatistics.builder()
+                    .setRowCount(Estimate.of(0))
+                    .build();
         }
 
         List<Types.NestedField> columns = icebergTable.schema().columns();
@@ -163,7 +167,9 @@ public class TableStatisticsMaker
         }
 
         if (summary == null) {
-            return TableStatistics.empty();
+            return TableStatistics.builder()
+                    .setRowCount(Estimate.of(0))
+                    .build();
         }
 
         double recordCount = summary.getRecordCount();


### PR DESCRIPTION
Cherry-pick of https://github.com/trinodb/trino/pull/12316/commits/7381fa2ffa138576800edc523dfe24b59a670b79
Return correct table statistics when an Iceberg table is empty.

Co-authored-by: Piotr Findeisen <piotr.findeisen@gmail.com>

Test plan - Added tests


```
== NO RELEASE NOTE ==
```
