### PR TITLE
Allow to create a copy of ColumnWriterOptions with disabled dictionaries

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/ColumnWriterOptions.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/ColumnWriterOptions.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import static com.facebook.presto.orc.OrcWriterOptions.DEFAULT_MAX_COMPRESSION_BUFFER_SIZE;
 import static com.facebook.presto.orc.OrcWriterOptions.DEFAULT_MAX_STRING_STATISTICS_LIMIT;
 import static com.facebook.presto.orc.OrcWriterOptions.DEFAULT_PRESERVE_DIRECT_ENCODING_STRIPE_COUNT;
+import static io.airlift.units.DataSize.Unit.BYTE;
 import static java.lang.Math.toIntExact;
 import static java.util.Objects.requireNonNull;
 
@@ -122,6 +123,33 @@ public class ColumnWriterOptions
     public Set<Integer> getFlattenedNodes()
     {
         return flattenedNodes;
+    }
+
+    /**
+     * Create a copy of this ColumnWriterOptions, but disable string and integer dictionary encodings.
+     */
+    public ColumnWriterOptions copyWithDisabledDictionaryEncoding()
+    {
+        return toBuilder()
+                .setStringDictionaryEncodingEnabled(false)
+                .setIntegerDictionaryEncodingEnabled(false)
+                .build();
+    }
+
+    public Builder toBuilder()
+    {
+        return new Builder()
+                .setCompressionKind(getCompressionKind())
+                .setCompressionLevel(getCompressionLevel())
+                .setCompressionMaxBufferSize(new DataSize(getCompressionMaxBufferSize(), BYTE))
+                .setStringStatisticsLimit(new DataSize(getStringStatisticsLimit(), BYTE))
+                .setIntegerDictionaryEncodingEnabled(isIntegerDictionaryEncodingEnabled())
+                .setStringDictionarySortingEnabled(isStringDictionarySortingEnabled())
+                .setStringDictionaryEncodingEnabled(isStringDictionaryEncodingEnabled())
+                .setIgnoreDictionaryRowGroupSizes(isIgnoreDictionaryRowGroupSizes())
+                .setPreserveDirectEncodingStripeCount(getPreserveDirectEncodingStripeCount())
+                .setCompressionBufferPool(getCompressionBufferPool())
+                .setFlattenedNodes(getFlattenedNodes());
     }
 
     public static Builder builder()

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestColumnWriterOptions.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestColumnWriterOptions.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc;
+
+import com.facebook.presto.orc.metadata.CompressionKind;
+import com.facebook.presto.orc.writer.CompressionBufferPool;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import io.airlift.units.DataSize;
+import org.testng.annotations.Test;
+
+import java.util.OptionalInt;
+import java.util.Set;
+
+import static java.lang.Math.toIntExact;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+
+public class TestColumnWriterOptions
+{
+    @Test
+    public void testProperties()
+    {
+        CompressionKind compressionKind = CompressionKind.ZSTD;
+        OptionalInt compressionLevel = OptionalInt.of(3);
+        DataSize compressionMaxBufferSize = DataSize.valueOf("56kB");
+        DataSize stringStatisticsLimit = DataSize.valueOf("17MB");
+        boolean integerDictionaryEncodingEnabled = true;
+        boolean stringDictionarySortingEnabled = true;
+        boolean stringDictionaryEncodingEnabled = true;
+        boolean ignoreDictionaryRowGroupSizes = true;
+        int preserveDirectEncodingStripeCount = 27;
+        CompressionBufferPool compressionBufferPool = new CompressionBufferPool.LastUsedCompressionBufferPool();
+        Set<Integer> flattenedNodes = ImmutableSet.of(1, 5);
+
+        ColumnWriterOptions options = ColumnWriterOptions.builder()
+                .setCompressionKind(compressionKind)
+                .setCompressionLevel(compressionLevel)
+                .setCompressionMaxBufferSize(compressionMaxBufferSize)
+                .setStringStatisticsLimit(stringStatisticsLimit)
+                .setIntegerDictionaryEncodingEnabled(integerDictionaryEncodingEnabled)
+                .setStringDictionarySortingEnabled(stringDictionarySortingEnabled)
+                .setStringDictionaryEncodingEnabled(stringDictionaryEncodingEnabled)
+                .setIgnoreDictionaryRowGroupSizes(ignoreDictionaryRowGroupSizes)
+                .setPreserveDirectEncodingStripeCount(preserveDirectEncodingStripeCount)
+                .setCompressionBufferPool(compressionBufferPool)
+                .setFlattenedNodes(flattenedNodes)
+                .build();
+
+        boolean checkDisabledDictionaryEncoding = false;
+
+        for (ColumnWriterOptions actual : ImmutableList.of(options, options.copyWithDisabledDictionaryEncoding())) {
+            assertEquals(actual.getCompressionKind(), compressionKind);
+            assertEquals(actual.getCompressionLevel(), compressionLevel);
+            assertEquals(actual.getCompressionMaxBufferSize(), toIntExact(compressionMaxBufferSize.toBytes()));
+            assertEquals(actual.getStringStatisticsLimit(), toIntExact(stringStatisticsLimit.toBytes()));
+            assertEquals(actual.isStringDictionarySortingEnabled(), stringDictionarySortingEnabled);
+            assertEquals(actual.isIgnoreDictionaryRowGroupSizes(), ignoreDictionaryRowGroupSizes);
+            assertEquals(actual.getPreserveDirectEncodingStripeCount(), preserveDirectEncodingStripeCount);
+            assertEquals(actual.getCompressionBufferPool(), compressionBufferPool);
+            assertEquals(actual.getFlattenedNodes(), flattenedNodes);
+
+            if (checkDisabledDictionaryEncoding) {
+                assertFalse(actual.isStringDictionaryEncodingEnabled());
+                assertFalse(actual.isIntegerDictionaryEncodingEnabled());
+            }
+            else {
+                assertEquals(actual.isStringDictionaryEncodingEnabled(), stringDictionaryEncodingEnabled);
+                assertEquals(actual.isIntegerDictionaryEncodingEnabled(), integerDictionaryEncodingEnabled);
+            }
+            checkDisabledDictionaryEncoding = true;
+        }
+    }
+}


### PR DESCRIPTION
Create a method allowing to clone ColumnWriterOptions but with disabled string and long dictionaries. This will be used by the flat map writer to prevent map value writers from creating their own dictionaries.

Test plan:
- new test cases

```
== NO RELEASE NOTE ==
```
