### PR TITLE
Introduce AlternativeMinMax aggr with REAL intermediate type.

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
+++ b/presto-main/src/main/java/com/facebook/presto/metadata/BuiltInTypeAndFunctionNamespaceManager.java
@@ -289,6 +289,8 @@ import static com.facebook.presto.common.type.UnknownType.UNKNOWN;
 import static com.facebook.presto.common.type.VarbinaryType.VARBINARY;
 import static com.facebook.presto.common.type.VarcharEnumParametricType.VARCHAR_ENUM;
 import static com.facebook.presto.metadata.SignatureBinder.applyBoundVariables;
+import static com.facebook.presto.operator.aggregation.AlternativeMaxAggregationFunction.ALTERNATIVE_MAX;
+import static com.facebook.presto.operator.aggregation.AlternativeMinAggregationFunction.ALTERNATIVE_MIN;
 import static com.facebook.presto.operator.aggregation.ArbitraryAggregationFunction.ARBITRARY_AGGREGATION;
 import static com.facebook.presto.operator.aggregation.ChecksumAggregationFunction.CHECKSUM_AGGREGATION;
 import static com.facebook.presto.operator.aggregation.CountColumn.COUNT_COLUMN;
@@ -896,6 +898,8 @@ public class BuiltInTypeAndFunctionNamespaceManager
 
         // Replace some aggregations for Velox to override intermediate aggregation type.
         if (featuresConfig.isUseAlternativeFunctionSignatures()) {
+            builder.override(MAX_AGGREGATION, ALTERNATIVE_MAX);
+            builder.override(MIN_AGGREGATION, ALTERNATIVE_MIN);
             builder.override(MAX_BY, ALTERNATIVE_MAX_BY);
             builder.override(MIN_BY, ALTERNATIVE_MIN_BY);
         }

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AbstractMinMaxAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AbstractMinMaxAggregationFunction.java
@@ -138,7 +138,7 @@ public abstract class AbstractMinMaxAggregationFunction
 
         AccumulatorStateFactory<?> stateFactory = StateCompiler.generateStateFactory(stateInterface, classLoader);
 
-        Type intermediateType = stateSerializer.getSerializedType();
+        Type intermediateType = overrideIntermediateType(type, stateSerializer.getSerializedType());
         AggregationMetadata metadata = new AggregationMetadata(
                 generateAggregationName(getSignature().getNameSuffix(), type.getTypeSignature(), inputTypes.stream().map(Type::getTypeSignature).collect(toImmutableList())),
                 createParameterMetadata(type),
@@ -153,6 +153,11 @@ public abstract class AbstractMinMaxAggregationFunction
 
         GenericAccumulatorFactoryBinder factory = AccumulatorCompiler.generateAccumulatorFactoryBinder(metadata, classLoader);
         return new InternalAggregationFunction(getSignature().getNameSuffix(), inputTypes, ImmutableList.of(intermediateType), type, true, false, factory);
+    }
+
+    protected Type overrideIntermediateType(Type inputType, Type defaultIntermediateType)
+    {
+        return defaultIntermediateType;
     }
 
     private static List<ParameterMetadata> createParameterMetadata(Type type)

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AlternativeMaxAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AlternativeMaxAggregationFunction.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.common.type.Type;
+
+public class AlternativeMaxAggregationFunction
+        extends MaxAggregationFunction
+{
+    public static final AlternativeMaxAggregationFunction ALTERNATIVE_MAX = new AlternativeMaxAggregationFunction();
+
+    public AlternativeMaxAggregationFunction()
+    {
+        super();
+    }
+
+    @Override
+    protected Type overrideIntermediateType(Type inputType, Type defaultIntermediateType)
+    {
+        return inputType;
+    }
+}

--- a/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AlternativeMinAggregationFunction.java
+++ b/presto-main/src/main/java/com/facebook/presto/operator/aggregation/AlternativeMinAggregationFunction.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.operator.aggregation;
+
+import com.facebook.presto.common.type.Type;
+
+public class AlternativeMinAggregationFunction
+        extends MinAggregationFunction
+{
+    public static final AlternativeMinAggregationFunction ALTERNATIVE_MIN = new AlternativeMinAggregationFunction();
+
+    public AlternativeMinAggregationFunction()
+    {
+        super();
+    }
+
+    @Override
+    protected Type overrideIntermediateType(Type inputType, Type defaultIntermediateType)
+    {
+        return inputType;
+    }
+}


### PR DESCRIPTION
Introduce AlternativeMinMax aggregation with REAL intermediate type instead of BIGINT (don't even ask me why it was BIGINT), so we have it running properly and not losing anything after floating point.
We'll use it for Prestissimo (C++ Velox-based Presto worker).

Test plan

Tested min() and max() with Prestissimo in the local mac setup and observed proper results. Also will add E2E tests, but they will be later in Prestissimo repo.

Please make sure your submission complies with our [Development](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#development), [Formatting](https://github.com/prestodb/presto/wiki/Presto-Development-Guidelines#formatting), and [Commit Message](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#commit-formatting-and-pull-requests) guidelines. Don't forget to follow our [attribution guidelines](https://github.com/prestodb/presto/wiki/Review-and-Commit-guidelines#attribution) for any code copied from other projects.

Fill in the release notes towards the bottom of the PR description.
See [Release Notes Guidelines](https://github.com/prestodb/presto/wiki/Release-Notes-Guidelines) for details.

```
== RELEASE NOTES ==

General Changes
* ...
* ...

Hive Changes
* ...
* ...
```

If release note is NOT required, use:

```
== NO RELEASE NOTE ==
```
