### PR TITLE
Implement Merge Join execution changes

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
+++ b/presto-main/src/main/java/com/facebook/presto/SystemSessionProperties.java
@@ -224,6 +224,7 @@ public final class SystemSessionProperties
     public static final String MAX_STAGE_COUNT_FOR_EAGER_SCHEDULING = "max_stage_count_for_eager_scheduling";
     public static final String HYPERLOGLOG_STANDARD_ERROR_WARNING_THRESHOLD = "hyperloglog_standard_error_warning_threshold";
     public static final String PREFER_MERGE_JOIN = "prefer_merge_join";
+    public static final String MERGE_JOIN_BUFFER_ENABLED = "merge_join_buffer_enabled";
     public static final String SEGMENTED_AGGREGATION_ENABLED = "segmented_aggregation_enabled";
 
     //TODO: Prestissimo related session properties that are temporarily put here. They will be relocated in the future
@@ -1198,6 +1199,13 @@ public final class SystemSessionProperties
                         featuresConfig.isPreferMergeJoin(),
                         true),
                 booleanProperty(
+                        MERGE_JOIN_BUFFER_ENABLED,
+                        "Enable buffering for right side pages during merge join. When there are too many leaf splits scheduled for task without buffering, the task " +
+                                "can be stuck indefinitely. This feature is enabled by default. If disabling the buffer, also adjust concurrent_lifespans_per_task so " +
+                                "that the task does not get stuck.",
+                        featuresConfig.isMergeJoinBufferEnabled(),
+                        true),
+                booleanProperty(
                         SEGMENTED_AGGREGATION_ENABLED,
                         "Enable segmented aggregation.",
                         featuresConfig.isSegmentedAggregationEnabled(),
@@ -2116,6 +2124,11 @@ public final class SystemSessionProperties
     public static boolean preferMergeJoin(Session session)
     {
         return session.getSystemProperty(PREFER_MERGE_JOIN, Boolean.class);
+    }
+
+    public static boolean isMergeJoinBufferEnabled(Session session)
+    {
+        return session.getSystemProperty(MERGE_JOIN_BUFFER_ENABLED, Boolean.class);
     }
 
     public static boolean isSegmentedAggregationEnabled(Session session)

--- a/presto-main/src/main/java/com/facebook/presto/operator/MergeJoinOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/MergeJoinOperator.java
@@ -1,0 +1,552 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.common.Page;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.google.common.collect.ImmutableList;
+import com.google.common.util.concurrent.ListenableFuture;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
+
+public class MergeJoinOperator
+        implements Operator
+{
+    private final OperatorContext operatorContext;
+    private final List<Type> leftTypes;
+    private final List<Type> leftOutputTypes;
+    private final List<Integer> leftOutputChannels;
+    private final List<Type> rightTypes;
+    private final List<Type> rightOutputTypes;
+    private final List<Integer> rightOutputChannels;
+    private final List<Integer> leftJoinChannels;
+    private final List<Integer> rightJoinChannels;
+
+    final MergeJoinSource mergeJoinSource;
+    private final JoinNode.Type joinType;
+
+    private MergeJoinPageBuilder outputPageBuilder;
+    private Page leftPage;
+    private Page rightPage;
+
+    Optional<Match> leftMatch;
+    Optional<Match> rightMatch;
+
+    private boolean finishing;
+    private boolean noMoreRightInput;
+    private int leftIndex;
+    private int rightIndex;
+
+    public MergeJoinOperator(
+            OperatorContext operatorContext,
+            List<Type> leftTypes,
+            List<Type> leftOutputTypes,
+            List<Integer> leftOutputChannels,
+            List<Type> rightTypes,
+            List<Type> rightOutputTypes,
+            List<Integer> rightOutputChannels,
+            List<Integer> leftJoinChannels,
+            List<Integer> rightJoinChannels,
+            JoinNode.Type joinType,
+            MergeJoinSource mergeJoinSource)
+    {
+        this.operatorContext = operatorContext;
+        this.leftTypes = ImmutableList.copyOf(leftTypes);
+        this.leftOutputTypes = ImmutableList.copyOf(leftOutputTypes);
+        this.leftOutputChannels = ImmutableList.copyOf(leftOutputChannels);
+        this.rightTypes = ImmutableList.copyOf(rightTypes);
+        this.rightOutputTypes = ImmutableList.copyOf(rightOutputTypes);
+        this.rightOutputChannels = ImmutableList.copyOf(rightOutputChannels);
+        this.leftJoinChannels = ImmutableList.copyOf(leftJoinChannels);
+        this.rightJoinChannels = ImmutableList.copyOf(rightJoinChannels);
+        this.joinType = requireNonNull(joinType);
+        this.leftMatch = Optional.empty();
+        this.rightMatch = Optional.empty();
+        this.leftIndex = 0;
+        this.rightIndex = 0;
+        this.mergeJoinSource = mergeJoinSource;
+    }
+
+    @Override
+    public OperatorContext getOperatorContext()
+    {
+        return operatorContext;
+    }
+
+    @Override
+    public boolean needsInput()
+    {
+        return !finishing && leftPage == null;
+    }
+
+    @Override
+    public void addInput(Page page)
+    {
+        requireNonNull(page, "page is null");
+        leftPage = page;
+        leftIndex = 0;
+    }
+
+    private int compare(
+            List<Type> types,
+            List<Integer> joinChannels,
+            Page batch,
+            int index,
+            List<Type> otherTypes,
+            List<Integer> otherJoinChannels,
+            Page otherBatch,
+            int otherIndex)
+    {
+        for (int i = 0; i < joinChannels.size(); i++) {
+            int channel = joinChannels.get(i);
+            int otherChannel = otherJoinChannels.get(i);
+            int compare = types.get(channel).compareTo(batch.getBlock(channel), index, otherBatch.getBlock(otherChannel), otherIndex);
+            if (compare != 0) {
+                return compare;
+            }
+        }
+        return 0;
+    }
+
+    // compare two rows from the left side
+    private int compareLeft(Page batch, int index, Page otherBatch, int otherIndex)
+    {
+        return compare(leftTypes, leftJoinChannels, batch, index, leftTypes, leftJoinChannels, otherBatch, otherIndex);
+    }
+
+    // compare two rows from the right side
+    private int compareRight(Page batch, int index, Page otherBatch, int otherIndex)
+    {
+        return compare(rightTypes, rightJoinChannels, batch, index, rightTypes, rightJoinChannels, otherBatch, otherIndex);
+    }
+
+    // compare rows on the left and right at leftIndex and rightIndex respectively
+    private int compare()
+    {
+        return compare(leftTypes, leftJoinChannels, leftPage, leftIndex, rightTypes, rightJoinChannels, rightPage, rightIndex);
+    }
+
+    // compare two rows on the left page: leftIndex and index
+    private int compareLeft(int index)
+    {
+        return compare(leftTypes, leftJoinChannels, leftPage, leftIndex, leftTypes, leftJoinChannels, leftPage, index);
+    }
+
+    // compare two rows on the right page: rightIndex and index
+    private int compareRight(int index)
+    {
+        return compare(rightTypes, rightJoinChannels, rightPage, rightIndex, rightTypes, rightJoinChannels, rightPage, index);
+    }
+
+    private boolean findEndOfMatch(Match match, Page input, List<Type> types, List<Integer> joinChannels)
+    {
+        if (match.complete) {
+            return true;
+        }
+
+        Page prevInput = match.inputs.get(match.inputs.size() - 1);
+        int prevIndex = prevInput.getPositionCount() - 1;
+
+        int numInput = input.getPositionCount();
+
+        int endIndex = 0;
+        while (endIndex < numInput && compare(types, joinChannels, input, endIndex, types, joinChannels, prevInput, prevIndex) == 0) {
+            ++endIndex;
+        }
+
+        if (endIndex == numInput) {
+            match.inputs.add(input);
+            match.endIndex = endIndex;
+            return false;
+        }
+
+        if (endIndex > 0) {
+            match.inputs.add(input);
+            match.endIndex = endIndex;
+        }
+
+        match.complete = true;
+        return true;
+    }
+
+    @Override
+    public Page getOutput()
+    {
+        // Make sure to have isBlocked or needsInput as valid when returning null output, else driver
+        // assumes operator is finished
+
+        // finishing is the no-more-inputs-on-the-left indicator, noMoreRightInput_ is for the right side
+        while (true) {
+            Page output = doGetOutput();
+            if (output != null) {
+                return output;
+            }
+
+            // check if we need more right side input
+            if (!noMoreRightInput && this.mergeJoinSource.getConsumerFuture().isDone() && rightPage == null) {
+                rightPage = mergeJoinSource.nextPage();
+
+                if (rightPage == null && !mergeJoinSource.isFinishing()) {
+                    return null;
+                }
+
+                if (rightPage != null) {
+                    rightIndex = 0;
+                }
+                else {
+                    noMoreRightInput = true;
+                }
+                continue;
+            }
+
+            return null;
+        }
+    }
+
+    private Page doGetOutput()
+    {
+        // check if we ran out of space in the output page in the middle of the match
+        if (leftMatch.isPresent() && leftMatch.get().getCursor().isPresent()) {
+            checkState(rightMatch.isPresent() && rightMatch.get().getCursor().isPresent());
+
+            // continue producing results from the current match
+            if (addToOutput()) {
+                return buildOutputPage();
+            }
+        }
+
+        // no output-in-progress match, but there could be incomplete match
+        if (leftMatch.isPresent()) {
+            checkState(rightMatch.isPresent());
+
+            if (leftPage != null) {
+                // look for continuation of match on the left and/or right sides
+
+                if (!findEndOfMatch(leftMatch.get(), leftPage, leftTypes, leftJoinChannels)) {
+                    // continue looking for end of the match
+                    leftPage = null;
+                    return null;
+                }
+
+                if (leftMatch.get().inputs.get(leftMatch.get().inputs.size() - 1) == leftPage) {
+                    leftIndex = leftMatch.get().endIndex;
+                }
+            }
+            else if (finishing) {
+                leftMatch.get().complete = true;
+            }
+            else {
+                // needs more input
+                return null;
+            }
+
+            if (rightPage != null) {
+                if (!findEndOfMatch(rightMatch.get(), rightPage, rightTypes, rightJoinChannels)) {
+                    // continue looking for end of the match
+                    rightPage = null;
+                    return null;
+                }
+
+                if (rightMatch.get().inputs.get(rightMatch.get().inputs.size() - 1) == rightPage) {
+                    rightIndex = rightMatch.get().endIndex;
+                }
+            }
+            else if (noMoreRightInput) {
+                rightMatch.get().complete = true;
+            }
+            else {
+                // needs more input
+                return null;
+            }
+        }
+
+        // there is no output-in-progress match, but there can be a complete match ready for output
+        if (leftMatch.isPresent()) {
+            checkState(leftMatch.get().complete);
+            checkState(rightMatch.isPresent() && rightMatch.get().complete);
+
+            if (addToOutput()) {
+                return buildOutputPage();
+            }
+        }
+
+        if (leftPage == null || rightPage == null) {
+            if (joinType == JoinNode.Type.LEFT) {
+                if (leftPage != null && noMoreRightInput) {
+                    prepareOutput();
+                    while (true) {
+                        if (outputPageBuilder.isFull()) {
+                            return buildOutputPage();
+                        }
+
+                        addOutputRowForLeftJoin();
+
+                        ++leftIndex;
+                        if (leftIndex == leftPage.getPositionCount()) {
+                            // ran out of rows on the left side
+                            leftPage = null;
+                            return null;
+                        }
+                    }
+                }
+
+                if (finishing && outputPageBuilder != null) {
+                    return buildOutputPage();
+                }
+            }
+            else {
+                if (finishing || noMoreRightInput) {
+                    if (outputPageBuilder != null) {
+                        return buildOutputPage();
+                    }
+                    leftPage = null;
+                }
+            }
+
+            return null;
+        }
+
+        // look for a new match starting with the leftIndex row on the left and rightIndex row on the right
+        int compareResult = compare();
+
+        while (true) {
+            // catch up leftPage with rightPage
+            while (compareResult < 0) {
+                if (joinType == JoinNode.Type.LEFT) {
+                    prepareOutput();
+                    if (outputPageBuilder.isFull()) {
+                        return buildOutputPage();
+                    }
+                    addOutputRowForLeftJoin();
+                }
+
+                ++leftIndex;
+                if (leftIndex == leftPage.getPositionCount()) {
+                    // ran out of rows on the left side
+                    leftPage = null;
+                    return null;
+                }
+                compareResult = compare();
+            }
+
+            // catchup rightPage with leftPage
+            while (compareResult > 0) {
+                ++rightIndex;
+                if (rightIndex == rightPage.getPositionCount()) {
+                    // ran out of rows on the right side
+                    rightPage = null;
+                    return null;
+                }
+                compareResult = compare();
+            }
+
+            if (compareResult == 0) {
+                // found match. identify all rows on the left and right that have matching keys
+                int endIndex = leftIndex + 1;
+                while (endIndex < leftPage.getPositionCount() && compareLeft(endIndex) == 0) {
+                    ++endIndex;
+                }
+                leftMatch = Optional.of(new Match(leftPage, leftIndex, endIndex, endIndex < leftPage.getPositionCount(), Optional.empty()));
+
+                int endRightIndex = rightIndex + 1;
+                while (endRightIndex < rightPage.getPositionCount() && compareRight(endRightIndex) == 0) {
+                    ++endRightIndex;
+                }
+                rightMatch = Optional.of(new Match(rightPage, rightIndex, endRightIndex, endRightIndex < rightPage.getPositionCount(), Optional.empty()));
+
+                if (!leftMatch.get().complete || !rightMatch.get().complete) {
+                    if (!leftMatch.get().complete) {
+                        // need to continue looking for end of match
+                        leftPage = null;
+                    }
+                    if (!rightMatch.get().complete) {
+                        // need to continue looking for end of match
+                        rightPage = null;
+                    }
+                    return null;
+                }
+
+                leftIndex = endIndex;
+                rightIndex = endRightIndex;
+
+                if (addToOutput()) {
+                    return buildOutputPage();
+                }
+                compareResult = compare();
+            }
+        }
+        // unreachable
+    }
+
+    private boolean addToOutput()
+    {
+        prepareOutput();
+
+        int firstLeftBatch;
+        int leftStartIndex;
+
+        if (leftMatch.get().getCursor().isPresent()) {
+            firstLeftBatch = leftMatch.get().getCursor().get().batchIndex;
+            leftStartIndex = leftMatch.get().getCursor().get().index;
+        }
+        else {
+            firstLeftBatch = 0;
+            leftStartIndex = leftMatch.get().startIndex;
+        }
+
+        int numLefts = leftMatch.get().inputs.size();
+        for (int l = firstLeftBatch; l < numLefts; ++l) {
+            Page left = leftMatch.get().inputs.get(l);
+            int leftStart = (l == firstLeftBatch) ? leftStartIndex : 0;
+            int leftEnd = (l == numLefts - 1) ? leftMatch.get().endIndex : left.getPositionCount();
+
+            for (int i = leftStart; i < leftEnd; ++i) {
+                int firstRightBatch = (l == firstLeftBatch && i == leftStart && rightMatch.get().getCursor().isPresent()) ? rightMatch.get().getCursor().get().batchIndex : 0;
+                int rightStartIndex = (l == firstLeftBatch && i == leftStart && rightMatch.get().getCursor().isPresent()) ? rightMatch.get().getCursor().get().index : rightMatch.get().startIndex;
+
+                int numRights = rightMatch.get().inputs.size();
+                for (int r = firstRightBatch; r < numRights; ++r) {
+                    Page right = rightMatch.get().inputs.get(r);
+                    int rightStart = (r == firstRightBatch) ? rightStartIndex : 0;
+                    int rightEnd = (r == numRights - 1) ? rightMatch.get().endIndex : right.getPositionCount();
+
+                    for (int j = rightStart; j < rightEnd; ++j) {
+                        if (outputPageBuilder.isFull()) {
+                            leftMatch.get().setCursor(l, i);
+                            rightMatch.get().setCursor(r, j);
+                            return true;
+                        }
+                        addOutputRow(left, i, right, j);
+                    }
+                }
+            }
+        }
+
+        leftMatch = Optional.empty();
+        rightMatch = Optional.empty();
+
+        return outputPageBuilder.isFull();
+    }
+
+    private void prepareOutput()
+    {
+        if (outputPageBuilder == null) {
+            outputPageBuilder = new MergeJoinPageBuilder(leftOutputTypes, rightOutputTypes);
+        }
+    }
+
+    private void addOutputRow(Page left, int leftIndex, Page right, int rightIndex)
+    {
+        outputPageBuilder.addRow(left, leftOutputChannels, leftIndex, right, rightOutputChannels, rightIndex);
+    }
+
+    private void addOutputRowForLeftJoin()
+    {
+        outputPageBuilder.addRowForLeftJoin(leftPage, leftOutputChannels, leftIndex);
+    }
+
+    private Page buildOutputPage()
+    {
+        Page outputPage = outputPageBuilder.build();
+        outputPageBuilder = null;
+        return outputPage;
+    }
+
+    @Override
+    public void finish()
+    {
+        finishing = true;
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        boolean noOutputRows = outputPageBuilder == null || outputPageBuilder.isEmpty();
+        return this.finishing && leftPage == null && noOutputRows;
+    }
+
+    @Override
+    public ListenableFuture<?> isBlocked()
+    {
+        if (mergeJoinSource.getConsumerFuture() != null) {
+            return mergeJoinSource.getConsumerFuture();
+        }
+        return NOT_BLOCKED;
+    }
+
+    @Override
+    public void close()
+    {
+        outputPageBuilder = null;
+        mergeJoinSource.close();
+    }
+
+    private static class Match
+    {
+        List<Page> inputs;
+        int startIndex;
+        int endIndex;
+        boolean complete;
+        Optional<Cursor> cursor;
+
+        public Match(Page input, int startIndex, int endIndex, boolean complete, Optional<Cursor> cursor)
+        {
+            requireNonNull(input, "input is null");
+            this.inputs = new ArrayList<>();
+            inputs.add(input);
+            this.startIndex = startIndex;
+            this.endIndex = endIndex;
+            this.complete = complete;
+            this.cursor = requireNonNull(cursor, "cursor is null");
+        }
+
+        public void setCursor(int batchIndex, int index)
+        {
+            cursor = Optional.of(new Cursor(batchIndex, index));
+        }
+
+        public Optional<Cursor> getCursor()
+        {
+            return cursor;
+        }
+
+        private static class Cursor
+        {
+            private final int batchIndex;
+            private final int index;
+
+            public Cursor(int batchIndex, int index)
+            {
+                this.batchIndex = batchIndex;
+                this.index = index;
+            }
+
+            public int getBatchIndex()
+            {
+                return batchIndex;
+            }
+
+            public int getIndex()
+            {
+                return index;
+            }
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/MergeJoinOperatorFactory.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/MergeJoinOperatorFactory.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.spi.plan.PlanNodeId;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+
+import java.util.List;
+
+import static com.google.common.base.Preconditions.checkState;
+
+public class MergeJoinOperatorFactory
+        implements OperatorFactory
+{
+    private final int operatorId;
+    private final PlanNodeId planNodeId;
+    private final List<Type> leftTypes;
+    private final List<Type> leftOutputTypes;
+    private final List<Integer> leftOutputChannels;
+    private final List<Type> rightTypes;
+    private final List<Type> rightOutputTypes;
+    private final List<Integer> rightOutputChannels;
+    private final List<Integer> leftJoinChannels;
+    private final List<Integer> rightJoinChannels;
+    private final JoinNode.Type mergeJoinType;
+    private final MergeJoinSourceManager mergeJoinSourceManager;
+
+    private boolean closed;
+
+    public MergeJoinOperatorFactory(
+            int operatorId,
+            PlanNodeId planNodeId,
+            MergeJoinSourceManager mergeJoinSourceManager,
+            List<Type> leftTypes,
+            List<Type> leftOutputTypes,
+            List<Integer> leftOutputChannels,
+            List<Type> rightTypes,
+            List<Type> rightOutputTypes,
+            List<Integer> rightOutputChannels,
+            List<Integer> leftJoinChannels,
+            List<Integer> rightJoinChannels,
+            JoinNode.Type mergeJoinType)
+    {
+        this.operatorId = operatorId;
+        this.planNodeId = planNodeId;
+        this.leftTypes = leftTypes;
+        this.leftOutputTypes = leftOutputTypes;
+        this.leftOutputChannels = leftOutputChannels;
+        this.rightTypes = rightTypes;
+        this.rightOutputTypes = rightOutputTypes;
+        this.rightOutputChannels = rightOutputChannels;
+        this.mergeJoinType = mergeJoinType;
+        this.mergeJoinSourceManager = mergeJoinSourceManager;
+        this.leftJoinChannels = leftJoinChannels;
+        this.rightJoinChannels = rightJoinChannels;
+    }
+
+    @Override
+    public Operator createOperator(DriverContext driverContext)
+    {
+        checkState(!closed, "Factory is already closed");
+
+        OperatorContext operatorContext = driverContext.addOperatorContext(operatorId, planNodeId, MergeJoinOperator.class.getSimpleName());
+        MergeJoinSource mergeJoinSource = mergeJoinSourceManager.getMergeJoinSource(driverContext.getLifespan(), null);
+        return new MergeJoinOperator(operatorContext, leftTypes, leftOutputTypes, leftOutputChannels, rightTypes, rightOutputTypes, rightOutputChannels, leftJoinChannels, rightJoinChannels, mergeJoinType, mergeJoinSource);
+    }
+
+    @Override
+    public void noMoreOperators()
+    {
+        checkState(!closed);
+        closed = true;
+    }
+
+    @Override
+    public OperatorFactory duplicate()
+    {
+        return null;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/MergeJoinPageBuilder.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/MergeJoinPageBuilder.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.common.Page;
+import com.facebook.presto.common.block.Block;
+import com.facebook.presto.common.block.BlockBuilder;
+import com.facebook.presto.common.type.Type;
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class MergeJoinPageBuilder
+{
+    private final List<Type> types;
+    private final List<BlockBuilder> builders;
+    private int positionCount;
+    private final long maxPositionCount = 1024;
+
+    public static MergeJoinPageBuilder mergeJoinPageBuilder(List<Type> leftTypes, List<Type> rightTypes)
+    {
+        return new MergeJoinPageBuilder(leftTypes, rightTypes);
+    }
+
+    MergeJoinPageBuilder(List<Type> leftTypes, List<Type> rightTypes)
+    {
+        this.types = Stream.concat(ImmutableList.copyOf(leftTypes).stream(), ImmutableList.copyOf(rightTypes).stream()).collect(Collectors.toList());
+        ImmutableList.Builder<BlockBuilder> builders = ImmutableList.builder();
+        for (Type type : types) {
+            builders.add(type.createBlockBuilder(null, 1024));
+        }
+        this.builders = builders.build();
+    }
+
+    public boolean isEmptyOutput()
+    {
+        return types.isEmpty();
+    }
+
+    public long getPositionCount()
+    {
+        return positionCount;
+    }
+
+    public boolean isEmpty()
+    {
+        return positionCount == 0;
+    }
+
+    public boolean isFull()
+    {
+        return positionCount == maxPositionCount;
+    }
+
+    public Page build()
+    {
+        Block[] blocks = new Block[builders.size()];
+        for (int i = 0; i < blocks.length; i++) {
+            blocks[i] = builders.get(i).build();
+        }
+        return new Page(positionCount, blocks);
+    }
+
+    public MergeJoinPageBuilder addRow(Page left, List<Integer> leftChannels, int leftIndex, Page right, List<Integer> rightChannels, int rightIndex)
+    {
+        if (isEmptyOutput()) {
+            positionCount++;
+            return this;
+        }
+        if (isNullMatch(left, leftChannels, leftIndex)) {
+            return this;
+        }
+
+        for (int i = 0; i < leftChannels.size(); i++) {
+            int channel = leftChannels.get(i);
+            BlockBuilder blockBuilder = builders.get(i);
+            types.get(i).appendTo(left.getBlock(channel), leftIndex, blockBuilder);
+        }
+
+        int offset = leftChannels.size();
+        for (int j = 0; j < rightChannels.size(); j++) {
+            int channel = rightChannels.get(j);
+            BlockBuilder blockBuilder = builders.get(j + offset);
+            types.get(j + offset).appendTo(right.getBlock(channel), rightIndex, blockBuilder);
+        }
+        positionCount++;
+        return this;
+    }
+
+    public MergeJoinPageBuilder addRowForLeftJoin(Page left, List<Integer> leftChannels, int leftIndex)
+    {
+        if (isEmptyOutput()) {
+            positionCount++;
+            return this;
+        }
+
+        if (isNullMatch(left, leftChannels, leftIndex)) {
+            return this;
+        }
+
+        for (int i = 0; i < leftChannels.size(); i++) {
+            int channel = leftChannels.get(i);
+            BlockBuilder blockBuilder = builders.get(i);
+            types.get(i).appendTo(left.getBlock(channel), leftIndex, blockBuilder);
+        }
+
+        int offset = leftChannels.size();
+        for (int j = 0; j < types.size() - offset; j++) {
+            BlockBuilder blockBuilder = builders.get(j + offset);
+            blockBuilder.appendNull();
+        }
+        positionCount++;
+        return this;
+    }
+
+    public boolean isNullMatch(Page page, List<Integer> channels, int index)
+    {
+        for (int channel : channels) {
+            if (page.getBlock(channel).isNull(index)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/MergeJoinSinkOperator.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/MergeJoinSinkOperator.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.common.Page;
+import com.facebook.presto.memory.context.LocalMemoryContext;
+import com.facebook.presto.spi.plan.PlanNodeId;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.util.concurrent.ListenableFuture;
+
+import static com.google.common.base.Preconditions.checkState;
+
+public class MergeJoinSinkOperator
+        implements Operator
+{
+    public static class MergeJoinSinkOperatorFactory
+            implements OperatorFactory
+    {
+        private final int operatorId;
+        private final PlanNodeId planNodeId;
+        private final MergeJoinSourceManager mergeJoinSourceManager;
+        private boolean closed;
+
+        public MergeJoinSinkOperatorFactory(
+                int operatorId,
+                PlanNodeId planNodeId,
+                MergeJoinSourceManager mergeJoinSourceManager)
+        {
+            this.operatorId = operatorId;
+            this.planNodeId = planNodeId;
+            this.mergeJoinSourceManager = mergeJoinSourceManager;
+        }
+
+        @Override
+        public MergeJoinSinkOperator createOperator(DriverContext driverContext)
+        {
+            checkState(!closed, "Factory is already closed");
+            OperatorContext operatorContext = driverContext.addOperatorContext(operatorId, planNodeId, MergeJoinSinkOperator.class.getSimpleName());
+            LocalMemoryContext memoryContext = operatorContext.aggregateUserMemoryContext().newLocalMemoryContext(MergeJoinSource.class.getSimpleName());
+            MergeJoinSource mergeJoinSource = mergeJoinSourceManager.getMergeJoinSource(driverContext.getLifespan(), memoryContext);
+            return new MergeJoinSinkOperator(operatorContext, mergeJoinSource);
+        }
+
+        @Override
+        public void noMoreOperators()
+        {
+            closed = true;
+        }
+
+        @Override
+        public OperatorFactory duplicate()
+        {
+            throw new UnsupportedOperationException("Callback sink can not be duplicated");
+        }
+    }
+
+    @VisibleForTesting
+    public enum State
+    {
+        CONSUMING_INPUT,
+        WAITING_FOR_CONSUMER,
+        CLOSED
+    }
+
+    private final OperatorContext operatorContext;
+    final MergeJoinSource mergeJoinSource;
+    private State state = State.CONSUMING_INPUT;
+
+    public MergeJoinSinkOperator(
+            OperatorContext operatorContext,
+            MergeJoinSource mergeJoinSource)
+    {
+        this.operatorContext = operatorContext;
+        this.mergeJoinSource = mergeJoinSource;
+    }
+
+    @Override
+    public OperatorContext getOperatorContext()
+    {
+        return operatorContext;
+    }
+
+    @VisibleForTesting
+    public State getState()
+    {
+        return state;
+    }
+
+    @Override
+    public ListenableFuture<?> isBlocked()
+    {
+        if (state == State.WAITING_FOR_CONSUMER) {
+            boolean canProduce = mergeJoinSource.getProducerFuture().isDone();
+            if (!canProduce) {
+                return mergeJoinSource.getProducerFuture();
+            }
+            state = State.CONSUMING_INPUT;
+        }
+        return NOT_BLOCKED;
+    }
+
+    @Override
+    public boolean needsInput()
+    {
+        return state == State.CONSUMING_INPUT;
+    }
+
+    @Override
+    public void addInput(Page page)
+    {
+        if (page == null || isFinished()) {
+            return;
+        }
+        checkState(state == State.CONSUMING_INPUT);
+
+        mergeJoinSource.addPage(page);
+        state = State.WAITING_FOR_CONSUMER;
+
+        operatorContext.recordOutput(page.getSizeInBytes(), page.getPositionCount());
+    }
+
+    @Override
+    public Page getOutput()
+    {
+        return null;
+    }
+
+    @Override
+    public void finish()
+    {
+        if (state == State.CONSUMING_INPUT) {
+            mergeJoinSource.addPage(null);
+            state = State.CLOSED;
+        }
+    }
+
+    @Override
+    public boolean isFinished()
+    {
+        return state == State.CLOSED;
+    }
+
+    @Override
+    public void close()
+    {
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/MergeJoinSource.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/MergeJoinSource.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.common.Page;
+import com.facebook.presto.memory.context.LocalMemoryContext;
+import com.google.common.util.concurrent.ListenableFuture;
+import com.google.common.util.concurrent.SettableFuture;
+
+import java.io.Closeable;
+import java.util.ArrayDeque;
+import java.util.Queue;
+
+import static com.facebook.presto.operator.Operator.NOT_BLOCKED;
+import static com.google.common.base.Preconditions.checkState;
+
+public class MergeJoinSource
+        implements Closeable
+{
+    private final Queue<Page> pages;
+    private final boolean buffered;
+    private LocalMemoryContext localMemoryContext;
+    private int pagesRemaining;
+    private boolean finishing;
+
+    // consumer is blocked initially, producer is not blocked
+    private ListenableFuture<?> consumerFuture = SettableFuture.create();
+    private ListenableFuture<?> producerFuture = NOT_BLOCKED;
+
+    public MergeJoinSource(boolean buffered)
+    {
+        this.buffered = buffered;
+        this.pages = new ArrayDeque<>();
+    }
+
+    public ListenableFuture<?> getConsumerFuture()
+    {
+        if (buffered && pagesRemaining > 0) {
+            unblock(consumerFuture);
+        }
+        return consumerFuture;
+    }
+
+    public ListenableFuture<?> getProducerFuture()
+    {
+        return producerFuture;
+    }
+
+    public void setLocalMemoryContext(LocalMemoryContext localMemoryContext)
+    {
+        this.localMemoryContext = localMemoryContext;
+    }
+
+    public Page nextPage()
+    {
+        synchronized (this) {
+            if (!pages.isEmpty()) {
+                // if not buffering, need to unblock producer to let it can produce more
+                if (!buffered) {
+                    unblock(producerFuture);
+                }
+
+                pagesRemaining--;
+                Page output = pages.remove();
+                if (localMemoryContext != null && !finishing) {
+                    localMemoryContext.setBytes(localMemoryContext.getBytes() - output.getSizeInBytes());
+                }
+                return output;
+            }
+
+            // if no input and is finishing
+            if (finishing) {
+                return null;
+            }
+
+            // we have no input, block consumer until we get more
+            consumerFuture = SettableFuture.create();
+            return null;
+        }
+    }
+
+    public void addPage(Page page)
+    {
+        synchronized (this) {
+            // if we are finishing, either no more right input or consumer closed early
+            if (finishing) {
+                return;
+            }
+
+            // no more right input
+            if (page == null) {
+                finishing = true;
+                unblock(consumerFuture);
+                return;
+            }
+
+            // make sure prev data is already consumed
+            if (!buffered) {
+                checkState(this.pages.isEmpty());
+            }
+
+            this.pages.add(page);
+            if (localMemoryContext != null) {
+                localMemoryContext.setBytes(localMemoryContext.getBytes() + page.getSizeInBytes());
+            }
+            pagesRemaining++;
+
+            // unblock consumer for consuming page
+            unblock(consumerFuture);
+
+            // if not buffering, need to block producer until data is consumed
+            if (!buffered) {
+                producerFuture = SettableFuture.create();
+            }
+        }
+    }
+
+    public boolean isFinishing()
+    {
+        return finishing;
+    }
+
+    @Override
+    public void close()
+    {
+        // consumer wants to close
+        synchronized (this) {
+            finishing = true;
+
+            // consumer want to close, unblock producer
+            if (producerFuture != NOT_BLOCKED) {
+                unblock(producerFuture);
+            }
+
+            // clear pages
+            this.pages.clear();
+        }
+    }
+
+    private void unblock(ListenableFuture<?> future)
+    {
+        if (future != null) {
+            ((SettableFuture<Boolean>) future).set(null);
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/MergeJoinSourceManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/MergeJoinSourceManager.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.execution.Lifespan;
+import com.facebook.presto.memory.context.LocalMemoryContext;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class MergeJoinSourceManager
+{
+    private final Map<Lifespan, MergeJoinSource> mergeJoinSourceMap;
+    private final boolean bufferPages;
+
+    public MergeJoinSourceManager(boolean bufferPages)
+    {
+        this.mergeJoinSourceMap = new HashMap<>();
+        this.bufferPages = bufferPages;
+    }
+
+    public MergeJoinSource getMergeJoinSource(Lifespan lifespan, LocalMemoryContext localMemoryContext)
+    {
+        synchronized (this) {
+            if (!mergeJoinSourceMap.containsKey(lifespan)) {
+                mergeJoinSourceMap.put(lifespan, new MergeJoinSource(bufferPages));
+            }
+            if (localMemoryContext != null) {
+                mergeJoinSourceMap.get(lifespan).setLocalMemoryContext(localMemoryContext);
+            }
+            return mergeJoinSourceMap.get(lifespan);
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/analyzer/FeaturesConfig.java
@@ -220,6 +220,7 @@ public class FeaturesConfig
 
     private boolean streamingForPartialAggregationEnabled;
     private boolean preferMergeJoin;
+    private boolean mergeJoinBufferEnabled = true;
     private boolean segmentedAggregationEnabled;
 
     private int maxStageCountForEagerScheduling = 25;
@@ -2069,6 +2070,18 @@ public class FeaturesConfig
     public FeaturesConfig setPreferMergeJoin(boolean preferMergeJoin)
     {
         this.preferMergeJoin = preferMergeJoin;
+        return this;
+    }
+
+    public boolean isMergeJoinBufferEnabled()
+    {
+        return mergeJoinBufferEnabled;
+    }
+
+    @Config("optimizer.merge-join-buffer-enabled")
+    public FeaturesConfig setMergeJoinBufferEnabled(boolean mergeJoinBufferEnabled)
+    {
+        this.mergeJoinBufferEnabled = mergeJoinBufferEnabled;
         return this;
     }
 

--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/SchedulingOrderVisitor.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/SchedulingOrderVisitor.java
@@ -20,6 +20,7 @@ import com.facebook.presto.spi.plan.TableScanNode;
 import com.facebook.presto.sql.planner.plan.IndexJoinNode;
 import com.facebook.presto.sql.planner.plan.InternalPlanVisitor;
 import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.sql.planner.plan.MergeJoinNode;
 import com.facebook.presto.sql.planner.plan.SemiJoinNode;
 import com.facebook.presto.sql.planner.plan.SpatialJoinNode;
 import com.google.common.collect.ImmutableList;
@@ -52,6 +53,14 @@ public class SchedulingOrderVisitor
 
         @Override
         public Void visitJoin(JoinNode node, Consumer<PlanNodeId> schedulingOrder)
+        {
+            node.getRight().accept(this, schedulingOrder);
+            node.getLeft().accept(this, schedulingOrder);
+            return null;
+        }
+
+        @Override
+        public Void visitMergeJoin(MergeJoinNode node, Consumer<PlanNodeId> schedulingOrder)
         {
             node.getRight().accept(this, schedulingOrder);
             node.getLeft().accept(this, schedulingOrder);

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestMergeJoinOperator.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestMergeJoinOperator.java
@@ -1,0 +1,530 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator;
+
+import com.facebook.presto.RowPagesBuilder;
+import com.facebook.presto.common.Page;
+import com.facebook.presto.common.block.SortOrder;
+import com.facebook.presto.common.type.Type;
+import com.facebook.presto.spi.PrestoException;
+import com.facebook.presto.spi.plan.PlanNodeId;
+import com.facebook.presto.sql.gen.OrderingCompiler;
+import com.facebook.presto.sql.planner.plan.JoinNode;
+import com.facebook.presto.testing.MaterializedResult;
+import com.facebook.presto.testing.TestingTaskContext;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.testng.internal.collections.Ints;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static com.facebook.airlift.concurrent.Threads.daemonThreadsNamed;
+import static com.facebook.presto.RowPagesBuilder.rowPagesBuilder;
+import static com.facebook.presto.SessionTestUtils.TEST_SESSION;
+import static com.facebook.presto.common.type.BigintType.BIGINT;
+import static com.facebook.presto.common.type.DoubleType.DOUBLE;
+import static com.facebook.presto.common.type.VarcharType.VARCHAR;
+import static com.facebook.presto.operator.OperatorAssertion.assertOperatorEquals;
+import static com.facebook.presto.operator.OperatorAssertion.toPages;
+import static com.facebook.presto.testing.TestingTaskContext.createTaskContext;
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static io.airlift.units.DataSize.succinctBytes;
+import static java.util.concurrent.Executors.newScheduledThreadPool;
+
+public class TestMergeJoinOperator
+{
+    private ExecutorService executor;
+    private ScheduledExecutorService scheduledExecutor;
+
+    @BeforeMethod
+    public void setUp()
+    {
+        executor = new ThreadPoolExecutor(
+                0,
+                Integer.MAX_VALUE,
+                60L,
+                TimeUnit.SECONDS,
+                new SynchronousQueue<>(),
+                daemonThreadsNamed("test-executor-%s"),
+                new ThreadPoolExecutor.DiscardPolicy());
+        scheduledExecutor = newScheduledThreadPool(2, daemonThreadsNamed("test-scheduledExecutor-%s"));
+    }
+
+    @Test
+    public void testInnerJoin()
+    {
+        TaskContext taskContext = createTaskContext(executor, scheduledExecutor, TEST_SESSION);
+
+        // right side
+        List<Type> rightTypes = ImmutableList.of(VARCHAR, BIGINT, BIGINT);
+        RowPagesBuilder rightPages = rowPagesBuilder(false, Ints.asList(0), rightTypes)
+                .addSequencePage(2, 20, 30, 40)
+                .addSequencePage(2, 22, 32, 42)
+                .addSequencePage(2, 24, 34, 44)
+                .addSequencePage(2, 26, 36, 46)
+                .addSequencePage(2, 28, 38, 48);
+
+        MergeJoinSourceManager mergeJoinSourceManager = new MergeJoinSourceManager(false);
+        setupAndInitializeRightDriver(taskContext, rightPages, mergeJoinSourceManager, true);
+
+        // left side
+        List<Type> leftTypes = ImmutableList.of(VARCHAR, BIGINT, BIGINT);
+        RowPagesBuilder leftPages = rowPagesBuilder(false, Ints.asList(0), leftTypes)
+                .addSequencePage(1000, 0, 1000, 2000);
+        List<Page> leftInput = sortPages(leftPages);
+
+        OperatorFactory mergeJoinOperatorFactory = mergeJoinOperatorFactory(leftTypes, rightTypes, mergeJoinSourceManager, JoinNode.Type.INNER);
+
+        // expected
+        MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), ImmutableList.copyOf(Iterables.concat(leftPages.getTypesWithoutHash(), rightPages.getTypesWithoutHash())))
+                .row("20", 1020L, 2020L, "20", 30L, 40L)
+                .row("21", 1021L, 2021L, "21", 31L, 41L)
+                .row("22", 1022L, 2022L, "22", 32L, 42L)
+                .row("23", 1023L, 2023L, "23", 33L, 43L)
+                .row("24", 1024L, 2024L, "24", 34L, 44L)
+                .row("25", 1025L, 2025L, "25", 35L, 45L)
+                .row("26", 1026L, 2026L, "26", 36L, 46L)
+                .row("27", 1027L, 2027L, "27", 37L, 47L)
+                .row("28", 1028L, 2028L, "28", 38L, 48L)
+                .row("29", 1029L, 2029L, "29", 39L, 49L)
+                .build();
+
+        assertOperatorEquals(mergeJoinOperatorFactory, taskContext.addPipelineContext(1, true, true, false).addDriverContext(), leftInput, expected, false);
+    }
+
+    @Test
+    public void testLeftJoin()
+    {
+        TaskContext taskContext = createTaskContext(executor, scheduledExecutor, TEST_SESSION);
+
+        // right side
+        List<Type> rightTypes = ImmutableList.of(VARCHAR, BIGINT);
+        RowPagesBuilder rightPages = rowPagesBuilder(false, Ints.asList(0), rightTypes)
+                .row("a", 1)
+                .row("b", 2)
+                .row("d", 5);
+
+        MergeJoinSourceManager mergeJoinSourceManager = new MergeJoinSourceManager(false);
+        setupAndInitializeRightDriver(taskContext, rightPages, mergeJoinSourceManager, true);
+
+        // left side
+        List<Type> leftTypes = ImmutableList.of(VARCHAR, BIGINT);
+        RowPagesBuilder leftPages = rowPagesBuilder(false, Ints.asList(0), leftTypes)
+                .row("2", 11)
+                .row("20", 11)
+                .row("3", 11)
+                .row("a", 11)
+                .row("a", 22)
+                .pageBreak()
+                .row("b", 22)
+                .row("c", 33)
+                .pageBreak()
+                .row("d", 55);
+        List<Page> leftInput = leftPages.build();
+
+        OperatorFactory mergeJoinOperatorFactory = mergeJoinOperatorFactory(leftTypes, rightTypes, mergeJoinSourceManager, JoinNode.Type.LEFT);
+
+        // expected
+        MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), ImmutableList.copyOf(Iterables.concat(leftTypes, rightTypes)))
+                .row("2", 11L, null, null)
+                .row("20", 11L, null, null)
+                .row("3", 11L, null, null)
+                .row("a", 11L, "a", 1L)
+                .row("a", 22L, "a", 1L)
+                .row("b", 22L, "b", 2L)
+                .row("c", 33L, null, null)
+                .row("d", 55L, "d", 5L)
+                .build();
+
+        assertOperatorEquals(mergeJoinOperatorFactory, taskContext.addPipelineContext(1, true, true, false).addDriverContext(), leftInput, expected, false);
+    }
+
+    @Test
+    public void testInnerJoinWithMultiplePages()
+    {
+        TaskContext taskContext = createTaskContext(executor, scheduledExecutor, TEST_SESSION);
+
+        // right side
+        List<Type> rightTypes = ImmutableList.of(VARCHAR, BIGINT);
+        RowPagesBuilder rightPages = rowPagesBuilder(false, Ints.asList(0), rightTypes)
+                .row("a", 1)
+                .pageBreak()
+                .row("b", 2)
+                .pageBreak()
+                .row("d", 5);
+
+        MergeJoinSourceManager mergeJoinSourceManager = new MergeJoinSourceManager(false);
+        // disable sorting so that the pages do not get merged by sort operator
+        setupAndInitializeRightDriver(taskContext, rightPages, mergeJoinSourceManager, /*sortPages=*/false);
+
+        // left side
+        List<Type> leftTypes = ImmutableList.of(VARCHAR, BIGINT);
+        RowPagesBuilder leftPages = rowPagesBuilder(false, Ints.asList(0), leftTypes)
+                .row("a", 11)
+                .pageBreak()
+                .row("b", 22)
+                .row("c", 33)
+                .pageBreak()
+                .row("d", 55);
+        List<Page> leftInput = leftPages.build();
+
+        OperatorFactory mergeJoinOperatorFactory = mergeJoinOperatorFactory(leftTypes, rightTypes, mergeJoinSourceManager, JoinNode.Type.INNER);
+
+        // expected
+        MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), ImmutableList.copyOf(Iterables.concat(leftTypes, rightTypes)))
+                .row("a", 11L, "a", 1L)
+                .row("b", 22L, "b", 2L)
+                .row("d", 55L, "d", 5L)
+                .build();
+
+        assertOperatorEquals(mergeJoinOperatorFactory, taskContext.addPipelineContext(1, true, true, false).addDriverContext(), leftInput, expected, false);
+    }
+
+    @Test
+    public void testInnerJoinWithNullLeft()
+    {
+        TaskContext taskContext = createTaskContext(executor, scheduledExecutor, TEST_SESSION);
+
+        // right side
+        List<Type> rightTypes = ImmutableList.of(VARCHAR);
+        RowPagesBuilder rightPages = rowPagesBuilder(false, Ints.asList(0), rightTypes)
+                .row("a")
+                .row("b")
+                .row("c");
+
+        MergeJoinSourceManager mergeJoinSourceManager = new MergeJoinSourceManager(true);
+        setupAndInitializeRightDriver(taskContext, rightPages, mergeJoinSourceManager, /*sortPages=*/true);
+
+        // left side
+        List<Type> leftTypes = ImmutableList.of(VARCHAR);
+        RowPagesBuilder leftPages = rowPagesBuilder(false, Ints.asList(0), leftTypes)
+                .row("a")
+                .row((String) null)
+                .row((String) null)
+                .row("a")
+                .row("b");
+        List<Page> leftInput = sortPages(leftPages);
+
+        OperatorFactory mergeJoinOperatorFactory = mergeJoinOperatorFactory(leftTypes, rightTypes, mergeJoinSourceManager, JoinNode.Type.INNER);
+        // expected
+        MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), ImmutableList.copyOf(Iterables.concat(leftTypes, rightTypes)))
+                .row("a", "a")
+                .row("a", "a")
+                .row("b", "b")
+                .build();
+
+        assertOperatorEquals(mergeJoinOperatorFactory, taskContext.addPipelineContext(1, true, true, false).addDriverContext(), leftInput, expected, false);
+    }
+
+    @Test
+    public void testInnerJoinWithNullRight()
+    {
+        TaskContext taskContext = createTaskContext(executor, scheduledExecutor, TEST_SESSION);
+
+        // right side
+        List<Type> rightTypes = ImmutableList.of(VARCHAR);
+        RowPagesBuilder rightPages = rowPagesBuilder(false, Ints.asList(0), rightTypes)
+                .row("a")
+                .row((String) null)
+                .row((String) null)
+                .row("a")
+                .row("b");
+
+        MergeJoinSourceManager mergeJoinSourceManager = new MergeJoinSourceManager(false);
+        setupAndInitializeRightDriver(taskContext, rightPages, mergeJoinSourceManager, /*sortPages=*/true);
+
+        // left side
+        List<Type> leftTypes = ImmutableList.of(VARCHAR);
+        RowPagesBuilder leftPages = rowPagesBuilder(false, Ints.asList(0), leftTypes)
+                .row("a")
+                .row("b")
+                .row("c");
+        List<Page> leftInput = sortPages(leftPages);
+
+        OperatorFactory mergeJoinOperatorFactory = mergeJoinOperatorFactory(leftTypes, rightTypes, mergeJoinSourceManager, JoinNode.Type.INNER);
+        // expected
+        MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), ImmutableList.copyOf(Iterables.concat(leftTypes, rightTypes)))
+                .row("a", "a")
+                .row("a", "a")
+                .row("b", "b")
+                .build();
+
+        assertOperatorEquals(mergeJoinOperatorFactory, taskContext.addPipelineContext(1, true, true, false).addDriverContext(), leftInput, expected, false);
+    }
+
+    @Test
+    public void testInnerJoinWithNullOnBothSides()
+    {
+        TaskContext taskContext = createTaskContext(executor, scheduledExecutor, TEST_SESSION);
+
+        // right side
+        List<Type> rightTypes = ImmutableList.of(VARCHAR);
+        RowPagesBuilder rightPages = rowPagesBuilder(false, Ints.asList(0), rightTypes)
+                .row("a")
+                .row((String) null)
+                .row((String) null)
+                .row("a")
+                .row("b");
+
+        MergeJoinSourceManager mergeJoinSourceManager = new MergeJoinSourceManager(false);
+        setupAndInitializeRightDriver(taskContext, rightPages, mergeJoinSourceManager, /*sortPages=*/true);
+
+        // left side
+        List<Type> leftTypes = ImmutableList.of(VARCHAR);
+        RowPagesBuilder leftPages = rowPagesBuilder(false, Ints.asList(0), leftTypes)
+                .row("a")
+                .row("b")
+                .row((String) null)
+                .row("c");
+        List<Page> leftInput = sortPages(leftPages);
+
+        OperatorFactory mergeJoinOperatorFactory = mergeJoinOperatorFactory(leftTypes, rightTypes, mergeJoinSourceManager, JoinNode.Type.INNER);
+        // expected
+        MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), ImmutableList.copyOf(Iterables.concat(leftTypes, rightTypes)))
+                .row("a", "a")
+                .row("a", "a")
+                .row("b", "b")
+                .build();
+
+        assertOperatorEquals(mergeJoinOperatorFactory, taskContext.addPipelineContext(1, true, true, false).addDriverContext(), leftInput, expected, false);
+    }
+
+    @Test
+    public void testInnerJoinWithEmptyRight()
+    {
+        TaskContext taskContext = createTaskContext(executor, scheduledExecutor, TEST_SESSION);
+
+        // right side
+        List<Type> rightTypes = ImmutableList.of(VARCHAR);
+        RowPagesBuilder rightPages = rowPagesBuilder(false, Ints.asList(0), rightTypes);
+
+        MergeJoinSourceManager mergeJoinSourceManager = new MergeJoinSourceManager(false);
+        setupAndInitializeRightDriver(taskContext, rightPages, mergeJoinSourceManager, /*sortPages=*/true);
+
+        // left side
+        List<Type> leftTypes = ImmutableList.of(VARCHAR);
+        RowPagesBuilder leftPages = rowPagesBuilder(false, Ints.asList(0), leftTypes)
+                .row("a");
+        List<Page> leftInput = sortPages(leftPages);
+
+        OperatorFactory mergeJoinOperatorFactory = mergeJoinOperatorFactory(leftTypes, rightTypes, mergeJoinSourceManager, JoinNode.Type.INNER);
+
+        MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), ImmutableList.copyOf(Iterables.concat(leftTypes, rightTypes)))
+                .build();
+
+        assertOperatorEquals(mergeJoinOperatorFactory, taskContext.addPipelineContext(1, true, true, false).addDriverContext(), leftInput, expected, false);
+    }
+
+    @Test
+    public void testInnerJoinWithNonEmptyRightAndEmptyLeft()
+    {
+        TaskContext taskContext = createTaskContext(executor, scheduledExecutor, TEST_SESSION);
+
+        // right side
+        List<Type> rightTypes = ImmutableList.of(VARCHAR);
+        RowPagesBuilder rightPages = rowPagesBuilder(false, Ints.asList(0), rightTypes)
+                .row("a")
+                .row("b")
+                .row((String) null)
+                .row("c");
+
+        MergeJoinSourceManager mergeJoinSourceManager = new MergeJoinSourceManager(false);
+        setupAndInitializeRightDriver(taskContext, rightPages, mergeJoinSourceManager, /*sortPages=*/true);
+
+        // left side
+        List<Type> leftTypes = ImmutableList.of(VARCHAR);
+        RowPagesBuilder leftPages = rowPagesBuilder(false, Ints.asList(0), leftTypes);
+        List<Page> leftInput = sortPages(leftPages);
+
+        OperatorFactory mergeJoinOperatorFactory = mergeJoinOperatorFactory(leftTypes, rightTypes, mergeJoinSourceManager, JoinNode.Type.INNER);
+
+        MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), ImmutableList.copyOf(Iterables.concat(leftTypes, rightTypes)))
+                .build();
+
+        assertOperatorEquals(mergeJoinOperatorFactory, taskContext.addPipelineContext(1, true, true, false).addDriverContext(), leftInput, expected, false);
+    }
+
+    @Test
+    public void testLeftJoinWithEmptyRight()
+    {
+        TaskContext taskContext = createTaskContext(executor, scheduledExecutor, TEST_SESSION);
+
+        // right side
+        List<Type> rightTypes = ImmutableList.of(VARCHAR);
+        RowPagesBuilder rightPages = rowPagesBuilder(false, Ints.asList(0), rightTypes);
+
+        MergeJoinSourceManager mergeJoinSourceManager = new MergeJoinSourceManager(false);
+        setupAndInitializeRightDriver(taskContext, rightPages, mergeJoinSourceManager, /*sortPages=*/true);
+
+        // left side
+        List<Type> leftTypes = ImmutableList.of(VARCHAR);
+        RowPagesBuilder leftPages = rowPagesBuilder(false, Ints.asList(0), leftTypes)
+                .row("a");
+        List<Page> leftInput = sortPages(leftPages);
+
+        OperatorFactory mergeJoinOperatorFactory = mergeJoinOperatorFactory(leftTypes, rightTypes, mergeJoinSourceManager, JoinNode.Type.LEFT);
+
+        MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), ImmutableList.copyOf(Iterables.concat(leftTypes, rightTypes)))
+                .row("a", null)
+                .build();
+
+        assertOperatorEquals(mergeJoinOperatorFactory, taskContext.addPipelineContext(1, true, true, false).addDriverContext(), leftInput, expected, false);
+    }
+
+    @Test
+    public void testLargeInput()
+    {
+        TaskContext taskContext = createTaskContext(executor, scheduledExecutor, TEST_SESSION);
+
+        // right side
+        List<Type> rightTypes = ImmutableList.of(BIGINT);
+        RowPagesBuilder rightPages = rowPagesBuilder(false, Ints.asList(0), rightTypes)
+                .addSequencePage(100000, 1);
+
+        MergeJoinSourceManager mergeJoinSourceManager = new MergeJoinSourceManager(false);
+        setupAndInitializeRightDriver(taskContext, rightPages, mergeJoinSourceManager, /*sortPages=*/false);
+
+        // left side
+        List<Type> leftTypes = ImmutableList.of(BIGINT, DOUBLE);
+        RowPagesBuilder leftPages = rowPagesBuilder(false, Ints.asList(0), leftTypes)
+                .addSequencePage(100000, 1, 1501);
+
+        List<Page> leftInput = leftPages.build();
+
+        OperatorFactory mergeJoinOperatorFactory = mergeJoinOperatorFactory(leftTypes, rightTypes, mergeJoinSourceManager, JoinNode.Type.INNER);
+
+        // expected
+        MaterializedResult expected = MaterializedResult.resultBuilder(taskContext.getSession(), ImmutableList.copyOf(Iterables.concat(leftTypes, rightTypes)))
+                .pages(rowPagesBuilder(false, Ints.asList(0), ImmutableList.of(BIGINT, DOUBLE, BIGINT)).addSequencePage(100000, 1, 1501, 1).build())
+                .build();
+
+        assertOperatorEquals(mergeJoinOperatorFactory, taskContext.addPipelineContext(1, true, true, false).addDriverContext(), leftInput, expected, false);
+    }
+
+    private List<Page> sortPages(RowPagesBuilder pages)
+    {
+        DriverContext driverContext = TestingTaskContext.builder(executor, scheduledExecutor, TEST_SESSION)
+                .setMemoryPoolSize(succinctBytes(1024))
+                .build()
+                .addPipelineContext(0, true, true, false)
+                .addDriverContext();
+
+        OrderByOperator.OrderByOperatorFactory operatorFactory = new OrderByOperator.OrderByOperatorFactory(
+                0,
+                new PlanNodeId("test"),
+                pages.getTypes(),
+                IntStream.range(0, pages.getTypes().size()).boxed().collect(Collectors.toList()),
+                1000,
+                ImmutableList.of(0),
+                ImmutableList.of(SortOrder.ASC_NULLS_FIRST),
+                new PagesIndex.TestingFactory(false),
+                false,
+                Optional.empty(),
+                new OrderingCompiler());
+        List<Page> sortedPages = toPages(operatorFactory, driverContext, pages.build(), false);
+        return sortedPages;
+    }
+
+    private void setupAndInitializeRightDriver(TaskContext taskContext, RowPagesBuilder rightPages, MergeJoinSourceManager mergeJoinSourceManager, boolean sortPages)
+    {
+        DriverContext rightDriverContext = taskContext.addPipelineContext(0, true, true, false).addDriverContext();
+
+        Operator valuesOperator = new ValuesOperator.ValuesOperatorFactory(1, new PlanNodeId("values"), rightPages.build()).createOperator(rightDriverContext);
+        Operator orderByOperator = new OrderByOperator.OrderByOperatorFactory(
+                2,
+                new PlanNodeId("orderby"),
+                rightPages.getTypes(),
+                IntStream.range(0, rightPages.getTypes().size()).boxed().collect(Collectors.toList()), 1000, ImmutableList.of(0), ImmutableList.of(SortOrder.ASC_NULLS_FIRST),
+                new PagesIndex.TestingFactory(false),
+                false,
+                Optional.empty(),
+                new OrderingCompiler())
+                .createOperator(rightDriverContext);
+        Operator mergeJoinSinkOperator = new MergeJoinSinkOperator.MergeJoinSinkOperatorFactory(
+                3,
+                new PlanNodeId("mergeJoinSink"),
+                mergeJoinSourceManager)
+                .createOperator(rightDriverContext);
+
+        Driver rightDriver;
+        if (sortPages) {
+            rightDriver = Driver.createDriver(
+                    rightDriverContext,
+                    valuesOperator,
+                    orderByOperator,
+                    mergeJoinSinkOperator);
+        }
+        else {
+            rightDriver = Driver.createDriver(
+                    rightDriverContext,
+                    valuesOperator,
+                    mergeJoinSinkOperator);
+        }
+
+        // run the right side driver in a separate thread
+        runDriverInThread(executor, rightDriver);
+    }
+
+    private OperatorFactory mergeJoinOperatorFactory(List<Type> leftTypes, List<Type> rightTypes, MergeJoinSourceManager mergeJoinSourceManager, JoinNode.Type joinType)
+    {
+        OperatorFactory mergeInnerJoinOperatorFactory = new MergeJoinOperatorFactory(
+                3,
+                new PlanNodeId("mergeJoinNode"),
+                mergeJoinSourceManager,
+                leftTypes,
+                leftTypes,
+                rangeList(leftTypes.size()),
+                rightTypes,
+                rightTypes,
+                rangeList(rightTypes.size()),
+                ImmutableList.of(0),
+                ImmutableList.of(0),
+                joinType);
+        return mergeInnerJoinOperatorFactory;
+    }
+
+    private static List<Integer> rangeList(int endExclusive)
+    {
+        return IntStream.range(0, endExclusive)
+                .boxed()
+                .collect(toImmutableList());
+    }
+
+    // run driver in another thread until it is finished
+    private static void runDriverInThread(ExecutorService executor, Driver driver)
+    {
+        executor.execute(() -> {
+            if (!driver.isFinished()) {
+                try {
+                    driver.process();
+                }
+                catch (PrestoException e) {
+                    driver.getDriverContext().failed(e);
+                    throw e;
+                }
+                runDriverInThread(executor, driver);
+            }
+        });
+    }
+}


### PR DESCRIPTION
This PR adds Merge Join execution side changes to Presto. 
The planning side changes for MergeJoin were added in #17407, #17759 

We add two operators to enable MergeJoin support:
- MergeJoinSinkOperator: This operator is installed for the right side source of the join.
    - The operator has no direct output, and it will add the pages to a MergeJoinSource object that is shared with the left side operator.
    - If buffering is enabled(default), it will add all the pages to queue inside of MergeJoinSource and will the operator will finish. Else if buffering is disabled, after it adds a page it is blocked until that page is consumed by the left side pipeline.
- MergeJoinOperator: This operator is installed for the left side of the join.
    - This operator gets the right side pages from the MergeJoinSource object and produces the joined output with its pages.
    - Holds a MergeJoinPageBuilder that will output pages for every 1024 output rows.

Currently, Merge Join only works when grouped execution is enabled as it uses the lifespan concept from GE to join buckets together.

For the buffering of the right pages, we have "merge_join_buffer_enabled" session property which is enabled by default.
The reason for enabling this is to prevent the right drivers from getting stuck. The MergeJoin is downstream of TableScan which means it is processing a leaf split, and since the scheduler initially schedules all the right side splits at once, these tasks get stuck as we need both side at same time to process MergeJoin. With buffering the right side will finish without waiting, and lets all tasks proceed.

We can disable the buffering, but we also must configure "concurrent_lifespans_per_task" (in this case, right side splits  scheduled initially for each task/worker) so that this value will always be less than available leaf splits at when task is running in the worker.

```
== NO RELEASE NOTE ==
```
