### PR TITLE
Allow special character when creating subfield from column

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/Analysis.java
@@ -808,7 +808,7 @@ public class Analysis
                             Map.Entry::getKey,
                             accessControlEntry -> accessControlEntry.getValue().entrySet().stream().collect(toImmutableMap(
                                     Map.Entry::getKey,
-                                    tableEntry -> tableEntry.getValue().stream().map(Subfield::new).collect(toImmutableSet())))));
+                                    tableEntry -> tableEntry.getValue().stream().map(column -> new Subfield(column, ImmutableList.of())).collect(toImmutableSet())))));
         }
         else if (!isCheckAccessControlOnUtilizedColumnsOnly(session)) {
             references = tableColumnAndSubfieldReferences;

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/ExpressionAnalyzer.java
@@ -433,7 +433,7 @@ public class ExpressionAnalyzer
 
             // If we found a direct column reference, and we will put it in tableColumnReferencesWithSubFields
             if (field.getOriginTable().isPresent() && field.getOriginColumnName().isPresent() && isTopMostReference(node, context)) {
-                tableColumnAndSubfieldReferences.put(field.getOriginTable().get(), new Subfield(field.getOriginColumnName().get()));
+                tableColumnAndSubfieldReferences.put(field.getOriginTable().get(), new Subfield(field.getOriginColumnName().get(), ImmutableList.of()));
             }
 
             FieldId previous = columnReferences.put(NodeRef.of(node), fieldId);

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/StatementAnalyzer.java
@@ -586,7 +586,7 @@ class StatementAnalyzer
                     accessControl,
                     session.getIdentity(),
                     ImmutableMultimap.<QualifiedObjectName, Subfield>builder()
-                            .putAll(tableName, metadata.getColumnHandles(session, tableHandle).keySet().stream().map(Subfield::new).collect(toImmutableSet()))
+                            .putAll(tableName, metadata.getColumnHandles(session, tableHandle).keySet().stream().map(column -> new Subfield(column, ImmutableList.of())).collect(toImmutableSet()))
                             .build());
             try {
                 accessControl.checkCanInsertIntoTable(session.getRequiredTransactionId(), session.getIdentity(), session.getAccessControlContext(), tableName);
@@ -1862,13 +1862,13 @@ class StatementAnalyzer
                     analysis.addTableColumnAndSubfieldReferences(
                             accessControl,
                             session.getIdentity(),
-                            ImmutableMultimap.of(leftField.get().getField().getOriginTable().get(), new Subfield(leftField.get().getField().getOriginColumnName().get())));
+                            ImmutableMultimap.of(leftField.get().getField().getOriginTable().get(), new Subfield(leftField.get().getField().getOriginColumnName().get(), ImmutableList.of())));
                 }
                 if (rightField.get().getField().getOriginTable().isPresent() && rightField.get().getField().getOriginColumnName().isPresent()) {
                     analysis.addTableColumnAndSubfieldReferences(
                             accessControl,
                             session.getIdentity(),
-                            ImmutableMultimap.of(rightField.get().getField().getOriginTable().get(), new Subfield(rightField.get().getField().getOriginColumnName().get())));
+                            ImmutableMultimap.of(rightField.get().getField().getOriginTable().get(), new Subfield(rightField.get().getField().getOriginColumnName().get(), ImmutableList.of())));
                 }
             }
 

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/AbstractAnalyzerTest.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/AbstractAnalyzerTest.java
@@ -260,6 +260,14 @@ public class AbstractAnalyzerTest
                                         new ArrayType(new ArrayType(RowType.from(ImmutableList.of(new RowType.Field(Optional.of("y"), BIGINT))))))))))),
                 false));
 
+        // table with columns containing special characters
+        SchemaTableName table12 = new SchemaTableName("s1", "t12");
+        inSetupTransaction(session -> metadata.createTable(session, TPCH_CATALOG,
+                new ConnectorTableMetadata(table12, ImmutableList.of(
+                        new ColumnMetadata("a.x", BIGINT),
+                        new ColumnMetadata("a&^[x", BIGINT))),
+                false));
+
         // valid view referencing table in same schema
         String viewData1 = JsonCodec.jsonCodec(ViewDefinition.class).toJson(
                 new ViewDefinition(

--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestColumnAndSubfieldAnalyzer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestColumnAndSubfieldAnalyzer.java
@@ -91,6 +91,14 @@ public class TestColumnAndSubfieldAnalyzer
     }
 
     @Test
+    public void testSelectSpecialCharacter()
+    {
+        assertTableColumns(
+                "SELECT * FROM tpch.s1.t12",
+                ImmutableMap.of(QualifiedObjectName.valueOf("tpch.s1.t12"), ImmutableSet.of("a.x", "a&^[x")));
+    }
+
+    @Test
     public void testSelectWithAlias()
     {
         assertTableColumns(
@@ -148,8 +156,9 @@ public class TestColumnAndSubfieldAnalyzer
                     Statement statement = SQL_PARSER.createStatement(query);
                     Analysis analysis = analyzer.analyze(statement);
                     assertEquals(
-                            analysis.getTableColumnAndSubfieldReferencesForAccessControl(session).values().stream().findFirst().get(),
-                            expected.entrySet().stream().collect(toImmutableMap(Map.Entry::getKey, entry -> entry.getValue().stream().map(Subfield::new).collect(toImmutableSet()))));
+                            analysis.getTableColumnAndSubfieldReferencesForAccessControl(session).values().stream().findFirst().get().entrySet().stream()
+                                    .collect(toImmutableMap(Map.Entry::getKey, entry -> entry.getValue().stream().map(Subfield::toString).collect(toImmutableSet()))),
+                            expected);
                 });
     }
 


### PR DESCRIPTION
Followup of https://github.com/prestodb/presto/pull/17787

Allowing just # will not cut it, as there can be many more special characters that Presto allows. A proper fix is to rely on Presto parsing and skip the Subfield parsing completely.

```
== NO RELEASE NOTE ==
```
