### PR TITLE
Migrate existing fucntions to adapt runtime metric unit

### DIFF
--- a/presto-cache/src/main/java/com/facebook/presto/cache/alluxio/PrestoCacheContext.java
+++ b/presto-cache/src/main/java/com/facebook/presto/cache/alluxio/PrestoCacheContext.java
@@ -19,6 +19,7 @@ import alluxio.client.quota.CacheScope;
 import com.facebook.presto.hive.HiveFileContext;
 import com.google.common.collect.ImmutableMap;
 
+import static com.facebook.presto.common.RuntimeUnit.NANO;
 import static java.util.Objects.requireNonNull;
 
 public class PrestoCacheContext
@@ -50,7 +51,7 @@ public class PrestoCacheContext
     @Override
     public void incrementCounter(String name, long value)
     {
-        hiveFileContext.incrementCounter(name, value);
+        hiveFileContext.incrementCounter(name, NANO, value);
     }
 
     public HiveFileContext getHiveFileContext()

--- a/presto-hive-common/src/main/java/com/facebook/presto/hive/HiveFileContext.java
+++ b/presto-hive-common/src/main/java/com/facebook/presto/hive/HiveFileContext.java
@@ -14,10 +14,10 @@
 package com.facebook.presto.hive;
 
 import com.facebook.presto.common.RuntimeStats;
+import com.facebook.presto.common.RuntimeUnit;
 
 import java.util.Optional;
 
-import static com.facebook.presto.common.RuntimeUnit.NONE;
 import static com.facebook.presto.hive.CacheQuota.NO_CACHE_CONSTRAINTS;
 import static java.util.Objects.requireNonNull;
 
@@ -80,10 +80,10 @@ public class HiveFileContext
         T getExtraFileInfo();
     }
 
-    public void incrementCounter(String name, long value)
+    public void incrementCounter(String name, RuntimeUnit unit, long value)
     {
         if (verboseRuntimeStatsEnabled) {
-            stats.addMetricValue(name, NONE, value);
+            stats.addMetricValue(name, unit, value);
         }
     }
 

--- a/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSourceFactory.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/parquet/ParquetPageSourceFactory.java
@@ -75,6 +75,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static com.facebook.presto.common.RuntimeUnit.BYTE;
+import static com.facebook.presto.common.RuntimeUnit.NONE;
 import static com.facebook.presto.common.type.StandardTypes.ARRAY;
 import static com.facebook.presto.common.type.StandardTypes.BIGINT;
 import static com.facebook.presto.common.type.StandardTypes.CHAR;
@@ -283,14 +285,14 @@ public class ParquetPageSourceFactory
                     blocks.add(block);
                     blockStarts.add(nextStart);
                     blockIndexStores.add(columnIndexStore.orElse(null));
-                    hiveFileContext.incrementCounter("parquet.blocksRead", 1);
-                    hiveFileContext.incrementCounter("parquet.rowsRead", block.getRowCount());
-                    hiveFileContext.incrementCounter("parquet.totalBytesRead", block.getTotalByteSize());
+                    hiveFileContext.incrementCounter("parquet.blocksRead", NONE, 1);
+                    hiveFileContext.incrementCounter("parquet.rowsRead", NONE, block.getRowCount());
+                    hiveFileContext.incrementCounter("parquet.totalBytesRead", BYTE, block.getTotalByteSize());
                 }
                 else {
-                    hiveFileContext.incrementCounter("parquet.blocksSkipped", 1);
-                    hiveFileContext.incrementCounter("parquet.rowsSkipped", block.getRowCount());
-                    hiveFileContext.incrementCounter("parquet.totalBytesSkipped", block.getTotalByteSize());
+                    hiveFileContext.incrementCounter("parquet.blocksSkipped", NONE, 1);
+                    hiveFileContext.incrementCounter("parquet.rowsSkipped", NONE, block.getRowCount());
+                    hiveFileContext.incrementCounter("parquet.totalBytesSkipped", BYTE, block.getTotalByteSize());
                 }
                 nextStart += block.getRowCount();
             }


### PR DESCRIPTION
## migrate existing functions to adapt runtime metric unit
- some functions now adopt the runtime unit in their signature rather than choosing one for them
- Note : [incrementCounter](https://github.com/prestodb/presto/blob/ceee614fd75d1b58120c82bcdf05aa0aa04f1d6e/presto-cache/src/main/java/com/facebook/presto/cache/alluxio/PrestoCacheContext.java#L50) overrides a function from an alluxio library which defines the function without the runtimeUnit signature. For that reason the call to the HiveFileContext implementation will use the NONE unit. Though this version dosent have any usage in the codebase regardless

Resolves #17777 

Test plan - (Please fill in how you tested your changes)
1. Make sure the project builds successfully

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```
