### PR TITLE
Allow # in SubfieldTokenizer - which is a valid column name

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/SubfieldTokenizer.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/SubfieldTokenizer.java
@@ -147,7 +147,7 @@ class SubfieldTokenizer
 
     private static boolean isUnquotedPathCharacter(char c)
     {
-        return c == ':' || c == '$' || c == '-' || c == '/' || c == '@' || c == '|' || c == ' ' || isUnquotedSubscriptCharacter(c);
+        return c == ':' || c == '$' || c == '-' || c == '/' || c == '@' || c == '|' || c == '#' || c == ' ' || isUnquotedSubscriptCharacter(c);
     }
 
     private Subfield.PathElement matchUnquotedSubscript()

--- a/presto-common/src/test/java/com/facebook/presto/common/TestSubfieldTokenizer.java
+++ b/presto-common/src/test/java/com/facebook/presto/common/TestSubfieldTokenizer.java
@@ -73,6 +73,7 @@ public class TestSubfieldTokenizer
     @Test
     public void testColumnNames()
     {
+        assertPath(new Subfield("#bucket", ImmutableList.of()));
         assertPath(new Subfield("$bucket", ImmutableList.of()));
         assertPath(new Subfield("apollo-11", ImmutableList.of()));
         assertPath(new Subfield("a/b/c:12", ImmutableList.of()));


### PR DESCRIPTION
We are seeing queries crash when using # in column names. We recently added logic to parse subfields for all columns. The subfield parsing logic incorrectly assumed there is no # in column name.

```
== NO RELEASE NOTE ==
```
