### PR TITLE
Support set session property for presto on spark

### DIFF
--- a/presto-spark-launcher/src/main/java/com/facebook/presto/spark/launcher/PrestoSparkClientOptions.java
+++ b/presto-spark-launcher/src/main/java/com/facebook/presto/spark/launcher/PrestoSparkClientOptions.java
@@ -34,4 +34,7 @@ public class PrestoSparkClientOptions
 
     @Option(name = "--schema", title = "schema", description = "Default schema")
     public String schema;
+
+    @Option(name = "--session-property-config", title = "file", description = "session-property-configuration.properties path")
+    public String sessionPropertyConfig;
 }

--- a/presto-spark-launcher/src/main/java/com/facebook/presto/spark/launcher/PrestoSparkLauncherCommand.java
+++ b/presto-spark-launcher/src/main/java/com/facebook/presto/spark/launcher/PrestoSparkLauncherCommand.java
@@ -24,6 +24,7 @@ import org.apache.spark.SparkContext;
 import javax.inject.Inject;
 
 import java.io.File;
+import java.util.Map;
 import java.util.Optional;
 
 import static com.facebook.presto.spark.launcher.LauncherUtils.checkFile;
@@ -52,6 +53,13 @@ public class PrestoSparkLauncherCommand
         TargzBasedPackageSupplier packageSupplier = new TargzBasedPackageSupplier(new File(clientOptions.packagePath));
         packageSupplier.deploy(sparkContext);
 
+        Optional<Map<String, String>> sessionPropertyConfigurationProperties;
+        if (clientOptions.sessionPropertyConfig == null) {
+            sessionPropertyConfigurationProperties = Optional.empty();
+        }
+        else {
+            sessionPropertyConfigurationProperties = Optional.of(loadProperties(checkFile(new File(clientOptions.sessionPropertyConfig))));
+        }
         PrestoSparkDistribution distribution = new PrestoSparkDistribution(
                 sparkContext,
                 packageSupplier,
@@ -60,7 +68,7 @@ public class PrestoSparkLauncherCommand
                 "LOCAL",
                 Optional.empty(),
                 Optional.empty(),
-                Optional.empty(),
+                sessionPropertyConfigurationProperties,
                 Optional.empty(),
                 Optional.empty());
 

--- a/presto-spark-package/pom.xml
+++ b/presto-spark-package/pom.xml
@@ -148,6 +148,14 @@
             <type>zip</type>
             <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-session-property-managers</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/presto-spark-package/src/main/assembly/presto.xml
+++ b/presto-spark-package/src/main/assembly/presto.xml
@@ -84,5 +84,9 @@
             <directory>${project.build.directory}/dependency/presto-sqlserver-${project.version}</directory>
             <outputDirectory>plugin/sqlserver</outputDirectory>
         </fileSet>
+        <fileSet>
+            <directory>${project.build.directory}/dependency/presto-session-property-managers-${project.version}</directory>
+            <outputDirectory>plugin/session-property-managers</outputDirectory>
+        </fileSet>
     </fileSets>
 </assembly>

--- a/presto-spark-testing/pom.xml
+++ b/presto-spark-testing/pom.xml
@@ -56,6 +56,12 @@
         </dependency>
 
         <dependency>
+            <groupId>com.facebook.airlift</groupId>
+            <artifactId>json</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-common</artifactId>
             <scope>test</scope>
@@ -70,6 +76,12 @@
         <dependency>
             <groupId>com.facebook.presto</groupId>
             <artifactId>presto-main</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.facebook.presto</groupId>
+            <artifactId>presto-session-property-managers</artifactId>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
Fix https://github.com/prestodb/presto/issues/17585

Users can set ` --session-property` to specify `session_property.properties`.
```
./bin/spark-submit \
    --master local \
    --deploy-mode client \
    --conf spark.executor.instances=1 \
    --conf spark.executor.cores=1 \
    --conf spark.task.cpus=1 \
    --class com.facebook.presto.spark.launcher.PrestoSparkLauncher \
    $PRESTO_SPARK_LAUNCHER_JAR \
    --package $PRESTO_SPARK_PACKAGE_GZ \
    --config $CONFIG \
    --catalogs $CATALOGS \
    --catalog $CATALOG \
    --schema $SCAMA \
    --session-property-config $SESSION_PROPERTY_DIR \
    --file $SQL_FILE
```
e.g.
session_property.properties
`session-property-config.configuration-manager=file
session-property-manager.config-file=/path/to/session-property-config.json`
session-property-config.json:
`[
    {
        "group": "global.*",
        "sessionProperties": {
            "query_max_execution_time": "5s"
        }
    }
]`

== RELEASE NOTE ==

Spark Changes
* Support set session property for presto on spark.
