### PR TITLE
Fix a bug with empty maps in MapFlatSelectiveStreamReader

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapFlatSelectiveStreamReader.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/MapFlatSelectiveStreamReader.java
@@ -236,8 +236,8 @@ public class MapFlatSelectiveStreamReader
 
         outputPositions = initializeOutputPositions(outputPositions, positions, positionCount);
 
-        if (presentStream != null && keyCount == 0) {
-            readAllNulls(positions, positionCount);
+        if (keyCount == 0 && presentStream == null) {
+            readAllEmpty(positions, positionCount);
         }
         else {
             readNotAllNulls(offset, positions, positionCount);
@@ -248,20 +248,19 @@ public class MapFlatSelectiveStreamReader
         return outputPositionCount;
     }
 
-    private void readAllNulls(int[] positions, int positionCount)
-            throws IOException
+    private void readAllEmpty(int[] positions, int positionCount)
     {
-        presentStream.skip(positions[positionCount - 1]);
+        outputPositions = positions;
+        outputPositionsReadOnly = true;
 
-        allNulls = true;
-
-        if (!nullsAllowed) {
+        if (!nonNullsAllowed) {
+            allNulls = true;
             outputPositionCount = 0;
         }
         else {
             outputPositionCount = positionCount;
-            outputPositions = positions;
-            outputPositionsReadOnly = true;
+            nestedLengths = ensureCapacity(nestedLengths, positionCount);
+            Arrays.fill(nestedLengths, 0);
         }
     }
 

--- a/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
@@ -289,13 +289,12 @@ public class OrcTester
         OrcTester orcTester = new OrcTester();
         orcTester.nullTestsEnabled = true;
         orcTester.skipBatchTestsEnabled = true;
+        orcTester.skipStripeTestsEnabled = true;
         orcTester.formats = ImmutableSet.of(DWRF);
         orcTester.compressions = ImmutableSet.of(ZLIB);
         orcTester.dwrfEncryptionEnabled = true;
         orcTester.flattenAllColumns = true;
-
-        // TODO: sdruzkin - enable this flag after fixing a bug with null/empty maps in the selective reader
-        // orcTester.useSelectiveOrcReader = true;
+        orcTester.useSelectiveOrcReader = true;
         return orcTester;
     }
 

--- a/presto-orc/src/test/java/com/facebook/presto/orc/TestFlatMapWriter.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/TestFlatMapWriter.java
@@ -51,21 +51,36 @@ public class TestFlatMapWriter
     private static final Map<?, ?> EMPTY_MAP = ImmutableMap.of();
 
     @Test
-    public void testComplexValueType()
+    public void testMapValueType()
+            throws Exception
+    {
+        runTest(mapType(INTEGER, mapType(INTEGER, VARCHAR)),
+                1, 2, 3,
+                ImmutableMap.of(10, "20"), ImmutableMap.of(11, "22"), ImmutableMap.of(12, "23"), ImmutableMap.of(13, "24"), ImmutableMap.of(14, "25"));
+    }
+
+    @Test
+    public void testArrayValueType()
             throws Exception
     {
         runTest(mapType(INTEGER, arrayType(INTEGER)),
                 1, 2, 3,
                 ImmutableList.of(1, 2), ImmutableList.of(3), ImmutableList.of(4, 5), ImmutableList.of(6), ImmutableList.of(9, 10));
+    }
 
+    @Test
+    public void testRowValueType()
+            throws Exception
+    {
         runTest(mapType(INTEGER, rowType(INTEGER, VARCHAR)),
                 1, 2, 3,
                 ImmutableList.of(10, "20"), ImmutableList.of(11, "22"), ImmutableList.of(12, "23"), ImmutableList.of(13, "24"), ImmutableList.of(14, "25"));
+    }
 
-        runTest(mapType(INTEGER, mapType(INTEGER, VARCHAR)),
-                1, 2, 3,
-                ImmutableMap.of(10, "20"), ImmutableMap.of(11, "22"), ImmutableMap.of(12, "23"), ImmutableMap.of(13, "24"), ImmutableMap.of(14, "25"));
-
+    @Test
+    public void testDeeplyNestedValueType()
+            throws Exception
+    {
         // do one deeply nested value type
         runTest(mapType(INTEGER, arrayType(arrayType(INTEGER))),
                 1, 2, 3,


### PR DESCRIPTION
MapFlatSelectiveStreamReader didn't handle correctly columns where all maps are either empty or null, it treated them as all nulls.

Test plan:
- extended existing tests

```
== NO RELEASE NOTE ==
```
