### PR TITLE
Make query.max-total-memory-per-node optional with default value dependent on query.max-memory-per-node

### DIFF
--- a/presto-docs/src/main/sphinx/admin/properties.rst
+++ b/presto-docs/src/main/sphinx/admin/properties.rst
@@ -75,7 +75,7 @@ Memory Management Properties
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
     * **Type:** ``data size``
-    * **Default value:** ``JVM max memory * 0.3``
+    * **Default value:** ``query.max-memory-per-node * 2``
 
     This is the max amount of user and system memory a query can use on a worker.
     System memory is allocated during execution for things that are not directly

--- a/presto-docs/src/main/sphinx/installation/deployment.rst
+++ b/presto-docs/src/main/sphinx/installation/deployment.rst
@@ -114,7 +114,6 @@ The following is a minimal configuration for the coordinator:
     http-server.http.port=8080
     query.max-memory=50GB
     query.max-memory-per-node=1GB
-    query.max-total-memory-per-node=2GB
     discovery-server.enabled=true
     discovery.uri=http://example.net:8080
 
@@ -126,7 +125,6 @@ And this is a minimal configuration for the workers:
     http-server.http.port=8080
     query.max-memory=50GB
     query.max-memory-per-node=1GB
-    query.max-total-memory-per-node=2GB
     discovery.uri=http://example.net:8080
 
 Alternatively, if you are setting up a single machine for testing that
@@ -139,7 +137,6 @@ will function as both a coordinator and worker, use this configuration:
     http-server.http.port=8080
     query.max-memory=5GB
     query.max-memory-per-node=1GB
-    query.max-total-memory-per-node=2GB
     discovery-server.enabled=true
     discovery.uri=http://example.net:8080
 
@@ -159,7 +156,6 @@ Minimum 1 resource manager is needed for a cluster and more can be added in to t
     thrift.server.port=8081
     query.max-memory=50GB
     query.max-memory-per-node=1GB
-    query.max-total-memory-per-node=2GB
     discovery-server.enabled=true
     discovery.uri=http://example.net:8080 (Point to resource manager host/vip)
     thrift.server.ssl.enabled=true
@@ -175,7 +171,6 @@ Cluster supports pool of coordinators. Each coordinator will run subset of queri
     http-server.http.port=8080
     query.max-memory=50GB
     query.max-memory-per-node=1GB
-    query.max-total-memory-per-node=2GB
     discovery.uri=http://example.net:8080 (Point to resource manager host/vip)
     resource-manager-enabled=true
 
@@ -189,7 +184,6 @@ Cluster supports pool of workers. They send their heartbeats to resource manager
     http-server.http.port=8080
     query.max-memory=50GB
     query.max-memory-per-node=1GB
-    query.max-total-memory-per-node=2GB
     discovery.uri=http://example.net:8080 (Point to resource manager host/vip)
     resource-manager-enabled=true
 
@@ -219,10 +213,6 @@ These properties require some explanation:
 
 * ``query.max-memory-per-node``:
   The maximum amount of user memory that a query may use on any one machine.
-
-* ``query.max-total-memory-per-node``:
-  The maximum amount of user and system memory that a query may use on any one machine,
-  where system memory is the memory used during execution by readers, writers, and network buffers, etc.
 
 * ``discovery-server.enabled``:
   Presto uses the Discovery service to find all the nodes in the cluster.

--- a/presto-main/src/main/java/com/facebook/presto/memory/NodeMemoryConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/memory/NodeMemoryConfig.java
@@ -38,7 +38,7 @@ public class NodeMemoryConfig
     private DataSize softMaxQueryMemoryPerNode;
 
     // This is a per-query limit for the user plus system allocations.
-    private DataSize maxQueryTotalMemoryPerNode = new DataSize(AVAILABLE_HEAP_MEMORY * 0.3, BYTE);
+    private DataSize maxQueryTotalMemoryPerNode;
     private DataSize softMaxQueryTotalMemoryPerNode;
     private DataSize heapHeadroom = new DataSize(AVAILABLE_HEAP_MEMORY * 0.3, BYTE);
 
@@ -106,6 +106,10 @@ public class NodeMemoryConfig
     @NotNull
     public DataSize getMaxQueryTotalMemoryPerNode()
     {
+        if (maxQueryTotalMemoryPerNode == null) {
+            DataSize maxQueryMemoryPerNode = getMaxQueryMemoryPerNode();
+            return new DataSize(maxQueryMemoryPerNode.getValue() * 2, maxQueryMemoryPerNode.getUnit());
+        }
         return maxQueryTotalMemoryPerNode;
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/memory/TestNodeMemoryConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/memory/TestNodeMemoryConfig.java
@@ -36,8 +36,8 @@ public class TestNodeMemoryConfig
                 .setMaxQueryBroadcastMemory(new DataSize(AVAILABLE_HEAP_MEMORY * 0.1, BYTE))
                 .setMaxQueryMemoryPerNode(new DataSize(AVAILABLE_HEAP_MEMORY * 0.1, BYTE))
                 .setSoftMaxQueryMemoryPerNode(new DataSize(AVAILABLE_HEAP_MEMORY * 0.1, BYTE))
-                .setMaxQueryTotalMemoryPerNode(new DataSize(AVAILABLE_HEAP_MEMORY * 0.3, BYTE))
-                .setSoftMaxQueryTotalMemoryPerNode(new DataSize(AVAILABLE_HEAP_MEMORY * 0.3, BYTE))
+                .setMaxQueryTotalMemoryPerNode(new DataSize(AVAILABLE_HEAP_MEMORY * 0.2, BYTE))
+                .setSoftMaxQueryTotalMemoryPerNode(new DataSize(AVAILABLE_HEAP_MEMORY * 0.2, BYTE))
                 .setHeapHeadroom(new DataSize(AVAILABLE_HEAP_MEMORY * 0.3, BYTE))
                 .setReservedPoolEnabled(true)
                 .setVerboseExceededMemoryLimitErrorsEnabled(true));

--- a/presto-product-tests/conf/presto/etc/config.properties
+++ b/presto-product-tests/conf/presto/etc/config.properties
@@ -43,6 +43,5 @@ plugin.bundles=\
 
 presto.version=testversion
 query.max-memory-per-node=1GB
-query.max-total-memory-per-node=1.25GB
 query.max-memory=1GB
 redistribute-writes=false

--- a/presto-product-tests/conf/presto/etc/multinode-tls-master.properties
+++ b/presto-product-tests/conf/presto/etc/multinode-tls-master.properties
@@ -16,7 +16,6 @@ discovery.uri=https://presto-master.docker.cluster:7778
 
 query.max-memory=1GB
 query.max-memory-per-node=512MB
-query.max-total-memory-per-node=1GB
 
 http-server.http.enabled=false
 http-server.https.enabled=true

--- a/presto-product-tests/conf/presto/etc/multinode-tls-worker.properties
+++ b/presto-product-tests/conf/presto/etc/multinode-tls-worker.properties
@@ -14,7 +14,6 @@ discovery.uri=https://presto-master.docker.cluster:7778
 
 query.max-memory=1GB
 query.max-memory-per-node=512MB
-query.max-total-memory-per-node=1GB
 
 http-server.http.enabled=false
 http-server.https.enabled=true

--- a/presto-product-tests/conf/presto/etc/multinode-worker.properties
+++ b/presto-product-tests/conf/presto/etc/multinode-worker.properties
@@ -12,5 +12,4 @@ coordinator=false
 http-server.http.port=8081
 query.max-memory=1GB
 query.max-memory-per-node=512MB
-query.max-total-memory-per-node=1GB
 discovery.uri=http://presto-master:8080

--- a/presto-product-tests/conf/presto/etc/singlenode-kerberized.properties
+++ b/presto-product-tests/conf/presto/etc/singlenode-kerberized.properties
@@ -13,7 +13,6 @@ coordinator=true
 node-scheduler.include-coordinator=true
 query.max-memory=1GB
 query.max-memory-per-node=512MB
-query.max-total-memory-per-node=1GB
 discovery-server.enabled=true
 discovery.uri=https://presto-master.docker.cluster:7778
 

--- a/presto-product-tests/conf/presto/etc/singlenode-ldap.properties
+++ b/presto-product-tests/conf/presto/etc/singlenode-ldap.properties
@@ -13,7 +13,6 @@ coordinator=true
 node-scheduler.include-coordinator=true
 query.max-memory=1GB
 query.max-memory-per-node=512MB
-query.max-total-memory-per-node=1GB
 discovery-server.enabled=true
 discovery.uri=https://presto-master:8443
 


### PR DESCRIPTION
Fixes https://github.com/prestodb/presto/issues/17805 issue.

Test plan

- Existing tests.

```
== RELEASE NOTES ==

General Changes
* Make query.max-total-memory-per-node property optional with default value dependent on query.max-memory-per-node
```
