### PR TITLE
Let some stats builders add a single value from the block

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriteValidation.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriteValidation.java
@@ -31,6 +31,7 @@ import com.facebook.presto.orc.metadata.StripeInformation;
 import com.facebook.presto.orc.metadata.statistics.BinaryStatisticsBuilder;
 import com.facebook.presto.orc.metadata.statistics.BooleanStatisticsBuilder;
 import com.facebook.presto.orc.metadata.statistics.ColumnStatistics;
+import com.facebook.presto.orc.metadata.statistics.CountStatisticsBuilder;
 import com.facebook.presto.orc.metadata.statistics.DateStatisticsBuilder;
 import com.facebook.presto.orc.metadata.statistics.DoubleStatisticsBuilder;
 import com.facebook.presto.orc.metadata.statistics.IntegerStatistics;
@@ -743,28 +744,6 @@ public class OrcWriteValidation
         {
             output.add(statisticsBuilder.buildColumnStatistics());
             fieldBuilders.forEach(fieldBuilders -> fieldBuilders.build(output));
-        }
-    }
-
-    private static class CountStatisticsBuilder
-            implements StatisticsBuilder
-    {
-        private long rowCount;
-
-        @Override
-        public void addBlock(Type type, Block block)
-        {
-            for (int position = 0; position < block.getPositionCount(); position++) {
-                if (!block.isNull(position)) {
-                    rowCount++;
-                }
-            }
-        }
-
-        @Override
-        public ColumnStatistics buildColumnStatistics()
-        {
-            return new ColumnStatistics(rowCount, null);
         }
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/CountStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/CountStatisticsBuilder.java
@@ -16,26 +16,37 @@ package com.facebook.presto.orc.metadata.statistics;
 import com.facebook.presto.common.block.Block;
 import com.facebook.presto.common.type.Type;
 
-public interface LongValueStatisticsBuilder
-        extends StatisticsBuilder
+public class CountStatisticsBuilder
+        implements StatisticsBuilder
 {
+    private long nonNullValueCount;
+
     @Override
-    default void addBlock(Type type, Block block)
+    public void addBlock(Type type, Block block)
     {
         for (int position = 0; position < block.getPositionCount(); position++) {
             if (!block.isNull(position)) {
-                addValue(type.getLong(block, position));
+                nonNullValueCount++;
             }
         }
     }
 
     @Override
-    default void addValue(Type type, Block block, int position)
+    public void addValue(Type type, Block block, int position)
     {
         if (!block.isNull(position)) {
-            addValue(type.getLong(block, position));
+            nonNullValueCount++;
         }
     }
 
-    void addValue(long value);
+    public void addValue()
+    {
+        nonNullValueCount++;
+    }
+
+    @Override
+    public ColumnStatistics buildColumnStatistics()
+    {
+        return new ColumnStatistics(nonNullValueCount, null);
+    }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/SliceColumnStatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/SliceColumnStatisticsBuilder.java
@@ -25,12 +25,20 @@ public interface SliceColumnStatisticsBuilder
     @Override
     default void addBlock(Type type, Block block)
     {
-        checkArgument(type instanceof AbstractVariableWidthType, "type is not a AbstractVariableWidthType");
-        AbstractVariableWidthType variableWidthType = (AbstractVariableWidthType) type;
+        checkArgument(type instanceof AbstractVariableWidthType, "type is not an AbstractVariableWidthType: %s", type);
         for (int position = 0; position < block.getPositionCount(); position++) {
             if (!block.isNull(position)) {
                 addValue(block, position);
             }
+        }
+    }
+
+    @Override
+    default void addValue(Type type, Block block, int position)
+    {
+        checkArgument(type instanceof AbstractVariableWidthType, "type is not an AbstractVariableWidthType: %s", type);
+        if (!block.isNull(position)) {
+            addValue(block, position);
         }
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/StatisticsBuilder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/StatisticsBuilder.java
@@ -20,5 +20,10 @@ public interface StatisticsBuilder
 {
     void addBlock(Type type, Block block);
 
+    default void addValue(Type type, Block block, int position)
+    {
+        throw new UnsupportedOperationException();
+    }
+
     ColumnStatistics buildColumnStatistics();
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/StatisticsBuilders.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/statistics/StatisticsBuilders.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.metadata.statistics;
+
+import com.facebook.presto.orc.ColumnWriterOptions;
+import com.facebook.presto.orc.metadata.OrcType;
+
+import java.util.function.Supplier;
+
+import static java.util.Objects.requireNonNull;
+
+public class StatisticsBuilders
+{
+    private StatisticsBuilders() {}
+
+    public static Supplier<StatisticsBuilder> createFlatMapKeyStatisticsBuilderSupplier(OrcType orcType, ColumnWriterOptions columnWriterOptions)
+    {
+        requireNonNull(orcType, "orcType is null");
+        requireNonNull(columnWriterOptions, "columnWriterOptions is null");
+
+        switch (orcType.getOrcTypeKind()) {
+            case BYTE:
+                // TODO: sdruzkin - byte should use IntegerStatisticsBuilder
+                return CountStatisticsBuilder::new;
+            case SHORT:
+            case INT:
+            case LONG:
+                return IntegerStatisticsBuilder::new;
+            case BINARY:
+                return BinaryStatisticsBuilder::new;
+            case VARCHAR:
+            case STRING:
+                int stringStatisticsLimit = columnWriterOptions.getStringStatisticsLimit();
+                return () -> new StringStatisticsBuilder(stringStatisticsLimit);
+            default:
+                throw new IllegalArgumentException("Unsupported type: " + orcType);
+        }
+    }
+}

--- a/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestBinaryStatisticsBuilder.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestBinaryStatisticsBuilder.java
@@ -79,6 +79,30 @@ public class TestBinaryStatisticsBuilder
     }
 
     @Test
+    public void testAddValueByPosition()
+    {
+        String alphabet = "abcdefghijklmnopqrstuvwxyz";
+        VariableWidthBlockBuilder blockBuilder = new VariableWidthBlockBuilder(null, alphabet.length(), alphabet.length());
+        Slice slice = utf8Slice(alphabet);
+        for (int i = 0; i < slice.length(); i++) {
+            VARBINARY.writeSlice(blockBuilder, slice, i, 1);
+        }
+        blockBuilder.appendNull();
+
+        BinaryStatisticsBuilder statisticsBuilder = new BinaryStatisticsBuilder();
+        int positionCount = blockBuilder.getPositionCount();
+        for (int position = 0; position < positionCount; position++) {
+            statisticsBuilder.addValue(VARBINARY, blockBuilder, position);
+        }
+
+        ColumnStatistics columnStatistics = statisticsBuilder.buildColumnStatistics();
+        assertEquals(columnStatistics.getNumberOfValues(), positionCount - 1);
+
+        BinaryStatistics binaryStatistics = columnStatistics.getBinaryStatistics();
+        assertEquals(binaryStatistics.getSum(), slice.length());
+    }
+
+    @Test
     public void testMerge()
     {
         List<ColumnStatistics> statisticsList = new ArrayList<>();

--- a/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestCountStatisticsBuilder.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestCountStatisticsBuilder.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.metadata.statistics;
+
+import com.facebook.presto.common.block.Block;
+import org.testng.annotations.Test;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static org.testng.Assert.assertEquals;
+
+public class TestCountStatisticsBuilder
+{
+    @Test
+    public void testNoValues()
+    {
+        CountStatisticsBuilder statisticsBuilder = new CountStatisticsBuilder();
+        ColumnStatistics columnStatistics = statisticsBuilder.buildColumnStatistics();
+        assertEquals(columnStatistics.getNumberOfValues(), 0);
+    }
+
+    @Test
+    public void testAddValue()
+    {
+        CountStatisticsBuilder statisticsBuilder = new CountStatisticsBuilder();
+        statisticsBuilder.addValue();
+        statisticsBuilder.addValue();
+        ColumnStatistics columnStatistics = statisticsBuilder.buildColumnStatistics();
+        assertEquals(columnStatistics.getNumberOfValues(), 2);
+    }
+
+    @Test
+    public void testAddBlockValues()
+    {
+        Block block = BIGINT.createBlockBuilder(null, 3)
+                .writeLong(3L)
+                .appendNull()
+                .writeLong(10L);
+
+        CountStatisticsBuilder statisticsBuilder = new CountStatisticsBuilder();
+        statisticsBuilder.addBlock(BIGINT, block);
+
+        ColumnStatistics columnStatistics = statisticsBuilder.buildColumnStatistics();
+        assertEquals(columnStatistics.getNumberOfValues(), 2);
+    }
+
+    @Test
+    public void testAddValueByPosition()
+    {
+        Block block = BIGINT.createBlockBuilder(null, 3)
+                .writeLong(3L)
+                .appendNull()
+                .writeLong(10L);
+
+        CountStatisticsBuilder statisticsBuilder = new CountStatisticsBuilder();
+        statisticsBuilder.addValue(BIGINT, block, 0);
+        statisticsBuilder.addValue(BIGINT, block, 1);
+
+        ColumnStatistics columnStatistics = statisticsBuilder.buildColumnStatistics();
+        assertEquals(columnStatistics.getNumberOfValues(), 1);
+    }
+}

--- a/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestStatisticsBuilders.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/metadata/statistics/TestStatisticsBuilders.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.metadata.statistics;
+
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.orc.ColumnWriterOptions;
+import com.facebook.presto.orc.metadata.CompressionKind;
+import com.facebook.presto.orc.metadata.OrcType;
+import org.testng.annotations.Test;
+
+import java.util.function.Supplier;
+
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.IntegerType.INTEGER;
+import static com.facebook.presto.common.type.RealType.REAL;
+import static com.facebook.presto.common.type.SmallintType.SMALLINT;
+import static com.facebook.presto.common.type.TinyintType.TINYINT;
+import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
+
+public class TestStatisticsBuilders
+{
+    @Test
+    public void testCreateStatisticsBuilderValidType()
+    {
+        assertTrue(createStatisticsBuilder(TINYINT) instanceof CountStatisticsBuilder);
+        assertTrue(createStatisticsBuilder(SMALLINT) instanceof IntegerStatisticsBuilder);
+        assertTrue(createStatisticsBuilder(INTEGER) instanceof IntegerStatisticsBuilder);
+        assertTrue(createStatisticsBuilder(BIGINT) instanceof IntegerStatisticsBuilder);
+        assertTrue(createStatisticsBuilder(VARCHAR) instanceof StringStatisticsBuilder);
+        assertTrue(createStatisticsBuilder(VARBINARY) instanceof BinaryStatisticsBuilder);
+    }
+
+    @Test
+    public void testCreateStatisticsBuilderInvalidType()
+    {
+        assertThrows(IllegalArgumentException.class, () -> createStatisticsBuilder(REAL));
+    }
+
+    private static StatisticsBuilder createStatisticsBuilder(Type type)
+    {
+        ColumnWriterOptions columnWriterOptions = ColumnWriterOptions.builder().setCompressionKind(CompressionKind.ZSTD).build();
+        OrcType orcType = OrcType.toOrcType(0, type).get(0);
+        Supplier<? extends StatisticsBuilder> supplier = StatisticsBuilders.createFlatMapKeyStatisticsBuilderSupplier(orcType, columnWriterOptions);
+        return supplier.get();
+    }
+}


### PR DESCRIPTION
Current implementation of stats builders are geared toward ColumnWriters and are heavily type dependent. They do not provide a unified interface to add a single value from a block. Flat map writer needs a unified interface allowing stats builder to add a value by position from a block to be able to build stats for the key node. 

This change adds a new method to the StatisticsBuilder interface:
```
void addValue(Type type, Block block, int position)
```

Flat map key types are limited to byte/short/int/long/varchar/varbinary, that's why only stats builders for these types received implementation of the new method.

Test plan:
- new tests

```
== NO RELEASE NOTE ==
```
