### PR TITLE
Fix flat map writer's getBufferedBytes

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/MapFlatColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/MapFlatColumnWriter.java
@@ -388,11 +388,10 @@ public class MapFlatColumnWriter
     @Override
     public long getBufferedBytes()
     {
-        long bufferedBytes = 0;
+        long bufferedBytes = presentStream.getBufferedBytes();
         for (MapFlatValueWriter valueWriter : valueWriters) {
-            bufferedBytes += valueWriter.getValueWriter().getBufferedBytes();
+            bufferedBytes += valueWriter.getBufferedBytes();
         }
-        // TODO Implement me
         return bufferedBytes;
     }
 

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/MapFlatValueWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/MapFlatValueWriter.java
@@ -131,6 +131,11 @@ class MapFlatValueWriter
         return valueWriter.getIndexStreams(Optional.of(inMapStream.getCheckpoints()));
     }
 
+    public long getBufferedBytes()
+    {
+        return valueWriter.getBufferedBytes() + inMapStream.getBufferedBytes();
+    }
+
     public void close()
     {
         inMapStream.close();


### PR DESCRIPTION
Report all buffered streams in getBufferedBytes. 

Note: flat map writer does lazy population of nested in_map streams, meaning that they won't be FULLY accounted in the getBufferedBytes and there would be some difference in the reported and actual data size. Value's in_map streams catch up either when there is a value written or when a row group is finished.

Test plan:
- existing tests

```
== NO RELEASE NOTE ==
```
