### PR TITLE
Add plan matching to materialized view join test

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/planner/assertions/PlanMatchPattern.java
@@ -177,8 +177,7 @@ public final class PlanMatchPattern
 
     private PlanMatchPattern addColumnReferences(String expectedTableName, Map<String, String> columnReferences)
     {
-        columnReferences.entrySet().forEach(
-                reference -> withAlias(reference.getKey(), columnReference(expectedTableName, reference.getValue())));
+        columnReferences.forEach((key, value) -> withAlias(key, columnReference(expectedTableName, value)));
         return this;
     }
 


### PR DESCRIPTION
Added `assertPlan` to `TestHiveMaterializedViewLogicalPlanner#testMaterializedViewForJoin`. Wanted to keep this separate from the next PR which will introduce a parallel test.


```
== NO RELEASE NOTE ==
```
