### PR TITLE
Refactor Iceberg hadoop and hive catalog tests

### DIFF
--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hadoop/TestIcebergDistributedHadoop.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hadoop/TestIcebergDistributedHadoop.java
@@ -11,14 +11,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.iceberg;
+package com.facebook.presto.iceberg.hadoop;
+
+import com.facebook.presto.iceberg.TestAbstractIcebergDistributed;
+import org.testng.annotations.Test;
 
 import static com.facebook.presto.iceberg.CatalogType.HADOOP;
 
-public class TestIcebergSmokeHadoop
-        extends TestAbstractIcebergSmoke
+@Test
+public class TestIcebergDistributedHadoop
+        extends TestAbstractIcebergDistributed
 {
-    public TestIcebergSmokeHadoop()
+    public TestIcebergDistributedHadoop()
     {
         super(HADOOP);
     }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hadoop/TestIcebergSmokeHadoop.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hadoop/TestIcebergSmokeHadoop.java
@@ -11,17 +11,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.iceberg;
+package com.facebook.presto.iceberg.hadoop;
 
-import org.testng.annotations.Test;
+import com.facebook.presto.iceberg.TestAbstractIcebergSmoke;
 
 import static com.facebook.presto.iceberg.CatalogType.HADOOP;
 
-@Test
-public class TestIcebergDistributedHadoop
-        extends TestAbstractIcebergDistributed
+public class TestIcebergSmokeHadoop
+        extends TestAbstractIcebergSmoke
 {
-    public TestIcebergDistributedHadoop()
+    public TestIcebergSmokeHadoop()
     {
         super(HADOOP);
     }

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hive/TestIcebergDistributedHive.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hive/TestIcebergDistributedHive.java
@@ -11,8 +11,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.iceberg;
+package com.facebook.presto.iceberg.hive;
 
+import com.facebook.presto.iceberg.TestAbstractIcebergDistributed;
 import org.testng.annotations.Test;
 
 import static com.facebook.presto.iceberg.CatalogType.HIVE;

--- a/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hive/TestIcebergSmokeHive.java
+++ b/presto-iceberg/src/test/java/com/facebook/presto/iceberg/hive/TestIcebergSmokeHive.java
@@ -11,9 +11,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.facebook.presto.iceberg;
+package com.facebook.presto.iceberg.hive;
 
 import com.facebook.presto.Session;
+import com.facebook.presto.iceberg.TestAbstractIcebergSmoke;
 import org.testng.annotations.Test;
 
 import java.util.List;


### PR DESCRIPTION
Refactors Iceberg hadoop and hive catalog tests into their packages respectively, making the tests consistent with the Nessie catalog tests.

```
== NO RELEASE NOTE ==
```
