### PR TITLE
Add read hints to ExtendedFileSystem open API

### DIFF
--- a/presto-cache/src/main/java/com/facebook/presto/cache/alluxio/AlluxioCachingFileSystem.java
+++ b/presto-cache/src/main/java/com/facebook/presto/cache/alluxio/AlluxioCachingFileSystem.java
@@ -85,7 +85,7 @@ public class AlluxioCachingFileSystem
                     .setLastModificationTimeMs(hiveFileContext.getModificationTime())
                     .setPath(path.toString())
                     .setFolder(false)
-                    .setLength(hiveFileContext.getFileSize().get());
+                    .setLength(hiveFileContext.getFileSize().getAsLong());
             String cacheIdentifier = md5().hashString(path.toString(), UTF_8).toString();
             // CacheContext is the mechanism to pass the cache related context to the source filesystem
             CacheContext cacheContext = PrestoCacheContext.build(cacheIdentifier, hiveFileContext, cacheQuotaEnabled);

--- a/presto-cache/src/test/java/com/facebook/presto/cache/alluxio/TestAlluxioCachingFileSystem.java
+++ b/presto-cache/src/test/java/com/facebook/presto/cache/alluxio/TestAlluxioCachingFileSystem.java
@@ -44,6 +44,7 @@ import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.Random;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
@@ -501,7 +502,17 @@ public class TestAlluxioCachingFileSystem
     private int readFully(AlluxioCachingFileSystem fileSystem, CacheQuota quota, long position, byte[] buffer, int offset, int length)
             throws Exception
     {
-        try (FSDataInputStream stream = fileSystem.openFile(new Path(testFilePath), new HiveFileContext(true, quota, Optional.empty(), Optional.of((long) DATA_LENGTH), 0, false))) {
+        try (FSDataInputStream stream = fileSystem.openFile(
+                new Path(testFilePath),
+                new HiveFileContext(
+                        true,
+                        quota,
+                        Optional.empty(),
+                        OptionalLong.of(DATA_LENGTH),
+                        OptionalLong.of(offset),
+                        OptionalLong.of(length),
+                        0,
+                        false))) {
             return stream.read(position, buffer, offset, length);
         }
     }

--- a/presto-hive-common/src/main/java/com/facebook/presto/hive/HiveFileContext.java
+++ b/presto-hive-common/src/main/java/com/facebook/presto/hive/HiveFileContext.java
@@ -17,29 +17,55 @@ import com.facebook.presto.common.RuntimeStats;
 import com.facebook.presto.common.RuntimeUnit;
 
 import java.util.Optional;
+import java.util.OptionalLong;
 
 import static com.facebook.presto.hive.CacheQuota.NO_CACHE_CONSTRAINTS;
 import static java.util.Objects.requireNonNull;
 
 public class HiveFileContext
 {
-    public static final HiveFileContext DEFAULT_HIVE_FILE_CONTEXT = new HiveFileContext(true, NO_CACHE_CONSTRAINTS, Optional.empty(), Optional.empty(), 0, false);
+    public static final HiveFileContext DEFAULT_HIVE_FILE_CONTEXT = new HiveFileContext(
+            true,
+            NO_CACHE_CONSTRAINTS,
+            Optional.empty(),
+            OptionalLong.empty(),
+            OptionalLong.empty(),
+            OptionalLong.empty(),
+            0,
+            false);
 
     private final boolean cacheable;
     private final CacheQuota cacheQuota;
     private final Optional<ExtraHiveFileInfo<?>> extraFileInfo;
-    private final Optional<Long> fileSize;
+    private final OptionalLong fileSize;
+    // HiveFileContext optionally contains startOffset and length that readers are going to read
+    // For large files, these hints will help in fetching only the required blocks from the storage
+    // Note: even when they are present, readers can read past this range like footer and stripe's
+    // start may be in this range, but end may be beyond this range. So this is a hint and readers
+    // should handle the read beyond the range gracefully.
+    private final OptionalLong startOffset;
+    private final OptionalLong length;
     private final long modificationTime;
     private final boolean verboseRuntimeStatsEnabled;
 
     private final RuntimeStats stats = new RuntimeStats();
 
-    public HiveFileContext(boolean cacheable, CacheQuota cacheQuota, Optional<ExtraHiveFileInfo<?>> extraFileInfo, Optional<Long> fileSize, long modificationTime, boolean verboseRuntimeStatsEnabled)
+    public HiveFileContext(
+            boolean cacheable,
+            CacheQuota cacheQuota,
+            Optional<ExtraHiveFileInfo<?>> extraFileInfo,
+            OptionalLong fileSize,
+            OptionalLong startOffset,
+            OptionalLong length,
+            long modificationTime,
+            boolean verboseRuntimeStatsEnabled)
     {
         this.cacheable = cacheable;
         this.cacheQuota = requireNonNull(cacheQuota, "cacheQuota is null");
         this.extraFileInfo = requireNonNull(extraFileInfo, "extraFileInfo is null");
         this.fileSize = requireNonNull(fileSize, "fileSize is null");
+        this.startOffset = requireNonNull(startOffset, "startOffset is null");
+        this.length = requireNonNull(length, "length is null");
         this.modificationTime = modificationTime;
         this.verboseRuntimeStatsEnabled = verboseRuntimeStatsEnabled;
     }
@@ -70,9 +96,19 @@ public class HiveFileContext
         return extraFileInfo;
     }
 
-    public Optional<Long> getFileSize()
+    public OptionalLong getFileSize()
     {
         return fileSize;
+    }
+
+    public OptionalLong getStartOffset()
+    {
+        return startOffset;
+    }
+
+    public OptionalLong getLength()
+    {
+        return length;
     }
 
     public interface ExtraHiveFileInfo<T>

--- a/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSourceProvider.java
+++ b/presto-hive/src/main/java/com/facebook/presto/hive/HivePageSourceProvider.java
@@ -56,6 +56,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.OptionalLong;
 import java.util.Properties;
 import java.util.Set;
 import java.util.function.Function;
@@ -213,7 +214,9 @@ public class HivePageSourceProvider
                         splitContext.isCacheable(),
                         cacheQuota,
                         hiveSplit.getExtraFileInfo().map(BinaryExtraHiveFileInfo::new),
-                        Optional.of(hiveSplit.getFileSize()),
+                        OptionalLong.of(hiveSplit.getFileSize()),
+                        OptionalLong.of(hiveSplit.getStart()),
+                        OptionalLong.of(hiveSplit.getLength()),
                         hiveSplit.getFileModifiedTime(),
                         HiveSessionProperties.isVerboseRuntimeStatsEnabled(session)),
                 hiveLayout.getRemainingPredicate(),
@@ -330,7 +333,9 @@ public class HivePageSourceProvider
                             splitContext.isCacheable(),
                             cacheQuota,
                             split.getExtraFileInfo().map(BinaryExtraHiveFileInfo::new),
-                            Optional.of(split.getFileSize()),
+                            OptionalLong.of(split.getFileSize()),
+                            OptionalLong.of(split.getStart()),
+                            OptionalLong.of(split.getLength()),
                             split.getFileModifiedTime(),
                             HiveSessionProperties.isVerboseRuntimeStatsEnabled(session)),
                     encryptionInformation,

--- a/presto-hive/src/test/java/com/facebook/presto/hive/benchmark/FileFormat.java
+++ b/presto-hive/src/test/java/com/facebook/presto/hive/benchmark/FileFormat.java
@@ -77,6 +77,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.Properties;
 
 import static com.facebook.presto.hive.CacheQuota.NO_CACHE_CONSTRAINTS;
@@ -493,7 +494,9 @@ public enum FileFormat
                                 true,
                                 NO_CACHE_CONSTRAINTS,
                                 Optional.empty(),
-                                Optional.empty(),
+                                OptionalLong.of(targetFile.length()),
+                                OptionalLong.of(0),
+                                OptionalLong.of(targetFile.length()),
                                 modificationTime,
                                 false),
                         Optional.empty())

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSourceProvider.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergPageSourceProvider.java
@@ -91,6 +91,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.function.Function;
 import java.util.stream.IntStream;
 
@@ -295,8 +296,15 @@ public class IcebergPageSourceProvider
             FileStatus fileStatus = fileSystem.getFileStatus(path);
             long fileSize = fileStatus.getLen();
             long modificationTime = fileStatus.getModificationTime();
-            HiveFileContext hiveFileContext = new HiveFileContext(true, NO_CACHE_CONSTRAINTS,
-                    Optional.empty(), Optional.of(fileSize), modificationTime, false);
+            HiveFileContext hiveFileContext = new HiveFileContext(
+                    true,
+                    NO_CACHE_CONSTRAINTS,
+                    Optional.empty(),
+                    OptionalLong.of(fileSize),
+                    OptionalLong.of(start),
+                    OptionalLong.of(length),
+                    modificationTime,
+                    false);
             FSDataInputStream inputStream = fileSystem.openFile(path, hiveFileContext);
             dataSource = buildHdfsParquetDataSource(inputStream, path, fileFormatDataSourceStats);
             ParquetMetadata parquetMetadata = MetadataReader.readFooter(dataSource, fileSize).getParquetMetadata();
@@ -446,8 +454,15 @@ public class IcebergPageSourceProvider
             FileStatus fileStatus = fileSystem.getFileStatus(path);
             long fileSize = fileStatus.getLen();
             long modificationTime = fileStatus.getModificationTime();
-            HiveFileContext hiveFileContext = new HiveFileContext(true, NO_CACHE_CONSTRAINTS,
-                    Optional.empty(), Optional.of(fileSize), modificationTime, false);
+            HiveFileContext hiveFileContext = new HiveFileContext(
+                    true,
+                    NO_CACHE_CONSTRAINTS,
+                    Optional.empty(),
+                    OptionalLong.of(fileSize),
+                    OptionalLong.of(start),
+                    OptionalLong.of(length),
+                    modificationTime,
+                    false);
             FSDataInputStream inputStream = hdfsEnvironment.doAs(user, () -> fileSystem.openFile(path, hiveFileContext));
             orcDataSource = new HdfsOrcDataSource(
                     new OrcDataSourceId(path.toString()),


### PR DESCRIPTION
Large files are stored in the blob storage. Each worker only processes
a part of the large file. Before this change the open call, has no hint
on what part of the file worker is going to work on. This change adds
the startOffset and length hint, which can be used by a file system
to open only the part of the file.

Test plan - 
Existing tests.

```
== NO RELEASE NOTE ==
```
