### PR TITLE
Fix bounds check in MultiChannelGroupByHash and BigintGroupByHash

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/operator/BigintGroupByHash.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/BigintGroupByHash.java
@@ -357,7 +357,7 @@ public class BigintGroupByHash
         public boolean process()
         {
             int positionCount = block.getPositionCount();
-            checkState(lastPosition < positionCount, "position count out of bound");
+            checkState(lastPosition <= positionCount, "position count out of bound");
 
             // needRehash() == false indicates we have reached capacity boundary and a rehash is needed.
             // We can only proceed if tryRehash() successfully did a rehash.
@@ -402,7 +402,7 @@ public class BigintGroupByHash
         public boolean process()
         {
             int positionCount = block.getPositionCount();
-            checkState(lastPosition < positionCount, "position count out of bound");
+            checkState(lastPosition <= positionCount, "position count out of bound");
             checkState(!finished);
 
             // needRehash() == false indicates we have reached capacity boundary and a rehash is needed.

--- a/presto-main/src/main/java/com/facebook/presto/operator/MultiChannelGroupByHash.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/MultiChannelGroupByHash.java
@@ -590,7 +590,7 @@ public class MultiChannelGroupByHash
         public boolean process()
         {
             int positionCount = page.getPositionCount();
-            checkState(lastPosition < positionCount, "position count out of bound");
+            checkState(lastPosition <= positionCount, "position count out of bound");
 
             // needRehash() == false indicates we have reached capacity boundary and a rehash is needed.
             // We can only proceed if tryRehash() successfully did a rehash.
@@ -637,7 +637,7 @@ public class MultiChannelGroupByHash
         public boolean process()
         {
             int positionCount = page.getPositionCount();
-            checkState(lastPosition < positionCount, "position count out of bound");
+            checkState(lastPosition <= positionCount, "position count out of bound");
 
             // needRehash() == false indicates we have reached capacity boundary and a rehash is needed.
             // We can only proceed if tryRehash() successfully did a rehash.
@@ -780,7 +780,7 @@ public class MultiChannelGroupByHash
         public boolean process()
         {
             int positionCount = page.getPositionCount();
-            checkState(lastPosition < positionCount, "position count out of bound");
+            checkState(lastPosition <= positionCount, "position count out of bound");
             checkState(!finished);
 
             // needRehash() == false indicates we have reached capacity boundary and a rehash is needed.

--- a/presto-main/src/test/java/com/facebook/presto/operator/TestGroupByHash.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/TestGroupByHash.java
@@ -286,6 +286,38 @@ public class TestGroupByHash
     }
 
     @Test(dataProvider = "dataType")
+    public void testEmptyPage(Type type)
+    {
+        // Create an empty page
+        int length = 0;
+        Block valuesBlock;
+        if (type == VARCHAR) {
+            valuesBlock = createStringSequenceBlock(0, length);
+        }
+        else if (type == BIGINT) {
+            valuesBlock = createLongSequenceBlock(0, length);
+        }
+        else {
+            throw new IllegalArgumentException("unsupported data type");
+        }
+        Block hashBlock = getHashBlock(ImmutableList.of(type), valuesBlock);
+        Page page = new Page(valuesBlock, hashBlock);
+        AtomicInteger currentQuota = new AtomicInteger(0);
+        AtomicInteger allowedQuota = new AtomicInteger(3);
+        UpdateMemory updateMemory = () -> {
+            if (currentQuota.get() < allowedQuota.get()) {
+                currentQuota.getAndIncrement();
+                return true;
+            }
+            return false;
+        };
+
+        GroupByHash groupByHash = createGroupByHash(ImmutableList.of(type), new int[] {0}, Optional.of(1), 1, false, JOIN_COMPILER, updateMemory);
+        Work<?> addPageWork = groupByHash.addPage(page);
+        assertTrue(addPageWork.process());
+    }
+
+    @Test(dataProvider = "dataType")
     public void testMemoryReservationYield(Type type)
     {
         // Create a page with positionCount >> expected size of groupByHash


### PR DESCRIPTION
Cherry-pick of https://github.com/trinodb/trino/pull/12597

There's an off-by-one error in the check that
can cause a failure when the page is empty

Co-authored-by: Karol Sobczak <napewnotrafi@gmail.com>


```
== NO RELEASE NOTE ==
```
