### PR TITLE
Fix stats validation for flat map files

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriteValidation.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriteValidation.java
@@ -25,6 +25,7 @@ import com.facebook.presto.common.type.StandardTypes;
 import com.facebook.presto.common.type.Type;
 import com.facebook.presto.common.type.VarcharType;
 import com.facebook.presto.orc.metadata.CompressionKind;
+import com.facebook.presto.orc.metadata.OrcType;
 import com.facebook.presto.orc.metadata.PostScript.HiveWriterVersion;
 import com.facebook.presto.orc.metadata.RowGroupIndex;
 import com.facebook.presto.orc.metadata.StripeInformation;
@@ -44,6 +45,8 @@ import com.facebook.presto.orc.metadata.statistics.StringStatistics;
 import com.facebook.presto.orc.metadata.statistics.StringStatisticsBuilder;
 import com.facebook.presto.orc.metadata.statistics.StripeStatistics;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Iterables;
 import io.airlift.slice.Slice;
@@ -53,6 +56,7 @@ import org.openjdk.jol.info.ClassLayout;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -85,13 +89,13 @@ import static com.facebook.presto.orc.OrcWriteValidation.OrcWriteValidationMode.
 import static com.facebook.presto.orc.metadata.DwrfMetadataWriter.STATIC_METADATA;
 import static com.facebook.presto.orc.metadata.OrcMetadataReader.maxStringTruncateToValidRange;
 import static com.facebook.presto.orc.metadata.OrcMetadataReader.minStringTruncateToValidRange;
+import static com.facebook.presto.orc.metadata.statistics.ColumnStatistics.mergeColumnStatistics;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Verify.verify;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
-import static java.util.function.Function.identity;
 
 public class OrcWriteValidation
 {
@@ -111,6 +115,16 @@ public class OrcWriteValidation
     private final List<ColumnStatistics> fileStatistics;
     private final int stringStatisticsLimitInBytes;
 
+    // keeps mapping from the map key node to the map node
+    private final Map<Integer, Integer> flattenedKeyToMapNodes;
+
+    // keeps mapping from the map node to all its value nodes
+    private final Map<Integer, Set<Integer>> flattenedMapToValueNodes;
+
+    // keeps all flat map value nodes
+    private final Set<Integer> flattenedValueNodes;
+
+    // all values passed into this constructor are collected by the writer
     private OrcWriteValidation(
             List<Integer> version,
             CompressionKind compression,
@@ -121,7 +135,9 @@ public class OrcWriteValidation
             Map<Long, List<RowGroupStatistics>> rowGroupStatistics,
             Map<Long, StripeStatistics> stripeStatistics,
             List<ColumnStatistics> fileStatistics,
-            int stringStatisticsLimitInBytes)
+            int stringStatisticsLimitInBytes,
+            Set<Integer> flattenedNodes,
+            List<OrcType> orcTypes)
     {
         this.version = version;
         this.compression = compression;
@@ -133,6 +149,9 @@ public class OrcWriteValidation
         this.stripeStatistics = stripeStatistics;
         this.fileStatistics = fileStatistics;
         this.stringStatisticsLimitInBytes = stringStatisticsLimitInBytes;
+        this.flattenedKeyToMapNodes = getFlattenedKeyToMapNodes(flattenedNodes, orcTypes);
+        this.flattenedValueNodes = getFlattenedValueNodes(flattenedNodes, orcTypes);
+        this.flattenedMapToValueNodes = getFlattenedMapToValueNodes(flattenedNodes, orcTypes);
     }
 
     public List<Integer> getVersion()
@@ -222,7 +241,7 @@ public class OrcWriteValidation
         requireNonNull(actualRowGroupStatistics, "actualRowGroupStatistics is null");
         List<RowGroupStatistics> expectedRowGroupStatistics = rowGroupStatistics.get(stripeOffset);
         if (expectedRowGroupStatistics == null) {
-            throw new OrcCorruptionException(orcDataSourceId, "Unexpected stripe at offset %s", stripeOffset);
+            throw new OrcCorruptionException(orcDataSourceId, "Missing row group column statistics for stripe at offset %s", stripeOffset);
         }
 
         int rowGroupCount = expectedRowGroupStatistics.size();
@@ -236,35 +255,146 @@ public class OrcWriteValidation
             RowGroupStatistics expectedRowGroup = expectedRowGroupStatistics.get(rowGroupIndex);
             if (expectedRowGroup.getValidationMode() != HASHED) {
                 Map<Integer, ColumnStatistics> expectedStatistics = expectedRowGroup.getColumnStatistics();
-                Set<Integer> actualColumns = actualRowGroupStatistics.keySet().stream()
-                        .map(StreamId::getColumn)
-                        .collect(Collectors.toSet());
-                if (!expectedStatistics.keySet().equals(actualColumns)) {
+                Map<Integer, ColumnStatistics> actualStatistics = aggregateRowGroupStatisticsFromRowIndex(orcDataSourceId, actualRowGroupStatistics, stripeOffset, rowGroupIndex);
+
+                // remove empty row group stats for empty flat maps
+                expectedStatistics = adjustRowGroupStatisticsForFlatMaps(orcDataSourceId, stripeOffset, expectedStatistics);
+                actualStatistics = adjustRowGroupStatisticsForFlatMaps(orcDataSourceId, stripeOffset, actualStatistics);
+
+                Set<Integer> actualColumns = actualStatistics.keySet();
+                Set<Integer> expectedColumns = expectedStatistics.keySet();
+
+                if (!expectedColumns.equals(actualColumns)) {
                     throw new OrcCorruptionException(orcDataSourceId, "Unexpected column in row group %s in stripe at offset %s", rowGroupIndex, stripeOffset);
                 }
+
                 for (Entry<StreamId, List<RowGroupIndex>> entry : actualRowGroupStatistics.entrySet()) {
-                    ColumnStatistics actual = entry.getValue().get(rowGroupIndex).getColumnStatistics();
-                    ColumnStatistics expected = expectedStatistics.get(entry.getKey().getColumn());
+                    int column = entry.getKey().getColumn();
+                    ColumnStatistics actual = actualStatistics.get(column);
+                    ColumnStatistics expected = expectedStatistics.get(column);
                     validateColumnStatisticsEquivalent(orcDataSourceId, "Row group " + rowGroupIndex + " in stripe at offset " + stripeOffset, actual, expected);
                 }
             }
 
             if (expectedRowGroup.getValidationMode() != DETAILED) {
-                RowGroupStatistics actualRowGroup = buildActualRowGroupStatistics(rowGroupIndex, actualRowGroupStatistics);
-                if (expectedRowGroup.getHash() != actualRowGroup.getHash()) {
+                Map<Integer, ColumnStatistics> actualStatistics = aggregateRowGroupStatisticsFromRowIndex(orcDataSourceId, actualRowGroupStatistics, stripeOffset, rowGroupIndex);
+                actualStatistics = adjustRowGroupStatisticsForFlatMaps(orcDataSourceId, stripeOffset, actualStatistics);
+                RowGroupStatistics actualRowGroup = new RowGroupStatistics(BOTH, actualStatistics);
+                RowGroupStatistics adjustedExpectedRowGroup = new RowGroupStatistics(BOTH, adjustRowGroupStatisticsForFlatMaps(orcDataSourceId, stripeOffset, expectedRowGroup.getColumnStatistics()));
+                if (adjustedExpectedRowGroup.getHash() != actualRowGroup.getHash()) {
                     throw new OrcCorruptionException(orcDataSourceId, "Checksum mismatch for row group %s in stripe at offset %s", rowGroupIndex, stripeOffset);
                 }
             }
         }
     }
 
-    private static RowGroupStatistics buildActualRowGroupStatistics(int rowGroupIndex, Map<StreamId, List<RowGroupIndex>> actualRowGroupStatistics)
+    private Map<Integer, ColumnStatistics> adjustRowGroupStatisticsForFlatMaps(OrcDataSourceId orcDataSourceId, long stripeOffset, Map<Integer, ColumnStatistics> stats)
     {
-        return new RowGroupStatistics(
-                BOTH,
-                actualRowGroupStatistics.entrySet()
-                        .stream()
-                        .collect(Collectors.toMap(entry -> entry.getKey().getColumn(), entry -> entry.getValue().get(rowGroupIndex).getColumnStatistics())));
+        if (this.flattenedKeyToMapNodes.isEmpty()) {
+            return stats;
+        }
+
+        // The only reliable way to detect that a flat map doesn't have non-null & non-empty
+        // values is to check the stripe stats for the key node. If it has 0 number of values
+        // it means that this flat map writer didn't write anything.
+        StripeStatistics stripeStats = this.stripeStatistics.get(stripeOffset);
+        if (stripeStats == null) {
+            throw new OrcCorruptionException(orcDataSourceId, "Could not find stripe statistics for a stripe at offset %s", stripeOffset);
+        }
+
+        List<ColumnStatistics> allStripeColumnStatistics = stripeStats.getColumnStatistics();
+        Set<Integer> excludedNodes = new HashSet<>();
+        for (Entry<Integer, Integer> keyToMapNodeEntry : flattenedKeyToMapNodes.entrySet()) {
+            int keyNode = keyToMapNodeEntry.getKey();
+
+            ColumnStatistics stripeColumnStat = allStripeColumnStatistics.get(keyNode);
+            if (stripeColumnStat.getNumberOfValues() == 0) {
+                // This flat map column writer didn't write any key/value.
+                // Go over all value nodes for this flat map and check that they
+                // have 0 values before marking them as excluded.
+                Integer mapNode = keyToMapNodeEntry.getValue();
+                Set<Integer> valueNodes = flattenedMapToValueNodes.get(mapNode);
+                for (int valueNode : valueNodes) {
+                    ColumnStatistics valueColumnStat = allStripeColumnStatistics.get(valueNode);
+                    if (valueColumnStat.getNumberOfValues() != 0) {
+                        throw new OrcCorruptionException(
+                                orcDataSourceId,
+                                "Stripe at offset %s has unexpected flat map value node column stats with non-zero number of values",
+                                stripeOffset);
+                    }
+                    excludedNodes.add(valueNode);
+                }
+            }
+        }
+
+        // return original stats excluding the flat map value stats for empty flat maps
+        return stats.entrySet().stream()
+                .filter(e -> !excludedNodes.contains(e.getKey()))
+                .collect(toImmutableMap(Entry::getKey, Entry::getValue));
+    }
+
+    private Map<Integer, ColumnStatistics> aggregateRowGroupStatisticsFromRowIndex(
+            OrcDataSourceId orcDataSourceId,
+            Map<StreamId, List<RowGroupIndex>> actualRowGroupStatistics,
+            long stripeOffset,
+            int rowGroupIndex)
+    {
+        // flattened nodes might have multiple ROW_INDEX with the same column, but different sequences
+        // aggregate such statistics before the validation
+        Map<Integer, List<ColumnStatistics>> actualColumnStatisticsByColumn = new HashMap<>();
+        for (Entry<StreamId, List<RowGroupIndex>> entry : actualRowGroupStatistics.entrySet()) {
+            int column = entry.getKey().getColumn();
+            ColumnStatistics actual = entry.getValue().get(rowGroupIndex).getColumnStatistics();
+            List<ColumnStatistics> aggregateStats = actualColumnStatisticsByColumn.computeIfAbsent(column, (key) -> new ArrayList<>());
+            aggregateStats.add(actual);
+
+            // Regular nodes have only 1 ColumnStatistics in the ROW_INDEX, flattened nodes
+            // might have zero or more column statistics.
+            if (aggregateStats.size() != 1 && !flattenedValueNodes.contains(column)) {
+                throw new OrcCorruptionException(
+                        orcDataSourceId,
+                        "Unexpected multiple column statistics for node %s in row group %s in stripe at offset %s",
+                        column,
+                        rowGroupIndex,
+                        stripeOffset);
+            }
+        }
+
+        return actualColumnStatisticsByColumn.entrySet().stream()
+                .collect(Collectors.toMap(Entry::getKey, entry -> mergeColumnStatistics(entry.getValue())));
+    }
+
+    private Map<Integer, Integer> getFlattenedKeyToMapNodes(Set<Integer> flattenedNodes, List<OrcType> orcTypes)
+    {
+        ImmutableMap.Builder<Integer, Integer> keyNodeToMapNode = ImmutableMap.builder();
+        flattenedNodes.forEach(mapNodeIndex -> keyNodeToMapNode.put(orcTypes.get(mapNodeIndex).getFieldTypeIndex(0), mapNodeIndex));
+        return keyNodeToMapNode.build();
+    }
+
+    private Map<Integer, Set<Integer>> getFlattenedMapToValueNodes(Set<Integer> flattenedNodes, List<OrcType> orcTypes)
+    {
+        ImmutableMap.Builder<Integer, Set<Integer>> keyNodeToMapNode = ImmutableMap.builder();
+        flattenedNodes.forEach(mapNodeIndex -> keyNodeToMapNode.put(mapNodeIndex, getFlattenedValueNodes(ImmutableSet.of(mapNodeIndex), orcTypes)));
+        return keyNodeToMapNode.build();
+    }
+
+    private Set<Integer> getFlattenedValueNodes(Set<Integer> flattenedNodes, List<OrcType> orcTypes)
+    {
+        ImmutableSet.Builder<Integer> valueNodes = ImmutableSet.builder();
+        List<Integer> stack = new ArrayList<>();
+
+        for (Integer mapNodeIndex : flattenedNodes) {
+            int valueNodeIndex = orcTypes.get(mapNodeIndex).getFieldTypeIndex(1); // get map.value node index
+            stack.add(valueNodeIndex);
+
+            while (!stack.isEmpty()) {
+                int nodeIndex = stack.remove(stack.size() - 1);
+                valueNodes.add(nodeIndex);
+                OrcType orcType = orcTypes.get(nodeIndex);
+                stack.addAll(orcType.getFieldTypeIndexes());
+            }
+        }
+        return valueNodes.build();
     }
 
     public void validateRowGroupStatistics(
@@ -282,19 +412,29 @@ public class OrcWriteValidation
             throw new OrcCorruptionException(orcDataSourceId, "Unexpected row group %s in stripe at offset %s", rowGroupIndex, stripeOffset);
         }
 
+        // exclude stats for flat map keys because they are not present in the row group stats
+        ImmutableList.Builder<ColumnStatistics> actualAdjusted = ImmutableList.builder();
+        ImmutableMap.Builder<Integer, ColumnStatistics> actualAdjustedByNode = ImmutableMap.builder();
+        for (int i = 1; i < actual.size(); i++) {
+            if (!flattenedKeyToMapNodes.containsKey(i)) {
+                actualAdjusted.add(actual.get(i));
+                actualAdjustedByNode.put(i, actual.get(i));
+            }
+        }
+
         RowGroupStatistics expectedRowGroup = rowGroups.get(rowGroupIndex);
-        RowGroupStatistics actualRowGroup = new RowGroupStatistics(BOTH, IntStream.range(1, actual.size()).boxed().collect(toImmutableMap(identity(), actual::get)));
+        RowGroupStatistics actualRowGroup = new RowGroupStatistics(BOTH, actualAdjustedByNode.build());
 
         if (expectedRowGroup.getValidationMode() != HASHED) {
             Map<Integer, ColumnStatistics> expectedByColumnIndex = expectedRowGroup.getColumnStatistics();
 
             // new writer does not write row group stats for column zero (table row column)
             List<ColumnStatistics> expected = IntStream.range(1, actual.size())
+                    .filter(column -> !flattenedKeyToMapNodes.containsKey(column))
                     .mapToObj(expectedByColumnIndex::get)
                     .collect(toImmutableList());
-            actual = actual.subList(1, actual.size());
 
-            validateColumnStatisticsEquivalent(orcDataSourceId, "Row group " + rowGroupIndex + " in stripe at offset " + stripeOffset, actual, expected);
+            validateColumnStatisticsEquivalent(orcDataSourceId, "Row group " + rowGroupIndex + " in stripe at offset " + stripeOffset, actualAdjusted.build(), expected);
         }
 
         if (expectedRowGroup.getValidationMode() != DETAILED) {
@@ -830,6 +970,8 @@ public class OrcWriteValidation
         private final Map<Long, StripeStatistics> stripeStatistics = new HashMap<>();
         private List<ColumnStatistics> fileStatistics;
         private long retainedSize = INSTANCE_SIZE;
+        private Set<Integer> flattenedNodes;
+        private List<OrcType> orcTypes;
 
         public OrcWriteValidationBuilder(OrcWriteValidationMode validationMode, List<Type> types)
         {
@@ -913,6 +1055,16 @@ public class OrcWriteValidation
             this.fileStatistics = fileStatistics;
         }
 
+        public void setFlattenedNodes(Set<Integer> flattenedNodes)
+        {
+            this.flattenedNodes = flattenedNodes;
+        }
+
+        public void setOrcTypes(List<OrcType> orcTypes)
+        {
+            this.orcTypes = orcTypes;
+        }
+
         public OrcWriteValidation build()
         {
             return new OrcWriteValidation(
@@ -925,7 +1077,9 @@ public class OrcWriteValidation
                     rowGroupStatisticsByStripe,
                     stripeStatistics,
                     fileStatistics,
-                    stringStatisticsLimitInBytes);
+                    stringStatisticsLimitInBytes,
+                    flattenedNodes,
+                    orcTypes);
         }
     }
 }

--- a/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/OrcWriter.java
@@ -67,6 +67,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.OptionalLong;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -209,6 +210,7 @@ public class OrcWriter
         this.orcTypes = inputOrcTypes.orElseGet(() -> OrcType.createOrcRowType(0, columnNames, types));
 
         requireNonNull(compressionKind, "compressionKind is null");
+        Set<Integer> flattenedNodes = mapColumnToNode(options.getFlattenedColumns(), orcTypes);
         this.columnWriterOptions = ColumnWriterOptions.builder()
                 .setCompressionKind(compressionKind)
                 .setCompressionLevel(options.getCompressionLevel())
@@ -220,9 +222,11 @@ public class OrcWriter
                 .setIgnoreDictionaryRowGroupSizes(options.isIgnoreDictionaryRowGroupSizes())
                 .setPreserveDirectEncodingStripeCount(options.getPreserveDirectEncodingStripeCount())
                 .setCompressionBufferPool(compressionBufferPool)
-                .setFlattenedNodes(mapColumnToNode(options.getFlattenedColumns(), orcTypes))
+                .setFlattenedNodes(flattenedNodes)
                 .build();
         recordValidation(validation -> validation.setCompression(compressionKind));
+        recordValidation(validation -> validation.setFlattenedNodes(flattenedNodes));
+        recordValidation(validation -> validation.setOrcTypes(orcTypes));
 
         requireNonNull(options, "options is null");
         this.flushPolicy = requireNonNull(options.getFlushPolicy(), "flushPolicy is null");

--- a/presto-orc/src/main/java/com/facebook/presto/orc/writer/MapFlatColumnWriter.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/writer/MapFlatColumnWriter.java
@@ -232,7 +232,6 @@ public class MapFlatColumnWriter
 
         return ImmutableMap.<Integer, ColumnStatistics>builder()
                 .put(nodeIndex, mapStats)
-                .put(keyNodeIndex, keyManager.getRowGroupColumnStatistics())
                 .putAll(getValueColumnStatistics(ColumnWriter::finishRowGroup))
                 .build();
     }
@@ -466,7 +465,6 @@ public class MapFlatColumnWriter
         protected StatisticsBuilder rowGroupStatsBuilder;
         protected final T keyToWriter;
         private final Supplier<StatisticsBuilder> statisticsBuilderSupplier;
-        private final List<ColumnStatistics> rowGroupColumnStatistics = new ArrayList<>();
 
         public KeyManager(T keyToWriter, Supplier<StatisticsBuilder> statisticsBuilderSupplier)
         {
@@ -477,22 +475,14 @@ public class MapFlatColumnWriter
 
         public abstract MapFlatValueWriter getOrCreateValueWriter(int position, Block keyBlock);
 
-        public ColumnStatistics getRowGroupColumnStatistics()
-        {
-            ColumnStatistics columnStatistics = rowGroupStatsBuilder.buildColumnStatistics();
-            rowGroupColumnStatistics.add(columnStatistics);
-            return columnStatistics;
-        }
-
         public ColumnStatistics getStripeColumnStatistics()
         {
-            return mergeColumnStatistics(rowGroupColumnStatistics);
+            return rowGroupStatsBuilder.buildColumnStatistics();
         }
 
         public void reset()
         {
             keyToWriter.clear();
-            rowGroupColumnStatistics.clear();
             rowGroupStatsBuilder = statisticsBuilderSupplier.get();
         }
     }

--- a/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
+++ b/presto-orc/src/test/java/com/facebook/presto/orc/OrcTester.java
@@ -1591,16 +1591,12 @@ public class OrcTester
 
         writer.write(new Page(blocks));
         writer.close();
-
-        // TODO: sdruzkin - fix row group stats validation for flat maps
-        if (flattenedColumns.isEmpty()) {
-            writer.validate(new FileOrcDataSource(
-                    outputFile,
-                    new DataSize(1, MEGABYTE),
-                    new DataSize(1, MEGABYTE),
-                    new DataSize(1, MEGABYTE),
-                    true));
-        }
+        writer.validate(new FileOrcDataSource(
+                outputFile,
+                new DataSize(1, MEGABYTE),
+                new DataSize(1, MEGABYTE),
+                new DataSize(1, MEGABYTE),
+                true));
     }
 
     public static List<StripeFooter> getStripes(File inputFile, OrcEncoding encoding)


### PR DESCRIPTION
Column statistics produced by the flat map writer have different behavior than stats for any other type encoding. This makes it unsuitable for writer validation as-is. 

There are a few reasons for the difference in behavior: 
1) no ROW_INDEX stats for the key node, 
2) no ROW_INDEX stats for the value nodes if map has all null/empty entries,
3) ROW_INDEX stats for the value nodes across all sequences need to be merged

Test plan:
- enabled writer validation for the flat map writer tests which was failing befor

```
== NO RELEASE NOTE ==
```
