### PR TITLE
Add release notes for 0.273.2

### DIFF
--- a/presto-docs/src/main/sphinx/release.rst
+++ b/presto-docs/src/main/sphinx/release.rst
@@ -5,6 +5,7 @@ Release Notes
 .. toctree::
     :maxdepth: 1
 
+    release/release-0.273.2
     release/release-0.273
     release/release-0.272
     release/release-0.271

--- a/presto-docs/src/main/sphinx/release/release-0.273.2.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.273.2.rst
@@ -1,0 +1,7 @@
+===============
+Release 0.273.2
+===============
+
+General Changes
+_______________
+* Fix a regression in query execution time caused due to the way we are processing HdfsConfiguration.

--- a/presto-docs/src/main/sphinx/release/release-0.273.rst
+++ b/presto-docs/src/main/sphinx/release/release-0.273.rst
@@ -2,6 +2,11 @@
 Release 0.273
 =============
 
+.. warning::
+
+   There is a regression in query execution times due to way we are processing HdfsConfiguration
+   and the issue is fixed in 0.273.2 release.
+
 **Highlights**
 ==============
 * Add new Presto connector for Clickhouse.


### PR DESCRIPTION
Test plan - 
Generated Release notes locally.

## Release 273 release notes

![image](https://user-images.githubusercontent.com/236188/171967186-83e73618-fa1a-4676-8e15-eefac0fc6759.png)



## Release 273.2 release notes

![image](https://user-images.githubusercontent.com/236188/171967344-a2e8c35c-9a4c-4cd5-bb27-7eeff41bd229.png)



```
== NO RELEASE NOTE ==
```
