### PR TITLE
Add microsecond timestamp support in ORC

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/type/SqlTimestamp.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/type/SqlTimestamp.java
@@ -73,6 +73,19 @@ public final class SqlTimestamp
         return precision.toMillis(value);
     }
 
+    public long getMicros()
+    {
+        checkState(!isLegacyTimestamp(), "getMicros() can be called in new timestamp semantics only");
+        return precision.toMicros(value);
+    }
+
+    @Deprecated
+    public long getMicrosUtc()
+    {
+        checkState(isLegacyTimestamp(), "getMicrosUtc() can be called in legacy timestamp semantics only");
+        return precision.toMicros(value);
+    }
+
     @Deprecated
     public Optional<TimeZoneKey> getSessionTimeZoneKey()
     {

--- a/presto-main/src/main/java/com/facebook/presto/testing/DateTimeTestingUtils.java
+++ b/presto-main/src/main/java/com/facebook/presto/testing/DateTimeTestingUtils.java
@@ -26,6 +26,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneId;
+import java.util.concurrent.TimeUnit;
 
 import static com.facebook.presto.util.DateTimeZoneIndex.getDateTimeZone;
 import static java.lang.Math.toIntExact;
@@ -106,6 +107,18 @@ public final class DateTimeTestingUtils
         }
         else {
             return new SqlTimestamp(millis, MILLISECONDS);
+        }
+    }
+
+    public static SqlTimestamp sqlTimestampOf(long value, ConnectorSession session, TimeUnit timeUnit)
+    {
+        SqlFunctionProperties properties = session.getSqlFunctionProperties();
+
+        if (properties.isLegacyTimestamp()) {
+            return new SqlTimestamp(value, properties.getTimeZoneKey(), timeUnit);
+        }
+        else {
+            return new SqlTimestamp(value, timeUnit);
         }
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriteValidation.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriteValidation.java
@@ -76,6 +76,7 @@ import static com.facebook.presto.common.type.StandardTypes.ARRAY;
 import static com.facebook.presto.common.type.StandardTypes.MAP;
 import static com.facebook.presto.common.type.StandardTypes.ROW;
 import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP_MICROSECONDS;
 import static com.facebook.presto.common.type.TinyintType.TINYINT;
 import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.orc.OrcWriteValidation.OrcWriteValidationMode.BOTH;
@@ -558,6 +559,16 @@ public class OrcWriteValidation
                 }
             }
 
+            if (type.getTypeSignature().getBase().equals(StandardTypes.TIMESTAMP_MICROSECONDS)) {
+                // A flaw in ORC encoding makes it impossible to represent timestamp
+                // between 1969-12-31 23:59:59.000000, exclusive, and 1970-01-01 00:00:00.000000, exclusive.
+                // Therefore, such data won't round trip. The data read back is expected to be 1 second later than the original value.
+                long micros = TIMESTAMP_MICROSECONDS.getLong(block, position);
+                if (micros > -1_000_000 && micros < 0) {
+                    return AbstractLongType.hash(micros + 1_000_000);
+                }
+            }
+
             return type.hash(block, position);
         }
 
@@ -680,7 +691,7 @@ public class OrcWriteValidation
                 fieldExtractor = ignored -> ImmutableList.of();
                 fieldBuilders = ImmutableList.of();
             }
-            else if (TIMESTAMP.equals(type)) {
+            else if (TIMESTAMP.equals(type) || TIMESTAMP_MICROSECONDS.equals(type)) {
                 statisticsBuilder = new CountStatisticsBuilder();
                 fieldExtractor = ignored -> ImmutableList.of();
                 fieldBuilders = ImmutableList.of();

--- a/presto-orc/src/main/java/com/facebook/presto/orc/checkpoint/Checkpoints.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/checkpoint/Checkpoints.java
@@ -110,6 +110,7 @@ public final class Checkpoints
                     checkpoints.putAll(getDoubleColumnCheckpoints(column, sequence, compressed, availableStreams, columnPositionsList));
                     break;
                 case TIMESTAMP:
+                case TIMESTAMP_MICROSECONDS:
                     checkpoints.putAll(getTimestampColumnCheckpoints(column, sequence, columnEncoding, compressed, availableStreams, columnPositionsList));
                     break;
                 case BINARY:

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfMetadataWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/DwrfMetadataWriter.java
@@ -194,6 +194,7 @@ public class DwrfMetadataWriter
             case BINARY:
                 return Type.Kind.BINARY;
             case TIMESTAMP:
+            case TIMESTAMP_MICROSECONDS:
                 return Type.Kind.TIMESTAMP;
             case LIST:
                 return Type.Kind.LIST;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcMetadataWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcMetadataWriter.java
@@ -192,6 +192,7 @@ public class OrcMetadataWriter
             case DATE:
                 return OrcProto.Type.Kind.DATE;
             case TIMESTAMP:
+            case TIMESTAMP_MICROSECONDS:
                 return OrcProto.Type.Kind.TIMESTAMP;
             case LIST:
                 return OrcProto.Type.Kind.LIST;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcType.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/metadata/OrcType.java
@@ -41,6 +41,7 @@ import static com.facebook.presto.common.type.StandardTypes.ARRAY;
 import static com.facebook.presto.common.type.StandardTypes.MAP;
 import static com.facebook.presto.common.type.StandardTypes.ROW;
 import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP_MICROSECONDS;
 import static com.facebook.presto.common.type.TinyintType.TINYINT;
 import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -72,6 +73,7 @@ public class OrcType
 
         DATE,
         TIMESTAMP,
+        TIMESTAMP_MICROSECONDS,
 
         LIST,
         MAP,
@@ -231,6 +233,9 @@ public class OrcType
         }
         if (TIMESTAMP.equals(type)) {
             return ImmutableList.of(new OrcType(OrcTypeKind.TIMESTAMP));
+        }
+        if (TIMESTAMP_MICROSECONDS.equals(type)) {
+            return ImmutableList.of(new OrcType(OrcTypeKind.TIMESTAMP_MICROSECONDS));
         }
         if (type instanceof DecimalType) {
             DecimalType decimalType = (DecimalType) type;

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/ApacheHiveTimestampDecoder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/ApacheHiveTimestampDecoder.java
@@ -22,7 +22,7 @@ final class ApacheHiveTimestampDecoder
     // This comes from the Apache Hive ORC code
     public static long decodeTimestamp(long seconds, long serializedNanos, DecodeTimestampOptions options)
     {
-        long millis = (seconds + options.getBaseSeconds()) * options.getUnitsPerSecond();
+        long value = (seconds + options.getBaseSeconds()) * options.getUnitsPerSecond();
         long nanos = parseNanos(serializedNanos);
         if (nanos > 999999999 || nanos < 0) {
             throw new IllegalArgumentException("nanos field of an encoded timestamp in ORC must be between 0 and 999999999 inclusive, got " + nanos);
@@ -33,11 +33,11 @@ final class ApacheHiveTimestampDecoder
         // to get the correct value we need
         // (-42 - 1)*1000 + 999 = -42001
         // (42)*1000 + 1 = 42001
-        if (millis < 0 && nanos != 0) {
-            millis -= options.getUnitsPerSecond();
+        if (value < 0 && nanos != 0) {
+            value -= options.getUnitsPerSecond();
         }
-        // Truncate nanos to millis and add to mills
-        return millis + (nanos / options.getNanosPerUnit());
+        // Truncate nanos to required units (millis / micros) and add to value
+        return value + (nanos / options.getNanosPerUnit());
     }
 
     // This comes from the Apache Hive ORC code

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/BatchStreamReaders.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/BatchStreamReaders.java
@@ -20,6 +20,8 @@ import com.facebook.presto.orc.OrcRecordReaderOptions;
 import com.facebook.presto.orc.StreamDescriptor;
 import org.joda.time.DateTimeZone;
 
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP_MICROSECONDS;
+
 public final class BatchStreamReaders
 {
     private BatchStreamReaders()
@@ -49,7 +51,9 @@ public final class BatchStreamReaders
             case CHAR:
                 return new SliceBatchStreamReader(type, streamDescriptor, systemMemoryContext);
             case TIMESTAMP:
-                return new TimestampBatchStreamReader(type, streamDescriptor, hiveStorageTimeZone);
+            case TIMESTAMP_MICROSECONDS:
+                boolean enableMicroPrecision = type == TIMESTAMP_MICROSECONDS;
+                return new TimestampBatchStreamReader(type, streamDescriptor, hiveStorageTimeZone, enableMicroPrecision);
             case LIST:
                 return new ListBatchStreamReader(type, streamDescriptor, hiveStorageTimeZone, options, systemMemoryContext);
             case STRUCT:

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/TimestampBatchStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/TimestampBatchStreamReader.java
@@ -69,10 +69,10 @@ public class TimestampBatchStreamReader
     private boolean rowGroupOpen;
     private final DecodeTimestampOptions decodeTimestampOptions;
 
-    public TimestampBatchStreamReader(Type type, StreamDescriptor streamDescriptor, DateTimeZone hiveStorageTimeZone)
+    public TimestampBatchStreamReader(Type type, StreamDescriptor streamDescriptor, DateTimeZone hiveStorageTimeZone, boolean enableMicroPrecision)
             throws OrcCorruptionException
     {
-        this.decodeTimestampOptions = new DecodeTimestampOptions(hiveStorageTimeZone, false);
+        this.decodeTimestampOptions = new DecodeTimestampOptions(hiveStorageTimeZone, enableMicroPrecision);
         requireNonNull(type, "type is null");
         verifyStreamType(streamDescriptor, type, TimestampType.class::isInstance);
         this.streamDescriptor = requireNonNull(streamDescriptor, "stream is null");

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/TimestampSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/TimestampSelectiveStreamReader.java
@@ -21,7 +21,6 @@ import com.facebook.presto.common.block.RunLengthEncodedBlock;
 import com.facebook.presto.common.predicate.TupleDomainFilter;
 import com.facebook.presto.orc.DecodeTimestampOptions;
 import com.facebook.presto.orc.OrcLocalMemoryContext;
-import com.facebook.presto.orc.OrcRecordReaderOptions;
 import com.facebook.presto.orc.StreamDescriptor;
 import com.facebook.presto.orc.Stripe;
 import com.facebook.presto.orc.stream.BooleanInputStream;
@@ -93,9 +92,9 @@ public class TimestampSelectiveStreamReader
             DateTimeZone hiveStorageTimeZone,
             boolean outputRequired,
             OrcLocalMemoryContext systemMemoryContext,
-            OrcRecordReaderOptions options)
+            boolean enableMicroPrecision)
     {
-        this.decodeTimestampOptions = new DecodeTimestampOptions(hiveStorageTimeZone, false);
+        this.decodeTimestampOptions = new DecodeTimestampOptions(hiveStorageTimeZone, enableMicroPrecision);
         requireNonNull(filter, "filter is null");
         checkArgument(filter.isPresent() || outputRequired, "filter must be present if outputRequired is false");
         this.streamDescriptor = requireNonNull(streamDescriptor, "streamDescriptor is null");

--- a/presto-orc/src/main/java/com/facebook/presto/orc/stream/ValueStreams.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/stream/ValueStreams.java
@@ -25,6 +25,7 @@ import static com.facebook.presto.orc.metadata.ColumnEncoding.ColumnEncodingKind
 import static com.facebook.presto.orc.metadata.OrcType.OrcTypeKind.DECIMAL;
 import static com.facebook.presto.orc.metadata.OrcType.OrcTypeKind.INT;
 import static com.facebook.presto.orc.metadata.OrcType.OrcTypeKind.TIMESTAMP;
+import static com.facebook.presto.orc.metadata.OrcType.OrcTypeKind.TIMESTAMP_MICROSECONDS;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.DICTIONARY_DATA;
 import static com.facebook.presto.orc.metadata.Stream.StreamKind.IN_DICTIONARY;
@@ -68,6 +69,8 @@ public final class ValueStreams
                 case INT:
                 case LONG:
                 case DATE:
+                case TIMESTAMP:
+                case TIMESTAMP_MICROSECONDS:
                     return createLongStream(inputStream, encoding, type, true, usesVInt);
                 case FLOAT:
                     return new FloatInputStream(inputStream);
@@ -78,8 +81,6 @@ public final class ValueStreams
                 case CHAR:
                 case BINARY:
                     return new ByteArrayInputStream(inputStream);
-                case TIMESTAMP:
-                    return createLongStream(inputStream, encoding, type, true, usesVInt);
                 case DECIMAL:
                     return new DecimalInputStream(inputStream);
             }
@@ -126,7 +127,7 @@ public final class ValueStreams
         }
 
         // length (nanos) of a timestamp column
-        if (type == TIMESTAMP && streamId.getStreamKind() == SECONDARY) {
+        if ((type == TIMESTAMP || type == TIMESTAMP_MICROSECONDS) && streamId.getStreamKind() == SECONDARY) {
             return createLongStream(inputStream, encoding, type, false, usesVInt);
         }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/ColumnWriters.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/ColumnWriters.java
@@ -90,6 +90,7 @@ public final class ColumnWriters
                 return new DecimalColumnWriter(nodeIndex, type, columnWriterOptions, orcEncoding, metadataWriter);
 
             case TIMESTAMP:
+            case TIMESTAMP_MICROSECONDS:
                 return new TimestampColumnWriter(nodeIndex, sequence, type, columnWriterOptions, dwrfEncryptor, orcEncoding, hiveStorageTimeZone, metadataWriter);
 
             case BINARY:

--- a/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
@@ -147,6 +147,7 @@ import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static com.facebook.presto.common.type.RealType.REAL;
 import static com.facebook.presto.common.type.SmallintType.SMALLINT;
 import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP_MICROSECONDS;
 import static com.facebook.presto.common.type.TinyintType.TINYINT;
 import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
@@ -981,7 +982,7 @@ public class OrcTester
         throw new UnsupportedOperationException("Unsupported filter type: " + filter.getClass().getSimpleName());
     }
 
-    private static void assertFileContentsPresto(
+    public static void assertFileContentsPresto(
             List<Type> types,
             TempFile tempFile,
             List<List<?>> expectedValues,
@@ -1790,6 +1791,10 @@ public class OrcTester
                 long millis = ((SqlTimestamp) value).getMillisUtc();
                 type.writeLong(blockBuilder, millis);
             }
+            else if (TIMESTAMP_MICROSECONDS.equals(type)) {
+                long micros = ((SqlTimestamp) value).getMicrosUtc();
+                type.writeLong(blockBuilder, micros);
+            }
             else {
                 String baseType = type.getTypeSignature().getBase();
                 if (StandardTypes.ARRAY.equals(baseType)) {
@@ -2132,7 +2137,7 @@ public class OrcTester
         if (type.equals(DATE)) {
             return javaDateObjectInspector;
         }
-        if (type.equals(TIMESTAMP)) {
+        if (type.equals(TIMESTAMP) || type.equals(TIMESTAMP_MICROSECONDS)) {
             return javaTimestampObjectInspector;
         }
         if (type instanceof DecimalType) {

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestTimestampWriteAndRead.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestTimestampWriteAndRead.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc;
+
+import com.facebook.presto.common.type.SqlTimestamp;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.orc.metadata.CompressionKind;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP_MICROSECONDS;
+import static com.facebook.presto.orc.OrcTester.Format.DWRF;
+import static com.facebook.presto.orc.OrcTester.Format.ORC_11;
+import static com.facebook.presto.orc.OrcTester.Format.ORC_12;
+import static com.facebook.presto.orc.OrcTester.assertFileContentsPresto;
+import static com.facebook.presto.orc.OrcTester.writeOrcColumnsPresto;
+import static com.facebook.presto.testing.DateTimeTestingUtils.sqlTimestampOf;
+import static com.facebook.presto.testing.TestingConnectorSession.SESSION;
+import static java.lang.Math.floorDiv;
+import static java.util.concurrent.TimeUnit.MICROSECONDS;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.stream.Collectors.toList;
+
+public class TestTimestampWriteAndRead
+{
+    private static final Set<OrcTester.Format> FORMATS = ImmutableSet.of(DWRF, ORC_12, ORC_11);
+
+    // Few positive, negative timestamp values
+    private static final List<SqlTimestamp> MICROSECOND_VALUES = ImmutableList.of(
+            sqlTimestampOf(0L, SESSION, MICROSECONDS), // 1970-01-01 00:00:00.000000
+            sqlTimestampOf(1L, SESSION, MICROSECONDS), // 1970-01-01 00:00:00.000001
+            sqlTimestampOf(999_999L, SESSION, MICROSECONDS), // 1970-01-01 00:00:00.999999
+            sqlTimestampOf(1_000_000L, SESSION, MICROSECONDS), // 1970-01-01 00:00:01.000000
+            sqlTimestampOf(-60_000_000_000_000_789L, SESSION, MICROSECONDS), // 0068-09-03 13:19:59.999211
+            sqlTimestampOf(-230_000_000_000_999_999L, SESSION, MICROSECONDS), // -5319-08-03 23:06:39.000001
+            sqlTimestampOf(1_650_483_250_000_507L, SESSION, MICROSECONDS), // 2022-04-20 19:34:10.000507
+            sqlTimestampOf(60_000_000_000_123_789L, SESSION, MICROSECONDS), // 3871-04-29 10:40:00.123789
+            sqlTimestampOf(230_000_000_000_999_999L, SESSION, MICROSECONDS)); // 9258-05-30 00:53:20.999999
+
+    private static final List<SqlTimestamp> MILLISECOND_VALUES = ImmutableList.of(
+            sqlTimestampOf(0L, SESSION, MILLISECONDS), // 1970-01-01 00:00:00.000
+            sqlTimestampOf(1L, SESSION, MILLISECONDS), // 1970-01-01 00:00:00.001
+            sqlTimestampOf(999L, SESSION, MILLISECONDS), // 1970-01-01 00:00:00.999
+            sqlTimestampOf(1_000L, SESSION, MILLISECONDS), // 1970-01-01 00:00:01.000
+            sqlTimestampOf(-60_000_000_000_789L, SESSION, MILLISECONDS), // 0068-09-03 13:19:59.211
+            sqlTimestampOf(-230_000_000_999_999L, SESSION, MILLISECONDS), // -5319-08-03 22:50:00.001
+            sqlTimestampOf(1_650_483_250_507L, SESSION, MILLISECONDS), // 2022-04-20 19:34:10.507
+            sqlTimestampOf(60_000_000_000_789L, SESSION, MILLISECONDS), // 3871-04-29 10:40:00.789
+            sqlTimestampOf(230_000_000_000_999L, SESSION, MILLISECONDS)); // 9258-05-30 00:53:20.999
+
+    @Test
+    public void testMicroWriteAndRead()
+            throws Exception
+    {
+        testPrestoRoundTrip(TIMESTAMP_MICROSECONDS, MICROSECOND_VALUES, TIMESTAMP_MICROSECONDS, MICROSECOND_VALUES);
+    }
+
+    @Test
+    public void testMilliWriteAndRead()
+            throws Exception
+    {
+        testPrestoRoundTrip(TIMESTAMP, MILLISECOND_VALUES, TIMESTAMP, MILLISECOND_VALUES);
+    }
+
+    @Test
+    public void testMicroWriteAndMilliRead()
+            throws Exception
+    {
+        List<SqlTimestamp> microSecondValuesInMilli = MICROSECOND_VALUES.stream()
+                .map(microTimestamp -> new SqlTimestamp(
+                        floorDiv(microTimestamp.getMicrosUtc(), 1000),
+                        microTimestamp.getSessionTimeZoneKey().get(),
+                        TimeUnit.MILLISECONDS))
+                .collect(toList());
+
+        testPrestoRoundTrip(TIMESTAMP_MICROSECONDS, MICROSECOND_VALUES, TIMESTAMP, microSecondValuesInMilli);
+    }
+
+    @Test
+    public void testMilliWriteAndMicroRead()
+            throws Exception
+    {
+        List<SqlTimestamp> milliSecondValuesInMicro = MILLISECOND_VALUES.stream()
+                .map(milliTimestamp -> new SqlTimestamp(
+                        milliTimestamp.getMillisUtc() * 1000,
+                        milliTimestamp.getSessionTimeZoneKey().get(),
+                        MICROSECONDS))
+                .collect(toList());
+
+        testPrestoRoundTrip(TIMESTAMP, MILLISECOND_VALUES, TIMESTAMP_MICROSECONDS, milliSecondValuesInMicro);
+    }
+
+    // Flaw in ORC encoding makes timestamp between 1969-12-31 23:59:59.000000, exclusive, and 1970-01-01 00:00:00.000000, exclusive.
+    // to be 1 second later than the original value written.
+    @Test
+    public void testOrcEncodingTimestampFlawMicros()
+            throws Exception
+    {
+        // Written Values
+        // (-1L, MICROSECONDS),         "1969-12-31 23:59:59.999999"
+        // (-999_999L, MICROSECONDS),   "1969-12-31 23:59:59.000001"
+        List<SqlTimestamp> timestampsWithFlaw = ImmutableList.of(
+                sqlTimestampOf(-1L, SESSION, MICROSECONDS),
+                sqlTimestampOf(-999_999L, SESSION, MICROSECONDS));
+
+        // Expected Values
+        // (999_999L, MICROSECONDS),    "1970-01-01 00:00:00.999999"
+        // (1L, MICROSECONDS),          "1970-01-01 00:00:00:000001"
+        List<SqlTimestamp> expectedTimestamps = ImmutableList.of(
+                sqlTimestampOf(999_999L, SESSION, MICROSECONDS),
+                sqlTimestampOf(1L, SESSION, MICROSECONDS));
+
+        testPrestoRoundTrip(TIMESTAMP_MICROSECONDS, timestampsWithFlaw, TIMESTAMP_MICROSECONDS, expectedTimestamps);
+    }
+
+    @Test
+    public void testOrcEncodingTimestampFlawMillis()
+            throws Exception
+    {
+        // Written Values
+        // (-1L, MICROSECONDS),         "1969-12-31 23:59:59.999"
+        // (-999L, MICROSECONDS),       "1969-12-31 23:59:59.001"
+        List<SqlTimestamp> timestampsWithFlaw = ImmutableList.of(
+                sqlTimestampOf(-1L, SESSION, MILLISECONDS),
+                sqlTimestampOf(-999L, SESSION, MILLISECONDS));
+
+        // Expected Values
+        // (999L, MICROSECONDS),        "1970-01-01 00:00:00.999"
+        // (1L, MICROSECONDS),          "1970-01-01 00:00:00:001"
+        List<SqlTimestamp> expectedTimestamps = ImmutableList.of(
+                sqlTimestampOf(999L, SESSION, MILLISECONDS),
+                sqlTimestampOf(1L, SESSION, MILLISECONDS));
+
+        testPrestoRoundTrip(TIMESTAMP, timestampsWithFlaw, TIMESTAMP, expectedTimestamps);
+    }
+
+    private void testPrestoRoundTrip(Type writeType, List<SqlTimestamp> writeValues, Type readType, List<SqlTimestamp> expectedValues)
+            throws Exception
+    {
+        for (OrcTester.Format format : FORMATS) {
+            try (TempFile tempFile = new TempFile()) {
+                writeOrcColumnsPresto(
+                        tempFile.getFile(),
+                        format,
+                        CompressionKind.ZLIB,
+                        Optional.empty(),
+                        ImmutableList.of(writeType),
+                        ImmutableList.of(writeValues),
+                        new NoOpOrcWriterStats());
+
+                assertFileContentsPresto(
+                        ImmutableList.of(readType),
+                        tempFile,
+                        ImmutableList.of(expectedValues),
+                        false,
+                        false,
+                        format.getOrcEncoding(),
+                        format,
+                        false,
+                        true,
+                        ImmutableList.of(),
+                        ImmutableMap.of());
+            }
+        }
+    }
+}

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestingOrcPredicate.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestingOrcPredicate.java
@@ -48,6 +48,7 @@ import static com.facebook.presto.common.type.StandardTypes.ARRAY;
 import static com.facebook.presto.common.type.StandardTypes.MAP;
 import static com.facebook.presto.common.type.StandardTypes.ROW;
 import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP_MICROSECONDS;
 import static com.facebook.presto.common.type.TinyintType.TINYINT;
 import static com.facebook.presto.orc.OrcTester.Format.DWRF;
 import static com.google.common.base.Predicates.equalTo;
@@ -98,6 +99,14 @@ public final class TestingOrcPredicate
                     columnIndex,
                     expectedValues.stream()
                             .map(value -> value == null ? null : ((SqlTimestamp) value).getMillisUtc())
+                            .collect(toList()),
+                    false);
+        }
+        if (TIMESTAMP_MICROSECONDS.equals(type)) {
+            return new LongOrcPredicate(false,
+                    columnIndex,
+                    expectedValues.stream()
+                            .map(value -> value == null ? null : ((SqlTimestamp) value).getMicrosUtc())
                             .collect(toList()),
                     false);
         }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/writer/TestColumnWriters.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/writer/TestColumnWriters.java
@@ -36,6 +36,7 @@ import static com.facebook.presto.common.type.IntegerType.INTEGER;
 import static com.facebook.presto.common.type.RealType.REAL;
 import static com.facebook.presto.common.type.SmallintType.SMALLINT;
 import static com.facebook.presto.common.type.TimestampType.TIMESTAMP;
+import static com.facebook.presto.common.type.TimestampType.TIMESTAMP_MICROSECONDS;
 import static com.facebook.presto.common.type.TinyintType.TINYINT;
 import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.common.type.VarcharType.VARCHAR;
@@ -96,6 +97,7 @@ public class TestColumnWriters
                 {toOrcTypes(DOUBLE), DOUBLE, DOUBLE.createFixedSizeBlockBuilder(2).appendNull().writeLong(1).build()},
                 {toOrcTypes(REAL), REAL, REAL.createFixedSizeBlockBuilder(2).appendNull().writeInt(1).build()},
                 {toOrcTypes(TIMESTAMP), TIMESTAMP, TIMESTAMP.createFixedSizeBlockBuilder(2).appendNull().writeLong(1).build()},
+                {toOrcTypes(TIMESTAMP_MICROSECONDS), TIMESTAMP_MICROSECONDS, TIMESTAMP_MICROSECONDS.createFixedSizeBlockBuilder(2).appendNull().writeLong(1).build()},
                 {toOrcTypes(VARCHAR), VARCHAR, stringBlock},
                 {toOrcTypes(VARBINARY), VARBINARY, stringBlock},
                 {toOrcTypes(arrayType), arrayType, arrayBlock},


### PR DESCRIPTION
ORC support to read timestamp as microseconds via a config option was removed in an earlier change. This change introduces microsecond support via types in ORC reader / writer. This uses the new typed introduced earlier TIMESTAMP_MICROSECONDS to enable read / write in microseconds.

Test plan

- Added new tests for microsecond read / write
- Tested in validation service for about 9 hours

```
== NO RELEASE NOTE ==
```
