### PR TITLE
Avoid silent overflows / underflows while reading micro timestamp

### DIFF
--- a/presto-orc/src/main/java/com/facebook/presto/orc/DecodeTimestampOptions.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/DecodeTimestampOptions.java
@@ -24,12 +24,14 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 public class DecodeTimestampOptions
 {
+    private final boolean enableMicroPrecision;
     private final long unitsPerSecond;
     private final long nanosecondsPerUnit;
     private final long baseSeconds;
 
     public DecodeTimestampOptions(DateTimeZone hiveStorageTimeZone, boolean enableMicroPrecision)
     {
+        this.enableMicroPrecision = enableMicroPrecision;
         TimeUnit timeUnit = enableMicroPrecision ? MICROSECONDS : MILLISECONDS;
 
         requireNonNull(hiveStorageTimeZone, "hiveStorageTimeZone is null");
@@ -38,6 +40,11 @@ public class DecodeTimestampOptions
         this.nanosecondsPerUnit = TimeUnit.NANOSECONDS.convert(1, timeUnit);
 
         this.baseSeconds = MILLISECONDS.toSeconds(new DateTime(2015, 1, 1, 0, 0, hiveStorageTimeZone).getMillis());
+    }
+
+    public boolean enableMicroPrecision()
+    {
+        return enableMicroPrecision;
     }
 
     public long getUnitsPerSecond()

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/ApacheHiveTimestampDecoder.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/ApacheHiveTimestampDecoder.java
@@ -22,7 +22,9 @@ final class ApacheHiveTimestampDecoder
     // This comes from the Apache Hive ORC code
     public static long decodeTimestamp(long seconds, long serializedNanos, DecodeTimestampOptions options)
     {
-        long value = (seconds + options.getBaseSeconds()) * options.getUnitsPerSecond();
+        boolean enableMicroPrecision = options.enableMicroPrecision();
+        long secondsWithBase = seconds + options.getBaseSeconds();
+        long value = getSecondsInRequiredUnits(enableMicroPrecision, secondsWithBase, options.getUnitsPerSecond());
         long nanos = parseNanos(serializedNanos);
         if (nanos > 999999999 || nanos < 0) {
             throw new IllegalArgumentException("nanos field of an encoded timestamp in ORC must be between 0 and 999999999 inclusive, got " + nanos);
@@ -36,8 +38,44 @@ final class ApacheHiveTimestampDecoder
         if (value < 0 && nanos != 0) {
             value -= options.getUnitsPerSecond();
         }
-        // Truncate nanos to required units (millis / micros) and add to value
-        return value + (nanos / options.getNanosPerUnit());
+        // Truncate nanos to required units (millis / micros)
+        long truncatedNanos = nanos / options.getNanosPerUnit();
+        return getValueWithNanos(enableMicroPrecision, value, truncatedNanos);
+    }
+
+    private static long getSecondsInRequiredUnits(boolean enableMicroPrecision, long secondsWithBase, long unitsPerSecond)
+    {
+        if (!enableMicroPrecision) {
+            // This can overflow/underflow, but to maintain backward compatibility this is not bounds checked.
+            return secondsWithBase * unitsPerSecond;
+        }
+        try {
+            // Overflow/underflow is detected and the code will raise error.
+            return Math.multiplyExact(secondsWithBase, unitsPerSecond);
+        }
+        catch (ArithmeticException e) {
+            String errorMessage = String.format("seconds field of timestamp exceeds maximum supported value, secondsWithBase: %s unitsPerSecond: %s.",
+                    secondsWithBase, unitsPerSecond);
+            throw new TimestampOutOfBoundsException(errorMessage, e);
+        }
+    }
+
+    // Add truncated nanos to seconds value
+    private static long getValueWithNanos(boolean enableMicroPrecision, long value, long truncatedNanos)
+    {
+        if (!enableMicroPrecision) {
+            // This can overflow/underflow, but to maintain backward compatibility this is not bounds checked.
+            return value + truncatedNanos;
+        }
+        try {
+            // Overflow/underflow is detected and the code will raise error.
+            return Math.addExact(value, truncatedNanos);
+        }
+        catch (ArithmeticException e) {
+            String errorMessage = String.format("Timestamp exceeds maximum supported value, value: %s truncatedNanos: %s.",
+                    value, truncatedNanos);
+            throw new TimestampOutOfBoundsException(errorMessage, e);
+        }
     }
 
     // This comes from the Apache Hive ORC code

--- a/presto-orc/src/main/java/com/facebook/presto/orc/reader/TimestampOutOfBoundsException.java
+++ b/presto-orc/src/main/java/com/facebook/presto/orc/reader/TimestampOutOfBoundsException.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.presto.orc.reader;
+
+public class TimestampOutOfBoundsException
+        extends RuntimeException
+{
+    public TimestampOutOfBoundsException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
+}


### PR DESCRIPTION
ORC support to read and write timestamp with microsecond precision was added as an option earlier using separate type TIMESTAMP_MICROSECONDS.

We recently noticed an issue in testing while reading a timestamp with micro precision, where the timestamp value overflowed max value in long variable causing an incorrect timestamp to be read.

The timestamp causing this issue was extreme and likely erroneous. This change addresses such issue and throws exception instead of silently overflowing / underflowing. 

No changes are required in the Presto ORC write side as we take a long variable as input to write timestamp, and it is already handled by the max value limit of Long variable.

Test plan
 - Added test cases to verify exception thrown due to overflow / underflow.
 - Testing in validation service 

```
== NO RELEASE NOTE ==
```
