### PR TITLE
Add laplace_cdf and inverse_laplace_cdf functions

### DIFF
--- a/presto-docs/src/main/sphinx/functions/math.rst
+++ b/presto-docs/src/main/sphinx/functions/math.rst
@@ -196,6 +196,11 @@ Probability Functions: cdf
     Compute the Chi-square cdf with given df (degrees of freedom) parameter:  P(N < value; df).
     The df parameter must be a positive real number, and value must be a non-negative real value (both of type DOUBLE).
 
+.. function:: laplace_cdf(mean, scale, value) -> double
+
+    Compute the Laplace cdf with given mean and scale parameters:  P(N < value; mean, scale).
+    The mean and value must be real values and the scale parameter must be a positive value (all of type DOUBLE).
+
 .. function:: normal_cdf(mean, sd, value) -> double
 
     Compute the Normal cdf with given mean and standard deviation (sd):  P(N < value; mean, sd).
@@ -238,6 +243,13 @@ Probability Functions: inverse_cdf
 
     Compute the inverse of the Chi-square cdf with given df (degrees of freedom) parameter for the cumulative
     probability (p): P(N < n). The df parameter must be positive real values.
+    The probability p must lie on the interval [0, 1].
+
+.. function:: inverse_laplace_cdf(mean, scale, p) -> double
+
+    Compute the inverse of the Laplace cdf with given mean and scale parameters
+    for the cumulative probability (p): P(N < n). The mean must be
+    a real value and the scale must be a positive real value (both of type DOUBLE).
     The probability p must lie on the interval [0, 1].
 
 .. function:: inverse_normal_cdf(mean, sd, p) -> double

--- a/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/scalar/MathFunctions.java
@@ -34,6 +34,7 @@ import org.apache.commons.math3.distribution.BetaDistribution;
 import org.apache.commons.math3.distribution.BinomialDistribution;
 import org.apache.commons.math3.distribution.CauchyDistribution;
 import org.apache.commons.math3.distribution.ChiSquaredDistribution;
+import org.apache.commons.math3.distribution.LaplaceDistribution;
 import org.apache.commons.math3.distribution.PoissonDistribution;
 import org.apache.commons.math3.distribution.WeibullDistribution;
 import org.apache.commons.math3.special.Erf;
@@ -897,6 +898,33 @@ public final class MathFunctions
         checkCondition(value >= 0, INVALID_FUNCTION_ARGUMENT, "value must non-negative");
         checkCondition(df > 0, INVALID_FUNCTION_ARGUMENT, "df must be greater than 0");
         ChiSquaredDistribution distribution = new ChiSquaredDistribution(null, df, ChiSquaredDistribution.DEFAULT_INVERSE_ABSOLUTE_ACCURACY);
+        return distribution.cumulativeProbability(value);
+    }
+
+    @Description("inverse of Laplace cdf given mean, scale parameters and probability")
+    @ScalarFunction
+    @SqlType(StandardTypes.DOUBLE)
+    public static double inverseLaplaceCdf(
+            @SqlType(StandardTypes.DOUBLE) double mean,
+            @SqlType(StandardTypes.DOUBLE) double scale,
+            @SqlType(StandardTypes.DOUBLE) double p)
+    {
+        checkCondition(scale > 0, INVALID_FUNCTION_ARGUMENT, "scale must be greater than 0");
+        checkCondition(p >= 0 && p <= 1, INVALID_FUNCTION_ARGUMENT, "p must be in the interval [0, 1]");
+        LaplaceDistribution distribution = new LaplaceDistribution(null, mean, scale);
+        return distribution.inverseCumulativeProbability(p);
+    }
+
+    @Description("Laplace cdf given mean, scale parameters and value")
+    @ScalarFunction
+    @SqlType(StandardTypes.DOUBLE)
+    public static double laplaceCdf(
+            @SqlType(StandardTypes.DOUBLE) double mean,
+            @SqlType(StandardTypes.DOUBLE) double scale,
+            @SqlType(StandardTypes.DOUBLE) double value)
+    {
+        checkCondition(scale > 0, INVALID_FUNCTION_ARGUMENT, "scale must be greater than 0");
+        LaplaceDistribution distribution = new LaplaceDistribution(null, mean, scale);
         return distribution.cumulativeProbability(value);
     }
 

--- a/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
+++ b/presto-main/src/test/java/com/facebook/presto/operator/scalar/TestMathFunctions.java
@@ -1468,6 +1468,33 @@ public class TestMathFunctions
     }
 
     @Test
+    public void testInverseLaplaceCdf()
+    {
+        assertFunction("inverse_laplace_cdf(5, 1, 0.5)", DOUBLE, 5.0);
+        assertFunction("inverse_laplace_cdf(5, 2, 0.5)", DOUBLE, 5.0);
+        assertFunction("round(inverse_laplace_cdf(5, 2, 0.6), 4)", DOUBLE, 5.0 + 0.4463);
+        assertFunction("round(inverse_laplace_cdf(-5, 2, 0.4), 4)", DOUBLE, -5.0 - 0.4463);
+
+        assertInvalidFunction("inverse_laplace_cdf(5, 2, -0.1)", "p must be in the interval [0, 1]");
+        assertInvalidFunction("inverse_laplace_cdf(5, 2, 1.1)", "p must be in the interval [0, 1]");
+        assertInvalidFunction("inverse_laplace_cdf(5, 0, 0.5)", "scale must be greater than 0");
+        assertInvalidFunction("inverse_laplace_cdf(5, -1, 0.5)", "scale must be greater than 0");
+    }
+
+    @Test
+    public void testLaplaceCdf()
+            throws Exception
+    {
+        assertFunction("laplace_cdf(4, 1, 4)", DOUBLE, 0.5);
+        assertFunction("laplace_cdf(4, 2, 4.0)", DOUBLE, 0.5);
+        assertFunction("round(laplace_cdf(4, 2, 4.0 - 0.4463), 2)", DOUBLE, 0.4);
+        assertFunction("round(laplace_cdf(-4, 2, -4.0 + 0.4463), 4)", DOUBLE, 0.6);
+
+        assertInvalidFunction("laplace_cdf(5, 0, 10)", "scale must be greater than 0");
+        assertInvalidFunction("laplace_cdf(5, -1, 10)", "scale must be greater than 0");
+    }
+
+    @Test
     public void testInversePoissonCdf()
     {
         assertFunction("inverse_poisson_cdf(3, 0.0)", INTEGER, 0);


### PR DESCRIPTION
Added CDF and inverse CDF functions corresponding to the [Laplace distribution](https://en.wikipedia.org/wiki/Laplace_distribution), commonly used in applications of [differential privacy](https://en.wikipedia.org/wiki/Differential_privacy). These functions (and their documentation) mimic the form of the other distributions that have been implemented in Presto (e.g., normal, binomial, etc.).

Test plan - Tested by executing manual queries in `presto-cli` as well as through a small suite of added unit tests. Built docs render appropriately.

```
== RELEASE NOTES ==

General Changes
* Add :func:`laplace_cdf` and :func:`inverse_laplace_cdf` functions
```
