### PR TITLE
Ratis Server Implementation with Resource Manager

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,7 @@
         <dep.hudi.version>0.11.0</dep.hudi.version>
         <dep.testcontainers.version>1.15.1</dep.testcontainers.version>
         <dep.docker-java.version>3.2.12</dep.docker-java.version>
+        <dep.ratis.version>2.2.0</dep.ratis.version>
         <!--
           America/Bahia_Banderas has:
            - offset change since 1970 (offset Jan 1970: -08:00, offset Jan 2018: -06:00)
@@ -1701,6 +1702,66 @@
                     <exclusion>
                         <groupId>org.apache.zookeeper</groupId>
                         <artifactId>zookeeper</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.ratis</groupId>
+                <artifactId>ratis-server</artifactId>
+                <version>${dep.ratis.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-api</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.ratis</groupId>
+                <artifactId>ratis-grpc</artifactId>
+                <version>${dep.ratis.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-api</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.ratis</groupId>
+                <artifactId>ratis-server-api</artifactId>
+                <version>${dep.ratis.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-api</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.ratis</groupId>
+                <artifactId>ratis-common</artifactId>
+                <version>${dep.ratis.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-api</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.apache.ratis</groupId>
+                <artifactId>ratis-client</artifactId>
+                <version>${dep.ratis.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-api</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>

--- a/presto-main/pom.xml
+++ b/presto-main/pom.xml
@@ -435,10 +435,70 @@
             <artifactId>presto-testng-services</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.ratis</groupId>
+            <artifactId>ratis-server</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.ratis</groupId>
+            <artifactId>ratis-grpc</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.ratis</groupId>
+            <artifactId>ratis-server-api</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.ratis</groupId>
+            <artifactId>ratis-common</artifactId>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.basepom.maven</groupId>
+                <artifactId>duplicate-finder-maven-plugin</artifactId>
+                <configuration>
+                    <ignoredDependencies>
+                        <dependency>
+                            <groupId>org.apache.ratis</groupId>
+                            <artifactId>ratis-client</artifactId>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.apache.ratis</groupId>
+                            <artifactId>ratis-common</artifactId>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.apache.ratis</groupId>
+                            <artifactId>ratis-server</artifactId>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.apache.ratis</groupId>
+                            <artifactId>ratis-grpc</artifactId>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.apache.ratis</groupId>
+                            <artifactId>ratis-metrics</artifactId>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.apache.ratis</groupId>
+                            <artifactId>ratis-proto</artifactId>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.apache.ratis</groupId>
+                            <artifactId>ratis-server-api</artifactId>
+                        </dependency>
+                    </ignoredDependencies>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.gaul</groupId>
                 <artifactId>modernizer-maven-plugin</artifactId>

--- a/presto-main/src/main/java/com/facebook/presto/metadata/InternalNode.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/InternalNode.java
@@ -67,6 +67,7 @@ public class InternalNode
     private final boolean resourceManager;
     private final boolean catalogServer;
     private final NodeStatus nodeStatus;
+    private final OptionalInt raftPort;
 
     public InternalNode(String nodeIdentifier, URI internalUri, NodeVersion nodeVersion, boolean coordinator)
     {
@@ -75,13 +76,23 @@ public class InternalNode
 
     public InternalNode(String nodeIdentifier, URI internalUri, NodeVersion nodeVersion, boolean coordinator, boolean resourceManager, boolean catalogServer)
     {
-        this(nodeIdentifier, internalUri, OptionalInt.empty(), nodeVersion, coordinator, resourceManager, catalogServer, ALIVE);
+        this(nodeIdentifier, internalUri, OptionalInt.empty(), nodeVersion, coordinator, resourceManager, catalogServer, ALIVE, OptionalInt.empty());
     }
 
     @ThriftConstructor
     public InternalNode(String nodeIdentifier, URI internalUri, OptionalInt thriftPort, String nodeVersion, boolean coordinator, boolean resourceManager, boolean catalogServer)
     {
-        this(nodeIdentifier, internalUri, thriftPort, new NodeVersion(nodeVersion), coordinator, resourceManager, catalogServer, ALIVE);
+        this(nodeIdentifier, internalUri, thriftPort, new NodeVersion(nodeVersion), coordinator, resourceManager, catalogServer, ALIVE, OptionalInt.empty());
+    }
+
+    public InternalNode(String nodeIdentifier, URI internalUri, OptionalInt thriftPort, String nodeVersion, boolean coordinator, boolean resourceManager, OptionalInt raftPort)
+    {
+        this(nodeIdentifier, internalUri, thriftPort, new NodeVersion(nodeVersion), coordinator, resourceManager, false, ALIVE, raftPort);
+    }
+
+    public InternalNode(String nodeIdentifier, URI internalUri, OptionalInt thriftPort, NodeVersion nodeVersion, boolean coordinator, boolean resourceManager, NodeStatus nodeStatus, OptionalInt raftPort)
+    {
+        this(nodeIdentifier, internalUri, thriftPort, nodeVersion, coordinator, resourceManager, false, nodeStatus, raftPort);
     }
 
     public InternalNode(
@@ -92,7 +103,8 @@ public class InternalNode
             boolean coordinator,
             boolean resourceManager,
             boolean catalogServer,
-            NodeStatus nodeStatus)
+            NodeStatus nodeStatus,
+            OptionalInt raftPort)
     {
         nodeIdentifier = emptyToNull(nullToEmpty(nodeIdentifier).trim());
         this.nodeIdentifier = requireNonNull(nodeIdentifier, "nodeIdentifier is null or empty");
@@ -103,6 +115,7 @@ public class InternalNode
         this.resourceManager = resourceManager;
         this.catalogServer = catalogServer;
         this.nodeStatus = nodeStatus;
+        this.raftPort = requireNonNull(raftPort, "raftPort is null");
     }
 
     @ThriftField(1)
@@ -182,6 +195,11 @@ public class InternalNode
         return catalogServer;
     }
 
+    public OptionalInt getRaftPort()
+    {
+        return raftPort;
+    }
+
     @Override
     public boolean equals(Object obj)
     {
@@ -212,6 +230,7 @@ public class InternalNode
                 .add("coordinator", coordinator)
                 .add("resourceManager", resourceManager)
                 .add("catalogServer", catalogServer)
+                .add("raftPort", raftPort)
                 .toString();
     }
 }

--- a/presto-main/src/main/java/com/facebook/presto/resourcemanager/RaftConfig.java
+++ b/presto-main/src/main/java/com/facebook/presto/resourcemanager/RaftConfig.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.resourcemanager;
+
+import com.facebook.airlift.configuration.Config;
+import com.facebook.presto.spi.function.Description;
+
+public class RaftConfig
+{
+    private boolean enabled;
+    private String groupId;
+    private String storageDir;
+    private int port;
+
+    public String getStorageDir()
+    {
+        return storageDir;
+    }
+
+    @Config("raft.storageDir")
+    @Description("The storage directory where each raft server's state machine stores their logs in")
+    public RaftConfig setStorageDir(String storageDir)
+    {
+        this.storageDir = storageDir;
+        return this;
+    }
+
+    public String getGroupId()
+    {
+        return groupId;
+    }
+
+    @Config("raft.groupId")
+    @Description("ID for the RaftGroup that server and client belong in")
+    public RaftConfig setGroupId(String groupId)
+    {
+        this.groupId = groupId;
+        return this;
+    }
+
+    public int getPort()
+    {
+        return port;
+    }
+
+    @Config("raft.port")
+    @Description("The port to which the RaftServer listens to")
+    public RaftConfig setPort(int port)
+    {
+        this.port = port;
+        return this;
+    }
+
+    public boolean isEnabled()
+    {
+        return enabled;
+    }
+
+    @Config("raft.isEnabled")
+    @Description("Enables the Ratis Server in the Resource Manager")
+    public RaftConfig setEnabled(boolean enabled)
+    {
+        this.enabled = enabled;
+        return this;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/resourcemanager/RatisServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/resourcemanager/RatisServer.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.resourcemanager;
+
+import com.facebook.presto.metadata.InternalNode;
+import com.facebook.presto.metadata.InternalNodeManager;
+import org.apache.ratis.conf.RaftProperties;
+import org.apache.ratis.grpc.GrpcConfigKeys;
+import org.apache.ratis.protocol.RaftGroup;
+import org.apache.ratis.protocol.RaftGroupId;
+import org.apache.ratis.protocol.RaftPeer;
+import org.apache.ratis.protocol.RaftPeerId;
+import org.apache.ratis.server.RaftServer;
+import org.apache.ratis.server.RaftServerConfigKeys;
+import org.apache.ratis.statemachine.impl.BaseStateMachine;
+
+import javax.annotation.PostConstruct;
+import javax.inject.Inject;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.Set;
+import java.util.UUID;
+
+import static java.util.Objects.requireNonNull;
+
+public class RatisServer
+{
+    private final InternalNodeManager internalNodeManager;
+    private final String id;
+    private final String groupId;
+    private final int port;
+    private final String storageDir;
+
+    @Inject
+    public RatisServer(InternalNodeManager internalNodeManager, RaftConfig raftConfig)
+    {
+        requireNonNull(internalNodeManager, "internalNodeManager is null");
+        this.internalNodeManager = internalNodeManager;
+        this.id = internalNodeManager.getCurrentNode().getNodeIdentifier();
+        requireNonNull(raftConfig, "raftConfig is null");
+        this.groupId = raftConfig.getGroupId();
+        this.port = raftConfig.getPort();
+        this.storageDir = raftConfig.getStorageDir();
+    }
+
+    public RaftPeer[] getPeers()
+    {
+        Set<InternalNode> resourceManagers = internalNodeManager.getResourceManagers();
+        return resourceManagers.stream()
+                .map(resourceManager -> {
+                    RaftPeer.Builder builder = RaftPeer.newBuilder();
+                    builder.setId(RaftPeerId.valueOf(resourceManager.getNodeIdentifier()))
+                        .setAddress(resourceManager.getHost() + ":" + resourceManager.getRaftPort().getAsInt());
+                    return builder.build();
+                }).toArray(RaftPeer[]::new);
+    }
+
+    @PostConstruct
+    public void start()
+            throws Exception
+    {
+        run();
+    }
+
+    public void run() throws Exception
+    {
+        RaftProperties properties = new RaftProperties();
+        GrpcConfigKeys.Server.setPort(properties, port);
+        File storage = new File(storageDir + "/" + id);
+        RaftServerConfigKeys.setStorageDir(properties, Collections.singletonList(storage));
+        final RaftGroup raftGroup = RaftGroup.valueOf(RaftGroupId.valueOf(UUID.nameUUIDFromBytes(groupId.getBytes())), getPeers());
+
+        RaftServer raftServer = RaftServer.newBuilder()
+                .setServerId(RaftPeerId.valueOf(id))
+                .setProperties(properties)
+                .setGroup(raftGroup)
+                .setStateMachine(new BaseStateMachine())
+                .build();
+        raftServer.start();
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/server/ResourceManagerModule.java
+++ b/presto-main/src/main/java/com/facebook/presto/server/ResourceManagerModule.java
@@ -28,6 +28,8 @@ import com.facebook.presto.resourcemanager.DistributedQueryInfoResource;
 import com.facebook.presto.resourcemanager.DistributedQueryResource;
 import com.facebook.presto.resourcemanager.DistributedResourceGroupInfoResource;
 import com.facebook.presto.resourcemanager.ForResourceManager;
+import com.facebook.presto.resourcemanager.RaftConfig;
+import com.facebook.presto.resourcemanager.RatisServer;
 import com.facebook.presto.resourcemanager.ResourceManagerClusterStateProvider;
 import com.facebook.presto.resourcemanager.ResourceManagerProxy;
 import com.facebook.presto.resourcemanager.ResourceManagerServer;
@@ -105,6 +107,11 @@ public class ResourceManagerModule
         binder.bind(ResourceManagerProxy.class).in(Scopes.SINGLETON);
         jsonBinder(binder).addSerializerBinding(Duration.class).to(DurationSerializer.class);
         jsonBinder(binder).addSerializerBinding(DataSize.class).to(DataSizeSerializer.class);
+
+        RaftConfig raftConfig = buildConfigObject(RaftConfig.class);
+        if (raftConfig.isEnabled()) {
+            binder.bind(RatisServer.class).in(Scopes.SINGLETON);
+        }
     }
 
     @Provides

--- a/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestRaftConfig.java
+++ b/presto-main/src/test/java/com/facebook/presto/resourcemanager/TestRaftConfig.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.resourcemanager;
+
+import com.facebook.airlift.configuration.testing.ConfigAssertions;
+import com.google.common.collect.ImmutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertFullMapping;
+import static com.facebook.airlift.configuration.testing.ConfigAssertions.assertRecordedDefaults;
+
+public class TestRaftConfig
+{
+    @Test
+    public void testDefaults()
+    {
+        assertRecordedDefaults(ConfigAssertions.recordDefaults(RaftConfig.class)
+                .setEnabled(false)
+                .setGroupId(null)
+                .setPort(0)
+                .setStorageDir(null));
+    }
+
+    @Test
+    public void testExplicitPropertyMappings()
+    {
+        Map<String, String> properties = new ImmutableMap.Builder<String, String>()
+                .put("raft.storageDir", "/tmp/raft-server")
+                .put("raft.groupId", "testRaftGroupId1")
+                .put("raft.port", "6000")
+                .put("raft.isEnabled", "true")
+                .build();
+
+        RaftConfig expected = new RaftConfig()
+                .setEnabled(true)
+                .setGroupId("testRaftGroupId1")
+                .setPort(6000)
+                .setStorageDir("/tmp/raft-server");
+
+        assertFullMapping(properties, expected);
+    }
+}

--- a/presto-tests/pom.xml
+++ b/presto-tests/pom.xml
@@ -280,10 +280,79 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.ratis</groupId>
+            <artifactId>ratis-client</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.ratis</groupId>
+            <artifactId>ratis-common</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.ratis</groupId>
+            <artifactId>ratis-server</artifactId>
+            <scope>runtime</scope>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.ratis</groupId>
+            <artifactId>ratis-grpc</artifactId>
+            <scope>runtime</scope>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.ratis</groupId>
+            <artifactId>ratis-server-api</artifactId>
+            <scope>runtime</scope>
+            <optional>true</optional>
+        </dependency>
+        
     </dependencies>
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.basepom.maven</groupId>
+                <artifactId>duplicate-finder-maven-plugin</artifactId>
+                <configuration>
+                    <ignoredDependencies>
+                        <dependency>
+                            <groupId>org.apache.ratis</groupId>
+                            <artifactId>ratis-client</artifactId>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.apache.ratis</groupId>
+                            <artifactId>ratis-common</artifactId>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.apache.ratis</groupId>
+                            <artifactId>ratis-server</artifactId>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.apache.ratis</groupId>
+                            <artifactId>ratis-grpc</artifactId>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.apache.ratis</groupId>
+                            <artifactId>ratis-metrics</artifactId>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.apache.ratis</groupId>
+                            <artifactId>ratis-proto</artifactId>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.apache.ratis</groupId>
+                            <artifactId>ratis-server-api</artifactId>
+                        </dependency>
+                    </ignoredDependencies>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>

--- a/presto-tests/src/test/java/com/facebook/presto/resourcemanager/TestRaftServer.java
+++ b/presto-tests/src/test/java/com/facebook/presto/resourcemanager/TestRaftServer.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.resourcemanager;
+
+import com.facebook.airlift.http.client.HttpClient;
+import com.facebook.airlift.http.client.jetty.JettyHttpClient;
+import com.facebook.presto.metadata.InternalNode;
+import com.facebook.presto.resourceGroups.FileResourceGroupConfigurationManagerFactory;
+import com.facebook.presto.server.testing.TestingPrestoServer;
+import com.facebook.presto.tests.DistributedQueryRunner;
+import com.google.common.collect.ImmutableMap;
+import org.apache.ratis.client.RaftClient;
+import org.apache.ratis.conf.RaftProperties;
+import org.apache.ratis.protocol.RaftGroup;
+import org.apache.ratis.protocol.RaftGroupId;
+import org.apache.ratis.protocol.RaftPeer;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import static com.facebook.airlift.testing.Closeables.closeQuietly;
+import static com.facebook.presto.tests.tpch.TpchQueryRunner.createQueryRunner;
+import static org.testng.Assert.assertTrue;
+
+public class TestRaftServer
+{
+    private static final String RESOURCE_GROUPS_CONFIG_FILE = "resource_groups_config_simple.json";
+    private static final int COORDINATOR_COUNT = 2;
+    private static final int RESOURCE_MANAGER_COUNT = 2;
+    private static final String RESOURCE_GROUP_GLOBAL = "global";
+    private HttpClient client;
+    private TestingPrestoServer coordinator1;
+    private TestingPrestoServer coordinator2;
+    private TestingPrestoServer resourceManager1;
+    private TestingPrestoServer resourceManager2;
+    private DistributedQueryRunner runner;
+    private String groupId;
+
+    @BeforeClass
+    public void setup()
+            throws Exception
+    {
+        client = new JettyHttpClient();
+        groupId = "testRaftGroupId1";
+        runner = createQueryRunner(
+                ImmutableMap.of(
+                        "resource-manager.query-expiration-timeout", "4m",
+                        "raft.isEnabled", "true",
+                        "raft.port", "6000",
+                        "raft.groupId", groupId,
+                        "raft.storageDir", "/tmp/raft-server"),
+                ImmutableMap.of(
+                        "query.client.timeout", "20s",
+                        "resource-manager.query-heartbeat-interval", "100ms",
+                        "resource-group-runtimeinfo-refresh-interval", "100ms",
+                        "concurrency-threshold-to-enable-resource-group-refresh", "0.1"),
+                ImmutableMap.of(),
+                COORDINATOR_COUNT,
+                RESOURCE_MANAGER_COUNT);
+        coordinator1 = runner.getCoordinator(0);
+        coordinator2 = runner.getCoordinator(1);
+        this.resourceManager1 = runner.getResourceManager(0);
+        this.resourceManager2 = runner.getResourceManager(1);
+        runner.getCoordinators().stream().forEach(coordinator -> {
+            coordinator.getResourceGroupManager().get().addConfigurationManagerFactory(new FileResourceGroupConfigurationManagerFactory());
+            coordinator.getResourceGroupManager().get()
+                    .setConfigurationManager("file", ImmutableMap.of("resource-groups.config-file", getResourceFilePath(RESOURCE_GROUPS_CONFIG_FILE)));
+        });
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void teardown()
+    {
+        closeQuietly(coordinator1);
+        closeQuietly(coordinator2);
+        closeQuietly(resourceManager1);
+        closeQuietly(resourceManager2);
+        closeQuietly(client);
+        coordinator1 = null;
+        coordinator2 = null;
+        resourceManager1 = null;
+        resourceManager2 = null;
+        client = null;
+    }
+
+    private String getResourceFilePath(String fileName)
+    {
+        return this.getClass().getClassLoader().getResource(fileName).getPath();
+    }
+
+    @Test(timeOut = 120_000)
+    public void testRaftServerForResourceManager()
+            throws Exception
+    {
+        //Making Raft Peers for resource managers
+        Set<InternalNode> resourceManagers = resourceManager1.getNodeManager().getResourceManagers();
+        RaftPeer[] peers = resourceManagers.stream().map(resourceManager -> {
+            RaftPeer.Builder builder = RaftPeer.newBuilder();
+            builder.setId(resourceManager.getNodeIdentifier())
+                    .setAddress(resourceManager.getHost() + ":" + resourceManager.getRaftPort().getAsInt());
+            return builder.build();
+        }).toArray(RaftPeer[]::new);
+
+        //Building Raft Client in order to check who the leader is
+        RaftClient.Builder builder = RaftClient.newBuilder()
+                .setProperties(new RaftProperties())
+                .setRaftGroup(RaftGroup.valueOf(RaftGroupId.valueOf(UUID.nameUUIDFromBytes(groupId.getBytes())), peers));
+        RaftClient client = builder.build();
+
+        //Checking resource manager leader is chosen
+        List<String> resourceManagerIdentifiers = new ArrayList<String>();
+        for (InternalNode resourceManager : resourceManager1.getNodeManager().getResourceManagers()) {
+            resourceManagerIdentifiers.add(resourceManager.getNodeIdentifier());
+        }
+        assertTrue(resourceManagerIdentifiers.contains(client.getLeaderId().toString()));
+    }
+}

--- a/presto-tests/src/test/java/com/facebook/presto/tests/tpch/TpchQueryRunner.java
+++ b/presto-tests/src/test/java/com/facebook/presto/tests/tpch/TpchQueryRunner.java
@@ -59,7 +59,7 @@ public final class TpchQueryRunner
             int coordinatorCount)
             throws Exception
     {
-        return createQueryRunner(resourceManagerProperties, catalogServerProperties, coordinatorProperties, extraProperties, coordinatorCount, false);
+        return createQueryRunner(resourceManagerProperties, catalogServerProperties, coordinatorProperties, extraProperties, coordinatorCount, false, 1);
     }
 
     public static DistributedQueryRunner createQueryRunnerWithNoClusterReadyCheck(
@@ -70,16 +70,16 @@ public final class TpchQueryRunner
             int coordinatorCount)
             throws Exception
     {
-        return createQueryRunner(resourceManagerProperties, catalogServerProperties, coordinatorProperties, extraProperties, coordinatorCount, true);
+        return createQueryRunner(resourceManagerProperties, catalogServerProperties, coordinatorProperties, extraProperties, coordinatorCount, true, 1);
     }
 
-    public static DistributedQueryRunner createQueryRunner(
-            Map<String, String> resourceManagerProperties,
-            Map<String, String> catalogServerProperties,
-            Map<String, String> coordinatorProperties,
-            Map<String, String> extraProperties,
-            int coordinatorCount,
-            boolean skipClusterReadyCheck)
+    public static DistributedQueryRunner createQueryRunner(Map<String, String> resourceManagerProperties, Map<String, String> coordinatorProperties, Map<String, String> extraProperties, int coordinatorCount, int resourceManagerCount)
+            throws Exception
+    {
+        return createQueryRunner(resourceManagerProperties, ImmutableMap.of(), coordinatorProperties, extraProperties, coordinatorCount, false, resourceManagerCount);
+    }
+
+    public static DistributedQueryRunner createQueryRunner(Map<String, String> resourceManagerProperties, Map<String, String> catalogServerProperties, Map<String, String> coordinatorProperties, Map<String, String> extraProperties, int coordinatorCount, boolean skipClusterReadyCheck, int resourceManagerCount)
             throws Exception
     {
         DistributedQueryRunner queryRunner = TpchQueryRunnerBuilder.builder()
@@ -89,6 +89,7 @@ public final class TpchQueryRunner
                 .setExtraProperties(extraProperties)
                 .setResourceManagerEnabled(true)
                 .setCoordinatorCount(coordinatorCount)
+                .setResourceManagerCount(resourceManagerCount)
                 .build();
         if (!skipClusterReadyCheck) {
             queryRunner.waitForClusterToGetReady();


### PR DESCRIPTION
Description - Introducing the raft consensus algorithm among resource managers using the Apache Ratis library. Each resource manager integrates a raft server which allows one of the resource managers to be chosen as the leader with which the coordinator can communicate with. 

Test plan - Created a unit test that runs multiple resource managers and builds a client. The client is used to check that one of the resource managers is elected as a leader in the leader election process of the raft algorithm. 

```
== RELEASE NOTES ==

General Changes
* Add raft server to resource manager with disaggregated coordinators using Apache Ratis. Raft server enabled in resource manager using the ``isEnabled`` property in Config file 
```
