### PR TITLE
Catalog Server thrift service implementation

### DIFF
--- a/presto-common/src/main/java/com/facebook/presto/common/CatalogSchemaName.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/CatalogSchemaName.java
@@ -13,11 +13,16 @@
  */
 package com.facebook.presto.common;
 
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
+
 import java.util.Objects;
 
 import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 
+@ThriftStruct
 public final class CatalogSchemaName
 {
     // TODO: Move out this class. Ideally this class should not be in presto-common module.
@@ -25,17 +30,20 @@ public final class CatalogSchemaName
     private final String catalogName;
     private final String schemaName;
 
+    @ThriftConstructor
     public CatalogSchemaName(String catalogName, String schemaName)
     {
         this.catalogName = requireNonNull(catalogName, "catalogName is null").toLowerCase(ENGLISH);
         this.schemaName = requireNonNull(schemaName, "schemaName is null").toLowerCase(ENGLISH);
     }
 
+    @ThriftField(1)
     public String getCatalogName()
     {
         return catalogName;
     }
 
+    @ThriftField(2)
     public String getSchemaName()
     {
         return schemaName;

--- a/presto-common/src/main/java/com/facebook/presto/common/QualifiedObjectName.java
+++ b/presto-common/src/main/java/com/facebook/presto/common/QualifiedObjectName.java
@@ -13,6 +13,9 @@
  */
 package com.facebook.presto.common;
 
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
@@ -25,6 +28,7 @@ import static java.util.Locale.ENGLISH;
 import static java.util.Objects.requireNonNull;
 
 @Immutable
+@ThriftStruct
 public class QualifiedObjectName
 {
     private final String catalogName;
@@ -54,6 +58,7 @@ public class QualifiedObjectName
         return new QualifiedObjectName(catalogName, schemaName, objectName.toLowerCase(ENGLISH));
     }
 
+    @ThriftConstructor
     public QualifiedObjectName(String catalogName, String schemaName, String objectName)
     {
         checkLowerCase(catalogName, "catalogName");
@@ -69,16 +74,19 @@ public class QualifiedObjectName
         return new CatalogSchemaName(catalogName, schemaName);
     }
 
+    @ThriftField(1)
     public String getCatalogName()
     {
         return catalogName;
     }
 
+    @ThriftField(2)
     public String getSchemaName()
     {
         return schemaName;
     }
 
+    @ThriftField(3)
     public String getObjectName()
     {
         return objectName;

--- a/presto-main/src/main/java/com/facebook/presto/catalogserver/CatalogServer.java
+++ b/presto-main/src/main/java/com/facebook/presto/catalogserver/CatalogServer.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.catalogserver;
+
+import com.facebook.drift.annotations.ThriftMethod;
+import com.facebook.drift.annotations.ThriftService;
+import com.facebook.presto.SessionRepresentation;
+import com.facebook.presto.common.CatalogSchemaName;
+import com.facebook.presto.common.QualifiedObjectName;
+import com.facebook.presto.metadata.Metadata;
+import com.facebook.presto.metadata.MetadataManager;
+import com.facebook.presto.metadata.QualifiedTablePrefix;
+import com.facebook.presto.metadata.SessionPropertyManager;
+import com.facebook.presto.metadata.ViewDefinition;
+import com.facebook.presto.spi.ConnectorMaterializedViewDefinition;
+import com.facebook.presto.spi.TableHandle;
+import com.facebook.presto.transaction.TransactionInfo;
+import com.facebook.presto.transaction.TransactionManager;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import javax.inject.Inject;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+@ThriftService(value = "presto-catalog-server", idlName = "PrestoCatalogServer")
+public class CatalogServer
+{
+    private static final String EMPTY_STRING = "";
+
+    private final Metadata metadataProvider;
+    private final SessionPropertyManager sessionPropertyManager;
+    private final TransactionManager transactionManager;
+    private final ObjectMapper objectMapper;
+
+    @Inject
+    public CatalogServer(MetadataManager metadataProvider, SessionPropertyManager sessionPropertyManager, TransactionManager transactionManager, ObjectMapper objectMapper)
+    {
+        this.metadataProvider = requireNonNull(metadataProvider, "metadataProvider is null");
+        this.sessionPropertyManager = requireNonNull(sessionPropertyManager, "sessionPropertyManager is null");
+        this.transactionManager = requireNonNull(transactionManager, "transactionManager is null");
+        this.objectMapper = requireNonNull(objectMapper, "handleResolver is null");
+    }
+
+    @ThriftMethod
+    public boolean schemaExists(TransactionInfo transactionInfo, SessionRepresentation session, CatalogSchemaName schema)
+    {
+        transactionManager.tryRegisterTransaction(transactionInfo);
+        return metadataProvider.schemaExists(session.toSession(sessionPropertyManager), schema);
+    }
+
+    @ThriftMethod
+    public boolean catalogExists(TransactionInfo transactionInfo, SessionRepresentation session, String catalogName)
+    {
+        transactionManager.tryRegisterTransaction(transactionInfo);
+        return metadataProvider.catalogExists(session.toSession(sessionPropertyManager), catalogName);
+    }
+
+    @ThriftMethod
+    public String listSchemaNames(TransactionInfo transactionInfo, SessionRepresentation session, String catalogName)
+    {
+        transactionManager.tryRegisterTransaction(transactionInfo);
+        List<String> schemaNames = metadataProvider.listSchemaNames(session.toSession(sessionPropertyManager), catalogName);
+        if (!schemaNames.isEmpty()) {
+            return writeValueAsString(schemaNames, objectMapper);
+        }
+        return EMPTY_STRING;
+    }
+
+    @ThriftMethod
+    public String getTableHandle(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedObjectName table)
+    {
+        transactionManager.tryRegisterTransaction(transactionInfo);
+        Optional<TableHandle> tableHandle = metadataProvider.getTableHandle(session.toSession(sessionPropertyManager), table);
+        return tableHandle.map(handle -> writeValueAsString(handle, objectMapper))
+                .orElse(EMPTY_STRING);
+    }
+
+    @ThriftMethod
+    public String listTables(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedTablePrefix prefix)
+    {
+        transactionManager.tryRegisterTransaction(transactionInfo);
+        List<QualifiedObjectName> tableList = metadataProvider.listTables(session.toSession(sessionPropertyManager), prefix);
+        if (!tableList.isEmpty()) {
+            return writeValueAsString(tableList, objectMapper);
+        }
+        return EMPTY_STRING;
+    }
+
+    @ThriftMethod
+    public String listViews(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedTablePrefix prefix)
+    {
+        transactionManager.tryRegisterTransaction(transactionInfo);
+        List<QualifiedObjectName> viewsList = metadataProvider.listViews(session.toSession(sessionPropertyManager), prefix);
+        if (!viewsList.isEmpty()) {
+            writeValueAsString(viewsList, objectMapper);
+        }
+        return EMPTY_STRING;
+    }
+
+    @ThriftMethod
+    public String getViews(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedTablePrefix prefix)
+    {
+        transactionManager.tryRegisterTransaction(transactionInfo);
+        Map<QualifiedObjectName, ViewDefinition> viewsMap = metadataProvider.getViews(session.toSession(sessionPropertyManager), prefix);
+        if (!viewsMap.isEmpty()) {
+            return writeValueAsString(viewsMap, objectMapper);
+        }
+        return EMPTY_STRING;
+    }
+
+    @ThriftMethod
+    public String getView(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedObjectName viewName)
+    {
+        transactionManager.tryRegisterTransaction(transactionInfo);
+        Optional<ViewDefinition> viewDefinition = metadataProvider.getView(session.toSession(sessionPropertyManager), viewName);
+        return viewDefinition.map(view -> writeValueAsString(view, objectMapper))
+                .orElse(EMPTY_STRING);
+    }
+
+    @ThriftMethod
+    public String getMaterializedView(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedObjectName viewName)
+    {
+        transactionManager.tryRegisterTransaction(transactionInfo);
+        Optional<ConnectorMaterializedViewDefinition> connectorMaterializedViewDefinition =
+                metadataProvider.getMaterializedView(session.toSession(sessionPropertyManager), viewName);
+        return connectorMaterializedViewDefinition.map(materializedView -> writeValueAsString(materializedView, objectMapper))
+                .orElse(EMPTY_STRING);
+    }
+
+    @ThriftMethod
+    public String getReferencedMaterializedViews(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedObjectName tableName)
+    {
+        transactionManager.tryRegisterTransaction(transactionInfo);
+        List<QualifiedObjectName> referencedMaterializedViewsList = metadataProvider.getReferencedMaterializedViews(session.toSession(sessionPropertyManager), tableName);
+        if (!referencedMaterializedViewsList.isEmpty()) {
+            return writeValueAsString(referencedMaterializedViewsList, objectMapper);
+        }
+        return EMPTY_STRING;
+    }
+
+    private static String writeValueAsString(Object value, ObjectMapper objectMapper)
+    {
+        try {
+            return objectMapper.writeValueAsString(value);
+        }
+        catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/catalogserver/CatalogServerClient.java
+++ b/presto-main/src/main/java/com/facebook/presto/catalogserver/CatalogServerClient.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.catalogserver;
+
+import com.facebook.drift.annotations.ThriftMethod;
+import com.facebook.drift.annotations.ThriftService;
+import com.facebook.presto.SessionRepresentation;
+import com.facebook.presto.common.CatalogSchemaName;
+import com.facebook.presto.common.QualifiedObjectName;
+import com.facebook.presto.metadata.QualifiedTablePrefix;
+import com.facebook.presto.transaction.TransactionInfo;
+
+@ThriftService("PrestoCatalogServer")
+public interface CatalogServerClient
+{
+    @ThriftMethod
+    boolean schemaExists(TransactionInfo transactionInfo, SessionRepresentation session, CatalogSchemaName schema);
+
+    @ThriftMethod
+    boolean catalogExists(TransactionInfo transactionInfo, SessionRepresentation session, String catalogName);
+
+    @ThriftMethod
+    String listSchemaNames(TransactionInfo transactionInfo, SessionRepresentation session, String catalogName);
+
+    @ThriftMethod
+    String getTableHandle(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedObjectName table);
+
+    @ThriftMethod
+    String listTables(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedTablePrefix prefix);
+
+    @ThriftMethod
+    String listViews(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedTablePrefix prefix);
+
+    @ThriftMethod
+    String getViews(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedTablePrefix prefix);
+
+    @ThriftMethod
+    String getView(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedObjectName viewName);
+
+    @ThriftMethod
+    String getMaterializedView(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedObjectName viewName);
+
+    @ThriftMethod
+    String getReferencedMaterializedViews(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedObjectName tableName);
+}

--- a/presto-main/src/main/java/com/facebook/presto/metadata/QualifiedTablePrefix.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/QualifiedTablePrefix.java
@@ -13,6 +13,9 @@
  */
 package com.facebook.presto.metadata;
 
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
 import com.facebook.presto.common.QualifiedObjectName;
 import com.facebook.presto.spi.SchemaTablePrefix;
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -28,6 +31,7 @@ import static com.facebook.presto.metadata.MetadataUtil.checkSchemaName;
 import static com.facebook.presto.metadata.MetadataUtil.checkTableName;
 
 @Immutable
+@ThriftStruct
 public class QualifiedTablePrefix
 {
     private final String catalogName;
@@ -56,6 +60,7 @@ public class QualifiedTablePrefix
     }
 
     @JsonCreator
+    @ThriftConstructor
     public QualifiedTablePrefix(
             @JsonProperty("catalogName") String catalogName,
             @JsonProperty("schemaName") Optional<String> schemaName,
@@ -73,18 +78,21 @@ public class QualifiedTablePrefix
     }
 
     @JsonProperty
+    @ThriftField(1)
     public String getCatalogName()
     {
         return catalogName;
     }
 
     @JsonProperty
+    @ThriftField(2)
     public Optional<String> getSchemaName()
     {
         return schemaName;
     }
 
     @JsonProperty
+    @ThriftField(3)
     public Optional<String> getTableName()
     {
         return tableName;

--- a/presto-main/src/main/java/com/facebook/presto/transaction/DelegatingTransactionManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/transaction/DelegatingTransactionManager.java
@@ -63,6 +63,12 @@ public class DelegatingTransactionManager
     }
 
     @Override
+    public void tryRegisterTransaction(TransactionInfo transactionInfo)
+    {
+        delegate.tryRegisterTransaction(transactionInfo);
+    }
+
+    @Override
     public TransactionId beginTransaction(boolean autoCommitContext)
     {
         return delegate.beginTransaction(autoCommitContext);

--- a/presto-main/src/main/java/com/facebook/presto/transaction/InMemoryTransactionManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/transaction/InMemoryTransactionManager.java
@@ -94,7 +94,12 @@ public class InMemoryTransactionManager
     private final Map<String, FunctionNamespaceManager<?>> functionNamespaceManagers = new HashMap<>();
     private final Map<String, String> companionCatalogs;
 
-    private InMemoryTransactionManager(Duration idleTimeout, int maxFinishingConcurrency, CatalogManager catalogManager, Executor finishingExecutor, Map<String, String> companionCatalogs)
+    private InMemoryTransactionManager(
+            Duration idleTimeout,
+            int maxFinishingConcurrency,
+            CatalogManager catalogManager,
+            Executor finishingExecutor,
+            Map<String, String> companionCatalogs)
     {
         this.catalogManager = catalogManager;
         requireNonNull(idleTimeout, "idleTimeout is null");
@@ -113,7 +118,12 @@ public class InMemoryTransactionManager
             CatalogManager catalogManager,
             ExecutorService finishingExecutor)
     {
-        InMemoryTransactionManager transactionManager = new InMemoryTransactionManager(config.getIdleTimeout(), config.getMaxFinishingConcurrency(), catalogManager, finishingExecutor, config.getCompanionCatalogs());
+        InMemoryTransactionManager transactionManager = new InMemoryTransactionManager(
+                config.getIdleTimeout(),
+                config.getMaxFinishingConcurrency(),
+                catalogManager,
+                finishingExecutor,
+                config.getCompanionCatalogs());
         transactionManager.scheduleIdleChecks(config.getIdleCheckInterval(), idleCheckExecutor);
         return transactionManager;
     }
@@ -175,6 +185,16 @@ public class InMemoryTransactionManager
     }
 
     @Override
+    public void tryRegisterTransaction(TransactionInfo transactionInfo)
+    {
+        TransactionId transactionId = transactionInfo.getTransactionId();
+        if (transactions.containsKey(transactionId)) {
+            return;
+        }
+        registerTransaction(transactionId, transactionInfo.getIsolationLevel(), transactionInfo.isReadOnly(), transactionInfo.isAutoCommitContext());
+    }
+
+    @Override
     public TransactionId beginTransaction(boolean autoCommitContext)
     {
         return beginTransaction(DEFAULT_ISOLATION, DEFAULT_READ_ONLY, autoCommitContext);
@@ -184,9 +204,7 @@ public class InMemoryTransactionManager
     public TransactionId beginTransaction(IsolationLevel isolationLevel, boolean readOnly, boolean autoCommitContext)
     {
         TransactionId transactionId = TransactionId.create();
-        BoundedExecutor executor = new BoundedExecutor(finishingExecutor, maxFinishingConcurrency);
-        TransactionMetadata transactionMetadata = new TransactionMetadata(transactionId, isolationLevel, readOnly, autoCommitContext, catalogManager, executor, functionNamespaceManagers, companionCatalogs);
-        checkState(transactions.put(transactionId, transactionMetadata) == null, "Duplicate transaction ID: %s", transactionId);
+        registerTransaction(transactionId, isolationLevel, readOnly, autoCommitContext);
         return transactionId;
     }
 
@@ -281,6 +299,21 @@ public class InMemoryTransactionManager
             throw unknownTransactionError(transactionId);
         }
         return transactionMetadata;
+    }
+
+    private void registerTransaction(TransactionId transactionId, IsolationLevel isolationLevel, boolean readOnly, boolean autoCommitContext)
+    {
+        BoundedExecutor executor = new BoundedExecutor(finishingExecutor, maxFinishingConcurrency);
+        TransactionMetadata transactionMetadata = new TransactionMetadata(
+                transactionId,
+                isolationLevel,
+                readOnly,
+                autoCommitContext,
+                catalogManager,
+                executor,
+                functionNamespaceManagers,
+                companionCatalogs);
+        checkState(transactions.put(transactionId, transactionMetadata) == null, "Duplicate transaction ID: %s", transactionId);
     }
 
     private Optional<TransactionMetadata> tryGetTransactionMetadata(TransactionId transactionId)
@@ -427,7 +460,9 @@ public class InMemoryTransactionManager
 
                 if (companionCatalogs.containsKey(catalogName)) {
                     Optional<Catalog> companionCatalog = catalogManager.getCatalog(companionCatalogs.get(catalogName));
-                    checkArgument(companionCatalog.isPresent(), format("Invalid config, no catalog exists for catalog name %s: %s", catalogName, companionCatalogs.get(catalogName)));
+                    checkArgument(
+                            companionCatalog.isPresent(),
+                            format("Invalid config, no catalog exists for catalog name %s: %s", catalogName, companionCatalogs.get(catalogName)));
                     registerCatalog(companionCatalog.get());
                 }
             }
@@ -570,7 +605,10 @@ public class InMemoryTransactionManager
             // for transactions with read and write, we only return the commit handle for write query.
             ConnectorTransactionMetadata writeConnector = connectorIdToMetadata.get(writeConnectorId);
             Supplier<ListenableFuture<?>> commitFunctionNamespaceTransactions = () -> functionNamespaceFuture;
-            ListenableFuture<?> readOnlyCommitFuture = Futures.transformAsync(commitFunctionNamespaceTransactions.get(), ignored -> commitReadOnlyConnectors.get(), directExecutor());
+            ListenableFuture<?> readOnlyCommitFuture = Futures.transformAsync(
+                    commitFunctionNamespaceTransactions.get(),
+                    ignored -> commitReadOnlyConnectors.get(),
+                    directExecutor());
             ListenableFuture<?> writeCommitFuture = Futures.transformAsync(readOnlyCommitFuture, ignored -> finishingExecutor.submit(writeConnector::commit), directExecutor());
             addExceptionCallback(writeCommitFuture, this::abortInternal);
 

--- a/presto-main/src/main/java/com/facebook/presto/transaction/NoOpTransactionManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/transaction/NoOpTransactionManager.java
@@ -50,6 +50,12 @@ public class NoOpTransactionManager
     }
 
     @Override
+    public void tryRegisterTransaction(TransactionInfo transactionInfo)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public TransactionId beginTransaction(boolean autoCommitContext)
     {
         throw new UnsupportedOperationException();

--- a/presto-main/src/main/java/com/facebook/presto/transaction/TransactionInfo.java
+++ b/presto-main/src/main/java/com/facebook/presto/transaction/TransactionInfo.java
@@ -13,6 +13,9 @@
  */
 package com.facebook.presto.transaction;
 
+import com.facebook.drift.annotations.ThriftConstructor;
+import com.facebook.drift.annotations.ThriftField;
+import com.facebook.drift.annotations.ThriftStruct;
 import com.facebook.presto.spi.ConnectorId;
 import com.facebook.presto.spi.transaction.IsolationLevel;
 import com.google.common.collect.ImmutableList;
@@ -24,6 +27,7 @@ import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
 
+@ThriftStruct
 public class TransactionInfo
 {
     private final TransactionId transactionId;
@@ -35,6 +39,7 @@ public class TransactionInfo
     private final List<ConnectorId> connectorIds;
     private final Optional<ConnectorId> writtenConnectorId;
 
+    @ThriftConstructor
     public TransactionInfo(
             TransactionId transactionId,
             IsolationLevel isolationLevel,
@@ -55,41 +60,49 @@ public class TransactionInfo
         this.writtenConnectorId = requireNonNull(writtenConnectorId, "writtenConnectorId is null");
     }
 
+    @ThriftField(1)
     public TransactionId getTransactionId()
     {
         return transactionId;
     }
 
+    @ThriftField(2)
     public IsolationLevel getIsolationLevel()
     {
         return isolationLevel;
     }
 
+    @ThriftField(3)
     public boolean isReadOnly()
     {
         return readOnly;
     }
 
+    @ThriftField(4)
     public boolean isAutoCommitContext()
     {
         return autoCommitContext;
     }
 
+    @ThriftField(5)
     public DateTime getCreateTime()
     {
         return createTime;
     }
 
+    @ThriftField(6)
     public Duration getIdleTime()
     {
         return idleTime;
     }
 
+    @ThriftField(7)
     public List<ConnectorId> getConnectorIds()
     {
         return connectorIds;
     }
 
+    @ThriftField(8)
     public Optional<ConnectorId> getWrittenConnectorId()
     {
         return writtenConnectorId;

--- a/presto-main/src/main/java/com/facebook/presto/transaction/TransactionManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/transaction/TransactionManager.java
@@ -38,6 +38,8 @@ public interface TransactionManager
 
     List<TransactionInfo> getAllTransactionInfos();
 
+    void tryRegisterTransaction(TransactionInfo transactionInfo);
+
     TransactionId beginTransaction(boolean autoCommitContext);
 
     TransactionId beginTransaction(IsolationLevel isolationLevel, boolean readOnly, boolean autoCommitContext);

--- a/presto-main/src/test/java/com/facebook/presto/catalogserver/TestCatalogServerResponse.java
+++ b/presto-main/src/test/java/com/facebook/presto/catalogserver/TestCatalogServerResponse.java
@@ -1,0 +1,240 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.catalogserver;
+
+import com.facebook.airlift.json.JsonModule;
+import com.facebook.presto.common.QualifiedObjectName;
+import com.facebook.presto.connector.informationSchema.InformationSchemaTableHandle;
+import com.facebook.presto.connector.informationSchema.InformationSchemaTransactionHandle;
+import com.facebook.presto.metadata.HandleJsonModule;
+import com.facebook.presto.metadata.ViewDefinition;
+import com.facebook.presto.spi.ConnectorId;
+import com.facebook.presto.spi.ConnectorMaterializedViewDefinition;
+import com.facebook.presto.spi.ConnectorTableHandle;
+import com.facebook.presto.spi.SchemaTableName;
+import com.facebook.presto.spi.TableHandle;
+import com.facebook.presto.spi.connector.ConnectorTransactionHandle;
+import com.facebook.presto.transaction.TransactionId;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.testng.Assert.assertEquals;
+
+public class TestCatalogServerResponse
+{
+    private TestingCatalogServerClient testingCatalogServerClient;
+    private ObjectMapper objectMapper;
+
+    @BeforeTest
+    public void setup()
+    {
+        this.testingCatalogServerClient = new TestingCatalogServerClient();
+        Injector injector = Guice.createInjector(new JsonModule(), new HandleJsonModule());
+        this.objectMapper = injector.getInstance(ObjectMapper.class);
+    }
+
+    @Test
+    public void testSchemaExists()
+            throws Exception
+    {
+        boolean schemaExists = testingCatalogServerClient.schemaExists(null, null, null);
+        boolean actualSchemaExists = false;
+
+        assertEquals(schemaExists, actualSchemaExists);
+    }
+
+    @Test
+    public void testCatalogExists()
+            throws Exception
+    {
+        boolean catalogExists = testingCatalogServerClient.catalogExists(null, null, null);
+        boolean actualCatalogExists = true;
+
+        assertEquals(catalogExists, actualCatalogExists);
+    }
+
+    @Test
+    public void testListSchemaNames()
+            throws Exception
+    {
+        String schemaNamesJson = testingCatalogServerClient.listSchemaNames(null, null, null);
+        List<String> schemaNames = objectMapper.readValue(schemaNamesJson, new TypeReference<List<String>>() {});
+        List<String> actualSchemaNames = new ArrayList<>(Arrays.asList(
+                "information_schema",
+                "tiny",
+                "sf1",
+                "sf100",
+                "sf300",
+                "sf1000",
+                "sf3000",
+                "sf10000",
+                "sf30000",
+                "sf100000"));
+
+        assertEquals(schemaNames, actualSchemaNames);
+    }
+
+    @Test
+    public void testGetTableHandle()
+            throws Exception
+    {
+        String tableHandleJson = testingCatalogServerClient.getTableHandle(null, null, null);
+        TableHandle tableHandle = objectMapper.readValue(tableHandleJson, TableHandle.class);
+        ConnectorId connectorId = new ConnectorId("$info_schema@system");
+        ConnectorTableHandle connectorHandle = new InformationSchemaTableHandle("system", "information_schema", "schemata");
+        UUID uuid = UUID.fromString("ffe9ae3e-60de-4175-a0b5-d635767085fa");
+        ConnectorTransactionHandle connectorTransactionHandle = new InformationSchemaTransactionHandle(new TransactionId(uuid));
+        TableHandle actualTableHandle = new TableHandle(connectorId, connectorHandle, connectorTransactionHandle, Optional.empty());
+
+        assertEquals(tableHandle, actualTableHandle);
+    }
+
+    @Test
+    public void testListTables()
+            throws Exception
+    {
+        String tableListJson = testingCatalogServerClient.listTables(null, null, null);
+        List<QualifiedObjectName> tableList = objectMapper.readValue(tableListJson, new TypeReference<List<QualifiedObjectName>>() {});
+        List<QualifiedObjectName> actualTableList = new ArrayList<>(Arrays.asList(new QualifiedObjectName("tpch", "sf1", "nation")));
+
+        assertEquals(tableList, actualTableList);
+    }
+
+    @Test
+    public void testListViews()
+            throws Exception
+    {
+        String viewsListJson = testingCatalogServerClient.listViews(null, null, null);
+        List<QualifiedObjectName> viewsList = objectMapper.readValue(viewsListJson, new TypeReference<List<QualifiedObjectName>>() {});
+        List<QualifiedObjectName> actualViewsList = new ArrayList<>(Arrays.asList(
+                new QualifiedObjectName("hive", "tpch", "eric"),
+                new QualifiedObjectName("hive", "tpch", "eric2")));
+
+        assertEquals(viewsList, actualViewsList);
+    }
+
+    @Test
+    public void testGetViews()
+            throws Exception
+    {
+        String viewsMapJson = testingCatalogServerClient.getViews(null, null, null);
+        Map<QualifiedObjectName, ViewDefinition> viewsMap = objectMapper.readValue(viewsMapJson, new TypeReference<Map<QualifiedObjectName, ViewDefinition>>() {});
+        Map<QualifiedObjectName, ViewDefinition> actualViewsMap = new HashMap<>();
+        QualifiedObjectName key = new QualifiedObjectName("hive", "tpch", "eric");
+        actualViewsMap.put(key, new ViewDefinition(
+                "SELECT name\nFROM\n  tpch.sf1.nation\n",
+                Optional.of("hive"),
+                Optional.of("tpch"),
+                new ArrayList<>(),
+                Optional.of("ericn576"),
+                false));
+        assertEquals(viewsMap.keySet(), actualViewsMap.keySet());
+        ViewDefinition viewDefinition = viewsMap.get(key);
+        ViewDefinition actualViewDefinition = actualViewsMap.get(key);
+
+        assertEquals(viewDefinition.getOriginalSql(), actualViewDefinition.getOriginalSql());
+        assertEquals(viewDefinition.getCatalog(), actualViewDefinition.getCatalog());
+        assertEquals(viewDefinition.getSchema(), actualViewDefinition.getSchema());
+        assertEquals(viewDefinition.getOwner(), actualViewDefinition.getOwner());
+    }
+
+    @Test
+    public void testGetView()
+            throws Exception
+    {
+        String viewDefinitionJson = testingCatalogServerClient.getView(null, null, null);
+        ViewDefinition viewDefinition = objectMapper.readValue(viewDefinitionJson, ViewDefinition.class);
+        ViewDefinition actualViewDefinition = new ViewDefinition(
+                "SELECT name\nFROM\n  tpch.sf1.nation\n",
+                Optional.of("hive"),
+                Optional.of("tpch"),
+                new ArrayList<>(),
+                Optional.of("ericn576"),
+                false);
+
+        assertEquals(viewDefinition.getOriginalSql(), actualViewDefinition.getOriginalSql());
+        assertEquals(viewDefinition.getCatalog(), actualViewDefinition.getCatalog());
+        assertEquals(viewDefinition.getSchema(), actualViewDefinition.getSchema());
+        assertEquals(viewDefinition.getOwner(), actualViewDefinition.getOwner());
+    }
+
+    @Test
+    public void testGetMaterializedView()
+            throws Exception
+    {
+        String connectorMaterializedViewDefinitionJson = testingCatalogServerClient.getMaterializedView(null, null, null);
+        ConnectorMaterializedViewDefinition connectorMaterializedViewDefinition = objectMapper.readValue(
+                connectorMaterializedViewDefinitionJson,
+                ConnectorMaterializedViewDefinition.class);
+        String originalSql = "SELECT\n  name\n, nationkey\nFROM\n  test_customer_base\n";
+        String schema = "tpch";
+        String table = "eric";
+        List<SchemaTableName> baseTables = new ArrayList<>(Arrays.asList(new SchemaTableName("tpch", "test_customer_base")));
+        Optional<String> owner = Optional.of("ericn576");
+        List<ConnectorMaterializedViewDefinition.ColumnMapping> columnMappings = new ArrayList<>();
+        ConnectorMaterializedViewDefinition.TableColumn tableColumn = new ConnectorMaterializedViewDefinition.TableColumn(
+                new SchemaTableName("tpch", "eric"),
+                "name",
+                true);
+        ConnectorMaterializedViewDefinition.TableColumn listTableColumn = new ConnectorMaterializedViewDefinition.TableColumn(
+                new SchemaTableName("tpch", "test_customer_base"),
+                "name",
+                true);
+        columnMappings.add(new ConnectorMaterializedViewDefinition.ColumnMapping(tableColumn, new ArrayList<>(Arrays.asList(listTableColumn))));
+        List<SchemaTableName> baseTablesOnOuterJoinSide = new ArrayList<>();
+        Optional<List<String>> validRefreshColumns = Optional.of(new ArrayList<>(Arrays.asList("nationkey")));
+        ConnectorMaterializedViewDefinition actualConnectorMaterializedViewDefinition = new ConnectorMaterializedViewDefinition(
+                originalSql,
+                schema,
+                table,
+                baseTables,
+                owner,
+                columnMappings,
+                baseTablesOnOuterJoinSide,
+                validRefreshColumns);
+
+        assertEquals(connectorMaterializedViewDefinition.getOriginalSql(), actualConnectorMaterializedViewDefinition.getOriginalSql());
+        assertEquals(connectorMaterializedViewDefinition.getSchema(), actualConnectorMaterializedViewDefinition.getSchema());
+        assertEquals(connectorMaterializedViewDefinition.getTable(), actualConnectorMaterializedViewDefinition.getTable());
+        assertEquals(connectorMaterializedViewDefinition.getBaseTables(), actualConnectorMaterializedViewDefinition.getBaseTables());
+        assertEquals(connectorMaterializedViewDefinition.getOwner(), actualConnectorMaterializedViewDefinition.getOwner());
+        assertEquals(connectorMaterializedViewDefinition.getColumnMappingsAsMap(), actualConnectorMaterializedViewDefinition.getColumnMappingsAsMap());
+        assertEquals(connectorMaterializedViewDefinition.getBaseTablesOnOuterJoinSide(), actualConnectorMaterializedViewDefinition.getBaseTablesOnOuterJoinSide());
+        assertEquals(connectorMaterializedViewDefinition.getValidRefreshColumns(), actualConnectorMaterializedViewDefinition.getValidRefreshColumns());
+    }
+
+    @Test
+    public void testGetReferencedMaterializedViews()
+            throws Exception
+    {
+        String referencedMaterializedViewsListJson = testingCatalogServerClient.getReferencedMaterializedViews(null, null, null);
+        List<QualifiedObjectName> referencedMaterializedViewsList = objectMapper.readValue(referencedMaterializedViewsListJson, new TypeReference<List<QualifiedObjectName>>() {});
+        List<QualifiedObjectName> actualReferencedMaterializedViewsList = new ArrayList<>(
+                Arrays.asList(new QualifiedObjectName("hive", "tpch", "test_customer_base")));
+
+        assertEquals(referencedMaterializedViewsList, actualReferencedMaterializedViewsList);
+    }
+}

--- a/presto-main/src/test/java/com/facebook/presto/catalogserver/TestingCatalogServerClient.java
+++ b/presto-main/src/test/java/com/facebook/presto/catalogserver/TestingCatalogServerClient.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.catalogserver;
+
+import com.facebook.presto.SessionRepresentation;
+import com.facebook.presto.common.CatalogSchemaName;
+import com.facebook.presto.common.QualifiedObjectName;
+import com.facebook.presto.metadata.QualifiedTablePrefix;
+import com.facebook.presto.transaction.TransactionInfo;
+
+class TestingCatalogServerClient
+        implements CatalogServerClient
+{
+    @Override
+    public boolean schemaExists(TransactionInfo transactionInfo, SessionRepresentation session, CatalogSchemaName schema)
+    {
+        return false;
+    }
+
+    @Override
+    public boolean catalogExists(TransactionInfo transactionInfo, SessionRepresentation session, String catalogName)
+    {
+        return true;
+    }
+
+    @Override
+    public String listSchemaNames(TransactionInfo transactionInfo, SessionRepresentation session, String catalogName)
+    {
+        return "[\"information_schema\",\"tiny\",\"sf1\",\"sf100\",\"sf300\",\"sf1000\",\"sf3000\",\"sf10000\",\"sf30000\",\"sf100000\"]";
+    }
+
+    @Override
+    public String getTableHandle(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedObjectName table)
+    {
+        return "{\"connectorId\":\"$info_schema@system\",\"connectorHandle\":{\"@type\":\"$info_schema\",\"catalogName\":\"system\",\"schemaName\":\"information_schema\"," +
+                "\"tableName\":\"schemata\"},\"transaction\":{\"@type\":\"$info_schema\",\"transactionId\":\"ffe9ae3e-60de-4175-a0b5-d635767085fa\"}}";
+    }
+
+    @Override
+    public String listTables(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedTablePrefix prefix)
+    {
+        return "[\"tpch.sf1.nation\"]";
+    }
+
+    @Override
+    public String listViews(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedTablePrefix prefix)
+    {
+        return "[\"hive.tpch.eric\",\"hive.tpch.eric2\"]";
+    }
+
+    @Override
+    public String getViews(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedTablePrefix prefix)
+    {
+        return "{\"hive.tpch.eric\":{\"originalSql\":\"SELECT name\\nFROM\\n  tpch.sf1.nation\\n\",\"catalog\":\"hive\",\"schema\":\"tpch\",\"columns\":[]," +
+                "\"owner\":\"ericn576\",\"runAsInvoker\":false}}";
+    }
+
+    @Override
+    public String getView(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedObjectName viewName)
+    {
+        return "{\"originalSql\":\"SELECT name\\nFROM\\n  tpch.sf1.nation\\n\",\"catalog\":\"hive\",\"schema\":\"tpch\",\"columns\":[],\"owner\":\"ericn576\"," +
+                "\"runAsInvoker\":false}";
+    }
+
+    @Override
+    public String getMaterializedView(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedObjectName viewName)
+    {
+        return "{\"originalSql\":\"SELECT\\n  name\\n, nationkey\\nFROM\\n  test_customer_base\\n\",\"schema\":\"tpch\",\"table\":\"eric\",\"baseTables\":[{\"schema\":\"tpch\"," +
+                "\"table\":\"test_customer_base\"}],\"owner\":\"ericn576\",\"columnMapping\":[{\"viewColumn\":{\"tableName\":{\"schema\":\"tpch\",\"table\":\"eric\"}," +
+                "\"columnName\":\"name\",\"isDirectMapped\":true},\"baseTableColumns\":[{\"tableName\":{\"schema\":\"tpch\",\"table\":\"test_customer_base\"}," +
+                "\"columnName\":\"name\",\"isDirectMapped\":true}]}],\"baseTablesOnOuterJoinSide\":[],\"validRefreshColumns\":[\"nationkey\"]}";
+    }
+
+    @Override
+    public String getReferencedMaterializedViews(TransactionInfo transactionInfo, SessionRepresentation session, QualifiedObjectName tableName)
+    {
+        return "[\"hive.tpch.test_customer_base\"]";
+    }
+}

--- a/presto-spi/src/main/java/com/facebook/presto/spi/transaction/IsolationLevel.java
+++ b/presto-spi/src/main/java/com/facebook/presto/spi/transaction/IsolationLevel.java
@@ -13,17 +13,22 @@
  */
 package com.facebook.presto.spi.transaction;
 
+import com.facebook.drift.annotations.ThriftEnum;
+import com.facebook.drift.annotations.ThriftEnumValue;
 import com.facebook.presto.spi.PrestoException;
 
 import static com.facebook.presto.spi.StandardErrorCode.UNSUPPORTED_ISOLATION_LEVEL;
 import static java.lang.String.format;
 
+@ThriftEnum
 public enum IsolationLevel
 {
-    SERIALIZABLE,
-    REPEATABLE_READ,
-    READ_COMMITTED,
-    READ_UNCOMMITTED;
+    SERIALIZABLE(0),
+    REPEATABLE_READ(1),
+    READ_COMMITTED(2),
+    READ_UNCOMMITTED(3);
+
+    private final int value;
 
     public boolean meetsRequirementOf(IsolationLevel requirement)
     {
@@ -45,6 +50,17 @@ public enum IsolationLevel
         }
 
         throw new AssertionError("Unhandled isolation level: " + this);
+    }
+
+    IsolationLevel(int value)
+    {
+        this.value = value;
+    }
+
+    @ThriftEnumValue
+    public int getValue()
+    {
+        return value;
     }
 
     @Override


### PR DESCRIPTION
### Catalog Server thrift service implementation
- Defined thrift service interface for catalog server. This involves all metadata functions that will be used by the catalog server
- Implementation of thrift service functions


### Test plan
You can try running all the tests from **TestCatalogServerResponse**. These tests will test all of the catalog server functions by taking a real return object json string and then manually recreating that same object then seeing if the string is 100% equal to that object after deserialization. **TestingCatalogServerClient** has the json strings that we will be testing with.

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```
