### PR TITLE
Add grouped execution session property check for merge join optimization

### DIFF
--- a/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/MergeJoinOptimizer.java
+++ b/presto-main/src/main/java/com/facebook/presto/sql/planner/optimizations/MergeJoinOptimizer.java
@@ -28,6 +28,7 @@ import com.facebook.presto.sql.planner.plan.SimplePlanRewriter;
 
 import java.util.List;
 
+import static com.facebook.presto.SystemSessionProperties.isGroupedExecutionEnabled;
 import static com.facebook.presto.SystemSessionProperties.preferMergeJoin;
 import static com.facebook.presto.common.block.SortOrder.ASC_NULLS_FIRST;
 import static com.facebook.presto.sql.planner.plan.JoinNode.Type.INNER;
@@ -54,7 +55,7 @@ public class MergeJoinOptimizer
         requireNonNull(variableAllocator, "variableAllocator is null");
         requireNonNull(idAllocator, "idAllocator is null");
 
-        if (preferMergeJoin(session)) {
+        if (isGroupedExecutionEnabled(session) && preferMergeJoin(session)) {
             return SimplePlanRewriter.rewriteWith(new MergeJoinOptimizer.Rewriter(variableAllocator, idAllocator, metadata, session), plan, null);
         }
         return plan;


### PR DESCRIPTION
Context: as discussed with @yuanzhanhku and @adkri, to simplify and expedite the first version of merge join feature, we plan to only support merge join when grouped execution is enabled, more discussion can be found in [this doc](https://docs.google.com/document/d/1qQGqVU8E1vOSRH_cEEoOfXFyBY-XsV9UWf86iPkuGU0/edit?usp=sharing)

Test plan - TestMergeJoinPlan

Release note: given merge join worker side implementation(https://github.com/prestodb/presto/pull/17829) is still being worked on, we will add release note until that PR is merged
```
== NO RELEASE NOTE ==
```
