### PR TITLE
Bump Iceberg to 0.13.2

### DIFF
--- a/presto-iceberg/pom.xml
+++ b/presto-iceberg/pom.xml
@@ -12,7 +12,7 @@
 
     <properties>
         <air.main.basedir>${project.parent.basedir}</air.main.basedir>
-        <dep.iceberg.version>0.13.1</dep.iceberg.version>
+        <dep.iceberg.version>0.13.2</dep.iceberg.version>
         <dep.nessie.version>0.30.0</dep.nessie.version>
     </properties>
 


### PR DESCRIPTION
Iceberg 0.13.2 is about to be released and this PR just makes sure that existing tests work with the new version