### PR TITLE
Make StripeEncryptionGroup work with flat map column encodings

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfMetadataWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfMetadataWriter.java
@@ -467,10 +467,7 @@ public class DwrfMetadataWriter
                 .addAllStreams(stripeEncryptionGroup.getStreams().stream()
                         .map(DwrfMetadataWriter::toStream)
                         .collect(toImmutableList()))
-                .addAllEncoding(stripeEncryptionGroup.getColumnEncodings().entrySet()
-                        .stream()
-                        .map(entry -> toColumnEncoding(entry.getKey(), entry.getValue()))
-                        .collect(toImmutableList()))
+                .addAllEncoding(toColumnEncodings(stripeEncryptionGroup.getColumnEncodings()))
                 .build();
     }
 


### PR DESCRIPTION
A quick follow up on #17716 discovered after running OrcTest for flat map writer. 

DwrfMetadataWriter.toStripeEncryptionGroup used a variant of toColumnEncodings intended to be used with regular ColumnEncodings. This change switches it to the one that can handle both regular and nested ColumnEncodings.

Testing:
- existing tests + upcoming tests for flat maps

```
== NO RELEASE NOTE ==
```
