### PR TITLE
Add materialized view rewrite optimization for COUNT

### DIFF
--- a/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestMaterializedViewQueryOptimizer.java
+++ b/presto-main/src/test/java/com/facebook/presto/sql/analyzer/TestMaterializedViewQueryOptimizer.java
@@ -134,6 +134,30 @@ public class TestMaterializedViewQueryOptimizer
     }
 
     @Test
+    public void testWithCount()
+    {
+        String originalViewSql = format("SELECT COUNT(a) as a_count, COUNT(b, c) as bc_count FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT COUNT(a), COUNT(b, c) FROM %s", BASE_TABLE_1);
+        String expectedRewrittenSql = format("SELECT SUM(a_count), SUM(bc_count) FROM %s", VIEW);
+
+        assertOptimizedQuery(originalViewSql, baseQuerySql, expectedRewrittenSql);
+    }
+
+    @Test
+    public void testWithCountDistinct()
+    {
+        String originalViewSql = format("SELECT COUNT((a)) as a_count, COUNT(b, c) as bc_count FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT COUNT(DISTINCT(a)), COUNT(b, c) FROM %s", BASE_TABLE_1);
+
+        assertOptimizedQuery(originalViewSql, baseQuerySql, baseQuerySql);
+
+        originalViewSql = format("SELECT COUNT(DISTINCT(a)) as a_count, COUNT(b, c) as bc_count FROM %s", BASE_TABLE_1);
+        baseQuerySql = format("SELECT COUNT(DISTINCT(a)), COUNT(b, c) FROM %s", BASE_TABLE_1);
+
+        assertOptimizedQuery(originalViewSql, baseQuerySql, baseQuerySql);
+    }
+
+    @Test
     public void testWithArithmeticBinary()
     {
         String originalViewSql = format("SELECT a, b, c FROM %s", BASE_TABLE_1);
@@ -326,18 +350,8 @@ public class TestMaterializedViewQueryOptimizer
     @Test
     public void testWithUnsupportedFunction()
     {
-        String originalViewSql = format("SELECT COUNT(a) FROM %s", BASE_TABLE_1);
-        String baseQuerySql = format("SELECT COUNT(a) FROM %s", BASE_TABLE_1);
-
-        assertOptimizedQuery(originalViewSql, baseQuerySql, baseQuerySql);
-
-        originalViewSql = format("SELECT a FROM %s", BASE_TABLE_1);
-        baseQuerySql = format("SELECT COUNT(a) FROM %s", BASE_TABLE_1);
-
-        assertOptimizedQuery(originalViewSql, baseQuerySql, baseQuerySql);
-
-        originalViewSql = format("SELECT AVG(a) FROM %s", BASE_TABLE_1);
-        baseQuerySql = format("SELECT AVG(a) FROM %s", BASE_TABLE_1);
+        String originalViewSql = format("SELECT AVG(a) FROM %s", BASE_TABLE_1);
+        String baseQuerySql = format("SELECT AVG(a) FROM %s", BASE_TABLE_1);
 
         assertOptimizedQuery(originalViewSql, baseQuerySql, baseQuerySql);
 

--- a/presto-tests/src/main/java/com/facebook/presto/tests/QueryAssertions.java
+++ b/presto-tests/src/main/java/com/facebook/presto/tests/QueryAssertions.java
@@ -85,7 +85,7 @@ public final class QueryAssertions
 
         if (results.getUpdateCount().isPresent()) {
             if (!count.isPresent()) {
-                fail("update count should not be present");
+                fail("update count should be present");
             }
             assertEquals(results.getUpdateCount().getAsLong(), count.getAsLong(), "update count");
         }


### PR DESCRIPTION
Previously, we only supported associative aggregate functions for materialized view query rewrite optimizations. This is easily achieved by rewriting `func(x)` as `func(y, z)`, where `y` is a column derived from `func(x)` in a materialized view and `z` is the result of calling `func(x)` on the base table over the domain for which the MV does not have fresh data. This doesn't work for `COUNT`, `COUNT(y, z)` != `COUNT(x)`. This PR special-cases `COUNT` to allow for the MV optimization in spite of this non-associativity.

Test plan -
Unit and integration tests to verify COUNT is being rewritten as expected, and that the rewritten query is executed in place of a matching base query when the optimization is turned on.

```
== NO RELEASE NOTE ==
```
