### PR TITLE
Reduce Iceberg metadata scans

### DIFF
--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/HiveTableOperations.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/HiveTableOperations.java
@@ -348,6 +348,15 @@ public class HiveTableOperations
         return LocationProviders.locationsFor(metadata.location(), metadata.properties());
     }
 
+    public void initializeFromMetadata(TableMetadata tableMetadata)
+    {
+        checkState(currentMetadata == null, "already initialized");
+        currentMetadata = tableMetadata;
+        currentMetadataLocation = tableMetadata.metadataFileLocation();
+        shouldRefresh = false;
+        version = parseVersion(currentMetadataLocation);
+    }
+
     private Table getTable()
     {
         return metastore.getTable(metastoreContext, database, tableName)

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSplitManager.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/IcebergSplitManager.java
@@ -32,7 +32,6 @@ import static com.facebook.presto.iceberg.CatalogType.HADOOP;
 import static com.facebook.presto.iceberg.CatalogType.NESSIE;
 import static com.facebook.presto.iceberg.ExpressionConverter.toIcebergExpression;
 import static com.facebook.presto.iceberg.IcebergSessionProperties.getMinimumAssignedSplitWeight;
-import static com.facebook.presto.iceberg.IcebergUtil.getHiveIcebergTable;
 import static com.facebook.presto.iceberg.IcebergUtil.getNativeIcebergTable;
 import static java.util.Objects.requireNonNull;
 
@@ -78,7 +77,7 @@ public class IcebergSplitManager
         }
         else {
             ExtendedHiveMetastore metastore = ((IcebergHiveMetadata) transactionManager.get(transaction)).getMetastore();
-            icebergTable = getHiveIcebergTable(metastore, hdfsEnvironment, session, table.getSchemaTableName());
+            icebergTable = ((IcebergHiveMetadata) transactionManager.get(transaction)).getHiveIcebergTable(metastore, hdfsEnvironment, session, table.getSchemaTableName());
         }
 
         TableScan tableScan = icebergTable.newScan()

--- a/presto-iceberg/src/main/java/com/facebook/presto/iceberg/RollbackToSnapshotProcedure.java
+++ b/presto-iceberg/src/main/java/com/facebook/presto/iceberg/RollbackToSnapshotProcedure.java
@@ -32,7 +32,7 @@ import static com.facebook.presto.common.type.StandardTypes.BIGINT;
 import static com.facebook.presto.common.type.StandardTypes.VARCHAR;
 import static com.facebook.presto.iceberg.CatalogType.HADOOP;
 import static com.facebook.presto.iceberg.CatalogType.NESSIE;
-import static com.facebook.presto.iceberg.IcebergUtil.getHiveIcebergTable;
+import static com.facebook.presto.iceberg.IcebergUtil.loadHiveIcebergTable;
 import static com.facebook.presto.iceberg.util.IcebergPrestoModelConverters.toIcebergTableIdentifier;
 import static java.util.Objects.requireNonNull;
 
@@ -89,7 +89,7 @@ public class RollbackToSnapshotProcedure
         }
         else {
             ExtendedHiveMetastore metastore = ((IcebergHiveMetadata) metadata).getMetastore();
-            icebergTable = getHiveIcebergTable(metastore, hdfsEnvironment, clientSession, schemaTableName);
+            icebergTable = loadHiveIcebergTable(metastore, hdfsEnvironment, clientSession, schemaTableName);
         }
         icebergTable.rollback().toSnapshotId(snapshotId).commit();
     }


### PR DESCRIPTION
Cherry-pick of https://github.com/trinodb/trino/pull/7367/commits/79d3919c783e61502263d5ce531e88cb017a44de
Cache Iceberg's TableMetadata object so that contents
of metadata file can be reused.

Co-authored-by: Pratham Desai <prathamd94@gmail.com>

```
== NO RELEASE NOTE ==
```
