### PR TITLE
Enable joins of > 2 tables in MV definition

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewPlanValidator.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/MaterializedViewPlanValidator.java
@@ -85,10 +85,6 @@ public class MaterializedViewPlanValidator
     {
         context.pushJoinNode(node);
 
-        if (context.getJoinNodes().size() > 1) {
-            throw new SemanticException(NOT_SUPPORTED, node, "More than one join in materialized view is not supported yet.");
-        }
-
         JoinCriteria joinCriteria;
         switch (node.getType()) {
             case INNER:


### PR DESCRIPTION
The logic to do this was already in place, this just removes a check that gated the functionality.

Test plan - Integration test covering materialized view creation, query equality, and plan matching.

```
== NO RELEASE NOTE ==
 ```
