### PR TITLE
Retry presto on spark queries with increased partition count

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/Session.java
+++ b/presto-main/src/main/java/com/facebook/presto/Session.java
@@ -34,7 +34,6 @@ import com.facebook.presto.spi.tracing.Tracer;
 import com.facebook.presto.sql.tree.Execute;
 import com.facebook.presto.transaction.TransactionId;
 import com.facebook.presto.transaction.TransactionManager;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
@@ -560,7 +559,6 @@ public final class Session
         return new SessionBuilder(sessionPropertyManager);
     }
 
-    @VisibleForTesting
     public static SessionBuilder builder(Session session)
     {
         return new SessionBuilder(session);

--- a/presto-main/src/main/java/com/facebook/presto/execution/ExecutionFailureInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/ExecutionFailureInfo.java
@@ -18,6 +18,7 @@ import com.facebook.drift.annotations.ThriftField;
 import com.facebook.drift.annotations.ThriftStruct;
 import com.facebook.presto.client.ErrorLocation;
 import com.facebook.presto.client.FailureInfo;
+import com.facebook.presto.spi.ErrorCause;
 import com.facebook.presto.spi.ErrorCode;
 import com.facebook.presto.spi.HostAddress;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -51,6 +52,7 @@ public class ExecutionFailureInfo
     private final ErrorCode errorCode;
     // use for transport errors
     private final HostAddress remoteHost;
+    private final ErrorCause errorCause;
 
     @JsonCreator
     @ThriftConstructor
@@ -62,7 +64,8 @@ public class ExecutionFailureInfo
             @JsonProperty("stack") List<String> stack,
             @JsonProperty("errorLocation") @Nullable ErrorLocation errorLocation,
             @JsonProperty("errorCode") @Nullable ErrorCode errorCode,
-            @JsonProperty("remoteHost") @Nullable HostAddress remoteHost)
+            @JsonProperty("remoteHost") @Nullable HostAddress remoteHost,
+            @JsonProperty("errorCause") @Nullable ErrorCause errorCause)
     {
         requireNonNull(type, "type is null");
         requireNonNull(suppressed, "suppressed is null");
@@ -76,6 +79,7 @@ public class ExecutionFailureInfo
         this.errorLocation = errorLocation;
         this.errorCode = errorCode;
         this.remoteHost = remoteHost;
+        this.errorCause = errorCause;
     }
 
     @JsonProperty
@@ -137,6 +141,14 @@ public class ExecutionFailureInfo
     public HostAddress getRemoteHost()
     {
         return remoteHost;
+    }
+
+    @Nullable
+    @JsonProperty
+    @ThriftField(9)
+    public ErrorCause getErrorCause()
+    {
+        return errorCause;
     }
 
     public FailureInfo toFailureInfo()

--- a/presto-main/src/main/java/com/facebook/presto/execution/SqlStageExecution.java
+++ b/presto-main/src/main/java/com/facebook/presto/execution/SqlStageExecution.java
@@ -666,7 +666,8 @@ public final class SqlStageExecution
                 executionFailureInfo.getStack(),
                 executionFailureInfo.getErrorLocation(),
                 REMOTE_HOST_GONE.toErrorCode(),
-                executionFailureInfo.getRemoteHost());
+                executionFailureInfo.getRemoteHost(),
+                executionFailureInfo.getErrorCause());
     }
 
     @Override

--- a/presto-main/src/main/java/com/facebook/presto/operator/HashBuilderOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/HashBuilderOperator.java
@@ -17,6 +17,7 @@ import com.facebook.airlift.log.Logger;
 import com.facebook.presto.common.Page;
 import com.facebook.presto.execution.Lifespan;
 import com.facebook.presto.memory.context.LocalMemoryContext;
+import com.facebook.presto.spi.ErrorCause;
 import com.facebook.presto.spi.plan.PlanNodeId;
 import com.facebook.presto.spiller.SingleStreamSpiller;
 import com.facebook.presto.spiller.SingleStreamSpillerFactory;
@@ -374,7 +375,7 @@ public class HashBuilderOperator
         long maxUserMemoryBytes = getQueryMaxMemoryPerNode(operatorContext.getSession()).toBytes();
         if (getSpiller().getSpilledPagesInMemorySize() > maxUserMemoryBytes) {
             String additionalInfo = format("Spilled: %s, Operator: %s", succinctBytes(getSpiller().getSpilledPagesInMemorySize()), HashBuilderOperator.class.getSimpleName());
-            throw exceededLocalUserMemoryLimit(succinctBytes(maxUserMemoryBytes), additionalInfo, false, Optional.empty());
+            throw exceededLocalUserMemoryLimit(succinctBytes(maxUserMemoryBytes), additionalInfo, false, Optional.empty(), ErrorCause.UNKNOWN);
         }
     }
 

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkConfig.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkConfig.java
@@ -51,6 +51,8 @@ public class PrestoSparkConfig
     private double memoryRevokingTarget;
     private boolean retryOnOutOfMemoryBroadcastJoinEnabled;
     private boolean retryOnOutOfMemoryWithIncreasedMemorySettingsEnabled;
+    private boolean retryOnOutOfMemoryWithHigherHashPartitionCount;
+    private double hashPartitionCountScalingFactorOnOutOfMemory = 2.0;
     private Map<String, String> outOfMemoryRetryPrestoSessionProperties = ImmutableMap.of();
     private Map<String, String> outOfMemoryRetrySparkConfigs = ImmutableMap.of();
     private DataSize averageInputDataSizePerExecutor = new DataSize(10, GIGABYTE);
@@ -389,6 +391,34 @@ public class PrestoSparkConfig
     public PrestoSparkConfig setSparkResourceAllocationStrategyEnabled(boolean isResourceAllocationStrategyEnabled)
     {
         this.isResourceAllocationStrategyEnabled = isResourceAllocationStrategyEnabled;
+        return this;
+    }
+
+    public boolean isRetryOnOutOfMemoryWithHigherHashPartitionCountEnabled()
+    {
+        return retryOnOutOfMemoryWithHigherHashPartitionCount;
+    }
+
+    @Config("spark.retry-on-out-of-memory-higher-hash-partition-count-enabled")
+    @ConfigDescription("Increases hash partition count by scaling factor specified by spark.hash-partition-count-scaling-factor-on-out-of-memory if query fails due to low hash partition count")
+    public PrestoSparkConfig setRetryOnOutOfMemoryWithHigherHashPartitionCountEnabled(boolean retryOnOutOfMemoryWithHigherHashPartitionCount)
+    {
+        this.retryOnOutOfMemoryWithHigherHashPartitionCount = retryOnOutOfMemoryWithHigherHashPartitionCount;
+        return this;
+    }
+
+    @DecimalMin("1.0")
+    @DecimalMax("10.0")
+    public double getHashPartitionCountScalingFactorOnOutOfMemory()
+    {
+        return hashPartitionCountScalingFactorOnOutOfMemory;
+    }
+
+    @Config("spark.hash-partition-count-scaling-factor-on-out-of-memory")
+    @ConfigDescription("Scaling factor for hash partition count when a query fails with out of memory error due to low hash partition count")
+    public PrestoSparkConfig setHashPartitionCountScalingFactorOnOutOfMemory(double hashPartitionCountScalingFactorOnOutOfMemory)
+    {
+        this.hashPartitionCountScalingFactorOnOutOfMemory = hashPartitionCountScalingFactorOnOutOfMemory;
         return this;
     }
 }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkSessionProperties.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/PrestoSparkSessionProperties.java
@@ -58,6 +58,8 @@ public class PrestoSparkSessionProperties
     public static final String SPARK_MAX_HASH_PARTITION_COUNT = "spark_max_hash_partition_count";
     public static final String SPARK_MIN_HASH_PARTITION_COUNT = "spark_min_hash_partition_count";
     public static final String SPARK_RESOURCE_ALLOCATION_STRATEGY_ENABLED = "spark_resource_allocation_strategy_enabled";
+    public static final String SPARK_RETRY_ON_OUT_OF_MEMORY_HIGHER_PARTITION_COUNT_ENABLED = "spark_retry_on_out_of_memory_higher_hash_partition_count_enabled";
+    public static final String SPARK_HASH_PARTITION_COUNT_SCALING_FACTOR_ON_OUT_OF_MEMORY = "spark_hash_partition_count_scaling_factor_on_out_of_memory";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -187,6 +189,16 @@ public class PrestoSparkSessionProperties
                         SPARK_RESOURCE_ALLOCATION_STRATEGY_ENABLED,
                         "Flag to enable optimized resource allocation strategy",
                         prestoSparkConfig.isSparkResourceAllocationStrategyEnabled(),
+                        false),
+                booleanProperty(
+                        SPARK_RETRY_ON_OUT_OF_MEMORY_HIGHER_PARTITION_COUNT_ENABLED,
+                        "Increases hash partition count by scaling factor specified by spark.hash-partition-count-scaling-factor-on-out-of-memory if query fails due to low hash partition count",
+                        prestoSparkConfig.isRetryOnOutOfMemoryWithHigherHashPartitionCountEnabled(),
+                        false),
+                doubleProperty(
+                        SPARK_HASH_PARTITION_COUNT_SCALING_FACTOR_ON_OUT_OF_MEMORY,
+                        "Scaling factor for hash partition count when a query fails with out of memory error due to low hash partition count",
+                        prestoSparkConfig.getHashPartitionCountScalingFactorOnOutOfMemory(),
                         false));
     }
 
@@ -307,5 +319,15 @@ public class PrestoSparkSessionProperties
     public static boolean isSparkResourceAllocationStrategyEnabled(Session session)
     {
         return session.getSystemProperty(SPARK_RESOURCE_ALLOCATION_STRATEGY_ENABLED, Boolean.class);
+    }
+
+    public static boolean isRetryOnOutOfMemoryWithHigherHashPartitionCountEnabled(Session session)
+    {
+        return session.getSystemProperty(SPARK_RETRY_ON_OUT_OF_MEMORY_HIGHER_PARTITION_COUNT_ENABLED, Boolean.class);
+    }
+
+    public static double getHashPartitionCountScalingFactorOnOutOfMemory(Session session)
+    {
+        return session.getSystemProperty(SPARK_HASH_PARTITION_COUNT_SCALING_FACTOR_ON_OUT_OF_MEMORY, Double.class);
     }
 }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkTaskExecutorFactory.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/execution/PrestoSparkTaskExecutorFactory.java
@@ -143,6 +143,7 @@ import static com.facebook.presto.spark.util.PrestoSparkUtils.deserializeZstdCom
 import static com.facebook.presto.spark.util.PrestoSparkUtils.getNullifyingIterator;
 import static com.facebook.presto.spark.util.PrestoSparkUtils.serializeZstdCompressed;
 import static com.facebook.presto.spark.util.PrestoSparkUtils.toPrestoSparkSerializedPage;
+import static com.facebook.presto.spi.ErrorCause.UNKNOWN;
 import static com.facebook.presto.sql.planner.SystemPartitioningHandle.FIXED_ARBITRARY_DISTRIBUTION;
 import static com.facebook.presto.util.Failures.toFailures;
 import static com.google.common.base.Preconditions.checkArgument;
@@ -480,7 +481,8 @@ public class PrestoSparkTaskExecutorFactory
                                             succinctBytes(pool.getQueryMemoryReservation(queryId)),
                                             succinctBytes(pool.getQueryRevocableMemoryReservation(queryId))),
                             isHeapDumpOnExceededMemoryLimitEnabled(session),
-                            Optional.ofNullable(heapDumpFilePath));
+                            Optional.ofNullable(heapDumpFilePath),
+                            UNKNOWN);
                 }
             });
         }

--- a/presto-spark-base/src/main/java/com/facebook/presto/spark/util/PrestoSparkFailureUtils.java
+++ b/presto-spark-base/src/main/java/com/facebook/presto/spark/util/PrestoSparkFailureUtils.java
@@ -17,6 +17,7 @@ import com.facebook.presto.Session;
 import com.facebook.presto.execution.ExecutionFailureInfo;
 import com.facebook.presto.spark.classloader_interface.PrestoSparkFailure;
 import com.facebook.presto.spark.classloader_interface.RetryExecutionStrategy;
+import com.facebook.presto.spi.ErrorCause;
 import com.facebook.presto.spi.ErrorCode;
 import com.google.common.collect.ImmutableList;
 
@@ -27,9 +28,12 @@ import java.util.Optional;
 
 import static com.facebook.presto.execution.ExecutionFailureInfo.toStackTraceElement;
 import static com.facebook.presto.spark.PrestoSparkSessionProperties.isRetryOnOutOfMemoryBroadcastJoinEnabled;
+import static com.facebook.presto.spark.PrestoSparkSessionProperties.isRetryOnOutOfMemoryWithHigherHashPartitionCountEnabled;
 import static com.facebook.presto.spark.PrestoSparkSessionProperties.isRetryOnOutOfMemoryWithIncreasedMemoryEnabled;
 import static com.facebook.presto.spark.classloader_interface.RetryExecutionStrategy.DISABLE_BROADCAST_JOIN;
 import static com.facebook.presto.spark.classloader_interface.RetryExecutionStrategy.INCREASE_CONTAINER_SIZE;
+import static com.facebook.presto.spark.classloader_interface.RetryExecutionStrategy.INCREASE_HASH_PARTITION_COUNT;
+import static com.facebook.presto.spi.ErrorCause.LOW_PARTITION_COUNT;
 import static com.facebook.presto.spi.StandardErrorCode.EXCEEDED_LOCAL_BROADCAST_JOIN_MEMORY_LIMIT;
 import static com.facebook.presto.spi.StandardErrorCode.EXCEEDED_LOCAL_MEMORY_LIMIT;
 import static com.google.common.base.Preconditions.checkState;
@@ -45,7 +49,10 @@ public class PrestoSparkFailureUtils
         PrestoSparkFailure prestoSparkFailure = toPrestoSparkFailure(executionFailureInfo);
         checkState(prestoSparkFailure != null);
 
-        Optional<RetryExecutionStrategy> retryExecutionStrategy = getRetryExecutionStrategy(session, executionFailureInfo.getErrorCode(), executionFailureInfo.getMessage());
+        Optional<RetryExecutionStrategy> retryExecutionStrategy = getRetryExecutionStrategy(session,
+                executionFailureInfo.getErrorCode(),
+                executionFailureInfo.getMessage(),
+                executionFailureInfo.getErrorCause());
         return new PrestoSparkFailure(
                 prestoSparkFailure.getMessage(),
                 prestoSparkFailure.getCause(),
@@ -80,18 +87,24 @@ public class PrestoSparkFailureUtils
         return prestoSparkFailure;
     }
 
-    private static Optional<RetryExecutionStrategy> getRetryExecutionStrategy(Session session, ErrorCode errorCode, String message)
+    private static Optional<RetryExecutionStrategy> getRetryExecutionStrategy(Session session, ErrorCode errorCode, String message, ErrorCause errorCause)
     {
         if (errorCode == null || message == null) {
             return Optional.empty();
         }
 
-        if (isRetryOnOutOfMemoryBroadcastJoinEnabled(session) && errorCode.equals(EXCEEDED_LOCAL_BROADCAST_JOIN_MEMORY_LIMIT.toErrorCode())) {
+        if (isRetryOnOutOfMemoryBroadcastJoinEnabled(session) &&
+                errorCode.equals(EXCEEDED_LOCAL_BROADCAST_JOIN_MEMORY_LIMIT.toErrorCode())) {
             return Optional.of(DISABLE_BROADCAST_JOIN);
         }
 
         if (isRetryOnOutOfMemoryWithIncreasedMemoryEnabled(session) && errorCode.equals(EXCEEDED_LOCAL_MEMORY_LIMIT.toErrorCode())) {
             return Optional.of(INCREASE_CONTAINER_SIZE);
+        }
+
+        if (isRetryOnOutOfMemoryWithHigherHashPartitionCountEnabled(session) &&
+                LOW_PARTITION_COUNT == errorCause) {
+            return Optional.of(INCREASE_HASH_PARTITION_COUNT);
         }
 
         return Optional.empty();

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkConfig.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkConfig.java
@@ -56,7 +56,9 @@ public class TestPrestoSparkConfig
                 .setAverageInputDataSizePerPartition(new DataSize(2, GIGABYTE))
                 .setMaxHashPartitionCount(4096)
                 .setMinHashPartitionCount(1024)
-                .setSparkResourceAllocationStrategyEnabled(false));
+                .setSparkResourceAllocationStrategyEnabled(false)
+                .setRetryOnOutOfMemoryWithHigherHashPartitionCountEnabled(false)
+                .setHashPartitionCountScalingFactorOnOutOfMemory(2.0));
     }
 
     @Test
@@ -88,6 +90,8 @@ public class TestPrestoSparkConfig
                 .put("spark.max-hash-partition-count", "333")
                 .put("spark.min-hash-partition-count", "30")
                 .put("spark.resource-allocation-strategy-enabled", "true")
+                .put("spark.retry-on-out-of-memory-higher-hash-partition-count-enabled", "true")
+                .put("spark.hash-partition-count-scaling-factor-on-out-of-memory", "5.6")
                 .build();
         PrestoSparkConfig expected = new PrestoSparkConfig()
                 .setSparkPartitionCountAutoTuneEnabled(false)
@@ -114,7 +118,9 @@ public class TestPrestoSparkConfig
                 .setAverageInputDataSizePerPartition(new DataSize(1, GIGABYTE))
                 .setMaxHashPartitionCount(333)
                 .setMinHashPartitionCount(30)
-                .setSparkResourceAllocationStrategyEnabled(true);
+                .setSparkResourceAllocationStrategyEnabled(true)
+                .setRetryOnOutOfMemoryWithHigherHashPartitionCountEnabled(true)
+                .setHashPartitionCountScalingFactorOnOutOfMemory(5.6);
         assertFullMapping(properties, expected);
     }
 }

--- a/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkQueryRunner.java
+++ b/presto-spark-base/src/test/java/com/facebook/presto/spark/TestPrestoSparkQueryRunner.java
@@ -31,16 +31,21 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static com.facebook.presto.SystemSessionProperties.HASH_PARTITION_COUNT;
 import static com.facebook.presto.SystemSessionProperties.JOIN_DISTRIBUTION_TYPE;
 import static com.facebook.presto.SystemSessionProperties.PARTIAL_MERGE_PUSHDOWN_STRATEGY;
+import static com.facebook.presto.SystemSessionProperties.QUERY_MAX_MEMORY;
 import static com.facebook.presto.SystemSessionProperties.QUERY_MAX_MEMORY_PER_NODE;
 import static com.facebook.presto.SystemSessionProperties.QUERY_MAX_TOTAL_MEMORY_PER_NODE;
+import static com.facebook.presto.SystemSessionProperties.VERBOSE_EXCEEDED_MEMORY_LIMIT_ERRORS_ENABLED;
 import static com.facebook.presto.spark.PrestoSparkQueryRunner.METASTORE_CONTEXT;
 import static com.facebook.presto.spark.PrestoSparkQueryRunner.createHivePrestoSparkQueryRunner;
 import static com.facebook.presto.spark.PrestoSparkSessionProperties.OUT_OF_MEMORY_RETRY_PRESTO_SESSION_PROPERTIES;
 import static com.facebook.presto.spark.PrestoSparkSessionProperties.OUT_OF_MEMORY_RETRY_SPARK_CONFIGS;
 import static com.facebook.presto.spark.PrestoSparkSessionProperties.SPARK_BROADCAST_JOIN_MAX_MEMORY_OVERRIDE;
+import static com.facebook.presto.spark.PrestoSparkSessionProperties.SPARK_HASH_PARTITION_COUNT_SCALING_FACTOR_ON_OUT_OF_MEMORY;
 import static com.facebook.presto.spark.PrestoSparkSessionProperties.SPARK_RETRY_ON_OUT_OF_MEMORY_BROADCAST_JOIN_ENABLED;
+import static com.facebook.presto.spark.PrestoSparkSessionProperties.SPARK_RETRY_ON_OUT_OF_MEMORY_HIGHER_PARTITION_COUNT_ENABLED;
 import static com.facebook.presto.spark.PrestoSparkSessionProperties.SPARK_RETRY_ON_OUT_OF_MEMORY_WITH_INCREASED_MEMORY_SETTINGS_ENABLED;
 import static com.facebook.presto.spark.PrestoSparkSessionProperties.SPARK_SPLIT_ASSIGNMENT_BATCH_SIZE;
 import static com.facebook.presto.spark.PrestoSparkSessionProperties.STORAGE_BASED_BROADCAST_JOIN_ENABLED;
@@ -928,6 +933,64 @@ public class TestPrestoSparkQueryRunner
                 session,
                 "select * from lineitem l join orders o on l.orderkey = o.orderkey",
                 "Query exceeded per-node broadcast memory limit of 2MB \\[Broadcast size: 2.*MB\\]");
+    }
+
+    @Test
+    public void testRetryWithHigherHashPartitionCount()
+    {
+        String query = "with l as (" +
+                "select * from lineitem UNION ALL select * from lineitem UNION ALL select * from lineitem" +
+                "), " +
+                "o as (" +
+                "select * from orders UNION ALL select * from orders UNION ALL select * from orders" +
+                ") " +
+                "select * from l right outer join o on l.orderkey = o.orderkey";
+
+        Session session = Session.builder(getSession())
+                .setSystemProperty(JOIN_DISTRIBUTION_TYPE, "partitioned")
+                .setSystemProperty(HASH_PARTITION_COUNT, "1")
+                .setSystemProperty(QUERY_MAX_TOTAL_MEMORY_PER_NODE, "6.5MB")
+                .setSystemProperty(QUERY_MAX_MEMORY, "100MB")
+                .setSystemProperty(VERBOSE_EXCEEDED_MEMORY_LIMIT_ERRORS_ENABLED, "true")
+                .setSystemProperty(SPARK_RETRY_ON_OUT_OF_MEMORY_HIGHER_PARTITION_COUNT_ENABLED, "false")
+                .build();
+        assertQueryFails(session,
+                query,
+                "Query exceeded per-node total memory limit of .*Top Consumers: \\{HashBuilderOperator.*");
+
+        session = Session.builder(getSession())
+                .setSystemProperty(JOIN_DISTRIBUTION_TYPE, "partitioned")
+                .setSystemProperty(HASH_PARTITION_COUNT, "1")
+                .setSystemProperty(QUERY_MAX_TOTAL_MEMORY_PER_NODE, "6.5MB")
+                .setSystemProperty(QUERY_MAX_MEMORY, "100MB")
+                .setSystemProperty(VERBOSE_EXCEEDED_MEMORY_LIMIT_ERRORS_ENABLED, "true")
+                .setSystemProperty(SPARK_RETRY_ON_OUT_OF_MEMORY_HIGHER_PARTITION_COUNT_ENABLED, "true")
+                .setSystemProperty(SPARK_HASH_PARTITION_COUNT_SCALING_FACTOR_ON_OUT_OF_MEMORY, "1.0")
+                .build();
+        assertQueryFails(session,
+                query,
+                "Query exceeded per-node total memory limit of .*Top Consumers: \\{HashBuilderOperator.*");
+
+        session = Session.builder(getSession())
+                .setSystemProperty(JOIN_DISTRIBUTION_TYPE, "partitioned")
+                .setSystemProperty(HASH_PARTITION_COUNT, "1")
+                .setSystemProperty(QUERY_MAX_TOTAL_MEMORY_PER_NODE, "6.5MB")
+                .setSystemProperty(QUERY_MAX_MEMORY, "100MB")
+                .setSystemProperty(VERBOSE_EXCEEDED_MEMORY_LIMIT_ERRORS_ENABLED, "true")
+                .setSystemProperty(SPARK_RETRY_ON_OUT_OF_MEMORY_HIGHER_PARTITION_COUNT_ENABLED, "true")
+                .build();
+        assertQuerySucceeds(session, query);
+
+        session = Session.builder(getSession())
+                .setSystemProperty(JOIN_DISTRIBUTION_TYPE, "partitioned")
+                .setSystemProperty(HASH_PARTITION_COUNT, "1")
+                .setSystemProperty(QUERY_MAX_TOTAL_MEMORY_PER_NODE, "6.5MB")
+                .setSystemProperty(QUERY_MAX_MEMORY, "100MB")
+                .setSystemProperty(VERBOSE_EXCEEDED_MEMORY_LIMIT_ERRORS_ENABLED, "true")
+                .setSystemProperty(SPARK_RETRY_ON_OUT_OF_MEMORY_HIGHER_PARTITION_COUNT_ENABLED, "true")
+                .setSystemProperty(SPARK_HASH_PARTITION_COUNT_SCALING_FACTOR_ON_OUT_OF_MEMORY, "2.0")
+                .build();
+        assertQuerySucceeds(session, query);
     }
 
     @Test

--- a/presto-spi/src/main/java/com/facebook/presto/spi/ErrorCause.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/ErrorCause.java
@@ -11,11 +11,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.spark.classloader_interface;
+package com.facebook.presto.spi;
 
-public enum RetryExecutionStrategy
+import com.facebook.drift.annotations.ThriftEnum;
+import com.facebook.drift.annotations.ThriftEnumValue;
+
+@ThriftEnum
+public enum ErrorCause
 {
-    DISABLE_BROADCAST_JOIN,
-    INCREASE_CONTAINER_SIZE,
-    INCREASE_HASH_PARTITION_COUNT
+    UNKNOWN(0),
+    LOW_PARTITION_COUNT(1),
+    EXCEEDS_BROADCAST_MEMORY_LIMIT(2);
+
+    private final int code;
+
+    ErrorCause(int code)
+    {
+        this.code = code;
+    }
+
+    @ThriftEnumValue
+    public int getCode()
+    {
+        return code;
+    }
 }


### PR DESCRIPTION
Test plan - 
Added unit test
Tested with failing queries in production

```
== RELEASE NOTES ==

General Changes
* Added retry with increased partition count if query fails due to low partition count
* Added session properties `spark_hash_partition_count_scaling_factor_on_out_of_memory` and `spark_retry_on_out_of_memory_higher_hash_partition_count_enabled` for this feature