### PR TITLE
Add support for StreamOrderingLayout

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/DwrfStreamOrderingConfig.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/DwrfStreamOrderingConfig.java
@@ -13,11 +13,13 @@
  */
 package com.facebook.presto.orc;
 
-import com.facebook.presto.orc.proto.DwrfProto;
+import com.facebook.presto.orc.proto.DwrfProto.KeyInfo;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static java.util.Objects.requireNonNull;
 
@@ -25,16 +27,20 @@ public class DwrfStreamOrderingConfig
 {
     // column is the logical columns index for a table with n columns
     // This index range from 0 to n - 1
-    private final ImmutableMap<Integer, List<DwrfProto.KeyInfo>> columnIdToFlatMapKeyIds;
+    private final ImmutableMap<Integer, Set<KeyInfo>> columnToKeySet;
 
-    public DwrfStreamOrderingConfig(Map<Integer, List<DwrfProto.KeyInfo>> columnIdToFlatMapKeyIds)
+    public DwrfStreamOrderingConfig(Map<Integer, List<KeyInfo>> columnToKeys)
     {
-        requireNonNull(columnIdToFlatMapKeyIds, "columnIdToFlatMapKeyIds cannot be null");
-        this.columnIdToFlatMapKeyIds = ImmutableMap.copyOf(columnIdToFlatMapKeyIds);
+        requireNonNull(columnToKeys, "columnToKeys cannot be null");
+        ImmutableMap.Builder<Integer, Set<KeyInfo>> columnToKeySetBuilder = new ImmutableMap.Builder<>();
+        for (Map.Entry<Integer, List<KeyInfo>> entry : columnToKeys.entrySet()) {
+            columnToKeySetBuilder.put(entry.getKey(), ImmutableSet.copyOf(entry.getValue()));
+        }
+        columnToKeySet = columnToKeySetBuilder.build();
     }
 
-    public Map<Integer, List<DwrfProto.KeyInfo>> getStreamOrdering()
+    public Map<Integer, Set<KeyInfo>> getStreamOrdering()
     {
-        return columnIdToFlatMapKeyIds;
+        return columnToKeySet;
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
@@ -567,7 +567,7 @@ public class OrcWriter
                     .mapToLong(StreamDataOutput::size)
                     .sum();
         }
-        streamLayout.reorder(dataStreams);
+        streamLayout.reorder(dataStreams, ImmutableMap.of(), ImmutableMap.of());
 
         // add data streams
         for (StreamDataOutput dataStream : dataStreams) {

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcType.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcType.java
@@ -326,4 +326,25 @@ public class OrcType
                 .map(rootType::getFieldTypeIndex)
                 .collect(toImmutableSet());
     }
+
+    public static Map<Integer, Integer> createNodeIdToColumnMap(List<OrcType> orcTypes)
+    {
+        requireNonNull(orcTypes, "orcTypes cannot be null");
+        int totalNodeCount = orcTypes.size();
+        int column = 0;
+        List<Integer> fieldTypeIndexes = orcTypes.get(0).getFieldTypeIndexes();
+        ImmutableMap.Builder<Integer, Integer> nodeIdToColumnBuilder = ImmutableMap.builder();
+        // create nodeId to colId mapping for all the columns except for the last one
+        for (int nodeIndex = 0; nodeIndex < fieldTypeIndexes.size(); nodeIndex++) {
+            boolean isLastNode = nodeIndex == fieldTypeIndexes.size() - 1;
+            int currentNodeId = fieldTypeIndexes.get(nodeIndex);
+            int nextNodeId = isLastNode ? totalNodeCount : fieldTypeIndexes.get(nodeIndex + 1);
+            int numberOfNodesPerColumn = nextNodeId - currentNodeId;
+            for (int i = 0; i < numberOfNodesPerColumn; i++) {
+                nodeIdToColumnBuilder.put(currentNodeId++, column);
+            }
+            column++;
+        }
+        return nodeIdToColumnBuilder.build();
+    }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/StreamLayout.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/StreamLayout.java
@@ -13,6 +13,7 @@
  */
 package com.facebook.presto.orc.writer;
 
+import com.facebook.presto.orc.metadata.ColumnEncoding;
 import com.facebook.presto.orc.metadata.Stream;
 import com.facebook.presto.orc.stream.StreamDataOutput;
 
@@ -30,7 +31,10 @@ import static java.util.Objects.requireNonNull;
  */
 public interface StreamLayout
 {
-    void reorder(List<StreamDataOutput> dataStreams);
+    void reorder(
+            List<StreamDataOutput> dataStreams,
+            Map<Integer, Integer> nodeIdToColumn,
+            Map<Integer, ColumnEncoding> nodeIdToColumnEncodings);
 
     /**
      * Streams are ordered by the Stream Size. There is no ordering between
@@ -42,10 +46,15 @@ public interface StreamLayout
     class ByStreamSize
             implements StreamLayout
     {
-        @Override
         public void reorder(List<StreamDataOutput> dataStreams)
         {
             Collections.sort(requireNonNull(dataStreams, "dataStreams is null"));
+        }
+
+        @Override
+        public void reorder(List<StreamDataOutput> dataStreams, Map<Integer, Integer> nodeIdToColumn, Map<Integer, ColumnEncoding> nodeIdToColumnEncodings)
+        {
+            reorder(dataStreams);
         }
 
         @Override
@@ -64,7 +73,6 @@ public interface StreamLayout
     class ByColumnSize
             implements StreamLayout
     {
-        @Override
         public void reorder(List<StreamDataOutput> dataStreams)
         {
             requireNonNull(dataStreams, "dataStreams is null");
@@ -99,6 +107,12 @@ public interface StreamLayout
 
                 return leftStream.getStreamKind().compareTo(rightStream.getStreamKind());
             });
+        }
+
+        @Override
+        public void reorder(List<StreamDataOutput> dataStreams, Map<Integer, Integer> nodeIdToColumn, Map<Integer, ColumnEncoding> nodeIdToColumnEncodings)
+        {
+            reorder(dataStreams);
         }
 
         @Override

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/StreamOrderingLayout.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/StreamOrderingLayout.java
@@ -1,0 +1,223 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.writer;
+
+import com.facebook.presto.orc.DwrfStreamOrderingConfig;
+import com.facebook.presto.orc.metadata.ColumnEncoding;
+import com.facebook.presto.orc.metadata.DwrfSequenceEncoding;
+import com.facebook.presto.orc.proto.DwrfProto;
+import com.facebook.presto.orc.stream.StreamDataOutput;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+public class StreamOrderingLayout
+        implements StreamLayout
+{
+    private final DwrfStreamOrderingConfig config;
+    private final StreamLayout nonStreamOrderingLayout;
+
+    public StreamOrderingLayout(
+            DwrfStreamOrderingConfig config,
+            StreamLayout layout)
+    {
+        this.config = requireNonNull(config, "config cannot be null");
+        this.nonStreamOrderingLayout = requireNonNull(layout, "layout cannot be null");
+    }
+
+    private static class StreamMetadata
+    {
+        // <Column Id, Sequence ID> -> List<Streams>>
+        private final Map<ColumnSequenceInfo, List<StreamDataOutput>> sequenceToStreams;
+        // <Column Id, KeyId> -> SequenceId
+        private final Map<ColumnKeyInfo, Integer> keyToSequence;
+
+        public StreamMetadata(Map<ColumnSequenceInfo, List<StreamDataOutput>> sequenceToStreams, Map<ColumnKeyInfo, Integer> keyToSequence)
+        {
+            this.sequenceToStreams = requireNonNull(sequenceToStreams, "sequenceToStreams cannot be null");
+            this.keyToSequence = requireNonNull(keyToSequence, "keyToSequence cannot be null");
+        }
+    }
+
+    private static class ColumnKeyInfo
+    {
+        private final int column;
+        private final DwrfProto.KeyInfo key;
+
+        public ColumnKeyInfo(int column, DwrfProto.KeyInfo key)
+        {
+            this.column = column;
+            this.key = requireNonNull(key, "key cannot be null");
+        }
+
+        @Override
+        public boolean equals(Object obj)
+        {
+            if (obj == null) {
+                return false;
+            }
+            if (!(obj instanceof ColumnKeyInfo)) {
+                return false;
+            }
+            ColumnKeyInfo input = (ColumnKeyInfo) obj;
+            return this.column == input.column && this.key.equals(input.key);
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(column, key);
+        }
+    }
+
+    private static class ColumnSequenceInfo
+    {
+        private final int column;
+        private final int sequence;
+
+        public ColumnSequenceInfo(int column, int sequence)
+        {
+            this.column = column;
+            this.sequence = sequence;
+        }
+
+        @Override
+        public boolean equals(Object obj)
+        {
+            if (obj == null) {
+                return false;
+            }
+            if (!(obj instanceof ColumnSequenceInfo)) {
+                return false;
+            }
+            ColumnSequenceInfo input = (ColumnSequenceInfo) obj;
+            return this.column == input.column && this.sequence == input.sequence;
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return Objects.hash(column, sequence);
+        }
+    }
+
+    private StreamMetadata getStreamMetadata(
+            Map<Integer, Integer> nodeIdToColumn,
+            Map<Integer, ColumnEncoding> nodeIdToColumnEncodings,
+            DwrfStreamOrderingConfig config)
+    {
+        ImmutableMap.Builder<ColumnKeyInfo, Integer> keyToSequenceBuilder = ImmutableMap.builder();
+        ImmutableMap.Builder<ColumnSequenceInfo, List<StreamDataOutput>> sequenceToStreamsBuilder = ImmutableMap.builder();
+        Map<Integer, Set<DwrfProto.KeyInfo>> columnToKeySet = config.getStreamOrdering();
+        // Adding a set to track which of the columns in the reorder list are already visited
+        // For complex maps (complex values for the value)
+        // there could be multiple nodeId(s) mapping to a single column ID
+        // For example,  if the flat map column is map<int, list<int>> with node ids (1: <2, 3<4>>) and column id 0
+        // There will be multiple entries in the nodeIdToColumnEncodings for each of the values
+        // 1 -> DWRF_MAP_FLAT encoding
+        // 3 -> DIRECT encoding  + SortedMap<Integer, DwrfSequenceEncoding> (sequence encodings)
+        // 4 -> DIRECT encoding  + SortedMap<Integer, DwrfSequenceEncoding> (sequence encodings)
+        Set<Integer> columnsVisited = new HashSet<>(columnToKeySet.size());
+
+        // iterate through all the encodings and if the encoding has additional sequence encodings put it in the map
+        for (Map.Entry<Integer, ColumnEncoding> entry : nodeIdToColumnEncodings.entrySet()) {
+            int nodeId = entry.getKey();
+            int column = nodeIdToColumn.get(nodeId);
+            if (entry.getValue().getAdditionalSequenceEncodings().isPresent() && columnToKeySet.containsKey(column) && !columnsVisited.contains(column)) {
+                // add entries only if stream ordering contains the column ID
+                Set<DwrfProto.KeyInfo> keysPerColumn = columnToKeySet.get(column);
+                for (Map.Entry<Integer, DwrfSequenceEncoding> sequenceToEncoding : entry.getValue().getAdditionalSequenceEncodings().get().entrySet()) {
+                    Integer sequence = sequenceToEncoding.getKey();
+                    DwrfProto.KeyInfo key = sequenceToEncoding.getValue().getKey();
+                    // add the stream only if it is present in the stream ordering config
+                    if (keysPerColumn.contains(key)) {
+                        keyToSequenceBuilder.put(new ColumnKeyInfo(column, key), sequence);
+                        sequenceToStreamsBuilder.put(new ColumnSequenceInfo(column, sequence), new ArrayList<>());
+                    }
+                }
+                columnsVisited.add(column);
+            }
+        }
+        return new StreamMetadata(sequenceToStreamsBuilder.build(), keyToSequenceBuilder.build());
+    }
+
+    @Override
+    public void reorder(
+            List<StreamDataOutput> dataStreams,
+            Map<Integer, Integer> nodeIdToColumn,
+            Map<Integer, ColumnEncoding> nodeIdToColumnEncodings)
+    {
+        List<StreamDataOutput> nonReorderStreams = new ArrayList<>();
+        StreamMetadata metadata = getStreamMetadata(nodeIdToColumn, nodeIdToColumnEncodings, config);
+        Map<ColumnSequenceInfo, List<StreamDataOutput>> sequenceToStreams = metadata.sequenceToStreams;
+        for (StreamDataOutput dataOutput : dataStreams) {
+            int nodeId = dataOutput.getStream().getColumn();
+            int sequence = dataOutput.getStream().getSequence();
+            int column = nodeIdToColumn.get(nodeId);
+            // only if sequence ID > 0, we do a look up in sequenceToStreams
+            if (sequence > 0) {
+                List<StreamDataOutput> streams = sequenceToStreams.get(new ColumnSequenceInfo(column, sequence));
+                if (streams == null) {
+                    nonReorderStreams.add(dataOutput);
+                }
+                else {
+                    streams.add(dataOutput);
+                }
+            }
+            else {
+                nonReorderStreams.add(dataOutput);
+            }
+        }
+
+        // reorder everything in the input order
+        List<StreamDataOutput> orderedStreams = new ArrayList<>();
+        Map<ColumnKeyInfo, Integer> keyToSequence = metadata.keyToSequence;
+        for (Map.Entry<Integer, Set<DwrfProto.KeyInfo>> columnToKeys : config.getStreamOrdering().entrySet()) {
+            int column = columnToKeys.getKey();
+            for (DwrfProto.KeyInfo key : columnToKeys.getValue()) {
+                ColumnKeyInfo columnKeyInfo = new ColumnKeyInfo(column, key);
+                Integer sequence = keyToSequence.get(columnKeyInfo);
+                if (sequence != null) {
+                    ColumnSequenceInfo columnSequenceInfo = new ColumnSequenceInfo(column, sequence);
+                    List<StreamDataOutput> groupedDataStreams = sequenceToStreams.get(columnSequenceInfo);
+                    checkState(groupedDataStreams != null, "list of streams for a sequence cannot be null");
+                    checkState(groupedDataStreams.size() > 0, "There should be at least one stream for a sequence");
+                    orderedStreams.addAll(groupedDataStreams);
+                }
+            }
+        }
+
+        // do actual reordering
+        nonStreamOrderingLayout.reorder(nonReorderStreams, ImmutableMap.of(), ImmutableMap.of());
+
+        // add all the streams
+        checkState(orderedStreams.size() + nonReorderStreams.size() == dataStreams.size(),
+                "Number ordered + non ordered streams should be equal to total number of data streams " +
+                "orderedStreams: %s, nonReorderStreams: %s, dataStreams: %s",
+                orderedStreams.size(),
+                nonReorderStreams.size(),
+                dataStreams.size());
+        dataStreams.clear();
+        dataStreams.addAll(orderedStreams);
+        dataStreams.addAll(nonReorderStreams);
+    }
+}

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestDwrfStreamOrdering.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestDwrfStreamOrdering.java
@@ -14,12 +14,14 @@
 
 package com.facebook.presto.orc;
 
-import com.facebook.presto.orc.proto.DwrfProto;
+import com.facebook.presto.orc.proto.DwrfProto.KeyInfo;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.testng.annotations.Test;
 
-import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 import static org.testng.Assert.assertEquals;
 
@@ -28,12 +30,19 @@ public class TestDwrfStreamOrdering
     @Test
     public void testDwrfStreamOrder()
     {
-        ImmutableMap<Integer, List<DwrfProto.KeyInfo>> columnIdToFlatMapKeyIds =
+        ImmutableMap<Integer, List<KeyInfo>> columnIdToFlatMapKeyIds =
                 ImmutableMap.of(
-                        1, Collections.singletonList(DwrfProto.KeyInfo.newBuilder().setIntKey(1).build()),
-                        2, Collections.singletonList(DwrfProto.KeyInfo.newBuilder().setIntKey(1).build()),
-                        3, Collections.singletonList(DwrfProto.KeyInfo.newBuilder().setIntKey(1).build()));
+                        1, ImmutableList.of(KeyInfo.newBuilder().setIntKey(1).build(), KeyInfo.newBuilder().setIntKey(2).build()),
+                        2, ImmutableList.of(KeyInfo.newBuilder().setIntKey(3).build()),
+                        3, ImmutableList.of(KeyInfo.newBuilder().setIntKey(5).build(), KeyInfo.newBuilder().setIntKey(4).build()));
+
+        ImmutableMap<Integer, Set<KeyInfo>> expectedResult =
+                ImmutableMap.of(
+                        1, ImmutableSet.of(KeyInfo.newBuilder().setIntKey(1).build(), KeyInfo.newBuilder().setIntKey(2).build()),
+                        2, ImmutableSet.of(KeyInfo.newBuilder().setIntKey(3).build()),
+                        3, ImmutableSet.of(KeyInfo.newBuilder().setIntKey(5).build(), KeyInfo.newBuilder().setIntKey(4).build()));
+
         DwrfStreamOrderingConfig config = new DwrfStreamOrderingConfig(columnIdToFlatMapKeyIds);
-        assertEquals(config.getStreamOrdering(), columnIdToFlatMapKeyIds);
+        assertEquals(expectedResult, config.getStreamOrdering());
     }
 }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestStreamLayout.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestStreamLayout.java
@@ -13,34 +13,62 @@
  */
 package com.facebook.presto.orc;
 
+import com.facebook.presto.orc.metadata.ColumnEncoding;
+import com.facebook.presto.orc.metadata.DwrfSequenceEncoding;
 import com.facebook.presto.orc.metadata.Stream;
 import com.facebook.presto.orc.metadata.Stream.StreamKind;
+import com.facebook.presto.orc.proto.DwrfProto;
 import com.facebook.presto.orc.stream.StreamDataOutput;
 import com.facebook.presto.orc.writer.StreamLayout.ByColumnSize;
 import com.facebook.presto.orc.writer.StreamLayout.ByStreamSize;
+import com.facebook.presto.orc.writer.StreamOrderingLayout;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSortedMap;
 import io.airlift.slice.Slices;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.SortedMap;
 
+import static com.facebook.presto.orc.metadata.ColumnEncoding.ColumnEncodingKind.DIRECT;
+import static com.facebook.presto.orc.metadata.ColumnEncoding.ColumnEncodingKind.DWRF_MAP_FLAT;
 import static com.facebook.presto.orc.metadata.ColumnEncoding.DEFAULT_SEQUENCE_ID;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 
 public class TestStreamLayout
 {
-    private static StreamDataOutput createStream(int column, StreamKind streamKind, int length)
+    private static StreamDataOutput createStream(int nodeId, int seqId, StreamKind streamKind, int length)
     {
-        Stream stream = new Stream(column, DEFAULT_SEQUENCE_ID, streamKind, length, true);
+        Stream stream = new Stream(nodeId, seqId, streamKind, length, true);
         return new StreamDataOutput(Slices.allocate(1024), stream);
     }
 
-    private static void verifyStream(Stream stream, int column, StreamKind streamKind, int length)
+    private static StreamDataOutput createStream(int nodeId, StreamKind streamKind, int length)
     {
-        assertEquals(stream.getColumn(), column);
+        Stream stream = new Stream(nodeId, DEFAULT_SEQUENCE_ID, streamKind, length, true);
+        return new StreamDataOutput(Slices.allocate(1024), stream);
+    }
+
+    private static void verifyStream(Stream stream, int nodeId, StreamKind streamKind, int length)
+    {
+        assertEquals(stream.getColumn(), nodeId);
+        assertEquals(stream.getLength(), length);
+        assertEquals(stream.getStreamKind(), streamKind);
+    }
+
+    private static void verifyStream(Stream stream, int nodeId, int seqId, StreamKind streamKind, int length)
+    {
+        assertEquals(stream.getColumn(), nodeId);
+        assertEquals(stream.getSequence(), seqId);
         assertEquals(stream.getLength(), length);
         assertEquals(stream.getStreamKind(), streamKind);
     }
@@ -107,5 +135,238 @@ public class TestStreamLayout
         verifyStream(iterator.next().getStream(), 3, StreamKind.DATA, Integer.MAX_VALUE);
 
         assertFalse(iterator.hasNext());
+    }
+
+    @DataProvider(name = "testParams")
+    public static Object[][] testParams()
+    {
+        return new Object[][] {{true}, {false}};
+    }
+
+    @Test(dataProvider = "testParams")
+    public void testByStreamSizeStreamOrdering(boolean isEmptyMap)
+    {
+        List<StreamDataOutput> streams = createStreams(isEmptyMap);
+        ByStreamSize streamLayout = new ByStreamSize();
+        StreamOrderingLayout streamOrderingLayout = new StreamOrderingLayout(createStreamReorderingInput(), streamLayout);
+        streamOrderingLayout.reorder(streams, createNodeIdToColumnId(), createColumnEncodings(isEmptyMap));
+
+        Iterator<StreamDataOutput> iterator = streams.iterator();
+        if (!isEmptyMap) {
+            verifyFlatMapColumns(iterator);
+        }
+        // non flat map columns
+        verifyStream(iterator.next().getStream(), 5, 0, StreamKind.DATA, 1);
+        verifyStream(iterator.next().getStream(), 2, 0, StreamKind.LENGTH, 2);
+        verifyStream(iterator.next().getStream(), 1, 0, StreamKind.DATA, 3);
+        verifyStream(iterator.next().getStream(), 4, 0, StreamKind.LENGTH, 5);
+        verifyStream(iterator.next().getStream(), 3, 0, StreamKind.DATA, 8);
+        verifyStream(iterator.next().getStream(), 1, 0, StreamKind.PRESENT, 12);
+        if (!isEmptyMap) {
+            // flat map stream not reordered
+            verifyStream(iterator.next().getStream(), 11, 5, StreamKind.IN_MAP, 13);
+            verifyStream(iterator.next().getStream(), 11, 5, StreamKind.LENGTH, 14);
+            verifyStream(iterator.next().getStream(), 12, 5, StreamKind.DATA, 15);
+        }
+        assertFalse(iterator.hasNext());
+    }
+
+    @Test(dataProvider = "testParams")
+    public void testByColumnSizeStreamOrdering(boolean isEmptyMap)
+    {
+        List<StreamDataOutput> streams = createStreams(isEmptyMap);
+        ByColumnSize streamLayout = new ByColumnSize();
+        StreamOrderingLayout streamOrderingLayout = new StreamOrderingLayout(createStreamReorderingInput(), streamLayout);
+        streamOrderingLayout.reorder(streams, createNodeIdToColumnId(), createColumnEncodings(isEmptyMap));
+
+        Iterator<StreamDataOutput> iterator = streams.iterator();
+        if (!isEmptyMap) {
+            verifyFlatMapColumns(iterator);
+        }
+        // non flat map columns
+        verifyStream(iterator.next().getStream(), 5, 0, StreamKind.DATA, 1);
+        verifyStream(iterator.next().getStream(), 2, 0, StreamKind.LENGTH, 2);
+        verifyStream(iterator.next().getStream(), 4, 0, StreamKind.LENGTH, 5);
+        verifyStream(iterator.next().getStream(), 3, 0, StreamKind.DATA, 8);
+        verifyStream(iterator.next().getStream(), 1, 0, StreamKind.DATA, 3);
+        verifyStream(iterator.next().getStream(), 1, 0, StreamKind.PRESENT, 12);
+        if (!isEmptyMap) {
+            // flat map stream not reordered
+            verifyStream(iterator.next().getStream(), 12, 5, StreamKind.DATA, 15);
+            verifyStream(iterator.next().getStream(), 11, 5, StreamKind.IN_MAP, 13);
+            verifyStream(iterator.next().getStream(), 11, 5, StreamKind.LENGTH, 14);
+        }
+        assertFalse(iterator.hasNext());
+    }
+
+    private static Map<Integer, ColumnEncoding> createColumnEncodings(boolean isEmptyMap)
+    {
+        SortedMap<Integer, DwrfSequenceEncoding> seqIdToEncodings1 = ImmutableSortedMap.of(
+                1, new DwrfSequenceEncoding(
+                        DwrfProto.KeyInfo.newBuilder().setIntKey(100).build(),
+                        new ColumnEncoding(DIRECT, 0)),
+                2, new DwrfSequenceEncoding(
+                        DwrfProto.KeyInfo.newBuilder().setIntKey(200).build(),
+                        new ColumnEncoding(DIRECT, 0)),
+                3, new DwrfSequenceEncoding(
+                        DwrfProto.KeyInfo.newBuilder().setIntKey(300).build(),
+                        new ColumnEncoding(DIRECT, 0)));
+
+        SortedMap<Integer, DwrfSequenceEncoding> seqIdToEncodings2 = ImmutableSortedMap.of(
+                1, new DwrfSequenceEncoding(
+                        DwrfProto.KeyInfo.newBuilder().setIntKey(100).build(),
+                        new ColumnEncoding(DIRECT, 0)),
+                2, new DwrfSequenceEncoding(
+                        DwrfProto.KeyInfo.newBuilder().setIntKey(200).build(),
+                        new ColumnEncoding(DIRECT, 0)),
+                3, new DwrfSequenceEncoding(
+                        DwrfProto.KeyInfo.newBuilder().setIntKey(300).build(),
+                        new ColumnEncoding(DIRECT, 0)),
+                4, new DwrfSequenceEncoding(
+                        DwrfProto.KeyInfo.newBuilder().setIntKey(400).build(),
+                        new ColumnEncoding(DIRECT, 0)),
+                5, new DwrfSequenceEncoding(
+                        DwrfProto.KeyInfo.newBuilder().setIntKey(500).build(),
+                        new ColumnEncoding(DIRECT, 0)));
+
+        return ImmutableMap.<Integer, ColumnEncoding>builder()
+                .put(1, new ColumnEncoding(DIRECT, 0))
+                .put(2, new ColumnEncoding(DIRECT, 0))
+                .put(3, new ColumnEncoding(DIRECT, 0))
+                .put(4, new ColumnEncoding(DIRECT, 0))
+                .put(5, new ColumnEncoding(DIRECT, 0))
+                .put(6, new ColumnEncoding(DWRF_MAP_FLAT, 0))
+                .put(8, new ColumnEncoding(DIRECT, 0, isEmptyMap ? Optional.empty() : Optional.of(seqIdToEncodings1)))
+                .put(9, new ColumnEncoding(DWRF_MAP_FLAT, 0))
+                .put(11, new ColumnEncoding(DIRECT, 0, isEmptyMap ? Optional.empty() : Optional.of(seqIdToEncodings2)))
+                .put(12, new ColumnEncoding(DIRECT, 0, isEmptyMap ? Optional.empty() : Optional.of(seqIdToEncodings2)))
+                .build();
+    }
+
+    private static Map<Integer, Integer> createNodeIdToColumnId()
+    {
+        // col Id 0, 1, 2, 3
+        // node Id 0 to 12
+        return ImmutableMap.<Integer, Integer>builder()
+                .put(1, 0)
+                .put(2, 1)
+                .put(3, 1)
+                .put(4, 1)
+                .put(5, 1)
+                .put(6, 2)
+                .put(7, 2)
+                .put(8, 2)
+                .put(9, 3)
+                .put(10, 3)
+                .put(11, 3)
+                .put(12, 3)
+                .build();
+    }
+
+    private static DwrfStreamOrderingConfig createStreamReorderingInput()
+    {
+        Map<Integer, List<DwrfProto.KeyInfo>> columnIdToFlatMapKeyIds = new HashMap<>();
+        columnIdToFlatMapKeyIds.put(
+                // column exists
+                //  complete overlap between column encodings and key ordering
+                2, ImmutableList.of(
+                        DwrfProto.KeyInfo.newBuilder().setIntKey(300).build(),
+                        DwrfProto.KeyInfo.newBuilder().setIntKey(200).build(),
+                        DwrfProto.KeyInfo.newBuilder().setIntKey(100).build()));
+        columnIdToFlatMapKeyIds.put(
+                // column exists,
+                // key 600 doesn't exist in the column encodings
+                // key 500 exists in the column encodings not present in the order list
+                3, ImmutableList.of(
+                        DwrfProto.KeyInfo.newBuilder().setIntKey(100).build(),
+                        DwrfProto.KeyInfo.newBuilder().setIntKey(200).build(),
+                        DwrfProto.KeyInfo.newBuilder().setIntKey(400).build(),
+                        DwrfProto.KeyInfo.newBuilder().setIntKey(300).build(),
+                        DwrfProto.KeyInfo.newBuilder().setIntKey(600).build()));
+        columnIdToFlatMapKeyIds.put(// column does not exist in the input schema
+                4, ImmutableList.of(
+                        DwrfProto.KeyInfo.newBuilder().setIntKey(100).build(),
+                        DwrfProto.KeyInfo.newBuilder().setIntKey(200).build()));
+        return new DwrfStreamOrderingConfig(columnIdToFlatMapKeyIds);
+    }
+
+    private static void verifyFlatMapColumns(Iterator<StreamDataOutput> iterator)
+    {
+        // column 2
+        verifyStream(iterator.next().getStream(), 8, 3, StreamKind.IN_MAP, 6);
+        verifyStream(iterator.next().getStream(), 8, 3, StreamKind.DATA, 7);
+        verifyStream(iterator.next().getStream(), 8, 2, StreamKind.IN_MAP, 4);
+        verifyStream(iterator.next().getStream(), 8, 2, StreamKind.DATA, 5);
+        verifyStream(iterator.next().getStream(), 8, 1, StreamKind.IN_MAP, 2);
+        verifyStream(iterator.next().getStream(), 8, 1, StreamKind.DATA, 3);
+
+        // column 3
+        verifyStream(iterator.next().getStream(), 11, 1, StreamKind.IN_MAP, 1);
+        verifyStream(iterator.next().getStream(), 11, 1, StreamKind.LENGTH, 2);
+        verifyStream(iterator.next().getStream(), 12, 1, StreamKind.DATA, 3);
+
+        verifyStream(iterator.next().getStream(), 11, 2, StreamKind.IN_MAP, 4);
+        verifyStream(iterator.next().getStream(), 11, 2, StreamKind.LENGTH, 5);
+        verifyStream(iterator.next().getStream(), 12, 2, StreamKind.DATA, 6);
+
+        verifyStream(iterator.next().getStream(), 11, 4, StreamKind.IN_MAP, 10);
+        verifyStream(iterator.next().getStream(), 11, 4, StreamKind.LENGTH, 11);
+        verifyStream(iterator.next().getStream(), 12, 4, StreamKind.DATA, 12);
+
+        verifyStream(iterator.next().getStream(), 11, 3, StreamKind.IN_MAP, 7);
+        verifyStream(iterator.next().getStream(), 11, 3, StreamKind.LENGTH, 8);
+        verifyStream(iterator.next().getStream(), 12, 3, StreamKind.DATA, 9);
+    }
+
+    private static List<StreamDataOutput> createStreams(boolean isEmptyMap)
+    {
+        // Assume the file has following schema
+        // column 0: INT (Node 0)
+        // column 1: MAP<INT, LIST<INT>> // non flat map
+        // column 2: MAP<INT, FLOAT> // flat map
+        // column 3: MAP<INT, LIST<INT> // flat map
+
+        List<StreamDataOutput> streams = new ArrayList<>();
+        // column 0
+        streams.add(createStream(1, StreamKind.DATA, 3));
+        streams.add(createStream(1, StreamKind.PRESENT, 12));
+
+        // column 1 MAP<INT, LIST<INT>> <2, <3, 4<5>>>>
+        streams.add(createStream(2, StreamKind.LENGTH, 2)); // MAP
+        streams.add(createStream(3, StreamKind.DATA, 8)); // INT
+        streams.add(createStream(4, StreamKind.LENGTH, 5)); // LIST<INT>
+        streams.add(createStream(5, StreamKind.DATA, 1)); // INT
+
+        if (!isEmptyMap) {
+            // column 2 MAP<INT, FLOAT> <6 <7, 8>>
+            streams.add(createStream(8, 1, StreamKind.IN_MAP, 2));
+            streams.add(createStream(8, 1, StreamKind.DATA, 3));
+            streams.add(createStream(8, 2, StreamKind.IN_MAP, 4));
+            streams.add(createStream(8, 2, StreamKind.DATA, 5));
+            streams.add(createStream(8, 3, StreamKind.IN_MAP, 6));
+            streams.add(createStream(8, 3, StreamKind.DATA, 7));
+
+            // column 3 MAP<INT, LIST<INT> <9 <10, 11<12>>>
+            streams.add(createStream(11, 1, StreamKind.IN_MAP, 1));
+            streams.add(createStream(11, 1, StreamKind.LENGTH, 2));
+            streams.add(createStream(12, 1, StreamKind.DATA, 3));
+
+            streams.add(createStream(11, 2, StreamKind.IN_MAP, 4));
+            streams.add(createStream(11, 2, StreamKind.LENGTH, 5));
+            streams.add(createStream(12, 2, StreamKind.DATA, 6));
+
+            streams.add(createStream(11, 3, StreamKind.IN_MAP, 7));
+            streams.add(createStream(11, 3, StreamKind.LENGTH, 8));
+            streams.add(createStream(12, 3, StreamKind.DATA, 9));
+
+            streams.add(createStream(11, 4, StreamKind.IN_MAP, 10));
+            streams.add(createStream(11, 4, StreamKind.LENGTH, 11));
+            streams.add(createStream(12, 4, StreamKind.DATA, 12));
+
+            streams.add(createStream(11, 5, StreamKind.IN_MAP, 13));
+            streams.add(createStream(11, 5, StreamKind.LENGTH, 14));
+            streams.add(createStream(12, 5, StreamKind.DATA, 15));
+        }
+        return streams;
     }
 }


### PR DESCRIPTION
Add a new StreamLayout class which accepts an order
of flat map keys for a given column id and ensures that
streams are laid out on disk by following the same order.
The remaining streams are ordered using the default stream
layout (streamSize or columnSize).

Also, add a utility to create nodeIdToColumn map using 
a list of OrcType 
Depends on [17776](https://github.com/prestodb/presto/pull/17776/files)


Test plan 
* Added unit tests

```
== NO RELEASE NOTE ==
```