### PR TITLE
Fix pinot connector generated query by adding single quote for time value in timeBoundary predicate

### DIFF
--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotClusterInfoFetcher.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotClusterInfoFetcher.java
@@ -468,8 +468,8 @@ public class PinotClusterInfoFetcher
                 @JsonProperty String timeValue)
         {
             if (timeColumn != null && timeValue != null) {
-                offlineTimePredicate = Optional.of(format("%s < %s", timeColumn, timeValue));
-                onlineTimePredicate = Optional.of(format("%s >= %s", timeColumn, timeValue));
+                offlineTimePredicate = Optional.of(format("%s < '%s'", timeColumn, timeValue));
+                onlineTimePredicate = Optional.of(format("%s >= '%s'", timeColumn, timeValue));
             }
             else {
                 onlineTimePredicate = Optional.empty();

--- a/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotSplitManager.java
+++ b/presto-pinot-toolkit/src/main/java/com/facebook/presto/pinot/PinotSplitManager.java
@@ -79,13 +79,13 @@ public class PinotSplitManager
 
         List<ConnectorSplit> splits = new ArrayList<>();
         if (!routingTable.isEmpty()) {
-            GeneratedPinotQuery segmentPql = tableHandle.getPinotQuery().orElseThrow(() -> new PinotException(PINOT_UNSUPPORTED_EXPRESSION, Optional.empty(), "Expected to find realtime and offline pql in " + tableHandle));
+            GeneratedPinotQuery segmentPinotQuery = tableHandle.getPinotQuery().orElseThrow(() -> new PinotException(PINOT_UNSUPPORTED_EXPRESSION, Optional.empty(), "Expected to find realtime and offline pinot query in " + tableHandle));
             PinotClusterInfoFetcher.TimeBoundary timeBoundary = new PinotClusterInfoFetcher.TimeBoundary(null, null);
             if (routingTable.containsKey(tableName + REALTIME_SUFFIX) && routingTable.containsKey(tableName + OFFLINE_SUFFIX)) {
                 timeBoundary = pinotPrestoConnection.getTimeBoundary(tableName);
             }
-            String realtime = getSegmentPql(segmentPql, REALTIME_SUFFIX, timeBoundary.getOnlineTimePredicate());
-            String offline = getSegmentPql(segmentPql, OFFLINE_SUFFIX, timeBoundary.getOfflineTimePredicate());
+            String realtime = getSegmentPinotQuery(segmentPinotQuery, REALTIME_SUFFIX, timeBoundary.getOnlineTimePredicate());
+            String offline = getSegmentPinotQuery(segmentPinotQuery, OFFLINE_SUFFIX, timeBoundary.getOfflineTimePredicate());
             generateSegmentSplits(splits, expectedColumnHandles, routingTable, tableName, "_REALTIME", session, realtime);
             generateSegmentSplits(splits, expectedColumnHandles, routingTable, tableName, "_OFFLINE", session, offline);
         }
@@ -94,17 +94,17 @@ public class PinotSplitManager
         return new FixedSplitSource(splits);
     }
 
-    private String getSegmentPql(GeneratedPinotQuery basePql, String suffix, Optional<String> timePredicate)
+    private String getSegmentPinotQuery(GeneratedPinotQuery basePinotQuery, String suffix, Optional<String> timePredicate)
     {
-        String pql = basePql.getQuery().replace(TABLE_NAME_SUFFIX_TEMPLATE, suffix);
+        String pinotQuery = basePinotQuery.getQuery().replace(TABLE_NAME_SUFFIX_TEMPLATE, suffix);
         if (timePredicate.isPresent()) {
             String tp = timePredicate.get();
-            pql = pql.replace(TIME_BOUNDARY_FILTER_TEMPLATE, basePql.isHaveFilter() ? " AND " + tp : " WHERE " + tp);
+            pinotQuery = pinotQuery.replace(TIME_BOUNDARY_FILTER_TEMPLATE, basePinotQuery.isHaveFilter() ? " AND " + tp : " WHERE " + tp);
         }
         else {
-            pql = pql.replace(TIME_BOUNDARY_FILTER_TEMPLATE, "");
+            pinotQuery = pinotQuery.replace(TIME_BOUNDARY_FILTER_TEMPLATE, "");
         }
-        return pql;
+        return pinotQuery;
     }
 
     protected void generateSegmentSplits(
@@ -114,7 +114,7 @@ public class PinotSplitManager
             String tableName,
             String tableNameSuffix,
             ConnectorSession session,
-            String pql)
+            String pinotQuery)
     {
         final String finalTableName = tableName + tableNameSuffix;
         int segmentsPerSplitConfigured = PinotSessionProperties.getNumSegmentsPerSplit(session);
@@ -129,7 +129,7 @@ public class PinotSplitManager
                 // segments is already shuffled
                 Iterables.partition(segments, numSegmentsInThisSplit).forEach(
                         segmentsForThisSplit -> splits.add(
-                                createSegmentSplit(connectorId, pql, expectedColumnHandles, segmentsForThisSplit, host, getGrpcPort(host))));
+                                createSegmentSplit(connectorId, pinotQuery, expectedColumnHandles, segmentsForThisSplit, host, getGrpcPort(host))));
             });
         }
     }

--- a/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/MockPinotClusterInfoFetcher.java
+++ b/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/MockPinotClusterInfoFetcher.java
@@ -427,6 +427,9 @@ public class MockPinotClusterInfoFetcher
         if (TestPinotSplitManager.hybridTable.getTableName().equalsIgnoreCase(table)) {
             return new TimeBoundary("secondsSinceEpoch", "4562345");
         }
+        if (TestPinotSplitManager.hybridTableWithTsTimeColumn.getTableName().equalsIgnoreCase(table)) {
+            return new TimeBoundary("ts", "2022-05-29 23:56:53.312");
+        }
 
         return new TimeBoundary();
     }

--- a/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotQueryBase.java
+++ b/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotQueryBase.java
@@ -92,6 +92,7 @@ public class TestPinotQueryBase
     protected static PinotTableHandle realtimeOnlyTable = new PinotTableHandle(pinotConnectorId.getCatalogName(), "schema", "realtimeOnly");
     protected static PinotTableHandle offlineOnlyTable = new PinotTableHandle(pinotConnectorId.getCatalogName(), "schema", "offlineOnly");
     protected static PinotTableHandle hybridTable = new PinotTableHandle(pinotConnectorId.getCatalogName(), "schema", "hybrid");
+    protected static PinotTableHandle hybridTableWithTsTimeColumn = new PinotTableHandle(pinotConnectorId.getCatalogName(), "schema", "hybridTableWithTsTimeColumn");
     protected static PinotColumnHandle regionId = new PinotColumnHandle("regionId", BIGINT, REGULAR);
     protected static PinotColumnHandle distinctCountDim = new PinotColumnHandle("distinctCountDim", BIGINT, REGULAR);
     protected static PinotColumnHandle city = new PinotColumnHandle("city", VARCHAR, REGULAR);

--- a/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotSplitManager.java
+++ b/presto-pinot-toolkit/src/test/java/com/facebook/presto/pinot/TestPinotSplitManager.java
@@ -150,6 +150,17 @@ public class TestPinotSplitManager
     }
 
     @Test
+    public void testGetTimeBoundaryForTable()
+    {
+        assertEquals(pinotConnection.getTimeBoundary("hybrid").getOfflineTimePredicate().get(), "secondsSinceEpoch < '4562345'");
+        assertEquals(pinotConnection.getTimeBoundary("hybrid").getOnlineTimePredicate().get(), "secondsSinceEpoch >= '4562345'");
+        assertEquals(pinotConnection.getTimeBoundary("hybridTableWithTsTimeColumn").getOfflineTimePredicate().get(), "ts < '2022-05-29 23:56:53.312'");
+        assertEquals(pinotConnection.getTimeBoundary("hybridTableWithTsTimeColumn").getOnlineTimePredicate().get(), "ts >= '2022-05-29 23:56:53.312'");
+        assertFalse(pinotConnection.getTimeBoundary("unknown").getOfflineTimePredicate().isPresent());
+        assertFalse(pinotConnection.getTimeBoundary("unknown").getOfflineTimePredicate().isPresent());
+    }
+
+    @Test
     public void testSplitsBroker()
     {
         PinotQueryGenerator.GeneratedPinotQuery generatedPql = new PinotQueryGenerator.GeneratedPinotQuery(realtimeOnlyTable.getTableName(), String.format("SELECT %s, COUNT(1) FROM %s GROUP BY %s TOP %d", city.getColumnName(), realtimeOnlyTable.getTableName(), city.getColumnName(), pinotConfig.getTopNLarge()), PinotQueryGenerator.PinotQueryFormat.PQL, ImmutableList.of(0, 1), 1, false, true);


### PR DESCRIPTION
Generated pinot segment query cannot be parsed when time column has time value contains space.
E.g. Below generated query cannot be parsed.
```
sql: "SELECT ... FROM myTable_OFFLINE WHERE ts < 2022-05-29 23:56:53.312 LIMIT 2147483647"
```
The right behavior should be:

```
sql: "SELECT ... FROM myTable_OFFLINE WHERE ts < '2022-05-29 23:56:53.312' LIMIT 2147483647"
```

```
== NO RELEASE NOTE ==
```
