### PR TITLE
Add empty java class to fix the test coverages staging deploy

### DIFF
--- a/presto-test-coverage/pom.xml
+++ b/presto-test-coverage/pom.xml
@@ -14,7 +14,6 @@
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
 
-        <maven.deploy.skip>true</maven.deploy.skip>
         <air.check.skip-enforcer>true</air.check.skip-enforcer>
         <air.check.skip-enforcer>true</air.check.skip-enforcer>
         <air.check.skip-duplicate-finder>true</air.check.skip-duplicate-finder>

--- a/presto-test-coverage/src/main/java/com/facebook/presto/coverage/Report.java
+++ b/presto-test-coverage/src/main/java/com/facebook/presto/coverage/Report.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.presto.coverage;
+
+public class Report
+{
+    public Object main()
+    {
+        return null;
+    }
+}


### PR DESCRIPTION
For the release of 273, there was a hiccup because the module presto-test-coverage didn't work with the staging plugin. This empty class should fix this issue by giving it something to deploy.

The staging plugin unfortunately doesn't like to be skipped with our
deployment process for release. Instead of adding a skip to deploy or
staging, it would just be better off if it had something empty that it
could deploy. That way if one were to try to run test coverage from
open source, the pom.xml would be there as well.

Test plan - mvn install works now without skipping deploy


```
== NO RELEASE NOTE ==
```
